### PR TITLE
chore: add OTel spans to logs, data warehouse, and elements property value endpoints

### DIFF
--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -3,6 +3,7 @@ from typing import Literal
 from django.conf import settings
 
 from drf_spectacular.utils import extend_schema
+from opentelemetry import trace
 from prometheus_client import Histogram
 from rest_framework import request, response, serializers, viewsets
 from rest_framework.exceptions import ValidationError
@@ -19,6 +20,8 @@ from posthog.models.element.sql import GET_ELEMENTS, GET_VALUES
 from posthog.models.property.util import parse_prop_grouped_clauses
 from posthog.queries.query_date_range import QueryDateRange
 from posthog.utils import format_query_params_absolute_url
+
+tracer = trace.get_tracer(__name__)
 
 ELEMENT_STATS_TIME_HISTOGRAM = Histogram(
     "element_stats_time_seconds",
@@ -182,9 +185,17 @@ class ElementViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     @action(methods=["GET"], detail=False)
     def values(self, request: request.Request, **kwargs) -> response.Response:
-        with PROPERTY_VALUES_DURATION.labels(endpoint_type="element").time():
+        with (
+            PROPERTY_VALUES_DURATION.labels(endpoint_type="element").time(),
+            tracer.start_as_current_span("elements_api_property_values") as span,
+        ):
             key = request.GET.get("key")
             value = request.GET.get("value")
+
+            span.set_attribute("team_id", self.team.pk)
+            span.set_attribute("property_key", key or "")
+            span.set_attribute("has_value_filter", value is not None)
+
             select_regex = '[:|"]{}="(.*?)"'.format(key)
 
             # Make sure key exists, otherwise could lead to sql injection lower down
@@ -210,6 +221,7 @@ class ElementViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     "filter_regex": filter_regex,
                 },
             )
+            span.set_attribute("result_count", len(result))
             return response.Response([{"name": value[0]} for value in result])
 
 

--- a/products/data_warehouse/backend/api/data_warehouse.py
+++ b/products/data_warehouse/backend/api/data_warehouse.py
@@ -12,6 +12,7 @@ import structlog
 import posthoganalytics
 from dateutil import parser
 from drf_spectacular.utils import extend_schema, inline_serializer
+from opentelemetry import trace
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
@@ -39,6 +40,7 @@ from products.data_warehouse.backend.models.util import get_view_or_table_by_nam
 from ee.billing.billing_manager import BillingManager
 
 logger = structlog.get_logger(__name__)
+tracer = trace.get_tracer(__name__)
 
 
 class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
@@ -50,10 +52,18 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
 
     @action(methods=["GET"], detail=False, required_scopes=["query:read"])
     def property_values(self, request: Request, **kwargs) -> Response:
-        with PROPERTY_VALUES_DURATION.labels(endpoint_type="data_warehouse").time():
+        with (
+            PROPERTY_VALUES_DURATION.labels(endpoint_type="data_warehouse").time(),
+            tracer.start_as_current_span("data_warehouse_api_property_values") as span,
+        ):
             key = request.GET.get("key")
             table_name = request.GET.get("table_name")
             value = request.GET.get("value")
+
+            span.set_attribute("team_id", self.team.pk)
+            span.set_attribute("property_key", key or "")
+            span.set_attribute("table_name", table_name or "")
+            span.set_attribute("has_value_filter", value is not None)
 
             if not key:
                 raise serializers.ValidationError("You must provide a key")
@@ -108,6 +118,7 @@ class DataWarehouseViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
             result = execute_hogql_query(query, team=self.team)
 
             values = [row[0] for row in result.results]
+            span.set_attribute("result_count", len(values))
             resp = Response(
                 {"results": [{"name": convert_property_value(value)} for value in flatten(values)], "refreshing": False}
             )

--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -7,6 +7,7 @@ from django.core.cache import cache
 from django.utils import timezone
 
 from drf_spectacular.utils import extend_schema
+from opentelemetry import trace
 from pydantic import ValidationError
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
@@ -46,6 +47,7 @@ from products.logs.backend.views_api import LogsViewViewSet
 
 __all__ = ["LogsViewSet", "LogExplainViewSet", "LogsAlertViewSet", "LogsViewViewSet"]
 
+tracer = trace.get_tracer(__name__)
 LOGS_MAX_EXPORT_ROWS = 10_000
 
 
@@ -423,11 +425,18 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
     @extend_schema(parameters=[_LogsValuesQuerySerializer])
     @action(detail=False, methods=["GET"], required_scopes=["logs:read"])
     def values(self, request: Request, *args, **kwargs) -> Response:
-        with PROPERTY_VALUES_DURATION.labels(endpoint_type="log").time():
+        with (
+            PROPERTY_VALUES_DURATION.labels(endpoint_type="log").time(),
+            tracer.start_as_current_span("logs_api_property_values") as span,
+        ):
             search = request.GET.get("value", "")
             limit = request.GET.get("limit", 100)
             offset = request.GET.get("offset", 0)
             attributeKey = request.GET.get("key", "")
+
+            span.set_attribute("team_id", self.team.pk)
+            span.set_attribute("property_key", attributeKey)
+            span.set_attribute("has_value_filter", bool(search))
 
             if not attributeKey:
                 return Response("key is required", status=status.HTTP_400_BAD_REQUEST)
@@ -453,6 +462,8 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             if attributeType not in ["log", "resource"]:
                 attributeType = "log"
 
+            span.set_attribute("attribute_type", attributeType)
+
             try:
                 limit = int(limit)
             except ValueError:
@@ -477,6 +488,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             runner = LogValuesQueryRunner(team=self.team, query=query)
 
             result = runner.calculate()
+            span.set_attribute("result_count", len(result.results))
             return Response(
                 {"results": [r.model_dump() for r in result.results], "refreshing": False},
                 status=status.HTTP_200_OK,


### PR DESCRIPTION
## Problem

Three property value endpoints (logs, data warehouse, elements) had Prometheus timing histograms (added in #54205) but no OpenTelemetry tracing spans. This meant they were invisible in Jaeger — we could see *how long* requests took via Prometheus but not *why* (no span attributes, no child span breakdown, no trace correlation).

This is part of ongoing work to understand and optimize property value lookup performance across all taxonomic filter endpoints.

## Changes

Adds OTel tracer spans to the three endpoints that were missing them:

| Endpoint | Span name | Attributes |
|---|---|---|
| `products/logs/backend/api.py` | `logs_api_property_values` | `team_id`, `property_key`, `has_value_filter`, `attribute_type`, `result_count` |
| `products/data_warehouse/backend/api/data_warehouse.py` | `data_warehouse_api_property_values` | `team_id`, `property_key`, `table_name`, `has_value_filter`, `result_count` |
| `posthog/api/element.py` | `elements_api_property_values` | `team_id`, `property_key`, `has_value_filter`, `result_count` |

Combined with the existing automatic `clickhouse.query` child spans from the ClickHouse client decorator, these will show the full request breakdown in Jaeger traces.

## How did you test this code?

- Element and session API tests pass (25/25)
- Ruff lint clean on all changed files
- I'm an agent and have not tested this manually beyond the automated tests above

## Publish to changelog?

No

## 🤖 LLM context

Follow-up to #54205 which added Prometheus histograms. That PR was merged before this OTel spans commit was pushed, so this is a separate PR for the tracing additions.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*