### PR TITLE
fix: restore Popover unmount cleanup and remove innerHTML gutting

### DIFF
--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -252,24 +252,14 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
         setShouldRenderPortal(false)
     }, [extraFloatingRef]) // oxlint-disable-line react-hooks/exhaustive-deps
 
-    // Chromium holds C++ persistent roots to detached DOM trees containing <input> elements
-    // (via internal ShadowRoot tracking). We can't prevent the browser from retaining the
-    // reference, but we can minimise what gets retained by gutting the portal content after
-    // the exit animation completes. The +100ms buffer accounts for React 18's batched state
-    // processing after CSSTransition's exit timeout fires.
-    //
-    // shouldRenderPortal is intentionally omitted from deps — including it would cause the
-    // effect to re-run (and cancel the timer) when onExited sets it to false.
     useEffect(() => {
-        if (!visible && shouldRenderPortal && floatingRef.current) {
-            const el = floatingRef.current
-            const animationDurationWithBuffer = delayMs + 100
-            const timer = setTimeout(() => {
-                el.innerHTML = ''
-            }, animationDurationWithBuffer)
-            return () => clearTimeout(timer)
+        return () => {
+            floatingRef.current = null
+            if (extraFloatingRef) {
+                extraFloatingRef.current = null
+            }
         }
-    }, [visible, delayMs]) // oxlint-disable-line react-hooks/exhaustive-deps
+    }, []) // oxlint-disable-line react-hooks/exhaustive-deps
 
     const _onClickInside: MouseEventHandler<HTMLDivElement> = (e): void => {
         if (e.target instanceof HTMLElement && e.target.closest(`.${CLICK_OUTSIDE_BLOCK_CLASS}`)) {


### PR DESCRIPTION
## Problem

Detached DOM element tracking shows regressions vs the 30-day baseline. The Popover fix from #54147 (`2a8367cf6b4`) introduced two issues:

1. The `innerHTML = ''` effect destroys DOM children while React still holds virtual DOM refs, causing React's reconciliation to create replacement nodes that also detach — making the problem worse
2. The unmount cleanup effect was removed, so navigating away from a page with an open Popover leaves dangling refs (CSSTransition's `onExited` won't fire if the component unmounts mid-animation)

## Changes

- Remove the `innerHTML = ''` gutting effect — the `shouldRenderPortal` + `CSSTransition unmountOnExit` + `onExited` callback already handles cleanup correctly
- Restore the unmount cleanup effect that nullifies `floatingRef` and `extraFloatingRef` on component teardown

## How did you test this code?

This is an agent-authored PR. Existing tests pass. The change is a targeted revert of the problematic parts of #54147. Manual verification with DevTools Memory snapshots should show reduced detached Popover/Tooltip elements after page navigation.

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Agent-authored fix based on analysis of detached DOM element tracking data comparing today's metrics to the 30-day baseline. The `innerHTML` approach fights React's DOM ownership and the missing unmount cleanup leaves refs dangling on navigation.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*