### PR TITLE
fix(llma): tolerate null numeric values in OTLP JSON ingestion

### DIFF
--- a/rust/capture/src/otel/ingestion.rs
+++ b/rust/capture/src/otel/ingestion.rs
@@ -256,24 +256,30 @@ mod tests {
 
     #[test]
     fn test_patch_otel_json_null_scalar_attrs() {
-        let mut v = serde_json::json!({
-            "resourceSpans": [{
-                "scopeSpans": [{
-                    "spans": [{
-                        "attributes": [
-                            {"key": "gen_ai.usage.cost", "value": {"doubleValue": null}},
-                            {"key": "gen_ai.usage.tokens", "value": {"intValue": null}},
-                            {"key": "gen_ai.model", "value": {"stringValue": "gpt-4"}}
-                        ]
-                    }]
-                }]
-            }]
-        });
+        for field in &[
+            "doubleValue",
+            "intValue",
+            "stringValue",
+            "boolValue",
+            "bytesValue",
+        ] {
+            let mut v = serde_json::json!({"value": {}});
+            v["value"]
+                .as_object_mut()
+                .unwrap()
+                .insert(field.to_string(), Value::Null);
+            patch_otel_json(&mut v);
+            assert_eq!(
+                v["value"],
+                Value::Null,
+                "field `{field}` with null should be stripped"
+            );
+        }
+
+        // Non-null scalar must be preserved.
+        let mut v = serde_json::json!({"value": {"stringValue": "gpt-4"}});
         patch_otel_json(&mut v);
-        let attrs = &v["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"];
-        assert_eq!(attrs[0]["value"], Value::Null);
-        assert_eq!(attrs[1]["value"], Value::Null);
-        assert_eq!(attrs[2]["value"]["stringValue"], "gpt-4");
+        assert_eq!(v["value"]["stringValue"], "gpt-4");
     }
 
     #[test]

--- a/rust/capture/src/otel/ingestion.rs
+++ b/rust/capture/src/otel/ingestion.rs
@@ -8,15 +8,32 @@ use tracing::warn;
 use crate::api::CaptureError;
 use crate::payload::decompression::decompress_gzip_to_bytes;
 
-/// Patch empty `{}` objects in OTEL JSON that should be `null` for proper deserialization.
-/// See https://github.com/open-telemetry/opentelemetry-rust/issues/1253
+/// Patch OTEL JSON AnyValue objects for proper deserialization into protobuf-derived Rust types.
+///
+/// Handles two cases:
+/// 1. Empty `{}` objects under `"value"` keys become `null` (opentelemetry-rust#1253).
+/// 2. Null-valued scalar fields (e.g. `{"doubleValue": null}`) are removed. In protobuf-JSON
+///    encoding a missing key is equivalent to an unset scalar, but serde rejects null for
+///    non-optional f64/i64/bool/String fields.
 fn patch_otel_json(v: &mut Value) {
     match v {
         Value::Object(map) => {
             if let Some(inner) = map.get_mut("value") {
-                if inner.is_object() && inner.as_object().map(|obj| obj.is_empty()).unwrap_or(false)
-                {
-                    *inner = Value::Null;
+                if let Some(obj) = inner.as_object_mut() {
+                    for field in &[
+                        "doubleValue",
+                        "intValue",
+                        "stringValue",
+                        "boolValue",
+                        "bytesValue",
+                    ] {
+                        if matches!(obj.get(*field), Some(Value::Null)) {
+                            obj.remove(*field);
+                        }
+                    }
+                    if obj.is_empty() {
+                        *inner = Value::Null;
+                    }
                 }
             }
             for (_, val) in map.iter_mut() {
@@ -235,5 +252,41 @@ mod tests {
             v["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"][0]["value"],
             Value::Null
         );
+    }
+
+    #[test]
+    fn test_patch_otel_json_null_scalar_attrs() {
+        let mut v = serde_json::json!({
+            "resourceSpans": [{
+                "scopeSpans": [{
+                    "spans": [{
+                        "attributes": [
+                            {"key": "gen_ai.usage.cost", "value": {"doubleValue": null}},
+                            {"key": "gen_ai.usage.tokens", "value": {"intValue": null}},
+                            {"key": "gen_ai.model", "value": {"stringValue": "gpt-4"}}
+                        ]
+                    }]
+                }]
+            }]
+        });
+        patch_otel_json(&mut v);
+        let attrs = &v["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"];
+        assert_eq!(attrs[0]["value"], Value::Null);
+        assert_eq!(attrs[1]["value"], Value::Null);
+        assert_eq!(attrs[2]["value"]["stringValue"], "gpt-4");
+    }
+
+    #[test]
+    fn test_parse_json_with_null_double_attr() {
+        let json = r#"{"resourceSpans":[{"scopeSpans":[{"spans":[{
+            "traceId":"","spanId":"",
+            "attributes":[{"key":"cost","value":{"doubleValue":null}}]
+        }]}]}]}"#;
+        let body = Bytes::from(json);
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "application/json".parse().unwrap());
+
+        let parsed = parse_request(&body, &headers, 4 * 1024 * 1024).unwrap();
+        assert_eq!(parsed.resource_spans.len(), 1);
     }
 }


### PR DESCRIPTION
## Problem

PostHog's OTEL ingestion endpoint (`/i/v0/ai/otel`) returns 400 when receiving OTLP/JSON payloads containing null-valued scalar attributes like `{"doubleValue": null}`. The Vercel AI SDK emits these for cost/token metrics on partial stream chunks. The `opentelemetry-proto` crate types `doubleValue` as `f64` (non-optional), so `serde_json::from_value` rejects the null with:

```
Invalid OTLP trace format: invalid type: null, expected f64
```

## Changes

Extends `patch_otel_json` in `rust/capture/src/otel/ingestion.rs` to strip null-valued OTLP scalar fields (`doubleValue`, `intValue`, `stringValue`, `boolValue`, `bytesValue`) from AnyValue objects before deserialization. In protobuf-JSON encoding, a missing key is equivalent to an unset scalar, so removal is semantically correct — no coercion to default values.

The existing `{} → null` patching (for opentelemetry-rust#1253) is preserved as a special case of the same logic.

## How did you test this code?

I am an agent and have not tested this manually. Automated testing:

- Added `test_patch_otel_json_null_scalar_attrs`: verifies `{"doubleValue": null}` and `{"intValue": null}` are stripped to `Value::Null` while `{"stringValue": "gpt-4"}` is preserved
- Added `test_parse_json_with_null_double_attr`: verifies the full pipeline (JSON parse → patch → deserialize into `ExportTraceServiceRequest`) succeeds with a null `doubleValue` attribute
- All 31 otel tests pass, clippy clean, fmt clean

## Publish to changelog?

no

## Docs update

N/A

## 🤖 LLM context

Agent-authored PR. Single-file change to `rust/capture/src/otel/ingestion.rs` — extends the existing JSON patching helper to handle a second class of OTLP/Rust type mismatch (null scalars in addition to empty objects).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*