### PR TITLE
fix(dags): avoid FK lookup in load_pending_deletions

### DIFF
--- a/posthog/dags/deletes.py
+++ b/posthog/dags/deletes.py
@@ -434,7 +434,7 @@ def load_pending_deletions(
                         "group_type_index": deletion.group_type_index,
                         "created_at": deletion.created_at,
                         "delete_verified_at": deletion.delete_verified_at,
-                        "created_by_id": str(deletion.created_by.id) if deletion.created_by else None,
+                        "created_by_id": str(deletion.created_by_id) if deletion.created_by_id else None,
                         "team_id": deletion.team_id,
                     }
                     for deletion in chunk


### PR DESCRIPTION
## Problem

`load_pending_deletions` in `deletes_job` crashes with `User.DoesNotExist` while building parameter dicts for the ClickHouse staging insert, aborting the run and skipping all downstream deletion steps.

```
File "posthog/dags/deletes.py", line 437, in load_pending_deletions
    "created_by_id": str(deletion.created_by.id) if deletion.created_by else None,
File ".../django/db/models/fields/related_descriptors.py", line 199, in get_object
    return qs.get(self.field.get_reverse_related_filter(instance))
posthog.models.user.User.DoesNotExist: User matching query does not exist.
```

Accessing `deletion.created_by` triggers Django's `ForwardManyToOneDescriptor`, which issues a lazy `User.objects.get(...)` query. That query returned zero rows and raised, even though the `AsyncDeletion` row referencing the user was successfully loaded by the outer iterator.

## Changes

Replace `deletion.created_by.id` with `deletion.created_by_id` — the raw FK column already loaded with the `AsyncDeletion` row. No lazy lookup, no second query, no way to raise `DoesNotExist`.

The downstream ClickHouse column (`pending_deletes_*.created_by_id`) is `Nullable(String)` and is audit metadata only — never joined, filtered, or otherwise read by the deletion logic. Both the old and new code emit either a stringified id or `None`, so the value written to CH is unchanged on every healthy row.

This is the only `.created_by` access in `posthog/dags/deletes.py`.

## How did you test this code?

Agent-authored. The fix rests on a deductive argument, not an empirical reproduction:

- `deletion.created_by_id` is Django's raw FK column attribute on a loaded model instance. It issues no SQL by design and cannot raise `DoesNotExist`. This is core Django behavior, not environment-specific.
- The old line is the only SQL-issuing code path for FK resolution in this op, and the stack trace points at it directly.
- The new line strictly removes a query relative to the old line — it cannot introduce a failure mode the old line was not already exposed to.
- The CH column's semantics (`Nullable(String)` holding an id or NULL) are preserved exactly.

I did not reproduce the original failure, did not identify a definitive root cause for why the lazy lookup returned zero rows, and did not run the job end-to-end before submitting. The definitive validation is the first post-merge run: if `load_pending_deletions` walks past the point it failed and downstream steps execute, the fix is confirmed.

## Publish to changelog?

No.

## Docs update

No docs update needed.

## 🤖 LLM context

Co-authored with Claude (Opus 4.6). Reviewed the failing stack, walked `posthog/dags/deletes.py` and `posthog/models/async_deletion/async_deletion.py`, investigated candidate root causes (orphaned FKs, cascade races, routing, visibility) without identifying a definitive trigger, and settled on removing the vulnerable lazy-lookup path as the minimal and provably correct fix.
