### PR TITLE
fix(cdp): Avoid reselect input instability in template selectors

### DIFF
--- a/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
+++ b/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
@@ -52,6 +52,11 @@ export type HogFunctionTemplateListLogicProps = {
     queryParams?: Record<string, string>
 }
 
+// Stable references for default prop values - avoids reselect input stability warnings
+// caused by `?? []` / `?? () => true` creating new references on every selector call.
+const EMPTY_ARRAY: never[] = []
+const ALWAYS_TRUE = (): boolean => true
+
 export const shouldShowHogFunctionTemplate = (
     hogFunctionTemplate: HogFunctionTemplateType,
     user?: UserType | null
@@ -119,8 +124,8 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
                 s.rawTemplates,
                 s.user,
                 s.featureFlags,
-                (_, p: HogFunctionTemplateListLogicProps) => p.manualTemplates ?? [],
-                (_, p: HogFunctionTemplateListLogicProps) => p.subTemplateIds ?? [],
+                (_, p: HogFunctionTemplateListLogicProps) => p.manualTemplates ?? EMPTY_ARRAY,
+                (_, p: HogFunctionTemplateListLogicProps) => p.subTemplateIds ?? EMPTY_ARRAY,
             ],
             (
                 rawTemplates,
@@ -180,7 +185,7 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
                 s.templates,
                 s.templatesFuse,
                 (_, props) => props.hideComingSoonByDefault ?? false,
-                (_, props) => props.customFilterFunction ?? (() => true),
+                (_, props) => props.customFilterFunction ?? ALWAYS_TRUE,
             ],
             (
                 filters,


### PR DESCRIPTION
## Problem

Sometimes on localhost, going through workflows (e.g. opening a hog function step like email action inside a workflow and then clicking "back" to return to the workflow overview) crashed the page with one of two errors bubbling up from PostHog's own `logs.js` console interceptor:

- `TypeError: Do not know how to serialize a BigInt`
- `SecurityError: Failed to read a named property 'toJSON' from 'Window': Blocked a frame with origin "http://localhost:8010" from accessing a cross-origin frame`

Both crashes originated from the same stack: `runInputStabilityCheck` -> `dependenciesChecker` -> `templates` / `filteredTemplates` selectors in `hogFunctionTemplateListLogic`.

Root cause: two input selectors returned a fresh reference on every call when their props were `null`/`undefined`:

```ts
(_, p) => p.manualTemplates ?? [],      // new [] each call
(_, p) => p.subTemplateIds ?? [],       // new [] each call
(_, props) => props.customFilterFunction ?? (() => true),  // new fn each call
```

Reselect's dev-mode stability check detects the instability and fires `console.warn(...)` with the selector inputs. PostHog's `logs.js` has wrapped `console.warn` to ship logs as events and calls `JSON.stringify` on the arguments, which crashes on whatever happens to be in the selector input state tree - BigInts in feature flag payloads, or a cross-origin `Window` reference coming from the email preview iframe.

<img width="1603" height="1012" alt="Screenshot 2026-04-13 at 17 12 51" src="https://github.com/user-attachments/assets/95a64878-d5ef-4feb-9367-6c4a83d22729" />

## Changes

Hoisted the default values to module-level constants so the input selectors return a stable reference when the caller doesn't provide them:

```ts
const EMPTY_ARRAY: never[] = []
const ALWAYS_TRUE = (): boolean => true
```

Three input selectors now reference these constants instead of creating new values inline. No behavioral change - just reference equality across selector calls.

## How did you test this code?

Manually tested clicking around workflows and destinations on localhost and making sure I didn't hit the error again, while without these changes I was hitting it quite regularly.

## Publish to changelog?

No