### PR TITLE
feat: add tooltips and disabled reasons to homepage config buttons

### DIFF
--- a/frontend/src/layout/scenes/ConfigurePinnedTabsModal.tsx
+++ b/frontend/src/layout/scenes/ConfigurePinnedTabsModal.tsx
@@ -183,7 +183,8 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                                 setHomepage(null)
                                             }}
                                             data-attr="configure-homepage-modal-set-launchpad"
-                                            disabled={isUsingProjectDefault}
+                                            tooltip="An AI-powered home with quick actions and recent items"
+                                            disabledReason={isUsingProjectDefault ? 'Already your homepage' : undefined}
                                         >
                                             Launchpad{' '}
                                             <LemonTag size="small" type="highlight" className="ml-1">
@@ -200,7 +201,8 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                                 setHomepage(newTabHomepage)
                                             }}
                                             data-attr="configure-homepage-modal-set-search"
-                                            disabled={isUsingNewTabHomepage}
+                                            tooltip="A search page to quickly find anything in your project"
+                                            disabledReason={isUsingNewTabHomepage ? 'Already your homepage' : undefined}
                                         >
                                             Search
                                         </LemonButton>
@@ -229,11 +231,13 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                                 }
                                             }}
                                             data-attr="configure-homepage-modal-set-default-dashboard"
-                                            disabled={isUsingDefaultDashboard || !currentTeam?.primary_dashboard}
+                                            tooltip="Open your project's default dashboard when you go home"
                                             disabledReason={
-                                                !currentTeam?.primary_dashboard
-                                                    ? 'No default dashboard configured'
-                                                    : undefined
+                                                isUsingDefaultDashboard
+                                                    ? 'Already your homepage'
+                                                    : !currentTeam?.primary_dashboard
+                                                      ? 'No default dashboard configured'
+                                                      : undefined
                                             }
                                         >
                                             Default dashboard
@@ -245,7 +249,7 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                             size="small"
                                             type="secondary"
                                             onClick={() => setHomepage(null)}
-                                            disabled={isUsingProjectDefault}
+                                            disabledReason={isUsingProjectDefault ? 'Already your homepage' : undefined}
                                         >
                                             Use default dashboard
                                         </LemonButton>
@@ -253,7 +257,7 @@ export function ConfigurePinnedTabsModal({ isOpen, onClose }: ConfigurePinnedTab
                                             size="small"
                                             type="secondary"
                                             onClick={() => setHomepage(newTabHomepage)}
-                                            disabled={isUsingNewTabHomepage}
+                                            disabledReason={isUsingNewTabHomepage ? 'Already your homepage' : undefined}
                                         >
                                             Use new tab page
                                         </LemonButton>


### PR DESCRIPTION
## Problem

In the "Configure tabs & home" modal, the homepage option buttons (Launchpad, Search, Default dashboard) have no tooltips explaining what each option does. When an option is already selected, it's disabled but gives no indication why — users just see a greyed-out button with no explanation.

## Changes

- Add `tooltip` descriptions to each button in the AI_FIRST path so users understand what Launchpad, Search, and Default dashboard mean
- Replace bare `disabled` props with `disabledReason` on all buttons so the currently-selected option shows "Already your homepage" on hover
- The Default dashboard button already had a `disabledReason` for "No default dashboard configured" — extended it to also cover the "already selected" case

## How did you test this code?

TypeScript check passes. Manual testing: open the Configure tabs & home modal, hover each button to see tooltips, verify disabled buttons show their reason.

## 🤖 LLM context

Agent-authored PR. Not manually tested — only verified via TypeScript type check.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*