### PR TITLE
chore: bypass proxy in SignalClient

### DIFF
--- a/rust/cymbal/src/signals.rs
+++ b/rust/cymbal/src/signals.rs
@@ -69,7 +69,10 @@ pub struct SignalClient {
 impl SignalClient {
     pub fn new(config: &Config) -> Self {
         Self {
-            http: reqwest::Client::new(),
+            http: reqwest::Client::builder()
+                .no_proxy()
+                .build()
+                .expect("Failed to build SignalClient HTTP client"),
             base_url: config.signals_api_base_url.clone(),
             secret: config.internal_api_secret.clone(),
         }


### PR DESCRIPTION
## Problem

We want to bypass the egress proxy when using the Signals client, as the base URL is a well-known, trusted one.

## Changes

Build the client using no proxies.

## How did you test this code?

Unit tests.
