### PR TITLE
fix(llma): add tooltips to generations input/output columns

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -290,6 +290,22 @@ function LLMAnalyticsGenerations(): JSX.Element {
                             )
                         },
                     },
+                    'properties.$ai_input[-1]': {
+                        ...llmAnalyticsColumnRenderers['properties.$ai_input[-1]'],
+                        renderTitle: () => (
+                            <Tooltip title="The last message in the input array sent to the LLM for this generation.">
+                                <span>Input</span>
+                            </Tooltip>
+                        ),
+                    },
+                    'properties.$ai_output_choices': {
+                        ...llmAnalyticsColumnRenderers['properties.$ai_output_choices'],
+                        renderTitle: () => (
+                            <Tooltip title="The LLM's response for this generation.">
+                                <span>Output</span>
+                            </Tooltip>
+                        ),
+                    },
                     person: llmAnalyticsColumnRenderers.person,
                     "'' -- Sentiment": llmAnalyticsColumnRenderers["'' -- Sentiment"],
                     'properties.$ai_tools_called': llmAnalyticsColumnRenderers['properties.$ai_tools_called'],


### PR DESCRIPTION
## Problem

On the LLM analytics generations tab, the Input and Output column headers were rendering as `$ai_input[-1]` and `AI output (LLM)` — the raw property keys / taxonomy labels. This happens because `renderColumnMeta.tsx` only looks up column titles in `context.columns`, not in `productColumnRenderers`, so the `title: 'Input'` / `title: 'Output'` defined in `llmAnalyticsColumnRenderers.tsx` are never read, and the columns fall through to `PropertyKeyInfo`.

The headers should be clean and self-explanatory, and users should have a way to understand what each column actually contains.

## Changes

Override `renderTitle` for `properties.$ai_input[-1]` and `properties.$ai_output_choices` in the generations tab's `context.columns` in `LLMAnalyticsScene.tsx`, matching the existing pattern used by the Cost column. Each header is now simply "Input" / "Output", wrapped in a `Tooltip` explaining what the column contains.

The cell `render` from `llmAnalyticsColumnRenderers` is preserved by spreading the existing entry, so the `AIInputCell` / `AIOutputCell` components still render the cells.

## How did you test this code?

I'm an agent and have not run this manually in the browser. The change mirrors the exact `renderTitle` pattern already used by the adjacent Cost / Latency / Model columns in the same file, and `Tooltip` + `llmAnalyticsColumnRenderers` were already imported. I was unable to run `pnpm typescript:check` to completion in this environment (Node ran out of heap before finishing), so a reviewer should sanity-check the generations tab in a local dev build.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Code. The fix was identified by tracing how `renderColumnMeta.tsx` resolves column titles: it checks `context.columns` first and falls back to `PropertyKeyInfo` for `properties.*` keys, never consulting `productColumnRenderers`. Because `$ai_input[-1]` has no taxonomy entry (the `[-1]` suffix breaks the lookup), it was rendered as the raw string; `$ai_output_choices` does have a taxonomy label ("AI output (LLM)") which is why it rendered differently. Adding the override in the scene context is consistent with how Cost/Latency/Model are already handled, so it's a minimal, localized fix.