### PR TITLE
fix(github): Fix duplicate GH integration env var

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2003,7 +2003,7 @@ class GitHubIntegration:
         Returns the GitHub username or None if the exchange fails.
         """
         client_id = settings.GITHUB_APP_CLIENT_ID
-        client_secret = settings.GITHUB_APP_OAUTH_CLIENT_SECRET
+        client_secret = settings.GITHUB_APP_CLIENT_SECRET
         if not client_id or not client_secret:
             logger.warning("GitHubIntegration: GITHUB_APP_CLIENT_ID/SECRET not configured, cannot exchange code")
             return None

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2002,10 +2002,10 @@ class GitHubIntegration:
 
         Returns the GitHub username or None if the exchange fails.
         """
-        client_id = settings.GITHUB_APP_OAUTH_CLIENT_ID
+        client_id = settings.GITHUB_APP_CLIENT_ID
         client_secret = settings.GITHUB_APP_OAUTH_CLIENT_SECRET
         if not client_id or not client_secret:
-            logger.warning("GitHubIntegration: GITHUB_APP_OAUTH_CLIENT_ID/SECRET not configured, cannot exchange code")
+            logger.warning("GitHubIntegration: GITHUB_APP_CLIENT_ID/SECRET not configured, cannot exchange code")
             return None
 
         try:

--- a/posthog/settings/integrations.py
+++ b/posthog/settings/integrations.py
@@ -35,10 +35,8 @@ LINEAR_APP_CLIENT_SECRET = get_from_env("LINEAR_APP_CLIENT_SECRET", "")
 
 GITHUB_APP_CLIENT_ID = get_from_env("GITHUB_APP_CLIENT_ID", "")
 GITHUB_APP_PRIVATE_KEY = get_from_env("GITHUB_APP_PRIVATE_KEY", "")
-# OAuth credentials for the GitHub App's user authorization flow (different from the App ID / private key above).
-# Used to exchange an authorization code for a user access token during "Request user authorization during installation".
-GITHUB_APP_OAUTH_CLIENT_ID = get_from_env("GITHUB_APP_OAUTH_CLIENT_ID", "")
-GITHUB_APP_OAUTH_CLIENT_SECRET = get_from_env("GITHUB_APP_OAUTH_CLIENT_SECRET", "")
+# The GH client secret is only available with "Request user authorization during installation" enabled, it's for OAuth
+GITHUB_APP_CLIENT_SECRET = get_from_env("GITHUB_APP_CLIENT_SECRET", "")
 
 ZENDESK_ADMIN_EMAIL = get_from_env("ZENDESK_ADMIN_EMAIL", "")
 ZENDESK_API_TOKEN = get_from_env("ZENDESK_API_TOKEN", "")


### PR DESCRIPTION
## Problem

Unknowingly duplicated `GITHUB_APP_CLIENT_ID` as `GITHUB_APP_OAUTH_CLIENT_ID` in  https://github.com/PostHog/posthog/pull/53767.

## Changes

`GITHUB_APP_OAUTH_CLIENT_ID` →  the pre-existing `GITHUB_APP_CLIENT_ID`
`GITHUB_APP_OAUTH_CLIENT_SECRET` → just `GITHUB_APP_CLIENT_SECRET`

Companion: https://github.com/PostHog/charts/pull/9900