### PR TITLE
chore(livestream): Add support for property filtering in Livestream service

### DIFF
--- a/frontend/src/scenes/activity/live/LiveEventsTable.tsx
+++ b/frontend/src/scenes/activity/live/LiveEventsTable.tsx
@@ -5,6 +5,8 @@ import { IconPauseFilled, IconPlayFilled, IconRefresh, IconTerminal } from '@pos
 import { LemonButton, Link } from '@posthog/lemon-ui'
 
 import { LiveRecordingsCount, LiveUserCount } from 'lib/components/LiveUserCount'
+import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
@@ -16,7 +18,7 @@ import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
-import { ActivityTab } from '~/types'
+import { ActivityTab, PropertyOperator } from '~/types'
 
 import { EventName } from 'products/actions/frontend/components/EventName'
 
@@ -83,6 +85,14 @@ export function LiveEventsTable(): JSX.Element {
                         onChange={(value) => setFilters({ ...filters, eventType: value })}
                         placeholder="Filter by event"
                         allEventsOption="clear"
+                    />
+                    <PropertyFilters
+                        pageKey="live-events"
+                        propertyFilters={filters.properties ?? []}
+                        onChange={(properties) => setFilters({ ...filters, properties })}
+                        taxonomicGroupTypes={[TaxonomicFilterGroupType.EventProperties]}
+                        operatorAllowlist={[PropertyOperator.Exact]}
+                        buttonText="Filter by property"
                     />
                     <LemonButton
                         icon={

--- a/frontend/src/scenes/activity/live/liveEventsLogic.tsx
+++ b/frontend/src/scenes/activity/live/liveEventsLogic.tsx
@@ -3,10 +3,11 @@ import { actions, connect, events, kea, listeners, path, props, reducers, select
 import { Spinner, lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
+import { isEventPropertyFilter } from 'lib/components/PropertyFilters/utils'
 import { liveEventsHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { LiveEvent } from '~/types'
+import { AnyPropertyFilter, LiveEvent, PropertyOperator } from '~/types'
 
 import { deduplicateEvents } from './deduplicateEvents'
 import type { liveEventsLogicType } from './liveEventsLogicType'
@@ -26,7 +27,7 @@ export const liveEventsLogic = kea<liveEventsLogicType>([
     actions(() => ({
         addEvents: (events: LiveEvent[]) => ({ events }),
         clearEvents: true,
-        setFilters: (filters: { eventType: string | null }) => ({ filters }),
+        setFilters: (filters: { eventType?: string | null; properties?: AnyPropertyFilter[] }) => ({ filters }),
         updateEventsConnection: true,
         pauseStream: true,
         resumeStream: true,
@@ -42,7 +43,7 @@ export const liveEventsLogic = kea<liveEventsLogicType>([
             },
         ],
         filters: [
-            { eventType: null } as { eventType: string | null },
+            { eventType: null, properties: [] } as { eventType: string | null; properties: AnyPropertyFilter[] },
             {
                 setFilters: (state, { filters }) => ({ ...state, ...filters }),
             },
@@ -117,10 +118,22 @@ export const liveEventsLogic = kea<liveEventsLogicType>([
                 return
             }
 
-            const { eventType } = values.filters
+            const { eventType, properties } = values.filters
             const url = new URL(`${liveEventsHostOrigin()}/events`)
             if (eventType) {
                 url.searchParams.append('eventType', eventType)
+            }
+            for (const pf of properties ?? []) {
+                if (!isEventPropertyFilter(pf) || pf.operator !== PropertyOperator.Exact || !pf.key) {
+                    continue
+                }
+                const vals = Array.isArray(pf.value) ? pf.value : [pf.value]
+                for (const v of vals) {
+                    if (v == null) {
+                        continue
+                    }
+                    url.searchParams.append('property', `${pf.key}=${String(v)}`)
+                }
             }
             url.searchParams.append('columns', '$current_url,$screen_name')
 

--- a/livestream/README.md
+++ b/livestream/README.md
@@ -16,6 +16,9 @@ Hog 3000 powers live event stream on PostHog: https://us.posthog.com/project/0/a
   - `eventType` - event type name,
   - `distinctId` - only events with a given distinctId,
   - `geo` - return only coordinates guessed based on IP,
+  - `property` - repeatable; each value is `key=value` for exact-match
+    filtering on top-level event properties. Multiple params with the same
+    key OR together, different keys AND together.
 - `/debug` - dummy html for SSE testing,
 - `/debug/sse/` - backend for `/debug` generating a server side events,
 - `/metrics` - exposes metrics in Prometheus format

--- a/livestream/events/filter.go
+++ b/livestream/events/filter.go
@@ -15,10 +15,11 @@ type Subscription struct {
 	SubID uint64
 
 	// Filters
-	TeamId     int
-	Token      string
-	DistinctId string
-	EventTypes []string
+	TeamId          int
+	Token           string
+	DistinctId      string
+	EventTypes      []string
+	PropertyFilters map[string][]string
 
 	Geo     bool
 	Columns []string
@@ -143,6 +144,20 @@ func (c *Filter) Run() {
 	}
 }
 
+func matchesPropertyFilters(props map[string]interface{}, filters map[string][]string) bool {
+	for key, allowed := range filters {
+		raw, ok := props[key]
+		if !ok {
+			return false
+		}
+		actual := fmt.Sprint(raw)
+		if !slices.Contains(allowed, actual) {
+			return false
+		}
+	}
+	return true
+}
+
 // Routes a single event to all matching subscriptions.
 // Used by both Filter (in-memory path) and TokenRouter (Redis pub/sub path).
 func deliverEvent(event PostHogEvent, subs []Subscription) {
@@ -158,6 +173,10 @@ func deliverEvent(event PostHogEvent, subs []Subscription) {
 		}
 
 		if len(sub.EventTypes) > 0 && !slices.Contains(sub.EventTypes, event.Event) {
+			continue
+		}
+
+		if len(sub.PropertyFilters) > 0 && !matchesPropertyFilters(event.Properties, sub.PropertyFilters) {
 			continue
 		}
 

--- a/livestream/events/filter_test.go
+++ b/livestream/events/filter_test.go
@@ -294,6 +294,201 @@ func TestFilterRunWithMultipleSubscribersDifferentProperties(t *testing.T) {
 	assert.Empty(t, filter.subs)
 }
 
+func TestMatchesPropertyFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		props   map[string]interface{}
+		filters map[string][]string
+		want    bool
+	}{
+		{
+			name:    "single key match",
+			props:   map[string]interface{}{"$browser": "Chrome"},
+			filters: map[string][]string{"$browser": {"Chrome"}},
+			want:    true,
+		},
+		{
+			name:    "single key miss",
+			props:   map[string]interface{}{"$browser": "Firefox"},
+			filters: map[string][]string{"$browser": {"Chrome"}},
+			want:    false,
+		},
+		{
+			name:    "multiple values OR match",
+			props:   map[string]interface{}{"$browser": "Firefox"},
+			filters: map[string][]string{"$browser": {"Chrome", "Firefox"}},
+			want:    true,
+		},
+		{
+			name:  "multi-key AND match",
+			props: map[string]interface{}{"$browser": "Chrome", "plan": "enterprise"},
+			filters: map[string][]string{
+				"$browser": {"Chrome"},
+				"plan":     {"enterprise"},
+			},
+			want: true,
+		},
+		{
+			name:  "multi-key AND miss on one key",
+			props: map[string]interface{}{"$browser": "Chrome", "plan": "free"},
+			filters: map[string][]string{
+				"$browser": {"Chrome"},
+				"plan":     {"enterprise"},
+			},
+			want: false,
+		},
+		{
+			name:    "missing key fails",
+			props:   map[string]interface{}{"$os": "Linux"},
+			filters: map[string][]string{"$browser": {"Chrome"}},
+			want:    false,
+		},
+		{
+			name:    "numeric value coerced",
+			props:   map[string]interface{}{"count": 42},
+			filters: map[string][]string{"count": {"42"}},
+			want:    true,
+		},
+		{
+			name:    "boolean value coerced",
+			props:   map[string]interface{}{"is_admin": true},
+			filters: map[string][]string{"is_admin": {"true"}},
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchesPropertyFilters(tt.props, tt.filters)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFilterRunWithPropertyFilter(t *testing.T) {
+	subChan := make(chan Subscription)
+	unSubChan := make(chan Subscription)
+	inboundChan := make(chan PostHogEvent)
+
+	filter := NewFilter(subChan, unSubChan, inboundChan)
+	go filter.Run()
+
+	eventChan := make(chan interface{}, 2)
+	sub := Subscription{
+		SubID:           1,
+		TeamId:          1,
+		Token:           "token1",
+		PropertyFilters: map[string][]string{"$browser": {"Chrome"}},
+		EventChan:       eventChan,
+		ShouldClose:     &atomic.Bool{},
+		DroppedEvents:   &atomic.Uint64{},
+	}
+	subChan <- sub
+	time.Sleep(10 * time.Millisecond)
+
+	matching := PostHogEvent{
+		Uuid:       "match",
+		Token:      "token1",
+		DistinctId: "user1",
+		Event:      "pageview",
+		Properties: map[string]interface{}{"$browser": "Chrome"},
+	}
+	nonMatching := PostHogEvent{
+		Uuid:       "miss",
+		Token:      "token1",
+		DistinctId: "user1",
+		Event:      "pageview",
+		Properties: map[string]interface{}{"$browser": "Firefox"},
+	}
+	inboundChan <- matching
+	inboundChan <- nonMatching
+
+	select {
+	case received := <-eventChan:
+		resp, ok := received.(ResponsePostHogEvent)
+		require.True(t, ok)
+		assert.Equal(t, "match", resp.Uuid)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Timed out waiting for matching event")
+	}
+
+	select {
+	case received := <-eventChan:
+		resp, _ := received.(ResponsePostHogEvent)
+		t.Fatalf("unexpected event delivered: %+v", resp)
+	case <-time.After(50 * time.Millisecond):
+		// expected: non-matching event was filtered out
+	}
+
+	unSubChan <- sub
+	time.Sleep(10 * time.Millisecond)
+}
+
+func TestFilterRunWithPropertyAndEventTypeFilter(t *testing.T) {
+	subChan := make(chan Subscription)
+	unSubChan := make(chan Subscription)
+	inboundChan := make(chan PostHogEvent)
+
+	filter := NewFilter(subChan, unSubChan, inboundChan)
+	go filter.Run()
+
+	eventChan := make(chan interface{}, 4)
+	sub := Subscription{
+		SubID:           1,
+		TeamId:          1,
+		Token:           "token1",
+		EventTypes:      []string{"checkout_completed"},
+		PropertyFilters: map[string][]string{"plan": {"enterprise"}},
+		EventChan:       eventChan,
+		ShouldClose:     &atomic.Bool{},
+		DroppedEvents:   &atomic.Uint64{},
+	}
+	subChan <- sub
+	time.Sleep(10 * time.Millisecond)
+
+	// Both match: event type and property
+	inboundChan <- PostHogEvent{
+		Uuid:       "both",
+		Token:      "token1",
+		Event:      "checkout_completed",
+		Properties: map[string]interface{}{"plan": "enterprise"},
+	}
+	// Wrong event type
+	inboundChan <- PostHogEvent{
+		Uuid:       "wrong-event",
+		Token:      "token1",
+		Event:      "pageview",
+		Properties: map[string]interface{}{"plan": "enterprise"},
+	}
+	// Wrong property
+	inboundChan <- PostHogEvent{
+		Uuid:       "wrong-prop",
+		Token:      "token1",
+		Event:      "checkout_completed",
+		Properties: map[string]interface{}{"plan": "free"},
+	}
+
+	select {
+	case received := <-eventChan:
+		resp, ok := received.(ResponsePostHogEvent)
+		require.True(t, ok)
+		assert.Equal(t, "both", resp.Uuid)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Timed out waiting for combined-match event")
+	}
+
+	select {
+	case received := <-eventChan:
+		resp, _ := received.(ResponsePostHogEvent)
+		t.Fatalf("unexpected event delivered: %+v", resp)
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+
+	unSubChan <- sub
+	time.Sleep(10 * time.Millisecond)
+}
+
 func TestResponsePostHogEvent_MarshalJSON(t *testing.T) {
 	event := ResponsePostHogEvent{
 		Uuid:       "123",

--- a/livestream/handlers/handlers.go
+++ b/livestream/handlers/handlers.go
@@ -133,17 +133,20 @@ func StreamEventsHandler(log echo.Logger, subChan chan events.Subscription, unSu
 			eventTypes = strings.Split(eventType, ",")
 		}
 
+		propertyFilters := parsePropertyFilters(c.QueryParams()["property"])
+
 		subscription := events.Subscription{
-			SubID:         atomic.AddUint64(&subID, 1),
-			TeamId:        teamID,
-			Token:         token,
-			DistinctId:    distinctId,
-			Geo:           geoOnly,
-			Columns:       columns,
-			EventTypes:    eventTypes,
-			EventChan:     make(chan interface{}, 100),
-			ShouldClose:   &atomic.Bool{},
-			DroppedEvents: &atomic.Uint64{},
+			SubID:           atomic.AddUint64(&subID, 1),
+			TeamId:          teamID,
+			Token:           token,
+			DistinctId:      distinctId,
+			Geo:             geoOnly,
+			Columns:         columns,
+			EventTypes:      eventTypes,
+			PropertyFilters: propertyFilters,
+			EventChan:       make(chan interface{}, 100),
+			ShouldClose:     &atomic.Bool{},
+			DroppedEvents:   &atomic.Uint64{},
 		}
 
 		subChan <- subscription
@@ -183,6 +186,24 @@ func StreamEventsHandler(log echo.Logger, subChan chan events.Subscription, unSu
 			}
 		}
 	}
+}
+
+func parsePropertyFilters(raw []string) map[string][]string {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(raw))
+	for _, entry := range raw {
+		k, v, ok := strings.Cut(entry, "=")
+		if !ok || k == "" {
+			continue
+		}
+		out[k] = append(out[k], v)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func NotificationsHandler(redisClient rueidis.Client) func(c echo.Context) error {

--- a/livestream/handlers/handlers_test.go
+++ b/livestream/handlers/handlers_test.go
@@ -249,3 +249,67 @@ func TestStatsHandler_FallsBackToLocal(t *testing.T) {
 	assert.Equal(t, 2, resp.ActiveRecordings)
 	assert.Empty(t, resp.Error)
 }
+
+func TestParsePropertyFilters(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  []string
+		want map[string][]string
+	}{
+		{
+			name: "nil input",
+			raw:  nil,
+			want: nil,
+		},
+		{
+			name: "empty input",
+			raw:  []string{},
+			want: nil,
+		},
+		{
+			name: "single key=value",
+			raw:  []string{"$browser=Chrome"},
+			want: map[string][]string{"$browser": {"Chrome"}},
+		},
+		{
+			name: "multiple keys AND",
+			raw:  []string{"$browser=Chrome", "plan=enterprise"},
+			want: map[string][]string{
+				"$browser": {"Chrome"},
+				"plan":     {"enterprise"},
+			},
+		},
+		{
+			name: "same key OR",
+			raw:  []string{"$browser=Chrome", "$browser=Firefox"},
+			want: map[string][]string{"$browser": {"Chrome", "Firefox"}},
+		},
+		{
+			name: "missing equals skipped",
+			raw:  []string{"$browser", "plan=free"},
+			want: map[string][]string{"plan": {"free"}},
+		},
+		{
+			name: "empty key skipped",
+			raw:  []string{"=Chrome", "plan=free"},
+			want: map[string][]string{"plan": {"free"}},
+		},
+		{
+			name: "all malformed returns nil",
+			raw:  []string{"=foo", "bar"},
+			want: nil,
+		},
+		{
+			name: "empty value allowed",
+			raw:  []string{"plan="},
+			want: map[string][]string{"plan": {""}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parsePropertyFilters(tt.raw)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Problem
I'd like to be able to filter events by a specific event property.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Adds a new `PropertyFilters` property on the subscription.


https://github.com/user-attachments/assets/fd90b0b8-0c22-4739-ab89-a8b94c672517


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally, tests
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
