### PR TITLE
feat: add resume-from-chunk support for experimental sessions backfill

### DIFF
--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -2,7 +2,7 @@ import time
 import base64
 from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import Any, Optional
+from typing import Any, NoReturn, Optional
 
 from django.conf import settings
 
@@ -524,7 +524,7 @@ def _raise_failure(
     *,
     sub_chunk_i: int | None = None,
     total_sub_chunks: int | None = None,
-) -> None:
+) -> NoReturn:
     """Re-raise an exception as dagster.Failure with progress metadata."""
     if sub_chunk_i is not None:
         description = (

--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -6,6 +6,7 @@ from typing import Any, Optional
 
 from django.conf import settings
 
+import dagster
 from clickhouse_driver import Client
 from clickhouse_driver.errors import ErrorCodes
 from dagster import (
@@ -39,6 +40,7 @@ from posthog.models.raw_sessions.sessions_v3 import (
     RAW_SESSION_TABLE_BACKFILL_RECORDINGS_SQL_V3,
     RAW_SESSION_TABLE_BACKFILL_SQL_V3,
 )
+from posthog.redis import get_client as get_redis_client
 
 # This is the number of days to backfill in one SQL operation
 MAX_PARTITIONS_PER_RUN = 1
@@ -129,6 +131,7 @@ class ExperimentalSessionsBackfillConfig(Config):
     parts_check_poll_frequency_seconds: int = 30
     parts_check_max_wait_seconds: int = 3600
     client_overrides: dict[str, Any]
+    force_fresh_restart: bool = False
 
 
 daily_partitions = DailyPartitionsDefinition(
@@ -489,6 +492,61 @@ def _sub_chunk_where(base_where: str, sub_chunk_i: int, total_sub_chunks: int) -
     return f"({base_where}) AND cityHash64(distinct_id) >= {low} AND cityHash64(distinct_id) < {high}"
 
 
+BACKFILL_PROGRESS_TTL_SECONDS = 7 * 24 * 60 * 60  # 7 days
+
+
+def _progress_key(asset_name: str, partition_key: str) -> str:
+    return f"posthog:sessions_backfill:progress:{asset_name}:{partition_key}"
+
+
+def _get_completed_chunk(asset_name: str, partition_key: str) -> int | None:
+    """Return the last completed chunk index, or None if no progress saved."""
+    val = get_redis_client().get(_progress_key(asset_name, partition_key))
+    return int(val) if val is not None else None
+
+
+def _save_completed_chunk(asset_name: str, partition_key: str, chunk_i: int) -> None:
+    """Save progress after completing a chunk."""
+    get_redis_client().set(_progress_key(asset_name, partition_key), str(chunk_i), ex=BACKFILL_PROGRESS_TTL_SECONDS)
+
+
+def _clear_progress(asset_name: str, partition_key: str) -> None:
+    """Clear saved progress (called on successful completion)."""
+    get_redis_client().delete(_progress_key(asset_name, partition_key))
+
+
+def _raise_failure(
+    context: AssetExecutionContext,
+    chunk_i: int,
+    num_chunks: int,
+    partition_range_str: str,
+    exc: Exception,
+    *,
+    sub_chunk_i: int | None = None,
+    total_sub_chunks: int | None = None,
+) -> None:
+    """Re-raise an exception as dagster.Failure with progress metadata."""
+    if sub_chunk_i is not None:
+        description = (
+            f"Failed on sub-chunk {sub_chunk_i + 1}/{total_sub_chunks} of chunk {chunk_i + 1}/{num_chunks}: {exc}"
+        )
+    else:
+        description = f"Failed on chunk {chunk_i + 1}/{num_chunks}: {exc}"
+
+    metadata: dict[str, dagster.MetadataValue] = {
+        "failed_chunk_index": dagster.MetadataValue.int(chunk_i),
+        "resume_from_chunk": dagster.MetadataValue.int(chunk_i),
+        "total_chunks": dagster.MetadataValue.int(num_chunks),
+        "partition_range": dagster.MetadataValue.text(partition_range_str),
+        "error_message": dagster.MetadataValue.text(str(exc)),
+    }
+    if sub_chunk_i is not None:
+        metadata["failed_sub_chunk_index"] = dagster.MetadataValue.int(sub_chunk_i)
+
+    context.log.error(f"{description} To resume, restart the job — it will automatically skip completed chunks.")
+    raise dagster.Failure(description=description, metadata=metadata) from exc
+
+
 def _do_experimental_backfill(
     sql_template: Callable,
     timestamp_field: str,
@@ -510,9 +568,28 @@ def _do_experimental_backfill(
 
     num_chunks, chunk_desc, chunk_where_fn = _get_experimental_chunking(config)
 
+    # Determine start chunk from Redis progress (unless force_fresh_restart is set)
+    asset_name = "experimental_sessions_v3_backfill"
+    partition_key = partition_range.start
+
+    if config.force_fresh_restart:
+        start_chunk = 0
+        context.log.info("force_fresh_restart=True, starting from chunk 0")
+    else:
+        last_completed = _get_completed_chunk(asset_name, partition_key)
+        if last_completed is not None:
+            start_chunk = last_completed + 1
+            context.log.info(f"Resuming from chunk {start_chunk}/{num_chunks} (last completed: {last_completed})")
+        else:
+            start_chunk = 0
+
+    if start_chunk >= num_chunks:
+        context.log.info(f"All {num_chunks} chunks already completed, nothing to do")
+        return
+
     context.log.info(
         f"Running backfill for Dagster partitions {partition_range_str} "
-        f"(where='{where_clause}', chunking={num_chunks} chunks on {chunk_desc}) "
+        f"(where='{where_clause}', chunking={num_chunks} chunks on {chunk_desc}, start_chunk={start_chunk}) "
         f"using commit {get_git_commit_short() or 'unknown'}"
     )
     if debug_url := metabase_debug_query_url(context.run_id):
@@ -528,8 +605,11 @@ def _do_experimental_backfill(
     with get_http_client(**kwargs, **config.client_overrides) as client:
         tags = dagster_tags(context)
         with tags_context(kind="dagster", dagster=tags, product=ProductKey.WEB_ANALYTICS, feature=Feature.BACKFILL):
-            for chunk_i in range(num_chunks):
-                wait_for_parts_to_merge(context, config, sync_client=client, table=target_table, use_cluster=False)
+            for chunk_i in range(start_chunk, num_chunks):
+                try:
+                    wait_for_parts_to_merge(context, config, sync_client=client, table=target_table, use_cluster=False)
+                except Exception as e:
+                    _raise_failure(context, chunk_i, num_chunks, partition_range_str, e)
 
                 if num_chunks > 1:
                     chunk_condition = chunk_where_fn(chunk_i)
@@ -549,7 +629,7 @@ def _do_experimental_backfill(
                     sync_execute(backfill_sql, settings=merged_settings, sync_client=client)
                 except Exception as e:
                     if not _is_oom_error(e):
-                        raise
+                        _raise_failure(context, chunk_i, num_chunks, partition_range_str, e)
 
                     context.log.warning(
                         f"OOM error on chunk {chunk_i + 1}/{num_chunks}, "
@@ -557,9 +637,20 @@ def _do_experimental_backfill(
                     )
 
                     for sub_i in range(OOM_RETRY_SUB_CHUNKS):
-                        wait_for_parts_to_merge(
-                            context, config, sync_client=client, table=target_table, use_cluster=False
-                        )
+                        try:
+                            wait_for_parts_to_merge(
+                                context, config, sync_client=client, table=target_table, use_cluster=False
+                            )
+                        except Exception as sub_e:
+                            _raise_failure(
+                                context,
+                                chunk_i,
+                                num_chunks,
+                                partition_range_str,
+                                sub_e,
+                                sub_chunk_i=sub_i,
+                                total_sub_chunks=OOM_RETRY_SUB_CHUNKS,
+                            )
 
                         sub_where = _sub_chunk_where(chunk_where_clause, sub_i, OOM_RETRY_SUB_CHUNKS)
                         sub_sql = sql_template(
@@ -571,7 +662,18 @@ def _do_experimental_backfill(
                             f"Running sub-chunk {sub_i + 1}/{OOM_RETRY_SUB_CHUNKS} for chunk {chunk_i + 1}/{num_chunks}"
                         )
                         context.log.info(sub_sql)
-                        sync_execute(sub_sql, settings=merged_settings, sync_client=client)
+                        try:
+                            sync_execute(sub_sql, settings=merged_settings, sync_client=client)
+                        except Exception as sub_e:
+                            _raise_failure(
+                                context,
+                                chunk_i,
+                                num_chunks,
+                                partition_range_str,
+                                sub_e,
+                                sub_chunk_i=sub_i,
+                                total_sub_chunks=OOM_RETRY_SUB_CHUNKS,
+                            )
                         context.log.info(
                             f"Completed sub-chunk {sub_i + 1}/{OOM_RETRY_SUB_CHUNKS} for chunk {chunk_i + 1}/{num_chunks}"
                         )
@@ -579,4 +681,7 @@ def _do_experimental_backfill(
                 if num_chunks > 1:
                     context.log.info(f"Completed chunk {chunk_i + 1}/{num_chunks}")
 
+                _save_completed_chunk(asset_name, partition_key, chunk_i)
+
+            _clear_progress(asset_name, partition_key)
             context.log.info(f"Successfully backfilled sessions_v3 for Dagster partitions {partition_range_str}")

--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -569,7 +569,7 @@ def _do_experimental_backfill(
     num_chunks, chunk_desc, chunk_where_fn = _get_experimental_chunking(config)
 
     # Determine start chunk from Redis progress (unless force_fresh_restart is set)
-    asset_name = "experimental_sessions_v3_backfill"
+    asset_name = context.asset_key.path[-1]
     partition_key = partition_range.start
 
     if config.force_fresh_restart:
@@ -585,6 +585,7 @@ def _do_experimental_backfill(
 
     if start_chunk >= num_chunks:
         context.log.info(f"All {num_chunks} chunks already completed, nothing to do")
+        _clear_progress(asset_name, partition_key)
         return
 
     context.log.info(

--- a/posthog/dags/tests/test_sessions.py
+++ b/posthog/dags/tests/test_sessions.py
@@ -2,13 +2,16 @@ from contextlib import contextmanager
 from datetime import datetime
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
+import dagster
 from parameterized import parameterized
 
 from posthog.dags.sessions import (
+    BACKFILL_PROGRESS_TTL_SECONDS,
     ExperimentalSessionsBackfillConfig,
     _do_experimental_backfill,
+    _progress_key,
     tags_for_sessions_partition,
 )
 
@@ -51,9 +54,11 @@ def _make_context(start: str = "2025-06-15", end: str = "2025-06-16") -> MagicMo
 
 
 @contextmanager
-def _patch_experimental_backfill_deps():
+def _patch_experimental_backfill_deps(redis_get_return=None):
     """Patch external dependencies so _do_experimental_backfill can run without ClickHouse."""
     mock_client = MagicMock()
+    mock_redis = MagicMock()
+    mock_redis.get.return_value = redis_get_return
 
     with (
         patch("posthog.dags.sessions.get_kwargs_for_client", return_value={}),
@@ -62,10 +67,11 @@ def _patch_experimental_backfill_deps():
         patch("posthog.dags.sessions.wait_for_parts_to_merge"),
         patch("posthog.dags.sessions.get_git_commit_short", return_value="abc123"),
         patch("posthog.dags.sessions.metabase_debug_query_url", return_value=None),
+        patch("posthog.dags.sessions.get_redis_client", return_value=mock_redis),
     ):
         mock_get_http_client.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_get_http_client.return_value.__exit__ = MagicMock(return_value=False)
-        yield mock_sync_execute
+        yield mock_sync_execute, mock_redis
 
 
 def _sql_template_stub(where: str, target_table: str, include_session_timestamp: bool) -> str:
@@ -85,7 +91,7 @@ class TestExperimentalBackfillChunking:
         config = ExperimentalSessionsBackfillConfig(**config_kwargs, client_overrides={})
         context = _make_context()
 
-        with _patch_experimental_backfill_deps() as mock_sync_execute:
+        with _patch_experimental_backfill_deps() as (mock_sync_execute, _mock_redis):
             _do_experimental_backfill(
                 sql_template=_sql_template_stub,
                 timestamp_field="timestamp",
@@ -93,7 +99,7 @@ class TestExperimentalBackfillChunking:
                 config=config,
             )
 
-        executed_sqls = [call.args[0] for call in mock_sync_execute.call_args_list]
+        executed_sqls = [c.args[0] for c in mock_sync_execute.call_args_list]
         assert executed_sqls == snapshot
 
     def test_both_chunking_strategies_raises(self):
@@ -108,3 +114,128 @@ class TestExperimentalBackfillChunking:
                     context=context,
                     config=config,
                 )
+
+
+ASSET_NAME = "experimental_sessions_v3_backfill"
+PARTITION_KEY = "2025-06-15"
+
+
+class TestExperimentalBackfillResume:
+    def test_resume_from_saved_progress(self):
+        config = ExperimentalSessionsBackfillConfig(distinct_id_chunks=4, client_overrides={})
+        context = _make_context()
+
+        with _patch_experimental_backfill_deps(redis_get_return=b"1") as (mock_sync_execute, mock_redis):
+            _do_experimental_backfill(
+                sql_template=_sql_template_stub,
+                timestamp_field="timestamp",
+                context=context,
+                config=config,
+            )
+
+        # Chunks 0 and 1 skipped, only 2 and 3 executed
+        assert mock_sync_execute.call_count == 2
+
+    def test_no_saved_progress_starts_from_zero(self):
+        config = ExperimentalSessionsBackfillConfig(distinct_id_chunks=4, client_overrides={})
+        context = _make_context()
+
+        with _patch_experimental_backfill_deps(redis_get_return=None) as (mock_sync_execute, _mock_redis):
+            _do_experimental_backfill(
+                sql_template=_sql_template_stub,
+                timestamp_field="timestamp",
+                context=context,
+                config=config,
+            )
+
+        assert mock_sync_execute.call_count == 4
+
+    def test_force_fresh_restart_ignores_saved_progress(self):
+        config = ExperimentalSessionsBackfillConfig(distinct_id_chunks=4, client_overrides={}, force_fresh_restart=True)
+        context = _make_context()
+
+        with _patch_experimental_backfill_deps(redis_get_return=b"1") as (mock_sync_execute, _mock_redis):
+            _do_experimental_backfill(
+                sql_template=_sql_template_stub,
+                timestamp_field="timestamp",
+                context=context,
+                config=config,
+            )
+
+        assert mock_sync_execute.call_count == 4
+
+    def test_progress_saved_after_each_chunk(self):
+        config = ExperimentalSessionsBackfillConfig(distinct_id_chunks=3, client_overrides={})
+        context = _make_context()
+        key = _progress_key(ASSET_NAME, PARTITION_KEY)
+
+        with _patch_experimental_backfill_deps() as (_mock_sync_execute, mock_redis):
+            _do_experimental_backfill(
+                sql_template=_sql_template_stub,
+                timestamp_field="timestamp",
+                context=context,
+                config=config,
+            )
+
+        set_calls = [c for c in mock_redis.set.call_args_list if c.args[0] == key]
+        assert len(set_calls) == 3
+        assert set_calls[0] == call(key, "0", ex=BACKFILL_PROGRESS_TTL_SECONDS)
+        assert set_calls[1] == call(key, "1", ex=BACKFILL_PROGRESS_TTL_SECONDS)
+        assert set_calls[2] == call(key, "2", ex=BACKFILL_PROGRESS_TTL_SECONDS)
+
+    def test_progress_cleared_on_completion(self):
+        config = ExperimentalSessionsBackfillConfig(distinct_id_chunks=2, client_overrides={})
+        context = _make_context()
+        key = _progress_key(ASSET_NAME, PARTITION_KEY)
+
+        with _patch_experimental_backfill_deps() as (_mock_sync_execute, mock_redis):
+            _do_experimental_backfill(
+                sql_template=_sql_template_stub,
+                timestamp_field="timestamp",
+                context=context,
+                config=config,
+            )
+
+        mock_redis.delete.assert_called_once_with(key)
+
+    def test_all_chunks_completed_is_noop(self):
+        config = ExperimentalSessionsBackfillConfig(distinct_id_chunks=4, client_overrides={})
+        context = _make_context()
+
+        # last_completed=3 means all 4 chunks (0-3) are done
+        with _patch_experimental_backfill_deps(redis_get_return=b"3") as (mock_sync_execute, _mock_redis):
+            _do_experimental_backfill(
+                sql_template=_sql_template_stub,
+                timestamp_field="timestamp",
+                context=context,
+                config=config,
+            )
+
+        assert mock_sync_execute.call_count == 0
+
+    def test_non_oom_error_raises_dagster_failure_with_metadata(self):
+        config = ExperimentalSessionsBackfillConfig(distinct_id_chunks=4, client_overrides={})
+        context = _make_context()
+
+        call_count = 0
+
+        def fail_on_third_call(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 3:
+                raise RuntimeError("Connection lost")
+
+        with _patch_experimental_backfill_deps() as (mock_sync_execute, _mock_redis):
+            mock_sync_execute.side_effect = fail_on_third_call
+            with pytest.raises(dagster.Failure) as exc_info:
+                _do_experimental_backfill(
+                    sql_template=_sql_template_stub,
+                    timestamp_field="timestamp",
+                    context=context,
+                    config=config,
+                )
+
+        failure = exc_info.value
+        assert failure.metadata["failed_chunk_index"].value == 2
+        assert failure.metadata["resume_from_chunk"].value == 2
+        assert failure.metadata["total_chunks"].value == 4

--- a/posthog/dags/tests/test_sessions.py
+++ b/posthog/dags/tests/test_sessions.py
@@ -43,6 +43,10 @@ class TestTagsForSessionsPartition:
         }
 
 
+ASSET_NAME = "experimental_sessions_v3_backfill"
+PARTITION_KEY = "2025-06-15"
+
+
 def _make_context(start: str = "2025-06-15", end: str = "2025-06-16") -> MagicMock:
     context = MagicMock()
     context.partition_time_window.start = datetime.strptime(start, "%Y-%m-%d")
@@ -50,6 +54,7 @@ def _make_context(start: str = "2025-06-15", end: str = "2025-06-16") -> MagicMo
     context.partition_key_range.start = start
     context.partition_key_range.end = end
     context.run_id = "test-run-id"
+    context.asset_key.path = [ASSET_NAME]
     return context
 
 
@@ -116,16 +121,23 @@ class TestExperimentalBackfillChunking:
                 )
 
 
-ASSET_NAME = "experimental_sessions_v3_backfill"
-PARTITION_KEY = "2025-06-15"
-
-
 class TestExperimentalBackfillResume:
-    def test_resume_from_saved_progress(self):
-        config = ExperimentalSessionsBackfillConfig(distinct_id_chunks=4, client_overrides={})
+    @parameterized.expand(
+        [
+            # (redis_get_return, force_fresh_restart, expected_call_count)
+            ("saved_progress_chunk1", b"1", False, 2),
+            ("no_saved_progress", None, False, 4),
+            ("force_fresh_restart", b"1", True, 4),
+            ("all_chunks_completed", b"3", False, 0),
+        ]
+    )
+    def test_resume_call_count(self, _name, redis_val, force_fresh, expected_count):
+        config = ExperimentalSessionsBackfillConfig(
+            distinct_id_chunks=4, client_overrides={}, force_fresh_restart=force_fresh
+        )
         context = _make_context()
 
-        with _patch_experimental_backfill_deps(redis_get_return=b"1") as (mock_sync_execute, mock_redis):
+        with _patch_experimental_backfill_deps(redis_get_return=redis_val) as (mock_sync_execute, _mock_redis):
             _do_experimental_backfill(
                 sql_template=_sql_template_stub,
                 timestamp_field="timestamp",
@@ -133,36 +145,7 @@ class TestExperimentalBackfillResume:
                 config=config,
             )
 
-        # Chunks 0 and 1 skipped, only 2 and 3 executed
-        assert mock_sync_execute.call_count == 2
-
-    def test_no_saved_progress_starts_from_zero(self):
-        config = ExperimentalSessionsBackfillConfig(distinct_id_chunks=4, client_overrides={})
-        context = _make_context()
-
-        with _patch_experimental_backfill_deps(redis_get_return=None) as (mock_sync_execute, _mock_redis):
-            _do_experimental_backfill(
-                sql_template=_sql_template_stub,
-                timestamp_field="timestamp",
-                context=context,
-                config=config,
-            )
-
-        assert mock_sync_execute.call_count == 4
-
-    def test_force_fresh_restart_ignores_saved_progress(self):
-        config = ExperimentalSessionsBackfillConfig(distinct_id_chunks=4, client_overrides={}, force_fresh_restart=True)
-        context = _make_context()
-
-        with _patch_experimental_backfill_deps(redis_get_return=b"1") as (mock_sync_execute, _mock_redis):
-            _do_experimental_backfill(
-                sql_template=_sql_template_stub,
-                timestamp_field="timestamp",
-                context=context,
-                config=config,
-            )
-
-        assert mock_sync_execute.call_count == 4
+        assert mock_sync_execute.call_count == expected_count
 
     def test_progress_saved_after_each_chunk(self):
         config = ExperimentalSessionsBackfillConfig(distinct_id_chunks=3, client_overrides={})
@@ -198,12 +181,12 @@ class TestExperimentalBackfillResume:
 
         mock_redis.delete.assert_called_once_with(key)
 
-    def test_all_chunks_completed_is_noop(self):
+    def test_all_chunks_completed_clears_progress(self):
         config = ExperimentalSessionsBackfillConfig(distinct_id_chunks=4, client_overrides={})
         context = _make_context()
+        key = _progress_key(ASSET_NAME, PARTITION_KEY)
 
-        # last_completed=3 means all 4 chunks (0-3) are done
-        with _patch_experimental_backfill_deps(redis_get_return=b"3") as (mock_sync_execute, _mock_redis):
+        with _patch_experimental_backfill_deps(redis_get_return=b"3") as (_mock_sync_execute, mock_redis):
             _do_experimental_backfill(
                 sql_template=_sql_template_stub,
                 timestamp_field="timestamp",
@@ -211,7 +194,7 @@ class TestExperimentalBackfillResume:
                 config=config,
             )
 
-        assert mock_sync_execute.call_count == 0
+        mock_redis.delete.assert_called_once_with(key)
 
     def test_non_oom_error_raises_dagster_failure_with_metadata(self):
         config = ExperimentalSessionsBackfillConfig(distinct_id_chunks=4, client_overrides={})


### PR DESCRIPTION
## Problem

The experimental sessions backfill job processes data in chunks (e.g. 64 or 128 distinct_id chunks). If it fails on chunk 70/128, the next run restarts from chunk 0, re-doing ~70 chunks of work unnecessarily. Since this runs across many partitions as part of a larger backfill, manually specifying a resume point per partition is not practical.

## Changes

- **Redis-based progress tracking**: Store the last completed chunk index in Redis (keyed by asset name + partition key, 7-day TTL). On startup, read saved progress and skip already-completed chunks automatically.
- **`force_fresh_restart` config option**: Set to `True` to ignore saved progress and start from chunk 0.
- **`dagster.Failure` with metadata**: All errors (non-OOM, sub-chunk, timeout) now raise `dagster.Failure` with structured metadata (`failed_chunk_index`, `resume_from_chunk`, `total_chunks`, `partition_range`) visible in the Dagster UI.
- **Progress lifecycle**: Save after each successful chunk; clear the Redis key on full completion (no stale state).

Redis key format: `posthog:sessions_backfill:progress:{asset_name}:{partition_key}`

## How did you test this code?

This PR was authored by an agent. Unit tests are included covering: resume from saved progress, no saved progress, force fresh restart, progress saved per chunk, progress cleared on completion, all-done no-op, and error metadata. Tests require Postgres for Dagster (CI infrastructure) and were not run locally.

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Authored by PostHog Code agent. The implementation follows existing patterns in the codebase: `dagster.Failure` with metadata (used in `persons_new_backfill.py` and others), and `get_client()` from `posthog.redis` for Redis access (same pattern as `posthog/temporal/data_imports/sources/common/resumable.py`).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*