### PR TITLE
feat(debug): show teams with precomputation enabled on query performance page

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -2,18 +2,39 @@ import { useValues } from 'kea'
 
 import { IconDatabase } from '@posthog/icons'
 
+import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { SceneExport } from 'scenes/sceneTypes'
 import { userLogic } from 'scenes/userLogic'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
+import { PrecomputationTeam, queryPerformanceLogic } from './queryPerformanceLogic'
+
 export const scene: SceneExport = {
     component: QueryPerformance,
+    logic: queryPerformanceLogic,
 }
+
+const precomputationColumns: LemonTableColumns<PrecomputationTeam> = [
+    {
+        title: 'Team ID',
+        dataIndex: 'team_id',
+        width: 100,
+    },
+    {
+        title: 'Team name',
+        dataIndex: 'team_name',
+    },
+    {
+        title: 'Organization',
+        dataIndex: 'organization_name',
+    },
+]
 
 export function QueryPerformance(): JSX.Element {
     const { user } = useValues(userLogic)
+    const { precomputationTeams, precomputationTeamsLoading } = useValues(queryPerformanceLogic)
 
     if (!user?.is_staff) {
         return (
@@ -47,7 +68,13 @@ export function QueryPerformance(): JSX.Element {
                     forceIcon: <IconDatabase />,
                 }}
             />
-            <p className="text-muted">Coming soon.</p>
+            <h2 className="mt-4">Teams with precomputation enabled</h2>
+            <LemonTable
+                columns={precomputationColumns}
+                dataSource={precomputationTeams}
+                loading={precomputationTeamsLoading}
+                emptyState="No teams have precomputation enabled"
+            />
         </SceneContent>
     )
 }

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -1,0 +1,29 @@
+import { afterMount, kea, path } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+
+import type { queryPerformanceLogicType } from './queryPerformanceLogicType'
+
+export interface PrecomputationTeam {
+    team_id: number
+    team_name: string
+    organization_name: string | null
+}
+
+export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
+    path(['scenes', 'instance', 'QueryPerformance', 'queryPerformanceLogic']),
+    loaders({
+        precomputationTeams: [
+            [] as PrecomputationTeam[],
+            {
+                loadPrecomputationTeams: async () => {
+                    return await api.get('api/debug_ch_queries/precomputation_teams/')
+                },
+            },
+        ],
+    }),
+    afterMount(({ actions }) => {
+        actions.loadPrecomputationTeams()
+    }),
+])

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -2,6 +2,7 @@ import { afterMount, kea, path } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
+import { userLogic } from 'scenes/userLogic'
 
 import type { queryPerformanceLogicType } from './queryPerformanceLogicType'
 
@@ -24,6 +25,8 @@ export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
         ],
     }),
     afterMount(({ actions }) => {
-        actions.loadPrecomputationTeams()
+        if (userLogic.findMounted()?.values.user?.is_staff) {
+            actions.loadPrecomputationTeams()
+        }
     }),
 ])

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -220,6 +220,30 @@ class DebugCHQueries(viewsets.ViewSet):
             response["hourly_stats"] = self.hourly_stats(filter_key, filter_value)
         return Response(response)
 
+    @action(detail=False, methods=["GET"], url_path="precomputation_teams")
+    def precomputation_teams(self, request):
+        if not request.user.is_staff:
+            raise exceptions.PermissionDenied("Only staff users can view precomputation teams.")
+
+        from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
+
+        configs = (
+            TeamExperimentsConfig.objects.filter(experiment_precomputation_enabled=True)
+            .select_related("team", "team__organization")
+            .order_by("team__name")
+        )
+
+        return Response(
+            [
+                {
+                    "team_id": config.team_id,
+                    "team_name": config.team.name,
+                    "organization_name": config.team.organization.name if config.team.organization else None,
+                }
+                for config in configs
+            ]
+        )
+
     @action(detail=False, methods=["POST"])
     def profile(self, request):
         if not request.user.is_staff:

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -21,6 +21,8 @@ from posthog.settings.base_variables import DEBUG
 from posthog.settings.data_stores import CLICKHOUSE_CLUSTER
 from posthog.utils import generate_short_id
 
+from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -224,8 +226,6 @@ class DebugCHQueries(viewsets.ViewSet):
     def precomputation_teams(self, request):
         if not request.user.is_staff:
             raise exceptions.PermissionDenied("Only staff users can view precomputation teams.")
-
-        from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
 
         configs = (
             TeamExperimentsConfig.objects.filter(experiment_precomputation_enabled=True)


### PR DESCRIPTION
## Problem

No visibility into which teams have experiment precomputation enabled.

## Changes

- Add staff-only `GET /api/debug_ch_queries/precomputation_teams/` endpoint that returns teams with `experiment_precomputation_enabled=True`
- Replace "Coming soon" placeholder on the query performance page with a table showing team ID, team name, and organization

## How did you test this code?
<img width="1191" height="460" alt="image" src="https://github.com/user-attachments/assets/0409afe5-9ce2-4b30-9564-95b7f2802f4f" />