### PR TITLE
fix(workflows): add DMARC to email templates and make it non-blocking

### DIFF
--- a/frontend/src/lib/components/DomainConnect/templates/posthog.com.email-verification-eu.json
+++ b/frontend/src/lib/components/DomainConnect/templates/posthog.com.email-verification-eu.json
@@ -48,6 +48,7 @@
             "host": "%mailFromSub%",
             "spfRules": "include:amazonses.com",
             "ttl": 3600
-        }
+        },
+        { "groupId": "dmarc", "type": "TXT", "host": "_dmarc", "data": "v=DMARC1; p=none;", "ttl": 3600 }
     ]
 }

--- a/frontend/src/lib/components/DomainConnect/templates/posthog.com.email-verification-us.json
+++ b/frontend/src/lib/components/DomainConnect/templates/posthog.com.email-verification-us.json
@@ -48,6 +48,7 @@
             "host": "%mailFromSub%",
             "spfRules": "include:amazonses.com",
             "ttl": 3600
-        }
+        },
+        { "groupId": "dmarc", "type": "TXT", "host": "_dmarc", "data": "v=DMARC1; p=none;", "ttl": 3600 }
     ]
 }

--- a/products/workflows/backend/providers/ses.py
+++ b/products/workflows/backend/providers/ses.py
@@ -202,13 +202,11 @@ class SESProvider:
 
         all_statuses = [verification_status, dkim_status, mail_from_status]
 
-        # Normalize overall status
-        if (
-            verification_status == "Success"
-            and dkim_status == "Success"
-            and mail_from_status == "Success"
-            and dmarc_status == "Success"
-        ):
+        # Normalize overall status — DMARC is recommended but not required for
+        # verification.  A missing DMARC record should not block the connector
+        # from being used; we still surface it in dnsRecords so the UI can show
+        # a recommendation to the user.
+        if verification_status == "Success" and dkim_status == "Success" and mail_from_status == "Success":
             overall = "success"
         elif "Failed" in all_statuses:
             overall = "failed"

--- a/products/workflows/backend/test/test_ses_provider.py
+++ b/products/workflows/backend/test/test_ses_provider.py
@@ -229,8 +229,8 @@ class TestSESProvider(TestCase):
             assert len(result["dnsRecords"]) > 0  # Records are now always returned
 
     @patch("products.workflows.backend.providers.ses.dns.resolver.Resolver")
-    def test_verify_email_domain_pending_when_dmarc_missing(self, mock_resolver_cls):
-        """All SES checks pass but DMARC lookup fails → overall status is pending."""
+    def test_verify_email_domain_success_when_dmarc_missing(self, mock_resolver_cls):
+        """All SES checks pass but DMARC lookup fails → overall status is still success (DMARC is recommended, not required)."""
         mock_resolver_cls.return_value.resolve.side_effect = dns.resolver.NXDOMAIN()
         provider = SESProvider()
 
@@ -247,7 +247,11 @@ class TestSESProvider(TestCase):
 
             result = provider.verify_email_domain(TEST_DOMAIN, mail_from_subdomain="mail", team_id=1)
 
-            assert result["status"] == "pending"
+            assert result["status"] == "success"
+            # DMARC record should still be present but with pending status
+            dmarc_records = [r for r in result["dnsRecords"] if r["type"] == "dmarc"]
+            assert len(dmarc_records) == 1
+            assert dmarc_records[0]["status"] == "pending"
 
     @parameterized.expand(
         [

--- a/products/workflows/frontend/Channels/EmailSetup/EmailSetupModal.tsx
+++ b/products/workflows/frontend/Channels/EmailSetup/EmailSetupModal.tsx
@@ -182,9 +182,19 @@ export const EmailSetupModal = (props: EmailSetupModalLogicProps): JSX.Element =
                                                     {verificationLoading ? (
                                                         <Spinner className="text-lg" />
                                                     ) : record.status === 'pending' ? (
-                                                        <div className="flex gap-1 items-center">
-                                                            <IconWarning className="size-6 text-warning" /> Not present
-                                                        </div>
+                                                        record.type === 'dmarc' ? (
+                                                            <Tooltip title="DMARC is recommended for better deliverability but not required for verification">
+                                                                <div className="flex gap-1 items-center">
+                                                                    <IconWarning className="size-6 text-muted" />{' '}
+                                                                    Recommended
+                                                                </div>
+                                                            </Tooltip>
+                                                        ) : (
+                                                            <div className="flex gap-1 items-center">
+                                                                <IconWarning className="size-6 text-warning" /> Not
+                                                                present
+                                                            </div>
+                                                        )
                                                     ) : record.status === 'success' ? (
                                                         <div className="flex gap-1 items-center">
                                                             <IconCheckCircle className="size-6 text-success" /> Verified


### PR DESCRIPTION
### Problem                                                                                   
                                                                                            
Closes #54148                                                                             
   
When users set up email connectors via automatic DNS configuration (Domain Connect), DMARC was not included in the templates. Since the backend requires DMARC for verification to succeed, auto-configured connectors would stay stuck in "pending" forever..even though all the records that actually matter (domain verification, DKIM, MAIL FROM) were correctly set up.

### Changes

  - Added a _dmarc TXT record (v=DMARC1; p=none;) to both US and EU Domain Connect templates so auto-configure sets it up out of the box
  - Relaxed backend verification so DMARC is no longer required to mark a connector as verified..domain verification, DKIM, and MAIL FROM are sufficient. The DMARC record is still returned and its status tracked, just not blocking
  - Updated the email setup UI to show "Recommended" instead of "Not present" when DMARC is missing, with a tooltip explaining it's not required                                      
  - p=none is the most permissive DMARC policy (tells receivers to take no action on failures), so it's safe as a default. Users can tighten it on their domain anytime        
                                                            
### How did you test this code?                                                               
                                                            
  - All existing SES provider tests pass, including updated test that verifies DMARC-missing no longer blocks overall verification status
  - Verified JSON template structure is valid
                                                                                            
### Publish to changelog?

no                                                        

### Docs update

- Docs around email connector DNS setup could mention that DMARC is recommended but optional.