### PR TITLE
fix(cohorts): handle string dates in Group.to_dict()

### DIFF
--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -75,8 +75,8 @@ class Group:
         days: Optional[int] = None,
         count: Optional[int] = None,
         count_operator: Optional[Literal["eq", "lte", "gte"]] = None,
-        start_date: Optional[datetime] = None,
-        end_date: Optional[datetime] = None,
+        start_date: Optional[Union[datetime, str]] = None,
+        end_date: Optional[Union[datetime, str]] = None,
         label: Optional[str] = None,
     ):
         if not properties and not action_id and not event_id:
@@ -93,8 +93,8 @@ class Group:
 
     def to_dict(self) -> dict[str, Any]:
         dup = self.__dict__.copy()
-        dup["start_date"] = self.start_date.isoformat() if self.start_date else self.start_date
-        dup["end_date"] = self.end_date.isoformat() if self.end_date else self.end_date
+        dup["start_date"] = self.start_date.isoformat() if isinstance(self.start_date, datetime) else self.start_date
+        dup["end_date"] = self.end_date.isoformat() if isinstance(self.end_date, datetime) else self.end_date
         return dup
 
 


### PR DESCRIPTION
## Problem

Cohort creation via the legacy groups API path crashes with `AttributeError: 'str' object has no attribute 'isoformat'` because `Group.to_dict()` assumes `start_date`/`end_date` are `datetime` objects. When groups data arrives from JSON input, these values are ISO strings, not datetime instances.

## Changes

- Changed `to_dict()` to use `isinstance(self.start_date, datetime)` check instead of truthiness before calling `.isoformat()`, so string values pass through unchanged
- Updated type hints on `start_date`/`end_date` to `Optional[Union[datetime, str]]` to reflect the actual runtime types

## How did you test this code?

I'm an agent and haven't tested this manually. The fix is a minimal, safe change — it narrows the condition under which `.isoformat()` is called from "any truthy value" to "only datetime instances". String and None values pass through unchanged, preserving existing behavior for all other callers.

## Publish to changelog?

No

## Docs update

N/A

## LLM context

Agent-authored fix for error tracking issue `019d58b6-665d-7f92-a746-83c900bc8960`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*