### PR TITLE
fix(quill): publish via npm CLI to enable OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-quill-npm.yml
+++ b/.github/workflows/publish-quill-npm.yml
@@ -54,9 +54,10 @@ jobs:
             # step so a failure shows up on the exact step that broke.
             - name: Publish @posthog/quill-tokens
               id: publish-tokens
+              working-directory: packages/quill/packages/tokens
               run: |
-                  pnpm --filter "@posthog/quill-tokens" publish --tag "$NPM_TAG" --no-git-checks --access public
-                  VERSION=$(node -p "require('./packages/quill/packages/tokens/package.json').version")
+                  npm publish --tag "$NPM_TAG" --access public
+                  VERSION=$(node -p "require('./package.json').version")
                   echo "version=$VERSION" >> $GITHUB_OUTPUT
               env:
                   NODE_AUTH_TOKEN: ''
@@ -65,9 +66,10 @@ jobs:
 
             - name: Publish @posthog/quill
               id: publish-quill
+              working-directory: packages/quill/packages/quill
               run: |
-                  pnpm --filter "@posthog/quill" publish --tag "$NPM_TAG" --no-git-checks --access public
-                  VERSION=$(node -p "require('./packages/quill/packages/quill/package.json').version")
+                  npm publish --tag "$NPM_TAG" --access public
+                  VERSION=$(node -p "require('./package.json').version")
                   echo "version=$VERSION" >> $GITHUB_OUTPUT
               env:
                   NODE_AUTH_TOKEN: ''
@@ -91,7 +93,7 @@ jobs:
               uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
               with:
                   method: chat.postMessage
-                  token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
                   payload: |
-                      channel: "${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}"
+                      channel: "C0AMDUUG09F"
                       text: "${{ job.status == 'success' && ':white_check_mark:' || ':red_circle:' }} Quill npm publish (${{ inputs.tag }}): ${{ job.status }}\n${{ steps.versions.outputs.summary }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"


### PR DESCRIPTION
## Problem

The Publish Quill npm packages workflow has been [failing on every run](https://github.com/PostHog/posthog/actions/runs/24336449837) with `ENEEDAUTH`:

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

Both `@posthog/quill-tokens` and `@posthog/quill` already have a Trusted Publisher configured on npmjs.com pointing at this workflow, repository, and the `Release` environment, so OIDC publishing should just work. The actual cause is that the workflow used `pnpm --filter ... publish`, and pnpm's publish wrapper does not propagate the GitHub Actions OIDC token through to the npm trusted publisher exchange. The result is an empty token and `ENEEDAUTH`.

A second, smaller issue: the Slack notify step referenced a secret (`SLACK_CLIENT_LIBRARIES_BOT_TOKEN`) and a var (`SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID`) that do not exist in this repo, so the notify step always failed with `Missing input! A token must be provided`.

## Changes

- Switch both publish steps to invoke `npm publish` directly from each package's `working-directory`, mirroring the working pattern in `build-hogql-parser-npm.yml`, the `hogvm` publish step in `ci-hog.yml`, and the npm publish step in `release.yml`. All other PostHog npm publish workflows already use `npm publish` for exactly this reason.
- Read the version after publishing via `require('./package.json').version` from inside the package directory, since we are no longer running from the repo root.
- Point the Slack notify step at the `SLACK_BOT_TOKEN` secret used by the rest of the repo and a real channel ID (`C0AMDUUG09F`) which is #design-engineering, so success/failure messages actually deliver.

No other workflows are touched.

## How did you test this code?

I am an agent and have not run the workflow end-to-end myself. Verification was via:

- Diffing this workflow against `build-hogql-parser-npm.yml`, `ci-hog.yml`, and `release.yml` to confirm the publish step shape matches what is already proven to work in this repo.
- Confirming on npmjs.com that both `@posthog/quill-tokens` and `@posthog/quill` already exist (`0.1.0-alpha.0`) with the Trusted Publisher pointing at `PostHog/posthog`, workflow `publish-quill-npm.yml`, environment `Release`.
- Confirming `SLACK_BOT_TOKEN` is the same secret used by 5 other workflows in `.github/workflows/`.

The real test is rerunning the `Publish Quill npm packages` workflow manually after this lands.

## Publish to changelog?

no

<!-- ## 🤖 LLM context -->
<!-- Authored by Claude (Opus 4.6, 1M context) in a Claude Code session. The session diagnosed the failing run https://github.com/PostHog/posthog/actions/runs/24336449837, traced the root cause to pnpm publish not forwarding the OIDC token, and matched the fix against the three other working npm publish workflows in this repo. -->