### PR TITLE
fix(ws): report liveness heartbeat during long-running partition merges

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -1,6 +1,6 @@
 import json
 import asyncio
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import Any, Literal
 
 from django.conf import settings
@@ -179,7 +179,7 @@ class DeltaTableHelper:
         write_type: Literal["incremental", "full_refresh", "append"],
         should_overwrite_table: bool,
         primary_keys: Sequence[Any] | None,
-        progress_callback: Any | None = None,
+        progress_callback: Callable[[], None] | None = None,
     ) -> deltalake.DeltaTable:
         delta_table = await self.get_delta_table()
 

--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -179,6 +179,7 @@ class DeltaTableHelper:
         write_type: Literal["incremental", "full_refresh", "append"],
         should_overwrite_table: bool,
         primary_keys: Sequence[Any] | None,
+        progress_callback: Any | None = None,
     ) -> deltalake.DeltaTable:
         delta_table = await self.get_delta_table()
 
@@ -243,6 +244,9 @@ class DeltaTableHelper:
                     merge_stats = await asyncio.to_thread(_do_merge, filtered_table, predicate)
 
                     await self._logger.adebug(f"Delta Merge Stats: {json.dumps(merge_stats)}")
+
+                    if progress_callback:
+                        progress_callback()
             else:
 
                 def _do_merge_unpartitioned(data: pa.Table, predicate_ops: list[str]):

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py
@@ -66,7 +66,7 @@ class KafkaConsumerService:
     def __init__(
         self,
         config: ConsumerConfig,
-        process_message: Callable[[Any], None],
+        process_message: Callable[..., None],
         kafka_hosts: Optional[list[str]] = None,
         kafka_security_protocol: Optional[str] = None,
     ):
@@ -270,7 +270,7 @@ class KafkaConsumerService:
             if msg_key is None:
                 # Can't track retries without identifiers — process directly
                 with BATCH_PROCESSING_DURATION_SECONDS.labels(team_id=team_id, schema_id=schema_id).time():
-                    self._process_message(message)
+                    self._process_message(message, progress_callback=health_reporter)
                 MESSAGES_PROCESSED_TOTAL.labels(team_id=team_id, schema_id=schema_id, status="success").inc()
                 if health_reporter:
                     health_reporter()
@@ -361,7 +361,7 @@ class KafkaConsumerService:
         for attempt in range(self._config.max_retries):
             try:
                 with BATCH_PROCESSING_DURATION_SECONDS.labels(team_id=team_id, schema_id=schema_id).time():
-                    self._process_message(message)
+                    self._process_message(message, progress_callback=health_reporter)
                 if health_reporter:
                     health_reporter()
                 return

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/test_consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/test_consumer.py
@@ -291,7 +291,7 @@ class TestProcessBatchPersistentRetry:
     def test_pre_increments_before_processing(self, mock_get, mock_inc, mock_clear):
         call_order: list[str] = []
 
-        def track_process(msg):
+        def track_process(msg, **kwargs):
             call_order.append("process")
 
         def _increment_side_effect(*a: Any) -> RetryInfo:
@@ -326,7 +326,7 @@ class TestProcessBatchPersistentRetry:
     def test_multiple_messages_first_fails_second_not_attempted(self, mock_get, mock_inc, mock_clear):
         call_count = 0
 
-        def process_fn(msg):
+        def process_fn(msg, **kwargs):
             nonlocal call_count
             call_count += 1
             if msg["batch_index"] == 0:

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from collections.abc import Callable
 from typing import Any, Literal
 
 import s3fs
@@ -252,7 +253,7 @@ def _mark_job_failed(export_signal: ExportSignalMessage, error: Exception) -> No
     )
 
 
-def process_message(message: Any) -> None:
+def process_message(message: Any, progress_callback: Callable[[], None] | None = None) -> None:
     export_signal = ExportSignalMessage.from_dict(message)
 
     # Clear cached S3FileSystem instances to avoid reusing sessions bound to a
@@ -427,6 +428,7 @@ def process_message(message: Any) -> None:
                     write_type=write_type,
                     should_overwrite_table=should_overwrite_table,
                     primary_keys=primary_keys,
+                    progress_callback=progress_callback,
                 )
 
         DELTA_ROWS_WRITTEN_TOTAL.labels(team_id=team_id_str, schema_id=schema_id_str).inc(pa_table.num_rows)


### PR DESCRIPTION
## Problem

When a message requires many partition merges the liveness heartbeat was only reported *after* `process_message()` completed, so the 60s liveness timeout expired mid-processing. k8s killed the pod, the offset was never committed, the message was redelivered, and the cycle repeated 

## Changes

  * Fixed liveness probe crash loop during long-running partitioned Delta Lake merges in `warehouse-sources-load`
  * Added `progress_callback` parameter to `DeltaTableHelper.write_to_deltalake()` — called after each partition merge
  * Threaded `health_reporter` through `process_message()` as `progress_callback`
  * Updated consumer type hint from `Callable[[Any], None]` to `Callable[..., None]` to support the new kwarg

## How did you test this code?

  * Local run
  * Test pass

## Publish to changelog?

NO
