### PR TITLE
fix(cdp): Improve Google Ads mapping UX and filter removed conversion actions

### DIFF
--- a/nodejs/src/cdp/templates/_destinations/google_ads/google.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/google_ads/google.template.test.ts
@@ -22,7 +22,7 @@ describe('google template', () => {
 
     it('works with single product event', async () => {
         const response = await tester.invokeMapping(
-            'Signed Up',
+            'Conversion',
             {
                 oauth: {
                     access_token: 'access-token',
@@ -82,7 +82,7 @@ describe('google template', () => {
 
     it('works with empty properties', async () => {
         const response = await tester.invokeMapping(
-            'Signed Up',
+            'Conversion',
             {
                 oauth: {
                     access_token: 'access-token',
@@ -120,7 +120,7 @@ describe('google template', () => {
 
     it('handles error responses', async () => {
         const response = await tester.invokeMapping(
-            'Signed Up',
+            'Conversion',
             {
                 oauth: {
                     access_token: 'access-token',
@@ -161,7 +161,7 @@ describe('google template', () => {
 
     it('handles missing gclid', async () => {
         const response = await tester.invokeMapping(
-            'Signed Up',
+            'Conversion',
             {
                 oauth: {
                     access_token: 'access-token',

--- a/nodejs/src/cdp/templates/_destinations/google_ads/google.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/google_ads/google.template.ts
@@ -143,10 +143,10 @@ if (res.status >= 400) {
     ],
     mapping_templates: [
         {
-            name: 'Signed Up',
+            name: 'Conversion',
             include_by_default: true,
             filters: {
-                events: [{ id: 'Signed Up', type: 'events' }],
+                events: [],
             },
             inputs_schema: [...build_inputs()],
         },

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -1114,7 +1114,9 @@ class GoogleAdsIntegration:
         response = requests.request(
             "POST",
             f"https://googleads.googleapis.com/v21/customers/{customer_id}/googleAds:searchStream",
-            json={"query": "SELECT conversion_action.id, conversion_action.name FROM conversion_action"},
+            json={
+                "query": "SELECT conversion_action.id, conversion_action.name FROM conversion_action WHERE conversion_action.status != 'REMOVED'"
+            },
             headers={
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {self.integration.sensitive_config['access_token']}",


### PR DESCRIPTION
## Problem

Customer feedback ([ticket](https://posthoghelp.zendesk.com/agent/tickets/55581)) said that the Google Ads Conversions destination mapping UX is confusing. The "Add mapping" dropdown only shows "Signed Up" as an option, forcing users to add it and then rename. Additionally, the conversion action dropdown shows deleted/removed conversion actions from Google Ads, cluttering the list.

## Changes

1. Renamed the mapping template from "Signed Up" to "Conversion" and removed the hardcoded event filter, so users start with a blank mapping they can configure for any event
2. Added `WHERE conversion_action.status != 'REMOVED'` to the Google Ads API query to filter out deleted conversion actions

When configuring new Google Ads destination:

<img width="1057" height="400" alt="Screenshot 2026-04-15 at 0 25 25" src="https://github.com/user-attachments/assets/4f7cfa28-1182-4639-bb31-ab49bee7eec5" />

## How did you test this code?

- Updated `google.template.test.ts` to reflect the renamed template; existing tests pass.
- Verified the GAQL query against a real Google Ads account using Google Ads Scripts

## Publish to changelog?

No