### PR TITLE
fix(quill): pin npm to 11.6.4 for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-quill-npm.yml
+++ b/.github/workflows/publish-quill-npm.yml
@@ -54,9 +54,10 @@ jobs:
             # step so a failure shows up on the exact step that broke.
             - name: Publish @posthog/quill-tokens
               id: publish-tokens
+              working-directory: packages/quill/packages/tokens
               run: |
-                  pnpm --filter "@posthog/quill-tokens" publish --tag "$NPM_TAG" --no-git-checks --access public
-                  VERSION=$(node -p "require('./packages/quill/packages/tokens/package.json').version")
+                  npm publish --tag "$NPM_TAG" --access public
+                  VERSION=$(node -p "require('./package.json').version")
                   echo "version=$VERSION" >> $GITHUB_OUTPUT
               env:
                   NODE_AUTH_TOKEN: ''
@@ -65,9 +66,10 @@ jobs:
 
             - name: Publish @posthog/quill
               id: publish-quill
+              working-directory: packages/quill/packages/quill
               run: |
-                  pnpm --filter "@posthog/quill" publish --tag "$NPM_TAG" --no-git-checks --access public
-                  VERSION=$(node -p "require('./packages/quill/packages/quill/package.json').version")
+                  npm publish --tag "$NPM_TAG" --access public
+                  VERSION=$(node -p "require('./package.json').version")
                   echo "version=$VERSION" >> $GITHUB_OUTPUT
               env:
                   NODE_AUTH_TOKEN: ''
@@ -91,7 +93,7 @@ jobs:
               uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
               with:
                   method: chat.postMessage
-                  token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
                   payload: |
-                      channel: "${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}"
+                      channel: "C0AMDUUG09F"
                       text: "${{ job.status == 'success' && ':white_check_mark:' || ':red_circle:' }} Quill npm publish (${{ inputs.tag }}): ${{ job.status }}\n${{ steps.versions.outputs.summary }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/publish-quill-npm.yml
+++ b/.github/workflows/publish-quill-npm.yml
@@ -41,6 +41,9 @@ jobs:
                   registry-url: https://registry.npmjs.org
                   cache: 'pnpm'
 
+            - name: Ensure modern npm (OIDC trusted publishing support)
+              run: npm install -g npm@11.6.4
+
             - name: Install dependencies
               run: pnpm install --frozen-lockfile --filter "@posthog/quill..." --filter "@posthog/quill-tokens"
 

--- a/.github/workflows/publish-quill-npm.yml
+++ b/.github/workflows/publish-quill-npm.yml
@@ -63,7 +63,6 @@ jobs:
                   VERSION=$(node -p "require('./package.json').version")
                   echo "version=$VERSION" >> $GITHUB_OUTPUT
               env:
-                  NODE_AUTH_TOKEN: ''
                   NPM_CONFIG_PROVENANCE: true
                   NPM_TAG: ${{ inputs.tag }}
 
@@ -75,7 +74,6 @@ jobs:
                   VERSION=$(node -p "require('./package.json').version")
                   echo "version=$VERSION" >> $GITHUB_OUTPUT
               env:
-                  NODE_AUTH_TOKEN: ''
                   NPM_CONFIG_PROVENANCE: true
                   NPM_TAG: ${{ inputs.tag }}
 


### PR DESCRIPTION
## Problem

After #54215 the quill publish workflow still fails with `ENEEDAUTH` (run: https://github.com/PostHog/posthog/actions/runs/24339164439). The root cause is the npm version: OIDC trusted publishing was added in npm `11.5.1` (September 2025), and the npm bundled with Node `24.13.0` in `.nvmrc` is older than that. Without a modern npm, the publish step ignores the OIDC flow and falls back to token auth, which is empty.

## Changes

- Add an `Ensure modern npm (OIDC trusted publishing support)` step before install that runs `npm install -g npm@11.6.4`. This mirrors the existing step in `release.yml` (added for the same reason) and is scoped to this workflow only.

No other workflows are touched.

## How did you test this code?

I am an agent and have not run the workflow end-to-end myself. Verification:

- Confirmed the failing run ran `npm publish` directly (so the previous `pnpm publish` change from #54215 was fine) and still hit `ENEEDAUTH` at the auth step, which is the signature of npm < 11.5.1 ignoring OIDC.
- Confirmed `release.yml` already pins `npm@11.6.4` for the same reason, with a comment explicitly citing OIDC support.

The real test is rerunning the `Publish Quill npm packages` workflow after this lands.

## Publish to changelog?

no

<!-- ## 🤖 LLM context -->
<!-- Authored by Claude (Opus 4.6, 1M context) in a Claude Code session. Diagnosed the post-merge failing run against the working release.yml pattern. -->