### PR TITLE
fix(llma): use UTC timezone in trace messages lazy loader query

### DIFF
--- a/products/llm_analytics/frontend/traceMessagesLazyLoaderLogic.ts
+++ b/products/llm_analytics/frontend/traceMessagesLazyLoaderLogic.ts
@@ -224,8 +224,8 @@ export const traceMessagesLazyLoaderLogic = kea<traceMessagesLazyLoaderLogicType
                                         ) AS last_output_fallback
                                     FROM events
                                     WHERE event IN ('$ai_trace', '$ai_generation')
-                                      AND timestamp >= toDateTime('${fromStr}')
-                                      AND timestamp <= toDateTime('${toStr}')
+                                      AND timestamp >= toDateTime('${fromStr}', 'UTC')
+                                      AND timestamp <= toDateTime('${toStr}', 'UTC')
                                       AND properties.$ai_trace_id IN (${idList})
                                     GROUP BY trace_id
                                 `,


### PR DESCRIPTION
## Problem

The trace list's Input Message and Output Message columns always show dashes instead of message content. Introduced in #54157.

The `traceMessagesLazyLoaderLogic` builds a time-window scan using `formatHogqlDateTime` which outputs UTC datetimes (via `Date.toISOString()`), but the HogQL `toDateTime('...')` call interprets bare datetime strings in the team's timezone. For a team in PDT (UTC-7), this shifts the scan window 7 hours into the future, causing the query to match zero events.

## Changes

Pass `'UTC'` as the second argument to `toDateTime()` so the time window is interpreted correctly regardless of team timezone.

## How did you test this code?

- Verified the broken query returns 0 rows using the PostHog MCP `execute-sql` tool
- Verified the fixed query (with `toDateTime('...', 'UTC')`) returns the expected trace message data
- TypeScript check passes

## Publish to changelog?

No