### PR TITLE
feat(experiments): show timeseries click hint in metric tooltip

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -734,7 +734,7 @@ export function MetricRowGroup({
                             visibility: tooltipState.isPositioned ? 'visible' : 'hidden',
                         }}
                     >
-                        {renderTooltipContent(tooltipState.variantResult, metric)}
+                        {renderTooltipContent(tooltipState.variantResult, metric, timeseriesEnabled)}
                     </div>,
                     document.body
                 )}

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -727,12 +727,17 @@ export function MetricRowGroup({
                 createPortal(
                     <div
                         ref={tooltipRef}
-                        className="fixed bg-bg-light border border-border px-3 py-2 rounded-md text-[13px] shadow-md z-[100] min-w-[280px]"
+                        className={`fixed bg-bg-light border border-border px-3 py-2 rounded-md text-[13px] shadow-md z-[100] min-w-[280px] ${timeseriesEnabled ? 'cursor-pointer hover:border-primary' : ''}`}
                         style={{
                             left: tooltipState.position.x,
                             top: tooltipState.position.y,
                             visibility: tooltipState.isPositioned ? 'visible' : 'hidden',
                         }}
+                        onClick={
+                            timeseriesEnabled && tooltipState.variantResult
+                                ? () => handleTimeseriesClick(tooltipState.variantResult!)
+                                : undefined
+                        }
                     >
                         {renderTooltipContent(tooltipState.variantResult, metric, timeseriesEnabled)}
                     </div>,

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroupTooltip.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroupTooltip.tsx
@@ -16,7 +16,11 @@ import {
     isWinning,
 } from '../shared/utils'
 
-export const renderTooltipContent = (variantResult: ExperimentVariantResult, metric: ExperimentMetric): JSX.Element => {
+export const renderTooltipContent = (
+    variantResult: ExperimentVariantResult,
+    metric: ExperimentMetric,
+    timeseriesEnabled?: boolean
+): JSX.Element => {
     const intervalPercent = formatIntervalPercent(variantResult)
     const intervalLabel = getIntervalLabel(variantResult)
     const significant = isSignificant(variantResult)
@@ -73,6 +77,10 @@ export const renderTooltipContent = (variantResult: ExperimentVariantResult, met
                 <span className="text-muted-alt font-semibold">{intervalLabel}:</span>
                 <span className="font-semibold">{intervalPercent}</span>
             </div>
+
+            {timeseriesEnabled && (
+                <div className="text-muted-alt text-xs mt-1 text-center">Click to view timeseries</div>
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroupTooltip.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroupTooltip.tsx
@@ -1,3 +1,5 @@
+import { IconCursorClick } from '@posthog/icons'
+
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { humanFriendlyNumber } from 'lib/utils'
 import { VariantTag } from 'scenes/experiments/ExperimentView/components'
@@ -79,7 +81,10 @@ export const renderTooltipContent = (
             </div>
 
             {timeseriesEnabled && (
-                <div className="text-muted-alt text-xs mt-1 text-center">Click to view timeseries</div>
+                <div className="text-muted-alt text-xs mt-1 text-center flex items-center justify-center gap-1">
+                    <IconCursorClick className="text-sm" />
+                    Click to view timeseries
+                </div>
             )}
         </div>
     )


### PR DESCRIPTION
## Problem

When hovering over a metric in the experiment delta chart, the popover gives no indication that clicking will open a timeseries view. Users don't know this interaction exists, and when timeseries isn't available, clicking does nothing with no explanation.

<img width="319" height="240" alt="Screenshot 2026-04-14 at 10 38 55" src="https://github.com/user-attachments/assets/3fcc0f59-1710-4b3b-90e4-edf0bab08e2a" />

## Changes

Added a "Click to view timeseries" hint at the bottom of the metric hover tooltip, only shown when `scheduling_config.timeseries` is enabled for the experiment.

<img width="305" height="255" alt="Screenshot 2026-04-14 at 10 43 48" src="https://github.com/user-attachments/assets/b3b19947-e0d5-4f86-99e5-06b6a0bd31b3" />


## Testing

- Open an experiment with timeseries enabled, hover over a metric bar — should see "Click to view timeseries" in the tooltip
- Open an experiment without timeseries — tooltip should look the same as before (no hint)