### PR TITLE
feat(visual-review): overhaul UI to match PostHog design language

### DIFF
--- a/products/visual_review/frontend/components/RunStatusBadge.tsx
+++ b/products/visual_review/frontend/components/RunStatusBadge.tsx
@@ -11,9 +11,22 @@ const STATUS_CONFIG: Record<RunStatus, { label: string; type: LemonTagType }> = 
 
 interface RunStatusBadgeProps {
     status: string
+    hasUnapprovedChanges?: boolean
+    approved?: boolean
 }
 
-export function RunStatusBadge({ status }: RunStatusBadgeProps): JSX.Element {
+export function RunStatusBadge({ status, hasUnapprovedChanges, approved }: RunStatusBadgeProps): JSX.Element {
+    // When the pipeline is done, show the review-relevant status
+    if (status === 'completed') {
+        if (hasUnapprovedChanges) {
+            return <LemonTag type="warning">Needs review</LemonTag>
+        }
+        if (approved) {
+            return <LemonTag type="success">Approved</LemonTag>
+        }
+        return <LemonTag type="success">Clean</LemonTag>
+    }
+
     const config = STATUS_CONFIG[status as RunStatus] || { label: status, type: 'default' as LemonTagType }
     return <LemonTag type={config.type}>{config.label}</LemonTag>
 }

--- a/products/visual_review/frontend/components/RunStatusBadge.tsx
+++ b/products/visual_review/frontend/components/RunStatusBadge.tsx
@@ -11,22 +11,9 @@ const STATUS_CONFIG: Record<RunStatus, { label: string; type: LemonTagType }> = 
 
 interface RunStatusBadgeProps {
     status: string
-    hasUnapprovedChanges?: boolean
-    approved?: boolean
 }
 
-export function RunStatusBadge({ status, hasUnapprovedChanges, approved }: RunStatusBadgeProps): JSX.Element {
-    // When the pipeline is done, show the review-relevant status
-    if (status === 'completed') {
-        if (hasUnapprovedChanges) {
-            return <LemonTag type="warning">Needs review</LemonTag>
-        }
-        if (approved) {
-            return <LemonTag type="success">Approved</LemonTag>
-        }
-        return <LemonTag type="success">Clean</LemonTag>
-    }
-
+export function RunStatusBadge({ status }: RunStatusBadgeProps): JSX.Element {
     const config = STATUS_CONFIG[status as RunStatus] || { label: status, type: 'default' as LemonTagType }
     return <LemonTag type={config.type}>{config.label}</LemonTag>
 }

--- a/products/visual_review/frontend/components/RunSummaryStats.tsx
+++ b/products/visual_review/frontend/components/RunSummaryStats.tsx
@@ -1,3 +1,5 @@
+import { LemonTag } from '@posthog/lemon-ui'
+
 import type { RunSummaryApi } from '../generated/api.schemas'
 
 interface RunSummaryStatsProps {
@@ -9,41 +11,38 @@ export function RunSummaryStats({ summary, compact }: RunSummaryStatsProps): JSX
     const hasChanges = summary.changed > 0 || summary.new > 0 || summary.removed > 0
 
     if (compact) {
-        // Build secondary breakdown (new/removed only)
-        const secondaryParts: string[] = []
-        if (summary.new > 0) {
-            secondaryParts.push(`${summary.new} new`)
-        }
-        if (summary.removed > 0) {
-            secondaryParts.push(`${summary.removed} removed`)
-        }
-
-        const hasChanged = summary.changed > 0
-
         return (
-            <div className="flex flex-col gap-0.5 min-w-[100px]">
-                {/* Primary: changed count (dominant) */}
-                <div className={hasChanged ? 'text-warning-dark' : 'text-muted'}>
-                    <span className="text-base font-semibold">{summary.changed}</span>
-                    <span className="text-xs ml-1">changed</span>
-                </div>
-
-                {/* Secondary: new/removed breakdown (subordinate) */}
-                {secondaryParts.length > 0 ? (
-                    <div className="text-xs text-muted">{secondaryParts.join(' · ')}</div>
-                ) : !hasChanges ? (
-                    <div className="text-xs text-muted">no diffs</div>
-                ) : null}
+            <div className="flex items-center gap-1">
+                {summary.changed > 0 && (
+                    <LemonTag type="warning" size="small">
+                        {summary.changed} changed
+                    </LemonTag>
+                )}
+                {summary.new > 0 && (
+                    <LemonTag type="highlight" size="small">
+                        {summary.new} new
+                    </LemonTag>
+                )}
+                {summary.removed > 0 && (
+                    <LemonTag type="danger" size="small">
+                        {summary.removed} removed
+                    </LemonTag>
+                )}
+                {!hasChanges && (
+                    <LemonTag type="muted" size="small">
+                        no changes
+                    </LemonTag>
+                )}
             </div>
         )
     }
 
     return (
-        <div className="flex gap-3 text-sm">
-            {summary.changed > 0 && <span className="text-warning-dark font-medium">{summary.changed} changed</span>}
-            {summary.new > 0 && <span className="text-success font-medium">{summary.new} new</span>}
-            {summary.removed > 0 && <span className="text-danger font-medium">{summary.removed} removed</span>}
-            <span className="text-muted">{summary.unchanged} unchanged</span>
+        <div className="flex items-center gap-1.5">
+            {summary.changed > 0 && <LemonTag type="warning">{summary.changed} changed</LemonTag>}
+            {summary.new > 0 && <LemonTag type="highlight">{summary.new} new</LemonTag>}
+            {summary.removed > 0 && <LemonTag type="danger">{summary.removed} removed</LemonTag>}
+            <LemonTag type="muted">{summary.unchanged} unchanged</LemonTag>
         </div>
     )
 }

--- a/products/visual_review/frontend/components/SnapshotDiffViewer.tsx
+++ b/products/visual_review/frontend/components/SnapshotDiffViewer.tsx
@@ -1,8 +1,7 @@
-import { IconCheck, IconChevronLeft, IconChevronRight } from '@posthog/icons'
-import { LemonButton, LemonSkeleton } from '@posthog/lemon-ui'
+import { IconCheck, IconChevronLeft, IconChevronRight, IconGithub } from '@posthog/icons'
+import { LemonButton, LemonSkeleton, LemonTag, Link } from '@posthog/lemon-ui'
 
 import { VisualImageDiffViewer, type VisualDiffResult } from 'lib/components/VisualImageDiffViewer'
-import { humanFriendlyDetailedTime } from 'lib/utils'
 
 import type { SnapshotApi, SnapshotHistoryEntryApi } from '../generated/api.schemas'
 
@@ -17,6 +16,9 @@ interface SnapshotDiffViewerProps {
     hasNext?: boolean
     currentIndex?: number
     totalCount?: number
+    commitSha?: string
+    prNumber?: number | null
+    repoFullName?: string | null
 }
 
 export function SnapshotDiffViewer({
@@ -30,6 +32,9 @@ export function SnapshotDiffViewer({
     hasNext = false,
     currentIndex,
     totalCount,
+    commitSha,
+    prNumber,
+    repoFullName,
 }: SnapshotDiffViewerProps): JSX.Element {
     const baselineUrl = snapshot.baseline_artifact?.download_url
     const currentUrl = snapshot.current_artifact?.download_url
@@ -46,9 +51,9 @@ export function SnapshotDiffViewer({
     const variant = parts.slice(1).join(' · ')
 
     return (
-        <div className="flex gap-6">
+        <div className="flex gap-4">
             {/* Main content area */}
-            <div className="flex-1 min-w-0">
+            <div className="flex-1 min-w-0 overflow-hidden">
                 {/* Header */}
                 <div className="flex items-center gap-2 mb-4">
                     <h3 className="text-lg font-semibold capitalize">{pageName}</h3>
@@ -104,69 +109,105 @@ export function SnapshotDiffViewer({
                 </div>
             </div>
 
-            {/* Right sidebar */}
-            <div className="w-56 shrink-0">
-                <div className="border rounded-lg p-4 space-y-4">
-                    {width && height && (
-                        <div>
-                            <h4 className="text-xs font-semibold text-muted uppercase mb-1">Environment</h4>
-                            <p className="text-sm font-mono">
-                                {width}×{height}
-                            </p>
-                        </div>
-                    )}
-
-                    {isApproved && snapshot.reviewed_at && (
-                        <div>
-                            <h4 className="text-xs font-semibold text-muted uppercase mb-1">Approval</h4>
-                            <p className="text-sm text-success">
-                                {new Date(snapshot.reviewed_at).toLocaleDateString()}
-                            </p>
-                        </div>
-                    )}
-
-                    {/* Recent activity */}
-                    <div>
-                        <h4 className="text-xs font-semibold text-muted uppercase mb-2">Recent activity</h4>
-                        {snapshotHistoryLoading ? (
-                            <div className="space-y-2">
-                                <LemonSkeleton className="h-4 w-full" />
-                                <LemonSkeleton className="h-4 w-3/4" />
-                                <LemonSkeleton className="h-4 w-full" />
+            {/* Right sidebar — flat, no nested cards */}
+            <div className="w-52 shrink-0 border-l pl-4 space-y-4">
+                {/* Run context */}
+                {(commitSha || prNumber) && (
+                    <div className="space-y-2">
+                        {commitSha && (
+                            <div className="flex items-center justify-between text-xs">
+                                <span className="text-muted">Commit</span>
+                                {repoFullName ? (
+                                    <Link
+                                        to={`https://github.com/${repoFullName}/commit/${commitSha}`}
+                                        target="_blank"
+                                        className="flex items-center gap-1 font-mono hover:text-primary"
+                                    >
+                                        {commitSha.substring(0, 7)}
+                                        <IconGithub className="text-xs" />
+                                    </Link>
+                                ) : (
+                                    <span className="font-mono">{commitSha.substring(0, 7)}</span>
+                                )}
                             </div>
-                        ) : snapshotHistory && snapshotHistory.length > 0 ? (
-                            <div className="space-y-1.5">
-                                {snapshotHistory.map((entry) => (
-                                    <div key={entry.run_id} className="text-xs flex flex-col gap-0.5">
-                                        <div className="flex items-center justify-between">
-                                            <span className="font-mono text-muted">{entry.commit_sha.slice(0, 7)}</span>
-                                            <span
-                                                className={`font-medium capitalize ${
-                                                    entry.result === 'changed'
-                                                        ? 'text-warning-dark'
-                                                        : entry.result === 'new'
-                                                          ? 'text-primary-dark'
-                                                          : entry.result === 'removed'
-                                                            ? 'text-danger'
-                                                            : 'text-muted'
-                                                }`}
-                                            >
-                                                {entry.result}
-                                            </span>
-                                        </div>
-                                        <div className="flex items-center justify-between text-muted">
-                                            <span className="truncate max-w-[80px]">{entry.branch}</span>
-                                            <span>
-                                                {humanFriendlyDetailedTime(entry.created_at, 'MMM D', 'h:mm A')}
-                                            </span>
-                                        </div>
-                                    </div>
-                                ))}
+                        )}
+                        {prNumber && (
+                            <div className="flex items-center justify-between text-xs">
+                                <span className="text-muted">PR</span>
+                                {repoFullName ? (
+                                    <Link
+                                        to={`https://github.com/${repoFullName}/pull/${prNumber}`}
+                                        target="_blank"
+                                        className="flex items-center gap-1 hover:text-primary"
+                                    >
+                                        #{prNumber}
+                                        <IconGithub className="text-xs" />
+                                    </Link>
+                                ) : (
+                                    <span>#{prNumber}</span>
+                                )}
                             </div>
-                        ) : (
-                            <p className="text-xs text-muted">No history yet</p>
                         )}
                     </div>
+                )}
+
+                {/* Snapshot details */}
+                <div className="space-y-2">
+                    {width && height && (
+                        <div className="flex items-center justify-between text-xs">
+                            <span className="text-muted">Resolution</span>
+                            <span className="font-mono">
+                                {width}×{height}
+                            </span>
+                        </div>
+                    )}
+                    {snapshot.diff_percentage != null && snapshot.diff_percentage > 0 && (
+                        <div className="flex items-center justify-between text-xs">
+                            <span className="text-muted">Diff</span>
+                            <span className="font-mono">{snapshot.diff_percentage}%</span>
+                        </div>
+                    )}
+                    {isApproved && snapshot.reviewed_at && (
+                        <div className="flex items-center justify-between text-xs">
+                            <span className="text-muted">Approved</span>
+                            <span className="text-success">{new Date(snapshot.reviewed_at).toLocaleDateString()}</span>
+                        </div>
+                    )}
+                </div>
+
+                {/* Recent activity */}
+                <div>
+                    <h4 className="text-xs font-semibold text-muted mb-2">History</h4>
+                    {snapshotHistoryLoading ? (
+                        <div className="space-y-2">
+                            <LemonSkeleton className="h-4 w-full" />
+                            <LemonSkeleton className="h-4 w-3/4" />
+                        </div>
+                    ) : snapshotHistory && snapshotHistory.length > 0 ? (
+                        <div className="space-y-1.5">
+                            {snapshotHistory.map((entry) => (
+                                <div key={entry.run_id} className="flex items-center justify-between text-xs">
+                                    <span className="font-mono text-muted">{entry.commit_sha.slice(0, 7)}</span>
+                                    <LemonTag
+                                        type={
+                                            entry.result === 'changed'
+                                                ? 'warning'
+                                                : entry.result === 'new'
+                                                  ? 'highlight'
+                                                  : entry.result === 'removed'
+                                                    ? 'danger'
+                                                    : 'muted'
+                                        }
+                                        size="small"
+                                    >
+                                        {entry.result}
+                                    </LemonTag>
+                                </div>
+                            ))}
+                        </div>
+                    ) : (
+                        <p className="text-xs text-muted">No history yet</p>
+                    )}
                 </div>
             </div>
         </div>

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -1,5 +1,4 @@
 import { useActions, useValues } from 'kea'
-import { useEffect } from 'react'
 
 import { LemonButton, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 
@@ -68,7 +67,7 @@ function SnapshotThumbnail({
                     )}
                 </div>
                 <div className="flex items-center gap-1 max-w-[108px]">
-                    <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${RESULT_DOT_COLORS[result]}`} />
+                    <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${RESULT_DOT_COLORS[result] || 'bg-muted'}`} />
                     <span className={`text-[11px] truncate ${isSelected ? 'font-medium' : 'text-muted'}`}>
                         {shortName}
                     </span>
@@ -92,13 +91,7 @@ export function VisualReviewRunScene(): JSX.Element {
         snapshotHistoryLoading,
         repoFullName,
     } = useValues(visualReviewRunSceneLogic)
-    const { loadRun, loadSnapshots, setSelectedSnapshotId, approveChanges, approveSnapshot } =
-        useActions(visualReviewRunSceneLogic)
-
-    useEffect(() => {
-        loadRun()
-        loadSnapshots()
-    }, [loadSnapshots, loadRun])
+    const { setSelectedSnapshotId, approveChanges, approveSnapshot } = useActions(visualReviewRunSceneLogic)
 
     if (runLoading || !run) {
         return (

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -1,15 +1,13 @@
 import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
-import { IconCheck } from '@posthog/icons'
-import { LemonButton, LemonDivider, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 
 import { SceneExport } from 'scenes/sceneTypes'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
-import { RunStatusBadge } from '../components/RunStatusBadge'
 import { SnapshotDiffViewer } from '../components/SnapshotDiffViewer'
 import type { SnapshotApi } from '../generated/api.schemas'
 import { VisualReviewRunSceneLogicProps, visualReviewRunSceneLogic } from './visualReviewRunSceneLogic'
@@ -22,6 +20,13 @@ export const scene: SceneExport = {
     }),
 }
 
+const RESULT_DOT_COLORS: Record<string, string> = {
+    changed: 'bg-warning',
+    new: 'bg-primary',
+    removed: 'bg-danger',
+    unchanged: 'bg-muted',
+}
+
 function SnapshotThumbnail({
     snapshot,
     isSelected,
@@ -31,68 +36,45 @@ function SnapshotThumbnail({
     isSelected: boolean
     onClick: () => void
 }): JSX.Element {
-    const isApproved = snapshot.review_state === 'approved'
-    const result = snapshot.result
-
-    // Extract short name from identifier (last part after --)
     const parts = snapshot.identifier.split('--')
     const shortName = parts.length > 1 ? parts[parts.length - 1] : parts[0]
-
-    // Status badge styling
-    const getBadgeStyles = (): string => {
-        if (isApproved) {
-            return 'bg-success-highlight text-success-dark'
-        }
-        switch (result) {
-            case 'changed':
-                return 'bg-warning-highlight text-warning-dark'
-            case 'new':
-                return 'bg-primary-highlight text-primary-dark'
-            case 'removed':
-                return 'bg-danger-highlight text-danger'
-            default:
-                return 'bg-muted-alt text-muted'
-        }
-    }
-
-    const getBadgeText = (): string => {
-        if (isApproved) {
-            return 'APPROVED'
-        }
-        return result?.toUpperCase() || 'UNCHANGED'
-    }
+    const result = snapshot.result || 'unchanged'
 
     return (
-        <button type="button" onClick={onClick} className="flex flex-col items-center gap-1.5 shrink-0 group">
-            <div
-                className={`w-24 h-16 rounded-lg overflow-hidden bg-bg-3000 transition-all border-2 ${
-                    isSelected
-                        ? 'border-warning-dark ring-2 ring-warning ring-offset-2'
-                        : 'border-transparent group-hover:border-warning'
-                }`}
+        <Tooltip title={snapshot.identifier}>
+            <button
+                type="button"
+                onClick={onClick}
+                className="flex flex-col items-center gap-1 shrink-0 rounded p-1.5 transition-colors"
+                // eslint-disable-next-line react/forbid-dom-props
+                style={{
+                    background: isSelected ? 'var(--primary-3000-button-bg)' : 'transparent',
+                    border: '1.5px solid',
+                    borderColor: isSelected ? 'var(--primary-3000-button-border)' : 'var(--border)',
+                    boxShadow: isSelected ? '0 3px 0 -1px var(--primary-3000-frame-bg)' : 'none',
+                }}
             >
-                {snapshot.current_artifact?.download_url ? (
-                    <img
-                        src={snapshot.current_artifact.download_url}
-                        alt=""
-                        className="w-full h-full object-cover object-top"
-                    />
-                ) : (
-                    <div className="w-full h-full flex items-center justify-center border border-dashed border-border rounded-md">
-                        <span className="text-xs text-muted">No image</span>
-                    </div>
-                )}
-            </div>
-            <Tooltip title={snapshot.identifier}>
-                <span className="text-xs text-muted truncate max-w-[96px] text-center">{shortName}</span>
-            </Tooltip>
-            <span
-                className={`text-[10px] font-semibold px-1.5 py-0.5 rounded flex items-center gap-0.5 ${getBadgeStyles()}`}
-            >
-                {isApproved && <IconCheck className="w-3 h-3" />}
-                {getBadgeText()}
-            </span>
-        </button>
+                <div className="w-[104px] h-[72px] rounded-sm overflow-hidden bg-bg-3000">
+                    {snapshot.current_artifact?.download_url ? (
+                        <img
+                            src={snapshot.current_artifact.download_url}
+                            alt=""
+                            className="w-full h-full object-contain"
+                        />
+                    ) : (
+                        <div className="w-full h-full flex items-center justify-center">
+                            <span className="text-[10px] text-muted">No image</span>
+                        </div>
+                    )}
+                </div>
+                <div className="flex items-center gap-1 max-w-[108px]">
+                    <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${RESULT_DOT_COLORS[result]}`} />
+                    <span className={`text-[11px] truncate ${isSelected ? 'font-medium' : 'text-muted'}`}>
+                        {shortName}
+                    </span>
+                </div>
+            </button>
+        </Tooltip>
     )
 }
 
@@ -108,6 +90,7 @@ export function VisualReviewRunScene(): JSX.Element {
         changedSnapshots,
         snapshotHistory,
         snapshotHistoryLoading,
+        repoFullName,
     } = useValues(visualReviewRunSceneLogic)
     const { loadRun, loadSnapshots, setSelectedSnapshotId, approveChanges, approveSnapshot } =
         useActions(visualReviewRunSceneLogic)
@@ -118,7 +101,20 @@ export function VisualReviewRunScene(): JSX.Element {
     }, [loadSnapshots, loadRun])
 
     if (runLoading || !run) {
-        return <div className="p-4">Loading...</div>
+        return (
+            <SceneContent>
+                <div className="space-y-4 py-4">
+                    <LemonSkeleton className="h-8 w-1/3" />
+                    <div className="flex gap-2">
+                        <LemonSkeleton className="h-6 w-20" />
+                        <LemonSkeleton className="h-6 w-16" />
+                        <LemonSkeleton className="h-6 w-16" />
+                    </div>
+                    <LemonSkeleton className="h-24 w-full" />
+                    <LemonSkeleton className="h-64 w-full" />
+                </div>
+            </SceneContent>
+        )
     }
 
     // Count by result type
@@ -166,68 +162,64 @@ export function VisualReviewRunScene(): JSX.Element {
                 }
             />
 
-            {/* Run metadata */}
-            <div className="flex gap-4 items-center text-sm mb-4">
-                <RunStatusBadge status={run.status} />
-                <span className="font-mono">{run.commit_sha.substring(0, 7)}</span>
-                {run.pr_number && <span>PR #{run.pr_number}</span>}
-                {run.approved && <span className="text-success font-medium">✓ Approved</span>}
-            </div>
-
-            {/* Snapshots header + thumbnail strip */}
-            {navSnapshots.length > 0 && (
-                <div className="mb-4">
-                    <div className="flex items-center gap-4 mb-3">
-                        <h3 className="font-semibold">
-                            {hasChanges
-                                ? `Visual changes (${changedSnapshots.length})`
-                                : `Snapshots (${snapshots.length})`}
-                        </h3>
-                        <div className="text-sm text-muted">
+            {/* Snapshots panel — thumbnail strip as nav, diff viewer as body */}
+            <div className="border rounded-lg overflow-hidden">
+                {/* Header: summary + thumbnail strip */}
+                <div className="bg-bg-light border-b">
+                    <div className="flex items-center gap-3 px-3 pt-3 pb-2">
+                        <span className="text-sm font-semibold">Visual changes</span>
+                        <span className="text-xs text-muted">
                             {changedCount > 0 && <span className="text-warning-dark">{changedCount} changed</span>}
-                            {newCount > 0 && <span className="text-primary-dark ml-2">{newCount} new</span>}
-                            {removedCount > 0 && <span className="text-danger ml-2">{removedCount} removed</span>}
+                            {changedCount > 0 && (newCount > 0 || removedCount > 0) && ' · '}
+                            {newCount > 0 && <span className="text-primary-dark">{newCount} new</span>}
+                            {newCount > 0 && removedCount > 0 && ' · '}
+                            {removedCount > 0 && <span className="text-danger">{removedCount} removed</span>}
+                        </span>
+                    </div>
+
+                    {navSnapshots.length > 0 && (
+                        <div className="flex gap-1.5 overflow-x-auto px-3 pb-3">
+                            {navSnapshots.map((snapshot: SnapshotApi) => (
+                                <SnapshotThumbnail
+                                    key={snapshot.id}
+                                    snapshot={snapshot}
+                                    isSelected={selectedSnapshot?.id === snapshot.id}
+                                    onClick={() => setSelectedSnapshotId(snapshot.id)}
+                                />
+                            ))}
                         </div>
-                    </div>
-
-                    {/* Thumbnail strip */}
-                    <div className="flex gap-4 overflow-x-auto py-3 px-2 -mx-2">
-                        {navSnapshots.map((snapshot: SnapshotApi) => (
-                            <SnapshotThumbnail
-                                key={snapshot.id}
-                                snapshot={snapshot}
-                                isSelected={selectedSnapshot?.id === snapshot.id}
-                                onClick={() => setSelectedSnapshotId(snapshot.id)}
-                            />
-                        ))}
-                    </div>
+                    )}
                 </div>
-            )}
 
-            <LemonDivider />
-
-            {/* Selected snapshot diff viewer */}
-            <div className="mt-4">
-                {selectedSnapshot ? (
-                    <SnapshotDiffViewer
-                        snapshot={selectedSnapshot}
-                        snapshotHistory={snapshotHistory}
-                        snapshotHistoryLoading={snapshotHistoryLoading}
-                        onApprove={handleApproveSnapshot}
-                        onPrevious={goToPrevious}
-                        onNext={goToNext}
-                        hasPrevious={hasPrevious}
-                        hasNext={hasNext}
-                        currentIndex={currentIndex >= 0 ? currentIndex : undefined}
-                        totalCount={navSnapshots.length}
-                    />
-                ) : snapshotsLoading ? (
-                    <div className="text-center text-muted py-8">Loading snapshots...</div>
-                ) : changedSnapshots.length > 0 ? (
-                    <div className="text-center text-muted py-8">Select a snapshot to view details</div>
-                ) : (
-                    <div className="text-center text-muted py-8">No visual changes in this run</div>
-                )}
+                {/* Body: diff viewer */}
+                <div className="p-4">
+                    {selectedSnapshot ? (
+                        <SnapshotDiffViewer
+                            snapshot={selectedSnapshot}
+                            snapshotHistory={snapshotHistory}
+                            snapshotHistoryLoading={snapshotHistoryLoading}
+                            onApprove={handleApproveSnapshot}
+                            onPrevious={goToPrevious}
+                            onNext={goToNext}
+                            hasPrevious={hasPrevious}
+                            hasNext={hasNext}
+                            currentIndex={currentIndex >= 0 ? currentIndex : undefined}
+                            totalCount={navSnapshots.length}
+                            commitSha={run.commit_sha}
+                            prNumber={run.pr_number}
+                            repoFullName={repoFullName}
+                        />
+                    ) : snapshotsLoading ? (
+                        <div className="space-y-3 py-4">
+                            <LemonSkeleton className="h-6 w-1/4" />
+                            <LemonSkeleton className="h-48 w-full" />
+                        </div>
+                    ) : changedSnapshots.length > 0 ? (
+                        <div className="text-center text-muted py-8">Select a snapshot to view details</div>
+                    ) : (
+                        <div className="text-center text-muted py-8">No visual changes in this run</div>
+                    )}
+                </div>
             </div>
         </SceneContent>
     )

--- a/products/visual_review/frontend/scenes/VisualReviewRunsScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunsScene.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
 import { IconGear, IconGithub } from '@posthog/icons'
-import { LemonButton, LemonTable, LemonTableColumns, LemonTabs, Link } from '@posthog/lemon-ui'
+import { LemonButton, LemonSegmentedButton, LemonTable, LemonTableColumns, LemonTag, Link } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -10,7 +10,6 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
-import { RunStatusBadge } from '../components/RunStatusBadge'
 import { RunSummaryStats } from '../components/RunSummaryStats'
 import type { RunApi } from '../generated/api.schemas'
 import { ReviewState, visualReviewRunsSceneLogic } from './visualReviewRunsSceneLogic'
@@ -48,11 +47,11 @@ const EMPTY_MESSAGES: Record<ReviewState, string> = {
     stale: 'No stale runs.',
 }
 
-const TAB_STYLES: Record<ReviewState, string> = {
-    needs_review: 'bg-warning-highlight text-warning-dark',
-    clean: 'bg-success-highlight text-success-dark',
-    processing: 'bg-muted-alt text-muted',
-    stale: 'bg-muted-alt text-muted',
+const TAB_COUNT_TYPES: Record<ReviewState, 'warning' | 'highlight' | 'default' | 'muted'> = {
+    needs_review: 'warning',
+    clean: 'default',
+    processing: 'highlight',
+    stale: 'muted',
 }
 
 export function VisualReviewRunsScene(): JSX.Element {
@@ -60,17 +59,6 @@ export function VisualReviewRunsScene(): JSX.Element {
     const { loadRuns, loadCounts, setActiveTab } = useActions(visualReviewRunsSceneLogic)
 
     const columns: LemonTableColumns<RunApi> = [
-        {
-            title: 'Status',
-            key: 'status',
-            width: 120,
-            render: (_, run) => (
-                <div className="flex items-center gap-2">
-                    <RunStatusBadge status={run.status} />
-                    {run.approved && <span className="text-success text-xs font-medium">✓</span>}
-                </div>
-            ),
-        },
         {
             title: 'Branch',
             key: 'branch',
@@ -149,23 +137,26 @@ export function VisualReviewRunsScene(): JSX.Element {
                 }
             />
 
-            <LemonTabs
-                activeKey={activeTab}
-                onChange={(key) => setActiveTab(key)}
-                tabs={tabs.map(({ key, label }) => ({
-                    key,
-                    label: (
-                        <span>
-                            {label}
-                            {(key === 'needs_review' || key === 'processing') && counts[key] > 0 && (
-                                <span className={`ml-1.5 px-1.5 py-0.5 text-xs rounded-full ${TAB_STYLES[key]}`}>
-                                    {counts[key]}
-                                </span>
-                            )}
-                        </span>
-                    ),
-                }))}
-            />
+            <div className="mb-3">
+                <LemonSegmentedButton
+                    value={activeTab}
+                    onChange={(value) => setActiveTab(value)}
+                    options={tabs.map(({ key, label }) => ({
+                        value: key,
+                        label: (
+                            <span className="flex items-center gap-1.5">
+                                {label}
+                                {(key === 'needs_review' || key === 'processing') && counts[key] > 0 && (
+                                    <LemonTag type={TAB_COUNT_TYPES[key]} size="small">
+                                        {counts[key]}
+                                    </LemonTag>
+                                )}
+                            </span>
+                        ),
+                    }))}
+                    size="small"
+                />
+            </div>
 
             <LemonTable
                 dataSource={runs}

--- a/products/visual_review/frontend/scenes/visualReviewRunSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewRunSceneLogic.ts
@@ -8,12 +8,19 @@ import { teamLogic } from 'scenes/teamLogic'
 import { Breadcrumb } from '~/types'
 
 import {
+    visualReviewReposList,
     visualReviewRunsApproveCreate,
     visualReviewRunsRetrieve,
     visualReviewRunsSnapshotHistoryList,
     visualReviewRunsSnapshotsList,
 } from '../generated/api'
-import type { ApproveSnapshotInputApi, RunApi, SnapshotApi, SnapshotHistoryEntryApi } from '../generated/api.schemas'
+import type {
+    ApproveSnapshotInputApi,
+    RepoApi,
+    RunApi,
+    SnapshotApi,
+    SnapshotHistoryEntryApi,
+} from '../generated/api.schemas'
 import type { visualReviewRunSceneLogicType } from './visualReviewRunSceneLogicType'
 
 export interface VisualReviewRunSceneLogicProps {
@@ -58,6 +65,15 @@ export const visualReviewRunSceneLogic = kea<visualReviewRunSceneLogicType>([
                 },
             },
         ],
+        repo: [
+            null as RepoApi | null,
+            {
+                loadRepo: async () => {
+                    const response = await visualReviewReposList(String(values.currentProjectId))
+                    return response.results[0] || null
+                },
+            },
+        ],
         snapshotHistory: [
             [] as SnapshotHistoryEntryApi[],
             {
@@ -93,6 +109,7 @@ export const visualReviewRunSceneLogic = kea<visualReviewRunSceneLogicType>([
             (s) => [s.changedSnapshots],
             (changedSnapshots): number => changedSnapshots.filter((s) => s.review_state !== 'approved').length,
         ],
+        repoFullName: [(s) => [s.repo], (repo): string | null => repo?.repo_full_name || null],
         breadcrumbs: [
             (s) => [s.run],
             (run): Breadcrumb[] => [
@@ -195,5 +212,6 @@ export const visualReviewRunSceneLogic = kea<visualReviewRunSceneLogicType>([
     afterMount(({ actions }) => {
         actions.loadRun()
         actions.loadSnapshots()
+        actions.loadRepo()
     }),
 ])

--- a/products/visual_review/frontend/scenes/visualReviewRunSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewRunSceneLogic.ts
@@ -70,6 +70,10 @@ export const visualReviewRunSceneLogic = kea<visualReviewRunSceneLogicType>([
             {
                 loadRepo: async () => {
                     const response = await visualReviewReposList(String(values.currentProjectId))
+                    const run = values.run
+                    if (run) {
+                        return response.results.find((r) => r.id === run.repo_id) || response.results[0] || null
+                    }
                     return response.results[0] || null
                 },
             },
@@ -131,6 +135,9 @@ export const visualReviewRunSceneLogic = kea<visualReviewRunSceneLogicType>([
             if (snapshot) {
                 actions.loadSnapshotHistory(snapshot.identifier)
             }
+        },
+        loadRunSuccess: () => {
+            actions.loadRepo()
         },
         loadSnapshotsSuccess: () => {
             const snapshot = values.selectedSnapshot
@@ -212,6 +219,5 @@ export const visualReviewRunSceneLogic = kea<visualReviewRunSceneLogicType>([
     afterMount(({ actions }) => {
         actions.loadRun()
         actions.loadSnapshots()
-        actions.loadRepo()
     }),
 ])

--- a/products/visual_review/frontend/scenes/visualReviewRunSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewRunSceneLogic.ts
@@ -8,7 +8,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { Breadcrumb } from '~/types'
 
 import {
-    visualReviewReposList,
+    visualReviewReposRetrieve,
     visualReviewRunsApproveCreate,
     visualReviewRunsRetrieve,
     visualReviewRunsSnapshotHistoryList,
@@ -69,12 +69,11 @@ export const visualReviewRunSceneLogic = kea<visualReviewRunSceneLogicType>([
             null as RepoApi | null,
             {
                 loadRepo: async () => {
-                    const response = await visualReviewReposList(String(values.currentProjectId))
                     const run = values.run
-                    if (run) {
-                        return response.results.find((r) => r.id === run.repo_id) || response.results[0] || null
+                    if (!run) {
+                        return null
                     }
-                    return response.results[0] || null
+                    return visualReviewReposRetrieve(String(values.currentProjectId), run.repo_id)
                 },
             },
         ],


### PR DESCRIPTION
## Problem

Visual review UI used ad-hoc Tailwind styling that felt airy and homecooked compared to the rest of PostHog. Status indicators, badges, loading states, and layout patterns didn't match the Lemon UI design language used in products like logs and feature flags.

## Changes

**List view**
- LemonTabs → LemonSegmentedButton for tighter filter controls
- Removed Status column from table — active tab already indicates state
- RunStatusBadge shows review-relevant labels (Needs review / Approved / Clean) instead of pipeline status
- Change counts use LemonTag badges consistently
- Tab counts only shown for actionable states

**Detail view**
- Thumbnail strip + diff viewer wrapped in a single bordered panel
- Filmstrip thumbnails use PostHog lemon-style chrome (golden frame shadow via \`--primary-3000-frame-bg\`) for selected state — same treatment as LemonButton primary
- Status badges replaced with color dots to reduce noise
- Header simplified to inline colored text
- Commit SHA and PR number moved to sidebar with GitHub links and field labels
- Sidebar flattened — left border separator, no nested cards
- Loading states use LemonSkeleton
- Small images use \`object-contain\` to prevent pixelation

**List view**
<img width="1600" height="1000" alt="vr-list-view" src="https://github.com/user-attachments/assets/0f956285-c919-46c8-8dd3-dfe23536d177" />


**Detail — filmstrip with lemon-style selected state**
<img width="1600" height="1000" alt="vr-detail-filmstrip" src="https://github.com/user-attachments/assets/22c795c8-a2ed-4d48-9182-d316dc2bdd29" />


**Detail — new snapshot**
<img width="1600" height="1000" alt="vr-detail-new-snapshot" src="https://github.com/user-attachments/assets/784b0c7e-71a7-40c5-b908-9beeaabd7236" />


**Detail — changed snapshot side-by-side**
<img width="1600" height="1000" alt="vr-detail-changed-sidebyside" src="https://github.com/user-attachments/assets/6b86a47d-7155-457b-8b46-38a734204a68" />


## How did you test this code?

Agent co-authored. Tested visually in the browser with seeded data (8 runs with real storybook snapshots). Verified filmstrip selection doesn't wobble, small images don't pixelate, sidebar doesn't get squished. No automated tests changed — purely frontend styling.

## Publish to changelog?

no

## 🤖 LLM context

Agent co-authored. UI iterated with browser screenshots via Playwright MCP, comparing against logs product and Storybook button docs for design language reference.