### PR TITLE
chore: Track background task timing

### DIFF
--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -110,6 +110,8 @@ const backgroundTaskHogTransformerDuration = new Histogram({
     labelNames: ['groupId'],
     buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
 })
+
+export class IngestionConsumer {
     protected name = 'ingestion-consumer'
     protected groupId: string
     protected topic: string

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -1,5 +1,5 @@
 import { Message } from 'node-rdkafka'
-import { Gauge } from 'prom-client'
+import { Gauge, Histogram } from 'prom-client'
 
 import { instrumentFn } from '~/common/tracing/tracing-utils'
 
@@ -95,6 +95,20 @@ export const latestOffsetTimestampGauge = new Gauge({
     help: 'Timestamp of the latest offset that has been committed.',
     labelNames: ['topic', 'partition', 'groupId'],
     aggregator: 'max',
+})
+
+const backgroundTaskProducesDuration = new Histogram({
+    name: 'ingestion_background_task_produces_duration_ms',
+    help: 'Time waiting for scheduled Kafka produces in the background task',
+    labelNames: ['groupId'],
+    buckets: [10, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
+})
+
+const backgroundTaskHogTransformerDuration = new Histogram({
+    name: 'ingestion_background_task_hog_transformer_duration_ms',
+    help: 'Time waiting for hog transformer invocation results in the background task',
+    labelNames: ['groupId'],
+    buckets: [10, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
 })
 
 export class IngestionConsumer {
@@ -369,7 +383,13 @@ export class IngestionConsumer {
 
         return {
             backgroundTask: this.runInstrumented('awaitScheduledWork', async () => {
-                await Promise.all([this.promiseScheduler.waitForAll(), this.hogTransformer.processInvocationResults()])
+                const labels = { groupId: this.groupId }
+                await Promise.all([
+                    timedHistogram(backgroundTaskProducesDuration, labels, () => this.promiseScheduler.waitForAll()),
+                    timedHistogram(backgroundTaskHogTransformerDuration, labels, () =>
+                        this.hogTransformer.processInvocationResults()
+                    ),
+                ])
             }),
         }
     }
@@ -397,5 +417,18 @@ export class IngestionConsumer {
             !!this.config.INGESTION_CONSUMER_OVERFLOW_TOPIC &&
             this.config.INGESTION_CONSUMER_OVERFLOW_TOPIC !== this.topic
         )
+    }
+}
+
+async function timedHistogram<T>(
+    histogram: Histogram,
+    labels: Record<string, string>,
+    fn: () => Promise<T>
+): Promise<T> {
+    const end = histogram.startTimer(labels)
+    try {
+        return await fn()
+    } finally {
+        end()
     }
 }

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -98,20 +98,18 @@ export const latestOffsetTimestampGauge = new Gauge({
 })
 
 const backgroundTaskProducesDuration = new Histogram({
-    name: 'ingestion_background_task_produces_duration_ms',
+    name: 'ingestion_background_task_produces_duration_seconds',
     help: 'Time waiting for scheduled Kafka produces in the background task',
     labelNames: ['groupId'],
-    buckets: [10, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
+    buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
 })
 
 const backgroundTaskHogTransformerDuration = new Histogram({
-    name: 'ingestion_background_task_hog_transformer_duration_ms',
+    name: 'ingestion_background_task_hog_transformer_duration_seconds',
     help: 'Time waiting for hog transformer invocation results in the background task',
     labelNames: ['groupId'],
-    buckets: [10, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
+    buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
 })
-
-export class IngestionConsumer {
     protected name = 'ingestion-consumer'
     protected groupId: string
     protected topic: string


### PR DESCRIPTION
## Problem

We have no visibility into what's causing latency in the ingestion pipeline's background task. The background task waits for all Kafka produces and hog transformer monitoring flushes via a single `Promise.all`, but we can't tell the impact of each phase.

Existing data from `ingestion_outputs_latency_seconds` shows that low-priority outputs (app_metrics, log_entries) have p99 latencies hitting 5s despite p50 of 34-110ms, while high-priority outputs (persons, groups) stay under 615ms at p99. But we can't directly measure how much each phase contributes to the overall background task duration.

## Changes

- Add two new histograms to the ingestion consumer's background task: `ingestion_background_task_produces_duration_ms` (time waiting for scheduled Kafka produces) and `ingestion_background_task_hog_transformer_duration_ms` (time waiting for hog transformer invocation results)

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
