### PR TITLE
fix(ci): ensure branch exists before ghcommit-action push

### DIFF
--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -155,6 +155,17 @@ jobs:
                     echo "Closed stale PR #$existing_pr and deleted branch"
                   fi
 
+            - name: Ensure branch exists
+              if: steps.check-changes.outputs.changed == 'true' && github.event_name != 'pull_request'
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+              run: |
+                  if ! gh api repos/${{ github.repository }}/git/ref/heads/chore/update-test-timings 2>/dev/null; then
+                    master_sha=$(gh api repos/${{ github.repository }}/git/ref/heads/master --jq '.object.sha')
+                    gh api repos/${{ github.repository }}/git/refs -f ref=refs/heads/chore/update-test-timings -f sha="$master_sha"
+                    echo "Created branch from master at $master_sha"
+                  fi
+
             # On schedule/dispatch: commit to a branch and create a PR
             - name: Commit via GitHub API (signed)
               if: steps.check-changes.outputs.changed == 'true' && github.event_name != 'pull_request'

--- a/.github/workflows/update-bot-ips.yml
+++ b/.github/workflows/update-bot-ips.yml
@@ -54,6 +54,17 @@ jobs:
                     echo "Closed stale PR #$existing_pr and deleted branch"
                   fi
 
+            - name: Ensure branch exists
+              if: steps.check-changes.outputs.changes == 'true'
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+              run: |
+                  if ! gh api repos/${{ github.repository }}/git/ref/heads/chore/update-bot-ips 2>/dev/null; then
+                    master_sha=$(gh api repos/${{ github.repository }}/git/ref/heads/master --jq '.object.sha')
+                    gh api repos/${{ github.repository }}/git/refs -f ref=refs/heads/chore/update-bot-ips -f sha="$master_sha"
+                    echo "Created branch from master at $master_sha"
+                  fi
+
             - name: Commit via GitHub API (signed)
               if: steps.check-changes.outputs.changes == 'true'
               uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20


### PR DESCRIPTION
## Problem

PR #52220 switched several automated workflows from `peter-evans/create-pull-request` to `planetscale/ghcommit-action` for signed commits. The `create-pull-request` action creates branches implicitly, but `ghcommit-action` only commits to existing branches. The `update-ai-costs` workflow got an "ensure branch exists" step, but `ci-backend-update-test-timing` and `update-bot-ips` were missed — causing "Branch not found" failures on scheduled runs.

## Changes

Add "Ensure branch exists" step (creates the branch from master via GitHub API if missing) to both workflows, matching the pattern already used in `update-ai-costs.yml`.

## How did you test this code?

Agent-authored — not tested manually beyond reading the logs from the [failing run](https://github.com/PostHog/posthog/actions/runs/24347563319). The fix matches the identical pattern already working in `update-ai-costs.yml`.

## Publish to changelog?

no

## 🤖 LLM context

Diagnosed from CI failure logs. The `ghcommit-action` entrypoint was confirmed to have no branch-creation logic.