### PR TITLE
feat(insights): allow retrieving insights by short_id

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1207,7 +1207,12 @@ class InsightViewSet(
     def safely_get_object(self, queryset: QuerySet) -> Insight | None:
         lookup_value = self.kwargs[self.lookup_field]
         if isinstance(lookup_value, str) and lookup_value.isdigit():
-            return queryset.filter(pk=int(lookup_value)).first()
+            # A numeric lookup is ambiguous: usually it's a primary key, but a small number of
+            # legacy rows have numeric-only short_ids. Try pk first (preserving existing behavior)
+            # and fall back to short_id so those legacy insights stay retrievable.
+            pk_match = queryset.filter(pk=int(lookup_value)).first()
+            if pk_match is not None:
+                return pk_match
         return queryset.filter(short_id=lookup_value).first()
 
     def order_queryset(self, queryset: QuerySet) -> QuerySet:

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1204,6 +1204,12 @@ class InsightViewSet(
 
         return self.order_queryset(queryset)
 
+    def safely_get_object(self, queryset: QuerySet) -> Insight | None:
+        lookup_value = self.kwargs[self.lookup_field]
+        if isinstance(lookup_value, str) and lookup_value.isdigit():
+            return queryset.filter(pk=int(lookup_value)).first()
+        return queryset.filter(short_id=lookup_value).first()
+
     def order_queryset(self, queryset: QuerySet) -> QuerySet:
         order = self.request.GET.get("order", None)
         if not order:

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -573,6 +573,39 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertEqual(response.json()["results"][0]["short_id"], "12345678")
         self.assertEqual(response.json()["results"][0]["filters"]["events"][0]["id"], "$pageview")
 
+    @parameterized.expand(
+        [
+            ("numeric_id", lambda insight: insight.id),
+            ("short_id", lambda insight: insight.short_id),
+        ]
+    )
+    def test_retrieve_insight_by_id_or_short_id(self, _name, lookup) -> None:
+        insight = Insight.objects.create(
+            filters=Filter(data={"events": [{"id": "$pageview"}]}).to_dict(),
+            team=self.team,
+            short_id="abcd1234",
+            name="dual-lookup",
+        )
+
+        # Another insight in a different team sharing the same short_id — must not be returned.
+        other_team = Team.objects.create(organization=self.organization)
+        Insight.objects.create(
+            filters=Filter(data={"events": [{"id": "$pageview"}]}).to_dict(),
+            team=other_team,
+            short_id="abcd1234",
+            name="other-team",
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/{lookup(insight)}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["id"], insight.id)
+        self.assertEqual(response.json()["short_id"], "abcd1234")
+        self.assertEqual(response.json()["name"], "dual-lookup")
+
+    def test_retrieve_insight_by_unknown_short_id_returns_404(self) -> None:
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/notthere/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_basic_results(self) -> None:
         """
         The `skip_results` query parameter can be passed so that only a list of objects is returned, without

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -606,6 +606,24 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         response = self.client.get(f"/api/projects/{self.team.id}/insights/notthere/")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_retrieve_insight_by_numeric_short_id_falls_back_to_short_id(self) -> None:
+        # A small number of legacy insights have numeric-only short_ids — they must remain retrievable
+        # when no insight matches the value as a primary key.
+        numeric_short_id = "99999999999"
+        assert not Insight.objects.filter(pk=int(numeric_short_id)).exists()
+        insight = Insight.objects.create(
+            filters=Filter(data={"events": [{"id": "$pageview"}]}).to_dict(),
+            team=self.team,
+            short_id=numeric_short_id,
+            name="numeric-short-id",
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/{numeric_short_id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["id"], insight.id)
+        self.assertEqual(response.json()["short_id"], numeric_short_id)
+        self.assertEqual(response.json()["name"], "numeric-short-id")
+
     def test_basic_results(self) -> None:
         """
         The `skip_results` query parameter can be passed so that only a list of objects is returned, without


### PR DESCRIPTION
## Problem

The manual MCP implementation of the insight tools retrieves data by using IDs and short IDs. The code-generated implementation needs to change the retrieval to accept both numeric IDs and short string IDs (short IDs), so we keep the same functionality.

## Changes

- Override `safely_get_object` on `InsightViewSet`: numeric lookup values hit `pk`, anything else hits `short_id`. The queryset is already team-scoped via `dangerously_get_queryset`, and permissions are still checked by the surrounding `TeamAndOrgViewSetMixin.get_object`.
- Short_id lookups are backed by the existing `unique_together = ("team", "short_id")` composite btree index, so they're an index scan — not a seq scan.

## How did you test this code?

- Added `test_retrieve_insight_by_id_or_short_id` (parameterized over numeric id and short_id) in `posthog/api/test/test_insight.py`, including a cross-team duplicate-short_id case to prove team scoping.
- Added `test_retrieve_insight_by_unknown_short_id_returns_404` to guard against the old `ValueError → 500` regression.
- Ran `hogli test posthog/api/test/test_insight.py -k 'retrieve_insight_by_id_or_short_id or retrieve_insight_by_unknown_short_id or test_get_insight_by_short_id'` → 4 passed.
- No manual browser testing — backend-only change covered by the new unit tests.

## Publish to changelog?

no

## 🤖 LLM context

Authored with Claude Code. Design hinges on the existing `safely_get_object` hook in `TeamAndOrgViewSetMixin` (`posthog/api/routing.py:215`) so access control keeps running via `check_object_permissions`.