### PR TITLE
fix(insights): guard stickiness criteria against null values

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/StickinessCriteria.tsx
+++ b/frontend/src/queries/nodes/InsightViz/StickinessCriteria.tsx
@@ -38,11 +38,16 @@ export function StickinessCriteria({ insightProps }: EditorFilterProps): JSX.Ele
             <LemonInput
                 type="number"
                 className="w-20"
-                defaultValue={currentValue}
+                value={currentValue}
                 min={1}
                 onChange={(newValue: number | undefined) => {
                     if (newValue !== undefined) {
                         updateInsightFilter({ stickinessCriteria: { operator: currentOperator, value: newValue } })
+                    }
+                }}
+                onBlur={() => {
+                    if (stickinessCriteria?.value == null) {
+                        updateInsightFilter({ stickinessCriteria: { operator: currentOperator, value: 1 } })
                     }
                 }}
             />

--- a/posthog/hogql_queries/insights/stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/stickiness_query_runner.py
@@ -113,8 +113,10 @@ class StickinessQueryRunner(AnalyticsQueryRunner[StickinessQueryResponse]):
     def _having_clause(self) -> ast.Expr:
         if not (self.query.stickinessFilter and self.query.stickinessFilter.stickinessCriteria):
             return parse_expr("count() > 0")
-        operator = self.query.stickinessFilter.stickinessCriteria.operator
-        value = ast.Constant(value=self.query.stickinessFilter.stickinessCriteria.value)
+        criteria = self.query.stickinessFilter.stickinessCriteria
+        operator = criteria.operator
+        criteria_value = criteria.value if criteria.value is not None else 1
+        value = ast.Constant(value=criteria_value)
         return parse_expr(f"""count() {get_count_operator(operator)} {{value}}""", {"value": value})
 
     def date_to_start_of_interval_hogql(self, date: ast.Expr) -> ast.Expr:

--- a/posthog/hogql_queries/insights/test/test_stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_stickiness_query_runner.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 
+from parameterized import parameterized
+
 from posthog.schema import (
     ActionsNode,
     CohortPropertyFilter,
@@ -793,20 +795,50 @@ class TestStickinessQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert response.results[0]["count"] == 2
         assert response.results[0]["data"] == [0, 1, 1, 0, 0, 0, 0, 0, 0, 0]
 
-    def test_stickiness_criteria_null_value_defaults_to_one(self):
+    @parameterized.expand(
+        [
+            # (criteria_value, operator, expected_value, seed_value_to_not_appear)
+            # null value falls back to 1 — seed with 5 so we can assert it was replaced
+            ("null_gte", None, "gte", 1, 5),
+            ("null_lte", None, "lte", 1, 5),
+            ("null_exact", None, "exact", 1, 5),
+            # non-null values pass through unchanged
+            ("valid_gte", 3, "gte", 3, None),
+            ("valid_exact", 7, "exact", 7, None),
+        ]
+    )
+    def test_stickiness_criteria_value_handling(self, _name, criteria_value, operator, expected_value, seed_value):
+        # Seed with a distinct value so we can confirm the null guard actually replaced it.
+        initial_value = seed_value if seed_value is not None else expected_value
         query = self._get_query(
             date_from="2020-01-12",
             date_to="2020-01-20",
-            filters=StickinessFilter(**{"stickinessCriteria": {"operator": "gte", "value": 1}}),
+            filters=StickinessFilter(**{"stickinessCriteria": {"operator": operator, "value": initial_value}}),
+        )
+        runner = StickinessQueryRunner(team=self.team, query=query)
+        runner.query.stickinessFilter.stickinessCriteria.value = criteria_value  # type: ignore
+
+        having_sql = str(runner._having_clause())
+
+        # Rendered form: "sql(equals(count(), 7))" / "sql(greaterOrEquals(count(), 1))" etc.
+        assert f"count(), {expected_value})" in having_sql, having_sql
+        if seed_value is not None:
+            assert f"count(), {seed_value})" not in having_sql, having_sql
+
+    def test_stickiness_missing_criteria_uses_default_clause(self):
+        # When stickinessCriteria is absent entirely, _having_clause takes a different branch
+        # and renders `count() > 0`, not `count() >= 1`. Locking this in so the null-guard
+        # doesn't accidentally collapse the two paths.
+        query = self._get_query(
+            date_from="2020-01-12",
+            date_to="2020-01-20",
+            filters=StickinessFilter(),
         )
         runner = StickinessQueryRunner(team=self.team, query=query)
 
-        # Simulate a null value reaching the backend (e.g. from a malformed API request)
-        runner.query.stickinessFilter.stickinessCriteria.value = None  # type: ignore
+        having_sql = str(runner._having_clause())
 
-        having = runner._having_clause()
-        # Should default to 1 instead of crashing
-        assert "1" in str(having)
+        assert "> 0" in having_sql or "0" in having_sql, having_sql
 
     def test_filter_test_accounts(self):
         self._create_test_events()

--- a/posthog/hogql_queries/insights/test/test_stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_stickiness_query_runner.py
@@ -793,6 +793,21 @@ class TestStickinessQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert response.results[0]["count"] == 2
         assert response.results[0]["data"] == [0, 1, 1, 0, 0, 0, 0, 0, 0, 0]
 
+    def test_stickiness_criteria_null_value_defaults_to_one(self):
+        query = self._get_query(
+            date_from="2020-01-12",
+            date_to="2020-01-20",
+            filters=StickinessFilter(**{"stickinessCriteria": {"operator": "gte", "value": 1}}),
+        )
+        runner = StickinessQueryRunner(team=self.team, query=query)
+
+        # Simulate a null value reaching the backend (e.g. from a malformed API request)
+        runner.query.stickinessFilter.stickinessCriteria.value = None  # type: ignore
+
+        having = runner._having_clause()
+        # Should default to 1 instead of crashing
+        assert "1" in str(having)
+
     def test_filter_test_accounts(self):
         self._create_test_events()
 


### PR DESCRIPTION
## Problem

The stickiness criteria number input can end up in an empty/null state — clearing the field leaves it blank, and that null value flows through to the backend, which then crashes inside the stickiness query runner.

## Changes

- `StickinessCriteria` input is controlled and falls back to 1 on blur instead of going empty
- stickiness query runner guards against a null criteria value instead of crashing

## How did you test this code?

Agent-authored, no manual testing. Added a unit test for the null-value guard in the runner.

## Publish to changelog?

no

## 🤖 LLM context

Authored via Claude Code.