### PR TITLE
fix(llma): reorder OTel provider matching to prevent classification shadowing

### DIFF
--- a/rust/capture/src/otel/mod.rs
+++ b/rust/capture/src/otel/mod.rs
@@ -125,6 +125,7 @@ pub async fn otel_handler(
     let raw_span_count = count_spans(&request);
 
     if raw_span_count == 0 {
+        counter!("capture_ai_otel_requests_success").increment(1);
         return Ok(Json(json!({})));
     }
 
@@ -156,6 +157,7 @@ pub async fn otel_handler(
     }
 
     if span_count == 0 {
+        counter!("capture_ai_otel_requests_success").increment(1);
         return Ok(Json(json!({})));
     }
     if span_count > MAX_SPANS_PER_REQUEST {

--- a/rust/capture/src/otel/providers.rs
+++ b/rust/capture/src/otel/providers.rs
@@ -74,9 +74,20 @@ const PYDANTIC_AI: SupportedProvider = SupportedProvider {
     classify: |_| "$ai_span",
 };
 
-/// The complete list of supported AI providers. To add a new provider: define
-/// a constant above and add it here.
-const SUPPORTED_PROVIDERS: &[SupportedProvider] = &[GEN_AI, VERCEL_AI, TRACELOOP, PYDANTIC_AI];
+/// Providers are matched in order — first prefix match wins. More specific
+/// matchers must come before less specific ones to avoid shadowing. For example,
+/// Vercel AI spans carry both `ai.*` and `gen_ai.*` attributes; if GEN_AI were
+/// checked first it would match on `gen_ai.*` but fail to classify (Vercel AI
+/// doesn't set `gen_ai.operation.name`), shadowing the VERCEL_AI classifier.
+const SUPPORTED_PROVIDERS: &[SupportedProvider] = &[
+    // 1. Framework-specific — dedicated SDKs with their own attribute namespaces
+    VERCEL_AI,
+    PYDANTIC_AI,
+    // 2. Spec variations — alternative telemetry standards with distinct classification keys
+    TRACELOOP,
+    // 3. Generic catch-all — standard OpenTelemetry semantic conventions (gen_ai.*)
+    GEN_AI,
+];
 
 /// Returns the matching provider for raw protobuf attributes, based on prefix
 /// matching. Used as a lightweight pre-filter to avoid converting irrelevant
@@ -168,7 +179,9 @@ mod tests {
     }
 
     #[test]
-    fn test_gen_ai_operation_name_takes_precedence() {
+    fn test_vercel_ai_takes_precedence_over_gen_ai() {
+        // Vercel AI spans carry both ai.* and gen_ai.* attributes. The
+        // SDK-specific VERCEL_AI provider should match first.
         let mut attrs = serde_json::Map::new();
         attrs.insert(
             "gen_ai.operation.name".to_string(),
@@ -177,6 +190,23 @@ mod tests {
         attrs.insert(
             "ai.operationId".to_string(),
             Value::String("ai.toolCall".to_string()),
+        );
+        assert_eq!(get_event_name(&attrs), Some("$ai_span"));
+    }
+
+    #[test]
+    fn test_vercel_ai_do_generate_with_gen_ai_attrs() {
+        // Real-world scenario: Vercel AI .doGenerate spans carry gen_ai.*
+        // attributes (e.g. gen_ai.request.model) but not gen_ai.operation.name.
+        // VERCEL_AI must match first and classify via ai.operationId.
+        let mut attrs = serde_json::Map::new();
+        attrs.insert(
+            "gen_ai.request.model".to_string(),
+            Value::String("gpt-4".to_string()),
+        );
+        attrs.insert(
+            "ai.operationId".to_string(),
+            Value::String("ai.generateText.doGenerate".to_string()),
         );
         assert_eq!(get_event_name(&attrs), Some("$ai_generation"));
     }


### PR DESCRIPTION
## Problem

PR #52696 introduced provider-based span filtering for the OTel ingestion pipeline. The filtering works correctly (non-AI noise dropped ~98%), but the provider ordering in `SUPPORTED_PROVIDERS` caused `GEN_AI` (the generic OpenTelemetry convention) to shadow SDK-specific classifiers. Vercel AI spans carry both `gen_ai.*` and `ai.*` attributes; `GEN_AI` matched first on prefix but couldn’t classify (Vercel AI SDK doesn’t set `gen_ai.operation.name`), so all Vercel AI generations were misclassified as `$ai_span`.

Confirmed via ClickHouse: ~7,165 events in 6 hours with span names like `ai.generateText.doGenerate` landing as `$ai_span` instead of `$ai_generation`.

Also fixes the `capture_ai_otel_requests_success` counter not being incremented for requests that return 200 but produce zero events after span filtering, making the success rate metric read ~3% instead of ~97%.

## Changes

- Reorder `SUPPORTED_PROVIDERS`: SDK-specific providers first (Vercel AI, Pydantic AI), spec variations (Traceloop), generic catch-all (GEN_AI) last
- Update precedence test to reflect new ordering
- Add test for the exact real-world scenario: span with `gen_ai.request.model` + `ai.operationId = "ai.generateText.doGenerate"`
- Increment success counter on `raw_span_count == 0` and `span_count == 0` early returns

## How did you test this code?

- All 9 provider unit tests pass (including 2 new ones)
- All 11 fan_out unit tests pass
- `cargo clippy -p capture` clean

## Publish to changelog?

no

## Docs update

N/A

## 🤖 LLM context

Bug identified and confirmed via Grafana metrics + ClickHouse queries in a Claude Code session. The classification regression was caused by provider ordering, not a logic error in any individual classifier.