### PR TITLE
fix: Opt-out of proxy in workflows batch export

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
@@ -138,7 +138,6 @@ class WorkflowsConsumer(Consumer):
 
         self.url = urllib.parse.urljoin(url, path)
         self.session = session
-        self.internal_api_secret = settings.INTERNAL_API_SECRET
         self.request_task_group = request_task_group
         self._requests_semaphore = asyncio.Semaphore(max_concurrent_requests)
 
@@ -157,10 +156,6 @@ class WorkflowsConsumer(Consumer):
                 self.url,
                 # Data is already JSON encoded, so we can't use json=data.
                 data=b'{"clickhouse_event":' + data + b"}",
-                headers={
-                    "Content-Type": "application/json",
-                    "X-Internal-Api-Secret": self.internal_api_secret,
-                },
             ) as response:
                 try:
                     response.raise_for_status()
@@ -252,9 +247,13 @@ async def insert_into_workflows_activity_from_stage(inputs: WorkflowsInsertInput
         tg = asyncio.TaskGroup()
         async with aiohttp.ClientSession(
             # The batch exports API resolves to a local address which our proxy blocks,
-            # so we disable it.
+            # so we have to disable it by not reading the environment configuration.
             trust_env=False,  # nosemgrep: aiohttp-missing-trust-env
             connector=aiohttp.TCPConnector(limit=settings.BATCH_EXPORT_WORKFLOWS_MAX_CONCURRENT_REQUESTS),
+            headers={
+                "Content-Type": "application/json",
+                "X-Internal-Api-Secret": settings.INTERNAL_API_SECRET,
+            },
         ) as session:
             consumer = WorkflowsConsumer(
                 inputs.url,

--- a/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
@@ -245,10 +245,10 @@ async def insert_into_workflows_activity_from_stage(inputs: WorkflowsInsertInput
         # the consumer are not raised in the TaskGroup context.
         # TODO: The consumer should be refactored.
         tg = asyncio.TaskGroup()
+        # The batch exports API resolves to a local address which our proxy blocks,
+        # so we have to disable it by not reading the environment configuration.
+        # nosemgrep: aiohttp-missing-trust-env
         async with aiohttp.ClientSession(
-            # The batch exports API resolves to a local address which our proxy blocks,
-            # so we have to disable it by not reading the environment configuration.
-            # nosemgrep: aiohttp-missing-trust-env
             trust_env=False,
             connector=aiohttp.TCPConnector(limit=settings.BATCH_EXPORT_WORKFLOWS_MAX_CONCURRENT_REQUESTS),
             headers={

--- a/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
@@ -251,7 +251,9 @@ async def insert_into_workflows_activity_from_stage(inputs: WorkflowsInsertInput
         # TODO: The consumer should be refactored.
         tg = asyncio.TaskGroup()
         async with aiohttp.ClientSession(
-            trust_env=True,
+            # The batch exports API resolves to a local address which our proxy blocks,
+            # so we disable it.
+            trust_env=False,  # nosemgrep: aiohttp-missing-trust-env
             connector=aiohttp.TCPConnector(limit=settings.BATCH_EXPORT_WORKFLOWS_MAX_CONCURRENT_REQUESTS),
         ) as session:
             consumer = WorkflowsConsumer(

--- a/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
@@ -154,8 +154,12 @@ class WorkflowsConsumer(Consumer):
         async with self._requests_semaphore:
             async with self.session.post(
                 self.url,
-                # Data is already JSON encoded, so we can't use json=data.
+                # Data is already JSON encoded, so we can't use json=data and must set
+                # the header ourselves.
                 data=b'{"clickhouse_event":' + data + b"}",
+                headers={
+                    "Content-Type": "application/json",
+                },
             ) as response:
                 try:
                     response.raise_for_status()
@@ -252,7 +256,6 @@ async def insert_into_workflows_activity_from_stage(inputs: WorkflowsInsertInput
             trust_env=False,
             connector=aiohttp.TCPConnector(limit=settings.BATCH_EXPORT_WORKFLOWS_MAX_CONCURRENT_REQUESTS),
             headers={
-                "Content-Type": "application/json",
                 "X-Internal-Api-Secret": settings.INTERNAL_API_SECRET,
             },
         ) as session:

--- a/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
@@ -248,7 +248,8 @@ async def insert_into_workflows_activity_from_stage(inputs: WorkflowsInsertInput
         async with aiohttp.ClientSession(
             # The batch exports API resolves to a local address which our proxy blocks,
             # so we have to disable it by not reading the environment configuration.
-            trust_env=False,  # nosemgrep: aiohttp-missing-trust-env
+            # nosemgrep: aiohttp-missing-trust-env
+            trust_env=False,
             connector=aiohttp.TCPConnector(limit=settings.BATCH_EXPORT_WORKFLOWS_MAX_CONCURRENT_REQUESTS),
             headers={
                 "Content-Type": "application/json",


### PR DESCRIPTION
## Problem

Our workflows batch export talks to an internal API that is blocked by default by the HTTP proxy.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Allow access to the internal API by disabling the proxy.

Also, I've taken the liberty of moving the `X-Internal-Api-Secret` header outside of the consumer. Since it is always the same, we can set it once in the session rather than on every request. This means the consumer doesn't need to keep the api secret as part of its state.

In contrast, I've kept the `content-type` header in the consumer. The `post` function has better context of why this is set, so it should be there.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually ran it in development environment. Without this change, we are blocked by the proxy.

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

Nope

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

Nein

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
