### PR TITLE
fix(insights): refactor insight type switch + restore filters

### DIFF
--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -737,6 +737,92 @@ describe('insightNavLogic', () => {
                 })
             })
 
+            it('preserves interval through round-trip via type with no interval support', async () => {
+                const trendsWithInterval: InsightVizNode = {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.EventsNode,
+                                name: '$pageview',
+                                event: '$pageview',
+                            },
+                        ],
+                        version: 2,
+                        interval: 'week',
+                    },
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(trendsWithInterval)
+                })
+
+                // Paths has no interval capability
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.PATHS)
+                }).toFinishAllListeners()
+
+                expect(builtInsightDataLogic.values.query).toMatchObject({
+                    source: expect.not.objectContaining({ interval: expect.anything() }),
+                })
+
+                // Switch back — interval should be restored
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.TRENDS)
+                }).toFinishAllListeners()
+
+                expect(builtInsightDataLogic.values.query).toMatchObject({
+                    source: expect.objectContaining({
+                        kind: 'TrendsQuery',
+                        interval: 'week',
+                    }),
+                })
+            })
+
+            it('filters breakdowns to person/event types when switching to retention', async () => {
+                const trendsWithGroupBreakdown: InsightVizNode = {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.EventsNode,
+                                name: '$pageview',
+                                event: '$pageview',
+                            },
+                        ],
+                        version: 2,
+                        breakdownFilter: {
+                            breakdowns: [
+                                { property: '$browser', type: 'event' },
+                                { property: 'company', type: 'group', group_type_index: 0 },
+                                { property: 'email', type: 'person' },
+                            ],
+                        },
+                    },
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(trendsWithGroupBreakdown)
+                })
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.RETENTION)
+                }).toFinishAllListeners()
+
+                const retentionQuery = (builtInsightDataLogic.values.query as InsightVizNode).source
+                expect(retentionQuery).toMatchObject({
+                    kind: 'RetentionQuery',
+                    breakdownFilter: {
+                        breakdowns: [
+                            { property: '$browser', type: 'event' },
+                            { property: 'email', type: 'person' },
+                        ],
+                    },
+                })
+            })
+
             it('keeps display when switching from trends to stickiness', async () => {
                 const trendsQueryForStickiness: InsightVizNode = {
                     kind: NodeKind.InsightVizNode,

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -649,6 +649,90 @@ describe('insightNavLogic', () => {
                 ])
             })
 
+            it('restores original breakdowns on round-trip even after edits on intermediate type', async () => {
+                const trendsWithMultipleBreakdowns: InsightVizNode = {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [{ kind: NodeKind.EventsNode, name: '$pageview', event: '$pageview' }],
+                        version: 2,
+                        breakdownFilter: {
+                            breakdowns: [
+                                { property: '$browser', type: 'event' },
+                                { property: '$os', type: 'event' },
+                            ],
+                        },
+                    },
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(trendsWithMultipleBreakdowns)
+                })
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.FUNNELS)
+                }).toFinishAllListeners()
+
+                // User edits the single-breakdown while on Funnels
+                const currentFunnel = (builtInsightDataLogic.values.query as InsightVizNode).source as FunnelsQuery
+                await expectLogic(builtInsightDataLogic, () => {
+                    builtInsightDataLogic.actions.setQuery({
+                        kind: NodeKind.InsightVizNode,
+                        source: {
+                            ...currentFunnel,
+                            breakdownFilter: { ...currentFunnel.breakdownFilter, breakdown: '$device_type' },
+                        },
+                    } as InsightVizNode)
+                }).toFinishAllListeners()
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.TRENDS)
+                }).toFinishAllListeners()
+
+                // Original multi-breakdown wins over the edit made on Funnels
+                const trendsQuery = (builtInsightDataLogic.values.query as InsightVizNode).source as TrendsQuery
+                expect(trendsQuery.breakdownFilter?.breakdowns).toEqual([
+                    { property: '$browser', type: 'event' },
+                    { property: '$os', type: 'event' },
+                ])
+            })
+
+            it('restores minute interval on round-trip even after edits on intermediate type', async () => {
+                const trendsWithMinute: InsightVizNode = {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [{ kind: NodeKind.EventsNode, name: '$pageview', event: '$pageview' }],
+                        interval: 'minute',
+                        version: 2,
+                    },
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(trendsWithMinute)
+                })
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.FUNNELS)
+                }).toFinishAllListeners()
+
+                // User edits interval while on Funnels
+                const currentFunnel = (builtInsightDataLogic.values.query as InsightVizNode).source as FunnelsQuery
+                await expectLogic(builtInsightDataLogic, () => {
+                    builtInsightDataLogic.actions.setQuery({
+                        kind: NodeKind.InsightVizNode,
+                        source: { ...currentFunnel, interval: 'day' },
+                    } as InsightVizNode)
+                }).toFinishAllListeners()
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.TRENDS)
+                }).toFinishAllListeners()
+
+                const trendsQuery = (builtInsightDataLogic.values.query as InsightVizNode).source as TrendsQuery
+                expect(trendsQuery.interval).toBe('minute')
+            })
+
             it('preserves breakdownFilter through round-trip via unsupported type', async () => {
                 const trendsWithBreakdown: InsightVizNode = {
                     kind: NodeKind.InsightVizNode,

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -696,6 +696,56 @@ describe('insightNavLogic', () => {
                 })
             })
 
+            it('truncates multi-breakdowns on multi-hop transition through unsupported type back to funnels', async () => {
+                const trendsWithMultipleBreakdowns: InsightVizNode = {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.EventsNode,
+                                name: '$pageview',
+                                event: '$pageview',
+                            },
+                        ],
+                        version: 2,
+                        breakdownFilter: {
+                            breakdowns: [
+                                { property: '$browser', type: 'event' },
+                                { property: '$os', type: 'event' },
+                            ],
+                        },
+                    },
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(trendsWithMultipleBreakdowns)
+                })
+
+                // Trends → Funnels (truncates to single)
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.FUNNELS)
+                }).toFinishAllListeners()
+
+                const funnelsQuery1 = (builtInsightDataLogic.values.query as InsightVizNode).source as FunnelsQuery
+                expect(funnelsQuery1.breakdownFilter?.breakdown).toBe('$browser')
+                expect(funnelsQuery1.breakdownFilter?.breakdowns).toBeUndefined()
+
+                // Funnels → Lifecycle (no breakdown support, cached)
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.LIFECYCLE)
+                }).toFinishAllListeners()
+
+                // Lifecycle → Funnels (must still truncate, not leak full breakdowns array)
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.FUNNELS)
+                }).toFinishAllListeners()
+
+                const funnelsQuery2 = (builtInsightDataLogic.values.query as InsightVizNode).source as FunnelsQuery
+                expect(funnelsQuery2.breakdownFilter?.breakdown).toBe('$browser')
+                expect(funnelsQuery2.breakdownFilter?.breakdowns).toBeUndefined()
+            })
+
             it('preserves compareFilter through round-trip via unsupported type', async () => {
                 const trendsWithCompare: InsightVizNode = {
                     kind: NodeKind.InsightVizNode,

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -503,27 +503,15 @@ describe('insightNavLogic', () => {
                     } as Node),
                 ])
 
+                // Switch back to Trends — full multi-breakdown should be restored
                 await expectLogic(builtInsightDataLogic, () => {
                     logic.actions.setActiveView(InsightType.TRENDS)
-                }).toDispatchActions([
-                    builtInsightDataLogic.actionCreators.setQuery({
-                        kind: 'InsightVizNode',
-                        source: {
-                            kind: 'TrendsQuery',
-                            series: [{ kind: 'EventsNode', name: '$pageview', event: '$pageview', math: 'total' }],
-                            trendsFilter: { showValuesOnSeries: true },
-                            filterTestAccounts: true,
-                            version: 2,
-                            interval: 'hour',
-                            breakdownFilter: {
-                                breakdowns: undefined,
-                                breakdown: '$pathname',
-                                breakdown_type: 'group',
-                                breakdown_group_type_index: 0,
-                                breakdown_normalize_url: true,
-                            },
-                        },
-                    } as Node),
+                }).toFinishAllListeners()
+
+                const restoredQuery = (builtInsightDataLogic.values.query as InsightVizNode).source as TrendsQuery
+                expect(restoredQuery.breakdownFilter?.breakdowns).toEqual([
+                    { property: '$pathname', type: 'group', normalize_url: true, group_type_index: 0 },
+                    { property: '$device_type', type: 'event' },
                 ])
             })
 
@@ -611,6 +599,141 @@ describe('insightNavLogic', () => {
                 })
                 expect((builtInsightDataLogic.values.query as InsightVizNode).source).not.toMatchObject({
                     retentionFilter: expect.objectContaining({ showValuesOnSeries: true }),
+                })
+            })
+
+            it('preserves multiple breakdowns through round-trip via single-breakdown type', async () => {
+                const trendsWithMultipleBreakdowns: InsightVizNode = {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.EventsNode,
+                                name: '$pageview',
+                                event: '$pageview',
+                            },
+                        ],
+                        version: 2,
+                        breakdownFilter: {
+                            breakdowns: [
+                                { property: '$browser', type: 'event' },
+                                { property: '$os', type: 'event' },
+                                { property: '$device_type', type: 'event' },
+                            ],
+                        },
+                    },
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(trendsWithMultipleBreakdowns)
+                })
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.FUNNELS)
+                }).toFinishAllListeners()
+
+                const funnelsQuery = (builtInsightDataLogic.values.query as InsightVizNode).source as FunnelsQuery
+                expect(funnelsQuery.breakdownFilter?.breakdown).toBe('$browser')
+                expect(funnelsQuery.breakdownFilter?.breakdowns).toBeUndefined()
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.TRENDS)
+                }).toFinishAllListeners()
+
+                const trendsQuery = (builtInsightDataLogic.values.query as InsightVizNode).source as TrendsQuery
+                expect(trendsQuery.breakdownFilter?.breakdowns).toEqual([
+                    { property: '$browser', type: 'event' },
+                    { property: '$os', type: 'event' },
+                    { property: '$device_type', type: 'event' },
+                ])
+            })
+
+            it('preserves breakdownFilter through round-trip via unsupported type', async () => {
+                const trendsWithBreakdown: InsightVizNode = {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.EventsNode,
+                                name: '$pageview',
+                                event: '$pageview',
+                            },
+                        ],
+                        version: 2,
+                        breakdownFilter: {
+                            breakdown: '$browser',
+                            breakdown_type: 'event',
+                        },
+                    },
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(trendsWithBreakdown)
+                })
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.STICKINESS)
+                }).toFinishAllListeners()
+
+                expect(builtInsightDataLogic.values.query).toMatchObject({
+                    source: expect.not.objectContaining({ breakdownFilter: expect.anything() }),
+                })
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.TRENDS)
+                }).toFinishAllListeners()
+
+                expect(builtInsightDataLogic.values.query).toMatchObject({
+                    source: expect.objectContaining({
+                        kind: 'TrendsQuery',
+                        breakdownFilter: {
+                            breakdown: '$browser',
+                            breakdown_type: 'event',
+                        },
+                    }),
+                })
+            })
+
+            it('preserves compareFilter through round-trip via unsupported type', async () => {
+                const trendsWithCompare: InsightVizNode = {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.EventsNode,
+                                name: '$pageview',
+                                event: '$pageview',
+                            },
+                        ],
+                        version: 2,
+                        compareFilter: { compare: true },
+                    },
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(trendsWithCompare)
+                })
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.FUNNELS)
+                }).toFinishAllListeners()
+
+                expect(builtInsightDataLogic.values.query).toMatchObject({
+                    source: expect.not.objectContaining({ compareFilter: expect.anything() }),
+                })
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.TRENDS)
+                }).toFinishAllListeners()
+
+                expect(builtInsightDataLogic.values.query).toMatchObject({
+                    source: expect.objectContaining({
+                        kind: 'TrendsQuery',
+                        compareFilter: { compare: true },
+                    }),
                 })
             })
 

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -16,6 +16,7 @@ import { getDefaultQuery } from '~/queries/nodes/InsightViz/utils'
 import {
     AnyDataWarehouseNode,
     AnyEntityNode,
+    BreakdownFilter,
     CalendarHeatmapFilter,
     DataWarehouseNode,
     EntityNode,
@@ -31,6 +32,7 @@ import {
     NodeKind,
     PathsFilter,
     PathsQuery,
+    ProductAnalyticsInsightQueryNode,
     RetentionFilter,
     RetentionQuery,
     StickinessFilter,
@@ -51,7 +53,6 @@ import {
     isFunnelsDataWarehouseNode,
     isHogQuery,
     isInsightQueryWithBreakdown,
-    isInsightQueryWithSeries,
     isInsightVizNode,
     isLifecycleDataWarehouseNode,
     isLifecycleQuery,
@@ -215,6 +216,83 @@ const cleanSeries = (
     dataWarehouseNodeKind: DataWarehouseNodeKind
 ): (AnyEntityNode<AnyDataWarehouseNode> | GroupNode)[] => {
     return cleanSeriesMath(cleanDataWarehouseNodes(series, dataWarehouseNodeKind), mathAvailability)
+}
+
+// --- Field capability map ---
+// Defines which "transferable" fields each insight type supports and how to
+// adapt cached values when merging into a new query type. Both
+// cachePropertiesFromQuery and mergeCachedProperties derive behavior from this.
+//
+// Field present = supported. Function = transform before applying. `true` = pass through.
+
+type SeriesArray = (AnyEntityNode<AnyDataWarehouseNode> | GroupNode)[]
+
+interface InsightTypeCapabilities {
+    series?: ((series: SeriesArray) => SeriesArray) | true
+    interval?: ((interval: string) => string) | true
+    breakdownFilter?: ((bf: BreakdownFilter, cache: QueryPropertyCache) => BreakdownFilter) | true
+    compareFilter?: true
+    funnelPathsFilter?: true
+}
+
+const downgradeMinuteInterval = (interval: string): string => (interval === 'minute' ? 'hour' : interval)
+
+const truncateToSingleBreakdown = (bf: BreakdownFilter, cache: QueryPropertyCache): BreakdownFilter => {
+    if (!('kind' in cache) || cache.kind !== NodeKind.TrendsQuery) {
+        return bf
+    }
+    if (bf.breakdowns?.length) {
+        const first = bf.breakdowns[0]
+        return {
+            ...bf,
+            breakdowns: undefined,
+            breakdown: first.property,
+            breakdown_type: first.type,
+            breakdown_histogram_bin_count: first.histogram_bin_count,
+            breakdown_group_type_index: first.group_type_index,
+            breakdown_normalize_url: first.normalize_url,
+        }
+    }
+    return { ...bf, breakdowns: undefined }
+}
+
+const filterRetentionBreakdowns = (bf: BreakdownFilter): BreakdownFilter => {
+    if (!bf.breakdowns) {
+        return bf
+    }
+    return { ...bf, breakdowns: bf.breakdowns.filter((b) => b.type === 'person' || b.type === 'event') }
+}
+
+const FIELD_CAPABILITIES: Partial<Record<NodeKind, InsightTypeCapabilities>> = {
+    [NodeKind.TrendsQuery]: {
+        series: (s) => cleanSeries(s, MathAvailability.All, NodeKind.DataWarehouseNode),
+        interval: true,
+        breakdownFilter: true,
+        compareFilter: true,
+    },
+    [NodeKind.FunnelsQuery]: {
+        series: (s) => cleanSeries(s, MathAvailability.FunnelsOnly, NodeKind.FunnelsDataWarehouseNode),
+        interval: downgradeMinuteInterval,
+        breakdownFilter: truncateToSingleBreakdown,
+    },
+    [NodeKind.RetentionQuery]: {
+        // TODO: map series to/from retentionFilter.targetEntity/returningEntity so switching
+        // between Retention and other insight types preserves configured events.
+        breakdownFilter: filterRetentionBreakdowns,
+    },
+    [NodeKind.PathsQuery]: {
+        funnelPathsFilter: true,
+    },
+    [NodeKind.StickinessQuery]: {
+        series: (s) => cleanSeries(expandGroupNodes(s), MathAvailability.ActorsOnly, NodeKind.DataWarehouseNode),
+        interval: downgradeMinuteInterval,
+        compareFilter: true,
+    },
+    [NodeKind.LifecycleQuery]: {
+        series: (s) =>
+            cleanSeries(expandGroupNodes(s).slice(0, 1), MathAvailability.None, NodeKind.LifecycleDataWarehouseNode),
+        interval: downgradeMinuteInterval,
+    },
 }
 
 type TrendsCommonVisualizationProperties = Pick<TrendsFilter, 'showValuesOnSeries' | 'showPercentStackView' | 'display'>
@@ -459,23 +537,33 @@ const cachePropertiesFromQuery = (query: InsightQueryNode, cache: QueryPropertyC
     // Preserve explicit removals for global filters when merging with the existing cache.
     newCache.properties = query.properties === undefined ? undefined : JSON.parse(JSON.stringify(query.properties))
 
-    // // set series (first two entries) from retention target and returning entity
-    // if (isRetentionQuery(query)) {
-    //     const { targetEntity, returningEntity } = query.retentionFilter || {}
-    //     const series = actionsAndEventsToSeries({
-    //         events: [
-    //             ...(targetEntity?.type === 'events' ? [targetEntity as ActionFilter] : []),
-    //             ...(returningEntity?.type === 'events' ? [returningEntity as ActionFilter] : []),
-    //         ],
-    //         actions: [
-    //             ...(targetEntity?.type === 'actions' ? [targetEntity as ActionFilter] : []),
-    //             ...(returningEntity?.type === 'actions' ? [returningEntity as ActionFilter] : []),
-    //         ],
-    //     })
-    //     if (series.length > 0) {
-    //         newCache.series = [...series, ...(cache?.series ? cache.series.slice(series.length) : [])]
-    //     }
-    // }
+    // Preserve cached values that the current query type doesn't fully support,
+    // so they survive a round-trip when switching back.
+    const caps = FIELD_CAPABILITIES[query.kind]
+    if (cache?.series && !caps?.series) {
+        newCache.series = cache.series
+    }
+    if (cache?.interval && !caps?.interval) {
+        newCache.interval = cache.interval
+    }
+    if (cache?.breakdownFilter && !caps?.breakdownFilter) {
+        newCache.breakdownFilter = cache.breakdownFilter
+    }
+    if (cache?.compareFilter && !caps?.compareFilter) {
+        newCache.compareFilter = cache.compareFilter
+    }
+    if (cache?.funnelPathsFilter && !caps?.funnelPathsFilter) {
+        newCache.funnelPathsFilter = cache.funnelPathsFilter
+    }
+    // Only Trends supports multiple breakdowns — preserve the full set through
+    // types that truncate to single breakdown (Funnels, Retention)
+    if (cache?.breakdownFilter?.breakdowns?.length && !isTrendsQuery(query) && isInsightQueryWithBreakdown(query)) {
+        newCache.breakdownFilter = cache.breakdownFilter
+    }
+    // Preserve minute interval through types that downgrade it to hour
+    if (cache?.interval === 'minute' && !isTrendsQuery(query)) {
+        newCache.interval = cache.interval
+    }
 
     if (isWebAnalyticsInsightQuery(query)) {
         return newCache
@@ -511,167 +599,87 @@ const cachePropertiesFromQuery = (query: InsightQueryNode, cache: QueryPropertyC
 }
 
 const mergeCachedProperties = (query: InsightQueryNode, cache: QueryPropertyCache): InsightQueryNode => {
+    if (isWebAnalyticsInsightQuery(query)) {
+        return query
+    }
+
     const mergedQuery = {
         ...query,
         ...(cache.dateRange ? { dateRange: cache.dateRange } : {}),
-        ...(cache.properties ? { properties: cache.properties } : {}),
+        ...(cache.properties !== undefined ? { properties: cache.properties } : {}),
         ...(cache.samplingFactor ? { samplingFactor: cache.samplingFactor } : {}),
     }
 
-    // series
-    if (isInsightQueryWithSeries(mergedQuery)) {
-        if (cache.series) {
-            if (isTrendsQuery(mergedQuery)) {
-                // Trends supports GroupNode, keep series as-is
-                mergedQuery.series = cleanSeries(
-                    cache.series,
-                    MathAvailability.All,
-                    NodeKind.DataWarehouseNode
-                ) as TrendsQuery['series']
-            } else if (isFunnelsQuery(mergedQuery)) {
-                mergedQuery.series = cleanSeries(
-                    cache.series,
-                    MathAvailability.FunnelsOnly,
-                    NodeKind.FunnelsDataWarehouseNode
-                ) as FunnelsQuery['series']
-            } else {
-                // Expand GroupNodes for insight types that don't support them
-                const expandedSeries = expandGroupNodes(cache.series)
-
-                if (isLifecycleQuery(mergedQuery)) {
-                    mergedQuery.series = cleanSeries(
-                        expandedSeries.slice(0, 1),
-                        MathAvailability.None,
-                        NodeKind.LifecycleDataWarehouseNode
-                    ) as LifecycleQuery['series']
-                } else {
-                    const mathAvailability = isStickinessQuery(mergedQuery)
-                        ? MathAvailability.ActorsOnly
-                        : MathAvailability.None
-                    mergedQuery.series = cleanSeries(
-                        expandedSeries,
-                        mathAvailability,
-                        NodeKind.DataWarehouseNode
-                    ) as typeof mergedQuery.series
-                }
-            }
+    const caps = FIELD_CAPABILITIES[query.kind]
+    if (caps) {
+        if (caps.series && cache.series) {
+            mergedQuery.series = (
+                typeof caps.series === 'function' ? caps.series(cache.series) : cache.series
+            ) as typeof mergedQuery.series
         }
-        // else if (cache.retentionFilter?.targetEntity || cache.retentionFilter?.returningEntity) {
-        //     mergedQuery.series = [
-        //         ...(cache.retentionFilter.targetEntity
-        //             ? [cache.retentionFilter.targetEntity as EventsNode | ActionsNode]
-        //             : []),
-        //         ...(cache.retentionFilter.returningEntity
-        //             ? [cache.retentionFilter.returningEntity as EventsNode | ActionsNode]
-        //             : []),
-        //     ]
-        // }
-    } else if (isRetentionQuery(mergedQuery) && cache.series) {
-        // mergedQuery.retentionFilter = {
-        //     ...mergedQuery.retentionFilter,
-        //     ...(cache.series.length > 0 ? { targetEntity: cache.series[0] } : {}),
-        //     ...(cache.series.length > 1 ? { returningEntity: cache.series[1] } : {}),
-        // }
-    }
-
-    // interval
-    if (isInsightQueryWithSeries(mergedQuery) && cache.interval) {
-        // Only support real time queries on trends for now
-        if (!isTrendsQuery(mergedQuery) && cache.interval == 'minute') {
-            mergedQuery.interval = 'hour'
-        } else {
-            mergedQuery.interval = cache.interval
+        if (caps.interval && cache.interval) {
+            mergedQuery.interval = typeof caps.interval === 'function' ? caps.interval(cache.interval) : cache.interval
+        }
+        if (caps.breakdownFilter && cache.breakdownFilter) {
+            mergedQuery.breakdownFilter =
+                typeof caps.breakdownFilter === 'function'
+                    ? caps.breakdownFilter(cache.breakdownFilter, cache)
+                    : cache.breakdownFilter
+        }
+        if (caps.compareFilter && cache.compareFilter) {
+            mergedQuery.compareFilter = cache.compareFilter
+        }
+        if (caps.funnelPathsFilter && cache.funnelPathsFilter) {
+            mergedQuery.funnelPathsFilter = cache.funnelPathsFilter
         }
     }
 
-    // breakdown filter
-    if (isInsightQueryWithBreakdown(mergedQuery) && cache.breakdownFilter) {
-        mergedQuery.breakdownFilter = cache.breakdownFilter
+    // Insight-specific filter merge (web analytics already returned above)
+    return {
+        ...mergedQuery,
+        ...buildInsightFilter(query as ProductAnalyticsInsightQueryNode, cache),
+    } as InsightQueryNode
+}
 
-        // If we've changed the query kind, convert multiple breakdowns to a single breakdown
-        if (isTrendsQuery(cache) && isFunnelsQuery(query)) {
-            if (cache.breakdownFilter.breakdowns?.length) {
-                const firstBreakdown = cache.breakdownFilter?.breakdowns?.[0]
-                mergedQuery.breakdownFilter = {
-                    ...cache.breakdownFilter,
-                    breakdowns: undefined,
-                    breakdown: firstBreakdown?.property,
-                    breakdown_type: firstBreakdown?.type,
-                    breakdown_histogram_bin_count: firstBreakdown?.histogram_bin_count,
-                    breakdown_group_type_index: firstBreakdown?.group_type_index,
-                    breakdown_normalize_url: firstBreakdown?.normalize_url,
-                }
-            } else {
-                mergedQuery.breakdownFilter = {
-                    ...cache.breakdownFilter,
-                    breakdowns: undefined,
-                }
-            }
-        }
+const buildInsightFilter = (
+    query: ProductAnalyticsInsightQueryNode,
+    cache: QueryPropertyCache
+): Partial<ProductAnalyticsInsightQueryNode> => {
+    if (!cache.commonFilter) {
+        return {}
+    }
 
-        if (isRetentionQuery(query) && cache.breakdownFilter?.breakdowns) {
-            mergedQuery.breakdownFilter = {
-                ...query.breakdownFilter,
-                breakdowns: cache.breakdownFilter.breakdowns.filter((b) => b.type === 'person' || b.type === 'event'),
-            }
+    const vizProps = getCommonVisualizationProperties(query, cache.commonFilter)
+    const sharedResultCustomizations = cache.commonFilterTrendsStickiness?.resultCustomizations
+        ? { resultCustomizations: cache.commonFilterTrendsStickiness.resultCustomizations }
+        : {}
+
+    if (isTrendsQuery(query)) {
+        return {
+            trendsFilter: { ...query.trendsFilter, ...cache.trendsFilter, ...vizProps, ...sharedResultCustomizations },
         }
     }
-
-    // funnel paths filter
-    if (isPathsQuery(mergedQuery) && cache.funnelPathsFilter) {
-        mergedQuery.funnelPathsFilter = cache.funnelPathsFilter
-    }
-
-    if (isWebAnalyticsInsightQuery(mergedQuery as InsightQueryNode)) {
-        return mergedQuery as InsightQueryNode
-    }
-
-    // insight specific filter
-    if (cache.commonFilter) {
-        if (isTrendsQuery(query) && isTrendsQuery(mergedQuery)) {
-            mergedQuery.trendsFilter = {
-                ...query.trendsFilter,
-                ...cache.trendsFilter,
-                ...getCommonVisualizationProperties(mergedQuery, cache.commonFilter),
-                ...(cache.commonFilterTrendsStickiness?.resultCustomizations
-                    ? { resultCustomizations: cache.commonFilterTrendsStickiness.resultCustomizations }
-                    : {}),
-            }
-        } else if (isStickinessQuery(query) && isStickinessQuery(mergedQuery)) {
-            mergedQuery.stickinessFilter = {
+    if (isStickinessQuery(query)) {
+        return {
+            stickinessFilter: {
                 ...query.stickinessFilter,
                 ...cache.stickinessFilter,
-                ...getCommonVisualizationProperties(mergedQuery, cache.commonFilter),
-                ...(cache.commonFilterTrendsStickiness?.resultCustomizations
-                    ? { resultCustomizations: cache.commonFilterTrendsStickiness.resultCustomizations }
-                    : {}),
-            }
-        } else if (isFunnelsQuery(query) && isFunnelsQuery(mergedQuery)) {
-            mergedQuery.funnelsFilter = {
-                ...query.funnelsFilter,
-                ...cache.funnelsFilter,
-                ...getCommonVisualizationProperties(mergedQuery, cache.commonFilter),
-            }
-        } else if (isRetentionQuery(query) && isRetentionQuery(mergedQuery)) {
-            mergedQuery.retentionFilter = {
-                ...query.retentionFilter,
-                ...cache.retentionFilter,
-                ...getCommonVisualizationProperties(mergedQuery, cache.commonFilter),
-            }
-        } else if (isPathsQuery(query) && isPathsQuery(mergedQuery)) {
-            mergedQuery.pathsFilter = {
-                ...query.pathsFilter,
-                ...cache.pathsFilter,
-                ...getCommonVisualizationProperties(mergedQuery, cache.commonFilter),
-            }
-        } else if (isLifecycleQuery(query) && isLifecycleQuery(mergedQuery)) {
-            mergedQuery.lifecycleFilter = {
-                ...query.lifecycleFilter,
-                ...cache.lifecycleFilter,
-                ...getCommonVisualizationProperties(mergedQuery, cache.commonFilter),
-            }
+                ...vizProps,
+                ...sharedResultCustomizations,
+            },
         }
     }
-
-    return mergedQuery as InsightQueryNode
+    if (isFunnelsQuery(query)) {
+        return { funnelsFilter: { ...query.funnelsFilter, ...cache.funnelsFilter, ...vizProps } }
+    }
+    if (isRetentionQuery(query)) {
+        return { retentionFilter: { ...query.retentionFilter, ...cache.retentionFilter, ...vizProps } }
+    }
+    if (isPathsQuery(query)) {
+        return { pathsFilter: { ...query.pathsFilter, ...cache.pathsFilter, ...vizProps } }
+    }
+    if (isLifecycleQuery(query)) {
+        return { lifecycleFilter: { ...query.lifecycleFilter, ...cache.lifecycleFilter, ...vizProps } }
+    }
+    return {}
 }

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -92,7 +92,6 @@ export interface QueryPropertyCache
         Omit<Partial<PathsQuery>, 'kind' | 'response'>,
         Omit<Partial<StickinessQuery>, 'kind' | 'response' | 'series'>,
         Omit<Partial<LifecycleQuery>, 'kind' | 'response' | 'series'> {
-    kind?: NodeKind
     series?: (AnyEntityNode | GroupNode)[]
     commonFilter: CommonInsightFilter
     commonFilterTrendsStickiness?: {
@@ -532,6 +531,10 @@ export const insightNavLogic = kea<insightNavLogicType>([
 const cachePropertiesFromQuery = (query: InsightQueryNode, cache: QueryPropertyCache | null): QueryPropertyCache => {
     const newCache = JSON.parse(JSON.stringify(query)) as QueryPropertyCache
 
+    if (isWebAnalyticsInsightQuery(query)) {
+        return newCache
+    }
+
     // Preserve explicit removals for global filters when merging with the existing cache.
     newCache.properties = query.properties === undefined ? undefined : JSON.parse(JSON.stringify(query.properties))
 
@@ -561,10 +564,6 @@ const cachePropertiesFromQuery = (query: InsightQueryNode, cache: QueryPropertyC
     // Preserve minute interval through types that downgrade it to hour
     if (cache?.interval === 'minute' && !isTrendsQuery(query)) {
         newCache.interval = cache.interval
-    }
-
-    if (isWebAnalyticsInsightQuery(query)) {
-        return newCache
     }
 
     /** store the insight specific filter in commonFilter */

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -610,35 +610,40 @@ const mergeCachedProperties = (query: InsightQueryNode, cache: QueryPropertyCach
         ...(cache.samplingFactor ? { samplingFactor: cache.samplingFactor } : {}),
     }
 
-    const caps = FIELD_CAPABILITIES[query.kind]
-    if (caps) {
-        if (caps.series && cache.series) {
-            mergedQuery.series = (
-                typeof caps.series === 'function' ? caps.series(cache.series) : cache.series
-            ) as typeof mergedQuery.series
-        }
-        if (caps.interval && cache.interval) {
-            mergedQuery.interval = typeof caps.interval === 'function' ? caps.interval(cache.interval) : cache.interval
-        }
-        if (caps.breakdownFilter && cache.breakdownFilter) {
-            mergedQuery.breakdownFilter =
-                typeof caps.breakdownFilter === 'function'
-                    ? caps.breakdownFilter(cache.breakdownFilter, cache)
-                    : cache.breakdownFilter
-        }
-        if (caps.compareFilter && cache.compareFilter) {
-            mergedQuery.compareFilter = cache.compareFilter
-        }
-        if (caps.funnelPathsFilter && cache.funnelPathsFilter) {
-            mergedQuery.funnelPathsFilter = cache.funnelPathsFilter
-        }
-    }
-
     // Insight-specific filter merge (web analytics already returned above)
     return {
         ...mergedQuery,
+        ...buildCachedFields(query, cache),
         ...buildInsightFilter(query as ProductAnalyticsInsightQueryNode, cache),
     } as InsightQueryNode
+}
+
+const buildCachedFields = (query: InsightQueryNode, cache: QueryPropertyCache): Partial<QueryPropertyCache> => {
+    const caps = FIELD_CAPABILITIES[query.kind]
+    if (!caps) {
+        return {}
+    }
+
+    const result: Partial<QueryPropertyCache> = {}
+    if (caps.series && cache.series) {
+        result.series = typeof caps.series === 'function' ? caps.series(cache.series) : cache.series
+    }
+    if (caps.interval && cache.interval) {
+        result.interval = typeof caps.interval === 'function' ? caps.interval(cache.interval) : cache.interval
+    }
+    if (caps.breakdownFilter && cache.breakdownFilter) {
+        result.breakdownFilter =
+            typeof caps.breakdownFilter === 'function'
+                ? caps.breakdownFilter(cache.breakdownFilter, cache)
+                : cache.breakdownFilter
+    }
+    if (caps.compareFilter && cache.compareFilter) {
+        result.compareFilter = cache.compareFilter
+    }
+    if (caps.funnelPathsFilter && cache.funnelPathsFilter) {
+        result.funnelPathsFilter = cache.funnelPathsFilter
+    }
+    return result
 }
 
 const buildInsightFilter = (

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -652,17 +652,18 @@ const buildInsightFilter = (
         return {}
     }
 
-    const vizProps = getCommonVisualizationProperties(query, cache.commonFilter)
     const sharedResultCustomizations = cache.commonFilterTrendsStickiness?.resultCustomizations
         ? { resultCustomizations: cache.commonFilterTrendsStickiness.resultCustomizations }
         : {}
 
     if (isTrendsQuery(query)) {
+        const vizProps = getCommonVisualizationProperties(query, cache.commonFilter)
         return {
             trendsFilter: { ...query.trendsFilter, ...cache.trendsFilter, ...vizProps, ...sharedResultCustomizations },
         }
     }
     if (isStickinessQuery(query)) {
+        const vizProps = getCommonVisualizationProperties(query, cache.commonFilter)
         return {
             stickinessFilter: {
                 ...query.stickinessFilter,
@@ -673,15 +674,19 @@ const buildInsightFilter = (
         }
     }
     if (isFunnelsQuery(query)) {
+        const vizProps = getCommonVisualizationProperties(query, cache.commonFilter)
         return { funnelsFilter: { ...query.funnelsFilter, ...cache.funnelsFilter, ...vizProps } }
     }
     if (isRetentionQuery(query)) {
+        const vizProps = getCommonVisualizationProperties(query, cache.commonFilter)
         return { retentionFilter: { ...query.retentionFilter, ...cache.retentionFilter, ...vizProps } }
     }
     if (isPathsQuery(query)) {
+        const vizProps = getCommonVisualizationProperties(query, cache.commonFilter)
         return { pathsFilter: { ...query.pathsFilter, ...cache.pathsFilter, ...vizProps } }
     }
     if (isLifecycleQuery(query)) {
+        const vizProps = getCommonVisualizationProperties(query, cache.commonFilter)
         return { lifecycleFilter: { ...query.lifecycleFilter, ...cache.lifecycleFilter, ...vizProps } }
     }
     return {}

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -14,12 +14,14 @@ import { expandGroupNodes } from '~/queries/nodes/InsightQuery/utils/filtersToQu
 import { nodeKindToInsightType } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 import { getDefaultQuery } from '~/queries/nodes/InsightViz/utils'
 import {
+    ActionsNode,
     AnyDataWarehouseNode,
     AnyEntityNode,
     BreakdownFilter,
     CalendarHeatmapFilter,
     DataWarehouseNode,
     EntityNode,
+    EventsNode,
     FunnelsDataWarehouseNode,
     FunnelsFilter,
     FunnelsQuery,
@@ -281,13 +283,22 @@ const FIELD_CAPABILITIES: Partial<Record<NodeKind, InsightTypeCapabilities>> = {
         funnelPathsFilter: true,
     },
     [NodeKind.StickinessQuery]: {
-        series: (s) => cleanSeries(expandGroupNodes(s), MathAvailability.ActorsOnly, NodeKind.DataWarehouseNode),
+        series: (s) =>
+            cleanSeries(
+                expandGroupNodes(s as (EventsNode | ActionsNode | DataWarehouseNode | GroupNode)[]),
+                MathAvailability.ActorsOnly,
+                NodeKind.DataWarehouseNode
+            ),
         interval: downgradeMinuteInterval,
         compareFilter: true,
     },
     [NodeKind.LifecycleQuery]: {
         series: (s) =>
-            cleanSeries(expandGroupNodes(s).slice(0, 1), MathAvailability.None, NodeKind.LifecycleDataWarehouseNode),
+            cleanSeries(
+                expandGroupNodes(s as (EventsNode | ActionsNode | DataWarehouseNode | GroupNode)[]).slice(0, 1),
+                MathAvailability.None,
+                NodeKind.LifecycleDataWarehouseNode
+            ),
         interval: downgradeMinuteInterval,
     },
 }
@@ -623,7 +634,9 @@ const buildCachedFields = (query: InsightQueryNode, cache: QueryPropertyCache): 
 
     const result: Partial<QueryPropertyCache> = {}
     if (caps.series && cache.series) {
-        result.series = typeof caps.series === 'function' ? caps.series(cache.series) : cache.series
+        result.series = (
+            typeof caps.series === 'function' ? caps.series(cache.series) : cache.series
+        ) as QueryPropertyCache['series']
     }
     if (caps.interval && cache.interval) {
         result.interval = typeof caps.interval === 'function' ? caps.interval(cache.interval) : cache.interval
@@ -651,14 +664,19 @@ const buildInsightFilter = (
         return {}
     }
 
-    const sharedResultCustomizations = cache.commonFilterTrendsStickiness?.resultCustomizations
+    const trendsStickinessResultCustomizations = cache.commonFilterTrendsStickiness?.resultCustomizations
         ? { resultCustomizations: cache.commonFilterTrendsStickiness.resultCustomizations }
         : {}
 
     if (isTrendsQuery(query)) {
         const vizProps = getCommonVisualizationProperties(query, cache.commonFilter)
         return {
-            trendsFilter: { ...query.trendsFilter, ...cache.trendsFilter, ...vizProps, ...sharedResultCustomizations },
+            trendsFilter: {
+                ...query.trendsFilter,
+                ...cache.trendsFilter,
+                ...vizProps,
+                ...trendsStickinessResultCustomizations,
+            },
         }
     }
     if (isStickinessQuery(query)) {
@@ -668,7 +686,7 @@ const buildInsightFilter = (
                 ...query.stickinessFilter,
                 ...cache.stickinessFilter,
                 ...vizProps,
-                ...sharedResultCustomizations,
+                ...trendsStickinessResultCustomizations,
             },
         }
     }

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -62,7 +62,7 @@ import {
     isTrendsQuery,
     isWebAnalyticsInsightQuery,
 } from '~/queries/utils'
-import { BaseMathType, InsightLogicProps, InsightType } from '~/types'
+import { BaseMathType, InsightLogicProps, InsightType, IntervalType } from '~/types'
 
 import { MathAvailability } from '../filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 import type { insightNavLogicType } from './insightNavLogicType'
@@ -92,8 +92,6 @@ export interface QueryPropertyCache
         Omit<Partial<PathsQuery>, 'kind' | 'response'>,
         Omit<Partial<StickinessQuery>, 'kind' | 'response' | 'series'>,
         Omit<Partial<LifecycleQuery>, 'kind' | 'response' | 'series'> {
-    // Present at runtime (from JSON.parse deep clone) — declared here so
-    // capability adapters can check the source query type safely.
     kind?: NodeKind
     series?: (AnyEntityNode | GroupNode)[]
     commonFilter: CommonInsightFilter
@@ -232,13 +230,13 @@ type SeriesArray = (AnyEntityNode<AnyDataWarehouseNode> | GroupNode)[]
 
 interface InsightTypeCapabilities {
     series?: ((series: SeriesArray) => SeriesArray) | true
-    interval?: ((interval: string) => string) | true
+    interval?: ((interval: IntervalType) => IntervalType) | true
     breakdownFilter?: ((bf: BreakdownFilter, cache: QueryPropertyCache) => BreakdownFilter) | true
     compareFilter?: true
     funnelPathsFilter?: true
 }
 
-const downgradeMinuteInterval = (interval: string): string => (interval === 'minute' ? 'hour' : interval)
+const downgradeMinuteInterval = (interval: IntervalType): IntervalType => (interval === 'minute' ? 'hour' : interval)
 
 const truncateToSingleBreakdown = (bf: BreakdownFilter, cache: QueryPropertyCache): BreakdownFilter => {
     if (cache.kind !== NodeKind.TrendsQuery) {

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -92,6 +92,9 @@ export interface QueryPropertyCache
         Omit<Partial<PathsQuery>, 'kind' | 'response'>,
         Omit<Partial<StickinessQuery>, 'kind' | 'response' | 'series'>,
         Omit<Partial<LifecycleQuery>, 'kind' | 'response' | 'series'> {
+    // Present at runtime (from JSON.parse deep clone) — declared here so
+    // capability adapters can check the source query type safely.
+    kind?: NodeKind
     series?: (AnyEntityNode | GroupNode)[]
     commonFilter: CommonInsightFilter
     commonFilterTrendsStickiness?: {
@@ -238,7 +241,7 @@ interface InsightTypeCapabilities {
 const downgradeMinuteInterval = (interval: string): string => (interval === 'minute' ? 'hour' : interval)
 
 const truncateToSingleBreakdown = (bf: BreakdownFilter, cache: QueryPropertyCache): BreakdownFilter => {
-    if (!('kind' in cache) || cache.kind !== NodeKind.TrendsQuery) {
+    if (cache.kind !== NodeKind.TrendsQuery) {
         return bf
     }
     if (bf.breakdowns?.length) {
@@ -614,7 +617,7 @@ const mergeCachedProperties = (query: InsightQueryNode, cache: QueryPropertyCach
     return {
         ...mergedQuery,
         ...buildCachedFields(query, cache),
-        ...buildInsightFilter(query as ProductAnalyticsInsightQueryNode, cache),
+        ...buildInsightFilter(query, cache),
     } as InsightQueryNode
 }
 
@@ -647,7 +650,7 @@ const buildCachedFields = (query: InsightQueryNode, cache: QueryPropertyCache): 
 }
 
 const buildInsightFilter = (
-    query: ProductAnalyticsInsightQueryNode,
+    query: InsightQueryNode,
     cache: QueryPropertyCache
 ): Partial<ProductAnalyticsInsightQueryNode> => {
     if (!cache.commonFilter) {

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -231,17 +231,14 @@ type SeriesArray = (AnyEntityNode<AnyDataWarehouseNode> | GroupNode)[]
 interface InsightTypeCapabilities {
     series?: ((series: SeriesArray) => SeriesArray) | true
     interval?: ((interval: IntervalType) => IntervalType) | true
-    breakdownFilter?: ((bf: BreakdownFilter, cache: QueryPropertyCache) => BreakdownFilter) | true
+    breakdownFilter?: ((bf: BreakdownFilter) => BreakdownFilter) | true
     compareFilter?: true
     funnelPathsFilter?: true
 }
 
 const downgradeMinuteInterval = (interval: IntervalType): IntervalType => (interval === 'minute' ? 'hour' : interval)
 
-const truncateToSingleBreakdown = (bf: BreakdownFilter, cache: QueryPropertyCache): BreakdownFilter => {
-    if (cache.kind !== NodeKind.TrendsQuery) {
-        return bf
-    }
+const truncateToSingleBreakdown = (bf: BreakdownFilter): BreakdownFilter => {
     if (bf.breakdowns?.length) {
         const first = bf.breakdowns[0]
         return {
@@ -635,7 +632,7 @@ const buildCachedFields = (query: InsightQueryNode, cache: QueryPropertyCache): 
     if (caps.breakdownFilter && cache.breakdownFilter) {
         result.breakdownFilter =
             typeof caps.breakdownFilter === 'function'
-                ? caps.breakdownFilter(cache.breakdownFilter, cache)
+                ? caps.breakdownFilter(cache.breakdownFilter)
                 : cache.breakdownFilter
     }
     if (caps.compareFilter && cache.compareFilter) {


### PR DESCRIPTION
First of a few PR's in this area, I want to make switching nicer and stop showing users errors. https://github.com/PostHog/posthog/pull/54330 to follow

## Problem

This insight switching code was quite hard to understand, and a bunch of it was commented out. Plus breakdown & compre properties failed to restore when navigating back and forth between insight types.


https://github.com/user-attachments/assets/bbb22a91-cee6-4b99-8bd8-20e39d8ea2b1


## Changes

- I've made this code clearer, removed some dead code
- Added a FIELD_CAPABILITIES map that declares which fields each insight type supports and how to adapt them when switching. 

https://github.com/user-attachments/assets/51078359-8501-4a9a-b11f-79a35a322f02


## How did you test this code?

Navigating between insight types, and tests

## Publish to changelog?

no

## 🤖 LLM context

Authored via Claude Code.