### PR TITLE
feat(visual-review): wire VR shard uploads into storybook and playwright CI

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -512,9 +512,10 @@ jobs:
               continue-on-error: true
               env:
                   VR_TOKEN: ${{ secrets.VR_API_TOKEN }}
+                  VR_RUN_ID: ${{ steps.vr-create.outputs.run_id }}
               run: |
                   vr run upload \
-                    --run-id "${{ steps.vr-create.outputs.run_id }}" \
+                    --run-id "$VR_RUN_ID" \
                     --dir playwright/__snapshots__/ \
                     --baseline playwright/snapshots.yml \
                     --token "$VR_TOKEN"

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -494,13 +494,16 @@ jobs:
               continue-on-error: true
               env:
                   VR_TOKEN: ${{ secrets.VR_API_TOKEN }}
+                  VR_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+                  VR_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+                  VR_PR: ${{ github.event.pull_request.number }}
               run: |
                   RUN_ID=$(vr run create \
                     --type playwright \
                     --baseline playwright/snapshots.yml \
-                    --branch "${{ github.event.pull_request.head.ref || github.ref_name }}" \
-                    --commit "${{ github.event.pull_request.head.sha || github.sha }}" \
-                    --pr "${{ github.event.pull_request.number }}" \
+                    --branch "$VR_BRANCH" \
+                    --commit "$VR_COMMIT" \
+                    --pr "$VR_PR" \
                     --token "$VR_TOKEN")
                   echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -165,6 +165,8 @@ jobs:
         # WARNING: Runner size is tuned to avoid CPU scheduling contention. Talk to #team-devex before changing.
         runs-on: depot-ubuntu-latest-16
         timeout-minutes: 45
+        outputs:
+            vr_run_id: ${{ steps.vr-create.outputs.run_id }}
         steps:
             - uses: actions/checkout@v6
               with:
@@ -480,6 +482,40 @@ jobs:
                   git fetch --no-tags --prune --depth=50 origin "$BASE_SHA"
                   .github/scripts/verify-playwright-new-tests-and-snapshots.sh "$BASE_SHA" 10
 
+            # Visual Review: create run + upload snapshots directly from the test job.
+            # Completion happens in handle-screenshots so the baseline lands in the same commit as PNGs.
+            - name: Install VR CLI deps
+              if: always() && github.event.pull_request.head.repo.full_name == github.repository
+              run: cd products/visual_review/cli && npm ci
+
+            - name: Create VR run
+              id: vr-create
+              if: always() && github.event.pull_request.head.repo.full_name == github.repository
+              continue-on-error: true
+              env:
+                  VR_TOKEN: ${{ secrets.VR_API_TOKEN }}
+              run: |
+                  RUN_ID=$(npx tsx products/visual_review/cli/src/index.ts run create \
+                    --type playwright \
+                    --baseline playwright/snapshots.yml \
+                    --branch "${{ github.event.pull_request.head.ref || github.ref_name }}" \
+                    --commit "${{ github.event.pull_request.head.sha || github.sha }}" \
+                    --pr "${{ github.event.pull_request.number }}" \
+                    --token "$VR_TOKEN")
+                  echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+
+            - name: Upload snapshots to Visual Review
+              if: always() && steps.vr-create.outputs.run_id != ''
+              continue-on-error: true
+              env:
+                  VR_TOKEN: ${{ secrets.VR_API_TOKEN }}
+              run: |
+                  npx tsx products/visual_review/cli/src/index.ts run upload \
+                    --run-id "${{ steps.vr-create.outputs.run_id }}" \
+                    --dir playwright/__snapshots__/ \
+                    --baseline playwright/snapshots.yml \
+                    --token "$VR_TOKEN"
+
             # Create git patch for aggregation (handles A/M/D including binary files)
             # Only run in UPDATE mode - CHECK mode doesn't update snapshots
             # Run even if tests failed, as long as snapshots may have been updated
@@ -768,7 +804,6 @@ jobs:
                     echo "Screenshot changes detected in patches"
                   fi
 
-            # Apply patches BEFORE VR so it hashes the final state
             # Uses --index so changes are staged for the downstream commit action
             - name: Apply screenshot patches
               if: steps.check-screenshots.outputs.has-changes == 'true'
@@ -778,30 +813,24 @@ jobs:
                     git apply --index "$patch"
                   done
 
-            # Visual Review: submit snapshots after patches are applied
+            # Visual Review: complete the run (test job already uploaded snapshots)
             - name: Install VR CLI deps
+              if: needs.playwright.outputs.vr_run_id != ''
               run: cd products/visual_review/cli && npm ci
 
-            - name: Submit to Visual Review
+            - name: Complete Visual Review run
+              if: needs.playwright.outputs.vr_run_id != ''
               continue-on-error: true
               env:
                   VR_TOKEN: ${{ secrets.VR_API_TOKEN }}
-                  VR_BRANCH: ${{ github.event.pull_request.head.ref }}
-                  VR_COMMIT: ${{ github.event.pull_request.head.sha }}
-                  VR_PR: ${{ github.event.pull_request.number }}
                   VR_AUTO_APPROVE: ${{ needs.changes.outputs.mode == 'update' && '--auto-approve' || '' }}
               run: |
-                  npx tsx products/visual_review/cli/src/index.ts submit \
-                    --dir playwright/__snapshots__/ \
-                    --type playwright \
+                  npx tsx products/visual_review/cli/src/index.ts run complete \
+                    --run-id "${{ needs.playwright.outputs.vr_run_id }}" \
                     --baseline playwright/snapshots.yml \
                     $VR_AUTO_APPROVE \
-                    --token "$VR_TOKEN" \
-                    --branch "$VR_BRANCH" \
-                    --commit "$VR_COMMIT" \
-                    --pr "$VR_PR"
+                    --token "$VR_TOKEN"
 
-            # Stage baseline if updated by VR submit — included in the screenshot commit
             - name: Check baseline changes
               id: check-baseline
               run: |
@@ -812,7 +841,7 @@ jobs:
                     git add playwright/snapshots.yml
                   fi
 
-            # UPDATE mode: commit PNGs + baseline together
+            # UPDATE mode: commit PNGs + baseline together in a single commit
             - name: Commit screenshot changes
               if: (steps.check-screenshots.outputs.has-changes == 'true' || steps.check-baseline.outputs.has-changes == 'true') && needs.changes.outputs.mode == 'update'
               uses: ./.github/actions/commit-snapshots

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -484,9 +484,9 @@ jobs:
 
             # Visual Review: create run + upload snapshots directly from the test job.
             # Completion happens in handle-screenshots so the baseline lands in the same commit as PNGs.
-            - name: Install VR CLI deps
+            - name: Install VR CLI
               if: always() && github.event.pull_request.head.repo.full_name == github.repository
-              run: cd products/visual_review/cli && npm ci
+              run: cd products/visual_review/cli && npm ci && npm run build && npm link
 
             - name: Create VR run
               id: vr-create
@@ -495,7 +495,7 @@ jobs:
               env:
                   VR_TOKEN: ${{ secrets.VR_API_TOKEN }}
               run: |
-                  RUN_ID=$(npx tsx products/visual_review/cli/src/index.ts run create \
+                  RUN_ID=$(vr run create \
                     --type playwright \
                     --baseline playwright/snapshots.yml \
                     --branch "${{ github.event.pull_request.head.ref || github.ref_name }}" \
@@ -510,7 +510,7 @@ jobs:
               env:
                   VR_TOKEN: ${{ secrets.VR_API_TOKEN }}
               run: |
-                  npx tsx products/visual_review/cli/src/index.ts run upload \
+                  vr run upload \
                     --run-id "${{ steps.vr-create.outputs.run_id }}" \
                     --dir playwright/__snapshots__/ \
                     --baseline playwright/snapshots.yml \
@@ -814,9 +814,9 @@ jobs:
                   done
 
             # Visual Review: complete the run (test job already uploaded snapshots)
-            - name: Install VR CLI deps
+            - name: Install VR CLI
               if: needs.playwright.outputs.vr_run_id != ''
-              run: cd products/visual_review/cli && npm ci
+              run: cd products/visual_review/cli && npm ci && npm run build && npm link
 
             - name: Complete Visual Review run
               if: needs.playwright.outputs.vr_run_id != ''
@@ -825,7 +825,7 @@ jobs:
                   VR_TOKEN: ${{ secrets.VR_API_TOKEN }}
                   VR_AUTO_APPROVE: ${{ needs.changes.outputs.mode == 'update' && '--auto-approve' || '' }}
               run: |
-                  npx tsx products/visual_review/cli/src/index.ts run complete \
+                  vr run complete \
                     --run-id "${{ needs.playwright.outputs.vr_run_id }}" \
                     --baseline playwright/snapshots.yml \
                     $VR_AUTO_APPROVE \

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -139,11 +139,56 @@ jobs:
                   path: common/storybook/dist
                   retention-days: 1
 
+    vr-setup:
+        name: Create Visual Review run
+        runs-on: ubuntu-latest
+        timeout-minutes: 2
+        needs: [changes]
+        if: needs.changes.outputs.frontend == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        outputs:
+            run_id: ${{ steps.create.outputs.run_id }}
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  ref: ${{ github.event.pull_request.head.sha || github.sha }}
+                  repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+                  sparse-checkout: |
+                      .nvmrc
+                      products/visual_review/cli
+                      frontend/snapshots.yml
+                  sparse-checkout-cone-mode: false
+
+            - name: Set up Node.js
+              uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+              with:
+                  node-version-file: .nvmrc
+
+            - name: Install VR CLI deps
+              run: cd products/visual_review/cli && npm ci
+
+            - name: Create VR run
+              id: create
+              continue-on-error: true
+              env:
+                  VR_TOKEN: ${{ secrets.VR_API_TOKEN }}
+              run: |
+                  RUN_ID=$(npx tsx products/visual_review/cli/src/index.ts run create \
+                    --type storybook \
+                    --baseline frontend/snapshots.yml \
+                    --branch "${{ github.event.pull_request.head.ref || github.ref_name }}" \
+                    --commit "${{ github.event.pull_request.head.sha || github.sha }}" \
+                    --pr "${{ github.event.pull_request.number }}" \
+                    --token "$VR_TOKEN")
+                  echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+
     visual-regression:
         name: Visual regression tests - ${{ matrix.browser }} (${{ matrix.shard }}/${{ matrix.shard_count }})
         runs-on: ubuntu-latest
-        needs: [changes, build-storybook]
-        if: needs.changes.outputs.frontend == 'true'
+        needs: [changes, build-storybook, vr-setup]
+        if: >-
+            always()
+            && needs.changes.outputs.frontend == 'true'
+            && needs.build-storybook.result == 'success'
         timeout-minutes: 60
         container:
             image: ghcr.io/posthog/playwright:v1.45.0
@@ -342,6 +387,23 @@ jobs:
                       exit 1
                     fi
                   fi
+
+            # Upload snapshots to Visual Review (runs in parallel across shards)
+            - name: Install VR CLI deps
+              if: always() && needs.vr-setup.outputs.run_id != ''
+              run: cd products/visual_review/cli && npm ci
+
+            - name: Upload snapshots to Visual Review
+              if: always() && needs.vr-setup.outputs.run_id != ''
+              continue-on-error: true
+              env:
+                  VR_TOKEN: ${{ secrets.VR_API_TOKEN }}
+              run: |
+                  npx tsx products/visual_review/cli/src/index.ts run upload \
+                    --run-id "${{ needs.vr-setup.outputs.run_id }}" \
+                    --dir frontend/__snapshots__/ \
+                    --baseline frontend/snapshots.yml \
+                    --token "$VR_TOKEN"
 
             - name: Archive failure screenshots
               if: failure()
@@ -587,7 +649,7 @@ jobs:
         name: Handle snapshot changes
         runs-on: ubuntu-latest
         timeout-minutes: 15
-        needs: [visual-regression, changes]
+        needs: [visual-regression, changes, vr-setup]
         if: always() && needs.changes.outputs.frontend == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         permissions:
             contents: write
@@ -637,7 +699,6 @@ jobs:
                     echo "Snapshot changes detected in patches"
                   fi
 
-            # Apply patches BEFORE VR so it hashes the final state
             # Uses --index so changes are staged for the downstream commit action
             - name: Apply snapshot patches
               if: steps.check-snapshots.outputs.has-changes == 'true'
@@ -647,28 +708,23 @@ jobs:
                     git apply --index "$patch"
                   done
 
-            # Visual Review: submit snapshots after patches are applied
+            # Visual Review: complete the run (shards already uploaded directly)
             - name: Install VR CLI deps
+              if: needs.vr-setup.outputs.run_id != ''
               run: cd products/visual_review/cli && npm ci
 
-            - name: Submit to Visual Review
+            - name: Complete Visual Review run
+              if: needs.vr-setup.outputs.run_id != ''
               continue-on-error: true
               env:
                   VR_TOKEN: ${{ secrets.VR_API_TOKEN }}
-                  VR_BRANCH: ${{ github.event.pull_request.head.ref }}
-                  VR_COMMIT: ${{ github.event.pull_request.head.sha }}
-                  VR_PR: ${{ github.event.pull_request.number }}
                   VR_AUTO_APPROVE: ${{ needs.changes.outputs.mode == 'update' && '--auto-approve' || '' }}
               run: |
-                  npx tsx products/visual_review/cli/src/index.ts submit \
-                    --dir frontend/__snapshots__/ \
-                    --type storybook \
+                  npx tsx products/visual_review/cli/src/index.ts run complete \
+                    --run-id "${{ needs.vr-setup.outputs.run_id }}" \
                     --baseline frontend/snapshots.yml \
                     $VR_AUTO_APPROVE \
-                    --token "$VR_TOKEN" \
-                    --branch "$VR_BRANCH" \
-                    --commit "$VR_COMMIT" \
-                    --pr "$VR_PR"
+                    --token "$VR_TOKEN"
 
             - name: Check baseline changes
               id: check-baseline
@@ -680,8 +736,7 @@ jobs:
                     git add frontend/snapshots.yml
                   fi
 
-            # UPDATE mode: commit PNGs + baseline together
-            # Patches already applied above — commit-snapshots will re-apply (idempotent)
+            # UPDATE mode: commit PNGs + baseline together in a single commit
             - name: Commit snapshot changes
               if: (steps.check-snapshots.outputs.has-changes == 'true' || steps.check-baseline.outputs.has-changes == 'true') && needs.changes.outputs.mode == 'update'
               uses: ./.github/actions/commit-snapshots

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -155,6 +155,7 @@ jobs:
                   sparse-checkout: |
                       .nvmrc
                       products/visual_review/cli
+                      products/visual_review/frontend/generated/api.schemas.ts
                       frontend/snapshots.yml
                   sparse-checkout-cone-mode: false
 

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -142,8 +142,8 @@ jobs:
     vr-setup:
         name: Create Visual Review run
         runs-on: ubuntu-latest
-        timeout-minutes: 2
-        needs: [changes]
+        timeout-minutes: 5
+        needs: [changes, build-storybook]
         if: needs.changes.outputs.frontend == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         outputs:
             run_id: ${{ steps.create.outputs.run_id }}
@@ -171,13 +171,16 @@ jobs:
               continue-on-error: true
               env:
                   VR_TOKEN: ${{ secrets.VR_API_TOKEN }}
+                  VR_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+                  VR_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+                  VR_PR: ${{ github.event.pull_request.number }}
               run: |
                   RUN_ID=$(vr run create \
                     --type storybook \
                     --baseline frontend/snapshots.yml \
-                    --branch "${{ github.event.pull_request.head.ref || github.ref_name }}" \
-                    --commit "${{ github.event.pull_request.head.sha || github.sha }}" \
-                    --pr "${{ github.event.pull_request.number }}" \
+                    --branch "$VR_BRANCH" \
+                    --commit "$VR_COMMIT" \
+                    --pr "$VR_PR" \
                     --token "$VR_TOKEN")
                   echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -163,8 +163,8 @@ jobs:
               with:
                   node-version-file: .nvmrc
 
-            - name: Install VR CLI deps
-              run: cd products/visual_review/cli && npm ci
+            - name: Install VR CLI
+              run: cd products/visual_review/cli && npm ci && npm run build && npm link
 
             - name: Create VR run
               id: create
@@ -172,7 +172,7 @@ jobs:
               env:
                   VR_TOKEN: ${{ secrets.VR_API_TOKEN }}
               run: |
-                  RUN_ID=$(npx tsx products/visual_review/cli/src/index.ts run create \
+                  RUN_ID=$(vr run create \
                     --type storybook \
                     --baseline frontend/snapshots.yml \
                     --branch "${{ github.event.pull_request.head.ref || github.ref_name }}" \
@@ -389,9 +389,9 @@ jobs:
                   fi
 
             # Upload snapshots to Visual Review (runs in parallel across shards)
-            - name: Install VR CLI deps
+            - name: Install VR CLI
               if: always() && needs.vr-setup.outputs.run_id != ''
-              run: cd products/visual_review/cli && npm ci
+              run: cd products/visual_review/cli && npm ci && npm run build && npm link
 
             - name: Upload snapshots to Visual Review
               if: always() && needs.vr-setup.outputs.run_id != ''
@@ -399,7 +399,7 @@ jobs:
               env:
                   VR_TOKEN: ${{ secrets.VR_API_TOKEN }}
               run: |
-                  npx tsx products/visual_review/cli/src/index.ts run upload \
+                  vr run upload \
                     --run-id "${{ needs.vr-setup.outputs.run_id }}" \
                     --dir frontend/__snapshots__/ \
                     --baseline frontend/snapshots.yml \
@@ -709,9 +709,9 @@ jobs:
                   done
 
             # Visual Review: complete the run (shards already uploaded directly)
-            - name: Install VR CLI deps
+            - name: Install VR CLI
               if: needs.vr-setup.outputs.run_id != ''
-              run: cd products/visual_review/cli && npm ci
+              run: cd products/visual_review/cli && npm ci && npm run build && npm link
 
             - name: Complete Visual Review run
               if: needs.vr-setup.outputs.run_id != ''
@@ -720,7 +720,7 @@ jobs:
                   VR_TOKEN: ${{ secrets.VR_API_TOKEN }}
                   VR_AUTO_APPROVE: ${{ needs.changes.outputs.mode == 'update' && '--auto-approve' || '' }}
               run: |
-                  npx tsx products/visual_review/cli/src/index.ts run complete \
+                  vr run complete \
                     --run-id "${{ needs.vr-setup.outputs.run_id }}" \
                     --baseline frontend/snapshots.yml \
                     $VR_AUTO_APPROVE \

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1558,34 +1558,6 @@ snapshots:
         hash: v1.k794b7964.9e82f2f24ab93ebaeef0e76c9b21eb703bbc220b71ae98fc315e08e0cb9dfd1e._LMAUIDTq3n1ZJPoVG8PaNUxUNc0c2hAJFf8vazZSlQ
     layout-navigation--app-page-with-side-bar-shown--light:
         hash: v1.k794b7964.bb328d2e28e14c1b504d0ea5eefd4fc081c8eb70dbbe2302a03c4921e996f509.pGojDXAWj4BkJ6bZzdfJ18pqLIuH5OYA5zyRvMBE838
-    layout-project-notice--demo-project--dark:
-        hash: v1.k794b7964.68bee37a99fa5630075413f1c45955a6b8569ee8f4bc30253f5e497ef8d3223d.t8WnA1AGE3ArbvHWlMeKvsnMGBkfwLNI8nzlfq9AY4Y
-    layout-project-notice--demo-project--light:
-        hash: v1.k794b7964.553d47c2c41c8bf6e48632396bbd05419aab67db570c926c6ee3a75af5d80439.iFdfRRTUihR1gaSIzgQ1V8NNkP5LnKwz8S4oQrM6g8A
-    layout-project-notice--demo-project-with-alt-team--dark:
-        hash: v1.k794b7964.32931c862c4503f05298701b4c122cc9e1670c704d1caf2d54b71cb913ad4266.OI1pP6rdz7zGTGjO-h55AUu8OJQYI40lVJmmGTcnoI8
-    layout-project-notice--demo-project-with-alt-team--light:
-        hash: v1.k794b7964.d404a608f359ab7e6f14c677dac5d6db077c9ceb9f902e6c13e1ab49e33151a7.s6cxJTGIEqx7RSFoTs_LQaX3znGaz2a4Q_lgW-77gF4
-    layout-project-notice--event-ingestion-restriction--dark:
-        hash: v1.k794b7964.7dd5ae35230c8c43fdb906635e2e6e249f6d28278649de087ba2ee8284e086c3.7CIub-ZLVLkS_4EyYwx7A33xajTcG6f9VkTqcGosDrk
-    layout-project-notice--event-ingestion-restriction--light:
-        hash: v1.k794b7964.64fb7d932901494d7c5bb4691f70265614ce34b91f127913e89f4f09cf321de3.nEXzG1vqaqouKrRwNrRF9Ron3cLHivzzEcRUQVX-GL8
-    layout-project-notice--internet-connection-issue--dark:
-        hash: v1.k794b7964.2010889350f38b461e85173b931809ac80a8e5481419f9b35c1866207e248442.DPR2_pNOPfsNMn6ZPXdo6aQfJk6uRnwPGLuiY1FDPaw
-    layout-project-notice--internet-connection-issue--light:
-        hash: v1.k794b7964.26bdfc231e725e604333fc48dd01012f1a6a667c38312bde234779be3a3337a1.8BRXF6QYWO33VFq6JVgdZi-rfRdFtaGC1zwdUMJfX3w
-    layout-project-notice--invite-teammates--dark:
-        hash: v1.k794b7964.88687f33fcf8e1cdb0326e9404a3df927f98853da2dfc1c3eb0d3b43e8f73567.z9y24ziwYxAss_pz8J4Pq7-CIzsd5GuV-iaw77OSSb0
-    layout-project-notice--invite-teammates--light:
-        hash: v1.k794b7964.409ab8e15c4af51ad5b660aef11754e6ca9988e448bb0b5767ac12ba79ad3813.prHJd6Qk0rK567qQpjIntc51vHU_jAqHRAiX2zKARR4
-    layout-project-notice--missing-reverse-proxy--dark:
-        hash: v1.k794b7964.db0bd45a6001ae837b1157ebea60bfcbff4ef8015a81f2a0e47d186bf927883d.SWOYCoRniFDRg4AdkERt3SbcyhyH4AeUAQbBiHaXKho
-    layout-project-notice--missing-reverse-proxy--light:
-        hash: v1.k794b7964.bc34c4d09d7a6fe2389e28811312977450a13f345bc984db9b0412c625c8df97.SLTErG38_QclLWR4L4IULKD9Kr3tJPaYM_uYfcOKdjQ
-    layout-project-notice--unverified-email--dark:
-        hash: v1.k794b7964.8565dcab1ba0b36672dbc73088479ea426ab60e90eb080f4517ea8178d07eae5.BGPGjnZwpC9_Hl3ldP8VYmaOfJZawIB5KFEzTO1tZZw
-    layout-project-notice--unverified-email--light:
-        hash: v1.k794b7964.9def21058cc79e7f18d17f3e6b9959eec249a67406e9860161994a729292c728.774_DNR3rf2Ru5krlP-dJPn3suwDW15ldaghk-NI6HA
     layout-project-tree-custom-products--all-products--dark:
         hash: v1.k794b7964.2903ceece81f6d06183f2b3e13f5c9d24cb3181e5408576aa810c813be2b831d.uLLpeyo495rU3G2TSGR0vLCFfYiymzqhPF1JiTyADRY
     layout-project-tree-custom-products--all-products--light:
@@ -3709,9 +3681,9 @@ snapshots:
     scenes-app-batchexports--backfills-empty--light:
         hash: v1.k794b7964.4e4c98f98fa348dbc37c7c347272c626fd323c101eaa6527cb0acb9ce16202f5.V14Aj2VNoFezUhf0D--BRLQRtw6Cwk3cgGQFAYt0HvM
     scenes-app-batchexports--backfills-with-estimates--dark:
-        hash: v1.k794b7964.5570909fab8ed939d53730402a17f900e0316954a5c5620132567d8c172d613a.TZ5WKTlYKaynJ-Nn483JTnhYD0RsYIKTbTHl9-t-Hbw
+        hash: v1.k794b7964.1a17b04c3acdcd513277b324a66d70cd461350b3840ab11600f12c6319f7b093.jP737iPRiHppODEqucRVRm-7qHZ54SpSmpnrveKOZRw
     scenes-app-batchexports--backfills-with-estimates--light:
-        hash: v1.k794b7964.e051d37658c287607c80efefc68f4c8f370fa009857f90de2d6e0aa027f12256.oO5StOeBEbel_6Ut9xPXGpK371eIc_tE6dQKkruvh4M
+        hash: v1.k794b7964.92b4119adade95cefc1f10cb232fbd00c8cc24925bcb3ae58e134ddf98c5dfd4.PFiFNVfR0WHFOcVZYLnPu1i1P8bX2MBr0Cj3--xRrW8
     scenes-app-batchexports--create-export--dark:
         hash: v1.k794b7964.7d5ea7974551c9d3d1710a2a4155fa6e4b69621afb88a378606f092cae7353db.sxqdTS5jzK6QA3sMXIhhK-xhXAnw_hYb6FJ3zZtf30Y
     scenes-app-batchexports--create-export--light:
@@ -4149,9 +4121,9 @@ snapshots:
     scenes-app-experiments--draft-experiment--light:
         hash: v1.k794b7964.8fb54e4b4443b983f28c00479b1beb8d431ca9503732fc25adf7f33fcca0cf24.499BL8AUV2eYHFWvjh0o6RK3vnvZviEjvsv5ykkKOWo
     scenes-app-experiments--experiment-asymmetric-intervals--dark:
-        hash: v1.k794b7964.31f418fb1fdb16e66dd9515548d937b7e2fc8eb3e5bcc76d07fdee0c1f25ba12.SNBxiiw3-oVXJ6CfPqscmMJgQFlzIn7IkZKr_hj4BeQ
+        hash: v1.k794b7964.16914f4b652c13c750dee72176a79456b267f45bf0a3962862126dbd1584375f.jBI-9QTK44vS4vMtD8iqqHT5feK59ljRloD0f3WXNVI
     scenes-app-experiments--experiment-asymmetric-intervals--light:
-        hash: v1.k794b7964.df89c2d40ab05dcd24da975c5f275d87509e972e1ac79085228bf94251a9005a.lkJ72fuQ5UFpIgyLNDu1aKax_EtUQMpo5OWCSSwmkW4
+        hash: v1.k794b7964.4afb637fa1f8fb7df9a99f8c676e9bda11170fa3e285cd92cdbf11f5f06a4979.SOblQbosGqCLau0uk7Pk1G1aTzPl2kL5skvZmbiexwo
     scenes-app-experiments--experiment-draft--dark:
         hash: v1.k794b7964.811e2dc2dc777450af3af4f92f1e3b615843044da047325657ce98b7709ba41b.wuj1nFfsRWvBLi6cn9Mzn2Qojweg6XwDWBDFoKhYXGs
     scenes-app-experiments--experiment-draft--light:
@@ -4161,9 +4133,9 @@ snapshots:
     scenes-app-experiments--experiment-frequentist-five-variants--light:
         hash: v1.k794b7964.8b3e4f8bb8ab4306ce627fd9520bfc02b5c220816900b0286169aa666b8403e4.6LgOrDnArxJrIyUxQs43pG12KDQwFUHQfSdxDboFXLg
     scenes-app-experiments--experiment-frequentist-two-variants--dark:
-        hash: v1.k794b7964.39ef45f73d8a083c15b86ee92bfcca2fd997757787d1f0a5c7fc22bfef97c4a6.TxzWsKqd53FY9FN1YTg6a3IsGLEocwfXZwZcU2tGqoA
+        hash: v1.k794b7964.684876c00fa1f644014b8cfaa3be1f6f062b009375c173e20ee920d889c0099d.qEPiJrxAExL5ODuQ-Hr1ZAHJ5XYZiTPg8L2zuAZARsg
     scenes-app-experiments--experiment-frequentist-two-variants--light:
-        hash: v1.k794b7964.5f4a79a5c0736a5984fd3b15807290f3ce60843570aa6f09388f8a4d51fe1599.21UEn15BswavWJElV6lrmwYLu-qPTIBM7s7uVDqijJc
+        hash: v1.k794b7964.87967f42f474ed52171cf5515ea5ca7e82c5842be774d8c85a0c9415b773e5c2.Z8s92NyqTdeWsjWxFYKTFtdNzhGCSoYBgzFUbd1oV_Y
     scenes-app-experiments--experiment-not-found--dark:
         hash: v1.k794b7964.2ea5e02f673abf0635bb26e97d7f444bda62720c2f26867b78ccdfc11856a3b9.Wf5T2t_jzFwoPLCDK3LzvkMAbQzmfk63eowrp4kkqOk
     scenes-app-experiments--experiment-not-found--light:
@@ -4185,9 +4157,9 @@ snapshots:
     scenes-app-experiments--experiment-with-asymmetric-intervals--light:
         hash: v1.k794b7964.2f309907f4bde04e40248772981bca7f6728ef29952fe23564c1b9f23810971e.dMqTcDV6ynTLYd2tbtR1Ey3R8H_i8ZYSw5ZzWPIrayg
     scenes-app-experiments--experiment-with-funnel-metric--dark:
-        hash: v1.k794b7964.4cb3942be1403a59d7c553c7420239f1d4e2111b23dbaf2fc1ec0d380a732a6f.04_em4D5UBjhQ3SdqCWQunl1nL5HTx1xBvw17wPf9eA
+        hash: v1.k794b7964.9c4583b5cd144fa46a5298604eaa58f2fd02ef595df144f9be5c96c8b9e1d637.eMKkNQhEulr9LRXpjXbXPXh30j5D6SNpLNiSavgcnQY
     scenes-app-experiments--experiment-with-funnel-metric--light:
-        hash: v1.k794b7964.3638cd13e39f8613b48ab7ab65921513eea9bcad09dea2e8f0f3f1bb8a94b327.hVQItb8K32dofy6SeWEUu0-DiNGXrLqHWYpZ4OGn0Pg
+        hash: v1.k794b7964.98dd8483c1578ea2b225ce844dab6e0d14344ee53f800f855cdbcfc5ea213591.DYBzYiDfrM2bm8IgsqsKx1R90LbhaQdcQowyUKvQ8v4
     scenes-app-experiments--experiment-with-legacy-funnels-query--dark:
         hash: v1.k794b7964.46dd2f7ee3fa1508b0abb60ac99ab0583456fd283278001f052d7b38ac46d7c3.jLEkS0S3xjAyLs0_DDYuzOpslmRaRGV5oVpAFkDDvwk
     scenes-app-experiments--experiment-with-legacy-funnels-query--light:
@@ -4197,21 +4169,21 @@ snapshots:
     scenes-app-experiments--experiment-with-legacy-trends-query--light:
         hash: v1.k794b7964.5dc3b16c8d58be17204f93366c877e20b8c02fd23c1b06b06496e0cd91450f61.CvpGwKYh_ddbyIkjelmqMN21eYWpWTENgnZAbaSJYzw
     scenes-app-experiments--experiment-with-mean-metric--dark:
-        hash: v1.k794b7964.70104fcb8bb0dd10c963e1838579cafe0c6fdf158eb309f5cda1929ff76fe730.voinAd2Cgq8kWvjPYbF0MluL4zF3pV41t5sZrdy695k
+        hash: v1.k794b7964.153a2dd9f1f0d1685be9acbf92de819b414fb7f3c9058519d886751a53e0d586.ZfP73xzHtxhz54aDhNvs_UgRA1UxRsH-M3rvC7NPlgg
     scenes-app-experiments--experiment-with-mean-metric--light:
-        hash: v1.k794b7964.b7ecb040d3d8d5334cc1e89b1a01dd5c8966a742e7c00f389bf970953f723fbf.n2Wf6_WfaMenlC3h9WWbXqjJB01ba6k_coO4k0MTC6Q
+        hash: v1.k794b7964.8bf800c4e1a415e434cb94e0a401950a837e5c2af1a9d26db8aefab7d736cf4d.D6zVmQbX9N0dZLzC7kgYqOZKnYYijv4epB1U6RtE92k
     scenes-app-experiments--experiment-with-multiple-metrics--dark:
-        hash: v1.k794b7964.9b70e3b470f77c093bc1930412057453368a8b9e03f219ae7236000f50c62a52.OHdnZ0A-HyR22u48S8RnPai6GolHp2hReq5icX285OQ
+        hash: v1.k794b7964.9e58fa913e22ecef7d1409191fbf6ac9d7573e3619ea50f9833d38410f833173.WwqVaQ_cKFSda3M5Sbbrme-nvA2yMepupFU838nrIN8
     scenes-app-experiments--experiment-with-multiple-metrics--light:
-        hash: v1.k794b7964.b7391395b3febb090a5725abe2701fab195be6a5306f53b93c020247db199e7f.GwwfCKOub3IaN9Mk_rJsNyDubOKhdnBlKnVzWiMAkYE
+        hash: v1.k794b7964.514077230e1db395c041f53fb63d1f6c670d80161fa81edc94ff43a80164998f.5h4pL7aaoA-pfKgSmBtxw08pGMMV2oOa7E_wYkCp2JY
     scenes-app-experiments--experiment-with-multiple-metrics-reordered--dark:
-        hash: v1.k794b7964.9a0fa5f6f16bdc48719e4b9c144d69ee2ede19a8fc1712ddbd6de4edea55513d.mVUP78_zQPRTSKaLfM6Wi-EU17Mnm-d1MScHUQ155AQ
+        hash: v1.k794b7964.7d89634100600727562f9dd8fac26228c624540bd6f4a832620df3c9d44698ca.oC9jr6AXhapyiwbQS9avLYftBQuEXXP3mkPXlmwOeb8
     scenes-app-experiments--experiment-with-multiple-metrics-reordered--light:
-        hash: v1.k794b7964.163e2dcf31cbb7fe50b04108b00ad2eda40e4e80587d88404ba18c7870bf92ff.6nrd2MhK4j6A4Ow0l-1M1m62U9LVbyEF33Xf4s9u6Ro
+        hash: v1.k794b7964.c1ab6996de94f44bd5352704e714de2d1455c85479923f0dcfcd1972a4e525dd.yNWMTaPWTZHic8Zn1mkn0MZE6X3gThVJQWYUvBF35-o
     scenes-app-experiments--experiment-with-ratio-metric--dark:
-        hash: v1.k794b7964.42bbbb1127b586c32f84c749de481b50661f46c95fccdb02598fa577c73da37d.NApBoVEvR-uH8mJMO3j19ckQcxvXk3ZWbhy0NNAvd7M
+        hash: v1.k794b7964.cb5bba447bc16cda43e9ab912400b53c1e44f6c8ef4435f67425e83daa4a13af.eCQzpjBalYQdk9NNIp_3FrE2geNrE3MffagXfK093Pw
     scenes-app-experiments--experiment-with-ratio-metric--light:
-        hash: v1.k794b7964.78e6847da4a20d5656ad51b387a359b5ce765a1dc8b85a8769cf28ef13bf5b63.NmNnN-0wAEOQNaJ75ibgNbTcn0nnalnH80NUW31nyjk
+        hash: v1.k794b7964.36beae77cf9d79db557e8c05c1231b2c00a55479256d6044a650ae6c79b3703b.nD9f5TMARZcCIK9ALOOVkLKiOn_36t3MMez1HqbKLJM
     scenes-app-experiments--experiment-with-three-metrics--dark:
         hash: v1.k794b7964.df17e2345cca4ab562a236432b98ae88bf880deb581d79d94a6048511143f0d7.hzNijSCjsK3nL-mcfamC3qBKC6MOdwKimnOa10qfqtI
     scenes-app-experiments--experiment-with-three-metrics--light:
@@ -5445,15 +5417,15 @@ snapshots:
     scenes-app-posthog-ai--thread-with-in-progress-conversation--light:
         hash: v1.k794b7964.9faf996d486a0b3a1c602157d62a3460d780f36bfe4bc0651e83ebb7a158fcba.MqLckhxn2jKEIjQ2zygT_DA2-3o76M4G2Ol4xV7yJ_Q
     scenes-app-posthog-ai--thread-with-mixed-field-type-form--dark:
-        hash: v1.k794b7964.79b9192b0a8da03089db9c961062ab172c6d6179154add0bd2d4bbd656aa9ec4.cPgH7kZkjvnsv8SFsd46RfA7i0yEkF5XhRlqgR1QBZI
+        hash: v1.k794b7964.9e64ae5b208d8dd2e955b169d750e895cd07532de6d5cebddae1f59ff2d0939c.KXViPyqxl_qouEC1Lm9jEC_GDoxe_wgnBVUwpARL2L0
     scenes-app-posthog-ai--thread-with-mixed-field-type-form--light:
-        hash: v1.k794b7964.e6eb7352ac777a7336b46457d10592f7c92868f9446adc14cd8e642be45892d5.saT3najGYIfAh7mp3lBTj7pGCIVS9e-K7stZ-X2lf-o
+        hash: v1.k794b7964.e360de2b48777f4235745aa90a4eb93c42a0a1df9addd4d7163686a8b95f52f5.UtqCOn7HW0z70rCGdAstFY0aE3KjnjWQzT3utXbzZgM
     scenes-app-posthog-ai--thread-with-multi-field-question--dark:
-        hash: v1.k794b7964.a7c918c07d7c0a1827fbfb880bed69c2977944b4826fb8dea0ca3d7d3a0d7448.5GsySXTbftwJRCD8dUD4kMBHqSErByb-B3MiyBsRt34
+        hash: v1.k794b7964.4132123326ee8464afc25b12c5a32984b6d73a092b47849d728c82e759b148e2.ZYHVX6KZm1wyB1yrWudQvPRHQoCbwqRQuFJgcRy9OLk
     scenes-app-posthog-ai--thread-with-multi-field-question--light:
         hash: v1.k794b7964.05e52d795ec79577621db090eecf1339d7b3bf31f0eaadbea4f1c219d9cd2cab.l9xuWTN9Q3_pnGMFMkJf5PSgqUAcB5enYRQTqpl_CCQ
     scenes-app-posthog-ai--thread-with-multi-question-form--dark:
-        hash: v1.k794b7964.7524e6f5b8d85e2b55ab9b9e124d72c3ea6320c2b85c8bc5d0ed4acbd1232ebc.qLIt-Rf-oHJ5T3y5B9sOLVDIV8VpJJoeXpACC3pvnhw
+        hash: v1.k794b7964.9447fc7ebf2eea1ba179706b50cb679333bcbff91148bbfe5f1f8fc11f218828.13m4k6OoiN3NNcg3PlchEAuBSjt8-3okv6dKKcDJEco
     scenes-app-posthog-ai--thread-with-multi-question-form--light:
         hash: v1.k794b7964.fbd131a2eec641400a0129f198364d4c63987e29ef05e135abe4a78b1fcb975d.dc_Kn9KiFG0NoHCwI9cQ-gSM2zmoqk3BGDYwmZSa0GE
     scenes-app-posthog-ai--thread-with-multi-question-form-long-content--dark:
@@ -5461,9 +5433,9 @@ snapshots:
     scenes-app-posthog-ai--thread-with-multi-question-form-long-content--light:
         hash: v1.k794b7964.7f76256bfa96249e5bc187e1e8a7f69305b22d6c3b33ab2a791170f2a4df6581.93uTUTgRiXkocFmXAOgTaAz7tvXMQhpBFGhpsYLPzIE
     scenes-app-posthog-ai--thread-with-multi-question-form-no-custom-answer--dark:
-        hash: v1.k794b7964.59f674fec6942896dabfddd5d178fb430d0558cc4ebb2ef5ab37264c52089cb2.Nhx-Tb1w-aYUayYkHlR3bBrEuoMr0BrCPu5Ichfr1bA
+        hash: v1.k794b7964.fbdf6d5eadf1888838564aa5eaca18e80197524ddc7f5271a19fe681da174ebe.fyMbnjIKsVQiy6CygauwQHrdMpuXPYpeyIDVXI9BjHA
     scenes-app-posthog-ai--thread-with-multi-question-form-no-custom-answer--light:
-        hash: v1.k794b7964.564e2e1e8cb942e6d4812f41f57fbf4a8f1b8a8d17361d7cd74a4cd4440d0b89.XStY3RQJpPO4H0YMCNZYq04PibMMsyh50YYNq-92uCA
+        hash: v1.k794b7964.3950ef02a7ed649f1a88f14d9d33b27ae8acfd606123dc8f7609384df74094d7.kEkabNZslMmyuUr6kVE_BjAsQ09pnWuiYZLdJdcxql0
     scenes-app-posthog-ai--thread-with-multiple-context-objects--dark:
         hash: v1.k794b7964.a619f9c0e0e0fc97a1789349bee0842fc25bc37ea0008d8e8dc3e07e7c8f4777.kBxTUCJjtx-KPJRSRChB-RsEXCDFv2iwjRioCiOwq9g
     scenes-app-posthog-ai--thread-with-multiple-context-objects--light:
@@ -5493,13 +5465,13 @@ snapshots:
     scenes-app-posthog-ai--thread-with-session-summary-link--light:
         hash: v1.k794b7964.44a5d7338da35b5128b913286f9905b51db76941838dc0eee9c85430245b9987.bWsRqlrm5CRYltzOVtButj-SybQCrIJMERHyW76MP0U
     scenes-app-posthog-ai--thread-with-single-question-form--dark:
-        hash: v1.k794b7964.b1d70efa3627ff21abc86d2404cd70c050eaf025edc51a18777632c7e4749dac.laX5youpWeymkIbrKy4uARejSVYplZLst_dkhRmUiD0
+        hash: v1.k794b7964.092ef23378cb4e28375d28217cc335d40eebbe72d008af3544e2a7a076befe74.tt0V4pYrrDvvgzsjGpfgQ4mP2PCDRhYH8_gL37iBc80
     scenes-app-posthog-ai--thread-with-single-question-form--light:
-        hash: v1.k794b7964.e1726a890b2931bf63271204467d5672e72be13173900a2ffebabaa400819ed1.2CI0CHd3OR56VmkMH9-uepZJzSIntaW4YZdGP5XXgJY
+        hash: v1.k794b7964.b9c9765d79a83185ed1819cfd3ed184bc6ad1f391b1a785dfada612f8a5fbee3.XLEVZ0HnKWF9teCQGGIh9WP-SaC9D4HlBDnOeqSTG9I
     scenes-app-posthog-ai--thread-with-slider-form--dark:
-        hash: v1.k794b7964.75ad5f35b1c27fcec09b19f7050b25fea2c3bfc9ecadd64c31c5fdfb7548c95a.oiY4Skx4jI0bWKaWEvfxkJw84LHoAVFJTvSbCE91muw
+        hash: v1.k794b7964.7ea568366550177254c99eb81af0fa54a3c220d98b9601f9e46df80445153f14.T03LwBs23tK1_mUG-wOm2Z5srVuQO9tv720XiPn3ckQ
     scenes-app-posthog-ai--thread-with-slider-form--light:
-        hash: v1.k794b7964.234ba54aa5e8d717d221c2d802037d74f1d9fae5c3abb0c890fd9eb09d94fcae.0mIBzqQO9aghu1Iou4h5Fd3Ma2Wh5kVutFJShNYa5RY
+        hash: v1.k794b7964.e259f4a33a30a465575c8003dc21933aefeef31ca256ed507b5f2ef64f512f65.VwJIT7vmAjJTqDDdcYBoXwUKoGCy7lYKV1nnKRyFiOU
     scenes-app-posthog-ai--thread-with-sql-query-overflow--dark:
         hash: v1.k794b7964.6d924ef3090680b7cea159da6cfe1418ff495937a130f6b7f05362d3c3454a94.WVVamIT6MoH_YlZUGwKa7c555EtyaK5_V9jY1r7sfzM
     scenes-app-posthog-ai--thread-with-sql-query-overflow--light:
@@ -5507,7 +5479,7 @@ snapshots:
     scenes-app-posthog-ai--thread-with-text-and-number-form--dark:
         hash: v1.k794b7964.2b577d2f50d407c1f9d660bd0f37b7b2823e20276d91a300f797793f8a81c731.IH0vzfvpnog-0ve6WpzZu4as6Myx2ME9mc-Zw0QPHTI
     scenes-app-posthog-ai--thread-with-text-and-number-form--light:
-        hash: v1.k794b7964.4f34fa8b00ab2e5064f99e34704ec2f9af429034e35a41b83be74d6595649732.snIpNzkUJ5Qnk6dCA71wZ47CsvedaJNrZv0oFW0jE1A
+        hash: v1.k794b7964.b4b408592172ae4ee4d998a85f69093173e857cecbcd3fd37f808d5233d2782d.ww8Ffe72xEKd1twI8zJHwW9nH9o9nJSV20S0ZqA7t4Y
     scenes-app-posthog-ai--welcome--dark:
         hash: v1.k794b7964.920dad83fa1f3d7147242cfaf9d8f2e1de3d68372c3f9fb4b4a72c69814e3b24.ScvL64se8JAosuryN1cJ2ms5o2QLwar9LpgtdOZTf0o
     scenes-app-posthog-ai--welcome--light:
@@ -5739,7 +5711,7 @@ snapshots:
     scenes-app-settings-user--settings-user-notifications--dark:
         hash: v1.k794b7964.2b01995610c990c188b0c55d028b1cd04f48b2ab132d1c4a9823976bf1fe628a.UGsb-zjKmoMn66_0x-e6QyplgtdOj7OaAHJEXtDd2WA
     scenes-app-settings-user--settings-user-notifications--light:
-        hash: v1.k794b7964.01f5dbc1c40ee3cdcf7a7a17872cc165ceac89597886598620e56cae8f643fa2.OQqMoEgfYKTxAnChEaue1TnR_XnT83qB3u_lgxKYDtM
+        hash: v1.k794b7964.02972859b3fd20be5cd0529ce60824ce8fc7f51df9452805db83ae4cd612173f.V6L3MCj1GiDQ0Zcz3WIE-pHVVCjjTk-vNNy89xC5AMI
     scenes-app-settings-user--settings-user-profile--dark:
         hash: v1.k794b7964.3a3874d1b09b3cfda9a6b2c31614c33c6b9dfd8ecb83ba501a5ed3f372a56ea9.XxF7t-2d8ZqMpP1ijBiz8uXefxN_Itz7o2Om6oBC6vg
     scenes-app-settings-user--settings-user-profile--light:

--- a/products/visual_review/cli/src/index.ts
+++ b/products/visual_review/cli/src/index.ts
@@ -365,8 +365,6 @@ async function runComplete(options: RunCompleteOptions): Promise<number> {
 
     log(`Completing run ${options.runId}`)
 
-    // No body — shards already sent everything. Removal detection is a follow-up
-    // (requires backend to track covered identifiers per shard).
     let run = await client.completeRun(options.runId)
 
     log(`Run status after complete: ${run.status}`)


### PR DESCRIPTION
## Problem

VR snapshot submission is currently coupled to the artifact+patch flow — shards create patches, handle-snapshots aggregates them, then runs `vr submit` on the merged result. This means VR can't work independently of the commit flow, which blocks the switch to VR as the sole gate.

## Changes

Decouple VR uploads from the patch pipeline. Each storybook shard now uploads directly via `vr run upload`, and the playwright test job creates a run and uploads in-place. Completion (`vr run complete`) stays in handle-snapshots/handle-screenshots so the baseline update lands in the same commit as PNG changes.

Storybook: new `vr-setup` job creates a run, shards upload in parallel, handle-snapshots completes.
Playwright: test job creates run + uploads, handle-screenshots completes.

All VR steps remain non-blocking (`continue-on-error`) — this is the validation phase before the atomic switch.

## How did you test this code?

Agent-authored. Needs a real CI run to validate the shard upload flow end to end. The existing `vr submit` path is replaced, not duplicated, so there's no risk of double-submission.

no

## 🤖 LLM context

Agent-authored PR. Restructured the CI workflows based on existing CLI shard commands (`vr run create/upload/complete`) that were already built but not wired into CI.