### PR TITLE
fix: sanitize CSV/XLSX export cell values to prevent formula injection

### DIFF
--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -49,6 +49,24 @@ RESULT_LIMIT_LENGTH = 10
 QUERY_PAGE_SIZE = 10000
 
 
+_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
+
+
+def sanitize_formula_injection(value: Any) -> Any:
+    """Prevent CSV/XLSX formula injection by prefixing dangerous cell values.
+
+    Spreadsheet software interprets cells starting with =, +, -, @, tab, or
+    carriage-return as formulas. Prepending a single-quote neutralises this
+    while remaining human-readable (the quote is hidden by most spreadsheet
+    applications).
+    """
+    if not isinstance(value, str):
+        return value
+    if value and value[0] in _FORMULA_PREFIXES:
+        return "'" + value
+    return value
+
+
 def sanitize_value_for_excel(value: Any) -> Any:
     if not isinstance(value, str):
         return value
@@ -72,7 +90,7 @@ class CsvWriter(TabularWriter):
 
     def write_row(self, row: dict) -> None:
         assert self._writer is not None
-        self._writer.writerow(row)
+        self._writer.writerow({k: sanitize_formula_injection(v) for k, v in row.items()})
 
     def finish(self) -> str:
         self._tmp.close()
@@ -103,6 +121,7 @@ class ExcelWriter(TabularWriter):
             value = row.get(col)
             if value is not None and not isinstance(value, str | int | float | bool):
                 value = str(value)
+            value = sanitize_formula_injection(value)
             values.append(sanitize_value_for_excel(value))
         try:
             self._worksheet.append(values)

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -37,6 +37,7 @@ from posthog.tasks.exports.csv_exporter import (
     _convert_response_to_csv_data,
     _format_breakdown_value,
     add_query_params,
+    sanitize_formula_injection,
     sanitize_value_for_excel,
 )
 from posthog.tasks.exports.failure_handler import ExcelColumnLimitExceeded
@@ -1532,6 +1533,24 @@ class TestCSVExporter(APIBaseTest):
         ]
         for input_value, expected in test_cases:
             assert sanitize_value_for_excel(input_value) == expected, f"Failed for input: {repr(input_value)}"
+
+    def test_sanitize_formula_injection(self) -> None:
+        test_cases = [
+            ("=cmd('calc')", "'=cmd('calc')"),
+            ("+cmd('calc')", "'+cmd('calc')"),
+            ("-cmd('calc')", "'-cmd('calc')"),
+            ("@SUM(A1)", "'@SUM(A1)"),
+            ("\tcmd", "'\tcmd"),
+            ("\rcmd", "'\rcmd"),
+            ("normal text", "normal text"),
+            ("", ""),
+            (123, 123),
+            (None, None),
+            (12.34, 12.34),
+            (True, True),
+        ]
+        for input_value, expected in test_cases:
+            assert sanitize_formula_injection(input_value) == expected, f"Failed for input: {repr(input_value)}"
 
     @patch("posthog.models.exported_asset.UUIDT")
     @patch("posthog.models.exported_asset.object_storage.write_from_file")


### PR DESCRIPTION
## Problem

CSV and XLSX exports are vulnerable to formula injection. Cell values starting with `=`, `+`, `-`, `@`, `\t`, or `\r` are interpreted as formulas by spreadsheet software (Excel, Google Sheets, LibreOffice Calc), which can lead to arbitrary command execution on the user's machine.

Closes #54149

This replaces #54150, which was auto-closed when the fork was deleted.

## Changes

- Added `sanitize_formula_injection()` helper in `posthog/tasks/exports/csv_exporter.py` that prepends a single-quote `'` to string values starting with dangerous characters (`=`, `+`, `-`, `@`, `\t`, `\r`)
- Applied sanitization in both `CsvWriter.write_row` and `ExcelWriter.write_row` so all export formats are covered
- Added unit tests for the new sanitization function

## How did you test this code?

- Added `test_sanitize_formula_injection` with parameterized test cases covering all dangerous prefixes, normal strings, empty strings, and non-string types (int, float, bool, None)

## Publish to changelog?

no

## Docs update

N/A