### PR TITLE
chore(insights): add chart benchmark scene for hog-charts vs chart.js

### DIFF
--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -30,6 +30,7 @@ export const appScenes: Record<Scene | string, () => any> = {
     [Scene.DeadLetterQueue]: () => import('./instance/DeadLetterQueue/DeadLetterQueue'),
     [Scene.QueryPerformance]: () => import('./instance/QueryPerformance/QueryPerformance'),
     [Scene.Destinations]: () => import('./data-pipelines/DestinationsScene'),
+    [Scene.ChartBench]: () => import('./debug/chart-bench/ChartBenchScene'),
     [Scene.DebugHog]: () => import('./debug/hog/HogRepl'),
     [Scene.DebugQuery]: () => import('./debug/DebugScene'),
 

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -32,6 +32,7 @@ export const appScenes: Record<Scene | string, () => any> = {
     [Scene.DeadLetterQueue]: () => import('./instance/DeadLetterQueue/DeadLetterQueue'),
     [Scene.QueryPerformance]: () => import('./instance/QueryPerformance/QueryPerformance'),
     [Scene.Destinations]: () => import('./data-pipelines/DestinationsScene'),
+    [Scene.ChartBench]: () => import('./debug/chart-bench/ChartBenchScene'),
     [Scene.DebugHog]: () => import('./debug/hog/HogRepl'),
     [Scene.DebugQuery]: () => import('./debug/DebugScene'),
 

--- a/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
+++ b/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
@@ -23,19 +23,30 @@ import { SweepResultsChart } from './SweepResultsChart'
 import type { ChartKind as SweepChartKind, SweepResult } from './sweepTypes'
 
 /**
- * Line-chart benchmark harness. Four chart "kinds":
+ * Chart benchmark harness. Chart "kinds":
  *
- *   - `hog`            — raw `lib/hog-charts` LineChart, synthetic data
- *   - `chartjs`        — raw chart.js Chart, synthetic data
- *   - `adapter-hog`    — real `TrendsLineChart` adapter fed through the
- *                        full insight kea logic tree (insight + data +
- *                        insightViz + trendsData) with cached results
- *   - `adapter-chartjs`— real `ActionsLineGraph` adapter (same logic tree,
- *                        chart.js under the hood)
+ *   - `hog`                  — raw `lib/hog-charts` LineChart, synthetic data
+ *   - `chartjs`              — raw chart.js Chart, synthetic data
+ *   - `hog-bar`              — raw `TimeSeriesBarChart`, vertical bars
+ *   - `hog-bar-horizontal`   — raw `TimeSeriesBarChart`, horizontal bars
+ *                              (same data, rotated)
+ *   - `adapter-hog`          — real `TrendsLineChart` adapter fed through the
+ *                              full insight kea logic tree (insight + data +
+ *                              insightViz + trendsData) with cached results
+ *   - `adapter-chartjs`      — real `ActionsLineGraph` adapter (same logic
+ *                              tree, chart.js under the hood)
+ *   - `adapter-bar`          — real `TrendsBarChart` adapter, vertical
+ *                              time-series bars (`ActionsBar`)
+ *   - `adapter-bar-horizontal`— real `TrendsBarChart` adapter, aggregated
+ *                              horizontal bars (`ActionsBarValue`)
  *
  * The raw cells isolate engine cost. The adapter cells include kea overhead,
  * the real PostHog tooltip (`TrendsTooltip` / `InsightTooltip`), and any
  * per-render selector/memoization cost — which is what actually ships.
+ *
+ * Horizontal layouts lay categories down the y-axis, so the hover sweep runs
+ * top-to-bottom for them and left-to-right for everything else (see
+ * `sweepHover` / `isHorizontalChart`).
  *
  * Results are exposed on `window.__chartBench` so a Playwright test can
  * iterate a matrix and compare.
@@ -70,10 +81,23 @@ const CHART_OPTIONS: { label: string; value: ChartKind }[] = [
     { label: 'hog-charts line (raw)', value: 'hog' },
     { label: 'chart.js line (raw)', value: 'chartjs' },
     { label: 'hog-charts bar (raw)', value: 'hog-bar' },
+    { label: 'hog-charts bar horizontal (raw)', value: 'hog-bar-horizontal' },
     { label: 'hog-charts (TrendsLineChart adapter)', value: 'adapter-hog' },
     { label: 'chart.js (ActionsLineGraph adapter)', value: 'adapter-chartjs' },
     { label: 'hog-charts (TrendsBarChart adapter)', value: 'adapter-bar' },
+    { label: 'hog-charts (TrendsBarChart horizontal adapter)', value: 'adapter-bar-horizontal' },
 ]
+
+/** Bar layouts whose categories run down the y-axis — the hover sweep must
+ * travel vertically to cross successive bars instead of horizontally. */
+const HORIZONTAL_CHART_KINDS: ReadonlySet<ChartKind> = new Set<ChartKind>([
+    'hog-bar-horizontal',
+    'adapter-bar-horizontal',
+])
+
+function isHorizontalChart(chart: ChartKind): boolean {
+    return HORIZONTAL_CHART_KINDS.has(chart)
+}
 
 const DEFAULT_SERIES = 10
 const DEFAULT_POINTS = 500
@@ -141,7 +165,16 @@ function parseSeriesList(raw: string): number[] {
         .filter((n) => Number.isFinite(n) && n > 0)
 }
 
-const ALL_CHART_KINDS: ChartKind[] = ['hog', 'chartjs', 'hog-bar', 'adapter-hog', 'adapter-chartjs', 'adapter-bar']
+const ALL_CHART_KINDS: ChartKind[] = [
+    'hog',
+    'chartjs',
+    'hog-bar',
+    'hog-bar-horizontal',
+    'adapter-hog',
+    'adapter-chartjs',
+    'adapter-bar',
+    'adapter-bar-horizontal',
+]
 
 interface ChartCellProps {
     chart: ChartKind
@@ -161,8 +194,8 @@ function ChartCell({ chart, series, points, seed, fillArea, showGrid, runKey }: 
     if (chart === 'chartjs') {
         return <ChartJsLineChart data={data} fillArea={fillArea} showGrid={showGrid} />
     }
-    if (chart === 'hog-bar') {
-        return <HogChartsBarChart data={data} showGrid={showGrid} />
+    if (chart === 'hog-bar' || chart === 'hog-bar-horizontal') {
+        return <HogChartsBarChart data={data} showGrid={showGrid} horizontal={chart === 'hog-bar-horizontal'} />
     }
     return <RealAdaptersCell kind={chart} data={data} runKey={runKey} fillArea={fillArea} />
 }
@@ -210,42 +243,50 @@ export function ChartBenchScene(): JSX.Element {
      * possible to tell whether a slow cell is bottlenecked in JS or in paint.
      * Both `pointermove` and `mousemove` are dispatched — chart.js listens on
      * pointer events, hog-charts on mouse events. Sync/frame are NaN if the
-     * canvas wasn't actually sized when the run started. */
-    const sweepHover = useCallback(async (): Promise<{ total: number; sync: number; frame: number }> => {
-        const canvas = findCanvas()
-        if (!canvas) {
-            return { total: NaN, sync: NaN, frame: NaN }
-        }
-        const rect = canvas.getBoundingClientRect()
-        if (rect.width < 10 || rect.height < 10) {
-            return { total: NaN, sync: NaN, frame: NaN }
-        }
-        const steps = 30
-        let totalSync = 0
-        let totalFrame = 0
-        for (let i = 0; i < steps; i++) {
-            const x = rect.left + (rect.width * (i + 0.5)) / steps
-            const y = rect.top + rect.height / 2
-            const init: PointerEventInit = {
-                bubbles: true,
-                cancelable: true,
-                clientX: x,
-                clientY: y,
-                view: window,
-                pointerType: 'mouse',
+     * canvas wasn't actually sized when the run started.
+     *
+     * `horizontal` charts lay their categories down the y-axis, so the sweep
+     * travels top-to-bottom (x fixed at center) to cross successive bars;
+     * upright charts sweep left-to-right (y fixed at center). */
+    const sweepHover = useCallback(
+        async (horizontal = false): Promise<{ total: number; sync: number; frame: number }> => {
+            const canvas = findCanvas()
+            if (!canvas) {
+                return { total: NaN, sync: NaN, frame: NaN }
             }
-            const dispatchStart = performance.now()
-            canvas.dispatchEvent(new PointerEvent('pointermove', init))
-            canvas.dispatchEvent(new MouseEvent('mousemove', init))
-            totalSync += performance.now() - dispatchStart
-            totalFrame += await nextFrame()
-        }
-        canvas.dispatchEvent(
-            new PointerEvent('pointerleave', { bubbles: true, cancelable: true, pointerType: 'mouse' })
-        )
-        canvas.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true, cancelable: true }))
-        return { total: totalSync + totalFrame, sync: totalSync, frame: totalFrame }
-    }, [findCanvas])
+            const rect = canvas.getBoundingClientRect()
+            if (rect.width < 10 || rect.height < 10) {
+                return { total: NaN, sync: NaN, frame: NaN }
+            }
+            const steps = 30
+            let totalSync = 0
+            let totalFrame = 0
+            for (let i = 0; i < steps; i++) {
+                const fraction = (i + 0.5) / steps
+                const x = horizontal ? rect.left + rect.width / 2 : rect.left + rect.width * fraction
+                const y = horizontal ? rect.top + rect.height * fraction : rect.top + rect.height / 2
+                const init: PointerEventInit = {
+                    bubbles: true,
+                    cancelable: true,
+                    clientX: x,
+                    clientY: y,
+                    view: window,
+                    pointerType: 'mouse',
+                }
+                const dispatchStart = performance.now()
+                canvas.dispatchEvent(new PointerEvent('pointermove', init))
+                canvas.dispatchEvent(new MouseEvent('mousemove', init))
+                totalSync += performance.now() - dispatchStart
+                totalFrame += await nextFrame()
+            }
+            canvas.dispatchEvent(
+                new PointerEvent('pointerleave', { bubbles: true, cancelable: true, pointerType: 'mouse' })
+            )
+            canvas.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true, cancelable: true }))
+            return { total: totalSync + totalFrame, sync: totalSync, frame: totalFrame }
+        },
+        [findCanvas]
+    )
 
     const runBenchmark = useCallback(async () => {
         setBusy(true)
@@ -265,7 +306,7 @@ export function ChartBenchScene(): JSX.Element {
             await nextFrame()
             readySamples.push(performance.now() - t0)
 
-            const hover = await sweepHover()
+            const hover = await sweepHover(isHorizontalChart(chart))
             hoverSamples.push(hover.total)
             hoverSyncSamples.push(hover.sync)
             hoverFrameSamples.push(hover.frame)
@@ -349,7 +390,7 @@ export function ChartBenchScene(): JSX.Element {
                 flushSync(() => setRunKey((k) => k + 1))
                 await nextFrame()
                 readySamples.push(performance.now() - t0)
-                const hover = await sweepHover()
+                const hover = await sweepHover(isHorizontalChart(cell.chart))
                 hoverSamples.push(hover.total)
                 hoverSyncSamples.push(hover.sync)
                 hoverFrameSamples.push(hover.frame)

--- a/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
+++ b/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
@@ -16,6 +16,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
 import { ChartJsLineChart } from './ChartJsLineChart'
 import { generateBenchData } from './generateBenchData'
+import { HogChartsBarChart } from './HogChartsBarChart'
 import { HogChartsLineChart } from './HogChartsLineChart'
 import { RealAdaptersCell } from './RealAdaptersCell'
 import { SweepResultsChart } from './SweepResultsChart'
@@ -66,10 +67,12 @@ declare global {
 }
 
 const CHART_OPTIONS: { label: string; value: ChartKind }[] = [
-    { label: 'hog-charts (raw)', value: 'hog' },
-    { label: 'chart.js (raw)', value: 'chartjs' },
+    { label: 'hog-charts line (raw)', value: 'hog' },
+    { label: 'chart.js line (raw)', value: 'chartjs' },
+    { label: 'hog-charts bar (raw)', value: 'hog-bar' },
     { label: 'hog-charts (TrendsLineChart adapter)', value: 'adapter-hog' },
     { label: 'chart.js (ActionsLineGraph adapter)', value: 'adapter-chartjs' },
+    { label: 'hog-charts (TrendsBarChart adapter)', value: 'adapter-bar' },
 ]
 
 const DEFAULT_SERIES = 10
@@ -138,7 +141,7 @@ function parseSeriesList(raw: string): number[] {
         .filter((n) => Number.isFinite(n) && n > 0)
 }
 
-const ALL_CHART_KINDS: ChartKind[] = ['hog', 'chartjs', 'adapter-hog', 'adapter-chartjs']
+const ALL_CHART_KINDS: ChartKind[] = ['hog', 'chartjs', 'hog-bar', 'adapter-hog', 'adapter-chartjs', 'adapter-bar']
 
 interface ChartCellProps {
     chart: ChartKind
@@ -157,6 +160,9 @@ function ChartCell({ chart, series, points, seed, fillArea, showGrid, runKey }: 
     }
     if (chart === 'chartjs') {
         return <ChartJsLineChart data={data} fillArea={fillArea} showGrid={showGrid} />
+    }
+    if (chart === 'hog-bar') {
+        return <HogChartsBarChart data={data} showGrid={showGrid} />
     }
     return <RealAdaptersCell kind={chart} data={data} runKey={runKey} fillArea={fillArea} />
 }

--- a/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
+++ b/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
@@ -23,7 +23,7 @@ import { RealAdaptersCell } from './RealAdaptersCell'
  *
  *   - `hog`            — raw `lib/hog-charts` LineChart, synthetic data
  *   - `chartjs`        — raw chart.js Chart, synthetic data
- *   - `adapter-hog`    — real `TrendsLineChartD3` adapter fed through the
+ *   - `adapter-hog`    — real `TrendsLineChart` adapter fed through the
  *                        full insight kea logic tree (insight + data +
  *                        insightViz + trendsData) with cached results
  *   - `adapter-chartjs`— real `ActionsLineGraph` adapter (same logic tree,
@@ -63,7 +63,7 @@ declare global {
 const CHART_OPTIONS: { label: string; value: ChartKind }[] = [
     { label: 'hog-charts (raw)', value: 'hog' },
     { label: 'chart.js (raw)', value: 'chartjs' },
-    { label: 'hog-charts (TrendsLineChartD3 adapter)', value: 'adapter-hog' },
+    { label: 'hog-charts (TrendsLineChart adapter)', value: 'adapter-hog' },
     { label: 'chart.js (ActionsLineGraph adapter)', value: 'adapter-chartjs' },
 ]
 
@@ -285,7 +285,7 @@ export function ChartBenchScene(): JSX.Element {
                     onChange={setShowGrid}
                     // The grid toggle only affects the raw cells — adapter
                     // modes always draw a grid (hog-charts sets `showGrid:true`
-                    // inside TrendsLineChartD3, chart.js draws grid by default).
+                    // inside TrendsLineChart, chart.js draws grid by default).
                     disabledReason={
                         chart.startsWith('adapter-')
                             ? 'Grid is baked into the adapter at this size — raw cells only'

--- a/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
+++ b/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
@@ -42,7 +42,7 @@ import type { ChartKind as SweepChartKind, SweepResult } from './sweepTypes'
 
 type ChartKind = SweepChartKind
 
-interface BenchResult {
+export interface BenchResult {
     chart: ChartKind
     series: number
     points: number

--- a/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
+++ b/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
@@ -14,6 +14,7 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
+import { ChartJsBarChart } from './ChartJsBarChart'
 import { ChartJsLineChart } from './ChartJsLineChart'
 import { generateBenchData } from './generateBenchData'
 import { HogChartsBarChart } from './HogChartsBarChart'
@@ -30,6 +31,9 @@ import type { ChartKind as SweepChartKind, SweepResult } from './sweepTypes'
  *   - `hog-bar`              — raw `TimeSeriesBarChart`, vertical bars
  *   - `hog-bar-horizontal`   — raw `TimeSeriesBarChart`, horizontal bars
  *                              (same data, rotated)
+ *   - `chartjs-bar`          — raw chart.js bar, stacked vertical bars
+ *   - `chartjs-bar-horizontal`— raw chart.js bar, `indexAxis: 'y'`
+ *                              (engine-cost counterpart to the hog bars)
  *   - `adapter-hog`          — real `TrendsLineChart` adapter fed through the
  *                              full insight kea logic tree (insight + data +
  *                              insightViz + trendsData) with cached results
@@ -82,6 +86,8 @@ const CHART_OPTIONS: { label: string; value: ChartKind }[] = [
     { label: 'chart.js line (raw)', value: 'chartjs' },
     { label: 'hog-charts bar (raw)', value: 'hog-bar' },
     { label: 'hog-charts bar horizontal (raw)', value: 'hog-bar-horizontal' },
+    { label: 'chart.js bar (raw)', value: 'chartjs-bar' },
+    { label: 'chart.js bar horizontal (raw)', value: 'chartjs-bar-horizontal' },
     { label: 'hog-charts (TrendsLineChart adapter)', value: 'adapter-hog' },
     { label: 'chart.js (ActionsLineGraph adapter)', value: 'adapter-chartjs' },
     { label: 'hog-charts (TrendsBarChart adapter)', value: 'adapter-bar' },
@@ -92,6 +98,7 @@ const CHART_OPTIONS: { label: string; value: ChartKind }[] = [
  * travel vertically to cross successive bars instead of horizontally. */
 const HORIZONTAL_CHART_KINDS: ReadonlySet<ChartKind> = new Set<ChartKind>([
     'hog-bar-horizontal',
+    'chartjs-bar-horizontal',
     'adapter-bar-horizontal',
 ])
 
@@ -170,6 +177,8 @@ const ALL_CHART_KINDS: ChartKind[] = [
     'chartjs',
     'hog-bar',
     'hog-bar-horizontal',
+    'chartjs-bar',
+    'chartjs-bar-horizontal',
     'adapter-hog',
     'adapter-chartjs',
     'adapter-bar',
@@ -196,6 +205,9 @@ function ChartCell({ chart, series, points, seed, fillArea, showGrid, runKey }: 
     }
     if (chart === 'hog-bar' || chart === 'hog-bar-horizontal') {
         return <HogChartsBarChart data={data} showGrid={showGrid} horizontal={chart === 'hog-bar-horizontal'} />
+    }
+    if (chart === 'chartjs-bar' || chart === 'chartjs-bar-horizontal') {
+        return <ChartJsBarChart data={data} showGrid={showGrid} horizontal={chart === 'chartjs-bar-horizontal'} />
     }
     return <RealAdaptersCell kind={chart} data={data} runKey={runKey} fillArea={fillArea} />
 }

--- a/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
+++ b/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
@@ -41,8 +41,12 @@ import type { ChartKind as SweepChartKind, SweepResult } from './sweepTypes'
  *                              tree, chart.js under the hood)
  *   - `adapter-bar`          — real `TrendsBarChart` adapter, vertical
  *                              time-series bars (`ActionsBar`)
+ *   - `adapter-chartjs-bar`  — chart.js engine counterpart of `adapter-bar`:
+ *                              `ActionsLineGraph` at the same `ActionsBar` display
  *   - `adapter-bar-horizontal`— real `TrendsBarChart` adapter, aggregated
  *                              horizontal bars (`ActionsBarValue`)
+ *   - `adapter-chartjs-bar-horizontal`— chart.js counterpart of the above:
+ *                              `ActionsHorizontalBar` at `ActionsBarValue`
  *
  * The raw cells isolate engine cost. The adapter cells include kea overhead,
  * the real PostHog tooltip (`TrendsTooltip` / `InsightTooltip`), and any
@@ -91,7 +95,25 @@ const CHART_OPTIONS: { label: string; value: ChartKind }[] = [
     { label: 'hog-charts (TrendsLineChart adapter)', value: 'adapter-hog' },
     { label: 'chart.js (ActionsLineGraph adapter)', value: 'adapter-chartjs' },
     { label: 'hog-charts (TrendsBarChart adapter)', value: 'adapter-bar' },
+    { label: 'chart.js (ActionsLineGraph bar adapter)', value: 'adapter-chartjs-bar' },
     { label: 'hog-charts (TrendsBarChart horizontal adapter)', value: 'adapter-bar-horizontal' },
+    { label: 'chart.js (ActionsHorizontalBar adapter)', value: 'adapter-chartjs-bar-horizontal' },
+]
+
+/** Dropdown label for each chart kind, so the sweep checkboxes read the same as the single-chart picker. */
+const CHART_LABELS: Record<ChartKind, string> = Object.fromEntries(
+    CHART_OPTIONS.map((o) => [o.value, o.label])
+) as Record<ChartKind, string>
+
+/** Sweep checkboxes grouped the same way the dropdown is ordered: raw line, raw bar, real adapters. */
+const CHART_GROUPS: { title: string; kinds: ChartKind[] }[] = [
+    { title: 'Line (raw)', kinds: ['hog', 'chartjs'] },
+    { title: 'Bar (raw)', kinds: ['hog-bar', 'hog-bar-horizontal', 'chartjs-bar', 'chartjs-bar-horizontal'] },
+    { title: 'Line adapters', kinds: ['adapter-hog', 'adapter-chartjs'] },
+    {
+        title: 'Bar adapters',
+        kinds: ['adapter-bar', 'adapter-chartjs-bar', 'adapter-bar-horizontal', 'adapter-chartjs-bar-horizontal'],
+    },
 ]
 
 /** Bar layouts whose categories run down the y-axis — the hover sweep must
@@ -100,6 +122,7 @@ const HORIZONTAL_CHART_KINDS: ReadonlySet<ChartKind> = new Set<ChartKind>([
     'hog-bar-horizontal',
     'chartjs-bar-horizontal',
     'adapter-bar-horizontal',
+    'adapter-chartjs-bar-horizontal',
 ])
 
 function isHorizontalChart(chart: ChartKind): boolean {
@@ -172,19 +195,6 @@ function parseSeriesList(raw: string): number[] {
         .filter((n) => Number.isFinite(n) && n > 0)
 }
 
-const ALL_CHART_KINDS: ChartKind[] = [
-    'hog',
-    'chartjs',
-    'hog-bar',
-    'hog-bar-horizontal',
-    'chartjs-bar',
-    'chartjs-bar-horizontal',
-    'adapter-hog',
-    'adapter-chartjs',
-    'adapter-bar',
-    'adapter-bar-horizontal',
-]
-
 interface ChartCellProps {
     chart: ChartKind
     series: number
@@ -193,9 +203,19 @@ interface ChartCellProps {
     fillArea: boolean
     showGrid: boolean
     runKey: number
+    adapterTooltip: boolean
 }
 
-function ChartCell({ chart, series, points, seed, fillArea, showGrid, runKey }: ChartCellProps): JSX.Element {
+function ChartCell({
+    chart,
+    series,
+    points,
+    seed,
+    fillArea,
+    showGrid,
+    runKey,
+    adapterTooltip,
+}: ChartCellProps): JSX.Element {
     const data = useMemo(() => generateBenchData(series, points, seed), [series, points, seed])
     if (chart === 'hog') {
         return <HogChartsLineChart data={data} fillArea={fillArea} showGrid={showGrid} />
@@ -209,7 +229,15 @@ function ChartCell({ chart, series, points, seed, fillArea, showGrid, runKey }: 
     if (chart === 'chartjs-bar' || chart === 'chartjs-bar-horizontal') {
         return <ChartJsBarChart data={data} showGrid={showGrid} horizontal={chart === 'chartjs-bar-horizontal'} />
     }
-    return <RealAdaptersCell kind={chart} data={data} runKey={runKey} fillArea={fillArea} />
+    return (
+        <RealAdaptersCell
+            kind={chart}
+            data={data}
+            runKey={runKey}
+            fillArea={fillArea}
+            tooltipEnabled={adapterTooltip}
+        />
+    )
 }
 
 export function ChartBenchScene(): JSX.Element {
@@ -222,6 +250,7 @@ export function ChartBenchScene(): JSX.Element {
     const [seed, setSeed] = useState<number>(readInt(initialParams, 'seed', DEFAULT_SEED))
     const [fillArea, setFillArea] = useState<boolean>(initialParams.get('fill') === '1')
     const [showGrid, setShowGrid] = useState<boolean>(initialParams.get('grid') !== '0')
+    const [adapterTooltip, setAdapterTooltip] = useState<boolean>(initialParams.get('tooltip') !== '0')
 
     const [runKey, setRunKey] = useState<number>(0)
     const [result, setResult] = useState<BenchResult | null>(null)
@@ -521,6 +550,18 @@ export function ChartBenchScene(): JSX.Element {
                             : undefined
                     }
                 />
+                <LemonSwitch
+                    label="Adapter tooltip"
+                    checked={adapterTooltip}
+                    onChange={setAdapterTooltip}
+                    // hog-charts bar adapter only — A/B the per-mousemove tooltip render cost
+                    // (the real InsightTooltip) against the bare engine.
+                    disabledReason={
+                        chart === 'adapter-bar' || chart === 'adapter-bar-horizontal'
+                            ? undefined
+                            : 'Only the hog-charts bar adapter (adapter-bar / -horizontal) supports toggling the tooltip'
+                    }
+                />
                 <LemonButton type="primary" onClick={runBenchmark} loading={busy} data-attr="chart-bench-run">
                     Run benchmark
                 </LemonButton>
@@ -528,9 +569,11 @@ export function ChartBenchScene(): JSX.Element {
 
             <div
                 ref={containerRef}
-                className="border rounded bg-bg-light flex flex-col"
+                className="border rounded bg-bg-light flex flex-col overflow-auto"
                 // Fixed size so repeated runs compare apples-to-apples. Flex
                 // column because hog-charts' internal wrapper uses `flex: 1`.
+                // overflow-auto so horizontal bars (which grow a fixed px per
+                // row) scroll inside the box instead of spilling onto content below.
                 style={{ width: 960, height: 480 }}
                 data-attr="chart-bench-stage"
             >
@@ -543,6 +586,7 @@ export function ChartBenchScene(): JSX.Element {
                     fillArea={fillArea}
                     showGrid={showGrid}
                     runKey={runKey}
+                    adapterTooltip={adapterTooltip}
                 />
             </div>
 
@@ -611,17 +655,21 @@ export function ChartBenchScene(): JSX.Element {
                     </div>
                     <LemonSwitch label="Log Y" checked={sweepLogY} onChange={setSweepLogY} />
                 </div>
-                <div className="flex flex-wrap gap-4 items-center mt-2">
-                    <span className="text-sm text-muted">Charts:</span>
-                    {ALL_CHART_KINDS.map((k) => (
-                        <LemonCheckbox
-                            key={k}
-                            label={k}
-                            checked={sweepKinds.includes(k)}
-                            onChange={(checked) =>
-                                setSweepKinds((prev) => (checked ? [...prev, k] : prev.filter((p) => p !== k)))
-                            }
-                        />
+                <div className="flex flex-col gap-2 mt-2">
+                    {CHART_GROUPS.map((group) => (
+                        <div key={group.title} className="flex flex-wrap gap-4 items-center">
+                            <span className="text-sm text-muted font-semibold w-20 shrink-0">{group.title}</span>
+                            {group.kinds.map((k) => (
+                                <LemonCheckbox
+                                    key={k}
+                                    label={CHART_LABELS[k]}
+                                    checked={sweepKinds.includes(k)}
+                                    onChange={(checked) =>
+                                        setSweepKinds((prev) => (checked ? [...prev, k] : prev.filter((p) => p !== k)))
+                                    }
+                                />
+                            ))}
+                        </div>
                     ))}
                 </div>
                 <div className="flex flex-wrap gap-2 items-center mt-3">
@@ -700,6 +748,8 @@ export function ChartBenchScene(): JSX.Element {
                                     <th className="text-right pr-4">points</th>
                                     <th className="text-right pr-4">ready ms</th>
                                     <th className="text-right pr-4">hover ms</th>
+                                    <th className="text-right pr-4">hover sync ms</th>
+                                    <th className="text-right pr-4">hover frame ms</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -713,6 +763,12 @@ export function ChartBenchScene(): JSX.Element {
                                         </td>
                                         <td className="text-right pr-4">
                                             {Number.isFinite(r.meanHoverMs) ? r.meanHoverMs : '—'}
+                                        </td>
+                                        <td className="text-right pr-4">
+                                            {Number.isFinite(r.meanHoverSyncMs) ? r.meanHoverSyncMs : '—'}
+                                        </td>
+                                        <td className="text-right pr-4">
+                                            {Number.isFinite(r.meanHoverFrameMs) ? r.meanHoverFrameMs : '—'}
                                         </td>
                                     </tr>
                                 ))}

--- a/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
+++ b/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
@@ -55,6 +55,8 @@ interface BenchResult {
     hoverMs: number[]
     meanReadyMs: number
     meanHoverMs: number
+    meanHoverSyncMs: number
+    meanHoverFrameMs: number
 }
 
 declare global {
@@ -86,10 +88,11 @@ function readInt(params: URLSearchParams, key: string, fallback: number): number
 }
 
 function mean(values: number[]): number {
-    if (values.length === 0) {
-        return 0
+    const valid = values.filter((v) => Number.isFinite(v))
+    if (valid.length === 0) {
+        return NaN
     }
-    return values.reduce((a, b) => a + b, 0) / values.length
+    return valid.reduce((a, b) => a + b, 0) / valid.length
 }
 
 function round(n: number): number {
@@ -195,40 +198,55 @@ export function ChartBenchScene(): JSX.Element {
         return containerRef.current.querySelector('canvas')
     }, [])
 
-    /** Dispatch mousemove events across the chart's plot area and sum the
-     * per-step frame time. This approximates real hover cost — both the chart
-     * engine's hit-test and its redraw/tooltip work. */
-    const sweepHover = useCallback(async (): Promise<number> => {
+    /** Dispatch hover events across the chart's plot area, capturing both the
+     * synchronous dispatch time (React handler + setState + sync effects) and
+     * the frame-wait time after dispatch returns. Splitting them out makes it
+     * possible to tell whether a slow cell is bottlenecked in JS or in paint.
+     * Both `pointermove` and `mousemove` are dispatched — chart.js listens on
+     * pointer events, hog-charts on mouse events. Sync/frame are NaN if the
+     * canvas wasn't actually sized when the run started. */
+    const sweepHover = useCallback(async (): Promise<{ total: number; sync: number; frame: number }> => {
         const canvas = findCanvas()
         if (!canvas) {
-            return 0
+            return { total: NaN, sync: NaN, frame: NaN }
         }
         const rect = canvas.getBoundingClientRect()
+        if (rect.width < 10 || rect.height < 10) {
+            return { total: NaN, sync: NaN, frame: NaN }
+        }
         const steps = 30
-        let total = 0
+        let totalSync = 0
+        let totalFrame = 0
         for (let i = 0; i < steps; i++) {
             const x = rect.left + (rect.width * (i + 0.5)) / steps
             const y = rect.top + rect.height / 2
-            canvas.dispatchEvent(
-                new MouseEvent('mousemove', {
-                    bubbles: true,
-                    cancelable: true,
-                    clientX: x,
-                    clientY: y,
-                    view: window,
-                })
-            )
-            total += await nextFrame()
+            const init: PointerEventInit = {
+                bubbles: true,
+                cancelable: true,
+                clientX: x,
+                clientY: y,
+                view: window,
+                pointerType: 'mouse',
+            }
+            const dispatchStart = performance.now()
+            canvas.dispatchEvent(new PointerEvent('pointermove', init))
+            canvas.dispatchEvent(new MouseEvent('mousemove', init))
+            totalSync += performance.now() - dispatchStart
+            totalFrame += await nextFrame()
         }
-        // Reset with a mouseleave so the next run starts clean.
+        canvas.dispatchEvent(
+            new PointerEvent('pointerleave', { bubbles: true, cancelable: true, pointerType: 'mouse' })
+        )
         canvas.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true, cancelable: true }))
-        return total
+        return { total: totalSync + totalFrame, sync: totalSync, frame: totalFrame }
     }, [findCanvas])
 
     const runBenchmark = useCallback(async () => {
         setBusy(true)
         const readySamples: number[] = []
         const hoverSamples: number[] = []
+        const hoverSyncSamples: number[] = []
+        const hoverFrameSamples: number[] = []
 
         for (let i = 0; i < runs; i++) {
             const t0 = performance.now()
@@ -241,7 +259,10 @@ export function ChartBenchScene(): JSX.Element {
             await nextFrame()
             readySamples.push(performance.now() - t0)
 
-            hoverSamples.push(await sweepHover())
+            const hover = await sweepHover()
+            hoverSamples.push(hover.total)
+            hoverSyncSamples.push(hover.sync)
+            hoverFrameSamples.push(hover.frame)
             // Small breather between runs so any async work settles.
             await new Promise((r) => setTimeout(r, 16))
         }
@@ -256,6 +277,8 @@ export function ChartBenchScene(): JSX.Element {
             hoverMs: hoverSamples,
             meanReadyMs: round(mean(readySamples)),
             meanHoverMs: round(mean(hoverSamples)),
+            meanHoverSyncMs: round(mean(hoverSyncSamples)),
+            meanHoverFrameMs: round(mean(hoverFrameSamples)),
         }
         window.__chartBench = finalResult
         setResult(finalResult)
@@ -310,6 +333,8 @@ export function ChartBenchScene(): JSX.Element {
 
             const readySamples: number[] = []
             const hoverSamples: number[] = []
+            const hoverSyncSamples: number[] = []
+            const hoverFrameSamples: number[] = []
             for (let i = 0; i < sweepRuns; i++) {
                 if (sweepAbortRef.current) {
                     break
@@ -318,7 +343,10 @@ export function ChartBenchScene(): JSX.Element {
                 flushSync(() => setRunKey((k) => k + 1))
                 await nextFrame()
                 readySamples.push(performance.now() - t0)
-                hoverSamples.push(await sweepHover())
+                const hover = await sweepHover()
+                hoverSamples.push(hover.total)
+                hoverSyncSamples.push(hover.sync)
+                hoverFrameSamples.push(hover.frame)
                 await new Promise((r) => setTimeout(r, 16))
             }
 
@@ -329,6 +357,8 @@ export function ChartBenchScene(): JSX.Element {
                 runs: readySamples.length,
                 meanReadyMs: round(mean(readySamples)),
                 meanHoverMs: round(mean(hoverSamples)),
+                meanHoverSyncMs: round(mean(hoverSyncSamples)),
+                meanHoverFrameMs: round(mean(hoverFrameSamples)),
                 readyMs: readySamples,
                 hoverMs: hoverSamples,
             }
@@ -464,7 +494,10 @@ export function ChartBenchScene(): JSX.Element {
                         {result.runs}
                     </div>
                     <div>mean ready (mount → post-paint): {result.meanReadyMs} ms</div>
-                    <div>mean hover sweep (30 moves): {result.meanHoverMs} ms</div>
+                    <div>
+                        mean hover sweep (30 moves): {result.meanHoverMs} ms (sync {result.meanHoverSyncMs} ms · frame{' '}
+                        {result.meanHoverFrameMs} ms)
+                    </div>
                 </div>
             ) : null}
 
@@ -570,22 +603,32 @@ export function ChartBenchScene(): JSX.Element {
                     ) : null}
                 </div>
 
-                {sweepResults.length > 0 ? (
-                    <div className="mt-4 grid grid-cols-1 lg:grid-cols-2 gap-4">
-                        <SweepResultsChart
-                            results={sweepResults}
-                            metric="meanReadyMs"
-                            title="Mount → post-paint (ms)"
-                            logY={sweepLogY}
-                        />
-                        <SweepResultsChart
-                            results={sweepResults}
-                            metric="meanHoverMs"
-                            title="Hover sweep, 30 moves (ms)"
-                            logY={sweepLogY}
-                        />
-                    </div>
-                ) : null}
+                {sweepResults.length > 0
+                    ? Array.from(new Set(sweepResults.map((r) => r.series)))
+                          .sort((a, b) => a - b)
+                          .map((seriesCount) => {
+                              const filtered = sweepResults.filter((r) => r.series === seriesCount)
+                              return (
+                                  <div key={seriesCount} className="mt-6">
+                                      <h4 className="text-sm font-semibold mb-2">{seriesCount} series</h4>
+                                      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                                          <SweepResultsChart
+                                              results={filtered}
+                                              metric="meanReadyMs"
+                                              title="Mount → post-paint (ms)"
+                                              logY={sweepLogY}
+                                          />
+                                          <SweepResultsChart
+                                              results={filtered}
+                                              metric="meanHoverMs"
+                                              title="Hover sweep, 30 moves (ms)"
+                                              logY={sweepLogY}
+                                          />
+                                      </div>
+                                  </div>
+                              )
+                          })
+                    : null}
 
                 {sweepResults.length > 0 ? (
                     <details className="mt-4">
@@ -606,8 +649,12 @@ export function ChartBenchScene(): JSX.Element {
                                         <td className="pr-4">{r.chart}</td>
                                         <td className="text-right pr-4">{r.series}</td>
                                         <td className="text-right pr-4">{r.points}</td>
-                                        <td className="text-right pr-4">{r.meanReadyMs}</td>
-                                        <td className="text-right pr-4">{r.meanHoverMs}</td>
+                                        <td className="text-right pr-4">
+                                            {Number.isFinite(r.meanReadyMs) ? r.meanReadyMs : '—'}
+                                        </td>
+                                        <td className="text-right pr-4">
+                                            {Number.isFinite(r.meanHoverMs) ? r.meanHoverMs : '—'}
+                                        </td>
                                     </tr>
                                 ))}
                             </tbody>

--- a/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
+++ b/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
@@ -4,6 +4,7 @@ import { flushSync } from 'react-dom'
 import { IconDatabaseBolt } from '@posthog/icons'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonCheckbox } from 'lib/lemon-ui/LemonCheckbox'
 import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel/LemonLabel'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
@@ -17,6 +18,8 @@ import { ChartJsLineChart } from './ChartJsLineChart'
 import { generateBenchData } from './generateBenchData'
 import { HogChartsLineChart } from './HogChartsLineChart'
 import { RealAdaptersCell } from './RealAdaptersCell'
+import { SweepResultsChart } from './SweepResultsChart'
+import type { ChartKind as SweepChartKind, SweepResult } from './sweepTypes'
 
 /**
  * Line-chart benchmark harness. Four chart "kinds":
@@ -37,7 +40,7 @@ import { RealAdaptersCell } from './RealAdaptersCell'
  * iterate a matrix and compare.
  */
 
-type ChartKind = 'hog' | 'chartjs' | 'adapter-hog' | 'adapter-chartjs'
+type ChartKind = SweepChartKind
 
 interface BenchResult {
     chart: ChartKind
@@ -103,6 +106,37 @@ function nextFrame(): Promise<number> {
     })
 }
 
+/** Log-spaced integers between min and max inclusive, deduplicated. */
+function logSpace(min: number, max: number, steps: number): number[] {
+    const lo = Math.max(2, Math.floor(min))
+    const hi = Math.max(lo + 1, Math.floor(max))
+    if (steps <= 1) {
+        return [lo]
+    }
+    const lmin = Math.log10(lo)
+    const lmax = Math.log10(hi)
+    const seen = new Set<number>()
+    const out: number[] = []
+    for (let i = 0; i < steps; i++) {
+        const t = i / (steps - 1)
+        const v = Math.round(Math.pow(10, lmin + (lmax - lmin) * t))
+        if (!seen.has(v)) {
+            seen.add(v)
+            out.push(v)
+        }
+    }
+    return out
+}
+
+function parseSeriesList(raw: string): number[] {
+    return raw
+        .split(',')
+        .map((s) => Number.parseInt(s.trim(), 10))
+        .filter((n) => Number.isFinite(n) && n > 0)
+}
+
+const ALL_CHART_KINDS: ChartKind[] = ['hog', 'chartjs', 'adapter-hog', 'adapter-chartjs']
+
 interface ChartCellProps {
     chart: ChartKind
     series: number
@@ -138,6 +172,17 @@ export function ChartBenchScene(): JSX.Element {
     const [runKey, setRunKey] = useState<number>(0)
     const [result, setResult] = useState<BenchResult | null>(null)
     const [busy, setBusy] = useState<boolean>(false)
+
+    const [sweepMin, setSweepMin] = useState<number>(10)
+    const [sweepMax, setSweepMax] = useState<number>(100_000)
+    const [sweepSteps, setSweepSteps] = useState<number>(10)
+    const [sweepSeriesList, setSweepSeriesList] = useState<string>('1, 10')
+    const [sweepKinds, setSweepKinds] = useState<ChartKind[]>(['hog', 'chartjs'])
+    const [sweepRuns, setSweepRuns] = useState<number>(3)
+    const [sweepLogY, setSweepLogY] = useState<boolean>(true)
+    const [sweepResults, setSweepResults] = useState<SweepResult[]>([])
+    const [sweepProgress, setSweepProgress] = useState<{ done: number; total: number; label: string } | null>(null)
+    const sweepAbortRef = useRef<boolean>(false)
 
     const containerRef = useRef<HTMLDivElement>(null)
 
@@ -217,6 +262,101 @@ export function ChartBenchScene(): JSX.Element {
         setBusy(false)
     }, [chart, seriesCount, pointCount, seed, runs, sweepHover])
 
+    const runSweep = useCallback(async () => {
+        const seriesValues = parseSeriesList(sweepSeriesList)
+        const pointValues = logSpace(sweepMin, sweepMax, sweepSteps)
+        if (sweepKinds.length === 0 || seriesValues.length === 0 || pointValues.length === 0) {
+            return
+        }
+        const cells: { chart: ChartKind; series: number; points: number }[] = []
+        for (const ck of sweepKinds) {
+            for (const sv of seriesValues) {
+                for (const pv of pointValues) {
+                    cells.push({ chart: ck, series: sv, points: pv })
+                }
+            }
+        }
+
+        sweepAbortRef.current = false
+        setBusy(true)
+        setSweepResults([])
+        setSweepProgress({ done: 0, total: cells.length, label: '' })
+
+        const collected: SweepResult[] = []
+        for (let idx = 0; idx < cells.length; idx++) {
+            if (sweepAbortRef.current) {
+                break
+            }
+            const cell = cells[idx]
+            setSweepProgress({
+                done: idx,
+                total: cells.length,
+                label: `${cell.chart} · ${cell.series}s × ${cell.points}p`,
+            })
+
+            // Drive the visible cell to this matrix point. flushSync forces
+            // React to commit before we measure, and the runKey bump produces
+            // fresh logic instances for the adapter cells.
+            flushSync(() => {
+                setChart(cell.chart)
+                setSeriesCount(cell.series)
+                setPointCount(cell.points)
+                setRunKey((k) => k + 1)
+            })
+            // Two frames: first to mount/draw, second to ensure any post-paint
+            // chart engine work has settled before we start measuring.
+            await nextFrame()
+            await nextFrame()
+
+            const readySamples: number[] = []
+            const hoverSamples: number[] = []
+            for (let i = 0; i < sweepRuns; i++) {
+                if (sweepAbortRef.current) {
+                    break
+                }
+                const t0 = performance.now()
+                flushSync(() => setRunKey((k) => k + 1))
+                await nextFrame()
+                readySamples.push(performance.now() - t0)
+                hoverSamples.push(await sweepHover())
+                await new Promise((r) => setTimeout(r, 16))
+            }
+
+            const cellResult: SweepResult = {
+                chart: cell.chart,
+                series: cell.series,
+                points: cell.points,
+                runs: readySamples.length,
+                meanReadyMs: round(mean(readySamples)),
+                meanHoverMs: round(mean(hoverSamples)),
+                readyMs: readySamples,
+                hoverMs: hoverSamples,
+            }
+            collected.push(cellResult)
+            setSweepResults([...collected])
+        }
+
+        setSweepProgress(null)
+        setBusy(false)
+    }, [sweepMin, sweepMax, sweepSteps, sweepSeriesList, sweepKinds, sweepRuns, sweepHover])
+
+    const stopSweep = useCallback(() => {
+        sweepAbortRef.current = true
+    }, [])
+
+    const exportSweep = useCallback(() => {
+        if (sweepResults.length === 0) {
+            return
+        }
+        const blob = new Blob([JSON.stringify(sweepResults, null, 2)], { type: 'application/json' })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = `chart-bench-sweep-${Date.now()}.json`
+        a.click()
+        URL.revokeObjectURL(url)
+    }, [sweepResults])
+
     // Keep the URL in sync with the controls so benchmark runs are shareable
     // and Playwright can parameterize via query string.
     useEffect(() => {
@@ -266,7 +406,7 @@ export function ChartBenchScene(): JSX.Element {
                         type="number"
                         value={pointCount}
                         min={2}
-                        max={5000}
+                        max={1_000_000}
                         onChange={(v) => setPointCount(Number(v) || 2)}
                     />
                 </div>
@@ -327,6 +467,154 @@ export function ChartBenchScene(): JSX.Element {
                     <div>mean hover sweep (30 moves): {result.meanHoverMs} ms</div>
                 </div>
             ) : null}
+
+            <div className="border-t pt-4 mt-4">
+                <h3 className="text-base font-semibold mb-2">Parameter sweep</h3>
+                <div className="text-xs text-muted mb-3">
+                    Walks a log-spaced grid of point counts × series counts × chart kinds, running the benchmark for
+                    each cell and plotting the results. Chart container above is reused for each measurement.
+                </div>
+                <div className="flex flex-wrap gap-4 items-end">
+                    <div>
+                        <LemonLabel>Min points</LemonLabel>
+                        <LemonInput
+                            type="number"
+                            value={sweepMin}
+                            min={2}
+                            onChange={(v) => setSweepMin(Number(v) || 2)}
+                        />
+                    </div>
+                    <div>
+                        <LemonLabel>Max points</LemonLabel>
+                        <LemonInput
+                            type="number"
+                            value={sweepMax}
+                            min={2}
+                            onChange={(v) => setSweepMax(Number(v) || 2)}
+                        />
+                    </div>
+                    <div>
+                        <LemonLabel>Steps</LemonLabel>
+                        <LemonInput
+                            type="number"
+                            value={sweepSteps}
+                            min={2}
+                            max={50}
+                            onChange={(v) => setSweepSteps(Number(v) || 2)}
+                        />
+                    </div>
+                    <div>
+                        <LemonLabel>Series (comma-separated)</LemonLabel>
+                        <LemonInput value={sweepSeriesList} onChange={(v) => setSweepSeriesList(v)} />
+                    </div>
+                    <div>
+                        <LemonLabel>Runs / cell</LemonLabel>
+                        <LemonInput
+                            type="number"
+                            value={sweepRuns}
+                            min={1}
+                            max={20}
+                            onChange={(v) => setSweepRuns(Number(v) || 1)}
+                        />
+                    </div>
+                    <LemonSwitch label="Log Y" checked={sweepLogY} onChange={setSweepLogY} />
+                </div>
+                <div className="flex flex-wrap gap-4 items-center mt-2">
+                    <span className="text-sm text-muted">Charts:</span>
+                    {ALL_CHART_KINDS.map((k) => (
+                        <LemonCheckbox
+                            key={k}
+                            label={k}
+                            checked={sweepKinds.includes(k)}
+                            onChange={(checked) =>
+                                setSweepKinds((prev) => (checked ? [...prev, k] : prev.filter((p) => p !== k)))
+                            }
+                        />
+                    ))}
+                </div>
+                <div className="flex flex-wrap gap-2 items-center mt-3">
+                    <LemonButton
+                        type="primary"
+                        onClick={runSweep}
+                        loading={busy && !!sweepProgress}
+                        disabledReason={
+                            sweepKinds.length === 0
+                                ? 'Pick at least one chart'
+                                : parseSeriesList(sweepSeriesList).length === 0
+                                  ? 'Series list is empty'
+                                  : undefined
+                        }
+                        data-attr="chart-bench-sweep-run"
+                    >
+                        Run sweep
+                    </LemonButton>
+                    {sweepProgress ? (
+                        <LemonButton type="secondary" onClick={stopSweep}>
+                            Stop
+                        </LemonButton>
+                    ) : null}
+                    {sweepResults.length > 0 ? (
+                        <LemonButton type="secondary" onClick={exportSweep}>
+                            Export JSON
+                        </LemonButton>
+                    ) : null}
+                    {sweepProgress ? (
+                        <span className="font-mono text-xs">
+                            {sweepProgress.done}/{sweepProgress.total} — {sweepProgress.label}
+                        </span>
+                    ) : null}
+                    {!sweepProgress && sweepResults.length > 0 ? (
+                        <span className="font-mono text-xs text-muted">
+                            {sweepResults.length} cells · grid: {logSpace(sweepMin, sweepMax, sweepSteps).join(', ')}
+                        </span>
+                    ) : null}
+                </div>
+
+                {sweepResults.length > 0 ? (
+                    <div className="mt-4 grid grid-cols-1 lg:grid-cols-2 gap-4">
+                        <SweepResultsChart
+                            results={sweepResults}
+                            metric="meanReadyMs"
+                            title="Mount → post-paint (ms)"
+                            logY={sweepLogY}
+                        />
+                        <SweepResultsChart
+                            results={sweepResults}
+                            metric="meanHoverMs"
+                            title="Hover sweep, 30 moves (ms)"
+                            logY={sweepLogY}
+                        />
+                    </div>
+                ) : null}
+
+                {sweepResults.length > 0 ? (
+                    <details className="mt-4">
+                        <summary className="text-sm cursor-pointer">Raw table ({sweepResults.length} rows)</summary>
+                        <table className="font-mono text-xs mt-2">
+                            <thead>
+                                <tr>
+                                    <th className="text-left pr-4">chart</th>
+                                    <th className="text-right pr-4">series</th>
+                                    <th className="text-right pr-4">points</th>
+                                    <th className="text-right pr-4">ready ms</th>
+                                    <th className="text-right pr-4">hover ms</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {sweepResults.map((r, i) => (
+                                    <tr key={i}>
+                                        <td className="pr-4">{r.chart}</td>
+                                        <td className="text-right pr-4">{r.series}</td>
+                                        <td className="text-right pr-4">{r.points}</td>
+                                        <td className="text-right pr-4">{r.meanReadyMs}</td>
+                                        <td className="text-right pr-4">{r.meanHoverMs}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </details>
+                ) : null}
+            </div>
         </SceneContent>
     )
 }

--- a/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
+++ b/frontend/src/scenes/debug/chart-bench/ChartBenchScene.tsx
@@ -1,0 +1,336 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { flushSync } from 'react-dom'
+
+import { IconDatabaseBolt } from '@posthog/icons'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
+import { LemonLabel } from 'lib/lemon-ui/LemonLabel/LemonLabel'
+import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
+import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
+import { SceneExport } from 'scenes/sceneTypes'
+
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+
+import { ChartJsLineChart } from './ChartJsLineChart'
+import { generateBenchData } from './generateBenchData'
+import { HogChartsLineChart } from './HogChartsLineChart'
+import { RealAdaptersCell } from './RealAdaptersCell'
+
+/**
+ * Line-chart benchmark harness. Four chart "kinds":
+ *
+ *   - `hog`            — raw `lib/hog-charts` LineChart, synthetic data
+ *   - `chartjs`        — raw chart.js Chart, synthetic data
+ *   - `adapter-hog`    — real `TrendsLineChartD3` adapter fed through the
+ *                        full insight kea logic tree (insight + data +
+ *                        insightViz + trendsData) with cached results
+ *   - `adapter-chartjs`— real `ActionsLineGraph` adapter (same logic tree,
+ *                        chart.js under the hood)
+ *
+ * The raw cells isolate engine cost. The adapter cells include kea overhead,
+ * the real PostHog tooltip (`TrendsTooltip` / `InsightTooltip`), and any
+ * per-render selector/memoization cost — which is what actually ships.
+ *
+ * Results are exposed on `window.__chartBench` so a Playwright test can
+ * iterate a matrix and compare.
+ */
+
+type ChartKind = 'hog' | 'chartjs' | 'adapter-hog' | 'adapter-chartjs'
+
+interface BenchResult {
+    chart: ChartKind
+    series: number
+    points: number
+    seed: number
+    runs: number
+    /** Time from `flushSync(setRunKey)` through the next rAF — covers React
+     * reconciliation, layout effects, paint, and any useEffect-scheduled draws. */
+    readyMs: number[]
+    /** Wall time for a 30-step mousemove sweep across the plot area. */
+    hoverMs: number[]
+    meanReadyMs: number
+    meanHoverMs: number
+}
+
+declare global {
+    interface Window {
+        __chartBench?: BenchResult
+    }
+}
+
+const CHART_OPTIONS: { label: string; value: ChartKind }[] = [
+    { label: 'hog-charts (raw)', value: 'hog' },
+    { label: 'chart.js (raw)', value: 'chartjs' },
+    { label: 'hog-charts (TrendsLineChartD3 adapter)', value: 'adapter-hog' },
+    { label: 'chart.js (ActionsLineGraph adapter)', value: 'adapter-chartjs' },
+]
+
+const DEFAULT_SERIES = 10
+const DEFAULT_POINTS = 500
+const DEFAULT_RUNS = 5
+const DEFAULT_SEED = 42
+
+/** Pull a number out of URLSearchParams, falling back to a default. */
+function readInt(params: URLSearchParams, key: string, fallback: number): number {
+    const raw = params.get(key)
+    if (raw == null) {
+        return fallback
+    }
+    const parsed = Number.parseInt(raw, 10)
+    return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function mean(values: number[]): number {
+    if (values.length === 0) {
+        return 0
+    }
+    return values.reduce((a, b) => a + b, 0) / values.length
+}
+
+function round(n: number): number {
+    return Math.round(n * 100) / 100
+}
+
+/** Waits for a single animation frame, returning the elapsed ms. */
+function nextFrame(): Promise<number> {
+    return new Promise((resolve) => {
+        const start = performance.now()
+        requestAnimationFrame(() => {
+            resolve(performance.now() - start)
+        })
+    })
+}
+
+interface ChartCellProps {
+    chart: ChartKind
+    series: number
+    points: number
+    seed: number
+    fillArea: boolean
+    showGrid: boolean
+    runKey: number
+}
+
+function ChartCell({ chart, series, points, seed, fillArea, showGrid, runKey }: ChartCellProps): JSX.Element {
+    const data = useMemo(() => generateBenchData(series, points, seed), [series, points, seed])
+    if (chart === 'hog') {
+        return <HogChartsLineChart data={data} fillArea={fillArea} showGrid={showGrid} />
+    }
+    if (chart === 'chartjs') {
+        return <ChartJsLineChart data={data} fillArea={fillArea} showGrid={showGrid} />
+    }
+    return <RealAdaptersCell kind={chart} data={data} runKey={runKey} fillArea={fillArea} />
+}
+
+export function ChartBenchScene(): JSX.Element {
+    const initialParams = useMemo(() => new URLSearchParams(window.location.search), [])
+
+    const [chart, setChart] = useState<ChartKind>((initialParams.get('chart') as ChartKind) || 'hog')
+    const [seriesCount, setSeriesCount] = useState<number>(readInt(initialParams, 'series', DEFAULT_SERIES))
+    const [pointCount, setPointCount] = useState<number>(readInt(initialParams, 'points', DEFAULT_POINTS))
+    const [runs, setRuns] = useState<number>(readInt(initialParams, 'runs', DEFAULT_RUNS))
+    const [seed, setSeed] = useState<number>(readInt(initialParams, 'seed', DEFAULT_SEED))
+    const [fillArea, setFillArea] = useState<boolean>(initialParams.get('fill') === '1')
+    const [showGrid, setShowGrid] = useState<boolean>(initialParams.get('grid') !== '0')
+
+    const [runKey, setRunKey] = useState<number>(0)
+    const [result, setResult] = useState<BenchResult | null>(null)
+    const [busy, setBusy] = useState<boolean>(false)
+
+    const containerRef = useRef<HTMLDivElement>(null)
+
+    /** Locate the canvas the current chart cell rendered. Both cells wrap their
+     * canvas in a div with a stable `data-attr`. */
+    const findCanvas = useCallback((): HTMLCanvasElement | null => {
+        if (!containerRef.current) {
+            return null
+        }
+        return containerRef.current.querySelector('canvas')
+    }, [])
+
+    /** Dispatch mousemove events across the chart's plot area and sum the
+     * per-step frame time. This approximates real hover cost — both the chart
+     * engine's hit-test and its redraw/tooltip work. */
+    const sweepHover = useCallback(async (): Promise<number> => {
+        const canvas = findCanvas()
+        if (!canvas) {
+            return 0
+        }
+        const rect = canvas.getBoundingClientRect()
+        const steps = 30
+        let total = 0
+        for (let i = 0; i < steps; i++) {
+            const x = rect.left + (rect.width * (i + 0.5)) / steps
+            const y = rect.top + rect.height / 2
+            canvas.dispatchEvent(
+                new MouseEvent('mousemove', {
+                    bubbles: true,
+                    cancelable: true,
+                    clientX: x,
+                    clientY: y,
+                    view: window,
+                })
+            )
+            total += await nextFrame()
+        }
+        // Reset with a mouseleave so the next run starts clean.
+        canvas.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true, cancelable: true }))
+        return total
+    }, [findCanvas])
+
+    const runBenchmark = useCallback(async () => {
+        setBusy(true)
+        const readySamples: number[] = []
+        const hoverSamples: number[] = []
+
+        for (let i = 0; i < runs; i++) {
+            const t0 = performance.now()
+            // flushSync forces the remount and all layout effects to run
+            // synchronously before returning. For chart.js this includes the
+            // constructor + draw because ChartJsLineChart uses useLayoutEffect.
+            // For hog-charts the draw is in a useEffect (post-paint), so we
+            // wait one rAF to include it in the measurement.
+            flushSync(() => setRunKey((k) => k + 1))
+            await nextFrame()
+            readySamples.push(performance.now() - t0)
+
+            hoverSamples.push(await sweepHover())
+            // Small breather between runs so any async work settles.
+            await new Promise((r) => setTimeout(r, 16))
+        }
+
+        const finalResult: BenchResult = {
+            chart,
+            series: seriesCount,
+            points: pointCount,
+            seed,
+            runs,
+            readyMs: readySamples,
+            hoverMs: hoverSamples,
+            meanReadyMs: round(mean(readySamples)),
+            meanHoverMs: round(mean(hoverSamples)),
+        }
+        window.__chartBench = finalResult
+        setResult(finalResult)
+        setBusy(false)
+    }, [chart, seriesCount, pointCount, seed, runs, sweepHover])
+
+    // Keep the URL in sync with the controls so benchmark runs are shareable
+    // and Playwright can parameterize via query string.
+    useEffect(() => {
+        const params = new URLSearchParams()
+        params.set('chart', chart)
+        params.set('series', String(seriesCount))
+        params.set('points', String(pointCount))
+        params.set('runs', String(runs))
+        params.set('seed', String(seed))
+        if (fillArea) {
+            params.set('fill', '1')
+        }
+        if (!showGrid) {
+            params.set('grid', '0')
+        }
+        const next = `${window.location.pathname}?${params.toString()}`
+        if (next !== window.location.pathname + window.location.search) {
+            window.history.replaceState(null, '', next)
+        }
+    }, [chart, seriesCount, pointCount, runs, seed, fillArea, showGrid])
+
+    return (
+        <SceneContent className="ChartBenchScene">
+            <SceneTitleSection
+                name="Chart benchmark"
+                description="Compare hog-charts vs chart.js rendering cost for line charts."
+                resourceType={{ type: 'debug', forceIcon: <IconDatabaseBolt /> }}
+            />
+            <div className="flex flex-wrap gap-4 items-end">
+                <div>
+                    <LemonLabel>Chart</LemonLabel>
+                    <LemonSelect value={chart} options={CHART_OPTIONS} onChange={(v) => setChart(v)} />
+                </div>
+                <div>
+                    <LemonLabel>Series</LemonLabel>
+                    <LemonInput
+                        type="number"
+                        value={seriesCount}
+                        min={1}
+                        max={200}
+                        onChange={(v) => setSeriesCount(Number(v) || 1)}
+                    />
+                </div>
+                <div>
+                    <LemonLabel>Points</LemonLabel>
+                    <LemonInput
+                        type="number"
+                        value={pointCount}
+                        min={2}
+                        max={5000}
+                        onChange={(v) => setPointCount(Number(v) || 2)}
+                    />
+                </div>
+                <div>
+                    <LemonLabel>Runs</LemonLabel>
+                    <LemonInput type="number" value={runs} min={1} max={50} onChange={(v) => setRuns(Number(v) || 1)} />
+                </div>
+                <div>
+                    <LemonLabel>Seed</LemonLabel>
+                    <LemonInput type="number" value={seed} onChange={(v) => setSeed(Number(v) || 0)} />
+                </div>
+                <LemonSwitch label="Fill area" checked={fillArea} onChange={setFillArea} />
+                <LemonSwitch
+                    label="Grid"
+                    checked={showGrid}
+                    onChange={setShowGrid}
+                    // The grid toggle only affects the raw cells — adapter
+                    // modes always draw a grid (hog-charts sets `showGrid:true`
+                    // inside TrendsLineChartD3, chart.js draws grid by default).
+                    disabledReason={
+                        chart.startsWith('adapter-')
+                            ? 'Grid is baked into the adapter at this size — raw cells only'
+                            : undefined
+                    }
+                />
+                <LemonButton type="primary" onClick={runBenchmark} loading={busy} data-attr="chart-bench-run">
+                    Run benchmark
+                </LemonButton>
+            </div>
+
+            <div
+                ref={containerRef}
+                className="border rounded bg-bg-light flex flex-col"
+                // Fixed size so repeated runs compare apples-to-apples. Flex
+                // column because hog-charts' internal wrapper uses `flex: 1`.
+                style={{ width: 960, height: 480 }}
+                data-attr="chart-bench-stage"
+            >
+                <ChartCell
+                    key={`${chart}-${runKey}`}
+                    chart={chart}
+                    series={seriesCount}
+                    points={pointCount}
+                    seed={seed}
+                    fillArea={fillArea}
+                    showGrid={showGrid}
+                    runKey={runKey}
+                />
+            </div>
+
+            {result ? (
+                <div className="font-mono text-sm" data-attr="chart-bench-result">
+                    <div>
+                        chart: <strong>{result.chart}</strong> · series {result.series} · points {result.points} · runs{' '}
+                        {result.runs}
+                    </div>
+                    <div>mean ready (mount → post-paint): {result.meanReadyMs} ms</div>
+                    <div>mean hover sweep (30 moves): {result.meanHoverMs} ms</div>
+                </div>
+            ) : null}
+        </SceneContent>
+    )
+}
+
+export const scene: SceneExport = {
+    component: ChartBenchScene,
+}

--- a/frontend/src/scenes/debug/chart-bench/ChartJsBarChart.tsx
+++ b/frontend/src/scenes/debug/chart-bench/ChartJsBarChart.tsx
@@ -1,0 +1,92 @@
+import { useLayoutEffect, useMemo, useRef } from 'react'
+
+import { Chart, ChartConfiguration, ChartDataset } from 'lib/Chart'
+import { buildTheme } from 'lib/charts/utils/theme'
+
+import type { BenchData } from './generateBenchData'
+
+interface ChartJsBarChartProps {
+    data: BenchData
+    showGrid: boolean
+    /** Render bars extending horizontally (chart.js `indexAxis: 'y'`). */
+    horizontal?: boolean
+}
+
+/**
+ * Minimal chart.js bar chart — the engine-cost counterpart to hog-charts'
+ * {@link HogChartsBarChart}. Bars are stacked to match hog-charts'
+ * `TimeSeriesBarChart` default layout, and `horizontal` flips the index axis so
+ * it lines up with `hog-bar-horizontal`. Bypasses LineGraph.tsx so the
+ * measurement is chart.js engine cost, not adapter overhead.
+ */
+export function ChartJsBarChart({ data, showGrid, horizontal = false }: ChartJsBarChartProps): JSX.Element {
+    const canvasRef = useRef<HTMLCanvasElement>(null)
+    const chartRef = useRef<Chart | null>(null)
+
+    const theme = useMemo(() => buildTheme(), [])
+
+    const config: ChartConfiguration<'bar'> = useMemo(() => {
+        const datasets: ChartDataset<'bar'>[] = data.series.map((s, idx) => {
+            const color = theme.colors[idx % theme.colors.length]
+            return {
+                label: s.label,
+                data: s.data,
+                backgroundColor: color,
+                borderColor: color,
+                borderWidth: 0,
+            }
+        })
+
+        return {
+            type: 'bar',
+            data: {
+                labels: data.labels,
+                datasets,
+            },
+            options: {
+                indexAxis: horizontal ? 'y' : 'x',
+                animation: false,
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: { display: false },
+                    tooltip: { enabled: true, mode: 'index', intersect: false },
+                },
+                interaction: { mode: 'index', intersect: false },
+                scales: {
+                    x: {
+                        stacked: true,
+                        grid: { display: showGrid, color: theme.gridColor },
+                        ticks: { color: theme.axisColor, maxRotation: 0, autoSkip: true },
+                    },
+                    y: {
+                        stacked: true,
+                        grid: { display: showGrid, color: theme.gridColor },
+                        ticks: { color: theme.axisColor },
+                    },
+                },
+            },
+        }
+    }, [data, showGrid, horizontal, theme])
+
+    // useLayoutEffect (not useEffect) so the chart.js construction + draw
+    // completes synchronously before paint, matching the measurement window
+    // used by the bench harness.
+    useLayoutEffect(() => {
+        if (!canvasRef.current) {
+            return
+        }
+        chartRef.current?.destroy()
+        chartRef.current = new Chart(canvasRef.current, config)
+        return () => {
+            chartRef.current?.destroy()
+            chartRef.current = null
+        }
+    }, [config])
+
+    return (
+        <div className="flex-1 min-h-0 relative" data-attr="chartjs-bar-bench">
+            <canvas ref={canvasRef} />
+        </div>
+    )
+}

--- a/frontend/src/scenes/debug/chart-bench/ChartJsLineChart.tsx
+++ b/frontend/src/scenes/debug/chart-bench/ChartJsLineChart.tsx
@@ -1,0 +1,91 @@
+import { useLayoutEffect, useMemo, useRef } from 'react'
+
+import { Chart, ChartConfiguration, ChartDataset } from 'lib/Chart'
+import { buildTheme } from 'lib/charts/utils/theme'
+import { hexToRGBA } from 'lib/utils'
+
+import type { BenchData } from './generateBenchData'
+
+interface ChartJsLineChartProps {
+    data: BenchData
+    fillArea: boolean
+    showGrid: boolean
+}
+
+/**
+ * Minimal chart.js line chart — mirrors the feature surface of hog-charts'
+ * LineChart for a fair comparison. Deliberately bypasses LineGraph.tsx (kea,
+ * insights glue, custom tooltip) so the measurement is chart.js engine cost
+ * vs the hog-charts engine cost, not adapter overhead.
+ */
+export function ChartJsLineChart({ data, fillArea, showGrid }: ChartJsLineChartProps): JSX.Element {
+    const canvasRef = useRef<HTMLCanvasElement>(null)
+    const chartRef = useRef<Chart | null>(null)
+
+    const theme = useMemo(() => buildTheme(), [])
+
+    const config: ChartConfiguration<'line'> = useMemo(() => {
+        const datasets: ChartDataset<'line'>[] = data.series.map((s, idx) => {
+            const color = theme.colors[idx % theme.colors.length]
+            return {
+                label: s.label,
+                data: s.data,
+                borderColor: color,
+                backgroundColor: fillArea ? hexToRGBA(color, 0.5) : color,
+                fill: fillArea,
+                pointRadius: 0,
+                borderWidth: 2,
+                tension: 0,
+            }
+        })
+
+        return {
+            type: 'line',
+            data: {
+                labels: data.labels,
+                datasets,
+            },
+            options: {
+                animation: false,
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: { display: false },
+                    tooltip: { enabled: true, mode: 'index', intersect: false },
+                },
+                interaction: { mode: 'index', intersect: false },
+                scales: {
+                    x: {
+                        grid: { display: showGrid, color: theme.gridColor },
+                        ticks: { color: theme.axisColor, maxRotation: 0, autoSkip: true },
+                    },
+                    y: {
+                        grid: { display: showGrid, color: theme.gridColor },
+                        ticks: { color: theme.axisColor },
+                    },
+                },
+            },
+        }
+    }, [data, fillArea, showGrid, theme])
+
+    // useLayoutEffect (not useEffect) so the chart.js construction + draw
+    // completes synchronously before paint, matching the measurement window
+    // used by the bench harness.
+    useLayoutEffect(() => {
+        if (!canvasRef.current) {
+            return
+        }
+        chartRef.current?.destroy()
+        chartRef.current = new Chart(canvasRef.current, config)
+        return () => {
+            chartRef.current?.destroy()
+            chartRef.current = null
+        }
+    }, [config])
+
+    return (
+        <div className="flex-1 min-h-0 relative" data-attr="chartjs-bench">
+            <canvas ref={canvasRef} />
+        </div>
+    )
+}

--- a/frontend/src/scenes/debug/chart-bench/HogChartsBarChart.tsx
+++ b/frontend/src/scenes/debug/chart-bench/HogChartsBarChart.tsx
@@ -9,6 +9,8 @@ import type { BenchData } from './generateBenchData'
 interface HogChartsBarChartProps {
     data: BenchData
     showGrid: boolean
+    /** Render time buckets down the y-axis with bars extending horizontally. */
+    horizontal?: boolean
 }
 
 const CONFIG: TimeSeriesBarChartConfig = {
@@ -19,9 +21,11 @@ const CONFIG: TimeSeriesBarChartConfig = {
  * Raw `lib/hog-charts` TimeSeriesBarChart, synthetic data. Mirrors
  * {@link HogChartsLineChart} so the bar engine cost can be compared against the
  * line engine on identical input. `fillArea` is meaningless for bars; the grid
- * toggle drives the axis grid lines.
+ * toggle drives the axis grid lines. The same time-series data renders either
+ * vertically (default) or horizontally — only the axis orientation differs, so
+ * the two are a clean rotated-vs-upright comparison.
  */
-export function HogChartsBarChart({ data, showGrid }: HogChartsBarChartProps): JSX.Element {
+export function HogChartsBarChart({ data, showGrid, horizontal = false }: HogChartsBarChartProps): JSX.Element {
     const theme = useMemo(() => buildTheme(), [])
 
     const series: Series[] = useMemo(
@@ -35,7 +39,10 @@ export function HogChartsBarChart({ data, showGrid }: HogChartsBarChartProps): J
         [data.series, theme.colors]
     )
 
-    const config: TimeSeriesBarChartConfig = useMemo(() => ({ ...CONFIG, yAxis: { showGrid } }), [showGrid])
+    const config: TimeSeriesBarChartConfig = useMemo(
+        () => ({ ...CONFIG, yAxis: { showGrid }, axisOrientation: horizontal ? 'horizontal' : 'vertical' }),
+        [showGrid, horizontal]
+    )
 
     return (
         <div className="flex flex-col flex-1 min-h-0" data-attr="hog-charts-bar-bench">

--- a/frontend/src/scenes/debug/chart-bench/HogChartsBarChart.tsx
+++ b/frontend/src/scenes/debug/chart-bench/HogChartsBarChart.tsx
@@ -1,0 +1,45 @@
+import { useMemo } from 'react'
+
+import { buildTheme } from 'lib/charts/utils/theme'
+import { TimeSeriesBarChart } from 'lib/hog-charts'
+import type { Series, TimeSeriesBarChartConfig } from 'lib/hog-charts'
+
+import type { BenchData } from './generateBenchData'
+
+interface HogChartsBarChartProps {
+    data: BenchData
+    showGrid: boolean
+}
+
+const CONFIG: TimeSeriesBarChartConfig = {
+    showCrosshair: true,
+}
+
+/**
+ * Raw `lib/hog-charts` TimeSeriesBarChart, synthetic data. Mirrors
+ * {@link HogChartsLineChart} so the bar engine cost can be compared against the
+ * line engine on identical input. `fillArea` is meaningless for bars; the grid
+ * toggle drives the axis grid lines.
+ */
+export function HogChartsBarChart({ data, showGrid }: HogChartsBarChartProps): JSX.Element {
+    const theme = useMemo(() => buildTheme(), [])
+
+    const series: Series[] = useMemo(
+        () =>
+            data.series.map((s, idx) => ({
+                key: s.key,
+                label: s.label,
+                data: s.data,
+                color: theme.colors[idx % theme.colors.length],
+            })),
+        [data.series, theme.colors]
+    )
+
+    const config: TimeSeriesBarChartConfig = useMemo(() => ({ ...CONFIG, yAxis: { showGrid } }), [showGrid])
+
+    return (
+        <div className="flex flex-col flex-1 min-h-0" data-attr="hog-charts-bar-bench">
+            <TimeSeriesBarChart series={series} labels={data.labels} config={config} theme={theme} />
+        </div>
+    )
+}

--- a/frontend/src/scenes/debug/chart-bench/HogChartsLineChart.tsx
+++ b/frontend/src/scenes/debug/chart-bench/HogChartsLineChart.tsx
@@ -1,0 +1,45 @@
+import { useMemo } from 'react'
+
+import { buildTheme } from 'lib/charts/utils/theme'
+import { LineChart } from 'lib/hog-charts'
+import type { LineChartConfig, Series } from 'lib/hog-charts'
+
+import type { BenchData } from './generateBenchData'
+
+interface HogChartsLineChartProps {
+    data: BenchData
+    fillArea: boolean
+    showGrid: boolean
+}
+
+const CONFIG: LineChartConfig = {
+    showGrid: true,
+    showCrosshair: true,
+    showTooltip: true,
+}
+
+export function HogChartsLineChart({ data, fillArea, showGrid }: HogChartsLineChartProps): JSX.Element {
+    const theme = useMemo(() => buildTheme(), [])
+
+    const series: Series[] = useMemo(
+        () =>
+            data.series.map((s, idx) => ({
+                key: s.key,
+                label: s.label,
+                data: s.data,
+                // LineChart auto-assigns colors when `color` is an empty string via the theme,
+                // but Series requires a color — pick from the theme palette ourselves.
+                color: theme.colors[idx % theme.colors.length],
+                fillArea,
+            })),
+        [data.series, fillArea, theme.colors]
+    )
+
+    const config: LineChartConfig = useMemo(() => ({ ...CONFIG, showGrid }), [showGrid])
+
+    return (
+        <div className="flex flex-col flex-1 min-h-0" data-attr="hog-charts-bench">
+            <LineChart series={series} labels={data.labels} config={config} theme={theme} />
+        </div>
+    )
+}

--- a/frontend/src/scenes/debug/chart-bench/HogChartsLineChart.tsx
+++ b/frontend/src/scenes/debug/chart-bench/HogChartsLineChart.tsx
@@ -15,7 +15,6 @@ interface HogChartsLineChartProps {
 const CONFIG: LineChartConfig = {
     showGrid: true,
     showCrosshair: true,
-    showTooltip: true,
 }
 
 export function HogChartsLineChart({ data, fillArea, showGrid }: HogChartsLineChartProps): JSX.Element {

--- a/frontend/src/scenes/debug/chart-bench/RealAdaptersCell.tsx
+++ b/frontend/src/scenes/debug/chart-bench/RealAdaptersCell.tsx
@@ -5,17 +5,20 @@ import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { ActionsLineGraph } from 'scenes/trends/viz/ActionsLineGraph'
-import { TrendsLineChart } from 'scenes/trends/viz/trends-line-chart/TrendsLineChart'
 
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import type { DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
+import { ChartDisplayType } from '~/types'
 import type { InsightLogicProps } from '~/types'
+
+import { TrendsBarChart } from 'products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart'
+import { TrendsLineChart } from 'products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart'
 
 import { buildCachedInsight } from './buildCachedInsight'
 import type { BenchData } from './generateBenchData'
 
-type AdapterKind = 'adapter-hog' | 'adapter-chartjs'
+type AdapterKind = 'adapter-hog' | 'adapter-chartjs' | 'adapter-bar'
 
 interface RealAdaptersCellProps {
     kind: AdapterKind
@@ -37,7 +40,14 @@ interface RealAdaptersCellProps {
  * re-using a warm logic cache.
  */
 export function RealAdaptersCell({ kind, data, runKey, fillArea }: RealAdaptersCellProps): JSX.Element {
-    const built = useMemo(() => buildCachedInsight(data, { fillArea }), [data, fillArea])
+    const built = useMemo(
+        () =>
+            buildCachedInsight(data, {
+                fillArea,
+                display: kind === 'adapter-bar' ? ChartDisplayType.ActionsBar : undefined,
+            }),
+        [data, fillArea, kind]
+    )
 
     const insightProps: InsightLogicProps = useMemo(
         () => ({
@@ -67,7 +77,13 @@ export function RealAdaptersCell({ kind, data, runKey, fillArea }: RealAdaptersC
                 <BindLogic logic={insightDataLogic} props={insightProps}>
                     <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
                         <BindLogic logic={insightVizDataLogic} props={insightProps}>
-                            {kind === 'adapter-hog' ? <TrendsLineChart /> : <ActionsLineGraph />}
+                            {kind === 'adapter-hog' ? (
+                                <TrendsLineChart />
+                            ) : kind === 'adapter-bar' ? (
+                                <TrendsBarChart />
+                            ) : (
+                                <ActionsLineGraph />
+                            )}
                         </BindLogic>
                     </BindLogic>
                 </BindLogic>

--- a/frontend/src/scenes/debug/chart-bench/RealAdaptersCell.tsx
+++ b/frontend/src/scenes/debug/chart-bench/RealAdaptersCell.tsx
@@ -18,7 +18,13 @@ import { TrendsLineChart } from 'products/product_analytics/frontend/insights/tr
 import { buildCachedInsight } from './buildCachedInsight'
 import type { BenchData } from './generateBenchData'
 
-type AdapterKind = 'adapter-hog' | 'adapter-chartjs' | 'adapter-bar'
+type AdapterKind = 'adapter-hog' | 'adapter-chartjs' | 'adapter-bar' | 'adapter-bar-horizontal'
+
+/** Display type each bar adapter kind drives the insight with. */
+const ADAPTER_BAR_DISPLAY: Partial<Record<AdapterKind, ChartDisplayType>> = {
+    'adapter-bar': ChartDisplayType.ActionsBar,
+    'adapter-bar-horizontal': ChartDisplayType.ActionsBarValue,
+}
 
 interface RealAdaptersCellProps {
     kind: AdapterKind
@@ -44,7 +50,7 @@ export function RealAdaptersCell({ kind, data, runKey, fillArea }: RealAdaptersC
         () =>
             buildCachedInsight(data, {
                 fillArea,
-                display: kind === 'adapter-bar' ? ChartDisplayType.ActionsBar : undefined,
+                display: ADAPTER_BAR_DISPLAY[kind],
             }),
         [data, fillArea, kind]
     )
@@ -79,7 +85,7 @@ export function RealAdaptersCell({ kind, data, runKey, fillArea }: RealAdaptersC
                         <BindLogic logic={insightVizDataLogic} props={insightProps}>
                             {kind === 'adapter-hog' ? (
                                 <TrendsLineChart />
-                            ) : kind === 'adapter-bar' ? (
+                            ) : kind === 'adapter-bar' || kind === 'adapter-bar-horizontal' ? (
                                 <TrendsBarChart />
                             ) : (
                                 <ActionsLineGraph />

--- a/frontend/src/scenes/debug/chart-bench/RealAdaptersCell.tsx
+++ b/frontend/src/scenes/debug/chart-bench/RealAdaptersCell.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { ActionsHorizontalBar } from 'scenes/trends/viz/ActionsHorizontalBar'
 import { ActionsLineGraph } from 'scenes/trends/viz/ActionsLineGraph'
 
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
@@ -18,12 +19,21 @@ import { TrendsLineChart } from 'products/product_analytics/frontend/insights/tr
 import { buildCachedInsight } from './buildCachedInsight'
 import type { BenchData } from './generateBenchData'
 
-type AdapterKind = 'adapter-hog' | 'adapter-chartjs' | 'adapter-bar' | 'adapter-bar-horizontal'
+type AdapterKind =
+    | 'adapter-hog'
+    | 'adapter-chartjs'
+    | 'adapter-bar'
+    | 'adapter-bar-horizontal'
+    | 'adapter-chartjs-bar'
+    | 'adapter-chartjs-bar-horizontal'
 
-/** Display type each bar adapter kind drives the insight with. */
+/** Display type each bar adapter kind drives the insight with. hog and chart.js bar adapters share
+ *  a display so they're a clean engine-vs-engine comparison; only the rendered component differs. */
 const ADAPTER_BAR_DISPLAY: Partial<Record<AdapterKind, ChartDisplayType>> = {
     'adapter-bar': ChartDisplayType.ActionsBar,
     'adapter-bar-horizontal': ChartDisplayType.ActionsBarValue,
+    'adapter-chartjs-bar': ChartDisplayType.ActionsBar,
+    'adapter-chartjs-bar-horizontal': ChartDisplayType.ActionsBarValue,
 }
 
 interface RealAdaptersCellProps {
@@ -31,6 +41,9 @@ interface RealAdaptersCellProps {
     data: BenchData
     runKey: number
     fillArea: boolean
+    /** Forwarded to the hog-charts bar adapter to A/B the tooltip's hover cost. Only affects
+     *  `adapter-bar` / `adapter-bar-horizontal`; the chart.js adapters have no equivalent hook. */
+    tooltipEnabled: boolean
 }
 
 /**
@@ -45,7 +58,7 @@ interface RealAdaptersCellProps {
  * `keyForInsightLogicProps`) so mount-time measurements aren't biased by
  * re-using a warm logic cache.
  */
-export function RealAdaptersCell({ kind, data, runKey, fillArea }: RealAdaptersCellProps): JSX.Element {
+export function RealAdaptersCell({ kind, data, runKey, fillArea, tooltipEnabled }: RealAdaptersCellProps): JSX.Element {
     const built = useMemo(
         () =>
             buildCachedInsight(data, {
@@ -86,7 +99,9 @@ export function RealAdaptersCell({ kind, data, runKey, fillArea }: RealAdaptersC
                             {kind === 'adapter-hog' ? (
                                 <TrendsLineChart />
                             ) : kind === 'adapter-bar' || kind === 'adapter-bar-horizontal' ? (
-                                <TrendsBarChart />
+                                <TrendsBarChart tooltipEnabled={tooltipEnabled} />
+                            ) : kind === 'adapter-chartjs-bar-horizontal' ? (
+                                <ActionsHorizontalBar />
                             ) : (
                                 <ActionsLineGraph />
                             )}

--- a/frontend/src/scenes/debug/chart-bench/RealAdaptersCell.tsx
+++ b/frontend/src/scenes/debug/chart-bench/RealAdaptersCell.tsx
@@ -5,7 +5,7 @@ import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { ActionsLineGraph } from 'scenes/trends/viz/ActionsLineGraph'
-import { TrendsLineChartD3 } from 'scenes/trends/viz/TrendsLineChartD3'
+import { TrendsLineChart } from 'scenes/trends/viz/TrendsLineChart'
 
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import type { DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'
@@ -27,7 +27,7 @@ interface RealAdaptersCellProps {
 /**
  * Mounts the real insight kea logic tree with synthetic cached data and
  * renders either the chart.js-based `ActionsLineGraph` or the hog-charts-based
- * `TrendsLineChartD3`. No HTTP — `dataNodeLogic` picks up `cachedResults` in
+ * `TrendsLineChart`. No HTTP — `dataNodeLogic` picks up `cachedResults` in
  * its `afterMount`/`propsChanged` hooks and calls `setResponse` directly,
  * so the insight pipeline sees our data as if it came from the API.
  *
@@ -67,7 +67,7 @@ export function RealAdaptersCell({ kind, data, runKey, fillArea }: RealAdaptersC
                 <BindLogic logic={insightDataLogic} props={insightProps}>
                     <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
                         <BindLogic logic={insightVizDataLogic} props={insightProps}>
-                            {kind === 'adapter-hog' ? <TrendsLineChartD3 /> : <ActionsLineGraph />}
+                            {kind === 'adapter-hog' ? <TrendsLineChart /> : <ActionsLineGraph />}
                         </BindLogic>
                     </BindLogic>
                 </BindLogic>

--- a/frontend/src/scenes/debug/chart-bench/RealAdaptersCell.tsx
+++ b/frontend/src/scenes/debug/chart-bench/RealAdaptersCell.tsx
@@ -5,7 +5,7 @@ import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { ActionsLineGraph } from 'scenes/trends/viz/ActionsLineGraph'
-import { TrendsLineChart } from 'scenes/trends/viz/TrendsLineChart'
+import { TrendsLineChart } from 'scenes/trends/viz/trends-line-chart/TrendsLineChart'
 
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import type { DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'

--- a/frontend/src/scenes/debug/chart-bench/RealAdaptersCell.tsx
+++ b/frontend/src/scenes/debug/chart-bench/RealAdaptersCell.tsx
@@ -1,0 +1,77 @@
+import { BindLogic } from 'kea'
+import { useMemo } from 'react'
+
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { ActionsLineGraph } from 'scenes/trends/viz/ActionsLineGraph'
+import { TrendsLineChartD3 } from 'scenes/trends/viz/TrendsLineChartD3'
+
+import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import type { DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
+import type { InsightLogicProps } from '~/types'
+
+import { buildCachedInsight } from './buildCachedInsight'
+import type { BenchData } from './generateBenchData'
+
+type AdapterKind = 'adapter-hog' | 'adapter-chartjs'
+
+interface RealAdaptersCellProps {
+    kind: AdapterKind
+    data: BenchData
+    runKey: number
+    fillArea: boolean
+}
+
+/**
+ * Mounts the real insight kea logic tree with synthetic cached data and
+ * renders either the chart.js-based `ActionsLineGraph` or the hog-charts-based
+ * `TrendsLineChartD3`. No HTTP — `dataNodeLogic` picks up `cachedResults` in
+ * its `afterMount`/`propsChanged` hooks and calls `setResponse` directly,
+ * so the insight pipeline sees our data as if it came from the API.
+ *
+ * Each runKey bump yields a fresh `dashboardItemId`, which produces fresh
+ * kea logic instances (keyed off `dashboardItemId` via
+ * `keyForInsightLogicProps`) so mount-time measurements aren't biased by
+ * re-using a warm logic cache.
+ */
+export function RealAdaptersCell({ kind, data, runKey, fillArea }: RealAdaptersCellProps): JSX.Element {
+    const built = useMemo(() => buildCachedInsight(data, { fillArea }), [data, fillArea])
+
+    const insightProps: InsightLogicProps = useMemo(
+        () => ({
+            dashboardItemId: `new-AdHoc.chart-bench-${runKey}`,
+            query: built.query,
+            cachedInsight: built.cachedInsight,
+            doNotLoad: true,
+            dataNodeCollectionId: `chart-bench-${runKey}`,
+        }),
+        [built.query, built.cachedInsight, runKey]
+    )
+
+    const dataNodeLogicProps: DataNodeLogicProps = useMemo(
+        () => ({
+            key: insightVizDataNodeKey(insightProps),
+            query: built.query.source,
+            cachedResults: built.cachedResults,
+            doNotLoad: true,
+            dataNodeCollectionId: `chart-bench-${runKey}`,
+        }),
+        [built.query.source, built.cachedResults, insightProps, runKey]
+    )
+
+    return (
+        <div className="flex flex-col flex-1 min-h-0" data-attr={`real-adapters-${kind}`}>
+            <BindLogic logic={insightLogic} props={insightProps}>
+                <BindLogic logic={insightDataLogic} props={insightProps}>
+                    <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
+                        <BindLogic logic={insightVizDataLogic} props={insightProps}>
+                            {kind === 'adapter-hog' ? <TrendsLineChartD3 /> : <ActionsLineGraph />}
+                        </BindLogic>
+                    </BindLogic>
+                </BindLogic>
+            </BindLogic>
+        </div>
+    )
+}

--- a/frontend/src/scenes/debug/chart-bench/SweepResultsChart.tsx
+++ b/frontend/src/scenes/debug/chart-bench/SweepResultsChart.tsx
@@ -5,9 +5,11 @@ import { buildTheme } from 'lib/charts/utils/theme'
 
 import type { ChartKind, SweepResult } from './sweepTypes'
 
+type SweepMetric = 'meanReadyMs' | 'meanHoverMs' | 'meanHoverSyncMs' | 'meanHoverFrameMs'
+
 interface SweepResultsChartProps {
     results: SweepResult[]
-    metric: 'meanReadyMs' | 'meanHoverMs'
+    metric: SweepMetric
     title: string
     logY: boolean
 }
@@ -15,7 +17,7 @@ interface SweepResultsChartProps {
 /** Group sweep results into one dataset per (chart, series) combination. */
 function buildDatasets(
     results: SweepResult[],
-    metric: 'meanReadyMs' | 'meanHoverMs',
+    metric: SweepMetric,
     colors: string[]
 ): { datasets: ChartDataset<'line'>[]; allPoints: number[] } {
     const groups = new Map<string, { chart: ChartKind; series: number; data: { x: number; y: number }[] }>()
@@ -24,7 +26,11 @@ function buildDatasets(
         if (!groups.has(key)) {
             groups.set(key, { chart: r.chart, series: r.series, data: [] })
         }
-        groups.get(key)!.data.push({ x: r.points, y: r[metric] })
+        const y = r[metric]
+        if (!Number.isFinite(y)) {
+            continue
+        }
+        groups.get(key)!.data.push({ x: r.points, y })
     }
     const allPointsSet = new Set<number>()
     for (const r of results) {

--- a/frontend/src/scenes/debug/chart-bench/SweepResultsChart.tsx
+++ b/frontend/src/scenes/debug/chart-bench/SweepResultsChart.tsx
@@ -1,0 +1,110 @@
+import { useLayoutEffect, useMemo, useRef } from 'react'
+
+import { Chart, ChartConfiguration, ChartDataset } from 'lib/Chart'
+import { buildTheme } from 'lib/charts/utils/theme'
+
+import type { ChartKind, SweepResult } from './sweepTypes'
+
+interface SweepResultsChartProps {
+    results: SweepResult[]
+    metric: 'meanReadyMs' | 'meanHoverMs'
+    title: string
+    logY: boolean
+}
+
+/** Group sweep results into one dataset per (chart, series) combination. */
+function buildDatasets(
+    results: SweepResult[],
+    metric: 'meanReadyMs' | 'meanHoverMs',
+    colors: string[]
+): { datasets: ChartDataset<'line'>[]; allPoints: number[] } {
+    const groups = new Map<string, { chart: ChartKind; series: number; data: { x: number; y: number }[] }>()
+    for (const r of results) {
+        const key = `${r.chart}|${r.series}`
+        if (!groups.has(key)) {
+            groups.set(key, { chart: r.chart, series: r.series, data: [] })
+        }
+        groups.get(key)!.data.push({ x: r.points, y: r[metric] })
+    }
+    const allPointsSet = new Set<number>()
+    for (const r of results) {
+        allPointsSet.add(r.points)
+    }
+    const allPoints = Array.from(allPointsSet).sort((a, b) => a - b)
+
+    let colorIdx = 0
+    const datasets: ChartDataset<'line'>[] = []
+    for (const [, group] of groups) {
+        const color = colors[colorIdx % colors.length]
+        colorIdx++
+        group.data.sort((a, b) => a.x - b.x)
+        datasets.push({
+            label: `${group.chart} · ${group.series}s`,
+            data: group.data,
+            borderColor: color,
+            backgroundColor: color,
+            fill: false,
+            pointRadius: 3,
+            borderWidth: 2,
+            tension: 0,
+        })
+    }
+    return { datasets, allPoints }
+}
+
+export function SweepResultsChart({ results, metric, title, logY }: SweepResultsChartProps): JSX.Element {
+    const canvasRef = useRef<HTMLCanvasElement>(null)
+    const chartRef = useRef<Chart | null>(null)
+    const theme = useMemo(() => buildTheme(), [])
+
+    const config: ChartConfiguration<'line'> = useMemo(() => {
+        const { datasets } = buildDatasets(results, metric, theme.colors)
+        return {
+            type: 'line',
+            data: { datasets },
+            options: {
+                animation: false,
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: { display: true, position: 'bottom', labels: { color: theme.axisColor } },
+                    tooltip: { enabled: true, mode: 'nearest', intersect: false },
+                    title: { display: true, text: title, color: theme.axisColor },
+                },
+                interaction: { mode: 'nearest', intersect: false },
+                scales: {
+                    x: {
+                        type: 'logarithmic',
+                        title: { display: true, text: 'points', color: theme.axisColor },
+                        grid: { display: true, color: theme.gridColor },
+                        ticks: { color: theme.axisColor },
+                    },
+                    y: {
+                        type: logY ? 'logarithmic' : 'linear',
+                        title: { display: true, text: 'ms', color: theme.axisColor },
+                        grid: { display: true, color: theme.gridColor },
+                        ticks: { color: theme.axisColor },
+                    },
+                },
+            },
+        }
+    }, [results, metric, title, logY, theme])
+
+    useLayoutEffect(() => {
+        if (!canvasRef.current) {
+            return
+        }
+        chartRef.current?.destroy()
+        chartRef.current = new Chart(canvasRef.current, config)
+        return () => {
+            chartRef.current?.destroy()
+            chartRef.current = null
+        }
+    }, [config])
+
+    return (
+        <div className="flex-1 min-h-0 relative" style={{ height: 320 }}>
+            <canvas ref={canvasRef} />
+        </div>
+    )
+}

--- a/frontend/src/scenes/debug/chart-bench/buildCachedInsight.ts
+++ b/frontend/src/scenes/debug/chart-bench/buildCachedInsight.ts
@@ -1,7 +1,7 @@
 import { NodeKind } from '~/queries/schema/schema-general'
 import type { EventsNode, InsightVizNode, TrendsQuery } from '~/queries/schema/schema-general'
 import type { QueryBasedInsightModel, TrendResult } from '~/types'
-import { BaseMathType, ChartDisplayType } from '~/types'
+import { BaseMathType, ChartDisplayType, InsightType } from '~/types'
 
 import type { BenchData } from './generateBenchData'
 
@@ -26,10 +26,13 @@ export interface BuiltInsight {
 
 interface BuildOptions {
     fillArea?: boolean
+    /** Overrides the display type. When omitted, falls back to the line/area choice driven by `fillArea`. */
+    display?: ChartDisplayType
 }
 
 export function buildCachedInsight(data: BenchData, options: BuildOptions = {}): BuiltInsight {
-    const display = options.fillArea ? ChartDisplayType.ActionsAreaGraph : ChartDisplayType.ActionsLineGraph
+    const display =
+        options.display ?? (options.fillArea ? ChartDisplayType.ActionsAreaGraph : ChartDisplayType.ActionsLineGraph)
     const trendsQuery: TrendsQuery = {
         kind: NodeKind.TrendsQuery,
         dateRange: {
@@ -83,7 +86,7 @@ export function buildCachedInsight(data: BenchData, options: BuildOptions = {}):
         days: data.labels.slice(),
         aggregated_value: 0,
         filter: {
-            insight: 'TRENDS',
+            insight: InsightType.TRENDS,
             interval: 'day',
             display,
         },

--- a/frontend/src/scenes/debug/chart-bench/buildCachedInsight.ts
+++ b/frontend/src/scenes/debug/chart-bench/buildCachedInsight.ts
@@ -16,7 +16,7 @@ import type { BenchData } from './generateBenchData'
  *
  * We deliberately don't try to match real PostHog data — the goal is to feed
  * `trendsDataLogic` enough structure that the adapters (`ActionsLineGraph`,
- * `TrendsLineChartD3`) render without touching the backend.
+ * `TrendsLineChart`) render without touching the backend.
  */
 export interface BuiltInsight {
     query: InsightVizNode

--- a/frontend/src/scenes/debug/chart-bench/buildCachedInsight.ts
+++ b/frontend/src/scenes/debug/chart-bench/buildCachedInsight.ts
@@ -64,33 +64,38 @@ export function buildCachedInsight(data: BenchData, options: BuildOptions = {}):
         full: false,
     }
 
-    const trendResults: TrendResult[] = data.series.map((s, idx) => ({
-        action: {
-            id: s.key,
-            type: 'events',
-            order: idx,
-            name: s.label,
-            custom_name: s.label,
-            math: 'total',
-            math_property: null,
-            math_group_type_index: null,
-            properties: [],
-        },
-        label: s.label,
-        count: s.data.reduce((a, b) => a + b, 0),
-        data: s.data,
-        // TrendResult's `labels` are human-readable (e.g. "4-Mar-2022") while
-        // `days` are ISO — the chart uses `days` for x-axis positioning and
-        // `labels` only for tooltip titles. We reuse the ISO strings for both.
-        labels: s.data.map((_, i) => data.labels[i] ?? ''),
-        days: data.labels.slice(),
-        aggregated_value: 0,
-        filter: {
-            insight: InsightType.TRENDS,
-            interval: 'day',
-            display,
-        },
-    }))
+    const trendResults: TrendResult[] = data.series.map((s, idx) => {
+        const total = s.data.reduce((a, b) => a + b, 0)
+        return {
+            action: {
+                id: s.key,
+                type: 'events',
+                order: idx,
+                name: s.label,
+                custom_name: s.label,
+                math: 'total',
+                math_property: null,
+                math_group_type_index: null,
+                properties: [],
+            },
+            label: s.label,
+            count: total,
+            data: s.data,
+            // TrendResult's `labels` are human-readable (e.g. "4-Mar-2022") while
+            // `days` are ISO — the chart uses `days` for x-axis positioning and
+            // `labels` only for tooltip titles. We reuse the ISO strings for both.
+            labels: s.data.map((_, i) => data.labels[i] ?? ''),
+            days: data.labels.slice(),
+            // Aggregated (horizontal `ActionsBarValue`) layouts drop series whose
+            // aggregated_value is 0, so carry the series total here too.
+            aggregated_value: total,
+            filter: {
+                insight: InsightType.TRENDS,
+                interval: 'day',
+                display,
+            },
+        }
+    })
 
     const cachedInsight: Partial<QueryBasedInsightModel> = {
         id: 0,

--- a/frontend/src/scenes/debug/chart-bench/buildCachedInsight.ts
+++ b/frontend/src/scenes/debug/chart-bench/buildCachedInsight.ts
@@ -1,7 +1,7 @@
 import { NodeKind } from '~/queries/schema/schema-general'
-import type { InsightVizNode, TrendsQuery } from '~/queries/schema/schema-general'
+import type { EventsNode, InsightVizNode, TrendsQuery } from '~/queries/schema/schema-general'
 import type { QueryBasedInsightModel, TrendResult } from '~/types'
-import { ChartDisplayType } from '~/types'
+import { BaseMathType, ChartDisplayType } from '~/types'
 
 import type { BenchData } from './generateBenchData'
 
@@ -37,19 +37,19 @@ export function buildCachedInsight(data: BenchData, options: BuildOptions = {}):
             date_to: data.labels[data.labels.length - 1] ?? null,
         },
         interval: 'day',
-        series: data.series.map((s, idx) => ({
-            kind: NodeKind.EventsNode,
-            event: '$pageview',
-            name: s.label,
-            custom_name: s.label,
-            math: 'total',
-            // Order lives on action.order in TrendResult — duplicated here
-            // because some selectors key off the series index too.
-            properties: [],
-            // @ts-expect-error — `order` isn't part of EventsNode in the
-            // schema but `trendsDataLogic` reads it off series entries.
-            order: idx,
-        })),
+        series: data.series.map(
+            (s, idx) =>
+                // `order` isn't in the EventsNode schema but `trendsDataLogic` reads it off series entries.
+                ({
+                    kind: NodeKind.EventsNode,
+                    event: '$pageview',
+                    name: s.label,
+                    custom_name: s.label,
+                    math: BaseMathType.TotalCount,
+                    properties: [],
+                    order: idx,
+                }) as EventsNode
+        ),
         trendsFilter: {
             display,
         },
@@ -71,7 +71,7 @@ export function buildCachedInsight(data: BenchData, options: BuildOptions = {}):
             math: 'total',
             math_property: null,
             math_group_type_index: null,
-            properties: {},
+            properties: [],
         },
         label: s.label,
         count: s.data.reduce((a, b) => a + b, 0),
@@ -96,7 +96,6 @@ export function buildCachedInsight(data: BenchData, options: BuildOptions = {}):
         derived_name: 'chart bench',
         query,
         result: trendResults,
-        filters: {},
         dashboards: [],
     }
 

--- a/frontend/src/scenes/debug/chart-bench/buildCachedInsight.ts
+++ b/frontend/src/scenes/debug/chart-bench/buildCachedInsight.ts
@@ -1,0 +1,108 @@
+import { NodeKind } from '~/queries/schema/schema-general'
+import type { InsightVizNode, TrendsQuery } from '~/queries/schema/schema-general'
+import type { QueryBasedInsightModel, TrendResult } from '~/types'
+import { ChartDisplayType } from '~/types'
+
+import type { BenchData } from './generateBenchData'
+
+/**
+ * Turns the harness's synthetic {labels, series[]} into the shape the real
+ * PostHog trend chart expects:
+ *
+ *   - a `TrendsQuery` with one `EventsNode` per series (used by
+ *     `trendsDataLogic` to drive display/interval/trendsFilter selectors).
+ *   - a `cachedInsight` wrapping that query as an `InsightVizNode`, plus a
+ *     `result` array of `TrendResult` carrying the actual numbers.
+ *
+ * We deliberately don't try to match real PostHog data — the goal is to feed
+ * `trendsDataLogic` enough structure that the adapters (`ActionsLineGraph`,
+ * `TrendsLineChartD3`) render without touching the backend.
+ */
+export interface BuiltInsight {
+    query: InsightVizNode
+    cachedInsight: Partial<QueryBasedInsightModel>
+    cachedResults: { results: TrendResult[] }
+}
+
+interface BuildOptions {
+    fillArea?: boolean
+}
+
+export function buildCachedInsight(data: BenchData, options: BuildOptions = {}): BuiltInsight {
+    const display = options.fillArea ? ChartDisplayType.ActionsAreaGraph : ChartDisplayType.ActionsLineGraph
+    const trendsQuery: TrendsQuery = {
+        kind: NodeKind.TrendsQuery,
+        dateRange: {
+            date_from: data.labels[0] ?? '-30d',
+            date_to: data.labels[data.labels.length - 1] ?? null,
+        },
+        interval: 'day',
+        series: data.series.map((s, idx) => ({
+            kind: NodeKind.EventsNode,
+            event: '$pageview',
+            name: s.label,
+            custom_name: s.label,
+            math: 'total',
+            // Order lives on action.order in TrendResult — duplicated here
+            // because some selectors key off the series index too.
+            properties: [],
+            // @ts-expect-error — `order` isn't part of EventsNode in the
+            // schema but `trendsDataLogic` reads it off series entries.
+            order: idx,
+        })),
+        trendsFilter: {
+            display,
+        },
+    }
+
+    const query: InsightVizNode = {
+        kind: NodeKind.InsightVizNode,
+        source: trendsQuery,
+        full: false,
+    }
+
+    const trendResults: TrendResult[] = data.series.map((s, idx) => ({
+        action: {
+            id: s.key,
+            type: 'events',
+            order: idx,
+            name: s.label,
+            custom_name: s.label,
+            math: 'total',
+            math_property: null,
+            math_group_type_index: null,
+            properties: {},
+        },
+        label: s.label,
+        count: s.data.reduce((a, b) => a + b, 0),
+        data: s.data,
+        // TrendResult's `labels` are human-readable (e.g. "4-Mar-2022") while
+        // `days` are ISO — the chart uses `days` for x-axis positioning and
+        // `labels` only for tooltip titles. We reuse the ISO strings for both.
+        labels: s.data.map((_, i) => data.labels[i] ?? ''),
+        days: data.labels.slice(),
+        aggregated_value: 0,
+        filter: {
+            insight: 'TRENDS',
+            interval: 'day',
+            display,
+        },
+    }))
+
+    const cachedInsight: Partial<QueryBasedInsightModel> = {
+        id: 0,
+        short_id: 'bench' as QueryBasedInsightModel['short_id'],
+        name: 'chart bench',
+        derived_name: 'chart bench',
+        query,
+        result: trendResults,
+        filters: {},
+        dashboards: [],
+    }
+
+    return {
+        query,
+        cachedInsight,
+        cachedResults: { results: trendResults },
+    }
+}

--- a/frontend/src/scenes/debug/chart-bench/generateBenchData.ts
+++ b/frontend/src/scenes/debug/chart-bench/generateBenchData.ts
@@ -1,0 +1,64 @@
+/**
+ * Deterministic synthetic data for the chart bench screen. Shared between the
+ * hog-charts and chart.js cells so both libraries render exactly the same
+ * numbers — any perf difference is the chart engine, not the input.
+ */
+
+export interface BenchData {
+    labels: string[]
+    series: {
+        key: string
+        label: string
+        data: number[]
+    }[]
+}
+
+/** Mulberry32 — tiny seeded PRNG, no dependencies, deterministic across runs. */
+function mulberry32(seed: number): () => number {
+    let a = seed >>> 0
+    return () => {
+        a = (a + 0x6d2b79f5) >>> 0
+        let t = a
+        t = Math.imul(t ^ (t >>> 15), t | 1)
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    }
+}
+
+export function generateBenchData(seriesCount: number, pointCount: number, seed: number): BenchData {
+    const rand = mulberry32(seed)
+
+    const labels: string[] = []
+    // Daily labels starting from a fixed epoch so the x-axis is identical across runs.
+    const epoch = new Date('2024-01-01T00:00:00Z').getTime()
+    const dayMs = 24 * 60 * 60 * 1000
+    for (let i = 0; i < pointCount; i++) {
+        labels.push(new Date(epoch + i * dayMs).toISOString().slice(0, 10))
+    }
+
+    const series: BenchData['series'] = []
+    for (let s = 0; s < seriesCount; s++) {
+        // Each series gets its own baseline, amplitude, phase and noise level —
+        // enough variety that stacking/overlap is realistic.
+        const baseline = 100 + rand() * 400
+        const amplitude = 20 + rand() * 200
+        const phase = rand() * Math.PI * 2
+        const period = 7 + rand() * 21
+        const noiseScale = 10 + rand() * 40
+
+        const data: number[] = []
+        for (let i = 0; i < pointCount; i++) {
+            const wave = Math.sin((i / period) * Math.PI * 2 + phase) * amplitude
+            const noise = (rand() - 0.5) * noiseScale
+            data.push(Math.max(0, Math.round(baseline + wave + noise)))
+        }
+
+        series.push({
+            key: `series-${s}`,
+            label: `Series ${s + 1}`,
+            data,
+        })
+    }
+
+    return { labels, series }
+}

--- a/frontend/src/scenes/debug/chart-bench/sweepTypes.ts
+++ b/frontend/src/scenes/debug/chart-bench/sweepTypes.ts
@@ -1,4 +1,4 @@
-export type ChartKind = 'hog' | 'chartjs' | 'adapter-hog' | 'adapter-chartjs'
+export type ChartKind = 'hog' | 'chartjs' | 'hog-bar' | 'adapter-hog' | 'adapter-chartjs' | 'adapter-bar'
 
 export interface SweepResult {
     chart: ChartKind

--- a/frontend/src/scenes/debug/chart-bench/sweepTypes.ts
+++ b/frontend/src/scenes/debug/chart-bench/sweepTypes.ts
@@ -9,6 +9,8 @@ export type ChartKind =
     | 'adapter-chartjs'
     | 'adapter-bar'
     | 'adapter-bar-horizontal'
+    | 'adapter-chartjs-bar'
+    | 'adapter-chartjs-bar-horizontal'
 
 export interface SweepResult {
     chart: ChartKind

--- a/frontend/src/scenes/debug/chart-bench/sweepTypes.ts
+++ b/frontend/src/scenes/debug/chart-bench/sweepTypes.ts
@@ -1,0 +1,12 @@
+export type ChartKind = 'hog' | 'chartjs' | 'adapter-hog' | 'adapter-chartjs'
+
+export interface SweepResult {
+    chart: ChartKind
+    series: number
+    points: number
+    runs: number
+    meanReadyMs: number
+    meanHoverMs: number
+    readyMs: number[]
+    hoverMs: number[]
+}

--- a/frontend/src/scenes/debug/chart-bench/sweepTypes.ts
+++ b/frontend/src/scenes/debug/chart-bench/sweepTypes.ts
@@ -7,6 +7,10 @@ export interface SweepResult {
     runs: number
     meanReadyMs: number
     meanHoverMs: number
+    /** Mean time per mousemove spent synchronously in event dispatch (React handler + setState + sync effects). */
+    meanHoverSyncMs: number
+    /** Mean time per mousemove spent awaiting the next animation frame after dispatch returns. */
+    meanHoverFrameMs: number
     readyMs: number[]
     hoverMs: number[]
 }

--- a/frontend/src/scenes/debug/chart-bench/sweepTypes.ts
+++ b/frontend/src/scenes/debug/chart-bench/sweepTypes.ts
@@ -3,6 +3,8 @@ export type ChartKind =
     | 'chartjs'
     | 'hog-bar'
     | 'hog-bar-horizontal'
+    | 'chartjs-bar'
+    | 'chartjs-bar-horizontal'
     | 'adapter-hog'
     | 'adapter-chartjs'
     | 'adapter-bar'

--- a/frontend/src/scenes/debug/chart-bench/sweepTypes.ts
+++ b/frontend/src/scenes/debug/chart-bench/sweepTypes.ts
@@ -1,4 +1,12 @@
-export type ChartKind = 'hog' | 'chartjs' | 'hog-bar' | 'adapter-hog' | 'adapter-chartjs' | 'adapter-bar'
+export type ChartKind =
+    | 'hog'
+    | 'chartjs'
+    | 'hog-bar'
+    | 'hog-bar-horizontal'
+    | 'adapter-hog'
+    | 'adapter-chartjs'
+    | 'adapter-bar'
+    | 'adapter-bar-horizontal'
 
 export interface SweepResult {
     chart: ChartKind

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -43,6 +43,7 @@ export enum Scene {
     DataWarehouseSourceSchema = 'DataWarehouseSourceSchema',
     DeadLetterQueue = 'DeadLetterQueue',
     Destinations = 'Destinations',
+    ChartBench = 'ChartBench',
     DebugHog = 'DebugHog',
     DebugQuery = 'DebugQuery',
     EarlyAccessFeatures = 'EarlyAccessFeatures',

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -40,6 +40,7 @@ export enum Scene {
     DataWarehouseSourceNew = 'DataWarehouseSourceNew',
     DeadLetterQueue = 'DeadLetterQueue',
     Destinations = 'Destinations',
+    ChartBench = 'ChartBench',
     DebugHog = 'DebugHog',
     DebugQuery = 'DebugQuery',
     EarlyAccessFeatures = 'EarlyAccessFeatures',

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -153,6 +153,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         activityScope: ActivityScope.HOG_FUNCTION,
         iconType: 'data_pipeline',
     },
+    [Scene.ChartBench]: { projectBased: true, name: 'Chart benchmark' },
     [Scene.DebugHog]: { projectBased: true, name: 'Hog Repl' },
     [Scene.DebugQuery]: { projectBased: true },
 
@@ -902,6 +903,7 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.stripeConfirmInstall()]: [Scene.StripeConfirmInstall, 'stripeConfirmInstall'],
     [urls.debugQuery()]: [Scene.DebugQuery, 'debugQuery'],
     [urls.debugHog()]: [Scene.DebugHog, 'debugHog'],
+    [urls.chartBench()]: [Scene.ChartBench, 'chartBench'],
 
     [urls.notebook(':shortId')]: [Scene.Notebook, 'notebook'],
     [urls.notebooks()]: [Scene.Notebooks, 'notebooks'],

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -196,6 +196,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         defaultDocsPath: '/docs/cdp/destinations',
         iconType: 'data_pipeline',
     },
+    [Scene.ChartBench]: { projectBased: true, name: 'Chart benchmark' },
     [Scene.DebugHog]: { projectBased: true, name: 'Hog Repl' },
     [Scene.DebugQuery]: { projectBased: true },
 
@@ -955,6 +956,7 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.integrationsRedirect(':kind')]: [Scene.IntegrationsRedirect, 'integrationsRedirect'],
     [urls.debugQuery()]: [Scene.DebugQuery, 'debugQuery'],
     [urls.debugHog()]: [Scene.DebugHog, 'debugHog'],
+    [urls.chartBench()]: [Scene.ChartBench, 'chartBench'],
 
     [urls.notebook(':shortId')]: [Scene.Notebook, 'notebook'],
     [urls.notebooks()]: [Scene.Notebooks, 'notebooks'],

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -252,6 +252,7 @@ export const urls = {
     debugQuery: (query?: string | Record<string, any>): string =>
         combineUrl('/debug', {}, query ? { q: typeof query === 'string' ? query : JSON.stringify(query) } : {}).url,
     debugHog: (): string => '/debug/hog',
+    chartBench: (): string => '/debug/chart-bench',
 
     moveToPostHogCloud: (): string => '/move-to-cloud',
     heatmaps: (params?: string): string =>

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -221,6 +221,7 @@ export const urls = {
     debugQuery: (query?: string | Record<string, any>): string =>
         combineUrl('/debug', {}, query ? { q: typeof query === 'string' ? query : JSON.stringify(query) } : {}).url,
     debugHog: (): string => '/debug/hog',
+    chartBench: (): string => '/debug/chart-bench',
 
     moveToPostHogCloud: (): string => '/move-to-cloud',
     heatmaps: (params?: string): string =>

--- a/playwright/e2e/chart-bench.spec.ts
+++ b/playwright/e2e/chart-bench.spec.ts
@@ -5,9 +5,11 @@ import type { BenchResult } from '~/scenes/debug/chart-bench/ChartBenchScene'
 import { test } from '../utils/playwright-test-base'
 
 /**
- * Line-chart benchmark runner. Walks a matrix of {chart, series, points},
- * runs the in-scene benchmark harness at `/debug/chart-bench`, and prints a
- * comparison table to stdout + attaches it to the Playwright report.
+ * Chart benchmark runner. Walks a matrix of {chart, series, points}, runs the
+ * in-scene benchmark harness at `/debug/chart-bench`, and prints a comparison
+ * table to stdout + attaches it to the Playwright report. The harness sweeps
+ * hover vertically for horizontal bar layouts and horizontally otherwise, so no
+ * per-orientation logic is needed here — selecting the chart kind is enough.
  *
  * Skipped by default because benchmark numbers are noisy and we don't want
  * CI to fail on them. Run locally with:
@@ -29,7 +31,16 @@ const MATRIX: { series: number; points: number }[] = [
     { series: 50, points: 2000 },
 ]
 
-const CHARTS: ChartKind[] = ['hog', 'chartjs', 'adapter-hog', 'adapter-chartjs']
+const CHARTS: ChartKind[] = [
+    'hog',
+    'chartjs',
+    'hog-bar',
+    'hog-bar-horizontal',
+    'adapter-hog',
+    'adapter-chartjs',
+    'adapter-bar',
+    'adapter-bar-horizontal',
+]
 const RUNS = 5
 const SEED = 42
 

--- a/playwright/e2e/chart-bench.spec.ts
+++ b/playwright/e2e/chart-bench.spec.ts
@@ -36,6 +36,8 @@ const CHARTS: ChartKind[] = [
     'chartjs',
     'hog-bar',
     'hog-bar-horizontal',
+    'chartjs-bar',
+    'chartjs-bar-horizontal',
     'adapter-hog',
     'adapter-chartjs',
     'adapter-bar',

--- a/playwright/e2e/chart-bench.spec.ts
+++ b/playwright/e2e/chart-bench.spec.ts
@@ -1,0 +1,100 @@
+import { expect } from '@playwright/test'
+
+import { test } from '../utils/playwright-test-base'
+
+/**
+ * Line-chart benchmark runner. Walks a matrix of {chart, series, points},
+ * runs the in-scene benchmark harness at `/debug/chart-bench`, and prints a
+ * comparison table to stdout + attaches it to the Playwright report.
+ *
+ * Skipped by default because benchmark numbers are noisy and we don't want
+ * CI to fail on them. Run locally with:
+ *
+ *   hogli test playwright/e2e/chart-bench.spec.ts
+ *
+ * Or set CHART_BENCH=1 in the environment to opt in.
+ */
+
+type ChartKind = 'hog' | 'chartjs' | 'adapter-hog' | 'adapter-chartjs'
+
+interface BenchResult {
+    chart: ChartKind
+    series: number
+    points: number
+    seed: number
+    runs: number
+    readyMs: number[]
+    hoverMs: number[]
+    meanReadyMs: number
+    meanHoverMs: number
+}
+
+declare global {
+    interface Window {
+        __chartBench?: BenchResult
+    }
+}
+
+const MATRIX: { series: number; points: number }[] = [
+    // Realistic sizes first — these dominate real product usage.
+    { series: 2, points: 30 }, // tiny tile
+    { series: 5, points: 90 }, // typical trend
+    { series: 20, points: 180 }, // 6mo daily breakdown
+    { series: 50, points: 365 }, // 1yr daily breakdown
+    // Stress sizes — upper bound, unlikely in product but useful as a ceiling.
+    { series: 50, points: 2000 },
+]
+
+const CHARTS: ChartKind[] = ['hog', 'chartjs', 'adapter-hog', 'adapter-chartjs']
+const RUNS = 5
+const SEED = 42
+
+const shouldRun = process.env.CHART_BENCH === '1'
+
+// Register tests under `describe` when opted in, `describe.skip` otherwise.
+// `test.skip()` inside the describe body throws at registration time and
+// swallows the for-loop below, which is why we branch on the describe helper.
+const describeBench = shouldRun ? test.describe : test.describe.skip
+
+describeBench('Chart bench', () => {
+    // One test per matrix cell so failures are scoped and the report is readable.
+    for (const cell of MATRIX) {
+        for (const chart of CHARTS) {
+            test(`${chart} — ${cell.series} series × ${cell.points} points`, async ({ page }) => {
+                const url = `/debug/chart-bench?chart=${chart}&series=${cell.series}&points=${cell.points}&runs=${RUNS}&seed=${SEED}`
+                await page.goto(url)
+
+                // Wait for the stage to mount before we click run, so the initial
+                // mount isn't counted in the first measured run.
+                await page.waitForSelector('[data-attr="chart-bench-stage"] canvas')
+
+                await page.click('[data-attr="chart-bench-run"]')
+                // The harness exposes the result on window when the run finishes.
+                await page.waitForFunction(
+                    (expectedRuns) => {
+                        const result = window.__chartBench
+                        return !!result && result.readyMs.length === expectedRuns
+                    },
+                    RUNS,
+                    { timeout: 60_000 }
+                )
+
+                const result = await page.evaluate(() => window.__chartBench)
+                expect(result).toBeTruthy()
+                const r = result!
+
+                // Attach the raw samples so they show up in the Playwright report.
+                await test.info().attach(`${chart}-${cell.series}x${cell.points}.json`, {
+                    body: JSON.stringify(r, null, 2),
+                    contentType: 'application/json',
+                })
+
+                // eslint-disable-next-line no-console
+                console.info(
+                    `[chart-bench] ${chart.padEnd(8)} ${String(cell.series).padStart(3)}s × ${String(cell.points).padStart(4)}p  ` +
+                        `ready=${r.meanReadyMs.toFixed(2)}ms  hover=${r.meanHoverMs.toFixed(2)}ms`
+                )
+            })
+        }
+    }
+})

--- a/playwright/e2e/chart-bench.spec.ts
+++ b/playwright/e2e/chart-bench.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from '@playwright/test'
 
+import type { BenchResult } from '~/scenes/debug/chart-bench/ChartBenchScene'
+
 import { test } from '../utils/playwright-test-base'
 
 /**
@@ -15,25 +17,7 @@ import { test } from '../utils/playwright-test-base'
  * Or set CHART_BENCH=1 in the environment to opt in.
  */
 
-type ChartKind = 'hog' | 'chartjs' | 'adapter-hog' | 'adapter-chartjs'
-
-interface BenchResult {
-    chart: ChartKind
-    series: number
-    points: number
-    seed: number
-    runs: number
-    readyMs: number[]
-    hoverMs: number[]
-    meanReadyMs: number
-    meanHoverMs: number
-}
-
-declare global {
-    interface Window {
-        __chartBench?: BenchResult
-    }
-}
+type ChartKind = BenchResult['chart']
 
 const MATRIX: { series: number; points: number }[] = [
     // Realistic sizes first — these dominate real product usage.

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -48,6 +48,9 @@ import {
 interface TrendsBarChartProps {
     context?: QueryContext<InsightVizNode>
     inSharedMode?: boolean
+    /** Defaults to true. Set false to render bars without the hover tooltip — used by the chart
+     *  benchmark harness to isolate the tooltip's per-mousemove render cost from the engine. */
+    tooltipEnabled?: boolean
 }
 
 const EMPTY_LABELS: string[] = []
@@ -75,7 +78,11 @@ const resolveGroupTypeLabel = (
 
 const handleChartError = makeChartErrorHandler('trends-bar-chart')
 
-export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChartProps): JSX.Element | null {
+export function TrendsBarChart({
+    context,
+    inSharedMode = false,
+    tooltipEnabled = true,
+}: TrendsBarChartProps): JSX.Element | null {
     const theme = useMemo(() => buildTheme(), [])
     const { insightProps, insight } = useValues(insightLogic)
 
@@ -199,7 +206,7 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
                 yAxisLabel: trendsFilter?.yAxisLabel,
                 goalLines,
                 valueLabels: showValuesOnSeries ? { formatter: valueLabelFormatter } : false,
-                tooltip: TIME_SERIES_TOOLTIP_CONFIG,
+                tooltip: { ...TIME_SERIES_TOOLTIP_CONFIG, enabled: tooltipEnabled },
             }),
         [
             trendsFilter,
@@ -215,6 +222,7 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
             goalLines,
             showValuesOnSeries,
             valueLabelFormatter,
+            tooltipEnabled,
         ]
     )
 
@@ -239,7 +247,7 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
         }
         return {
             showGrid: true,
-            tooltip: AGGREGATED_TOOLTIP_CONFIG,
+            tooltip: { ...AGGREGATED_TOOLTIP_CONFIG, enabled: tooltipEnabled },
             yScaleType: yAxisScaleType === 'log10' ? 'log' : 'linear',
             axisOrientation: 'horizontal',
             barLayout: 'stacked',
@@ -255,6 +263,7 @@ export function TrendsBarChart({ context, inSharedMode = false }: TrendsBarChart
         trendsFilter?.yAxisLabel,
         displayLabels,
         labels,
+        tooltipEnabled,
     ])
 
     const canHandleClick = !!context?.onDataPointClick || !!hasPersonsModal


### PR DESCRIPTION
## Problem

Wanted a way to measure rendering cost for the new `lib/hog-charts` line chart against the existing chart.js-based one — both in isolation and in the way they actually ship, with the full `trendsDataLogic` + tooltip stack on top. Without a harness there's no objective signal to gate the hog-charts rollout on.

## Changes

- New `/debug/chart-bench` scene with URL-param controls for chart kind, series count, point count, runs, seed, fill, and grid
- Four modes: raw `lib/hog-charts` `LineChart`, raw chart.js `Chart`, and the two kea-connected adapters (`TrendsLineChartD3`, `ActionsLineGraph`)
- Adapter modes feed data through the full `insightLogic` → `dataNodeLogic` → `trendsDataLogic` tree via `cachedInsight` + `cachedResults`, no HTTP
- Harness measures `ready` (React commit + layout effects + next paint, via `flushSync` + rAF) and `hover` (30-step mousemove sweep) and exposes them on `window.__chartBench`
- Playwright matrix at `playwright/e2e/chart-bench.spec.ts` — 5 sizes × 4 chart kinds, **skipped by default**, opt in with `CHART_BENCH=1`

## How did you test this code?

I'm an agent. I ran the Playwright matrix (`CHART_BENCH=1 pnpm exec playwright test e2e/chart-bench.spec.ts`) locally — all 20 tests pass against the local dev server. I also spot-checked each of the four chart modes in a browser via Playwright MCP, confirmed canvases render at the right size, hover produces the real `TrendsTooltip` in adapter-hog mode, and fill/grid toggles behave correctly.

I did **not** manually click around in a non-benchmark context, and I did not run full `tsc` (OOMs locally). The scene is dev-only (`/debug/chart-bench`) and guarded by the existing debug route pattern.

## Publish to changelog?

<!-- dev-only benchmark scene — probably not -->