### PR TITLE
fix(replay): trust empty matched_recordings for funnels in persons modal

### DIFF
--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.test.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.test.ts
@@ -458,10 +458,6 @@ describe('personsModalLogic', () => {
         })
 
         it('does not fall back to event filters for FunnelsActorsQuery without session IDs', () => {
-            // Funnels match persons across sessions, but a same-session AND of all funnel events
-            // would never reproduce that — it just guarantees an empty list. When the backend has
-            // no matched_recordings (events lacked $session_id, recordings expired), trust that and
-            // return only scoping filters so the recordings page renders its default state.
             logic = personsModalLogic({
                 query: {
                     kind: NodeKind.FunnelsActorsQuery,

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.test.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.test.ts
@@ -456,5 +456,60 @@ describe('personsModalLogic', () => {
                 ])
             )
         })
+
+        it('does not fall back to event filters for FunnelsActorsQuery without session IDs', () => {
+            // Funnels match persons across sessions, but a same-session AND of all funnel events
+            // would never reproduce that — it just guarantees an empty list. When the backend has
+            // no matched_recordings (events lacked $session_id, recordings expired), trust that and
+            // return only scoping filters so the recordings page renders its default state.
+            logic = personsModalLogic({
+                query: {
+                    kind: NodeKind.FunnelsActorsQuery,
+                    source: {
+                        kind: NodeKind.FunnelsQuery,
+                        series: [
+                            { kind: NodeKind.EventsNode, event: '$pageview' },
+                            { kind: NodeKind.EventsNode, event: 'sign_up' },
+                        ],
+                    },
+                    funnelStep: 1,
+                    includeRecordings: true,
+                },
+                url: '/api/environments/1/persons?',
+                additionalSelect: { matched_recordings: 'matched_recordings' },
+            })
+            logic.mount()
+
+            logic.actions.loadActorsSuccess({
+                results: [
+                    {
+                        count: 1,
+                        people: [
+                            {
+                                type: 'person',
+                                id: 'person-1',
+                                distinct_ids: ['user-1'],
+                                is_identified: true,
+                                properties: {},
+                                created_at: '2024-01-01',
+                                matched_recordings: [],
+                                value_at_data_point: null,
+                            },
+                        ],
+                    },
+                ],
+                missing_persons: 0,
+            })
+
+            expectLogic(logic).toMatchValues({
+                recordingFilters: {
+                    filter_group: {
+                        type: FilterLogicalOperator.And,
+                        values: [{ type: FilterLogicalOperator.And, values: [] }],
+                    },
+                    duration: [],
+                },
+            })
+        })
     })
 })

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -574,7 +574,26 @@ export const personsModalLogic = kea<personsModalLogicType>([
                     }
                 }
 
-                // For non-funnel queries or funnels without session IDs, use filter-based approach
+                // For funnels, matched_recordings is the source of truth — if empty, the backend has nothing
+                // to surface (events lacked $session_id, or the recordings expired). The events-fallback below
+                // can't approximate the funnel's cross-session person set with a same-session AND filter, so we
+                // return only the breakdown scope and let the recordings page render its default state.
+                if (source.kind === NodeKind.FunnelsActorsQuery) {
+                    return {
+                        filter_group: {
+                            type: FilterLogicalOperator.And,
+                            values: [
+                                {
+                                    type: FilterLogicalOperator.And,
+                                    values: funnelBreakdownFilter ? [funnelBreakdownFilter] : [],
+                                },
+                            ],
+                        },
+                        duration: [],
+                    }
+                }
+
+                // For non-funnel queries, use the filter-based approach
                 const filters: UniversalFilterValue[] = []
 
                 // The actual insight query (with series, properties, etc.) is nested at source.source

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -574,10 +574,9 @@ export const personsModalLogic = kea<personsModalLogicType>([
                     }
                 }
 
-                // For funnels, matched_recordings is the source of truth — if empty, the backend has nothing
-                // to surface (events lacked $session_id, or the recordings expired). The events-fallback below
-                // can't approximate the funnel's cross-session person set with a same-session AND filter, so we
-                // return only the breakdown scope and let the recordings page render its default state.
+                // A same-session AND of all funnel events can't approximate a funnel's cross-session person
+                // set, so when matched_recordings is empty we don't fall back to an events filter — return
+                // only the breakdown scope and let the recordings page render its default state.
                 if (source.kind === NodeKind.FunnelsActorsQuery) {
                     return {
                         filter_group: {
@@ -593,7 +592,6 @@ export const personsModalLogic = kea<personsModalLogicType>([
                     }
                 }
 
-                // For non-funnel queries, use the filter-based approach
                 const filters: UniversalFilterValue[] = []
 
                 // The actual insight query (with series, properties, etc.) is nested at source.source


### PR DESCRIPTION
## Problem

Clicking "View recordings" from a funnel persons modal shows "No matching recordings" even when the modal lists hundreds of completers. The persons modal had a fallback (added in #52743) that, when `matched_recordings` came back empty from the backend, dumped the funnel's step events into a `Match: all` filter on the recordings panel. That filter requires every event to occur in the same session, but funnels match persons across sessions — so the filter is guaranteed to under-match and usually returns nothing.

The original design (#44486) was: trust `matched_recordings` from the backend as the source of truth for which recordings tie to the funnel. The fallback was meant to help non-funnel insights (trends/lifecycle) but accidentally regressed the funnel path.

## Changes

- Gate the events-extraction fallback on `source.kind !== FunnelsActorsQuery` in `personsModalLogic.recordingFilters`
- For funnels with empty `matched_recordings`, return only the breakdown scope so the recordings page renders its default state
- Trends and other insight types keep the existing event-filter fallback unchanged
- Add a regression test asserting the funnel branch does not include event filters when `matched_recordings` is empty

## How did you test this code?

Clicked through a funnel locally to verify I now see recordings after clicking View recordings'

## Publish to changelog?