### PR TITLE
revert: prevent high-cardinality metric labels in Victoria Metric

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1721,7 +1721,6 @@ dependencies = [
  "chrono",
  "common-alloc",
  "common-continuous-profiling",
- "common-metrics",
  "common-redis",
  "common-types",
  "envconfig",
@@ -8776,7 +8775,6 @@ name = "serve-metrics"
 version = "0.1.0"
 dependencies = [
  "axum 0.7.9",
- "common-metrics",
  "metrics",
  "metrics-exporter-prometheus",
  "tokio",

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -22,7 +22,6 @@ lifecycle = { path = "../common/lifecycle" }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
 common-alloc = { path = "../common/alloc" }
-common-metrics = { path = "../common/metrics" }
 common-continuous-profiling = { path = "../common/continuous_profiling" }
 common-redis = { path = "../common/redis" }
 common-types = { path = "../common/types" }

--- a/rust/capture/src/metrics_middleware.rs
+++ b/rust/capture/src/metrics_middleware.rs
@@ -9,7 +9,6 @@ use axum::{
     response::IntoResponse,
     routing::Router,
 };
-use common_metrics::normalize_unmatched_path;
 use metrics::gauge;
 
 // Global atomic counter for active connections
@@ -41,7 +40,7 @@ pub async fn track_metrics(req: Request<Body>, next: Next) -> impl IntoResponse 
     let path = if let Some(matched_path) = req.extensions().get::<MatchedPath>() {
         matched_path.as_str().to_owned()
     } else {
-        normalize_unmatched_path(req.uri().path())
+        req.uri().path().to_owned()
     };
 
     let method = req.method().clone();

--- a/rust/common/metrics/src/lib.rs
+++ b/rust/common/metrics/src/lib.rs
@@ -56,17 +56,6 @@ pub fn setup_metrics_recorder() -> PrometheusHandle {
         .unwrap()
 }
 
-/// Normalize an unmatched path to its first segment to avoid high-cardinality
-/// metric labels from arbitrary 404 paths (tokens, locales, scanner probes, etc.).
-///
-/// Examples: `/array/phc_xxx/config.js` → `/array/`, `/metrics` → `/metrics`
-pub fn normalize_unmatched_path(raw: &str) -> String {
-    match raw.find('/').and_then(|_| raw[1..].find('/')) {
-        Some(i) => raw[..i + 2].to_owned(),
-        None => raw.to_owned(),
-    }
-}
-
 /// Middleware to record some common HTTP metrics
 /// Someday tower-http might provide a metrics middleware: https://github.com/tower-rs/tower-http/issues/57
 pub async fn track_metrics(req: Request<Body>, next: Next) -> impl IntoResponse {
@@ -75,7 +64,7 @@ pub async fn track_metrics(req: Request<Body>, next: Next) -> impl IntoResponse 
     let path = if let Some(matched_path) = req.extensions().get::<MatchedPath>() {
         matched_path.as_str().to_owned()
     } else {
-        normalize_unmatched_path(req.uri().path())
+        req.uri().path().to_owned()
     };
 
     let method = req.method().clone();
@@ -209,29 +198,5 @@ impl<'a> TimingGuardLabels<'a> {
                 labels.push((key.to_string(), value.to_string()));
             }
         };
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::normalize_unmatched_path;
-
-    #[test]
-    fn test_normalize_unmatched_path() {
-        let cases = [
-            // (input, expected)
-            ("/array/phc_xxx/config.js", "/array/"),
-            ("/array/phc_xxx/en_GB/config.js", "/array/"),
-            ("/array/N/A/config", "/array/"),
-            ("/array/https:/us.i.posthog.com/config", "/array/"),
-            ("/api/surveys/blah", "/api/"),
-            ("/array/env", "/array/"),
-            ("/array/package.json", "/array/"),
-            ("/metrics", "/metrics"),
-            ("/", "/"),
-        ];
-        for (input, expected) in cases {
-            assert_eq!(normalize_unmatched_path(input), expected, "input: {input}");
-        }
     }
 }

--- a/rust/common/serve_metrics/Cargo.toml
+++ b/rust/common/serve_metrics/Cargo.toml
@@ -11,4 +11,3 @@ axum = { workspace = true }
 tokio = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 metrics = { workspace = true }
-common-metrics = { path = "../metrics" }

--- a/rust/common/serve_metrics/src/lib.rs
+++ b/rust/common/serve_metrics/src/lib.rs
@@ -4,7 +4,6 @@ use axum::{
     body::Body, extract::MatchedPath, http::Request, middleware::Next, response::IntoResponse,
     routing::get, Router,
 };
-use common_metrics::normalize_unmatched_path;
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 
 /// Bind a `TcpListener` on the provided bind address to serve a `Router` on it.
@@ -49,7 +48,7 @@ pub async fn track_metrics(req: Request<Body>, next: Next) -> impl IntoResponse 
     let path = if let Some(matched_path) = req.extensions().get::<MatchedPath>() {
         matched_path.as_str().to_owned()
     } else {
-        normalize_unmatched_path(req.uri().path())
+        req.uri().path().to_owned()
     };
 
     let method = req.method().clone();

--- a/rust/hypercache-server/src/router.rs
+++ b/rust/hypercache-server/src/router.rs
@@ -61,12 +61,11 @@ pub fn router(
             "/array/:token/config.js",
             any(remote_config::config_js_endpoint),
         )
-        // Catch-all 404s for known prefixes to avoid high-cardinality unmatched paths in metrics.
-        // Without these, unmatched requests fall through with the raw URI as the metric label,
-        // creating a unique time series for every distinct 404 path (tokens, locales, probes, etc.).
-        // With explicit routes, axum sets MatchedPath so metrics get clean parameterized labels.
-        .route("/array/:token/*rest", any(|| ready(StatusCode::NOT_FOUND)))
-        .route("/array/*rest", any(|| ready(StatusCode::NOT_FOUND)))
+        // Explicit 404 for sourcemap requests to avoid high-cardinality unmatched paths in metrics
+        .route(
+            "/array/:token/config.js.map",
+            any(|| ready(StatusCode::NOT_FOUND)),
+        )
         .layer(ConcurrencyLimitLayer::new(config.max_concurrency));
 
     let router = Router::new()


### PR DESCRIPTION
Reverts PostHog/posthog#54271