### PR TITLE
fix(data-warehouse): Fixed changing a table to webhook would reset it

### DIFF
--- a/products/data_warehouse/backend/api/external_data_schema.py
+++ b/products/data_warehouse/backend/api/external_data_schema.py
@@ -175,26 +175,30 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
             ExternalDataSchema.SyncType.WEBHOOK,
         ):
             payload = instance.sync_type_config
-            payload["incremental_field"] = data.get("incremental_field")
-            payload["incremental_field_type"] = data.get("incremental_field_type")
 
-            # Only check for incremental field changes on sync types that use them
+            # Detect incremental field changes before mutating payload
+            incremental_field_changed = False
             if sync_type in (ExternalDataSchema.SyncType.INCREMENTAL, ExternalDataSchema.SyncType.APPEND):
                 incremental_field_changed = (
-                    instance.sync_type_config.get("incremental_field") != data.get("incremental_field")
-                    or instance.sync_type_config.get("incremental_field_last_value") is None
+                    payload.get("incremental_field") != data.get("incremental_field")
+                    or payload.get("incremental_field_last_value") is None
                 )
 
-                if incremental_field_changed:
-                    if instance.table is not None:
-                        # Get the max_value and set it on incremental_field_last_value
-                        max_value = instance.table.get_max_value_for_column(data.get("incremental_field"))
-                        if max_value:
-                            instance.update_incremental_field_value(max_value, save=False)
-                        else:
-                            # if we can't get the max value, reset the table
-                            payload["incremental_field_last_value"] = None
-                            trigger_refresh = True
+            if "incremental_field" in data:
+                payload["incremental_field"] = data.get("incremental_field")
+            if "incremental_field_type" in data:
+                payload["incremental_field_type"] = data.get("incremental_field_type")
+
+            if incremental_field_changed:
+                if instance.table is not None:
+                    # Get the max_value and set it on incremental_field_last_value
+                    max_value = instance.table.get_max_value_for_column(data.get("incremental_field"))
+                    if max_value:
+                        instance.update_incremental_field_value(max_value, save=False)
+                    else:
+                        # if we can't get the max value, reset the table
+                        payload["incremental_field_last_value"] = None
+                        trigger_refresh = True
 
             validated_data["sync_type_config"] = payload
         elif sync_type == ExternalDataSchema.SyncType.CDC:

--- a/products/data_warehouse/backend/api/external_data_schema.py
+++ b/products/data_warehouse/backend/api/external_data_schema.py
@@ -174,26 +174,27 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
             ExternalDataSchema.SyncType.APPEND,
             ExternalDataSchema.SyncType.WEBHOOK,
         ):
-            incremental_field_changed = (
-                instance.sync_type_config.get("incremental_field") != data.get("incremental_field")
-                or instance.sync_type_config.get("incremental_field_last_value") is None
-            )
-
             payload = instance.sync_type_config
             payload["incremental_field"] = data.get("incremental_field")
             payload["incremental_field_type"] = data.get("incremental_field_type")
 
-            # If the incremental field has changed
-            if incremental_field_changed:
-                if instance.table is not None:
-                    # Get the max_value and set it on incremental_field_last_value
-                    max_value = instance.table.get_max_value_for_column(data.get("incremental_field"))
-                    if max_value:
-                        instance.update_incremental_field_value(max_value, save=False)
-                    else:
-                        # if we can't get the max value, reset the table
-                        payload["incremental_field_last_value"] = None
-                        trigger_refresh = True
+            # Only check for incremental field changes on sync types that use them
+            if sync_type in (ExternalDataSchema.SyncType.INCREMENTAL, ExternalDataSchema.SyncType.APPEND):
+                incremental_field_changed = (
+                    instance.sync_type_config.get("incremental_field") != data.get("incremental_field")
+                    or instance.sync_type_config.get("incremental_field_last_value") is None
+                )
+
+                if incremental_field_changed:
+                    if instance.table is not None:
+                        # Get the max_value and set it on incremental_field_last_value
+                        max_value = instance.table.get_max_value_for_column(data.get("incremental_field"))
+                        if max_value:
+                            instance.update_incremental_field_value(max_value, save=False)
+                        else:
+                            # if we can't get the max value, reset the table
+                            payload["incremental_field_last_value"] = None
+                            trigger_refresh = True
 
             validated_data["sync_type_config"] = payload
         elif sync_type == ExternalDataSchema.SyncType.CDC:

--- a/products/data_warehouse/backend/api/test/test_external_data_schema.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_schema.py
@@ -11,6 +11,7 @@ from django.test.client import Client as HttpClient
 import psycopg
 import pytest_asyncio
 from asgiref.sync import sync_to_async
+from parameterized import parameterized
 from temporalio.service import RPCError
 
 from posthog.api.test.test_organization import create_organization
@@ -237,8 +238,7 @@ class TestExternalDataSchema(APIBaseTest):
             assert schema.sync_type_config.get("reset_pipeline") is None
             assert schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH
 
-    @pytest.mark.parametrize(
-        "from_sync_type",
+    @parameterized.expand(
         [ExternalDataSchema.SyncType.APPEND, ExternalDataSchema.SyncType.INCREMENTAL],
     )
     def test_update_schema_to_webhook_does_not_reset_pipeline(self, from_sync_type):

--- a/products/data_warehouse/backend/api/test/test_external_data_schema.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_schema.py
@@ -284,6 +284,9 @@ class TestExternalDataSchema(APIBaseTest):
 
             assert schema.sync_type == ExternalDataSchema.SyncType.WEBHOOK
             assert schema.sync_type_config.get("reset_pipeline") is None
+            assert schema.sync_type_config.get("incremental_field") == "created"
+            assert schema.sync_type_config.get("incremental_field_type") == "integer"
+            assert schema.sync_type_config.get("incremental_field_last_value") == 1000
 
     def test_update_schema_change_sync_type_incremental_field(self):
         source = ExternalDataSource.objects.create(

--- a/products/data_warehouse/backend/api/test/test_external_data_schema.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_schema.py
@@ -237,7 +237,11 @@ class TestExternalDataSchema(APIBaseTest):
             assert schema.sync_type_config.get("reset_pipeline") is None
             assert schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH
 
-    def test_update_schema_from_append_to_webhook_does_not_reset_pipeline(self):
+    @pytest.mark.parametrize(
+        "from_sync_type",
+        [ExternalDataSchema.SyncType.APPEND, ExternalDataSchema.SyncType.INCREMENTAL],
+    )
+    def test_update_schema_to_webhook_does_not_reset_pipeline(self, from_sync_type):
         source = ExternalDataSource.objects.create(
             team=self.team,
             source_type=ExternalDataSourceType.STRIPE,
@@ -250,7 +254,7 @@ class TestExternalDataSchema(APIBaseTest):
             source=source,
             should_sync=True,
             status=ExternalDataSchema.Status.COMPLETED,
-            sync_type=ExternalDataSchema.SyncType.APPEND,
+            sync_type=from_sync_type,
             sync_type_config={
                 "incremental_field": "created",
                 "incremental_field_type": "integer",

--- a/products/data_warehouse/backend/api/test/test_external_data_schema.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_schema.py
@@ -237,6 +237,50 @@ class TestExternalDataSchema(APIBaseTest):
             assert schema.sync_type_config.get("reset_pipeline") is None
             assert schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH
 
+    def test_update_schema_from_append_to_webhook_does_not_reset_pipeline(self):
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_type=ExternalDataSourceType.STRIPE,
+            job_inputs={"auth_method": {"selection": "api_key", "stripe_secret_key": "123"}},
+        )
+        table = DataWarehouseTable.objects.create(team=self.team)
+        schema = ExternalDataSchema.objects.create(
+            name="BalanceTransaction",
+            team=self.team,
+            source=source,
+            should_sync=True,
+            status=ExternalDataSchema.Status.COMPLETED,
+            sync_type=ExternalDataSchema.SyncType.APPEND,
+            sync_type_config={
+                "incremental_field": "created",
+                "incremental_field_type": "integer",
+                "incremental_field_last_value": 1000,
+            },
+            table=table,
+        )
+
+        with (
+            mock.patch(
+                "products.data_warehouse.backend.api.external_data_schema.trigger_external_data_workflow"
+            ) as mock_trigger_external_data_workflow,
+            mock.patch(
+                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                return_value=True,
+            ),
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
+                data={"sync_type": "webhook"},
+            )
+
+            assert response.status_code == 200
+            mock_trigger_external_data_workflow.assert_not_called()
+
+            schema.refresh_from_db()
+
+            assert schema.sync_type == ExternalDataSchema.SyncType.WEBHOOK
+            assert schema.sync_type_config.get("reset_pipeline") is None
+
     def test_update_schema_change_sync_type_incremental_field(self):
         source = ExternalDataSource.objects.create(
             team=self.team,


### PR DESCRIPTION
## Problem
- When a table/schema was changed from append or incremental sync type to webhook, it'd set the `reset_table` flag and cause a full refresh to occur

## Changes
Basically, don't do ^ there is no need 🙃 

## How did you test this code?
Unit tests inniittt 
