### PR TITLE
fix(quill): re-add empty NODE_AUTH_TOKEN to override setup-node placeholder

### DIFF
--- a/.github/workflows/publish-quill-npm.yml
+++ b/.github/workflows/publish-quill-npm.yml
@@ -63,6 +63,14 @@ jobs:
                   VERSION=$(node -p "require('./package.json').version")
                   echo "version=$VERSION" >> $GITHUB_OUTPUT
               env:
+                  # actions/setup-node's `registry-url` input exports
+                  # NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX as a placeholder and
+                  # writes it into .npmrc. With OIDC trusted publishing we do
+                  # not have a real token, so we must clear it at the step
+                  # level — otherwise npm sends the placeholder as the bearer
+                  # token and the registry returns a 404. Matches the pattern
+                  # in release.yml and build-hogql-parser-npm.yml.
+                  NODE_AUTH_TOKEN: ''
                   NPM_CONFIG_PROVENANCE: true
                   NPM_TAG: ${{ inputs.tag }}
 
@@ -74,6 +82,7 @@ jobs:
                   VERSION=$(node -p "require('./package.json').version")
                   echo "version=$VERSION" >> $GITHUB_OUTPUT
               env:
+                  NODE_AUTH_TOKEN: ''
                   NPM_CONFIG_PROVENANCE: true
                   NPM_TAG: ${{ inputs.tag }}
 


### PR DESCRIPTION
## Problem

After #54215 and #54224, the quill publish workflow got past OIDC trusted publishing — the failing run (https://github.com/PostHog/posthog/actions/runs/24340385592) shows:

```
npm notice Publishing to https://registry.npmjs.org/ with tag alpha and public access
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=1283902385
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@posthog%2fquill-tokens - Not found
```

Provenance signed fine, sigstore transparency log entry created, and then the actual publish `PUT` came back with a 404. That is not a "package does not exist" 404 — `@posthog/quill-tokens@0.1.0-alpha.0` exists — it is what the npm registry returns when you send a malformed auth header (auth failures are masked as 404 on purpose).

The source of the bad auth header is `actions/setup-node` itself. When `registry-url` is passed in, setup-node's `authutil.ts` does `core.exportVariable('NODE_AUTH_TOKEN', 'XXXXX-XXXXX-XXXXX-XXXXX')` — it exports the literal placeholder string as an env var and writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into `.npmrc`. npm then expands the placeholder and sends it as the bearer token on top of the OIDC flow, and the registry rejects it.

You can see the placeholder in the step's env dump from the failing run:

```
NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
NPM_CONFIG_PROVENANCE: true
NPM_TAG: alpha
```

This is why both `release.yml` and `build-hogql-parser-npm.yml` explicitly set `NODE_AUTH_TOKEN: ''` on their publish steps — it is not a cosmetic leftover, it is load-bearing. It was removed from the quill workflow earlier under the assumption it was unused; that was wrong.

## Changes

- Re-add `NODE_AUTH_TOKEN: ''` to both publish steps in `publish-quill-npm.yml`.
- Leave a comment on the first step explaining why it is there, so this doesn't get removed again in the future.

No other workflows are touched.

## How did you test this code?

I am an agent and have not run the workflow end-to-end myself. Verification:

- Confirmed the failing run got past OIDC and sigstore attestation and only failed at the PUT, which matches a bad auth header rather than a missing trusted publisher or old npm.
- Confirmed `release.yml` publishes posthog-cli successfully with the same `actions/setup-node` SHA plus explicit `NODE_AUTH_TOKEN: ''` — see the successful run from 2026-04-06 (`posthog-cli/v0.7.5`, run id `24036482440`).

The real test is rerunning the `Publish Quill npm packages` workflow after this lands.

## Publish to changelog?

no

<!-- ## 🤖 LLM context -->
<!-- Authored by Claude (Opus 4.6, 1M context) in a Claude Code session. Diagnosed the failing run by noticing the sigstore provenance upload succeeded while the final publish PUT failed with a masked auth-failure 404, and traced the bad auth to actions/setup-node's placeholder export. -->