### PR TITLE
chore(data-warehouse): Removed DLT from normalize_identifier

### DIFF
--- a/posthog/temporal/data_imports/README.md
+++ b/posthog/temporal/data_imports/README.md
@@ -41,7 +41,7 @@ To connect to a pod, follow this runbook: [https://runbooks.posthog.com/EKS/acce
 The following code snippet will both disable billing and reset the table - which means deleting all existing table files (other than query files). Make sure to run this on a `temporal-worker-data-warehouse` pod - they have all the correct env vars set up for this:
 
 ```python
-from dlt.common.normalizers.naming.snake_case import NamingConvention
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 import os
 import s3fs
 import time
@@ -55,7 +55,7 @@ for index, schema_id in enumerate(schema_ids):
     team_id = schema.team_id
     schema_id = schema.id
     source_id = schema.source.id
-    schema_name = NamingConvention().normalize_identifier(schema.name)
+    schema_name = NamingConvention.normalize_identifier(schema.name)
     s3_folder = f"{os.environ['BUCKET_URL']}/{schema.folder_path()}/{schema_name}"
     print(f"Deleting {s3_folder}")
     try:
@@ -73,7 +73,7 @@ for index, schema_id in enumerate(schema_ids):
 If you want to sync a table without resetting it - then the below snippet is for you instead:
 
 ```python
-from dlt.common.normalizers.naming.snake_case import NamingConvention
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 import os
 import s3fs
 import time
@@ -87,7 +87,7 @@ for index, schema_id in enumerate(schema_ids):
     team_id = schema.team_id
     schema_id = schema.id
     source_id = schema.source.id
-    schema_name = NamingConvention().normalize_identifier(schema.name)
+    schema_name = NamingConvention.normalize_identifier(schema.name)
     print("Starting temporal worker...")
     try:
         os.system('python manage.py start_temporal_workflow external-data-job "{\\"team_id\\": ' + str(team_id) + ',\\"external_data_source_id\\":\\"' + str(source_id) + '\\",\\"external_data_schema_id\\":\\"' + str(schema_id) + '\\",\\"billable\\":false,\\"reset_pipeline\\":false}" --workflow-id ' + str(schema_id) + '-resync-' + str(time.time()) + ' --task-queue data-warehouse-task-queue')

--- a/posthog/temporal/data_imports/naming_convention.py
+++ b/posthog/temporal/data_imports/naming_convention.py
@@ -12,7 +12,7 @@ import re
 import math
 import base64
 import hashlib
-from functools import cache
+from functools import lru_cache
 
 RE_UNDERSCORES = re.compile("__+")
 RE_LEADING_DIGITS = re.compile(r"^\d+")
@@ -57,7 +57,7 @@ class NamingConvention:
         return _normalize_identifier(identifier, max_length)
 
 
-@cache
+@lru_cache
 def _normalize_identifier(identifier: str, max_length: int | None) -> str:
     normalized = identifier.translate(_TR_REDUCE_ALPHABET)
     normalized = RE_NON_ALPHANUMERIC.sub("_", normalized)
@@ -79,7 +79,7 @@ def _to_snake_case(identifier: str) -> str:
     return RE_UNDERSCORES.sub("_", stripped)
 
 
-@cache
+@lru_cache
 def _shorten_identifier(
     normalized_ident: str,
     identifier: str,

--- a/posthog/temporal/data_imports/naming_convention.py
+++ b/posthog/temporal/data_imports/naming_convention.py
@@ -1,0 +1,118 @@
+"""Snake case naming convention used for normalizing identifiers coming from
+external data sources.
+
+This is a port of ``dlt.common.normalizers.naming.snake_case.NamingConvention``
+so we can drop the DLT runtime dependency from the data import code paths. The
+behavior must stay byte-for-byte compatible with the DLT implementation because
+existing schemas, column names and table names stored in ClickHouse/S3 were
+produced by it.
+"""
+
+import re
+import math
+import base64
+import hashlib
+from functools import cache
+
+RE_UNDERSCORES = re.compile("__+")
+RE_LEADING_DIGITS = re.compile(r"^\d+")
+RE_NON_ALPHANUMERIC = re.compile(r"[^a-zA-Z\d_]+")
+
+_SNAKE_CASE_BREAK_1 = re.compile("([^_])([A-Z][a-z]+)")
+_SNAKE_CASE_BREAK_2 = re.compile("([a-z0-9])([A-Z])")
+
+_REDUCE_ALPHABET = ("+-*@|", "x_xal")
+_TR_REDUCE_ALPHABET = str.maketrans(_REDUCE_ALPHABET[0], _REDUCE_ALPHABET[1])
+
+# base64 produces `+` and `/`; translate them to alphanumeric so the resulting
+# tag survives the alphanumeric-only identifier rules.
+_TR_TAG_TABLE = bytes.maketrans(b"/+", b"ab")
+
+_DEFAULT_COLLISION_PROB = 0.001
+
+
+class NamingConvention:
+    """Case insensitive snake_case naming convention with a reduced alphabet.
+
+    - Spaces around the identifier are trimmed.
+    - All ascii characters except alphanumerics and underscores are removed.
+    - Prepends ``_`` if the name starts with a number.
+    - Multiples of ``_`` are collapsed to a single ``_``.
+    - Trailing ``_`` characters are replaced with ``x``.
+    - ``+`` and ``*`` become ``x``, ``-`` becomes ``_``, ``@`` becomes ``a``,
+      ``|`` becomes ``l``.
+
+    When ``max_length`` is set, identifiers longer than that are truncated and
+    a short deterministic tag derived from the original identifier is inserted
+    in the middle so that collisions remain unlikely.
+    """
+
+    @staticmethod
+    def normalize_identifier(identifier: str, max_length: int | None = None) -> str:
+        if identifier is None:
+            raise ValueError("`name` is None")
+        identifier = identifier.strip()
+        if not identifier:
+            raise ValueError(identifier)
+        return _normalize_identifier(identifier, max_length)
+
+
+@cache
+def _normalize_identifier(identifier: str, max_length: int | None) -> str:
+    normalized = identifier.translate(_TR_REDUCE_ALPHABET)
+    normalized = RE_NON_ALPHANUMERIC.sub("_", normalized)
+    normalized = _to_snake_case(normalized)
+    return _shorten_identifier(normalized, identifier, max_length)
+
+
+def _to_snake_case(identifier: str) -> str:
+    identifier = _SNAKE_CASE_BREAK_1.sub(r"\1_\2", identifier)
+    identifier = _SNAKE_CASE_BREAK_2.sub(r"\1_\2", identifier).lower()
+
+    if RE_LEADING_DIGITS.match(identifier):
+        identifier = "_" + identifier
+
+    stripped = identifier.rstrip("_")
+    strip_count = len(identifier) - len(stripped)
+    stripped += "x" * strip_count
+
+    return RE_UNDERSCORES.sub("_", stripped)
+
+
+@cache
+def _shorten_identifier(
+    normalized_ident: str,
+    identifier: str,
+    max_length: int | None,
+    collision_prob: float = _DEFAULT_COLLISION_PROB,
+) -> str:
+    if max_length and len(normalized_ident) > max_length:
+        tag = _compute_tag(identifier, collision_prob)
+        normalized_ident = _trim_and_tag(normalized_ident, tag, max_length)
+    return normalized_ident
+
+
+def _compute_tag(identifier: str, collision_prob: float) -> str:
+    # Assume shake_128 has ~perfect collision resistance 2^(N/2); account for
+    # the ~1.5x bit overhead introduced by lower-casing base64 output.
+    tl_bytes = int(((2 + 1) * math.log2(1 / collision_prob) // 8) + 1)
+    return (
+        base64.b64encode(hashlib.shake_128(identifier.encode("utf-8")).digest(tl_bytes))
+        .rstrip(b"=")
+        .translate(_TR_TAG_TABLE)
+        .lower()
+        .decode("ascii")
+    )
+
+
+def _trim_and_tag(identifier: str, tag: str, max_length: int) -> str:
+    assert len(tag) <= max_length
+    remaining_length = max_length - len(tag)
+    remaining_overflow = remaining_length % 2
+    trimmed = (
+        identifier[: remaining_length // 2 + remaining_overflow]
+        + tag
+        + identifier[len(identifier) - remaining_length // 2 :]
+    )
+    assert len(trimmed) == max_length
+    return trimmed

--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -11,11 +11,11 @@ import deltalake as deltalake
 import pyarrow.compute as pc
 import deltalake.exceptions
 from dlt.common.libs.deltalake import ensure_delta_compatible_arrow_schema
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 from structlog.types import FilteringBoundLogger
 
 from posthog.exceptions_capture import capture_exception
 from posthog.sync import database_sync_to_async_pool
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.pipeline.consts import PARTITION_KEY
 from posthog.temporal.data_imports.pipelines.pipeline.utils import conditional_lru_cache_async, normalize_column_name
 
@@ -105,7 +105,7 @@ class DeltaTableHelper:
         }
 
     async def _get_delta_table_uri(self) -> str:
-        normalized_resource_name = NamingConvention().normalize_identifier(self._resource_name)
+        normalized_resource_name = NamingConvention.normalize_identifier(self._resource_name)
         folder_path = await database_sync_to_async_pool(self._job.folder_path)()
         return f"{settings.BUCKET_URL}/{folder_path}/{normalized_resource_name}"
 

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -20,11 +20,11 @@ from circular_dict import CircularDict
 from dateutil import parser
 from dlt.common.data_types.typing import TDataType
 from dlt.common.libs.deltalake import ensure_delta_compatible_arrow_schema
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 from dlt.sources import DltResource
 from structlog.types import FilteringBoundLogger
 
 from posthog.sync import database_sync_to_async_pool
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.pipeline.consts import PARTITION_KEY
 from posthog.temporal.data_imports.pipelines.pipeline.typings import PartitionFormat, PartitionMode, SourceResponse
 
@@ -66,7 +66,7 @@ class TemporaryFileSizeExceedsLimitException(Exception):
 
 
 def normalize_column_name(column_name: str) -> str:
-    return NamingConvention().normalize_identifier(column_name)
+    return NamingConvention.normalize_identifier(column_name)
 
 
 def safe_parse_datetime(date_str) -> None | pa.TimestampScalar | datetime.datetime:

--- a/posthog/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_sync.py
@@ -16,11 +16,11 @@ import dlt.common.libs.pyarrow
 import dlt.extract.incremental
 import dlt.extract.incremental.transform
 from clickhouse_driver.errors import ServerException
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 
 from posthog.exceptions_capture import capture_exception
 from posthog.sync import database_sync_to_async_pool
 from posthog.temporal.common.logger import get_logger
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.helpers import build_table_name
 
 from products.data_warehouse.backend.models.external_data_job import ExternalDataJob
@@ -177,7 +177,7 @@ async def validate_schema_and_update_table(
         incremental_or_append = external_data_schema.should_use_incremental_field
 
         table_name = build_table_name(job.pipeline, _schema_name)
-        normalized_schema_name = NamingConvention().normalize_identifier(_schema_name)
+        normalized_schema_name = NamingConvention.normalize_identifier(_schema_name)
         new_url_pattern = job.url_pattern_by_schema(normalized_schema_name)
 
         # Check
@@ -303,7 +303,7 @@ async def register_cdc_companion_table(
     def _register():
         job = ExternalDataJob.objects.prefetch_related("pipeline").get(pk=run_id)
 
-        normalized_resource_name = NamingConvention().normalize_identifier(resource_name)
+        normalized_resource_name = NamingConvention.normalize_identifier(resource_name)
         companion_table_name = build_table_name(job.pipeline, resource_name)
         new_url_pattern = job.url_pattern_by_schema(normalized_resource_name)
 

--- a/posthog/temporal/data_imports/pipelines/test_pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/test_pipeline_sync.py
@@ -3,8 +3,7 @@ import uuid
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
-from dlt.common.normalizers.naming.snake_case import NamingConvention
-
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.helpers import build_table_name
 from posthog.temporal.data_imports.pipelines.pipeline_sync import merge_columns
 
@@ -35,7 +34,7 @@ def _register_companion_sync(
         return
 
     job = ExternalDataJob.objects.prefetch_related("pipeline").get(pk=run_id)
-    normalized_resource_name = NamingConvention().normalize_identifier(resource_name)
+    normalized_resource_name = NamingConvention.normalize_identifier(resource_name)
     companion_table_name = build_table_name(job.pipeline, resource_name)
     new_url_pattern = job.url_pattern_by_schema(normalized_resource_name)
 

--- a/posthog/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/posthog/temporal/data_imports/sources/bigquery/bigquery.py
@@ -6,7 +6,6 @@ import collections.abc
 from datetime import date, datetime
 
 import pyarrow as pa
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 from google.api_core.exceptions import Forbidden
 from google.cloud import bigquery, bigquery_storage
 from google.cloud.bigquery.job import QueryJobConfig
@@ -14,6 +13,7 @@ from google.oauth2 import service_account
 from structlog.types import FilteringBoundLogger
 
 from posthog.exceptions_capture import capture_exception
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.helpers import incremental_type_to_initial_value
 from posthog.temporal.data_imports.pipelines.pipeline.consts import DEFAULT_TABLE_SIZE_BYTES
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
@@ -403,7 +403,7 @@ def bigquery_source(
     """
 
     project_id_for_dataset = dataset_project_id or project_id
-    name = NamingConvention().normalize_identifier(table_name)
+    name = NamingConvention.normalize_identifier(table_name)
     fully_qualified_table_name = f"{project_id_for_dataset}.{dataset_id}.{table_name}"
 
     with bigquery_client(

--- a/posthog/temporal/data_imports/sources/bing_ads/bing_ads.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/bing_ads.py
@@ -4,9 +4,9 @@ import collections.abc
 from dataclasses import dataclass
 
 import structlog
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 
 from posthog.settings import integrations
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.helpers import initial_datetime
 from posthog.temporal.data_imports.pipelines.pipeline.typings import PartitionFormat, PartitionMode, SourceResponse
 
@@ -70,7 +70,7 @@ def bing_ads_source(
     incremental_field: str | None = None,
     incremental_field_type: IncrementalFieldType | None = None,
 ) -> SourceResponse:
-    name = NamingConvention().normalize_identifier(resource_name)
+    name = NamingConvention.normalize_identifier(resource_name)
     schema = get_schemas()[resource_name]
 
     # Define generator function for lazy evaluation - dlt will call this when ready to fetch data

--- a/posthog/temporal/data_imports/sources/doit/doit.py
+++ b/posthog/temporal/data_imports/sources/doit/doit.py
@@ -6,9 +6,9 @@ import pyarrow as pa
 import requests
 import structlog
 from dateutil import parser
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 from structlog.types import FilteringBoundLogger
 
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.temporal.data_imports.pipelines.pipeline.utils import table_from_iterator
 from posthog.temporal.data_imports.sources.generated_configs import DoItSourceConfig
@@ -70,7 +70,7 @@ def doit_list_reports(config: DoItSourceConfig, logger: Optional[FilteringBoundL
             logger.warning("Skipping DoIt report with empty name", report_id=report_id)
             continue
         try:
-            normalized = NamingConvention().normalize_identifier(report_name)
+            normalized = NamingConvention.normalize_identifier(report_name)
             result.append((normalized, report["id"]))
         except ValueError:
             logger.warning("Skipping DoIt report with invalid name", report_id=report_id, report_name=report_name)

--- a/posthog/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/posthog/temporal/data_imports/sources/google_ads/google_ads.py
@@ -5,7 +5,6 @@ import collections.abc
 from django.conf import settings
 
 import pyarrow as pa
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.v23.common import types as ga_common
 from google.ads.googleads.v23.enums import types as ga_enums
@@ -15,6 +14,7 @@ from google.oauth2 import service_account
 from google.protobuf.json_format import MessageToJson
 
 from posthog.models.integration import Integration
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.helpers import incremental_type_to_initial_value
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.temporal.data_imports.sources.common import config
@@ -365,7 +365,7 @@ def google_ads_source(
     yield batches of rows as `pyarrow.Table`.
     """
 
-    name = NamingConvention().normalize_identifier(resource_name)
+    name = NamingConvention.normalize_identifier(resource_name)
     table = get_schemas(config, team_id)[resource_name]
 
     if table.requires_filter and not should_use_incremental_field:

--- a/posthog/temporal/data_imports/sources/google_sheets/google_sheets.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/google_sheets.py
@@ -6,9 +6,9 @@ from django.conf import settings
 
 import gspread
 from cachetools import Cache, TTLCache, cached
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 from google.oauth2 import service_account
 
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.temporal.data_imports.pipelines.pipeline.utils import table_from_py_list
 from posthog.temporal.data_imports.sources.generated_configs import GoogleSheetsSourceConfig
@@ -69,7 +69,7 @@ def get_schemas(config: GoogleSheetsSourceConfig) -> list[tuple[str, int]]:
     spreadsheet = client.open_by_url(config.spreadsheet_url)
     worksheets = spreadsheet.worksheets()
 
-    return [(NamingConvention().normalize_identifier(worksheet.title), worksheet.id) for worksheet in worksheets]
+    return [(NamingConvention.normalize_identifier(worksheet.title), worksheet.id) for worksheet in worksheets]
 
 
 def get_schema_incremental_fields(config: GoogleSheetsSourceConfig, worksheet_name: str) -> list[IncrementalField]:

--- a/posthog/temporal/data_imports/sources/linkedin_ads/linkedin_ads.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/linkedin_ads.py
@@ -3,9 +3,8 @@ import datetime as dt
 import collections.abc
 from dataclasses import dataclass
 
-from dlt.common.normalizers.naming.snake_case import NamingConvention
-
 from posthog.models.integration import Integration
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.helpers import incremental_type_to_initial_value, initial_datetime
 from posthog.temporal.data_imports.pipelines.pipeline.typings import PartitionFormat, PartitionMode, SourceResponse
 from posthog.temporal.data_imports.sources.generated_configs import LinkedinAdsSourceConfig
@@ -106,7 +105,7 @@ def linkedin_ads_source(
     Uses the LinkedIn Marketing API to query for the configured resource and
     yields batches of records as list[dict].
     """
-    name = NamingConvention().normalize_identifier(resource_name)
+    name = NamingConvention.normalize_identifier(resource_name)
     schema = get_schemas()[resource_name]
 
     def get_rows() -> collections.abc.Iterator[list[dict]]:

--- a/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
@@ -5,9 +5,9 @@ import collections.abc
 from dataclasses import dataclass
 
 import requests
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 
 from posthog.models.integration import ERROR_TOKEN_REFRESH_FAILED, Integration, MetaAdsIntegration
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.pipeline.typings import PartitionFormat, PartitionMode, SourceResponse
 from posthog.temporal.data_imports.sources.generated_configs import MetaAdsSourceConfig
 from posthog.temporal.data_imports.sources.meta_ads.schemas import RESOURCE_SCHEMAS
@@ -229,7 +229,7 @@ def meta_ads_source(
     incremental_field_type: IncrementalFieldType | None = None,
 ) -> SourceResponse:
     """A data warehouse Meta Ads source."""
-    name = NamingConvention().normalize_identifier(resource_name)
+    name = NamingConvention.normalize_identifier(resource_name)
     schema = get_schemas()[resource_name]
 
     sync_lookback_days = getattr(config, "sync_lookback_days", None)

--- a/posthog/temporal/data_imports/sources/mongodb/mongo.py
+++ b/posthog/temporal/data_imports/sources/mongodb/mongo.py
@@ -9,13 +9,13 @@ from typing import Any, Optional
 
 import certifi
 from bson import ObjectId
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 from pymongo import MongoClient
 from pymongo.collection import Collection
 from pymongo.server_description import ServerDescription
 from structlog.types import FilteringBoundLogger
 
 from posthog.exceptions_capture import capture_exception
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.helpers import incremental_type_to_initial_value
 from posthog.temporal.data_imports.pipelines.pipeline.consts import DEFAULT_CHUNK_SIZE
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
@@ -427,7 +427,7 @@ def mongo_source(
 
                 yield result
 
-    name = NamingConvention().normalize_identifier(collection_name)
+    name = NamingConvention.normalize_identifier(collection_name)
 
     return SourceResponse(
         name=name,

--- a/posthog/temporal/data_imports/sources/mssql/mssql.py
+++ b/posthog/temporal/data_imports/sources/mssql/mssql.py
@@ -8,10 +8,10 @@ from contextlib import _GeneratorContextManager
 from typing import Any
 
 import pyarrow as pa
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 from structlog.types import FilteringBoundLogger
 
 from posthog.exceptions_capture import capture_exception
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.helpers import incremental_type_to_initial_value
 from posthog.temporal.data_imports.pipelines.pipeline.consts import DEFAULT_CHUNK_SIZE, DEFAULT_TABLE_SIZE_BYTES
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
@@ -561,7 +561,7 @@ def mssql_source(
 
                         yield table_from_iterator((dict(zip(column_names, row)) for row in rows), arrow_schema)
 
-    name = NamingConvention().normalize_identifier(table_name)
+    name = NamingConvention.normalize_identifier(table_name)
 
     return SourceResponse(
         name=name,

--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -13,12 +13,12 @@ from django.conf import settings
 import pyarrow as pa
 import pymysql
 import pymysql.converters
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 from pymysql.constants import FIELD_TYPE
 from pymysql.cursors import Cursor, SSCursor
 from structlog.types import FilteringBoundLogger
 
 from posthog.exceptions_capture import capture_exception
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.helpers import incremental_type_to_initial_value
 from posthog.temporal.data_imports.pipelines.pipeline.consts import DEFAULT_CHUNK_SIZE, DEFAULT_TABLE_SIZE_BYTES
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
@@ -656,7 +656,7 @@ def mysql_source(
 
                         yield table_from_iterator((dict(zip(column_names, row)) for row in rows), arrow_schema)
 
-    name = NamingConvention().normalize_identifier(table_name)
+    name = NamingConvention.normalize_identifier(table_name)
 
     return SourceResponse(
         name=name,

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -13,12 +13,12 @@ from django.conf import settings
 
 import psycopg
 import pyarrow as pa
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 from psycopg import sql
 from psycopg.adapt import Loader
 from structlog.types import FilteringBoundLogger
 
 from posthog.exceptions_capture import capture_exception
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.helpers import incremental_type_to_initial_value
 from posthog.temporal.data_imports.pipelines.pipeline.consts import DEFAULT_CHUNK_SIZE, DEFAULT_TABLE_SIZE_BYTES
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
@@ -1231,7 +1231,7 @@ def postgres_source(
 
                 raise
 
-    name = NamingConvention().normalize_identifier(table_name)
+    name = NamingConvention.normalize_identifier(table_name)
 
     return SourceResponse(
         name=name,

--- a/posthog/temporal/data_imports/sources/redshift/redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/redshift.py
@@ -8,12 +8,12 @@ from typing import Any, Literal, LiteralString, Optional, cast
 
 import psycopg
 import pyarrow as pa
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 from psycopg import sql
 from psycopg.adapt import Loader
 from structlog.types import FilteringBoundLogger
 
 from posthog.exceptions_capture import capture_exception
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.helpers import incremental_type_to_initial_value
 from posthog.temporal.data_imports.pipelines.pipeline.consts import DEFAULT_CHUNK_SIZE, DEFAULT_TABLE_SIZE_BYTES
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
@@ -678,7 +678,7 @@ def redshift_source(
 
                         yield table_from_iterator((dict(zip(column_names, row)) for row in rows), arrow_schema)
 
-    name = NamingConvention().normalize_identifier(table_name)
+    name = NamingConvention.normalize_identifier(table_name)
 
     return SourceResponse(
         name=name,

--- a/posthog/temporal/data_imports/sources/snowflake/snowflake.py
+++ b/posthog/temporal/data_imports/sources/snowflake/snowflake.py
@@ -7,11 +7,11 @@ from typing import Any, Optional
 import snowflake.connector
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 from snowflake.connector.cursor import SnowflakeCursor
 from structlog.types import FilteringBoundLogger
 
 from posthog.exceptions_capture import capture_exception
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.helpers import incremental_type_to_initial_value
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.temporal.data_imports.sources.generated_configs import SnowflakeSourceConfig
@@ -266,6 +266,6 @@ def snowflake_source(
                 # https://github.com/snowflakedb/snowflake-connector-python/issues/1712
                 yield from cursor.fetch_arrow_batches()
 
-    name = NamingConvention().normalize_identifier(table_name)
+    name = NamingConvention.normalize_identifier(table_name)
 
     return SourceResponse(name=name, items=get_rows, primary_keys=primary_keys, rows_to_sync=rows_to_sync)

--- a/posthog/temporal/data_imports/tests/test_naming_convention.py
+++ b/posthog/temporal/data_imports/tests/test_naming_convention.py
@@ -1,0 +1,141 @@
+import pytest
+
+from dlt.common.normalizers.naming.snake_case import NamingConvention as DltNamingConvention
+
+from posthog.temporal.data_imports.naming_convention import NamingConvention
+
+# Hand-verified outputs — these double as documentation of the convention.
+HAND_VERIFIED_CASES = [
+    # simple lowercase identifiers pass through
+    ("name", "name"),
+    ("hello_world", "hello_world"),
+    # whitespace is stripped
+    ("  padded  ", "padded"),
+    # camelCase and PascalCase split on case boundaries
+    ("camelCase", "camel_case"),
+    ("CamelCase", "camel_case"),
+    ("HTTPRequest", "http_request"),
+    ("HTTPRequestID", "http_request_id"),
+    ("getUserByID", "get_user_by_id"),
+    ("parseURLParam", "parse_url_param"),
+    ("User2Name", "user2_name"),
+    # leading digits get an underscore prefix
+    ("123abc", "_123abc"),
+    ("1col", "_1col"),
+    ("2024_orders", "_2024_orders"),
+    # non-alphanumeric characters collapse to underscores
+    ("hello world", "hello_world"),
+    ("foo.bar.baz", "foo_bar_baz"),
+    ("foo/bar", "foo_bar"),
+    ("col#1", "col_1"),
+    # trailing underscores convert to x's, one per underscore
+    ("name_", "namex"),
+    ("name__", "namexx"),
+    ("trailing___", "trailingxxx"),
+    # trailing non-alphanumerics collapse then convert to a single x
+    ("col[0]", "col_0x"),
+    ("price$", "pricex"),
+    ("name (copy)", "name_copyx"),
+    # multiple internal underscores collapse to one
+    ("foo__bar", "foo_bar"),
+    ("foo___bar", "foo_bar"),
+    # reduced-alphabet translations happen before non-alnum substitution
+    ("a+b", "axb"),
+    ("a-b", "a_b"),
+    ("a*b", "axb"),
+    ("a@b", "aab"),
+    ("a|b", "alb"),
+    ("C++", "cxx"),
+    ("customer@email", "customeraemail"),
+    # unicode characters are treated as non-alphanumeric
+    ("café", "cafx"),
+    # single character and edge inputs
+    ("a", "a"),
+    ("A", "a"),
+    ("1", "_1"),
+    ("_", "x"),
+    # already snake_case stays stable
+    ("already_snake", "already_snake"),
+    ("snake_case_123", "snake_case_123"),
+    # realistic column names from external sources
+    ("Customer ID", "customer_id"),
+    ("createdAt", "created_at"),
+]
+
+
+# Cases we don't hardcode — just assert ours matches DLT byte-for-byte.
+DLT_PARITY_CASES = [
+    "simple",
+    "camelCase",
+    "HTTPResponse",
+    "weird+name-with*chars",
+    "name with spaces and 123",
+    "Orders (2024) ver 2",
+    "My Column-Name+42",
+    "UserProfile.firstName",
+    "orders[2024]",
+    "leadingDigits123Trailing___",
+    "a_very_long_identifier_that_should_still_match_dlt_output_exactly",
+    "Mix3dC4seWith_Underscores",
+    "____only_underscores____",
+    "über",
+    "A1B2C3",
+    "XMLParser",
+    "IOError",
+    "some+very-mixed*string@with|lots_of#chars!",
+    "   leading and trailing   ",
+]
+
+
+class TestNamingConvention:
+    def test_none_raises(self):
+        with pytest.raises(ValueError, match="`name` is None"):
+            NamingConvention.normalize_identifier(None)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("value", ["", " ", "   ", "\t\n"])
+    def test_empty_after_strip_raises(self, value):
+        with pytest.raises(ValueError):
+            NamingConvention.normalize_identifier(value)
+
+    @pytest.mark.parametrize("source,expected", HAND_VERIFIED_CASES)
+    def test_hand_verified(self, source, expected):
+        assert NamingConvention.normalize_identifier(source) == expected
+
+    @pytest.mark.parametrize("source,_expected", HAND_VERIFIED_CASES)
+    def test_hand_verified_matches_dlt(self, source, _expected):
+        ours = NamingConvention.normalize_identifier(source)
+        theirs = DltNamingConvention().normalize_identifier(source)
+        assert ours == theirs
+
+    @pytest.mark.parametrize("source", DLT_PARITY_CASES)
+    def test_matches_dlt(self, source):
+        ours = NamingConvention.normalize_identifier(source)
+        theirs = DltNamingConvention().normalize_identifier(source)
+        assert ours == theirs
+
+    def test_default_no_max_length_keeps_long_names(self):
+        long_name = "a" * 500
+        assert NamingConvention.normalize_identifier(long_name) == long_name
+
+    @pytest.mark.parametrize("max_length", [8, 16, 32, 63, 128])
+    def test_max_length_matches_dlt(self, max_length):
+        identifier = "this_is_a_fairly_long_identifier_that_needs_to_be_shortened_several_times"
+        ours = NamingConvention.normalize_identifier(identifier, max_length=max_length)
+        theirs = DltNamingConvention(max_length=max_length).normalize_identifier(identifier)
+        assert ours == theirs
+        assert len(ours) <= max_length
+
+    def test_max_length_leaves_short_identifiers_alone(self):
+        assert NamingConvention.normalize_identifier("short", max_length=32) == "short"
+
+    def test_max_length_tag_is_deterministic(self):
+        long_name = "some_really_long_column_name_here"
+        first = NamingConvention.normalize_identifier(long_name, max_length=16)
+        second = NamingConvention.normalize_identifier(long_name, max_length=16)
+        assert first == second
+        assert len(first) == 16
+
+    def test_max_length_tag_differs_for_different_inputs(self):
+        a = NamingConvention.normalize_identifier("prefix_common_suffix_a", max_length=16)
+        b = NamingConvention.normalize_identifier("prefix_common_suffix_b", max_length=16)
+        assert a != b

--- a/posthog/temporal/data_imports/util.py
+++ b/posthog/temporal/data_imports/util.py
@@ -5,11 +5,11 @@ from typing import Literal, Optional
 
 from django.conf import settings
 
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 from structlog.types import FilteringBoundLogger
 
 from posthog.exceptions import capture_exception
 from posthog.settings.utils import get_from_env
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.utils import str_to_bool
 
 from products.data_warehouse.backend.s3 import aget_s3_client
@@ -65,7 +65,7 @@ async def prepare_s3_files_for_querying(
     async with aget_s3_client() as s3:
         s3.invalidate_cache()
 
-        normalized_table_name = NamingConvention().normalize_identifier(table_name)
+        normalized_table_name = NamingConvention.normalize_identifier(table_name)
 
         s3_folder_for_job = f"{settings.BUCKET_URL}/{folder_path}"
 

--- a/products/data_warehouse/backend/models/datawarehouse_saved_query.py
+++ b/products/data_warehouse/backend/models/datawarehouse_saved_query.py
@@ -9,7 +9,6 @@ from django.core.exceptions import ValidationError
 from django.db import models, transaction
 
 import structlog
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 
 from posthog.schema import DataWarehouseSavedQueryOrigin, HogQLQueryModifiers
 
@@ -22,6 +21,7 @@ from posthog.hogql.database.s3_table import DataWarehouseTable as HogQLDataWareh
 from posthog.exceptions_capture import capture_exception
 from posthog.models.utils import CreatedMetaFields, DeletedMetaFields, UpdatedMetaFields, UUIDTModel
 from posthog.sync import database_sync_to_async
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 
 from products.data_warehouse.backend.models.util import (
     CLICKHOUSE_HOGQL_MAPPING,
@@ -302,7 +302,7 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, UpdatedMetaFields, 
 
     @property
     def normalized_name(self):
-        return NamingConvention().normalize_identifier(self.name)
+        return NamingConvention.normalize_identifier(self.name)
 
     @property
     def url_pattern(self):

--- a/products/data_warehouse/backend/models/external_data_schema.py
+++ b/products/data_warehouse/backend/models/external_data_schema.py
@@ -8,12 +8,12 @@ from django.db import models
 import numpy
 from dateutil import parser
 from django_deprecate_fields import deprecate_field
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 
 from posthog.exceptions_capture import capture_exception
 from posthog.models.activity_logging.model_activity import ModelActivityMixin
 from posthog.models.utils import CreatedMetaFields, DeletedMetaFields, UpdatedMetaFields, UUIDTModel, sane_repr
 from posthog.sync import database_sync_to_async
+from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.pipeline.typings import PartitionFormat, PartitionMode
 
 from products.data_warehouse.backend.data_load.service import (
@@ -83,7 +83,7 @@ class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
 
     @property
     def normalized_name(self):
-        return NamingConvention().normalize_identifier(self.name)
+        return NamingConvention.normalize_identifier(self.name)
 
     @property
     def is_incremental(self):


### PR DESCRIPTION
## Problem
- I want to remove the DLT library from the codebase, to do so, we need to reimplement some functionality we use from it

## Changes
Implement the `NamingConvetion` class for how we deal with table/column identifiers

## How did you test this code?
Added unit tests
