### PR TITLE
fix(insights): convert warehouse series when switching between insight types

### DIFF
--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -8,7 +8,7 @@ import { insightNavLogic } from 'scenes/insights/InsightNav/insightNavLogic'
 import { useMocks } from '~/mocks/jest'
 import { examples } from '~/queries/examples'
 import { nodeKindToDefaultQuery } from '~/queries/nodes/InsightQuery/defaults'
-import { FunnelsQuery, InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import { FunnelsQuery, InsightVizNode, NodeKind, TrendsQuery, Node } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import {
     ChartDisplayType,
@@ -661,7 +661,7 @@ describe('insightNavLogic', () => {
                 label: string
                 source: InsightVizNode['source']
                 targetView: InsightType
-                expectedSource: Partial<InsightVizNode['source']>
+                expectedSource: Record<string, any>
             }[] = [
                 {
                     label: 'trends DW to funnels',
@@ -693,7 +693,7 @@ describe('insightNavLogic', () => {
                                 aggregation_target_field: 'customer_id',
                             },
                         ],
-                        funnelsFilter: { funnelVizType: 'steps' },
+                        funnelsFilter: { funnelVizType: FunnelVizType.Steps },
                     },
                 },
                 {
@@ -864,7 +864,7 @@ describe('insightNavLogic', () => {
                     builtInsightDataLogic.actions.setQuery({
                         kind: NodeKind.InsightVizNode,
                         source,
-                    })
+                    } as any)
                 })
 
                 await expectLogic(builtInsightDataLogic, () => {

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -657,9 +657,14 @@ describe('insightNavLogic', () => {
                 })
             })
 
-            it('converts trends data warehouse series to funnel equivalent', async () => {
-                const trendsQueryWithDataWarehouse: InsightVizNode = {
-                    kind: NodeKind.InsightVizNode,
+            const dataWarehouseTestCases: {
+                label: string
+                source: InsightVizNode['source']
+                targetView: InsightType
+                expectedSource: Partial<InsightVizNode['source']>
+            }[] = [
+                {
+                    label: 'trends DW to funnels',
                     source: {
                         kind: NodeKind.TrendsQuery,
                         series: [
@@ -674,19 +679,8 @@ describe('insightNavLogic', () => {
                             },
                         ],
                     },
-                }
-
-                await expectLogic(logic, () => {
-                    builtInsightDataLogic.actions.setQuery(trendsQueryWithDataWarehouse)
-                })
-
-                await expectLogic(builtInsightDataLogic, () => {
-                    logic.actions.setActiveView(InsightType.FUNNELS)
-                }).toFinishAllListeners()
-
-                expect(builtInsightDataLogic.values.query).toMatchObject({
-                    kind: NodeKind.InsightVizNode,
-                    source: {
+                    targetView: InsightType.FUNNELS,
+                    expectedSource: {
                         kind: NodeKind.FunnelsQuery,
                         series: [
                             {
@@ -701,12 +695,41 @@ describe('insightNavLogic', () => {
                         ],
                         funnelsFilter: { funnelVizType: 'steps' },
                     },
-                })
-            })
-
-            it('converts funnels data warehouse series to trends equivalent', async () => {
-                const funnelsQueryWithDataWarehouse: InsightVizNode = {
-                    kind: NodeKind.InsightVizNode,
+                },
+                {
+                    label: 'trends DW to lifecycle',
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.DataWarehouseNode,
+                                id: 'warehouse_orders',
+                                name: 'Warehouse orders',
+                                table_name: 'warehouse_orders',
+                                id_field: 'id',
+                                timestamp_field: 'created_at',
+                                distinct_id_field: 'customer_id',
+                            },
+                        ],
+                    },
+                    targetView: InsightType.LIFECYCLE,
+                    expectedSource: {
+                        kind: NodeKind.LifecycleQuery,
+                        series: [
+                            {
+                                kind: NodeKind.LifecycleDataWarehouseNode,
+                                id: 'warehouse_orders',
+                                name: 'Warehouse orders',
+                                table_name: 'warehouse_orders',
+                                timestamp_field: 'created_at',
+                                aggregation_target_field: 'customer_id',
+                                created_at_field: 'created_at',
+                            },
+                        ],
+                    },
+                },
+                {
+                    label: 'funnels DW to trends',
                     source: {
                         kind: NodeKind.FunnelsQuery,
                         series: [
@@ -722,19 +745,8 @@ describe('insightNavLogic', () => {
                         ],
                         funnelsFilter: { funnelVizType: FunnelVizType.Steps },
                     },
-                }
-
-                await expectLogic(logic, () => {
-                    builtInsightDataLogic.actions.setQuery(funnelsQueryWithDataWarehouse)
-                })
-
-                await expectLogic(builtInsightDataLogic, () => {
-                    logic.actions.setActiveView(InsightType.TRENDS)
-                }).toFinishAllListeners()
-
-                expect(builtInsightDataLogic.values.query).toMatchObject({
-                    kind: NodeKind.InsightVizNode,
-                    source: {
+                    targetView: InsightType.TRENDS,
+                    expectedSource: {
                         kind: NodeKind.TrendsQuery,
                         series: [
                             {
@@ -748,38 +760,42 @@ describe('insightNavLogic', () => {
                             },
                         ],
                     },
-                })
-            })
-
-            it('converts trends data warehouse series to lifecycle equivalent', async () => {
-                const trendsQueryWithDataWarehouse: InsightVizNode = {
-                    kind: NodeKind.InsightVizNode,
+                },
+                {
+                    label: 'funnels DW to lifecycle',
                     source: {
-                        kind: NodeKind.TrendsQuery,
+                        kind: NodeKind.FunnelsQuery,
                         series: [
                             {
-                                kind: NodeKind.DataWarehouseNode,
+                                kind: NodeKind.FunnelsDataWarehouseNode,
                                 id: 'warehouse_orders',
                                 name: 'Warehouse orders',
                                 table_name: 'warehouse_orders',
                                 id_field: 'id',
                                 timestamp_field: 'created_at',
-                                distinct_id_field: 'customer_id',
+                                aggregation_target_field: 'customer_id',
+                            },
+                        ],
+                        funnelsFilter: { funnelVizType: FunnelVizType.Steps },
+                    },
+                    targetView: InsightType.LIFECYCLE,
+                    expectedSource: {
+                        kind: NodeKind.LifecycleQuery,
+                        series: [
+                            {
+                                kind: NodeKind.LifecycleDataWarehouseNode,
+                                id: 'warehouse_orders',
+                                name: 'Warehouse orders',
+                                table_name: 'warehouse_orders',
+                                timestamp_field: 'created_at',
+                                aggregation_target_field: 'customer_id',
+                                created_at_field: 'created_at',
                             },
                         ],
                     },
-                }
-
-                await expectLogic(logic, () => {
-                    builtInsightDataLogic.actions.setQuery(trendsQueryWithDataWarehouse)
-                })
-
-                await expectLogic(builtInsightDataLogic, () => {
-                    logic.actions.setActiveView(InsightType.LIFECYCLE)
-                }).toFinishAllListeners()
-
-                expect(builtInsightDataLogic.values.query).toMatchObject({
-                    kind: NodeKind.InsightVizNode,
+                },
+                {
+                    label: 'lifecycle DW to trends',
                     source: {
                         kind: NodeKind.LifecycleQuery,
                         series: [
@@ -794,6 +810,70 @@ describe('insightNavLogic', () => {
                             },
                         ],
                     },
+                    targetView: InsightType.TRENDS,
+                    expectedSource: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.DataWarehouseNode,
+                                id: 'warehouse_orders',
+                                name: 'Warehouse orders',
+                                table_name: 'warehouse_orders',
+                                timestamp_field: 'created_at',
+                                distinct_id_field: 'customer_id',
+                            },
+                        ],
+                    },
+                },
+                {
+                    label: 'lifecycle DW to funnels',
+                    source: {
+                        kind: NodeKind.LifecycleQuery,
+                        series: [
+                            {
+                                kind: NodeKind.LifecycleDataWarehouseNode,
+                                id: 'warehouse_orders',
+                                name: 'Warehouse orders',
+                                table_name: 'warehouse_orders',
+                                timestamp_field: 'created_at',
+                                aggregation_target_field: 'customer_id',
+                                created_at_field: 'created_at',
+                            },
+                        ],
+                    },
+                    targetView: InsightType.FUNNELS,
+                    expectedSource: {
+                        kind: NodeKind.FunnelsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.FunnelsDataWarehouseNode,
+                                id: 'warehouse_orders',
+                                name: 'Warehouse orders',
+                                table_name: 'warehouse_orders',
+                                timestamp_field: 'created_at',
+                                aggregation_target_field: 'customer_id',
+                            },
+                        ],
+                        funnelsFilter: { funnelVizType: 'steps' },
+                    },
+                },
+            ]
+
+            it.each(dataWarehouseTestCases)('converts $label', async ({ source, targetView, expectedSource }) => {
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery({
+                        kind: NodeKind.InsightVizNode,
+                        source,
+                    })
+                })
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(targetView)
+                }).toFinishAllListeners()
+
+                expect(builtInsightDataLogic.values.query).toMatchObject({
+                    kind: NodeKind.InsightVizNode,
+                    source: expectedSource,
                 })
             })
         })

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -8,7 +8,7 @@ import { insightNavLogic } from 'scenes/insights/InsightNav/insightNavLogic'
 import { useMocks } from '~/mocks/jest'
 import { examples } from '~/queries/examples'
 import { nodeKindToDefaultQuery } from '~/queries/nodes/InsightQuery/defaults'
-import { FunnelsQuery, InsightVizNode, Node, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import { FunnelsQuery, InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import {
     ChartDisplayType,
@@ -653,6 +653,146 @@ describe('insightNavLogic', () => {
                             display: ChartDisplayType.ActionsBar,
                             showValuesOnSeries: true,
                         }),
+                    },
+                })
+            })
+
+            it('converts trends data warehouse series to funnel equivalent', async () => {
+                const trendsQueryWithDataWarehouse: InsightVizNode = {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.DataWarehouseNode,
+                                id: 'warehouse_orders',
+                                name: 'Warehouse orders',
+                                table_name: 'warehouse_orders',
+                                id_field: 'id',
+                                timestamp_field: 'created_at',
+                                distinct_id_field: 'customer_id',
+                            },
+                        ],
+                    },
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(trendsQueryWithDataWarehouse)
+                })
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.FUNNELS)
+                }).toFinishAllListeners()
+
+                expect(builtInsightDataLogic.values.query).toMatchObject({
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.FunnelsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.FunnelsDataWarehouseNode,
+                                id: 'warehouse_orders',
+                                name: 'Warehouse orders',
+                                table_name: 'warehouse_orders',
+                                id_field: 'id',
+                                timestamp_field: 'created_at',
+                                aggregation_target_field: 'customer_id',
+                            },
+                        ],
+                        funnelsFilter: { funnelVizType: 'steps' },
+                    },
+                })
+            })
+
+            it('converts funnels data warehouse series to trends equivalent', async () => {
+                const funnelsQueryWithDataWarehouse: InsightVizNode = {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.FunnelsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.FunnelsDataWarehouseNode,
+                                id: 'warehouse_orders',
+                                name: 'Warehouse orders',
+                                table_name: 'warehouse_orders',
+                                id_field: 'id',
+                                timestamp_field: 'created_at',
+                                aggregation_target_field: 'customer_id',
+                            },
+                        ],
+                        funnelsFilter: { funnelVizType: FunnelVizType.Steps },
+                    },
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(funnelsQueryWithDataWarehouse)
+                })
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.TRENDS)
+                }).toFinishAllListeners()
+
+                expect(builtInsightDataLogic.values.query).toMatchObject({
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.DataWarehouseNode,
+                                id: 'warehouse_orders',
+                                name: 'Warehouse orders',
+                                table_name: 'warehouse_orders',
+                                id_field: 'id',
+                                timestamp_field: 'created_at',
+                                distinct_id_field: 'customer_id',
+                            },
+                        ],
+                    },
+                })
+            })
+
+            it('converts trends data warehouse series to lifecycle equivalent', async () => {
+                const trendsQueryWithDataWarehouse: InsightVizNode = {
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            {
+                                kind: NodeKind.DataWarehouseNode,
+                                id: 'warehouse_orders',
+                                name: 'Warehouse orders',
+                                table_name: 'warehouse_orders',
+                                id_field: 'id',
+                                timestamp_field: 'created_at',
+                                distinct_id_field: 'customer_id',
+                            },
+                        ],
+                    },
+                }
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(trendsQueryWithDataWarehouse)
+                })
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.LIFECYCLE)
+                }).toFinishAllListeners()
+
+                expect(builtInsightDataLogic.values.query).toMatchObject({
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.LifecycleQuery,
+                        series: [
+                            {
+                                kind: NodeKind.LifecycleDataWarehouseNode,
+                                id: 'warehouse_orders',
+                                name: 'Warehouse orders',
+                                table_name: 'warehouse_orders',
+                                timestamp_field: 'created_at',
+                                aggregation_target_field: 'customer_id',
+                                created_at_field: 'created_at',
+                            },
+                        ],
                     },
                 })
             })

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -14,13 +14,18 @@ import { expandGroupNodes } from '~/queries/nodes/InsightQuery/utils/filtersToQu
 import { nodeKindToInsightType } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 import { getDefaultQuery } from '~/queries/nodes/InsightViz/utils'
 import {
+    AnyDataWarehouseNode,
     AnyEntityNode,
     CalendarHeatmapFilter,
+    DataWarehouseNode,
+    EntityNode,
+    FunnelsDataWarehouseNode,
     FunnelsFilter,
     FunnelsQuery,
     GroupNode,
     InsightQueryNode,
     InsightVizNode,
+    LifecycleDataWarehouseNode,
     LifecycleFilter,
     LifecycleQuery,
     NodeKind,
@@ -96,9 +101,9 @@ export interface QueryPropertyCache
 }
 
 const cleanSeriesEntityMath = (
-    entity: AnyEntityNode | GroupNode,
+    entity: AnyEntityNode<AnyDataWarehouseNode> | GroupNode,
     mathAvailability: MathAvailability
-): AnyEntityNode | GroupNode => {
+): AnyEntityNode<AnyDataWarehouseNode> | GroupNode => {
     const { math, math_property, math_group_type_index, math_hogql, ...baseEntity } = entity
 
     // Recursively clean nested nodes in GroupNode
@@ -123,9 +128,9 @@ const cleanSeriesEntityMath = (
 }
 
 const cleanSeriesMath = (
-    series: (AnyEntityNode | GroupNode)[],
+    series: (AnyEntityNode<AnyDataWarehouseNode> | GroupNode)[],
     mathAvailability: MathAvailability
-): (AnyEntityNode | GroupNode)[] => {
+): (AnyEntityNode<AnyDataWarehouseNode> | GroupNode)[] => {
     return series.map((entity) => cleanSeriesEntityMath(entity, mathAvailability))
 }
 
@@ -134,10 +139,17 @@ type DataWarehouseNodeKind =
     | NodeKind.FunnelsDataWarehouseNode
     | NodeKind.LifecycleDataWarehouseNode
 
+type DataWarehouseNodeSharedFields = Partial<{
+    id_field: DataWarehouseNode['id_field']
+    distinct_id_field: DataWarehouseNode['distinct_id_field']
+    aggregation_target_field: FunnelsDataWarehouseNode['aggregation_target_field']
+    created_at_field: LifecycleDataWarehouseNode['created_at_field']
+}>
+
 const cleanDataWarehouseNode = (
-    entity: AnyEntityNode | GroupNode,
+    entity: AnyEntityNode<AnyDataWarehouseNode> | GroupNode,
     dataWarehouseNodeKind: DataWarehouseNodeKind
-): AnyEntityNode | GroupNode => {
+): AnyEntityNode<AnyDataWarehouseNode> | GroupNode => {
     if ('nodes' in entity && Array.isArray(entity.nodes)) {
         return {
             ...entity,
@@ -156,7 +168,7 @@ const cleanDataWarehouseNode = (
         aggregation_target_field,
         created_at_field,
         ...baseEntity
-    } = entity
+    } = entity as EntityNode & DataWarehouseNodeSharedFields
 
     if (dataWarehouseNodeKind === NodeKind.DataWarehouseNode) {
         return {
@@ -178,7 +190,7 @@ const cleanDataWarehouseNode = (
             ...(id_field ? { id_field } : {}),
             aggregation_target_field:
                 aggregation_target_field ?? (isDataWarehouseNode(entity) ? entity.distinct_id_field : undefined),
-        } as AnyEntityNode | GroupNode
+        } as FunnelsDataWarehouseNode | GroupNode
     }
 
     return {
@@ -187,21 +199,21 @@ const cleanDataWarehouseNode = (
         aggregation_target_field:
             aggregation_target_field ?? (isDataWarehouseNode(entity) ? entity.distinct_id_field : undefined),
         created_at_field: created_at_field ?? entity.timestamp_field,
-    } as AnyEntityNode | GroupNode
+    } as LifecycleDataWarehouseNode | GroupNode
 }
 
 const cleanDataWarehouseNodes = (
-    series: (AnyEntityNode | GroupNode)[],
+    series: (AnyEntityNode<AnyDataWarehouseNode> | GroupNode)[],
     dataWarehouseNodeKind: DataWarehouseNodeKind
-): (AnyEntityNode | GroupNode)[] => {
+): (AnyEntityNode<AnyDataWarehouseNode> | GroupNode)[] => {
     return series.map((entity) => cleanDataWarehouseNode(entity, dataWarehouseNodeKind))
 }
 
 const cleanSeries = (
-    series: (AnyEntityNode | GroupNode)[],
+    series: (AnyEntityNode<AnyDataWarehouseNode> | GroupNode)[],
     mathAvailability: MathAvailability,
     dataWarehouseNodeKind: DataWarehouseNodeKind
-): (AnyEntityNode | GroupNode)[] => {
+): (AnyEntityNode<AnyDataWarehouseNode> | GroupNode)[] => {
     return cleanSeriesMath(cleanDataWarehouseNodes(series, dataWarehouseNodeKind), mathAvailability)
 }
 

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -465,10 +465,6 @@ const cachePropertiesFromQuery = (query: InsightQueryNode, cache: QueryPropertyC
     //     }
     // }
 
-    if (isLifecycleQuery(query)) {
-        newCache.series = cache?.series
-    }
-
     if (isWebAnalyticsInsightQuery(query)) {
         return newCache
     }

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -23,6 +23,7 @@ import {
     InsightVizNode,
     LifecycleFilter,
     LifecycleQuery,
+    NodeKind,
     PathsFilter,
     PathsQuery,
     RetentionFilter,
@@ -36,14 +37,18 @@ import {
     containsHogQLQuery,
     getResultCustomizations,
     filterForQuery,
+    isAnyDataWarehouseNode,
     isDataTableNode,
     isDataVisualizationNode,
+    isDataWarehouseNode,
     isEndpointsUsageQuery,
     isFunnelsQuery,
+    isFunnelsDataWarehouseNode,
     isHogQuery,
     isInsightQueryWithBreakdown,
     isInsightQueryWithSeries,
     isInsightVizNode,
+    isLifecycleDataWarehouseNode,
     isLifecycleQuery,
     isPathsQuery,
     isRetentionQuery,
@@ -122,6 +127,82 @@ const cleanSeriesMath = (
     mathAvailability: MathAvailability
 ): (AnyEntityNode | GroupNode)[] => {
     return series.map((entity) => cleanSeriesEntityMath(entity, mathAvailability))
+}
+
+type DataWarehouseNodeKind =
+    | NodeKind.DataWarehouseNode
+    | NodeKind.FunnelsDataWarehouseNode
+    | NodeKind.LifecycleDataWarehouseNode
+
+const cleanDataWarehouseNode = (
+    entity: AnyEntityNode | GroupNode,
+    dataWarehouseNodeKind: DataWarehouseNodeKind
+): AnyEntityNode | GroupNode => {
+    if ('nodes' in entity && Array.isArray(entity.nodes)) {
+        return {
+            ...entity,
+            nodes: entity.nodes.map((node) => cleanDataWarehouseNode(node, dataWarehouseNodeKind) as AnyEntityNode),
+        }
+    }
+
+    if (!isAnyDataWarehouseNode(entity) || entity.kind === dataWarehouseNodeKind) {
+        return entity
+    }
+
+    const {
+        kind: _kind,
+        id_field,
+        distinct_id_field,
+        aggregation_target_field,
+        created_at_field,
+        ...baseEntity
+    } = entity
+
+    if (dataWarehouseNodeKind === NodeKind.DataWarehouseNode) {
+        return {
+            ...baseEntity,
+            kind: NodeKind.DataWarehouseNode,
+            ...(id_field ? { id_field } : {}),
+            distinct_id_field:
+                distinct_id_field ??
+                (isFunnelsDataWarehouseNode(entity) || isLifecycleDataWarehouseNode(entity)
+                    ? entity.aggregation_target_field
+                    : undefined),
+        } as AnyEntityNode | GroupNode
+    }
+
+    if (dataWarehouseNodeKind === NodeKind.FunnelsDataWarehouseNode) {
+        return {
+            ...baseEntity,
+            kind: NodeKind.FunnelsDataWarehouseNode,
+            ...(id_field ? { id_field } : {}),
+            aggregation_target_field:
+                aggregation_target_field ?? (isDataWarehouseNode(entity) ? entity.distinct_id_field : undefined),
+        } as AnyEntityNode | GroupNode
+    }
+
+    return {
+        ...baseEntity,
+        kind: NodeKind.LifecycleDataWarehouseNode,
+        aggregation_target_field:
+            aggregation_target_field ?? (isDataWarehouseNode(entity) ? entity.distinct_id_field : undefined),
+        created_at_field: created_at_field ?? entity.timestamp_field,
+    } as AnyEntityNode | GroupNode
+}
+
+const cleanDataWarehouseNodes = (
+    series: (AnyEntityNode | GroupNode)[],
+    dataWarehouseNodeKind: DataWarehouseNodeKind
+): (AnyEntityNode | GroupNode)[] => {
+    return series.map((entity) => cleanDataWarehouseNode(entity, dataWarehouseNodeKind))
+}
+
+const cleanSeries = (
+    series: (AnyEntityNode | GroupNode)[],
+    mathAvailability: MathAvailability,
+    dataWarehouseNodeKind: DataWarehouseNodeKind
+): (AnyEntityNode | GroupNode)[] => {
+    return cleanSeriesMath(cleanDataWarehouseNodes(series, dataWarehouseNodeKind), mathAvailability)
 }
 
 type TrendsCommonVisualizationProperties = Pick<TrendsFilter, 'showValuesOnSeries' | 'showPercentStackView' | 'display'>
@@ -434,26 +515,36 @@ const mergeCachedProperties = (query: InsightQueryNode, cache: QueryPropertyCach
         if (cache.series) {
             if (isTrendsQuery(mergedQuery)) {
                 // Trends supports GroupNode, keep series as-is
-                mergedQuery.series = cleanSeriesMath(cache.series, MathAvailability.All) as TrendsQuery['series']
-            } else if (isFunnelsQuery(mergedQuery)) {
-                mergedQuery.series = cleanSeriesMath(
+                mergedQuery.series = cleanSeries(
                     cache.series,
-                    MathAvailability.FunnelsOnly
+                    MathAvailability.All,
+                    NodeKind.DataWarehouseNode
+                ) as TrendsQuery['series']
+            } else if (isFunnelsQuery(mergedQuery)) {
+                mergedQuery.series = cleanSeries(
+                    cache.series,
+                    MathAvailability.FunnelsOnly,
+                    NodeKind.FunnelsDataWarehouseNode
                 ) as FunnelsQuery['series']
             } else {
                 // Expand GroupNodes for insight types that don't support them
                 const expandedSeries = expandGroupNodes(cache.series)
 
                 if (isLifecycleQuery(mergedQuery)) {
-                    mergedQuery.series = cleanSeriesMath(
+                    mergedQuery.series = cleanSeries(
                         expandedSeries.slice(0, 1),
-                        MathAvailability.None
+                        MathAvailability.None,
+                        NodeKind.LifecycleDataWarehouseNode
                     ) as LifecycleQuery['series']
                 } else {
                     const mathAvailability = isStickinessQuery(mergedQuery)
                         ? MathAvailability.ActorsOnly
                         : MathAvailability.None
-                    mergedQuery.series = cleanSeriesMath(expandedSeries, mathAvailability) as typeof mergedQuery.series
+                    mergedQuery.series = cleanSeries(
+                        expandedSeries,
+                        mathAvailability,
+                        NodeKind.DataWarehouseNode
+                    ) as typeof mergedQuery.series
                 }
             }
         }


### PR DESCRIPTION
## Problem

Navigating between insight types with data warehouse nodes leads to invalid configurations.

## Changes

Convert the various data warehouse nodes between each other.

## How did you test this code?

Added tests and manual verification