### PR TITLE
fix(stamphog): track final verdict separately from gate verdict

### DIFF
--- a/tools/pr-approval-agent/review_pr.py
+++ b/tools/pr-approval-agent/review_pr.py
@@ -45,6 +45,17 @@ from gates import (
 from github import PRData, check_team_membership, fetch_pr
 from reviewer import Reviewer
 
+try:
+    import os
+
+    import posthoganalytics
+
+    posthoganalytics.api_key = os.environ.get("POSTHOG_API_KEY", "")
+    posthoganalytics.host = os.environ.get("POSTHOG_HOST", "https://us.i.posthog.com")
+    _POSTHOG_AVAILABLE = bool(posthoganalytics.api_key)
+except ImportError:
+    _POSTHOG_AVAILABLE = False
+
 # ── Repo root detection ──────────────────────────────────────────
 
 
@@ -353,6 +364,39 @@ class Pipeline:
             self.final_verdict = "ESCALATE"
             print(f"\n{_warn('ESCALATE')} — needs human review")
 
+        self._capture_review_completed(gate_verdict, llm_verdict)
+
+    def _capture_review_completed(self, gate_verdict: str, llm_verdict: str) -> None:
+        """Send a stamphog_review_completed event with all verdict data."""
+        if not _POSTHOG_AVAILABLE:
+            return
+
+        cl = self.classification
+        pr = self.pr
+        posthoganalytics.capture(
+            distinct_id=pr.author,
+            event="stamphog_review_completed",
+            properties={
+                "ai_product": "stamphog",
+                "stamphog_pr_number": pr.number,
+                "stamphog_repo": pr.repo,
+                "stamphog_author": pr.author,
+                "stamphog_pr_title": pr.title,
+                "stamphog_tier": cl.get("tier", ""),
+                "stamphog_t1_subclass": cl.get("t1_subclass", ""),
+                "stamphog_breadth": cl.get("breadth", ""),
+                "stamphog_commit_type": cl.get("commit_type") or "",
+                "stamphog_files_changed": len(pr.files),
+                "stamphog_lines_total": pr.lines_total,
+                "stamphog_gate_verdict": gate_verdict,
+                "stamphog_llm_verdict": llm_verdict,
+                "stamphog_final_verdict": self.final_verdict,
+                "stamphog_llm_reasoning": (self.reviewer_output or {}).get("reasoning", ""),
+                "stamphog_llm_risk": (self.reviewer_output or {}).get("risk", ""),
+                "stamphog_llm_issues": (self.reviewer_output or {}).get("issues", []),
+            },
+        )
+
     # ── Output ───────────────────────────────────────────────────
 
     def to_dict(self) -> dict:
@@ -406,6 +450,9 @@ def main() -> None:
 
     if args.output_json:
         pipeline.save_json(args.output_json)
+
+    if _POSTHOG_AVAILABLE:
+        posthoganalytics.flush()
 
 
 if __name__ == "__main__":

--- a/tools/pr-approval-agent/reviewer.py
+++ b/tools/pr-approval-agent/reviewer.py
@@ -267,9 +267,15 @@ class Reviewer:
                     "stamphog_commit_type": classification.get("commit_type") or "",
                     "stamphog_deny_categories": classification.get("deny_categories", []),
                     "stamphog_author_on_owning_team": classification.get("author_on_owning_team"),
-                    "stamphog_verdict": gate_context.get("gate_verdict", ""),
+                    "stamphog_gate_verdict": gate_context.get("gate_verdict", ""),
+                    "stamphog_llm_verdict": "",
                 },
             }
+
+        # Keep a reference so we can mutate it when the verdict arrives —
+        # the SDK sends the $ai_trace event after the generator completes,
+        # so updates here propagate to the trace.
+        props = posthog_kwargs.get("posthog_properties", {})
 
         structured_output = None
         async for message in query(prompt=prompt, options=options, **posthog_kwargs):
@@ -280,6 +286,8 @@ class Reviewer:
                     raise RuntimeError("Agent could not produce valid structured output after retries")
                 if message.structured_output:
                     structured_output = message.structured_output
+                    # Stamp the LLM verdict onto the trace properties
+                    props["stamphog_llm_verdict"] = structured_output.get("verdict", "")
             elif isinstance(message, AssistantMessage):
                 for block in message.content:
                     if isinstance(block, ToolUseBlock) and self.verbose:


### PR DESCRIPTION
## Problem

`stamphog_verdict` on `$ai_trace` events was set to the **deterministic gate verdict** (`PENDING`/`DENIED`/`AUTO-APPROVED`) before the LLM agent ran. The agent's actual decision was never reflected in PostHog analytics — so the "approved PRs per day" chart on the [Stamphog dashboard](https://us.posthog.com/project/2/dashboard/1456650) was severely undercounting.

For example, [this trace](https://us.posthog.com/project/2/llm-analytics/traces/21e1e692-b544-40c9-81c8-428256bb48d6) shows the LLM decided `APPROVE`, but the trace property was `PENDING`.

## Changes

- **`reviewer.py`**: Rename `stamphog_verdict` → `stamphog_gate_verdict` on trace properties. Add `stamphog_llm_verdict` — mutated when structured output arrives so the `$ai_trace` event picks it up.
- **`review_pr.py`**: Capture a new `stamphog_review_completed` event after the pipeline finishes, with all three verdict levels:
  - `stamphog_gate_verdict` — deterministic gate decision
  - `stamphog_llm_verdict` — what the LLM said (APPROVE/REFUSE/ESCALATE)
  - `stamphog_final_verdict` — combined pipeline decision (APPROVED/REFUSED/ESCALATE)
  - Plus LLM reasoning, risk, and issues for debugging

## How does this work?

1. The `posthog_properties` dict is passed by reference to the SDK's `query()` wrapper. When we mutate it after getting the `ResultMessage`, the SDK's final `$ai_trace` event (sent after the generator completes) picks up `stamphog_llm_verdict`.
2. A separate `stamphog_review_completed` event gives us a clean, reliable source for dashboard charts — independent of trace event timing.

## Test plan

- [ ] Run a stamphog review locally with `POSTHOG_API_KEY` set, verify `stamphog_review_completed` event appears in PostHog with all three verdict fields
- [ ] Check LLM analytics trace shows `stamphog_gate_verdict` and `stamphog_llm_verdict` on the `$ai_trace` event
- [ ] Verify existing dashboard charts still work (they filter on `ai_product=stamphog` which is unchanged)

## Follow-up

Dashboard insights that break down by `stamphog_verdict` need updating to use `stamphog_gate_verdict` (or switch to `stamphog_review_completed` + `stamphog_final_verdict`). Tracked separately — will do once new events are flowing.