### PR TITLE
fix: lift AccordionPrimitive.Root from per-item to per-level in LemonTree

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -252,7 +252,6 @@ const LemonTreeItemRow = forwardRef<HTMLDivElement, LemonTreeItemRowProps>(
             renderItemTooltip,
             renderItemIcon,
             expandedItemIds,
-            onSetExpandedItemIds,
             defaultNodeIcon,
             showFolderActiveState,
             isItemActive,
@@ -441,110 +440,98 @@ const LemonTreeItemRow = forwardRef<HTMLDivElement, LemonTreeItemRowProps>(
         }
 
         const content = (
-            <AccordionPrimitive.Root
-                type="multiple"
-                value={expandedItemIds}
-                onValueChange={(s) => {
-                    onSetExpandedItemIds?.(s)
-                }}
-                ref={ref}
-                key={item.id}
+            <AccordionPrimitive.Item
+                value={item.id}
                 disabled={!!item.disabledReason}
+                className="flex flex-col w-full gap-y-px"
             >
-                <AccordionPrimitive.Item value={item.id} className="flex flex-col w-full gap-y-px">
-                    <AccordionPrimitive.Trigger className="flex items-center gap-2 w-full h-8" asChild>
-                        <ButtonGroupPrimitive
-                            fullWidth
-                            className={cn(
-                                'group/lemon-tree-button-group relative h-[var(--lemon-tree-button-height)] bg-transparent',
-                                className
-                            )}
-                        >
-                            <TreeNodeDisplayCheckbox
-                                item={item}
-                                handleCheckedChange={(checked, shift) => {
-                                    onItemChecked?.(item.id, checked, shift)
+                <AccordionPrimitive.Trigger className="flex items-center gap-2 w-full h-8" asChild>
+                    <ButtonGroupPrimitive
+                        fullWidth
+                        className={cn(
+                            'group/lemon-tree-button-group relative h-[var(--lemon-tree-button-height)] bg-transparent',
+                            className
+                        )}
+                    >
+                        <TreeNodeDisplayCheckbox
+                            item={item}
+                            handleCheckedChange={(checked, shift) => {
+                                onItemChecked?.(item.id, checked, shift)
+                            }}
+                            className={cn('absolute z-2', {
+                                hidden: selectMode !== 'multi',
+                            })}
+                            style={{
+                                left: `${firstColumnOffset - 20}px`,
+                            }}
+                        />
+
+                        {isItemEditing?.(item) ? (
+                            <InlineEditField
+                                value={item.name}
+                                handleSubmit={(value) => {
+                                    onItemNameChange?.(item, value)
+                                    disableKeyboardInput?.(false)
                                 }}
-                                className={cn('absolute z-2', {
-                                    hidden: selectMode !== 'multi',
-                                })}
+                                className="z-1"
                                 style={{
-                                    left: `${firstColumnOffset - 20}px`,
+                                    width:
+                                        selectMode === 'multi' && !item.disableSelect
+                                            ? `${emptySpaceOffset + 26}px`
+                                            : `${emptySpaceOffset}px`,
                                 }}
-                            />
-
-                            {isItemEditing?.(item) ? (
-                                <InlineEditField
-                                    value={item.name}
-                                    handleSubmit={(value) => {
-                                        onItemNameChange?.(item, value)
-                                        disableKeyboardInput?.(false)
-                                    }}
-                                    className="z-1"
-                                    style={{
-                                        width:
-                                            selectMode === 'multi' && !item.disableSelect
-                                                ? `${emptySpaceOffset + 26}px`
-                                                : `${emptySpaceOffset}px`,
-                                    }}
-                                >
-                                    {renderItemIcon ? (
-                                        renderItemIcon?.(item)
-                                    ) : (
-                                        <TreeNodeDisplayIcon
-                                            item={item}
-                                            expandedItemIds={expandedItemIds ?? []}
-                                            defaultNodeIcon={defaultNodeIcon}
-                                        />
-                                    )}
-                                </InlineEditField>
-                            ) : (
-                                button
-                            )}
-
-                            {itemSideAction &&
-                                itemSideAction(item) !== undefined &&
-                                !isEmptyFolder &&
-                                size === 'default' && (
-                                    <DropdownMenu>
-                                        <DropdownMenuTrigger asChild>
-                                            {itemSideActionButton?.(item) ?? (
-                                                <ButtonPrimitive
-                                                    iconOnly
-                                                    isSideActionRight
-                                                    className="
-                                                        absolute right-0
-                                                        opacity-0
-                                                        group-hover/lemon-tree-button-group:opacity-100
-                                                        z-10
-                                                        data-[state=open]:opacity-100
-                                                        -outline-offset-2
-                                                        focus-visible:opacity-100
-                                                    "
-                                                >
-                                                    <IconEllipsis className="text-tertiary size-3 group-hover/lemon-tree-button-group:text-primary z-10" />
-                                                </ButtonPrimitive>
-                                            )}
-                                        </DropdownMenuTrigger>
-
-                                        {!!itemSideAction(item) && (
-                                            <DropdownMenuContent
-                                                loop
-                                                align="end"
-                                                side="bottom"
-                                                className="max-w-[250px]"
-                                            >
-                                                {itemSideAction(item)}
-                                            </DropdownMenuContent>
-                                        )}
-                                    </DropdownMenu>
+                            >
+                                {renderItemIcon ? (
+                                    renderItemIcon?.(item)
+                                ) : (
+                                    <TreeNodeDisplayIcon
+                                        item={item}
+                                        expandedItemIds={expandedItemIds ?? []}
+                                        defaultNodeIcon={defaultNodeIcon}
+                                    />
                                 )}
-                        </ButtonGroupPrimitive>
-                    </AccordionPrimitive.Trigger>
+                            </InlineEditField>
+                        ) : (
+                            button
+                        )}
 
-                    {childrenContent}
-                </AccordionPrimitive.Item>
-            </AccordionPrimitive.Root>
+                        {itemSideAction &&
+                            itemSideAction(item) !== undefined &&
+                            !isEmptyFolder &&
+                            size === 'default' && (
+                                <DropdownMenu>
+                                    <DropdownMenuTrigger asChild>
+                                        {itemSideActionButton?.(item) ?? (
+                                            <ButtonPrimitive
+                                                iconOnly
+                                                isSideActionRight
+                                                className="
+                                                    absolute right-0
+                                                    opacity-0
+                                                    group-hover/lemon-tree-button-group:opacity-100
+                                                    z-10
+                                                    data-[state=open]:opacity-100
+                                                    -outline-offset-2
+                                                    focus-visible:opacity-100
+                                                "
+                                            >
+                                                <IconEllipsis className="text-tertiary size-3 group-hover/lemon-tree-button-group:text-primary z-10" />
+                                            </ButtonPrimitive>
+                                        )}
+                                    </DropdownMenuTrigger>
+
+                                    {!!itemSideAction(item) && (
+                                        <DropdownMenuContent loop align="end" side="bottom" className="max-w-[250px]">
+                                            {itemSideAction(item)}
+                                        </DropdownMenuContent>
+                                    )}
+                                </DropdownMenu>
+                            )}
+                    </ButtonGroupPrimitive>
+                </AccordionPrimitive.Trigger>
+
+                {childrenContent}
+            </AccordionPrimitive.Item>
         )
 
         let wrappedContent = content
@@ -559,6 +546,7 @@ const LemonTreeItemRow = forwardRef<HTMLDivElement, LemonTreeItemRowProps>(
 
         return (
             <div
+                ref={ref}
                 key={item.id}
                 className={cn(virtualizedRowHeight && 'overflow-hidden')}
                 // eslint-disable-next-line react/forbid-dom-props
@@ -582,7 +570,14 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
         const items = data instanceof Array ? data : [data]
 
         return (
-            <div className={cn('flex flex-col gap-y-px list-none m-0 p-0 h-full w-full', className)}>
+            <AccordionPrimitive.Root
+                type="multiple"
+                value={props.expandedItemIds}
+                onValueChange={(s) => {
+                    props.onSetExpandedItemIds?.(s)
+                }}
+                className={cn('flex flex-col gap-y-px list-none m-0 p-0 h-full w-full', className)}
+            >
                 {items.map((item, index) => {
                     if (item.type === 'separator') {
                         return (
@@ -623,7 +618,7 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                         />
                     )
                 })}
-            </div>
+            </AccordionPrimitive.Root>
         )
     }
 )
@@ -1575,63 +1570,74 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
                     <TreeNodeDroppable id="" isDroppable={enableDragAndDrop} isRoot isDragging={isDragging}>
                         <div ref={virtualizationAnchorRef}>
                             {virtualized ? (
-                                <div
-                                    className={cn('relative p-1', {
-                                        'flex-1': isDragging,
-                                    })}
-                                    // eslint-disable-next-line react/forbid-dom-props
-                                    style={{ height: `${flattenedVisibleItems.length * virtualizedRowHeight}px` }}
+                                <AccordionPrimitive.Root
+                                    type="multiple"
+                                    value={expandedItemIdsState}
+                                    onValueChange={(ids) => {
+                                        setExpandedItemIdsState(ids)
+                                        onSetExpandedItemIds?.(ids)
+                                    }}
                                 >
-                                    {virtualizedSegments.map((segment) => {
-                                        return (
-                                            <div
-                                                key={`segment-${segment.startIndex}`}
-                                                className="absolute inset-x-0 top-0"
-                                                // eslint-disable-next-line react/forbid-dom-props
-                                                style={{
-                                                    transform: `translateY(${segment.startIndex * virtualizedRowHeight}px)`,
-                                                }}
-                                            >
-                                                {segment.items.map(({ item, depth, ariaSetSize, ariaPosInSet }) => (
-                                                    <LemonTreeItemRow
-                                                        key={item.id}
-                                                        item={item}
-                                                        ariaSetSize={ariaSetSize}
-                                                        ariaPosInSet={ariaPosInSet}
-                                                        selectedId={selectedId}
-                                                        handleClick={handleClick}
-                                                        expandedItemIds={expandedItemIdsState}
-                                                        onSetExpandedItemIds={(ids) => {
-                                                            setExpandedItemIdsState(ids)
-                                                            onSetExpandedItemIds?.(ids)
-                                                        }}
-                                                        defaultNodeIcon={defaultNodeIcon}
-                                                        showFolderActiveState={showFolderActiveState}
-                                                        itemSideAction={itemSideAction}
-                                                        isItemEditing={isItemEditing}
-                                                        onItemNameChange={onItemNameChange}
-                                                        isItemDraggable={isItemDraggable}
-                                                        isItemDroppable={isItemDroppable}
-                                                        enableDragAndDrop={enableDragAndDrop}
-                                                        disableKeyboardInput={(disable) => {
-                                                            setDisableKeyboardInput(disable)
-                                                        }}
-                                                        itemContextMenu={itemContextMenu}
-                                                        selectMode={selectMode}
-                                                        onItemChecked={onItemChecked}
-                                                        isDragging={isDragging}
-                                                        checkedItemCount={checkedItemCount}
-                                                        setFocusToElementFromId={focusElementFromId}
-                                                        depth={depth}
-                                                        size={size}
-                                                        virtualizedRowHeight={virtualizedRowHeight}
-                                                        {...props}
-                                                    />
-                                                ))}
-                                            </div>
-                                        )
-                                    })}
-                                </div>
+                                    <div
+                                        className={cn('relative p-1', {
+                                            'flex-1': isDragging,
+                                        })}
+                                        // eslint-disable-next-line react/forbid-dom-props
+                                        style={{
+                                            height: `${flattenedVisibleItems.length * virtualizedRowHeight}px`,
+                                        }}
+                                    >
+                                        {virtualizedSegments.map((segment) => {
+                                            return (
+                                                <div
+                                                    key={`segment-${segment.startIndex}`}
+                                                    className="absolute inset-x-0 top-0"
+                                                    // eslint-disable-next-line react/forbid-dom-props
+                                                    style={{
+                                                        transform: `translateY(${segment.startIndex * virtualizedRowHeight}px)`,
+                                                    }}
+                                                >
+                                                    {segment.items.map(({ item, depth, ariaSetSize, ariaPosInSet }) => (
+                                                        <LemonTreeItemRow
+                                                            key={item.id}
+                                                            item={item}
+                                                            ariaSetSize={ariaSetSize}
+                                                            ariaPosInSet={ariaPosInSet}
+                                                            selectedId={selectedId}
+                                                            handleClick={handleClick}
+                                                            expandedItemIds={expandedItemIdsState}
+                                                            onSetExpandedItemIds={(ids) => {
+                                                                setExpandedItemIdsState(ids)
+                                                                onSetExpandedItemIds?.(ids)
+                                                            }}
+                                                            defaultNodeIcon={defaultNodeIcon}
+                                                            showFolderActiveState={showFolderActiveState}
+                                                            itemSideAction={itemSideAction}
+                                                            isItemEditing={isItemEditing}
+                                                            onItemNameChange={onItemNameChange}
+                                                            isItemDraggable={isItemDraggable}
+                                                            isItemDroppable={isItemDroppable}
+                                                            enableDragAndDrop={enableDragAndDrop}
+                                                            disableKeyboardInput={(disable) => {
+                                                                setDisableKeyboardInput(disable)
+                                                            }}
+                                                            itemContextMenu={itemContextMenu}
+                                                            selectMode={selectMode}
+                                                            onItemChecked={onItemChecked}
+                                                            isDragging={isDragging}
+                                                            checkedItemCount={checkedItemCount}
+                                                            setFocusToElementFromId={focusElementFromId}
+                                                            depth={depth}
+                                                            size={size}
+                                                            virtualizedRowHeight={virtualizedRowHeight}
+                                                            {...props}
+                                                        />
+                                                    ))}
+                                                </div>
+                                            )
+                                        })}
+                                    </div>
+                                </AccordionPrimitive.Root>
                             ) : (
                                 <LemonTreeNode
                                     data={data}


### PR DESCRIPTION
## Problem

LemonTree wraps **every tree item** in its own `AccordionPrimitive.Root` (`@radix-ui/react-accordion`). Radix renders this as an `AccordionProvider` context. For a sidebar with 100 items, this creates 100 AccordionProviders. When items re-render or are removed (navigation, folder collapse), each AccordionProvider detaches and retains DOM references.

This was identified as the source of the new `AccordionProvider` signal in detached element tracking, appearing across all pages (dashboard: 420, replay: 1,880, feature_flags: 1,816, activity/explore: 92) — because LemonTree powers the sidebar navigation present on every page.

LemonTree also nests `ButtonGroupPrimitive` and `DropdownMenu` inside each accordion trigger, directly explaining the ButtonGroupPrimitive spike (52K vs 2K baseline) and Dropdown increase.

## Changes

Lift `AccordionPrimitive.Root` from per-item to per-level:

- **Non-virtualized path** (`LemonTreeNode`): Wrap the items list in a single Root per sibling group. Each recursive `LemonTreeNode` (for children) creates its own Root, giving one Root per depth level.
- **Virtualized path** (`LemonTree`): Wrap the entire virtualized container in a single Root.
- **`LemonTreeItemRow`**: Replace Root+Item wrapper with just `AccordionPrimitive.Item`, moving `disabled` from Root to Item.

For a sidebar with 100 items: 100 AccordionProviders → ~5 (one per depth level).

## How did you test this code?

This is an agent-authored PR. All 5 existing LemonTree tests pass (covering virtualization, scroll, ancestor mounting, and overscan). The refactor preserves the Radix Accordion API contract — Items don't need to be direct children of Root (Root uses React context).

Manual verification should confirm: expand/collapse, keyboard navigation (arrow keys, Enter), drag-and-drop, context menus, and side action dropdowns still work in the sidebar.

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Agent-authored refactor based on analysis of detached DOM element tracking data. The per-item AccordionPrimitive.Root pattern is structurally inefficient — Radix Accordion is designed for one Root wrapping many Items, not one Root per Item.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*