### PR TITLE
feat(integrations): paginate GitHub repos endpoint with limit/offset

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5321,8 +5321,11 @@ const api = {
         async linearTeams(id: IntegrationType['id']): Promise<{ teams: LinearTeamType[] }> {
             return await new ApiRequest().integrationLinearTeams(id).get()
         },
-        async githubRepositories(id: IntegrationType['id']): Promise<GitHubReposResponseApi> {
-            return await new ApiRequest().integrationGitHubRepositories(id).get()
+        async githubRepositories(
+            id: IntegrationType['id'],
+            params?: { limit?: number; offset?: number }
+        ): Promise<GitHubReposResponseApi> {
+            return await new ApiRequest().integrationGitHubRepositories(id).withQueryString(params).get()
         },
         async jiraProjects(id: IntegrationType['id']): Promise<{ projects: JiraProjectType[] }> {
             return await new ApiRequest().integrationJiraProjects(id).get()

--- a/frontend/src/lib/integrations/IntegrationView.tsx
+++ b/frontend/src/lib/integrations/IntegrationView.tsx
@@ -99,7 +99,7 @@ export function IntegrationView({
                             </div>
                         ) : null}
                         {isGitHub &&
-                            (githubRepositoriesLoading ? (
+                            (githubRepositoriesLoading && repositories.length === 0 ? (
                                 <div className="flex items-center gap-1 text-xs text-muted mr-4 min-h-5">
                                     <Spinner className="text-sm" />
                                     Loading repositories...

--- a/frontend/src/lib/integrations/githubIntegrationLogic.ts
+++ b/frontend/src/lib/integrations/githubIntegrationLogic.ts
@@ -1,5 +1,4 @@
-import { actions, kea, key, path, props } from 'kea'
-import { loaders } from 'kea-loaders'
+import { actions, kea, key, listeners, path, props, reducers } from 'kea'
 
 import api from 'lib/api'
 
@@ -7,23 +6,72 @@ import type { GitHubRepoApi } from 'products/integrations/frontend/generated/api
 
 import type { githubIntegrationLogicType } from './githubIntegrationLogicType'
 
+const PAGE_SIZE = 500
+
 export const githubIntegrationLogic = kea<githubIntegrationLogicType>([
     props({} as { id: number }),
     key((props) => props.id),
     path((key) => ['lib', 'integrations', 'githubIntegrationLogic', key]),
+
     actions({
-        loadRepositories: () => ({}),
+        loadRepositories: true,
+        loadRepositoriesPage: (offset: number) => ({ offset }),
+        loadRepositoriesPageSuccess: (repositories: GitHubRepoApi[], hasMore: boolean) => ({
+            repositories,
+            hasMore,
+        }),
+        loadRepositoriesPageFailure: true,
     }),
 
-    loaders(({ props }) => ({
+    reducers({
         repositories: [
             [] as GitHubRepoApi[],
             {
-                loadRepositories: async () => {
-                    const response = await api.integrations.githubRepositories(props.id)
-                    return response.repositories
+                loadRepositories: () => [],
+                loadRepositoriesPageSuccess: (state, { repositories }) => {
+                    const seenIds = new Set(state.map((r) => r.id))
+                    const newRepos = repositories.filter((r) => !seenIds.has(r.id))
+                    return [...state, ...newRepos]
                 },
             },
         ],
+        repositoriesLoading: [
+            false,
+            {
+                loadRepositories: () => true,
+                loadRepositoriesPageSuccess: (_, { hasMore }) => hasMore,
+                loadRepositoriesPageFailure: () => false,
+            },
+        ],
+        currentOffset: [
+            0,
+            {
+                loadRepositories: () => 0,
+                loadRepositoriesPageSuccess: (state) => state + PAGE_SIZE,
+            },
+        ],
+    }),
+
+    listeners(({ actions, values, props }) => ({
+        loadRepositories: () => {
+            actions.loadRepositoriesPage(0)
+        },
+        loadRepositoriesPageSuccess: ({ hasMore }) => {
+            if (hasMore) {
+                actions.loadRepositoriesPage(values.currentOffset)
+            }
+        },
+        loadRepositoriesPage: async ({ offset }, breakpoint) => {
+            try {
+                const response = await api.integrations.githubRepositories(props.id, {
+                    limit: PAGE_SIZE,
+                    offset,
+                })
+                await breakpoint()
+                actions.loadRepositoriesPageSuccess(response.repositories, response.has_more)
+            } catch {
+                actions.loadRepositoriesPageFailure()
+            }
+        },
     })),
 ])

--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -46,6 +46,17 @@ export const integrationsLogic = kea<integrationsLogicType>([
         openSetupModal: (integration?: IntegrationType, channelType?: ChannelType) => ({ integration, channelType }),
         closeSetupModal: true,
         loadGitHubRepositories: (integrationId: number) => ({ integrationId }),
+        loadGitHubRepositoriesPage: (integrationId: number, offset: number) => ({ integrationId, offset }),
+        loadGitHubRepositoriesPageSuccess: (
+            integrationId: number,
+            repositories: GitHubRepoApi[],
+            hasMore: boolean
+        ) => ({
+            integrationId,
+            repositories,
+            hasMore,
+        }),
+        loadGitHubRepositoriesPageFailure: (integrationId: number) => ({ integrationId }),
     }),
     reducers({
         newIntegrationModalKind: [
@@ -74,6 +85,29 @@ export const integrationsLogic = kea<integrationsLogicType>([
             {
                 openSetupModal: (_, { integration }) => integration ?? null,
                 closeSetupModal: () => null,
+            },
+        ],
+        githubRepositories: [
+            {} as Record<number, GitHubRepoApi[]>,
+            {
+                loadGitHubRepositories: (state, { integrationId }) => ({
+                    ...state,
+                    [integrationId]: [],
+                }),
+                loadGitHubRepositoriesPageSuccess: (state, { integrationId, repositories }) => {
+                    const existing = state[integrationId] || []
+                    const seenIds = new Set(existing.map((r) => r.id))
+                    const newRepos = repositories.filter((r) => !seenIds.has(r.id))
+                    return { ...state, [integrationId]: [...existing, ...newRepos] }
+                },
+            },
+        ],
+        githubRepositoriesLoading: [
+            false,
+            {
+                loadGitHubRepositories: () => true,
+                loadGitHubRepositoriesPageSuccess: (_, { hasMore }) => hasMore,
+                loadGitHubRepositoriesPageFailure: () => false,
             },
         ],
     }),
@@ -127,23 +161,29 @@ export const integrationsLogic = kea<integrationsLogicType>([
                 },
             },
         ],
-        githubRepositories: [
-            {} as Record<number, GitHubRepoApi[]>,
-            {
-                loadGitHubRepositories: async ({ integrationId }) => {
-                    const response = await integrationsGithubReposRetrieve(
-                        String(values.currentProjectId),
-                        integrationId
-                    )
-                    return {
-                        ...values.githubRepositories,
-                        [integrationId]: response.repositories || [],
-                    }
-                },
-            },
-        ],
     })),
     listeners(({ actions, values }) => ({
+        loadGitHubRepositories: ({ integrationId }) => {
+            actions.loadGitHubRepositoriesPage(integrationId, 0)
+        },
+        loadGitHubRepositoriesPageSuccess: ({ integrationId, hasMore }) => {
+            if (hasMore) {
+                const currentRepos = values.githubRepositories[integrationId] || []
+                actions.loadGitHubRepositoriesPage(integrationId, currentRepos.length)
+            }
+        },
+        loadGitHubRepositoriesPage: async ({ integrationId, offset }, breakpoint) => {
+            try {
+                const response = await integrationsGithubReposRetrieve(String(values.currentProjectId), integrationId, {
+                    limit: 100,
+                    offset,
+                })
+                await breakpoint()
+                actions.loadGitHubRepositoriesPageSuccess(integrationId, response.repositories, response.has_more)
+            } catch {
+                actions.loadGitHubRepositoriesPageFailure(integrationId)
+            }
+        },
         handleGithubCallback: async ({ searchParams }) => {
             const { state, installation_id } = searchParams
             const { next, token } = fromParamsGivenUrl(state ?? '')

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -62,8 +62,25 @@ class GitHubRepoSerializer(serializers.Serializer):
     full_name = serializers.CharField()
 
 
+class GitHubReposQuerySerializer(serializers.Serializer):
+    limit = serializers.IntegerField(
+        required=False,
+        default=100,
+        min_value=1,
+        max_value=500,
+        help_text="Maximum number of repositories to return per request (max 500).",
+    )
+    offset = serializers.IntegerField(
+        required=False,
+        default=0,
+        min_value=0,
+        help_text="Number of repositories to skip before returning results.",
+    )
+
+
 class GitHubReposResponseSerializer(serializers.Serializer):
     repositories = GitHubRepoSerializer(many=True)
+    has_more = serializers.BooleanField(help_text="Whether more repositories are available beyond this page.")
 
 
 class GitHubBranchesQuerySerializer(serializers.Serializer):
@@ -558,10 +575,21 @@ class IntegrationViewSet(
         linear = LinearIntegration(self.get_object())
         return Response({"teams": linear.list_teams()})
 
-    @action(methods=["GET"], detail=True, url_path="github_repos", responses=GitHubReposResponseSerializer)
+    @extend_schema(
+        parameters=[GitHubReposQuerySerializer],
+        responses={200: GitHubReposResponseSerializer},
+    )
+    @action(methods=["GET"], detail=True, url_path="github_repos")
     def github_repos(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        query_serializer = GitHubReposQuerySerializer(data=request.query_params)
+        query_serializer.is_valid(raise_exception=True)
+        limit = query_serializer.validated_data["limit"]
+        offset = query_serializer.validated_data["offset"]
+
         github = GitHubIntegration(self.get_object())
-        return Response({"repositories": github.list_all_repositories()})
+        repositories, has_more = github.list_repositories(limit=limit, offset=offset)
+
+        return Response({"repositories": repositories, "has_more": has_more})
 
     @extend_schema(
         parameters=[GitHubBranchesQuerySerializer],

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -613,12 +613,15 @@ class TestIntegrationAPIKeyAccess:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    @patch("posthog.models.integration.GitHubIntegration.list_all_repositories")
+    @patch("posthog.models.integration.GitHubIntegration.list_repositories")
     def test_github_repos_with_scope_succeeds(self, mock_list_repos, client: HttpClient):
-        mock_list_repos.return_value = [
-            {"id": 1, "name": "repo1", "full_name": "org/repo1"},
-            {"id": 2, "name": "repo2", "full_name": "org/repo2"},
-        ]
+        mock_list_repos.return_value = (
+            [
+                {"id": 1, "name": "repo1", "full_name": "org/repo1"},
+                {"id": 2, "name": "repo2", "full_name": "org/repo2"},
+            ],
+            False,
+        )
 
         key_value = "test_key_123"
         PersonalAPIKey.objects.create(
@@ -634,10 +637,83 @@ class TestIntegrationAPIKeyAccess:
         )
 
         assert response.status_code == status.HTTP_200_OK
-        repos = response.json()["repositories"]
-        assert len(repos) == 2
-        assert repos[0]["name"] == "repo1"
-        assert repos[1]["name"] == "repo2"
+        data = response.json()
+        assert len(data["repositories"]) == 2
+        assert data["repositories"][0]["name"] == "repo1"
+        assert data["repositories"][1]["name"] == "repo2"
+        assert data["has_more"] is False
+        mock_list_repos.assert_called_once_with(limit=100, offset=0)
+
+    @patch("posthog.models.integration.GitHubIntegration.list_repositories")
+    def test_github_repos_pagination(self, mock_list_repos, client: HttpClient):
+        repos = [{"id": i, "name": f"repo{i}", "full_name": f"org/repo{i}"} for i in range(100)]
+        mock_list_repos.return_value = (repos, True)
+
+        key_value = "test_key_123"
+        PersonalAPIKey.objects.create(
+            label="Test Key",
+            user=self.user,
+            secure_value=hash_key_value(key_value),
+            scopes=["integration:read"],
+        )
+
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/{self.github_integration.id}/github_repos/?limit=100&offset=100",
+            HTTP_AUTHORIZATION=f"Bearer {key_value}",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data["repositories"]) == 100
+        assert data["has_more"] is True
+        mock_list_repos.assert_called_once_with(limit=100, offset=100)
+
+    @patch("posthog.models.integration.GitHubIntegration.list_repositories")
+    def test_github_repos_has_more_false_when_partial_page(self, mock_list_repos, client: HttpClient):
+        repos = [{"id": i, "name": f"repo{i}", "full_name": f"org/repo{i}"} for i in range(50)]
+        mock_list_repos.return_value = (repos, False)
+
+        key_value = "test_key_123"
+        PersonalAPIKey.objects.create(
+            label="Test Key",
+            user=self.user,
+            secure_value=hash_key_value(key_value),
+            scopes=["integration:read"],
+        )
+
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/{self.github_integration.id}/github_repos/",
+            HTTP_AUTHORIZATION=f"Bearer {key_value}",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data["repositories"]) == 50
+        assert data["has_more"] is False
+
+    @patch("posthog.models.integration.GitHubIntegration.list_repositories")
+    def test_github_repos_passes_limit_offset(self, mock_list_repos, client: HttpClient):
+        repos = [{"id": i, "name": f"repo{i}", "full_name": f"org/repo{i}"} for i in range(10)]
+        mock_list_repos.return_value = (repos, True)
+
+        key_value = "test_key_123"
+        PersonalAPIKey.objects.create(
+            label="Test Key",
+            user=self.user,
+            secure_value=hash_key_value(key_value),
+            scopes=["integration:read"],
+        )
+
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/{self.github_integration.id}/github_repos/?limit=10&offset=50",
+            HTTP_AUTHORIZATION=f"Bearer {key_value}",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data["repositories"]) == 10
+        assert data["has_more"] is True
+        mock_list_repos.assert_called_once_with(limit=10, offset=50)
 
     def test_github_repos_without_scope_fails(self, client: HttpClient):
         key_value = "test_key_123"

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2113,18 +2113,26 @@ class GitHubIntegration:
         commit_url = data.get("html_url", f"https://github.com/{repository}/commit/{sha}")
         return GitHubCommitAuthor(login=author["login"], name=name, commit_url=commit_url)
 
-    def list_repositories(self, page: int = 1) -> list[dict]:
-        # Proactively refresh token if it's close to expiring to avoid intermittent 401s
+    def list_repositories(self, *, limit: int = 100, offset: int = 0) -> tuple[list[dict], bool]:
+        """List installation repositories via the GitHub API.
+
+        Fetches only the GitHub pages needed to satisfy the requested
+        ``[offset, offset+limit)`` window. Returns a tuple of
+        ``(repositories, has_more)`` where *has_more* indicates whether
+        additional repositories exist beyond the returned window.
+        """
+        GITHUB_PER_PAGE = 100
+
         try:
             if self.access_token_expired():
                 self.refresh_access_token()
         except Exception:
             logger.warning("GitHubIntegration: token refresh pre-check failed", exc_info=True)
 
-        def fetch() -> requests.Response:
+        def fetch(page: int) -> requests.Response:
             access_token = self.integration.sensitive_config.get("access_token")
             return requests.get(
-                f"https://api.github.com/installation/repositories?page={page}&per_page=100",
+                f"https://api.github.com/installation/repositories?page={page}&per_page={GITHUB_PER_PAGE}",
                 headers={
                     "Accept": "application/vnd.github+json",
                     "Authorization": f"Bearer {access_token}",
@@ -2132,19 +2140,50 @@ class GitHubIntegration:
                 },
             )
 
+        def extract_repos(body: dict) -> list[dict]:
+            repositories = body.get("repositories")
+            if not isinstance(repositories, list):
+                return []
+            return [
+                {
+                    "id": repo["id"],
+                    "name": repo["name"],
+                    "full_name": repo["full_name"],
+                }
+                for repo in repositories
+                if isinstance(repo, dict)
+                and isinstance(repo.get("id"), int)
+                and isinstance(repo.get("name"), str)
+                and isinstance(repo.get("full_name"), str)
+            ]
+
+        # Work out which GitHub pages cover the requested window.
+        first_page = offset // GITHUB_PER_PAGE + 1
+        skip = offset % GITHUB_PER_PAGE
+        needed = skip + limit
+
+        # Fetch the first required page with 401-retry and transient-error retry.
         transient_status_codes = {502, 503, 504}
+        current_page = first_page
 
         for attempt in range(2):
-            response = fetch()
+            try:
+                response = fetch(current_page)
+            except requests.RequestException:
+                logger.warning("GitHubIntegration: list_repositories network error", exc_info=True)
+                return [], False
 
-            # If unauthorized, try a single refresh and retry
             if response.status_code == 401:
                 try:
                     self.refresh_access_token()
                 except Exception:
                     logger.warning("GitHubIntegration: token refresh after 401 failed", exc_info=True)
-                else:
-                    response = fetch()
+                    return [], False
+                try:
+                    response = fetch(current_page)
+                except requests.RequestException:
+                    logger.warning("GitHubIntegration: list_repositories network error on retry", exc_info=True)
+                    return [], False
 
             try:
                 body = response.json()
@@ -2155,27 +2194,17 @@ class GitHubIntegration:
                         status_code=response.status_code,
                     )
                     continue
-
                 logger.warning(
                     "GitHubIntegration: list_repositories non-JSON response",
                     status_code=response.status_code,
                 )
-                return []
+                return [], False
 
-            repositories = body.get("repositories")
-            if response.status_code == 200 and isinstance(repositories, list):
-                return [
-                    {
-                        "id": repo["id"],
-                        "name": repo["name"],
-                        "full_name": repo["full_name"],
-                    }
-                    for repo in repositories
-                    if isinstance(repo, dict)
-                    and isinstance(repo.get("id"), int)
-                    and isinstance(repo.get("name"), str)
-                    and isinstance(repo.get("full_name"), str)
-                ]
+            if response.status_code == 200 and isinstance(body, dict):
+                page_repos = extract_repos(body)
+                all_fetched = page_repos
+                has_next_page = len(page_repos) == GITHUB_PER_PAGE
+                break
 
             if response.status_code in transient_status_codes and attempt == 0:
                 logger.info(
@@ -2190,30 +2219,37 @@ class GitHubIntegration:
                 status_code=response.status_code,
                 error=body if isinstance(body, dict) else None,
             )
-            return []
+            return [], False
+        else:
+            return [], False
 
-        return []
+        # Fetch subsequent pages until we have enough items.
+        while len(all_fetched) < needed and has_next_page:
+            current_page += 1
+            try:
+                response = fetch(current_page)
+            except requests.RequestException:
+                logger.warning("GitHubIntegration: list_repositories network error on page", page=current_page)
+                break
+            try:
+                body = response.json()
+            except Exception:
+                break
+            if response.status_code != 200 or not isinstance(body, dict):
+                break
+            page_repos = extract_repos(body)
+            all_fetched.extend(page_repos)
+            has_next_page = len(page_repos) == GITHUB_PER_PAGE
+
+        result = all_fetched[skip : skip + limit]
+        has_more = has_next_page or (skip + limit < len(all_fetched))
+
+        return result, has_more
 
     def list_all_repositories(self, max_repos: int = 500) -> list[dict]:
         """Fetch all accessible repositories, paginating through GitHub's API."""
-        all_repos: list[dict] = []
-        seen_ids: set[int] = set()
-        page = 1
-        per_page = 100
-
-        while True:
-            repo_entries = self.list_repositories(page=page)
-            for repo in repo_entries:
-                if repo["id"] not in seen_ids:
-                    seen_ids.add(repo["id"])
-                    all_repos.append(repo)
-                    if len(all_repos) >= max_repos:
-                        return all_repos
-            if len(repo_entries) < per_page:
-                break
-            page += 1
-
-        return all_repos
+        repos, _ = self.list_repositories(limit=max_repos, offset=0)
+        return repos
 
     def get_top_starred_repository(self) -> str | None:
         """Get the repository with the most stars from the GitHub integration.

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -823,12 +823,13 @@ class TestGitHubIntegrationModel(BaseTest):
 
         mock_get.side_effect = [transient, success]
 
-        repos = GitHubIntegration(integration).list_repositories()
+        repos, has_more = GitHubIntegration(integration).list_repositories()
 
         assert repos == [
             {"id": 1, "name": "posthog", "full_name": "PostHog/posthog"},
             {"id": 2, "name": "posthog-js", "full_name": "PostHog/posthog-js"},
         ]
+        assert has_more is False
         assert mock_get.call_count == 2
 
     @patch("posthog.models.integration.requests.get")
@@ -849,30 +850,26 @@ class TestGitHubIntegrationModel(BaseTest):
 
         mock_get.side_effect = [transient_1, transient_2]
 
-        repos = GitHubIntegration(integration).list_repositories()
+        repos, has_more = GitHubIntegration(integration).list_repositories()
 
         assert repos == []
+        assert has_more is False
         assert mock_get.call_count == 2
 
     @patch("posthog.models.integration.GitHubIntegration.list_repositories")
-    def test_list_all_repositories_paginates(self, mock_list):
+    def test_list_all_repositories_delegates_with_limit(self, mock_list):
         integration = self.create_integration(
             {"installation_id": "INSTALL", "account": {"name": "PostHog"}},
             {"access_token": "ACCESS_TOKEN"},
         )
 
-        page1 = [{"id": i, "name": f"repo-{i}", "full_name": f"PostHog/repo-{i}"} for i in range(100)]
-        page2 = [{"id": i, "name": f"repo-{i}", "full_name": f"PostHog/repo-{i}"} for i in range(100, 130)]
-        mock_list.side_effect = [page1, page2]
+        all_repos = [{"id": i, "name": f"repo-{i}", "full_name": f"PostHog/repo-{i}"} for i in range(130)]
+        mock_list.return_value = (all_repos, False)
 
         repos = GitHubIntegration(integration).list_all_repositories()
 
         assert len(repos) == 130
-        assert repos[0] == {"id": 0, "name": "repo-0", "full_name": "PostHog/repo-0"}
-        assert repos[-1] == {"id": 129, "name": "repo-129", "full_name": "PostHog/repo-129"}
-        assert mock_list.call_count == 2
-        mock_list.assert_any_call(page=1)
-        mock_list.assert_any_call(page=2)
+        mock_list.assert_called_once_with(limit=500, offset=0)
 
     @patch("posthog.models.integration.GitHubIntegration.list_repositories")
     def test_list_all_repositories_respects_max_repos(self, mock_list):
@@ -881,29 +878,13 @@ class TestGitHubIntegrationModel(BaseTest):
             {"access_token": "ACCESS_TOKEN"},
         )
 
-        page = [{"id": i, "name": f"repo-{i}", "full_name": f"PostHog/repo-{i}"} for i in range(100)]
-        mock_list.return_value = page
+        repos_50 = [{"id": i, "name": f"repo-{i}", "full_name": f"PostHog/repo-{i}"} for i in range(50)]
+        mock_list.return_value = (repos_50, True)
 
         repos = GitHubIntegration(integration).list_all_repositories(max_repos=50)
 
         assert len(repos) == 50
-        assert mock_list.call_count == 1
-
-    @patch("posthog.models.integration.GitHubIntegration.list_repositories")
-    def test_list_all_repositories_deduplicates(self, mock_list):
-        integration = self.create_integration(
-            {"installation_id": "INSTALL", "account": {"name": "PostHog"}},
-            {"access_token": "ACCESS_TOKEN"},
-        )
-
-        page1 = [{"id": 1, "name": "repo-1", "full_name": "PostHog/repo-1"}] * 100
-        page2 = [{"id": 1, "name": "repo-1", "full_name": "PostHog/repo-1"}]
-        mock_list.side_effect = [page1, page2]
-
-        repos = GitHubIntegration(integration).list_all_repositories()
-
-        assert len(repos) == 1
-        assert repos[0]["id"] == 1
+        mock_list.assert_called_once_with(limit=50, offset=0)
 
 
 class TestDatabricksIntegrationModel(BaseTest):

--- a/products/integrations/frontend/generated/api.schemas.ts
+++ b/products/integrations/frontend/generated/api.schemas.ts
@@ -267,9 +267,9 @@ export type IntegrationsGithubBranchesRetrieveParams = {
 
 export type IntegrationsGithubReposRetrieveParams = {
     /**
-     * Maximum number of repositories to return per request (max 100, matching GitHub's page size).
+     * Maximum number of repositories to return per request (max 500).
      * @minimum 1
-     * @maximum 100
+     * @maximum 500
      */
     limit?: number
     /**

--- a/products/integrations/frontend/generated/api.schemas.ts
+++ b/products/integrations/frontend/generated/api.schemas.ts
@@ -231,6 +231,8 @@ export interface GitHubRepoApi {
 
 export interface GitHubReposResponseApi {
     repositories: GitHubRepoApi[]
+    /** Whether more repositories are available beyond this page. */
+    has_more: boolean
 }
 
 export type IntegrationsListParams = {
@@ -261,4 +263,18 @@ export type IntegrationsGithubBranchesRetrieveParams = {
      * @minLength 1
      */
     repo: string
+}
+
+export type IntegrationsGithubReposRetrieveParams = {
+    /**
+     * Maximum number of repositories to return per request (max 100, matching GitHub's page size).
+     * @minimum 1
+     * @maximum 100
+     */
+    limit?: number
+    /**
+     * Number of repositories to skip before returning results.
+     * @minimum 0
+     */
+    offset?: number
 }

--- a/products/integrations/frontend/generated/api.ts
+++ b/products/integrations/frontend/generated/api.ts
@@ -13,6 +13,7 @@ import type {
     GitHubReposResponseApi,
     IntegrationApi,
     IntegrationsGithubBranchesRetrieveParams,
+    IntegrationsGithubReposRetrieveParams,
     IntegrationsList2Params,
     IntegrationsListParams,
     OrganizationIntegrationApi,
@@ -330,16 +331,33 @@ export const integrationsGithubBranchesRetrieve = async (
     })
 }
 
-export const getIntegrationsGithubReposRetrieveUrl = (projectId: string, id: number) => {
-    return `/api/projects/${projectId}/integrations/${id}/github_repos/`
+export const getIntegrationsGithubReposRetrieveUrl = (
+    projectId: string,
+    id: number,
+    params?: IntegrationsGithubReposRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/integrations/${id}/github_repos/?${stringifiedParams}`
+        : `/api/projects/${projectId}/integrations/${id}/github_repos/`
 }
 
 export const integrationsGithubReposRetrieve = async (
     projectId: string,
     id: number,
+    params?: IntegrationsGithubReposRetrieveParams,
     options?: RequestInit
 ): Promise<GitHubReposResponseApi> => {
-    return apiMutator<GitHubReposResponseApi>(getIntegrationsGithubReposRetrieveUrl(projectId, id), {
+    return apiMutator<GitHubReposResponseApi>(getIntegrationsGithubReposRetrieveUrl(projectId, id, params), {
         ...options,
         method: 'GET',
     })

--- a/products/tasks/backend/repository_resolver.py
+++ b/products/tasks/backend/repository_resolver.py
@@ -159,7 +159,7 @@ async def resolve_legacy_repository(issue) -> list[RepositoryContext]:
         return []
 
     github = GitHubIntegration(integration)
-    repositories = github.list_repositories()
+    repositories, _ = github.list_repositories()
 
     if not repositories:
         return []

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16057,6 +16057,8 @@ export namespace Schemas {
 
     export interface GitHubReposResponse {
       repositories: GitHubRepo[];
+      /** Whether more repositories are available beyond this page. */
+      has_more: boolean;
     }
 
     export interface Group {
@@ -32323,6 +32325,20 @@ export namespace Schemas {
     repo: string;
     };
 
+    export type EnvironmentsIntegrationsGithubReposRetrieveParams = {
+    /**
+     * Maximum number of repositories to return per request (max 100, matching GitHub's page size).
+     * @minimum 1
+     * @maximum 100
+     */
+    limit?: number;
+    /**
+     * Number of repositories to skip before returning results.
+     * @minimum 0
+     */
+    offset?: number;
+    };
+
     export type EnvironmentsLogsAlertsListParams = {
     /**
      * Number of results to return per page.
@@ -35522,6 +35538,20 @@ export namespace Schemas {
      * @minLength 1
      */
     repo: string;
+    };
+
+    export type IntegrationsGithubReposRetrieveParams = {
+    /**
+     * Maximum number of repositories to return per request (max 100, matching GitHub's page size).
+     * @minimum 1
+     * @maximum 100
+     */
+    limit?: number;
+    /**
+     * Number of repositories to skip before returning results.
+     * @minimum 0
+     */
+    offset?: number;
     };
 
     export type LiveDebuggerBreakpointsListParams = {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -32327,9 +32327,9 @@ export namespace Schemas {
 
     export type EnvironmentsIntegrationsGithubReposRetrieveParams = {
     /**
-     * Maximum number of repositories to return per request (max 100, matching GitHub's page size).
+     * Maximum number of repositories to return per request (max 500).
      * @minimum 1
-     * @maximum 100
+     * @maximum 500
      */
     limit?: number;
     /**
@@ -35542,9 +35542,9 @@ export namespace Schemas {
 
     export type IntegrationsGithubReposRetrieveParams = {
     /**
-     * Maximum number of repositories to return per request (max 100, matching GitHub's page size).
+     * Maximum number of repositories to return per request (max 500).
      * @minimum 1
-     * @maximum 100
+     * @maximum 500
      */
     limit?: number;
     /**


### PR DESCRIPTION
## Problem

Organizations with more than 500 GitHub repositories couldn't see all their repos inthe tasks repository picker. The `github_repos` endpoint fetched all repos server-side (up to a hard cap of 500) before respondin are incomplete for large orgs.

## Changes

**Backend:**
- `list_repositories()` on `GitHubIntegration` now accepts `limit`/`offset` kwargs and returns `tuple[list[dict], bool]`, matching the `list_branches` pattern from #53931. Multi-page GitHub API fetching lives in the model layer.
- `list_all_repositories()` is now a thin wrapper that delegates to `list_repositories(limit=max_repos)`.
- `github_repos` endpoint accepts `limit` (max 500) and `offset` query params, returns `has_more` boolean.

**Frontend:**
- `githubIntegrationLogic` auto-loads pages sequentially in the background via a kea listener chain. Users see repos immediately as each page loads.
- `integrationsLogic` uses the same pattern for `IntegrationView` and Visual Review settings.
- `IntegrationView` shows repo count as soon as the first page arrives instead of waiting for all pages.

## How did you test this code?

- Added backend tests for pagination, `has_more` logic, and limit/offset passthrough (`posthog/api/test/test_integration.py`, `posthog/models/test/test_integration_model.py`)
- Verified TypeScript compiles with no errors in changed files
- Manually tested with a GitHub integration — repos load progressively in the data warehouse picker

## Publish to changelog?

No

## Docs update

No docs changes needed.
