### PR TITLE
chore(replay): remove unused session replay Celery queues

### DIFF
--- a/bin/celery-queues.env
+++ b/bin/celery-queues.env
@@ -2,4 +2,4 @@
 # Important: Add new queues to make Celery consume tasks from them.
 
 # NOTE: Keep in sync with posthog/tasks/utils.py
-CELERY_WORKER_QUEUES=celery,stats,email,analytics_queries,analytics_limited,long_running,exports,subscription_delivery,usage_reports,session_replay_embeddings,session_replay_persistence,integrations,feature_flags,feature_flags_long_running
+CELERY_WORKER_QUEUES=celery,stats,email,analytics_queries,analytics_limited,long_running,exports,subscription_delivery,usage_reports,integrations,feature_flags,feature_flags_long_running

--- a/posthog/tasks/utils.py
+++ b/posthog/tasks/utils.py
@@ -100,8 +100,6 @@ class CeleryQueue(Enum):
     EXPORTS = "exports"
     SUBSCRIPTION_DELIVERY = "subscription_delivery"
     USAGE_REPORTS = "usage_reports"
-    SESSION_REPLAY_EMBEDDINGS = "session_replay_embeddings"
-    SESSION_REPLAY_PERSISTENCE = "session_replay_persistence"
     INTEGRATIONS = "integrations"
     FEATURE_FLAGS = "feature_flags"
     FEATURE_FLAGS_LONG_RUNNING = "feature_flags_long_running"


### PR DESCRIPTION
## Problem

The `session_replay_embeddings` and `session_replay_persistence` Celery queues are defined in the `CeleryQueue` enum and `bin/celery-queues.env`, but no tasks route to either of them.

- `session_replay_embeddings`: Was created for an early replay embeddings experiment. The ClickHouse `session_replay_embeddings` table it was meant to serve has zero rows in production and was superseded by the unified `document_embeddings` system.
- `session_replay_persistence`: No tasks have ever routed to this queue.
- `session_replay_general`: Already removed in #53840 when the last Celery tasks (`replay_count_metrics`, `count_items_in_playlists`, `count_recordings_that_match_playlist_filters`) were migrated to Temporal.

## Changes

- Remove `SESSION_REPLAY_EMBEDDINGS` and `SESSION_REPLAY_PERSISTENCE` from the `CeleryQueue` enum in `posthog/tasks/utils.py`
- Remove both queue names from `bin/celery-queues.env`

A companion PR in PostHog/charts removes the `session-replay-worker` consumer that served these queues.

## How did you test this code?

Comprehensive codebase search confirmed zero Celery tasks route to either queue. Verified the ClickHouse `session_replay_embeddings` table has zero rows in US prod.

## 🤖 LLM context

Follow-up cleanup from the Celery-to-Temporal migration (#53840, #54235). Queues verified unused via code search and production ClickHouse query.