### PR TITLE
chore(quill): bump to 0.1.0-alpha.3 and add stamphog dist-tag

### DIFF
--- a/.github/workflows/publish-quill-npm.yml
+++ b/.github/workflows/publish-quill-npm.yml
@@ -4,13 +4,14 @@ on:
     workflow_dispatch:
         inputs:
             tag:
-                description: 'npm dist-tag (e.g. alpha, latest)'
+                description: 'npm dist-tag (e.g. alpha, latest, stamphog)'
                 required: true
                 default: 'alpha'
                 type: choice
                 options:
                     - alpha
                     - latest
+                    - stamphog
 
 permissions:
     contents: read

--- a/packages/quill/packages/quill/package.json
+++ b/packages/quill/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill",
-    "version": "0.1.0-alpha.2",
+    "version": "0.1.0-alpha.3",
     "description": "PostHog's unified design system — primitives, components, and blocks with a pre-compiled stylesheet.",
     "license": "MIT",
     "repository": {

--- a/packages/quill/packages/tokens/package.json
+++ b/packages/quill/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-tokens",
-    "version": "0.1.0-alpha.2",
+    "version": "0.1.0-alpha.3",
     "license": "MIT",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Problem

After fixing the OIDC trusted publishing flow in #54215, #54224, and #54237, the next run of the publish workflow got all the way through OIDC auth, provenance signing, and sigstore upload — but then failed the final `PUT` with:

```
npm error 403 Forbidden - PUT https://registry.npmjs.org/@posthog%2fquill-tokens - You cannot publish over the previously published versions: 0.1.0-alpha.2.
```

The version already exists on npm (one of the earlier debugging runs must have leaked through), so republishing the same version is rejected.

We also want a `stamphog` dist-tag available as a publish option alongside `alpha` and `latest`.

## Changes

- Bump `@posthog/quill` and `@posthog/quill-tokens` from `0.1.0-alpha.2` to `0.1.0-alpha.3` so the next workflow run has a fresh version to publish.
- Add `stamphog` as a third option on the `workflow_dispatch.inputs.tag` choice so the publish workflow can target that dist-tag from the Actions UI.

## How did you test this code?

I am an agent and have not run the workflow end-to-end myself. Verification:

- `npm view @posthog/quill-tokens versions` → `["0.1.0-alpha.0", "0.1.0-alpha.2"]`, confirming `alpha.2` already exists on npm and `alpha.3` is free.
- `npm view @posthog/quill versions` → `["0.1.0-alpha.0"]`, so `alpha.3` is free there too.
- Verified the earlier publish-side plumbing (OIDC flow, npm 11.6.4 pin, `NODE_AUTH_TOKEN` override, trusted publisher config) is already in place on master — this PR only handles the version bump and dist-tag option.

The real test is running the `Publish Quill npm packages` workflow after this lands with `tag=stamphog` (or `alpha`).

## Publish to changelog?

no

<!-- ## 🤖 LLM context -->
<!-- Authored by Claude (Opus 4.6, 1M context) in a Claude Code session. Continuation of the quill publishing fix series — once OIDC trusted publishing was working, the immediate block became the version conflict on 0.1.0-alpha.2. -->