### PR TITLE
feat(debug): add search and toggle for experiment precomputation teams

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -57,16 +57,11 @@ export function QueryPerformance(): JSX.Element {
         },
         {
             title: 'Organization',
-            render: function Organization(_, team) {
-                return (
-                    <span>
-                        {team.organization_name}
-                        {team.organization_id && (
-                            <span className="ml-1 text-muted text-xs font-mono">{team.organization_id}</span>
-                        )}
-                    </span>
-                )
-            },
+            dataIndex: 'organization_name',
+        },
+        {
+            title: 'Organization ID',
+            dataIndex: 'organization_id',
         },
         {
             title: 'Precomputation',

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -1,7 +1,9 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 
 import { IconDatabase } from '@posthog/icons'
 
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
+import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { SceneExport } from 'scenes/sceneTypes'
 import { userLogic } from 'scenes/userLogic'
@@ -16,25 +18,10 @@ export const scene: SceneExport = {
     logic: queryPerformanceLogic,
 }
 
-const precomputationColumns: LemonTableColumns<PrecomputationTeam> = [
-    {
-        title: 'Team ID',
-        dataIndex: 'team_id',
-        width: 100,
-    },
-    {
-        title: 'Team name',
-        dataIndex: 'team_name',
-    },
-    {
-        title: 'Organization',
-        dataIndex: 'organization_name',
-    },
-]
-
 export function QueryPerformance(): JSX.Element {
     const { user } = useValues(userLogic)
-    const { precomputationTeams, precomputationTeamsLoading } = useValues(queryPerformanceLogic)
+    const { precomputationTeams, precomputationTeamsLoading, search } = useValues(queryPerformanceLogic)
+    const { setSearch, setPrecomputation } = useActions(queryPerformanceLogic)
 
     if (!user?.is_staff) {
         return (
@@ -58,6 +45,34 @@ export function QueryPerformance(): JSX.Element {
         )
     }
 
+    const columns: LemonTableColumns<PrecomputationTeam> = [
+        {
+            title: 'Team ID',
+            dataIndex: 'team_id',
+            width: 100,
+        },
+        {
+            title: 'Team name',
+            dataIndex: 'team_name',
+        },
+        {
+            title: 'Organization',
+            dataIndex: 'organization_name',
+        },
+        {
+            title: 'Precomputation',
+            width: 140,
+            render: function PrecomputationToggle(_, team) {
+                return (
+                    <LemonSwitch
+                        checked={team.experiment_precomputation_enabled}
+                        onChange={(enabled) => setPrecomputation(team.team_id, enabled)}
+                    />
+                )
+            },
+        },
+    ]
+
     return (
         <SceneContent>
             <SceneTitleSection
@@ -68,12 +83,19 @@ export function QueryPerformance(): JSX.Element {
                     forceIcon: <IconDatabase />,
                 }}
             />
-            <h2 className="mt-4">Teams with precomputation enabled</h2>
+            <h2 className="mt-4">Experiment precomputation</h2>
+            <LemonInput
+                type="search"
+                placeholder="Search by organization name..."
+                value={search}
+                onChange={setSearch}
+                className="mb-4 max-w-md"
+            />
             <LemonTable
-                columns={precomputationColumns}
+                columns={columns}
                 dataSource={precomputationTeams}
                 loading={precomputationTeamsLoading}
-                emptyState="No teams have precomputation enabled"
+                emptyState={search ? 'No teams found' : 'No teams have precomputation enabled'}
             />
         </SceneContent>
     )

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -57,7 +57,16 @@ export function QueryPerformance(): JSX.Element {
         },
         {
             title: 'Organization',
-            dataIndex: 'organization_name',
+            render: function Organization(_, team) {
+                return (
+                    <span>
+                        {team.organization_name}
+                        {team.organization_id && (
+                            <span className="ml-1 text-muted text-xs font-mono">{team.organization_id}</span>
+                        )}
+                    </span>
+                )
+            },
         },
         {
             title: 'Precomputation',

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -9,6 +9,7 @@ import type { queryPerformanceLogicType } from './queryPerformanceLogicType'
 export interface PrecomputationTeam {
     team_id: number
     team_name: string
+    organization_id: string | null
     organization_name: string | null
     experiment_precomputation_enabled: boolean
 }

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -1,4 +1,4 @@
-import { afterMount, kea, path } from 'kea'
+import { actions, afterMount, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
@@ -10,20 +10,55 @@ export interface PrecomputationTeam {
     team_id: number
     team_name: string
     organization_name: string | null
+    experiment_precomputation_enabled: boolean
 }
 
 export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
     path(['scenes', 'instance', 'QueryPerformance', 'queryPerformanceLogic']),
-    loaders({
+    actions({
+        setSearch: (search: string) => ({ search }),
+        setPrecomputation: (teamId: number, enabled: boolean) => ({ teamId, enabled }),
+    }),
+    reducers({
+        search: [
+            '',
+            {
+                setSearch: (_, { search }) => search,
+            },
+        ],
+    }),
+    loaders(({ values }) => ({
         precomputationTeams: [
             [] as PrecomputationTeam[],
             {
                 loadPrecomputationTeams: async () => {
-                    return await api.get('api/debug_ch_queries/precomputation_teams/')
+                    const params = new URLSearchParams()
+                    if (values.search) {
+                        params.append('search', values.search)
+                    }
+                    return await api.get(`api/debug_ch_queries/precomputation_teams/?${params.toString()}`)
+                },
+                setPrecomputation: async ({ teamId, enabled }) => {
+                    const updated: PrecomputationTeam = await api.create('api/debug_ch_queries/precomputation_teams/', {
+                        team_id: teamId,
+                        experiment_precomputation_enabled: enabled,
+                    })
+                    // Replace the updated team in the list
+                    return values.precomputationTeams.map((team) => (team.team_id === updated.team_id ? updated : team))
                 },
             },
         ],
-    }),
+    })),
+    listeners(({ actions }) => ({
+        setSearch: async ({ search }, breakpoint) => {
+            // Debounce: wait 300ms, then reload
+            await breakpoint(300)
+            // If search is cleared, reload to show only enabled teams
+            if (search || search === '') {
+                actions.loadPrecomputationTeams()
+            }
+        },
+    })),
     afterMount(({ actions }) => {
         if (userLogic.findMounted()?.values.user?.is_staff) {
             actions.loadPrecomputationTeams()

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -44,20 +44,21 @@ export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
                         team_id: teamId,
                         experiment_precomputation_enabled: enabled,
                     })
-                    // Replace the updated team in the list
-                    return values.precomputationTeams.map((team) => (team.team_id === updated.team_id ? updated : team))
+                    const updatedList = values.precomputationTeams.map((team) =>
+                        team.team_id === updated.team_id ? updated : team
+                    )
+                    // If no search active, filter out disabled teams to match backend default
+                    return values.search
+                        ? updatedList
+                        : updatedList.filter((team) => team.experiment_precomputation_enabled)
                 },
             },
         ],
     })),
     listeners(({ actions }) => ({
-        setSearch: async ({ search }, breakpoint) => {
-            // Debounce: wait 300ms, then reload
+        setSearch: async (_, breakpoint) => {
             await breakpoint(300)
-            // If search is cleared, reload to show only enabled teams
-            if (search || search === '') {
-                actions.loadPrecomputationTeams()
-            }
+            actions.loadPrecomputationTeams()
         },
     })),
     afterMount(({ actions }) => {

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -277,8 +277,8 @@ class DebugCHQueries(viewsets.ViewSet):
             raise exceptions.ValidationError("team_id and experiment_precomputation_enabled are required.")
 
         try:
-            team = Team.objects.select_related("organization").get(id=team_id)
-        except Team.DoesNotExist:
+            team = Team.objects.select_related("organization").get(id=int(team_id))
+        except (Team.DoesNotExist, TypeError, ValueError):
             raise exceptions.NotFound(f"Team {team_id} not found.")
 
         config = get_or_create_team_extension(team, TeamExperimentsConfig)

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -228,6 +228,7 @@ class DebugCHQueries(viewsets.ViewSet):
         return {
             "team_id": team.id,
             "team_name": team.name,
+            "organization_id": str(team.organization.id) if team.organization else None,
             "organization_name": team.organization.name if team.organization else None,
             "experiment_precomputation_enabled": enabled,
         }

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -17,6 +17,8 @@ from rest_framework.response import Response
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload, get_client_from_pool
 from posthog.cloud_utils import is_cloud
+from posthog.models.team.extensions import get_or_create_team_extension
+from posthog.models.team.team import Team
 from posthog.settings.base_variables import DEBUG
 from posthog.settings.data_stores import CLICKHOUSE_CLUSTER
 from posthog.utils import generate_short_id
@@ -222,27 +224,67 @@ class DebugCHQueries(viewsets.ViewSet):
             response["hourly_stats"] = self.hourly_stats(filter_key, filter_value)
         return Response(response)
 
-    @action(detail=False, methods=["GET"], url_path="precomputation_teams")
+    def _serialize_precomputation_team(self, team: Team, enabled: bool) -> dict:
+        return {
+            "team_id": team.id,
+            "team_name": team.name,
+            "organization_name": team.organization.name if team.organization else None,
+            "experiment_precomputation_enabled": enabled,
+        }
+
+    @action(detail=False, methods=["GET", "POST"], url_path="precomputation_teams")
     def precomputation_teams(self, request):
         if not request.user.is_staff:
-            raise exceptions.PermissionDenied("Only staff users can view precomputation teams.")
+            raise exceptions.PermissionDenied("Only staff users can manage precomputation teams.")
 
+        if request.method == "POST":
+            return self._update_precomputation(request)
+
+        search = request.query_params.get("search", "").strip()
+
+        if search:
+            # Search by org name — return all teams in matching orgs
+            teams = (
+                Team.objects.filter(organization__name__icontains=search)
+                .select_related("organization")
+                .order_by("organization__name", "name")
+            )
+            # Batch-fetch precomputation configs for matched teams
+            configs_by_team = dict(
+                TeamExperimentsConfig.objects.filter(
+                    team__in=teams,
+                    experiment_precomputation_enabled=True,
+                ).values_list("team_id", "experiment_precomputation_enabled")
+            )
+            return Response(
+                [self._serialize_precomputation_team(team, configs_by_team.get(team.id, False)) for team in teams]
+            )
+
+        # Default: only teams with precomputation enabled
         configs = (
             TeamExperimentsConfig.objects.filter(experiment_precomputation_enabled=True)
             .select_related("team", "team__organization")
             .order_by("team__name")
         )
+        return Response([self._serialize_precomputation_team(config.team, True) for config in configs])
 
-        return Response(
-            [
-                {
-                    "team_id": config.team_id,
-                    "team_name": config.team.name,
-                    "organization_name": config.team.organization.name if config.team.organization else None,
-                }
-                for config in configs
-            ]
-        )
+    def _update_precomputation(self, request) -> Response:
+        team_id = request.data.get("team_id")
+        enabled = request.data.get("experiment_precomputation_enabled")
+
+        if team_id is None or enabled is None:
+            raise exceptions.ValidationError("team_id and experiment_precomputation_enabled are required.")
+
+        try:
+            team = Team.objects.select_related("organization").get(id=team_id)
+        except Team.DoesNotExist:
+            raise exceptions.NotFound(f"Team {team_id} not found.")
+
+        config = get_or_create_team_extension(team, TeamExperimentsConfig)
+        config.experiment_precomputation_enabled = enabled
+        config.save(update_fields=["experiment_precomputation_enabled"])
+
+        return Response(self._serialize_precomputation_team(team, enabled))
 
     @action(detail=False, methods=["POST"])
     def profile(self, request):


### PR DESCRIPTION
## Problem

Can't search for teams or toggle precomputation from the query performance page — had to use management commands.

## Changes

- `GET /api/debug_ch_queries/precomputation_teams/` now supports `?search=` filtering by organization name, returning all teams in matching orgs
- `POST /api/debug_ch_queries/precomputation_teams/` toggles `experiment_precomputation_enabled` for a given team
- Default view (no search) shows only teams with precomputation enabled
- Search returns all matching teams regardless of precomputation status
- Frontend: search input + toggle switch column

## How did you test this code?
Tested manually.

<img width="1192" height="376" alt="image" src="https://github.com/user-attachments/assets/30b723ec-0b96-4c24-aa19-46da9efcc548" />