### PR TITLE
fix(slo): reject undispatchable export formats and retry transient Slack errors

### DIFF
--- a/ee/tasks/subscriptions/slack_subscriptions.py
+++ b/ee/tasks/subscriptions/slack_subscriptions.py
@@ -12,11 +12,23 @@ from posthog.models.exported_asset import ExportedAsset
 from posthog.models.integration import Integration, SlackIntegration
 from posthog.models.subscription import Subscription
 
-from ee.tasks.subscriptions.subscription_utils import ASSET_GENERATION_FAILED_MESSAGE, _has_asset_failed
+from ee.tasks.subscriptions.subscription_utils import ASSET_GENERATION_FAILED_MESSAGE, UTM_TAGS_BASE, _has_asset_failed
 
 logger = structlog.get_logger(__name__)
 
-UTM_TAGS_BASE = "utm_source=posthog&utm_campaign=subscription_report"
+# Slack API error codes that indicate transient server-side issues — safe to retry.
+# These are 5xx-equivalents in Slack's string-coded error model. Permanent errors
+# (channel_not_found, invalid_auth, etc.) are NOT in this set and should fail fast.
+_RETRYABLE_SLACK_ERRORS = frozenset(
+    {
+        "internal_error",
+        "service_unavailable",
+        "fatal_error",
+        "request_timeout",
+        "ratelimited",
+        "rate_limited",
+    }
+)
 
 
 @dataclass
@@ -219,9 +231,12 @@ async def _send_slack_message_with_retry(client, max_retries: int = 3, **kwargs)
         except (TimeoutError, SlackApiError) as e:
             if isinstance(e, SlackApiError):
                 slack_error = e.response.get("error", "")
-                if slack_error != "invalid_blocks":
+                if slack_error == "invalid_blocks":
+                    log_event = "_send_slack_message_with_retry.invalid_blocks_retrying"
+                elif slack_error in _RETRYABLE_SLACK_ERRORS:
+                    log_event = "_send_slack_message_with_retry.transient_error_retrying"
+                else:
                     raise
-                log_event = "_send_slack_message_with_retry.invalid_blocks_retrying"
             else:
                 log_event = "_send_slack_message_with_retry.timeout_retrying"
 

--- a/ee/tasks/test/subscriptions/test_slack_subscriptions.py
+++ b/ee/tasks/test/subscriptions/test_slack_subscriptions.py
@@ -6,6 +6,8 @@ from posthog.test.base import APIBaseTest
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from parameterized import parameterized
+from slack_sdk.errors import SlackApiError
+from slack_sdk.web.async_slack_response import AsyncSlackResponse
 
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.insight import Insight
@@ -21,6 +23,16 @@ from ee.tasks.subscriptions.slack_subscriptions import (
 )
 from ee.tasks.subscriptions.subscription_utils import ASSET_GENERATION_FAILED_MESSAGE
 from ee.tasks.test.subscriptions.subscriptions_test_factory import create_subscription
+
+
+def _make_slack_api_error(error_code: str, **extra_data) -> SlackApiError:
+    data = {"ok": False, "error": error_code, **extra_data}
+    return SlackApiError(
+        "Error",
+        AsyncSlackResponse(
+            client=None, http_verb="POST", api_url="", req_args={}, data=data, headers={}, status_code=200
+        ),
+    )
 
 
 @patch("ee.tasks.subscriptions.slack_subscriptions.SlackIntegration")
@@ -273,12 +285,15 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
         )
         self.integration = Integration.objects.create(team=self.team, kind="slack")
 
-    def test_async_delivery_all_message_success(self, MockSlackIntegration: MagicMock) -> None:
+    def _setup_async_mock(self, MockSlackIntegration: MagicMock) -> AsyncMock:
         mock_slack_integration = MagicMock()
         MockSlackIntegration.return_value = mock_slack_integration
-
         mock_async_client = AsyncMock()
         mock_slack_integration.async_client = MagicMock(return_value=mock_async_client)
+        return mock_async_client
+
+    def test_async_delivery_all_message_success(self, MockSlackIntegration: MagicMock) -> None:
+        mock_async_client = self._setup_async_mock(MockSlackIntegration)
         mock_async_client.chat_postMessage.return_value = {"ts": "1.234"}
 
         asset2 = ExportedAsset.objects.create(
@@ -314,11 +329,7 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
     @patch("ee.tasks.subscriptions.slack_subscriptions.asyncio.sleep", new_callable=AsyncMock)
     def test_async_delivery_partial_success(self, mock_sleep: AsyncMock, MockSlackIntegration: MagicMock) -> None:
         """Test that thread message timeouts are retried and result in partial success."""
-        mock_slack_integration = MagicMock()
-        MockSlackIntegration.return_value = mock_slack_integration
-
-        mock_async_client = AsyncMock()
-        mock_slack_integration.async_client = MagicMock(return_value=mock_async_client)
+        mock_async_client = self._setup_async_mock(MockSlackIntegration)
 
         mock_async_client.chat_postMessage.side_effect = [
             {"ts": "1.234"},  # Main message
@@ -362,11 +373,7 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
     def test_async_delivery_main_message_timeout_raises(
         self, mock_sleep: AsyncMock, MockSlackIntegration: MagicMock
     ) -> None:
-        mock_slack_integration = MagicMock()
-        MockSlackIntegration.return_value = mock_slack_integration
-
-        mock_async_client = AsyncMock()
-        mock_slack_integration.async_client = MagicMock(return_value=mock_async_client)
+        mock_async_client = self._setup_async_mock(MockSlackIntegration)
 
         mock_async_client.chat_postMessage.side_effect = [
             TimeoutError(),  # Attempt 1
@@ -390,11 +397,7 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
         self, mock_sleep: AsyncMock, MockSlackIntegration: MagicMock
     ) -> None:
         """Test that retry logic succeeds on second attempt."""
-        mock_slack_integration = MagicMock()
-        MockSlackIntegration.return_value = mock_slack_integration
-
-        mock_async_client = AsyncMock()
-        mock_slack_integration.async_client = MagicMock(return_value=mock_async_client)
+        mock_async_client = self._setup_async_mock(MockSlackIntegration)
 
         # Main message times out once, then succeeds
         mock_async_client.chat_postMessage.side_effect = [
@@ -419,25 +422,10 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
     def test_async_delivery_retry_on_invalid_blocks_failure(
         self, mock_sleep: AsyncMock, MockSlackIntegration: MagicMock
     ) -> None:
-        from slack_sdk.errors import SlackApiError
-        from slack_sdk.web.async_slack_response import AsyncSlackResponse
+        mock_async_client = self._setup_async_mock(MockSlackIntegration)
 
-        mock_slack_integration = MagicMock()
-        MockSlackIntegration.return_value = mock_slack_integration
-
-        mock_async_client = AsyncMock()
-        mock_slack_integration.async_client = MagicMock(return_value=mock_async_client)
-
-        mock_response = {
-            "ok": False,
-            "error": "invalid_blocks",
-            "errors": ["downloading image failed [json-pointer:/blocks/0/image_url]"],
-        }
-        slack_error = SlackApiError(
-            "Error",
-            AsyncSlackResponse(
-                client=None, http_verb="POST", api_url="", req_args={}, data=mock_response, headers={}, status_code=200
-            ),
+        slack_error = _make_slack_api_error(
+            "invalid_blocks", errors=["downloading image failed [json-pointer:/blocks/0/image_url]"]
         )
 
         mock_async_client.chat_postMessage.side_effect = [slack_error, slack_error, slack_error]
@@ -457,25 +445,10 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
     def test_async_delivery_retry_on_invalid_blocks_success(
         self, mock_sleep: AsyncMock, MockSlackIntegration: MagicMock
     ) -> None:
-        from slack_sdk.errors import SlackApiError
-        from slack_sdk.web.async_slack_response import AsyncSlackResponse
+        mock_async_client = self._setup_async_mock(MockSlackIntegration)
 
-        mock_slack_integration = MagicMock()
-        MockSlackIntegration.return_value = mock_slack_integration
-
-        mock_async_client = AsyncMock()
-        mock_slack_integration.async_client = MagicMock(return_value=mock_async_client)
-
-        mock_response = {
-            "ok": False,
-            "error": "invalid_blocks",
-            "errors": ["downloading image failed [json-pointer:/blocks/0/image_url]"],
-        }
-        slack_error = SlackApiError(
-            "Error",
-            AsyncSlackResponse(
-                client=None, http_verb="POST", api_url="", req_args={}, data=mock_response, headers={}, status_code=200
-            ),
+        slack_error = _make_slack_api_error(
+            "invalid_blocks", errors=["downloading image failed [json-pointer:/blocks/0/image_url]"]
         )
 
         mock_async_client.chat_postMessage.side_effect = [
@@ -494,6 +467,102 @@ class TestSlackSubscriptionsAsyncTasks(APIBaseTest):
         assert mock_async_client.chat_postMessage.call_count == 3
         assert result.is_complete_success
         mock_sleep.assert_awaited_once_with(1)
+
+    @parameterized.expand(
+        [
+            ("internal_error",),
+            ("service_unavailable",),
+            ("fatal_error",),
+            ("request_timeout",),
+            ("ratelimited",),
+            ("rate_limited",),
+        ]
+    )
+    @patch("ee.tasks.subscriptions.slack_subscriptions.asyncio.sleep", new_callable=AsyncMock)
+    def test_async_delivery_retries_transient_slack_errors_and_exhausts(
+        self,
+        slack_error_code: str,
+        mock_sleep: AsyncMock,
+        MockSlackIntegration: MagicMock,
+    ) -> None:
+        mock_async_client = self._setup_async_mock(MockSlackIntegration)
+
+        slack_error = _make_slack_api_error(slack_error_code)
+
+        mock_async_client.chat_postMessage.side_effect = [slack_error, slack_error, slack_error]
+        assets = list(ExportedAsset.objects.filter(id=self.asset.id).select_related("insight"))
+
+        with pytest.raises(SlackApiError):
+            asyncio.run(
+                send_slack_message_with_integration_async(
+                    self.integration, self.subscription, assets, self.TOTAL_ASSET_COUNT
+                )
+            )
+
+        # Three attempts (max_retries=3), with backoff sleeps between attempts
+        assert mock_async_client.chat_postMessage.call_count == 3
+        mock_sleep.assert_has_awaits([call(1), call(2)])
+
+    @patch("ee.tasks.subscriptions.slack_subscriptions.asyncio.sleep", new_callable=AsyncMock)
+    def test_async_delivery_retry_on_internal_error_success(
+        self, mock_sleep: AsyncMock, MockSlackIntegration: MagicMock
+    ) -> None:
+        """First attempt hits Slack `internal_error` (transient 5xx-equivalent); second attempt succeeds."""
+        mock_async_client = self._setup_async_mock(MockSlackIntegration)
+
+        slack_error = _make_slack_api_error("internal_error")
+
+        mock_async_client.chat_postMessage.side_effect = [
+            slack_error,  # Main message attempt 1 — transient failure
+            {"ts": "1.234"},  # Main message attempt 2 — success
+            {"ts": "2.345"},  # Thread "Showing 1 of 10" message
+        ]
+        assets = list(ExportedAsset.objects.filter(id=self.asset.id).select_related("insight"))
+
+        result = asyncio.run(
+            send_slack_message_with_integration_async(
+                self.integration, self.subscription, assets, self.TOTAL_ASSET_COUNT
+            )
+        )
+
+        assert mock_async_client.chat_postMessage.call_count == 3
+        assert result.is_complete_success
+        mock_sleep.assert_awaited_once_with(1)
+
+    @parameterized.expand(
+        [
+            ("channel_not_found",),
+            ("invalid_auth",),
+            ("not_in_channel",),
+            ("token_revoked",),
+            ("missing_scope",),
+        ]
+    )
+    @patch("ee.tasks.subscriptions.slack_subscriptions.asyncio.sleep", new_callable=AsyncMock)
+    def test_async_delivery_fails_fast_on_non_retryable_slack_errors(
+        self,
+        slack_error_code: str,
+        mock_sleep: AsyncMock,
+        MockSlackIntegration: MagicMock,
+    ) -> None:
+        """Permanent Slack errors (config issues) should NOT be retried — fail on first attempt."""
+        mock_async_client = self._setup_async_mock(MockSlackIntegration)
+
+        slack_error = _make_slack_api_error(slack_error_code)
+
+        mock_async_client.chat_postMessage.side_effect = [slack_error]
+        assets = list(ExportedAsset.objects.filter(id=self.asset.id).select_related("insight"))
+
+        with pytest.raises(SlackApiError):
+            asyncio.run(
+                send_slack_message_with_integration_async(
+                    self.integration, self.subscription, assets, self.TOTAL_ASSET_COUNT
+                )
+            )
+
+        # Single attempt — no retries, no sleeps
+        assert mock_async_client.chat_postMessage.call_count == 1
+        mock_sleep.assert_not_awaited()
 
 
 class TestSlackErrorTruncation(APIBaseTest):

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -159,6 +159,16 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
             if not ok:
                 raise ValidationError({"export_context": [f"heatmap_url not allowed: {err}"]})
 
+        # Reject undispatchable formats before any workflow is enqueued.
+        # Without this gate, e.g. a JSON export request would be dispatched to
+        # image_exporter, raise NotImplementedError, and pollute the export SLO
+        # with a "failure" event for what is really a 4xx client error.
+        # Externally-handled formats (videos via VideoExportWorkflow, PDF via
+        # the sharing flow) are routed elsewhere and bypass this check.
+        if export_format and export_format not in ExportedAsset.EXTERNALLY_HANDLED_FORMATS:
+            if export_format not in ExportedAsset.DISPATCHABLE_FORMATS:
+                raise ValidationError({"export_format": [f"{export_format} is not currently supported."]})
+
         data["team_id"] = self.context["team_id"]
         return data
 
@@ -201,7 +211,7 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
         )
 
         if not force_async:
-            if instance.export_format in ("video/mp4", "video/webm", "image/gif"):
+            if instance.export_format in ExportedAsset.VIDEO_FORMATS:
                 # recordings-only
                 if not (instance.export_context and instance.export_context.get("session_recording_id")):
                     raise serializers.ValidationError(

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -311,6 +311,22 @@ class TestExports(APIBaseTest):
             },
         )
 
+    @parameterized.expand(
+        [
+            ("insight", lambda self: {"insight": self.insight.id}),
+            ("dashboard", lambda self: {"dashboard": self.dashboard.id}),
+        ]
+    )
+    def test_rejects_json_export(self, _name: str, payload_fn) -> None:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/exports",
+            {"export_format": "application/json", **payload_fn(self)},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        body = response.json()
+        self.assertEqual(body["attr"], "export_format")
+        self.assertIn("not currently supported", body["detail"])
+
     def test_will_error_if_dashboard_missing(self) -> None:
         response = self.client.post(
             f"/api/projects/{self.team.id}/exports",
@@ -758,7 +774,7 @@ class TestExports(APIBaseTest):
     def test_export_expiry_varies_by_format(
         self, export_format, expected_delta, mock_async_connect, mock_async_to_sync
     ) -> None:
-        is_video_format = export_format in ("video/mp4", "video/webm", "image/gif")
+        is_video_format = export_format in ExportedAsset.VIDEO_FORMATS
 
         if is_video_format:
             payload = {

--- a/posthog/models/exported_asset.py
+++ b/posthog/models/exported_asset.py
@@ -54,16 +54,21 @@ class ExportedAsset(models.Model):
         GIF = "image/gif", "image/gif"
         JSON = "application/json", "application/json"
 
-    SUPPORTED_FORMATS = [
-        ExportFormat.PNG,
-        ExportFormat.PDF,
-        ExportFormat.CSV,
-        ExportFormat.XLSX,
-        ExportFormat.WEBM,
-        ExportFormat.MP4,
-        ExportFormat.GIF,
-        ExportFormat.JSON,
-    ]
+    # Format routing for the standard exporter dispatch (`posthog/tasks/exporter.py`).
+    # Tabular formats are fed to csv_exporter; visual formats go through image_exporter.
+    TABULAR_FORMATS = frozenset({ExportFormat.CSV, ExportFormat.XLSX})
+    VISUAL_FORMATS = frozenset({ExportFormat.PNG})
+    DISPATCHABLE_FORMATS = TABULAR_FORMATS | VISUAL_FORMATS
+
+    # Formats routed by separate code paths that bypass the standard dispatch:
+    #   - PDF          -> separate sharing/embed flow
+    #   - WEBM/MP4/GIF -> VideoExportWorkflow (session recordings only)
+    EXTERNALLY_HANDLED_FORMATS = frozenset({ExportFormat.PDF, ExportFormat.WEBM, ExportFormat.MP4, ExportFormat.GIF})
+    VIDEO_FORMATS = frozenset({ExportFormat.WEBM, ExportFormat.MP4, ExportFormat.GIF})
+
+    # JSON is in ExportFormat.choices but has no working dispatch — rejected at
+    # the serializer to stop polluting the export SLO.
+    SUPPORTED_FORMATS = list(DISPATCHABLE_FORMATS | EXTERNALLY_HANDLED_FORMATS | {ExportFormat.JSON})
 
     # Relations
     team = models.ForeignKey("Team", on_delete=models.CASCADE)
@@ -111,9 +116,9 @@ class ExportedAsset(models.Model):
 
     @classmethod
     def get_expiry_delta(cls, export_format: str) -> timedelta:
-        if export_format in (cls.ExportFormat.CSV, cls.ExportFormat.XLSX):
+        if export_format in cls.TABULAR_FORMATS:
             return SEVEN_DAYS
-        elif export_format in (cls.ExportFormat.MP4, cls.ExportFormat.WEBM, cls.ExportFormat.GIF):
+        elif export_format in cls.VIDEO_FORMATS:
             return TWELVE_MONTHS
         return SIX_MONTHS
 

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -113,10 +113,20 @@ def export_asset_direct(
     export_source = source or EventSource.EXPORT
 
     try:
-        if exported_asset.export_format in (ExportedAsset.ExportFormat.CSV, ExportedAsset.ExportFormat.XLSX):
+        if exported_asset.export_format in ExportedAsset.TABULAR_FORMATS:
             csv_exporter.export_tabular(exported_asset, limit=limit, source=export_source)
-        else:
+        elif exported_asset.export_format in ExportedAsset.VISUAL_FORMATS:
             image_exporter.export_image(exported_asset, max_height_pixels=max_height_pixels, source=export_source)
+        else:
+            # Defense in depth: the API serializer should reject unsupported
+            # format/asset combinations, but if we get here the asset was
+            # constructed by a non-API code path that bypassed validation.
+            # Each branch (csv_exporter / image_exporter) also has its own
+            # NotImplementedError as a third-line backstop.
+            raise NotImplementedError(
+                f"Export format {exported_asset.export_format} cannot be dispatched. "
+                f"This format is either handled by a separate workflow or has no implementation."
+            )
 
         EXPORT_SUCCEEDED_COUNTER.labels(type=exported_asset.export_format).inc()
         logger.info(


### PR DESCRIPTION
## Problem

Two sources of noise in the export and subscription SLOs:

1. Export requests with undispatchable formats (e.g. JSON for insights) get enqueued as workflows, hit `NotImplementedError` in the exporter, and count as SLO failures — but they're really client errors (4xx).
2. Transient Slack API errors (`internal_error`, `service_unavailable`, etc.) cause subscription deliveries to fail immediately instead of retrying, inflating the failure rate.

## Changes

**Export format validation:**
- Centralise format constants on `ExportedAsset`: `TABULAR_FORMATS`, `VISUAL_FORMATS`, `VIDEO_FORMATS`, `DISPATCHABLE_FORMATS`, `EXTERNALLY_HANDLED_FORMATS`
- Derive `SUPPORTED_FORMATS` from these constants instead of maintaining a separate list
- Reject undispatchable formats at the serializer before any workflow is enqueued
- Add explicit `else` branch with `NotImplementedError` in the exporter as defense-in-depth
- Use constants in `get_expiry_delta` and video format checks (replacing inline tuples)

**Slack transient error retry:**
- Add `_RETRYABLE_SLACK_ERRORS` frozenset for transient 5xx-equivalent Slack errors
- Retry these with exponential backoff; permanent errors (`channel_not_found`, `invalid_auth`, etc.) fail fast
- Import `UTM_TAGS_BASE` from `subscription_utils` instead of redefining it

**Test cleanup:**
- Extract `_make_slack_api_error` helper and `_setup_async_mock` method to eliminate boilerplate
- Move `SlackApiError`/`AsyncSlackResponse` imports to module level
- Add parameterized tests for all retryable and non-retryable Slack error codes
- Parameterize JSON rejection tests

## How did you test this code?

Ran `ruff check` and `ruff format` — all clean. Unit tests require postgres (not available in this environment), but all files pass Python syntax validation. Ran 4 rounds of automated code review (reuse, quality, efficiency) with iterative fixes until graded A.

## 🤖 LLM context

Agent-assisted review and cleanup session. Original implementation was human-authored; agent ran `/code-review` and `/simplify` skills iteratively (4 rounds) to surface and fix: test boilerplate duplication, format constant consolidation, `UTM_TAGS_BASE` dedup, inline tuple replacement, and parameterized test opportunities. Agent also caught that the shape-based format validation gate was over-restrictive (rejected CSV for insights) — simplified to just reject undispatchable formats.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*