### PR TITLE
fix(js-debugger): fix persistence

### DIFF
--- a/posthog/cdp/templates/_siteapps/template_debug_posthog.py
+++ b/posthog/cdp/templates/_siteapps/template_debug_posthog.py
@@ -14,7 +14,8 @@ template: HogFunctionTemplateDC = HogFunctionTemplateDC(
 export function onLoad({ inputs, posthog }) {
     if (inputs.enable_debugging) {
         console.log("[PostHog JS debugger site app] Enabling PostHog.js debugging", posthog)
-        posthog.debug(true)
+        globalThis.POSTHOG_DEBUG = true
+        globalThis.__POSTHOG_JS_DEBUGGER_ENABLED = true
     }
 
     if (inputs.capture_config) {


### PR DESCRIPTION
## Problem

The JS debugger site app would not unload because it persisted its state in localstorage, which was never cleared

## Changes

Use a global constant instead.

## How did you test this code?

👀 
