### PR TITLE
feat(hog-charts): apply 50% opacity to compare-previous period series

### DIFF
--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
@@ -75,22 +75,26 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
         () =>
             (indexedResults ?? [])
                 .filter((r: IndexedTrendResult) => r.count !== 0)
-                .map((r: IndexedTrendResult) => ({
-                    key: `${r.id}`,
-                    label: r.label ?? '',
-                    data: r.data,
-                    color: getTrendsColor(r),
-                    fillArea: display === ChartDisplayType.ActionsAreaGraph,
-                    meta: {
-                        action: r.action,
-                        breakdown_value: r.breakdown_value,
-                        compare_label: r.compare_label,
-                        days: r.days,
-                        // Fall back to the pre-filter index (r.id) so ordering is stable when earlier series are dropped.
-                        order: r.action?.order ?? r.id,
-                        filter: r.filter,
-                    },
-                })),
+                .map((r: IndexedTrendResult) => {
+                    const isPrevious = r.compare_label === 'previous'
+                    const color = isPrevious ? `${getTrendsColor(r)}80` : getTrendsColor(r)
+                    return {
+                        key: `${r.id}`,
+                        label: r.label ?? '',
+                        data: r.data,
+                        color,
+                        fillArea: display === ChartDisplayType.ActionsAreaGraph,
+                        meta: {
+                            action: r.action,
+                            breakdown_value: r.breakdown_value,
+                            compare_label: r.compare_label,
+                            days: r.days,
+                            // Fall back to the pre-filter index (r.id) so ordering is stable when earlier series are dropped.
+                            order: r.action?.order ?? r.id,
+                            filter: r.filter,
+                        },
+                    }
+                }),
         [indexedResults, display, getTrendsColor]
     )
 


### PR DESCRIPTION
## Problem

In the new hog-charts `TrendsLineChartD3`, compare-previous period series render with the same solid color as the current period, making them visually indistinguishable. The legacy `LineGraph` applies 50% hex alpha (`80`) to previous-period colors.

## Changes

- When `compare_label === 'previous'`, append `80` (50% hex alpha) to the color returned by `getTrendsColor`, matching the legacy `LineGraph` behavior.
- Convert the `.map()` from an implicit return to an explicit block to accommodate the color logic.

## How did you test this code?

I'm an AI agent. I ran the existing `TrendsLineChartD3.test.tsx` suite (13 tests, all passing), including the compare-mode tooltip test.

## LLM context

One-line change in the `hogSeries` useMemo to differentiate current vs previous period visually, matching the legacy chart's approach.

## Publish to changelog?