### PR TITLE
chore(data-warehouse): Batch webhook S3 files to reduce delta merging time

### DIFF
--- a/posthog/temporal/data_imports/sources/common/test/test_webhook_s3.py
+++ b/posthog/temporal/data_imports/sources/common/test/test_webhook_s3.py
@@ -529,7 +529,7 @@ class TestWebhookSourceManagerWithMinIO:
         assert len(tables) == 1
         assert tables[0].column_names == ["id"]
 
-    async def test_get_items_processes_multiple_files_in_order(self, minio_client):
+    async def test_get_items_batches_multiple_small_files(self, minio_client):
         team_id = 99
         schema_id = "test-schema-multi"
         prefix = f"source_webhook_producer/{team_id}/{schema_id}"
@@ -544,11 +544,39 @@ class TestWebhookSourceManagerWithMinIO:
         manager = _make_manager(team_id=team_id, schema_id=schema_id)
         tables = [table async for table in manager.get_items()]
 
-        assert len(tables) == 2
-        ids = sorted([t.column("id").to_pylist()[0] for t in tables])  # type: ignore
+        # Small files are batched into a single table
+        assert len(tables) == 1
+        ids = sorted(id for id in tables[0].column("id").to_pylist() if id is not None)
         assert ids == ["a", "b"]
 
         # Both files should be deleted
+        response = await minio_client.list_objects_v2(Bucket=BUCKET_NAME, Prefix=prefix)
+        assert response.get("Contents", []) == []
+
+    async def test_get_items_yields_multiple_batches_when_row_limit_exceeded(self, minio_client):
+        team_id = 99
+        schema_id = "test-schema-batch-limit"
+        prefix = f"source_webhook_producer/{team_id}/{schema_id}"
+
+        await _upload_parquet_to_minio(
+            minio_client, f"{prefix}/batch_a.parquet", [{"id": "a"}], team_id=team_id, schema_id=schema_id
+        )
+        await _upload_parquet_to_minio(
+            minio_client, f"{prefix}/batch_b.parquet", [{"id": "b"}], team_id=team_id, schema_id=schema_id
+        )
+        await _upload_parquet_to_minio(
+            minio_client, f"{prefix}/batch_c.parquet", [{"id": "c"}], team_id=team_id, schema_id=schema_id
+        )
+
+        manager = _make_manager(team_id=team_id, schema_id=schema_id)
+        # Set row limit to 2 so that 3 files (1 row each) produce 2 batches
+        tables = [table async for table in manager.get_items(batch_row_limit=2)]
+
+        assert len(tables) == 2
+        all_ids = sorted([row for t in tables for row in t.column("id").to_pylist() if row is not None])
+        assert all_ids == ["a", "b", "c"]
+
+        # All files should be deleted
         response = await minio_client.list_objects_v2(Bucket=BUCKET_NAME, Prefix=prefix)
         assert response.get("Contents", []) == []
 

--- a/posthog/temporal/data_imports/sources/common/webhook_s3.py
+++ b/posthog/temporal/data_imports/sources/common/webhook_s3.py
@@ -84,11 +84,19 @@ class WebhookSourceManager:
                 return []
 
     async def get_items(
-        self, table_transformer: Optional[Callable[[pa.Table], pa.Table]] = None
+        self,
+        table_transformer: Optional[Callable[[pa.Table], pa.Table]] = None,
+        batch_row_limit: int = 5000,
+        batch_byte_limit: int = 200 * 1024 * 1024,
     ) -> AsyncGenerator[pa.Table]:
         files = await self._list_webhook_parquet_files()
 
         await self._logger.adebug(f"Webhook source reading {len(files)} files")
+
+        batch_tables: list[pa.Table] = []
+        batch_paths: list[str] = []
+        batch_rows = 0
+        batch_bytes = 0
 
         async with aget_s3_client() as s3:
             for file in files:
@@ -110,9 +118,43 @@ class WebhookSourceManager:
                 if table_transformer:
                     table = table_transformer(table)
 
-                yield table
+                batch_tables.append(table)
+                batch_paths.append(path)
+                batch_rows += table.num_rows
+                batch_bytes += table.nbytes
 
-                await s3._rm(path)
+                if batch_rows >= batch_row_limit or batch_bytes >= batch_byte_limit:
+                    merged = pa.concat_tables(batch_tables, promote_options="permissive")
+                    await self._logger.adebug(
+                        "webhook_batch_yield",
+                        file_count=len(batch_paths),
+                        row_count=merged.num_rows,
+                        byte_count=merged.nbytes,
+                    )
+
+                    yield merged
+
+                    for p in batch_paths:
+                        await s3._rm(p)
+                    batch_tables = []
+                    batch_paths = []
+                    batch_rows = 0
+                    batch_bytes = 0
+
+            # Yield any remaining rows
+            if batch_tables:
+                merged = pa.concat_tables(batch_tables, promote_options="permissive")
+                await self._logger.adebug(
+                    "webhook_batch_yield",
+                    file_count=len(batch_paths),
+                    row_count=merged.num_rows,
+                    byte_count=merged.nbytes,
+                )
+
+                yield merged
+
+                for p in batch_paths:
+                    await s3._rm(p)
 
     async def _validate_webhook_table(self, table: pa.Table) -> pa.Table:
         expected_team_id = self._inputs.team_id


### PR DESCRIPTION
## Problem
- When a stripe table is set to a long sync cycle (e.g. every 6 hours), it means we end up with a lot of small files in S3, containing only a few rows at a time. When we process these files, we're yielding each file individually to the pipeline, meaning we could be running the same deltalake merge operation over multiple yields, causing the pipeline to take quite a long time to pull in the stripe data

## Changes
- Batch the data when reading from S3 (within limits)

## How did you test this code?
Added a unit test

## Publish to changelog?
No

## Docs update
No