### PR TITLE
fix(replay): remove ORDER BY from delete-recordings visibility query

### DIFF
--- a/posthog/admin/admins/team_admin.py
+++ b/posthog/admin/admins/team_admin.py
@@ -616,7 +616,7 @@ class TeamAdmin(admin.ModelAdmin):
                 "delete-recordings-with-session-ids",
             ]
             type_clauses = " OR ".join(f'WorkflowType = "{wt}"' for wt in workflow_types)
-            query = f"PostHogTeamId = {team_id} AND ({type_clauses}) ORDER BY StartTime DESC"
+            query = f"PostHogTeamId = {team_id} AND ({type_clauses})"
 
             async def fetch_workflows():
                 workflows = []

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -451,6 +451,7 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
+    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',


### PR DESCRIPTION
## Problem

Follow-up to #54318. The Temporal visibility query added in that PR includes `ORDER BY StartTime DESC`, which Temporal Cloud doesn't support. The query fails silently (caught by the exception handler which returns `[]`), so the workflows table on the delete-recordings admin page is always empty.

## Changes

Remove `ORDER BY StartTime DESC` from the visibility query. Temporal returns results in reverse chronological order by default.

Verified the query works against prod US:
```
temporal workflow list --env prod-us \
  --query 'PostHogTeamId = 2 AND WorkflowType = "delete-recordings-with-session-ids"' \
  --limit 5
```

## How did you test this code?

Tested the query directly against Temporal Cloud prod-us and confirmed it returns the expected workflow.

## Publish to changelog?

No