### PR TITLE
fix(error-tracking): remove ordering from fingerprint backfill query

### DIFF
--- a/posthog/management/commands/fingerprint_embeddings_backfill.py
+++ b/posthog/management/commands/fingerprint_embeddings_backfill.py
@@ -45,15 +45,11 @@ class Command(BaseCommand):
         team_id = options["team_id"]
 
         # Fetch the fingerprints
-        fingerprints = (
-            ErrorTrackingIssueFingerprintV2.objects.filter(
-                team_id=team_id,
-                created_at__gte=fingerprint_start_date,
-                created_at__lte=fingerprint_end_date,
-            )
-            .order_by("created_at")
-            .iterator()
-        )
+        fingerprints = ErrorTrackingIssueFingerprintV2.objects.filter(
+            team_id=team_id,
+            created_at__gte=fingerprint_start_date,
+            created_at__lte=fingerprint_end_date,
+        ).iterator()
 
         # Iterate through the fingerprints in batches of 100 at a time
         batch: list[ErrorTrackingIssueFingerprintV2] = []


### PR DESCRIPTION
The fingerprint embeddings backfill command sorts by `created_at`, which has no index, causing slow cursor creation.

Removed the `.order_by("created_at")` — ordering is unnecessary for a backfill that just needs to process every row.