### PR TITLE
fix: harden cli failure

### DIFF
--- a/cli/src/invocation_context.rs
+++ b/cli/src/invocation_context.rs
@@ -127,14 +127,16 @@ impl InvocationContext {
             let mut event = Event::new_anon(event_name);
 
             for (key, value) in &props {
-                event
-                    .insert_prop(key, value)
-                    .expect("Inserting prop succeeds");
+                if let Err(e) = event.insert_prop(key, value) {
+                    debug!("Failed to insert prop {}: {:?}", key, e);
+                    return;
+                }
             }
 
-            event
-                .insert_prop("env_id", env_id)
-                .expect("Inserting env_id prop succeeds");
+            if let Err(e) = event.insert_prop("env_id", env_id) {
+                debug!("Failed to insert env_id prop: {:?}", e);
+                return;
+            }
 
             debug!("Capturing event");
             let res = posthog_rs::capture(event); // Purposefully ignore errors here
@@ -155,7 +157,11 @@ impl InvocationContext {
             .lock()
             .unwrap()
             .drain(..)
-            .for_each(|handle| handle.join().unwrap());
+            .for_each(|handle| {
+                if let Err(e) = handle.join() {
+                    debug!("Telemetry thread panicked: {:?}", e);
+                }
+            });
 
         info!("Finished!")
     }


### PR DESCRIPTION
## Problem

The CLI's telemetry code can cause the process to exit non-zero even when the actual operation succeeds. This is breaking our release pipeline in PostHog/code — the `@posthog/rollup-plugin` runs `posthog-cli sourcemap process` during our Electron Forge build, and if the CLI exits non-zero, the entire macOS publish fails.

`capture_event()` spawns background threads that use `.expect()` for `insert_prop` calls, which will panic the thread if insertion fails. Then `finish()` joins those threads with `.unwrap()`, which propagates the panic to the main thread — crashing the process after the actual work already completed successfully.

## Fix

- Replace `.expect()` in the telemetry thread with `if let Err` + early return
- Log the failure and move on instead of panicking
- Replace `.unwrap()` on `handle.join()` in `finish()` with graceful error handling

Telemetry is best-effort and should never be able to turn a successful operation into a failure.