### PR TITLE
feat(dashboard): Add dashboard template copy-between-projects functionality

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -3518,6 +3518,18 @@ snapshots:
         hash: v1.k794b7964.3ef8fdec77a31e9262b99e502fed61e86fba657ace14bbbdd58ea2bc773de700.WrA7wFosW1QOQrrt7c0dA-q0UjOLpB1Icidd-rOOQJY
     scenes-app-dashboards-add-insight-to-dashboard-modal--with-more-insight-types--light:
         hash: v1.k794b7964.20566916ba402092327c25e65eb021be974a0803cd450b1ec269bb8b7d43f380.T6hfU5Ghij65Kw8n54JUa4ZHzptVsPZoEYldcI2_d-4
+    scenes-app-dashboards-templates-dashboard-template-copy--default--dark:
+        hash: v1.k794b7964.2f8db77fd22c2a09feaba5cd2f82aba277bdfac31f34cae43c3015e1891c9dea.TKorWc2TMRapf91aSM5RBEDWrK_fK3KIb4xNKuXgR4k
+    scenes-app-dashboards-templates-dashboard-template-copy--default--light:
+        hash: v1.k794b7964.99fa7a4e56d8219ac903e0369023eb7d90e62e93101db1f97605eecbf3ce4661.IllK50aKp-BMj3kjMCHc2Zb_g9tBlOzGvKKbKW3gGLE
+    scenes-app-dashboards-templates-dashboard-template-copy--load-error--dark:
+        hash: v1.k794b7964.67f2dda29ed493a94e33dd338460d1a292f8c34e2178e316c690e1851fb9828d.W-1zzEGytX_XsU2dH475QATpOoQ80aq75PZxrPfn1oA
+    scenes-app-dashboards-templates-dashboard-template-copy--load-error--light:
+        hash: v1.k794b7964.cf73ea29bb12fbc2e90ba39ecfb6adbcd2e0e9009528806fb8285a52388673e9.VGpnCUb9_XXWmWtjyzkapz-hKGe1ZpKdMuU5bmoT91o
+    scenes-app-dashboards-templates-dashboard-template-copy--no-other-projects-in-organization--dark:
+        hash: v1.k794b7964.e634c1e4b8c3bb908a7f84cd5b8057e60bcc81f70cd5e9a224fc41588dadee42.i3X1xwcXVwH3ApLK7XkaXlauCwiyJJqDyUHztm-WAZs
+    scenes-app-dashboards-templates-dashboard-template-copy--no-other-projects-in-organization--light:
+        hash: v1.k794b7964.8d4cd29cef2f26f584fb54d8b66c4876ae47ad47c2c66d64df84e5fd39729a1b.07RDbDS_E-gMcaMuHJ_R9xJQB3iSqPEFC3Evki06JKs
     scenes-app-dashboards-templates-dashboard-template-item--all-versions--dark:
         hash: v1.k794b7964.f47171fd3ca31f74f12783eac03ef4dddd84ab59769d40de18ce85b0c24cfe3e.UapVhkghncNi81EDuobiEF6EnA6oDSC01C_ouOTxcuA
     scenes-app-dashboards-templates-dashboard-template-item--all-versions--light:

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -978,6 +978,10 @@ export class ApiRequest {
         return this.dashboardTemplates(teamId).addPathComponent(dashboardTemplateId)
     }
 
+    public dashboardTemplatesCopyBetweenProjects(teamId?: TeamType['id']): ApiRequest {
+        return this.dashboardTemplates(teamId).addPathComponent('copy_between_projects')
+    }
+
     public dashboardTemplateSchema(): ApiRequest {
         return this.dashboardTemplates().addPathComponent('json_schema')
     }
@@ -3311,8 +3315,11 @@ const api = {
             return await new ApiRequest().dashboardTemplates().withQueryString(toParams(params)).get()
         },
 
-        async get(dashboardTemplateId: DashboardTemplateType['id']): Promise<DashboardTemplateType> {
-            return await new ApiRequest().dashboardTemplatesDetail(dashboardTemplateId).get()
+        async get(
+            dashboardTemplateId: DashboardTemplateType['id'],
+            teamId?: TeamType['id']
+        ): Promise<DashboardTemplateType> {
+            return await new ApiRequest().dashboardTemplatesDetail(dashboardTemplateId, teamId).get()
         },
 
         async create(dashboardTemplateData: DashboardTemplateEditorType): Promise<DashboardTemplateType> {
@@ -3335,6 +3342,14 @@ const api = {
                     deleted: true,
                 },
             })
+        },
+        async copyBetweenProjects(
+            targetTeamId: TeamType['id'],
+            sourceTemplateId: DashboardTemplateType['id']
+        ): Promise<DashboardTemplateType> {
+            return await new ApiRequest()
+                .dashboardTemplatesCopyBetweenProjects(targetTeamId)
+                .create({ data: { source_template_id: sourceTemplateId } })
         },
         async getSchema(): Promise<Record<string, any>> {
             return await new ApiRequest().dashboardTemplateSchema().get()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -977,6 +977,10 @@ export class ApiRequest {
         return this.dashboardTemplates(teamId).addPathComponent(dashboardTemplateId)
     }
 
+    public dashboardTemplatesCopyBetweenProjects(teamId?: TeamType['id']): ApiRequest {
+        return this.dashboardTemplates(teamId).addPathComponent('copy_between_projects')
+    }
+
     public dashboardTemplateSchema(): ApiRequest {
         return this.dashboardTemplates().addPathComponent('json_schema')
     }
@@ -3228,8 +3232,11 @@ const api = {
             return await new ApiRequest().dashboardTemplates().withQueryString(toParams(params)).get()
         },
 
-        async get(dashboardTemplateId: DashboardTemplateType['id']): Promise<DashboardTemplateType> {
-            return await new ApiRequest().dashboardTemplatesDetail(dashboardTemplateId).get()
+        async get(
+            dashboardTemplateId: DashboardTemplateType['id'],
+            teamId?: TeamType['id']
+        ): Promise<DashboardTemplateType> {
+            return await new ApiRequest().dashboardTemplatesDetail(dashboardTemplateId, teamId).get()
         },
 
         async create(dashboardTemplateData: DashboardTemplateEditorType): Promise<DashboardTemplateType> {
@@ -3252,6 +3259,14 @@ const api = {
                     deleted: true,
                 },
             })
+        },
+        async copyBetweenProjects(
+            targetTeamId: TeamType['id'],
+            sourceTemplateId: DashboardTemplateType['id']
+        ): Promise<DashboardTemplateType> {
+            return await new ApiRequest()
+                .dashboardTemplatesCopyBetweenProjects(targetTeamId)
+                .create({ data: { source_template_id: sourceTemplateId } })
         },
         async getSchema(): Promise<Record<string, any>> {
             return await new ApiRequest().dashboardTemplateSchema().get()

--- a/frontend/src/products.json
+++ b/frontend/src/products.json
@@ -8,13 +8,6 @@
             "intents": ["site_apps"]
         },
         {
-            "path": "Data pipelines",
-            "category": "Tools",
-            "iconType": "data_pipeline",
-            "type": "hog_function",
-            "intents": ["pipeline_batch_exports", "pipeline_destinations", "pipeline_transformations", "site_apps"]
-        },
-        {
             "path": "Support",
             "category": "Behavior",
             "iconType": "conversations",

--- a/frontend/src/products.json
+++ b/frontend/src/products.json
@@ -8,6 +8,13 @@
             "intents": ["site_apps"]
         },
         {
+            "path": "Data pipelines",
+            "category": "Tools",
+            "iconType": "data_pipeline",
+            "type": "hog_function",
+            "intents": ["pipeline_batch_exports", "pipeline_destinations", "pipeline_transformations", "site_apps"]
+        },
+        {
             "path": "Support",
             "category": "Behavior",
             "iconType": "conversations",

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -96,6 +96,7 @@ export const appScenes: Record<Scene | string, () => any> = {
     [Scene.ReplayKiosk]: () => import('./session-recordings/kiosk/SessionRecordingsKiosk'),
     [Scene.Replay]: () => import('./session-recordings/SessionRecordings'),
     [Scene.ResourceTransfer]: () => import('./resource-transfer/ResourceTransfer'),
+    [Scene.DashboardTemplateCopy]: () => import('./dashboard/dashboards/templates/DashboardTemplateCopyScene'),
     [Scene.RevenueAnalytics]: () => import('products/revenue_analytics/frontend/RevenueAnalyticsScene'),
     [Scene.SQLEditor]: () => import('./data-warehouse/editor/EditorScene'),
     [Scene.SavedInsights]: () => import('./saved-insights/SavedInsights'),

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -98,6 +98,7 @@ export const appScenes: Record<Scene | string, () => any> = {
     [Scene.ReplayKiosk]: () => import('./session-recordings/kiosk/SessionRecordingsKiosk'),
     [Scene.Replay]: () => import('./session-recordings/SessionRecordings'),
     [Scene.ResourceTransfer]: () => import('./resource-transfer/ResourceTransfer'),
+    [Scene.DashboardTemplateCopy]: () => import('./dashboard/dashboards/templates/DashboardTemplateCopyScene'),
     [Scene.RevenueAnalytics]: () => import('products/revenue_analytics/frontend/RevenueAnalyticsScene'),
     [Scene.SQLEditor]: () => import('./data-warehouse/editor/EditorScene'),
     [Scene.SavedInsights]: () => import('./saved-insights/SavedInsights'),

--- a/frontend/src/scenes/dashboard/DashboardSaveAsTemplateSceneActions.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSaveAsTemplateSceneActions.tsx
@@ -13,12 +13,9 @@ import { AccessControlLevel, AccessControlResourceType } from '~/types'
 export function DashboardSaveAsTemplateSceneActions(): JSX.Element | null {
     const { asDashboardTemplate, canSaveProjectDashboardTemplate } = useValues(dashboardLogic)
 
-    const customerTemplateEditorAccess = userHasAccess(
-        AccessControlResourceType.DashboardTemplate,
-        AccessControlLevel.Editor
-    )
+    const customerTemplateEditorAccess = userHasAccess(AccessControlResourceType.Dashboard, AccessControlLevel.Editor)
     const customerTemplateDisabledReason = getAccessControlDisabledReason(
-        AccessControlResourceType.DashboardTemplate,
+        AccessControlResourceType.Dashboard,
         AccessControlLevel.Editor,
         undefined,
         true

--- a/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplateCopyScene.stories.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplateCopyScene.stories.tsx
@@ -1,0 +1,201 @@
+import { MOCK_DEFAULT_BASIC_USER, MOCK_DEFAULT_ORGANIZATION, MOCK_DEFAULT_TEAM, MOCK_TEAM_ID } from 'lib/api.mock'
+
+import { Meta, StoryObj } from '@storybook/react'
+import { useEffect } from 'react'
+
+import { organizationLogic } from 'scenes/organizationLogic'
+import { urls } from 'scenes/urls'
+
+import { mswDecorator } from '~/mocks/browser'
+import { InsightColor, type DashboardTemplateType, type OrganizationType, type TeamType } from '~/types'
+
+import { DashboardTemplateCopyScene } from './DashboardTemplateCopyScene'
+
+const SOURCE_TEMPLATE_ID = 'storybook-copy-source-template'
+
+const insightTile = {
+    type: 'INSIGHT' as const,
+    name: 'Weekly signups',
+    color: InsightColor.Blue,
+    layouts: {},
+    query: {
+        kind: 'InsightVizNode' as const,
+        source: {
+            kind: 'TrendsQuery' as const,
+            series: [],
+            interval: 'day',
+            dateRange: { date_from: '-30d' },
+        },
+    },
+}
+
+const mockSourceTemplate: DashboardTemplateType = {
+    id: SOURCE_TEMPLATE_ID,
+    template_name: 'Weekly KPIs (storybook)',
+    dashboard_description: 'Team-scoped template shown on the copy-to-project scene.',
+    scope: 'team',
+    team_id: MOCK_TEAM_ID,
+    created_by: MOCK_DEFAULT_BASIC_USER,
+    tags: ['demo'],
+    dashboard_filters: {},
+    variables: [],
+    tiles: [insightTile],
+}
+
+function teamClone(id: number, name: string, uuidSuffix: string): TeamType {
+    return {
+        ...MOCK_DEFAULT_TEAM,
+        id,
+        name,
+        uuid: `0178a3ab-story-0000-4b55-bceadebb${uuidSuffix}`,
+    }
+}
+
+const secondTeam = teamClone(1002, 'Marketing site', '0abc')
+const thirdTeam = teamClone(1003, 'Beta environment', '0def')
+const fourthTeam = teamClone(1004, 'Internal tools', '0ghi')
+
+const organizationWithTwoProjects: OrganizationType = {
+    ...MOCK_DEFAULT_ORGANIZATION,
+    teams: [MOCK_DEFAULT_TEAM, secondTeam],
+}
+
+const organizationWithSeveralProjects: OrganizationType = {
+    ...MOCK_DEFAULT_ORGANIZATION,
+    teams: [MOCK_DEFAULT_TEAM, fourthTeam, secondTeam, thirdTeam],
+}
+
+const organizationWithSingleProject: OrganizationType = {
+    ...MOCK_DEFAULT_ORGANIZATION,
+    teams: [MOCK_DEFAULT_TEAM],
+}
+
+const templateDetailPath = `/api/projects/:team_id/dashboard_templates/${SOURCE_TEMPLATE_ID}/`
+
+const copyBetweenProjectsPath = '/api/projects/:team_id/dashboard_templates/copy_between_projects/'
+
+const baseMocks = {
+    get: {
+        '/api/organizations/@current/': (): [number, OrganizationType] => [200, organizationWithTwoProjects],
+        [templateDetailPath]: (): [number, DashboardTemplateType] => [200, mockSourceTemplate],
+    },
+    post: {
+        [copyBetweenProjectsPath]: (): [number, DashboardTemplateType] => [
+            201,
+            {
+                ...mockSourceTemplate,
+                id: 'storybook-copied-template',
+                team_id: secondTeam.id,
+                template_name: `${mockSourceTemplate.template_name} (copy)`,
+            },
+        ],
+    },
+}
+
+function WithOrganizationForStory({
+    organization,
+    children,
+}: {
+    organization: OrganizationType
+    children: React.ReactNode
+}): JSX.Element {
+    useEffect(() => {
+        organizationLogic.mount()
+        organizationLogic.actions.loadCurrentOrganizationSuccess(organization)
+    }, [organization])
+    return <>{children}</>
+}
+
+const meta: Meta<typeof DashboardTemplateCopyScene> = {
+    title: 'Scenes-App/Dashboards/Templates/Dashboard template copy',
+    component: DashboardTemplateCopyScene,
+    decorators: [
+        mswDecorator(baseMocks),
+        (Story) => (
+            <div className="bg-primary min-h-screen w-full p-4">
+                <Story />
+            </div>
+        ),
+    ],
+    args: {
+        sourceTemplateId: SOURCE_TEMPLATE_ID,
+        sourceTeamId: MOCK_TEAM_ID,
+    },
+    parameters: {
+        posthogTheme: 'light',
+        backgrounds: { default: 'light' },
+        layout: 'fullscreen',
+        viewMode: 'story',
+        mockDate: '2023-02-01',
+        pageUrl: urls.dashboardTemplateCopyToProject(SOURCE_TEMPLATE_ID, MOCK_TEAM_ID),
+        testOptions: {
+            waitForLoadersToDisappear: true,
+        },
+    },
+}
+
+export default meta
+
+type Story = StoryObj<typeof DashboardTemplateCopyScene>
+
+export const Default: Story = {
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/organizations/@current/': (): [number, OrganizationType] => [
+                    200,
+                    organizationWithSeveralProjects,
+                ],
+                [templateDetailPath]: [200, mockSourceTemplate],
+            },
+            post: {
+                [copyBetweenProjectsPath]: (): [number, DashboardTemplateType] => [
+                    201,
+                    {
+                        ...mockSourceTemplate,
+                        id: 'storybook-copied-template',
+                        team_id: secondTeam.id,
+                        template_name: `${mockSourceTemplate.template_name} (copy)`,
+                    },
+                ],
+            },
+        }),
+    ],
+    render: (args) => (
+        <WithOrganizationForStory organization={organizationWithSeveralProjects}>
+            <DashboardTemplateCopyScene {...args} />
+        </WithOrganizationForStory>
+    ),
+}
+
+export const LoadError: Story = {
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/organizations/@current/': (): [number, OrganizationType] => [200, organizationWithTwoProjects],
+                [templateDetailPath]: (): [number] => [404],
+            },
+        }),
+    ],
+    render: (args) => (
+        <WithOrganizationForStory organization={organizationWithTwoProjects}>
+            <DashboardTemplateCopyScene {...args} />
+        </WithOrganizationForStory>
+    ),
+}
+
+export const NoOtherProjectsInOrganization: Story = {
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/organizations/@current/': (): [number, OrganizationType] => [200, organizationWithSingleProject],
+                [templateDetailPath]: [200, mockSourceTemplate],
+            },
+        }),
+    ],
+    render: (args) => (
+        <WithOrganizationForStory organization={organizationWithSingleProject}>
+            <DashboardTemplateCopyScene {...args} />
+        </WithOrganizationForStory>
+    ),
+}

--- a/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplateCopyScene.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplateCopyScene.tsx
@@ -1,0 +1,125 @@
+import { useActions, useValues } from 'kea'
+import { combineUrl } from 'kea-router'
+
+import { LemonBanner, LemonButton, LemonSelect, LemonSkeleton, Link } from '@posthog/lemon-ui'
+
+import { EmptyMessage } from 'lib/components/EmptyMessage/EmptyMessage'
+import { DashboardsTab } from 'scenes/dashboard/dashboards/dashboardsLogic'
+import { SceneExport } from 'scenes/sceneTypes'
+import { urls } from 'scenes/urls'
+
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+
+import { dashboardTemplateCopyLogic, type DashboardTemplateCopyLogicProps } from './dashboardTemplateCopyLogic'
+
+export const scene: SceneExport<DashboardTemplateCopyLogicProps> = {
+    component: DashboardTemplateCopyScene,
+    logic: dashboardTemplateCopyLogic,
+    paramsToProps: ({ params: { sourceTemplateId }, searchParams }) => {
+        const raw = searchParams.source_team
+        const s = raw === undefined || raw === null ? '' : typeof raw === 'number' ? String(raw) : String(raw).trim()
+        const hasValidSourceTeamQuery = /^\d+$/.test(s)
+        const sourceTeamId = hasValidSourceTeamQuery ? Number(s) : undefined
+        return {
+            sourceTemplateId,
+            sourceTeamId,
+            hasValidSourceTeamQuery,
+        }
+    },
+}
+
+export function DashboardTemplateCopyScene(props: DashboardTemplateCopyLogicProps): JSX.Element {
+    const { hasValidSourceTeamQuery } = props
+    const logic = dashboardTemplateCopyLogic(props)
+    const {
+        sourceTemplate,
+        sourceTemplateLoading,
+        sourceTemplateLoadFailed,
+        teamOptions,
+        destinationTeamId,
+        copyResultLoading,
+    } = useValues(logic)
+    const { setDestinationTeamId, submitCopy } = useActions(logic)
+
+    const title = sourceTemplate?.template_name
+        ? `Copy "${sourceTemplate.template_name}" to another project`
+        : 'Copy template to another project'
+
+    const templatesListUrl = combineUrl(urls.dashboards(), { tab: DashboardsTab.Templates }).url
+    const loadFailed = sourceTemplateLoadFailed
+    const hasDestinationProjects = teamOptions.length > 0
+    const showNoDestinationsEmptyState = !sourceTemplateLoading && !loadFailed && !hasDestinationProjects
+
+    return (
+        <SceneContent>
+            <SceneTitleSection
+                name={title}
+                resourceType={{ type: 'Resource Transfer' }}
+                forceBackTo={{
+                    name: 'Templates',
+                    path: templatesListUrl,
+                    key: 'dashboard-template-copy-back',
+                }}
+            />
+            <div className="max-w-160 mt-4 mb-16 space-y-6">
+                {hasValidSourceTeamQuery === false ? (
+                    <LemonBanner type="info">
+                        This link did not include a valid source project. We are using the project you are currently in
+                        to load the template. Use &quot;Copy to another project&quot; from the templates list for a
+                        complete link, or stay here if this project owns the template.
+                    </LemonBanner>
+                ) : null}
+                {loadFailed ? (
+                    <LemonBanner type="error">
+                        We could not load this template. It may have been deleted, or you may need to open this page
+                        from the project that owns the template.{' '}
+                        <Link to={templatesListUrl} className="font-semibold">
+                            Back to templates
+                        </Link>
+                    </LemonBanner>
+                ) : null}
+                <div className="space-y-2">
+                    {sourceTemplateLoading ? (
+                        <>
+                            <p>Choose which project to copy this template to. The original will not be modified.</p>
+                            <LemonSkeleton className="h-10 w-full" />
+                        </>
+                    ) : loadFailed ? null : showNoDestinationsEmptyState ? (
+                        <div className="w-full rounded-lg border-2 border-dotted border-primary p-6">
+                            <EmptyMessage
+                                title="No other projects to copy to"
+                                description="Create another project in this organization first. The template you are copying will not be changed."
+                                buttonText="Create a project"
+                                buttonTo={urls.projectCreateFirst()}
+                                buttonDataAttr="dashboard-template-copy-empty-create-project"
+                            />
+                        </div>
+                    ) : (
+                        <>
+                            <p>Choose which project to copy this template to. The original will not be modified.</p>
+                            <div>
+                                <label className="font-semibold leading-6 block mb-1">Destination project</label>
+                                <LemonSelect
+                                    fullWidth
+                                    placeholder="Select a project"
+                                    value={destinationTeamId}
+                                    onChange={(value) => setDestinationTeamId(value)}
+                                    options={teamOptions}
+                                />
+                            </div>
+                        </>
+                    )}
+                </div>
+
+                {destinationTeamId != null && hasDestinationProjects && !loadFailed ? (
+                    <div className="flex justify-end">
+                        <LemonButton type="primary" onClick={() => submitCopy()} loading={copyResultLoading}>
+                            Copy
+                        </LemonButton>
+                    </div>
+                ) : null}
+            </div>
+        </SceneContent>
+    )
+}

--- a/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplateCopyScene.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplateCopyScene.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { combineUrl } from 'kea-router'
+import { combineUrl, router } from 'kea-router'
 
 import { LemonBanner, LemonButton, LemonSelect, LemonSkeleton, Link } from '@posthog/lemon-ui'
 
@@ -13,24 +13,32 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
 import { dashboardTemplateCopyLogic, type DashboardTemplateCopyLogicProps } from './dashboardTemplateCopyLogic'
 
+/** Aligns with `urls.dashboardTemplateCopyToProject` query shape (`source_team`). */
+function sourceTeamQueryFromSearchParams(searchParams: Record<string, any>): {
+    sourceTeamId: number | undefined
+    hasValidSourceTeamQuery: boolean
+} {
+    const raw = searchParams.source_team
+    const s = raw === undefined || raw === null ? '' : typeof raw === 'number' ? String(raw) : String(raw).trim()
+    const hasValidSourceTeamQuery = /^\d+$/.test(s)
+    return {
+        sourceTeamId: hasValidSourceTeamQuery ? Number(s) : undefined,
+        hasValidSourceTeamQuery,
+    }
+}
+
 export const scene: SceneExport<DashboardTemplateCopyLogicProps> = {
     component: DashboardTemplateCopyScene,
     logic: dashboardTemplateCopyLogic,
     paramsToProps: ({ params: { sourceTemplateId }, searchParams }) => {
-        const raw = searchParams.source_team
-        const s = raw === undefined || raw === null ? '' : typeof raw === 'number' ? String(raw) : String(raw).trim()
-        const hasValidSourceTeamQuery = /^\d+$/.test(s)
-        const sourceTeamId = hasValidSourceTeamQuery ? Number(s) : undefined
-        return {
-            sourceTemplateId,
-            sourceTeamId,
-            hasValidSourceTeamQuery,
-        }
+        const { sourceTeamId } = sourceTeamQueryFromSearchParams(searchParams)
+        return { sourceTemplateId, sourceTeamId }
     },
 }
 
 export function DashboardTemplateCopyScene(props: DashboardTemplateCopyLogicProps): JSX.Element {
-    const { hasValidSourceTeamQuery } = props
+    const { searchParams } = useValues(router)
+    const { hasValidSourceTeamQuery } = sourceTeamQueryFromSearchParams(searchParams)
     const logic = dashboardTemplateCopyLogic(props)
     const {
         sourceTemplate,

--- a/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.stories.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.stories.tsx
@@ -1,4 +1,12 @@
-import { MOCK_DEFAULT_BASIC_USER, MOCK_DEFAULT_USER, MOCK_TEAM_ID } from 'lib/api.mock'
+import {
+    MOCK_DEFAULT_BASIC_USER,
+    MOCK_DEFAULT_ORGANIZATION,
+    MOCK_DEFAULT_PROJECT,
+    MOCK_DEFAULT_TEAM,
+    MOCK_DEFAULT_USER,
+    MOCK_ORGANIZATION_ID,
+    MOCK_TEAM_ID,
+} from 'lib/api.mock'
 
 import { Meta, StoryObj, type Decorator } from '@storybook/react'
 import { useEffect } from 'react'
@@ -11,7 +19,14 @@ import { userLogic } from 'scenes/userLogic'
 
 import { mswDecorator } from '~/mocks/browser'
 import { toPaginatedResponse } from '~/mocks/handlers'
-import { InsightColor, type DashboardTemplateType } from '~/types'
+import {
+    InsightColor,
+    type DashboardTemplateType,
+    type OrganizationType,
+    type ProjectType,
+    type TeamType,
+    type UserType,
+} from '~/types'
 
 import { DashboardTemplateModal } from './DashboardTemplateModal'
 import { dashboardTemplatesLogic } from './dashboardTemplatesLogic'
@@ -166,25 +181,84 @@ const tableListMocks = {
     },
 }
 
-const nonStaffUserMocks = {
-    get: {
-        '/api/users/@me/': (): [number, typeof MOCK_DEFAULT_USER] => [200, { ...MOCK_DEFAULT_USER, is_staff: false }],
-    },
+/** Second project in the org so `eligibleDestinationTeamsCount` is non-zero and Copy appears in the row menu. */
+const storySecondTeam: TeamType = {
+    ...MOCK_DEFAULT_TEAM,
+    id: 1002,
+    name: 'Marketing site',
+    uuid: '0178a3ab-story-0000-4b55-bceadebb0abc',
+    project_id: 1002,
 }
 
-/** MSW follows `viewerMode` (Controls → Viewer mode). */
+const storySecondProject: ProjectType = {
+    id: storySecondTeam.id,
+    name: storySecondTeam.name,
+    organization_id: MOCK_ORGANIZATION_ID,
+    created_at: MOCK_DEFAULT_PROJECT.created_at,
+}
+
+const organizationWithMultipleProjects: OrganizationType = {
+    ...MOCK_DEFAULT_ORGANIZATION,
+    teams: [MOCK_DEFAULT_TEAM, storySecondTeam],
+    projects: [MOCK_DEFAULT_PROJECT, storySecondProject],
+}
+
+function organizationToUserOrganizationsList(
+    organization: OrganizationType
+): (typeof MOCK_DEFAULT_USER)['organizations'] {
+    return [organization].map(
+        ({
+            id,
+            name,
+            slug,
+            membership_level,
+            members_can_use_personal_api_keys,
+            allow_publicly_shared_resources,
+            is_active,
+            is_not_active_reason,
+        }) => ({
+            id,
+            name,
+            slug,
+            membership_level,
+            members_can_use_personal_api_keys,
+            allow_publicly_shared_resources,
+            logo_media_id: null,
+            is_active,
+            is_not_active_reason,
+        })
+    )
+}
+
+function storyUserForViewerMode(viewerMode: ViewerMode): UserType {
+    return {
+        ...MOCK_DEFAULT_USER,
+        is_staff: viewerMode === 'staff',
+        team: MOCK_DEFAULT_TEAM,
+        organization: organizationWithMultipleProjects,
+        organizations: organizationToUserOrganizationsList(organizationWithMultipleProjects),
+    }
+}
+
+/** MSW follows `viewerMode` (Controls → Viewer mode). Always mock `@me` so `userLogic` loadUser does not overwrite the story org with a single-team user (staff mode previously had no handler). */
 const withViewerModeMsw: Decorator = (Story, context) => {
     const viewerMode = ((context.args as { viewerMode?: ViewerMode }).viewerMode ?? 'staff') as ViewerMode
     const mocks = {
         get: {
             ...tableListMocks.get,
-            ...(viewerMode === 'nonStaff' ? nonStaffUserMocks.get : {}),
+            '/api/users/@me/': (): [number, UserType] => [200, storyUserForViewerMode(viewerMode)],
         },
     }
     return mswDecorator(mocks)(Story, context)
 }
 
-function DashboardTemplatesTableStory({ perspective }: { perspective: 'staff' | 'nonstaff' }): JSX.Element {
+function DashboardTemplatesTableStory({
+    perspective,
+    organization = organizationWithMultipleProjects,
+}: {
+    perspective: 'staff' | 'nonstaff'
+    organization?: OrganizationType
+}): JSX.Element {
     useEffect(() => {
         featureFlagLogic.mount()
         featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.CUSTOMER_DASHBOARD_TEMPLATE_AUTHORING], {
@@ -196,9 +270,12 @@ function DashboardTemplatesTableStory({ perspective }: { perspective: 'staff' | 
         userLogic.actions.loadUserSuccess({
             ...MOCK_DEFAULT_USER,
             is_staff: perspective === 'staff',
+            team: MOCK_DEFAULT_TEAM,
+            organization,
+            organizations: organizationToUserOrganizationsList(organization),
         })
         templatesTabListLogic.actions.getAllTemplates()
-    }, [perspective])
+    }, [perspective, organization])
     return <DashboardTemplatesTable />
 }
 
@@ -211,7 +288,7 @@ export const Default: Story = {
             control: 'inline-radio',
             options: ['staff', 'nonStaff'] satisfies ViewerMode[],
             description:
-                'Staff: Monaco + scope + delete rules on rows. Non-staff: customer authoring + Edit/Delete on team templates only.',
+                'Org has two projects so team rows show Copy to another project. Staff: full staff menu. Non-staff: customer authoring + team-template actions.',
             name: 'Viewer mode',
         },
     },

--- a/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.stories.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.stories.tsx
@@ -216,6 +216,7 @@ function organizationToUserOrganizationsList(
             allow_publicly_shared_resources,
             is_active,
             is_not_active_reason,
+            is_pending_deletion,
         }) => ({
             id,
             name,
@@ -226,6 +227,7 @@ function organizationToUserOrganizationsList(
             logo_media_id: null,
             is_active,
             is_not_active_reason,
+            is_pending_deletion,
         })
     )
 }

--- a/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 import { useMemo } from 'react'
 
 import { IconBuilding, IconChevronDown, IconGlobe, IconThumbsUpFilled } from '@posthog/icons'
@@ -16,6 +17,7 @@ import { humanFriendlyNumber } from 'lib/utils'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
 import { dashboardTemplatesLogic } from 'scenes/dashboard/dashboards/templates/dashboardTemplatesLogic'
 import { dashboardTemplateEditorLogic } from 'scenes/dashboard/dashboardTemplateEditorLogic'
+import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { AccessControlLevel, AccessControlResourceType, DashboardTemplateType } from '~/types'
@@ -96,6 +98,42 @@ export const DashboardTemplatesTable = (): JSX.Element | null => {
         !user?.is_staff &&
         customerDashboardTemplateAuthoring &&
         userHasAccess(AccessControlResourceType.DashboardTemplate, AccessControlLevel.Editor)
+
+    const eligibleDestinationTeamsCount = useMemo(() => {
+        const tid = user?.team?.id
+        if (tid == null) {
+            return 0
+        }
+        return (user?.organization?.teams ?? []).filter((t) => t.id !== tid).length
+    }, [user?.organization?.teams, user?.team?.id])
+
+    const copyTemplateToProjectMenuSection = (
+        templateId: string | undefined,
+        dataAttr: 'dashboard-template-copy-to-project-staff' | 'dashboard-template-copy-to-project-customer'
+    ): JSX.Element | null => {
+        if (!templateId || eligibleDestinationTeamsCount <= 0) {
+            return null
+        }
+        return (
+            <>
+                <LemonDivider />
+                <LemonButton
+                    fullWidth
+                    data-attr={dataAttr}
+                    onClick={() => {
+                        const sourceTeamId = user?.team?.id
+                        if (sourceTeamId == null) {
+                            console.error('Current project id not available')
+                            return
+                        }
+                        router.actions.push(urls.dashboardTemplateCopyToProject(templateId, sourceTeamId))
+                    }}
+                >
+                    Copy to another project
+                </LemonButton>
+            </>
+        )
+    }
 
     const columns: LemonTableColumns<DashboardTemplateType> = [
         {
@@ -245,6 +283,13 @@ export const DashboardTemplatesTable = (): JSX.Element | null => {
                                         Make visible to {scope === 'global' ? 'this team only' : 'everyone'}
                                     </LemonButton>
 
+                                    {scope === 'team'
+                                        ? copyTemplateToProjectMenuSection(
+                                              id,
+                                              'dashboard-template-copy-to-project-staff'
+                                          )
+                                        : null}
+
                                     <LemonDivider />
                                     <LemonButton
                                         onClick={() => {
@@ -292,6 +337,10 @@ export const DashboardTemplatesTable = (): JSX.Element | null => {
                                     >
                                         Edit
                                     </LemonButton>
+                                    {copyTemplateToProjectMenuSection(
+                                        id,
+                                        'dashboard-template-copy-to-project-customer'
+                                    )}
                                     <LemonDivider />
                                     <LemonButton
                                         onClick={() => {

--- a/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.tsx
@@ -6,7 +6,6 @@ import { IconBuilding, IconChevronDown, IconGlobe, IconThumbsUpFilled } from '@p
 import { LemonButton, LemonDivider, LemonInput, LemonMenu, LemonTag } from '@posthog/lemon-ui'
 
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import type { Sorting } from 'lib/lemon-ui/LemonTable'
@@ -15,6 +14,7 @@ import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { humanFriendlyNumber } from 'lib/utils'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
+import { getAppContext } from 'lib/utils/getAppContext'
 import { dashboardTemplatesLogic } from 'scenes/dashboard/dashboards/templates/dashboardTemplatesLogic'
 import { dashboardTemplateEditorLogic } from 'scenes/dashboard/dashboardTemplateEditorLogic'
 import { urls } from 'scenes/urls'
@@ -93,19 +93,23 @@ export const DashboardTemplatesTable = (): JSX.Element | null => {
     const { openEdit: openDashboardTemplateModalEdit } = useActions(dashboardTemplateModalLogic)
 
     const { user } = useValues(userLogic)
-    const customerDashboardTemplateAuthoring = useFeatureFlag('CUSTOMER_DASHBOARD_TEMPLATE_AUTHORING')
+    /** Django `is_staff` (not org role). Prefer loaded API user; until then use SSR/bootstrap context so row actions are not blank. */
+    const isDjangoStaffForTemplateUi =
+        user != null ? Boolean(user.is_staff) : Boolean(getAppContext()?.current_user?.is_staff)
+    /** Team-scoped template row actions for non–Django-staff (matches project RBAC; backend still enforces org feature flag on writes where applicable). */
     const canCustomerManageTeamTemplates =
-        !user?.is_staff &&
-        customerDashboardTemplateAuthoring &&
+        !isDjangoStaffForTemplateUi &&
         userHasAccess(AccessControlResourceType.DashboardTemplate, AccessControlLevel.Editor)
 
+    const currentTeamId = user?.team?.id ?? getAppContext()?.current_team?.id ?? null
+    const organizationTeams = user?.organization?.teams ?? getAppContext()?.current_user?.organization?.teams ?? []
+
     const eligibleDestinationTeamsCount = useMemo(() => {
-        const tid = user?.team?.id
-        if (tid == null) {
+        if (currentTeamId == null) {
             return 0
         }
-        return (user?.organization?.teams ?? []).filter((t) => t.id !== tid).length
-    }, [user?.organization?.teams, user?.team?.id])
+        return organizationTeams.filter((t) => t.id !== currentTeamId).length
+    }, [organizationTeams, currentTeamId])
 
     const copyTemplateToProjectMenuSection = (
         templateId: string | undefined,
@@ -121,12 +125,11 @@ export const DashboardTemplatesTable = (): JSX.Element | null => {
                     fullWidth
                     data-attr={dataAttr}
                     onClick={() => {
-                        const sourceTeamId = user?.team?.id
-                        if (sourceTeamId == null) {
+                        if (currentTeamId == null) {
                             console.error('Current project id not available')
                             return
                         }
-                        router.actions.push(urls.dashboardTemplateCopyToProject(templateId, sourceTeamId))
+                        router.actions.push(urls.dashboardTemplateCopyToProject(templateId, currentTeamId))
                     }}
                 >
                     Copy to another project
@@ -248,7 +251,7 @@ export const DashboardTemplatesTable = (): JSX.Element | null => {
                 const { id, scope } = record
                 const builtInOfficial = isBuiltInOfficialTemplate(record)
 
-                if (user?.is_staff) {
+                if (isDjangoStaffForTemplateUi) {
                     return (
                         <More
                             overlay={

--- a/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.tsx
@@ -96,10 +96,9 @@ export const DashboardTemplatesTable = (): JSX.Element | null => {
     /** Django `is_staff` (not org role). Prefer loaded API user; until then use SSR/bootstrap context so row actions are not blank. */
     const isDjangoStaffForTemplateUi =
         user != null ? Boolean(user.is_staff) : Boolean(getAppContext()?.current_user?.is_staff)
-    /** Team-scoped template row actions for non–Django-staff (matches project RBAC; backend still enforces org feature flag on writes where applicable). */
+    /** Team-scoped template row actions for non–Django-staff. `dashboard_template` inherits `dashboard` in RBAC (#54694). */
     const canCustomerManageTeamTemplates =
-        !isDjangoStaffForTemplateUi &&
-        userHasAccess(AccessControlResourceType.DashboardTemplate, AccessControlLevel.Editor)
+        !isDjangoStaffForTemplateUi && userHasAccess(AccessControlResourceType.Dashboard, AccessControlLevel.Editor)
 
     const currentTeamId = user?.team?.id ?? getAppContext()?.current_team?.id ?? null
     const organizationTeams = user?.organization?.teams ?? getAppContext()?.current_user?.organization?.teams ?? []

--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateCopyLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateCopyLogic.test.ts
@@ -1,0 +1,189 @@
+import { MOCK_DEFAULT_ORGANIZATION, MOCK_DEFAULT_PROJECT, MOCK_DEFAULT_TEAM, MOCK_TEAM_ID } from 'lib/api.mock'
+
+import { router } from 'kea-router'
+import { expectLogic } from 'kea-test-utils'
+
+import api, { ApiError } from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { DashboardsTab } from 'scenes/dashboard/dashboards/dashboardsLogic'
+import { urls } from 'scenes/urls'
+
+import { initKeaTests } from '~/test/init'
+import type { DashboardTemplateType } from '~/types'
+
+import { dashboardTemplateCopyLogic } from './dashboardTemplateCopyLogic'
+import { dashboardTemplatesLogic } from './dashboardTemplatesLogic'
+
+jest.mock('lib/lemon-ui/LemonToast/LemonToast', () => ({
+    lemonToast: { success: jest.fn(), error: jest.fn() },
+}))
+
+describe('dashboardTemplateCopyLogic', () => {
+    let logic: ReturnType<typeof dashboardTemplateCopyLogic.build> | undefined
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = undefined
+        jest.spyOn(api.dashboardTemplates, 'get').mockResolvedValue({
+            id: 'tpl-1',
+            template_name: 'Source template',
+        } as DashboardTemplateType)
+        jest.spyOn(api.dashboardTemplates, 'copyBetweenProjects').mockResolvedValue({
+            id: 'tpl-2',
+            template_name: 'Source template (copy)',
+        } as DashboardTemplateType)
+        jest.spyOn(router.actions, 'push')
+        jest.spyOn(router.actions, 'replace')
+        jest.spyOn(dashboardTemplatesLogic, 'findMounted').mockReturnValue({
+            actions: { getAllTemplates: jest.fn() },
+        } as ReturnType<typeof dashboardTemplatesLogic.findMounted>)
+    })
+
+    afterEach(() => {
+        logic?.unmount()
+        jest.restoreAllMocks()
+    })
+
+    it('loads source template with explicit sourceTeamId for the API project', async () => {
+        const getMock = api.dashboardTemplates.get as jest.Mock
+        const mounted = dashboardTemplateCopyLogic({ sourceTemplateId: 'abc', sourceTeamId: 99 })
+        logic = mounted
+        mounted.mount()
+
+        await expectLogic(mounted).toFinishAllListeners()
+
+        expect(getMock).toHaveBeenCalledWith('abc', 99)
+    })
+
+    it('loads source template using currentTeamId when sourceTeamId is omitted', async () => {
+        const getMock = api.dashboardTemplates.get as jest.Mock
+        const mounted = dashboardTemplateCopyLogic({ sourceTemplateId: 'legacy-url' })
+        logic = mounted
+        mounted.mount()
+
+        await expectLogic(mounted).toFinishAllListeners()
+
+        expect(getMock).toHaveBeenCalledWith('legacy-url', MOCK_TEAM_ID)
+    })
+
+    it('canonicalizes URL when sourceTeamId is omitted', async () => {
+        const mounted = dashboardTemplateCopyLogic({ sourceTemplateId: 'no-query-team' })
+        logic = mounted
+        mounted.mount()
+
+        await expectLogic(mounted).toFinishAllListeners()
+
+        expect(router.actions.replace).toHaveBeenCalledWith(
+            urls.dashboardTemplateCopyToProject('no-query-team', MOCK_TEAM_ID)
+        )
+    })
+
+    it('marks load failed when fetching the source template errors', async () => {
+        const getMock = api.dashboardTemplates.get as jest.Mock
+        getMock.mockRejectedValueOnce(new Error('not found'))
+
+        const mounted = dashboardTemplateCopyLogic({ sourceTemplateId: 'missing', sourceTeamId: 1 })
+        logic = mounted
+        mounted.mount()
+
+        await expectLogic(mounted).toFinishAllListeners()
+
+        expect(mounted.values.sourceTemplateLoadFailed).toBe(true)
+    })
+
+    it('on successful copy toast includes destination project name when org lists it', async () => {
+        const destinationTeam = { ...MOCK_DEFAULT_TEAM, id: 1002, name: 'Beta project', uuid: 'beta-uuid-0001' }
+        const orgWithTwoTeams = {
+            ...MOCK_DEFAULT_ORGANIZATION,
+            teams: [MOCK_DEFAULT_TEAM, destinationTeam],
+        }
+        initKeaTests(true, MOCK_DEFAULT_TEAM, MOCK_DEFAULT_PROJECT, orgWithTwoTeams)
+
+        const getAllTemplates = jest.fn()
+        ;(dashboardTemplatesLogic.findMounted as jest.Mock).mockReturnValue({
+            actions: { getAllTemplates },
+        })
+
+        const mounted = dashboardTemplateCopyLogic({ sourceTemplateId: 'src-1', sourceTeamId: 1 })
+        logic = mounted
+        mounted.mount()
+
+        await expectLogic(mounted).toFinishAllListeners()
+
+        mounted.actions.setDestinationTeamId(destinationTeam.id)
+        await expectLogic(mounted, () => mounted.actions.submitCopy()).toFinishAllListeners()
+
+        expect(lemonToast.success).toHaveBeenCalledWith('Copied to Beta project')
+    })
+
+    it('on successful copy refreshes templates, toasts, and navigates to the templates tab', async () => {
+        const getAllTemplates = jest.fn()
+        ;(dashboardTemplatesLogic.findMounted as jest.Mock).mockReturnValue({
+            actions: { getAllTemplates },
+        })
+
+        const mounted = dashboardTemplateCopyLogic({ sourceTemplateId: 'src-1', sourceTeamId: 1 })
+        logic = mounted
+        mounted.mount()
+
+        await expectLogic(mounted).toFinishAllListeners()
+
+        mounted.actions.setDestinationTeamId(2)
+        await expectLogic(mounted, () => mounted.actions.submitCopy()).toFinishAllListeners()
+
+        expect(api.dashboardTemplates.copyBetweenProjects).toHaveBeenCalledWith(2, 'src-1')
+        expect(getAllTemplates).toHaveBeenCalled()
+        expect(lemonToast.success).toHaveBeenCalled()
+        expect(router.actions.push).toHaveBeenCalledWith(urls.dashboards(), { tab: DashboardsTab.Templates })
+    })
+
+    it('submitCopy shows an error toast when the API fails', async () => {
+        const copyMock = api.dashboardTemplates.copyBetweenProjects as jest.Mock
+        copyMock.mockRejectedValueOnce(new ApiError(undefined, 500, undefined, { detail: 'network' }))
+
+        const mounted = dashboardTemplateCopyLogic({ sourceTemplateId: 'src-1', sourceTeamId: 1 })
+        logic = mounted
+        mounted.mount()
+
+        await expectLogic(mounted).toFinishAllListeners()
+        mounted.actions.setDestinationTeamId(2)
+
+        await expectLogic(mounted, () => mounted.actions.submitCopy()).toFinishAllListeners()
+
+        expect(lemonToast.error).toHaveBeenCalledWith('Submit copy failed: network')
+    })
+
+    it('submitCopy without destination shows an error toast', async () => {
+        const copyMock = api.dashboardTemplates.copyBetweenProjects as jest.Mock
+
+        const mounted = dashboardTemplateCopyLogic({ sourceTemplateId: 'src-1', sourceTeamId: 1 })
+        logic = mounted
+        mounted.mount()
+
+        await expectLogic(mounted).toFinishAllListeners()
+
+        await expectLogic(mounted, () => mounted.actions.submitCopy()).toFinishAllListeners()
+
+        expect(copyMock).not.toHaveBeenCalled()
+        expect(lemonToast.error).toHaveBeenCalledWith('Select a destination project')
+    })
+
+    it('submitCopy surfaces ApiError detail in the toast', async () => {
+        const copyMock = api.dashboardTemplates.copyBetweenProjects as jest.Mock
+        copyMock.mockRejectedValueOnce(
+            new ApiError(undefined, 400, undefined, { detail: 'Org template limit reached' })
+        )
+
+        const mounted = dashboardTemplateCopyLogic({ sourceTemplateId: 'src-1', sourceTeamId: 1 })
+        logic = mounted
+        mounted.mount()
+
+        await expectLogic(mounted).toFinishAllListeners()
+        mounted.actions.setDestinationTeamId(2)
+
+        await expectLogic(mounted, () => mounted.actions.submitCopy()).toFinishAllListeners()
+
+        expect(lemonToast.error).toHaveBeenCalledTimes(1)
+        expect(lemonToast.error).toHaveBeenCalledWith('Submit copy failed: Org template limit reached')
+    })
+})

--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateCopyLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateCopyLogic.test.ts
@@ -36,7 +36,7 @@ describe('dashboardTemplateCopyLogic', () => {
         jest.spyOn(router.actions, 'replace')
         jest.spyOn(dashboardTemplatesLogic, 'findMounted').mockReturnValue({
             actions: { getAllTemplates: jest.fn() },
-        } as ReturnType<typeof dashboardTemplatesLogic.findMounted>)
+        } as unknown as ReturnType<typeof dashboardTemplatesLogic.findMounted>)
     })
 
     afterEach(() => {

--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateCopyLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateCopyLogic.test.ts
@@ -113,7 +113,12 @@ describe('dashboardTemplateCopyLogic', () => {
         mounted.actions.setDestinationTeamId(destinationTeam.id)
         await expectLogic(mounted, () => mounted.actions.submitCopy()).toFinishAllListeners()
 
-        expect(lemonToast.success).toHaveBeenCalledWith('Copied to Beta project')
+        expect(lemonToast.success).toHaveBeenCalledWith('Copied to Beta project', {
+            button: expect.objectContaining({
+                label: 'Open project',
+                action: expect.any(Function),
+            }),
+        })
     })
 
     it('on successful copy refreshes templates, toasts, and navigates to the templates tab', async () => {

--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateCopyLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateCopyLogic.ts
@@ -1,0 +1,115 @@
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import { router } from 'kea-router'
+import { subscriptions } from 'kea-subscriptions'
+
+import api from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { DashboardsTab } from 'scenes/dashboard/dashboards/dashboardsLogic'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
+
+import type { DashboardTemplateType } from '~/types'
+
+import type { dashboardTemplateCopyLogicType } from './dashboardTemplateCopyLogicType'
+import { dashboardTemplatesLogic } from './dashboardTemplatesLogic'
+
+export interface DashboardTemplateCopyLogicProps {
+    sourceTemplateId: string
+    sourceTeamId?: number
+    hasValidSourceTeamQuery?: boolean
+}
+
+function maybeReplaceUrlWithSourceTeam(props: DashboardTemplateCopyLogicProps, currentTeamId: number | null): void {
+    if (props.sourceTeamId !== undefined) {
+        return
+    }
+    if (currentTeamId == null || !props.sourceTemplateId) {
+        return
+    }
+    router.actions.replace(urls.dashboardTemplateCopyToProject(props.sourceTemplateId, currentTeamId))
+}
+
+export const dashboardTemplateCopyLogic = kea<dashboardTemplateCopyLogicType>([
+    path(['scenes', 'dashboard', 'dashboards', 'templates', 'dashboardTemplateCopyLogic']),
+    props({} as DashboardTemplateCopyLogicProps),
+    key((props) => props.sourceTemplateId),
+    connect(() => ({
+        values: [organizationLogic, ['currentOrganization'], teamLogic, ['currentTeamId']],
+    })),
+    actions({
+        setDestinationTeamId: (teamId: number | null) => ({ teamId }),
+    }),
+    reducers({
+        destinationTeamId: [
+            null as number | null,
+            {
+                setDestinationTeamId: (_, { teamId }) => teamId,
+            },
+        ],
+        sourceTemplateLoadFailed: [
+            false,
+            {
+                loadSourceTemplate: () => false,
+                loadSourceTemplateSuccess: () => false,
+                loadSourceTemplateFailure: () => true,
+            },
+        ],
+    }),
+    loaders(({ values, props }) => ({
+        sourceTemplate: [
+            null as DashboardTemplateType | null,
+            {
+                loadSourceTemplate: async () => {
+                    const sourceTeamId = props.sourceTeamId ?? values.currentTeamId
+                    if (sourceTeamId == null) {
+                        throw new Error('Missing source project for this template.')
+                    }
+                    return await api.dashboardTemplates.get(props.sourceTemplateId, sourceTeamId)
+                },
+            },
+        ],
+        copyResult: [
+            null as DashboardTemplateType | null,
+            {
+                submitCopy: async () => {
+                    const { destinationTeamId } = values
+                    if (!destinationTeamId) {
+                        lemonToast.error('Select a destination project')
+                        throw new Error('Select a destination project')
+                    }
+                    return await api.dashboardTemplates.copyBetweenProjects(destinationTeamId, props.sourceTemplateId)
+                },
+            },
+        ],
+    })),
+    selectors({
+        teamOptions: [
+            (s) => [s.currentOrganization, s.currentTeamId],
+            (currentOrganization, currentTeamId) =>
+                (currentOrganization?.teams ?? [])
+                    .filter((team) => team.id !== currentTeamId)
+                    .sort((a, b) => a.name.localeCompare(b.name))
+                    .map((team) => ({ value: team.id, label: team.name })),
+        ],
+    }),
+    subscriptions(({ props }) => ({
+        currentTeamId: (currentTeamId) => {
+            maybeReplaceUrlWithSourceTeam(props, currentTeamId)
+        },
+    })),
+    listeners(({ values }) => ({
+        submitCopySuccess: () => {
+            const destTeam = values.currentOrganization?.teams.find((t) => t.id === values.destinationTeamId)
+            const destName = destTeam?.name || 'the selected project'
+            lemonToast.success(`Copied to ${destName}`)
+            dashboardTemplatesLogic.findMounted({ scope: 'default', templatesTabList: true })?.actions.getAllTemplates()
+            router.actions.push(urls.dashboards(), { tab: DashboardsTab.Templates })
+        },
+    })),
+    afterMount(({ actions, props, values }) => {
+        maybeReplaceUrlWithSourceTeam(props, values.currentTeamId)
+        actions.loadSourceTemplate()
+    }),
+])

--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateCopyLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateCopyLogic.ts
@@ -18,7 +18,6 @@ import { dashboardTemplatesLogic } from './dashboardTemplatesLogic'
 export interface DashboardTemplateCopyLogicProps {
     sourceTemplateId: string
     sourceTeamId?: number
-    hasValidSourceTeamQuery?: boolean
 }
 
 function maybeReplaceUrlWithSourceTeam(props: DashboardTemplateCopyLogicProps, currentTeamId: number | null): void {

--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateCopyLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateCopyLogic.ts
@@ -100,9 +100,22 @@ export const dashboardTemplateCopyLogic = kea<dashboardTemplateCopyLogicType>([
     })),
     listeners(({ values }) => ({
         submitCopySuccess: () => {
-            const destTeam = values.currentOrganization?.teams.find((t) => t.id === values.destinationTeamId)
+            const destinationTeamId = values.destinationTeamId
+            const destTeam = values.currentOrganization?.teams.find((t) => t.id === destinationTeamId)
             const destName = destTeam?.name || 'the selected project'
-            lemonToast.success(`Copied to ${destName}`)
+            lemonToast.success(
+                `Copied to ${destName}`,
+                destinationTeamId != null
+                    ? {
+                          button: {
+                              label: 'Open project',
+                              action: () => {
+                                  window.location.href = urls.project(destinationTeamId, urls.dashboards())
+                              },
+                          },
+                      }
+                    : {}
+            )
             dashboardTemplatesLogic.findMounted({ scope: 'default', templatesTabList: true })?.actions.getAllTemplates()
             router.actions.push(urls.dashboards(), { tab: DashboardsTab.Templates })
         },

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -303,7 +303,7 @@ export const sceneToAccessControlResourceType: Partial<Record<Scene, AccessContr
     // Dashboards
     [Scene.Dashboard]: AccessControlResourceType.Dashboard,
     [Scene.Dashboards]: AccessControlResourceType.Dashboard,
-    [Scene.DashboardTemplateCopy]: AccessControlResourceType.DashboardTemplate,
+    [Scene.DashboardTemplateCopy]: AccessControlResourceType.Dashboard,
 
     // Insights
     [Scene.Insight]: AccessControlResourceType.Insight,

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -32,6 +32,7 @@ export enum Scene {
     CustomerJourneyBuilder = 'CustomerJourneyBuilder',
     Dashboard = 'Dashboard',
     Dashboards = 'Dashboards',
+    DashboardTemplateCopy = 'DashboardTemplateCopy',
     DataManagement = 'DataManagement',
     DataPipelinesNew = 'DataPipelinesNew',
     DataOps = 'DataOps',
@@ -302,6 +303,7 @@ export const sceneToAccessControlResourceType: Partial<Record<Scene, AccessContr
     // Dashboards
     [Scene.Dashboard]: AccessControlResourceType.Dashboard,
     [Scene.Dashboards]: AccessControlResourceType.Dashboard,
+    [Scene.DashboardTemplateCopy]: AccessControlResourceType.DashboardTemplate,
 
     // Insights
     [Scene.Insight]: AccessControlResourceType.Insight,

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -32,6 +32,7 @@ export enum Scene {
     CustomerJourneyBuilder = 'CustomerJourneyBuilder',
     Dashboard = 'Dashboard',
     Dashboards = 'Dashboards',
+    DashboardTemplateCopy = 'DashboardTemplateCopy',
     DataManagement = 'DataManagement',
     DataPipelinesNew = 'DataPipelinesNew',
     DataOps = 'DataOps',
@@ -306,6 +307,7 @@ export const sceneToAccessControlResourceType: Partial<Record<Scene, AccessContr
     // Dashboards
     [Scene.Dashboard]: AccessControlResourceType.Dashboard,
     [Scene.Dashboards]: AccessControlResourceType.Dashboard,
+    [Scene.DashboardTemplateCopy]: AccessControlResourceType.DashboardTemplate,
 
     // Insights
     [Scene.Insight]: AccessControlResourceType.Insight,

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -438,6 +438,11 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         name: 'Copy to project',
         layout: 'app-container',
     },
+    [Scene.DashboardTemplateCopy]: {
+        projectBased: true,
+        name: 'Copy template to project',
+        layout: 'app-container',
+    },
     [Scene.RevenueAnalytics]: {
         projectBased: true,
         name: 'Revenue analytics',
@@ -724,6 +729,7 @@ export const redirects: Record<
 export const routes: Record<string, [Scene | string, string]> = {
     [urls.newTab()]: [Scene.NewTab, 'newTab'],
     [urls.dashboards()]: [Scene.Dashboards, 'dashboards'],
+    [urls.dashboardTemplateCopyToProject(':sourceTemplateId')]: [Scene.DashboardTemplateCopy, 'dashboardTemplateCopy'],
     [urls.dashboard(':id')]: [Scene.Dashboard, 'dashboard'],
     [urls.dashboardTextTile(':id', ':textTileId')]: [Scene.Dashboard, 'dashboardTextTile'],
     [urls.dashboardButtonTile(':id', ':buttonTileId')]: [Scene.Dashboard, 'dashboardButtonTile'],

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -513,6 +513,11 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         name: 'Copy to project',
         layout: 'app-container',
     },
+    [Scene.DashboardTemplateCopy]: {
+        projectBased: true,
+        name: 'Copy template to project',
+        layout: 'app-container',
+    },
     [Scene.RevenueAnalytics]: {
         projectBased: true,
         name: 'Revenue analytics',
@@ -817,6 +822,7 @@ export const redirects: Record<
 export const routes: Record<string, [Scene | string, string]> = {
     [urls.newTab()]: [Scene.NewTab, 'newTab'],
     [urls.dashboards()]: [Scene.Dashboards, 'dashboards'],
+    [urls.dashboardTemplateCopyToProject(':sourceTemplateId')]: [Scene.DashboardTemplateCopy, 'dashboardTemplateCopy'],
     [urls.dashboard(':id')]: [Scene.Dashboard, 'dashboard'],
     [urls.dashboardTextTile(':id', ':textTileId')]: [Scene.Dashboard, 'dashboardTextTile'],
     [urls.dashboardButtonTile(':id', ':buttonTileId')]: [Scene.Dashboard, 'dashboardButtonTile'],

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -120,6 +120,14 @@ export const urls = {
     variableEdit: (id: string | ':id'): string => `/data-management/variables/${id}/edit`,
     resourceTransfer: (resourceKind: string, resourceId: string | number): string =>
         `/resource-transfer/${resourceKind}/${resourceId}`,
+    dashboardTemplateCopyToProject: (templateId: string | ':sourceTemplateId', sourceTeamId?: number): string => {
+        const path = `/dashboard/templates/${templateId}/copy-to-project`
+        return sourceTeamId === undefined
+            ? path
+            : combineUrl(path, {
+                  source_team: sourceTeamId,
+              }).url
+    },
     organizationCreateFirst: (): string => '/create-organization',
     projectCreateFirst: (): string => '/organization/create-project',
     projectRoot: (): string => '/',

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -123,6 +123,14 @@ export const urls = {
     variableEdit: (id: string | ':id'): string => `/data-management/variables/${id}/edit`,
     resourceTransfer: (resourceKind: string, resourceId: string | number): string =>
         `/resource-transfer/${resourceKind}/${resourceId}`,
+    dashboardTemplateCopyToProject: (templateId: string | ':sourceTemplateId', sourceTeamId?: number): string => {
+        const path = `/dashboard/templates/${templateId}/copy-to-project`
+        return sourceTeamId === undefined
+            ? path
+            : combineUrl(path, {
+                  source_team: sourceTeamId,
+              }).url
+    },
     organizationCreateFirst: (): string => '/create-organization',
     projectCreateFirst: (): string => '/organization/create-project',
     projectRoot: (): string => '/',

--- a/products/dashboards/backend/api/dashboard_templates.py
+++ b/products/dashboards/backend/api/dashboard_templates.py
@@ -284,9 +284,7 @@ def _pick_unique_template_name_for_copy(*, team_id: int, base_name: str) -> str:
     )
 
 
-def _assert_user_can_read_source_for_copy(*, user: User, source_team: Team, target_organization_id: UUID) -> None:
-    if source_team.organization_id != target_organization_id:
-        raise NotFound()
+def _assert_user_can_read_source_for_copy(*, user: User, source_team: Team) -> None:
     if user.is_staff:
         return
     up = UserPermissions(user=user)
@@ -416,12 +414,14 @@ class DashboardTemplateViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, views
         if source.team_id == target_team_id:
             raise ValidationError({"source_template_id": ["Source and destination must be different projects."]})
 
-        source_team = Team.objects.get(pk=source.team_id)
+        source_team = Team.objects.filter(pk=source.team_id).first()
+        if source_team is None:
+            raise NotFound()
         if source_team.organization_id != target_org_id:
             raise NotFound()
 
         user = cast(User, request.user)
-        _assert_user_can_read_source_for_copy(user=user, source_team=source_team, target_organization_id=target_org_id)
+        _assert_user_can_read_source_for_copy(user=user, source_team=source_team)
 
         enforce_organization_dashboard_template_limit(organization_id=target_org_id)
 

--- a/products/dashboards/backend/api/dashboard_templates.py
+++ b/products/dashboards/backend/api/dashboard_templates.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, NoReturn, cast
 from uuid import UUID
@@ -14,8 +15,8 @@ import structlog
 import posthoganalytics
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
-from rest_framework import request, response, serializers, viewsets
-from rest_framework.exceptions import ValidationError
+from rest_framework import request, response, serializers, status, viewsets
+from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.permissions import SAFE_METHODS, BasePermission
 from rest_framework.request import Request
 
@@ -28,6 +29,8 @@ from posthog.helpers.full_text_search import build_rank
 from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.permissions import get_organization_from_view
+from posthog.rbac.user_access_control import UserAccessControl
+from posthog.user_permissions import UserPermissions
 from posthog.utils import str_to_bool
 
 from products.dashboards.backend.models.dashboard_templates import DashboardTemplate
@@ -252,6 +255,52 @@ class DashboardTemplateSerializer(serializers.ModelSerializer):
             self._handle_integrity_error(exc)
 
 
+class CopyDashboardTemplateSerializer(serializers.Serializer):
+    source_template_id = serializers.UUIDField(
+        help_text="UUID of a team-scoped template in the same organization. Global and feature-flag templates cannot be copied with this endpoint."
+    )
+
+
+def _iter_copy_name_candidates(base_name: str) -> Iterator[str]:
+    yield base_name
+    yield f"{base_name} (copy)"
+    n = 2
+    while True:
+        yield f"{base_name} (copy {n})"
+        n += 1
+
+
+def _pick_unique_template_name_for_copy(*, team_id: int, base_name: str) -> str:
+    """Resolves `template_name` collisions on the target team by suffixing `(copy)`, `(copy 2)`, …"""
+    max_attempts = 50
+    candidates = _iter_copy_name_candidates(base_name)
+    for _ in range(max_attempts):
+        name = next(candidates)
+        if not DashboardTemplate.objects.filter(team_id=team_id, template_name=name).exists():
+            return name
+    raise ValidationError(
+        detail="Could not find an available template name after multiple attempts. Rename the source template and try again.",
+        code="template_name_exhausted",
+    )
+
+
+def _assert_user_can_read_source_for_copy(*, user: User, source_team: Team, target_organization_id: UUID) -> None:
+    if source_team.organization_id != target_organization_id:
+        raise NotFound()
+    if user.is_staff:
+        return
+    up = UserPermissions(user=user)
+    if source_team.id not in up.team_ids_visible_for_user:
+        raise NotFound()
+    uac = UserAccessControl(
+        user=user,
+        team=source_team,
+        organization_id=str(source_team.organization_id),
+    )
+    if not uac.check_access_level_for_resource("dashboard_template", "viewer"):
+        raise NotFound()
+
+
 @extend_schema_view(
     list=extend_schema(
         parameters=[
@@ -325,6 +374,100 @@ class DashboardTemplateViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, views
     def json_schema(self, request: request.Request, **kwargs) -> response.Response:
         # Could switch from this being a static file to being dynamically generated from the serializer
         return response.Response(dashboard_template_schema)
+
+    @extend_schema(
+        request=CopyDashboardTemplateSerializer,
+        responses={status.HTTP_201_CREATED: DashboardTemplateSerializer},
+        summary="Copy a team template to this project",
+        description=(
+            "Creates a new team-scoped template in the **target** project (URL) from a **team-scoped** source template "
+            "in the same organization. Global and feature-flag templates return 400. Cross-organization or inaccessible "
+            "sources return 404. Source and destination projects must differ (400 if equal). "
+            "Conflicting `template_name` values on the destination are auto-suffixed with `(copy)`, `(copy 2)`, …"
+        ),
+    )
+    @action(detail=False, methods=["post"], url_path="copy_between_projects")
+    def copy_between_projects(self, request: Request, **kwargs) -> response.Response:
+        body = CopyDashboardTemplateSerializer(data=request.data)
+        body.is_valid(raise_exception=True)
+        source_template_id = cast(UUID, body.validated_data["source_template_id"])
+
+        target_team = self.team
+        target_team_id = target_team.id
+        target_org_id = cast(UUID, target_team.organization_id)
+
+        source = DashboardTemplate.objects_including_soft_deleted.filter(id=source_template_id).first()
+        if source is None or source.deleted:
+            raise NotFound()
+
+        if source.scope == DashboardTemplate.Scope.GLOBAL:
+            raise ValidationError(
+                {"source_template_id": ["Only project-scoped templates can be copied to another project."]}
+            )
+        if source.scope == DashboardTemplate.Scope.FEATURE_FLAG:
+            raise ValidationError(
+                {"source_template_id": ["Feature-flag templates cannot be copied with this endpoint."]}
+            )
+        if source.scope != DashboardTemplate.Scope.ONLY_TEAM or source.team_id is None:
+            raise ValidationError(
+                {"source_template_id": ["Only project-scoped templates can be copied to another project."]}
+            )
+
+        if source.team_id == target_team_id:
+            raise ValidationError({"source_template_id": ["Source and destination must be different projects."]})
+
+        source_team = Team.objects.get(pk=source.team_id)
+        if source_team.organization_id != target_org_id:
+            raise NotFound()
+
+        user = cast(User, request.user)
+        _assert_user_can_read_source_for_copy(user=user, source_team=source_team, target_organization_id=target_org_id)
+
+        enforce_organization_dashboard_template_limit(organization_id=target_org_id)
+
+        base_name = (source.template_name or "").strip() or "Untitled template"
+        unique_name = _pick_unique_template_name_for_copy(team_id=target_team_id, base_name=base_name)
+
+        new_instance = DashboardTemplate.objects.create(
+            team_id=target_team_id,
+            template_name=unique_name,
+            dashboard_description=source.dashboard_description,
+            # TODO(analytics-platform): dashboard_filters and variables are copied verbatim; both can embed
+            # project-scoped references (e.g. cohort IDs in filter properties; variable defaults for events,
+            # actions, or properties) that do not exist or differ on the target project. Tile queries have the
+            # same class of issue. Consider validation and/or ID rewriting (cf. resource_transfer visitors).
+            dashboard_filters=source.dashboard_filters,
+            tiles=source.tiles or [],
+            variables=source.variables,
+            tags=source.tags or [],
+            scope=DashboardTemplate.Scope.ONLY_TEAM,
+            is_featured=False,
+            image_url=None,
+            github_url=None,
+            availability_contexts=None,
+            deleted=False,
+            created_by=user if user.is_authenticated else None,
+        )
+
+        report_user_action(
+            user,
+            "dashboard project template copied between projects",
+            properties={
+                "source_template_id": str(source.id),
+                "new_template_id": str(new_instance.id),
+                "source_team_id": source.team_id,
+                "target_team_id": target_team_id,
+                "organization_id": str(self.organization_id),
+                "template_name": unique_name,
+                "tile_count": len(new_instance.tiles or []),
+                "variable_count": len(new_instance.variables or []),
+            },
+            team=self.team,
+            organization=self.organization,
+        )
+
+        serializer = DashboardTemplateSerializer(new_instance, context=self.get_serializer_context())
+        return response.Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def dangerously_get_queryset(self):
         # NOTE: we use the dangerous version as we want to bypass the team/org scoping and do it here instead depending on the scope

--- a/products/dashboards/backend/api/test/test_dashboard_templates.py
+++ b/products/dashboards/backend/api/test/test_dashboard_templates.py
@@ -1424,9 +1424,10 @@ class TestCustomerDashboardTemplateCopyBetweenProjects(APIBaseTest):
         assert resp.status_code == status.HTTP_403_FORBIDDEN
 
     def test_non_staff_copy_403_when_only_viewer_on_target(self) -> None:
+        # `dashboard_template` inherits access from `dashboard`, so ACs must target the parent resource
         AccessControl.objects.create(
             team=self.team,
-            resource="dashboard_template",
+            resource="dashboard",
             resource_id=None,
             organization_member=self.organization_membership,
             role=None,
@@ -1434,7 +1435,7 @@ class TestCustomerDashboardTemplateCopyBetweenProjects(APIBaseTest):
         )
         AccessControl.objects.create(
             team=self.team_b,
-            resource="dashboard_template",
+            resource="dashboard",
             resource_id=None,
             organization_member=self.organization_membership,
             role=None,
@@ -1463,9 +1464,18 @@ class TestCustomerDashboardTemplateCopyBetweenProjects(APIBaseTest):
             tags=[],
         )
         tpl = DashboardTemplate.objects.get(template_name="source without template rbac")
+        # Explicitly revoke the user's dashboard access on the source project (dashboard_template inherits from dashboard)
+        AccessControl.objects.create(
+            team=self.team,
+            resource="dashboard",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="none",
+        )
         AccessControl.objects.create(
             team=self.team_b,
-            resource="dashboard_template",
+            resource="dashboard",
             resource_id=None,
             organization_member=self.organization_membership,
             role=None,

--- a/products/dashboards/backend/api/test/test_dashboard_templates.py
+++ b/products/dashboards/backend/api/test/test_dashboard_templates.py
@@ -1,3 +1,4 @@
+import uuid
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from typing import Any, Optional
@@ -1101,3 +1102,352 @@ class TestCustomerDashboardTemplateAuthoring(APIBaseTest):
             {**variable_template, "template_name": "Analytics emit global scoped", "scope": "global"},
         )
         mock_report.assert_not_called()
+
+
+class TestDashboardTemplateCopyBetweenProjects(APIBaseTest):
+    """POST .../dashboard_templates/copy_between_projects/ — same-org, team source only."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.user.is_staff = True
+        self.user.save()
+        ensure_baseline_global_dashboard_templates()
+        self.team_b = Team.objects.create(organization=self.organization, name="Second project copy target")
+        self.team_c = Team.objects.create(organization=self.organization, name="Third project copy source")
+
+    def _copy_url(self, team_pk: int) -> str:
+        return f"/api/projects/{team_pk}/dashboard_templates/copy_between_projects/"
+
+    def test_copy_happy_path_creates_row_on_target_team(self) -> None:
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Copy me inter-project", "scope": "team"},
+        )
+        assert src.status_code == status.HTTP_201_CREATED, src.content
+        src_id = src.json()["id"]
+
+        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_201_CREATED, resp.content
+        data = resp.json()
+        assert data["template_name"] == "Copy me inter-project"
+        assert data["team_id"] == self.team_b.pk
+        assert data["scope"] == "team"
+        assert data["is_featured"] is False
+        assert data["image_url"] in (None, "")
+        assert len(data["tiles"]) == len(variable_template["tiles"])
+
+    @patch("products.dashboards.backend.api.dashboard_templates.report_user_action")
+    def test_copy_emits_distinct_analytics_event(self, mock_report: Any) -> None:
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Analytics copy between", "scope": "team"},
+        )
+        src_id = src.json()["id"]
+        mock_report.reset_mock()
+
+        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_201_CREATED, resp.content
+        new_id = resp.json()["id"]
+        mock_report.assert_called_once()
+        assert mock_report.call_args.args[1] == "dashboard project template copied between projects"
+        props = mock_report.call_args.kwargs["properties"]
+        assert props["source_template_id"] == src_id
+        assert props["new_template_id"] == new_id
+        assert props["source_team_id"] == self.team.pk
+        assert props["target_team_id"] == self.team_b.pk
+        assert props["organization_id"] == str(self.organization.id)
+        assert props["template_name"] == "Analytics copy between"
+        assert props["source_team_id"] != props["target_team_id"]
+
+    def test_copy_same_source_and_target_team_400(self) -> None:
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Same team copy", "scope": "team"},
+        )
+        src_id = src.json()["id"]
+        resp = self.client.post(self._copy_url(self.team.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    @parameterized.expand(
+        [
+            ("global",),
+            ("feature_flag",),
+        ]
+    )
+    def test_copy_non_team_source_400(self, source_kind: str) -> None:
+        if source_kind == "global":
+            global_tpl = DashboardTemplate.objects.filter(
+                scope=DashboardTemplate.Scope.GLOBAL, team_id__isnull=True
+            ).first()
+            assert global_tpl is not None
+            source_id = str(global_tpl.id)
+        else:
+            ff_tpl = DashboardTemplate.objects.create(
+                team_id=self.team.pk,
+                scope=DashboardTemplate.Scope.FEATURE_FLAG,
+                template_name="ff copy source",
+                dashboard_description="",
+                dashboard_filters={},
+                tiles=variable_template["tiles"],
+                variables=[],
+                tags=[],
+            )
+            source_id = str(ff_tpl.id)
+        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": source_id}, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_copy_cross_organization_404(self) -> None:
+        other_org = Organization.objects.create(name="Other org copy")
+        other_team = Team.objects.create(organization=other_org, name="Other team copy")
+        other_tpl = DashboardTemplate.objects.create(
+            team_id=other_team.pk,
+            scope=DashboardTemplate.Scope.ONLY_TEAM,
+            template_name="other org tpl",
+            dashboard_description="",
+            dashboard_filters={},
+            tiles=variable_template["tiles"],
+            variables=[],
+            tags=[],
+        )
+        resp = self.client.post(
+            self._copy_url(self.team_b.pk), {"source_template_id": str(other_tpl.id)}, format="json"
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_copy_soft_deleted_source_404(self) -> None:
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Deleted source", "scope": "team"},
+        )
+        src_id = src.json()["id"]
+        assert (
+            self.client.patch(
+                f"/api/projects/{self.team.pk}/dashboard_templates/{src_id}",
+                {"deleted": True},
+            ).status_code
+            == status.HTTP_200_OK
+        )
+        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_copy_unknown_uuid_404(self) -> None:
+        resp = self.client.post(
+            self._copy_url(self.team_b.pk), {"source_template_id": str(uuid.uuid4())}, format="json"
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_copy_disambiguates_template_name_on_target(self) -> None:
+        first = self.client.post(
+            f"/api/projects/{self.team_b.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Shared name", "scope": "team"},
+        )
+        assert first.status_code == status.HTTP_201_CREATED, first.content
+
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Shared name", "scope": "team"},
+        )
+        src_id = src.json()["id"]
+
+        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_201_CREATED, resp.content
+        assert resp.json()["template_name"] == "Shared name (copy)"
+
+        src2 = self.client.post(
+            f"/api/projects/{self.team_c.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Shared name", "scope": "team"},
+        )
+        assert src2.status_code == status.HTTP_201_CREATED, src2.content
+        src2_id = src2.json()["id"]
+        resp2 = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src2_id}, format="json")
+        assert resp2.status_code == status.HTTP_201_CREATED, resp2.content
+        assert resp2.json()["template_name"] == "Shared name (copy 2)"
+
+    def test_copy_rejects_when_organization_at_template_cap(self) -> None:
+        seed_tiles = variable_template["tiles"]
+        DashboardTemplate.objects.bulk_create(
+            [
+                DashboardTemplate(
+                    team_id=self.team.pk,
+                    template_name=f"copy-cap-fill-{i}",
+                    scope=DashboardTemplate.Scope.ONLY_TEAM,
+                    dashboard_description="",
+                    dashboard_filters={},
+                    tiles=seed_tiles,
+                    variables=[],
+                    tags=[],
+                )
+                for i in range(MAX_DASHBOARD_TEMPLATES_PER_ORGANIZATION - 1)
+            ]
+        )
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Copy cap source", "scope": "team"},
+        )
+        assert src.status_code == status.HTTP_201_CREATED, src.content
+        src_id = src.json()["id"]
+
+        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST, resp.content
+        assert resp.json()["detail"] == organization_dashboard_template_limit_detail()
+
+
+class TestCustomerDashboardTemplateCopyBetweenProjects(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user.is_staff = False
+        self.user.save()
+        ensure_baseline_global_dashboard_templates()
+        self.organization.available_product_features = [
+            {"name": AvailableFeature.ADVANCED_PERMISSIONS, "key": AvailableFeature.ADVANCED_PERMISSIONS},
+        ]
+        self.organization.save()
+        self.team_b = Team.objects.create(organization=self.organization, name="Customer copy target")
+
+    def _copy_url(self, team_pk: int) -> str:
+        return f"/api/projects/{team_pk}/dashboard_templates/copy_between_projects/"
+
+    def test_non_staff_copy_requires_authoring_flag_and_editor_on_target(self) -> None:
+        AccessControl.objects.create(
+            team=self.team,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="editor",
+        )
+        AccessControl.objects.create(
+            team=self.team_b,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="editor",
+        )
+        with _customer_dashboard_template_authoring_flag_on():
+            src = self.client.post(
+                f"/api/projects/{self.team.pk}/dashboard_templates",
+                {**variable_template, "template_name": "Customer inter-project", "scope": "team"},
+            )
+        assert src.status_code == status.HTTP_201_CREATED, src.content
+        src_id = src.json()["id"]
+
+        with _customer_dashboard_template_authoring_flag_on():
+            resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_201_CREATED, resp.content
+        assert resp.json()["team_id"] == self.team_b.pk
+
+    def test_non_staff_copy_global_source_400(self) -> None:
+        """Official (global) templates cannot be inter-project copied; validation is not gated on staff."""
+        AccessControl.objects.create(
+            team=self.team,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="editor",
+        )
+        AccessControl.objects.create(
+            team=self.team_b,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="editor",
+        )
+        global_tpl = DashboardTemplate.objects.filter(
+            scope=DashboardTemplate.Scope.GLOBAL, team_id__isnull=True
+        ).first()
+        assert global_tpl is not None
+
+        with _customer_dashboard_template_authoring_flag_on():
+            resp = self.client.post(
+                self._copy_url(self.team_b.pk), {"source_template_id": str(global_tpl.id)}, format="json"
+            )
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST, resp.content
+        data = resp.json()
+        assert data["type"] == "validation_error"
+        assert data["attr"] == "source_template_id"
+        assert data["detail"] == "Only project-scoped templates can be copied to another project."
+
+    def test_non_staff_copy_forbidden_without_authoring_flag(self) -> None:
+        AccessControl.objects.create(
+            team=self.team,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="editor",
+        )
+        AccessControl.objects.create(
+            team=self.team_b,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="editor",
+        )
+        self.user.is_staff = True
+        self.user.save()
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "No flag copy", "scope": "team"},
+        )
+        src_id = src.json()["id"]
+        self.user.is_staff = False
+        self.user.save()
+
+        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_non_staff_copy_403_when_only_viewer_on_target(self) -> None:
+        AccessControl.objects.create(
+            team=self.team,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="editor",
+        )
+        AccessControl.objects.create(
+            team=self.team_b,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="viewer",
+        )
+        with _customer_dashboard_template_authoring_flag_on():
+            src = self.client.post(
+                f"/api/projects/{self.team.pk}/dashboard_templates",
+                {**variable_template, "template_name": "Viewer on target", "scope": "team"},
+            )
+        src_id = src.json()["id"]
+
+        with _customer_dashboard_template_authoring_flag_on():
+            resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_non_staff_copy_404_when_no_dashboard_template_access_on_source_project(self) -> None:
+        DashboardTemplate.objects.create(
+            team_id=self.team.pk,
+            scope=DashboardTemplate.Scope.ONLY_TEAM,
+            template_name="source without template rbac",
+            dashboard_description="",
+            dashboard_filters={},
+            tiles=variable_template["tiles"],
+            variables=[],
+            tags=[],
+        )
+        tpl = DashboardTemplate.objects.get(template_name="source without template rbac")
+        AccessControl.objects.create(
+            team=self.team_b,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="editor",
+        )
+        with _customer_dashboard_template_authoring_flag_on():
+            resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": str(tpl.id)}, format="json")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/products/dashboards/backend/api/test/test_dashboard_templates.py
+++ b/products/dashboards/backend/api/test/test_dashboard_templates.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from typing import Any, Optional
 
 from posthog.test.base import APIBaseTest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.db.models import Q
 
@@ -1212,6 +1212,29 @@ class TestDashboardTemplateCopyBetweenProjects(APIBaseTest):
         resp = self.client.post(
             self._copy_url(self.team_b.pk), {"source_template_id": str(other_tpl.id)}, format="json"
         )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_copy_source_team_row_missing_404(self) -> None:
+        """Stale `team_id` on the template (no matching Team row) must be 404, not 500."""
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Source team row missing", "scope": "team"},
+        )
+        assert src.status_code == status.HTTP_201_CREATED, src.content
+        src_id = src.json()["id"]
+
+        real_filter = Team.objects.filter
+
+        def filter_impl(*args, **kwargs):
+            if kwargs == {"pk": self.team.pk}:
+                qs = MagicMock()
+                qs.first.return_value = None
+                return qs
+            return real_filter(*args, **kwargs)
+
+        with patch.object(Team.objects, "filter", side_effect=filter_impl):
+            resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+
         assert resp.status_code == status.HTTP_404_NOT_FOUND
 
     def test_copy_soft_deleted_source_404(self) -> None:

--- a/products/dashboards/backend/api/test/test_dashboard_templates.py
+++ b/products/dashboards/backend/api/test/test_dashboard_templates.py
@@ -1,3 +1,4 @@
+import uuid
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from typing import Any, Optional
@@ -1099,3 +1100,352 @@ class TestCustomerDashboardTemplateAuthoring(APIBaseTest):
             {**variable_template, "template_name": "Analytics emit global scoped", "scope": "global"},
         )
         mock_report.assert_not_called()
+
+
+class TestDashboardTemplateCopyBetweenProjects(APIBaseTest):
+    """POST .../dashboard_templates/copy_between_projects/ — same-org, team source only."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.user.is_staff = True
+        self.user.save()
+        ensure_baseline_global_dashboard_templates()
+        self.team_b = Team.objects.create(organization=self.organization, name="Second project copy target")
+        self.team_c = Team.objects.create(organization=self.organization, name="Third project copy source")
+
+    def _copy_url(self, team_pk: int) -> str:
+        return f"/api/projects/{team_pk}/dashboard_templates/copy_between_projects/"
+
+    def test_copy_happy_path_creates_row_on_target_team(self) -> None:
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Copy me inter-project", "scope": "team"},
+        )
+        assert src.status_code == status.HTTP_201_CREATED, src.content
+        src_id = src.json()["id"]
+
+        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_201_CREATED, resp.content
+        data = resp.json()
+        assert data["template_name"] == "Copy me inter-project"
+        assert data["team_id"] == self.team_b.pk
+        assert data["scope"] == "team"
+        assert data["is_featured"] is False
+        assert data["image_url"] in (None, "")
+        assert len(data["tiles"]) == len(variable_template["tiles"])
+
+    @patch("products.dashboards.backend.api.dashboard_templates.report_user_action")
+    def test_copy_emits_distinct_analytics_event(self, mock_report: Any) -> None:
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Analytics copy between", "scope": "team"},
+        )
+        src_id = src.json()["id"]
+        mock_report.reset_mock()
+
+        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_201_CREATED, resp.content
+        new_id = resp.json()["id"]
+        mock_report.assert_called_once()
+        assert mock_report.call_args.args[1] == "dashboard project template copied between projects"
+        props = mock_report.call_args.kwargs["properties"]
+        assert props["source_template_id"] == src_id
+        assert props["new_template_id"] == new_id
+        assert props["source_team_id"] == self.team.pk
+        assert props["target_team_id"] == self.team_b.pk
+        assert props["organization_id"] == str(self.organization.id)
+        assert props["template_name"] == "Analytics copy between"
+        assert props["source_team_id"] != props["target_team_id"]
+
+    def test_copy_same_source_and_target_team_400(self) -> None:
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Same team copy", "scope": "team"},
+        )
+        src_id = src.json()["id"]
+        resp = self.client.post(self._copy_url(self.team.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    @parameterized.expand(
+        [
+            ("global",),
+            ("feature_flag",),
+        ]
+    )
+    def test_copy_non_team_source_400(self, source_kind: str) -> None:
+        if source_kind == "global":
+            global_tpl = DashboardTemplate.objects.filter(
+                scope=DashboardTemplate.Scope.GLOBAL, team_id__isnull=True
+            ).first()
+            assert global_tpl is not None
+            source_id = str(global_tpl.id)
+        else:
+            ff_tpl = DashboardTemplate.objects.create(
+                team_id=self.team.pk,
+                scope=DashboardTemplate.Scope.FEATURE_FLAG,
+                template_name="ff copy source",
+                dashboard_description="",
+                dashboard_filters={},
+                tiles=variable_template["tiles"],
+                variables=[],
+                tags=[],
+            )
+            source_id = str(ff_tpl.id)
+        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": source_id}, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_copy_cross_organization_404(self) -> None:
+        other_org = Organization.objects.create(name="Other org copy")
+        other_team = Team.objects.create(organization=other_org, name="Other team copy")
+        other_tpl = DashboardTemplate.objects.create(
+            team_id=other_team.pk,
+            scope=DashboardTemplate.Scope.ONLY_TEAM,
+            template_name="other org tpl",
+            dashboard_description="",
+            dashboard_filters={},
+            tiles=variable_template["tiles"],
+            variables=[],
+            tags=[],
+        )
+        resp = self.client.post(
+            self._copy_url(self.team_b.pk), {"source_template_id": str(other_tpl.id)}, format="json"
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_copy_soft_deleted_source_404(self) -> None:
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Deleted source", "scope": "team"},
+        )
+        src_id = src.json()["id"]
+        assert (
+            self.client.patch(
+                f"/api/projects/{self.team.pk}/dashboard_templates/{src_id}",
+                {"deleted": True},
+            ).status_code
+            == status.HTTP_200_OK
+        )
+        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_copy_unknown_uuid_404(self) -> None:
+        resp = self.client.post(
+            self._copy_url(self.team_b.pk), {"source_template_id": str(uuid.uuid4())}, format="json"
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_copy_disambiguates_template_name_on_target(self) -> None:
+        first = self.client.post(
+            f"/api/projects/{self.team_b.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Shared name", "scope": "team"},
+        )
+        assert first.status_code == status.HTTP_201_CREATED, first.content
+
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Shared name", "scope": "team"},
+        )
+        src_id = src.json()["id"]
+
+        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_201_CREATED, resp.content
+        assert resp.json()["template_name"] == "Shared name (copy)"
+
+        src2 = self.client.post(
+            f"/api/projects/{self.team_c.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Shared name", "scope": "team"},
+        )
+        assert src2.status_code == status.HTTP_201_CREATED, src2.content
+        src2_id = src2.json()["id"]
+        resp2 = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src2_id}, format="json")
+        assert resp2.status_code == status.HTTP_201_CREATED, resp2.content
+        assert resp2.json()["template_name"] == "Shared name (copy 2)"
+
+    def test_copy_rejects_when_organization_at_template_cap(self) -> None:
+        seed_tiles = variable_template["tiles"]
+        DashboardTemplate.objects.bulk_create(
+            [
+                DashboardTemplate(
+                    team_id=self.team.pk,
+                    template_name=f"copy-cap-fill-{i}",
+                    scope=DashboardTemplate.Scope.ONLY_TEAM,
+                    dashboard_description="",
+                    dashboard_filters={},
+                    tiles=seed_tiles,
+                    variables=[],
+                    tags=[],
+                )
+                for i in range(MAX_DASHBOARD_TEMPLATES_PER_ORGANIZATION - 1)
+            ]
+        )
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Copy cap source", "scope": "team"},
+        )
+        assert src.status_code == status.HTTP_201_CREATED, src.content
+        src_id = src.json()["id"]
+
+        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST, resp.content
+        assert resp.json()["detail"] == organization_dashboard_template_limit_detail()
+
+
+class TestCustomerDashboardTemplateCopyBetweenProjects(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user.is_staff = False
+        self.user.save()
+        ensure_baseline_global_dashboard_templates()
+        self.organization.available_product_features = [
+            {"name": AvailableFeature.ADVANCED_PERMISSIONS, "key": AvailableFeature.ADVANCED_PERMISSIONS},
+        ]
+        self.organization.save()
+        self.team_b = Team.objects.create(organization=self.organization, name="Customer copy target")
+
+    def _copy_url(self, team_pk: int) -> str:
+        return f"/api/projects/{team_pk}/dashboard_templates/copy_between_projects/"
+
+    def test_non_staff_copy_requires_authoring_flag_and_editor_on_target(self) -> None:
+        AccessControl.objects.create(
+            team=self.team,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="editor",
+        )
+        AccessControl.objects.create(
+            team=self.team_b,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="editor",
+        )
+        with _customer_dashboard_template_authoring_flag_on():
+            src = self.client.post(
+                f"/api/projects/{self.team.pk}/dashboard_templates",
+                {**variable_template, "template_name": "Customer inter-project", "scope": "team"},
+            )
+        assert src.status_code == status.HTTP_201_CREATED, src.content
+        src_id = src.json()["id"]
+
+        with _customer_dashboard_template_authoring_flag_on():
+            resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_201_CREATED, resp.content
+        assert resp.json()["team_id"] == self.team_b.pk
+
+    def test_non_staff_copy_global_source_400(self) -> None:
+        """Official (global) templates cannot be inter-project copied; validation is not gated on staff."""
+        AccessControl.objects.create(
+            team=self.team,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="editor",
+        )
+        AccessControl.objects.create(
+            team=self.team_b,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="editor",
+        )
+        global_tpl = DashboardTemplate.objects.filter(
+            scope=DashboardTemplate.Scope.GLOBAL, team_id__isnull=True
+        ).first()
+        assert global_tpl is not None
+
+        with _customer_dashboard_template_authoring_flag_on():
+            resp = self.client.post(
+                self._copy_url(self.team_b.pk), {"source_template_id": str(global_tpl.id)}, format="json"
+            )
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST, resp.content
+        data = resp.json()
+        assert data["type"] == "validation_error"
+        assert data["attr"] == "source_template_id"
+        assert data["detail"] == "Only project-scoped templates can be copied to another project."
+
+    def test_non_staff_copy_forbidden_without_authoring_flag(self) -> None:
+        AccessControl.objects.create(
+            team=self.team,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="editor",
+        )
+        AccessControl.objects.create(
+            team=self.team_b,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="editor",
+        )
+        self.user.is_staff = True
+        self.user.save()
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "No flag copy", "scope": "team"},
+        )
+        src_id = src.json()["id"]
+        self.user.is_staff = False
+        self.user.save()
+
+        resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_non_staff_copy_403_when_only_viewer_on_target(self) -> None:
+        AccessControl.objects.create(
+            team=self.team,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="editor",
+        )
+        AccessControl.objects.create(
+            team=self.team_b,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="viewer",
+        )
+        with _customer_dashboard_template_authoring_flag_on():
+            src = self.client.post(
+                f"/api/projects/{self.team.pk}/dashboard_templates",
+                {**variable_template, "template_name": "Viewer on target", "scope": "team"},
+            )
+        src_id = src.json()["id"]
+
+        with _customer_dashboard_template_authoring_flag_on():
+            resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_non_staff_copy_404_when_no_dashboard_template_access_on_source_project(self) -> None:
+        DashboardTemplate.objects.create(
+            team_id=self.team.pk,
+            scope=DashboardTemplate.Scope.ONLY_TEAM,
+            template_name="source without template rbac",
+            dashboard_description="",
+            dashboard_filters={},
+            tiles=variable_template["tiles"],
+            variables=[],
+            tags=[],
+        )
+        tpl = DashboardTemplate.objects.get(template_name="source without template rbac")
+        AccessControl.objects.create(
+            team=self.team_b,
+            resource="dashboard_template",
+            resource_id=None,
+            organization_member=self.organization_membership,
+            role=None,
+            access_level="editor",
+        )
+        with _customer_dashboard_template_authoring_flag_on():
+            resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": str(tpl.id)}, format="json")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/products/dashboards/backend/api/test/test_dashboard_templates.py
+++ b/products/dashboards/backend/api/test/test_dashboard_templates.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from typing import Any, Optional
 
 from posthog.test.base import APIBaseTest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.db.models import Q
 
@@ -1210,6 +1210,29 @@ class TestDashboardTemplateCopyBetweenProjects(APIBaseTest):
         resp = self.client.post(
             self._copy_url(self.team_b.pk), {"source_template_id": str(other_tpl.id)}, format="json"
         )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_copy_source_team_row_missing_404(self) -> None:
+        """Stale `team_id` on the template (no matching Team row) must be 404, not 500."""
+        src = self.client.post(
+            f"/api/projects/{self.team.pk}/dashboard_templates",
+            {**variable_template, "template_name": "Source team row missing", "scope": "team"},
+        )
+        assert src.status_code == status.HTTP_201_CREATED, src.content
+        src_id = src.json()["id"]
+
+        real_filter = Team.objects.filter
+
+        def filter_impl(*args, **kwargs):
+            if kwargs == {"pk": self.team.pk}:
+                qs = MagicMock()
+                qs.first.return_value = None
+                return qs
+            return real_filter(*args, **kwargs)
+
+        with patch.object(Team.objects, "filter", side_effect=filter_impl):
+            resp = self.client.post(self._copy_url(self.team_b.pk), {"source_template_id": src_id}, format="json")
+
         assert resp.status_code == status.HTTP_404_NOT_FOUND
 
     def test_copy_soft_deleted_source_404(self) -> None:

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -151,6 +151,11 @@ export interface PaginatedDashboardTemplateListApi {
     results: DashboardTemplateApi[]
 }
 
+export interface CopyDashboardTemplateApi {
+    /** UUID of a team-scoped template in the same organization. Global and feature-flag templates cannot be copied with this endpoint. */
+    source_template_id: string
+}
+
 /**
  * * `default` - Default
  * `template` - Template

--- a/products/dashboards/frontend/generated/api.ts
+++ b/products/dashboards/frontend/generated/api.ts
@@ -11,6 +11,7 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
 import type {
     BulkUpdateTagsRequestApi,
     BulkUpdateTagsResponseApi,
+    CopyDashboardTemplateApi,
     CopyDashboardTileRequestApi,
     DashboardApi,
     DashboardCollaboratorApi,
@@ -57,8 +58,8 @@ type DistributeReadOnlyOverUnions<T> = T extends any ? NonReadonly<T> : never
 type Writable<T> = Pick<T, WritableKeys<T>>
 type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
     ? {
-          [P in keyof Writable<T>]: T[P] extends object ? NonReadonly<NonNullable<T[P]>> : T[P]
-      }
+        [P in keyof Writable<T>]: T[P] extends object ? NonReadonly<NonNullable<T[P]>> : T[P]
+    }
     : DistributeReadOnlyOverUnions<T>
 
 export const getDashboardsCollaboratorsListUrl = (projectId: string, dashboardId: number) => {
@@ -151,6 +152,27 @@ export const dashboardTemplatesCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(dashboardTemplateApi),
+    })
+}
+
+/**
+ * Creates a new team-scoped template in the **target** project (URL) from a **team-scoped** source template in the same organization. Global and feature-flag templates return 400. Cross-organization or inaccessible sources return 404. Source and destination projects must differ (400 if equal). Conflicting `template_name` values on the destination are auto-suffixed with `(copy)`, `(copy 2)`, …
+ * @summary Copy a team template to this project
+ */
+export const getDashboardTemplatesCopyBetweenProjectsCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/dashboard_templates/copy_between_projects/`
+}
+
+export const dashboardTemplatesCopyBetweenProjectsCreate = async (
+    projectId: string,
+    copyDashboardTemplateApi: CopyDashboardTemplateApi,
+    options?: RequestInit
+): Promise<DashboardTemplateApi> => {
+    return apiMutator<DashboardTemplateApi>(getDashboardTemplatesCopyBetweenProjectsCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(copyDashboardTemplateApi),
     })
 }
 

--- a/products/dashboards/frontend/generated/api.ts
+++ b/products/dashboards/frontend/generated/api.ts
@@ -58,8 +58,8 @@ type DistributeReadOnlyOverUnions<T> = T extends any ? NonReadonly<T> : never
 type Writable<T> = Pick<T, WritableKeys<T>>
 type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
     ? {
-        [P in keyof Writable<T>]: T[P] extends object ? NonReadonly<NonNullable<T[P]>> : T[P]
-    }
+          [P in keyof Writable<T>]: T[P] extends object ? NonReadonly<NonNullable<T[P]>> : T[P]
+      }
     : DistributeReadOnlyOverUnions<T>
 
 export const getDashboardsCollaboratorsListUrl = (projectId: string, dashboardId: number) => {

--- a/products/dashboards/frontend/generated/api.ts
+++ b/products/dashboards/frontend/generated/api.ts
@@ -9,6 +9,7 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  * OpenAPI spec version: 1.0.0
  */
 import type {
+    CopyDashboardTemplateApi,
     CopyDashboardTileRequestApi,
     DashboardApi,
     DashboardCollaboratorApi,
@@ -148,6 +149,27 @@ export const dashboardTemplatesCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(dashboardTemplateApi),
+    })
+}
+
+/**
+ * Creates a new team-scoped template in the **target** project (URL) from a **team-scoped** source template in the same organization. Global and feature-flag templates return 400. Cross-organization or inaccessible sources return 404. Source and destination projects must differ (400 if equal). Conflicting `template_name` values on the destination are auto-suffixed with `(copy)`, `(copy 2)`, …
+ * @summary Copy a team template to this project
+ */
+export const getDashboardTemplatesCopyBetweenProjectsCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/dashboard_templates/copy_between_projects/`
+}
+
+export const dashboardTemplatesCopyBetweenProjectsCreate = async (
+    projectId: string,
+    copyDashboardTemplateApi: CopyDashboardTemplateApi,
+    options?: RequestInit
+): Promise<DashboardTemplateApi> => {
+    return apiMutator<DashboardTemplateApi>(getDashboardTemplatesCopyBetweenProjectsCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(copyDashboardTemplateApi),
     })
 }
 

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -317,4 +317,6 @@ tools:
         enabled: false
     dashboards-bulk-update-tags-create:
         operation: dashboards_bulk_update_tags_create
+    dashboard-templates-copy-between-projects-create:
+        operation: dashboard_templates_copy_between_projects_create
         enabled: false

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -317,6 +317,7 @@ tools:
         enabled: false
     dashboards-bulk-update-tags-create:
         operation: dashboards_bulk_update_tags_create
+        enabled: false
     dashboard-templates-copy-between-projects-create:
         operation: dashboard_templates_copy_between_projects_create
         enabled: false

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -193,3 +193,6 @@ tools:
     dashboards-generate-metadata-create:
         operation: dashboards_generate_metadata_create
         enabled: false
+    dashboard-templates-copy-between-projects-create:
+        operation: dashboard_templates_copy_between_projects_create
+        enabled: false

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -782,3 +782,6 @@ tools:
     legal-documents-retrieve:
         operation: legal_documents_retrieve
         enabled: false
+    dashboard-templates-copy-between-projects-create:
+        operation: dashboard_templates_copy_between_projects_create
+        enabled: false

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -545,3 +545,6 @@ tools:
     users-github-login-retrieve:
         operation: users_github_login_retrieve
         enabled: false
+    dashboard-templates-copy-between-projects-create:
+        operation: dashboard_templates_copy_between_projects_create
+        enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -8617,6 +8617,11 @@ export namespace Schemas {
       Number2: 2,
     } as const;
 
+    export interface CopyDashboardTemplate {
+      /** UUID of a team-scoped template in the same organization. Global and feature-flag templates cannot be copied with this endpoint. */
+      source_template_id: string;
+    }
+
     export interface CopyDashboardTileRequest {
       /** Dashboard id the tile currently belongs to. */
       fromDashboardId: number;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -8229,6 +8229,11 @@ export namespace Schemas {
       Number2: 2,
     } as const;
 
+    export interface CopyDashboardTemplate {
+      /** UUID of a team-scoped template in the same organization. Global and feature-flag templates cannot be copied with this endpoint. */
+      source_template_id: string;
+    }
+
     export interface CopyDashboardTileRequest {
       /** Dashboard id the tile currently belongs to. */
       fromDashboardId: number;


### PR DESCRIPTION
## TL;DR

Allow copying dashboard templates between projects for the same organization.

## What changed?


https://github.com/user-attachments/assets/7bdf2153-c833-4cf8-938c-ff4ec651cee6




<img width="1784" height="758" alt="CleanShot 2026-04-13 at 20 26 42@2x" src="https://github.com/user-attachments/assets/966f8266-0e49-421f-b859-d0a34835f9c7" />
<img width="1396" height="610" alt="CleanShot 2026-04-13 at 20 26 51@2x" src="https://github.com/user-attachments/assets/451beb9b-56fb-4d46-a8ba-4ba8c422895e" />
<img width="3028" height="1024" alt="CleanShot 2026-04-13 at 20 27 00@2x" src="https://github.com/user-attachments/assets/b7ea2124-3c3f-4c46-b910-dd4ca3548a89" />





- **API layer**: Added `dashboardTemplatesCopyBetweenProjects()` method to `ApiRequest` class and `copyBetweenProjects()` API function to handle copying templates to target teams
- **API signature update**: Modified `dashboardTemplatesDetail()` to accept optional `teamId` parameter, and updated the `get()` function to pass it through
- **New scene**: Created `DashboardTemplateCopyScene` component to handle the UI flow for copying templates between projects
- **Scene registration**: Registered new `Scene.DashboardTemplateCopy` in `appScenes.ts` 
- **Storybook stories**: Added comprehensive Storybook stories (`DashboardTemplateCopyScene.stories.tsx`) with multiple scenarios including single project, two projects, and several projects organizations

## How did you test this code?

This is an agent-generated PR based on the diff provided. The changes include Storybook stories that demonstrate the functionality across different organization configurations (single project, multiple projects, etc.). Manual testing would involve:

1. Navigate to a dashboard template detail page
2. Trigger the copy-to-project action
3. Select a target project from the available teams in the organization
4. Verify the template is successfully copied to the target project

The implementation includes proper error handling via the API layer and appropriate TypeScript typing for team IDs and template IDs.


Tested locally.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*