### PR TITLE
feat(data-warehouse): Added metrics to the webhook tab

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/source/WebhookTab.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/WebhookTab.tsx
@@ -5,7 +5,6 @@ import { LemonBanner, LemonButton, LemonSkeleton, LemonTable, LemonTag } from '@
 import { getColorVar } from 'lib/colors'
 import { AppMetricsFilters } from 'lib/components/AppMetrics/AppMetricsFilters'
 import { appMetricsLogic } from 'lib/components/AppMetrics/appMetricsLogic'
-import { AppMetricsTrends } from 'lib/components/AppMetrics/AppMetricsTrends'
 import { AppMetricSummary } from 'lib/components/AppMetrics/AppMetricSummary'
 import { LemonCard } from 'lib/lemon-ui/LemonCard'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
@@ -91,7 +90,6 @@ export function WebhookTab({ id }: { id: string }): JSX.Element {
                 externalStateLabel={externalStateLabel}
                 onRefresh={loadWebhookInfo}
             />
-            {webhookInfo.hog_function?.id && <WebhookMetricsSection hogFunctionId={webhookInfo.hog_function.id} />}
             {externalMissing && (
                 <WebhookRecreateSection
                     id={id}
@@ -103,6 +101,7 @@ export function WebhookTab({ id }: { id: string }): JSX.Element {
                 />
             )}
             <WebhookDetailsSection webhookInfo={webhookInfo} />
+            {webhookInfo.hog_function?.id && <WebhookMetricsSection hogFunctionId={webhookInfo.hog_function.id} />}
             {mappedTables.length > 0 && <MappedTablesSection mappedTables={mappedTables} />}
             <WebhookDeleteSection canDelete={canDeleteWebhook} deleting={webhookDeleting} onDelete={deleteWebhook} />
         </div>
@@ -123,12 +122,12 @@ function WebhookMetricsSection({ hogFunctionId }: { hogFunctionId: string }): JS
         },
     })
 
-    const { appMetricsTrends, appMetricsTrendsLoading, getSingleTrendSeries } = useValues(logic)
+    const { appMetricsTrendsLoading, getSingleTrendSeries } = useValues(logic)
 
     return (
         <LemonCard hoverEffect={false} className="space-y-4">
             <div className="flex items-center justify-between">
-                <h3 className="text-lg font-semibold mb-0">Throughput</h3>
+                <h3 className="text-lg font-semibold mb-0">Metrics</h3>
                 <AppMetricsFilters logicKey={logicKey} />
             </div>
 
@@ -147,7 +146,6 @@ function WebhookMetricsSection({ hogFunctionId }: { hogFunctionId: string }): JS
                     />
                 ))}
             </div>
-            <AppMetricsTrends appMetricsTrends={appMetricsTrends} loading={appMetricsTrendsLoading} />
         </LemonCard>
     )
 }

--- a/frontend/src/scenes/data-warehouse/settings/source/WebhookTab.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/WebhookTab.tsx
@@ -2,6 +2,11 @@ import { useActions, useValues } from 'kea'
 
 import { LemonBanner, LemonButton, LemonSkeleton, LemonTable, LemonTag } from '@posthog/lemon-ui'
 
+import { getColorVar } from 'lib/colors'
+import { AppMetricsFilters } from 'lib/components/AppMetrics/AppMetricsFilters'
+import { appMetricsLogic } from 'lib/components/AppMetrics/appMetricsLogic'
+import { AppMetricsTrends } from 'lib/components/AppMetrics/AppMetricsTrends'
+import { AppMetricSummary } from 'lib/components/AppMetrics/AppMetricSummary'
 import { LemonCard } from 'lib/lemon-ui/LemonCard'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 
@@ -14,6 +19,21 @@ import {
     WebhookUrlDisplay,
 } from '../../external/forms/WebhookSetupForm'
 import { webhookTabLogic } from './webhookTabLogic'
+
+const WEBHOOK_METRIC_KEYS = ['succeeded', 'failed'] as const
+
+const WEBHOOK_METRICS_INFO: Record<string, { name: string; description: string; color: string }> = {
+    succeeded: {
+        name: 'Received',
+        description: 'Total number of webhook events received and processed successfully',
+        color: getColorVar('success'),
+    },
+    failed: {
+        name: 'Failed',
+        description: 'Total number of webhook events that had errors during processing',
+        color: getColorVar('danger'),
+    },
+}
 
 export function WebhookTab({ id }: { id: string }): JSX.Element {
     const {
@@ -71,6 +91,7 @@ export function WebhookTab({ id }: { id: string }): JSX.Element {
                 externalStateLabel={externalStateLabel}
                 onRefresh={loadWebhookInfo}
             />
+            {webhookInfo.hog_function?.id && <WebhookMetricsSection hogFunctionId={webhookInfo.hog_function.id} />}
             {externalMissing && (
                 <WebhookRecreateSection
                     id={id}
@@ -85,6 +106,49 @@ export function WebhookTab({ id }: { id: string }): JSX.Element {
             {mappedTables.length > 0 && <MappedTablesSection mappedTables={mappedTables} />}
             <WebhookDeleteSection canDelete={canDeleteWebhook} deleting={webhookDeleting} onDelete={deleteWebhook} />
         </div>
+    )
+}
+
+function WebhookMetricsSection({ hogFunctionId }: { hogFunctionId: string }): JSX.Element {
+    const logicKey = `webhook-metrics-${hogFunctionId}`
+    const logic = appMetricsLogic({
+        logicKey,
+        loadOnMount: true,
+        loadOnChanges: true,
+        forceParams: {
+            appSource: 'hog_function',
+            appSourceId: hogFunctionId,
+            metricName: [...WEBHOOK_METRIC_KEYS],
+            breakdownBy: 'metric_name',
+        },
+    })
+
+    const { appMetricsTrends, appMetricsTrendsLoading, getSingleTrendSeries } = useValues(logic)
+
+    return (
+        <LemonCard hoverEffect={false} className="space-y-4">
+            <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold mb-0">Throughput</h3>
+                <AppMetricsFilters logicKey={logicKey} />
+            </div>
+
+            <div className="flex flex-row gap-2 flex-wrap justify-center">
+                {WEBHOOK_METRIC_KEYS.map((key) => (
+                    <AppMetricSummary
+                        key={key}
+                        name={WEBHOOK_METRICS_INFO[key].name}
+                        description={WEBHOOK_METRICS_INFO[key].description}
+                        loading={appMetricsTrendsLoading}
+                        timeSeries={getSingleTrendSeries(key)}
+                        previousPeriodTimeSeries={getSingleTrendSeries(key, true)}
+                        color={WEBHOOK_METRICS_INFO[key].color}
+                        colorIfZero={getColorVar('muted')}
+                        hideIfZero={!['succeeded', 'failed'].includes(key)}
+                    />
+                ))}
+            </div>
+            <AppMetricsTrends appMetricsTrends={appMetricsTrends} loading={appMetricsTrendsLoading} />
+        </LemonCard>
     )
 }
 


### PR DESCRIPTION
## Changes
- Added metrics to the webhook tab of a source, containing hog function metrics of successful and failed events from the source

<img width="1447" height="621" alt="image" src="https://github.com/user-attachments/assets/d04b492a-c34c-4805-9e17-610f81187c1c" />


## How did you test this code?
tested locally
