### PR TITLE
Fix retrieval of insights with numeric-only short IDs

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1207,7 +1207,12 @@ class InsightViewSet(
     def safely_get_object(self, queryset: QuerySet) -> Insight | None:
         lookup_value = self.kwargs[self.lookup_field]
         if isinstance(lookup_value, str) and lookup_value.isdigit():
-            return queryset.filter(pk=int(lookup_value)).first()
+            # A numeric lookup is ambiguous: usually it's a primary key, but a small number of
+            # legacy rows have numeric-only short_ids. Try pk first (preserving existing behavior)
+            # and fall back to short_id so those legacy insights stay retrievable.
+            pk_match = queryset.filter(pk=int(lookup_value)).first()
+            if pk_match is not None:
+                return pk_match
         return queryset.filter(short_id=lookup_value).first()
 
     def order_queryset(self, queryset: QuerySet) -> QuerySet:

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -606,6 +606,24 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         response = self.client.get(f"/api/projects/{self.team.id}/insights/notthere/")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_retrieve_insight_by_numeric_short_id_falls_back_to_short_id(self) -> None:
+        # A small number of legacy insights have numeric-only short_ids — they must remain retrievable
+        # when no insight matches the value as a primary key.
+        numeric_short_id = "99999999999"
+        assert not Insight.objects.filter(pk=int(numeric_short_id)).exists()
+        insight = Insight.objects.create(
+            filters=Filter(data={"events": [{"id": "$pageview"}]}).to_dict(),
+            team=self.team,
+            short_id=numeric_short_id,
+            name="numeric-short-id",
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/{numeric_short_id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["id"], insight.id)
+        self.assertEqual(response.json()["short_id"], numeric_short_id)
+        self.assertEqual(response.json()["name"], "numeric-short-id")
+
     def test_basic_results(self) -> None:
         """
         The `skip_results` query parameter can be passed so that only a list of objects is returned, without


### PR DESCRIPTION
## Problem

A small number of legacy insights have numeric-only `short_id` values. When attempting to retrieve these insights via the API using their numeric short ID, the lookup fails because the code only attempts to match against the primary key (`pk`), not the `short_id` field. This makes these legacy insights unretrievable.

## Changes

Modified the `safely_get_object` method in `posthog/api/insight.py` to implement a fallback lookup strategy:
1. When a numeric lookup value is provided, first attempt to match by primary key (preserving existing behavior for the majority of cases)
2. If no primary key match is found, fall back to matching by `short_id` to handle legacy insights with numeric-only short IDs

Added a comprehensive test case `test_retrieve_insight_by_numeric_short_id_falls_back_to_short_id` to verify that insights with numeric-only short IDs remain retrievable even when no insight exists with that numeric value as a primary key.

## How did you test this code?

Added automated test coverage in `posthog/api/test/test_insight.py` that:
- Creates an insight with a numeric-only `short_id` that doesn't match any existing primary key
- Verifies the insight can be retrieved via the API using that numeric short ID
- Confirms the response contains the correct insight data

The test ensures the fallback behavior works correctly while maintaining backward compatibility with existing primary key lookups.

## Publish to changelog?

no

https://claude.ai/code/session_011UXNk9DZt4GqaQXyQ62ugt