### PR TITLE
chore: Add a feedback banner to the Health Overview

### DIFF
--- a/frontend/src/scenes/health/HealthScene.tsx
+++ b/frontend/src/scenes/health/HealthScene.tsx
@@ -128,7 +128,7 @@ const UnifiedHealthScene = (): JSX.Element => {
                 </div>
             </div>
 
-            <div className="flex flex-col gap-6 max-w-5xl">
+            <div className="flex flex-col gap-6">
                 <LemonBanner
                     type="info"
                     className="mb-2"

--- a/frontend/src/scenes/health/HealthScene.tsx
+++ b/frontend/src/scenes/health/HealthScene.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconCheck, IconCode, IconDatabase, IconEllipsis, IconRefresh, IconSupport, IconWarning } from '@posthog/icons'
-import { LemonButton, LemonMenu, Link } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonMenu, Link } from '@posthog/lemon-ui'
 
 import { supportLogic } from 'lib/components/Support/supportLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -129,6 +129,14 @@ const UnifiedHealthScene = (): JSX.Element => {
             </div>
 
             <div className="flex flex-col gap-6 max-w-5xl">
+                <LemonBanner
+                    type="info"
+                    className="mb-2"
+                    dismissKey="unified-health-page-feedback-banner"
+                    action={{ children: 'Send feedback', id: 'unified-health-page-feedback-button' }}
+                >
+                    We'd love your feedback on the new Health page. Let us know what's working and what could be better!
+                </LemonBanner>
                 <PlatformStatusBanner />
                 <HealthIssueSummaryCards />
                 <HealthIssueList />

--- a/frontend/src/scenes/health/components/HealthIssueList.tsx
+++ b/frontend/src/scenes/health/components/HealthIssueList.tsx
@@ -53,7 +53,7 @@ export const HealthIssueList = (): JSX.Element => {
     const populatedCategories = CATEGORY_ORDER.filter((cat) => groupedByCategory[cat])
 
     return (
-        <div className="flex flex-col gap-4 max-w-3xl">
+        <div className="flex flex-col gap-4">
             {populatedCategories.map((category) => {
                 const categoryIssues = groupedByCategory[category]!
                 const config = HEALTH_CATEGORY_CONFIG[category]

--- a/frontend/src/scenes/health/components/HealthIssueSummaryCards.tsx
+++ b/frontend/src/scenes/health/components/HealthIssueSummaryCards.tsx
@@ -17,7 +17,7 @@ export const HealthIssueSummaryCards = (): JSX.Element => {
 
     if (healthIssuesLoading && !healthIssues) {
         return (
-            <div className="grid grid-cols-1 @2xl/main-content:grid-cols-3 gap-4 max-w-3xl">
+            <div className="grid grid-cols-1 @2xl/main-content:grid-cols-3 gap-4">
                 {Array.from({ length: 3 }, (_, i) => (
                     <LemonSkeleton key={i} className="h-28 rounded" />
                 ))}
@@ -30,7 +30,7 @@ export const HealthIssueSummaryCards = (): JSX.Element => {
     }
 
     return (
-        <div className="grid grid-cols-1 @2xl/main-content:grid-cols-3 gap-4 max-w-3xl">
+        <div className="grid grid-cols-1 @2xl/main-content:grid-cols-3 gap-4">
             {categorySummaries.map((summary: CategoryHealthSummary) => (
                 <CategoryCard key={summary.category} summary={summary} />
             ))}

--- a/frontend/src/scenes/health/components/PlatformStatusBanner.tsx
+++ b/frontend/src/scenes/health/components/PlatformStatusBanner.tsx
@@ -37,7 +37,6 @@ export const PlatformStatusBanner = (): JSX.Element => {
     return (
         <LemonBanner
             type={bannerType}
-            className="max-w-3xl"
             icon={<Hog className="size-10 shrink-0" />}
             hideIcon={false}
             action={{


### PR DESCRIPTION
## Problem
Add a feedback banner to the health overview page
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
<img width="3012" height="1812" alt="image" src="https://github.com/user-attachments/assets/998a9d84-f749-48ef-8bfb-895b639c47ab" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
