### PR TITLE
fix(customer-analytics): Optimize usage metrics query runner with interval grouping

### DIFF
--- a/products/customer_analytics/backend/hogql_queries/test/__snapshots__/test_usage_metrics_query_runner.ambr
+++ b/products/customer_analytics/backend/hogql_queries/test/__snapshots__/test_usage_metrics_query_runner.ambr
@@ -1,31 +1,20 @@
 # serializer version: 1
 # name: TestUsageMetricsQueryRunner.test_complex_event_filter
   '''
-  SELECT id AS id,
-         name AS name,
-         format AS format,
-         display AS display,
-         interval AS interval,
-         value AS value,
-         previous AS previous,
-         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
-  FROM
-    (SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
-            'Test metric' AS name,
-            'numeric' AS format,
-            'number' AS display,
-            7 AS interval,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))), 'Float64') AS value,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))), 'Float64') AS previous
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')), and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome'), 0), equals(events.event, 'metric_event'))))
+  SELECT toStartOfDay(toTimeZone(toTimeZone(events.timestamp, 'UTC'), 'UTC')) AS day,
+         accurateCastOrNull(countIf(and(and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome'), 0), equals(events.event, 'metric_event')), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))))), 'Float64') AS m0_value,
+         accurateCastOrNull(countIf(and(and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome'), 0), equals(events.event, 'metric_event')), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))), 'Float64') AS m0_previous
+  FROM events
+  LEFT OUTER JOIN
+    (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+            person_distinct_id_overrides.distinct_id AS distinct_id
+     FROM person_distinct_id_overrides
+     WHERE equals(person_distinct_id_overrides.team_id, 99999)
+     GROUP BY person_distinct_id_overrides.distinct_id
+     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')))
+  GROUP BY day
+  ORDER BY day ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -40,44 +29,13 @@
 # ---
 # name: TestUsageMetricsQueryRunner.test_group_metric
   '''
-  SELECT id AS id,
-         name AS name,
-         format AS format,
-         display AS display,
-         interval AS interval,
-         value AS value,
-         previous AS previous,
-         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
-  FROM
-    (SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
-            'Test metric' AS name,
-            'numeric' AS format,
-            'number' AS display,
-            7 AS interval,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-10-02 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))), 'Float64') AS value,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-25 12:11:00.000000', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-10-02 12:11:00.000000', 6, 'UTC')))), 'Float64') AS previous
-     FROM events
-     WHERE and(equals(events.team_id, 99999), equals(events.`$group_0`, 'test_group'), greaterOrEquals(events.timestamp, toDateTime64('2025-09-25 12:11:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')), equals(events.event, 'metric_event')))
-  LIMIT 100
-  UNION ALL
-  SELECT id AS id,
-         name AS name,
-         format AS format,
-         display AS display,
-         interval AS interval,
-         value AS value,
-         previous AS previous,
-         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
-  FROM
-    (SELECT '1d2b5e4e-c338-4de9-af6c-9671d639ce1e' AS id,
-            'Another test metric' AS name,
-            'currency' AS format,
-            'sparkline' AS display,
-            30 AS interval,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-09 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))), 'Float64') AS value,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-08-10 12:11:00.000000', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-09 12:11:00.000000', 6, 'UTC')))), 'Float64') AS previous
-     FROM events
-     WHERE and(equals(events.team_id, 99999), equals(events.`$group_0`, 'test_group'), greaterOrEquals(events.timestamp, toDateTime64('2025-08-10 12:11:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')), equals(events.event, 'another_metric_event')))
+  SELECT toStartOfDay(toTimeZone(toTimeZone(events.timestamp, 'UTC'), 'UTC')) AS day,
+         accurateCastOrNull(countIf(and(equals(events.event, 'metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-10-02 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))))), 'Float64') AS m0_value,
+         accurateCastOrNull(countIf(and(equals(events.event, 'metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-25 12:11:00.000000', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-10-02 12:11:00.000000', 6, 'UTC'))))), 'Float64') AS m0_previous
+  FROM events
+  WHERE and(equals(events.team_id, 99999), equals(events.`$group_0`, 'test_group'), greaterOrEquals(events.timestamp, toDateTime64('2025-09-25 12:11:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')))
+  GROUP BY day
+  ORDER BY day ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -90,17 +48,15 @@
                      use_hive_partitioning=0
   '''
 # ---
-# name: TestUsageMetricsQueryRunner.test_handles_failed_metric_gracefully
+# name: TestUsageMetricsQueryRunner.test_group_metric.1
   '''
-  SELECT 0 AS id,
-         0 AS name,
-         0 AS format,
-         0 AS display,
-         0 AS interval,
-         0 AS value,
-         0 AS previous,
-         0 AS change_from_previous_pct
-  WHERE 0
+  SELECT toStartOfDay(toTimeZone(toTimeZone(events.timestamp, 'UTC'), 'UTC')) AS day,
+         accurateCastOrNull(countIf(and(equals(events.event, 'another_metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-09 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))))), 'Float64') AS m0_value,
+         accurateCastOrNull(countIf(and(equals(events.event, 'another_metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-08-10 12:11:00.000000', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-09 12:11:00.000000', 6, 'UTC'))))), 'Float64') AS m0_previous
+  FROM events
+  WHERE and(equals(events.team_id, 99999), equals(events.`$group_0`, 'test_group'), greaterOrEquals(events.timestamp, toDateTime64('2025-08-10 12:11:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')))
+  GROUP BY day
+  ORDER BY day ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -115,54 +71,20 @@
 # ---
 # name: TestUsageMetricsQueryRunner.test_metric_interval
   '''
-  SELECT id AS id,
-         name AS name,
-         format AS format,
-         display AS display,
-         interval AS interval,
-         value AS value,
-         previous AS previous,
-         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
-  FROM
-    (SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
-            'Test metric' AS name,
-            'numeric' AS format,
-            'number' AS display,
-            7 AS interval,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))), 'Float64') AS value,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))), 'Float64') AS previous
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')), equals(events.event, 'metric_event')))
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
-  '''
-# ---
-# name: TestUsageMetricsQueryRunner.test_no_metrics
-  '''
-  SELECT 0 AS id,
-         0 AS name,
-         0 AS format,
-         0 AS display,
-         0 AS interval,
-         0 AS value,
-         0 AS previous,
-         0 AS change_from_previous_pct
-  WHERE 0
+  SELECT toStartOfDay(toTimeZone(toTimeZone(events.timestamp, 'UTC'), 'UTC')) AS day,
+         accurateCastOrNull(countIf(and(equals(events.event, 'metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))))), 'Float64') AS m0_value,
+         accurateCastOrNull(countIf(and(equals(events.event, 'metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))), 'Float64') AS m0_previous
+  FROM events
+  LEFT OUTER JOIN
+    (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+            person_distinct_id_overrides.distinct_id AS distinct_id
+     FROM person_distinct_id_overrides
+     WHERE equals(person_distinct_id_overrides.team_id, 99999)
+     GROUP BY person_distinct_id_overrides.distinct_id
+     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')))
+  GROUP BY day
+  ORDER BY day ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -177,58 +99,48 @@
 # ---
 # name: TestUsageMetricsQueryRunner.test_person_metric
   '''
-  SELECT id AS id,
-         name AS name,
-         format AS format,
-         display AS display,
-         interval AS interval,
-         value AS value,
-         previous AS previous,
-         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
-  FROM
-    (SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
-            'Test metric' AS name,
-            'numeric' AS format,
-            'number' AS display,
-            7 AS interval,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))), 'Float64') AS value,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))), 'Float64') AS previous
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')), equals(events.event, 'metric_event')))
-  LIMIT 100
-  UNION ALL
-  SELECT id AS id,
-         name AS name,
-         format AS format,
-         display AS display,
-         interval AS interval,
-         value AS value,
-         previous AS previous,
-         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
-  FROM
-    (SELECT '1d2b5e4e-c338-4de9-af6c-9671d639ce1e' AS id,
-            'Another test metric' AS name,
-            'currency' AS format,
-            'sparkline' AS display,
-            30 AS interval,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))), 'Float64') AS value,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))), 'Float64') AS previous
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')), equals(events.event, 'another_metric_event')))
+  SELECT toStartOfDay(toTimeZone(toTimeZone(events.timestamp, 'UTC'), 'UTC')) AS day,
+         accurateCastOrNull(countIf(and(equals(events.event, 'metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))))), 'Float64') AS m0_value,
+         accurateCastOrNull(countIf(and(equals(events.event, 'metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))), 'Float64') AS m0_previous
+  FROM events
+  LEFT OUTER JOIN
+    (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+            person_distinct_id_overrides.distinct_id AS distinct_id
+     FROM person_distinct_id_overrides
+     WHERE equals(person_distinct_id_overrides.team_id, 99999)
+     GROUP BY person_distinct_id_overrides.distinct_id
+     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')))
+  GROUP BY day
+  ORDER BY day ASC
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestUsageMetricsQueryRunner.test_person_metric.1
+  '''
+  SELECT toStartOfDay(toTimeZone(toTimeZone(events.timestamp, 'UTC'), 'UTC')) AS day,
+         accurateCastOrNull(countIf(and(equals(events.event, 'another_metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))))), 'Float64') AS m0_value,
+         accurateCastOrNull(countIf(and(equals(events.event, 'another_metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))), 'Float64') AS m0_previous
+  FROM events
+  LEFT OUTER JOIN
+    (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+            person_distinct_id_overrides.distinct_id AS distinct_id
+     FROM person_distinct_id_overrides
+     WHERE equals(person_distinct_id_overrides.team_id, 99999)
+     GROUP BY person_distinct_id_overrides.distinct_id
+     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')))
+  GROUP BY day
+  ORDER BY day ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -243,31 +155,20 @@
 # ---
 # name: TestUsageMetricsQueryRunner.test_sum_math_aggregation
   '''
-  SELECT id AS id,
-         name AS name,
-         format AS format,
-         display AS display,
-         interval AS interval,
-         value AS value,
-         previous AS previous,
-         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
-  FROM
-    (SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
-            'Revenue' AS name,
-            'currency' AS format,
-            'number' AS display,
-            7 AS interval,
-            ifNull(sumIf(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))), 0) AS value,
-            ifNull(sumIf(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))), 0) AS previous
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')), equals(events.event, 'purchase')))
+  SELECT toStartOfDay(toTimeZone(toTimeZone(events.timestamp, 'UTC'), 'UTC')) AS day,
+         ifNull(sumIf(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64'), and(equals(events.event, 'purchase'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))))), 0) AS m0_value,
+         ifNull(sumIf(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64'), and(equals(events.event, 'purchase'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))), 0) AS m0_previous
+  FROM events
+  LEFT OUTER JOIN
+    (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+            person_distinct_id_overrides.distinct_id AS distinct_id
+     FROM person_distinct_id_overrides
+     WHERE equals(person_distinct_id_overrides.team_id, 99999)
+     GROUP BY person_distinct_id_overrides.distinct_id
+     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')))
+  GROUP BY day
+  ORDER BY day ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/products/customer_analytics/backend/hogql_queries/test/__snapshots__/test_usage_metrics_query_runner.ambr
+++ b/products/customer_analytics/backend/hogql_queries/test/__snapshots__/test_usage_metrics_query_runner.ambr
@@ -1,31 +1,20 @@
 # serializer version: 1
 # name: TestUsageMetricsQueryRunner.test_complex_event_filter
   '''
-  SELECT id AS id,
-         name AS name,
-         format AS format,
-         display AS display,
-         interval AS interval,
-         value AS value,
-         previous AS previous,
-         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
-  FROM
-    (SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
-            'Test metric' AS name,
-            'numeric' AS format,
-            'number' AS display,
-            7 AS interval,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))), 'Float64') AS value,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))), 'Float64') AS previous
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome'), 0), equals(events.event, 'metric_event'))))
+  SELECT toStartOfDay(toTimeZone(toTimeZone(events.timestamp, 'UTC'), 'UTC')) AS day,
+         accurateCastOrNull(countIf(and(and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome'), 0), equals(events.event, 'metric_event')), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))))), 'Float64') AS m0_value,
+         accurateCastOrNull(countIf(and(and(ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$browser'), ''), 'null'), '^"|"$', ''), 'Chrome'), 0), equals(events.event, 'metric_event')), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))), 'Float64') AS m0_previous
+  FROM events
+  LEFT OUTER JOIN
+    (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+            person_distinct_id_overrides.distinct_id AS distinct_id
+     FROM person_distinct_id_overrides
+     WHERE equals(person_distinct_id_overrides.team_id, 99999)
+     GROUP BY person_distinct_id_overrides.distinct_id
+     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))
+  GROUP BY day
+  ORDER BY day ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -40,44 +29,13 @@
 # ---
 # name: TestUsageMetricsQueryRunner.test_group_metric
   '''
-  SELECT id AS id,
-         name AS name,
-         format AS format,
-         display AS display,
-         interval AS interval,
-         value AS value,
-         previous AS previous,
-         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
-  FROM
-    (SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
-            'Test metric' AS name,
-            'numeric' AS format,
-            'number' AS display,
-            7 AS interval,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-10-02 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))), 'Float64') AS value,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-25 12:11:00.000000', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-10-02 12:11:00.000000', 6, 'UTC')))), 'Float64') AS previous
-     FROM events
-     WHERE and(equals(events.team_id, 99999), equals(events.`$group_0`, 'test_group'), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-25 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), equals(events.event, 'metric_event')))
-  LIMIT 100
-  UNION ALL
-  SELECT id AS id,
-         name AS name,
-         format AS format,
-         display AS display,
-         interval AS interval,
-         value AS value,
-         previous AS previous,
-         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
-  FROM
-    (SELECT '1d2b5e4e-c338-4de9-af6c-9671d639ce1e' AS id,
-            'Another test metric' AS name,
-            'currency' AS format,
-            'sparkline' AS display,
-            30 AS interval,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-09 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))), 'Float64') AS value,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-08-10 12:11:00.000000', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-09 12:11:00.000000', 6, 'UTC')))), 'Float64') AS previous
-     FROM events
-     WHERE and(equals(events.team_id, 99999), equals(events.`$group_0`, 'test_group'), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-08-10 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), equals(events.event, 'another_metric_event')))
+  SELECT toStartOfDay(toTimeZone(toTimeZone(events.timestamp, 'UTC'), 'UTC')) AS day,
+         accurateCastOrNull(countIf(and(equals(events.event, 'metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-10-02 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))))), 'Float64') AS m0_value,
+         accurateCastOrNull(countIf(and(equals(events.event, 'metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-25 12:11:00.000000', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-10-02 12:11:00.000000', 6, 'UTC'))))), 'Float64') AS m0_previous
+  FROM events
+  WHERE and(equals(events.team_id, 99999), equals(events.`$group_0`, 'test_group'), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-25 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))
+  GROUP BY day
+  ORDER BY day ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -90,17 +48,15 @@
                      use_hive_partitioning=0
   '''
 # ---
-# name: TestUsageMetricsQueryRunner.test_handles_failed_metric_gracefully
+# name: TestUsageMetricsQueryRunner.test_group_metric.1
   '''
-  SELECT 0 AS id,
-         0 AS name,
-         0 AS format,
-         0 AS display,
-         0 AS interval,
-         0 AS value,
-         0 AS previous,
-         0 AS change_from_previous_pct
-  WHERE 0
+  SELECT toStartOfDay(toTimeZone(toTimeZone(events.timestamp, 'UTC'), 'UTC')) AS day,
+         accurateCastOrNull(countIf(and(equals(events.event, 'another_metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-09 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))))), 'Float64') AS m0_value,
+         accurateCastOrNull(countIf(and(equals(events.event, 'another_metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-08-10 12:11:00.000000', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-09-09 12:11:00.000000', 6, 'UTC'))))), 'Float64') AS m0_previous
+  FROM events
+  WHERE and(equals(events.team_id, 99999), equals(events.`$group_0`, 'test_group'), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2025-08-10 12:11:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))
+  GROUP BY day
+  ORDER BY day ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -115,54 +71,20 @@
 # ---
 # name: TestUsageMetricsQueryRunner.test_metric_interval
   '''
-  SELECT id AS id,
-         name AS name,
-         format AS format,
-         display AS display,
-         interval AS interval,
-         value AS value,
-         previous AS previous,
-         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
-  FROM
-    (SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
-            'Test metric' AS name,
-            'numeric' AS format,
-            'number' AS display,
-            7 AS interval,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))), 'Float64') AS value,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))), 'Float64') AS previous
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), equals(events.event, 'metric_event')))
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
-  '''
-# ---
-# name: TestUsageMetricsQueryRunner.test_no_metrics
-  '''
-  SELECT 0 AS id,
-         0 AS name,
-         0 AS format,
-         0 AS display,
-         0 AS interval,
-         0 AS value,
-         0 AS previous,
-         0 AS change_from_previous_pct
-  WHERE 0
+  SELECT toStartOfDay(toTimeZone(toTimeZone(events.timestamp, 'UTC'), 'UTC')) AS day,
+         accurateCastOrNull(countIf(and(equals(events.event, 'metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))))), 'Float64') AS m0_value,
+         accurateCastOrNull(countIf(and(equals(events.event, 'metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))), 'Float64') AS m0_previous
+  FROM events
+  LEFT OUTER JOIN
+    (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+            person_distinct_id_overrides.distinct_id AS distinct_id
+     FROM person_distinct_id_overrides
+     WHERE equals(person_distinct_id_overrides.team_id, 99999)
+     GROUP BY person_distinct_id_overrides.distinct_id
+     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))
+  GROUP BY day
+  ORDER BY day ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -177,58 +99,48 @@
 # ---
 # name: TestUsageMetricsQueryRunner.test_person_metric
   '''
-  SELECT id AS id,
-         name AS name,
-         format AS format,
-         display AS display,
-         interval AS interval,
-         value AS value,
-         previous AS previous,
-         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
-  FROM
-    (SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
-            'Test metric' AS name,
-            'numeric' AS format,
-            'number' AS display,
-            7 AS interval,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))), 'Float64') AS value,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))), 'Float64') AS previous
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), equals(events.event, 'metric_event')))
-  LIMIT 100
-  UNION ALL
-  SELECT id AS id,
-         name AS name,
-         format AS format,
-         display AS display,
-         interval AS interval,
-         value AS value,
-         previous AS previous,
-         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
-  FROM
-    (SELECT '1d2b5e4e-c338-4de9-af6c-9671d639ce1e' AS id,
-            'Another test metric' AS name,
-            'currency' AS format,
-            'sparkline' AS display,
-            30 AS interval,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))), 'Float64') AS value,
-            accurateCastOrNull(countIf(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))), 'Float64') AS previous
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), equals(events.event, 'another_metric_event')))
+  SELECT toStartOfDay(toTimeZone(toTimeZone(events.timestamp, 'UTC'), 'UTC')) AS day,
+         accurateCastOrNull(countIf(and(equals(events.event, 'metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))))), 'Float64') AS m0_value,
+         accurateCastOrNull(countIf(and(equals(events.event, 'metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))), 'Float64') AS m0_previous
+  FROM events
+  LEFT OUTER JOIN
+    (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+            person_distinct_id_overrides.distinct_id AS distinct_id
+     FROM person_distinct_id_overrides
+     WHERE equals(person_distinct_id_overrides.team_id, 99999)
+     GROUP BY person_distinct_id_overrides.distinct_id
+     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))
+  GROUP BY day
+  ORDER BY day ASC
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestUsageMetricsQueryRunner.test_person_metric.1
+  '''
+  SELECT toStartOfDay(toTimeZone(toTimeZone(events.timestamp, 'UTC'), 'UTC')) AS day,
+         accurateCastOrNull(countIf(and(equals(events.event, 'another_metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))))), 'Float64') AS m0_value,
+         accurateCastOrNull(countIf(and(equals(events.event, 'another_metric_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))), 'Float64') AS m0_previous
+  FROM events
+  LEFT OUTER JOIN
+    (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+            person_distinct_id_overrides.distinct_id AS distinct_id
+     FROM person_distinct_id_overrides
+     WHERE equals(person_distinct_id_overrides.team_id, 99999)
+     GROUP BY person_distinct_id_overrides.distinct_id
+     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))
+  GROUP BY day
+  ORDER BY day ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -243,31 +155,20 @@
 # ---
 # name: TestUsageMetricsQueryRunner.test_sum_math_aggregation
   '''
-  SELECT id AS id,
-         name AS name,
-         format AS format,
-         display AS display,
-         interval AS interval,
-         value AS value,
-         previous AS previous,
-         if(ifNull(greater(previous, 0), 0), multiply(divide(minus(value, previous), previous), 100), NULL) AS change_from_previous_pct
-  FROM
-    (SELECT '19bda517-7081-4004-8c1d-30d0b2b11bf5' AS id,
-            'Revenue' AS name,
-            'currency' AS format,
-            'number' AS display,
-            7 AS interval,
-            ifNull(sumIf(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))), 0) AS value,
-            ifNull(sumIf(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))), 0) AS previous
-     FROM events
-     LEFT OUTER JOIN
-       (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), equals(events.event, 'purchase')))
+  SELECT toStartOfDay(toTimeZone(toTimeZone(events.timestamp, 'UTC'), 'UTC')) AS day,
+         ifNull(sumIf(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64'), and(equals(events.event, 'purchase'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC'))))), 0) AS m0_value,
+         ifNull(sumIf(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'amount'), ''), 'null'), '^"|"$', ''), 'Float64'), and(equals(events.event, 'purchase'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))), 0) AS m0_previous
+  FROM events
+  LEFT OUTER JOIN
+    (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+            person_distinct_id_overrides.distinct_id AS distinct_id
+     FROM person_distinct_id_overrides
+     WHERE equals(person_distinct_id_overrides.team_id, 99999)
+     GROUP BY person_distinct_id_overrides.distinct_id
+     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  WHERE and(equals(events.team_id, 99999), ifNull(equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), '00000000-0000-0000-0000-000000000000'), 0), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')))
+  GROUP BY day
+  ORDER BY day ASC
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/products/customer_analytics/backend/hogql_queries/test/test_usage_metrics_query_runner.py
+++ b/products/customer_analytics/backend/hogql_queries/test/test_usage_metrics_query_runner.py
@@ -1,4 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 from freezegun import freeze_time
@@ -10,6 +11,7 @@ from posthog.test.base import (
     flush_persons_and_events,
     snapshot_clickhouse_queries,
 )
+from unittest.mock import patch
 
 from django.test import override_settings
 from django.utils import timezone
@@ -670,3 +672,73 @@ class TestUsageMetricsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert isinstance(response2, CachedUsageMetricsQueryResponse)
         self.assertFalse(response2.is_cached)
         self.assertEqual(len(response2.results), 0)
+
+    @freeze_time("2025-10-09T12:11:00")
+    def test_usage_metrics_fetched_once_per_runner(self):
+        GroupUsageMetric.objects.create(
+            id=self.test_metric_id,
+            team=self.team,
+            group_type_index=0,
+            name="Test metric",
+            format=GroupUsageMetric.Format.NUMERIC,
+            interval=7,
+            display=GroupUsageMetric.Display.NUMBER,
+            filters={"events": [{"id": "metric_event", "type": "events", "order": 0}]},
+        )
+        runner = UsageMetricsQueryRunner(
+            team=self.team,
+            query=UsageMetricsQuery(kind="UsageMetricsQuery", person_id=str(self.person.uuid)),
+        )
+
+        with patch.object(GroupUsageMetric.objects, "filter", wraps=GroupUsageMetric.objects.filter) as filter_spy:
+            runner.get_cache_payload()
+            runner.calculate()
+            runner.to_query()
+
+        self.assertEqual(filter_spy.call_count, 1)
+
+    @freeze_time("2025-10-09T12:11:00")
+    def test_datetime_now_shared_between_query_build_and_post_process(self):
+        GroupUsageMetric.objects.create(
+            id=self.test_metric_id,
+            team=self.team,
+            group_type_index=0,
+            name="Test metric",
+            format=GroupUsageMetric.Format.NUMERIC,
+            interval=7,
+            display=GroupUsageMetric.Display.NUMBER,
+            filters={"events": [{"id": "metric_event", "type": "events", "order": 0}]},
+        )
+        _create_event(
+            event="metric_event",
+            team=self.team,
+            person_id=str(self.person.uuid),
+            distinct_id=self.person_distinct_id,
+        )
+        flush_persons_and_events()
+
+        fake_now = datetime(2025, 10, 9, 12, 11, 0, tzinfo=ZoneInfo("UTC"))
+        call_log: list[datetime] = []
+
+        class TimeDriftingDatetime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                # Each call advances by 12 hours to simulate worst-case drift across the day boundary
+                value = fake_now + timedelta(hours=12 * len(call_log))
+                call_log.append(value)
+                return value
+
+        with patch(
+            "products.customer_analytics.backend.hogql_queries.usage_metrics_query_runner.datetime",
+            TimeDriftingDatetime,
+        ):
+            runner = UsageMetricsQueryRunner(
+                team=self.team,
+                query=UsageMetricsQuery(kind="UsageMetricsQuery", person_id=str(self.person.uuid)),
+            )
+            query_result = runner.calculate().model_dump()
+
+        self.assertEqual(len(call_log), 1)
+        results = query_result["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["value"], 1.0)

--- a/products/customer_analytics/backend/hogql_queries/usage_metrics_query_runner.py
+++ b/products/customer_analytics/backend/hogql_queries/usage_metrics_query_runner.py
@@ -1,12 +1,11 @@
-from datetime import datetime, timedelta
+from collections import defaultdict
+from datetime import date, datetime, timedelta
 from functools import cached_property
 from zoneinfo import ZoneInfo
 
 from posthog.schema import CachedUsageMetricsQueryResponse, UsageMetric, UsageMetricsQuery, UsageMetricsQueryResponse
 
 from posthog.hogql import ast
-from posthog.hogql.database.models import UnknownDatabaseField
-from posthog.hogql.parser import parse_select
 
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.models.group_usage_metric import GroupUsageMetric
@@ -35,40 +34,62 @@ class UsageMetricsQueryRunner(AnalyticsQueryRunner[UsageMetricsQueryResponse]):
     def _calculate(self):
         from posthog.hogql.query import execute_hogql_query
 
-        with self.timings.measure("usage_metrics_query_hogql_execute"):
-            response = execute_hogql_query(
-                query_type="usage_metrics_query",
-                query=self.to_query(),
-                team=self.team,
-                timings=self.timings,
-                modifiers=self.modifiers,
-            )
+        interval_groups = self._group_metrics_by_interval(self._usage_metrics)
 
-        with self.timings.measure("post_processing_query_results"):
-            if not response.columns or not response.results:
-                # Check is here so that mypy is happy
-                results = []
-            else:
-                results = [UsageMetric.model_validate(dict(zip(response.columns, row))) for row in response.results]
-            results.sort(key=lambda x: x.name, reverse=True)
+        if not interval_groups:
+            return UsageMetricsQueryResponse(results=[], modifiers=self.modifiers)
+
+        date_to = datetime.now(tz=ZoneInfo("UTC"))
+        all_results: list[UsageMetric] = []
+        last_hogql: str | None = None
+        all_timings = list(self.timings.to_list())
+
+        for interval, group in interval_groups.items():
+            query = self._build_interval_group_query(interval, group, date_to=date_to)
+
+            with self.timings.measure(f"usage_metrics_interval_{interval}_execute"):
+                response = execute_hogql_query(
+                    query_type="usage_metrics_query",
+                    query=query,
+                    team=self.team,
+                    timings=self.timings,
+                    modifiers=self.modifiers,
+                )
+
+            last_hogql = response.hogql
+            if response.timings:
+                all_timings.extend(response.timings)
+
+            with self.timings.measure(f"usage_metrics_interval_{interval}_post_process"):
+                results = self._process_group_results(response, interval, group, date_to=date_to)
+                all_results.extend(results)
+
+        all_results.sort(key=lambda x: x.name, reverse=True)
 
         return UsageMetricsQueryResponse(
-            results=results,
-            timings=response.timings,
-            hogql=response.hogql,
+            results=all_results,
+            timings=all_timings or None,
+            hogql=last_hogql,
             modifiers=self.modifiers,
         )
 
     def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
-        metric_queries: list[ast.SelectQuery | ast.SelectSetQuery] = [
-            query for metric in self._usage_metrics if (query := self._get_metric_query(metric)) is not None
+        interval_groups = self._group_metrics_by_interval(self._usage_metrics)
+
+        if not interval_groups:
+            from posthog.hogql.database.models import UnknownDatabaseField
+
+            return ast.SelectQuery.empty(columns={"day": UnknownDatabaseField(name="day")})
+
+        date_to = datetime.now(tz=ZoneInfo("UTC"))
+        queries = [
+            self._build_interval_group_query(interval, group, date_to=date_to)
+            for interval, group in interval_groups.items()
         ]
 
-        if not metric_queries:
-            columns = ["id", "name", "format", "display", "interval", "value", "previous", "change_from_previous_pct"]
-            return ast.SelectQuery.empty(columns={key: UnknownDatabaseField(name=key) for key in columns})
-
-        return ast.SelectSetQuery.create_from_queries(queries=metric_queries, set_operator="UNION ALL")
+        if len(queries) == 1:
+            return queries[0]
+        return ast.SelectSetQuery.create_from_queries(queries=queries, set_operator="UNION ALL")
 
     @cached_property
     def _usage_metrics(self) -> list[GroupUsageMetric]:
@@ -85,106 +106,171 @@ class UsageMetricsQueryRunner(AnalyticsQueryRunner[UsageMetricsQueryResponse]):
                 )
             )
 
-    def _get_metric_query(self, metric: GroupUsageMetric) -> ast.SelectQuery | ast.SelectSetQuery | None:
-        with self.timings.measure("get_metric_query"):
-            filter_expr = metric.get_expr()
+    def _group_metrics_by_interval(
+        self, metrics: list[GroupUsageMetric]
+    ) -> dict[int, list[tuple[GroupUsageMetric, ast.Expr]]]:
+        groups: dict[int, list[tuple[GroupUsageMetric, ast.Expr]]] = defaultdict(list)
+        for metric in metrics:
+            if metric.math == GroupUsageMetric.Math.SUM and not metric.math_property:
+                continue
+            with self.timings.measure("get_metric_filter_expr"):
+                filter_expr = metric.get_expr()
             if filter_expr == ast.Constant(value=True):
-                return None
+                continue
+            groups[metric.interval].append((metric, filter_expr))
+        return dict(groups)
 
-            where_expr = ast.And(exprs=[self._get_entity_filter(), *self._get_date_filter(metric=metric), filter_expr])
-            date_to = datetime.now(tz=ZoneInfo("UTC"))
-            date_from = date_to - timedelta(days=metric.interval)
-            prev_date_from = date_to - 2 * timedelta(days=metric.interval)
-            agg_exprs = self._build_aggregation_exprs(metric, date_from, date_to, prev_date_from)
-            if agg_exprs is None:
-                return None
-            value_expr, previous_expr = agg_exprs
+    def _build_interval_group_query(
+        self, interval: int, group: list[tuple[GroupUsageMetric, ast.Expr]], date_to: datetime
+    ) -> ast.SelectQuery:
+        date_from = date_to - timedelta(days=interval)
+        prev_date_from = date_to - 2 * timedelta(days=interval)
 
-        return parse_select(
-            """
-            SELECT
-                *,
-                if(previous > 0, ((value - previous) / previous) * 100, NULL) as change_from_previous_pct
-            FROM (
-                SELECT
-                    {id} as id,
-                    {name} as name,
-                    {format} as format,
-                    {display} as display,
-                    {interval} as interval,
-                    {value_expr} as value,
-                    {previous_expr} as previous
-                FROM events
-                WHERE {where_expr}
+        current_condition = self._build_period_condition(date_from, date_to)
+        previous_condition = self._build_period_condition(prev_date_from, date_from, upper_exclusive=True)
+
+        select_exprs: list[ast.Expr] = [
+            ast.Alias(
+                alias="day",
+                expr=ast.Call(
+                    name="toStartOfDay",
+                    args=[
+                        ast.Call(name="toTimeZone", args=[ast.Field(chain=["timestamp"]), ast.Constant(value="UTC")])
+                    ],
+                ),
+            ),
+        ]
+
+        for i, (metric, filter_expr) in enumerate(group):
+            value_expr, prev_expr = self._build_conditional_aggregation(
+                metric, filter_expr, current_condition, previous_condition
             )
-        """,
-            placeholders={
-                "id": ast.Constant(value=str(metric.id)),
-                "name": ast.Constant(value=metric.name),
-                "format": ast.Constant(value=metric.format),
-                "display": ast.Constant(value=metric.display),
-                "interval": ast.Constant(value=metric.interval),
-                "where_expr": where_expr,
-                "value_expr": value_expr,
-                "previous_expr": previous_expr,
-            },
+            select_exprs.append(ast.Alias(alias=f"m{i}_value", expr=value_expr))
+            select_exprs.append(ast.Alias(alias=f"m{i}_previous", expr=prev_expr))
+
+        where_exprs: list[ast.Expr] = [
+            self._get_entity_filter(),
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.GtEq,
+                left=ast.Field(chain=["timestamp"]),
+                right=ast.Constant(value=prev_date_from),
+            ),
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.LtEq,
+                left=ast.Field(chain=["timestamp"]),
+                right=ast.Constant(value=date_to),
+            ),
+        ]
+
+        return ast.SelectQuery(
+            select=select_exprs,
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=ast.And(exprs=where_exprs),
+            group_by=[ast.Field(chain=["day"])],
+            order_by=[ast.OrderExpr(expr=ast.Field(chain=["day"]), order="ASC")],
         )
 
-    def _build_aggregation_exprs(
+    def _build_period_condition(
+        self, period_from: datetime, period_to: datetime, upper_exclusive: bool = False
+    ) -> ast.Expr:
+        upper_op = ast.CompareOperationOp.Lt if upper_exclusive else ast.CompareOperationOp.LtEq
+        return ast.And(
+            exprs=[
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.GtEq,
+                    left=ast.Field(chain=["timestamp"]),
+                    right=ast.Constant(value=period_from),
+                ),
+                ast.CompareOperation(
+                    op=upper_op,
+                    left=ast.Field(chain=["timestamp"]),
+                    right=ast.Constant(value=period_to),
+                ),
+            ]
+        )
+
+    def _build_conditional_aggregation(
         self,
         metric: GroupUsageMetric,
-        date_from: datetime,
-        date_to: datetime,
-        prev_date_from: datetime,
-    ) -> tuple[ast.Expr, ast.Expr] | None:
-        current_condition = ast.And(
-            exprs=[
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.GtEq,
-                    left=ast.Field(chain=["timestamp"]),
-                    right=ast.Constant(value=date_from),
-                ),
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.LtEq,
-                    left=ast.Field(chain=["timestamp"]),
-                    right=ast.Constant(value=date_to),
-                ),
-            ]
-        )
-        previous_condition = ast.And(
-            exprs=[
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.GtEq,
-                    left=ast.Field(chain=["timestamp"]),
-                    right=ast.Constant(value=prev_date_from),
-                ),
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.Lt,
-                    left=ast.Field(chain=["timestamp"]),
-                    right=ast.Constant(value=date_from),
-                ),
-            ]
-        )
+        filter_expr: ast.Expr,
+        current_condition: ast.Expr,
+        previous_condition: ast.Expr,
+    ) -> tuple[ast.Expr, ast.Expr]:
+        current_cond = ast.And(exprs=[filter_expr, current_condition])
+        previous_cond = ast.And(exprs=[filter_expr, previous_condition])
 
         if metric.math == GroupUsageMetric.Math.SUM:
-            if not metric.math_property:
-                return None
             prop_as_float = ast.Call(name="toFloat", args=[ast.Field(chain=["properties", metric.math_property])])
             return (
                 ast.Call(
                     name="ifNull",
-                    args=[ast.Call(name="sumIf", args=[prop_as_float, current_condition]), ast.Constant(value=0)],
+                    args=[ast.Call(name="sumIf", args=[prop_as_float, current_cond]), ast.Constant(value=0)],
                 ),
                 ast.Call(
                     name="ifNull",
-                    args=[ast.Call(name="sumIf", args=[prop_as_float, previous_condition]), ast.Constant(value=0)],
+                    args=[ast.Call(name="sumIf", args=[prop_as_float, previous_cond]), ast.Constant(value=0)],
                 ),
             )
 
         return (
-            ast.Call(name="toFloat", args=[ast.Call(name="countIf", args=[current_condition])]),
-            ast.Call(name="toFloat", args=[ast.Call(name="countIf", args=[previous_condition])]),
+            ast.Call(name="toFloat", args=[ast.Call(name="countIf", args=[current_cond])]),
+            ast.Call(name="toFloat", args=[ast.Call(name="countIf", args=[previous_cond])]),
         )
+
+    def _process_group_results(
+        self,
+        response,
+        interval: int,
+        group: list[tuple[GroupUsageMetric, ast.Expr]],
+        date_to: datetime,
+    ) -> list[UsageMetric]:
+        date_from = date_to - timedelta(days=interval)
+        prev_date_from = date_to - 2 * timedelta(days=interval)
+
+        rows_by_day: dict[date, list] = {}
+        if response.results:
+            for row in response.results:
+                day = row[0]
+                if isinstance(day, datetime):
+                    day = day.date()
+                rows_by_day[day] = list(row[1:])
+
+        num_metric_cols = len(group) * 2
+        current_dates = self._date_range(date_from.date(), date_to.date())
+        previous_dates = self._date_range(prev_date_from.date(), (date_from - timedelta(seconds=1)).date())
+
+        results: list[UsageMetric] = []
+        for i, (metric, _filter_expr) in enumerate(group):
+            value_col = i * 2
+            prev_col = i * 2 + 1
+
+            zero_row = [0.0] * num_metric_cols
+            current_daily = [float(rows_by_day.get(d, zero_row)[value_col]) for d in current_dates]
+            previous_daily = [float(rows_by_day.get(d, zero_row)[prev_col]) for d in previous_dates]
+
+            total_value = sum(current_daily)
+            total_previous = sum(previous_daily)
+            change_pct = ((total_value - total_previous) / total_previous * 100) if total_previous > 0 else None
+
+            results.append(
+                UsageMetric(
+                    id=str(metric.id),
+                    name=metric.name,
+                    format=metric.format,
+                    display=metric.display,
+                    interval=metric.interval,
+                    value=total_value,
+                    previous=total_previous,
+                    change_from_previous_pct=change_pct,
+                )
+            )
+
+        return results
+
+    @staticmethod
+    def _date_range(start: date, end: date) -> list[date]:
+        num_days = (end - start).days + 1
+        return [start + timedelta(days=i) for i in range(max(0, num_days))]
 
     def _get_entity_filter(self) -> ast.CompareOperation:
         if self._is_group_query:
@@ -199,23 +285,6 @@ class UsageMetricsQueryRunner(AnalyticsQueryRunner[UsageMetricsQueryResponse]):
             left=ast.Field(chain=["person_id"]),
             right=ast.Constant(value=self.query.person_id),
         )
-
-    def _get_date_filter(self, metric: GroupUsageMetric) -> list[ast.CompareOperation]:
-        date_to = datetime.now(tz=ZoneInfo("UTC"))
-        date_from = date_to - 2 * timedelta(days=metric.interval)
-
-        return [
-            ast.CompareOperation(
-                op=ast.CompareOperationOp.GtEq,
-                left=ast.Field(chain=["timestamp"]),
-                right=ast.Constant(value=date_from),
-            ),
-            ast.CompareOperation(
-                op=ast.CompareOperationOp.LtEq,
-                left=ast.Field(chain=["timestamp"]),
-                right=ast.Constant(value=date_to),
-            ),
-        ]
 
     def get_cache_payload(self) -> dict:
         """

--- a/products/customer_analytics/backend/hogql_queries/usage_metrics_query_runner.py
+++ b/products/customer_analytics/backend/hogql_queries/usage_metrics_query_runner.py
@@ -1,11 +1,10 @@
-from datetime import datetime, timedelta
+from collections import defaultdict
+from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from posthog.schema import CachedUsageMetricsQueryResponse, UsageMetric, UsageMetricsQuery, UsageMetricsQueryResponse
 
 from posthog.hogql import ast
-from posthog.hogql.database.models import UnknownDatabaseField
-from posthog.hogql.parser import parse_select
 
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.models.group_usage_metric import GroupUsageMetric
@@ -34,40 +33,61 @@ class UsageMetricsQueryRunner(AnalyticsQueryRunner[UsageMetricsQueryResponse]):
     def _calculate(self):
         from posthog.hogql.query import execute_hogql_query
 
-        with self.timings.measure("usage_metrics_query_hogql_execute"):
-            response = execute_hogql_query(
-                query_type="usage_metrics_query",
-                query=self.to_query(),
-                team=self.team,
-                timings=self.timings,
-                modifiers=self.modifiers,
-            )
+        metrics = self._get_usage_metrics()
+        interval_groups = self._group_metrics_by_interval(metrics)
 
-        with self.timings.measure("post_processing_query_results"):
-            if not response.columns or not response.results:
-                # Check is here so that mypy is happy
-                results = []
-            else:
-                results = [UsageMetric.model_validate(dict(zip(response.columns, row))) for row in response.results]
-            results.sort(key=lambda x: x.name, reverse=True)
+        if not interval_groups:
+            return UsageMetricsQueryResponse(results=[], modifiers=self.modifiers)
+
+        all_results: list[UsageMetric] = []
+        last_hogql: str | None = None
+        all_timings = list(self.timings.to_list())
+
+        for interval, group in interval_groups.items():
+            query = self._build_interval_group_query(interval, group)
+
+            with self.timings.measure(f"usage_metrics_interval_{interval}_execute"):
+                response = execute_hogql_query(
+                    query_type="usage_metrics_query",
+                    query=query,
+                    team=self.team,
+                    timings=self.timings,
+                    modifiers=self.modifiers,
+                )
+
+            last_hogql = response.hogql
+            if response.timings:
+                all_timings.extend(response.timings)
+
+            with self.timings.measure(f"usage_metrics_interval_{interval}_post_process"):
+                results = self._process_group_results(response, interval, group)
+                all_results.extend(results)
+
+        all_results.sort(key=lambda x: x.name, reverse=True)
 
         return UsageMetricsQueryResponse(
-            results=results,
-            timings=response.timings,
-            hogql=response.hogql,
+            results=all_results,
+            timings=all_timings or None,
+            hogql=last_hogql,
             modifiers=self.modifiers,
         )
 
     def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
-        metric_queries: list[ast.SelectQuery | ast.SelectSetQuery] = [
-            query for metric in self._get_usage_metrics() if (query := self._get_metric_query(metric)) is not None
-        ]
+        """Returns a representative query for debugging/explain purposes."""
+        metrics = self._get_usage_metrics()
+        interval_groups = self._group_metrics_by_interval(metrics)
 
-        if not metric_queries:
-            columns = ["id", "name", "format", "display", "interval", "value", "previous", "change_from_previous_pct"]
+        if not interval_groups:
+            columns = ["day"]
+            from posthog.hogql.database.models import UnknownDatabaseField
+
             return ast.SelectQuery.empty(columns={key: UnknownDatabaseField(name=key) for key in columns})
 
-        return ast.SelectSetQuery.create_from_queries(queries=metric_queries, set_operator="UNION ALL")
+        queries = [self._build_interval_group_query(interval, group) for interval, group in interval_groups.items()]
+
+        if len(queries) == 1:
+            return queries[0]
+        return ast.SelectSetQuery.create_from_queries(queries=queries, set_operator="UNION ALL")
 
     def _get_usage_metrics(self) -> list[GroupUsageMetric]:
         """
@@ -83,101 +103,170 @@ class UsageMetricsQueryRunner(AnalyticsQueryRunner[UsageMetricsQueryResponse]):
                 )
             )
 
-    def _get_metric_query(self, metric: GroupUsageMetric) -> ast.SelectQuery | ast.SelectSetQuery | None:
-        with self.timings.measure("get_metric_query"):
-            filter_expr = metric.get_expr()
+    def _group_metrics_by_interval(
+        self, metrics: list[GroupUsageMetric]
+    ) -> dict[int, list[tuple[GroupUsageMetric, ast.Expr]]]:
+        groups: dict[int, list[tuple[GroupUsageMetric, ast.Expr]]] = defaultdict(list)
+        for metric in metrics:
+            with self.timings.measure("get_metric_filter_expr"):
+                filter_expr = metric.get_expr()
             if filter_expr == ast.Constant(value=True):
-                return None
+                continue
+            groups[metric.interval].append((metric, filter_expr))
+        return dict(groups)
 
-            where_expr = ast.And(exprs=[self._get_entity_filter(), *self._get_date_filter(metric=metric), filter_expr])
-            date_to = datetime.now(tz=ZoneInfo("UTC"))
-            date_from = date_to - timedelta(days=metric.interval)
-            prev_date_from = date_to - 2 * timedelta(days=metric.interval)
-            value_expr, previous_expr = self._build_aggregation_exprs(metric, date_from, date_to, prev_date_from)
+    def _build_interval_group_query(
+        self, interval: int, group: list[tuple[GroupUsageMetric, ast.Expr]]
+    ) -> ast.SelectQuery:
+        date_to = datetime.now(tz=ZoneInfo("UTC"))
+        date_from = date_to - timedelta(days=interval)
+        prev_date_from = date_to - 2 * timedelta(days=interval)
 
-        return parse_select(
-            """
-            SELECT
-                *,
-                if(previous > 0, ((value - previous) / previous) * 100, NULL) as change_from_previous_pct
-            FROM (
-                SELECT
-                    {id} as id,
-                    {name} as name,
-                    {format} as format,
-                    {display} as display,
-                    {interval} as interval,
-                    {value_expr} as value,
-                    {previous_expr} as previous
-                FROM events
-                WHERE {where_expr}
+        current_condition = self._build_period_condition(date_from, date_to)
+        previous_condition = self._build_period_condition(prev_date_from, date_from, upper_exclusive=True)
+
+        select_exprs: list[ast.Expr] = [
+            ast.Alias(
+                alias="day",
+                expr=ast.Call(
+                    name="toStartOfDay",
+                    args=[
+                        ast.Call(name="toTimeZone", args=[ast.Field(chain=["timestamp"]), ast.Constant(value="UTC")])
+                    ],
+                ),
+            ),
+        ]
+
+        for i, (metric, filter_expr) in enumerate(group):
+            value_expr, prev_expr = self._build_conditional_aggregation(
+                metric, filter_expr, current_condition, previous_condition
             )
-        """,
-            placeholders={
-                "id": ast.Constant(value=str(metric.id)),
-                "name": ast.Constant(value=metric.name),
-                "format": ast.Constant(value=metric.format),
-                "display": ast.Constant(value=metric.display),
-                "interval": ast.Constant(value=metric.interval),
-                "where_expr": where_expr,
-                "value_expr": value_expr,
-                "previous_expr": previous_expr,
-            },
+            select_exprs.append(ast.Alias(alias=f"m{i}_value", expr=value_expr))
+            select_exprs.append(ast.Alias(alias=f"m{i}_previous", expr=prev_expr))
+
+        where_exprs: list[ast.Expr] = [
+            self._get_entity_filter(),
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.GtEq,
+                left=ast.Field(chain=["timestamp"]),
+                right=ast.Constant(value=prev_date_from),
+            ),
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.LtEq,
+                left=ast.Field(chain=["timestamp"]),
+                right=ast.Constant(value=date_to),
+            ),
+        ]
+
+        return ast.SelectQuery(
+            select=select_exprs,
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=ast.And(exprs=where_exprs),
+            group_by=[ast.Field(chain=["day"])],
+            order_by=[ast.OrderExpr(expr=ast.Field(chain=["day"]), order="ASC")],
         )
 
-    def _build_aggregation_exprs(
+    def _build_period_condition(
+        self, period_from: datetime, period_to: datetime, upper_exclusive: bool = False
+    ) -> ast.Expr:
+        upper_op = ast.CompareOperationOp.Lt if upper_exclusive else ast.CompareOperationOp.LtEq
+        return ast.And(
+            exprs=[
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.GtEq,
+                    left=ast.Field(chain=["timestamp"]),
+                    right=ast.Constant(value=period_from),
+                ),
+                ast.CompareOperation(
+                    op=upper_op,
+                    left=ast.Field(chain=["timestamp"]),
+                    right=ast.Constant(value=period_to),
+                ),
+            ]
+        )
+
+    def _build_conditional_aggregation(
         self,
         metric: GroupUsageMetric,
-        date_from: datetime,
-        date_to: datetime,
-        prev_date_from: datetime,
+        filter_expr: ast.Expr,
+        current_condition: ast.Expr,
+        previous_condition: ast.Expr,
     ) -> tuple[ast.Expr, ast.Expr]:
-        current_condition = ast.And(
-            exprs=[
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.GtEq,
-                    left=ast.Field(chain=["timestamp"]),
-                    right=ast.Constant(value=date_from),
-                ),
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.LtEq,
-                    left=ast.Field(chain=["timestamp"]),
-                    right=ast.Constant(value=date_to),
-                ),
-            ]
-        )
-        previous_condition = ast.And(
-            exprs=[
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.GtEq,
-                    left=ast.Field(chain=["timestamp"]),
-                    right=ast.Constant(value=prev_date_from),
-                ),
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.Lt,
-                    left=ast.Field(chain=["timestamp"]),
-                    right=ast.Constant(value=date_from),
-                ),
-            ]
-        )
+        current_cond = ast.And(exprs=[filter_expr, current_condition])
+        previous_cond = ast.And(exprs=[filter_expr, previous_condition])
 
         if metric.math == GroupUsageMetric.Math.SUM:
             prop_as_float = ast.Call(name="toFloat", args=[ast.Field(chain=["properties", metric.math_property])])
             return (
                 ast.Call(
                     name="ifNull",
-                    args=[ast.Call(name="sumIf", args=[prop_as_float, current_condition]), ast.Constant(value=0)],
+                    args=[ast.Call(name="sumIf", args=[prop_as_float, current_cond]), ast.Constant(value=0)],
                 ),
                 ast.Call(
                     name="ifNull",
-                    args=[ast.Call(name="sumIf", args=[prop_as_float, previous_condition]), ast.Constant(value=0)],
+                    args=[ast.Call(name="sumIf", args=[prop_as_float, previous_cond]), ast.Constant(value=0)],
                 ),
             )
 
         return (
-            ast.Call(name="toFloat", args=[ast.Call(name="countIf", args=[current_condition])]),
-            ast.Call(name="toFloat", args=[ast.Call(name="countIf", args=[previous_condition])]),
+            ast.Call(name="toFloat", args=[ast.Call(name="countIf", args=[current_cond])]),
+            ast.Call(name="toFloat", args=[ast.Call(name="countIf", args=[previous_cond])]),
         )
+
+    def _process_group_results(
+        self,
+        response,
+        interval: int,
+        group: list[tuple[GroupUsageMetric, ast.Expr]],
+    ) -> list[UsageMetric]:
+        date_to = datetime.now(tz=ZoneInfo("UTC"))
+        date_from = date_to - timedelta(days=interval)
+        prev_date_from = date_to - 2 * timedelta(days=interval)
+
+        rows_by_day: dict[date, list] = {}
+        if response.results:
+            for row in response.results:
+                day = row[0]
+                if isinstance(day, datetime):
+                    day = day.date()
+                rows_by_day[day] = list(row[1:])
+
+        num_metric_cols = len(group) * 2
+        current_dates = self._date_range(date_from.date(), date_to.date())
+        previous_dates = self._date_range(prev_date_from.date(), (date_from - timedelta(seconds=1)).date())
+
+        results: list[UsageMetric] = []
+        for i, (metric, _filter_expr) in enumerate(group):
+            value_col = i * 2
+            prev_col = i * 2 + 1
+
+            zero_row = [0.0] * num_metric_cols
+            current_daily = [float(rows_by_day.get(d, zero_row)[value_col]) for d in current_dates]
+            previous_daily = [float(rows_by_day.get(d, zero_row)[prev_col]) for d in previous_dates]
+
+            total_value = sum(current_daily)
+            total_previous = sum(previous_daily)
+            change_pct = ((total_value - total_previous) / total_previous * 100) if total_previous > 0 else None
+
+            results.append(
+                UsageMetric(
+                    id=str(metric.id),
+                    name=metric.name,
+                    format=metric.format,
+                    display=metric.display,
+                    interval=metric.interval,
+                    value=total_value,
+                    previous=total_previous,
+                    change_from_previous_pct=change_pct,
+                )
+            )
+
+        return results
+
+    @staticmethod
+    def _date_range(start: date, end: date) -> list[date]:
+        num_days = (end - start).days + 1
+        return [start + timedelta(days=i) for i in range(max(0, num_days))]
 
     def _get_entity_filter(self) -> ast.CompareOperation:
         if self._is_group_query:
@@ -192,23 +281,6 @@ class UsageMetricsQueryRunner(AnalyticsQueryRunner[UsageMetricsQueryResponse]):
             left=ast.Field(chain=["person_id"]),
             right=ast.Constant(value=self.query.person_id),
         )
-
-    def _get_date_filter(self, metric: GroupUsageMetric) -> list[ast.CompareOperation]:
-        date_to = datetime.now(tz=ZoneInfo("UTC"))
-        date_from = date_to - 2 * timedelta(days=metric.interval)
-
-        return [
-            ast.CompareOperation(
-                op=ast.CompareOperationOp.GtEq,
-                left=ast.Field(chain=["timestamp"]),
-                right=ast.Constant(value=date_from),
-            ),
-            ast.CompareOperation(
-                op=ast.CompareOperationOp.LtEq,
-                left=ast.Field(chain=["timestamp"]),
-                right=ast.Constant(value=date_to),
-            ),
-        ]
 
     def get_cache_payload(self) -> dict:
         """


### PR DESCRIPTION
## Problem

The usage metrics query runner generated one `SELECT` per metric, UNION ALL'd together, each independently scanning the events table. With multiple metrics configured, this meant redundant scans of the same data — all metrics for a given entity (person/group) share the same base filter.

## Changes

- Refactored query runner to group metrics by interval and build one query per interval group using `countIf`/`sumIf` conditional aggregation
- Daily bucketing with `toStartOfDay` + gap-filling in Python, replacing per-metric `parse_select` template queries
- Single events table scan per interval group instead of per-metric UNION ALL

## How did you test this code?

Existing test suite passes with updated snapshots confirming the new query structure. `hogli test products/customer_analytics/backend/hogql_queries/test/test_usage_metrics_query_runner.py` — 25 tests pass.

## Publish to changelog?

No

## Docs update

## 🤖 LLM context

Authored by PostHog Code (Claude Code).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*