### PR TITLE
feat(hog-charts): make Series meta generic for typed adapters

### DIFF
--- a/frontend/src/lib/hog-charts/__tests__/interaction.test.ts
+++ b/frontend/src/lib/hog-charts/__tests__/interaction.test.ts
@@ -1,8 +1,8 @@
 import { buildPointClickData, buildTooltipContext, findNearestIndex, isInPlotArea } from '../core/interaction'
-import type { ResolveValueFn, Series } from '../core/types'
+import type { ResolveValueFn } from '../core/types'
 import { dimensions, makeSeries } from '../test-helpers'
 
-const defaultResolveValue: ResolveValueFn = (s: Series, i: number): number => s.data[i]
+const defaultResolveValue: ResolveValueFn = (s, i) => s.data[i]
 
 const fakeCanvasBounds = {
     x: 0,
@@ -226,7 +226,7 @@ describe('hog-charts interaction', () => {
         it('uses the resolveValue function for both value and crossSeriesData', () => {
             const s1 = makeSeries({ key: 's1', data: [0] })
             const s2 = makeSeries({ key: 's2', data: [0] })
-            const customResolve: ResolveValueFn = (s: Series): number => (s.key === 's1' ? 111 : 222)
+            const customResolve: ResolveValueFn = (s) => (s.key === 's1' ? 111 : 222)
             const result = buildPointClickData(0, [s1, s2], ['a'], customResolve)
             expect(result?.value).toBe(111)
             expect(result?.crossSeriesData[0].value).toBe(111)

--- a/frontend/src/lib/hog-charts/charts/LineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart.tsx
@@ -17,18 +17,18 @@ import type {
     TooltipContext,
 } from '../core/types'
 
-export interface LineChartProps {
-    series: Series[]
+export interface LineChartProps<Meta = unknown> {
+    series: Series<Meta>[]
     labels: string[]
     config?: LineChartConfig
     theme: ChartTheme
-    tooltip?: (ctx: TooltipContext) => React.ReactNode
-    onPointClick?: (data: PointClickData) => void
+    tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
+    onPointClick?: (data: PointClickData<Meta>) => void
     className?: string
     children?: React.ReactNode
 }
 
-export function LineChart({
+export function LineChart<Meta = unknown>({
     series,
     labels,
     config,
@@ -37,7 +37,7 @@ export function LineChart({
     onPointClick,
     className,
     children,
-}: LineChartProps): React.ReactElement {
+}: LineChartProps<Meta>): React.ReactElement {
     const { yScaleType = 'linear', percentStackView = false, showGrid = false, goalLines } = config ?? {}
 
     const hasAreaFill = useMemo(() => series.some((s) => s.fillArea), [series])

--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -37,15 +37,15 @@ function OverlayLayer({ children }: { children: React.ReactNode }): React.ReactE
     return <div style={OVERLAY_STYLE}>{children}</div>
 }
 
-export interface ChartProps {
-    series: Series[]
+export interface ChartProps<Meta = unknown> {
+    series: Series<Meta>[]
     labels: string[]
     config?: ChartConfig
     theme: ChartTheme
     createScales: CreateScalesFn
     draw: (args: ChartDrawArgs) => void
-    tooltip?: (ctx: TooltipContext) => React.ReactNode
-    onPointClick?: (data: PointClickData) => void
+    tooltip?: (ctx: TooltipContext<Meta>) => React.ReactNode
+    onPointClick?: (data: PointClickData<Meta>) => void
     className?: string
     children?: React.ReactNode
     /** Resolves the y-value for a series at a given index. Defaults to series.data[index]. */
@@ -54,7 +54,7 @@ export interface ChartProps {
 
 export const DEFAULT_MARGINS: ChartMargins = { top: 16, right: 16, bottom: 32, left: 48 }
 
-export function Chart({
+export function Chart<Meta = unknown>({
     series,
     labels,
     config,
@@ -66,7 +66,7 @@ export function Chart({
     className,
     children,
     resolveValue,
-}: ChartProps): React.ReactElement {
+}: ChartProps<Meta>): React.ReactElement {
     const {
         xTickFormatter,
         yTickFormatter,
@@ -116,7 +116,7 @@ export function Chart({
         return (v: number) => autoFormatYTick(v, domainMax)
     }, [yTickFormatter, scales])
 
-    const { hoverIndex, tooltipCtx, handlers } = useChartInteraction({
+    const { hoverIndex, tooltipCtx, handlers } = useChartInteraction<Meta>({
         scales,
         dimensions,
         labels,

--- a/frontend/src/lib/hog-charts/core/chart-context.ts
+++ b/frontend/src/lib/hog-charts/core/chart-context.ts
@@ -2,23 +2,23 @@ import { createContext, useContext } from 'react'
 
 import type { ChartDimensions, ChartScales, Series } from './types'
 
-export interface BaseChartContext {
+export interface BaseChartContext<Meta = unknown> {
     dimensions: ChartDimensions
     labels: string[]
-    series: Series[]
+    series: Series<Meta>[]
     scales: ChartScales
     hoverIndex: number
 }
 
 const ChartContext = createContext<BaseChartContext | null>(null)
 
-export function useChart<T extends BaseChartContext = BaseChartContext>(): T {
+export function useChart<Meta = unknown>(): BaseChartContext<Meta> {
     const ctx = useContext(ChartContext)
 
     if (!ctx) {
         throw new Error('useChart must be used inside a chart component (e.g. <LineChart>)')
     }
-    return ctx as T
+    return ctx as BaseChartContext<Meta>
 }
 
 export { ChartContext }

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
@@ -5,22 +5,22 @@ import type { ChartDimensions, ChartScales, PointClickData, ResolveValueFn, Seri
 
 const defaultResolveValue: ResolveValueFn = (series, dataIndex) => series.data[dataIndex] ?? 0
 
-interface UseChartInteractionOptions {
+interface UseChartInteractionOptions<Meta> {
     scales: ChartScales | null
     dimensions: ChartDimensions | null
     labels: string[]
-    series: Series[]
+    series: Series<Meta>[]
     canvasRef: React.RefObject<HTMLCanvasElement>
     wrapperRef: React.RefObject<HTMLDivElement>
     showTooltip: boolean
     pinnable: boolean
-    onPointClick?: (data: PointClickData) => void
+    onPointClick?: (data: PointClickData<Meta>) => void
     resolveValue?: ResolveValueFn
 }
 
-interface UseChartInteractionResult {
+interface UseChartInteractionResult<Meta> {
     hoverIndex: number
-    tooltipCtx: TooltipContext | null
+    tooltipCtx: TooltipContext<Meta> | null
     handlers: {
         onMouseMove: (e: React.MouseEvent<HTMLDivElement>) => void
         onMouseLeave: () => void
@@ -28,7 +28,7 @@ interface UseChartInteractionResult {
     }
 }
 
-export function useChartInteraction({
+export function useChartInteraction<Meta = unknown>({
     scales,
     dimensions,
     labels,
@@ -39,9 +39,9 @@ export function useChartInteraction({
     pinnable,
     onPointClick,
     resolveValue = defaultResolveValue,
-}: UseChartInteractionOptions): UseChartInteractionResult {
+}: UseChartInteractionOptions<Meta>): UseChartInteractionResult<Meta> {
     const [hoverIndex, setHoverIndex] = useState<number>(-1)
-    const [tooltipCtx, setTooltipCtx] = useState<TooltipContext | null>(null)
+    const [tooltipCtx, setTooltipCtx] = useState<TooltipContext<Meta> | null>(null)
     const hoverIndexRef = useRef<number>(hoverIndex)
     hoverIndexRef.current = hoverIndex
 

--- a/frontend/src/lib/hog-charts/core/interaction.ts
+++ b/frontend/src/lib/hog-charts/core/interaction.ts
@@ -37,15 +37,15 @@ export function isInPlotArea(mouseX: number, mouseY: number, dimensions: ChartDi
     )
 }
 
-export function buildTooltipContext(
+export function buildTooltipContext<Meta = unknown>(
     dataIndex: number,
-    series: Series[],
+    series: Series<Meta>[],
     labels: string[],
     xScale: (label: string) => number | undefined,
     yScale: (value: number) => number,
     canvasBounds: DOMRect,
     resolveValue: ResolveValueFn
-): TooltipContext | null {
+): TooltipContext<Meta> | null {
     if (dataIndex < 0 || dataIndex >= labels.length) {
         return null
     }
@@ -56,7 +56,7 @@ export function buildTooltipContext(
         return null
     }
 
-    const seriesData: TooltipContext['seriesData'] = []
+    const seriesData: TooltipContext<Meta>['seriesData'] = []
     const yPixels: number[] = []
     for (const s of series) {
         if (s.hidden) {
@@ -82,12 +82,12 @@ export function buildTooltipContext(
     }
 }
 
-export function buildPointClickData(
+export function buildPointClickData<Meta = unknown>(
     dataIndex: number,
-    series: Series[],
+    series: Series<Meta>[],
     labels: string[],
     resolveValue: ResolveValueFn
-): PointClickData | null {
+): PointClickData<Meta> | null {
     if (dataIndex < 0 || dataIndex >= labels.length) {
         return null
     }

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -1,7 +1,7 @@
 import type { AxisFormat, ChartTheme } from 'lib/charts/types'
 export type { AxisFormat, ChartTheme }
 
-export interface Series {
+export interface Series<Meta = unknown> {
     /** Unique identifier used to key React elements and look up stacked data. */
     key: string
     /** Human-readable name shown in tooltips and legends. */
@@ -22,8 +22,10 @@ export interface Series {
     pointRadius?: number
     /** Arbitrary consumer data attached to this series. Flows through to TooltipContext
      *  so custom tooltip components can access domain-specific information (e.g. breakdown
-     *  values, comparison labels, anomaly scores) without the library needing to know about them. */
-    meta?: Record<string, unknown>
+     *  values, comparison labels, anomaly scores) without the library needing to know about them.
+     *  Defaults to `unknown` so the library is meta-agnostic internally; adapters narrow it
+     *  via `Series<MyMeta>` to get typed reads in their tooltip/click handlers. */
+    meta?: Meta
 }
 
 /** A horizontal reference line drawn across the chart at a fixed y-value. */
@@ -39,29 +41,29 @@ export interface GoalLine {
 }
 
 /** Data passed to the `onPointClick` callback when a user clicks a data point. */
-export interface PointClickData {
+export interface PointClickData<Meta = unknown> {
     /** Index of the clicked series within the original series array. */
     seriesIndex: number
     /** Index along the x-axis (into the labels array) that was clicked. */
     dataIndex: number
     /** The series that was clicked. */
-    series: Series
+    series: Series<Meta>
     /** The y-value at the clicked point. */
     value: number
     /** The x-axis label at the clicked point. */
     label: string
     /** Values from all visible series at this x-axis index, for cross-series comparisons. */
-    crossSeriesData: { series: Series; value: number }[]
+    crossSeriesData: { series: Series<Meta>; value: number }[]
 }
 
 /** Context object passed to the `renderTooltip` render prop and tooltip event callbacks. */
-export interface TooltipContext {
+export interface TooltipContext<Meta = unknown> {
     /** Index along the x-axis that the tooltip represents. */
     dataIndex: number
     /** The x-axis label at this index. */
     label: string
     /** One entry per visible series with its value and color at this index. */
-    seriesData: { series: Series; value: number; color: string }[]
+    seriesData: { series: Series<Meta>; value: number; color: string }[]
     /** Pixel position (relative to the chart container) for anchoring the tooltip. */
     position: { x: number; y: number }
     /** Bounding rect of the canvas element, useful for portal-based tooltip positioning. */

--- a/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
+++ b/frontend/src/lib/hog-charts/overlays/Tooltip.tsx
@@ -3,12 +3,12 @@ import React, { useLayoutEffect, useMemo } from 'react'
 
 import type { TooltipContext } from '../core/types'
 
-interface TooltipProps {
-    context: TooltipContext
-    renderTooltip: (ctx: TooltipContext) => React.ReactNode
+interface TooltipProps<Meta> {
+    context: TooltipContext<Meta>
+    renderTooltip: (ctx: TooltipContext<Meta>) => React.ReactNode
 }
 
-export function Tooltip({ context, renderTooltip }: TooltipProps): React.ReactElement {
+export function Tooltip<Meta = unknown>({ context, renderTooltip }: TooltipProps<Meta>): React.ReactElement {
     const virtualReference = useMemo<VirtualElement>(
         () => ({
             getBoundingClientRect() {

--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
@@ -7,18 +7,28 @@ import { LineChart } from 'lib/hog-charts'
 import type { LineChartConfig, Series } from 'lib/hog-charts'
 import type { TooltipContext } from 'lib/hog-charts/core/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { groupsModel } from '~/models/groupsModel'
 import { GoalLine as SchemaGoalLine, InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
-import { ChartDisplayType } from '~/types'
+import { ActionFilter, ChartDisplayType } from '~/types'
 
 import { InsightEmptyState } from '../../insights/EmptyStates'
 import { trendsDataLogic } from '../trendsDataLogic'
 import type { IndexedTrendResult } from '../types'
 import { TrendsTooltip } from './TrendsTooltip'
+
+export type TrendsSeriesMeta = {
+    action?: ActionFilter
+    breakdown_value?: string | number | string[]
+    compare_label?: SeriesDatum['compare_label']
+    days?: string[]
+    order?: number
+    filter?: SeriesDatum['filter']
+}
 
 interface TrendsLineChartD3Props {
     context?: QueryContext<InsightVizNode>
@@ -65,7 +75,7 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
         indexedResults[0]?.data &&
         indexedResults.filter((result: IndexedTrendResult) => result.count !== 0).length > 0
 
-    const hogSeries: Series[] = useMemo(
+    const hogSeries: Series<TrendsSeriesMeta>[] = useMemo(
         () =>
             (indexedResults ?? [])
                 .filter((r: IndexedTrendResult) => r.count !== 0)
@@ -111,7 +121,7 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
 
     const formatCompareLabel = context?.formatCompareLabel
     const renderTooltip = useCallback(
-        (ctx: TooltipContext) => (
+        (ctx: TooltipContext<TrendsSeriesMeta>) => (
             <TrendsTooltip
                 context={ctx}
                 timezone={timezone}

--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
@@ -7,28 +7,19 @@ import { LineChart } from 'lib/hog-charts'
 import type { LineChartConfig, Series } from 'lib/hog-charts'
 import type { TooltipContext } from 'lib/hog-charts/core/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { groupsModel } from '~/models/groupsModel'
 import { GoalLine as SchemaGoalLine, InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
-import { ActionFilter, ChartDisplayType } from '~/types'
+import { ChartDisplayType } from '~/types'
 
 import { InsightEmptyState } from '../../insights/EmptyStates'
 import { trendsDataLogic } from '../trendsDataLogic'
 import type { IndexedTrendResult } from '../types'
+import type { TrendsSeriesMeta } from './trendsSeriesMeta'
 import { TrendsTooltip } from './TrendsTooltip'
-
-export type TrendsSeriesMeta = {
-    action?: ActionFilter
-    breakdown_value?: string | number | string[]
-    compare_label?: SeriesDatum['compare_label']
-    days?: string[]
-    order?: number
-    filter?: SeriesDatum['filter']
-}
 
 interface TrendsLineChartD3Props {
     context?: QueryContext<InsightVizNode>

--- a/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
@@ -5,39 +5,12 @@ import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
 import { getDatumTitle, SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 
 import { BreakdownFilter, CurrencyCode, DateRange, TrendsFilter } from '~/queries/schema/schema-general'
-import { ActionFilter, IntervalType } from '~/types'
+import { IntervalType } from '~/types'
 
-interface TrendsSeriesMeta {
-    action?: ActionFilter
-    breakdown_value?: string | number | string[]
-    compare_label?: SeriesDatum['compare_label']
-    days?: string[]
-    order?: number
-    filter?: SeriesDatum['filter']
-}
-
-function extractMeta(raw: Record<string, unknown> | undefined): TrendsSeriesMeta {
-    if (!raw) {
-        return {}
-    }
-    const action = typeof raw.action === 'object' && raw.action !== null ? (raw.action as ActionFilter) : undefined
-    const breakdown_value =
-        typeof raw.breakdown_value === 'string' ||
-        typeof raw.breakdown_value === 'number' ||
-        Array.isArray(raw.breakdown_value)
-            ? (raw.breakdown_value as string | number | string[])
-            : undefined
-    const compare_label =
-        typeof raw.compare_label === 'string' ? (raw.compare_label as SeriesDatum['compare_label']) : undefined
-    const days = Array.isArray(raw.days) ? (raw.days as string[]) : undefined
-    const order = typeof raw.order === 'number' ? raw.order : undefined
-    const filter =
-        typeof raw.filter === 'object' && raw.filter !== null ? (raw.filter as SeriesDatum['filter']) : undefined
-    return { action, breakdown_value, compare_label, days, order, filter }
-}
+import type { TrendsSeriesMeta } from './TrendsLineChartD3'
 
 interface TrendsTooltipProps {
-    context: TooltipContext
+    context: TooltipContext<TrendsSeriesMeta>
     timezone?: string
     interval?: IntervalType
     breakdownFilter?: BreakdownFilter
@@ -72,7 +45,7 @@ export function TrendsTooltip({
     // are, the bridge (or TrendsLineChartD3) will need to mark them as non-tooltip rows — legacy
     // Chart.js path used a `hideTooltip: true` flag on the dataset for this.
     const seriesData: SeriesDatum[] = context.seriesData.map((entry, idx) => {
-        const meta = extractMeta(entry.series.meta)
+        const meta = entry.series.meta ?? {}
         return {
             id: idx,
             dataIndex: context.dataIndex,
@@ -89,8 +62,7 @@ export function TrendsTooltip({
         }
     })
 
-    const firstMeta = extractMeta(context.seriesData[0]?.series.meta)
-    const date = firstMeta.days?.[context.dataIndex]
+    const date = context.seriesData[0]?.series.meta?.days?.[context.dataIndex]
 
     const renderCount = (value: number): string => {
         if (showPercentView) {

--- a/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsTooltip.tsx
@@ -7,7 +7,7 @@ import { getDatumTitle, SeriesDatum } from 'scenes/insights/InsightTooltip/insig
 import { BreakdownFilter, CurrencyCode, DateRange, TrendsFilter } from '~/queries/schema/schema-general'
 import { IntervalType } from '~/types'
 
-import type { TrendsSeriesMeta } from './TrendsLineChartD3'
+import type { TrendsSeriesMeta } from './trendsSeriesMeta'
 
 interface TrendsTooltipProps {
     context: TooltipContext<TrendsSeriesMeta>

--- a/frontend/src/scenes/trends/viz/trendsSeriesMeta.ts
+++ b/frontend/src/scenes/trends/viz/trendsSeriesMeta.ts
@@ -1,0 +1,12 @@
+import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
+
+import type { ActionFilter } from '~/types'
+
+export type TrendsSeriesMeta = {
+    action?: ActionFilter
+    breakdown_value?: string | number | string[]
+    compare_label?: SeriesDatum['compare_label']
+    days?: string[]
+    order?: number
+    filter?: SeriesDatum['filter']
+}


### PR DESCRIPTION
## Problem

The hog-charts library typed `Series.meta` as `Record<string, unknown>`, which forced adapters like the Trends line chart to do defensive runtime unpacking (`extractMeta`) with per-field `typeof` checks just to read their own data. The library internals don't need to know the meta shape, but consumers do.

## Changes

- Made `Series`, `TooltipContext`, `PointClickData`, `BaseChartContext`, `Chart`, `LineChart`, `Tooltip`, and `useChartInteraction` generic over a `Meta` type parameter (defaults to `unknown`).
- `buildTooltipContext` / `buildPointClickData` thread `Meta` through as well.
- `TrendsLineChartD3` now exports `TrendsSeriesMeta` and types its series as `Series<TrendsSeriesMeta>`.
- `TrendsTooltip` reads `entry.series.meta` directly — dropped the `extractMeta` runtime guard.

## How did you test this code?

I'm an agent. I did not test this manually.

- Ran the existing `frontend/src/lib/hog-charts/__tests__/interaction.test.ts` locally (updated call sites so the inferred generics match).
- Did not run full `tsc` or the dev server.

## Publish to changelog?

<!-- For features only -->

## 🤖 LLM context

Authored by Claude Code (Opus 4.6) in a pairing session focused on reducing runtime type erosion at the hog-charts / Trends adapter boundary. No schema or backend changes.