### PR TITLE
fix(funnels): avoid query for incomplete configurations

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -137,7 +137,6 @@ export function InsightVizDisplay({
         hasDetailedResultsTable,
         showLegend,
         hasFormula,
-        funnelsFilter,
         supportsDisplay,
         samplingFactor,
         insightDataLoading,
@@ -149,14 +148,13 @@ export function InsightVizDisplay({
         display,
         series,
         insightData,
-        isFunnelWithEnoughSteps,
-        isFunnelWithIncompleteDataWarehouseStep,
         validationError,
         theme,
     } = useValues(insightVizDataLogic(insightProps))
     const { loadData } = useActions(insightVizDataLogic(insightProps))
     const { exportContext, queryId } = useValues(insightDataLogic(insightProps))
-    const { hasFunnelResults } = useValues(funnelDataLogic(insightProps))
+    const { funnelsFilter, hasFunnelResults, isFunnelWithEnoughSteps, isFunnelWithIncompleteDataWarehouseStep } =
+        useValues(funnelDataLogic(insightProps))
 
     const isFlowViz = funnelsFilter?.funnelVizType === FunnelVizType.Flow
     const actionable = !embedded && editMode
@@ -178,6 +176,7 @@ export function InsightVizDisplay({
         if (display === ChartDisplayType.BoxPlot && (!series?.length || series.some((s) => !s?.math_property))) {
             return <BoxPlotMissingPropertyState />
         }
+
         if (activeView === InsightType.FUNNELS && !isFlowViz) {
             if (isFunnelWithIncompleteDataWarehouseStep) {
                 return <FunnelDataWarehouseStepIncompleteState />

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -136,7 +136,7 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
                 'funnelsFilter',
                 'breakdownFilter',
                 'goalLines',
-                'series',
+                'series as vizSeries',
                 'interval',
                 'insightData',
                 'insightDataError',
@@ -204,7 +204,7 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
         ],
 
         series: [
-            (s) => [s.vizQuerySource, s.series],
+            (s) => [s.vizQuerySource, s.vizSeries],
             (vizQuerySource, series) => (isFunnelsQuery(vizQuerySource) ? (series as FunnelsQuery['series']) : null),
         ],
 

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -203,6 +203,11 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
             (vizQuerySource) => (isFunnelsQuery(vizQuerySource) ? vizQuerySource : null),
         ],
 
+        series: [
+            (s) => [s.vizQuerySource, s.series],
+            (vizQuerySource, series) => (isFunnelsQuery(vizQuerySource) ? (series as FunnelsQuery['series']) : null),
+        ],
+
         isStepsFunnel: [
             (s) => [s.funnelsFilter],
             (funnelsFilter): boolean | null => {

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -15,7 +15,8 @@ import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { getFunnelDatasetKey, getFunnelResultCustomizationColorToken } from 'scenes/insights/utils'
 
 import { Noun, groupsModel } from '~/models/groupsModel'
-import { InsightQueryNode } from '~/queries/schema/schema-general'
+import { seriesNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
+import { FunnelExclusionSteps, InsightQueryNode } from '~/queries/schema/schema-general'
 import { FunnelsFilter, FunnelsQuery, NodeKind } from '~/queries/schema/schema-general'
 import { isFunnelsQuery, isWebOverviewQuery, isWebStatsTableQuery } from '~/queries/utils'
 import {
@@ -36,6 +37,7 @@ import {
     InsightType,
     StepOrderValue,
     TrendResult,
+    FilterType,
 } from '~/types'
 
 import type { funnelDataLogicType } from './funnelDataLogicType'
@@ -49,6 +51,8 @@ import {
     getReferenceStep,
     getVisibilityKey,
     isBreakdownFunnelResults,
+    isFunnelWithEnoughSteps,
+    isFunnelWithIncompleteDataWarehouseStep,
     stepsWithConversionMetrics,
 } from './funnelUtils'
 
@@ -694,6 +698,33 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
                     return false
                 }
             },
+        ],
+
+        // Validations
+        isFunnelWithEnoughSteps: [(s) => [s.series], (series) => isFunnelWithEnoughSteps(series)],
+        isFunnelWithIncompleteDataWarehouseStep: [
+            (s) => [s.series],
+            (series) => isFunnelWithIncompleteDataWarehouseStep(series),
+        ],
+
+        // Exclusion filters
+        exclusionDefaultStepRange: [
+            (s) => [s.querySource],
+            (querySource: FunnelsQuery): FunnelExclusionSteps => ({
+                funnelFromStep: 0,
+                funnelToStep: (querySource.series || []).length > 1 ? querySource.series.length - 1 : 1,
+            }),
+        ],
+        exclusionFilters: [
+            (s) => [s.funnelsFilter],
+            (funnelsFilter): FilterType => ({
+                events: funnelsFilter?.exclusions?.map(({ funnelFromStep, funnelToStep, ...rest }, index) => ({
+                    funnel_from_step: funnelFromStep,
+                    funnel_to_step: funnelToStep,
+                    order: index,
+                    ...seriesNodeToFilter(rest),
+                })),
+            }),
         ],
     })),
 

--- a/frontend/src/scenes/funnels/funnelUtils.test.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.test.ts
@@ -1,6 +1,6 @@
 import { dayjs } from 'lib/dayjs'
 
-import { EventsNode } from '~/queries/schema/schema-general'
+import { EventsNode, FunnelsQuery, NodeKind } from '~/queries/schema/schema-general'
 import {
     FunnelConversionWindowTimeUnit,
     FunnelCorrelation,
@@ -22,6 +22,8 @@ import {
     getReferenceStep,
     getStepBreakdownSeries,
     getVisibilityKey,
+    isFunnelWithEnoughSteps,
+    isFunnelWithIncompleteDataWarehouseStep,
     parseDisplayNameForCorrelation,
     stepsWithConversionMetrics,
 } from './funnelUtils'
@@ -750,5 +752,85 @@ describe('getStepBreakdownSeries', () => {
         },
     ])('$scenario', ({ step, breakdownFilter, expected }) => {
         expect(getStepBreakdownSeries(step as any, breakdownFilter as any)).toBe(expected)
+    })
+})
+
+describe('isFunnelWithEnoughSteps', () => {
+    it.each([
+        { scenario: 'no steps', series: [], expected: false },
+        { scenario: 'one step', series: [{ kind: NodeKind.EventsNode }], expected: false },
+        {
+            scenario: 'two steps',
+            series: [{ kind: NodeKind.EventsNode }, { kind: NodeKind.EventsNode }],
+            expected: true,
+        },
+    ])('returns $expected for $scenario', ({ series, expected }) => {
+        expect(isFunnelWithEnoughSteps(series as FunnelsQuery['series'])).toBe(expected)
+    })
+})
+
+describe('isFunnelWithIncompleteDataWarehouseStep', () => {
+    it.each([
+        {
+            scenario: 'no steps',
+            series: [],
+            expected: false,
+        },
+        {
+            scenario: 'non-funnel data warehouse step',
+            series: [
+                {
+                    kind: NodeKind.DataWarehouseNode,
+                    id: 'warehouse_orders',
+                    name: 'Orders',
+                    table_name: 'warehouse_orders',
+                    timestamp_field: 'created_at',
+                    id_field: 'order_id',
+                    distinct_id_field: 'customer_id',
+                },
+            ],
+            expected: false,
+        },
+        {
+            scenario: 'complete funnel data warehouse step',
+            series: [
+                {
+                    kind: NodeKind.EventsNode,
+                    name: '$pageview',
+                    event: '$pageview',
+                },
+                {
+                    kind: NodeKind.FunnelsDataWarehouseNode,
+                    id: 'warehouse_orders',
+                    name: 'Orders',
+                    table_name: 'warehouse_orders',
+                    timestamp_field: 'created_at',
+                    id_field: 'order_id',
+                    aggregation_target_field: 'customer_id',
+                },
+            ],
+            expected: false,
+        },
+        {
+            scenario: 'missing aggregation target field',
+            series: [
+                {
+                    kind: NodeKind.EventsNode,
+                    name: '$pageview',
+                    event: '$pageview',
+                },
+                {
+                    kind: NodeKind.FunnelsDataWarehouseNode,
+                    id: 'warehouse_orders',
+                    name: 'Orders',
+                    table_name: 'warehouse_orders',
+                    timestamp_field: 'created_at',
+                    id_field: 'order_id',
+                },
+            ],
+            expected: true,
+        },
+    ])('returns $expected for $scenario', ({ series, expected }) => {
+        expect(isFunnelWithIncompleteDataWarehouseStep(series as FunnelsQuery['series'])).toBe(expected)
     })
 })

--- a/frontend/src/scenes/funnels/funnelUtils.tsx
+++ b/frontend/src/scenes/funnels/funnelUtils.tsx
@@ -12,8 +12,15 @@ import { elementsToAction } from 'scenes/activity/explore/createActionFromEvent'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { Noun } from '~/models/groupsModel'
-import { AnyEntityNode, BreakdownFilter, FunnelExclusionSteps, FunnelsFilter } from '~/queries/schema/schema-general'
+import {
+    AnyEntityNode,
+    BreakdownFilter,
+    FunnelExclusionSteps,
+    FunnelsFilter,
+    FunnelsQuery,
+} from '~/queries/schema/schema-general'
 import { integer } from '~/queries/schema/type-utils'
+import { isFunnelsDataWarehouseNode } from '~/queries/utils'
 import {
     AnyPropertyFilter,
     Breakdown,
@@ -676,4 +683,16 @@ export function getStepBreakdownSeries(
     }
 
     return single
+}
+
+export function isFunnelWithEnoughSteps(series: FunnelsQuery['series']): boolean {
+    return (series?.length || 0) > 1
+}
+
+export function isFunnelWithIncompleteDataWarehouseStep(series: FunnelsQuery['series']): boolean {
+    return (series || []).some(
+        (step) =>
+            isFunnelsDataWarehouseNode(step) &&
+            (!step.table_name || !step.id_field || !step.timestamp_field || !step.aggregation_target_field)
+    )
 }

--- a/frontend/src/scenes/funnels/funnelUtils.tsx
+++ b/frontend/src/scenes/funnels/funnelUtils.tsx
@@ -16,6 +16,7 @@ import {
     AnyEntityNode,
     BreakdownFilter,
     FunnelExclusionSteps,
+    FunnelsDataWarehouseNode,
     FunnelsFilter,
     FunnelsQuery,
 } from '~/queries/schema/schema-general'
@@ -251,7 +252,7 @@ export const getBreakdownStepValues = (
 
 export const getClampedFunnelStepRange = (
     stepRange: FunnelExclusionSteps | FunnelsFilter,
-    series: AnyEntityNode[] | null | undefined
+    series: AnyEntityNode<FunnelsDataWarehouseNode>[] | null | undefined
 ): { funnelFromStep?: integer; funnelToStep?: integer } => {
     const maxStepIndex = Math.max((series?.length || 0) - 1, 1)
     const { funnelFromStep, funnelToStep } = stepRange
@@ -685,11 +686,11 @@ export function getStepBreakdownSeries(
     return single
 }
 
-export function isFunnelWithEnoughSteps(series: FunnelsQuery['series']): boolean {
+export function isFunnelWithEnoughSteps(series: FunnelsQuery['series'] | null | undefined): boolean {
     return (series?.length || 0) > 1
 }
 
-export function isFunnelWithIncompleteDataWarehouseStep(series: FunnelsQuery['series']): boolean {
+export function isFunnelWithIncompleteDataWarehouseStep(series: FunnelsQuery['series'] | null | undefined): boolean {
     return (series || []).some(
         (step) =>
             isFunnelsDataWarehouseNode(step) &&

--- a/frontend/src/scenes/insights/filters/FunnelExclusionsFilter/ExclusionRowSuffix.tsx
+++ b/frontend/src/scenes/insights/filters/FunnelExclusionsFilter/ExclusionRowSuffix.tsx
@@ -4,10 +4,10 @@ import { IconFilter, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonSelect } from '@posthog/lemon-ui'
 
 import { IconWithCount } from 'lib/lemon-ui/icons'
+import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { getClampedFunnelStepRange } from 'scenes/funnels/funnelUtils'
 import { entityFilterLogic } from 'scenes/insights/filters/ActionFilter/entityFilterLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
 import { AnyEntityNode, NodeKind } from '~/queries/schema/schema-general'
 
@@ -24,9 +24,9 @@ export function ExclusionRowSuffix({
 }: ExclusionRowSuffixComponentBaseProps): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const { funnelsFilter, series, isFunnelWithEnoughSteps, exclusionDefaultStepRange } = useValues(
-        insightVizDataLogic(insightProps)
+        funnelDataLogic(insightProps)
     )
-    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
 
     // Get the entity filter logic that was created by the parent ActionFilter component
     const mountedLogic = entityFilterLogic.findMounted({ typeKey })

--- a/frontend/src/scenes/insights/filters/FunnelExclusionsFilter/ExclusionRowSuffix.tsx
+++ b/frontend/src/scenes/insights/filters/FunnelExclusionsFilter/ExclusionRowSuffix.tsx
@@ -9,7 +9,7 @@ import { getClampedFunnelStepRange } from 'scenes/funnels/funnelUtils'
 import { entityFilterLogic } from 'scenes/insights/filters/ActionFilter/entityFilterLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
-import { AnyEntityNode, NodeKind } from '~/queries/schema/schema-general'
+import { AnyEntityNode, FunnelsDataWarehouseNode, NodeKind } from '~/queries/schema/schema-general'
 
 type ExclusionRowSuffixComponentBaseProps = {
     index: number
@@ -44,8 +44,8 @@ export function ExclusionRowSuffix({
 
     const onChange = (funnelFromStep = stepRange.funnelFromStep, funnelToStep = stepRange.funnelToStep): void => {
         // Filter out GroupNodes as funnels don't support them
-        const nonGroupSeries: AnyEntityNode[] | null | undefined = series?.filter(
-            (s): s is AnyEntityNode => s.kind !== NodeKind.GroupNode
+        const nonGroupSeries: AnyEntityNode<FunnelsDataWarehouseNode>[] | null | undefined = series?.filter(
+            (s): s is AnyEntityNode<FunnelsDataWarehouseNode> => s.kind !== NodeKind.GroupNode
         )
         const newStepRange = getClampedFunnelStepRange({ funnelFromStep, funnelToStep }, nonGroupSeries)
         const newExclusions = funnelsFilter?.exclusions?.map((exclusion, exclusionIndex) =>

--- a/frontend/src/scenes/insights/filters/FunnelExclusionsFilter/FunnelExclusionsFilter.tsx
+++ b/frontend/src/scenes/insights/filters/FunnelExclusionsFilter/FunnelExclusionsFilter.tsx
@@ -2,10 +2,10 @@ import { useActions, useValues } from 'kea'
 import { useRef } from 'react'
 
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 
 import { legacyEntityToNode } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
@@ -18,9 +18,9 @@ import { ExclusionRowSuffix } from './ExclusionRowSuffix'
 export function FunnelExclusionsFilter(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { exclusionFilters, exclusionDefaultStepRange, isFunnelWithEnoughSteps } = useValues(
-        insightVizDataLogic(insightProps)
+        funnelDataLogic(insightProps)
     )
-    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
 
     const ref = useRef(null)
 

--- a/frontend/src/scenes/insights/insightVizDataLogic.test.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.test.ts
@@ -7,15 +7,7 @@ import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
 import { useMocks } from '~/mocks/jest'
 import { funnelsQueryDefault, trendsQueryDefault } from '~/queries/nodes/InsightQuery/defaults'
-import {
-    ActionsNode,
-    EventsNode,
-    FunnelsQuery,
-    InsightQueryNode,
-    LifecycleQuery,
-    NodeKind,
-    TrendsQuery,
-} from '~/queries/schema/schema-general'
+import { FunnelsQuery, LifecycleQuery, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import {
     BaseMathType,
@@ -636,100 +628,6 @@ describe('insightVizDataLogic', () => {
                         },
                     },
                 })
-        })
-    })
-
-    describe('isFunnelWithEnoughSteps', () => {
-        const queryWithSeries = (series: (ActionsNode | EventsNode)[]): FunnelsQuery => ({
-            kind: NodeKind.FunnelsQuery,
-            series,
-        })
-
-        it('with enough/not enough steps', () => {
-            expectLogic(builtInsightVizDataLogic, () => {
-                builtInsightVizDataLogic.actions.updateQuerySource({
-                    kind: NodeKind.RetentionQuery,
-                } as InsightQueryNode)
-            }).toMatchValues({ isFunnelWithEnoughSteps: false })
-
-            expectLogic(builtInsightVizDataLogic, () => {
-                builtInsightVizDataLogic.actions.updateQuerySource(queryWithSeries([]))
-            }).toMatchValues({ isFunnelWithEnoughSteps: false })
-
-            expectLogic(builtInsightVizDataLogic, () => {
-                builtInsightVizDataLogic.actions.updateQuerySource(
-                    queryWithSeries([{ kind: NodeKind.EventsNode }, { kind: NodeKind.EventsNode }])
-                )
-            }).toMatchValues({ isFunnelWithEnoughSteps: true })
-        })
-    })
-
-    describe('isFunnelWithIncompleteDataWarehouseStep', () => {
-        const queryWithSeries = (series: FunnelsQuery['series']): FunnelsQuery => ({
-            kind: NodeKind.FunnelsQuery,
-            series,
-        })
-
-        it('returns false for non-funnels and complete funnel steps', () => {
-            expectLogic(builtInsightVizDataLogic, () => {
-                builtInsightVizDataLogic.actions.updateQuerySource({
-                    kind: NodeKind.TrendsQuery,
-                    series: [
-                        {
-                            kind: NodeKind.DataWarehouseNode,
-                            id: 'warehouse_orders',
-                            name: 'Orders',
-                            table_name: 'warehouse_orders',
-                            timestamp_field: 'created_at',
-                            id_field: 'order_id',
-                            distinct_id_field: 'customer_id',
-                        },
-                    ],
-                } as TrendsQuery)
-            }).toMatchValues({ isFunnelWithIncompleteDataWarehouseStep: false })
-
-            expectLogic(builtInsightVizDataLogic, () => {
-                builtInsightVizDataLogic.actions.updateQuerySource(
-                    queryWithSeries([
-                        {
-                            kind: NodeKind.EventsNode,
-                            name: '$pageview',
-                            event: '$pageview',
-                        },
-                        {
-                            kind: NodeKind.FunnelsDataWarehouseNode,
-                            id: 'warehouse_orders',
-                            name: 'Orders',
-                            table_name: 'warehouse_orders',
-                            timestamp_field: 'created_at',
-                            id_field: 'order_id',
-                            aggregation_target_field: 'customer_id',
-                        },
-                    ])
-                )
-            }).toMatchValues({ isFunnelWithIncompleteDataWarehouseStep: false })
-        })
-
-        it('returns true when any funnel data warehouse step is missing a required field', () => {
-            expectLogic(builtInsightVizDataLogic, () => {
-                builtInsightVizDataLogic.actions.updateQuerySource(
-                    queryWithSeries([
-                        {
-                            kind: NodeKind.EventsNode,
-                            name: '$pageview',
-                            event: '$pageview',
-                        },
-                        {
-                            kind: NodeKind.FunnelsDataWarehouseNode,
-                            id: 'warehouse_orders',
-                            name: 'Orders',
-                            table_name: 'warehouse_orders',
-                            timestamp_field: 'created_at',
-                            id_field: 'order_id',
-                        } as FunnelsQuery['series'][number],
-                    ])
-                )
-            }).toMatchValues({ isFunnelWithIncompleteDataWarehouseStep: true })
         })
     })
 

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -15,11 +15,7 @@ import { dateMapping, is12HoursOrLess, isLessThan2Days } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { dataThemeLogic } from 'scenes/dataThemeLogic'
-import {
-    getClampedFunnelStepRange,
-    isFunnelWithEnoughSteps,
-    isFunnelWithIncompleteDataWarehouseStep,
-} from 'scenes/funnels/funnelUtils'
+import { getClampedFunnelStepRange } from 'scenes/funnels/funnelUtils'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { AggregationType } from 'scenes/insights/views/InsightsTable/insightsTableDataLogic'
@@ -28,7 +24,6 @@ import { filterTestAccountsDefaultsLogic } from 'scenes/settings/environment/fil
 import { BASE_MATH_DEFINITIONS } from 'scenes/trends/mathsLogic'
 
 import { actionsModel } from '~/models/actionsModel'
-import { seriesNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 import { extractValidationError, getAllEventNames, queryFromKind } from '~/queries/nodes/InsightViz/utils'
 import {
     AnyDataWarehouseNode,
@@ -37,7 +32,6 @@ import {
     CompareFilter,
     DatabaseSchemaField,
     DateRange,
-    FunnelExclusionSteps,
     FunnelsFilter,
     FunnelsQuery,
     GroupNode,
@@ -95,14 +89,7 @@ import {
     nodeKindToFilterProperty,
     supportsPercentStackView,
 } from '~/queries/utils'
-import {
-    BaseMathType,
-    ChartDisplayType,
-    FilterType,
-    InsightLogicProps,
-    LabelGroupType,
-    SlowQueryPossibilities,
-} from '~/types'
+import { BaseMathType, ChartDisplayType, InsightLogicProps, LabelGroupType, SlowQueryPossibilities } from '~/types'
 
 import type { insightVizDataLogicType } from './insightVizDataLogicType'
 
@@ -510,35 +497,6 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         ],
 
         timezone: [(s) => [s.insightData], (insightData) => insightData?.timezone || 'UTC'],
-
-        /*
-         * Funnels
-         */
-        isFunnelWithEnoughSteps: [(s) => [s.series], (series) => isFunnelWithEnoughSteps(series)],
-        isFunnelWithIncompleteDataWarehouseStep: [
-            (s) => [s.series],
-            (series) => isFunnelWithIncompleteDataWarehouseStep(series),
-        ],
-
-        // Exclusion filters
-        exclusionDefaultStepRange: [
-            (s) => [s.querySource],
-            (querySource: FunnelsQuery): FunnelExclusionSteps => ({
-                funnelFromStep: 0,
-                funnelToStep: (querySource.series || []).length > 1 ? querySource.series.length - 1 : 1,
-            }),
-        ],
-        exclusionFilters: [
-            (s) => [s.funnelsFilter],
-            (funnelsFilter): FilterType => ({
-                events: funnelsFilter?.exclusions?.map(({ funnelFromStep, funnelToStep, ...rest }, index) => ({
-                    funnel_from_step: funnelFromStep,
-                    funnel_to_step: funnelToStep,
-                    order: index,
-                    ...seriesNodeToFilter(rest),
-                })),
-            }),
-        ],
 
         // all events used in the insight (useful for fetching only relevant property definitions)
         allEventNames: [

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -15,7 +15,11 @@ import { dateMapping, is12HoursOrLess, isLessThan2Days } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { dataThemeLogic } from 'scenes/dataThemeLogic'
-import { getClampedFunnelStepRange } from 'scenes/funnels/funnelUtils'
+import {
+    getClampedFunnelStepRange,
+    isFunnelWithEnoughSteps,
+    isFunnelWithIncompleteDataWarehouseStep,
+} from 'scenes/funnels/funnelUtils'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { AggregationType } from 'scenes/insights/views/InsightsTable/insightsTableDataLogic'
@@ -75,7 +79,6 @@ import {
     isAnyDataWarehouseNode,
     isDataWarehouseNode,
     isEventsNode,
-    isFunnelsDataWarehouseNode,
     isFunnelsQuery,
     isInsightQueryNode,
     isInsightVizNode,
@@ -511,21 +514,10 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         /*
          * Funnels
          */
-        isFunnelWithEnoughSteps: [
-            (s) => [s.series],
-            (series) => {
-                return (series?.length || 0) > 1
-            },
-        ],
+        isFunnelWithEnoughSteps: [(s) => [s.series], (series) => isFunnelWithEnoughSteps(series)],
         isFunnelWithIncompleteDataWarehouseStep: [
             (s) => [s.series],
-            (series) => {
-                return (series || []).some(
-                    (step) =>
-                        isFunnelsDataWarehouseNode(step) &&
-                        (!step.table_name || !step.id_field || !step.timestamp_field || !step.aggregation_target_field)
-                )
-            },
+            (series) => isFunnelWithIncompleteDataWarehouseStep(series),
         ],
 
         // Exclusion filters

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -32,6 +32,7 @@ import {
     CompareFilter,
     DatabaseSchemaField,
     DateRange,
+    FunnelsDataWarehouseNode,
     FunnelsFilter,
     FunnelsQuery,
     GroupNode,
@@ -43,6 +44,7 @@ import {
     NodeKind,
     ProductAnalyticsInsightQueryNode,
     RetentionQuery,
+    StickinessQuery,
     TrendsFilter,
     TrendsFormulaNode,
     TrendsQuery,
@@ -731,7 +733,7 @@ const handleQuerySourceUpdateSideEffects = (
 ): QuerySourceUpdate => {
     const mergedUpdate = { ...update } as InsightQueryNode
 
-    const maybeChangedSeries = (update as TrendsQuery).series || null
+    const maybeChangedSeries = (update as TrendsQuery | FunnelsQuery | StickinessQuery | LifecycleQuery).series || null
     const maybeChangedActiveUsersMath = maybeChangedSeries ? getActiveUsersMath(maybeChangedSeries) : null
     const kind = (update as Partial<InsightQueryNode>).kind || currentState.kind
     const insightFilter = filterForQuery(currentState as ProductAnalyticsInsightQueryNode) as Partial<InsightFilter>
@@ -777,8 +779,8 @@ const handleQuerySourceUpdateSideEffects = (
             (insightFilter as FunnelsFilter)?.funnelToStep != null)
     ) {
         // Filter out GroupNode types as funnels only use AnyEntityNode
-        const funnelSeries = maybeChangedSeries.filter(
-            (node): node is AnyEntityNode => node.kind !== NodeKind.GroupNode
+        const funnelSeries: AnyEntityNode<FunnelsDataWarehouseNode>[] = maybeChangedSeries.filter(
+            (node): node is AnyEntityNode<FunnelsDataWarehouseNode> => node.kind !== NodeKind.GroupNode
         )
         ;(mergedUpdate as FunnelsQuery).funnelsFilter = {
             ...(insightFilter as FunnelsFilter),

--- a/frontend/src/scenes/insights/utils/queryUtils.test.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.test.ts
@@ -1,5 +1,4 @@
 import { NodeKind } from '~/queries/schema/schema-general'
-import { ChartDisplayType } from '~/types'
 
 import {
     filterVariablesReferencedInQuery,
@@ -163,18 +162,6 @@ describe('validateQuery', () => {
             ],
         }
         expect(validateQuery(funnelQuery)).toBe(false)
-    })
-
-    it('returns false for invalid InsightVizNode source queries', () => {
-        const insightVizQuery = {
-            kind: NodeKind.InsightVizNode,
-            source: {
-                kind: NodeKind.TrendsQuery,
-                trendsFilter: { display: ChartDisplayType.BoxPlot },
-                series: [{ kind: NodeKind.EventsNode, event: '$pageview' }],
-            },
-        }
-        expect(validateQuery(insightVizQuery)).toBe(false)
     })
 
     it('returns false for query with invalid regex property filter', () => {

--- a/frontend/src/scenes/insights/utils/queryUtils.test.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.test.ts
@@ -1,4 +1,5 @@
 import { NodeKind } from '~/queries/schema/schema-general'
+import { ChartDisplayType } from '~/types'
 
 import {
     filterVariablesReferencedInQuery,
@@ -146,6 +147,34 @@ describe('validateQuery', () => {
             ],
         }
         expect(validateQuery(funnelQuery)).toBe(true)
+    })
+
+    it('returns false for funnels with incomplete data warehouse step', () => {
+        const funnelQuery = {
+            kind: NodeKind.FunnelsQuery,
+            series: [
+                {
+                    kind: NodeKind.FunnelsDataWarehouseNode,
+                    table_name: 'events_table',
+                    id_field: 'person_id',
+                    timestamp_field: 'timestamp',
+                },
+                { kind: NodeKind.EventsNode, event: '$signup' },
+            ],
+        }
+        expect(validateQuery(funnelQuery)).toBe(false)
+    })
+
+    it('returns false for invalid InsightVizNode source queries', () => {
+        const insightVizQuery = {
+            kind: NodeKind.InsightVizNode,
+            source: {
+                kind: NodeKind.TrendsQuery,
+                trendsFilter: { display: ChartDisplayType.BoxPlot },
+                series: [{ kind: NodeKind.EventsNode, event: '$pageview' }],
+            },
+        }
+        expect(validateQuery(insightVizQuery)).toBe(false)
     })
 
     it('returns false for query with invalid regex property filter', () => {

--- a/frontend/src/scenes/insights/utils/queryUtils.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.ts
@@ -155,10 +155,6 @@ export const hasInvalidRegexFilter = (obj: unknown): boolean => {
 }
 
 export const validateQuery = (q: DataNode): boolean => {
-    if (isInsightVizNode(q) && isInsightQueryNode(q.source)) {
-        return validateQuery(q.source)
-    }
-
     if (isFunnelsQuery(q)) {
         return isFunnelWithEnoughSteps(q.series) && !isFunnelWithIncompleteDataWarehouseStep(q.series)
     }

--- a/frontend/src/scenes/insights/utils/queryUtils.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.ts
@@ -1,5 +1,6 @@
 import { objectCleanWithEmpty, objectsEqual, removeUndefinedAndNull } from 'lib/utils'
 import { isValidRE2 } from 'lib/utils/regexp'
+import { isFunnelWithEnoughSteps, isFunnelWithIncompleteDataWarehouseStep } from 'scenes/funnels/funnelUtils'
 
 import { Variable } from '~/queries/nodes/DataVisualization/types'
 import { DataNode, HogQLVariable, InsightQueryNode, Node } from '~/queries/schema/schema-general'
@@ -154,9 +155,14 @@ export const hasInvalidRegexFilter = (obj: unknown): boolean => {
 }
 
 export const validateQuery = (q: DataNode): boolean => {
-    if (isFunnelsQuery(q)) {
-        return q.series.length >= 2
+    if (isInsightVizNode(q) && isInsightQueryNode(q.source)) {
+        return validateQuery(q.source)
     }
+
+    if (isFunnelsQuery(q)) {
+        return isFunnelWithEnoughSteps(q.series) && !isFunnelWithIncompleteDataWarehouseStep(q.series)
+    }
+
     if (isTrendsQuery(q) && q.trendsFilter?.display === ChartDisplayType.BoxPlot) {
         return q.series?.length > 0 && q.series.every((s) => !!s?.math_property)
     }

--- a/frontend/src/scenes/insights/views/Funnels/FunnelStepsPicker.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelStepsPicker.tsx
@@ -3,15 +3,15 @@ import { useActions, useValues } from 'kea'
 import { LemonSelect, LemonSelectOption, LemonSelectOptions } from '@posthog/lemon-ui'
 
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
+import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
 import { seriesNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 
 export function FunnelStepsPicker(): JSX.Element | null {
     const { insightProps, editingDisabledReason } = useValues(insightLogic)
-    const { series, isFunnelWithEnoughSteps, funnelsFilter } = useValues(insightVizDataLogic(insightProps))
-    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const { series, isFunnelWithEnoughSteps, funnelsFilter } = useValues(funnelDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(funnelDataLogic(insightProps))
 
     const onChange = (funnelFromStep?: number, funnelToStep?: number): void => {
         updateInsightFilter({ funnelFromStep, funnelToStep })


### PR DESCRIPTION
## Problem

Insights show an empty state for funnels with an incomplete data warehouse configuration. A request to `/query` is still made however.

## Changes

Let's avoid making those request and clean up code a bit:
- extracted `isFunnelWithEnoughSteps` and `isFunnelWithIncompleteDataWarehouseStep` utils
- uses them in `validateQuery` to prevent queries
- moves funnel related selectors to `funnelDataLogic`

## How did you test this code?

- Verified no additional request is made and the empty state shows as expected
- Verified insights still work as expected