### PR TITLE
fix(dashboard): prevent info popover from inheriting Link context menu

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -646,12 +646,8 @@ export function InsightMetaContent({
     showDescription?: boolean
     infoPopover?: JSX.Element | null
 }): JSX.Element {
-    let titleEl: JSX.Element = (
-        <h4
-            title={!compact ? title : undefined}
-            data-attr="insight-card-title"
-            className={clsx(infoPopover && 'inline-flex items-center overflow-visible')}
-        >
+    const titleContent = (
+        <>
             <span className={clsx(infoPopover && 'truncate')}>{title || <i>{fallbackTitle || 'Untitled'}</i>}</span>
             {(loading || loadingQueued) && (
                 <Tooltip
@@ -664,16 +660,25 @@ export function InsightMetaContent({
                     </span>
                 </Tooltip>
             )}
+        </>
+    )
+
+    const titleEl = (
+        <h4
+            title={!compact ? title : undefined}
+            data-attr="insight-card-title"
+            className={clsx(infoPopover && 'inline-flex items-center overflow-visible')}
+        >
+            {link ? (
+                <Link to={link} className="max-w-full truncate">
+                    {titleContent}
+                </Link>
+            ) : (
+                titleContent
+            )}
             {infoPopover}
         </h4>
     )
-    if (link) {
-        titleEl = (
-            <Link to={link} className="max-w-full truncate">
-                {titleEl}
-            </Link>
-        )
-    }
 
     return (
         <>


### PR DESCRIPTION
## Problem
Dashboard card info icon popover is completely wrapped in a Link's context menu (?), making everything inside the popup behave as a link, blocking regular context menus (for example: copy text shown here)


## Changes
Move the info popover component outside of the Link wrapper in InsightMetaContent. Previously, the popover was rendered inside the Link, causing the entire popover to inherit the Link's context menu behavior. This blocked normal right-click actions like copying text within the popover.

## How did you test this code?
Working locally, had to add `text-primary` as Link accent color leaked through because of the change

![2026-04-13 10 31 28](https://github.com/user-attachments/assets/b661080e-07ee-4350-896a-119436d81f0c)


## Publish to changelog?
No

## Docs update
No