### PR TITLE
fix(surveys): improve survey notification setup and test preview

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -60,6 +60,7 @@ import {
     PropertyGroupFilter,
     PropertyGroupFilterValue,
     Survey,
+    SurveyEventName,
     SurveyEventProperties,
 } from '~/types'
 

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -17,6 +17,7 @@ import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { addProductIntent } from 'lib/utils/product-intents'
 import { asDisplay } from 'scenes/persons/person-utils'
 import { projectLogic } from 'scenes/projectLogic'
+import { buildSurveyExampleInvocationGlobals } from 'scenes/surveys/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
@@ -828,68 +829,85 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             },
         ],
         exampleInvocationGlobals: [
-            (s) => [s.configuration, s.currentProject, s.groupTypes, s.contextId],
-            (configuration, currentProject, groupTypes, contextId): CyclotronJobInvocationGlobals => {
+            (s) => [s.configuration, s.currentProject, s.groupTypes, s.contextId, s.survey],
+            (configuration, currentProject, groupTypes, contextId, survey): CyclotronJobInvocationGlobals => {
                 const currentUrl = window.location.href.split('#')[0]
                 const eventId = uuid()
                 const personId = uuid()
-                const event = {
-                    uuid: eventId,
-                    distinct_id: uuid(),
-                    timestamp: dayjs().toISOString(),
-                    elements_chain: '',
-                    url: `${window.location.origin}/project/${currentProject?.id}/events/`,
-                    ...(contextId === 'error-tracking'
-                        ? {
-                              event: configuration?.filters?.events?.[0].id || '$error_tracking_issue_created',
-                              properties: {
-                                  name: 'Test issue',
-                                  description: 'This is the issue description',
+                const source = {
+                    name: configuration?.name ?? 'Unnamed',
+                    url: currentUrl,
+                }
+                const globals: CyclotronJobInvocationGlobals =
+                    configuration?.filters?.events?.[0]?.id === SurveyEventName.SENT
+                        ? buildSurveyExampleInvocationGlobals({
+                              survey,
+                              projectId: currentProject?.id || 0,
+                              projectName: currentProject?.name || '',
+                              projectUrl: `${window.location.origin}/project/${currentProject?.id}`,
+                              source,
+                              eventUuid: eventId,
+                              distinctId: uuid(),
+                              timestamp: dayjs().toISOString(),
+                              personId,
+                              personName: 'Example person',
+                              personEmail: 'example@posthog.com',
+                          })
+                        : {
+                              event: {
+                                  uuid: eventId,
+                                  distinct_id: uuid(),
+                                  timestamp: dayjs().toISOString(),
+                                  elements_chain: '',
+                                  url: `${window.location.origin}/project/${currentProject?.id}/events/`,
+                                  ...(contextId === 'error-tracking'
+                                      ? {
+                                            event:
+                                                configuration?.filters?.events?.[0].id ||
+                                                '$error_tracking_issue_created',
+                                            properties: {
+                                                name: 'Test issue',
+                                                description: 'This is the issue description',
+                                            },
+                                        }
+                                      : contextId === 'activity-log'
+                                        ? {
+                                              event: '$activity_log_entry_created',
+                                              properties: {
+                                                  activity: 'created',
+                                                  scope: 'Insight',
+                                                  item_id: 'abcdef',
+                                              },
+                                          }
+                                        : {
+                                              event: '$pageview',
+                                              properties: {
+                                                  $current_url: currentUrl,
+                                                  $browser: 'Chrome',
+                                                  $ip: '89.160.20.129',
+                                                  this_is_an_example_event: true,
+                                              },
+                                          }),
                               },
+                              person:
+                                  contextId !== 'error-tracking'
+                                      ? {
+                                            id: personId,
+                                            properties: {
+                                                email: 'example@posthog.com',
+                                            },
+                                            name: 'Example person',
+                                            url: `${window.location.origin}/person/${personId}`,
+                                        }
+                                      : undefined,
+                              groups: {},
+                              project: {
+                                  id: currentProject?.id || 0,
+                                  name: currentProject?.name || '',
+                                  url: `${window.location.origin}/project/${currentProject?.id}`,
+                              },
+                              source,
                           }
-                        : contextId === 'activity-log'
-                          ? {
-                                event: '$activity_log_entry_created',
-                                properties: {
-                                    activity: 'created',
-                                    scope: 'Insight',
-                                    item_id: 'abcdef',
-                                },
-                            }
-                          : {
-                                event: '$pageview',
-                                properties: {
-                                    $current_url: currentUrl,
-                                    $browser: 'Chrome',
-                                    $ip: '89.160.20.129',
-                                    this_is_an_example_event: true,
-                                },
-                            }),
-                }
-                const globals: CyclotronJobInvocationGlobals = {
-                    event,
-                    person:
-                        contextId !== 'error-tracking'
-                            ? {
-                                  id: personId,
-                                  properties: {
-                                      email: 'example@posthog.com',
-                                  },
-                                  name: 'Example person',
-                                  url: `${window.location.origin}/person/${personId}`,
-                              }
-                            : undefined,
-                    groups: {},
-                    project: {
-                        id: currentProject?.id || 0,
-                        name: currentProject?.name || '',
-                        url: `${window.location.origin}/project/${currentProject?.id}`,
-                    },
-                    source: {
-                        name: configuration?.name ?? 'Unnamed',
-                        url: currentUrl,
-                    },
-                }
 
                 if (contextId !== 'error-tracking') {
                     groupTypes.forEach((groupType) => {

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -8,7 +8,6 @@ import {
     PropertyFilterType,
     PropertyOperator,
     SurveyEventName,
-    SurveyEventProperties,
 } from '~/types'
 
 export const HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES: Record<
@@ -25,14 +24,6 @@ export const HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES: Record<
                 {
                     id: SurveyEventName.SENT,
                     type: 'events',
-                    properties: [
-                        {
-                            key: SurveyEventProperties.SURVEY_RESPONSE,
-                            type: PropertyFilterType.Event,
-                            value: 'is_set',
-                            operator: PropertyOperator.IsSet,
-                        },
-                    ],
                 },
             ],
         },

--- a/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
+++ b/frontend/src/scenes/surveys/surveyNotificationModalLogic.ts
@@ -12,7 +12,11 @@ import {
 } from 'scenes/hog-functions/sub-templates/sub-templates'
 import { NEW_SURVEY } from 'scenes/surveys/constants'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
-import { getSurveyNotificationFilters, getSurveyIdBasedResponseKey } from 'scenes/surveys/utils'
+import {
+    buildSurveyExampleInvocationGlobals,
+    getSurveyNotificationFilters,
+    getSurveyIdBasedResponseKey,
+} from 'scenes/surveys/utils'
 
 import { HogFunctionTemplateType, HogFunctionType, IntegrationType, Survey, SurveyQuestionType } from '~/types'
 
@@ -199,45 +203,12 @@ function buildSurveyNotificationForm(survey: SurveyNotificationContext): SurveyN
 }
 
 function buildTemplateGlobals(survey: SurveyNotificationContext): Record<string, unknown> {
-    const responseProperties = Object.fromEntries(
-        survey.questions
-            .filter((question) => question.id && question.type !== SurveyQuestionType.Link)
-            .map((question, index) => [
-                getSurveyIdBasedResponseKey(question.id!),
-                question.question || `Example answer ${index + 1}`,
-            ])
-    )
-    const previewTimestamp = new Date().toISOString()
-
-    return {
-        project: {
-            id: 1,
-            name: 'Project',
-            url: 'https://app.posthog.com/project/1',
-        },
-        event: {
-            event: 'survey sent',
-            uuid: '00000000-0000-0000-0000-000000000000',
-            distinct_id: 'example-distinct-id',
-            timestamp: previewTimestamp,
-            properties: {
-                $survey_id: survey.id === NEW_SURVEY.id ? 'survey-id' : survey.id,
-                $survey_name: survey.name || 'Survey',
-                $survey_completed: true,
-                ...responseProperties,
-            },
-            url: `https://app.posthog.com/project/1/events/example/${encodeURIComponent(previewTimestamp)}`,
-        },
-        person: {
-            id: 'person-id',
-            name: 'Jane Doe',
-            url: 'https://app.posthog.com/project/1/person/example-distinct-id',
-            properties: {
-                email: 'jane@example.com',
-            },
-        },
-        groups: {},
-    }
+    return buildSurveyExampleInvocationGlobals({
+        survey,
+        projectId: 1,
+        projectName: 'Project',
+        projectUrl: 'https://app.posthog.com/project/1',
+    })
 }
 
 function notificationNameFor(destination: DestinationKey, surveyName?: string | null): string {

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -17,6 +17,7 @@ import {
 } from '~/types'
 
 import {
+    buildSurveyExampleInvocationGlobals,
     buildPartialResponsesFilter,
     buildSurveyTimestampFilter,
     calculateNpsBreakdown,
@@ -197,6 +198,59 @@ describe('survey utils', () => {
                         ],
                     },
                 ],
+            })
+        })
+    })
+
+    describe('buildSurveyExampleInvocationGlobals', () => {
+        it('builds a survey sent example payload with question response properties', () => {
+            const globals = buildSurveyExampleInvocationGlobals({
+                survey: {
+                    id: 'survey-123',
+                    name: 'Onboarding survey',
+                    questions: [
+                        { id: 'q1', type: SurveyQuestionType.Open, question: 'Tell us more' },
+                        {
+                            id: 'q2',
+                            type: SurveyQuestionType.SingleChoice,
+                            question: 'How did you hear about us?',
+                            choices: ['Twitter', 'Word of mouth'],
+                        },
+                        {
+                            id: 'q3',
+                            type: SurveyQuestionType.MultipleChoice,
+                            question: 'What do you use most?',
+                            choices: ['Funnels', 'Session replay', 'Feature flags'],
+                        },
+                        {
+                            id: 'q4',
+                            type: SurveyQuestionType.Rating,
+                            question: 'How satisfied are you?',
+                            scale: 10,
+                            display: 'number',
+                            lowerBoundLabel: 'Low',
+                            upperBoundLabel: 'High',
+                        },
+                    ],
+                } as Survey,
+                projectId: 1,
+                projectName: 'Project',
+                projectUrl: 'https://app.posthog.com/project/1',
+                timestamp: '2026-04-13T12:00:00.000Z',
+                eventUuid: 'event-uuid',
+                distinctId: 'person-distinct-id',
+            })
+
+            expect(globals.event.event).toEqual(SurveyEventName.SENT)
+            expect(globals.event.properties).toEqual({
+                $survey_id: 'survey-123',
+                $survey_name: 'Onboarding survey',
+                $survey_completed: true,
+                $survey_submission_id: 'survey-submission-id',
+                $survey_response_q1: 'Tell us more',
+                $survey_response_q2: 'Twitter',
+                $survey_response_q3: ['Funnels', 'Session replay'],
+                $survey_response_q4: '9',
             })
         })
     })

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -164,12 +164,6 @@ describe('survey utils', () => {
                         type: 'events',
                         properties: [
                             {
-                                key: SurveyEventProperties.SURVEY_RESPONSE,
-                                type: PropertyFilterType.Event,
-                                value: 'is_set',
-                                operator: PropertyOperator.IsSet,
-                            },
-                            {
                                 key: SurveyEventProperties.SURVEY_ID,
                                 type: PropertyFilterType.Event,
                                 value: 'survey-123',
@@ -194,12 +188,6 @@ describe('survey utils', () => {
                         id: SurveyEventName.SENT,
                         type: 'events',
                         properties: [
-                            {
-                                key: SurveyEventProperties.SURVEY_RESPONSE,
-                                type: PropertyFilterType.Event,
-                                value: 'is_set',
-                                operator: PropertyOperator.IsSet,
-                            },
                             {
                                 key: SurveyEventProperties.SURVEY_ID,
                                 type: PropertyFilterType.Event,

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -162,6 +162,7 @@ export function buildSurveyExampleInvocationGlobals({
             uuid: eventUuid,
             distinct_id: distinctId,
             timestamp,
+            elements_chain: '',
             properties: {
                 [SurveyEventProperties.SURVEY_ID]: survey?.id && survey.id !== NEW_SURVEY.id ? survey.id : 'survey-id',
                 $survey_name: survey?.name || 'Survey',

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -1030,12 +1030,6 @@ export function getSurveyNotificationFilters(
 ): CyclotronJobFiltersType {
     const properties: EventPropertyFilter[] = [
         {
-            key: SurveyEventProperties.SURVEY_RESPONSE,
-            type: PropertyFilterType.Event,
-            value: 'is_set',
-            operator: PropertyOperator.IsSet,
-        },
-        {
             key: SurveyEventProperties.SURVEY_ID,
             type: PropertyFilterType.Event,
             value: surveyId,

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -10,6 +10,7 @@ import { SurveyRatingResults } from 'scenes/surveys/surveyLogic'
 
 import {
     BasicSurveyQuestion,
+    CyclotronJobInvocationGlobals,
     CyclotronJobFiltersType,
     EventPropertyFilter,
     FeatureFlagFilters,
@@ -96,6 +97,91 @@ export function getSurveyResponseKey(questionIndex: number): string {
 
 export function getSurveyIdBasedResponseKey(questionId: string): string {
     return `${SurveyEventProperties.SURVEY_RESPONSE}_${questionId}`
+}
+
+type SurveyExampleContext = Pick<Survey, 'id' | 'name' | 'questions'> | null | undefined
+
+function getExampleSurveyResponseValue(question: SurveyQuestion, index: number): string | string[] | undefined {
+    switch (question.type) {
+        case SurveyQuestionType.Open:
+            return question.question || `Example answer ${index + 1}`
+        case SurveyQuestionType.Rating:
+            return String(question.scale >= 10 ? 9 : Math.min(question.scale, 4))
+        case SurveyQuestionType.SingleChoice:
+            return question.choices[0] || `Option ${index + 1}`
+        case SurveyQuestionType.MultipleChoice:
+            return question.choices.slice(0, Math.min(question.choices.length, 2))
+        case SurveyQuestionType.Link:
+            return undefined
+    }
+}
+
+export function buildSurveyExampleInvocationGlobals({
+    survey,
+    projectId,
+    projectName,
+    projectUrl,
+    source,
+    timestamp = new Date().toISOString(),
+    eventUuid = '00000000-0000-0000-0000-000000000000',
+    distinctId = 'example-distinct-id',
+    personId = 'person-id',
+    personName = 'Jane Doe',
+    personEmail = 'jane@example.com',
+}: {
+    survey: SurveyExampleContext
+    projectId: number
+    projectName: string
+    projectUrl: string
+    source?: CyclotronJobInvocationGlobals['source']
+    timestamp?: string
+    eventUuid?: string
+    distinctId?: string
+    personId?: string
+    personName?: string
+    personEmail?: string
+}): CyclotronJobInvocationGlobals {
+    const responseProperties = Object.fromEntries(
+        (survey?.questions ?? [])
+            .filter((question) => question.id && question.type !== SurveyQuestionType.Link)
+            .map((question, index) => [
+                getSurveyIdBasedResponseKey(question.id!),
+                getExampleSurveyResponseValue(question, index),
+            ])
+            .filter(([, value]) => value !== undefined)
+    )
+
+    return {
+        project: {
+            id: projectId,
+            name: projectName,
+            url: projectUrl,
+        },
+        event: {
+            event: SurveyEventName.SENT,
+            uuid: eventUuid,
+            distinct_id: distinctId,
+            timestamp,
+            properties: {
+                [SurveyEventProperties.SURVEY_ID]: survey?.id && survey.id !== NEW_SURVEY.id ? survey.id : 'survey-id',
+                $survey_name: survey?.name || 'Survey',
+                [SurveyEventProperties.SURVEY_COMPLETED]: true,
+                [SurveyEventProperties.SURVEY_SUBMISSION_ID]: 'survey-submission-id',
+                ...responseProperties,
+            },
+            url: `${projectUrl}/events/${encodeURIComponent(eventUuid)}/${encodeURIComponent(timestamp)}`,
+        },
+        person: {
+            id: personId,
+            name: personName,
+            url: `${projectUrl}/person/${encodeURIComponent(distinctId)}`,
+            properties: {
+                email: personEmail,
+            },
+        },
+        groups: {},
+        ...(source ? { source } : {}),
+    }
 }
 
 // Helper function to generate the response field keys with proper typing


### PR DESCRIPTION
## Problem

Survey notifications were being created with a redundant `"$survey_response" is set` filter, and hog functions using `survey sent` still showed a generic example event while testing. That made the generated configuration and the test payload less representative than they should be.

## Changes

- remove the default `"$survey_response" is set` filter from survey notification creation
- remove the same default from the shared `survey-response` hog function sub-template
- add a shared survey example globals helper for `survey sent` events
- use that helper in hog function testing so survey-triggered functions get a realistic sample payload
- use the same helper in the survey notification modal preview to keep both previews aligned
- update survey utils tests to cover the new filter shape and survey example payload

## How did you test this code?

- Ran `pnpm --filter=@posthog/frontend exec jest --watchman=false --testPathPattern='(frontend/|products/|common/)' --forceExit --runTestsByPath src/scenes/surveys/utils.test.ts`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update needed.

## 🤖 LLM context

Authored with Codex in the local repository.

Validated the targeted frontend test above with Watchman disabled because the sandbox blocks the Watchman socket.
