### PR TITLE
fix: use free text instead of multiple choice survey

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
@@ -763,7 +763,7 @@ function SessionSummaryFeedbackSurvey(): JSX.Element | null {
     return (
         <div className="border rounded p-3 mt-3">
             <div className="flex items-start justify-between">
-                <strong className="text-sm">{question?.question ?? 'What could be better about this summary?'}</strong>
+                <strong className="text-sm">{question?.question}</strong>
                 <LemonButton size="xsmall" icon={<IconX />} onClick={() => setShowFeedbackSurvey(false)} />
             </div>
             {submitted ? (

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
@@ -743,10 +743,12 @@ function SessionSummaryFeedbackSurvey(): JSX.Element | null {
         })
     }, [])
 
+    const trimmedText = openText.trim()
+
     const handleSubmit = (): void => {
         posthog.capture('survey sent', {
             $survey_id: SESSION_SUMMARY_FEEDBACK_SURVEY_ID,
-            $survey_response: openText,
+            $survey_response: trimmedText,
         })
         setSubmitted(true)
         setTimeout(() => setShowFeedbackSurvey(false), 3000)
@@ -779,7 +781,7 @@ function SessionSummaryFeedbackSurvey(): JSX.Element | null {
                         type="primary"
                         size="small"
                         className="mt-2"
-                        disabledReason={!openText ? 'Please enter your feedback' : undefined}
+                        disabledReason={!trimmedText ? 'Please enter your feedback' : undefined}
                         onClick={handleSubmit}
                         data-attr="session-summary-feedback-submit"
                     >

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
@@ -22,7 +22,7 @@ import {
     IconThumbsUp,
     IconWarning,
 } from '@posthog/icons'
-import { LemonBanner, LemonCheckbox, LemonDivider, LemonTag, LemonTextArea, Link, Tooltip } from '@posthog/lemon-ui'
+import { LemonBanner, LemonDivider, LemonTag, LemonTextArea, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS, SESSION_SUMMARY_FEEDBACK_SURVEY_ID } from 'lib/constants'
 import { usePageVisibility } from 'lib/hooks/usePageVisibility'
@@ -730,7 +730,6 @@ function SessionSummaryFeedbackSurvey(): JSX.Element | null {
     const { setShowFeedbackSurvey } = useActions(playerMetaLogic(logicProps))
 
     const [survey, setSurvey] = useState<{ questions: any[] } | null>(null)
-    const [selectedChoices, setSelectedChoices] = useState<string[]>([])
     const [openText, setOpenText] = useState('')
     const [submitted, setSubmitted] = useState(false)
 
@@ -744,18 +743,10 @@ function SessionSummaryFeedbackSurvey(): JSX.Element | null {
         })
     }, [])
 
-    const handleChoiceToggle = (choice: string, checked: boolean): void => {
-        setSelectedChoices((prev) => (checked ? [...prev, choice] : prev.filter((c) => c !== choice)))
-    }
-
     const handleSubmit = (): void => {
-        const response = [...selectedChoices]
-        if (openText) {
-            response.push(openText)
-        }
         posthog.capture('survey sent', {
             $survey_id: SESSION_SUMMARY_FEEDBACK_SURVEY_ID,
-            $survey_response: response,
+            $survey_response: openText,
         })
         setSubmitted(true)
         setTimeout(() => setShowFeedbackSurvey(false), 3000)
@@ -770,48 +761,25 @@ function SessionSummaryFeedbackSurvey(): JSX.Element | null {
     return (
         <div className="border rounded p-3 mt-3">
             <div className="flex items-start justify-between">
-                <strong className="text-sm">{question?.question}</strong>
+                <strong className="text-sm">{question?.question ?? 'What could be better about this summary?'}</strong>
                 <LemonButton size="xsmall" icon={<IconX />} onClick={() => setShowFeedbackSurvey(false)} />
             </div>
             {submitted ? (
                 <p className="text-sm text-muted mt-2">Thanks for your feedback!</p>
             ) : (
                 <>
-                    {question?.choices && (
-                        <ul className="list-none mt-2 space-y-1">
-                            {question.choices.map((choice: string, index: number) => {
-                                if (index === question.choices.length - 1 && question.hasOpenChoice) {
-                                    return (
-                                        <LemonTextArea
-                                            key={choice}
-                                            placeholder="Any other feedback?"
-                                            value={openText}
-                                            onChange={setOpenText}
-                                            className="mt-2"
-                                            data-attr="session-summary-feedback-open-text"
-                                        />
-                                    )
-                                }
-                                return (
-                                    <li key={choice}>
-                                        <LemonCheckbox
-                                            onChange={(checked) => handleChoiceToggle(choice, checked)}
-                                            label={choice}
-                                            className="font-normal"
-                                            data-attr={`session-summary-feedback-choice-${index}`}
-                                        />
-                                    </li>
-                                )
-                            })}
-                        </ul>
-                    )}
+                    <LemonTextArea
+                        placeholder="Share your feedback..."
+                        value={openText}
+                        onChange={setOpenText}
+                        className="mt-2"
+                        data-attr="session-summary-feedback-open-text"
+                    />
                     <LemonButton
                         type="primary"
                         size="small"
                         className="mt-2"
-                        disabledReason={
-                            selectedChoices.length === 0 && !openText ? 'Please select at least one option' : undefined
-                        }
+                        disabledReason={!openText ? 'Please enter your feedback' : undefined}
                         onClick={handleSubmit}
                         data-attr="session-summary-feedback-submit"
                     >


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
survey should be open text not multiple choice

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- changes ai summary survey from multiple choice to open text type

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
