### PR TITLE
feat(hog-charts): add dual y-axes support

### DIFF
--- a/frontend/src/lib/hog-charts/__tests__/interaction.test.ts
+++ b/frontend/src/lib/hog-charts/__tests__/interaction.test.ts
@@ -199,6 +199,52 @@ describe('hog-charts interaction', () => {
             const result = buildTooltipContext(0, series, ['a'], xConst, yConst, fakeCanvasBounds, customResolve)
             expect(result?.seriesData[0].value).toBe(999)
         })
+
+        it('resolves each series y-pixel through its own axis scale when yAxes is provided', () => {
+            // Two series on different axes with the same value, but each axis maps that
+            // value to a different pixel — the tooltip's y-position should reflect the
+            // min of the per-axis resolutions (not of calling the single yScale twice).
+            const leftSeries = makeSeries({ key: 'l', data: [50], yAxisId: 'left' })
+            const rightSeries = makeSeries({ key: 'r', data: [50], yAxisId: 'y1' })
+            const leftScale = (): number => 200
+            const rightScale = (): number => 80
+            const yAxes = {
+                left: { scale: leftScale, ticks: () => [0, 50, 100], position: 'left' as const },
+                y1: { scale: rightScale, ticks: () => [0, 50, 100], position: 'right' as const },
+            }
+            const fallbackY = (): number => 999 // should never be used when yAxes resolves
+            const result = buildTooltipContext(
+                0,
+                [leftSeries, rightSeries],
+                ['a'],
+                xConst,
+                fallbackY,
+                fakeCanvasBounds,
+                defaultResolveValue,
+                yAxes
+            )
+            // min of (200, 80) = 80
+            expect(result?.position.y).toBe(80)
+        })
+
+        it('falls back to the default yScale for series on an axis id that is not in yAxes', () => {
+            const series = [makeSeries({ key: 's', data: [10], yAxisId: 'unknown' })]
+            const fallbackY = (): number => 42
+            const yAxes = {
+                left: { scale: () => 999, ticks: () => [0, 10], position: 'left' as const },
+            }
+            const result = buildTooltipContext(
+                0,
+                series,
+                ['a'],
+                xConst,
+                fallbackY,
+                fakeCanvasBounds,
+                defaultResolveValue,
+                yAxes
+            )
+            expect(result?.position.y).toBe(42)
+        })
     })
 
     describe('buildPointClickData', () => {

--- a/frontend/src/lib/hog-charts/__tests__/scales.test.ts
+++ b/frontend/src/lib/hog-charts/__tests__/scales.test.ts
@@ -1,4 +1,12 @@
-import { autoFormatYTick, computePercentStackData, computeStackData, createXScale, createYScale } from '../core/scales'
+import {
+    autoFormatYTick,
+    computePercentStackData,
+    computeStackData,
+    createScales,
+    createXScale,
+    createYScale,
+} from '../core/scales'
+import { DEFAULT_Y_AXIS_ID } from '../core/types'
 import { dimensions, makeSeries } from '../test-helpers'
 
 describe('hog-charts scales', () => {
@@ -133,6 +141,80 @@ describe('hog-charts scales', () => {
             const series = [makeSeries({ key: 's1', data: [1] })]
             const scale = createYScale(series, dimensions, { percentStack: true })
             expect(scale(1)).toBeCloseTo(dimensions.plotTop, 0)
+        })
+    })
+
+    describe('createScales — single axis', () => {
+        it('returns no yAxes map when all visible series share the default axis', () => {
+            const series = [makeSeries({ key: 's1', data: [10] }), makeSeries({ key: 's2', data: [20] })]
+            const result = createScales(series, ['a'], dimensions)
+            expect(result.yAxes).toBeUndefined()
+        })
+
+        it('treats all-hidden series as single-axis (no yAxes map)', () => {
+            const series = [
+                makeSeries({ key: 'h1', data: [10], hidden: true, yAxisId: 'y1' }),
+                makeSeries({ key: 'h2', data: [20], hidden: true, yAxisId: 'y2' }),
+            ]
+            const result = createScales(series, ['a'], dimensions)
+            expect(result.yAxes).toBeUndefined()
+        })
+    })
+
+    describe('createScales — multi-axis', () => {
+        it('builds independent per-axis scales with their own domains', () => {
+            const small = makeSeries({ key: 'small', data: [0, 1], yAxisId: DEFAULT_Y_AXIS_ID })
+            const large = makeSeries({ key: 'large', data: [0, 1000], yAxisId: 'y1' })
+            const result = createScales([small, large], ['a', 'b'], dimensions)
+            expect(result.yAxes).not.toBeUndefined()
+            const left = result.yAxes![DEFAULT_Y_AXIS_ID].scale
+            const right = result.yAxes!.y1.scale
+            // 50 is in the middle of left's [0, 1] domain → top of plot; and far below right's [0, 1000]
+            // domain midpoint. Different scales → different pixels.
+            expect(left(1)).not.toBeCloseTo(right(1), 0)
+        })
+
+        it('assigns left to DEFAULT_Y_AXIS_ID and right to the second axis', () => {
+            const a = makeSeries({ key: 'a', data: [10], yAxisId: DEFAULT_Y_AXIS_ID })
+            const b = makeSeries({ key: 'b', data: [20], yAxisId: 'y1' })
+            const result = createScales([a, b], ['x'], dimensions)
+            expect(result.yAxes![DEFAULT_Y_AXIS_ID].position).toBe('left')
+            expect(result.yAxes!.y1.position).toBe('right')
+        })
+
+        it('keeps DEFAULT_Y_AXIS_ID on the left even when a non-default series appears first', () => {
+            // Series order reversed: the 'y1' series comes first, 'left' second.
+            const b = makeSeries({ key: 'b', data: [20], yAxisId: 'y1' })
+            const a = makeSeries({ key: 'a', data: [10], yAxisId: DEFAULT_Y_AXIS_ID })
+            const result = createScales([b, a], ['x'], dimensions)
+            expect(result.yAxes![DEFAULT_Y_AXIS_ID].position).toBe('left')
+            expect(result.yAxes!.y1.position).toBe('right')
+        })
+
+        it('points scales.y at the default axis for backward compat', () => {
+            const a = makeSeries({ key: 'a', data: [0, 10], yAxisId: DEFAULT_Y_AXIS_ID })
+            const b = makeSeries({ key: 'b', data: [0, 1000], yAxisId: 'y1' })
+            const result = createScales([a, b], ['x', 'y'], dimensions)
+            expect(result.y(10)).toBe(result.yAxes![DEFAULT_Y_AXIS_ID].scale(10))
+        })
+
+        it('falls back scales.y to the first axis when no series uses DEFAULT_Y_AXIS_ID', () => {
+            const a = makeSeries({ key: 'a', data: [0, 10], yAxisId: 'y1' })
+            const b = makeSeries({ key: 'b', data: [0, 1000], yAxisId: 'y2' })
+            const result = createScales([a, b], ['x', 'y'], dimensions)
+            // Without 'left', 'y1' takes the left position; scales.y should mirror it.
+            expect(result.yAxes!.y1.position).toBe('left')
+            expect(result.y(10)).toBe(result.yAxes!.y1.scale(10))
+        })
+
+        it('excludes hidden series from per-axis domain calculation', () => {
+            const visible = makeSeries({ key: 'v', data: [0, 10], yAxisId: DEFAULT_Y_AXIS_ID })
+            const hiddenOnLeft = makeSeries({ key: 'h', data: [0, 9999], hidden: true, yAxisId: DEFAULT_Y_AXIS_ID })
+            const otherAxis = makeSeries({ key: 'o', data: [0, 500], yAxisId: 'y1' })
+            const result = createScales([visible, hiddenOnLeft, otherAxis], ['a', 'b'], dimensions)
+            const [, leftMax] = result.yAxes![DEFAULT_Y_AXIS_ID].scale.domain() as [number, number]
+            // nice() can extend the domain slightly but nowhere near 9999.
+            expect(leftMax).toBeLessThan(100)
         })
     })
 

--- a/frontend/src/lib/hog-charts/__tests__/scales.test.ts
+++ b/frontend/src/lib/hog-charts/__tests__/scales.test.ts
@@ -174,19 +174,13 @@ describe('hog-charts scales', () => {
             expect(left(1)).not.toBeCloseTo(right(1), 0)
         })
 
-        it('assigns left to DEFAULT_Y_AXIS_ID and right to the second axis', () => {
-            const a = makeSeries({ key: 'a', data: [10], yAxisId: DEFAULT_Y_AXIS_ID })
-            const b = makeSeries({ key: 'b', data: [20], yAxisId: 'y1' })
+        it.each([
+            ['DEFAULT_Y_AXIS_ID first', [DEFAULT_Y_AXIS_ID, 'y1']],
+            ['non-default first', ['y1', DEFAULT_Y_AXIS_ID]],
+        ] as const)('assigns left to DEFAULT_Y_AXIS_ID regardless of series order (%s)', (_, [firstId, secondId]) => {
+            const a = makeSeries({ key: 'a', data: [10], yAxisId: firstId })
+            const b = makeSeries({ key: 'b', data: [20], yAxisId: secondId })
             const result = createScales([a, b], ['x'], dimensions)
-            expect(result.yAxes![DEFAULT_Y_AXIS_ID].position).toBe('left')
-            expect(result.yAxes!.y1.position).toBe('right')
-        })
-
-        it('keeps DEFAULT_Y_AXIS_ID on the left even when a non-default series appears first', () => {
-            // Series order reversed: the 'y1' series comes first, 'left' second.
-            const b = makeSeries({ key: 'b', data: [20], yAxisId: 'y1' })
-            const a = makeSeries({ key: 'a', data: [10], yAxisId: DEFAULT_Y_AXIS_ID })
-            const result = createScales([b, a], ['x'], dimensions)
             expect(result.yAxes![DEFAULT_Y_AXIS_ID].position).toBe('left')
             expect(result.yAxes!.y1.position).toBe('right')
         })

--- a/frontend/src/lib/hog-charts/charts/LineChart.tsx
+++ b/frontend/src/lib/hog-charts/charts/LineChart.tsx
@@ -5,6 +5,7 @@ import type { DrawContext } from '../core/canvas-renderer'
 import { Chart } from '../core/Chart'
 import { computePercentStackData, computeStackData, createScales as createLineScales } from '../core/scales'
 import type { ScaleSet, StackedBand } from '../core/scales'
+import { DEFAULT_Y_AXIS_ID } from '../core/types'
 import type {
     ChartDimensions,
     ChartDrawArgs,
@@ -15,6 +16,7 @@ import type {
     PointClickData,
     Series,
     TooltipContext,
+    YAxisScale,
 } from '../core/types'
 
 export interface LineChartProps<Meta = unknown> {
@@ -82,10 +84,24 @@ export function LineChart<Meta = unknown>({
                 percentStack: percentStackView,
             })
             d3ScalesRef.current = d3Scales
+
+            let yAxes: Record<string, YAxisScale> | undefined
+            if (d3Scales.yAxes) {
+                yAxes = {}
+                for (const [axisId, { scale, position }] of Object.entries(d3Scales.yAxes)) {
+                    yAxes[axisId] = {
+                        scale: (value: number) => scale(value),
+                        ticks: () => scale.ticks?.() ?? [],
+                        position,
+                    }
+                }
+            }
+
             return {
                 x: (label: string) => d3Scales.x(label),
                 y: (value: number) => d3Scales.y(value),
                 yTicks: () => d3Scales.y.ticks?.() ?? [],
+                yAxes,
             }
         },
         [yScaleType, percentStackView, stackedData]
@@ -97,7 +113,18 @@ export function LineChart<Meta = unknown>({
             if (!d3Scales) {
                 return
             }
-            const drawCtx: DrawContext = {
+
+            const resolveYScale = (s: Series): typeof d3Scales.y => {
+                const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
+                return d3Scales.yAxes?.[axisId]?.scale ?? d3Scales.y
+            }
+
+            const resolveChartYScale = (s: Series): ((value: number) => number) => {
+                const axisId = s.yAxisId ?? DEFAULT_Y_AXIS_ID
+                return scales.yAxes?.[axisId]?.scale ?? scales.y
+            }
+
+            const baseDrawCtx: DrawContext = {
                 ctx,
                 dimensions,
                 xScale: d3Scales.x,
@@ -106,7 +133,7 @@ export function LineChart<Meta = unknown>({
             }
 
             if (showGrid) {
-                drawGrid(drawCtx, { gridColor: theme.gridColor })
+                drawGrid(baseDrawCtx, { gridColor: theme.gridColor })
             }
 
             for (const s of coloredSeries) {
@@ -114,6 +141,7 @@ export function LineChart<Meta = unknown>({
                     continue
                 }
 
+                const drawCtx: DrawContext = { ...baseDrawCtx, yScale: resolveYScale(s) }
                 const band = stackedData?.get(s.key)
                 const yValues = band?.top
 
@@ -131,7 +159,8 @@ export function LineChart<Meta = unknown>({
                     }
                     const data = stackedData?.get(s.key)?.top ?? s.data
                     const x = scales.x(drawLabels[hoverIndex])
-                    const y = scales.y(data[hoverIndex])
+                    const yScaleFn = resolveChartYScale(s)
+                    const y = yScaleFn(data[hoverIndex])
                     if (x != null && isFinite(y)) {
                         drawHighlightPoint(ctx, x, y, s.color, theme.backgroundColor ?? '#ffffff')
                     }

--- a/frontend/src/lib/hog-charts/core/Chart.tsx
+++ b/frontend/src/lib/hog-charts/core/Chart.tsx
@@ -10,6 +10,7 @@ import { useChartCanvas } from './hooks/useChartCanvas'
 import { useChartDraw } from './hooks/useChartDraw'
 import { useChartInteraction } from './hooks/useChartInteraction'
 import { autoFormatYTick } from './scales'
+import { DEFAULT_Y_AXIS_ID } from './types'
 import type {
     ChartConfig,
     ChartDrawArgs,
@@ -76,6 +77,11 @@ export function Chart<Meta = unknown>({
         showCrosshair = false,
     } = config ?? {}
 
+    const hasMultipleAxes = useMemo(() => {
+        const axisIds = new Set(series.filter((s) => !s.hidden).map((s) => s.yAxisId ?? DEFAULT_Y_AXIS_ID))
+        return axisIds.size > 1
+    }, [series])
+
     const margins = useMemo<ChartMargins>(() => {
         const m = { ...DEFAULT_MARGINS }
         if (hideXAxis) {
@@ -84,8 +90,11 @@ export function Chart<Meta = unknown>({
         if (hideYAxis) {
             m.left = 8
         }
+        if (hasMultipleAxes && !hideYAxis) {
+            m.right = 48
+        }
         return m
-    }, [hideXAxis, hideYAxis])
+    }, [hideXAxis, hideYAxis, hasMultipleAxes])
 
     const { canvasRef, wrapperRef, dimensions, ctx } = useChartCanvas({ margins })
 
@@ -110,6 +119,19 @@ export function Chart<Meta = unknown>({
             return yTickFormatter
         }
         const ticks = scales?.yTicks() ?? []
+        const domainMax = ticks.length > 0 ? Math.abs(Math.max(...ticks)) : 1
+        return (v: number) => autoFormatYTick(v, domainMax)
+    }, [yTickFormatter, scales])
+
+    const resolvedYRightFormatter = useMemo(() => {
+        if (yTickFormatter) {
+            return yTickFormatter
+        }
+        const rightAxis = scales?.yAxes && Object.values(scales.yAxes).find((a) => a.position === 'right')
+        if (!rightAxis) {
+            return undefined
+        }
+        const ticks = rightAxis.ticks()
         const domainMax = ticks.length > 0 ? Math.abs(Math.max(...ticks)) : 1
         return (v: number) => autoFormatYTick(v, domainMax)
     }, [yTickFormatter, scales])
@@ -181,6 +203,7 @@ export function Chart<Meta = unknown>({
                             <AxisLabels
                                 xTickFormatter={xTickFormatter}
                                 yTickFormatter={resolvedYFormatter}
+                                yRightTickFormatter={resolvedYRightFormatter}
                                 hideXAxis={hideXAxis}
                                 hideYAxis={hideYAxis}
                                 axisColor={theme.axisColor}

--- a/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
+++ b/frontend/src/lib/hog-charts/core/hooks/useChartInteraction.ts
@@ -128,7 +128,16 @@ export function useChartInteraction<Meta = unknown>({
                 const canvasBounds = canvasRef.current?.getBoundingClientRect() ?? new DOMRect()
                 // Always propagate the result (including null) so tooltipCtx stays in sync with hoverIndex.
                 setTooltipCtx(
-                    buildTooltipContext(index, series, labels, scales.x, scales.y, canvasBounds, resolveValue)
+                    buildTooltipContext(
+                        index,
+                        series,
+                        labels,
+                        scales.x,
+                        scales.y,
+                        canvasBounds,
+                        resolveValue,
+                        scales.yAxes
+                    )
                 )
             }
         },

--- a/frontend/src/lib/hog-charts/core/interaction.ts
+++ b/frontend/src/lib/hog-charts/core/interaction.ts
@@ -1,6 +1,7 @@
 import { bisector } from 'd3'
 
-import type { ChartDimensions, PointClickData, ResolveValueFn, Series, TooltipContext } from './types'
+import type { ChartDimensions, PointClickData, ResolveValueFn, Series, TooltipContext, YAxisScale } from './types'
+import { DEFAULT_Y_AXIS_ID } from './types'
 
 export function findNearestIndex(
     mouseX: number,
@@ -44,7 +45,8 @@ export function buildTooltipContext<Meta = unknown>(
     xScale: (label: string) => number | undefined,
     yScale: (value: number) => number,
     canvasBounds: DOMRect,
-    resolveValue: ResolveValueFn
+    resolveValue: ResolveValueFn,
+    yAxes?: Record<string, YAxisScale>
 ): TooltipContext<Meta> | null {
     if (dataIndex < 0 || dataIndex >= labels.length) {
         return null
@@ -66,7 +68,8 @@ export function buildTooltipContext<Meta = unknown>(
         if (!s.hideFromTooltip) {
             seriesData.push({ series: s, value, color: s.color })
         }
-        const yVal = yScale(value)
+        const seriesYScale = yAxes?.[s.yAxisId ?? DEFAULT_Y_AXIS_ID]?.scale ?? yScale
+        const yVal = seriesYScale(value)
         if (isFinite(yVal)) {
             yPixels.push(yVal)
         }

--- a/frontend/src/lib/hog-charts/core/scales.ts
+++ b/frontend/src/lib/hog-charts/core/scales.ts
@@ -1,10 +1,15 @@
 import * as d3 from 'd3'
 
 import type { ChartDimensions, Series } from './types'
+import { DEFAULT_Y_AXIS_ID } from './types'
+
+type D3YScale = d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number>
 
 export interface ScaleSet {
     x: d3.ScalePoint<string>
-    y: d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number>
+    y: D3YScale
+    /** Per-axis d3 scales keyed by axis id. Only populated when multiple axes are present. */
+    yAxes?: Record<string, { scale: D3YScale; position: 'left' | 'right' }>
 }
 
 export function createXScale(labels: string[], dimensions: ChartDimensions): d3.ScalePoint<string> {
@@ -78,11 +83,38 @@ export function createScales(
     } = {}
 ): ScaleSet {
     const x = createXScale(labels, dimensions)
-    const y = createYScale(series, dimensions, {
-        scaleType: options.scaleType,
-        percentStack: options.percentStack,
+
+    const axisIds = new Set(series.filter((s) => !s.hidden).map((s) => s.yAxisId ?? DEFAULT_Y_AXIS_ID))
+    const hasMultipleAxes = axisIds.size > 1
+
+    if (!hasMultipleAxes) {
+        const y = createYScale(series, dimensions, {
+            scaleType: options.scaleType,
+            percentStack: options.percentStack,
+        })
+        return { x, y }
+    }
+
+    // DEFAULT_Y_AXIS_ID is always the left axis when present, regardless of series order.
+    // Remaining axis ids keep their first-encountered order and take the right position.
+    const orderedAxisIds = [
+        ...(axisIds.has(DEFAULT_Y_AXIS_ID) ? [DEFAULT_Y_AXIS_ID] : []),
+        ...Array.from(axisIds).filter((id) => id !== DEFAULT_Y_AXIS_ID),
+    ]
+
+    const yAxes: Record<string, { scale: D3YScale; position: 'left' | 'right' }> = {}
+    orderedAxisIds.forEach((axisId, axisIndex) => {
+        const axisSeries = series.filter((s) => !s.hidden && (s.yAxisId ?? DEFAULT_Y_AXIS_ID) === axisId)
+        const scale = createYScale(axisSeries, dimensions, {
+            scaleType: options.scaleType,
+            percentStack: options.percentStack,
+        })
+        yAxes[axisId] = { scale, position: axisIndex === 0 ? 'left' : 'right' }
     })
-    return { x, y }
+
+    const primaryAxis = yAxes[DEFAULT_Y_AXIS_ID] ?? yAxes[orderedAxisIds[0]]
+
+    return { x, y: primaryAxis.scale, yAxes }
 }
 
 export interface StackedBand {

--- a/frontend/src/lib/hog-charts/core/types.ts
+++ b/frontend/src/lib/hog-charts/core/types.ts
@@ -1,6 +1,9 @@
 import type { AxisFormat, ChartTheme } from 'lib/charts/types'
 export type { AxisFormat, ChartTheme }
 
+/** Default axis id used when a series doesn't specify one. */
+export const DEFAULT_Y_AXIS_ID = 'left'
+
 export interface Series<Meta = unknown> {
     /** Unique identifier used to key React elements and look up stacked data. */
     key: string
@@ -35,6 +38,8 @@ export interface Series<Meta = unknown> {
      *  Defaults to `unknown` so the library is meta-agnostic internally; adapters narrow it
      *  via `Series<MyMeta>` to get typed reads in their tooltip/click handlers. */
     meta?: Meta
+    /** Which y-axis this series is scaled against. Defaults to {@link DEFAULT_Y_AXIS_ID}. */
+    yAxisId?: string
 }
 
 /** Data passed to the `onPointClick` callback when a user clicks a data point. */
@@ -153,12 +158,25 @@ export type ResolveValueFn = (series: Series, dataIndex: number) => number
 /** Factory function that chart types provide to create their scales from dimensions and data. */
 export type CreateScalesFn = (series: Series[], labels: string[], dimensions: ChartDimensions) => ChartScales
 
+/** Per-axis scale: a mapping function and its tick values. */
+export interface YAxisScale {
+    /** Maps a y value to a pixel coordinate on this axis. */
+    scale: (value: number) => number
+    /** Returns tick values for this axis. */
+    ticks: () => number[]
+    /** Visual position of this axis. */
+    position: 'left' | 'right'
+}
+
 /** Generic scale interface that Chart uses for shared overlays and interaction. */
 export interface ChartScales {
     /** Maps a label to an x pixel coordinate. */
     x: (label: string) => number | undefined
-    /** Maps a y value to a pixel coordinate. */
+    /** Maps a y value to a pixel coordinate. Uses the default (left) axis. */
     y: (value: number) => number
-    /** Returns tick values for the y-axis. */
+    /** Returns tick values for the default (left) y-axis. */
     yTicks: () => number[]
+    /** Per-axis y scales keyed by axis id. Present when dual axes are active.
+     *  When absent, all series use `y` / `yTicks`. */
+    yAxes?: Record<string, YAxisScale>
 }

--- a/frontend/src/lib/hog-charts/index.ts
+++ b/frontend/src/lib/hog-charts/index.ts
@@ -21,7 +21,9 @@ export type {
     ResolveValueFn,
     Series,
     TooltipContext,
+    YAxisScale,
 } from './core/types'
+export { DEFAULT_Y_AXIS_ID } from './core/types'
 
 // Built-in tooltip (for reference or extension)
 export { DefaultTooltip } from './overlays/DefaultTooltip'

--- a/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
+++ b/frontend/src/lib/hog-charts/overlays/AxisLabels.tsx
@@ -5,6 +5,8 @@ import { useChart } from '../core/chart-context'
 interface AxisLabelsProps {
     xTickFormatter?: (value: string, index: number) => string | null
     yTickFormatter?: (value: number) => string
+    /** Formatter for the right y-axis. Falls back to `yTickFormatter` if not provided. */
+    yRightTickFormatter?: (value: number) => string
     hideXAxis?: boolean
     hideYAxis?: boolean
     axisColor?: string
@@ -77,6 +79,7 @@ const TICK_STYLE_BASE: React.CSSProperties = {
 export function AxisLabels({
     xTickFormatter,
     yTickFormatter,
+    yRightTickFormatter,
     hideXAxis,
     hideYAxis,
     axisColor = 'rgba(0, 0, 0, 0.5)',
@@ -84,10 +87,20 @@ export function AxisLabels({
     const { scales, dimensions, labels } = useChart()
     const yTicks = scales.yTicks()
 
+    const rightAxis = useMemo(() => {
+        if (!scales.yAxes) {
+            return null
+        }
+        return Object.values(scales.yAxes).find((a) => a.position === 'right') ?? null
+    }, [scales.yAxes])
+    const rightTicks = useMemo(() => rightAxis?.ticks() ?? [], [rightAxis])
+
     const visibleXLabels = useMemo(
         () => (hideXAxis ? [] : computeVisibleXLabels(labels, scales.x, xTickFormatter)),
         [hideXAxis, labels, scales.x, xTickFormatter]
     )
+
+    const rightFormatter = yRightTickFormatter ?? yTickFormatter
 
     return (
         <>
@@ -104,6 +117,30 @@ export function AxisLabels({
                             style={{
                                 ...TICK_STYLE_BASE,
                                 right: dimensions.width - dimensions.plotLeft + 8,
+                                top: y,
+                                transform: 'translateY(-50%)',
+                                color: axisColor,
+                            }}
+                        >
+                            {label}
+                        </div>
+                    )
+                })}
+
+            {!hideYAxis &&
+                rightAxis &&
+                rightTicks.map((tick: number) => {
+                    const y = rightAxis.scale(tick)
+                    if (!isFinite(y)) {
+                        return null
+                    }
+                    const label = rightFormatter ? rightFormatter(tick) : String(tick)
+                    return (
+                        <div
+                            key={`yr-${tick}`}
+                            style={{
+                                ...TICK_STYLE_BASE,
+                                left: dimensions.plotLeft + dimensions.plotWidth + 8,
                                 top: y,
                                 transform: 'translateY(-50%)',
                                 color: axisColor,

--- a/frontend/src/lib/hog-charts/overlays/ReferenceLine.test.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ReferenceLine.test.tsx
@@ -97,6 +97,39 @@ describe('ReferenceLine', () => {
             const fill = divs[0]
             expect(parseFloat(fill.style.top)).toBeGreaterThan(DIMENSIONS.plotTop)
         })
+
+        it('uses the matching yAxes scale when a yAxisId is specified', () => {
+            // Primary (left) scale ranges 0-100; right axis 'y1' ranges 0-1000.
+            // Rendering `value=500` on the left axis would fall outside bounds, but the
+            // right axis maps it to the middle of the plot.
+            const rightScale = (v: number): number => 368 - (v / 1000) * 352
+            const multiAxisContext: BaseChartContext = {
+                ...CONTEXT,
+                scales: {
+                    ...CONTEXT.scales,
+                    yAxes: {
+                        left: { scale: yScale, ticks: () => [0, 50, 100], position: 'left' },
+                        y1: { scale: rightScale, ticks: () => [0, 500, 1000], position: 'right' },
+                    },
+                },
+            }
+            const { container } = render(
+                <ChartContext.Provider value={multiAxisContext}>
+                    <ReferenceLine value={500} yAxisId="y1" />
+                </ChartContext.Provider>
+            )
+            const line = lineDiv(container, 'top')
+            expect(line).not.toBeNull()
+            // rightScale(500) = 192; width 2 → top = 191
+            expect(line!.style.top).toBe('191px')
+        })
+
+        it('falls back to the primary y-scale when yAxisId is unknown or absent', () => {
+            const { container } = renderInChart(<ReferenceLine value={50} yAxisId="missing" />)
+            const line = lineDiv(container, 'top')
+            // Unknown axis id → default scale → same pixel as the plain `value=50` case (191px).
+            expect(line!.style.top).toBe('191px')
+        })
     })
 
     describe('vertical', () => {

--- a/frontend/src/lib/hog-charts/overlays/ReferenceLine.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ReferenceLine.tsx
@@ -89,7 +89,8 @@ export function ReferenceLine(props: ReferenceLineProps): React.ReactElement | n
     const { orientation = 'horizontal', variant = 'goal', style } = props
     const resolved = useMemo(
         () => resolveStyle(variant, style),
-        [variant, style?.color, style?.stroke, style?.width, style]
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [variant, style?.color, style?.stroke, style?.width]
     )
 
     const common: ResolvedProps = {

--- a/frontend/src/lib/hog-charts/overlays/ReferenceLine.tsx
+++ b/frontend/src/lib/hog-charts/overlays/ReferenceLine.tsx
@@ -41,6 +41,8 @@ export interface ReferenceLineProps {
     fillSide?: ReferenceLineFillSide
     /** Preset: `goal` (dashed grey), `alert` (dashed red), `marker` (solid thin grey). Defaults to `goal`. */
     variant?: ReferenceLineVariant
+    /** Which y-axis this line references. Only used for horizontal lines. Defaults to the primary axis. */
+    yAxisId?: string
 }
 
 interface ResolvedStyle {
@@ -85,7 +87,10 @@ export function ReferenceLines({ lines }: { lines: ReferenceLineProps[] }): Reac
  *  {@link ReferenceLineView}. */
 export function ReferenceLine(props: ReferenceLineProps): React.ReactElement | null {
     const { orientation = 'horizontal', variant = 'goal', style } = props
-    const resolved = useMemo(() => resolveStyle(variant, style), [variant, style?.color, style?.stroke, style?.width])
+    const resolved = useMemo(
+        () => resolveStyle(variant, style),
+        [variant, style?.color, style?.stroke, style?.width, style]
+    )
 
     const common: ResolvedProps = {
         resolved,
@@ -97,7 +102,9 @@ export function ReferenceLine(props: ReferenceLineProps): React.ReactElement | n
     }
 
     if (orientation === 'horizontal') {
-        return typeof props.value === 'number' ? <HorizontalReferenceLine y={props.value} {...common} /> : null
+        return typeof props.value === 'number' ? (
+            <HorizontalReferenceLine y={props.value} yAxisId={props.yAxisId} {...common} />
+        ) : null
     }
     return typeof props.value === 'string' ? <VerticalReferenceLine xLabel={props.value} {...common} /> : null
 }
@@ -113,19 +120,21 @@ interface ResolvedProps {
 
 function HorizontalReferenceLine({
     y: value,
+    yAxisId,
     resolved,
     fillSide,
     fillColor,
     fillOpacity,
     label,
     labelPosition,
-}: ResolvedProps & { y: number }): React.ReactElement | null {
+}: ResolvedProps & { y: number; yAxisId?: string }): React.ReactElement | null {
     const { scales, dimensions } = useChart()
     const { plotLeft, plotTop, plotWidth, plotHeight, width: containerWidth } = dimensions
     const plotRight = plotLeft + plotWidth
     const plotBottom = plotTop + plotHeight
 
-    const y = scales.y(value)
+    const yScaleFn = yAxisId && scales.yAxes?.[yAxisId] ? scales.yAxes[yAxisId].scale : scales.y
+    const y = yScaleFn(value)
     if (!isFinite(y) || y < plotTop || y > plotBottom) {
         return null
     }

--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
@@ -91,8 +91,7 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
                         key: `${r.id}`,
                         label: r.label ?? '',
                         data: r.data,
-                        color:
-                            r.compare_label === 'previous' ? hexToRGBA(getTrendsColor(r), 0.5) : getTrendsColor(r),
+                        color: r.compare_label === 'previous' ? hexToRGBA(getTrendsColor(r), 0.5) : getTrendsColor(r),
                         fillArea: display === ChartDisplayType.ActionsAreaGraph,
                         dashedFromIndex,
                         yAxisId: showMultipleYAxes && index > 0 ? `y${index}` : DEFAULT_Y_AXIS_ID,

--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
@@ -81,30 +81,28 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
 
     const hogSeries: Series<TrendsSeriesMeta>[] = useMemo(
         () =>
-            (indexedResults ?? [])
-                .filter((r: IndexedTrendResult) => r.count !== 0)
-                .map((r: IndexedTrendResult, index: number) => {
-                    const isActiveSeries = !r.compare || r.compare_label !== 'previous'
-                    const dashedFromIndex =
-                        isInProgress && isActiveSeries ? r.data.length + incompletenessOffsetFromEnd : undefined
-                    return {
-                        key: `${r.id}`,
-                        label: r.label ?? '',
-                        data: r.data,
-                        color: r.compare_label === 'previous' ? hexToRGBA(getTrendsColor(r), 0.5) : getTrendsColor(r),
-                        fillArea: display === ChartDisplayType.ActionsAreaGraph,
-                        dashedFromIndex,
-                        yAxisId: showMultipleYAxes && index > 0 ? `y${index}` : DEFAULT_Y_AXIS_ID,
-                        meta: {
-                            action: r.action,
-                            breakdown_value: r.breakdown_value,
-                            compare_label: r.compare_label,
-                            days: r.days,
-                            order: r.action?.order ?? r.id,
-                            filter: r.filter,
-                        },
-                    }
-                }),
+            (indexedResults ?? []).map((r: IndexedTrendResult, index: number) => {
+                const isActiveSeries = !r.compare || r.compare_label !== 'previous'
+                const dashedFromIndex =
+                    isInProgress && isActiveSeries ? r.data.length + incompletenessOffsetFromEnd : undefined
+                return {
+                    key: `${r.id}`,
+                    label: r.label ?? '',
+                    data: r.data,
+                    color: r.compare_label === 'previous' ? hexToRGBA(getTrendsColor(r), 0.5) : getTrendsColor(r),
+                    fillArea: display === ChartDisplayType.ActionsAreaGraph,
+                    dashedFromIndex,
+                    yAxisId: showMultipleYAxes && index > 0 ? `y${index}` : DEFAULT_Y_AXIS_ID,
+                    meta: {
+                        action: r.action,
+                        breakdown_value: r.breakdown_value,
+                        compare_label: r.compare_label,
+                        days: r.days,
+                        order: r.action?.order ?? r.id,
+                        filter: r.filter,
+                    },
+                }
+            }),
         [indexedResults, display, getTrendsColor, isInProgress, incompletenessOffsetFromEnd, showMultipleYAxes]
     )
 

--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react'
 
 import { createXAxisTickCallback } from 'lib/charts/utils/dates'
 import { buildTheme } from 'lib/charts/utils/theme'
-import { LineChart } from 'lib/hog-charts'
+import { DEFAULT_Y_AXIS_ID, LineChart } from 'lib/hog-charts'
 import type { LineChartConfig, PointClickData, Series } from 'lib/hog-charts'
 import type { TooltipContext } from 'lib/hog-charts/core/types'
 import { ReferenceLines } from 'lib/hog-charts/overlays/ReferenceLine'
@@ -43,6 +43,7 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
         showPercentStackView,
         supportsPercentStackView,
         yAxisScaleType,
+        showMultipleYAxes,
         goalLines,
         getTrendsColor,
         currentPeriodResult,
@@ -80,28 +81,32 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
 
     const hogSeries: Series<TrendsSeriesMeta>[] = useMemo(
         () =>
-            (indexedResults ?? []).map((r: IndexedTrendResult) => {
-                const isActiveSeries = !r.compare || r.compare_label !== 'previous'
-                const dashedFromIndex =
-                    isInProgress && isActiveSeries ? r.data.length + incompletenessOffsetFromEnd : undefined
-                return {
-                    key: `${r.id}`,
-                    label: r.label ?? '',
-                    data: r.data,
-                    color: r.compare_label === 'previous' ? hexToRGBA(getTrendsColor(r), 0.5) : getTrendsColor(r),
-                    fillArea: display === ChartDisplayType.ActionsAreaGraph,
-                    dashedFromIndex,
-                    meta: {
-                        action: r.action,
-                        breakdown_value: r.breakdown_value,
-                        compare_label: r.compare_label,
-                        days: r.days,
-                        order: r.action?.order ?? r.id,
-                        filter: r.filter,
-                    },
-                }
-            }),
-        [indexedResults, display, getTrendsColor, isInProgress, incompletenessOffsetFromEnd]
+            (indexedResults ?? [])
+                .filter((r: IndexedTrendResult) => r.count !== 0)
+                .map((r: IndexedTrendResult, index: number) => {
+                    const isActiveSeries = !r.compare || r.compare_label !== 'previous'
+                    const dashedFromIndex =
+                        isInProgress && isActiveSeries ? r.data.length + incompletenessOffsetFromEnd : undefined
+                    return {
+                        key: `${r.id}`,
+                        label: r.label ?? '',
+                        data: r.data,
+                        color:
+                            r.compare_label === 'previous' ? hexToRGBA(getTrendsColor(r), 0.5) : getTrendsColor(r),
+                        fillArea: display === ChartDisplayType.ActionsAreaGraph,
+                        dashedFromIndex,
+                        yAxisId: showMultipleYAxes && index > 0 ? `y${index}` : DEFAULT_Y_AXIS_ID,
+                        meta: {
+                            action: r.action,
+                            breakdown_value: r.breakdown_value,
+                            compare_label: r.compare_label,
+                            days: r.days,
+                            order: r.action?.order ?? r.id,
+                            filter: r.filter,
+                        },
+                    }
+                }),
+        [indexedResults, display, getTrendsColor, isInProgress, incompletenessOffsetFromEnd, showMultipleYAxes]
     )
 
     const chartConfig: LineChartConfig = useMemo(() => {
@@ -211,6 +216,7 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
             theme={theme}
             tooltip={renderTooltip}
             onPointClick={canHandleClick ? onPointClick : undefined}
+            className="LineGraph"
         >
             <ReferenceLines lines={referenceLines} />
         </LineChart>


### PR DESCRIPTION
## Problem

We need to support multiple y-axis

## Changes

**Library (`lib/hog-charts`):**
- Add `Series.yAxisId?: string` with a `DEFAULT_Y_AXIS_ID` (`'left'`) fallback.
- Extend `ChartScales` with an optional `yAxes` map of per-axis scales (`scale`, `ticks`, `position`); `scales.y` / `yTicks` remain the primary axis for backward compat.
- `createScales` groups visible series by `yAxisId` and builds independent d3 scales per axis. `DEFAULT_Y_AXIS_ID` is always the left axis when present, regardless of series order; subsequent axes take the right position.
- `LineChart` resolves the correct y-scale per series when drawing lines, areas, points, and hover highlights.
- `buildTooltipContext` looks up each series' own scale when computing tooltip pixel positions.
- `AxisLabels` renders a second column of tick labels on the right when a right-positioned axis exists, with an optional `yRightTickFormatter`; `Chart` computes the right-axis formatter from the right axis's own domain so precision matches the values being labeled.
- `ReferenceLine` accepts an optional `yAxisId` prop on horizontal lines.
- `Chart` expands the right margin to 48px when multiple axes are present.

**Adapter (`TrendsLineChartD3`):**
- Pull `showMultipleYAxes` from `trendsDataLogic` and assign `yAxisId` per series (first → `left`, subsequent → `y1`, `y2`, …) matching the legacy Chart.js behavior.

## How did you test this code?

Manually, tests then the bot did:
I'm an agent. Automated coverage:

- All 130 hog-charts Jest tests pass, including 12 new cases covering multi-axis scale construction (`createScales`), default-axis ordering, per-series tooltip pixel resolution, and `ReferenceLine` with `yAxisId`.
- Type-checked the changed files — no errors.

Manual verification via Playwright MCP (on a local branch that also swaps `TrendsLineChartD3` in for line/area trends insights — not in this PR):

- Opened a Trends insight with two Pageview series on Last 90 days.
- Confirmed the hog-charts `TrendsLineChartD3` renders with real data.
- Toggled \"Show multiple Y-axes\" and confirmed left + right tick columns both render.
- No app-level console errors.

## Publish to changelog?
no

## 🤖 LLM context

Authored by Claude Code (Opus 4.6). The library work refactors the single-axis `ChartScales` shape into an optional multi-axis form while keeping `scales.y` / `scales.yTicks` working for every existing consumer, so chart types and overlays that don't know about multiple axes keep compiling. Reviewers: worth sanity-checking that the fallback path (`yAxes` absent) still exercises the original single-axis code path unchanged.

The routing swap in `Trends.tsx` to render `TrendsLineChartD3` in place of the legacy `ActionsLineGraph` is intentionally **not** in this PR — it'll land separately behind a feature flag or after broader manual verification.