### PR TITLE
fix: upgrade torph to fix matchMedia listener memory leak

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -243,7 +243,7 @@
         "simple-statistics": "^7.8.8",
         "snappy-wasm": "^0.3.0",
         "tailwind-merge": "^2.2.2",
-        "torph": "^0.0.5",
+        "torph": "^0.0.9",
         "ts-pattern": "catalog:",
         "use-debounce": "catalog:",
         "use-resize-observer": "^8.0.0",

--- a/frontend/src/lib/components/Cards/CardMeta.tsx
+++ b/frontend/src/lib/components/Cards/CardMeta.tsx
@@ -1,7 +1,8 @@
 import './CardMeta.scss'
 
+import { useMergeRefs } from '@floating-ui/react'
 import clsx from 'clsx'
-import React from 'react'
+import React, { useRef } from 'react'
 import { Transition } from 'react-transition-group'
 
 import { IconPieChart } from '@posthog/icons'
@@ -74,6 +75,8 @@ export function CardMeta({
     const { ref: detailsRef, height: detailsHeight } = useResizeObserver()
     const { ref: topRef, width: topWidth } = useResizeObserver()
     const { ref: headingRef, width: headingWidth } = useResizeObserver()
+    const transitionNodeRef = useRef<HTMLDivElement>(null)
+    const mergedDetailsRef = useMergeRefs([transitionNodeRef, detailsRef])
 
     // Calculate available space for controls (doesn't depend on label state, so no cyclic dependency)
     const controlsAvailableSpace = (topWidth ?? 0) - (headingWidth ?? 0)
@@ -186,8 +189,14 @@ export function CardMeta({
                     }}
                 >
                     {/* By using a transition about displaying then we make sure we aren't rendering the content when not needed */}
-                    <Transition in={areDetailsShown} timeout={200} mountOnEnter unmountOnExit>
-                        <div className="CardMeta__details__content" ref={detailsRef}>
+                    <Transition
+                        nodeRef={transitionNodeRef}
+                        in={areDetailsShown}
+                        timeout={200}
+                        mountOnEnter
+                        unmountOnExit
+                    >
+                        <div className="CardMeta__details__content" ref={mergedDetailsRef}>
                             {/* Stops the padding getting in the height calc  */}
                             <div className="p-4">{metaDetails}</div>
                         </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1125,8 +1125,8 @@ importers:
         specifier: ^2.2.2
         version: 2.2.2
       torph:
-        specifier: ^0.0.5
-        version: 0.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^0.0.9
+        version: 0.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-pattern:
         specifier: 'catalog:'
         version: 4.3.0
@@ -2691,8 +2691,8 @@ importers:
         specifier: '*'
         version: 15.11.0(typescript@5.8.3)
       torph:
-        specifier: ^0.0.5
-        version: 0.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^0.0.9
+        version: 0.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -3123,8 +3123,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       torph:
-        specifier: ^0.0.5
-        version: 0.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^0.0.9
+        version: 0.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       kea-test-utils:
         specifier: 'catalog:'
@@ -22054,12 +22054,12 @@ packages:
     resolution: {integrity: sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==}
     hasBin: true
 
-  torph@0.0.5:
-    resolution: {integrity: sha512-A9mwvWouyRIIZ8Y9McJioZ4O5itSjgtfPQMGxU+qvA5MYaF31EY1Cq3OpOLT34wXLhsfOC7tto5Gzg0d6I3NQg==}
+  torph@0.0.9:
+    resolution: {integrity: sha512-WrFMtJwqXCfIXbLNuTOwHWff0XVm/Ewctb+71bFis3HykPvCXl1CHXapU0r67pQhAI323fsA1L2pGPeqxXeRRA==}
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
-      svelte: '>=4'
+      svelte: '>=5'
       vue: '>=3'
     peerDependenciesMeta:
       react:
@@ -22564,8 +22564,8 @@ packages:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.398.0:
-    resolution: {integrity: sha512-bqSs038ZPxhlXlnetanpaeUHlt7HfzqYphF8GL7ofwyRwaBAUwxqDsPwff6rfd2ASpIMmqoEPk9lOvkfVU66sQ==}
+  unlayer-types@1.399.0:
+    resolution: {integrity: sha512-VbqOnzfc2iOlgW9kmZsK93/f9IqH8jq5UgTemvSbAFrrxVSQgnqH87cThEHxO1GeMoAv5PyH4VIrh2ULlK5o7Q==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -47099,7 +47099,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.3.1):
     dependencies:
       react: 18.3.1
-      unlayer-types: 1.398.0
+      unlayer-types: 1.399.0
 
   react-error-overlay@6.0.9: {}
 
@@ -49082,7 +49082,7 @@ snapshots:
     dependencies:
       commander: 2.20.3
 
-  torph@0.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  torph@0.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     optionalDependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -49609,7 +49609,7 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unlayer-types@1.398.0: {}
+  unlayer-types@1.399.0: {}
 
   unpipe@1.0.0: {}
 

--- a/products/llm_analytics/package.json
+++ b/products/llm_analytics/package.json
@@ -11,7 +11,7 @@
         "kea-subscriptions": "catalog:",
         "partial-json": "^0.1.7",
         "posthog-js": "catalog:",
-        "torph": "^0.0.5"
+        "torph": "^0.0.9"
     },
     "devDependencies": {
         "kea-test-utils": "catalog:"

--- a/products/tasks/package.json
+++ b/products/tasks/package.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "fast-deep-equal": "catalog:",
         "kea-subscriptions": "catalog:",
-        "torph": "^0.0.5"
+        "torph": "^0.0.9"
     },
     "devDependencies": {
         "kea-test-utils": "catalog:"


### PR DESCRIPTION
## Problem

Detached `data-attr="insight-empty-state"` DOM nodes (35 nodes each) and `Popover--exit-done` elements accumulate in Chrome DevTools Memory tab during normal dashboard usage.

## Changes

**Root cause**: The `torph` library (TextMorph component) v0.0.5 has a memory leak. Its constructor registers an anonymous function on `window.matchMedia("(prefers-reduced-motion: reduce)")`, but `destroy()` tries to remove a *different* class method (`this.handleMediaQueryChange`). Since `removeEventListener` is a no-op when given a non-matching function, the listener is never removed. The global `MediaQueryList` retains the closure → TextMorph instance → `this.element` → DOM node chain indefinitely.

Every `StatelessInsightLoadingState` on a dashboard renders a `TextMorph`, so each loading card leaks its DOM subtree.

**Fix**: Upgrade torph from v0.0.5 to v0.0.9, which extracts matchMedia handling into a `createReducedMotionListener()` utility that correctly uses the same `onChange` function reference for both `addEventListener` and `removeEventListener`.

Also adds `nodeRef` to CardMeta's `<Transition>` component, which was missing and causing `ReactDOM.findDOMNode()` usage that can retain detached DOM references.

## How did you test this code?

This PR was authored by an agent. Manual verification recommended:
1. Navigate to a dashboard with multiple insight cards
2. Wait for cards to cycle through loading states
3. Navigate away, check Memory → Detached elements
4. Verify `insight-empty-state` nodes no longer accumulate

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored. Root cause found by reading torph v0.0.5 source in node_modules — confirmed the mismatched listener function references in the minified output. Verified v0.0.9 fixes the bug by reading the upstream source on GitHub.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

Related to #32479
