### PR TITLE
feat: expose oauth provisioning fields in admin

### DIFF
--- a/posthog/admin/admins/oauth_admin.py
+++ b/posthog/admin/admins/oauth_admin.py
@@ -35,6 +35,11 @@ class OAuthApplicationForm(forms.ModelForm):
             self.fields["authorization_grant_type"].disabled = True
             self.fields["authorization_grant_type"].help_text = "Only authorization code grant type is supported"
 
+        if "provisioning_signing_secret" in self.fields:
+            self.fields["provisioning_signing_secret"].help_text = (
+                "Only used for HMAC provisioning partners. Leave blank for PKCE or bearer clients."
+            )
+
         # For new applications, set defaults
         if not self.instance.pk:
             # Pre-generate client_id and client_secret
@@ -74,6 +79,9 @@ class OAuthApplicationAdmin(admin.ModelAdmin):
         "is_cimd_client",
         "is_first_party",
         "auth_brand",
+        "provisioning_active",
+        "provisioning_auth_method",
+        "provisioning_partner_type",
     )
     search_fields = ("name", "client_id", "user__email", "organization__name")
     autocomplete_fields = ("user", "organization")
@@ -104,6 +112,19 @@ class OAuthApplicationAdmin(admin.ModelAdmin):
             return ("id", "is_dcr_client", "is_cimd_client")
 
     def get_fieldsets(self, request, obj=None):
+        provisioning_fields = [
+            "provisioning_auth_method",
+            "provisioning_partner_type",
+            "provisioning_active",
+            "provisioning_can_create_accounts",
+            "provisioning_can_provision_resources",
+            "provisioning_rate_limit_account_requests",
+            "provisioning_rate_limit_token_exchanges",
+            "provisioning_rate_limit_resource_creates",
+        ]
+        if obj is None or obj.provisioning_auth_method == "hmac":
+            provisioning_fields.append("provisioning_signing_secret")
+
         if obj:
             return (
                 (None, {"fields": ("id", "name", "client_id", "client_type", "auth_brand", "logo_uri")}),
@@ -113,6 +134,13 @@ class OAuthApplicationAdmin(admin.ModelAdmin):
                 ),
                 ("Ownership", {"fields": ("user", "organization")}),
                 ("Status", {"fields": ("is_verified", "is_first_party", "is_dcr_client", "is_cimd_client")}),
+                (
+                    "Provisioning",
+                    {
+                        "description": "Provisioning settings for agentic partners. HMAC signing secret is only used for HMAC clients.",
+                        "fields": tuple(provisioning_fields),
+                    },
+                ),
                 (
                     "CIMD",
                     {

--- a/posthog/admin/admins/oauth_admin.py
+++ b/posthog/admin/admins/oauth_admin.py
@@ -36,9 +36,9 @@ class OAuthApplicationForm(forms.ModelForm):
             self.fields["authorization_grant_type"].help_text = "Only authorization code grant type is supported"
 
         if "provisioning_signing_secret" in self.fields:
-            self.fields["provisioning_signing_secret"].help_text = (
-                "Only used for HMAC provisioning partners. Leave blank for PKCE or bearer clients."
-            )
+            self.fields[
+                "provisioning_signing_secret"
+            ].help_text = "Only used for HMAC provisioning partners. Leave blank for PKCE or bearer clients."
 
         # For new applications, set defaults
         if not self.instance.pk:
@@ -112,20 +112,20 @@ class OAuthApplicationAdmin(admin.ModelAdmin):
             return ("id", "is_dcr_client", "is_cimd_client")
 
     def get_fieldsets(self, request, obj=None):
-        provisioning_fields = [
-            "provisioning_auth_method",
-            "provisioning_partner_type",
-            "provisioning_active",
-            "provisioning_can_create_accounts",
-            "provisioning_can_provision_resources",
-            "provisioning_rate_limit_account_requests",
-            "provisioning_rate_limit_token_exchanges",
-            "provisioning_rate_limit_resource_creates",
-        ]
-        if obj is None or obj.provisioning_auth_method == "hmac":
-            provisioning_fields.append("provisioning_signing_secret")
-
         if obj:
+            provisioning_fields = [
+                "provisioning_auth_method",
+                "provisioning_partner_type",
+                "provisioning_active",
+                "provisioning_can_create_accounts",
+                "provisioning_can_provision_resources",
+                "provisioning_rate_limit_account_requests",
+                "provisioning_rate_limit_token_exchanges",
+                "provisioning_rate_limit_resource_creates",
+            ]
+            if obj.provisioning_auth_method == "hmac":
+                provisioning_fields.append("provisioning_signing_secret")
+
             return (
                 (None, {"fields": ("id", "name", "client_id", "client_type", "auth_brand", "logo_uri")}),
                 (

--- a/posthog/admin/test_oauth_admin.py
+++ b/posthog/admin/test_oauth_admin.py
@@ -1,0 +1,41 @@
+from django.contrib.admin import AdminSite
+
+from posthog.admin.admins.oauth_admin import OAuthApplicationAdmin, OAuthApplicationForm
+from posthog.models.oauth import OAuthApplication
+from posthog.test.base import BaseTest
+
+
+class TestOAuthApplicationAdmin(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.admin = OAuthApplicationAdmin(OAuthApplication, AdminSite())
+
+    def test_list_filter_includes_provisioning_fields(self):
+        assert "provisioning_active" in self.admin.list_filter
+        assert "provisioning_auth_method" in self.admin.list_filter
+        assert "provisioning_partner_type" in self.admin.list_filter
+
+    def test_pkce_app_hides_hmac_signing_secret(self):
+        app = OAuthApplication(
+            provisioning_auth_method="pkce",
+        )
+
+        fieldsets = self.admin.get_fieldsets(request=None, obj=app)
+        provisioning = next(fieldset for fieldset in fieldsets if fieldset[0] == "Provisioning")
+
+        assert "provisioning_signing_secret" not in provisioning[1]["fields"]
+
+    def test_hmac_app_shows_hmac_signing_secret(self):
+        app = OAuthApplication(
+            provisioning_auth_method="hmac",
+        )
+
+        fieldsets = self.admin.get_fieldsets(request=None, obj=app)
+        provisioning = next(fieldset for fieldset in fieldsets if fieldset[0] == "Provisioning")
+
+        assert "provisioning_signing_secret" in provisioning[1]["fields"]
+
+    def test_form_marks_signing_secret_as_hmac_only(self):
+        form = OAuthApplicationForm()
+
+        assert "Only used for HMAC provisioning partners" in form.fields["provisioning_signing_secret"].help_text

--- a/posthog/admin/test_oauth_admin.py
+++ b/posthog/admin/test_oauth_admin.py
@@ -2,6 +2,8 @@ from posthog.test.base import BaseTest
 
 from django.contrib.admin import AdminSite
 
+from parameterized import parameterized
+
 from posthog.admin.admins.oauth_admin import OAuthApplicationAdmin, OAuthApplicationForm
 from posthog.models.oauth import OAuthApplication
 
@@ -16,25 +18,20 @@ class TestOAuthApplicationAdmin(BaseTest):
         assert "provisioning_auth_method" in self.admin.list_filter
         assert "provisioning_partner_type" in self.admin.list_filter
 
-    def test_pkce_app_hides_hmac_signing_secret(self):
-        app = OAuthApplication(
-            provisioning_auth_method="pkce",
-        )
-
+    @parameterized.expand(
+        [
+            ("pkce", False),
+            ("hmac", True),
+        ]
+    )
+    def test_signing_secret_visibility(self, auth_method, expected_visible):
+        app = OAuthApplication(provisioning_auth_method=auth_method)
         fieldsets = self.admin.get_fieldsets(request=None, obj=app)
         provisioning = next(fieldset for fieldset in fieldsets if fieldset[0] == "Provisioning")
-
-        assert "provisioning_signing_secret" not in provisioning[1]["fields"]
-
-    def test_hmac_app_shows_hmac_signing_secret(self):
-        app = OAuthApplication(
-            provisioning_auth_method="hmac",
-        )
-
-        fieldsets = self.admin.get_fieldsets(request=None, obj=app)
-        provisioning = next(fieldset for fieldset in fieldsets if fieldset[0] == "Provisioning")
-
-        assert "provisioning_signing_secret" in provisioning[1]["fields"]
+        if expected_visible:
+            assert "provisioning_signing_secret" in provisioning[1]["fields"]
+        else:
+            assert "provisioning_signing_secret" not in provisioning[1]["fields"]
 
     def test_form_marks_signing_secret_as_hmac_only(self):
         form = OAuthApplicationForm()

--- a/posthog/admin/test_oauth_admin.py
+++ b/posthog/admin/test_oauth_admin.py
@@ -1,8 +1,9 @@
+from posthog.test.base import BaseTest
+
 from django.contrib.admin import AdminSite
 
 from posthog.admin.admins.oauth_admin import OAuthApplicationAdmin, OAuthApplicationForm
 from posthog.models.oauth import OAuthApplication
-from posthog.test.base import BaseTest
 
 
 class TestOAuthApplicationAdmin(BaseTest):


### PR DESCRIPTION
## What changed

Expose OAuth provisioning configuration fields in Django admin for existing `OAuthApplication` records.

This adds a dedicated `Provisioning` fieldset on the OAuth application edit page, adds provisioning-focused list filters, and adds a small admin test for the fieldset behavior.

## Why

The provisioning fields already exist on `OAuthApplication`, but they are not currently editable in Django admin.

That makes post-deploy setup for provisioning partners harder than it needs to be. In particular, the `PostHog Wizard` OAuth app needs admin-set provisioning values in production to allow the PKCE signup flow.

## Admin UX details

- Adds a `Provisioning` fieldset to the edit form
- Adds changelist filters for:
  - `provisioning_active`
  - `provisioning_auth_method`
  - `provisioning_partner_type`
- Makes the signing secret help text explicit that it is only used for HMAC partners
- Hides `provisioning_signing_secret` from the fieldset for non-HMAC apps, while still showing it for HMAC apps

## Impact

This does not change model behavior or provisioning logic. It only makes the existing fields visible and easier to configure safely in admin.

## Validation

- Added a small admin test covering:
  - provisioning list filters are present
  - PKCE apps do not show the HMAC signing secret field
  - HMAC apps do show the signing secret field
  - signing secret help text makes the HMAC-only usage explicit
- Verified Python syntax with `python3 -m py_compile`

## Notes

I could not run the full Django test target in this local environment because `pytest` was not available in the active Python environment for the worktree.