### PR TITLE
perf(sessions): short-circuit $session_id event property filter

### DIFF
--- a/posthog/hogql_queries/sessions_query_runner.py
+++ b/posthog/hogql_queries/sessions_query_runner.py
@@ -4,7 +4,14 @@ from typing import Optional
 
 from django.utils.timezone import now
 
-from posthog.schema import CachedSessionsQueryResponse, DashboardFilter, SessionsQuery, SessionsQueryResponse
+from posthog.schema import (
+    CachedSessionsQueryResponse,
+    DashboardFilter,
+    EventPropertyFilter,
+    PropertyOperator,
+    SessionsQuery,
+    SessionsQueryResponse,
+)
 
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr, parse_order_expr
@@ -324,10 +331,9 @@ class SessionsQueryRunner(AnalyticsQueryRunner[SessionsQueryResponse]):
                         if self.query.eventProperties:
                             for prop in self.query.eventProperties:
                                 if (
-                                    hasattr(prop, "key")
+                                    isinstance(prop, EventPropertyFilter)
                                     and prop.key == "$session_id"
-                                    and hasattr(prop, "operator")
-                                    and (prop.operator is None or prop.operator == "exact")
+                                    and prop.operator in (None, PropertyOperator.EXACT)
                                     and prop.value is not None
                                 ):
                                     if isinstance(prop.value, list):

--- a/posthog/hogql_queries/sessions_query_runner.py
+++ b/posthog/hogql_queries/sessions_query_runner.py
@@ -316,69 +316,102 @@ class SessionsQueryRunner(AnalyticsQueryRunner[SessionsQueryResponse]):
                 # Filter sessions by events
                 if self.query.event or self.query.actionId or self.query.eventProperties:
                     with self.timings.measure("event_filter"):
-                        # Build the events subquery conditions
-                        event_where_exprs = []
-
-                        if self.query.event:
-                            event_where_exprs.append(
-                                parse_expr(
-                                    "event = {event}",
-                                    {"event": ast.Constant(value=self.query.event)},
-                                    timings=self.timings,
-                                )
-                            )
-                        elif self.query.actionId:
-                            try:
-                                action = Action.objects.get(
-                                    pk=self.query.actionId, team__project_id=self.team.project_id
-                                )
-                            except Action.DoesNotExist:
-                                raise Exception("Action does not exist")
-                            if not action.steps:
-                                raise Exception("Action does not have any match groups")
-                            event_where_exprs.append(action_to_expr(action))
-
-                        # Add event property filters if specified
+                        # Extract $session_id exact-match filters from eventProperties and apply
+                        # them directly on the sessions table, avoiding an unnecessary events
+                        # table round-trip.
+                        remaining_event_properties = []
+                        session_id_values: list[str] = []
                         if self.query.eventProperties:
-                            event_where_exprs.extend(
-                                property_to_expr(property, self.team) for property in self.query.eventProperties
+                            for prop in self.query.eventProperties:
+                                if (
+                                    hasattr(prop, "key")
+                                    and prop.key == "$session_id"
+                                    and hasattr(prop, "operator")
+                                    and (prop.operator is None or prop.operator == "exact")
+                                    and prop.value is not None
+                                ):
+                                    if isinstance(prop.value, list):
+                                        session_id_values.extend(str(v) for v in prop.value)
+                                    else:
+                                        session_id_values.append(str(prop.value))
+                                else:
+                                    remaining_event_properties.append(prop)
+
+                        if session_id_values:
+                            where_exprs.append(
+                                ast.CompareOperation(
+                                    left=ast.Field(chain=["session_id"]),
+                                    right=ast.Tuple(exprs=[ast.Constant(value=v) for v in session_id_values]),
+                                    op=ast.CompareOperationOp.In,
+                                )
                             )
 
-                        # Add timestamp filter to events subquery based on session date range
-                        if self.query.after and self.query.after != "all":
-                            parsed_after = relative_date_parse(self.query.after, self.team.timezone_info)
+                        # Build the events subquery for remaining filters
+                        needs_events_subquery = bool(
+                            self.query.event or self.query.actionId or remaining_event_properties
+                        )
+                        if needs_events_subquery:
+                            event_where_exprs = []
+
+                            if self.query.event:
+                                event_where_exprs.append(
+                                    parse_expr(
+                                        "event = {event}",
+                                        {"event": ast.Constant(value=self.query.event)},
+                                        timings=self.timings,
+                                    )
+                                )
+                            elif self.query.actionId:
+                                try:
+                                    action = Action.objects.get(
+                                        pk=self.query.actionId, team__project_id=self.team.project_id
+                                    )
+                                except Action.DoesNotExist:
+                                    raise Exception("Action does not exist")
+                                if not action.steps:
+                                    raise Exception("Action does not have any match groups")
+                                event_where_exprs.append(action_to_expr(action))
+
+                            if remaining_event_properties:
+                                event_where_exprs.extend(
+                                    property_to_expr(property, self.team) for property in remaining_event_properties
+                                )
+
+                            # Add timestamp filter to events subquery based on session date range
+                            if self.query.after and self.query.after != "all":
+                                parsed_after = relative_date_parse(self.query.after, self.team.timezone_info)
+                                event_where_exprs.append(
+                                    parse_expr(
+                                        "timestamp > {timestamp}",
+                                        {"timestamp": ast.Constant(value=parsed_after)},
+                                        timings=self.timings,
+                                    )
+                                )
+                            before = self.query.before or (now() + timedelta(seconds=5)).isoformat()
+                            parsed_before = relative_date_parse(before, self.team.timezone_info)
                             event_where_exprs.append(
                                 parse_expr(
-                                    "timestamp > {timestamp}",
-                                    {"timestamp": ast.Constant(value=parsed_after)},
+                                    "timestamp < {timestamp}",
+                                    {"timestamp": ast.Constant(value=parsed_before)},
                                     timings=self.timings,
                                 )
                             )
-                        before = self.query.before or (now() + timedelta(seconds=5)).isoformat()
-                        parsed_before = relative_date_parse(before, self.team.timezone_info)
-                        event_where_exprs.append(
-                            parse_expr(
-                                "timestamp < {timestamp}",
-                                {"timestamp": ast.Constant(value=parsed_before)},
-                                timings=self.timings,
-                            )
-                        )
 
-                        # Build subquery: session_id IN (SELECT DISTINCT $session_id FROM events WHERE ...)
-                        events_subquery = ast.SelectQuery(
-                            select=[ast.Field(chain=["$session_id"])],
-                            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
-                            where=ast.And(exprs=event_where_exprs) if len(event_where_exprs) > 0 else None,
-                            distinct=True,
-                        )
-
-                        where_exprs.append(
-                            ast.CompareOperation(
-                                left=ast.Field(chain=["session_id"]),
-                                right=events_subquery,
-                                op=ast.CompareOperationOp.In,
+                            # Build subquery: session_id IN (SELECT DISTINCT $session_id FROM events WHERE ...)
+                            events_subquery = ast.SelectQuery(
+                                select=[ast.Field(chain=["$session_id"])],
+                                select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+                                where=ast.And(exprs=event_where_exprs) if len(event_where_exprs) > 0 else None,
+                                distinct=True,
                             )
-                        )
+
+                            where_exprs.append(
+                                ast.CompareOperation(
+                                    left=ast.Field(chain=["session_id"]),
+                                    right=events_subquery,
+                                    op=ast.CompareOperationOp.In,
+                                )
+                            )
 
             with self.timings.measure("timestamps"):
                 # prevent accidentally future sessions from being visible by default

--- a/posthog/hogql_queries/sessions_query_runner.py
+++ b/posthog/hogql_queries/sessions_query_runner.py
@@ -44,6 +44,26 @@ SUPPORTED_PERSON_PROPERTY_OPERATORS = frozenset(
     }
 )
 
+
+def _extract_session_id_values(prop) -> Optional[list[str]]:
+    # Returns a list of session IDs extracted from a `$session_id` exact-match
+    # EventPropertyFilter, or None if the prop is not such a filter and should
+    # continue to flow through the events subquery. An empty list is returned
+    # verbatim so callers can emit a zero-result constraint — matching the
+    # semantic intent of `$session_id IN ()`.
+    if not isinstance(prop, EventPropertyFilter):
+        return None
+    if prop.key != "$session_id":
+        return None
+    if prop.operator not in (None, PropertyOperator.EXACT):
+        return None
+    if prop.value is None:
+        return None
+    if isinstance(prop.value, list):
+        return [str(v) for v in prop.value]
+    return [str(prop.value)]
+
+
 # Allow-listed fields returned when you select "*" from sessions
 SELECT_STAR_FROM_SESSIONS_FIELDS = [
     "session_id",
@@ -328,22 +348,21 @@ class SessionsQueryRunner(AnalyticsQueryRunner[SessionsQueryResponse]):
                         # table round-trip.
                         remaining_event_properties = []
                         session_id_values: list[str] = []
+                        extracted_empty_session_id_filter = False
                         if self.query.eventProperties:
                             for prop in self.query.eventProperties:
-                                if (
-                                    isinstance(prop, EventPropertyFilter)
-                                    and prop.key == "$session_id"
-                                    and prop.operator in (None, PropertyOperator.EXACT)
-                                    and prop.value is not None
-                                ):
-                                    if isinstance(prop.value, list):
-                                        session_id_values.extend(str(v) for v in prop.value)
-                                    else:
-                                        session_id_values.append(str(prop.value))
-                                else:
+                                extracted = _extract_session_id_values(prop)
+                                if extracted is None:
                                     remaining_event_properties.append(prop)
+                                elif not extracted:
+                                    # `$session_id IN ()` must match zero sessions.
+                                    extracted_empty_session_id_filter = True
+                                else:
+                                    session_id_values.extend(extracted)
 
-                        if session_id_values:
+                        if extracted_empty_session_id_filter:
+                            where_exprs.append(ast.Constant(value=False))
+                        elif session_id_values:
                             where_exprs.append(
                                 ast.CompareOperation(
                                     left=ast.Field(chain=["session_id"]),

--- a/posthog/hogql_queries/test/test_sessions_query_runner.py
+++ b/posthog/hogql_queries/test/test_sessions_query_runner.py
@@ -1099,6 +1099,100 @@ class TestSessionsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             assert isinstance(response, CachedSessionsQueryResponse)
             assert len(response.results) == 2
 
+    def test_session_id_event_property_filter_short_circuits_events_subquery(self):
+        """When eventProperties only contains a $session_id filter, we should filter
+        directly on the sessions table without building an events subquery."""
+        self._create_test_sessions(
+            data=[
+                ("alice", "session1", "2024-01-01T12:00:00Z", {}),
+                ("bob", "session2", "2024-01-01T12:05:00Z", {}),
+            ]
+        )
+        flush_persons_and_events()
+
+        with freeze_time("2024-01-01T14:00:00Z"):
+            # Get session IDs first
+            all_query = SessionsQuery(after="2024-01-01", kind="SessionsQuery", select=["session_id"])
+            all_response = SessionsQueryRunner(query=all_query, team=self.team).run()
+            assert isinstance(all_response, CachedSessionsQueryResponse)
+            assert len(all_response.results) == 2
+            target_session_id = all_response.results[0][0]
+
+            # Filter by $session_id as an event property — should short-circuit
+            query = SessionsQuery(
+                after="2024-01-01",
+                kind="SessionsQuery",
+                select=["session_id"],
+                eventProperties=[
+                    EventPropertyFilter(key="$session_id", value=target_session_id, operator="exact", type="event")
+                ],
+            )
+
+            runner = SessionsQueryRunner(query=query, team=self.team)
+            response = runner.run()
+            assert isinstance(response, CachedSessionsQueryResponse)
+            assert len(response.results) == 1
+            assert response.results[0][0] == target_session_id
+            # The generated HogQL should NOT contain "FROM events"
+            assert "FROM events" not in response.hogql
+
+    def test_session_id_event_property_filter_with_list_values(self):
+        """$session_id filter with a list of values should short-circuit."""
+        self._create_test_sessions(
+            data=[
+                ("alice", "session1", "2024-01-01T12:00:00Z", {}),
+                ("bob", "session2", "2024-01-01T12:05:00Z", {}),
+                ("charlie", "session3", "2024-01-01T12:10:00Z", {}),
+            ]
+        )
+        flush_persons_and_events()
+
+        with freeze_time("2024-01-01T14:00:00Z"):
+            all_query = SessionsQuery(after="2024-01-01", kind="SessionsQuery", select=["session_id"])
+            all_response = SessionsQueryRunner(query=all_query, team=self.team).run()
+            assert isinstance(all_response, CachedSessionsQueryResponse)
+            session_ids = [r[0] for r in all_response.results]
+
+            query = SessionsQuery(
+                after="2024-01-01",
+                kind="SessionsQuery",
+                select=["session_id"],
+                eventProperties=[
+                    EventPropertyFilter(key="$session_id", value=session_ids[:2], operator="exact", type="event")
+                ],
+            )
+
+            runner = SessionsQueryRunner(query=query, team=self.team)
+            response = runner.run()
+            assert isinstance(response, CachedSessionsQueryResponse)
+            assert len(response.results) == 2
+            assert "FROM events" not in response.hogql
+
+    def test_session_id_event_property_with_other_event_filters_keeps_subquery(self):
+        """When $session_id is combined with an event name filter, we still need the events subquery
+        for the event filter, but $session_id is applied directly to sessions."""
+        with freeze_time("2024-01-01T14:00:00Z"):
+            query = SessionsQuery(
+                after="2024-01-01",
+                kind="SessionsQuery",
+                select=["session_id"],
+                event="$pageview",
+                eventProperties=[
+                    EventPropertyFilter(key="$session_id", value="test-session-id", operator="exact", type="event")
+                ],
+            )
+
+            runner = SessionsQueryRunner(query=query, team=self.team)
+            hogql = runner.to_query()
+
+            from posthog.hogql.printer import to_printed_hogql
+
+            printed = to_printed_hogql(hogql, team=self.team)
+            # $session_id should be filtered directly on sessions
+            assert "in(session_id, tuple('test-session-id'))" in printed
+            # Events subquery should still exist for the event name filter
+            assert "events" in printed
+
     @snapshot_clickhouse_queries
     def test_filter_by_session_properties(self):
         self._create_test_sessions(

--- a/posthog/hogql_queries/test/test_sessions_query_runner.py
+++ b/posthog/hogql_queries/test/test_sessions_query_runner.py
@@ -1168,6 +1168,26 @@ class TestSessionsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             assert len(response.results) == 2
             assert "FROM events" not in response.hogql
 
+    def test_session_id_event_property_filter_empty_list_returns_no_sessions(self):
+        self._create_test_sessions(
+            data=[
+                ("alice", "session1", "2024-01-01T12:00:00Z", {}),
+                ("bob", "session2", "2024-01-01T12:05:00Z", {}),
+            ]
+        )
+        flush_persons_and_events()
+
+        with freeze_time("2024-01-01T14:00:00Z"):
+            query = SessionsQuery(
+                after="2024-01-01",
+                kind="SessionsQuery",
+                select=["session_id"],
+                eventProperties=[EventPropertyFilter(key="$session_id", value=[], operator="exact", type="event")],
+            )
+            response = SessionsQueryRunner(query=query, team=self.team).run()
+            assert isinstance(response, CachedSessionsQueryResponse)
+            assert response.results == []
+
     def test_session_id_event_property_with_other_event_filters_keeps_subquery(self):
         """When $session_id is combined with an event name filter, we still need the events subquery
         for the event filter, but $session_id is applied directly to sessions."""


### PR DESCRIPTION
## Problem

When `SessionsQuery.eventProperties` contains a `$session_id = 'xxx'` filter, the query runner builds an events subquery that round-trips through the entire events table just to return the same session ID back:

```sql
session_id IN (SELECT DISTINCT $session_id FROM events WHERE $session_id = 'xxx' AND ...)
```

This is expensive and unnecessary. We can filter directly on the sessions table for this property.

## Changes

Extract `$session_id` exact-match filters from `eventProperties` and apply them as direct `session_id IN (...)` filters on the sessions table. The events subquery is only built if there are remaining event/action filters that actually need it.

## How did you test this code?

Updating the tests and running the resulting queries myself.

## Publish to changelog?

no

