### PR TITLE
feat(workflows): Add note explaining schedule triggers lack person/event context

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -340,7 +340,7 @@ export function StepTriggerConfiguration({ node }: { node: Node<TriggerAction> }
             ) : node.data.config.type === 'manual' ? (
                 <StepTriggerConfigurationManual />
             ) : node.data.config.type === 'schedule' ? (
-                <>
+                <div className="flex flex-col gap-2 w-full">
                     <p className="text-xs text-muted mb-0">
                         Schedule triggers run without a person or event. If your workflow needs to target specific
                         users, use a batch trigger instead.
@@ -348,7 +348,7 @@ export function StepTriggerConfiguration({ node }: { node: Node<TriggerAction> }
                     <LemonField.Pure error={validationResult?.errors?.schedule}>
                         <RecurringSchedulePicker />
                     </LemonField.Pure>
-                </>
+                </div>
             ) : node.data.config.type === 'batch' ? (
                 <StepTriggerConfigurationBatch action={node.data} config={node.data.config} />
             ) : node.data.config.type === 'tracking_pixel' ? (

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -340,9 +340,15 @@ export function StepTriggerConfiguration({ node }: { node: Node<TriggerAction> }
             ) : node.data.config.type === 'manual' ? (
                 <StepTriggerConfigurationManual />
             ) : node.data.config.type === 'schedule' ? (
-                <LemonField.Pure error={validationResult?.errors?.schedule}>
-                    <RecurringSchedulePicker />
-                </LemonField.Pure>
+                <>
+                    <p className="text-xs text-muted mb-0">
+                        Schedule triggers run without a person or event. If your workflow needs to target specific
+                        users, use a batch trigger instead.
+                    </p>
+                    <LemonField.Pure error={validationResult?.errors?.schedule}>
+                        <RecurringSchedulePicker />
+                    </LemonField.Pure>
+                </>
             ) : node.data.config.type === 'batch' ? (
                 <StepTriggerConfigurationBatch action={node.data} config={node.data.config} />
             ) : node.data.config.type === 'tracking_pixel' ? (


### PR DESCRIPTION
## Problem

Schedule triggers (added in https://github.com/PostHog/posthog/pull/54115) run without a real person or event - the executor fills in a synthetic `$workflow_scheduled` event and no `person` context. Users setting up a schedule workflow might not realize this and add actions that reference `{{person.properties.email }}` expecting it to work, leading to silently broken workflows.

## Changes

Added a short note below the schedule trigger type dropdown:

> Schedule triggers run without a person or event. If your workflow needs to target specific users, use a batch trigger instead.

Points users who need person context to the batch trigger, which is the right primitive for that use case.

<img width="2230" height="1586" alt="image" src="https://github.com/user-attachments/assets/804f9317-e36f-45b5-936a-45dfd9b029e1" />

## How did you test this code?

Just a manual test of the displayed note on the screenshot

## Publish to changelog?

No
