### PR TITLE
feat: add pulsing red dot to quick start button (experiment)

### DIFF
--- a/frontend/src/lib/components/ProductSetup/ProductSetupButton.tsx
+++ b/frontend/src/lib/components/ProductSetup/ProductSetupButton.tsx
@@ -6,6 +6,8 @@ import { LemonButton } from '@posthog/lemon-ui'
 
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
 import { useAppShortcut } from 'lib/components/AppShortcuts/useAppShortcut'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonBadge } from 'lib/lemon-ui/LemonBadge'
 import { organizationLogic } from 'scenes/organizationLogic'
 
@@ -23,6 +25,7 @@ export function ProductSetupButton(): JSX.Element | null {
     const { selectedProduct, isGlobalModalOpen, sceneHasNoSetup } = useValues(globalSetupLogic)
     const { openGlobalSetup, closeGlobalSetup, setSelectedProduct } = useActions(globalSetupLogic)
     const { isCurrentOrganizationNew } = useValues(organizationLogic)
+    const showPulseIndicator = useFeatureFlag(FEATURE_FLAGS.QUICK_START_PULSE_INDICATOR, 'test')
 
     // Get the setup state for the selected product
     const logic = productSetupLogic({ productKey: selectedProduct })
@@ -71,6 +74,7 @@ export function ProductSetupButton(): JSX.Element | null {
                     showBadge={shouldShowSetup}
                     isActive={isGlobalModalOpen}
                     onClick={handleToggle}
+                    showPulse={showPulseIndicator}
                 />
             )}
         </ProductSetupPopover>
@@ -113,12 +117,15 @@ interface ExpandedButtonProps {
     showBadge: boolean
     isActive: boolean
     onClick: () => void
+    showPulse: boolean
 }
 
 const ExpandedButton = forwardRef<HTMLButtonElement, ExpandedButtonProps>(function ExpandedButton(
-    { remainingCount, showBadge, isActive, onClick },
+    { remainingCount, showBadge, isActive, onClick, showPulse },
     ref
 ) {
+    const showIndicator = showBadge && remainingCount > 0 && !isActive
+
     return (
         <LemonButton
             ref={ref}
@@ -129,8 +136,15 @@ const ExpandedButton = forwardRef<HTMLButtonElement, ExpandedButtonProps>(functi
             active={isActive}
             data-attr="global-product-setup-button"
             sideIcon={
-                showBadge && remainingCount > 0 ? (
-                    <LemonBadge.Number count={remainingCount} status="warning" size="small" />
+                showIndicator ? (
+                    showPulse ? (
+                        <span className="relative flex h-3 w-3">
+                            <span className="absolute inline-flex h-full w-full rounded-full bg-danger animate-ping opacity-75" />
+                            <span className="relative inline-flex h-3 w-3 rounded-full bg-danger" />
+                        </span>
+                    ) : (
+                        <LemonBadge.Number count={remainingCount} status="warning" size="small" />
+                    )
                 ) : undefined
             }
         >

--- a/frontend/src/lib/components/ProductSetup/ProductSetupButton.tsx
+++ b/frontend/src/lib/components/ProductSetup/ProductSetupButton.tsx
@@ -6,7 +6,6 @@ import { LemonButton } from '@posthog/lemon-ui'
 
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
 import { useAppShortcut } from 'lib/components/AppShortcuts/useAppShortcut'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonBadge } from 'lib/lemon-ui/LemonBadge'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -25,7 +24,7 @@ export function ProductSetupButton(): JSX.Element | null {
     const { selectedProduct, isGlobalModalOpen, sceneHasNoSetup } = useValues(globalSetupLogic)
     const { openGlobalSetup, closeGlobalSetup, setSelectedProduct } = useActions(globalSetupLogic)
     const { isCurrentOrganizationNew } = useValues(organizationLogic)
-    const showPulseIndicator = useFeatureFlag(FEATURE_FLAGS.QUICK_START_PULSE_INDICATOR, 'test')
+    const showPulseIndicator = useFeatureFlag('QUICK_START_PULSE_INDICATOR', 'test')
 
     // Get the setup state for the selected product
     const logic = productSetupLogic({ productKey: selectedProduct })
@@ -124,7 +123,9 @@ const ExpandedButton = forwardRef<HTMLButtonElement, ExpandedButtonProps>(functi
     { remainingCount, showBadge, isActive, onClick, showPulse },
     ref
 ) {
-    const showIndicator = showBadge && remainingCount > 0 && !isActive
+    // Hide the pulse when the popover is open to avoid distracting the user, but keep the
+    // numeric badge visible in the control variant so its behavior matches the pre-experiment baseline.
+    const showIndicator = showBadge && remainingCount > 0 && (!showPulse || !isActive)
 
     return (
         <LemonButton

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -394,6 +394,7 @@ export const FEATURE_FLAGS = {
     ONBOARDING_DATA_WAREHOUSE_VALUE_PROP: 'onboarding-data-warehouse-value-prop', // owner: @fercgomes #team-growth multivariate=control,table,query
     OWNER_ONLY_BILLING: 'owner-only-billing', // owner: @pawelcebula #team-billing
     POST_ONBOARDING_MODAL_EXPERIMENT: 'post-onboarding-modal-experiment', // owner: @fercgomes #team-growth multivariate=control,test
+    QUICK_START_PULSE_INDICATOR: 'quick-start-pulse-indicator', // owner: @fercgomes #team-growth multivariate=control,test
     PASSKEY_SIGNUP_ENABLED: 'passkey-signup-enabled', // owner: @reecejones #team-platform-features
     PASSWORD_PROTECTED_SHARES: 'password-protected-shares', // owner: @aspicer
     DASHBOARD_AUTO_PREVIEW_LIMIT: 'dashboard-auto-preview-limit', // owner: @pauldambra #team-product-analytics


### PR DESCRIPTION
## Problem

Growth activation rate (signup -> deliberate setup task) is declining: signups grew 73% but deliberate task completions dropped 38-53%. Users click through config toggles during onboarding but never reach the deliberate tasks that correlate with retention.

Data shows completing 1+ deliberate setup task predicts ~70% month-3 retention at every engagement level, vs ~20% without — and it's not survivorship bias (proven by engagement-controlled analysis).

## Changes

Add a pulsing red dot indicator to the "Quick start" button when there are remaining setup tasks, gated behind the `quick-start-pulse-indicator` feature flag (multivariate: control/test).

- **Control:** Existing numeric badge (e.g., "Quick start [3]")
- **Test:** Pulsing red dot next to "Quick start" text — disappears when the popover is opened

Uses the same `animate-ping` + solid dot pattern already used in `SessionDisplay.tsx` and `OnboardingLiveEvents.tsx`.

## How did you test this code?

I'm an agent — I haven't tested this manually. The change is small (pulsing dot vs numeric badge) and purely visual, gated behind a flag.

## Publish to changelog?

No

## 🤖 LLM context

Part of the Activation V2 research session. See the full analysis in [Activation V2 Slack canvas](https://posthog.slack.com/docs/TSS5W8YQZ/F0AS6N2AZRD) and [Team Growth NSM dashboard](https://us.posthog.com/project/2/dashboard/1352327).