### PR TITLE
fix(flags): allow clearing percentage inputs in feature flag forms

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagForm.tsx
@@ -70,6 +70,7 @@ import { FeatureFlagCodeExample } from './FeatureFlagCodeExample'
 import { FeatureFlagEvaluationContexts } from './FeatureFlagEvaluationContexts'
 import { FeatureFlagLogicProps, featureFlagLogic, slugifyFeatureFlagKey } from './featureFlagLogic'
 import { FeatureFlagReleaseConditionsCollapsible } from './FeatureFlagReleaseConditionsCollapsible'
+import { PercentageInput } from './PercentageInput'
 
 interface SortableVariantHeaderProps {
     variant: MultivariateFlagVariant
@@ -823,19 +824,15 @@ export function FeatureFlagForm({ id }: FeatureFlagLogicProps): JSX.Element {
                                                                 )}
 
                                                                 <LemonLabel>Rollout percentage</LemonLabel>
-                                                                <LemonInput
-                                                                    type="number"
-                                                                    min={0}
-                                                                    max={100}
-                                                                    value={variant.rollout_percentage || 0}
+                                                                <PercentageInput
+                                                                    value={variant.rollout_percentage}
                                                                     onChange={(value) =>
                                                                         updateVariant(
                                                                             index,
                                                                             'rollout_percentage',
-                                                                            parseInt(value?.toString() || '0')
+                                                                            value
                                                                         )
                                                                     }
-                                                                    suffix={<span>%</span>}
                                                                     data-attr={`feature-flag-variant-rollout-${index}`}
                                                                 />
 

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -6,7 +6,7 @@ import { router } from 'kea-router'
 import { Fragment } from 'react'
 
 import { IconCopy, IconFlag, IconInfo, IconPlus, IconTrash } from '@posthog/icons'
-import { LemonInput, LemonLabel, LemonSelect, LemonSnack, Link, Tooltip } from '@posthog/lemon-ui'
+import { LemonLabel, LemonSelect, LemonSnack, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { allOperatorsToHumanName } from 'lib/components/DefinitionPopover/utils'
 import { EditableField } from 'lib/components/EditableField/EditableField'
@@ -28,6 +28,7 @@ import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { capitalizeFirstLetter, clamp, dateFilterToText, dateStringToComponents, humanFriendlyNumber } from 'lib/utils'
 import { FeatureFlagConditionWarning } from 'scenes/feature-flags/FeatureFlagConditionWarning'
+import { PercentageInput } from 'scenes/feature-flags/PercentageInput'
 import { urls } from 'scenes/urls'
 
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
@@ -177,6 +178,8 @@ export function FeatureFlagReleaseConditions({
         )
 
     const renderReleaseConditionGroup = (group: FeatureFlagGroupType, index: number): JSX.Element => {
+        const rolloutValue = group.rollout_percentage ?? 100
+
         return (
             <div className="w-full" key={group.sort_key}>
                 {index > 0 && <div className="condition-set-separator my-1 py-0">OR</div>}
@@ -420,7 +423,7 @@ export function FeatureFlagReleaseConditions({
                             <div className="flex flex-wrap items-center gap-1">
                                 Roll out to{' '}
                                 <LemonSlider
-                                    value={group.rollout_percentage !== null ? group.rollout_percentage : 100}
+                                    value={rolloutValue}
                                     onChange={(value) => {
                                         updateConditionSet(index, value)
                                     }}
@@ -430,18 +433,11 @@ export function FeatureFlagReleaseConditions({
                                     className="ml-1.5 w-20"
                                 />
                                 <LemonField.Pure error={propertySelectErrors?.[index]?.rollout_percentage} inline>
-                                    <LemonInput
+                                    <PercentageInput
                                         data-attr="rollout-percentage"
-                                        type="number"
                                         className="ml-2 mr-1.5 max-w-30"
-                                        onChange={(value): void => {
-                                            updateConditionSet(index, value === undefined ? 0 : value)
-                                        }}
-                                        value={group.rollout_percentage !== null ? group.rollout_percentage : 100}
-                                        min={0}
-                                        max={100}
-                                        step="any"
-                                        suffix={<span>%</span>}
+                                        value={rolloutValue}
+                                        onChange={(value) => updateConditionSet(index, value)}
                                     />
                                 </LemonField.Pure>{' '}
                                 <div

--- a/frontend/src/scenes/feature-flags/FeatureFlagVariantsForm.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagVariantsForm.tsx
@@ -10,6 +10,7 @@ import { Lettermark, LettermarkColor } from 'lib/lemon-ui/Lettermark'
 import { Link } from 'lib/lemon-ui/Link'
 import { alphabet } from 'lib/utils'
 import { JSONEditorInput } from 'scenes/feature-flags/JSONEditorInput'
+import { PercentageInput } from 'scenes/feature-flags/PercentageInput'
 import { getSurveyForFeatureFlagVariant } from 'scenes/surveys/utils'
 import { urls } from 'scenes/urls'
 
@@ -254,22 +255,10 @@ export function FeatureFlagVariantsForm({
                     </div>
                     <div className="col-span-3">
                         <div>
-                            <LemonInput
-                                type="number"
-                                min={0}
-                                max={100}
+                            <PercentageInput
+                                value={variant.rollout_percentage}
+                                onChange={(value) => onVariantChange?.(index, 'rollout_percentage', value)}
                                 step={0.01}
-                                value={variant.rollout_percentage || 0}
-                                onChange={(changedValue) => {
-                                    const raw =
-                                        changedValue !== undefined && !isNaN(Number(changedValue))
-                                            ? parseFloat(changedValue.toString())
-                                            : 0
-                                    const numValue = Math.round(raw * 100) / 100
-
-                                    onVariantChange?.(index, 'rollout_percentage', numValue)
-                                }}
-                                suffix={<span>%</span>}
                                 data-attr="feature-flag-variant-rollout-percentage-input"
                             />
                             {filterGroups.filter((group) => group.variant === variant.key).length > 0 && (

--- a/frontend/src/scenes/feature-flags/PercentageInput.tsx
+++ b/frontend/src/scenes/feature-flags/PercentageInput.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from 'react'
+
+/** A percentage input (0–100) that allows clearing the field while typing.
+ *  Uses a native text input with local string state to avoid React's
+ *  controlled <input type="number"> limitation where empty fields snap back. */
+export function PercentageInput({
+    value,
+    onChange,
+    className,
+    ...rest
+}: {
+    value: number
+    onChange: (value: number) => void
+    step?: number
+    className?: string
+    'data-attr'?: string
+}): JSX.Element {
+    const [localValue, setLocalValue] = useState(String(value))
+    const isFocusedRef = useRef(false)
+
+    // Sync from parent when not focused (e.g. slider changes, distribute evenly)
+    useEffect(() => {
+        if (!isFocusedRef.current) {
+            setLocalValue(String(value))
+        }
+    }, [value])
+
+    return (
+        <span className="LemonInput input-like LemonInput--type-number LemonInput--medium LemonInput--full-width">
+            <input
+                className={`LemonInput__input ${className ?? ''}`}
+                type="text"
+                inputMode="decimal"
+                value={localValue}
+                onChange={(e) => {
+                    const raw = e.target.value
+                    // Only allow digits, decimal point, and empty
+                    if (raw !== '' && !/^\d*\.?\d*$/.test(raw)) {
+                        return
+                    }
+                    setLocalValue(raw)
+                    const parsed = parseFloat(raw)
+                    if (!isNaN(parsed)) {
+                        onChange(Math.round(Math.min(100, Math.max(0, parsed)) * 100) / 100)
+                    }
+                }}
+                onFocus={() => {
+                    isFocusedRef.current = true
+                }}
+                onBlur={() => {
+                    isFocusedRef.current = false
+                    const parsed = parseFloat(localValue)
+                    if (isNaN(parsed) || localValue.trim() === '') {
+                        onChange(0)
+                        setLocalValue('0')
+                    } else {
+                        const clamped = Math.round(Math.min(100, Math.max(0, parsed)) * 100) / 100
+                        onChange(clamped)
+                        setLocalValue(String(clamped))
+                    }
+                }}
+                data-attr={rest['data-attr']}
+            />
+            <span className="LemonInput__suffix">%</span>
+        </span>
+    )
+}


### PR DESCRIPTION
## Problem

Users cannot clear the "0" from rollout percentage inputs in feature flag forms. When you delete the 0, it immediately repopulates because React's controlled `<input type="number">` snaps empty values back to 0.

## Changes

Introduced a `PercentageInput` component that uses a native `<input type="text" inputMode="decimal">` with local string state. This sidesteps the React controlled number input limitation by:

- Tracking the raw string locally so the field can be empty while typing
- Only propagating parsed numeric values to the parent on valid input
- Restoring to "0" on blur if the field is left empty
- Clamping values to 0–100

Applied to all three percentage input locations:
- `FeatureFlagForm.tsx` (multivariant rollout percentages)
- `FeatureFlagVariantsForm.tsx` (variant rollout percentages)
- `FeatureFlagReleaseConditions.tsx` (release condition percentages)

## Demo

![2026-04-14 13 49 38](https://github.com/user-attachments/assets/b303f7b6-810a-49aa-859e-80cad6903275)

## How did you test this code?

Manually verified in the multivariant feature flag UI that:
- The "0" can be deleted, leaving an empty field
- Typing a new number works as expected (no "010" prefix issue)
- On blur, empty fields reset to "0"
- Values are clamped between 0 and 100

## LLM context

Co-authored with PostHog Code. The core issue was that `FeatureFlagForm.tsx` was still using a plain `LemonInput type="number"` while the other two forms had been updated — the multivariant UI the reviewer was testing hit the unconverted code path.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*