### PR TITLE
fix(data-warehouse): Show the correct error message in the toast

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/dataWarehouseSourcesTableSyncMethodModalLogic.ts
+++ b/frontend/src/scenes/data-warehouse/settings/dataWarehouseSourcesTableSyncMethodModalLogic.ts
@@ -36,7 +36,7 @@ export const dataWarehouseSourcesTableSyncMethodModalLogic = kea<dataWarehouseSo
                     try {
                         return await api.externalDataSchemas.incremental_fields(schemaId)
                     } catch (e: any) {
-                        lemonToast.error(e?.message ?? e)
+                        lemonToast.error(e?.data?.message ?? e?.message ?? e)
                         throw e
                     }
                 },


### PR DESCRIPTION
## Problem
- When trying to change the sync type of a schema, if we run into an error, we show a toast with the raw http error and not the friendly error we return (such as "you lack permissions etc")

<img width="523" height="294" alt="image" src="https://github.com/user-attachments/assets/d3cef7d5-4c9c-452e-bb4d-a79101425843" />

## Changes
- Show the correct error message 
