### PR TITLE
feat(phrocs): add filter mode on processes

### DIFF
--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -69,6 +69,10 @@ type Model struct {
 	searchMatches []int // line indices that contain the match
 	searchCursor  int   // index into searchMatches (current highlighted match)
 
+	// Filter mode: shows only matching lines in the viewport
+	filterMode  bool
+	filterQuery string
+
 	// Sidebar with list of processes, always visible (when not in copy mode)
 	services       []*process.Process
 	servicesCursor int
@@ -204,11 +208,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				break
 			}
 			m.reloadActiveLines()
+			if m.filterMode {
+				m.recomputeFilter()
+			}
 			if m.searchQuery != "" {
 				m.recomputeSearch()
 			}
 			// Don't auto-scroll while the user is selecting text in copy mode
-			if m.viewportAtBottom && !m.copyMode && !m.searchMode {
+			if m.viewportAtBottom && !m.copyMode && !m.searchMode && !m.filterMode {
 				m.viewport.GotoBottom()
 			}
 		}
@@ -282,8 +289,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.containerLines = append(m.containerLines, msg.Line)
 			lineIndex := len(m.containerLines) - 1
-			m.viewport.SetContent(strings.Join(m.containerLines, "\n"))
-			if m.viewportAtBottom && !m.copyMode && !m.searchMode {
+			if m.filterMode {
+				m.recomputeFilter()
+			} else {
+				m.viewport.SetContent(strings.Join(m.containerLines, "\n"))
+			}
+			if m.viewportAtBottom && !m.copyMode && !m.searchMode && !m.filterMode {
 				m.viewport.GotoBottom()
 			}
 			if m.searchQuery != "" {
@@ -302,6 +313,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var handled bool
 		if m.searchMode {
 			m, cmds, handled = m.handleSearchKey(msg, cmds)
+		} else if m.filterMode {
+			m, cmds, handled = m.handleFilterKey(msg, cmds)
 		} else if m.copyMode {
 			m, cmds, handled = m.handleCopyKey(msg, cmds)
 		} else if m.infoMode {
@@ -390,7 +403,7 @@ func (m Model) View() tea.View {
 // Returns true when sidebars should be hidden and the output pane
 // fills the full width (copy mode or any search state).
 func (m Model) isFullScreen() bool {
-	return m.copyMode || m.searchMode || m.setupMode
+	return m.copyMode || m.searchMode || m.filterMode || m.setupMode
 }
 
 func (m Model) activeProc() *process.Process {
@@ -477,6 +490,8 @@ func (m Model) loadActiveProc() (Model, []tea.Cmd) {
 
 	m.copyMode = false
 	m.searchMode = false
+	m.filterMode = false
+	m.filterQuery = ""
 	m.inputBuffer = ""
 	m.viewport.StyleLineFunc = nil
 

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -63,15 +63,13 @@ type Model struct {
 	copyAnchor int
 	copyCursor int
 
-	// Search mode: output line filtering
+	// Search / filter query — shared between searchMode (highlights matches)
+	// and filterMode (shows only matching lines)
 	searchMode    bool
+	filterMode    bool
 	searchQuery   string
 	searchMatches []int // line indices that contain the match
 	searchCursor  int   // index into searchMatches (current highlighted match)
-
-	// Filter mode: shows only matching lines in the viewport
-	filterMode  bool
-	filterQuery string
 
 	// Sidebar with list of processes, always visible (when not in copy mode)
 	services       []*process.Process
@@ -210,8 +208,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.reloadActiveLines()
 			if m.filterMode {
 				m.recomputeFilter()
-			}
-			if m.searchQuery != "" {
+			} else if m.searchQuery != "" {
 				m.recomputeSearch()
 			}
 			// Don't auto-scroll while the user is selecting text in copy mode
@@ -297,7 +294,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.viewportAtBottom && !m.copyMode && !m.searchMode && !m.filterMode {
 				m.viewport.GotoBottom()
 			}
-			if m.searchQuery != "" {
+			if !m.filterMode && m.searchQuery != "" {
 				m.updateSearchForLine(msg.Line, lineIndex, evicted)
 			}
 		}
@@ -491,7 +488,6 @@ func (m Model) loadActiveProc() (Model, []tea.Cmd) {
 	m.copyMode = false
 	m.searchMode = false
 	m.filterMode = false
-	m.filterQuery = ""
 	m.inputBuffer = ""
 	m.viewport.StyleLineFunc = nil
 

--- a/tools/phrocs/internal/tui/app_test.go
+++ b/tools/phrocs/internal/tui/app_test.go
@@ -531,6 +531,220 @@ func TestSearch_dockerIncrementalLogLineUpdatesMatches(t *testing.T) {
 	}
 }
 
+// ── Filter ────────────────────────────────────────────────────────────────────
+
+func TestFilter_enterAndExit(t *testing.T) {
+	m := readyModel(t, "backend")
+	m = update(m, keypress('f'))
+	if !m.filterMode {
+		t.Error("f should enter filter mode")
+	}
+	m = update(m, specialKey(tea.KeyEscape))
+	if m.filterMode {
+		t.Error("esc should exit filter mode")
+	}
+	if m.filterQuery != "" {
+		t.Error("esc should clear filter query")
+	}
+}
+
+func TestFilter_typeQuery(t *testing.T) {
+	m := readyModel(t, "backend")
+	m = update(m, keypress('f'))
+	m = update(m, keypress('e'))
+	m = update(m, keypress('r'))
+	m = update(m, keypress('r'))
+	if m.filterQuery != "err" {
+		t.Errorf("typed 'err', got %q", m.filterQuery)
+	}
+}
+
+func TestFilter_backspace(t *testing.T) {
+	m := readyModel(t, "backend")
+	m = update(m, keypress('f'))
+	m = update(m, keypress('e'))
+	m = update(m, keypress('r'))
+	m = update(m, tea.KeyPressMsg{Code: tea.KeyBackspace, Text: "backspace"})
+	if m.filterQuery != "e" {
+		t.Errorf("after backspace want %q, got %q", "e", m.filterQuery)
+	}
+}
+
+func TestFilter_showsOnlyMatchingLines(t *testing.T) {
+	m := readyModel(t, "backend")
+	p, _ := m.mgr.Get("backend")
+	for _, line := range []string{"hello world", "error here", "another error", "info log"} {
+		p.AppendLine(line)
+		m = update(m, process.OutputMsg{Name: "backend"})
+	}
+	m = update(m, keypress('f'))
+	for _, ch := range "error" {
+		m = update(m, keypress(ch))
+	}
+	// Only 2 lines contain "error", so the viewport should have 2 lines
+	if m.viewport.TotalLineCount() != 2 {
+		t.Errorf("want 2 filtered lines, got %d", m.viewport.TotalLineCount())
+	}
+}
+
+func TestFilter_noMatchShowsEmpty(t *testing.T) {
+	m := readyModel(t, "backend")
+	p, _ := m.mgr.Get("backend")
+	p.AppendLine("hello world")
+	m = update(m, process.OutputMsg{Name: "backend"})
+	m = update(m, keypress('f'))
+	for _, ch := range "zzz" {
+		m = update(m, keypress(ch))
+	}
+	if m.viewport.TotalLineCount() != 0 {
+		t.Errorf("want 0 lines for no matches, got %d", m.viewport.TotalLineCount())
+	}
+}
+
+func TestFilter_emptyQueryShowsAllLines(t *testing.T) {
+	m := readyModel(t, "backend")
+	p, _ := m.mgr.Get("backend")
+	for _, line := range []string{"line 1", "line 2", "line 3"} {
+		p.AppendLine(line)
+		m = update(m, process.OutputMsg{Name: "backend"})
+	}
+	before := m.viewport.TotalLineCount()
+	m = update(m, keypress('f'))
+	// With empty filter query, all lines should be visible
+	if m.viewport.TotalLineCount() != before {
+		t.Errorf("empty filter should show all lines: want %d, got %d", before, m.viewport.TotalLineCount())
+	}
+}
+
+func TestFilter_isFullScreen(t *testing.T) {
+	m := readyModel(t, "backend")
+	m = update(m, keypress('f'))
+	if !m.isFullScreen() {
+		t.Error("filter mode should be full screen")
+	}
+}
+
+func TestFilter_liveUpdate(t *testing.T) {
+	m := readyModel(t, "backend")
+	p, _ := m.mgr.Get("backend")
+	p.AppendLine("error one")
+	m = update(m, process.OutputMsg{Name: "backend"})
+	m = update(m, keypress('f'))
+	for _, ch := range "error" {
+		m = update(m, keypress(ch))
+	}
+	if m.viewport.TotalLineCount() != 1 {
+		t.Fatalf("want 1 filtered line initially, got %d", m.viewport.TotalLineCount())
+	}
+	// New matching line arrives
+	p.AppendLine("error two")
+	m = update(m, process.OutputMsg{Name: "backend"})
+	if m.viewport.TotalLineCount() != 2 {
+		t.Errorf("after new matching line: want 2 filtered lines, got %d", m.viewport.TotalLineCount())
+	}
+}
+
+func TestFilter_exitRestoresAllLines(t *testing.T) {
+	m := readyModel(t, "backend")
+	p, _ := m.mgr.Get("backend")
+	for _, line := range []string{"error one", "info two", "error three"} {
+		p.AppendLine(line)
+		m = update(m, process.OutputMsg{Name: "backend"})
+	}
+	before := m.viewport.TotalLineCount()
+	// Enter filter, type query
+	m = update(m, keypress('f'))
+	for _, ch := range "error" {
+		m = update(m, keypress(ch))
+	}
+	if m.viewport.TotalLineCount() >= before {
+		t.Fatal("filter should reduce visible lines")
+	}
+	// Exit filter
+	m = update(m, specialKey(tea.KeyEscape))
+	if m.viewport.TotalLineCount() != before {
+		t.Errorf("after exit, want %d lines restored, got %d", before, m.viewport.TotalLineCount())
+	}
+}
+
+func TestFilter_negativeExcludesLines(t *testing.T) {
+	m := readyModel(t, "backend")
+	p, _ := m.mgr.Get("backend")
+	for _, line := range []string{"error: crash", "debug: verbose", "info: started", "warning: slow"} {
+		p.AppendLine(line)
+		m = update(m, process.OutputMsg{Name: "backend"})
+	}
+	m = update(m, keypress('f'))
+	// Type "!debug"
+	m = update(m, tea.KeyPressMsg{Code: '!', Mod: tea.ModShift, Text: "!"})
+	for _, ch := range "debug" {
+		m = update(m, keypress(ch))
+	}
+	// Should show 3 lines (all except "debug: verbose")
+	if m.viewport.TotalLineCount() != 3 {
+		t.Errorf("want 3 lines excluding debug, got %d", m.viewport.TotalLineCount())
+	}
+}
+
+func TestFilter_multipleNegatives(t *testing.T) {
+	m := readyModel(t, "backend")
+	p, _ := m.mgr.Get("backend")
+	for _, line := range []string{"error: crash", "debug: verbose", "info: started", "warning: slow"} {
+		p.AppendLine(line)
+		m = update(m, process.OutputMsg{Name: "backend"})
+	}
+	m = update(m, keypress('f'))
+	// Type "!debug !warning" (two negative tokens separated by space)
+	for _, ch := range "!debug" {
+		if ch == '!' {
+			m = update(m, tea.KeyPressMsg{Code: '!', Mod: tea.ModShift, Text: "!"})
+		} else {
+			m = update(m, keypress(ch))
+		}
+	}
+	m = update(m, tea.KeyPressMsg{Code: tea.KeySpace, Text: "space"})
+	for _, ch := range "!warning" {
+		if ch == '!' {
+			m = update(m, tea.KeyPressMsg{Code: '!', Mod: tea.ModShift, Text: "!"})
+		} else {
+			m = update(m, keypress(ch))
+		}
+	}
+	// Should show 2 lines (error + info)
+	if m.viewport.TotalLineCount() != 2 {
+		t.Errorf("want 2 lines excluding debug+warning, got %d", m.viewport.TotalLineCount())
+	}
+}
+
+func TestFilter_spaceInQuery(t *testing.T) {
+	m := readyModel(t, "backend")
+	m = update(m, keypress('f'))
+	m = update(m, keypress('h'))
+	m = update(m, tea.KeyPressMsg{Code: tea.KeySpace, Text: "space"})
+	m = update(m, keypress('w'))
+	if m.filterQuery != "h w" {
+		t.Errorf("space in filter query: want %q, got %q", "h w", m.filterQuery)
+	}
+}
+
+func TestFilter_clearedOnProcSwitch(t *testing.T) {
+	m := readyModel(t, "alpha", "beta")
+	m = update(m, keypress('f'))
+	m = update(m, keypress('x'))
+	if m.filterQuery != "x" {
+		t.Fatal("filter query should be set")
+	}
+	// Switch to next proc
+	m = update(m, specialKey(tea.KeyEscape)) // exit filter first
+	m = update(m, keypress('j'))             // move to beta
+	if m.filterQuery != "" {
+		t.Error("filter query should be cleared on proc switch")
+	}
+	if m.filterMode {
+		t.Error("filter mode should be cleared on proc switch")
+	}
+}
+
 func TestCopySelectedText_dockerUsesContainerLogs(t *testing.T) {
 	m := readyDockerModel(t)
 	m.containerLines = []string{"first", "\x1b[31msecond\x1b[0m", "third"}

--- a/tools/phrocs/internal/tui/app_test.go
+++ b/tools/phrocs/internal/tui/app_test.go
@@ -345,7 +345,7 @@ func TestSearch_matchesHighlighted(t *testing.T) {
 	}
 }
 
-func TestSearch_enterConfirmsAndKeepsMatches(t *testing.T) {
+func TestSearch_enterCommitsToFilter(t *testing.T) {
 	m := readyModel(t, "backend")
 	p, _ := m.mgr.Get("backend")
 	for _, line := range []string{"foo", "bar", "foo again"} {
@@ -356,40 +356,47 @@ func TestSearch_enterConfirmsAndKeepsMatches(t *testing.T) {
 	m = update(m, keypress('f'))
 	m = update(m, keypress('o'))
 	m = update(m, keypress('o'))
-	m = update(m, tea.KeyPressMsg{Code: tea.KeyEnter, Text: "enter"})
-	if m.searchQuery != "foo" {
-		t.Errorf("query should be preserved after enter, got %q", m.searchQuery)
+	m = update(m, specialKey(tea.KeyEnter))
+	if m.searchMode {
+		t.Error("search mode should be off after enter (committed)")
 	}
-	if len(m.searchMatches) != 2 {
-		t.Errorf("matches should persist after enter, want 2 got %d", len(m.searchMatches))
+	if !m.filterMode {
+		t.Error("filter mode should be on after enter")
+	}
+	if m.searchQuery != "foo" {
+		t.Errorf("query should be preserved after commit, got %q", m.searchQuery)
+	}
+	if m.viewport.TotalLineCount() != 2 {
+		t.Errorf("filter should show 2 matching lines, got %d", m.viewport.TotalLineCount())
 	}
 }
 
-func TestSearch_navigateWithEnter(t *testing.T) {
+func TestSearch_navigateWithArrows(t *testing.T) {
 	m := readyModel(t, "backend")
 	p, _ := m.mgr.Get("backend")
-	for _, line := range []string{"match one", "no match", "match two"} {
+	for _, line := range []string{"match one", "nothing here", "match two"} {
 		p.AppendLine(line)
 		m = update(m, process.OutputMsg{Name: "backend"})
 	}
-	// Enter search and confirm
 	m = update(m, keypress('/'))
 	for _, ch := range "match" {
 		m = update(m, keypress(ch))
 	}
-	m = update(m, tea.KeyPressMsg{Code: tea.KeyEnter, Text: "enter"})
-	if m.searchCursor != 1 {
-		t.Fatalf("after enter cursor should be 1, got %d", m.searchCursor)
+	if len(m.searchMatches) != 2 {
+		t.Fatalf("want 2 matches, got %d", len(m.searchMatches))
 	}
-	// ↵ → next match
-	m = update(m, tea.KeyPressMsg{Code: tea.KeyEnter, Text: "enter"})
-	if m.searchCursor != 2 {
-		t.Errorf("enter: want cursor 2, got %d", m.searchCursor)
+	if m.searchCursor != 0 {
+		t.Fatalf("initial cursor should be 0, got %d", m.searchCursor)
 	}
-	// ⇧↵ → prev match
-	m = update(m, tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift, Text: "shift+enter"})
+	// ↓ → next match
+	m = update(m, specialKey(tea.KeyDown))
 	if m.searchCursor != 1 {
-		t.Errorf("shift+enter: want cursor 1, got %d", m.searchCursor)
+		t.Errorf("down: want cursor 1, got %d", m.searchCursor)
+	}
+	// ↑ → prev match
+	m = update(m, specialKey(tea.KeyUp))
+	if m.searchCursor != 0 {
+		t.Errorf("up: want cursor 0, got %d", m.searchCursor)
 	}
 }
 
@@ -406,7 +413,6 @@ func TestSearch_incrementalUpdate(t *testing.T) {
 	for _, ch := range "error" {
 		m = update(m, keypress(ch))
 	}
-	m = update(m, tea.KeyPressMsg{Code: tea.KeyEnter, Text: "enter"})
 	if len(m.searchMatches) != 1 {
 		t.Fatalf("want 1 match for 'error', got %d", len(m.searchMatches))
 	}
@@ -442,7 +448,6 @@ func TestSearch_eviction(t *testing.T) {
 	m = update(m, keypress('e'))
 	m = update(m, keypress('r'))
 	m = update(m, keypress('r'))
-	m = update(m, tea.KeyPressMsg{Code: tea.KeyEnter, Text: "enter"})
 	if len(m.searchMatches) != 2 {
 		t.Fatalf("want 2 matches, got %d", len(m.searchMatches))
 	}
@@ -465,17 +470,15 @@ func TestSearch_escClearsActiveSearch(t *testing.T) {
 	p, _ := m.mgr.Get("backend")
 	p.AppendLine("something")
 	m = update(m, process.OutputMsg{Name: "backend"})
-	// Build a search result, then exit typing mode
+	// Build a search result, then exit via esc
 	m = update(m, keypress('/'))
 	m = update(m, keypress('s'))
-	m = update(m, tea.KeyPressMsg{Code: tea.KeyEnter, Text: "enter"})
 	if m.searchQuery == "" {
 		t.Fatal("search query should be set")
 	}
-	// Esc in normal mode should clear the search
 	m = update(m, specialKey(tea.KeyEscape))
 	if m.searchQuery != "" {
-		t.Error("esc in normal mode should clear search query")
+		t.Error("esc should clear search query")
 	}
 	if len(m.searchMatches) != 0 {
 		t.Error("esc should clear search matches")
@@ -533,40 +536,47 @@ func TestSearch_dockerIncrementalLogLineUpdatesMatches(t *testing.T) {
 
 // ── Filter ────────────────────────────────────────────────────────────────────
 
+// enterFilterMode opens search via / and commits to filter via enter.
+func enterFilterMode(m Model) Model {
+	m = update(m, keypress('/'))
+	m = update(m, specialKey(tea.KeyEnter))
+	return m
+}
+
 func TestFilter_enterAndExit(t *testing.T) {
 	m := readyModel(t, "backend")
-	m = update(m, keypress('f'))
+	m = enterFilterMode(m)
 	if !m.filterMode {
-		t.Error("f should enter filter mode")
+		t.Error("/ then tab should enter filter mode")
 	}
 	m = update(m, specialKey(tea.KeyEscape))
 	if m.filterMode {
 		t.Error("esc should exit filter mode")
 	}
-	if m.filterQuery != "" {
-		t.Error("esc should clear filter query")
+	if m.searchQuery != "" {
+		t.Error("esc should clear query")
 	}
 }
 
 func TestFilter_typeQuery(t *testing.T) {
 	m := readyModel(t, "backend")
-	m = update(m, keypress('f'))
+	m = enterFilterMode(m)
 	m = update(m, keypress('e'))
 	m = update(m, keypress('r'))
 	m = update(m, keypress('r'))
-	if m.filterQuery != "err" {
-		t.Errorf("typed 'err', got %q", m.filterQuery)
+	if m.searchQuery != "err" {
+		t.Errorf("typed 'err', got %q", m.searchQuery)
 	}
 }
 
 func TestFilter_backspace(t *testing.T) {
 	m := readyModel(t, "backend")
-	m = update(m, keypress('f'))
+	m = enterFilterMode(m)
 	m = update(m, keypress('e'))
 	m = update(m, keypress('r'))
 	m = update(m, tea.KeyPressMsg{Code: tea.KeyBackspace, Text: "backspace"})
-	if m.filterQuery != "e" {
-		t.Errorf("after backspace want %q, got %q", "e", m.filterQuery)
+	if m.searchQuery != "e" {
+		t.Errorf("after backspace want %q, got %q", "e", m.searchQuery)
 	}
 }
 
@@ -577,7 +587,7 @@ func TestFilter_showsOnlyMatchingLines(t *testing.T) {
 		p.AppendLine(line)
 		m = update(m, process.OutputMsg{Name: "backend"})
 	}
-	m = update(m, keypress('f'))
+	m = enterFilterMode(m)
 	for _, ch := range "error" {
 		m = update(m, keypress(ch))
 	}
@@ -592,7 +602,7 @@ func TestFilter_noMatchShowsEmpty(t *testing.T) {
 	p, _ := m.mgr.Get("backend")
 	p.AppendLine("hello world")
 	m = update(m, process.OutputMsg{Name: "backend"})
-	m = update(m, keypress('f'))
+	m = enterFilterMode(m)
 	for _, ch := range "zzz" {
 		m = update(m, keypress(ch))
 	}
@@ -609,7 +619,7 @@ func TestFilter_emptyQueryShowsAllLines(t *testing.T) {
 		m = update(m, process.OutputMsg{Name: "backend"})
 	}
 	before := m.viewport.TotalLineCount()
-	m = update(m, keypress('f'))
+	m = enterFilterMode(m)
 	// With empty filter query, all lines should be visible
 	if m.viewport.TotalLineCount() != before {
 		t.Errorf("empty filter should show all lines: want %d, got %d", before, m.viewport.TotalLineCount())
@@ -618,7 +628,7 @@ func TestFilter_emptyQueryShowsAllLines(t *testing.T) {
 
 func TestFilter_isFullScreen(t *testing.T) {
 	m := readyModel(t, "backend")
-	m = update(m, keypress('f'))
+	m = enterFilterMode(m)
 	if !m.isFullScreen() {
 		t.Error("filter mode should be full screen")
 	}
@@ -629,7 +639,7 @@ func TestFilter_liveUpdate(t *testing.T) {
 	p, _ := m.mgr.Get("backend")
 	p.AppendLine("error one")
 	m = update(m, process.OutputMsg{Name: "backend"})
-	m = update(m, keypress('f'))
+	m = enterFilterMode(m)
 	for _, ch := range "error" {
 		m = update(m, keypress(ch))
 	}
@@ -653,7 +663,7 @@ func TestFilter_exitRestoresAllLines(t *testing.T) {
 	}
 	before := m.viewport.TotalLineCount()
 	// Enter filter, type query
-	m = update(m, keypress('f'))
+	m = enterFilterMode(m)
 	for _, ch := range "error" {
 		m = update(m, keypress(ch))
 	}
@@ -674,7 +684,7 @@ func TestFilter_negativeExcludesLines(t *testing.T) {
 		p.AppendLine(line)
 		m = update(m, process.OutputMsg{Name: "backend"})
 	}
-	m = update(m, keypress('f'))
+	m = enterFilterMode(m)
 	// Type "!debug"
 	m = update(m, tea.KeyPressMsg{Code: '!', Mod: tea.ModShift, Text: "!"})
 	for _, ch := range "debug" {
@@ -693,7 +703,7 @@ func TestFilter_multipleNegatives(t *testing.T) {
 		p.AppendLine(line)
 		m = update(m, process.OutputMsg{Name: "backend"})
 	}
-	m = update(m, keypress('f'))
+	m = enterFilterMode(m)
 	// Type "!debug !warning" (two negative tokens separated by space)
 	for _, ch := range "!debug" {
 		if ch == '!' {
@@ -718,30 +728,124 @@ func TestFilter_multipleNegatives(t *testing.T) {
 
 func TestFilter_spaceInQuery(t *testing.T) {
 	m := readyModel(t, "backend")
-	m = update(m, keypress('f'))
+	m = enterFilterMode(m)
 	m = update(m, keypress('h'))
 	m = update(m, tea.KeyPressMsg{Code: tea.KeySpace, Text: "space"})
 	m = update(m, keypress('w'))
-	if m.filterQuery != "h w" {
-		t.Errorf("space in filter query: want %q, got %q", "h w", m.filterQuery)
+	if m.searchQuery != "h w" {
+		t.Errorf("space in filter query: want %q, got %q", "h w", m.searchQuery)
 	}
 }
 
 func TestFilter_clearedOnProcSwitch(t *testing.T) {
 	m := readyModel(t, "alpha", "beta")
-	m = update(m, keypress('f'))
+	m = enterFilterMode(m)
 	m = update(m, keypress('x'))
-	if m.filterQuery != "x" {
-		t.Fatal("filter query should be set")
+	if m.searchQuery != "x" {
+		t.Fatal("query should be set")
 	}
 	// Switch to next proc
-	m = update(m, specialKey(tea.KeyEscape)) // exit filter first
+	m = update(m, specialKey(tea.KeyEscape)) // exit filter first (clears query)
 	m = update(m, keypress('j'))             // move to beta
-	if m.filterQuery != "" {
-		t.Error("filter query should be cleared on proc switch")
+	if m.searchQuery != "" {
+		t.Error("query should be cleared on proc switch")
 	}
 	if m.filterMode {
 		t.Error("filter mode should be cleared on proc switch")
+	}
+}
+
+func TestSearch_homeEndScrollsViewport(t *testing.T) {
+	m := readyModel(t, "backend")
+	p, _ := m.mgr.Get("backend")
+	for i := 0; i < 100; i++ {
+		p.AppendLine(fmt.Sprintf("line %d", i))
+	}
+	m = update(m, process.OutputMsg{Name: "backend"})
+	m = update(m, keypress('/'))
+	m.viewport.GotoBottom()
+	m = update(m, specialKey(tea.KeyHome))
+	if m.viewport.YOffset() != 0 {
+		t.Errorf("home in search mode: want YOffset 0, got %d", m.viewport.YOffset())
+	}
+	m = update(m, specialKey(tea.KeyEnd))
+	if !m.viewport.AtBottom() {
+		t.Error("end in search mode: viewport should be at bottom")
+	}
+}
+
+func TestFilter_homeEndScrollsViewport(t *testing.T) {
+	m := readyModel(t, "backend")
+	p, _ := m.mgr.Get("backend")
+	for i := 0; i < 100; i++ {
+		p.AppendLine(fmt.Sprintf("line %d", i))
+	}
+	m = update(m, process.OutputMsg{Name: "backend"})
+	m = enterFilterMode(m)
+	m.viewport.GotoBottom()
+	m = update(m, specialKey(tea.KeyHome))
+	if m.viewport.YOffset() != 0 {
+		t.Errorf("home in filter mode: want YOffset 0, got %d", m.viewport.YOffset())
+	}
+	m = update(m, specialKey(tea.KeyEnd))
+	if !m.viewport.AtBottom() {
+		t.Error("end in filter mode: viewport should be at bottom")
+	}
+}
+
+func TestFilter_backspaceOnEmptyGoesBackToSearch(t *testing.T) {
+	m := readyModel(t, "backend")
+	p, _ := m.mgr.Get("backend")
+	p.AppendLine("hello")
+	m = update(m, process.OutputMsg{Name: "backend"})
+	m = enterFilterMode(m)
+	if !m.filterMode || m.searchQuery != "" {
+		t.Fatalf("setup: filterMode=%v query=%q", m.filterMode, m.searchQuery)
+	}
+	m = update(m, tea.KeyPressMsg{Code: tea.KeyBackspace, Text: "backspace"})
+	if m.filterMode {
+		t.Error("filter mode should be off after backspace on empty query")
+	}
+	if !m.searchMode {
+		t.Error("search mode should be on after backspace on empty query")
+	}
+}
+
+func TestFilter_tabGoesBackToSearch(t *testing.T) {
+	m := readyModel(t, "backend")
+	p, _ := m.mgr.Get("backend")
+	for _, line := range []string{"error here", "info ok", "another error"} {
+		p.AppendLine(line)
+		m = update(m, process.OutputMsg{Name: "backend"})
+	}
+	m = enterFilterMode(m)
+	for _, ch := range "error" {
+		m = update(m, keypress(ch))
+	}
+	// Tab → back to search mode
+	m = update(m, specialKey(tea.KeyTab))
+	if m.filterMode {
+		t.Error("filter mode should be off after toggle")
+	}
+	if !m.searchMode {
+		t.Error("search mode should be on after toggle")
+	}
+	if m.searchQuery != "error" {
+		t.Errorf("query should carry over, got %q", m.searchQuery)
+	}
+	if len(m.searchMatches) != 2 {
+		t.Errorf("want 2 search matches, got %d", len(m.searchMatches))
+	}
+}
+
+func TestNormal_fDoesNotEnterFilterMode(t *testing.T) {
+	m := readyModel(t, "backend")
+	m = update(m, keypress('f'))
+	if m.filterMode {
+		t.Error("f in normal mode should not enter filter mode")
+	}
+	if m.searchMode {
+		t.Error("f in normal mode should not enter search mode")
 	}
 }
 

--- a/tools/phrocs/internal/tui/filter.go
+++ b/tools/phrocs/internal/tui/filter.go
@@ -1,0 +1,30 @@
+package tui
+
+import (
+	"strings"
+)
+
+// recomputeFilter rebuilds the viewport with only lines matching filterQuery.
+func (m *Model) recomputeFilter() {
+	lines := m.searchableLines()
+	if m.filterQuery == "" || len(lines) == 0 {
+		m.viewport.SetContent(strings.Join(lines, "\n"))
+		return
+	}
+	tokens := parseMatchTokens(m.filterQuery)
+	if len(tokens) == 0 {
+		m.viewport.SetContent(strings.Join(lines, "\n"))
+		return
+	}
+	var filtered []string
+	for _, line := range lines {
+		if lineMatchesTokens(line, tokens) {
+			filtered = append(filtered, line)
+		}
+	}
+	if len(filtered) == 0 {
+		m.viewport.SetContent("")
+	} else {
+		m.viewport.SetContent(strings.Join(filtered, "\n"))
+	}
+}

--- a/tools/phrocs/internal/tui/filter.go
+++ b/tools/phrocs/internal/tui/filter.go
@@ -4,14 +4,14 @@ import (
 	"strings"
 )
 
-// recomputeFilter rebuilds the viewport with only lines matching filterQuery.
+// recomputeFilter rebuilds the viewport with only lines matching searchQuery.
 func (m *Model) recomputeFilter() {
 	lines := m.searchableLines()
-	if m.filterQuery == "" || len(lines) == 0 {
+	if m.searchQuery == "" || len(lines) == 0 {
 		m.viewport.SetContent(strings.Join(lines, "\n"))
 		return
 	}
-	tokens := parseMatchTokens(m.filterQuery)
+	tokens := parseMatchTokens(m.searchQuery)
 	if len(tokens) == 0 {
 		m.viewport.SetContent(strings.Join(lines, "\n"))
 		return

--- a/tools/phrocs/internal/tui/keymap.go
+++ b/tools/phrocs/internal/tui/keymap.go
@@ -3,34 +3,35 @@ package tui
 import "charm.land/bubbles/v2/key"
 
 type keyMap struct {
-	PrevProc   key.Binding
-	NextProc   key.Binding
-	KeyUp      key.Binding
-	KeyDown    key.Binding
-	ScrollUp   key.Binding
-	ScrollDown key.Binding
-	GotoTop    key.Binding
-	GotoBottom key.Binding
-	NextPane   key.Binding
-	PrevPane   key.Binding
-	Start      key.Binding
-	Stop       key.Binding
-	Restart    key.Binding
-	ClearLogs  key.Binding
-	CopyMode   key.Binding
-	InfoMode   key.Binding
-	SearchMode key.Binding
-	SearchNext key.Binding
-	SearchPrev key.Binding
-	FilterMode key.Binding
-	Quit       key.Binding
-	Help       key.Binding
-	Backspace  key.Binding
-	Hedgehog   key.Binding
-	Sort       key.Binding
-	LazyDocker key.Binding
-	ProcViewer key.Binding
-	SetupMode  key.Binding
+	PrevProc     key.Binding
+	NextProc     key.Binding
+	KeyUp        key.Binding
+	KeyDown      key.Binding
+	ScrollUp     key.Binding
+	ScrollDown   key.Binding
+	GotoTop      key.Binding
+	GotoBottom   key.Binding
+	NextPane     key.Binding
+	PrevPane     key.Binding
+	Start        key.Binding
+	Stop         key.Binding
+	Restart      key.Binding
+	ClearLogs    key.Binding
+	CopyMode     key.Binding
+	InfoMode     key.Binding
+	SearchMode   key.Binding
+	SearchNext   key.Binding
+	SearchPrev   key.Binding
+	CommitFilter key.Binding
+	ToggleFilter key.Binding
+	Quit         key.Binding
+	Help         key.Binding
+	Backspace    key.Binding
+	Hedgehog     key.Binding
+	Sort         key.Binding
+	LazyDocker   key.Binding
+	ProcViewer   key.Binding
+	SetupMode    key.Binding
 }
 
 func defaultKeyMap() keyMap {
@@ -98,16 +99,20 @@ func defaultKeyMap() keyMap {
 			key.WithHelp("/:", "search"),
 		),
 		SearchNext: key.NewBinding(
-			key.WithKeys("enter"),
-			key.WithHelp("↵:", "next match"),
+			key.WithKeys("down"),
+			key.WithHelp("↓:", "next match"),
 		),
 		SearchPrev: key.NewBinding(
-			key.WithKeys("shift+enter"),
-			key.WithHelp("⇧↵:", "prev match"),
+			key.WithKeys("up"),
+			key.WithHelp("↑:", "prev match"),
 		),
-		FilterMode: key.NewBinding(
-			key.WithKeys("f"),
-			key.WithHelp("f:", "filter"),
+		CommitFilter: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("↵:", "filter"),
+		),
+		ToggleFilter: key.NewBinding(
+			key.WithKeys("tab"),
+			key.WithHelp("↹:", "back to search"),
 		),
 		Quit: key.NewBinding(
 			key.WithKeys("q", "ctrl+c"),
@@ -151,19 +156,25 @@ func defaultKeyMap() keyMap {
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Start, k.Stop, k.Restart, k.ClearLogs, k.SearchMode, k.FilterMode, k.CopyMode, k.InfoMode, k.SetupMode, k.Quit, k.Help}
+	return []key.Binding{k.Start, k.Stop, k.Restart, k.ClearLogs, k.SearchMode, k.CopyMode, k.InfoMode, k.SetupMode, k.Quit, k.Help}
+}
+
+func (k keyMap) SearchModeHelp() []key.Binding {
+	return []key.Binding{k.SearchNext, k.SearchPrev, k.CommitFilter}
+}
+
+func (k keyMap) FilterModeHelp() []key.Binding {
+	return []key.Binding{k.ToggleFilter}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.KeyDown, k.KeyUp, k.Sort},
 		{k.ScrollUp, k.ScrollDown},
-		{k.GotoTop, k.GotoBottom},
+		{k.GotoTop, k.GotoBottom, k.ClearLogs},
 		{k.NextPane, k.PrevPane, k.LazyDocker, k.ProcViewer},
-		{k.Start, k.Stop, k.Restart, k.ClearLogs},
-		{k.SearchMode, k.SearchNext, k.SearchPrev},
-		{k.FilterMode},
-		{k.CopyMode, k.InfoMode, k.SetupMode},
-		{k.Quit, k.Help, k.Hedgehog},
+		{k.Start, k.Stop, k.Restart, k.InfoMode},
+		{k.SearchMode, k.CopyMode, k.SetupMode},
+		{k.Quit, k.Help},
 	}
 }

--- a/tools/phrocs/internal/tui/keymap.go
+++ b/tools/phrocs/internal/tui/keymap.go
@@ -22,6 +22,7 @@ type keyMap struct {
 	SearchMode key.Binding
 	SearchNext key.Binding
 	SearchPrev key.Binding
+	FilterMode key.Binding
 	Quit       key.Binding
 	Help       key.Binding
 	Backspace  key.Binding
@@ -104,6 +105,10 @@ func defaultKeyMap() keyMap {
 			key.WithKeys("shift+enter"),
 			key.WithHelp("⇧↵:", "prev match"),
 		),
+		FilterMode: key.NewBinding(
+			key.WithKeys("f"),
+			key.WithHelp("f:", "filter"),
+		),
 		Quit: key.NewBinding(
 			key.WithKeys("q", "ctrl+c"),
 			key.WithHelp("q:", "quit"),
@@ -146,7 +151,7 @@ func defaultKeyMap() keyMap {
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Start, k.Stop, k.Restart, k.ClearLogs, k.SearchMode, k.CopyMode, k.InfoMode, k.SetupMode, k.Quit, k.Help}
+	return []key.Binding{k.Start, k.Stop, k.Restart, k.ClearLogs, k.SearchMode, k.FilterMode, k.CopyMode, k.InfoMode, k.SetupMode, k.Quit, k.Help}
 }
 
 func (k keyMap) FullHelp() [][]key.Binding {
@@ -157,6 +162,7 @@ func (k keyMap) FullHelp() [][]key.Binding {
 		{k.NextPane, k.PrevPane, k.LazyDocker, k.ProcViewer},
 		{k.Start, k.Stop, k.Restart, k.ClearLogs},
 		{k.SearchMode, k.SearchNext, k.SearchPrev},
+		{k.FilterMode},
 		{k.CopyMode, k.InfoMode, k.SetupMode},
 		{k.Quit, k.Help, k.Hedgehog},
 	}

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -112,6 +112,38 @@ func (m Model) handleSearchKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []te
 	return m, cmds, true
 }
 
+func (m Model) handleFilterKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []tea.Cmd, bool) {
+	switch {
+	case msg.Code == tea.KeyEscape:
+		m.filterMode = false
+		m.filterQuery = ""
+		m.reloadActiveLines()
+		m = m.applySize()
+		if m.viewportAtBottom {
+			m.viewport.GotoBottom()
+		}
+	case key.Matches(msg, m.keys.Backspace):
+		if len(m.filterQuery) > 0 {
+			runes := []rune(m.filterQuery)
+			m.filterQuery = string(runes[:len(runes)-1])
+			m.recomputeFilter()
+		}
+	default:
+		s := msg.String()
+		var ch string
+		if s == "space" {
+			ch = " "
+		} else if runes := []rune(s); len(runes) == 1 && runes[0] >= 32 {
+			ch = s
+		}
+		if ch != "" {
+			m.filterQuery += ch
+			m.recomputeFilter()
+		}
+	}
+	return m, cmds, true
+}
+
 func (m Model) handleCopyKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []tea.Cmd, bool) {
 	switch {
 	case key.Matches(msg, m.keys.Quit), msg.Code == tea.KeyEscape:
@@ -392,6 +424,12 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 	case key.Matches(msg, m.keys.SearchMode):
 		m.searchMode = true
 		m.clearSearch()
+		m = m.applySize()
+
+	case key.Matches(msg, m.keys.FilterMode):
+		m.filterMode = true
+		m.filterQuery = ""
+		m.recomputeFilter()
 		m = m.applySize()
 
 	case key.Matches(msg, m.keys.CopyMode):

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -56,6 +56,26 @@ func (m *Model) forwardToViewport(msg tea.Msg) tea.Cmd {
 	return cmd
 }
 
+// Handles viewport navigation keys (home/end/pgup/pgdn). Returns true if the
+// key was consumed.
+func (m *Model) handleViewportNavKey(msg tea.KeyPressMsg, cmds *[]tea.Cmd) bool {
+	switch {
+	case key.Matches(msg, m.keys.GotoTop):
+		m.dbg("viewport: home → goto top")
+		m.viewport.GotoTop()
+		m.viewportAtBottom = false
+	case key.Matches(msg, m.keys.GotoBottom):
+		m.dbg("viewport: end → goto bottom")
+		m.viewport.GotoBottom()
+		m.viewportAtBottom = true
+	case key.Matches(msg, m.keys.ScrollUp), key.Matches(msg, m.keys.ScrollDown):
+		*cmds = append(*cmds, m.forwardToViewport(msg))
+	default:
+		return false
+	}
+	return true
+}
+
 // Cycles the focused pane forward (+1) or backward (-1).
 func (m *Model) cyclePane(dir int) {
 	panes := []focusPane{focusServices, focusOutput}
@@ -77,6 +97,15 @@ func (m Model) handleSearchKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []te
 		m.searchMode = false
 		m.clearSearch()
 		m = m.applySize()
+	case key.Matches(msg, m.keys.CommitFilter):
+		// Preserve query; drop search-only match state before switching to filter
+		m.searchMatches = nil
+		m.searchCursor = 0
+		m.viewport.StyleLineFunc = nil
+		m.searchMode = false
+		m.filterMode = true
+		m.recomputeFilter()
+		m = m.applySize()
 	case key.Matches(msg, m.keys.SearchNext):
 		if len(m.searchMatches) > 0 {
 			m.searchCursor = (m.searchCursor + 1) % len(m.searchMatches)
@@ -96,6 +125,9 @@ func (m Model) handleSearchKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []te
 			m.recomputeSearch()
 		}
 	default:
+		if m.handleViewportNavKey(msg, &cmds) {
+			break
+		}
 		// Search consumes all printable characters for the query
 		s := msg.String()
 		var ch string
@@ -116,19 +148,38 @@ func (m Model) handleFilterKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []te
 	switch {
 	case msg.Code == tea.KeyEscape:
 		m.filterMode = false
-		m.filterQuery = ""
+		m.searchQuery = ""
 		m.reloadActiveLines()
 		m = m.applySize()
 		if m.viewportAtBottom {
 			m.viewport.GotoBottom()
 		}
+	case key.Matches(msg, m.keys.ToggleFilter):
+		// Preserve query; restore unfiltered viewport and rebuild search match state
+		m.filterMode = false
+		m.reloadActiveLines()
+		m.searchMode = true
+		m.recomputeSearch()
+		m.jumpToCurrentMatch()
+		m = m.applySize()
 	case key.Matches(msg, m.keys.Backspace):
-		if len(m.filterQuery) > 0 {
-			runes := []rune(m.filterQuery)
-			m.filterQuery = string(runes[:len(runes)-1])
+		if len(m.searchQuery) > 0 {
+			runes := []rune(m.searchQuery)
+			m.searchQuery = string(runes[:len(runes)-1])
 			m.recomputeFilter()
+		} else {
+			// Backspace on empty query exits filter back to search
+			m.filterMode = false
+			m.reloadActiveLines()
+			m.searchMode = true
+			m.recomputeSearch()
+			m.jumpToCurrentMatch()
+			m = m.applySize()
 		}
 	default:
+		if m.handleViewportNavKey(msg, &cmds) {
+			break
+		}
 		s := msg.String()
 		var ch string
 		if s == "space" {
@@ -137,7 +188,7 @@ func (m Model) handleFilterKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []te
 			ch = s
 		}
 		if ch != "" {
-			m.filterQuery += ch
+			m.searchQuery += ch
 			m.recomputeFilter()
 		}
 	}
@@ -382,16 +433,6 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 			m.viewportAtBottom = true
 		}
 
-	case key.Matches(msg, m.keys.GotoTop):
-		m.dbg("viewport: home → goto top")
-		m.viewport.GotoTop()
-		m.viewportAtBottom = false
-
-	case key.Matches(msg, m.keys.GotoBottom):
-		m.dbg("viewport: end → goto bottom")
-		m.viewport.GotoBottom()
-		m.viewportAtBottom = true
-
 	case key.Matches(msg, m.keys.Start):
 		if p := m.activeProc(); p != nil && !p.IsRunning() {
 			m.dbg("start: proc=%s", p.Name)
@@ -424,12 +465,6 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 	case key.Matches(msg, m.keys.SearchMode):
 		m.searchMode = true
 		m.clearSearch()
-		m = m.applySize()
-
-	case key.Matches(msg, m.keys.FilterMode):
-		m.filterMode = true
-		m.filterQuery = ""
-		m.recomputeFilter()
 		m = m.applySize()
 
 	case key.Matches(msg, m.keys.CopyMode):
@@ -489,6 +524,9 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 		}
 
 	default:
+		if m.handleViewportNavKey(msg, &cmds) {
+			break
+		}
 		if m.focusedPane == focusOutput {
 			cmds = append(cmds, m.forwardToViewport(msg))
 		}

--- a/tools/phrocs/internal/tui/match.go
+++ b/tools/phrocs/internal/tui/match.go
@@ -52,8 +52,14 @@ func parseMatchTokens(query string) []matchToken {
 // lineMatchesTokens returns true if the line satisfies all token conditions:
 //   - every positive token must match
 //   - no negative token may match
+//
+// Plain tokens match case-insensitively via a lowered copy of the line; regex
+// tokens match against the original (ANSI-stripped) line so character classes
+// like [A-Z] or Unicode properties like \p{Lu} behave as users expect. Case
+// insensitivity for regex is handled by the (?i) flag injected at parse time.
 func lineMatchesTokens(line string, tokens []matchToken) bool {
-	stripped := strings.ToLower(ansi.Strip(line))
+	stripped := ansi.Strip(line)
+	strippedLower := strings.ToLower(stripped)
 	for _, t := range tokens {
 		var matches bool
 		if t.isRegex {
@@ -62,7 +68,7 @@ func lineMatchesTokens(line string, tokens []matchToken) bool {
 			}
 			// invalid regex → no match
 		} else {
-			matches = strings.Contains(stripped, t.pattern)
+			matches = strings.Contains(strippedLower, t.pattern)
 		}
 		if t.negative && matches {
 			return false

--- a/tools/phrocs/internal/tui/match.go
+++ b/tools/phrocs/internal/tui/match.go
@@ -1,0 +1,89 @@
+package tui
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+type matchToken struct {
+	pattern  string
+	negative bool
+	isRegex  bool
+	re       *regexp.Regexp // compiled regex; nil if plain or invalid
+}
+
+// parseMatchTokens splits a query into space-separated tokens.
+// Each token can be:
+//
+//	"term"       — positive plain substring
+//	"!term"      — negative plain substring (exclude matching lines)
+//	"re:pattern" — positive regex
+//	"!re:pattern"— negative regex
+func parseMatchTokens(query string) []matchToken {
+	parts := strings.Fields(query)
+	tokens := make([]matchToken, 0, len(parts))
+	for _, part := range parts {
+		var t matchToken
+		s := part
+		if strings.HasPrefix(s, "!") {
+			t.negative = true
+			s = s[1:]
+		}
+		if strings.HasPrefix(s, "re:") {
+			t.isRegex = true
+			s = s[3:]
+			if s != "" {
+				if re, err := regexp.Compile("(?i)" + s); err == nil {
+					t.re = re
+				}
+			}
+		}
+		t.pattern = strings.ToLower(s)
+		if t.pattern == "" && !t.isRegex {
+			continue // skip empty plain tokens (e.g. lone "!")
+		}
+		tokens = append(tokens, t)
+	}
+	return tokens
+}
+
+// lineMatchesTokens returns true if the line satisfies all token conditions:
+//   - every positive token must match
+//   - no negative token may match
+func lineMatchesTokens(line string, tokens []matchToken) bool {
+	stripped := strings.ToLower(ansi.Strip(line))
+	for _, t := range tokens {
+		var matches bool
+		if t.isRegex {
+			if t.re != nil {
+				matches = t.re.MatchString(stripped)
+			}
+			// invalid regex → no match
+		} else {
+			matches = strings.Contains(stripped, t.pattern)
+		}
+		if t.negative && matches {
+			return false
+		}
+		if !t.negative && !matches {
+			return false
+		}
+	}
+	return true
+}
+
+// lineMatchesQuery is a convenience wrapper: parses the query into tokens
+// and checks the line against them. For hot paths that call this in a loop,
+// prefer parsing once with parseMatchTokens and calling lineMatchesTokens.
+func lineMatchesQuery(line, query string) bool {
+	if query == "" {
+		return true
+	}
+	tokens := parseMatchTokens(query)
+	if len(tokens) == 0 {
+		return true
+	}
+	return lineMatchesTokens(line, tokens)
+}

--- a/tools/phrocs/internal/tui/match_test.go
+++ b/tools/phrocs/internal/tui/match_test.go
@@ -1,0 +1,194 @@
+package tui
+
+import "testing"
+
+func TestParseMatchTokens_plain(t *testing.T) {
+	tokens := parseMatchTokens("error")
+	if len(tokens) != 1 {
+		t.Fatalf("want 1 token, got %d", len(tokens))
+	}
+	if tokens[0].pattern != "error" || tokens[0].negative || tokens[0].isRegex {
+		t.Errorf("unexpected token: %+v", tokens[0])
+	}
+}
+
+func TestParseMatchTokens_negative(t *testing.T) {
+	tokens := parseMatchTokens("!warning")
+	if len(tokens) != 1 {
+		t.Fatalf("want 1 token, got %d", len(tokens))
+	}
+	if tokens[0].pattern != "warning" || !tokens[0].negative {
+		t.Errorf("unexpected token: %+v", tokens[0])
+	}
+}
+
+func TestParseMatchTokens_regex(t *testing.T) {
+	tokens := parseMatchTokens("re:\\d+")
+	if len(tokens) != 1 {
+		t.Fatalf("want 1 token, got %d", len(tokens))
+	}
+	if !tokens[0].isRegex || tokens[0].re == nil {
+		t.Errorf("expected compiled regex: %+v", tokens[0])
+	}
+}
+
+func TestParseMatchTokens_negativeRegex(t *testing.T) {
+	tokens := parseMatchTokens("!re:debug")
+	if len(tokens) != 1 {
+		t.Fatalf("want 1 token, got %d", len(tokens))
+	}
+	if !tokens[0].negative || !tokens[0].isRegex || tokens[0].re == nil {
+		t.Errorf("unexpected token: %+v", tokens[0])
+	}
+}
+
+func TestParseMatchTokens_multiple(t *testing.T) {
+	tokens := parseMatchTokens("!error !warning !note")
+	if len(tokens) != 3 {
+		t.Fatalf("want 3 tokens, got %d", len(tokens))
+	}
+	for i, tok := range tokens {
+		if !tok.negative {
+			t.Errorf("token %d should be negative", i)
+		}
+	}
+}
+
+func TestParseMatchTokens_mixed(t *testing.T) {
+	tokens := parseMatchTokens("api !debug re:^\\d{3}")
+	if len(tokens) != 3 {
+		t.Fatalf("want 3 tokens, got %d", len(tokens))
+	}
+	if tokens[0].negative || tokens[0].isRegex {
+		t.Errorf("token 0 should be plain positive: %+v", tokens[0])
+	}
+	if !tokens[1].negative || tokens[1].isRegex {
+		t.Errorf("token 1 should be plain negative: %+v", tokens[1])
+	}
+	if tokens[2].negative || !tokens[2].isRegex {
+		t.Errorf("token 2 should be regex positive: %+v", tokens[2])
+	}
+}
+
+func TestParseMatchTokens_skipEmpty(t *testing.T) {
+	tokens := parseMatchTokens("!")
+	if len(tokens) != 0 {
+		t.Errorf("lone '!' should produce no tokens, got %d", len(tokens))
+	}
+}
+
+func TestParseMatchTokens_invalidRegex(t *testing.T) {
+	tokens := parseMatchTokens("re:[invalid")
+	if len(tokens) != 1 {
+		t.Fatalf("want 1 token, got %d", len(tokens))
+	}
+	if tokens[0].re != nil {
+		t.Error("invalid regex should have nil compiled pattern")
+	}
+}
+
+func TestLineMatchesTokens_plainPositive(t *testing.T) {
+	tokens := parseMatchTokens("error")
+	if !lineMatchesTokens("an error occurred", tokens) {
+		t.Error("should match line containing 'error'")
+	}
+	if lineMatchesTokens("all is well", tokens) {
+		t.Error("should not match line without 'error'")
+	}
+}
+
+func TestLineMatchesTokens_plainNegative(t *testing.T) {
+	tokens := parseMatchTokens("!debug")
+	if !lineMatchesTokens("error: something failed", tokens) {
+		t.Error("should match line without 'debug'")
+	}
+	if lineMatchesTokens("debug: checking cache", tokens) {
+		t.Error("should exclude line containing 'debug'")
+	}
+}
+
+func TestLineMatchesTokens_multipleNegative(t *testing.T) {
+	tokens := parseMatchTokens("!error !warning !note")
+	if !lineMatchesTokens("info: server started", tokens) {
+		t.Error("should match line without any excluded terms")
+	}
+	if lineMatchesTokens("warning: low memory", tokens) {
+		t.Error("should exclude line with 'warning'")
+	}
+	if lineMatchesTokens("note: config loaded", tokens) {
+		t.Error("should exclude line with 'note'")
+	}
+}
+
+func TestLineMatchesTokens_positiveAndNegative(t *testing.T) {
+	tokens := parseMatchTokens("api !debug")
+	if !lineMatchesTokens("api: request received", tokens) {
+		t.Error("should match: has 'api', no 'debug'")
+	}
+	if lineMatchesTokens("api debug: verbose output", tokens) {
+		t.Error("should exclude: has both 'api' and 'debug'")
+	}
+	if lineMatchesTokens("worker: task complete", tokens) {
+		t.Error("should exclude: missing 'api'")
+	}
+}
+
+func TestLineMatchesTokens_regex(t *testing.T) {
+	tokens := parseMatchTokens("re:^\\d{3}\\s")
+	if !lineMatchesTokens("200 OK", tokens) {
+		t.Error("should match line starting with 3 digits")
+	}
+	if lineMatchesTokens("info: status 200", tokens) {
+		t.Error("should not match: digits not at start")
+	}
+}
+
+func TestLineMatchesTokens_negativeRegex(t *testing.T) {
+	tokens := parseMatchTokens("!re:^(debug|trace)")
+	if !lineMatchesTokens("error: something broke", tokens) {
+		t.Error("should match: doesn't start with debug or trace")
+	}
+	if lineMatchesTokens("debug: checking state", tokens) {
+		t.Error("should exclude: starts with debug")
+	}
+}
+
+func TestLineMatchesTokens_caseInsensitive(t *testing.T) {
+	tokens := parseMatchTokens("ERROR")
+	if !lineMatchesTokens("Error: something failed", tokens) {
+		t.Error("plain matching should be case-insensitive")
+	}
+}
+
+func TestLineMatchesTokens_regexCaseInsensitive(t *testing.T) {
+	tokens := parseMatchTokens("re:error")
+	if !lineMatchesTokens("ERROR: something", tokens) {
+		t.Error("regex matching should be case-insensitive")
+	}
+}
+
+func TestLineMatchesTokens_invalidRegexNoMatch(t *testing.T) {
+	tokens := parseMatchTokens("re:[bad")
+	if lineMatchesTokens("anything", tokens) {
+		t.Error("invalid positive regex should not match")
+	}
+}
+
+func TestLineMatchesTokens_ansiStripped(t *testing.T) {
+	tokens := parseMatchTokens("error")
+	if !lineMatchesTokens("\x1b[31merror\x1b[0m: red text", tokens) {
+		t.Error("should match after stripping ANSI codes")
+	}
+}
+
+func TestLineMatchesQuery_empty(t *testing.T) {
+	if !lineMatchesQuery("anything", "") {
+		t.Error("empty query should match everything")
+	}
+}
+
+func TestLineMatchesQuery_loneExclamation(t *testing.T) {
+	if !lineMatchesQuery("anything", "!") {
+		t.Error("lone '!' query should match everything (empty token skipped)")
+	}
+}

--- a/tools/phrocs/internal/tui/match_test.go
+++ b/tools/phrocs/internal/tui/match_test.go
@@ -2,193 +2,168 @@ package tui
 
 import "testing"
 
-func TestParseMatchTokens_plain(t *testing.T) {
-	tokens := parseMatchTokens("error")
-	if len(tokens) != 1 {
-		t.Fatalf("want 1 token, got %d", len(tokens))
+func TestParseMatchTokens(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   string
+		wantLen int
+		check   func(t *testing.T, tokens []matchToken)
+	}{
+		{
+			name:    "plain",
+			query:   "error",
+			wantLen: 1,
+			check: func(t *testing.T, toks []matchToken) {
+				if toks[0].pattern != "error" || toks[0].negative || toks[0].isRegex {
+					t.Errorf("unexpected token: %+v", toks[0])
+				}
+			},
+		},
+		{
+			name:    "negative",
+			query:   "!warning",
+			wantLen: 1,
+			check: func(t *testing.T, toks []matchToken) {
+				if toks[0].pattern != "warning" || !toks[0].negative {
+					t.Errorf("unexpected token: %+v", toks[0])
+				}
+			},
+		},
+		{
+			name:    "regex",
+			query:   "re:\\d+",
+			wantLen: 1,
+			check: func(t *testing.T, toks []matchToken) {
+				if !toks[0].isRegex || toks[0].re == nil {
+					t.Errorf("expected compiled regex: %+v", toks[0])
+				}
+			},
+		},
+		{
+			name:    "negative regex",
+			query:   "!re:debug",
+			wantLen: 1,
+			check: func(t *testing.T, toks []matchToken) {
+				if !toks[0].negative || !toks[0].isRegex || toks[0].re == nil {
+					t.Errorf("unexpected token: %+v", toks[0])
+				}
+			},
+		},
+		{
+			name:    "multiple negatives",
+			query:   "!error !warning !note",
+			wantLen: 3,
+			check: func(t *testing.T, toks []matchToken) {
+				for i, tok := range toks {
+					if !tok.negative {
+						t.Errorf("token %d should be negative", i)
+					}
+				}
+			},
+		},
+		{
+			name:    "mixed",
+			query:   "api !debug re:^\\d{3}",
+			wantLen: 3,
+			check: func(t *testing.T, toks []matchToken) {
+				if toks[0].negative || toks[0].isRegex {
+					t.Errorf("token 0 should be plain positive: %+v", toks[0])
+				}
+				if !toks[1].negative || toks[1].isRegex {
+					t.Errorf("token 1 should be plain negative: %+v", toks[1])
+				}
+				if toks[2].negative || !toks[2].isRegex {
+					t.Errorf("token 2 should be regex positive: %+v", toks[2])
+				}
+			},
+		},
+		{
+			name:    "lone exclamation is skipped",
+			query:   "!",
+			wantLen: 0,
+		},
+		{
+			name:    "invalid regex leaves nil compiled pattern",
+			query:   "re:[invalid",
+			wantLen: 1,
+			check: func(t *testing.T, toks []matchToken) {
+				if toks[0].re != nil {
+					t.Error("invalid regex should have nil compiled pattern")
+				}
+			},
+		},
 	}
-	if tokens[0].pattern != "error" || tokens[0].negative || tokens[0].isRegex {
-		t.Errorf("unexpected token: %+v", tokens[0])
-	}
-}
-
-func TestParseMatchTokens_negative(t *testing.T) {
-	tokens := parseMatchTokens("!warning")
-	if len(tokens) != 1 {
-		t.Fatalf("want 1 token, got %d", len(tokens))
-	}
-	if tokens[0].pattern != "warning" || !tokens[0].negative {
-		t.Errorf("unexpected token: %+v", tokens[0])
-	}
-}
-
-func TestParseMatchTokens_regex(t *testing.T) {
-	tokens := parseMatchTokens("re:\\d+")
-	if len(tokens) != 1 {
-		t.Fatalf("want 1 token, got %d", len(tokens))
-	}
-	if !tokens[0].isRegex || tokens[0].re == nil {
-		t.Errorf("expected compiled regex: %+v", tokens[0])
-	}
-}
-
-func TestParseMatchTokens_negativeRegex(t *testing.T) {
-	tokens := parseMatchTokens("!re:debug")
-	if len(tokens) != 1 {
-		t.Fatalf("want 1 token, got %d", len(tokens))
-	}
-	if !tokens[0].negative || !tokens[0].isRegex || tokens[0].re == nil {
-		t.Errorf("unexpected token: %+v", tokens[0])
-	}
-}
-
-func TestParseMatchTokens_multiple(t *testing.T) {
-	tokens := parseMatchTokens("!error !warning !note")
-	if len(tokens) != 3 {
-		t.Fatalf("want 3 tokens, got %d", len(tokens))
-	}
-	for i, tok := range tokens {
-		if !tok.negative {
-			t.Errorf("token %d should be negative", i)
-		}
-	}
-}
-
-func TestParseMatchTokens_mixed(t *testing.T) {
-	tokens := parseMatchTokens("api !debug re:^\\d{3}")
-	if len(tokens) != 3 {
-		t.Fatalf("want 3 tokens, got %d", len(tokens))
-	}
-	if tokens[0].negative || tokens[0].isRegex {
-		t.Errorf("token 0 should be plain positive: %+v", tokens[0])
-	}
-	if !tokens[1].negative || tokens[1].isRegex {
-		t.Errorf("token 1 should be plain negative: %+v", tokens[1])
-	}
-	if tokens[2].negative || !tokens[2].isRegex {
-		t.Errorf("token 2 should be regex positive: %+v", tokens[2])
-	}
-}
-
-func TestParseMatchTokens_skipEmpty(t *testing.T) {
-	tokens := parseMatchTokens("!")
-	if len(tokens) != 0 {
-		t.Errorf("lone '!' should produce no tokens, got %d", len(tokens))
-	}
-}
-
-func TestParseMatchTokens_invalidRegex(t *testing.T) {
-	tokens := parseMatchTokens("re:[invalid")
-	if len(tokens) != 1 {
-		t.Fatalf("want 1 token, got %d", len(tokens))
-	}
-	if tokens[0].re != nil {
-		t.Error("invalid regex should have nil compiled pattern")
-	}
-}
-
-func TestLineMatchesTokens_plainPositive(t *testing.T) {
-	tokens := parseMatchTokens("error")
-	if !lineMatchesTokens("an error occurred", tokens) {
-		t.Error("should match line containing 'error'")
-	}
-	if lineMatchesTokens("all is well", tokens) {
-		t.Error("should not match line without 'error'")
-	}
-}
-
-func TestLineMatchesTokens_plainNegative(t *testing.T) {
-	tokens := parseMatchTokens("!debug")
-	if !lineMatchesTokens("error: something failed", tokens) {
-		t.Error("should match line without 'debug'")
-	}
-	if lineMatchesTokens("debug: checking cache", tokens) {
-		t.Error("should exclude line containing 'debug'")
-	}
-}
-
-func TestLineMatchesTokens_multipleNegative(t *testing.T) {
-	tokens := parseMatchTokens("!error !warning !note")
-	if !lineMatchesTokens("info: server started", tokens) {
-		t.Error("should match line without any excluded terms")
-	}
-	if lineMatchesTokens("warning: low memory", tokens) {
-		t.Error("should exclude line with 'warning'")
-	}
-	if lineMatchesTokens("note: config loaded", tokens) {
-		t.Error("should exclude line with 'note'")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			toks := parseMatchTokens(tc.query)
+			if len(toks) != tc.wantLen {
+				t.Fatalf("want %d token(s), got %d", tc.wantLen, len(toks))
+			}
+			if tc.check != nil {
+				tc.check(t, toks)
+			}
+		})
 	}
 }
 
-func TestLineMatchesTokens_positiveAndNegative(t *testing.T) {
-	tokens := parseMatchTokens("api !debug")
-	if !lineMatchesTokens("api: request received", tokens) {
-		t.Error("should match: has 'api', no 'debug'")
+func TestLineMatchesTokens(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		line  string
+		want  bool
+	}{
+		{"plain positive match", "error", "an error occurred", true},
+		{"plain positive miss", "error", "all is well", false},
+
+		{"plain negative match", "!debug", "error: something failed", true},
+		{"plain negative exclude", "!debug", "debug: checking cache", false},
+
+		{"multiple negatives match", "!error !warning !note", "info: server started", true},
+		{"multiple negatives exclude on warning", "!error !warning !note", "warning: low memory", false},
+		{"multiple negatives exclude on note", "!error !warning !note", "note: config loaded", false},
+
+		{"positive and negative match", "api !debug", "api: request received", true},
+		{"positive and negative exclude on negative", "api !debug", "api debug: verbose output", false},
+		{"positive and negative exclude missing positive", "api !debug", "worker: task complete", false},
+
+		{"regex match", "re:^\\d{3}\\s", "200 OK", true},
+		{"regex miss", "re:^\\d{3}\\s", "info: status 200", false},
+
+		{"negative regex match", "!re:^(debug|trace)", "error: something broke", true},
+		{"negative regex exclude", "!re:^(debug|trace)", "debug: checking state", false},
+
+		{"plain match is case-insensitive", "ERROR", "Error: something failed", true},
+		{"regex match is case-insensitive", "re:error", "ERROR: something", true},
+
+		{"invalid positive regex never matches", "re:[bad", "anything", false},
+		{"ansi codes are stripped before matching", "error", "\x1b[31merror\x1b[0m: red text", true},
 	}
-	if lineMatchesTokens("api debug: verbose output", tokens) {
-		t.Error("should exclude: has both 'api' and 'debug'")
-	}
-	if lineMatchesTokens("worker: task complete", tokens) {
-		t.Error("should exclude: missing 'api'")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			toks := parseMatchTokens(tc.query)
+			if got := lineMatchesTokens(tc.line, toks); got != tc.want {
+				t.Errorf("lineMatchesTokens(%q, %q) = %v, want %v", tc.line, tc.query, got, tc.want)
+			}
+		})
 	}
 }
 
-func TestLineMatchesTokens_regex(t *testing.T) {
-	tokens := parseMatchTokens("re:^\\d{3}\\s")
-	if !lineMatchesTokens("200 OK", tokens) {
-		t.Error("should match line starting with 3 digits")
+func TestLineMatchesQuery(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		line  string
+		want  bool
+	}{
+		{"empty query matches everything", "", "anything", true},
+		{"lone exclamation matches everything (empty token skipped)", "!", "anything", true},
 	}
-	if lineMatchesTokens("info: status 200", tokens) {
-		t.Error("should not match: digits not at start")
-	}
-}
-
-func TestLineMatchesTokens_negativeRegex(t *testing.T) {
-	tokens := parseMatchTokens("!re:^(debug|trace)")
-	if !lineMatchesTokens("error: something broke", tokens) {
-		t.Error("should match: doesn't start with debug or trace")
-	}
-	if lineMatchesTokens("debug: checking state", tokens) {
-		t.Error("should exclude: starts with debug")
-	}
-}
-
-func TestLineMatchesTokens_caseInsensitive(t *testing.T) {
-	tokens := parseMatchTokens("ERROR")
-	if !lineMatchesTokens("Error: something failed", tokens) {
-		t.Error("plain matching should be case-insensitive")
-	}
-}
-
-func TestLineMatchesTokens_regexCaseInsensitive(t *testing.T) {
-	tokens := parseMatchTokens("re:error")
-	if !lineMatchesTokens("ERROR: something", tokens) {
-		t.Error("regex matching should be case-insensitive")
-	}
-}
-
-func TestLineMatchesTokens_invalidRegexNoMatch(t *testing.T) {
-	tokens := parseMatchTokens("re:[bad")
-	if lineMatchesTokens("anything", tokens) {
-		t.Error("invalid positive regex should not match")
-	}
-}
-
-func TestLineMatchesTokens_ansiStripped(t *testing.T) {
-	tokens := parseMatchTokens("error")
-	if !lineMatchesTokens("\x1b[31merror\x1b[0m: red text", tokens) {
-		t.Error("should match after stripping ANSI codes")
-	}
-}
-
-func TestLineMatchesQuery_empty(t *testing.T) {
-	if !lineMatchesQuery("anything", "") {
-		t.Error("empty query should match everything")
-	}
-}
-
-func TestLineMatchesQuery_loneExclamation(t *testing.T) {
-	if !lineMatchesQuery("anything", "!") {
-		t.Error("lone '!' query should match everything (empty token skipped)")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lineMatchesQuery(tc.line, tc.query); got != tc.want {
+				t.Errorf("lineMatchesQuery(%q, %q) = %v, want %v", tc.line, tc.query, got, tc.want)
+			}
+		})
 	}
 }

--- a/tools/phrocs/internal/tui/match_test.go
+++ b/tools/phrocs/internal/tui/match_test.go
@@ -138,6 +138,13 @@ func TestLineMatchesTokens(t *testing.T) {
 
 		{"invalid positive regex never matches", "re:[bad", "anything", false},
 		{"ansi codes are stripped before matching", "error", "\x1b[31merror\x1b[0m: red text", true},
+
+		// Regex matches on the case-preserved line so users can opt out of
+		// case-insensitivity via (?-i) and use Unicode classes meaningfully.
+		{"regex with (?-i) override matches only uppercase", "re:(?-i)[A-Z]+", "HELLO world", true},
+		{"regex with (?-i) override rejects lowercase", "re:(?-i)[A-Z]+", "hello world", false},
+		{"regex on Unicode uppercase class", "re:(?-i)\\p{Lu}", "Hello", true},
+		{"regex on Unicode uppercase class rejects all-lowercase", "re:(?-i)\\p{Lu}", "hello", false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tools/phrocs/internal/tui/render.go
+++ b/tools/phrocs/internal/tui/render.go
@@ -233,30 +233,29 @@ func (m Model) renderFooter() string {
 			lipgloss.NewStyle().Foreground(colorYellow).Render(hint),
 		)
 	} else if m.filterMode {
-		var matchInfo string
-		if m.filterQuery == "" {
-			matchInfo = ""
-		} else {
-			count := m.viewport.TotalLineCount()
-			if count == 0 {
+		matchInfo := ""
+		if m.searchQuery != "" {
+			if count := m.viewport.TotalLineCount(); count == 0 {
 				matchInfo = "  [no matches]"
 			} else {
 				matchInfo = fmt.Sprintf("  [%d lines]", count)
 			}
 		}
-		prompt := lipgloss.NewStyle().Foreground(colorGreen).Render(fmt.Sprintf("filter: %s▌%s", m.filterQuery, matchInfo))
-		return footerStyle.Width(m.width - 2).Render(prompt)
+		prompt := lipgloss.NewStyle().Foreground(colorGreen).Render(fmt.Sprintf("| %s▌%s", m.searchQuery, matchInfo))
+		helpBar := m.help.ShortHelpView(m.keys.FilterModeHelp())
+		return footerStyle.Width(m.width - 2).Render(lipgloss.JoinVertical(lipgloss.Left, prompt, helpBar))
 	} else if m.searchMode {
-		var matchInfo string
-		if m.searchQuery == "" {
-			matchInfo = ""
-		} else if len(m.searchMatches) == 0 {
-			matchInfo = "  [no matches]"
-		} else {
-			matchInfo = fmt.Sprintf("  [%d/%d]", m.searchCursor+1, len(m.searchMatches))
+		matchInfo := ""
+		if m.searchQuery != "" {
+			if len(m.searchMatches) == 0 {
+				matchInfo = "  [no matches]"
+			} else {
+				matchInfo = fmt.Sprintf("  [%d/%d]", m.searchCursor+1, len(m.searchMatches))
+			}
 		}
 		prompt := lipgloss.NewStyle().Foreground(colorYellow).Render(fmt.Sprintf("/ %s▌%s", m.searchQuery, matchInfo))
-		return footerStyle.Width(m.width - 2).Render(prompt)
+		helpBar := m.help.ShortHelpView(m.keys.SearchModeHelp())
+		return footerStyle.Width(m.width - 2).Render(lipgloss.JoinVertical(lipgloss.Left, prompt, helpBar))
 	} else if m.setupMode {
 		var hint string
 		if m.setupError != "" {

--- a/tools/phrocs/internal/tui/render.go
+++ b/tools/phrocs/internal/tui/render.go
@@ -232,6 +232,20 @@ func (m Model) renderFooter() string {
 		return footerStyle.Width(m.width - 2).Render(
 			lipgloss.NewStyle().Foreground(colorYellow).Render(hint),
 		)
+	} else if m.filterMode {
+		var matchInfo string
+		if m.filterQuery == "" {
+			matchInfo = ""
+		} else {
+			count := m.viewport.TotalLineCount()
+			if count == 0 {
+				matchInfo = "  [no matches]"
+			} else {
+				matchInfo = fmt.Sprintf("  [%d lines]", count)
+			}
+		}
+		prompt := lipgloss.NewStyle().Foreground(colorGreen).Render(fmt.Sprintf("filter: %s▌%s", m.filterQuery, matchInfo))
+		return footerStyle.Width(m.width - 2).Render(prompt)
 	} else if m.searchMode {
 		var matchInfo string
 		if m.searchQuery == "" {

--- a/tools/phrocs/internal/tui/render.go
+++ b/tools/phrocs/internal/tui/render.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"charm.land/bubbles/v2/key"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 	sharedpalette "github.com/posthog/posthog/phrocs/internal/palette"
@@ -242,8 +243,7 @@ func (m Model) renderFooter() string {
 			}
 		}
 		prompt := lipgloss.NewStyle().Foreground(colorGreen).Render(fmt.Sprintf("| %s▌%s", m.searchQuery, matchInfo))
-		helpBar := m.help.ShortHelpView(m.keys.FilterModeHelp())
-		return footerStyle.Width(m.width - 2).Render(lipgloss.JoinVertical(lipgloss.Left, prompt, helpBar))
+		return footerStyle.Width(m.width - 2).Render(m.joinPromptWithHelp(prompt, m.keys.FilterModeHelp()))
 	} else if m.searchMode {
 		matchInfo := ""
 		if m.searchQuery != "" {
@@ -254,8 +254,7 @@ func (m Model) renderFooter() string {
 			}
 		}
 		prompt := lipgloss.NewStyle().Foreground(colorYellow).Render(fmt.Sprintf("/ %s▌%s", m.searchQuery, matchInfo))
-		helpBar := m.help.ShortHelpView(m.keys.SearchModeHelp())
-		return footerStyle.Width(m.width - 2).Render(lipgloss.JoinVertical(lipgloss.Left, prompt, helpBar))
+		return footerStyle.Width(m.width - 2).Render(m.joinPromptWithHelp(prompt, m.keys.SearchModeHelp()))
 	} else if m.setupMode {
 		var hint string
 		if m.setupError != "" {
@@ -295,6 +294,15 @@ func (m Model) renderFooter() string {
 		content = m.help.ShortHelpView(m.keys.ShortHelp())
 	}
 	return footerStyle.Width(m.width - 2).Render(content)
+}
+
+// Joins a prompt line with a help bar, or returns the prompt alone when help
+// is hidden — keeps search/filter footer height consistent with footerHeight().
+func (m Model) joinPromptWithHelp(prompt string, helpBindings []key.Binding) string {
+	if m.hideHelp {
+		return prompt
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, prompt, m.help.ShortHelpView(helpBindings))
 }
 
 // Rebuilds the info content and sets it on the viewport.

--- a/tools/phrocs/internal/tui/search.go
+++ b/tools/phrocs/internal/tui/search.go
@@ -1,10 +1,7 @@
 package tui
 
 import (
-	"strings"
-
 	"charm.land/lipgloss/v2"
-	"github.com/charmbracelet/x/ansi"
 )
 
 // recomputeSearch fetches lines and delegates to recomputeSearchWith.
@@ -25,10 +22,10 @@ func (m *Model) recomputeSearchWith(lines []string) {
 		m.searchMatches = nil
 		return
 	}
-	query := strings.ToLower(m.searchQuery)
+	tokens := parseMatchTokens(m.searchQuery)
 	m.searchMatches = nil
 	for i, line := range lines {
-		if strings.Contains(strings.ToLower(ansi.Strip(line)), query) {
+		if lineMatchesTokens(line, tokens) {
 			m.searchMatches = append(m.searchMatches, i)
 		}
 	}
@@ -78,7 +75,7 @@ func (m *Model) updateSearchForLine(line string, lineIndex int, evicted bool) {
 			m.searchMatches[i]--
 		}
 	}
-	if strings.Contains(strings.ToLower(ansi.Strip(line)), strings.ToLower(m.searchQuery)) {
+	if lineMatchesQuery(line, m.searchQuery) {
 		m.searchMatches = append(m.searchMatches, lineIndex)
 	}
 	m.applySearchStyle()


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

search is cool and all, but i sometimes want to see just the log lines that i are about and not jump up and down

## Changes

- add filter mode
    - allows regex (prefixed with `re:` or `!re:` for negative filter) and regular mode
    - option to add multiple patterns

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

running it locally and filtering

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->