### PR TITLE
feat(hog-charts): add Series.hideFromTooltip flag

### DIFF
--- a/frontend/src/lib/hog-charts/README.md
+++ b/frontend/src/lib/hog-charts/README.md
@@ -65,3 +65,12 @@ dimensions, and hover state.
 
 For custom tooltip content, pass a component to the `tooltip` prop. It receives
 `TooltipContext` as props. Omit to use the built-in `DefaultTooltip`.
+
+### Series visibility flags
+
+- `hidden`: fully excludes the series — no rendering, no scale contribution, no
+  tooltip row, no hit-testing.
+- `hideFromTooltip`: the series still renders and participates in scales and
+  hit-testing, but is omitted from `TooltipContext.seriesData` so it doesn't
+  appear as a tooltip row. Useful for background/reference series that
+  shouldn't clutter the tooltip.

--- a/frontend/src/lib/hog-charts/__tests__/interaction.test.ts
+++ b/frontend/src/lib/hog-charts/__tests__/interaction.test.ts
@@ -148,6 +148,26 @@ describe('hog-charts interaction', () => {
             expect(result?.seriesData[0].series.key).toBe('v')
         })
 
+        it('excludes hideFromTooltip series from seriesData but still uses their values for position.y', () => {
+            const shown = makeSeries({ key: 'shown', data: [10] })
+            const hiddenFromTooltip = makeSeries({ key: 'hft', data: [50], hideFromTooltip: true })
+            const alsoShown = makeSeries({ key: 'also', data: [20] })
+            // yScale: 10 -> 80, 20 -> 60, 50 -> 5. position.y is min(yPixels)
+            // — if the hideFromTooltip series contributes, result is 5; otherwise 60.
+            const yScale = (v: number): number => ({ 10: 80, 20: 60, 50: 5 })[v] ?? 0
+            const result = buildTooltipContext(
+                0,
+                [shown, hiddenFromTooltip, alsoShown],
+                ['a'],
+                xConst,
+                yScale,
+                fakeCanvasBounds,
+                defaultResolveValue
+            )
+            expect(result?.seriesData.map((d) => d.series.key)).toEqual(['shown', 'also'])
+            expect(result?.position.y).toBe(5)
+        })
+
         it('includes correct pixel position from xScale and minimum yScale output', () => {
             const s1 = makeSeries({ key: 's1', data: [10] })
             const s2 = makeSeries({ key: 's2', data: [50] })

--- a/frontend/src/lib/hog-charts/core/interaction.ts
+++ b/frontend/src/lib/hog-charts/core/interaction.ts
@@ -63,7 +63,9 @@ export function buildTooltipContext(
             continue
         }
         const value = resolveValue(s, dataIndex)
-        seriesData.push({ series: s, value, color: s.color })
+        if (!s.hideFromTooltip) {
+            seriesData.push({ series: s, value, color: s.color })
+        }
         const yVal = yScale(value)
         if (isFinite(yVal)) {
             yPixels.push(yVal)

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -18,6 +18,9 @@ export interface Series {
     dashPattern?: number[]
     /** When true, the series is excluded from rendering, scales, and tooltips. */
     hidden?: boolean
+    /** When true, the series still renders and participates in scales and hit-testing,
+     *  but is omitted from the tooltip's seriesData so it doesn't appear as a row. */
+    hideFromTooltip?: boolean
     /** Radius in px for data point dots. Set to 0 or omit to hide dots. */
     pointRadius?: number
     /** Arbitrary consumer data attached to this series. Flows through to TooltipContext


### PR DESCRIPTION
## Problem

We want to support things like goal lines that render on the chart but shouldn't show up as rows in the tooltip. `Series.hidden` is too blunt — it also removes the series from rendering and scales.

## Changes

- Add optional `Series.hideFromTooltip` flag in `frontend/src/lib/hog-charts/core/types.ts`
- `buildTooltipContext` skips flagged series when building `seriesData`, but still folds their resolved y-values into `position.y`
- Default behavior (flag undefined/false) is unchanged — no adapter changes
- Documented the flag in `hog-charts/README.md` alongside `hidden`

## How did you test this code?

I'm an agent — no manual testing. Ran the jest suite for the changed file:

- `frontend/src/lib/hog-charts/__tests__/interaction.test.ts` — 31 tests pass, including a new case that mixes a normal series, a `hideFromTooltip: true` series, and another normal series and asserts (a) the flagged series is absent from `seriesData` and (b) its y-value still contributes to `position.y`.

## Publish to changelog?

## 🤖 LLM context

Authored by Claude (claude-opus-4-6, 1M context). Scope was intentionally narrow: pure library addition, no adapter or styling changes.