### PR TITLE
fix: add missing unmount cleanup for dashboard drag refs

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -86,6 +86,11 @@ export function DashboardItems(): JSX.Element {
             if (scrollAnimationRef.current) {
                 cancelAnimationFrame(scrollAnimationRef.current)
             }
+            if (dragEndTimeout.current) {
+                window.clearTimeout(dragEndTimeout.current)
+            }
+            scrollContainerRef.current = null
+            scrollContainerRectRef.current = null
         }
     }, [])
     const className = clsx({


### PR DESCRIPTION
## Problem

DashboardItems has refs for auto-scroll during drag (`scrollContainerRef`, `scrollContainerRectRef`, `dragEndTimeout`) that are cleaned up in `onDragStop` but not on component unmount. If the user navigates away during a drag, these refs retain DOM references contributing to detached elements.

## Changes

Extend the existing unmount cleanup effect to also clear `dragEndTimeout`, `scrollContainerRef`, and `scrollContainerRectRef`.

## How did you test this code?

This is an agent-authored PR. The change adds defensive cleanup to an existing effect. No behavioral change unless the component unmounts during an active drag operation.

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Agent-authored fix identified during detached DOM element investigation. The DraggableCore spike on dashboards (2.8M today vs 634K baseline) is partially caused by refs surviving component unmount.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*