### PR TITLE
fix: require payment credentials for paid plan provisioning

### DIFF
--- a/ee/api/agentic_provisioning/test/test_spt.py
+++ b/ee/api/agentic_provisioning/test/test_spt.py
@@ -44,6 +44,18 @@ class TestSharedPaymentToken(StripeProvisioningTestBase):
         assert res.status_code == 200
         assert res.json()["status"] == "complete"
 
+    def test_provisioning_pay_as_you_go_without_spt_returns_error(self):
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources",
+            data={"service_id": "pay_as_you_go"},
+            token=token,
+        )
+        assert res.status_code == 400
+        body = res.json()
+        assert body["status"] == "error"
+        assert body["error"]["code"] == "requires_payment_credentials"
+
     @patch("ee.api.agentic_provisioning.views.requests.post")
     def test_provisioning_ignores_invalid_payment_credentials_type(self, mock_post):
         token = self._get_bearer_token()

--- a/ee/api/agentic_provisioning/test/test_update_service.py
+++ b/ee/api/agentic_provisioning/test/test_update_service.py
@@ -57,7 +57,7 @@ class TestProvisioningUpdateService(StripeProvisioningTestBase):
         assert res.status_code == 400
         assert res.json()["error"]["code"] == "billing_activation_failed"
 
-    def test_update_service_without_spt(self):
+    def test_update_service_without_spt_to_free_succeeds(self):
         token = self._get_bearer_token()
         res = self._post_signed_with_bearer(
             f"/api/agentic/provisioning/resources/{self.team.id}/update_service",
@@ -70,6 +70,18 @@ class TestProvisioningUpdateService(StripeProvisioningTestBase):
         assert data["service_id"] == "free"
         assert "api_key" in data["complete"]["access_configuration"]
         assert "host" in data["complete"]["access_configuration"]
+
+    def test_update_service_to_pay_as_you_go_without_spt_returns_error(self):
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            f"/api/agentic/provisioning/resources/{self.team.id}/update_service",
+            data={"service_id": "pay_as_you_go"},
+            token=token,
+        )
+        assert res.status_code == 400
+        body = res.json()
+        assert body["status"] == "error"
+        assert body["error"]["code"] == "requires_payment_credentials"
 
     def test_update_service_rejects_unknown_service_id(self):
         token = self._get_bearer_token()

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -1033,6 +1033,16 @@ def provisioning_resources_create(request: Request) -> Response:
             status=400,
         )
 
+    if resolved_service_id == PAY_AS_YOU_GO_SERVICE_ID and billing_result is None:
+        _capture_provisioning_event(
+            "resource_created",
+            "error",
+            error_code="requires_payment_credentials",
+            service_id=resolved_service_id,
+            team_id=team.id,
+        )
+        return _error_response("requires_payment_credentials", "Payment credentials required for paid plan")
+
     region = get_instance_region() or "US"
     host = _region_to_host(region)
 
@@ -1186,6 +1196,14 @@ def provisioning_update_service(request: Request, resource_id: str) -> Response:
             "billing_activation_failed",
             "Failed to activate billing with payment credentials",
             resource_id=resource_id,
+        )
+
+    if service_id == PAY_AS_YOU_GO_SERVICE_ID and billing_result is None:
+        _capture_provisioning_event(
+            "update_service", "error", error_code="requires_payment_credentials", service_id=service_id, team_id=team_id
+        )
+        return _error_response(
+            "requires_payment_credentials", "Payment credentials required for paid plan", resource_id=resource_id
         )
 
     _set_provisioning_service_id(team, service_id)


### PR DESCRIPTION
## Problem

When provisioning or upgrading to the `pay_as_you_go` plan, the orchestrator is expected to send `payment_credentials` (SPT) so billing can be activated. If the orchestrator omits them, the current code silently succeeds - creating the resource and reporting success even though billing was never activated. This is worse than failing explicitly because the customer ends up in a broken state with no billing.

## Changes

- In `provisioning_resources_create`: after the existing `_try_activate_billing_with_spt` call, check if `billing_result is None` (no SPT present) and the resolved service is `pay_as_you_go`. If so, return a `requires_payment_credentials` error instead of proceeding.
- In `provisioning_update_service`: same enforcement when upgrading to `pay_as_you_go` without payment credentials.
- Added tests for both paths confirming a 400 with `requires_payment_credentials` error code is returned.
- Renamed `test_update_service_without_spt` to `test_update_service_without_spt_to_free_succeeds` for clarity.

## How did you test this code?

- Added unit tests in `test_spt.py` and `test_update_service.py` covering the new enforcement paths.
- Could not run tests locally in this environment (no DB available in worktree), but the changes are straightforward guard clauses using existing helpers.

I am an agent and have not tested this manually.

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Co-authored by Claude Code. The change adds two guard clauses using existing `_error_response` and `_capture_provisioning_event` helpers, plus corresponding test coverage.