### PR TITLE
feat(hog-charts): add ReferenceLine overlay primitive

### DIFF
--- a/frontend/src/lib/hog-charts/overlays/ReferenceLine.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ReferenceLine.tsx
@@ -1,0 +1,256 @@
+/* eslint-disable react/forbid-dom-props -- dynamic pixel positions from d3 scales */
+import React, { useMemo } from 'react'
+
+import { resolveVariableColor } from 'lib/charts/utils/color'
+
+import { useChart } from '../core/chart-context'
+
+export type ReferenceLineOrientation = 'horizontal' | 'vertical'
+export type ReferenceLineVariant = 'goal' | 'alert' | 'marker'
+export type ReferenceLineFillSide = 'above' | 'below' | 'left' | 'right'
+export type ReferenceLineLabelPosition = 'start' | 'end'
+export type ReferenceLineStroke = 'dashed' | 'solid'
+
+export interface ReferenceLineStyle {
+    /** CSS color string. Supports `var(--my-color)`. Overrides the variant default. */
+    color?: string
+    /** Stroke style. Defaults to the variant default. */
+    stroke?: ReferenceLineStroke
+    /** Line thickness in px. Defaults to the variant default. */
+    width?: number
+    /** CSS color used for the filled half-plane when `fillSide` is set. Defaults to `color`. */
+    fillColor?: string
+    /** Opacity 0-1 for the filled half-plane. Defaults to 0.1. */
+    fillOpacity?: number
+}
+
+export interface ReferenceLineProps {
+    /** The axis value at which to draw the line. For horizontal lines this is a numeric
+     *  y-value; for vertical lines it's an x-axis label (matching the chart's `labels`). */
+    value: number | string
+    /** `horizontal` draws across the plot at a y-value (default).
+     *  `vertical` draws top-to-bottom at an x-axis label. */
+    orientation?: ReferenceLineOrientation
+    /** Optional text label rendered alongside the line. */
+    label?: string
+    /** Anchor the label at the `start` or `end` of the line. Defaults to `end`. */
+    labelPosition?: ReferenceLineLabelPosition
+    /** Style overrides. Variant picks sensible defaults; anything set here wins. */
+    style?: ReferenceLineStyle
+    /** Optional filled half-plane on one side of the line. */
+    fillSide?: ReferenceLineFillSide
+    /** Preset: `goal` (dashed grey), `alert` (dashed red), `marker` (solid thin grey). Defaults to `goal`. */
+    variant?: ReferenceLineVariant
+}
+
+interface ResolvedStyle {
+    color: string
+    stroke: ReferenceLineStroke
+    width: number
+}
+
+const VARIANT_DEFAULTS: Record<ReferenceLineVariant, ResolvedStyle> = {
+    goal: { color: 'rgba(0, 0, 0, 0.4)', stroke: 'dashed', width: 2 },
+    alert: { color: 'var(--danger)', stroke: 'dashed', width: 2 },
+    marker: { color: 'rgba(0, 0, 0, 0.5)', stroke: 'solid', width: 1 },
+}
+
+/** Vertical distance from the line to the top edge of the text label. */
+const LABEL_OFFSET = 18
+/** Padding between the label and the plot edge. */
+const LABEL_PADDING = 4
+
+function resolveStyle(variant: ReferenceLineVariant, style: ReferenceLineStyle | undefined): ResolvedStyle {
+    const defaults = VARIANT_DEFAULTS[variant]
+    return {
+        color: resolveVariableColor(style?.color) ?? resolveVariableColor(defaults.color) ?? defaults.color,
+        stroke: style?.stroke ?? defaults.stroke,
+        width: style?.width ?? defaults.width,
+    }
+}
+
+/** Renders a list of reference lines. */
+export function ReferenceLines({ lines }: { lines: ReferenceLineProps[] }): React.ReactElement {
+    return (
+        <>
+            {lines.map((props, i) => (
+                <ReferenceLine key={`${props.value}-${props.label ?? i}`} {...props} />
+            ))}
+        </>
+    )
+}
+
+/** Dispatches to the orientation-specific renderer. Each sub-component does its own
+ *  type narrowing, scale lookup, and bounds check, then hands pre-computed styles to
+ *  {@link ReferenceLineView}. */
+export function ReferenceLine(props: ReferenceLineProps): React.ReactElement | null {
+    const { orientation = 'horizontal', variant = 'goal', style } = props
+    const resolved = useMemo(() => resolveStyle(variant, style), [variant, style])
+
+    const common: ResolvedProps = {
+        resolved,
+        fillSide: props.fillSide,
+        fillColor: style?.fillColor ?? resolved.color,
+        fillOpacity: style?.fillOpacity ?? 0.1,
+        label: props.label,
+        labelPosition: props.labelPosition ?? 'end',
+    }
+
+    if (orientation === 'horizontal') {
+        return typeof props.value === 'number' ? <HorizontalReferenceLine y={props.value} {...common} /> : null
+    }
+    return typeof props.value === 'string' ? <VerticalReferenceLine xLabel={props.value} {...common} /> : null
+}
+
+interface ResolvedProps {
+    resolved: ResolvedStyle
+    fillSide: ReferenceLineFillSide | undefined
+    fillColor: string
+    fillOpacity: number
+    label: string | undefined
+    labelPosition: ReferenceLineLabelPosition
+}
+
+function HorizontalReferenceLine({
+    y: value,
+    resolved,
+    fillSide,
+    fillColor,
+    fillOpacity,
+    label,
+    labelPosition,
+}: ResolvedProps & { y: number }): React.ReactElement | null {
+    const { scales, dimensions } = useChart()
+    const { plotLeft, plotTop, plotWidth, plotHeight, width: containerWidth } = dimensions
+    const plotRight = plotLeft + plotWidth
+    const plotBottom = plotTop + plotHeight
+
+    const y = scales.y(value)
+    if (!isFinite(y) || y < plotTop || y > plotBottom) {
+        return null
+    }
+
+    const lineStyle: React.CSSProperties = {
+        left: plotLeft,
+        top: y - resolved.width / 2,
+        width: plotWidth,
+        height: 0,
+        borderTop: `${resolved.width}px ${resolved.stroke} ${resolved.color}`,
+    }
+    const labelStyle: React.CSSProperties = {
+        top: y - LABEL_OFFSET,
+        ...(labelPosition === 'end'
+            ? { right: containerWidth - plotRight + LABEL_PADDING }
+            : { left: plotLeft + LABEL_PADDING }),
+        color: resolved.color,
+    }
+
+    let fillRect: React.CSSProperties | null = null
+    if (fillSide === 'above') {
+        fillRect = { left: plotLeft, top: plotTop, width: plotWidth, height: y - plotTop }
+    } else if (fillSide === 'below') {
+        fillRect = { left: plotLeft, top: y, width: plotWidth, height: plotBottom - y }
+    }
+
+    return (
+        <ReferenceLineView
+            fillRect={fillRect}
+            fillColor={fillColor}
+            fillOpacity={fillOpacity}
+            lineStyle={lineStyle}
+            label={label}
+            labelStyle={labelStyle}
+        />
+    )
+}
+
+function VerticalReferenceLine({
+    xLabel,
+    resolved,
+    fillSide,
+    fillColor,
+    fillOpacity,
+    label,
+    labelPosition,
+}: ResolvedProps & { xLabel: string }): React.ReactElement | null {
+    const { scales, dimensions } = useChart()
+    const { plotLeft, plotTop, plotWidth, plotHeight, height: containerHeight } = dimensions
+    const plotRight = plotLeft + plotWidth
+    const plotBottom = plotTop + plotHeight
+
+    const x = scales.x(xLabel)
+    if (x == null || !isFinite(x) || x < plotLeft || x > plotRight) {
+        return null
+    }
+
+    const lineStyle: React.CSSProperties = {
+        left: x - resolved.width / 2,
+        top: plotTop,
+        width: 0,
+        height: plotHeight,
+        borderLeft: `${resolved.width}px ${resolved.stroke} ${resolved.color}`,
+    }
+    const labelStyle: React.CSSProperties = {
+        left: x + LABEL_PADDING,
+        ...(labelPosition === 'end'
+            ? { bottom: containerHeight - plotBottom + LABEL_PADDING }
+            : { top: plotTop + LABEL_PADDING }),
+        color: resolved.color,
+    }
+
+    let fillRect: React.CSSProperties | null = null
+    if (fillSide === 'left') {
+        fillRect = { left: plotLeft, top: plotTop, width: x - plotLeft, height: plotHeight }
+    } else if (fillSide === 'right') {
+        fillRect = { left: x, top: plotTop, width: plotRight - x, height: plotHeight }
+    }
+
+    return (
+        <ReferenceLineView
+            fillRect={fillRect}
+            fillColor={fillColor}
+            fillOpacity={fillOpacity}
+            lineStyle={lineStyle}
+            label={label}
+            labelStyle={labelStyle}
+        />
+    )
+}
+
+/** The shared shell: optional filled half-plane, the stroked line, and an optional label.
+ *  Sub-components compute the pixel geometry; this just paints it. */
+function ReferenceLineView({
+    fillRect,
+    fillColor,
+    fillOpacity,
+    lineStyle,
+    label,
+    labelStyle,
+}: {
+    fillRect: React.CSSProperties | null
+    fillColor: string
+    fillOpacity: number
+    lineStyle: React.CSSProperties
+    label: string | undefined
+    labelStyle: React.CSSProperties
+}): React.ReactElement {
+    return (
+        <>
+            {fillRect && (
+                <div
+                    className="absolute pointer-events-none"
+                    style={{ ...fillRect, backgroundColor: fillColor, opacity: fillOpacity }}
+                />
+            )}
+            <div className="absolute pointer-events-none" style={lineStyle} />
+            {label && (
+                <div
+                    className="absolute pointer-events-none whitespace-nowrap font-medium text-[11px]"
+                    style={labelStyle}
+                >
+                    {label}
+                </div>
+            )}
+        </>
+    )
+}

--- a/frontend/src/lib/hog-charts/overlays/ReferenceLine.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ReferenceLine.tsx
@@ -74,7 +74,7 @@ export function ReferenceLines({ lines }: { lines: ReferenceLineProps[] }): Reac
     return (
         <>
             {lines.map((props, i) => (
-                <ReferenceLine key={`${props.value}-${props.label ?? i}`} {...props} />
+                <ReferenceLine key={`${i}-${props.value}-${props.label ?? ''}`} {...props} />
             ))}
         </>
     )
@@ -85,12 +85,12 @@ export function ReferenceLines({ lines }: { lines: ReferenceLineProps[] }): Reac
  *  {@link ReferenceLineView}. */
 export function ReferenceLine(props: ReferenceLineProps): React.ReactElement | null {
     const { orientation = 'horizontal', variant = 'goal', style } = props
-    const resolved = useMemo(() => resolveStyle(variant, style), [variant, style])
+    const resolved = useMemo(() => resolveStyle(variant, style), [variant, style?.color, style?.stroke, style?.width])
 
     const common: ResolvedProps = {
         resolved,
         fillSide: props.fillSide,
-        fillColor: style?.fillColor ?? resolved.color,
+        fillColor: resolveVariableColor(style?.fillColor) ?? resolved.color,
         fillOpacity: style?.fillOpacity ?? 0.1,
         label: props.label,
         labelPosition: props.labelPosition ?? 'end',


### PR DESCRIPTION
## Problem

hog-charts needs a composable way to draw reference lines (goal lines, alert thresholds, markers) on chart overlays. The existing `GoalLines` component is tightly coupled to a specific use case and doesn't support vertical lines, fill regions, or multiple visual variants.

## Changes

Adds a `ReferenceLine` component to `hog-charts/overlays/` with:

- Horizontal lines (at a y-value) and vertical lines (at an x-axis label)
- Three visual variants: `goal` (dashed grey), `alert` (dashed red), `marker` (solid thin grey)
- Optional text labels anchored at `start` or `end`
- Optional filled half-plane (above/below/left/right) for threshold regions
- Full style overrides (color, stroke, width, fill color/opacity)
- CSS variable color support via `resolveVariableColor`

A batch `ReferenceLines` wrapper is included for rendering multiple lines from an array.

No existing code is modified — this is a purely additive new file.

## How did you test this code?

Tests and integration with the rest of the charting library will follow in subsequent PRs.

## 🤖 LLM context

PR split out from #54180 by Claude Code. Component only — tests, exports, and migration from GoalLines will follow separately.