### PR TITLE
fix: Guard against undefined choices

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -2359,9 +2359,10 @@ export const surveyLogic = kea<surveyLogicType>([
                         ) {
                             return {
                                 ...questionErrors,
-                                choices: question.choices.some((choice) => !choice.trim())
-                                    ? 'Please ensure all choices are non-empty.'
-                                    : undefined,
+                                choices:
+                                    !question.choices?.length || question.choices.some((choice) => !choice.trim())
+                                        ? 'Please ensure all choices are non-empty.'
+                                        : undefined,
                             }
                         }
 


### PR DESCRIPTION
## Problem

Fixes https://us.posthog.com/project/2/error_tracking/019d82e7-ccf2-7ff0-a138-6e9ee77b7150?622c8a9198d8ddb5232ecc5abaa6a9336c1295c11f599ff36ba7a5331a980c2da8aac55e4349365dbb3ee19da0db00b7dda4bdf7ff90a292516c9ca761b7243d&timestamp=2026-04-12%2011%3A23%3A16.546000-07%3A00

Reported in https://posthoghelp.zendesk.com/agent/tickets/55697 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/56447)

It looks like PostHog AI created a single choice question and told the user they could 'add the options later' - looking into this aspect a bit more to see if it's something we can protect against.

## Changes

Add a check on `!question.choices?.length` - although the type shouldn't allow choices to be `undefined`, we have similar guards elsewhere in the file.