### PR TITLE
feat(llma): add evaluation reports frontend (4/5)

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -458,6 +458,7 @@ export const FEATURE_FLAGS = {
     SURVEYS_ERROR_TRACKING_CROSS_SELL: 'surveys-in-error-tracking', // owner: @adboio #team-surveys
     SURVEYS_FORM_BUILDER: 'surveys-form-builder', // owner: @adboio #team-surveys
     SURVEYS_INSIGHT_BUTTON_EXPERIMENT: 'ask-users-why-ai-vs-quickcreate', // owner: @adboio #team-surveys multivariate=true
+    SURVEYS_TOOLBAR: 'surveys-toolbar', // owner: @fcgomes
     SURVEYS_WEB_ANALYTICS_CROSS_SELL: 'surveys-in-web-analytics', // owner: @adboio #team-surveys
     TASK_SUMMARIES: 'task-summaries', // owner: #team-llm-analytics
     TASK_TOOL: 'phai-task-tool', // owner: @kappa90 #team-posthog-ai

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -326,6 +326,7 @@ export const FEATURE_FLAGS = {
     LLM_ANALYTICS_EVALUATIONS: 'llm-analytics-evaluations', // owner: #team-llm-analytics
     LLM_ANALYTICS_EVALUATIONS_CUSTOM_MODELS: 'llm-analytics-evaluations-custom-models', // owner: #team-llm-analytics
     LLM_ANALYTICS_EVALUATIONS_HOG_CODE: 'llm-analytics-evaluations-hog-code', // owner: #team-llm-analytics
+    LLM_ANALYTICS_EVALUATIONS_REPORTS: 'llm-analytics-evaluations-reports', // owner: #team-llm-analytics
     LLM_ANALYTICS_EVALUATIONS_SUMMARY: 'llm-analytics-evaluations-summary', // owner: #team-llm-analytics
     LLM_ANALYTICS_OFFLINE_EVALS: 'llm-analytics-offline-evals', // owner: #team-llm-analytics
     LLM_ANALYTICS_SENTIMENT: 'llm-analytics-sentiment', // owner: #team-llm-analytics
@@ -457,7 +458,6 @@ export const FEATURE_FLAGS = {
     SURVEYS_ERROR_TRACKING_CROSS_SELL: 'surveys-in-error-tracking', // owner: @adboio #team-surveys
     SURVEYS_FORM_BUILDER: 'surveys-form-builder', // owner: @adboio #team-surveys
     SURVEYS_INSIGHT_BUTTON_EXPERIMENT: 'ask-users-why-ai-vs-quickcreate', // owner: @adboio #team-surveys multivariate=true
-    SURVEYS_TOOLBAR: 'surveys-toolbar', // owner: @fcgomes
     SURVEYS_WEB_ANALYTICS_CROSS_SELL: 'surveys-in-web-analytics', // owner: @adboio #team-surveys
     TASK_SUMMARIES: 'task-summaries', // owner: #team-llm-analytics
     TASK_TOOL: 'phai-task-tool', // owner: @kappa90 #team-posthog-ai

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -321,6 +321,7 @@ export const FEATURE_FLAGS = {
     LLM_ANALYTICS_TRACE_NAVIGATION: 'llm-analytics-trace-navigation', // owner: #team-llm-analytics
     LLM_ANALYTICS_EVALUATIONS_CUSTOM_MODELS: 'llm-analytics-evaluations-custom-models', // owner: #team-llm-analytics
     LLM_ANALYTICS_EVALUATIONS_HOG_CODE: 'llm-analytics-evaluations-hog-code', // owner: #team-llm-analytics
+    LLM_ANALYTICS_EVALUATIONS_REPORTS: 'llm-analytics-evaluations-reports', // owner: #team-llm-analytics
     LLM_ANALYTICS_EVALUATIONS_SUMMARY: 'llm-analytics-evaluations-summary', // owner: #team-llm-analytics
     LLM_ANALYTICS_SESSION_SUMMARIZATION: 'llm-analytics-session-summarization', // owner: #team-llm-analytics
     LLM_ANALYTICS_CLUSTERS_TAB: 'llm-analytics-clusters-tab', // owner: #team-llm-analytics
@@ -391,7 +392,6 @@ export const FEATURE_FLAGS = {
     ONBOARDING_WIZARD_PROMINENCE: 'onboarding-wizard-prominence', // owner: #team-growth multivariate=control,wizard-hero,wizard-tab,wizard-only
     ONBOARDING_WIZARD_INSTALLATION_IMPROVED_COPY: 'onboarding-wizard-installation-improved-copy', // owner: @fercgomes #team-growth multivariate=control,test
     ONBOARDING_MOBILE_INSTALL_HELPER: 'onboarding-mobile-install-helper', // owner: @fercgomes #team-growth multivariate=control,test — target $device_type=Mobile at the flag level
-    ONBOARDING_DATA_WAREHOUSE_VALUE_PROP: 'onboarding-data-warehouse-value-prop', // owner: @fercgomes #team-growth multivariate=control,table,query
     OWNER_ONLY_BILLING: 'owner-only-billing', // owner: @pawelcebula #team-billing
     POST_ONBOARDING_MODAL_EXPERIMENT: 'post-onboarding-modal-experiment', // owner: @fercgomes #team-growth multivariate=control,test
     QUICK_START_PULSE_INDICATOR: 'quick-start-pulse-indicator', // owner: @fercgomes #team-growth multivariate=control,test
@@ -445,7 +445,6 @@ export const FEATURE_FLAGS = {
     SURVEYS_FORM_BUILDER: 'surveys-form-builder', // owner: @adboio #team-surveys
     SURVEY_HEADLINE_SUMMARY: 'survey-headline-summary', // owner: @adboio #team-surveys
     SURVEYS_INSIGHT_BUTTON_EXPERIMENT: 'ask-users-why-ai-vs-quickcreate', // owner: @adboio #team-surveys multivariate=true
-    SURVEYS_TOOLBAR: 'surveys-toolbar', // owner: @fcgomes
     SURVEYS_WEB_ANALYTICS_CROSS_SELL: 'surveys-in-web-analytics', // owner: @adboio #team-surveys
     TASK_SUMMARIES: 'task-summaries', // owner: #team-llm-analytics
     TASK_TOOL: 'phai-task-tool', // owner: @kappa90 #team-posthog-ai

--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
@@ -35,6 +35,8 @@ import { modelPickerLogic } from '../modelPickerLogic'
 import { providerKeyStateIssueDescription, providerLabel } from '../settings/providerKeyStateUtils'
 import { EvaluationCodeEditor } from './components/EvaluationCodeEditor'
 import { EvaluationPromptEditor } from './components/EvaluationPromptEditor'
+import { EvaluationReportConfig } from './components/EvaluationReportConfig'
+import { EvaluationReportsTab } from './components/EvaluationReportsTab'
 import { EvaluationRunsTable } from './components/EvaluationRunsTable'
 import { EvaluationTriggers } from './components/EvaluationTriggers'
 import { LLMEvaluationLogicProps, llmEvaluationLogic } from './llmEvaluationLogic'
@@ -317,6 +319,18 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
                             </div>
                         ),
                     },
+                    !isNewEvaluation &&
+                        !!featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EVALUATIONS_REPORTS] && {
+                            key: 'reports',
+                            label: 'Reports',
+                            'data-attr': 'llma-evaluation-reports-tab',
+                            content: (
+                                <EvaluationReportsTab
+                                    evaluationId={evaluation.id}
+                                    onConfigureClick={() => setActiveTab('configuration')}
+                                />
+                            ),
+                        },
                     {
                         key: 'configuration',
                         label: 'Configuration',
@@ -473,7 +487,20 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
                                         </p>
                                         <EvaluationTriggers />
                                     </div>
+
+                                    {/* Scheduled Reports (inline config for new evaluations) */}
+                                    {isNewEvaluation &&
+                                        featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EVALUATIONS_REPORTS] && (
+                                            <EvaluationReportConfig evaluationId="new" />
+                                        )}
                                 </Form>
+
+                                {/* Scheduled Reports (for existing evaluations, outside the form) */}
+                                {!isNewEvaluation && featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EVALUATIONS_REPORTS] && (
+                                    <div className="mt-6">
+                                        <EvaluationReportConfig evaluationId={evaluation.id} />
+                                    </div>
+                                )}
                             </div>
                         ),
                     },

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationReportConfig.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationReportConfig.tsx
@@ -1,28 +1,94 @@
 import { useActions, useValues } from 'kea'
-import { useEffect, useState } from 'react'
 
-import { LemonButton, LemonDialog, LemonInput, LemonSelect, LemonSwitch, LemonTextArea } from '@posthog/lemon-ui'
+import {
+    LemonButton,
+    LemonCalendarSelectInput,
+    LemonDialog,
+    LemonInput,
+    LemonSelect,
+    LemonSwitch,
+    LemonTextArea,
+} from '@posthog/lemon-ui'
 
+import { dayjs } from 'lib/dayjs'
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { SlackChannelPicker, SlackNotConfiguredBanner } from 'lib/integrations/SlackIntegrationHelpers'
 
-import { evaluationReportLogic } from '../evaluationReportLogic'
-import type { EvaluationReportDeliveryTarget, EvaluationReportFrequency } from '../types'
+import { buildDeliveryTargets, evaluationReportLogic, TRIGGER_THRESHOLD_DEFAULT } from '../evaluationReportLogic'
 
 const GUIDANCE_PLACEHOLDER =
     "Optional guidance for the report agent. e.g. 'Focus on cost regressions across models', 'Compare latency between gpt-4o-mini and claude-sonnet', 'Keep it to 2 sections max'"
 
 const FREQUENCY_OPTIONS = [
-    { value: 'hourly' as const, label: 'Hourly' },
-    { value: 'daily' as const, label: 'Daily' },
-    { value: 'weekly' as const, label: 'Weekly' },
     { value: 'every_n' as const, label: 'Every N evaluations' },
+    { value: 'scheduled' as const, label: 'On a schedule' },
 ]
+
+const RRULE_PLACEHOLDER = 'FREQ=DAILY'
+const RRULE_EXAMPLES = 'Examples: FREQ=DAILY · FREQ=WEEKLY;BYDAY=MO,FR · FREQ=HOURLY;INTERVAL=6'
 
 const TRIGGER_THRESHOLD_MIN = 10
 const TRIGGER_THRESHOLD_MAX = 10_000
-const TRIGGER_THRESHOLD_DEFAULT = 100
+
+/** RRULE + starts_at + timezone inputs shown when frequency is 'scheduled'.
+ * Accepts a raw RRULE string (RFC 5545) — matches the HogFlowSchedule contract in
+ * products/workflows. A richer picker (RecurringSchedulePicker) can replace this later. */
+function ScheduleConfig({
+    rrule,
+    startsAt,
+    timezoneName,
+    onRruleChange,
+    onStartsAtChange,
+    onTimezoneChange,
+}: {
+    rrule: string
+    startsAt: string | null
+    timezoneName: string
+    onRruleChange: (value: string) => void
+    onStartsAtChange: (value: string | null) => void
+    onTimezoneChange: (value: string) => void
+}): JSX.Element {
+    return (
+        <div className="space-y-3">
+            <div>
+                <label className="font-semibold text-sm">Schedule (RRULE)</label>
+                <LemonInput
+                    value={rrule}
+                    onChange={onRruleChange}
+                    placeholder={RRULE_PLACEHOLDER}
+                    fullWidth
+                />
+                <p className="text-xs text-muted mt-1">{RRULE_EXAMPLES}</p>
+            </div>
+            <div>
+                <label className="font-semibold text-sm">Starts at</label>
+                <LemonCalendarSelectInput
+                    buttonProps={{ fullWidth: true }}
+                    format="MMMM D, YYYY h:mm A"
+                    clearable
+                    value={startsAt ? dayjs(startsAt) : null}
+                    onChange={(d) => onStartsAtChange(d ? d.toISOString() : null)}
+                    granularity="minute"
+                    showTimeToggle={false}
+                />
+                <p className="text-xs text-muted mt-1">
+                    Anchor datetime used when expanding the RRULE. Used as the first occurrence for plain frequencies.
+                </p>
+            </div>
+            <div>
+                <label className="font-semibold text-sm">Timezone</label>
+                <LemonInput
+                    value={timezoneName}
+                    onChange={onTimezoneChange}
+                    placeholder="UTC"
+                    fullWidth
+                />
+                <p className="text-xs text-muted mt-1">IANA timezone name (e.g. UTC, America/New_York).</p>
+            </div>
+        </div>
+    )
+}
 
 /** Threshold config shown when frequency is 'every_n' */
 function ThresholdConfig({ value, onChange }: { value: number; onChange: (value: number) => void }): JSX.Element {
@@ -63,6 +129,8 @@ function DeliveryTargetsConfig({
     onSlackChannelChange: (value: string) => void
 }): JSX.Element {
     const { slackIntegrations, integrations } = useValues(integrationsLogic)
+    const selectedIntegration =
+        slackIntegrationId !== null ? integrations?.find((i) => i.id === slackIntegrationId) : undefined
 
     return (
         <>
@@ -92,17 +160,13 @@ function DeliveryTargetsConfig({
                                 onSlackIntegrationChange(newValue)
                             }}
                         />
-                        {slackIntegrationId &&
-                            (() => {
-                                const selectedIntegration = integrations?.find((i) => i.id === slackIntegrationId)
-                                return selectedIntegration ? (
-                                    <SlackChannelPicker
-                                        value={slackChannelValue}
-                                        onChange={(val) => onSlackChannelChange(val || '')}
-                                        integration={selectedIntegration}
-                                    />
-                                ) : null
-                            })()}
+                        {selectedIntegration && (
+                            <SlackChannelPicker
+                                value={slackChannelValue}
+                                onChange={(val) => onSlackChannelChange(val || '')}
+                                integration={selectedIntegration}
+                            />
+                        )}
                     </div>
                 )}
             </div>
@@ -110,18 +174,103 @@ function DeliveryTargetsConfig({
     )
 }
 
+/** Shared form body used by both the create-evaluation and edit-existing-evaluation paths.
+ * All state is backed by `evaluationReportLogic.configDraft` keyed by evaluationId. */
+function ReportFormFields({ evaluationId }: { evaluationId: string }): JSX.Element {
+    const { configDraft } = useValues(evaluationReportLogic({ evaluationId }))
+    const {
+        setDraftFrequency,
+        setDraftRrule,
+        setDraftStartsAt,
+        setDraftTimezoneName,
+        setDraftEmailValue,
+        setDraftSlackIntegrationId,
+        setDraftSlackChannelValue,
+        setDraftReportPromptGuidance,
+        setDraftTriggerThreshold,
+    } = useActions(evaluationReportLogic({ evaluationId }))
+
+    return (
+        <div className="space-y-4 mt-4">
+            <div>
+                <label className="font-semibold text-sm">Frequency</label>
+                <LemonSelect
+                    value={configDraft.frequency}
+                    onChange={(val) => val && setDraftFrequency(val)}
+                    options={FREQUENCY_OPTIONS}
+                    fullWidth
+                />
+            </div>
+            {configDraft.frequency === 'every_n' && (
+                <ThresholdConfig value={configDraft.triggerThreshold} onChange={setDraftTriggerThreshold} />
+            )}
+            {configDraft.frequency === 'scheduled' && (
+                <ScheduleConfig
+                    rrule={configDraft.rrule}
+                    startsAt={configDraft.startsAt}
+                    timezoneName={configDraft.timezoneName}
+                    onRruleChange={setDraftRrule}
+                    onStartsAtChange={setDraftStartsAt}
+                    onTimezoneChange={setDraftTimezoneName}
+                />
+            )}
+            <DeliveryTargetsConfig
+                emailValue={configDraft.emailValue}
+                onEmailChange={setDraftEmailValue}
+                slackIntegrationId={configDraft.slackIntegrationId}
+                onSlackIntegrationChange={setDraftSlackIntegrationId}
+                slackChannelValue={configDraft.slackChannelValue}
+                onSlackChannelChange={setDraftSlackChannelValue}
+            />
+            <div>
+                <label className="font-semibold text-sm">Report agent guidance (optional)</label>
+                <LemonTextArea
+                    value={configDraft.reportPromptGuidance}
+                    onChange={setDraftReportPromptGuidance}
+                    placeholder={GUIDANCE_PLACEHOLDER}
+                    rows={3}
+                />
+                <p className="text-xs text-muted mt-1">
+                    Steers the agent's focus, section choices, or scope. Appended to the base prompt.
+                </p>
+            </div>
+        </div>
+    )
+}
+
+/** Save button for the edit path. Disabled based on draft dirtiness and target presence. */
+function SaveReportButton({ evaluationId }: { evaluationId: string }): JSX.Element {
+    const logic = evaluationReportLogic({ evaluationId })
+    const { configDraft, isConfigDirty, reportsLoading } = useValues(logic)
+    const { saveDraft } = useActions(logic)
+
+    const hasAnyTarget = buildDeliveryTargets(configDraft).length > 0
+
+    return (
+        <div className="flex justify-end">
+            <LemonButton
+                type="primary"
+                size="small"
+                loading={reportsLoading}
+                onClick={() => saveDraft()}
+                disabledReason={
+                    !isConfigDirty
+                        ? 'No changes to save'
+                        : !hasAnyTarget
+                          ? 'Add at least one delivery target'
+                          : undefined
+                }
+            >
+                Save changes
+            </LemonButton>
+        </div>
+    )
+}
+
 /** Inline config shown during new evaluation creation */
 function PendingReportConfig({ evaluationId }: { evaluationId: string }): JSX.Element {
-    const { pendingConfig } = useValues(evaluationReportLogic({ evaluationId }))
-    const {
-        setPendingEnabled,
-        setPendingFrequency,
-        setPendingEmailValue,
-        setPendingSlackIntegrationId,
-        setPendingSlackChannelValue,
-        setPendingReportPromptGuidance,
-        setPendingTriggerThreshold,
-    } = useActions(evaluationReportLogic({ evaluationId }))
+    const { configDraft } = useValues(evaluationReportLogic({ evaluationId }))
+    const { setDraftEnabled } = useActions(evaluationReportLogic({ evaluationId }))
 
     return (
         <div className="bg-bg-light border rounded p-6">
@@ -134,49 +283,13 @@ function PendingReportConfig({ evaluationId }: { evaluationId: string }): JSX.El
                     </p>
                 </div>
                 <LemonSwitch
-                    checked={pendingConfig.enabled}
-                    onChange={setPendingEnabled}
+                    checked={configDraft.enabled}
+                    onChange={setDraftEnabled}
                     bordered
-                    label={pendingConfig.enabled ? 'Enabled' : 'Disabled'}
+                    label={configDraft.enabled ? 'Enabled' : 'Disabled'}
                 />
             </div>
-
-            {pendingConfig.enabled && (
-                <div className="space-y-4 mt-4">
-                    <div>
-                        <label className="font-semibold text-sm">Frequency</label>
-                        <LemonSelect
-                            value={pendingConfig.frequency}
-                            onChange={(val) => val && setPendingFrequency(val)}
-                            options={FREQUENCY_OPTIONS}
-                            fullWidth
-                        />
-                    </div>
-                    {pendingConfig.frequency === 'every_n' && (
-                        <ThresholdConfig value={pendingConfig.triggerThreshold} onChange={setPendingTriggerThreshold} />
-                    )}
-                    <DeliveryTargetsConfig
-                        emailValue={pendingConfig.emailValue}
-                        onEmailChange={setPendingEmailValue}
-                        slackIntegrationId={pendingConfig.slackIntegrationId}
-                        onSlackIntegrationChange={setPendingSlackIntegrationId}
-                        slackChannelValue={pendingConfig.slackChannelValue}
-                        onSlackChannelChange={setPendingSlackChannelValue}
-                    />
-                    <div>
-                        <label className="font-semibold text-sm">Report agent guidance (optional)</label>
-                        <LemonTextArea
-                            value={pendingConfig.reportPromptGuidance}
-                            onChange={setPendingReportPromptGuidance}
-                            placeholder={GUIDANCE_PLACEHOLDER}
-                            rows={3}
-                        />
-                        <p className="text-xs text-muted mt-1">
-                            Steers the agent's focus, section choices, or scope. Appended to the base prompt.
-                        </p>
-                    </div>
-                </div>
-            )}
+            {configDraft.enabled && <ReportFormFields evaluationId={evaluationId} />}
         </div>
     )
 }
@@ -184,44 +297,15 @@ function PendingReportConfig({ evaluationId }: { evaluationId: string }): JSX.El
 /** Toggle-based report management for existing evaluations */
 function ExistingReportConfig({ evaluationId }: { evaluationId: string }): JSX.Element {
     const logic = evaluationReportLogic({ evaluationId })
-    const { activeReport, reportsLoading } = useValues(logic)
-    const { updateReport, deleteReport, createReport } = useActions(logic)
+    const { activeReport, reportsLoading, configDraft } = useValues(logic)
+    const { deleteReport, saveDraft, setDraftEnabled } = useActions(logic)
 
-    // Local state: toggle controls form visibility, Save button creates the report.
-    // All fields are local-first so the user can change multiple things before saving.
-    const [formEnabled, setFormEnabled] = useState(false)
-    const [frequency, setFrequency] = useState<EvaluationReportFrequency>('daily')
-    const [emailValue, setEmailValue] = useState('')
-    const [slackIntegrationId, setSlackIntegrationId] = useState<number | null>(null)
-    const [slackChannelValue, setSlackChannelValue] = useState('')
-    const [guidance, setGuidance] = useState('')
-    const [triggerThreshold, setTriggerThreshold] = useState(TRIGGER_THRESHOLD_DEFAULT)
-
-    // Seed local form state from the active report so the user can edit
-    // any field without having to disable + recreate the schedule.
-    useEffect(() => {
-        if (!activeReport) {
-            return
-        }
-        const emailTarget = activeReport.delivery_targets.find(
-            (t: EvaluationReportDeliveryTarget) => t.type === 'email'
-        )
-        const slackTarget = activeReport.delivery_targets.find(
-            (t: EvaluationReportDeliveryTarget) => t.type === 'slack'
-        )
-        setFrequency(activeReport.frequency)
-        setEmailValue(emailTarget?.value ?? '')
-        setSlackIntegrationId(slackTarget?.integration_id ?? null)
-        setSlackChannelValue(slackTarget?.channel ?? '')
-        setGuidance(activeReport.report_prompt_guidance ?? '')
-        setTriggerThreshold(activeReport.trigger_threshold ?? TRIGGER_THRESHOLD_DEFAULT)
-    }, [activeReport])
-
-    const isEnabled = !!activeReport || formEnabled
+    const isEnabled = !!activeReport || configDraft.enabled
+    const hasAnyTarget = buildDeliveryTargets(configDraft).length > 0
 
     const handleToggle = (checked: boolean): void => {
         if (checked) {
-            setFormEnabled(true)
+            setDraftEnabled(true)
         } else if (activeReport) {
             LemonDialog.open({
                 title: 'Disable scheduled reports?',
@@ -234,29 +318,8 @@ function ExistingReportConfig({ evaluationId }: { evaluationId: string }): JSX.E
                 secondaryButton: { children: 'Cancel' },
             })
         } else {
-            setFormEnabled(false)
+            setDraftEnabled(false)
         }
-    }
-
-    const hasEmail = emailValue.trim().length > 0
-    const hasSlack = slackIntegrationId !== null && slackChannelValue.length > 0
-
-    const handleSave = (): void => {
-        const targets: EvaluationReportDeliveryTarget[] = []
-        if (hasEmail) {
-            targets.push({ type: 'email', value: emailValue.trim() })
-        }
-        if (hasSlack) {
-            targets.push({ type: 'slack', integration_id: slackIntegrationId!, channel: slackChannelValue })
-        }
-        createReport({
-            evaluationId,
-            frequency,
-            delivery_targets: targets,
-            report_prompt_guidance: guidance,
-            trigger_threshold: frequency === 'every_n' ? triggerThreshold : null,
-        })
-        setFormEnabled(false)
     }
 
     return (
@@ -279,172 +342,40 @@ function ExistingReportConfig({ evaluationId }: { evaluationId: string }): JSX.E
             </div>
 
             {activeReport ? (
-                <div className="space-y-4 mt-4">
-                    <div>
-                        <label className="font-semibold text-sm">Frequency</label>
-                        <LemonSelect
-                            value={frequency}
-                            onChange={(val) => val && setFrequency(val)}
-                            options={FREQUENCY_OPTIONS}
-                            fullWidth
-                        />
-                    </div>
-
-                    {frequency === 'every_n' && (
-                        <ThresholdConfig value={triggerThreshold} onChange={setTriggerThreshold} />
-                    )}
-
-                    <DeliveryTargetsConfig
-                        emailValue={emailValue}
-                        onEmailChange={setEmailValue}
-                        slackIntegrationId={slackIntegrationId}
-                        onSlackIntegrationChange={setSlackIntegrationId}
-                        slackChannelValue={slackChannelValue}
-                        onSlackChannelChange={setSlackChannelValue}
-                    />
-
-                    <div>
-                        <label className="font-semibold text-sm">Report agent guidance (optional)</label>
-                        <LemonTextArea
-                            value={guidance}
-                            onChange={setGuidance}
-                            placeholder={GUIDANCE_PLACEHOLDER}
-                            rows={3}
-                        />
-                        <p className="text-xs text-muted mt-1">
-                            Steers the agent's focus, section choices, or scope. Appended to the base prompt.
-                        </p>
-                    </div>
-
-                    {(() => {
-                        const currentEmail =
-                            activeReport.delivery_targets.find(
-                                (t: EvaluationReportDeliveryTarget) => t.type === 'email'
-                            )?.value ?? ''
-                        const currentSlack = activeReport.delivery_targets.find(
-                            (t: EvaluationReportDeliveryTarget) => t.type === 'slack'
-                        )
-                        const currentSlackIntegrationId: number | null = currentSlack?.integration_id ?? null
-                        const currentSlackChannel = currentSlack?.channel ?? ''
-                        const currentGuidance = activeReport.report_prompt_guidance ?? ''
-                        const currentThreshold = activeReport.trigger_threshold ?? TRIGGER_THRESHOLD_DEFAULT
-                        const frequencyDirty = frequency !== activeReport.frequency
-                        const targetsDirty =
-                            emailValue.trim() !== currentEmail ||
-                            slackIntegrationId !== currentSlackIntegrationId ||
-                            slackChannelValue !== currentSlackChannel
-                        const guidanceDirty = guidance !== currentGuidance
-                        const thresholdDirty = frequency === 'every_n' && triggerThreshold !== currentThreshold
-                        const isDirty = frequencyDirty || targetsDirty || guidanceDirty || thresholdDirty
-                        const hasAnyTarget = hasEmail || hasSlack
-                        return (
-                            <div className="flex justify-end">
-                                <LemonButton
-                                    type="primary"
-                                    size="small"
-                                    loading={reportsLoading}
-                                    disabledReason={
-                                        !isDirty
-                                            ? 'No changes to save'
-                                            : !hasAnyTarget
-                                              ? 'Add at least one delivery target'
-                                              : undefined
-                                    }
-                                    onClick={() => {
-                                        const targets: EvaluationReportDeliveryTarget[] = []
-                                        if (hasEmail) {
-                                            targets.push({ type: 'email', value: emailValue.trim() })
-                                        }
-                                        if (hasSlack) {
-                                            targets.push({
-                                                type: 'slack',
-                                                integration_id: slackIntegrationId!,
-                                                channel: slackChannelValue,
-                                            })
-                                        }
-                                        const data: Record<string, unknown> = {
-                                            frequency,
-                                            delivery_targets: targets,
-                                            report_prompt_guidance: guidance,
-                                        }
-                                        if (frequency === 'every_n') {
-                                            data.trigger_threshold = triggerThreshold
-                                        }
-                                        updateReport({
-                                            reportId: activeReport.id,
-                                            data,
-                                        })
-                                    }}
-                                >
-                                    Save changes
-                                </LemonButton>
-                            </div>
-                        )
-                    })()}
-
-                    {frequency === 'every_n' ? (
-                        <div className="text-sm text-muted">
+                <>
+                    <ReportFormFields evaluationId={evaluationId} />
+                    <SaveReportButton evaluationId={evaluationId} />
+                    {configDraft.frequency === 'every_n' ? (
+                        <div className="text-sm text-muted mt-4">
                             A report will be generated when{' '}
                             {activeReport.trigger_threshold ?? TRIGGER_THRESHOLD_DEFAULT} new evaluation results arrive.
                             Checked every 5 minutes.
                         </div>
                     ) : (
                         activeReport.next_delivery_date && (
-                            <div className="text-sm text-muted">
+                            <div className="text-sm text-muted mt-4">
                                 Next delivery: {new Date(activeReport.next_delivery_date).toLocaleString()}
                             </div>
                         )
                     )}
-
-                    <p className="text-xs text-muted m-0">Generated reports appear in the Reports tab.</p>
-                </div>
+                    <p className="text-xs text-muted m-0 mt-2">Generated reports appear in the Reports tab.</p>
+                </>
             ) : (
-                formEnabled && (
-                    <div className="space-y-4 mt-4">
-                        <div>
-                            <label className="font-semibold text-sm">Frequency</label>
-                            <LemonSelect
-                                value={frequency}
-                                onChange={(val) => val && setFrequency(val)}
-                                options={FREQUENCY_OPTIONS}
-                                fullWidth
-                            />
-                        </div>
-                        {frequency === 'every_n' && (
-                            <ThresholdConfig value={triggerThreshold} onChange={setTriggerThreshold} />
-                        )}
-                        <DeliveryTargetsConfig
-                            emailValue={emailValue}
-                            onEmailChange={setEmailValue}
-                            slackIntegrationId={slackIntegrationId}
-                            onSlackIntegrationChange={setSlackIntegrationId}
-                            slackChannelValue={slackChannelValue}
-                            onSlackChannelChange={setSlackChannelValue}
-                        />
-                        <div>
-                            <label className="font-semibold text-sm">Report agent guidance (optional)</label>
-                            <LemonTextArea
-                                value={guidance}
-                                onChange={setGuidance}
-                                placeholder={GUIDANCE_PLACEHOLDER}
-                                rows={3}
-                            />
-                            <p className="text-xs text-muted mt-1">
-                                Steers the agent's focus, section choices, or scope. Appended to the base prompt.
-                            </p>
-                        </div>
-                        <div className="flex justify-end">
+                configDraft.enabled && (
+                    <>
+                        <ReportFormFields evaluationId={evaluationId} />
+                        <div className="flex justify-end mt-4">
                             <LemonButton
                                 type="primary"
                                 size="small"
-                                onClick={handleSave}
+                                onClick={() => saveDraft()}
                                 loading={reportsLoading}
-                                disabledReason={!hasEmail && !hasSlack ? 'Add at least one delivery target' : undefined}
+                                disabledReason={!hasAnyTarget ? 'Add at least one delivery target' : undefined}
                             >
                                 Save report schedule
                             </LemonButton>
                         </div>
-                    </div>
+                    </>
                 )
             )}
         </div>

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationReportConfig.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationReportConfig.tsx
@@ -1,0 +1,455 @@
+import { useActions, useValues } from 'kea'
+import { useEffect, useState } from 'react'
+
+import { LemonButton, LemonDialog, LemonInput, LemonSelect, LemonSwitch, LemonTextArea } from '@posthog/lemon-ui'
+
+import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
+import { integrationsLogic } from 'lib/integrations/integrationsLogic'
+import { SlackChannelPicker, SlackNotConfiguredBanner } from 'lib/integrations/SlackIntegrationHelpers'
+
+import { evaluationReportLogic } from '../evaluationReportLogic'
+import type { EvaluationReportDeliveryTarget, EvaluationReportFrequency } from '../types'
+
+const GUIDANCE_PLACEHOLDER =
+    "Optional guidance for the report agent. e.g. 'Focus on cost regressions across models', 'Compare latency between gpt-4o-mini and claude-sonnet', 'Keep it to 2 sections max'"
+
+const FREQUENCY_OPTIONS = [
+    { value: 'hourly' as const, label: 'Hourly' },
+    { value: 'daily' as const, label: 'Daily' },
+    { value: 'weekly' as const, label: 'Weekly' },
+    { value: 'every_n' as const, label: 'Every N evaluations' },
+]
+
+const TRIGGER_THRESHOLD_MIN = 10
+const TRIGGER_THRESHOLD_MAX = 10_000
+const TRIGGER_THRESHOLD_DEFAULT = 100
+
+/** Threshold config shown when frequency is 'every_n' */
+function ThresholdConfig({ value, onChange }: { value: number; onChange: (value: number) => void }): JSX.Element {
+    return (
+        <div>
+            <label className="font-semibold text-sm">Evaluation count threshold</label>
+            <LemonInput
+                type="number"
+                min={TRIGGER_THRESHOLD_MIN}
+                max={TRIGGER_THRESHOLD_MAX}
+                value={value}
+                onChange={(val) => onChange(Number(val))}
+                fullWidth
+            />
+            <p className="text-xs text-muted mt-1">
+                A report will be generated after this many new evaluation results arrive. Checked every 5 minutes. Min{' '}
+                {TRIGGER_THRESHOLD_MIN}, max {TRIGGER_THRESHOLD_MAX.toLocaleString()}. Cooldown: at most one report per
+                hour, up to 10 per day.
+            </p>
+        </div>
+    )
+}
+
+/** Shared delivery targets configuration */
+function DeliveryTargetsConfig({
+    emailValue,
+    onEmailChange,
+    slackIntegrationId,
+    onSlackIntegrationChange,
+    slackChannelValue,
+    onSlackChannelChange,
+}: {
+    emailValue: string
+    onEmailChange: (value: string) => void
+    slackIntegrationId: number | null
+    onSlackIntegrationChange: (value: number | null) => void
+    slackChannelValue: string
+    onSlackChannelChange: (value: string) => void
+}): JSX.Element {
+    const { slackIntegrations, integrations } = useValues(integrationsLogic)
+
+    return (
+        <>
+            <div>
+                <label className="font-semibold text-sm">Email recipients</label>
+                <LemonInput
+                    value={emailValue}
+                    onChange={onEmailChange}
+                    placeholder="email1@example.com, email2@example.com"
+                    fullWidth
+                />
+                <p className="text-xs text-muted mt-1">Comma-separated email addresses</p>
+            </div>
+            <div>
+                <label className="font-semibold text-sm">Slack channel</label>
+                {!slackIntegrations?.length ? (
+                    <SlackNotConfiguredBanner />
+                ) : (
+                    <div className="space-y-2">
+                        <IntegrationChoice
+                            integration="slack"
+                            value={slackIntegrationId ?? undefined}
+                            onChange={(newValue) => {
+                                if (newValue !== slackIntegrationId) {
+                                    onSlackChannelChange('')
+                                }
+                                onSlackIntegrationChange(newValue)
+                            }}
+                        />
+                        {slackIntegrationId && (
+                            <SlackChannelPicker
+                                value={slackChannelValue}
+                                onChange={(val) => onSlackChannelChange(val || '')}
+                                integration={integrations!.find((i) => i.id === slackIntegrationId)!}
+                            />
+                        )}
+                    </div>
+                )}
+            </div>
+        </>
+    )
+}
+
+/** Inline config shown during new evaluation creation */
+function PendingReportConfig({ evaluationId }: { evaluationId: string }): JSX.Element {
+    const { pendingConfig } = useValues(evaluationReportLogic({ evaluationId }))
+    const {
+        setPendingEnabled,
+        setPendingFrequency,
+        setPendingEmailValue,
+        setPendingSlackIntegrationId,
+        setPendingSlackChannelValue,
+        setPendingReportPromptGuidance,
+        setPendingTriggerThreshold,
+    } = useActions(evaluationReportLogic({ evaluationId }))
+
+    return (
+        <div className="bg-bg-light border rounded p-6">
+            <div className="flex items-center justify-between mb-4">
+                <div>
+                    <h3 className="text-lg font-semibold mb-1">Scheduled reports</h3>
+                    <p className="text-muted text-sm">
+                        AI-generated analysis of evaluation results. Reports are always available in the Reports tab.
+                        Optionally add email or Slack to get notified.
+                    </p>
+                </div>
+                <LemonSwitch
+                    checked={pendingConfig.enabled}
+                    onChange={setPendingEnabled}
+                    bordered
+                    label={pendingConfig.enabled ? 'Enabled' : 'Disabled'}
+                />
+            </div>
+
+            {pendingConfig.enabled && (
+                <div className="space-y-4 mt-4">
+                    <div>
+                        <label className="font-semibold text-sm">Frequency</label>
+                        <LemonSelect
+                            value={pendingConfig.frequency}
+                            onChange={(val) => val && setPendingFrequency(val)}
+                            options={FREQUENCY_OPTIONS}
+                            fullWidth
+                        />
+                    </div>
+                    {pendingConfig.frequency === 'every_n' && (
+                        <ThresholdConfig value={pendingConfig.triggerThreshold} onChange={setPendingTriggerThreshold} />
+                    )}
+                    <DeliveryTargetsConfig
+                        emailValue={pendingConfig.emailValue}
+                        onEmailChange={setPendingEmailValue}
+                        slackIntegrationId={pendingConfig.slackIntegrationId}
+                        onSlackIntegrationChange={setPendingSlackIntegrationId}
+                        slackChannelValue={pendingConfig.slackChannelValue}
+                        onSlackChannelChange={setPendingSlackChannelValue}
+                    />
+                    <div>
+                        <label className="font-semibold text-sm">Report agent guidance (optional)</label>
+                        <LemonTextArea
+                            value={pendingConfig.reportPromptGuidance}
+                            onChange={setPendingReportPromptGuidance}
+                            placeholder={GUIDANCE_PLACEHOLDER}
+                            rows={3}
+                        />
+                        <p className="text-xs text-muted mt-1">
+                            Steers the agent's focus, section choices, or scope. Appended to the base prompt.
+                        </p>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}
+
+/** Toggle-based report management for existing evaluations */
+function ExistingReportConfig({ evaluationId }: { evaluationId: string }): JSX.Element {
+    const logic = evaluationReportLogic({ evaluationId })
+    const { activeReport, reportsLoading } = useValues(logic)
+    const { updateReport, deleteReport, createReport } = useActions(logic)
+
+    // Local state: toggle controls form visibility, Save button creates the report.
+    // All fields are local-first so the user can change multiple things before saving.
+    const [formEnabled, setFormEnabled] = useState(false)
+    const [frequency, setFrequency] = useState<EvaluationReportFrequency>('daily')
+    const [emailValue, setEmailValue] = useState('')
+    const [slackIntegrationId, setSlackIntegrationId] = useState<number | null>(null)
+    const [slackChannelValue, setSlackChannelValue] = useState('')
+    const [guidance, setGuidance] = useState('')
+    const [triggerThreshold, setTriggerThreshold] = useState(TRIGGER_THRESHOLD_DEFAULT)
+
+    // Seed local form state from the active report so the user can edit
+    // any field without having to disable + recreate the schedule.
+    useEffect(() => {
+        if (!activeReport) {
+            return
+        }
+        const emailTarget = activeReport.delivery_targets.find(
+            (t: EvaluationReportDeliveryTarget) => t.type === 'email'
+        )
+        const slackTarget = activeReport.delivery_targets.find(
+            (t: EvaluationReportDeliveryTarget) => t.type === 'slack'
+        )
+        setFrequency(activeReport.frequency)
+        setEmailValue(emailTarget?.value ?? '')
+        setSlackIntegrationId(slackTarget?.integration_id ?? null)
+        setSlackChannelValue(slackTarget?.channel ?? '')
+        setGuidance(activeReport.report_prompt_guidance ?? '')
+        setTriggerThreshold(activeReport.trigger_threshold ?? TRIGGER_THRESHOLD_DEFAULT)
+    }, [activeReport])
+
+    const isEnabled = !!activeReport || formEnabled
+
+    const handleToggle = (checked: boolean): void => {
+        if (checked) {
+            setFormEnabled(true)
+        } else if (activeReport) {
+            LemonDialog.open({
+                title: 'Disable scheduled reports?',
+                description: 'This will stop all future report deliveries. Past reports will be preserved.',
+                primaryButton: {
+                    children: 'Disable',
+                    status: 'danger',
+                    onClick: () => deleteReport(activeReport.id),
+                },
+                secondaryButton: { children: 'Cancel' },
+            })
+        } else {
+            setFormEnabled(false)
+        }
+    }
+
+    const hasEmail = emailValue.trim().length > 0
+    const hasSlack = slackIntegrationId !== null && slackChannelValue.length > 0
+
+    const handleSave = (): void => {
+        const targets: EvaluationReportDeliveryTarget[] = []
+        if (hasEmail) {
+            targets.push({ type: 'email', value: emailValue.trim() })
+        }
+        if (hasSlack) {
+            targets.push({ type: 'slack', integration_id: slackIntegrationId!, channel: slackChannelValue })
+        }
+        createReport({
+            evaluationId,
+            frequency,
+            delivery_targets: targets,
+            report_prompt_guidance: guidance,
+            trigger_threshold: frequency === 'every_n' ? triggerThreshold : null,
+        })
+        setFormEnabled(false)
+    }
+
+    return (
+        <div className="bg-bg-light border rounded p-6">
+            <div className="flex items-center justify-between mb-4">
+                <div>
+                    <h3 className="text-lg font-semibold mb-1">Scheduled reports</h3>
+                    <p className="text-muted text-sm">
+                        AI-generated analysis of evaluation results. Reports are always available in the Reports tab.
+                        Optionally add email or Slack to get notified.
+                    </p>
+                </div>
+                <LemonSwitch
+                    checked={isEnabled}
+                    onChange={handleToggle}
+                    bordered
+                    loading={reportsLoading}
+                    label={isEnabled ? 'Enabled' : 'Disabled'}
+                />
+            </div>
+
+            {activeReport ? (
+                <div className="space-y-4 mt-4">
+                    <div>
+                        <label className="font-semibold text-sm">Frequency</label>
+                        <LemonSelect
+                            value={frequency}
+                            onChange={(val) => val && setFrequency(val)}
+                            options={FREQUENCY_OPTIONS}
+                            fullWidth
+                        />
+                    </div>
+
+                    {frequency === 'every_n' && (
+                        <ThresholdConfig value={triggerThreshold} onChange={setTriggerThreshold} />
+                    )}
+
+                    <DeliveryTargetsConfig
+                        emailValue={emailValue}
+                        onEmailChange={setEmailValue}
+                        slackIntegrationId={slackIntegrationId}
+                        onSlackIntegrationChange={setSlackIntegrationId}
+                        slackChannelValue={slackChannelValue}
+                        onSlackChannelChange={setSlackChannelValue}
+                    />
+
+                    <div>
+                        <label className="font-semibold text-sm">Report agent guidance (optional)</label>
+                        <LemonTextArea
+                            value={guidance}
+                            onChange={setGuidance}
+                            placeholder={GUIDANCE_PLACEHOLDER}
+                            rows={3}
+                        />
+                        <p className="text-xs text-muted mt-1">
+                            Steers the agent's focus, section choices, or scope. Appended to the base prompt.
+                        </p>
+                    </div>
+
+                    {(() => {
+                        const currentEmail =
+                            activeReport.delivery_targets.find(
+                                (t: EvaluationReportDeliveryTarget) => t.type === 'email'
+                            )?.value ?? ''
+                        const currentSlack = activeReport.delivery_targets.find(
+                            (t: EvaluationReportDeliveryTarget) => t.type === 'slack'
+                        )
+                        const currentSlackIntegrationId: number | null = currentSlack?.integration_id ?? null
+                        const currentSlackChannel = currentSlack?.channel ?? ''
+                        const currentGuidance = activeReport.report_prompt_guidance ?? ''
+                        const currentThreshold = activeReport.trigger_threshold ?? TRIGGER_THRESHOLD_DEFAULT
+                        const frequencyDirty = frequency !== activeReport.frequency
+                        const targetsDirty =
+                            emailValue.trim() !== currentEmail ||
+                            slackIntegrationId !== currentSlackIntegrationId ||
+                            slackChannelValue !== currentSlackChannel
+                        const guidanceDirty = guidance !== currentGuidance
+                        const thresholdDirty = frequency === 'every_n' && triggerThreshold !== currentThreshold
+                        const isDirty = frequencyDirty || targetsDirty || guidanceDirty || thresholdDirty
+                        const hasAnyTarget = hasEmail || hasSlack
+                        return (
+                            <div className="flex justify-end">
+                                <LemonButton
+                                    type="primary"
+                                    size="small"
+                                    loading={reportsLoading}
+                                    disabledReason={
+                                        !isDirty
+                                            ? 'No changes to save'
+                                            : !hasAnyTarget
+                                              ? 'Add at least one delivery target'
+                                              : undefined
+                                    }
+                                    onClick={() => {
+                                        const targets: EvaluationReportDeliveryTarget[] = []
+                                        if (hasEmail) {
+                                            targets.push({ type: 'email', value: emailValue.trim() })
+                                        }
+                                        if (hasSlack) {
+                                            targets.push({
+                                                type: 'slack',
+                                                integration_id: slackIntegrationId!,
+                                                channel: slackChannelValue,
+                                            })
+                                        }
+                                        const data: Record<string, unknown> = {
+                                            frequency,
+                                            delivery_targets: targets,
+                                            report_prompt_guidance: guidance,
+                                        }
+                                        if (frequency === 'every_n') {
+                                            data.trigger_threshold = triggerThreshold
+                                        }
+                                        updateReport({
+                                            reportId: activeReport.id,
+                                            data,
+                                        })
+                                    }}
+                                >
+                                    Save changes
+                                </LemonButton>
+                            </div>
+                        )
+                    })()}
+
+                    {frequency === 'every_n' ? (
+                        <div className="text-sm text-muted">
+                            A report will be generated when{' '}
+                            {activeReport.trigger_threshold ?? TRIGGER_THRESHOLD_DEFAULT} new evaluation results arrive.
+                            Checked every 5 minutes.
+                        </div>
+                    ) : (
+                        activeReport.next_delivery_date && (
+                            <div className="text-sm text-muted">
+                                Next delivery: {new Date(activeReport.next_delivery_date).toLocaleString()}
+                            </div>
+                        )
+                    )}
+
+                    <p className="text-xs text-muted m-0">Generated reports appear in the Reports tab.</p>
+                </div>
+            ) : (
+                formEnabled && (
+                    <div className="space-y-4 mt-4">
+                        <div>
+                            <label className="font-semibold text-sm">Frequency</label>
+                            <LemonSelect
+                                value={frequency}
+                                onChange={(val) => val && setFrequency(val)}
+                                options={FREQUENCY_OPTIONS}
+                                fullWidth
+                            />
+                        </div>
+                        {frequency === 'every_n' && (
+                            <ThresholdConfig value={triggerThreshold} onChange={setTriggerThreshold} />
+                        )}
+                        <DeliveryTargetsConfig
+                            emailValue={emailValue}
+                            onEmailChange={setEmailValue}
+                            slackIntegrationId={slackIntegrationId}
+                            onSlackIntegrationChange={setSlackIntegrationId}
+                            slackChannelValue={slackChannelValue}
+                            onSlackChannelChange={setSlackChannelValue}
+                        />
+                        <div>
+                            <label className="font-semibold text-sm">Report agent guidance (optional)</label>
+                            <LemonTextArea
+                                value={guidance}
+                                onChange={setGuidance}
+                                placeholder={GUIDANCE_PLACEHOLDER}
+                                rows={3}
+                            />
+                            <p className="text-xs text-muted mt-1">
+                                Steers the agent's focus, section choices, or scope. Appended to the base prompt.
+                            </p>
+                        </div>
+                        <div className="flex justify-end">
+                            <LemonButton
+                                type="primary"
+                                size="small"
+                                onClick={handleSave}
+                                loading={reportsLoading}
+                                disabledReason={!hasEmail && !hasSlack ? 'Add at least one delivery target' : undefined}
+                            >
+                                Save report schedule
+                            </LemonButton>
+                        </div>
+                    </div>
+                )
+            )}
+        </div>
+    )
+}
+
+export function EvaluationReportConfig({ evaluationId }: { evaluationId: string }): JSX.Element {
+    if (evaluationId === 'new') {
+        return <PendingReportConfig evaluationId={evaluationId} />
+    }
+    return <ExistingReportConfig evaluationId={evaluationId} />
+}

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationReportConfig.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationReportConfig.tsx
@@ -92,13 +92,17 @@ function DeliveryTargetsConfig({
                                 onSlackIntegrationChange(newValue)
                             }}
                         />
-                        {slackIntegrationId && (
-                            <SlackChannelPicker
-                                value={slackChannelValue}
-                                onChange={(val) => onSlackChannelChange(val || '')}
-                                integration={integrations!.find((i) => i.id === slackIntegrationId)!}
-                            />
-                        )}
+                        {slackIntegrationId &&
+                            (() => {
+                                const selectedIntegration = integrations?.find((i) => i.id === slackIntegrationId)
+                                return selectedIntegration ? (
+                                    <SlackChannelPicker
+                                        value={slackChannelValue}
+                                        onChange={(val) => onSlackChannelChange(val || '')}
+                                        integration={selectedIntegration}
+                                    />
+                                ) : null
+                            })()}
                     </div>
                 )}
             </div>

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationReportConfig.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationReportConfig.tsx
@@ -10,8 +10,8 @@ import {
     LemonTextArea,
 } from '@posthog/lemon-ui'
 
-import { dayjs } from 'lib/dayjs'
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
+import { dayjs } from 'lib/dayjs'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { SlackChannelPicker, SlackNotConfiguredBanner } from 'lib/integrations/SlackIntegrationHelpers'
 
@@ -53,12 +53,7 @@ function ScheduleConfig({
         <div className="space-y-3">
             <div>
                 <label className="font-semibold text-sm">Schedule (RRULE)</label>
-                <LemonInput
-                    value={rrule}
-                    onChange={onRruleChange}
-                    placeholder={RRULE_PLACEHOLDER}
-                    fullWidth
-                />
+                <LemonInput value={rrule} onChange={onRruleChange} placeholder={RRULE_PLACEHOLDER} fullWidth />
                 <p className="text-xs text-muted mt-1">{RRULE_EXAMPLES}</p>
             </div>
             <div>
@@ -78,12 +73,7 @@ function ScheduleConfig({
             </div>
             <div>
                 <label className="font-semibold text-sm">Timezone</label>
-                <LemonInput
-                    value={timezoneName}
-                    onChange={onTimezoneChange}
-                    placeholder="UTC"
-                    fullWidth
-                />
+                <LemonInput value={timezoneName} onChange={onTimezoneChange} placeholder="UTC" fullWidth />
                 <p className="text-xs text-muted mt-1">IANA timezone name (e.g. UTC, America/New_York).</p>
             </div>
         </div>

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationReportConfig.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationReportConfig.tsx
@@ -1,5 +1,4 @@
 import { useActions, useValues } from 'kea'
-import { useEffect, useState } from 'react'
 
 import { LemonButton, LemonDialog, LemonInput, LemonSelect, LemonSwitch, LemonTextArea } from '@posthog/lemon-ui'
 
@@ -7,8 +6,7 @@ import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/Inte
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { SlackChannelPicker, SlackNotConfiguredBanner } from 'lib/integrations/SlackIntegrationHelpers'
 
-import { evaluationReportLogic } from '../evaluationReportLogic'
-import type { EvaluationReportDeliveryTarget, EvaluationReportFrequency } from '../types'
+import { buildDeliveryTargets, evaluationReportLogic, TRIGGER_THRESHOLD_DEFAULT } from '../evaluationReportLogic'
 
 const GUIDANCE_PLACEHOLDER =
     "Optional guidance for the report agent. e.g. 'Focus on cost regressions across models', 'Compare latency between gpt-4o-mini and claude-sonnet', 'Keep it to 2 sections max'"
@@ -22,7 +20,6 @@ const FREQUENCY_OPTIONS = [
 
 const TRIGGER_THRESHOLD_MIN = 10
 const TRIGGER_THRESHOLD_MAX = 10_000
-const TRIGGER_THRESHOLD_DEFAULT = 100
 
 /** Threshold config shown when frequency is 'every_n' */
 function ThresholdConfig({ value, onChange }: { value: number; onChange: (value: number) => void }): JSX.Element {
@@ -63,6 +60,8 @@ function DeliveryTargetsConfig({
     onSlackChannelChange: (value: string) => void
 }): JSX.Element {
     const { slackIntegrations, integrations } = useValues(integrationsLogic)
+    const selectedIntegration =
+        slackIntegrationId !== null ? integrations?.find((i) => i.id === slackIntegrationId) : undefined
 
     return (
         <>
@@ -92,17 +91,13 @@ function DeliveryTargetsConfig({
                                 onSlackIntegrationChange(newValue)
                             }}
                         />
-                        {slackIntegrationId &&
-                            (() => {
-                                const selectedIntegration = integrations?.find((i) => i.id === slackIntegrationId)
-                                return selectedIntegration ? (
-                                    <SlackChannelPicker
-                                        value={slackChannelValue}
-                                        onChange={(val) => onSlackChannelChange(val || '')}
-                                        integration={selectedIntegration}
-                                    />
-                                ) : null
-                            })()}
+                        {selectedIntegration && (
+                            <SlackChannelPicker
+                                value={slackChannelValue}
+                                onChange={(val) => onSlackChannelChange(val || '')}
+                                integration={selectedIntegration}
+                            />
+                        )}
                     </div>
                 )}
             </div>
@@ -110,18 +105,90 @@ function DeliveryTargetsConfig({
     )
 }
 
+/** Shared form body used by both the create-evaluation and edit-existing-evaluation paths.
+ * All state is backed by `evaluationReportLogic.configDraft` keyed by evaluationId. */
+function ReportFormFields({ evaluationId }: { evaluationId: string }): JSX.Element {
+    const { configDraft } = useValues(evaluationReportLogic({ evaluationId }))
+    const {
+        setDraftFrequency,
+        setDraftEmailValue,
+        setDraftSlackIntegrationId,
+        setDraftSlackChannelValue,
+        setDraftReportPromptGuidance,
+        setDraftTriggerThreshold,
+    } = useActions(evaluationReportLogic({ evaluationId }))
+
+    return (
+        <div className="space-y-4 mt-4">
+            <div>
+                <label className="font-semibold text-sm">Frequency</label>
+                <LemonSelect
+                    value={configDraft.frequency}
+                    onChange={(val) => val && setDraftFrequency(val)}
+                    options={FREQUENCY_OPTIONS}
+                    fullWidth
+                />
+            </div>
+            {configDraft.frequency === 'every_n' && (
+                <ThresholdConfig value={configDraft.triggerThreshold} onChange={setDraftTriggerThreshold} />
+            )}
+            <DeliveryTargetsConfig
+                emailValue={configDraft.emailValue}
+                onEmailChange={setDraftEmailValue}
+                slackIntegrationId={configDraft.slackIntegrationId}
+                onSlackIntegrationChange={setDraftSlackIntegrationId}
+                slackChannelValue={configDraft.slackChannelValue}
+                onSlackChannelChange={setDraftSlackChannelValue}
+            />
+            <div>
+                <label className="font-semibold text-sm">Report agent guidance (optional)</label>
+                <LemonTextArea
+                    value={configDraft.reportPromptGuidance}
+                    onChange={setDraftReportPromptGuidance}
+                    placeholder={GUIDANCE_PLACEHOLDER}
+                    rows={3}
+                />
+                <p className="text-xs text-muted mt-1">
+                    Steers the agent's focus, section choices, or scope. Appended to the base prompt.
+                </p>
+            </div>
+        </div>
+    )
+}
+
+/** Save button for the edit path. Disabled based on draft dirtiness and target presence. */
+function SaveReportButton({ evaluationId }: { evaluationId: string }): JSX.Element {
+    const logic = evaluationReportLogic({ evaluationId })
+    const { configDraft, isConfigDirty, reportsLoading } = useValues(logic)
+    const { saveDraft } = useActions(logic)
+
+    const hasAnyTarget = buildDeliveryTargets(configDraft).length > 0
+
+    return (
+        <div className="flex justify-end">
+            <LemonButton
+                type="primary"
+                size="small"
+                loading={reportsLoading}
+                onClick={() => saveDraft()}
+                disabledReason={
+                    !isConfigDirty
+                        ? 'No changes to save'
+                        : !hasAnyTarget
+                          ? 'Add at least one delivery target'
+                          : undefined
+                }
+            >
+                Save changes
+            </LemonButton>
+        </div>
+    )
+}
+
 /** Inline config shown during new evaluation creation */
 function PendingReportConfig({ evaluationId }: { evaluationId: string }): JSX.Element {
-    const { pendingConfig } = useValues(evaluationReportLogic({ evaluationId }))
-    const {
-        setPendingEnabled,
-        setPendingFrequency,
-        setPendingEmailValue,
-        setPendingSlackIntegrationId,
-        setPendingSlackChannelValue,
-        setPendingReportPromptGuidance,
-        setPendingTriggerThreshold,
-    } = useActions(evaluationReportLogic({ evaluationId }))
+    const { configDraft } = useValues(evaluationReportLogic({ evaluationId }))
+    const { setDraftEnabled } = useActions(evaluationReportLogic({ evaluationId }))
 
     return (
         <div className="bg-bg-light border rounded p-6">
@@ -134,49 +201,13 @@ function PendingReportConfig({ evaluationId }: { evaluationId: string }): JSX.El
                     </p>
                 </div>
                 <LemonSwitch
-                    checked={pendingConfig.enabled}
-                    onChange={setPendingEnabled}
+                    checked={configDraft.enabled}
+                    onChange={setDraftEnabled}
                     bordered
-                    label={pendingConfig.enabled ? 'Enabled' : 'Disabled'}
+                    label={configDraft.enabled ? 'Enabled' : 'Disabled'}
                 />
             </div>
-
-            {pendingConfig.enabled && (
-                <div className="space-y-4 mt-4">
-                    <div>
-                        <label className="font-semibold text-sm">Frequency</label>
-                        <LemonSelect
-                            value={pendingConfig.frequency}
-                            onChange={(val) => val && setPendingFrequency(val)}
-                            options={FREQUENCY_OPTIONS}
-                            fullWidth
-                        />
-                    </div>
-                    {pendingConfig.frequency === 'every_n' && (
-                        <ThresholdConfig value={pendingConfig.triggerThreshold} onChange={setPendingTriggerThreshold} />
-                    )}
-                    <DeliveryTargetsConfig
-                        emailValue={pendingConfig.emailValue}
-                        onEmailChange={setPendingEmailValue}
-                        slackIntegrationId={pendingConfig.slackIntegrationId}
-                        onSlackIntegrationChange={setPendingSlackIntegrationId}
-                        slackChannelValue={pendingConfig.slackChannelValue}
-                        onSlackChannelChange={setPendingSlackChannelValue}
-                    />
-                    <div>
-                        <label className="font-semibold text-sm">Report agent guidance (optional)</label>
-                        <LemonTextArea
-                            value={pendingConfig.reportPromptGuidance}
-                            onChange={setPendingReportPromptGuidance}
-                            placeholder={GUIDANCE_PLACEHOLDER}
-                            rows={3}
-                        />
-                        <p className="text-xs text-muted mt-1">
-                            Steers the agent's focus, section choices, or scope. Appended to the base prompt.
-                        </p>
-                    </div>
-                </div>
-            )}
+            {configDraft.enabled && <ReportFormFields evaluationId={evaluationId} />}
         </div>
     )
 }
@@ -184,44 +215,15 @@ function PendingReportConfig({ evaluationId }: { evaluationId: string }): JSX.El
 /** Toggle-based report management for existing evaluations */
 function ExistingReportConfig({ evaluationId }: { evaluationId: string }): JSX.Element {
     const logic = evaluationReportLogic({ evaluationId })
-    const { activeReport, reportsLoading } = useValues(logic)
-    const { updateReport, deleteReport, createReport } = useActions(logic)
+    const { activeReport, reportsLoading, configDraft } = useValues(logic)
+    const { deleteReport, saveDraft, setDraftEnabled } = useActions(logic)
 
-    // Local state: toggle controls form visibility, Save button creates the report.
-    // All fields are local-first so the user can change multiple things before saving.
-    const [formEnabled, setFormEnabled] = useState(false)
-    const [frequency, setFrequency] = useState<EvaluationReportFrequency>('daily')
-    const [emailValue, setEmailValue] = useState('')
-    const [slackIntegrationId, setSlackIntegrationId] = useState<number | null>(null)
-    const [slackChannelValue, setSlackChannelValue] = useState('')
-    const [guidance, setGuidance] = useState('')
-    const [triggerThreshold, setTriggerThreshold] = useState(TRIGGER_THRESHOLD_DEFAULT)
-
-    // Seed local form state from the active report so the user can edit
-    // any field without having to disable + recreate the schedule.
-    useEffect(() => {
-        if (!activeReport) {
-            return
-        }
-        const emailTarget = activeReport.delivery_targets.find(
-            (t: EvaluationReportDeliveryTarget) => t.type === 'email'
-        )
-        const slackTarget = activeReport.delivery_targets.find(
-            (t: EvaluationReportDeliveryTarget) => t.type === 'slack'
-        )
-        setFrequency(activeReport.frequency)
-        setEmailValue(emailTarget?.value ?? '')
-        setSlackIntegrationId(slackTarget?.integration_id ?? null)
-        setSlackChannelValue(slackTarget?.channel ?? '')
-        setGuidance(activeReport.report_prompt_guidance ?? '')
-        setTriggerThreshold(activeReport.trigger_threshold ?? TRIGGER_THRESHOLD_DEFAULT)
-    }, [activeReport])
-
-    const isEnabled = !!activeReport || formEnabled
+    const isEnabled = !!activeReport || configDraft.enabled
+    const hasAnyTarget = buildDeliveryTargets(configDraft).length > 0
 
     const handleToggle = (checked: boolean): void => {
         if (checked) {
-            setFormEnabled(true)
+            setDraftEnabled(true)
         } else if (activeReport) {
             LemonDialog.open({
                 title: 'Disable scheduled reports?',
@@ -234,29 +236,8 @@ function ExistingReportConfig({ evaluationId }: { evaluationId: string }): JSX.E
                 secondaryButton: { children: 'Cancel' },
             })
         } else {
-            setFormEnabled(false)
+            setDraftEnabled(false)
         }
-    }
-
-    const hasEmail = emailValue.trim().length > 0
-    const hasSlack = slackIntegrationId !== null && slackChannelValue.length > 0
-
-    const handleSave = (): void => {
-        const targets: EvaluationReportDeliveryTarget[] = []
-        if (hasEmail) {
-            targets.push({ type: 'email', value: emailValue.trim() })
-        }
-        if (hasSlack) {
-            targets.push({ type: 'slack', integration_id: slackIntegrationId!, channel: slackChannelValue })
-        }
-        createReport({
-            evaluationId,
-            frequency,
-            delivery_targets: targets,
-            report_prompt_guidance: guidance,
-            trigger_threshold: frequency === 'every_n' ? triggerThreshold : null,
-        })
-        setFormEnabled(false)
     }
 
     return (
@@ -279,172 +260,40 @@ function ExistingReportConfig({ evaluationId }: { evaluationId: string }): JSX.E
             </div>
 
             {activeReport ? (
-                <div className="space-y-4 mt-4">
-                    <div>
-                        <label className="font-semibold text-sm">Frequency</label>
-                        <LemonSelect
-                            value={frequency}
-                            onChange={(val) => val && setFrequency(val)}
-                            options={FREQUENCY_OPTIONS}
-                            fullWidth
-                        />
-                    </div>
-
-                    {frequency === 'every_n' && (
-                        <ThresholdConfig value={triggerThreshold} onChange={setTriggerThreshold} />
-                    )}
-
-                    <DeliveryTargetsConfig
-                        emailValue={emailValue}
-                        onEmailChange={setEmailValue}
-                        slackIntegrationId={slackIntegrationId}
-                        onSlackIntegrationChange={setSlackIntegrationId}
-                        slackChannelValue={slackChannelValue}
-                        onSlackChannelChange={setSlackChannelValue}
-                    />
-
-                    <div>
-                        <label className="font-semibold text-sm">Report agent guidance (optional)</label>
-                        <LemonTextArea
-                            value={guidance}
-                            onChange={setGuidance}
-                            placeholder={GUIDANCE_PLACEHOLDER}
-                            rows={3}
-                        />
-                        <p className="text-xs text-muted mt-1">
-                            Steers the agent's focus, section choices, or scope. Appended to the base prompt.
-                        </p>
-                    </div>
-
-                    {(() => {
-                        const currentEmail =
-                            activeReport.delivery_targets.find(
-                                (t: EvaluationReportDeliveryTarget) => t.type === 'email'
-                            )?.value ?? ''
-                        const currentSlack = activeReport.delivery_targets.find(
-                            (t: EvaluationReportDeliveryTarget) => t.type === 'slack'
-                        )
-                        const currentSlackIntegrationId: number | null = currentSlack?.integration_id ?? null
-                        const currentSlackChannel = currentSlack?.channel ?? ''
-                        const currentGuidance = activeReport.report_prompt_guidance ?? ''
-                        const currentThreshold = activeReport.trigger_threshold ?? TRIGGER_THRESHOLD_DEFAULT
-                        const frequencyDirty = frequency !== activeReport.frequency
-                        const targetsDirty =
-                            emailValue.trim() !== currentEmail ||
-                            slackIntegrationId !== currentSlackIntegrationId ||
-                            slackChannelValue !== currentSlackChannel
-                        const guidanceDirty = guidance !== currentGuidance
-                        const thresholdDirty = frequency === 'every_n' && triggerThreshold !== currentThreshold
-                        const isDirty = frequencyDirty || targetsDirty || guidanceDirty || thresholdDirty
-                        const hasAnyTarget = hasEmail || hasSlack
-                        return (
-                            <div className="flex justify-end">
-                                <LemonButton
-                                    type="primary"
-                                    size="small"
-                                    loading={reportsLoading}
-                                    disabledReason={
-                                        !isDirty
-                                            ? 'No changes to save'
-                                            : !hasAnyTarget
-                                              ? 'Add at least one delivery target'
-                                              : undefined
-                                    }
-                                    onClick={() => {
-                                        const targets: EvaluationReportDeliveryTarget[] = []
-                                        if (hasEmail) {
-                                            targets.push({ type: 'email', value: emailValue.trim() })
-                                        }
-                                        if (hasSlack) {
-                                            targets.push({
-                                                type: 'slack',
-                                                integration_id: slackIntegrationId!,
-                                                channel: slackChannelValue,
-                                            })
-                                        }
-                                        const data: Record<string, unknown> = {
-                                            frequency,
-                                            delivery_targets: targets,
-                                            report_prompt_guidance: guidance,
-                                        }
-                                        if (frequency === 'every_n') {
-                                            data.trigger_threshold = triggerThreshold
-                                        }
-                                        updateReport({
-                                            reportId: activeReport.id,
-                                            data,
-                                        })
-                                    }}
-                                >
-                                    Save changes
-                                </LemonButton>
-                            </div>
-                        )
-                    })()}
-
-                    {frequency === 'every_n' ? (
-                        <div className="text-sm text-muted">
+                <>
+                    <ReportFormFields evaluationId={evaluationId} />
+                    <SaveReportButton evaluationId={evaluationId} />
+                    {configDraft.frequency === 'every_n' ? (
+                        <div className="text-sm text-muted mt-4">
                             A report will be generated when{' '}
                             {activeReport.trigger_threshold ?? TRIGGER_THRESHOLD_DEFAULT} new evaluation results arrive.
                             Checked every 5 minutes.
                         </div>
                     ) : (
                         activeReport.next_delivery_date && (
-                            <div className="text-sm text-muted">
+                            <div className="text-sm text-muted mt-4">
                                 Next delivery: {new Date(activeReport.next_delivery_date).toLocaleString()}
                             </div>
                         )
                     )}
-
-                    <p className="text-xs text-muted m-0">Generated reports appear in the Reports tab.</p>
-                </div>
+                    <p className="text-xs text-muted m-0 mt-2">Generated reports appear in the Reports tab.</p>
+                </>
             ) : (
-                formEnabled && (
-                    <div className="space-y-4 mt-4">
-                        <div>
-                            <label className="font-semibold text-sm">Frequency</label>
-                            <LemonSelect
-                                value={frequency}
-                                onChange={(val) => val && setFrequency(val)}
-                                options={FREQUENCY_OPTIONS}
-                                fullWidth
-                            />
-                        </div>
-                        {frequency === 'every_n' && (
-                            <ThresholdConfig value={triggerThreshold} onChange={setTriggerThreshold} />
-                        )}
-                        <DeliveryTargetsConfig
-                            emailValue={emailValue}
-                            onEmailChange={setEmailValue}
-                            slackIntegrationId={slackIntegrationId}
-                            onSlackIntegrationChange={setSlackIntegrationId}
-                            slackChannelValue={slackChannelValue}
-                            onSlackChannelChange={setSlackChannelValue}
-                        />
-                        <div>
-                            <label className="font-semibold text-sm">Report agent guidance (optional)</label>
-                            <LemonTextArea
-                                value={guidance}
-                                onChange={setGuidance}
-                                placeholder={GUIDANCE_PLACEHOLDER}
-                                rows={3}
-                            />
-                            <p className="text-xs text-muted mt-1">
-                                Steers the agent's focus, section choices, or scope. Appended to the base prompt.
-                            </p>
-                        </div>
-                        <div className="flex justify-end">
+                configDraft.enabled && (
+                    <>
+                        <ReportFormFields evaluationId={evaluationId} />
+                        <div className="flex justify-end mt-4">
                             <LemonButton
                                 type="primary"
                                 size="small"
-                                onClick={handleSave}
+                                onClick={() => saveDraft()}
                                 loading={reportsLoading}
-                                disabledReason={!hasEmail && !hasSlack ? 'Add at least one delivery target' : undefined}
+                                disabledReason={!hasAnyTarget ? 'Add at least one delivery target' : undefined}
                             >
                                 Save report schedule
                             </LemonButton>
                         </div>
-                    </div>
+                    </>
                 )
             )}
         </div>

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationReportViewer.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationReportViewer.tsx
@@ -28,17 +28,18 @@ function linkifyUuids(content: string, citationMap: Record<string, string>): str
 // The agent sometimes prefixes each section's content with its own heading,
 // which duplicates the heading the renderer emits separately.
 //
-// Inspect only the first line via split so the heading regex doesn't need to
-// scan past a newline — that also sidesteps the overlapping-\s quantifiers
-// that CodeQL flagged as a ReDoS surface on inputs with many tabs/spaces.
+// Parsed as three independent linear scans rather than one multi-quantifier
+// regex so there's no backtracking ambiguity for CodeQL to flag: (1) find
+// the newline, (2) match just the `#` prefix on the first line with a
+// bounded regex, (3) plain string slice + trim for the title text.
 function stripRedundantLeadingHeading(content: string, sectionTitle: string): string {
     const newlineIdx = content.search(/\r?\n/)
     const firstLine = newlineIdx === -1 ? content : content.slice(0, newlineIdx)
-    const match = firstLine.match(/^ {0,3}(#{1,6})[ \t]+(.+?)[ \t]*$/)
-    if (!match) {
+    const hashMatch = firstLine.match(/^ {0,3}#{1,6}(?=[ \t])/)
+    if (!hashMatch) {
         return content
     }
-    const headingText = match[2].trim().toLowerCase()
+    const headingText = firstLine.slice(hashMatch[0].length).trim().toLowerCase()
     if (!headingText.startsWith(sectionTitle.toLowerCase())) {
         return content
     }

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationReportViewer.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationReportViewer.tsx
@@ -5,57 +5,100 @@ import { LemonBadge, LemonButton, LemonCollapse, LemonDivider } from '@posthog/l
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { urls } from 'scenes/urls'
 
-import type { EvaluationReportMetrics, EvaluationReportRun, EvaluationReportSection } from '../types'
+import type {
+    EvaluationReportCitation,
+    EvaluationReportMetrics,
+    EvaluationReportRun,
+    EvaluationReportSection,
+} from '../types'
 
-// Match any UUID in the content — optional single-char wrapper (backtick or angle bracket)
-// on each side. Using `?` (not `*`) avoids polynomial backtracking on inputs like "<<<<<xxx".
-const UUID_REGEX = /[`<]?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})[`>]?/g
-
-// Rewrite `<uuid>` backtick tokens into markdown links pointing to the correct
-// trace URL. Uses the citations list to map generation_id → trace_id so the link
-// opens the right trace with the generation highlighted.
-function linkifyUuids(content: string, citationMap: Record<string, string>): string {
-    return content.replace(UUID_REGEX, (_match, generationId: string) => {
-        const traceId = citationMap[generationId]
-        const url = traceId
-            ? urls.llmAnalyticsTrace(traceId, { event: generationId })
-            : urls.llmAnalyticsTrace(generationId)
-        return `[\`${generationId.slice(0, 8)}...\`](${url})`
+// Rewrite each cited generation_id in the content into a markdown link to the
+// trace viewer. Uses the structured citations list (not regex scanning) so:
+// - only ids the agent explicitly cited get linked (no false positives)
+// - the trace_id for the correct URL is guaranteed available
+// - there's no ReDoS surface on arbitrary prose input
+//
+// Two-phase placeholder swap prevents double-wrapping when an id is mentioned
+// multiple times, and prevents one id's generated link from being re-matched
+// by a later citation. Wrapper variants (`uuid`, <uuid>, bare) are collapsed
+// in descending specificity so the wrappers themselves get absorbed into the
+// replacement rather than surviving around a link.
+function linkifyCitations(content: string, citations: EvaluationReportCitation[]): string {
+    if (citations.length === 0) {
+        return content
+    }
+    const tokens: Array<{ token: string; link: string }> = []
+    let out = content
+    citations.forEach((c, idx) => {
+        if (!c.generation_id) {
+            return
+        }
+        const token = `\0CITE${idx}\0`
+        const url = c.trace_id
+            ? urls.llmAnalyticsTrace(c.trace_id, { event: c.generation_id })
+            : urls.llmAnalyticsTrace(c.generation_id)
+        const link = `[\`${c.generation_id.slice(0, 8)}...\`](${url})`
+        const before = out
+        out = out.split(`\`${c.generation_id}\``).join(token)
+        out = out.split(`<${c.generation_id}>`).join(token)
+        out = out.split(c.generation_id).join(token)
+        if (out !== before) {
+            tokens.push({ token, link })
+        }
     })
+    for (const { token, link } of tokens) {
+        out = out.split(token).join(link)
+    }
+    return out
 }
 
 // Strip a leading markdown heading line if it matches the section title.
 // The agent sometimes prefixes each section's content with its own heading,
 // which duplicates the heading the renderer emits separately.
 //
-// Parsed as three independent linear scans rather than one multi-quantifier
-// regex so there's no backtracking ambiguity for CodeQL to flag: (1) find
-// the newline, (2) match just the `#` prefix on the first line with a
-// bounded regex, (3) plain string slice + trim for the title text.
+// Implemented as line-by-line string ops (no regex) — ATX headings are a
+// well-defined subset of CommonMark: up to 3 leading spaces, then 1-6 `#`,
+// then at least one space/tab, then the title text.
 function stripRedundantLeadingHeading(content: string, sectionTitle: string): string {
-    const newlineIdx = content.search(/\r?\n/)
-    const firstLine = newlineIdx === -1 ? content : content.slice(0, newlineIdx)
-    const hashMatch = firstLine.match(/^ {0,3}#{1,6}(?=[ \t])/)
-    if (!hashMatch) {
+    const lines = content.split('\n')
+    if (lines.length === 0) {
         return content
     }
-    const headingText = firstLine.slice(hashMatch[0].length).trim().toLowerCase()
+    const first = lines[0].trimStart()
+    let hashCount = 0
+    while (hashCount < 6 && first[hashCount] === '#') {
+        hashCount++
+    }
+    if (hashCount === 0) {
+        return content
+    }
+    const after = first[hashCount]
+    if (after !== ' ' && after !== '\t') {
+        return content
+    }
+    const headingText = first
+        .slice(hashCount + 1)
+        .trim()
+        .toLowerCase()
     if (!headingText.startsWith(sectionTitle.toLowerCase())) {
         return content
     }
-    // Strip the first line and any leading blank lines that followed it.
-    const afterHeading = newlineIdx === -1 ? '' : content.slice(newlineIdx + (content[newlineIdx] === '\r' ? 2 : 1))
-    return afterHeading.replace(/^[ \t]*\r?\n/, '')
+    // Drop the heading line plus any blank lines that followed it.
+    let startIdx = 1
+    while (startIdx < lines.length && lines[startIdx].trim() === '') {
+        startIdx++
+    }
+    return lines.slice(startIdx).join('\n')
 }
 
 function ReportSectionContent({
     section,
-    citationMap,
+    citations,
 }: {
     section: EvaluationReportSection
-    citationMap: Record<string, string>
+    citations: EvaluationReportCitation[]
 }): JSX.Element {
-    const markdown = linkifyUuids(stripRedundantLeadingHeading(section.content, section.title), citationMap)
+    const markdown = linkifyCitations(stripRedundantLeadingHeading(section.content, section.title), citations)
     return (
         <LemonMarkdown lowKeyHeadings className="text-sm">
             {markdown}
@@ -145,17 +188,7 @@ export function EvaluationReportViewer({
     const content = reportRun.content
     const sections = content.sections ?? []
     const metrics = content.metrics
-
-    // Build generation_id → trace_id lookup from citations for correct trace URLs
-    const citationMap = useMemo(() => {
-        const map: Record<string, string> = {}
-        for (const c of content.citations ?? []) {
-            if (c.generation_id && c.trace_id) {
-                map[c.generation_id] = c.trace_id
-            }
-        }
-        return map
-    }, [content.citations])
+    const citations = useMemo(() => content.citations ?? [], [content.citations])
 
     // Default to executive summary (first section) expanded. Memoized so Expand/Collapse all
     // buttons can set the list deterministically.
@@ -248,7 +281,7 @@ export function EvaluationReportViewer({
                         panels={sections.map((section, idx) => ({
                             key: idx.toString(),
                             header: section.title,
-                            content: <ReportSectionContent section={section} citationMap={citationMap} />,
+                            content: <ReportSectionContent section={section} citations={citations} />,
                         }))}
                     />
                 </>

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationReportViewer.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationReportViewer.tsx
@@ -211,8 +211,6 @@ export function EvaluationReportViewer({
                 </div>
             )}
 
-            {!compact && content.title && <h3 className="font-semibold text-sm mb-2">{content.title}</h3>}
-
             {metrics && <MetricsCard metrics={metrics} />}
 
             {sections.length > 0 && (

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationReportViewer.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationReportViewer.tsx
@@ -7,9 +7,9 @@ import { urls } from 'scenes/urls'
 
 import type { EvaluationReportMetrics, EvaluationReportRun, EvaluationReportSection } from '../types'
 
-// Match any UUID in the content — surrounding punctuation (backticks, angle brackets, etc.)
-// is stripped so we don't depend on how the LLM formats references.
-const UUID_REGEX = /[`<]*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})[`>]*/g
+// Match any UUID in the content — optional single-char wrapper (backtick or angle bracket)
+// on each side. Using `?` (not `*`) avoids polynomial backtracking on inputs like "<<<<<xxx".
+const UUID_REGEX = /[`<]?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})[`>]?/g
 
 // Rewrite `<uuid>` backtick tokens into markdown links pointing to the correct
 // trace URL. Uses the citations list to map generation_id → trace_id so the link
@@ -27,16 +27,24 @@ function linkifyUuids(content: string, citationMap: Record<string, string>): str
 // Strip a leading markdown heading line if it matches the section title.
 // The agent sometimes prefixes each section's content with its own heading,
 // which duplicates the heading the renderer emits separately.
+//
+// Inspect only the first line via split so the heading regex doesn't need to
+// scan past a newline — that also sidesteps the overlapping-\s quantifiers
+// that CodeQL flagged as a ReDoS surface on inputs with many tabs/spaces.
 function stripRedundantLeadingHeading(content: string, sectionTitle: string): string {
-    const match = content.match(/^\s*(#{1,6})\s+(.+?)\s*(?:\r?\n|$)/)
+    const newlineIdx = content.search(/\r?\n/)
+    const firstLine = newlineIdx === -1 ? content : content.slice(0, newlineIdx)
+    const match = firstLine.match(/^ {0,3}(#{1,6})[ \t]+(.+?)[ \t]*$/)
     if (!match) {
         return content
     }
     const headingText = match[2].trim().toLowerCase()
-    if (headingText.startsWith(sectionTitle.toLowerCase())) {
-        return content.slice(match[0].length).replace(/^\s+/, '')
+    if (!headingText.startsWith(sectionTitle.toLowerCase())) {
+        return content
     }
-    return content
+    // Strip the first line and any leading blank lines that followed it.
+    const afterHeading = newlineIdx === -1 ? '' : content.slice(newlineIdx + (content[newlineIdx] === '\r' ? 2 : 1))
+    return afterHeading.replace(/^[ \t]*\r?\n/, '')
 }
 
 function ReportSectionContent({

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationReportViewer.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationReportViewer.tsx
@@ -5,12 +5,7 @@ import { LemonBadge, LemonButton, LemonCollapse, LemonDivider } from '@posthog/l
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { urls } from 'scenes/urls'
 
-import type {
-    EvaluationReportMetrics,
-    EvaluationReportRun,
-    EvaluationReportRunContent,
-    EvaluationReportSection,
-} from '../types'
+import type { EvaluationReportMetrics, EvaluationReportRun, EvaluationReportSection } from '../types'
 
 // Match any UUID in the content — surrounding punctuation (backticks, angle brackets, etc.)
 // is stripped so we don't depend on how the LLM formats references.
@@ -138,7 +133,7 @@ export function EvaluationReportViewer({
     /** When true, hides the header/close row — useful when the parent already provides framing (e.g. an expanded table row). */
     compact?: boolean
 }): JSX.Element {
-    const content = reportRun.content as EvaluationReportRunContent
+    const content = reportRun.content
     const sections = content.sections ?? []
     const metrics = content.metrics
 

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationReportViewer.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationReportViewer.tsx
@@ -1,0 +1,267 @@
+import { useMemo, useState } from 'react'
+
+import { LemonBadge, LemonButton, LemonCollapse, LemonDivider } from '@posthog/lemon-ui'
+
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { urls } from 'scenes/urls'
+
+import type {
+    EvaluationReportMetrics,
+    EvaluationReportRun,
+    EvaluationReportRunContent,
+    EvaluationReportSection,
+} from '../types'
+
+// Match any UUID in the content — surrounding punctuation (backticks, angle brackets, etc.)
+// is stripped so we don't depend on how the LLM formats references.
+const UUID_REGEX = /[`<]*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})[`>]*/g
+
+// Rewrite `<uuid>` backtick tokens into markdown links pointing to the correct
+// trace URL. Uses the citations list to map generation_id → trace_id so the link
+// opens the right trace with the generation highlighted.
+function linkifyUuids(content: string, citationMap: Record<string, string>): string {
+    return content.replace(UUID_REGEX, (_match, generationId: string) => {
+        const traceId = citationMap[generationId]
+        const url = traceId
+            ? urls.llmAnalyticsTrace(traceId, { event: generationId })
+            : urls.llmAnalyticsTrace(generationId)
+        return `[\`${generationId.slice(0, 8)}...\`](${url})`
+    })
+}
+
+// Strip a leading markdown heading line if it matches the section title.
+// The agent sometimes prefixes each section's content with its own heading,
+// which duplicates the heading the renderer emits separately.
+function stripRedundantLeadingHeading(content: string, sectionTitle: string): string {
+    const match = content.match(/^\s*(#{1,6})\s+(.+?)\s*(?:\r?\n|$)/)
+    if (!match) {
+        return content
+    }
+    const headingText = match[2].trim().toLowerCase()
+    if (headingText.startsWith(sectionTitle.toLowerCase())) {
+        return content.slice(match[0].length).replace(/^\s+/, '')
+    }
+    return content
+}
+
+function ReportSectionContent({
+    section,
+    citationMap,
+}: {
+    section: EvaluationReportSection
+    citationMap: Record<string, string>
+}): JSX.Element {
+    const markdown = linkifyUuids(stripRedundantLeadingHeading(section.content, section.title), citationMap)
+    return (
+        <LemonMarkdown lowKeyHeadings className="text-sm">
+            {markdown}
+        </LemonMarkdown>
+    )
+}
+
+function formatPassRate(rate: number | null | undefined): string {
+    if (rate == null) {
+        return '—'
+    }
+    return `${rate.toFixed(2)}%`
+}
+
+function MetricsCard({ metrics }: { metrics: EvaluationReportMetrics }): JSX.Element {
+    // Period-over-period delta (if we have a previous pass rate to compare)
+    let deltaEl: JSX.Element | null = null
+    if (metrics.previous_pass_rate != null) {
+        const diff = metrics.pass_rate - metrics.previous_pass_rate
+        const arrow = diff > 0 ? '▲' : diff < 0 ? '▼' : '—'
+        const color = diff > 0 ? 'text-success' : diff < 0 ? 'text-danger' : 'text-muted'
+        deltaEl = (
+            <span className={`text-xs ml-1 ${color}`}>
+                {arrow} {Math.abs(diff).toFixed(2)}pp vs previous
+            </span>
+        )
+    }
+
+    return (
+        <div className="bg-bg-light border rounded p-3 mb-3">
+            <div className="flex items-center gap-6 flex-wrap text-sm">
+                <div>
+                    <div className="text-muted text-xs">Pass rate</div>
+                    <div className="font-semibold">
+                        {formatPassRate(metrics.pass_rate)}
+                        {deltaEl}
+                    </div>
+                </div>
+                <div>
+                    <div className="text-muted text-xs">Total runs</div>
+                    <div className="font-semibold">{metrics.total_runs}</div>
+                </div>
+                <div>
+                    <div className="text-muted text-xs">Pass</div>
+                    <div className="font-semibold text-success">{metrics.pass_count}</div>
+                </div>
+                <div>
+                    <div className="text-muted text-xs">Fail</div>
+                    <div className="font-semibold text-danger">{metrics.fail_count}</div>
+                </div>
+                <div>
+                    <div className="text-muted text-xs">N/A</div>
+                    <div className="font-semibold">{metrics.na_count}</div>
+                </div>
+                {metrics.previous_total_runs != null && (
+                    <div>
+                        <div className="text-muted text-xs">Previous runs</div>
+                        <div className="font-semibold text-muted">{metrics.previous_total_runs}</div>
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}
+
+function DeliveryStatusBadge({ status }: { status: string }): JSX.Element {
+    const statusMap: Record<string, { label: string; status: 'success' | 'warning' | 'danger' | 'muted' }> = {
+        delivered: { label: 'Delivered', status: 'success' },
+        pending: { label: 'Pending', status: 'muted' },
+        partial_failure: { label: 'Partial failure', status: 'warning' },
+        failed: { label: 'Failed', status: 'danger' },
+    }
+    const info = statusMap[status] || { label: status, status: 'muted' as const }
+    return <LemonBadge content={info.label} status={info.status} />
+}
+
+export function EvaluationReportViewer({
+    reportRun,
+    onClose,
+    compact = false,
+}: {
+    reportRun: EvaluationReportRun
+    onClose?: () => void
+    /** When true, hides the header/close row — useful when the parent already provides framing (e.g. an expanded table row). */
+    compact?: boolean
+}): JSX.Element {
+    const content = reportRun.content as EvaluationReportRunContent
+    const sections = content.sections ?? []
+    const metrics = content.metrics
+
+    // Build generation_id → trace_id lookup from citations for correct trace URLs
+    const citationMap = useMemo(() => {
+        const map: Record<string, string> = {}
+        for (const c of content.citations ?? []) {
+            if (c.generation_id && c.trace_id) {
+                map[c.generation_id] = c.trace_id
+            }
+        }
+        return map
+    }, [content.citations])
+
+    // Default to executive summary (first section) expanded. Memoized so Expand/Collapse all
+    // buttons can set the list deterministically.
+    const sectionKeys = useMemo(() => sections.map((_, i) => i.toString()), [sections])
+    const [expandedKeys, setExpandedKeys] = useState<string[]>(sections.length > 0 ? ['0'] : [])
+
+    const allExpanded = expandedKeys.length === sectionKeys.length && sectionKeys.length > 0
+    const allCollapsed = expandedKeys.length === 0
+
+    return (
+        <div>
+            {!compact && (
+                <>
+                    <div className="flex items-center justify-between mb-2">
+                        <div className="flex items-center gap-2">
+                            <h2 className="font-bold text-base mb-0">{content.title || 'Report'}</h2>
+                            <DeliveryStatusBadge status={reportRun.delivery_status} />
+                        </div>
+                        {onClose && (
+                            <LemonButton size="small" onClick={onClose}>
+                                Close
+                            </LemonButton>
+                        )}
+                    </div>
+                    <div className="text-xs text-muted mb-3">
+                        Period: {new Date(reportRun.period_start).toLocaleString()} –{' '}
+                        {new Date(reportRun.period_end).toLocaleString()}
+                    </div>
+
+                    <LemonDivider className="my-3" />
+                </>
+            )}
+
+            {compact && (
+                <div className="flex items-center justify-between mb-2">
+                    {content.title ? <h3 className="font-semibold text-sm mb-0">{content.title}</h3> : <div />}
+                    {sections.length > 0 && (
+                        <div className="flex gap-2">
+                            <LemonButton
+                                size="xsmall"
+                                type="tertiary"
+                                onClick={() => setExpandedKeys(sectionKeys)}
+                                disabledReason={allExpanded ? 'All sections already expanded' : undefined}
+                            >
+                                Expand all
+                            </LemonButton>
+                            <LemonButton
+                                size="xsmall"
+                                type="tertiary"
+                                onClick={() => setExpandedKeys([])}
+                                disabledReason={allCollapsed ? 'All sections already collapsed' : undefined}
+                            >
+                                Collapse all
+                            </LemonButton>
+                        </div>
+                    )}
+                </div>
+            )}
+
+            {!compact && content.title && <h3 className="font-semibold text-sm mb-2">{content.title}</h3>}
+
+            {metrics && <MetricsCard metrics={metrics} />}
+
+            {sections.length > 0 && (
+                <>
+                    {!compact && (
+                        <div className="flex justify-end gap-2 mb-2">
+                            <LemonButton
+                                size="xsmall"
+                                type="tertiary"
+                                onClick={() => setExpandedKeys(sectionKeys)}
+                                disabledReason={allExpanded ? 'All sections already expanded' : undefined}
+                            >
+                                Expand all
+                            </LemonButton>
+                            <LemonButton
+                                size="xsmall"
+                                type="tertiary"
+                                onClick={() => setExpandedKeys([])}
+                                disabledReason={allCollapsed ? 'All sections already collapsed' : undefined}
+                            >
+                                Collapse all
+                            </LemonButton>
+                        </div>
+                    )}
+
+                    <LemonCollapse
+                        multiple
+                        size="small"
+                        activeKeys={expandedKeys}
+                        onChange={(keys) => setExpandedKeys(keys as string[])}
+                        panels={sections.map((section, idx) => ({
+                            key: idx.toString(),
+                            header: section.title,
+                            content: <ReportSectionContent section={section} citationMap={citationMap} />,
+                        }))}
+                    />
+                </>
+            )}
+
+            {reportRun.delivery_errors.length > 0 && (
+                <div className="mt-4 p-2 bg-danger-highlight rounded">
+                    <h4 className="font-semibold text-sm text-danger">Delivery errors</h4>
+                    <ul className="text-xs">
+                        {reportRun.delivery_errors.map((err, i) => (
+                            <li key={i}>{err}</li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/evaluations/components/EvaluationReportsTab.tsx
+++ b/products/llm_analytics/frontend/evaluations/components/EvaluationReportsTab.tsx
@@ -1,0 +1,156 @@
+import { useActions, useValues } from 'kea'
+
+import { IconInfo } from '@posthog/icons'
+import { LemonButton, LemonTable, LemonTag, Tooltip } from '@posthog/lemon-ui'
+
+import { TZLabel } from 'lib/components/TZLabel'
+
+import { evaluationReportLogic } from '../evaluationReportLogic'
+import type { EvaluationReportRun } from '../types'
+import { EvaluationReportViewer } from './EvaluationReportViewer'
+
+interface EvaluationReportsTabProps {
+    evaluationId: string
+    /** Called when the user clicks the "Set up scheduled reports" CTA in the empty state. */
+    onConfigureClick?: () => void
+}
+
+const STATUS_STYLES: Record<
+    EvaluationReportRun['delivery_status'],
+    { label: string; type: 'success' | 'warning' | 'danger' | 'muted' }
+> = {
+    delivered: { label: 'Delivered', type: 'success' },
+    pending: { label: 'Pending', type: 'muted' },
+    partial_failure: { label: 'Partial failure', type: 'warning' },
+    failed: { label: 'Failed', type: 'danger' },
+}
+
+export function EvaluationReportsTab({ evaluationId, onConfigureClick }: EvaluationReportsTabProps): JSX.Element {
+    const logic = evaluationReportLogic({ evaluationId })
+    const { reportRuns, reportRunsLoading, reportsLoading, activeReport, generateResultLoading } = useValues(logic)
+    const { generateReport, loadReportRuns } = useActions(logic)
+
+    // No schedule configured at all → CTA pointing to the Configuration tab.
+    // Avoids hiding the Reports tab entirely so it stays discoverable.
+    if (!reportsLoading && !activeReport) {
+        return (
+            <div className="max-w-6xl">
+                <div className="bg-bg-light border rounded p-8 text-center space-y-3">
+                    <h3 className="text-lg font-semibold m-0">No scheduled reports yet</h3>
+                    <p className="text-muted text-sm m-0">
+                        Scheduled reports deliver AI-generated analysis of this evaluation's results to email or Slack
+                        on a recurring basis.
+                    </p>
+                    {onConfigureClick && (
+                        <LemonButton type="primary" onClick={onConfigureClick}>
+                            Set up scheduled reports
+                        </LemonButton>
+                    )}
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <div className="max-w-6xl">
+            <div className="flex items-center justify-between mb-4">
+                <p className="text-muted text-sm m-0">
+                    History of AI-generated reports for this evaluation. Click a row to expand the full report. Schedule
+                    and delivery targets are configured in the Configuration tab.
+                </p>
+                {activeReport && (
+                    <div className="flex items-center gap-2">
+                        <LemonButton
+                            type="secondary"
+                            size="small"
+                            onClick={() => loadReportRuns(activeReport.id)}
+                            loading={reportRunsLoading}
+                        >
+                            Refresh
+                        </LemonButton>
+                        <LemonButton
+                            type="primary"
+                            size="small"
+                            onClick={() => generateReport(activeReport.id)}
+                            loading={generateResultLoading}
+                        >
+                            Generate now
+                        </LemonButton>
+                    </div>
+                )}
+            </div>
+
+            <LemonTable
+                dataSource={reportRuns}
+                loading={reportRunsLoading}
+                rowKey="id"
+                columns={[
+                    {
+                        title: 'Generated',
+                        key: 'created_at',
+                        render: (_, run: EvaluationReportRun) => <TZLabel time={run.created_at} />,
+                    },
+                    {
+                        title: 'Title',
+                        key: 'title',
+                        render: (_, run: EvaluationReportRun) => (
+                            <span className="font-medium truncate block max-w-md" title={run.content?.title}>
+                                {run.content?.title || '–'}
+                            </span>
+                        ),
+                    },
+                    {
+                        title: 'Pass rate',
+                        key: 'pass_rate',
+                        render: (_, run: EvaluationReportRun) => {
+                            const pct = run.content?.metrics?.pass_rate ?? run.metadata?.pass_rate
+                            return typeof pct === 'number' ? `${pct.toFixed(1)}%` : '–'
+                        },
+                    },
+                    {
+                        title: 'Runs',
+                        key: 'total_runs',
+                        render: (_, run: EvaluationReportRun) =>
+                            run.content?.metrics?.total_runs ?? run.metadata?.total_runs ?? '–',
+                    },
+                    {
+                        title: 'Status',
+                        key: 'delivery_status',
+                        render: (_, run: EvaluationReportRun) => {
+                            const info = STATUS_STYLES[run.delivery_status] || {
+                                label: run.delivery_status,
+                                type: 'default' as const,
+                            }
+                            return (
+                                <LemonTag type={info.type} size="small">
+                                    {info.label}
+                                </LemonTag>
+                            )
+                        },
+                    },
+                    {
+                        key: 'info',
+                        width: 0,
+                        render: (_, run: EvaluationReportRun) => (
+                            <Tooltip
+                                title={`Period: ${new Date(run.period_start).toLocaleString()} – ${new Date(run.period_end).toLocaleString()}`}
+                            >
+                                <IconInfo className="text-muted text-base" />
+                            </Tooltip>
+                        ),
+                    },
+                ]}
+                expandable={{
+                    noIndent: true,
+                    expandedRowRender: (run: EvaluationReportRun) => (
+                        <div className="p-4 bg-bg-light">
+                            <EvaluationReportViewer reportRun={run} compact />
+                        </div>
+                    ),
+                }}
+                emptyState="No reports generated yet"
+                size="small"
+            />
+        </div>
+    )
+}

--- a/products/llm_analytics/frontend/evaluations/evaluationReportLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/evaluationReportLogic.ts
@@ -17,9 +17,14 @@ export interface EvaluationReportLogicProps {
     evaluationId: string
 }
 
-export interface PendingReportConfig {
+/** Draft state for the report config form — used for both the create-new-evaluation path
+ * (keyed as 'new') and the edit-existing-evaluation path (keyed by the real evaluation id). */
+export interface ReportConfigDraft {
     enabled: boolean
     frequency: EvaluationReportFrequency
+    rrule: string
+    startsAt: string | null
+    timezoneName: string
     emailValue: string
     slackIntegrationId: number | null
     slackChannelValue: string
@@ -27,14 +32,54 @@ export interface PendingReportConfig {
     triggerThreshold: number
 }
 
-const DEFAULT_PENDING_CONFIG: PendingReportConfig = {
+export const TRIGGER_THRESHOLD_DEFAULT = 100
+export const DEFAULT_RRULE = 'FREQ=DAILY'
+export const DEFAULT_TIMEZONE = 'UTC'
+
+const DEFAULT_CONFIG_DRAFT: ReportConfigDraft = {
     enabled: true,
     frequency: 'every_n',
+    rrule: '',
+    startsAt: null,
+    timezoneName: DEFAULT_TIMEZONE,
     emailValue: '',
     slackIntegrationId: null,
     slackChannelValue: '',
     reportPromptGuidance: '',
-    triggerThreshold: 100,
+    triggerThreshold: TRIGGER_THRESHOLD_DEFAULT,
+}
+
+function draftFromReport(report: EvaluationReport): ReportConfigDraft {
+    const emailTarget = report.delivery_targets.find((t) => t.type === 'email')
+    const slackTarget = report.delivery_targets.find((t) => t.type === 'slack')
+    return {
+        enabled: true,
+        frequency: report.frequency,
+        rrule: report.rrule ?? '',
+        startsAt: report.starts_at ?? null,
+        timezoneName: report.timezone_name ?? DEFAULT_TIMEZONE,
+        emailValue: emailTarget?.value ?? '',
+        slackIntegrationId: slackTarget?.integration_id ?? null,
+        slackChannelValue: slackTarget?.channel ?? '',
+        reportPromptGuidance: report.report_prompt_guidance ?? '',
+        triggerThreshold: report.trigger_threshold ?? TRIGGER_THRESHOLD_DEFAULT,
+    }
+}
+
+export function buildDeliveryTargets(draft: ReportConfigDraft): EvaluationReportDeliveryTarget[] {
+    const targets: EvaluationReportDeliveryTarget[] = []
+    const email = draft.emailValue.trim()
+    if (email.length > 0) {
+        targets.push({ type: 'email', value: email })
+    }
+    if (draft.slackIntegrationId !== null && draft.slackChannelValue.length > 0) {
+        targets.push({
+            type: 'slack',
+            integration_id: draft.slackIntegrationId,
+            channel: draft.slackChannelValue,
+        })
+    }
+    return targets
 }
 
 export const evaluationReportLogic = kea<evaluationReportLogicType>([
@@ -46,44 +91,62 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
     }),
 
     actions({
-        // Pending config for new evaluations
-        setPendingEnabled: (enabled: boolean) => ({ enabled }),
-        setPendingFrequency: (frequency: EvaluationReportFrequency) => ({ frequency }),
-        setPendingEmailValue: (emailValue: string) => ({ emailValue }),
-        setPendingSlackIntegrationId: (integrationId: number | null) => ({ integrationId }),
-        setPendingSlackChannelValue: (channelValue: string) => ({ channelValue }),
-        setPendingReportPromptGuidance: (reportPromptGuidance: string) => ({ reportPromptGuidance }),
-        setPendingTriggerThreshold: (triggerThreshold: number) => ({ triggerThreshold }),
-        createPendingReport: (evaluationId: string) => ({ evaluationId }),
+        setDraftEnabled: (enabled: boolean) => ({ enabled }),
+        setDraftFrequency: (frequency: EvaluationReportFrequency) => ({ frequency }),
+        setDraftRrule: (rrule: string) => ({ rrule }),
+        setDraftStartsAt: (startsAt: string | null) => ({ startsAt }),
+        setDraftTimezoneName: (timezoneName: string) => ({ timezoneName }),
+        setDraftEmailValue: (emailValue: string) => ({ emailValue }),
+        setDraftSlackIntegrationId: (integrationId: number | null) => ({ integrationId }),
+        setDraftSlackChannelValue: (channelValue: string) => ({ channelValue }),
+        setDraftReportPromptGuidance: (reportPromptGuidance: string) => ({ reportPromptGuidance }),
+        setDraftTriggerThreshold: (triggerThreshold: number) => ({ triggerThreshold }),
+        seedDraftFromReport: (report: EvaluationReport) => ({ report }),
+        resetDraft: true,
 
-        // Existing report actions
+        /** Save the current draft against the active report — creates if none exists, updates otherwise. */
+        saveDraft: true,
+
         selectReportRun: (reportRun: EvaluationReportRun | null) => ({ reportRun }),
     }),
 
     reducers({
-        pendingConfig: [
-            DEFAULT_PENDING_CONFIG as PendingReportConfig,
+        configDraft: [
+            DEFAULT_CONFIG_DRAFT as ReportConfigDraft,
             {
-                setPendingEnabled: (state, { enabled }) => ({ ...state, enabled }),
-                setPendingFrequency: (state, { frequency }) => ({ ...state, frequency }),
-                setPendingEmailValue: (state, { emailValue }) => ({ ...state, emailValue }),
-                setPendingSlackIntegrationId: (state, { integrationId }) => ({
+                setDraftEnabled: (state, { enabled }) => ({ ...state, enabled }),
+                setDraftFrequency: (state, { frequency }) => {
+                    // Seed a default rrule when switching into scheduled mode for the first time so
+                    // the Save button can commit without forcing the user to fill the field manually.
+                    const rrule = frequency === 'scheduled' && !state.rrule ? DEFAULT_RRULE : state.rrule
+                    const startsAt = frequency === 'scheduled' && !state.startsAt ? new Date().toISOString() : state.startsAt
+                    return { ...state, frequency, rrule, startsAt }
+                },
+                setDraftRrule: (state, { rrule }) => ({ ...state, rrule }),
+                setDraftStartsAt: (state, { startsAt }) => ({ ...state, startsAt }),
+                setDraftTimezoneName: (state, { timezoneName }) => ({ ...state, timezoneName }),
+                setDraftEmailValue: (state, { emailValue }) => ({ ...state, emailValue }),
+                setDraftSlackIntegrationId: (state, { integrationId }) => ({
                     ...state,
                     slackIntegrationId: integrationId,
+                    // Clear channel when switching Slack workspaces so we don't send a
+                    // channel id from a different workspace.
                     slackChannelValue: integrationId !== state.slackIntegrationId ? '' : state.slackChannelValue,
                 }),
-                setPendingSlackChannelValue: (state, { channelValue }) => ({
+                setDraftSlackChannelValue: (state, { channelValue }) => ({
                     ...state,
                     slackChannelValue: channelValue,
                 }),
-                setPendingReportPromptGuidance: (state, { reportPromptGuidance }) => ({
+                setDraftReportPromptGuidance: (state, { reportPromptGuidance }) => ({
                     ...state,
                     reportPromptGuidance,
                 }),
-                setPendingTriggerThreshold: (state, { triggerThreshold }) => ({
+                setDraftTriggerThreshold: (state, { triggerThreshold }) => ({
                     ...state,
                     triggerThreshold,
                 }),
+                seedDraftFromReport: (_, { report }) => draftFromReport(report),
+                resetDraft: () => DEFAULT_CONFIG_DRAFT,
             },
         ],
         selectedReportRun: [
@@ -110,6 +173,9 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                 createReport: async (params: {
                     evaluationId: string
                     frequency: EvaluationReportFrequency
+                    rrule?: string
+                    starts_at?: string | null
+                    timezone_name?: string
                     delivery_targets: EvaluationReportDeliveryTarget[]
                     report_prompt_guidance?: string
                     trigger_threshold?: number | null
@@ -117,10 +183,14 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                     const body: Record<string, unknown> = {
                         evaluation: params.evaluationId,
                         frequency: params.frequency,
-                        start_date: new Date().toISOString(),
                         delivery_targets: params.delivery_targets,
                         report_prompt_guidance: params.report_prompt_guidance ?? '',
                         enabled: true,
+                    }
+                    if (params.frequency === 'scheduled') {
+                        body.rrule = params.rrule ?? ''
+                        body.starts_at = params.starts_at ?? null
+                        body.timezone_name = params.timezone_name ?? DEFAULT_TIMEZONE
                     }
                     if (params.frequency === 'every_n' && params.trigger_threshold != null) {
                         body.trigger_threshold = params.trigger_threshold
@@ -179,15 +249,41 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                 return reports.find((r: EvaluationReport) => r.enabled && !r.deleted) || null
             },
         ],
+        isConfigDirty: [
+            (s) => [s.activeReport, s.configDraft],
+            (activeReport, draft): boolean => {
+                if (!activeReport) {
+                    // No report yet: draft is "dirty" if it has any savable content.
+                    return buildDeliveryTargets(draft).length > 0 || draft.reportPromptGuidance.trim().length > 0
+                }
+                const baseline = draftFromReport(activeReport)
+                const scheduleDirty =
+                    draft.frequency === 'scheduled' &&
+                    (baseline.rrule !== draft.rrule ||
+                        baseline.startsAt !== draft.startsAt ||
+                        baseline.timezoneName !== draft.timezoneName)
+                return (
+                    baseline.frequency !== draft.frequency ||
+                    baseline.emailValue !== draft.emailValue.trim() ||
+                    baseline.slackIntegrationId !== draft.slackIntegrationId ||
+                    baseline.slackChannelValue !== draft.slackChannelValue ||
+                    baseline.reportPromptGuidance !== draft.reportPromptGuidance ||
+                    (draft.frequency === 'every_n' && baseline.triggerThreshold !== draft.triggerThreshold) ||
+                    scheduleDirty
+                )
+            },
+        ],
     }),
 
-    listeners(({ actions, values }) => ({
-        loadReportsSuccess: ({ reports }: { reports: EvaluationReport[] }) => {
+    listeners(({ actions, values, props }) => ({
+        loadReportsSuccess: ({ reports }) => {
             // Auto-load the run history for the active report so the Reports tab knows
             // whether to render itself and can show data immediately.
             const active = reports.find((r: EvaluationReport) => r.enabled && !r.deleted)
             if (active) {
                 actions.loadReportRuns(active.id)
+                // Seed the draft so the config form reflects the saved report instead of defaults.
+                actions.seedDraftFromReport(active)
             }
         },
         generateReportSuccess: () => {
@@ -202,32 +298,34 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
         updateReportSuccess: () => {
             actions.loadReports()
         },
-        createPendingReport: ({ evaluationId }) => {
-            const { pendingConfig } = values
-            if (!pendingConfig.enabled) {
-                return
-            }
-            const targets: EvaluationReportDeliveryTarget[] = []
-            if (pendingConfig.emailValue.trim()) {
-                targets.push({ type: 'email', value: pendingConfig.emailValue.trim() })
-            }
-            if (pendingConfig.slackIntegrationId && pendingConfig.slackChannelValue) {
-                targets.push({
-                    type: 'slack',
-                    integration_id: pendingConfig.slackIntegrationId,
-                    channel: pendingConfig.slackChannelValue,
-                })
-            }
-            // The backend auto-creates a default report config on eval creation.
-            // If the user configured delivery targets or custom settings, update
-            // the auto-created report after creation via the existing reports list.
-            if (targets.length > 0 || pendingConfig.reportPromptGuidance.trim()) {
-                actions.createReport({
-                    evaluationId,
-                    frequency: pendingConfig.frequency,
+        saveDraft: () => {
+            const { configDraft, activeReport } = values
+            const targets = buildDeliveryTargets(configDraft)
+            if (activeReport) {
+                const data: Record<string, unknown> = {
+                    frequency: configDraft.frequency,
                     delivery_targets: targets,
-                    report_prompt_guidance: pendingConfig.reportPromptGuidance,
-                    trigger_threshold: pendingConfig.frequency === 'every_n' ? pendingConfig.triggerThreshold : null,
+                    report_prompt_guidance: configDraft.reportPromptGuidance,
+                }
+                if (configDraft.frequency === 'scheduled') {
+                    data.rrule = configDraft.rrule
+                    data.starts_at = configDraft.startsAt
+                    data.timezone_name = configDraft.timezoneName
+                }
+                if (configDraft.frequency === 'every_n') {
+                    data.trigger_threshold = configDraft.triggerThreshold
+                }
+                actions.updateReport({ reportId: activeReport.id, data })
+            } else {
+                actions.createReport({
+                    evaluationId: props.evaluationId,
+                    frequency: configDraft.frequency,
+                    rrule: configDraft.rrule,
+                    starts_at: configDraft.startsAt,
+                    timezone_name: configDraft.timezoneName,
+                    delivery_targets: targets,
+                    report_prompt_guidance: configDraft.reportPromptGuidance,
+                    trigger_threshold: configDraft.frequency === 'every_n' ? configDraft.triggerThreshold : null,
                 })
             }
         },

--- a/products/llm_analytics/frontend/evaluations/evaluationReportLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/evaluationReportLogic.ts
@@ -119,7 +119,8 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                     // Seed a default rrule when switching into scheduled mode for the first time so
                     // the Save button can commit without forcing the user to fill the field manually.
                     const rrule = frequency === 'scheduled' && !state.rrule ? DEFAULT_RRULE : state.rrule
-                    const startsAt = frequency === 'scheduled' && !state.startsAt ? new Date().toISOString() : state.startsAt
+                    const startsAt =
+                        frequency === 'scheduled' && !state.startsAt ? new Date().toISOString() : state.startsAt
                     return { ...state, frequency, rrule, startsAt }
                 },
                 setDraftRrule: (state, { rrule }) => ({ ...state, rrule }),

--- a/products/llm_analytics/frontend/evaluations/evaluationReportLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/evaluationReportLogic.ts
@@ -52,13 +52,16 @@ const DEFAULT_CONFIG_DRAFT: ReportConfigDraft = {
 function draftFromReport(report: EvaluationReport): ReportConfigDraft {
     const emailTarget = report.delivery_targets.find((t) => t.type === 'email')
     const slackTarget = report.delivery_targets.find((t) => t.type === 'slack')
+    // Normalise here so the dirty check (which compares against draft.emailValue
+    // that buildDeliveryTargets later trims) doesn't fire a false positive when
+    // the stored value is surrounded by whitespace.
     return {
         enabled: true,
         frequency: report.frequency,
         rrule: report.rrule ?? '',
         startsAt: report.starts_at ?? null,
         timezoneName: report.timezone_name ?? DEFAULT_TIMEZONE,
-        emailValue: emailTarget?.value ?? '',
+        emailValue: (emailTarget?.value ?? '').trim(),
         slackIntegrationId: slackTarget?.integration_id ?? null,
         slackChannelValue: slackTarget?.channel ?? '',
         reportPromptGuidance: report.report_prompt_guidance ?? '',

--- a/products/llm_analytics/frontend/evaluations/evaluationReportLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/evaluationReportLogic.ts
@@ -1,0 +1,241 @@
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
+import { teamLogic } from 'scenes/teamLogic'
+
+import type { evaluationReportLogicType } from './evaluationReportLogicType'
+import type {
+    EvaluationReport,
+    EvaluationReportDeliveryTarget,
+    EvaluationReportFrequency,
+    EvaluationReportRun,
+} from './types'
+
+export interface EvaluationReportLogicProps {
+    evaluationId: string
+}
+
+export interface PendingReportConfig {
+    enabled: boolean
+    frequency: EvaluationReportFrequency
+    emailValue: string
+    slackIntegrationId: number | null
+    slackChannelValue: string
+    reportPromptGuidance: string
+    triggerThreshold: number
+}
+
+const DEFAULT_PENDING_CONFIG: PendingReportConfig = {
+    enabled: true,
+    frequency: 'every_n',
+    emailValue: '',
+    slackIntegrationId: null,
+    slackChannelValue: '',
+    reportPromptGuidance: '',
+    triggerThreshold: 100,
+}
+
+export const evaluationReportLogic = kea<evaluationReportLogicType>([
+    path(['products', 'llm_analytics', 'frontend', 'evaluations', 'evaluationReportLogic']),
+    props({} as EvaluationReportLogicProps),
+    key((props) => props.evaluationId),
+    connect({
+        values: [teamLogic, ['currentTeamId']],
+    }),
+
+    actions({
+        // Pending config for new evaluations
+        setPendingEnabled: (enabled: boolean) => ({ enabled }),
+        setPendingFrequency: (frequency: EvaluationReportFrequency) => ({ frequency }),
+        setPendingEmailValue: (emailValue: string) => ({ emailValue }),
+        setPendingSlackIntegrationId: (integrationId: number | null) => ({ integrationId }),
+        setPendingSlackChannelValue: (channelValue: string) => ({ channelValue }),
+        setPendingReportPromptGuidance: (reportPromptGuidance: string) => ({ reportPromptGuidance }),
+        setPendingTriggerThreshold: (triggerThreshold: number) => ({ triggerThreshold }),
+        createPendingReport: (evaluationId: string) => ({ evaluationId }),
+
+        // Existing report actions
+        selectReportRun: (reportRun: EvaluationReportRun | null) => ({ reportRun }),
+    }),
+
+    reducers({
+        pendingConfig: [
+            DEFAULT_PENDING_CONFIG as PendingReportConfig,
+            {
+                setPendingEnabled: (state, { enabled }) => ({ ...state, enabled }),
+                setPendingFrequency: (state, { frequency }) => ({ ...state, frequency }),
+                setPendingEmailValue: (state, { emailValue }) => ({ ...state, emailValue }),
+                setPendingSlackIntegrationId: (state, { integrationId }) => ({
+                    ...state,
+                    slackIntegrationId: integrationId,
+                    slackChannelValue: integrationId !== state.slackIntegrationId ? '' : state.slackChannelValue,
+                }),
+                setPendingSlackChannelValue: (state, { channelValue }) => ({
+                    ...state,
+                    slackChannelValue: channelValue,
+                }),
+                setPendingReportPromptGuidance: (state, { reportPromptGuidance }) => ({
+                    ...state,
+                    reportPromptGuidance,
+                }),
+                setPendingTriggerThreshold: (state, { triggerThreshold }) => ({
+                    ...state,
+                    triggerThreshold,
+                }),
+            },
+        ],
+        selectedReportRun: [
+            null as EvaluationReportRun | null,
+            {
+                selectReportRun: (_, { reportRun }) => reportRun,
+            },
+        ],
+    }),
+
+    loaders(({ props, values }) => ({
+        reports: [
+            [] as EvaluationReport[],
+            {
+                loadReports: async () => {
+                    if (props.evaluationId === 'new') {
+                        return []
+                    }
+                    const response = await api.get(
+                        `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/`
+                    )
+                    return (response.results || []).filter((r: EvaluationReport) => r.evaluation === props.evaluationId)
+                },
+                createReport: async (params: {
+                    evaluationId: string
+                    frequency: EvaluationReportFrequency
+                    delivery_targets: EvaluationReportDeliveryTarget[]
+                    report_prompt_guidance?: string
+                    trigger_threshold?: number | null
+                }) => {
+                    const body: Record<string, unknown> = {
+                        evaluation: params.evaluationId,
+                        frequency: params.frequency,
+                        start_date: new Date().toISOString(),
+                        delivery_targets: params.delivery_targets,
+                        report_prompt_guidance: params.report_prompt_guidance ?? '',
+                        enabled: true,
+                    }
+                    if (params.frequency === 'every_n' && params.trigger_threshold != null) {
+                        body.trigger_threshold = params.trigger_threshold
+                    }
+                    const report = await api.create(
+                        `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/`,
+                        body
+                    )
+                    return [...values.reports, report]
+                },
+                updateReport: async ({ reportId, data }: { reportId: string; data: Partial<EvaluationReport> }) => {
+                    const updated = await api.update(
+                        `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/${reportId}/`,
+                        data
+                    )
+                    return values.reports.map((r) => (r.id === reportId ? updated : r))
+                },
+                deleteReport: async (reportId: string) => {
+                    await api.update(
+                        `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/${reportId}/`,
+                        { deleted: true }
+                    )
+                    return values.reports.filter((r) => r.id !== reportId)
+                },
+            },
+        ],
+        reportRuns: [
+            [] as EvaluationReportRun[],
+            {
+                loadReportRuns: async (reportId: string) => {
+                    const response = await api.get(
+                        `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/${reportId}/runs/`
+                    )
+                    return response || []
+                },
+            },
+        ],
+        generateResult: [
+            null as null,
+            {
+                generateReport: async (reportId: string) => {
+                    await api.create(
+                        `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/${reportId}/generate/`
+                    )
+                    return null
+                },
+            },
+        ],
+    })),
+
+    selectors({
+        isNewEvaluation: [(_, p) => [p.evaluationId], (evaluationId: string) => evaluationId === 'new'],
+        activeReport: [
+            (s) => [s.reports],
+            (reports): EvaluationReport | null => {
+                return reports.find((r: EvaluationReport) => r.enabled && !r.deleted) || null
+            },
+        ],
+    }),
+
+    listeners(({ actions, values }) => ({
+        loadReportsSuccess: ({ reports }: { reports: EvaluationReport[] }) => {
+            // Auto-load the run history for the active report so the Reports tab knows
+            // whether to render itself and can show data immediately.
+            const active = reports.find((r: EvaluationReport) => r.enabled && !r.deleted)
+            if (active) {
+                actions.loadReportRuns(active.id)
+            }
+        },
+        generateReportSuccess: () => {
+            lemonToast.success('Report is being generated and will be delivered to your configured targets shortly.')
+        },
+        generateReportFailure: () => {
+            lemonToast.error('Failed to trigger report generation. Please try again.')
+        },
+        createReportSuccess: () => {
+            actions.loadReports()
+        },
+        updateReportSuccess: () => {
+            actions.loadReports()
+        },
+        createPendingReport: ({ evaluationId }) => {
+            const { pendingConfig } = values
+            if (!pendingConfig.enabled) {
+                return
+            }
+            const targets: EvaluationReportDeliveryTarget[] = []
+            if (pendingConfig.emailValue.trim()) {
+                targets.push({ type: 'email', value: pendingConfig.emailValue.trim() })
+            }
+            if (pendingConfig.slackIntegrationId && pendingConfig.slackChannelValue) {
+                targets.push({
+                    type: 'slack',
+                    integration_id: pendingConfig.slackIntegrationId,
+                    channel: pendingConfig.slackChannelValue,
+                })
+            }
+            // The backend auto-creates a default report config on eval creation.
+            // If the user configured delivery targets or custom settings, update
+            // the auto-created report after creation via the existing reports list.
+            if (targets.length > 0 || pendingConfig.reportPromptGuidance.trim()) {
+                actions.createReport({
+                    evaluationId,
+                    frequency: pendingConfig.frequency,
+                    delivery_targets: targets,
+                    report_prompt_guidance: pendingConfig.reportPromptGuidance,
+                    trigger_threshold: pendingConfig.frequency === 'every_n' ? pendingConfig.triggerThreshold : null,
+                })
+            }
+        },
+    })),
+
+    afterMount(({ actions, props }) => {
+        if (props.evaluationId !== 'new') {
+            actions.loadReports()
+        }
+    }),
+])

--- a/products/llm_analytics/frontend/evaluations/evaluationReportLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/evaluationReportLogic.ts
@@ -103,9 +103,9 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                         return []
                     }
                     const response = await api.get(
-                        `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/`
+                        `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/?evaluation=${props.evaluationId}`
                     )
-                    return (response.results || []).filter((r: EvaluationReport) => r.evaluation === props.evaluationId)
+                    return response.results || []
                 },
                 createReport: async (params: {
                     evaluationId: string

--- a/products/llm_analytics/frontend/evaluations/evaluationReportLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/evaluationReportLogic.ts
@@ -17,7 +17,9 @@ export interface EvaluationReportLogicProps {
     evaluationId: string
 }
 
-export interface PendingReportConfig {
+/** Draft state for the report config form — used for both the create-new-evaluation path
+ * (keyed as 'new') and the edit-existing-evaluation path (keyed by the real evaluation id). */
+export interface ReportConfigDraft {
     enabled: boolean
     frequency: EvaluationReportFrequency
     emailValue: string
@@ -27,14 +29,46 @@ export interface PendingReportConfig {
     triggerThreshold: number
 }
 
-const DEFAULT_PENDING_CONFIG: PendingReportConfig = {
+export const TRIGGER_THRESHOLD_DEFAULT = 100
+
+const DEFAULT_CONFIG_DRAFT: ReportConfigDraft = {
     enabled: true,
     frequency: 'every_n',
     emailValue: '',
     slackIntegrationId: null,
     slackChannelValue: '',
     reportPromptGuidance: '',
-    triggerThreshold: 100,
+    triggerThreshold: TRIGGER_THRESHOLD_DEFAULT,
+}
+
+function draftFromReport(report: EvaluationReport): ReportConfigDraft {
+    const emailTarget = report.delivery_targets.find((t) => t.type === 'email')
+    const slackTarget = report.delivery_targets.find((t) => t.type === 'slack')
+    return {
+        enabled: true,
+        frequency: report.frequency,
+        emailValue: emailTarget?.value ?? '',
+        slackIntegrationId: slackTarget?.integration_id ?? null,
+        slackChannelValue: slackTarget?.channel ?? '',
+        reportPromptGuidance: report.report_prompt_guidance ?? '',
+        triggerThreshold: report.trigger_threshold ?? TRIGGER_THRESHOLD_DEFAULT,
+    }
+}
+
+export function buildDeliveryTargets(draft: ReportConfigDraft): EvaluationReportDeliveryTarget[] {
+    const targets: EvaluationReportDeliveryTarget[] = []
+    const email = draft.emailValue.trim()
+    if (email.length > 0) {
+        targets.push({ type: 'email', value: email })
+    }
+    if (draft.slackIntegrationId !== null && draft.slackChannelValue.length > 0) {
+        targets.push({
+            type: 'slack',
+            integration_id: draft.slackIntegrationId,
+            channel: draft.slackChannelValue,
+        })
+    }
+    return targets
 }
 
 export const evaluationReportLogic = kea<evaluationReportLogicType>([
@@ -46,44 +80,50 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
     }),
 
     actions({
-        // Pending config for new evaluations
-        setPendingEnabled: (enabled: boolean) => ({ enabled }),
-        setPendingFrequency: (frequency: EvaluationReportFrequency) => ({ frequency }),
-        setPendingEmailValue: (emailValue: string) => ({ emailValue }),
-        setPendingSlackIntegrationId: (integrationId: number | null) => ({ integrationId }),
-        setPendingSlackChannelValue: (channelValue: string) => ({ channelValue }),
-        setPendingReportPromptGuidance: (reportPromptGuidance: string) => ({ reportPromptGuidance }),
-        setPendingTriggerThreshold: (triggerThreshold: number) => ({ triggerThreshold }),
-        createPendingReport: (evaluationId: string) => ({ evaluationId }),
+        setDraftEnabled: (enabled: boolean) => ({ enabled }),
+        setDraftFrequency: (frequency: EvaluationReportFrequency) => ({ frequency }),
+        setDraftEmailValue: (emailValue: string) => ({ emailValue }),
+        setDraftSlackIntegrationId: (integrationId: number | null) => ({ integrationId }),
+        setDraftSlackChannelValue: (channelValue: string) => ({ channelValue }),
+        setDraftReportPromptGuidance: (reportPromptGuidance: string) => ({ reportPromptGuidance }),
+        setDraftTriggerThreshold: (triggerThreshold: number) => ({ triggerThreshold }),
+        seedDraftFromReport: (report: EvaluationReport) => ({ report }),
+        resetDraft: true,
 
-        // Existing report actions
+        /** Save the current draft against the active report — creates if none exists, updates otherwise. */
+        saveDraft: true,
+
         selectReportRun: (reportRun: EvaluationReportRun | null) => ({ reportRun }),
     }),
 
     reducers({
-        pendingConfig: [
-            DEFAULT_PENDING_CONFIG as PendingReportConfig,
+        configDraft: [
+            DEFAULT_CONFIG_DRAFT as ReportConfigDraft,
             {
-                setPendingEnabled: (state, { enabled }) => ({ ...state, enabled }),
-                setPendingFrequency: (state, { frequency }) => ({ ...state, frequency }),
-                setPendingEmailValue: (state, { emailValue }) => ({ ...state, emailValue }),
-                setPendingSlackIntegrationId: (state, { integrationId }) => ({
+                setDraftEnabled: (state, { enabled }) => ({ ...state, enabled }),
+                setDraftFrequency: (state, { frequency }) => ({ ...state, frequency }),
+                setDraftEmailValue: (state, { emailValue }) => ({ ...state, emailValue }),
+                setDraftSlackIntegrationId: (state, { integrationId }) => ({
                     ...state,
                     slackIntegrationId: integrationId,
+                    // Clear channel when switching Slack workspaces so we don't send a
+                    // channel id from a different workspace.
                     slackChannelValue: integrationId !== state.slackIntegrationId ? '' : state.slackChannelValue,
                 }),
-                setPendingSlackChannelValue: (state, { channelValue }) => ({
+                setDraftSlackChannelValue: (state, { channelValue }) => ({
                     ...state,
                     slackChannelValue: channelValue,
                 }),
-                setPendingReportPromptGuidance: (state, { reportPromptGuidance }) => ({
+                setDraftReportPromptGuidance: (state, { reportPromptGuidance }) => ({
                     ...state,
                     reportPromptGuidance,
                 }),
-                setPendingTriggerThreshold: (state, { triggerThreshold }) => ({
+                setDraftTriggerThreshold: (state, { triggerThreshold }) => ({
                     ...state,
                     triggerThreshold,
                 }),
+                seedDraftFromReport: (_, { report }) => draftFromReport(report),
+                resetDraft: () => DEFAULT_CONFIG_DRAFT,
             },
         ],
         selectedReportRun: [
@@ -179,15 +219,35 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                 return reports.find((r: EvaluationReport) => r.enabled && !r.deleted) || null
             },
         ],
+        isConfigDirty: [
+            (s) => [s.activeReport, s.configDraft],
+            (activeReport, draft): boolean => {
+                if (!activeReport) {
+                    // No report yet: draft is "dirty" if it has any savable content.
+                    return buildDeliveryTargets(draft).length > 0 || draft.reportPromptGuidance.trim().length > 0
+                }
+                const baseline = draftFromReport(activeReport)
+                return (
+                    baseline.frequency !== draft.frequency ||
+                    baseline.emailValue !== draft.emailValue.trim() ||
+                    baseline.slackIntegrationId !== draft.slackIntegrationId ||
+                    baseline.slackChannelValue !== draft.slackChannelValue ||
+                    baseline.reportPromptGuidance !== draft.reportPromptGuidance ||
+                    (draft.frequency === 'every_n' && baseline.triggerThreshold !== draft.triggerThreshold)
+                )
+            },
+        ],
     }),
 
-    listeners(({ actions, values }) => ({
-        loadReportsSuccess: ({ reports }: { reports: EvaluationReport[] }) => {
+    listeners(({ actions, values, props }) => ({
+        loadReportsSuccess: ({ reports }) => {
             // Auto-load the run history for the active report so the Reports tab knows
             // whether to render itself and can show data immediately.
             const active = reports.find((r: EvaluationReport) => r.enabled && !r.deleted)
             if (active) {
                 actions.loadReportRuns(active.id)
+                // Seed the draft so the config form reflects the saved report instead of defaults.
+                actions.seedDraftFromReport(active)
             }
         },
         generateReportSuccess: () => {
@@ -202,32 +262,26 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
         updateReportSuccess: () => {
             actions.loadReports()
         },
-        createPendingReport: ({ evaluationId }) => {
-            const { pendingConfig } = values
-            if (!pendingConfig.enabled) {
-                return
-            }
-            const targets: EvaluationReportDeliveryTarget[] = []
-            if (pendingConfig.emailValue.trim()) {
-                targets.push({ type: 'email', value: pendingConfig.emailValue.trim() })
-            }
-            if (pendingConfig.slackIntegrationId && pendingConfig.slackChannelValue) {
-                targets.push({
-                    type: 'slack',
-                    integration_id: pendingConfig.slackIntegrationId,
-                    channel: pendingConfig.slackChannelValue,
-                })
-            }
-            // The backend auto-creates a default report config on eval creation.
-            // If the user configured delivery targets or custom settings, update
-            // the auto-created report after creation via the existing reports list.
-            if (targets.length > 0 || pendingConfig.reportPromptGuidance.trim()) {
-                actions.createReport({
-                    evaluationId,
-                    frequency: pendingConfig.frequency,
+        saveDraft: () => {
+            const { configDraft, activeReport } = values
+            const targets = buildDeliveryTargets(configDraft)
+            if (activeReport) {
+                const data: Record<string, unknown> = {
+                    frequency: configDraft.frequency,
                     delivery_targets: targets,
-                    report_prompt_guidance: pendingConfig.reportPromptGuidance,
-                    trigger_threshold: pendingConfig.frequency === 'every_n' ? pendingConfig.triggerThreshold : null,
+                    report_prompt_guidance: configDraft.reportPromptGuidance,
+                }
+                if (configDraft.frequency === 'every_n') {
+                    data.trigger_threshold = configDraft.triggerThreshold
+                }
+                actions.updateReport({ reportId: activeReport.id, data })
+            } else {
+                actions.createReport({
+                    evaluationId: props.evaluationId,
+                    frequency: configDraft.frequency,
+                    delivery_targets: targets,
+                    report_prompt_guidance: configDraft.reportPromptGuidance,
+                    trigger_threshold: configDraft.frequency === 'every_n' ? configDraft.triggerThreshold : null,
                 })
             }
         },

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -20,6 +20,7 @@ import { isUnhealthyProviderKeyState } from '../settings/providerKeyStateUtils'
 import { queryEvaluationRuns } from '../utils'
 import { evaluationErrorMessage } from './apiErrors'
 import { EVALUATION_SUMMARY_MAX_RUNS } from './constants'
+import { evaluationReportLogic } from './evaluationReportLogic'
 import type { llmEvaluationLogicType } from './llmEvaluationLogicType'
 import { EvaluationTemplateKey, defaultEvaluationTemplates } from './templates'
 import {
@@ -505,6 +506,13 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                 enabled: true,
                 config: { ...existing?.config, evaluation_ids: newIds },
             })
+        },
+
+        saveEvaluationSuccess: ({ evaluation }) => {
+            if (props.evaluationId === 'new' && evaluation?.id) {
+                // Create the pending report if the user configured one during evaluation creation
+                evaluationReportLogic({ evaluationId: 'new' }).actions.createPendingReport(evaluation.id)
+            }
         },
 
         saveEvaluation: async () => {

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -20,7 +20,7 @@ import { isUnhealthyProviderKeyState } from '../settings/providerKeyStateUtils'
 import { queryEvaluationRuns } from '../utils'
 import { evaluationErrorMessage } from './apiErrors'
 import { EVALUATION_SUMMARY_MAX_RUNS } from './constants'
-import { evaluationReportLogic } from './evaluationReportLogic'
+import { buildDeliveryTargets, evaluationReportLogic } from './evaluationReportLogic'
 import type { llmEvaluationLogicType } from './llmEvaluationLogicType'
 import { EvaluationTemplateKey, defaultEvaluationTemplates } from './templates'
 import {
@@ -508,13 +508,6 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
             })
         },
 
-        saveEvaluationSuccess: ({ evaluation }) => {
-            if (props.evaluationId === 'new' && evaluation?.id) {
-                // Create the pending report if the user configured one during evaluation creation
-                evaluationReportLogic({ evaluationId: 'new' }).actions.createPendingReport(evaluation.id)
-            }
-        },
-
         saveEvaluation: async () => {
             try {
                 const teamId = teamLogic.values.currentTeamId
@@ -525,6 +518,36 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                 if (props.evaluationId === 'new') {
                     const response = await api.create(`/api/environments/${teamId}/evaluations/`, values.evaluation!)
                     actions.saveEvaluationSuccess(response)
+                    // Create the pending report before navigating away. The 'new'-keyed
+                    // evaluationReportLogic unmounts when the component tears down, so
+                    // snapshot its draft now and fire the create directly.
+                    if (response?.id) {
+                        const draft = evaluationReportLogic({ evaluationId: 'new' }).values.configDraft
+                        const targets = buildDeliveryTargets(draft)
+                        if (draft.enabled && (targets.length > 0 || draft.reportPromptGuidance.trim().length > 0)) {
+                            const body: Record<string, unknown> = {
+                                evaluation: response.id,
+                                frequency: draft.frequency,
+                                delivery_targets: targets,
+                                report_prompt_guidance: draft.reportPromptGuidance,
+                                enabled: true,
+                            }
+                            if (draft.frequency === 'scheduled') {
+                                body.rrule = draft.rrule
+                                body.starts_at = draft.startsAt
+                                body.timezone_name = draft.timezoneName
+                            }
+                            if (draft.frequency === 'every_n') {
+                                body.trigger_threshold = draft.triggerThreshold
+                            }
+                            try {
+                                await api.create(`api/environments/${teamId}/llm_analytics/evaluation_reports/`, body)
+                            } catch (reportError) {
+                                // Don't block navigation if the (optional) pending report fails
+                                posthog.captureException(reportError, { tag: 'eval-report-pending-create' })
+                            }
+                        }
+                    }
                 } else {
                     const response = await api.update(
                         `/api/environments/${teamId}/evaluations/${props.evaluationId}/`,

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -20,7 +20,7 @@ import { isUnhealthyProviderKeyState } from '../settings/providerKeyStateUtils'
 import { queryEvaluationRuns } from '../utils'
 import { evaluationErrorMessage } from './apiErrors'
 import { EVALUATION_SUMMARY_MAX_RUNS } from './constants'
-import { evaluationReportLogic } from './evaluationReportLogic'
+import { buildDeliveryTargets, evaluationReportLogic } from './evaluationReportLogic'
 import type { llmEvaluationLogicType } from './llmEvaluationLogicType'
 import { EvaluationTemplateKey, defaultEvaluationTemplates } from './templates'
 import {
@@ -508,13 +508,6 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
             })
         },
 
-        saveEvaluationSuccess: ({ evaluation }) => {
-            if (props.evaluationId === 'new' && evaluation?.id) {
-                // Create the pending report if the user configured one during evaluation creation
-                evaluationReportLogic({ evaluationId: 'new' }).actions.createPendingReport(evaluation.id)
-            }
-        },
-
         saveEvaluation: async () => {
             try {
                 const teamId = teamLogic.values.currentTeamId
@@ -525,6 +518,32 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                 if (props.evaluationId === 'new') {
                     const response = await api.create(`/api/environments/${teamId}/evaluations/`, values.evaluation!)
                     actions.saveEvaluationSuccess(response)
+                    // Create the pending report before navigating away. The 'new'-keyed
+                    // evaluationReportLogic unmounts when the component tears down, so
+                    // snapshot its draft now and fire the create directly.
+                    if (response?.id) {
+                        const draft = evaluationReportLogic({ evaluationId: 'new' }).values.configDraft
+                        const targets = buildDeliveryTargets(draft)
+                        if (draft.enabled && (targets.length > 0 || draft.reportPromptGuidance.trim().length > 0)) {
+                            const body: Record<string, unknown> = {
+                                evaluation: response.id,
+                                frequency: draft.frequency,
+                                start_date: new Date().toISOString(),
+                                delivery_targets: targets,
+                                report_prompt_guidance: draft.reportPromptGuidance,
+                                enabled: true,
+                            }
+                            if (draft.frequency === 'every_n') {
+                                body.trigger_threshold = draft.triggerThreshold
+                            }
+                            try {
+                                await api.create(`api/environments/${teamId}/llm_analytics/evaluation_reports/`, body)
+                            } catch (reportError) {
+                                // Don't block navigation if the (optional) pending report fails
+                                posthog.captureException(reportError, { tag: 'eval-report-pending-create' })
+                            }
+                        }
+                    }
                 } else {
                     const response = await api.update(
                         `/api/environments/${teamId}/evaluations/${props.evaluationId}/`,

--- a/products/llm_analytics/frontend/evaluations/types.ts
+++ b/products/llm_analytics/frontend/evaluations/types.ts
@@ -86,6 +86,86 @@ export interface HogTestResult {
     error: string | null
 }
 
+export type EvaluationReportFrequency = 'hourly' | 'daily' | 'weekly' | 'every_n'
+
+export interface EvaluationReportDeliveryTarget {
+    type: 'email' | 'slack'
+    value?: string
+    integration_id?: number
+    channel?: string
+}
+
+export interface EvaluationReport {
+    id: string
+    evaluation: string
+    frequency: EvaluationReportFrequency
+    byweekday: string[] | null
+    start_date: string
+    next_delivery_date: string | null
+    delivery_targets: EvaluationReportDeliveryTarget[]
+    max_sample_size: number
+    enabled: boolean
+    deleted: boolean
+    last_delivered_at: string | null
+    /** Optional per-report custom guidance appended to the agent's system prompt. */
+    report_prompt_guidance: string
+    /** Number of new eval results that triggers a report (only for every_n frequency). */
+    trigger_threshold: number | null
+    /** Minimum minutes between count-triggered reports. */
+    cooldown_minutes: number
+    /** Maximum count-triggered report runs per calendar day (UTC). */
+    daily_run_cap: number
+    created_by: number | null
+    created_at: string
+}
+
+/** A titled markdown section of the report (v2: agent-chosen title). */
+export interface EvaluationReportSection {
+    title: string
+    content: string
+}
+
+/** A trace reference cited by the agent to ground a specific finding. */
+export interface EvaluationReportCitation {
+    generation_id: string
+    trace_id: string
+    reason: string
+}
+
+/** Structured metrics computed mechanically from ClickHouse (agent cannot fabricate). */
+export interface EvaluationReportMetrics {
+    total_runs: number
+    pass_count: number
+    fail_count: number
+    na_count: number
+    pass_rate: number
+    period_start: string
+    period_end: string
+    previous_total_runs: number | null
+    previous_pass_rate: number | null
+}
+
+/** Top-level report content stored in EvaluationReportRun.content. */
+export interface EvaluationReportRunContent {
+    title: string
+    sections: EvaluationReportSection[]
+    citations: EvaluationReportCitation[]
+    metrics: EvaluationReportMetrics
+}
+
+export interface EvaluationReportRun {
+    id: string
+    report: string
+    content: EvaluationReportRunContent
+    /** Legacy mirror of content.metrics — populated by the store activity for backwards compat. */
+    metadata: EvaluationReportMetrics
+    period_start: string
+    period_end: string
+    delivery_status: 'pending' | 'delivered' | 'partial_failure' | 'failed'
+    delivery_errors: string[]
+    created_at: string
+}
+
 export type EvaluationSummaryFilter = 'all' | 'pass' | 'fail' | 'na'
 
 export interface EvaluationPattern {

--- a/products/llm_analytics/frontend/evaluations/types.ts
+++ b/products/llm_analytics/frontend/evaluations/types.ts
@@ -86,7 +86,7 @@ export interface HogTestResult {
     error: string | null
 }
 
-export type EvaluationReportFrequency = 'hourly' | 'daily' | 'weekly' | 'every_n'
+export type EvaluationReportFrequency = 'scheduled' | 'every_n'
 
 export interface EvaluationReportDeliveryTarget {
     type: 'email' | 'slack'
@@ -99,8 +99,12 @@ export interface EvaluationReport {
     id: string
     evaluation: string
     frequency: EvaluationReportFrequency
-    byweekday: string[] | null
-    start_date: string
+    /** RFC 5545 RRULE string (empty for every_n). */
+    rrule: string
+    /** Anchor datetime for rrule expansion (null for every_n). */
+    starts_at: string | null
+    /** IANA timezone for expanding rrule occurrences. */
+    timezone_name: string
     next_delivery_date: string | null
     delivery_targets: EvaluationReportDeliveryTarget[]
     max_sample_size: number


### PR DESCRIPTION
## Problem

Part of a 5-PR stack that adds scheduled evaluation reports to LLM analytics. See the tracking issue #54454 for the full feature overview.

This PR (4/5) adds everything the user sees, gated behind the `llm-analytics-evaluations-reports` feature flag. With the flag off, the tabs and configuration UI are hidden even though the backend from #54363 and #54365 is already running.

## Changes

- `EvaluationReportConfig` form: frequency, count threshold, delivery targets (email + Slack channel picker), optional prompt guidance
- `EvaluationReportsTab` history table with delivery status badges
- `EvaluationReportViewer` for rendered report content (sections, metrics, trace citation links)
- `evaluationReportLogic` (kea) handling load, create, update, delete, and manual generate against the `/api/environments/.../llm_analytics/evaluation_reports/` endpoints; uses the server-side `?evaluation=` filter
- `createPendingReport` wiring so that a user-configured schedule is applied after eval creation
- Feature flag constant and flag gating in `LLMAnalyticsEvaluation.tsx`

## How did you test this code?

- Jest snapshots updated for new components
- Local smoke: created an evaluation, toggled a report on, switched between hourly / every_n frequencies, confirmed delivery target validation, viewed a generated report in the Reports tab
- As an agent I did not run Playwright against this branch; manual testing was limited to local dev

## Publish to changelog?

no

## Docs update

no