### PR TITLE
fix(ws): build HogQL schema from Delta table to cover all batch columns in v3 load

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/hogql_schema.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/hogql_schema.py
@@ -23,6 +23,42 @@ class HogQLSchema:
         for field in table.schema:
             self.add_field(field, table.column(field.name))
 
+    def add_pyarrow_schema(self, schema: pa.Schema) -> None:
+        """Register fields from a PyArrow schema without column data.
+
+        Unlike add_pyarrow_table, this cannot inspect values to distinguish
+        StringJSONDatabaseField from StringDatabaseField.  Call this before
+        add_pyarrow_table so the data-informed pass can upgrade string types.
+        """
+        for field in schema:
+            existing_type = self.schema.get(field.name)
+            if existing_type is not None and existing_type != StringDatabaseField.__name__:
+                continue
+
+            if pa.types.is_binary(field.type):
+                continue
+
+            hogql_type: type[DatabaseField] = DatabaseField
+
+            if pa.types.is_time(field.type):
+                hogql_type = DateTimeDatabaseField
+            elif pa.types.is_timestamp(field.type):
+                hogql_type = DateTimeDatabaseField
+            elif pa.types.is_date(field.type):
+                hogql_type = DateDatabaseField
+            elif pa.types.is_decimal(field.type):
+                hogql_type = FloatDatabaseField
+            elif pa.types.is_floating(field.type):
+                hogql_type = FloatDatabaseField
+            elif pa.types.is_boolean(field.type):
+                hogql_type = BooleanDatabaseField
+            elif pa.types.is_integer(field.type):
+                hogql_type = IntegerDatabaseField
+            elif pa.types.is_string(field.type):
+                hogql_type = StringDatabaseField
+
+            self.schema[field.name] = hogql_type.__name__
+
     def add_field(self, field: pa.Field, column: pa.ChunkedArray) -> None:
         existing_type = self.schema.get(field.name)
         if existing_type is not None and existing_type != StringDatabaseField.__name__:

--- a/posthog/temporal/data_imports/pipelines/pipeline/hogql_schema.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/hogql_schema.py
@@ -38,26 +38,7 @@ class HogQLSchema:
             if pa.types.is_binary(field.type):
                 continue
 
-            hogql_type: type[DatabaseField] = DatabaseField
-
-            if pa.types.is_time(field.type):
-                hogql_type = DateTimeDatabaseField
-            elif pa.types.is_timestamp(field.type):
-                hogql_type = DateTimeDatabaseField
-            elif pa.types.is_date(field.type):
-                hogql_type = DateDatabaseField
-            elif pa.types.is_decimal(field.type):
-                hogql_type = FloatDatabaseField
-            elif pa.types.is_floating(field.type):
-                hogql_type = FloatDatabaseField
-            elif pa.types.is_boolean(field.type):
-                hogql_type = BooleanDatabaseField
-            elif pa.types.is_integer(field.type):
-                hogql_type = IntegerDatabaseField
-            elif pa.types.is_string(field.type):
-                hogql_type = StringDatabaseField
-
-            self.schema[field.name] = hogql_type.__name__
+            self.schema[field.name] = self._map_arrow_type(field.type).__name__
 
     def add_field(self, field: pa.Field, column: pa.ChunkedArray) -> None:
         existing_type = self.schema.get(field.name)
@@ -67,25 +48,9 @@ class HogQLSchema:
         if pa.types.is_binary(field.type):
             return
 
-        hogql_type: type[DatabaseField] = DatabaseField
+        hogql_type = self._map_arrow_type(field.type)
 
-        if pa.types.is_time(field.type):
-            hogql_type = DateTimeDatabaseField
-        elif pa.types.is_timestamp(field.type):
-            hogql_type = DateTimeDatabaseField
-        elif pa.types.is_date(field.type):
-            hogql_type = DateDatabaseField
-        elif pa.types.is_decimal(field.type):
-            hogql_type = FloatDatabaseField
-        elif pa.types.is_floating(field.type):
-            hogql_type = FloatDatabaseField
-        elif pa.types.is_boolean(field.type):
-            hogql_type = BooleanDatabaseField
-        elif pa.types.is_integer(field.type):
-            hogql_type = IntegerDatabaseField
-        elif pa.types.is_string(field.type):
-            hogql_type = StringDatabaseField
-
+        if hogql_type is StringDatabaseField:
             # Checking for JSON string columns with the first non-null value in the column
             for value in column:
                 value_str = value.as_py()
@@ -96,6 +61,25 @@ class HogQLSchema:
                     break
 
         self.schema[field.name] = hogql_type.__name__
+
+    def _map_arrow_type(self, arrow_type: pa.DataType) -> type[DatabaseField]:
+        if pa.types.is_time(arrow_type):
+            return DateTimeDatabaseField
+        elif pa.types.is_timestamp(arrow_type):
+            return DateTimeDatabaseField
+        elif pa.types.is_date(arrow_type):
+            return DateDatabaseField
+        elif pa.types.is_decimal(arrow_type):
+            return FloatDatabaseField
+        elif pa.types.is_floating(arrow_type):
+            return FloatDatabaseField
+        elif pa.types.is_boolean(arrow_type):
+            return BooleanDatabaseField
+        elif pa.types.is_integer(arrow_type):
+            return IntegerDatabaseField
+        elif pa.types.is_string(arrow_type):
+            return StringDatabaseField
+        return DatabaseField
 
     def to_hogql_types(self) -> dict[str, str]:
         return self.schema

--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_hogql_schema.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_hogql_schema.py
@@ -23,28 +23,22 @@ class TestHogQLSchemaJsonDetection:
 
 
 class TestAddPyarrowSchema:
-    def test_maps_all_arrow_types(self):
-        arrow_schema = pa.schema(
-            [
-                pa.field("str_col", pa.string()),
-                pa.field("int_col", pa.int64()),
-                pa.field("float_col", pa.float64()),
-                pa.field("bool_col", pa.bool_()),
-                pa.field("ts_col", pa.timestamp("us")),
-                pa.field("date_col", pa.date32()),
-                pa.field("decimal_col", pa.decimal128(10, 2)),
-            ]
-        )
+    @parameterized.expand(
+        [
+            ("string", pa.string(), "StringDatabaseField"),
+            ("int64", pa.int64(), "IntegerDatabaseField"),
+            ("float64", pa.float64(), "FloatDatabaseField"),
+            ("bool", pa.bool_(), "BooleanDatabaseField"),
+            ("timestamp_us", pa.timestamp("us"), "DateTimeDatabaseField"),
+            ("date32", pa.date32(), "DateDatabaseField"),
+            ("decimal128", pa.decimal128(10, 2), "FloatDatabaseField"),
+        ]
+    )
+    def test_maps_arrow_type(self, _name: str, arrow_type: pa.DataType, expected: str):
         schema = HogQLSchema()
-        schema.add_pyarrow_schema(arrow_schema)
-
-        assert schema.schema["str_col"] == "StringDatabaseField"
-        assert schema.schema["int_col"] == "IntegerDatabaseField"
-        assert schema.schema["float_col"] == "FloatDatabaseField"
-        assert schema.schema["bool_col"] == "BooleanDatabaseField"
-        assert schema.schema["ts_col"] == "DateTimeDatabaseField"
-        assert schema.schema["date_col"] == "DateDatabaseField"
-        assert schema.schema["decimal_col"] == "FloatDatabaseField"
+        fields: list[pa.Field] = [pa.field("col", arrow_type)]
+        schema.add_pyarrow_schema(pa.schema(fields))
+        assert schema.schema["col"] == expected
 
     def test_skips_binary_fields(self):
         arrow_schema = pa.schema([pa.field("bin_col", pa.binary())])
@@ -75,13 +69,12 @@ class TestAddPyarrowSchema:
         assert schema.schema["col"] == "StringJSONDatabaseField"
 
     def test_covers_columns_missing_from_batch(self):
-        arrow_schema = pa.schema(
-            [
-                pa.field("col_a", pa.string()),
-                pa.field("col_b", pa.int64()),
-                pa.field("col_c", pa.float64()),
-            ]
-        )
+        fields: list[pa.Field] = [
+            pa.field("col_a", pa.string()),
+            pa.field("col_b", pa.int64()),
+            pa.field("col_c", pa.float64()),
+        ]
+        arrow_schema = pa.schema(fields)
         table = pa.table({"col_a": pa.array(["hello"], type=pa.string())})
 
         schema = HogQLSchema()

--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_hogql_schema.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_hogql_schema.py
@@ -22,6 +22,79 @@ class TestHogQLSchemaJsonDetection:
         assert schema.schema["col"] == expected_type
 
 
+class TestAddPyarrowSchema:
+    def test_maps_all_arrow_types(self):
+        arrow_schema = pa.schema(
+            [
+                pa.field("str_col", pa.string()),
+                pa.field("int_col", pa.int64()),
+                pa.field("float_col", pa.float64()),
+                pa.field("bool_col", pa.bool_()),
+                pa.field("ts_col", pa.timestamp("us")),
+                pa.field("date_col", pa.date32()),
+                pa.field("decimal_col", pa.decimal128(10, 2)),
+            ]
+        )
+        schema = HogQLSchema()
+        schema.add_pyarrow_schema(arrow_schema)
+
+        assert schema.schema["str_col"] == "StringDatabaseField"
+        assert schema.schema["int_col"] == "IntegerDatabaseField"
+        assert schema.schema["float_col"] == "FloatDatabaseField"
+        assert schema.schema["bool_col"] == "BooleanDatabaseField"
+        assert schema.schema["ts_col"] == "DateTimeDatabaseField"
+        assert schema.schema["date_col"] == "DateDatabaseField"
+        assert schema.schema["decimal_col"] == "FloatDatabaseField"
+
+    def test_skips_binary_fields(self):
+        arrow_schema = pa.schema([pa.field("bin_col", pa.binary())])
+        schema = HogQLSchema()
+        schema.add_pyarrow_schema(arrow_schema)
+
+        assert "bin_col" not in schema.schema
+
+    def test_does_not_overwrite_non_string_types(self):
+        schema = HogQLSchema()
+        table = pa.table({"col": pa.array([1, 2], type=pa.int64())})
+        schema.add_pyarrow_table(table)
+
+        # Schema from a different batch has the same column as string
+        arrow_schema = pa.schema([pa.field("col", pa.string())])
+        schema.add_pyarrow_schema(arrow_schema)
+
+        assert schema.schema["col"] == "IntegerDatabaseField"
+
+    def test_add_pyarrow_table_upgrades_string_to_json(self):
+        arrow_schema = pa.schema([pa.field("col", pa.string())])
+        schema = HogQLSchema()
+        schema.add_pyarrow_schema(arrow_schema)
+        assert schema.schema["col"] == "StringDatabaseField"
+
+        table = pa.table({"col": pa.array(['{"key": "value"}'], type=pa.string())})
+        schema.add_pyarrow_table(table)
+        assert schema.schema["col"] == "StringJSONDatabaseField"
+
+    def test_covers_columns_missing_from_batch(self):
+        arrow_schema = pa.schema(
+            [
+                pa.field("col_a", pa.string()),
+                pa.field("col_b", pa.int64()),
+                pa.field("col_c", pa.float64()),
+            ]
+        )
+        table = pa.table({"col_a": pa.array(["hello"], type=pa.string())})
+
+        schema = HogQLSchema()
+        schema.add_pyarrow_schema(arrow_schema)
+        schema.add_pyarrow_table(table)
+
+        assert "col_a" in schema.schema
+        assert "col_b" in schema.schema
+        assert "col_c" in schema.schema
+        assert schema.schema["col_b"] == "IntegerDatabaseField"
+        assert schema.schema["col_c"] == "FloatDatabaseField"
+
+
 class TestMergeColumnsJsonPreservation:
     @parameterized.expand(
         [

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -2,7 +2,6 @@ import datetime as dt
 from typing import Any, Literal
 
 import s3fs
-import pyarrow as pa
 import structlog
 import pyarrow.compute as pc
 import posthoganalytics
@@ -192,7 +191,7 @@ def _run_post_load_for_already_processed_batch(export_signal: ExportSignalMessag
 
         pa_table = read_parquet(export_signal.s3_path)
         internal_schema = HogQLSchema()
-        internal_schema.add_pyarrow_schema(pa.schema(delta_table.schema().to_arrow()))
+        internal_schema.add_pyarrow_schema(delta_table.schema().to_arrow())  # type: ignore[arg-type]  # arro3 Schema
         internal_schema.add_pyarrow_table(pa_table)
         table_schema_dict = internal_schema.to_hogql_types()
 
@@ -434,7 +433,7 @@ def process_message(message: Any) -> None:
         internal_schema = HogQLSchema()
         # Build from the Delta table schema first to cover all columns from
         # all batches, then overlay the current batch for JSON detection.
-        internal_schema.add_pyarrow_schema(pa.schema(delta_table.schema().to_arrow()))
+        internal_schema.add_pyarrow_schema(delta_table.schema().to_arrow())  # type: ignore[arg-type]  # arro3 Schema
         internal_schema.add_pyarrow_table(pa_table)
 
         logger.debug(

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -191,6 +191,7 @@ def _run_post_load_for_already_processed_batch(export_signal: ExportSignalMessag
 
         pa_table = read_parquet(export_signal.s3_path)
         internal_schema = HogQLSchema()
+        internal_schema.add_pyarrow_schema(delta_table.schema().to_arrow())
         internal_schema.add_pyarrow_table(pa_table)
         table_schema_dict = internal_schema.to_hogql_types()
 
@@ -430,6 +431,9 @@ def process_message(message: Any) -> None:
         DELTA_ROWS_WRITTEN_TOTAL.labels(team_id=team_id_str, schema_id=schema_id_str).inc(pa_table.num_rows)
 
         internal_schema = HogQLSchema()
+        # Build from the Delta table schema first to cover all columns from
+        # all batches, then overlay the current batch for JSON detection.
+        internal_schema.add_pyarrow_schema(delta_table.schema().to_arrow())
         internal_schema.add_pyarrow_table(pa_table)
 
         logger.debug(

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -2,6 +2,7 @@ import datetime as dt
 from typing import Any, Literal
 
 import s3fs
+import pyarrow as pa
 import structlog
 import pyarrow.compute as pc
 import posthoganalytics
@@ -191,7 +192,7 @@ def _run_post_load_for_already_processed_batch(export_signal: ExportSignalMessag
 
         pa_table = read_parquet(export_signal.s3_path)
         internal_schema = HogQLSchema()
-        internal_schema.add_pyarrow_schema(delta_table.schema().to_arrow())
+        internal_schema.add_pyarrow_schema(pa.schema(delta_table.schema().to_arrow()))
         internal_schema.add_pyarrow_table(pa_table)
         table_schema_dict = internal_schema.to_hogql_types()
 
@@ -433,7 +434,7 @@ def process_message(message: Any) -> None:
         internal_schema = HogQLSchema()
         # Build from the Delta table schema first to cover all columns from
         # all batches, then overlay the current batch for JSON detection.
-        internal_schema.add_pyarrow_schema(delta_table.schema().to_arrow())
+        internal_schema.add_pyarrow_schema(pa.schema(delta_table.schema().to_arrow()))
         internal_schema.add_pyarrow_table(pa_table)
 
         logger.debug(

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -2,6 +2,7 @@ import datetime as dt
 from typing import Any, Literal
 
 import s3fs
+import pyarrow as pa
 import structlog
 import pyarrow.compute as pc
 import posthoganalytics
@@ -191,7 +192,7 @@ def _run_post_load_for_already_processed_batch(export_signal: ExportSignalMessag
 
         pa_table = read_parquet(export_signal.s3_path)
         internal_schema = HogQLSchema()
-        internal_schema.add_pyarrow_schema(delta_table.schema().to_arrow())
+        internal_schema.add_pyarrow_schema(pa.schema(delta_table.schema().to_arrow()))
         internal_schema.add_pyarrow_table(pa_table)
         table_schema_dict = internal_schema.to_hogql_types()
 
@@ -433,7 +434,7 @@ def process_message(message: Any) -> None:
         internal_schema = HogQLSchema()
         # Build from the Delta table schema first to cover all columns from
         # all batches, then overlay the current batch for JSON detection.
-        internal_schema.add_pyarrow_schema(delta_table.schema().to_arrow())  # type: ignore[arg-type]  # arro3 Schema
+        internal_schema.add_pyarrow_schema(pa.schema(delta_table.schema().to_arrow()))  # type: ignore[arg-type]  # arro3 Schema implements the Arrow C Data Interface
         internal_schema.add_pyarrow_table(pa_table)
 
         logger.debug(

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -191,7 +191,7 @@ def _run_post_load_for_already_processed_batch(export_signal: ExportSignalMessag
 
         pa_table = read_parquet(export_signal.s3_path)
         internal_schema = HogQLSchema()
-        internal_schema.add_pyarrow_schema(delta_table.schema().to_arrow())  # type: ignore[arg-type]  # arro3 Schema
+        internal_schema.add_pyarrow_schema(delta_table.schema().to_arrow())
         internal_schema.add_pyarrow_table(pa_table)
         table_schema_dict = internal_schema.to_hogql_types()
 


### PR DESCRIPTION
## Problem

In pipeline v3's load consumer, the HogQL schema is built from only the final batch's PyArrow table. When columns vary across batches (common with sources like Facebook Ads where different API pages return different columns), columns from earlier batches exist in S3 but are missing from the schema dict.

This causes `merge_columns` to fire `capture_exception("HogQL type not found for column: ...")` and silently drop those columns from the table metadata, making them invisible to HogQL queries even though the data is in S3.

The non-v3 pipeline avoids this by accumulating a single `HogQLSchema` across all batches in memory. The v3 pipeline can't do this but the Delta table's merged schema is the durable equivalent.

## Changes

  - Added `HogQLSchema.add_pyarrow_schema()` — maps Arrow field types to HogQL types without needing column data. Called **before** `add_pyarrow_table` so the data-informed pass can still upgrade
  `StringDatabaseField` → `StringJSONDatabaseField` where actual JSON data is detected.
  - Updated `process_message()` and `_run_post_load_for_already_processed_batch()` in the v3 load processor to build the schema from the Delta table's schema first, then overlay the current batch.
  - Internal columns (`_ph_partition_key`, `_dlt_id`, etc.) are intentionally included — matching the non-v3 pipeline behavior. Downstream `hogql_definition()` already strips them.

## How did you test this code?

Local run
Test pass

## Publish to changelog?

NO

## 🤖 LLM context

Co-authored by Claude Code. The root cause was identified by tracing the `HogQL type not found for column` error path through `merge_columns` → `validate_schema_and_update_table` → `process_message`, comparing how v3 (single-batch schema) differs from the non-v3 pipeline (accumulated schema).
