### PR TITLE
chore(kafka): make enable.partition.eof configurable via env var

### DIFF
--- a/nodejs/src/kafka/consumer.ts
+++ b/nodejs/src/kafka/consumer.ts
@@ -141,6 +141,7 @@ export type KafkaConsumerConfig = {
     callEachBatchWhenEmpty?: boolean
     autoOffsetStore?: boolean
     autoCommit?: boolean
+    enablePartitionEof?: boolean
     waitForBackgroundTasksOnRebalance?: boolean
 }
 
@@ -224,11 +225,13 @@ export class KafkaConsumer {
             'client.rack': defaultConfig.KAFKA_CLIENT_RACK, // Helps with cross-AZ traffic awareness and is not unique to the consumer
             'metadata.max.age.ms': 30000, // Refresh metadata every 30s - Relevant for leader loss (MSK Security Patches)
             'socket.timeout.ms': 30000,
+            'enable.partition.eof': this.config.enablePartitionEof ?? true,
             // Only enable statistics when using loop-based health check
             ...(defaultConfig.CONSUMER_LOOP_BASED_HEALTH_CHECK
                 ? { 'statistics.interval.ms': STATISTICS_INTERVAL_MS }
                 : {}),
             // Custom settings and overrides - this is where most configuration overrides should be done
+            // e.g. KAFKA_CONSUMER_ENABLE_PARTITION_EOF=false to override the default above
             ...getKafkaConfigFromEnv('CONSUMER'),
             // Finally any specifically given consumer config overrides
             ...rdKafkaConfig,
@@ -236,7 +239,6 @@ export class KafkaConsumer {
             'partition.assignment.strategy': isTestEnv() ? 'roundrobin' : 'cooperative-sticky', // Roundrobin is used for testing to avoid flakiness caused by running librdkafka v2.2.0
             'enable.auto.offset.store': false, // NOTE: This is always false - we handle it using a custom function
             'enable.auto.commit': this.config.autoCommit,
-            'enable.partition.eof': true,
             rebalance_cb: rebalancecb,
             offset_commit_cb: true,
         }


### PR DESCRIPTION
### Problem 


We're investigating an issue where specific Kafka partitions randomly stop being consumed while the consumer remains healthy.. lag builds linearly on those partitions until a rebalance reassigns them, at which point lag drops instantly (cliff-drop, not gradual drain). This happens across multiple consumers (cdp-events, cyclotron-hog-worker, ...), on both MSK and WarpStream, regardless of load level it seems. With enable.partition.eof set to true, librdkafka tracks when a partition has been fully drained  and enters an internal EOF state.

### Theory

Librdkafka thinks the partition is at the end and stops fetching from it, even though new messages are arriving. A rebalance   resets the internal fetch state, which is why it fixes the issue. Setting this to false removes the EOF tracking entirely so librdkafka keeps polling every partition at the same frequency regardless of whether it was recently empty.

### Is this safe?

We do not consume or listen to any EOF events in our application.

### Changes

Move the hardcoded `enable.partition.eof: true` rdkafka setting to a configurable `CONSUMER_ENABLE_PARTITION_EOF` env var (default: true).

This allows testing whether disabling partition EOF handling resolves stuck partition issues where specific partitions stop being consumed while the consumer remains healthy.