### PR TITLE
feat(batch-exports): fail Workflows batch export runs early if high error rate

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
@@ -37,7 +37,11 @@ from products.batch_exports.backend.temporal.utils import (
 LOGGER = get_write_only_logger(__name__)
 EXTERNAL_LOGGER = get_logger("EXTERNAL")
 
-NON_RETRYABLE_ERROR_TYPES: list[str] = ["NotFoundErrorGroup", "BadRequestErrorGroup"]
+NON_RETRYABLE_ERROR_TYPES: list[str] = [
+    "NotFoundErrorGroup",
+    "BadRequestErrorGroup",
+    "HogFunctionErrorThresholdExceeded",
+]
 HOG_FUNCTION_API_PATH = "/api/projects/{team_id}/hog_functions/{hog_function_id}/batch_export_invocations"
 
 
@@ -107,6 +111,20 @@ class NotFoundErrorGroup(ClientResponseErrorGroup):
         return NotFoundErrorGroup(self.message, excs)
 
 
+class HogFunctionErrorThresholdExceeded(Exception):
+    """Raised when too many Hog function executions fail with status=error."""
+
+    def __init__(self, failed_count: int, total_count: int, latest_error: str | None = None):
+        self.failed_count = failed_count
+        self.total_count = total_count
+        self.latest_error = latest_error
+
+        message = f"Hog function error rate above threshold: {failed_count}/{total_count} executions failed."
+        if latest_error:
+            message += f" Latest error message: '{latest_error}'"
+        super().__init__(message)
+
+
 def _make_exception(
     exc: type[aiohttp.ClientResponseError], err: aiohttp.ClientResponseError
 ) -> aiohttp.ClientResponseError:
@@ -127,6 +145,8 @@ class WorkflowsConsumer(Consumer):
         request_task_group: asyncio.TaskGroup,
         model: str = "events",
         max_concurrent_requests: int = 1_000,
+        hog_function_error_threshold_pct: float = 0.5,
+        hog_function_error_threshold_min_requests: int = 100,
     ):
         super().__init__(model=model)
 
@@ -140,6 +160,12 @@ class WorkflowsConsumer(Consumer):
         self.session = session
         self.request_task_group = request_task_group
         self._requests_semaphore = asyncio.Semaphore(max_concurrent_requests)
+        # Abort once failure ratio crosses `pct`, but only after `min_requests` requests.
+        self.hog_function_error_threshold_pct = hog_function_error_threshold_pct
+        self.hog_function_error_threshold_min_requests = hog_function_error_threshold_min_requests
+        self.total_requests_count = 0
+        # Most recent hog function error message, used for error reporting.
+        self.latest_hog_function_error: str | None = None
 
     async def consume_chunk(self, data: bytes) -> None:
         post = make_retryable_with_exponential_backoff(
@@ -180,12 +206,26 @@ class WorkflowsConsumer(Consumer):
                             raise _make_exception(InternalServerError, err)
                 else:
                     response_body = await response.json()
+                    self.total_requests_count += 1
                     if response_body.get("status") == "error":
-                        self.logger.warning(
-                            "Hog function execution failed",
-                            errors=response_body.get("errors", []),
-                        )
+                        errors = response_body.get("errors", [])
+                        self.logger.warning("Hog function execution failed", errors=errors)
                         self.records_failed_count += 1
+                        if errors:
+                            self.latest_hog_function_error = errors[-1]
+
+                        if (
+                            self.total_requests_count >= self.hog_function_error_threshold_min_requests
+                            and self.records_failed_count / self.total_requests_count
+                            >= self.hog_function_error_threshold_pct
+                        ):
+                            exc = HogFunctionErrorThresholdExceeded(
+                                failed_count=self.records_failed_count,
+                                total_count=self.total_requests_count,
+                                latest_error=self.latest_hog_function_error,
+                            )
+                            self.external_logger.error(str(exc))
+                            raise exc
 
     async def finalize_file(self):
         """Required by consumer interface."""
@@ -290,6 +330,12 @@ async def insert_into_workflows_activity_from_stage(inputs: WorkflowsInsertInput
                 raise BadRequestErrorGroup(exc_group.message, exc_group.exceptions) from exc_group  # type: ignore[arg-type]
             except* NotFound as exc_group:
                 raise NotFoundErrorGroup(exc_group.message, exc_group.exceptions) from exc_group  # type: ignore[arg-type]
+            except* HogFunctionErrorThresholdExceeded as exc_group:
+                raise HogFunctionErrorThresholdExceeded(
+                    failed_count=consumer.records_failed_count,
+                    total_count=consumer.total_requests_count,
+                    latest_error=consumer.latest_hog_function_error,
+                ) from exc_group
 
         return consumer.collect_result()
 

--- a/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
@@ -112,14 +112,14 @@ class NotFoundErrorGroup(ClientResponseErrorGroup):
 
 
 class HogFunctionErrorThresholdExceeded(Exception):
-    """Raised when too many Hog function executions fail with status=error."""
+    """Raised when too many Hog Function executions fail with status=error."""
 
     def __init__(self, failed_count: int, total_count: int, latest_error: str | None = None):
         self.failed_count = failed_count
         self.total_count = total_count
         self.latest_error = latest_error
 
-        message = f"Hog function error rate above threshold: {failed_count}/{total_count} executions failed."
+        message = f"Hog Function error rate above threshold: {failed_count}/{total_count} executions failed."
         if latest_error:
             message += f" Latest error message: '{latest_error}'"
         super().__init__(message)
@@ -136,6 +136,21 @@ def _make_exception(
 
 
 class WorkflowsConsumer(Consumer):
+    """Consumer that posts each record as a Hog Function invocation to the CDP API.
+
+    One HTTP POST request per record is issued concurrently via `request_task_group`, up
+    to `max_concurrent_requests` in flight at a time.
+
+    A 2xx response with a `{"status": "error", ...}` body is treated as a Hog Function
+    execution error (the CDP call succeeded but the function itself failed).
+
+    If the ratio of such execution errors to total handled records exceeds
+    `hog_function_error_threshold_pct` — once at least
+    `hog_function_error_threshold_min_records` records have been handled —
+    the consumer aborts the run by raising a non-retryable
+    `HogFunctionErrorThresholdExceeded` exception.
+    """
+
     def __init__(
         self,
         url: str,
@@ -146,7 +161,7 @@ class WorkflowsConsumer(Consumer):
         model: str = "events",
         max_concurrent_requests: int = 1_000,
         hog_function_error_threshold_pct: float = 0.5,
-        hog_function_error_threshold_min_requests: int = 100,
+        hog_function_error_threshold_min_records: int = 100,
     ):
         super().__init__(model=model)
 
@@ -160,11 +175,9 @@ class WorkflowsConsumer(Consumer):
         self.session = session
         self.request_task_group = request_task_group
         self._requests_semaphore = asyncio.Semaphore(max_concurrent_requests)
-        # Abort once failure ratio crosses `pct`, but only after `min_requests` requests.
         self.hog_function_error_threshold_pct = hog_function_error_threshold_pct
-        self.hog_function_error_threshold_min_requests = hog_function_error_threshold_min_requests
-        self.total_requests_count = 0
-        # Most recent hog function error message, used for error reporting.
+        self.hog_function_error_threshold_min_records = hog_function_error_threshold_min_records
+        self.records_handled_count = 0
         self.latest_hog_function_error: str | None = None
 
     async def consume_chunk(self, data: bytes) -> None:
@@ -206,26 +219,24 @@ class WorkflowsConsumer(Consumer):
                             raise _make_exception(InternalServerError, err)
                 else:
                     response_body = await response.json()
-                    self.total_requests_count += 1
+                    self.records_handled_count += 1
                     if response_body.get("status") == "error":
                         errors = response_body.get("errors", [])
-                        self.logger.warning("Hog function execution failed", errors=errors)
+                        self.logger.warning("Hog Function execution failed", errors=errors)
                         self.records_failed_count += 1
                         if errors:
                             self.latest_hog_function_error = errors[-1]
 
                         if (
-                            self.total_requests_count >= self.hog_function_error_threshold_min_requests
-                            and self.records_failed_count / self.total_requests_count
+                            self.records_handled_count >= self.hog_function_error_threshold_min_records
+                            and self.records_failed_count / self.records_handled_count
                             >= self.hog_function_error_threshold_pct
                         ):
-                            exc = HogFunctionErrorThresholdExceeded(
+                            raise HogFunctionErrorThresholdExceeded(
                                 failed_count=self.records_failed_count,
-                                total_count=self.total_requests_count,
+                                total_count=self.records_handled_count,
                                 latest_error=self.latest_hog_function_error,
                             )
-                            self.external_logger.error(str(exc))
-                            raise exc
 
     async def finalize_file(self):
         """Required by consumer interface."""
@@ -330,16 +341,18 @@ async def insert_into_workflows_activity_from_stage(inputs: WorkflowsInsertInput
                 raise BadRequestErrorGroup(exc_group.message, exc_group.exceptions) from exc_group  # type: ignore[arg-type]
             except* NotFound as exc_group:
                 raise NotFoundErrorGroup(exc_group.message, exc_group.exceptions) from exc_group  # type: ignore[arg-type]
-            except* HogFunctionErrorThresholdExceeded as exc_group:
+            except* HogFunctionErrorThresholdExceeded:
                 # Since we're making multiple requests in parallel, as soon as we hit the error threshold
                 # we expect any new errors to also raise the same exception.
                 # Therefore, rather than raising an ExceptionGroup we just re-raise the exception once,
                 # but using the most recent values.
-                raise HogFunctionErrorThresholdExceeded(
+                exc = HogFunctionErrorThresholdExceeded(
                     failed_count=consumer.records_failed_count,
-                    total_count=consumer.total_requests_count,
+                    total_count=consumer.records_handled_count,
                     latest_error=consumer.latest_hog_function_error,
-                ) from exc_group
+                )
+                external_logger.exception(str(exc))
+                raise exc
 
         return consumer.collect_result()
 

--- a/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
@@ -331,6 +331,10 @@ async def insert_into_workflows_activity_from_stage(inputs: WorkflowsInsertInput
             except* NotFound as exc_group:
                 raise NotFoundErrorGroup(exc_group.message, exc_group.exceptions) from exc_group  # type: ignore[arg-type]
             except* HogFunctionErrorThresholdExceeded as exc_group:
+                # Since we're making multiple requests in parallel, as soon as we hit the error threshold
+                # we expect any new errors to also raise the same exception.
+                # Therefore, rather than raising an ExceptionGroup we just re-raise the exception once,
+                # but using the most recent values.
                 raise HogFunctionErrorThresholdExceeded(
                     failed_count=consumer.records_failed_count,
                     total_count=consumer.total_requests_count,

--- a/products/batch_exports/backend/tests/temporal/destinations/workflows/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/workflows/conftest.py
@@ -121,7 +121,7 @@ class Handler:
             should_error = True
         if should_error:
             self.hog_function_errors_returned += 1
-            return aiohttp.web.json_response({"status": "error", "errors": ["hog function failed"], "logs": []})
+            return aiohttp.web.json_response({"status": "error", "errors": ["Hog Function failed"], "logs": []})
         return aiohttp.web.json_response({"status": "success", "errors": [], "logs": []})
 
 

--- a/products/batch_exports/backend/tests/temporal/destinations/workflows/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/workflows/conftest.py
@@ -66,15 +66,25 @@ class Handler:
 
     If ``hog_function_error`` is True, the handler will return HTTP 200 but with
     ``status: "error"`` in the JSON body, simulating a hog function execution failure.
+
+    If ``hog_function_error_count`` is set, the handler returns the hog function error
+    body for the first N successful (2xx) requests and a success body afterwards.
     """
 
-    def __init__(self, error: int | None = None, hog_function_error: bool = False):
+    def __init__(
+        self,
+        error: int | None = None,
+        hog_function_error: bool = False,
+        hog_function_error_count: int | None = None,
+    ):
         self.data: list[RequestData] = []
 
         self.error_data: list[RequestData] = []
         self.error = error
         self.has_errored_once = False
         self.hog_function_error = hog_function_error
+        self.hog_function_error_count = hog_function_error_count
+        self.hog_function_errors_returned = 0
 
     def __call__(self, request):
         return self.handle(request)
@@ -103,7 +113,14 @@ class Handler:
             return aiohttp.web.Response(status=self.error, text="error")
 
         self.data.append(RequestData(team_id, hog_function_id, body))
-        if self.hog_function_error:
+        should_error = self.hog_function_error
+        if (
+            self.hog_function_error_count is not None
+            and self.hog_function_errors_returned < self.hog_function_error_count
+        ):
+            should_error = True
+        if should_error:
+            self.hog_function_errors_returned += 1
             return aiohttp.web.json_response({"status": "error", "errors": ["hog function failed"], "logs": []})
         return aiohttp.web.json_response({"status": "success", "errors": [], "logs": []})
 
@@ -127,8 +144,21 @@ def hog_function_error(request) -> bool:
 
 
 @pytest.fixture
-def handler(error, hog_function_error):
-    return Handler(error=error, hog_function_error=hog_function_error)
+def hog_function_error_count(request) -> int | None:
+    """Parameterize to return hog function errors for the first N successful requests."""
+    try:
+        return request.param
+    except AttributeError:
+        return None
+
+
+@pytest.fixture
+def handler(error, hog_function_error, hog_function_error_count):
+    return Handler(
+        error=error,
+        hog_function_error=hog_function_error,
+        hog_function_error_count=hog_function_error_count,
+    )
 
 
 @pytest_asyncio.fixture

--- a/products/batch_exports/backend/tests/temporal/destinations/workflows/test_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/workflows/test_activity.py
@@ -337,8 +337,8 @@ async def test_insert_into_workflows_activity_from_stage_fails_when_hog_function
 
     assert result.error is not None
     assert result.error.type == "HogFunctionErrorThresholdExceeded"
-    assert "Hog function error rate above threshold" in result.error.message
-    assert "hog function failed" in result.error.message
+    assert "Hog Function error rate above threshold" in result.error.message
+    assert "Hog Function failed" in result.error.message
     # Threshold requires >=100 requests to have been made before aborting.
     assert len(handler.data) >= 100
     # And the run aborted before consuming every generated event.

--- a/products/batch_exports/backend/tests/temporal/destinations/workflows/test_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/workflows/test_activity.py
@@ -286,7 +286,7 @@ async def test_insert_into_workflows_activity_from_stage_fails_with_empty_url(
 
 
 @pytest.mark.parametrize("hog_function_error", [True], indirect=True)
-async def test_insert_into_workflows_activity_tracks_hog_function_failures(
+async def test_insert_into_workflows_activity_from_stage_fails_when_hog_function_error_threshold_exceeded(
     clickhouse_client,
     activity_environment,
     data_interval_start,
@@ -298,6 +298,70 @@ async def test_insert_into_workflows_activity_tracks_hog_function_failures(
     handler,
     hog_function_id,
 ):
+    """When every hog function execution errors, the activity should abort after the threshold trips."""
+    model = BatchExportModel(name="events", schema=None)
+
+    batch_export_id = str(uuid.uuid4())
+    batch_export_inputs = BatchExportInsertInputs(
+        team_id=ateam.pk,
+        data_interval_start=data_interval_start.isoformat(),
+        data_interval_end=data_interval_end.isoformat(),
+        batch_export_model=model,
+        batch_export_id=batch_export_id,
+    )
+    workflows_inputs = WorkflowsInsertInputs(
+        batch_export=batch_export_inputs,
+        url=urllib.parse.urlunsplit((server.scheme, f"{server.host}:{server.port}", "/", "", "")),
+        hog_function_id=hog_function_id,
+    )
+    await activity_environment.run(
+        insert_into_internal_stage_activity,
+        BatchExportInsertIntoInternalStageInputs(
+            team_id=workflows_inputs.batch_export.team_id,
+            batch_export_id=batch_export_id,
+            data_interval_start=workflows_inputs.batch_export.data_interval_start,
+            data_interval_end=workflows_inputs.batch_export.data_interval_end,
+            exclude_events=workflows_inputs.batch_export.exclude_events,
+            include_events=None,
+            run_id=None,
+            backfill_details=None,
+            num_partitions=1,
+            is_workflows=True,
+            batch_export_model=workflows_inputs.batch_export.batch_export_model,
+            batch_export_schema=workflows_inputs.batch_export.batch_export_schema,
+            destination_default_fields=workflows_default_fields(batch_export_id),
+        ),
+    )
+
+    result = await activity_environment.run(insert_into_workflows_activity_from_stage, workflows_inputs)
+
+    assert result.error is not None
+    assert result.error.type == "HogFunctionErrorThresholdExceeded"
+    assert "Hog function error rate above threshold" in result.error.message
+    assert "hog function failed" in result.error.message
+    # Threshold requires >=100 requests to have been made before aborting.
+    assert len(handler.data) >= 100
+    # And the run aborted before consuming every generated event.
+    events_created, _ = generate_test_data
+    assert len(handler.data) < len(events_created)
+
+
+@pytest.mark.parametrize("hog_function_error_count", [10], indirect=True)
+async def test_insert_into_workflows_activity_from_stage_tolerates_hog_function_errors_below_threshold(
+    clickhouse_client,
+    activity_environment,
+    exclude_events,
+    data_interval_start,
+    data_interval_end,
+    generate_test_data,
+    ateam,
+    server,
+    path,
+    handler,
+    hog_function_id,
+    hog_function_error_count,
+):
+    """A small number of hog function errors (well under the threshold) should not fail the run."""
     model = BatchExportModel(name="events", schema=None)
 
     result = await _run_activity(
@@ -313,7 +377,6 @@ async def test_insert_into_workflows_activity_tracks_hog_function_failures(
         sort_key="event",
     )
 
-    total_events = len(handler.data)
-    assert total_events > 0
-    assert result.records_failed == total_events
-    assert result.records_completed == 0
+    assert result.error is None
+    assert result.records_failed == hog_function_error_count
+    assert result.records_completed == len(handler.data) - hog_function_error_count


### PR DESCRIPTION
## Problem

At the moment, if the CDP destination is setup incorrectly or is returning a high number of errors for whatever reason, batch exports will continue sending events regardless. We could end up sending a very large number of events, which we know are unlikely to succeed.

## Changes

- Introduce an error threshold for hog function execution errors
    - Note, this is not for internal errors (eg when the CDP API returns 429s or internal server errors)
    - At the moment, the values for the threshold have been chosen very arbitrarily: 50% of requests failing and at least 100 requests in total
        - Not sure how to pick these values; is it going to depend on the destination, should it be user-configurable? 

## Future improvements

- Also cancel the backfill associated with the run (I don't think this happens automatically at the moment?)
    - If the run is part of a larger backfill, we will continue to generate runs, which are also likely to fail. Eg a user could set up a backfill for a year's worth of data and the auth for the destination has not been set up correctly. This would result in 24*365=8,760 runs, which would all run and fail with the same bunch of errors
- Display the `latest_error` in the Runs table
    -  Think this would be useful in general, but particularly for Workflows, as we only show CDP logs in the Logs UI, and they won't know the reason for the run failing
- Retry on certain hog function errors?
- Allow thresholds to be customizable

## How did you test this code?

- Local testing
- Added new integration tests which test the activity


## Publish to changelog?

No.

## Docs update

N/A

## 🤖 LLM context

Co-authored with Claude Code.
