### PR TITLE
fix: use UTC with Z suffix in jump-to-timestamp date range

### DIFF
--- a/frontend/src/lib/components/DateFilter/JumpToTimestampForm.tsx
+++ b/frontend/src/lib/components/DateFilter/JumpToTimestampForm.tsx
@@ -8,7 +8,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
 import { WindowDirection, WindowSize, computeDateRange, parseTimestampInput } from './jumpToTimestampUtils'
 
-const PLACEHOLDER_ISO = dayjs().format('YYYY-MM-DDTHH:mm:ss[Z]')
+const PLACEHOLDER_ISO = dayjs().utc().format('YYYY-MM-DDTHH:mm:ss[Z]')
 const PLACEHOLDER_UNIX = Math.floor(Date.now() / 1000).toString()
 
 export interface JumpToTimestampFormProps {
@@ -34,7 +34,7 @@ export function JumpToTimestampForm({ onSubmit, children }: JumpToTimestampFormP
     }
 
     const statusSuffix = parsed ? (
-        <Tooltip title={`Parsed as: ${parsed.format('MMM D, YYYY HH:mm:ss')}`}>
+        <Tooltip title={`Parsed as: ${parsed.utc().format('MMM D, YYYY HH:mm:ss')} UTC`}>
             <IconCheck className="text-success text-base" />
         </Tooltip>
     ) : isInvalid ? (
@@ -93,11 +93,11 @@ export function JumpToTimestampForm({ onSubmit, children }: JumpToTimestampFormP
                 <div className="text-xs text-secondary mt-3">
                     Will show events from{' '}
                     <span className="whitespace-nowrap font-medium text-primary bg-fill-highlight-100 rounded px-0.5">
-                        {dayjs(dateRange.date_from).format('MMM D, YYYY HH:mm')}
+                        {dayjs.utc(dateRange.date_from).format('MMM D, YYYY HH:mm')} UTC
                     </span>{' '}
                     to{' '}
                     <span className="whitespace-nowrap font-medium text-primary bg-fill-highlight-100 rounded px-0.5">
-                        {dayjs(dateRange.date_to).format('MMM D, YYYY HH:mm')}
+                        {dayjs.utc(dateRange.date_to).format('MMM D, YYYY HH:mm')} UTC
                     </span>
                 </div>
             )}

--- a/frontend/src/lib/components/DateFilter/jumpToTimestampUtils.test.ts
+++ b/frontend/src/lib/components/DateFilter/jumpToTimestampUtils.test.ts
@@ -45,22 +45,30 @@ describe('jumpToTimestamp', () => {
     })
 
     describe('computeDateRange', () => {
-        const ts = dayjs('2024-01-15T12:00:00')
+        const ts = dayjs.utc('2024-01-15T12:00:00')
 
         it.each<[WindowDirection, WindowSize, string, string]>([
-            ['before', '5m', '2024-01-15T11:55:00', '2024-01-15T12:00:00'],
-            ['before', '10m', '2024-01-15T11:50:00', '2024-01-15T12:00:00'],
-            ['before', '1h', '2024-01-15T11:00:00', '2024-01-15T12:00:00'],
-            ['around', '5m', '2024-01-15T11:57:30', '2024-01-15T12:02:30'],
-            ['around', '10m', '2024-01-15T11:55:00', '2024-01-15T12:05:00'],
-            ['around', '1h', '2024-01-15T11:30:00', '2024-01-15T12:30:00'],
-            ['after', '5m', '2024-01-15T12:00:00', '2024-01-15T12:05:00'],
-            ['after', '10m', '2024-01-15T12:00:00', '2024-01-15T12:10:00'],
-            ['after', '1h', '2024-01-15T12:00:00', '2024-01-15T13:00:00'],
+            ['before', '5m', '2024-01-15T11:55:00Z', '2024-01-15T12:00:00Z'],
+            ['before', '10m', '2024-01-15T11:50:00Z', '2024-01-15T12:00:00Z'],
+            ['before', '1h', '2024-01-15T11:00:00Z', '2024-01-15T12:00:00Z'],
+            ['around', '5m', '2024-01-15T11:57:30Z', '2024-01-15T12:02:30Z'],
+            ['around', '10m', '2024-01-15T11:55:00Z', '2024-01-15T12:05:00Z'],
+            ['around', '1h', '2024-01-15T11:30:00Z', '2024-01-15T12:30:00Z'],
+            ['after', '5m', '2024-01-15T12:00:00Z', '2024-01-15T12:05:00Z'],
+            ['after', '10m', '2024-01-15T12:00:00Z', '2024-01-15T12:10:00Z'],
+            ['after', '1h', '2024-01-15T12:00:00Z', '2024-01-15T13:00:00Z'],
         ])('direction=%s window=%s → %s to %s', (direction, windowSize, expectedFrom, expectedTo) => {
             const result = computeDateRange(ts, windowSize, direction)
             expect(result.date_from).toBe(expectedFrom)
             expect(result.date_to).toBe(expectedTo)
+        })
+
+        it('converts timezone-aware timestamps to UTC output', () => {
+            // 10:30 at +05:00 = 05:30 UTC
+            const ts2 = dayjs('2024-01-15T10:30:00+05:00')
+            const result = computeDateRange(ts2, '5m', 'around')
+            expect(result.date_from).toBe('2024-01-15T05:27:30Z')
+            expect(result.date_to).toBe('2024-01-15T05:32:30Z')
         })
     })
 })

--- a/frontend/src/lib/components/DateFilter/jumpToTimestampUtils.ts
+++ b/frontend/src/lib/components/DateFilter/jumpToTimestampUtils.ts
@@ -83,24 +83,30 @@ export function computeDateRange(
     direction: WindowDirection
 ): { date_from: string; date_to: string } {
     const minutes = WINDOW_MINUTES[windowSize]
-    const fmt = 'YYYY-MM-DDTHH:mm:ss'
+    const fmt = 'YYYY-MM-DDTHH:mm:ss[Z]'
 
     switch (direction) {
         case 'before':
             return {
-                date_from: timestamp.subtract(minutes, 'minute').format(fmt),
-                date_to: timestamp.format(fmt),
+                date_from: timestamp.subtract(minutes, 'minute').utc().format(fmt),
+                date_to: timestamp.utc().format(fmt),
             }
         case 'after':
             return {
-                date_from: timestamp.format(fmt),
-                date_to: timestamp.add(minutes, 'minute').format(fmt),
+                date_from: timestamp.utc().format(fmt),
+                date_to: timestamp.add(minutes, 'minute').utc().format(fmt),
             }
         case 'around':
         default:
             return {
-                date_from: timestamp.subtract(minutes / 2, 'minute').format(fmt),
-                date_to: timestamp.add(minutes / 2, 'minute').format(fmt),
+                date_from: timestamp
+                    .subtract(minutes / 2, 'minute')
+                    .utc()
+                    .format(fmt),
+                date_to: timestamp
+                    .add(minutes / 2, 'minute')
+                    .utc()
+                    .format(fmt),
             }
     }
 }


### PR DESCRIPTION
## Problem

When using "Jump to timestamp", the computed time window was formatted in the browser's local timezone and sent to the backend as a naive datetime string (no `Z` suffix). The backend interprets naive strings in the project timezone via `.replace(tzinfo=...)`, so if the user's browser timezone differs from the project timezone, the queried window is off by the UTC offset difference.

For example, a user in Brasilia (UTC-3) pasting a Unix timestamp for an event at 18:50 UTC would see "15:48 to 15:53" in the UI, and the backend would query around 15:50 in the project timezone instead of 18:50 UTC.

## Changes

- `computeDateRange()` now calls `.utc().format()` with the `Z` suffix, producing unambiguous UTC strings like `2026-04-01T18:48:00Z`
- Display in `JumpToTimestampForm` uses `dayjs.utc()` and shows "UTC" labels
- Fixed `PLACEHOLDER_ISO` to also use `.utc()` so the placeholder doesn't show local time with a misleading Z
- Added a test verifying timezone-offset inputs are correctly converted to UTC

## Test plan

- [x] All 28 unit tests pass
- [ ] Manual: paste a Unix timestamp while in a non-UTC timezone, verify the displayed range and queried events match UTC

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*