### PR TITLE
fix(error-tracking): iterate teams individually in issue state backfill

### DIFF
--- a/products/error_tracking/backend/management/commands/backfill_error_tracking_issue_state.py
+++ b/products/error_tracking/backend/management/commands/backfill_error_tracking_issue_state.py
@@ -96,9 +96,12 @@ class Command(BaseCommand):
         else:
             logger.info("backfill_starting", mode="DRY-RUN (use --live-run to produce)")
 
-        queryset = self._build_queryset(team_id=team_id, start_from_team_id=start_from_team_id, end_team_id=end_team_id)
+        team_ids = self._get_team_ids(team_id=team_id, start_from_team_id=start_from_team_id, end_team_id=end_team_id)
+        logger.info("backfill_teams_found", count=len(team_ids))
 
-        total_count = queryset.count()
+        total_count = self._build_queryset(
+            team_id=team_id, start_from_team_id=start_from_team_id, end_team_id=end_team_id
+        ).count()
         logger.info("backfill_total_fingerprints", count=total_count)
 
         if not live_run:
@@ -109,45 +112,60 @@ class Command(BaseCommand):
         produced = 0
         since_last_flush = 0
         start_time = time.monotonic()
-        current_team_id = None
 
-        for fp in queryset.iterator(chunk_size=batch_size):
-            if fp.team_id != current_team_id:
-                current_team_id = fp.team_id
-                logger.info("backfill_processing_team", team_id=current_team_id, produced_so_far=produced)
+        for current_team_id in team_ids:
+            team_qs = self._build_queryset(team_id=current_team_id).iterator(chunk_size=batch_size)
+            logger.info("backfill_processing_team", team_id=current_team_id, produced_so_far=produced)
 
-            data = self._build_row(fp)
-            producer.produce(
-                sql=INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE,
-                topic=KAFKA_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE,
-                data=data,
-            )
-
-            produced += 1
-            since_last_flush += 1
-
-            if since_last_flush >= batch_size:
-                if producer.producer is not None:
-                    producer.producer.flush()
-                since_last_flush = 0
-                elapsed = time.monotonic() - start_time
-                rate = produced / elapsed if elapsed > 0 else 0
-                logger.info(
-                    "backfill_progress",
-                    produced=produced,
-                    total=total_count,
-                    percent=round(produced / total_count * 100, 1) if total_count > 0 else 0,
-                    rate=round(rate),
-                    elapsed_s=round(elapsed),
+            for fp in team_qs:
+                data = self._build_row(fp)
+                producer.produce(
+                    sql=INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE,
+                    topic=KAFKA_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE,
+                    data=data,
                 )
+
+                produced += 1
+                since_last_flush += 1
+
+                if since_last_flush >= batch_size:
+                    if producer.producer is not None:
+                        producer.producer.flush()
+                    since_last_flush = 0
+                    elapsed = time.monotonic() - start_time
+                    rate = produced / elapsed if elapsed > 0 else 0
+                    logger.info(
+                        "backfill_progress",
+                        produced=produced,
+                        total=total_count,
+                        percent=round(produced / total_count * 100, 1) if total_count > 0 else 0,
+                        rate=round(rate),
+                        elapsed_s=round(elapsed),
+                    )
 
         if producer.producer is not None:
             producer.producer.flush()
         elapsed = time.monotonic() - start_time
         logger.info("backfill_complete", produced=produced, elapsed_s=round(elapsed))
 
-    def _build_queryset(self, *, team_id: int | None, start_from_team_id: int | None, end_team_id: int | None):
-        qs = ErrorTrackingIssueFingerprintV2.objects.select_related("issue", "issue__assignment").order_by("team_id")
+    def _get_team_ids(
+        self, *, team_id: int | None, start_from_team_id: int | None, end_team_id: int | None
+    ) -> list[int]:
+        if team_id is not None:
+            return [team_id]
+
+        qs = ErrorTrackingIssueFingerprintV2.objects.all()
+        if start_from_team_id is not None:
+            qs = qs.filter(team_id__gte=start_from_team_id)
+        if end_team_id is not None:
+            qs = qs.filter(team_id__lte=end_team_id)
+
+        return list(qs.values_list("team_id", flat=True).distinct().order_by("team_id"))
+
+    def _build_queryset(
+        self, *, team_id: int | None = None, start_from_team_id: int | None = None, end_team_id: int | None = None
+    ):
+        qs = ErrorTrackingIssueFingerprintV2.objects.select_related("issue", "issue__assignment")
 
         if team_id is not None:
             qs = qs.filter(team_id=team_id)


### PR DESCRIPTION
Backfill was stuck on multi-team runs because the single query with JOINs across 30M+ rows.

Now fetches distinct team IDs first, then processes each team independently - each per-team query is fast