### PR TITLE
fix: Move heatmaps to its own section in support sidebar

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -3,6 +3,8 @@ import { forms } from 'kea-forms'
 import { urlToAction } from 'kea-router'
 import posthog from 'posthog-js'
 
+import { LemonSelectOptions } from '@posthog/lemon-ui'
+
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { uuid } from 'lib/utils'
@@ -116,187 +118,190 @@ const SUPPORT_TICKET_KIND_TO_TITLE: Record<SupportTicketKind, string> = {
     bug: 'Report a bug',
 }
 
+const TARGET_AREA_TO_NAME_GENERAL = [
+    {
+        value: 'login',
+        'data-attr': `support-form-target-area-login`,
+        label: 'Authentication (incl. login, sign-up, invites)',
+    },
+    {
+        value: 'analytics_platform',
+        'data-attr': `support-form-target-area-analytics_platform`,
+        label: 'Analytics features (incl. alerts, subscriptions, exports, etc.)',
+    },
+    {
+        value: 'billing',
+        'data-attr': `support-form-target-area-billing`,
+        label: 'Billing',
+    },
+    {
+        value: 'cohorts',
+        'data-attr': `support-form-target-area-cohorts`,
+        label: 'Cohorts',
+    },
+    {
+        value: 'data_ingestion',
+        'data-attr': `support-form-target-area-data_ingestion`,
+        label: 'Data ingestion',
+    },
+    {
+        value: 'health_overview',
+        'data-attr': `support-form-target-area-health_overview`,
+        label: 'Health overview',
+    },
+    {
+        value: 'data_management',
+        'data-attr': `support-form-target-area-data_management`,
+        label: 'Data management (incl. events, actions, properties)',
+    },
+    {
+        value: 'mobile',
+        'data-attr': `support-form-target-area-mobile`,
+        label: 'Mobile',
+    },
+    {
+        value: 'notebooks',
+        'data-attr': `support-form-target-area-notebooks`,
+        label: 'Notebooks',
+    },
+    {
+        value: 'onboarding',
+        'data-attr': `support-form-target-area-onboarding`,
+        label: 'Onboarding',
+    },
+    {
+        value: 'platform_addons',
+        'data-attr': `support-form-target-area-platform_addons`,
+        label: 'Platform addons',
+    },
+    {
+        value: 'sdk',
+        'data-attr': `support-form-target-area-onboarding`,
+        label: 'SDK / Implementation',
+    },
+    {
+        value: 'setup-wizard',
+        'data-attr': `support-form-target-area-setup-wizard`,
+        label: 'Wizard',
+    },
+] as const satisfies LemonSelectOptions<string>
+
+const TARGET_AREA_TO_NAME_PRODUCTS = [
+    {
+        value: 'data_warehouse',
+        'data-attr': `support-form-target-area-data_warehouse`,
+        label: 'Data warehouse (sources)',
+    },
+    {
+        value: 'data_modeling',
+        'data-attr': `support-form-target-area-data_modeling`,
+        label: 'Data modeling (views, matviews, endpoints)',
+    },
+    {
+        value: 'batch_exports',
+        'data-attr': `support-form-target-area-batch_exports`,
+        label: 'Destinations (batch exports)',
+    },
+    {
+        value: 'cdp_destinations',
+        'data-attr': `support-form-target-area-cdp_destinations`,
+        label: 'Destinations (real-time)',
+    },
+    {
+        value: 'error_tracking',
+        'data-attr': `support-form-target-area-error_tracking`,
+        label: 'Error tracking',
+    },
+    {
+        value: 'experiments',
+        'data-attr': `support-form-target-area-experiments`,
+        label: 'Experiments',
+    },
+    {
+        value: 'feature_flags',
+        'data-attr': `support-form-target-area-feature_flags`,
+        label: 'Feature flags',
+    },
+    {
+        value: 'group_analytics',
+        'data-attr': `support-form-target-area-group-analytics`,
+        label: 'Group analytics',
+    },
+    {
+        value: 'customer_analytics',
+        'data-attr': `support-form-target-area-customer-analytics`,
+        label: 'Customer analytics',
+    },
+    {
+        value: 'heatmaps',
+        'data-attr': `support-form-target-area-heatmaps`,
+        label: 'Heatmaps',
+    },
+    {
+        value: 'llm-analytics',
+        'data-attr': `support-form-target-area-llm-analytics`,
+        label: 'LLM analytics',
+    },
+    {
+        value: 'logs',
+        'data-attr': `support-form-target-area-logs`,
+        label: 'Logs',
+    },
+    {
+        value: 'max-ai',
+        'data-attr': `support-form-target-area-max-ai`,
+        label: 'PostHog AI',
+    },
+    {
+        value: 'posthog-mcp',
+        'data-attr': `support-form-target-area-posthog-mcp`,
+        label: 'MCP Server',
+    },
+    {
+        value: 'workflows',
+        'data-attr': `support-form-target-area-workflows`,
+        label: 'Workflows / Messaging',
+    },
+    {
+        value: 'analytics',
+        'data-attr': `support-form-target-area-analytics`,
+        label: 'Product analytics (incl. insights, dashboards, etc.)',
+    },
+    {
+        value: 'revenue_analytics',
+        'data-attr': `support-form-target-area-revenue-analytics`,
+        label: 'Revenue analytics',
+    },
+    {
+        value: 'session_replay',
+        'data-attr': `support-form-target-area-session_replay`,
+        label: 'Session replay (incl. recordings)',
+    },
+    {
+        value: 'surveys',
+        'data-attr': `support-form-target-area-surveys`,
+        label: 'Surveys',
+    },
+    {
+        value: 'toolbar',
+        'data-attr': `support-form-target-area-toolbar`,
+        label: 'Toolbar',
+    },
+    {
+        value: 'web_analytics',
+        'data-attr': `support-form-target-area-web_analytics`,
+        label: 'Web analytics',
+    },
+    {
+        value: 'logs',
+        'data-attr': `support-form-target-area-logs`,
+        label: 'Logs',
+    },
+] as const satisfies LemonSelectOptions<string>
+
 export const TARGET_AREA_TO_NAME = [
-    {
-        title: 'General',
-        options: [
-            {
-                value: 'login',
-                'data-attr': `support-form-target-area-login`,
-                label: 'Authentication (incl. login, sign-up, invites)',
-            },
-            {
-                value: 'analytics_platform',
-                'data-attr': `support-form-target-area-analytics_platform`,
-                label: 'Analytics features (incl. alerts, subscriptions, exports, etc.)',
-            },
-            {
-                value: 'billing',
-                'data-attr': `support-form-target-area-billing`,
-                label: 'Billing',
-            },
-            {
-                value: 'cohorts',
-                'data-attr': `support-form-target-area-cohorts`,
-                label: 'Cohorts',
-            },
-            {
-                value: 'data_ingestion',
-                'data-attr': `support-form-target-area-data_ingestion`,
-                label: 'Data ingestion',
-            },
-            {
-                value: 'health_overview',
-                'data-attr': `support-form-target-area-health_overview`,
-                label: 'Health overview',
-            },
-            {
-                value: 'data_management',
-                'data-attr': `support-form-target-area-data_management`,
-                label: 'Data management (incl. events, actions, properties)',
-            },
-            {
-                value: 'mobile',
-                'data-attr': `support-form-target-area-mobile`,
-                label: 'Mobile',
-            },
-            {
-                value: 'notebooks',
-                'data-attr': `support-form-target-area-notebooks`,
-                label: 'Notebooks',
-            },
-            {
-                value: 'onboarding',
-                'data-attr': `support-form-target-area-onboarding`,
-                label: 'Onboarding',
-            },
-            {
-                value: 'platform_addons',
-                'data-attr': `support-form-target-area-platform_addons`,
-                label: 'Platform addons',
-            },
-            {
-                value: 'sdk',
-                'data-attr': `support-form-target-area-onboarding`,
-                label: 'SDK / Implementation',
-            },
-            {
-                value: 'setup-wizard',
-                'data-attr': `support-form-target-area-setup-wizard`,
-                label: 'Wizard',
-            },
-        ],
-    },
-    {
-        title: 'Individual product',
-        options: [
-            {
-                value: 'data_warehouse',
-                'data-attr': `support-form-target-area-data_warehouse`,
-                label: 'Data warehouse (sources)',
-            },
-            {
-                value: 'data_modeling',
-                'data-attr': `support-form-target-area-data_modeling`,
-                label: 'Data modeling (views, matviews, endpoints)',
-            },
-            {
-                value: 'batch_exports',
-                'data-attr': `support-form-target-area-batch_exports`,
-                label: 'Destinations (batch exports)',
-            },
-            {
-                value: 'cdp_destinations',
-                'data-attr': `support-form-target-area-cdp_destinations`,
-                label: 'Destinations (real-time)',
-            },
-            {
-                value: 'error_tracking',
-                'data-attr': `support-form-target-area-error_tracking`,
-                label: 'Error tracking',
-            },
-            {
-                value: 'experiments',
-                'data-attr': `support-form-target-area-experiments`,
-                label: 'Experiments',
-            },
-            {
-                value: 'feature_flags',
-                'data-attr': `support-form-target-area-feature_flags`,
-                label: 'Feature flags',
-            },
-            {
-                value: 'group_analytics',
-                'data-attr': `support-form-target-area-group-analytics`,
-                label: 'Group analytics',
-            },
-            {
-                value: 'customer_analytics',
-                'data-attr': `support-form-target-area-customer-analytics`,
-                label: 'Customer analytics',
-            },
-            {
-                value: 'llm-analytics',
-                'data-attr': `support-form-target-area-llm-analytics`,
-                label: 'LLM analytics',
-            },
-            {
-                value: 'logs',
-                'data-attr': `support-form-target-area-logs`,
-                label: 'Logs',
-            },
-            {
-                value: 'max-ai',
-                'data-attr': `support-form-target-area-max-ai`,
-                label: 'PostHog AI',
-            },
-            {
-                value: 'posthog-mcp',
-                'data-attr': `support-form-target-area-posthog-mcp`,
-                label: 'MCP Server',
-            },
-            {
-                value: 'workflows',
-                'data-attr': `support-form-target-area-workflows`,
-                label: 'Workflows / Messaging',
-            },
-            {
-                value: 'analytics',
-                'data-attr': `support-form-target-area-analytics`,
-                label: 'Product analytics (incl. insights, dashboards, etc.)',
-            },
-            {
-                value: 'revenue_analytics',
-                'data-attr': `support-form-target-area-revenue-analytics`,
-                label: 'Revenue analytics',
-            },
-            {
-                value: 'session_replay',
-                'data-attr': `support-form-target-area-session_replay`,
-                label: 'Session replay (incl. recordings)',
-            },
-            {
-                value: 'surveys',
-                'data-attr': `support-form-target-area-surveys`,
-                label: 'Surveys',
-            },
-            {
-                value: 'toolbar',
-                'data-attr': `support-form-target-area-toolbar`,
-                label: 'Toolbar (incl. heatmaps)',
-            },
-            {
-                value: 'web_analytics',
-                'data-attr': `support-form-target-area-web_analytics`,
-                label: 'Web analytics',
-            },
-            {
-                value: 'logs',
-                'data-attr': `support-form-target-area-logs`,
-                label: 'Logs',
-            },
-        ],
-    },
+    { title: 'General', options: TARGET_AREA_TO_NAME_GENERAL },
+    { title: 'Individual product', options: TARGET_AREA_TO_NAME_PRODUCTS },
 ]
 
 export const SEVERITY_LEVEL_TO_NAME = {
@@ -313,32 +318,8 @@ export const SUPPORT_KIND_TO_SUBJECT = {
 }
 
 export type SupportTicketTargetArea =
-    | 'experiments'
-    | 'apps'
-    | 'login'
-    | 'billing'
-    | 'onboarding'
-    | 'cohorts'
-    | 'data_management'
-    | 'notebooks'
-    | 'data_warehouse'
-    | 'data_modeling'
-    | 'feature_flags'
-    | 'analytics'
-    | 'session_replay'
-    | 'toolbar'
-    | 'surveys'
-    | 'web_analytics'
-    | 'error_tracking'
-    | 'cdp_destinations'
-    | 'data_ingestion'
-    | 'batch_exports'
-    | 'workflows'
-    | 'platform_addons'
-    | 'max-ai'
-    | 'customer-analytics'
-    | 'logs'
-    | 'health_overview'
+    | (typeof TARGET_AREA_TO_NAME_GENERAL)[number]['value']
+    | (typeof TARGET_AREA_TO_NAME_PRODUCTS)[number]['value']
 export type SupportTicketSeverityLevel = keyof typeof SEVERITY_LEVEL_TO_NAME
 export type SupportTicketKind = keyof typeof SUPPORT_KIND_TO_SUBJECT
 
@@ -369,8 +350,8 @@ export const URL_PATH_TO_TARGET_AREA: Record<string, SupportTicketTargetArea> = 
     annotations: 'analytics',
     persons: 'analytics',
     groups: 'analytics',
-    app: 'apps',
-    toolbar: 'session_replay',
+    heatmaps: 'heatmaps',
+    toolbar: 'toolbar',
     warehouse: 'data_warehouse',
     surveys: 'surveys',
     web: 'web_analytics',

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -292,11 +292,6 @@ const TARGET_AREA_TO_NAME_PRODUCTS = [
         'data-attr': `support-form-target-area-web_analytics`,
         label: 'Web analytics',
     },
-    {
-        value: 'logs',
-        'data-attr': `support-form-target-area-logs`,
-        label: 'Logs',
-    },
 ] as const satisfies LemonSelectOptions<string>
 
 export const TARGET_AREA_TO_NAME = [

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -188,14 +188,9 @@ const TARGET_AREA_TO_NAME_GENERAL = [
 
 const TARGET_AREA_TO_NAME_PRODUCTS = [
     {
-        value: 'data_warehouse',
-        'data-attr': `support-form-target-area-data_warehouse`,
-        label: 'Data warehouse (sources)',
-    },
-    {
-        value: 'data_modeling',
-        'data-attr': `support-form-target-area-data_modeling`,
-        label: 'Data modeling (views, matviews, endpoints)',
+        value: 'apps',
+        'data-attr': `support-form-target-area-apps`,
+        label: 'Apps (incl. integrations, plugins, webhooks, and custom apps)',
     },
     {
         value: 'batch_exports',
@@ -206,6 +201,16 @@ const TARGET_AREA_TO_NAME_PRODUCTS = [
         value: 'cdp_destinations',
         'data-attr': `support-form-target-area-cdp_destinations`,
         label: 'Destinations (real-time)',
+    },
+    {
+        value: 'data_modeling',
+        'data-attr': `support-form-target-area-data_modeling`,
+        label: 'Data modeling (views, matviews, endpoints)',
+    },
+    {
+        value: 'data_warehouse',
+        'data-attr': `support-form-target-area-data_warehouse`,
+        label: 'Data warehouse (sources)',
     },
     {
         value: 'error_tracking',
@@ -258,11 +263,6 @@ const TARGET_AREA_TO_NAME_PRODUCTS = [
         label: 'MCP Server',
     },
     {
-        value: 'workflows',
-        'data-attr': `support-form-target-area-workflows`,
-        label: 'Workflows / Messaging',
-    },
-    {
         value: 'analytics',
         'data-attr': `support-form-target-area-analytics`,
         label: 'Product analytics (incl. insights, dashboards, etc.)',
@@ -291,6 +291,11 @@ const TARGET_AREA_TO_NAME_PRODUCTS = [
         value: 'web_analytics',
         'data-attr': `support-form-target-area-web_analytics`,
         label: 'Web analytics',
+    },
+    {
+        value: 'workflows',
+        'data-attr': `support-form-target-area-workflows`,
+        label: 'Workflows / Messaging',
     },
 ] as const satisfies LemonSelectOptions<string>
 


### PR DESCRIPTION
Heatmaps are now managed by Web Analytics. Toolbar is managed by the Growth team. So, let's separate these.
