### PR TITLE
feat(cloud-agent): task streams alive during idle reconnects

### DIFF
--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -2099,7 +2099,7 @@ export async function onEventImplementation(
 
         const entry = parseLogEvent(
             parsedResponse,
-            cache.sandboxEventIndex++,
+            `sandbox-${cache.sandboxEventIndex++}`,
             cache.sandboxToolMap as Map<string, LogEntry>
         )
         if (!entry) {

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -67,6 +67,9 @@ from .temporal.client import execute_posthog_code_agent_relay_workflow, execute_
 from .temporal.process_task.utils import PrAuthorshipMode, cache_github_user_token, parse_run_state
 
 logger = logging.getLogger(__name__)
+TASK_RUN_STREAM_KEEPALIVE_INTERVAL_SECONDS = 20.0
+TASK_RUN_STREAM_KEEPALIVE_EVENT_NAME = "keepalive"
+TASK_RUN_STREAM_KEEPALIVE_PAYLOAD = {"type": "keepalive"}
 
 
 class TasksAccessPermission(BasePermission):
@@ -1127,7 +1130,17 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             if not last_event_id and start_latest:
                 start_id = await redis_stream.get_latest_stream_id() or "0"
             try:
-                async for event_id, event in redis_stream.read_stream_entries(start_id=start_id):
+                async for stream_item in redis_stream.read_stream_entries(
+                    start_id=start_id,
+                    keepalive_interval_seconds=TASK_RUN_STREAM_KEEPALIVE_INTERVAL_SECONDS,
+                ):
+                    if stream_item is None:
+                        yield format_sse_event(
+                            TASK_RUN_STREAM_KEEPALIVE_PAYLOAD,
+                            event_name=TASK_RUN_STREAM_KEEPALIVE_EVENT_NAME,
+                        )
+                        continue
+                    event_id, event = stream_item
                     yield format_sse_event(event, event_id=event_id)
             except TaskRunStreamError as e:
                 logger.error("TaskRunRedisStream error for stream %s: %s", stream_key, e, exc_info=True)

--- a/products/tasks/backend/stream/redis_stream.py
+++ b/products/tasks/backend/stream/redis_stream.py
@@ -21,6 +21,8 @@ TASK_RUN_STREAM_PREFIX = "task-run-stream:"
 TASK_RUN_STREAM_READ_COUNT = 16
 
 DATA_KEY = b"data"
+TaskRunStreamEntry = tuple[str, dict]
+TaskRunStreamEntryOrKeepalive = TaskRunStreamEntry | None
 
 
 def _normalize_stream_id(stream_id: str | bytes) -> str:
@@ -98,8 +100,17 @@ class TaskRunRedisStream:
         start_id: str = "0",
         block_ms: int = 100,
         count: Optional[int] = TASK_RUN_STREAM_READ_COUNT,
+        keepalive_interval_seconds: float | None = None,
     ) -> AsyncGenerator[dict, None]:
-        async for _stream_id, data in self.read_stream_entries(start_id=start_id, block_ms=block_ms, count=count):
+        async for item in self.read_stream_entries(
+            start_id=start_id,
+            block_ms=block_ms,
+            count=count,
+            keepalive_interval_seconds=keepalive_interval_seconds,
+        ):
+            if item is None:
+                continue
+            _stream_id, data = item
             yield data
 
     async def read_stream_entries(
@@ -107,18 +118,23 @@ class TaskRunRedisStream:
         start_id: str = "0",
         block_ms: int = 100,
         count: Optional[int] = TASK_RUN_STREAM_READ_COUNT,
-    ) -> AsyncGenerator[tuple[str, dict], None]:
+        keepalive_interval_seconds: float | None = None,
+    ) -> AsyncGenerator[TaskRunStreamEntryOrKeepalive, None]:
         """Read events from the Redis stream.
 
         Yields Redis stream IDs and parsed JSON dicts.
+        When keepalive_interval_seconds is set, yields None after that many
+        idle seconds so callers can inject protocol-level keepalives.
         Stops when a complete sentinel is received.
         Raises TaskRunStreamError on error sentinel or timeout.
         """
         current_id = start_id
         start_time = asyncio.get_running_loop().time()
+        last_yield_time = start_time
 
         while True:
-            if asyncio.get_running_loop().time() - start_time > self._timeout:
+            now = asyncio.get_running_loop().time()
+            if now - start_time > self._timeout:
                 raise TaskRunStreamError("Stream timeout — task run took too long")
 
             try:
@@ -129,6 +145,10 @@ class TaskRunRedisStream:
                 )
 
                 if not messages:
+                    now = asyncio.get_running_loop().time()
+                    if keepalive_interval_seconds is not None and now - last_yield_time >= keepalive_interval_seconds:
+                        last_yield_time = now
+                        yield None
                     continue
 
                 for _, stream_messages in messages:
@@ -145,6 +165,7 @@ class TaskRunRedisStream:
                             elif status == "error":
                                 raise TaskRunStreamError(data.get("error", "Unknown stream error"))
                         else:
+                            last_yield_time = asyncio.get_running_loop().time()
                             yield normalized_stream_id, data
 
             except (TaskRunStreamError, GeneratorExit):

--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -41,11 +41,12 @@ from products.tasks.backend.temporal.process_task.workflow import (
     ProcessTaskWorkflow,
 )
 
-pytestmark = pytest.mark.asyncio
-
 
 def _build_context(
-    *, github_integration_id: int | None, repository: str | None = "posthog/posthog-js"
+    *,
+    github_integration_id: int | None,
+    repository: str | None = "posthog/posthog-js",
+    state: dict | None = None,
 ) -> TaskProcessingContext:
     return TaskProcessingContext(
         task_id="task-id",
@@ -57,12 +58,13 @@ def _build_context(
         repository=repository,
         distinct_id="distinct-id",
         create_pr=True,
-        state={},
+        state=state or {},
         _branch="feature-branch",
     )
 
 
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
 @pytest.mark.skipif(
     not os.environ.get("MODAL_TOKEN_ID") or not os.environ.get("MODAL_TOKEN_SECRET"),
     reason="MODAL_TOKEN_ID and MODAL_TOKEN_SECRET environment variables not set",
@@ -240,6 +242,30 @@ class TestProcessTaskWorkflow:
 
 @pytest.mark.django_db
 class TestProcessTaskWorkflowUnit:
+    @pytest.mark.parametrize(
+        "state, expected",
+        [
+            ({"mode": "interactive", "pending_user_message": "this is nice"}, False),
+            ({"mode": "background", "pending_user_message": "this is nice"}, True),
+            (
+                {
+                    "mode": "background",
+                    "pending_user_message": "this is nice",
+                    "resume_from_run_id": "previous-run-id",
+                },
+                False,
+            ),
+        ],
+    )
+    def test_should_forward_pending_message(self, state: dict, expected: bool):
+        workflow = ProcessTaskWorkflow()
+        workflow._context = _build_context(
+            github_integration_id=123,
+            state=state,
+        )
+
+        assert workflow._should_forward_pending_user_message() is expected
+
     async def test_run_cleans_up_sandbox_when_provisioning_fails_after_creation(self, monkeypatch):
         workflow = ProcessTaskWorkflow()
         get_task_processing_context_mock = AsyncMock(return_value=_build_context(github_integration_id=123))

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -151,8 +151,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             else:
                 relay_task = asyncio.ensure_future(asyncio.sleep(0))  # no-op future
 
-            is_resume = bool((self.context.state or {}).get("resume_from_run_id"))
-            if not is_resume:
+            if self._should_forward_pending_user_message():
                 try:
                     await self._forward_pending_user_message()
                 except Exception as e:
@@ -365,6 +364,13 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             start_to_close_timeout=timedelta(seconds=PENDING_MESSAGE_FORWARD_TIMEOUT_SECONDS),
             retry_policy=RetryPolicy(maximum_attempts=1),
         )
+
+    def _should_forward_pending_user_message(self) -> bool:
+        if not self._context:
+            return False
+
+        is_resume = bool((self.context.state or {}).get("resume_from_run_id"))
+        return self.context.mode != "interactive" and not is_resume
 
     async def _track_workflow_event(self, event_name: str, properties: dict) -> None:
         track_input = TrackWorkflowEventInput(

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -3,10 +3,12 @@ import time
 import uuid
 import asyncio
 import threading
-from typing import ClassVar
+from collections.abc import Iterator
+from typing import ClassVar, cast
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from django.http import StreamingHttpResponse
 from django.test import TestCase, override_settings
 
 import jwt
@@ -1685,6 +1687,83 @@ class TestTaskRunStreamAPI(BaseTaskAPITest):
         self.assertGreaterEqual(len(events), 1)
         self.assertTrue(all(event["data"]["notification"]["method"] == "_posthog/console" for event in events), events)
         self.assertEqual(events[-1]["data"]["notification"]["params"]["message"], "late hello")
+
+
+class TestTaskRunRedisStreamKeepalive(TestCase):
+    def test_read_stream_entries_yields_keepalive_sentinel_when_idle(self):
+        class StubRedis:
+            def __init__(self):
+                self.calls = 0
+
+            async def xread(self, *_args, **_kwargs):
+                self.calls += 1
+                if self.calls == 1:
+                    return []
+                return [
+                    [
+                        b"task-run-stream:test",
+                        [
+                            (
+                                b"1-0",
+                                {b"data": json.dumps({"type": "STREAM_STATUS", "status": "complete"}).encode("utf-8")},
+                            )
+                        ],
+                    ]
+                ]
+
+        async def collect_items() -> list[object]:
+            redis_stream = TaskRunRedisStream("task-run-stream:test")
+            redis_stream._redis_client = StubRedis()
+            items: list[object] = []
+            # Force the idle branch immediately so the test does not wait on wall-clock time.
+            async for item in redis_stream.read_stream_entries(keepalive_interval_seconds=0):
+                items.append(item)
+            return items
+
+        self.assertEqual(asyncio.run(collect_items()), [None])
+
+
+class TestTaskRunStreamKeepaliveAPI(BaseTaskAPITest):
+    def _stream_url(self, task: Task, run: TaskRun) -> str:
+        return f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/stream/"
+
+    def test_stream_emits_keepalive_comments_while_idle(self):
+        task = self.create_task()
+        run = task.create_run()
+
+        async def fake_read_stream_entries(self, *args, **kwargs):
+            yield None
+            yield (
+                "1-0",
+                {
+                    "type": "notification",
+                    "timestamp": "2026-01-01T00:00:01Z",
+                    "notification": {
+                        "jsonrpc": "2.0",
+                        "method": "_posthog/console",
+                        "params": {
+                            "sessionId": str(run.id),
+                            "level": "info",
+                            "message": "after idle gap",
+                        },
+                    },
+                },
+            )
+
+        with (
+            patch.object(TaskRunRedisStream, "wait_for_stream", new=AsyncMock(return_value=True)),
+            patch.object(TaskRunRedisStream, "read_stream_entries", new=fake_read_stream_entries),
+        ):
+            response = cast(
+                StreamingHttpResponse,
+                self.client.get(self._stream_url(task, run), HTTP_ACCEPT="text/event-stream"),
+            )
+            content = b"".join(cast(Iterator[bytes], response.streaming_content)).decode("utf-8")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("event: keepalive", content)
+        self.assertIn('"type": "keepalive"', content)
+        self.assertIn("after idle gap", content)
 
 
 class TestTasksAPIPermissions(BaseTaskAPITest):

--- a/products/tasks/frontend/lib/parse-logs.ts
+++ b/products/tasks/frontend/lib/parse-logs.ts
@@ -110,7 +110,12 @@ function isACPNotification(parsed: unknown): parsed is ACPNotification {
     )
 }
 
-function parseACPNotification(parsed: ACPNotification, id: string, toolMap: Map<string, LogEntry>): LogEntry | null {
+function parseACPNotification(
+    parsed: ACPNotification,
+    id: string,
+    toolMap: Map<string, LogEntry>,
+    onToolEntryUpdated?: (entry: LogEntry) => void
+): LogEntry | null {
     const { notification, timestamp } = parsed
     const method = notification.method
 
@@ -181,6 +186,7 @@ function parseACPNotification(parsed: ACPNotification, id: string, toolMap: Map<
                     } else if (update.rawOutput !== undefined) {
                         existing.toolResult = normalizeRawOutput(update.rawOutput)
                     }
+                    onToolEntryUpdated?.({ ...existing })
                     return null
                 }
                 const entry: LogEntry = {
@@ -210,6 +216,7 @@ function parseACPNotification(parsed: ACPNotification, id: string, toolMap: Map<
                         } else if (update.rawOutput !== undefined) {
                             existing.toolResult = normalizeRawOutput(update.rawOutput)
                         }
+                        onToolEntryUpdated?.({ ...existing })
                         return null
                     }
                 }
@@ -325,13 +332,12 @@ function parseLogLine(line: string, index: number, toolMap: Map<string, LogEntry
  */
 export function parseLogEvent(
     event: Record<string, unknown>,
-    index: number,
-    toolMap: Map<string, LogEntry>
+    id: string,
+    toolMap: Map<string, LogEntry>,
+    onToolEntryUpdated?: (entry: LogEntry) => void
 ): LogEntry | null {
-    const id = `stream-${index}`
-
     if (isACPNotification(event)) {
-        return parseACPNotification(event as ACPNotification, id, toolMap)
+        return parseACPNotification(event as ACPNotification, id, toolMap, onToolEntryUpdated)
     }
 
     return parseLogObject(event, id)

--- a/products/tasks/frontend/logics/taskDetailSceneLogic.test.ts
+++ b/products/tasks/frontend/logics/taskDetailSceneLogic.test.ts
@@ -1,4 +1,5 @@
 import { expectLogic } from 'kea-test-utils'
+import { ReadableStream as NodeReadableStream } from 'stream/web'
 
 import { initKeaTests } from '~/test/init'
 
@@ -39,9 +40,125 @@ const createMockRun = (id: string, status: TaskRunStatus): TaskRun => ({
     completed_at: null,
 })
 
+function buildReadableStream(chunks: string[], keepOpen = false): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder()
+    let index = 0
+    const StreamConstructor = globalThis.ReadableStream ?? NodeReadableStream
+
+    return new StreamConstructor({
+        pull(controller) {
+            if (index < chunks.length) {
+                controller.enqueue(encoder.encode(chunks[index]))
+                index += 1
+            } else if (!keepOpen) {
+                controller.close()
+            }
+        },
+    })
+}
+
+function createSseResponse(chunks: string[], keepOpen = false): Response {
+    return {
+        ok: true,
+        body: buildReadableStream(chunks, keepOpen),
+    } as Response
+}
+
+function createConsoleSseEvent(id: string, message: string): string {
+    return `id: ${id}\nevent: message\ndata: ${JSON.stringify({
+        type: 'notification',
+        timestamp: '2024-01-01T00:00:00Z',
+        notification: {
+            jsonrpc: '2.0',
+            method: '_posthog/console',
+            params: { level: 'info', message },
+        },
+    })}\n\n`
+}
+
+function createToolCallSseEvent(id: string, toolCallId: string, status: string, rawOutput?: unknown): string {
+    return `id: ${id}\nevent: message\ndata: ${JSON.stringify({
+        type: 'notification',
+        timestamp: '2024-01-01T00:00:00Z',
+        notification: {
+            jsonrpc: '2.0',
+            method: 'session/update',
+            params: {
+                update: {
+                    sessionUpdate: status === 'pending' || status === 'in_progress' ? 'tool_call' : 'tool_call_update',
+                    toolCallId,
+                    title: 'Read file',
+                    status,
+                    rawInput: { path: 'README.md' },
+                    ...(rawOutput !== undefined ? { rawOutput } : {}),
+                },
+            },
+        },
+    })}\n\n`
+}
+
+function createJsonResponse(payload: unknown): Response {
+    return new Response(JSON.stringify(payload), {
+        headers: { 'Content-Type': 'application/json' },
+    })
+}
+
+function createFetchMock({
+    runs = {},
+    streamResponses = [],
+}: {
+    runs?: Record<string, TaskRun>
+    streamResponses?: Response[]
+} = {}): typeof fetch {
+    return jest.fn((input: RequestInfo | URL) => {
+        const url = String(input)
+        const taskRunMatch = url.match(/\/tasks\/([^/]+)\/runs\/([^/]+)\/$/)
+        const streamMatch = url.match(/\/tasks\/([^/]+)\/runs\/([^/]+)\/stream\/$/)
+        const logsMatch = url.match(/\/tasks\/([^/]+)\/runs\/([^/]+)\/logs\/$/)
+        const runsListMatch = url.match(/\/tasks\/([^/]+)\/runs\/$/)
+        const taskMatch = url.match(/\/tasks\/([^/]+)\/$/)
+
+        if (streamMatch) {
+            const nextResponse = streamResponses.shift()
+            if (!nextResponse) {
+                throw new Error(`Missing stream response for ${url}`)
+            }
+            return Promise.resolve(nextResponse)
+        }
+        if (logsMatch) {
+            return Promise.resolve(new Response(''))
+        }
+        if (taskRunMatch) {
+            return Promise.resolve(
+                createJsonResponse(runs[taskRunMatch[2]] ?? createMockRun(taskRunMatch[2], TaskRunStatus.COMPLETED))
+            )
+        }
+        if (runsListMatch) {
+            return Promise.resolve(createJsonResponse({ results: [] }))
+        }
+        if (taskMatch) {
+            return Promise.resolve(createJsonResponse(createMockTask(taskMatch[1])))
+        }
+        throw new Error(`Unexpected fetch url: ${url}`)
+    }) as typeof fetch
+}
+
+async function flushStreaming(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
 describe('taskDetailSceneLogic', () => {
+    const originalFetch = global.fetch
+
     beforeEach(() => {
         initKeaTests()
+        global.fetch = createFetchMock()
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+        global.fetch = originalFetch
     })
 
     describe('setSelectedRunId cross-talk prevention', () => {
@@ -133,6 +250,7 @@ describe('taskDetailSceneLogic', () => {
 
             const logic = taskDetailSceneLogic({ taskId: 'task-123' })
             logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
 
             const updatedTask = { ...mockTask, title: 'New Title' }
             logic.actions.loadTaskSuccess(updatedTask)
@@ -142,6 +260,223 @@ describe('taskDetailSceneLogic', () => {
 
             logic.unmount()
             tasksLogicInstance.unmount()
+        })
+    })
+
+    describe('streaming', () => {
+        it('restarts streaming after a clean EOF when the run is still in progress', async () => {
+            const run = createMockRun('run-1', TaskRunStatus.IN_PROGRESS)
+            global.fetch = createFetchMock({
+                runs: { [run.id]: run },
+                streamResponses: [
+                    createSseResponse([createConsoleSseEvent('1-0', 'first message')]),
+                    createSseResponse([createConsoleSseEvent('2-0', 'second message')], true),
+                ],
+            })
+
+            const logic = taskDetailSceneLogic({ taskId: 'task-123' })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            logic.actions.setSelectedRunId(run.id, 'task-123')
+            await expectLogic(logic).toFinishAllListeners()
+            await flushStreaming()
+            await flushStreaming()
+
+            const streamCalls = (global.fetch as jest.Mock).mock.calls.filter(([url]) =>
+                String(url).includes('/stream/')
+            )
+            expect(streamCalls).toHaveLength(2)
+            expect(logic.values.isStreaming).toBe(true)
+            expect(logic.values.streamEntries.map((entry) => entry.message)).toEqual([
+                'first message',
+                'second message',
+            ])
+            expect(logic.values.streamEntries.map((entry) => entry.id)).toEqual(['stream-1-0', 'stream-2-0'])
+
+            logic.unmount()
+        })
+
+        it('does not restart an active stream when selected run reloads', async () => {
+            const run = createMockRun('run-1', TaskRunStatus.IN_PROGRESS)
+            global.fetch = createFetchMock({
+                runs: { [run.id]: run },
+                streamResponses: [
+                    createSseResponse(
+                        ['id: 1-0\nevent: message\ndata: {"type":"assistant","content":"hello"}\n\n'],
+                        true
+                    ),
+                ],
+            })
+
+            const logic = taskDetailSceneLogic({ taskId: 'task-123' })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            logic.actions.setSelectedRunId(run.id, 'task-123')
+            await expectLogic(logic).toFinishAllListeners()
+            await flushStreaming()
+
+            const streamCallsAfterFirstLoad = (global.fetch as jest.Mock).mock.calls.filter(([url]) =>
+                String(url).includes('/stream/')
+            )
+            expect(streamCallsAfterFirstLoad).toHaveLength(1)
+
+            logic.actions.loadSelectedRunSuccess(run)
+            await expectLogic(logic).toFinishAllListeners()
+            await flushStreaming()
+
+            const streamCallsAfterReload = (global.fetch as jest.Mock).mock.calls.filter(([url]) =>
+                String(url).includes('/stream/')
+            )
+            expect(streamCallsAfterReload).toHaveLength(1)
+            expect(logic.values.streamEntries.map((entry) => entry.message)).toEqual(['hello'])
+
+            logic.unmount()
+        })
+
+        it('resumes with Last-Event-ID and ignores replayed events', async () => {
+            const run = createMockRun('run-1', TaskRunStatus.IN_PROGRESS)
+            global.fetch = createFetchMock({
+                runs: { [run.id]: run },
+                streamResponses: [
+                    createSseResponse(
+                        [
+                            'id: 1-0\nevent: message\ndata: {"type":"user","content":"hello"}\n\n',
+                            'id: 2-0\nevent: message\ndata: {"type":"assistant","content":"world"}\n\n',
+                        ],
+                        true
+                    ),
+                    createSseResponse(
+                        [
+                            'id: 1-0\nevent: message\ndata: {"type":"user","content":"hello"}\n\n',
+                            'event: keepalive\ndata: {"status":"ok"}\n\n',
+                            'id: 3-0\nevent: message\ndata: {"type":"assistant","content":"again"}\n\n',
+                        ],
+                        true
+                    ),
+                ],
+            })
+
+            const logic = taskDetailSceneLogic({ taskId: 'task-123' })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            logic.actions.setSelectedRunId(run.id, 'task-123')
+            await expectLogic(logic).toFinishAllListeners()
+            await flushStreaming()
+
+            expect(logic.values.lastStreamEventId).toBe('2-0')
+            expect(logic.values.streamEntries.map((entry) => entry.message)).toEqual(['hello', 'world'])
+
+            logic.actions.stopStreaming()
+            await expectLogic(logic).toFinishAllListeners()
+
+            logic.actions.startStreaming()
+            await expectLogic(logic).toFinishAllListeners()
+            await flushStreaming()
+
+            const streamCalls = (global.fetch as jest.Mock).mock.calls.filter(([url]) =>
+                String(url).includes('/stream/')
+            )
+            expect(streamCalls).toHaveLength(2)
+            expect((streamCalls[1][1] as RequestInit)?.headers).toMatchObject({
+                Accept: 'text/event-stream',
+                'Last-Event-ID': '2-0',
+            })
+            expect(logic.values.lastStreamEventId).toBe('3-0')
+            expect(logic.values.streamEntries.map((entry) => entry.message)).toEqual(['hello', 'worldagain'])
+
+            logic.unmount()
+        })
+
+        it('ignores duplicate event ids that arrive in the same chunk', async () => {
+            const run = createMockRun('run-1', TaskRunStatus.IN_PROGRESS)
+            global.fetch = createFetchMock({
+                runs: { [run.id]: run },
+                streamResponses: [
+                    createSseResponse(
+                        [
+                            [
+                                'id: 1-0',
+                                'event: message',
+                                'data: {"type":"assistant","content":"hello"}',
+                                '',
+                                'id: 1-0',
+                                'event: message',
+                                'data: {"type":"assistant","content":"hello"}',
+                                '',
+                            ].join('\n'),
+                        ],
+                        true
+                    ),
+                ],
+            })
+
+            const logic = taskDetailSceneLogic({ taskId: 'task-123' })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            logic.actions.setSelectedRunId(run.id, 'task-123')
+            await expectLogic(logic).toFinishAllListeners()
+            await flushStreaming()
+
+            expect(logic.values.lastStreamEventId).toBe('1-0')
+            expect(logic.values.streamEntries.map((entry) => entry.id)).toEqual(['stream-1-0'])
+            expect(logic.values.streamEntries.map((entry) => entry.message)).toEqual(['hello'])
+
+            logic.unmount()
+        })
+
+        it('preserves tool state across resumed streams', async () => {
+            const run = createMockRun('run-1', TaskRunStatus.IN_PROGRESS)
+            global.fetch = createFetchMock({
+                runs: { [run.id]: run },
+                streamResponses: [
+                    createSseResponse([createToolCallSseEvent('1-0', 'tool-1', 'in_progress')], true),
+                    createSseResponse(
+                        [
+                            createToolCallSseEvent('1-0', 'tool-1', 'in_progress'),
+                            createToolCallSseEvent('2-0', 'tool-1', 'completed', { content: 'done' }),
+                        ],
+                        true
+                    ),
+                ],
+            })
+
+            const logic = taskDetailSceneLogic({ taskId: 'task-123' })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            logic.actions.setSelectedRunId(run.id, 'task-123')
+            await expectLogic(logic).toFinishAllListeners()
+            await flushStreaming()
+
+            const firstToolEntry = logic.values.streamEntries[0]
+            expect(logic.values.streamEntries).toHaveLength(1)
+            expect(firstToolEntry.type).toBe('tool')
+            expect(firstToolEntry.id).toBe('stream-1-0')
+            expect(firstToolEntry.toolStatus).toBe('running')
+
+            logic.actions.stopStreaming()
+            await expectLogic(logic).toFinishAllListeners()
+
+            logic.actions.startStreaming()
+            await expectLogic(logic).toFinishAllListeners()
+            await flushStreaming()
+
+            expect(logic.values.lastStreamEventId).toBe('2-0')
+            expect(logic.values.streamEntries).toHaveLength(1)
+            expect(logic.values.streamEntries[0]).toMatchObject({
+                id: 'stream-1-0',
+                type: 'tool',
+                toolCallId: 'tool-1',
+                toolStatus: 'completed',
+                toolResult: { content: 'done' },
+            })
+            expect(logic.values.streamEntries[0]).not.toBe(firstToolEntry)
+
+            logic.unmount()
         })
     })
 })

--- a/products/tasks/frontend/logics/taskDetailSceneLogic.ts
+++ b/products/tasks/frontend/logics/taskDetailSceneLogic.ts
@@ -29,6 +29,54 @@ const LOG_POLL_INTERVAL_MS = 1000
 
 export type TaskDetailSceneLogicProps = TaskLogicProps
 
+interface ParsedSseEvent {
+    data: string
+    eventType: string | null
+    id: string | null
+}
+
+function buildToolMap(entries: LogEntry[]): Map<string, LogEntry> {
+    const toolMap = new Map<string, LogEntry>()
+    for (const entry of entries) {
+        if (entry.type === 'tool' && entry.toolCallId) {
+            toolMap.set(entry.toolCallId, { ...entry })
+        }
+    }
+    return toolMap
+}
+
+function parseSseEventBlock(block: string): ParsedSseEvent | null {
+    let data = ''
+    let eventType: string | null = null
+    let id: string | null = null
+
+    for (const line of block.split('\n')) {
+        if (!line) {
+            continue
+        }
+        if (line.startsWith(':')) {
+            continue
+        }
+        if (line.startsWith('event:')) {
+            eventType = line.slice(6).trim() || null
+            continue
+        }
+        if (line.startsWith('id:')) {
+            id = line.slice(3).trim() || null
+            continue
+        }
+        if (line.startsWith('data:')) {
+            data = data ? `${data}\n${line.slice(5).trimStart()}` : line.slice(5).trimStart()
+        }
+    }
+
+    if (!data && !eventType && !id) {
+        return null
+    }
+
+    return { data, eventType, id }
+}
+
 export const taskDetailSceneLogic = kea<taskDetailSceneLogicType>([
     path(['products', 'tasks', 'taskDetailSceneLogic']),
     props({} as TaskDetailSceneLogicProps),
@@ -52,6 +100,8 @@ export const taskDetailSceneLogic = kea<taskDetailSceneLogicType>([
         stopStreaming: true,
         markStreamingFailed: true,
         appendStreamEntries: (entries: LogEntry[]) => ({ entries }),
+        updateStreamEntries: (entries: LogEntry[]) => ({ entries }),
+        recordStreamProgress: (lastEventId: string | null, seenEventIds: string[]) => ({ lastEventId, seenEventIds }),
         setLogs: (logs: string) => ({ logs }),
         updateRun: (run: TaskRun) => ({ run }),
     }),
@@ -110,6 +160,44 @@ export const taskDetailSceneLogic = kea<taskDetailSceneLogicType>([
                         ]
                     }
                     return [...state, ...entries]
+                },
+                updateStreamEntries: (state, { entries }) => {
+                    if (entries.length === 0) {
+                        return state
+                    }
+                    const entriesById = new Map(entries.map((entry) => [entry.id, entry]))
+                    let changed = false
+                    const nextState = state.map((entry) => {
+                        const updatedEntry = entriesById.get(entry.id)
+                        if (!updatedEntry) {
+                            return entry
+                        }
+                        changed = true
+                        return updatedEntry
+                    })
+                    return changed ? nextState : state
+                },
+            },
+        ],
+        lastStreamEventId: [
+            null as string | null,
+            {
+                setSelectedRunId: (state, { taskId }) => (taskId === props.taskId ? null : state),
+                recordStreamProgress: (state, { lastEventId }) => lastEventId ?? state,
+            },
+        ],
+        seenStreamEventIds: [
+            {} as Record<string, true>,
+            {
+                setSelectedRunId: (state, { taskId }) => (taskId === props.taskId ? {} : state),
+                recordStreamProgress: (state, { seenEventIds }) => {
+                    if (seenEventIds.length === 0) {
+                        return state
+                    }
+                    return {
+                        ...state,
+                        ...Object.fromEntries(seenEventIds.map((eventId) => [eventId, true])),
+                    }
                 },
             },
         ],
@@ -259,7 +347,7 @@ export const taskDetailSceneLogic = kea<taskDetailSceneLogicType>([
             if (values.shouldPoll) {
                 if (values.streamingFailed) {
                     actions.startPolling()
-                } else {
+                } else if (!values.isStreaming) {
                     actions.startStreaming()
                 }
             } else {
@@ -290,14 +378,17 @@ export const taskDetailSceneLogic = kea<taskDetailSceneLogicType>([
                 }
 
                 const streamUrl = `/api/projects/@current/tasks/${props.taskId}/runs/${runId}/stream/`
-                const toolMap = new Map<string, LogEntry>()
-                let eventIndex = 0
+                const toolMap = buildToolMap(values.streamEntries)
+                let eventIndex = values.streamEntries.length
 
                 const consume = async (): Promise<void> => {
                     try {
                         const response = await fetch(streamUrl, {
                             signal: abortController.signal,
-                            headers: { Accept: 'text/event-stream' },
+                            headers: {
+                                Accept: 'text/event-stream',
+                                ...(values.lastStreamEventId ? { 'Last-Event-ID': values.lastStreamEventId } : {}),
+                            },
                         })
 
                         if (!response.ok || !response.body) {
@@ -318,20 +409,40 @@ export const taskDetailSceneLogic = kea<taskDetailSceneLogicType>([
                                 break
                             }
 
-                            buffer += decoder.decode(value, { stream: true })
-                            const lines = buffer.split('\n')
-                            // Keep the last incomplete line in the buffer
-                            buffer = lines.pop() || ''
+                            buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, '\n')
+                            const blocks = buffer.split('\n\n')
+                            buffer = blocks.pop() || ''
 
                             const batch: LogEntry[] = []
-                            for (const line of lines) {
-                                if (!line.startsWith('data: ')) {
+                            const updatedEntriesById = new Map<string, LogEntry>()
+                            let lastProcessedEventId: string | null = null
+                            const newlySeenEventIds: string[] = []
+
+                            for (const block of blocks) {
+                                const parsedEvent = parseSseEventBlock(block)
+                                if (!parsedEvent || parsedEvent.eventType === 'keepalive' || !parsedEvent.data) {
                                     continue
                                 }
-                                const jsonStr = line.slice(6)
+
+                                if (parsedEvent.id) {
+                                    if (
+                                        values.seenStreamEventIds[parsedEvent.id] ||
+                                        newlySeenEventIds.includes(parsedEvent.id)
+                                    ) {
+                                        continue
+                                    }
+                                    newlySeenEventIds.push(parsedEvent.id)
+                                    lastProcessedEventId = parsedEvent.id
+                                }
+
                                 try {
-                                    const event = JSON.parse(jsonStr) as Record<string, unknown>
-                                    const entry = parseLogEvent(event, eventIndex++, toolMap)
+                                    const event = JSON.parse(parsedEvent.data) as Record<string, unknown>
+                                    const entryId = parsedEvent.id
+                                        ? `stream-${parsedEvent.id}`
+                                        : `stream-${eventIndex++}`
+                                    const entry = parseLogEvent(event, entryId, toolMap, (updatedEntry) => {
+                                        updatedEntriesById.set(updatedEntry.id, updatedEntry)
+                                    })
                                     if (entry) {
                                         // Merge consecutive agent/thinking messages
                                         const last = batch[batch.length - 1]
@@ -349,11 +460,20 @@ export const taskDetailSceneLogic = kea<taskDetailSceneLogicType>([
                                 }
                             }
 
+                            if (newlySeenEventIds.length > 0) {
+                                actions.recordStreamProgress(lastProcessedEventId, newlySeenEventIds)
+                            }
+                            if (updatedEntriesById.size > 0) {
+                                actions.updateStreamEntries(Array.from(updatedEntriesById.values()))
+                            }
                             if (batch.length > 0) {
                                 actions.appendStreamEntries(batch)
                             }
                         }
 
+                        // Clear streaming state before refreshing the run so in-progress
+                        // runs can reconnect cleanly after an EOF.
+                        actions.stopStreaming()
                         // Stream ended normally — do a final poll to get the latest run status
                         actions.loadSelectedRun()
                     } catch (e) {


### PR DESCRIPTION
## Problem

Cloud task runs could lose their live stream during idle periods, which caused noisy disconnect/reconnect behavior and duplicated task log history in the task detail view. 
Interactive runs could also submit the pending startup prompt twice, creating duplicated initial user messages.

## Changes

- task-run SSE keepalive events during idle Redis stream periods so the live stream stays open without replay churn
- stop forwarding `pending_user_message` for interactive startup runs, while preserving the existing behavior for background runs.
- make the task detail stream resumable with `Last-Event-ID`, dedupe replayed SSE events, and reconnect cleanly
