### PR TITLE
feat(debug): add slowest experiment queries view to query performance page

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -2,26 +2,43 @@ import { useActions, useValues } from 'kea'
 
 import { IconDatabase } from '@posthog/icons'
 
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { SceneExport } from 'scenes/sceneTypes'
 import { userLogic } from 'scenes/userLogic'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
-import { PrecomputationTeam, queryPerformanceLogic } from './queryPerformanceLogic'
+import { PrecomputationTeam, queryPerformanceLogic, SlowestQuery } from './queryPerformanceLogic'
 
 export const scene: SceneExport = {
     component: QueryPerformance,
     logic: queryPerformanceLogic,
 }
 
+const TIME_RANGE_OPTIONS = [
+    { label: '1h', hours: 1 },
+    { label: '6h', hours: 6 },
+    { label: '24h', hours: 24 },
+    { label: '7d', hours: 168 },
+]
+
 export function QueryPerformance(): JSX.Element {
     const { user } = useValues(userLogic)
-    const { precomputationTeams, precomputationTeamsLoading, search } = useValues(queryPerformanceLogic)
-    const { setSearch, setPrecomputation } = useActions(queryPerformanceLogic)
+    const {
+        precomputationTeams,
+        precomputationTeamsLoading,
+        search,
+        slowestQueries,
+        slowestQueriesLoading,
+        hoursBack,
+    } = useValues(queryPerformanceLogic)
+    const { setSearch, setPrecomputation, setHoursBack, loadSlowestQueries } = useActions(queryPerformanceLogic)
 
     if (!user?.is_staff) {
         return (
@@ -45,7 +62,7 @@ export function QueryPerformance(): JSX.Element {
         )
     }
 
-    const columns: LemonTableColumns<PrecomputationTeam> = [
+    const precomputationColumns: LemonTableColumns<PrecomputationTeam> = [
         {
             title: 'Team ID',
             dataIndex: 'team_id',
@@ -77,6 +94,63 @@ export function QueryPerformance(): JSX.Element {
         },
     ]
 
+    const slowestQueryColumns: LemonTableColumns<SlowestQuery> = [
+        {
+            title: 'Time',
+            dataIndex: 'timestamp',
+            width: 160,
+            render: function Timestamp(_, item) {
+                return <span className="font-mono text-xs">{String(item.timestamp)}</span>
+            },
+        },
+        {
+            title: 'Duration (ms)',
+            dataIndex: 'execution_time',
+            width: 120,
+            render: function Duration(_, item) {
+                return <span className="font-mono">{Math.round(item.execution_time)}</span>
+            },
+        },
+        {
+            title: 'Team ID',
+            dataIndex: 'team_id',
+            width: 80,
+        },
+        {
+            title: 'Experiment',
+            dataIndex: 'experiment_name',
+        },
+        {
+            title: 'Metric',
+            dataIndex: 'experiment_metric_name',
+        },
+        {
+            title: 'Path',
+            width: 120,
+            render: function Path(_, item) {
+                if (!item.experiment_execution_path) {
+                    return null
+                }
+                return (
+                    <LemonTag type={item.experiment_execution_path === 'precomputed' ? 'success' : 'default'}>
+                        {item.experiment_execution_path}
+                    </LemonTag>
+                )
+            },
+        },
+        {
+            title: 'Status',
+            width: 80,
+            render: function Status(_, item) {
+                return item.exception ? (
+                    <LemonTag type="danger">Error</LemonTag>
+                ) : (
+                    <LemonTag type="success">OK</LemonTag>
+                )
+            },
+        },
+    ]
+
     return (
         <SceneContent>
             <SceneTitleSection
@@ -87,7 +161,52 @@ export function QueryPerformance(): JSX.Element {
                     forceIcon: <IconDatabase />,
                 }}
             />
-            <h2 className="mt-4">Experiment precomputation</h2>
+
+            <h2 className="mt-4">Slowest experiment queries</h2>
+            <div className="flex gap-2 mb-4 items-center">
+                {TIME_RANGE_OPTIONS.map(({ label, hours }) => (
+                    <LemonButton
+                        key={hours}
+                        type={hoursBack === hours ? 'primary' : 'tertiary'}
+                        size="small"
+                        onClick={() => setHoursBack(hours)}
+                    >
+                        {label}
+                    </LemonButton>
+                ))}
+                <LemonButton
+                    type="secondary"
+                    size="small"
+                    onClick={() => loadSlowestQueries()}
+                    disabledReason={slowestQueriesLoading ? 'Loading...' : undefined}
+                >
+                    Refresh
+                </LemonButton>
+            </div>
+            <LemonTable
+                columns={slowestQueryColumns}
+                dataSource={slowestQueries}
+                loading={slowestQueriesLoading}
+                emptyState="No experiment queries found in this time range"
+                expandable={{
+                    expandedRowRender: function ExpandedQuery(item) {
+                        return (
+                            <div className="p-2">
+                                {item.exception && (
+                                    <div className="mb-2 p-2 bg-danger-highlight rounded text-xs font-mono">
+                                        {item.exception}
+                                    </div>
+                                )}
+                                <CodeSnippet language={Language.SQL} thing="query" maxLinesWithoutExpansion={10}>
+                                    {item.query}
+                                </CodeSnippet>
+                            </div>
+                        )
+                    },
+                }}
+            />
+
+            <h2 className="mt-8">Experiment precomputation</h2>
             <LemonInput
                 type="search"
                 placeholder="Search by organization name..."
@@ -96,7 +215,7 @@ export function QueryPerformance(): JSX.Element {
                 className="mb-4 max-w-md"
             />
             <LemonTable
-                columns={columns}
+                columns={precomputationColumns}
                 dataSource={precomputationTeams}
                 loading={precomputationTeamsLoading}
                 emptyState={search ? 'No teams found' : 'No teams have precomputation enabled'}

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -152,7 +152,7 @@ export function QueryPerformance(): JSX.Element {
     ]
 
     return (
-        <SceneContent>
+        <SceneContent className="overflow-y-auto pb-8">
             <SceneTitleSection
                 name="Query performance"
                 description="Internal tooling for monitoring and managing query performance across all projects."

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -152,7 +152,7 @@ export function QueryPerformance(): JSX.Element {
     ]
 
     return (
-        <SceneContent>
+        <SceneContent className="overflow-y-auto">
             <SceneTitleSection
                 name="Query performance"
                 description="Internal tooling for monitoring and managing query performance across all projects."

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -152,7 +152,7 @@ export function QueryPerformance(): JSX.Element {
     ]
 
     return (
-        <SceneContent className="overflow-y-auto pb-8">
+        <SceneContent className="mt-4">
             <SceneTitleSection
                 name="Query performance"
                 description="Internal tooling for monitoring and managing query performance across all projects."
@@ -189,6 +189,7 @@ export function QueryPerformance(): JSX.Element {
                 loading={slowestQueriesLoading}
                 emptyState="No experiment queries found in this time range"
                 pagination={{ pageSize: 20 }}
+                className="overflow-visible!"
                 expandable={{
                     expandedRowRender: function ExpandedQuery(item) {
                         return (

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -183,29 +183,31 @@ export function QueryPerformance(): JSX.Element {
                     Refresh
                 </LemonButton>
             </div>
-            <LemonTable
-                columns={slowestQueryColumns}
-                dataSource={slowestQueries}
-                loading={slowestQueriesLoading}
-                emptyState="No experiment queries found in this time range"
-                pagination={{ pageSize: 20 }}
-                expandable={{
-                    expandedRowRender: function ExpandedQuery(item) {
-                        return (
-                            <div className="p-2">
-                                {item.exception && (
-                                    <div className="mb-2 p-2 bg-danger-highlight rounded text-xs font-mono">
-                                        {item.exception}
-                                    </div>
-                                )}
-                                <CodeSnippet language={Language.SQL} thing="query" maxLinesWithoutExpansion={10}>
-                                    {item.query}
-                                </CodeSnippet>
-                            </div>
-                        )
-                    },
-                }}
-            />
+            <div className="max-h-[60vh] overflow-y-auto border rounded">
+                <LemonTable
+                    columns={slowestQueryColumns}
+                    dataSource={slowestQueries}
+                    loading={slowestQueriesLoading}
+                    emptyState="No experiment queries found in this time range"
+                    pagination={{ pageSize: 20 }}
+                    expandable={{
+                        expandedRowRender: function ExpandedQuery(item) {
+                            return (
+                                <div className="p-2">
+                                    {item.exception && (
+                                        <div className="mb-2 p-2 bg-danger-highlight rounded text-xs font-mono">
+                                            {item.exception}
+                                        </div>
+                                    )}
+                                    <CodeSnippet language={Language.SQL} thing="query" maxLinesWithoutExpansion={10}>
+                                        {item.query}
+                                    </CodeSnippet>
+                                </div>
+                            )
+                        },
+                    }}
+                />
+            </div>
 
             <h2 className="mt-8">Experiment precomputation</h2>
             <LemonInput

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -100,7 +100,7 @@ export function QueryPerformance(): JSX.Element {
             dataIndex: 'timestamp',
             width: 160,
             render: function Timestamp(_, item) {
-                return <span className="font-mono text-xs">{String(item.timestamp)}</span>
+                return <span className="font-mono text-xs">{item.timestamp}</span>
             },
         },
         {

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -183,30 +183,29 @@ export function QueryPerformance(): JSX.Element {
                     Refresh
                 </LemonButton>
             </div>
-            <div className="max-h-[60vh] overflow-y-auto border rounded">
-                <LemonTable
-                    columns={slowestQueryColumns}
-                    dataSource={slowestQueries}
-                    loading={slowestQueriesLoading}
-                    emptyState="No experiment queries found in this time range"
-                    expandable={{
-                        expandedRowRender: function ExpandedQuery(item) {
-                            return (
-                                <div className="p-2">
-                                    {item.exception && (
-                                        <div className="mb-2 p-2 bg-danger-highlight rounded text-xs font-mono">
-                                            {item.exception}
-                                        </div>
-                                    )}
-                                    <CodeSnippet language={Language.SQL} thing="query" maxLinesWithoutExpansion={10}>
-                                        {item.query}
-                                    </CodeSnippet>
-                                </div>
-                            )
-                        },
-                    }}
-                />
-            </div>
+            <LemonTable
+                columns={slowestQueryColumns}
+                dataSource={slowestQueries}
+                loading={slowestQueriesLoading}
+                emptyState="No experiment queries found in this time range"
+                pagination={{ pageSize: 20 }}
+                expandable={{
+                    expandedRowRender: function ExpandedQuery(item) {
+                        return (
+                            <div className="p-2">
+                                {item.exception && (
+                                    <div className="mb-2 p-2 bg-danger-highlight rounded text-xs font-mono">
+                                        {item.exception}
+                                    </div>
+                                )}
+                                <CodeSnippet language={Language.SQL} thing="query" maxLinesWithoutExpansion={10}>
+                                    {item.query}
+                                </CodeSnippet>
+                            </div>
+                        )
+                    },
+                }}
+            />
 
             <h2 className="mt-8">Experiment precomputation</h2>
             <LemonInput

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -183,31 +183,29 @@ export function QueryPerformance(): JSX.Element {
                     Refresh
                 </LemonButton>
             </div>
-            <div className="max-h-[60vh] overflow-y-auto border rounded">
-                <LemonTable
-                    columns={slowestQueryColumns}
-                    dataSource={slowestQueries}
-                    loading={slowestQueriesLoading}
-                    emptyState="No experiment queries found in this time range"
-                    pagination={{ pageSize: 20 }}
-                    expandable={{
-                        expandedRowRender: function ExpandedQuery(item) {
-                            return (
-                                <div className="p-2">
-                                    {item.exception && (
-                                        <div className="mb-2 p-2 bg-danger-highlight rounded text-xs font-mono">
-                                            {item.exception}
-                                        </div>
-                                    )}
-                                    <CodeSnippet language={Language.SQL} thing="query" maxLinesWithoutExpansion={10}>
-                                        {item.query}
-                                    </CodeSnippet>
-                                </div>
-                            )
-                        },
-                    }}
-                />
-            </div>
+            <LemonTable
+                columns={slowestQueryColumns}
+                dataSource={slowestQueries}
+                loading={slowestQueriesLoading}
+                emptyState="No experiment queries found in this time range"
+                pagination={{ pageSize: 20 }}
+                expandable={{
+                    expandedRowRender: function ExpandedQuery(item) {
+                        return (
+                            <div className="p-2">
+                                {item.exception && (
+                                    <div className="mb-2 p-2 bg-danger-highlight rounded text-xs font-mono">
+                                        {item.exception}
+                                    </div>
+                                )}
+                                <CodeSnippet language={Language.SQL} thing="query" maxLinesWithoutExpansion={10}>
+                                    {item.query}
+                                </CodeSnippet>
+                            </div>
+                        )
+                    },
+                }}
+            />
 
             <h2 className="mt-8">Experiment precomputation</h2>
             <LemonInput

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -152,7 +152,7 @@ export function QueryPerformance(): JSX.Element {
     ]
 
     return (
-        <SceneContent className="overflow-y-auto">
+        <SceneContent>
             <SceneTitleSection
                 name="Query performance"
                 description="Internal tooling for monitoring and managing query performance across all projects."
@@ -183,28 +183,30 @@ export function QueryPerformance(): JSX.Element {
                     Refresh
                 </LemonButton>
             </div>
-            <LemonTable
-                columns={slowestQueryColumns}
-                dataSource={slowestQueries}
-                loading={slowestQueriesLoading}
-                emptyState="No experiment queries found in this time range"
-                expandable={{
-                    expandedRowRender: function ExpandedQuery(item) {
-                        return (
-                            <div className="p-2">
-                                {item.exception && (
-                                    <div className="mb-2 p-2 bg-danger-highlight rounded text-xs font-mono">
-                                        {item.exception}
-                                    </div>
-                                )}
-                                <CodeSnippet language={Language.SQL} thing="query" maxLinesWithoutExpansion={10}>
-                                    {item.query}
-                                </CodeSnippet>
-                            </div>
-                        )
-                    },
-                }}
-            />
+            <div className="max-h-[60vh] overflow-y-auto border rounded">
+                <LemonTable
+                    columns={slowestQueryColumns}
+                    dataSource={slowestQueries}
+                    loading={slowestQueriesLoading}
+                    emptyState="No experiment queries found in this time range"
+                    expandable={{
+                        expandedRowRender: function ExpandedQuery(item) {
+                            return (
+                                <div className="p-2">
+                                    {item.exception && (
+                                        <div className="mb-2 p-2 bg-danger-highlight rounded text-xs font-mono">
+                                            {item.exception}
+                                        </div>
+                                    )}
+                                    <CodeSnippet language={Language.SQL} thing="query" maxLinesWithoutExpansion={10}>
+                                        {item.query}
+                                    </CodeSnippet>
+                                </div>
+                            )
+                        },
+                    }}
+                />
+            </div>
 
             <h2 className="mt-8">Experiment precomputation</h2>
             <LemonInput

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -14,17 +14,38 @@ export interface PrecomputationTeam {
     experiment_precomputation_enabled: boolean
 }
 
+export interface SlowestQuery {
+    query_id: string
+    query: string
+    timestamp: string
+    execution_time: number
+    exception: string
+    status: number
+    team_id: number
+    query_type: string
+    experiment_name: string
+    experiment_metric_name: string
+    experiment_execution_path: string
+}
+
 export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
     path(['scenes', 'instance', 'QueryPerformance', 'queryPerformanceLogic']),
     actions({
         setSearch: (search: string) => ({ search }),
         setPrecomputation: (teamId: number, enabled: boolean) => ({ teamId, enabled }),
+        setHoursBack: (hours: number) => ({ hours }),
     }),
     reducers({
         search: [
             '',
             {
                 setSearch: (_, { search }) => search,
+            },
+        ],
+        hoursBack: [
+            1,
+            {
+                setHoursBack: (_, { hours }) => hours,
             },
         ],
     }),
@@ -54,16 +75,28 @@ export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
                 },
             },
         ],
+        slowestQueries: [
+            [] as SlowestQuery[],
+            {
+                loadSlowestQueries: async () => {
+                    return await api.get(`api/debug_ch_queries/slowest_queries/?hours=${values.hoursBack}`)
+                },
+            },
+        ],
     })),
     listeners(({ actions }) => ({
         setSearch: async (_, breakpoint) => {
             await breakpoint(300)
             actions.loadPrecomputationTeams()
         },
+        setHoursBack: () => {
+            actions.loadSlowestQueries()
+        },
     })),
     afterMount(({ actions }) => {
         if (userLogic.findMounted()?.values.user?.is_staff) {
             actions.loadPrecomputationTeams()
+            actions.loadSlowestQueries()
         }
     }),
 ])

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -292,30 +292,33 @@ class DebugCHQueries(viewsets.ViewSet):
         if not request.user.is_staff:
             raise exceptions.PermissionDenied("Only staff users can view slowest queries.")
 
-        hours = int(request.query_params.get("hours", 1))
+        try:
+            hours = int(request.query_params.get("hours", 1))
+        except (TypeError, ValueError):
+            raise exceptions.ValidationError("hours must be an integer.")
         hours = max(1, min(hours, 168))  # clamp to 1h–7d
 
         response = sync_execute(
             """
             SELECT
                 query_id,
-                query,
-                query_start_time,
-                query_duration_ms,
-                exception,
-                toInt8(type) AS status,
-                JSONExtractInt(log_comment, 'team_id') AS team_id,
-                JSONExtractString(log_comment, 'query_type') AS query_type,
-                JSONExtractString(log_comment, 'experiment_name') AS experiment_name,
-                JSONExtractString(log_comment, 'experiment_metric_name') AS experiment_metric_name,
-                JSONExtractString(log_comment, 'experiment_execution_path') AS experiment_execution_path
+                argMax(query, type) AS query,
+                argMax(query_start_time, type) AS query_start_time,
+                argMax(query_duration_ms, type) AS query_duration_ms,
+                argMax(exception, type) AS exception,
+                max(type) AS status,
+                argMax(JSONExtractInt(log_comment, 'team_id'), type) AS team_id,
+                argMax(JSONExtractString(log_comment, 'query_type'), type) AS query_type,
+                argMax(JSONExtractString(log_comment, 'experiment_name'), type) AS experiment_name,
+                argMax(JSONExtractString(log_comment, 'experiment_metric_name'), type) AS experiment_metric_name,
+                argMax(JSONExtractString(log_comment, 'experiment_execution_path'), type) AS experiment_execution_path
             FROM clusterAllReplicas(%(cluster)s, system, query_log)
             WHERE
                 event_time > now() - INTERVAL %(hours)s HOUR
                 AND JSONExtractString(log_comment, 'product') = 'experiments'
-                AND type = 2
                 AND is_initial_query
                 AND query NOT LIKE %(not_query)s
+            GROUP BY query_id
             ORDER BY query_duration_ms DESC
             LIMIT 100
             SETTINGS skip_unavailable_shards=1

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -287,6 +287,65 @@ class DebugCHQueries(viewsets.ViewSet):
 
         return Response(self._serialize_precomputation_team(team, enabled))
 
+    @action(detail=False, methods=["GET"], url_path="slowest_queries")
+    def slowest_queries(self, request):
+        if not request.user.is_staff:
+            raise exceptions.PermissionDenied("Only staff users can view slowest queries.")
+
+        hours = int(request.query_params.get("hours", 1))
+        hours = max(1, min(hours, 168))  # clamp to 1h–7d
+
+        response = sync_execute(
+            """
+            SELECT
+                query_id,
+                query,
+                query_start_time,
+                query_duration_ms,
+                exception,
+                toInt8(type) AS status,
+                JSONExtractInt(log_comment, 'team_id') AS team_id,
+                JSONExtractString(log_comment, 'query_type') AS query_type,
+                JSONExtractString(log_comment, 'experiment_name') AS experiment_name,
+                JSONExtractString(log_comment, 'experiment_metric_name') AS experiment_metric_name,
+                JSONExtractString(log_comment, 'experiment_execution_path') AS experiment_execution_path
+            FROM clusterAllReplicas(%(cluster)s, system, query_log)
+            WHERE
+                event_time > now() - INTERVAL %(hours)s HOUR
+                AND JSONExtractString(log_comment, 'product') = 'experiments'
+                AND type = 2
+                AND is_initial_query
+                AND query NOT LIKE %(not_query)s
+            ORDER BY query_duration_ms DESC
+            LIMIT 100
+            SETTINGS skip_unavailable_shards=1
+            """,
+            {
+                "cluster": CLICKHOUSE_CLUSTER,
+                "hours": hours,
+                "not_query": "%request:_api_debug_ch_queries_%",
+            },
+        )
+
+        return Response(
+            [
+                {
+                    "query_id": row[0],
+                    "query": row[1],
+                    "timestamp": row[2],
+                    "execution_time": row[3],
+                    "exception": row[4],
+                    "status": row[5],
+                    "team_id": row[6],
+                    "query_type": row[7],
+                    "experiment_name": row[8],
+                    "experiment_metric_name": row[9],
+                    "experiment_execution_path": row[10],
+                }
+                for row in response
+            ]
+        )
+
     @action(detail=False, methods=["POST"])
     def profile(self, request):
         if not request.user.is_staff:


### PR DESCRIPTION
## Problem

No visibility into which experiment queries are slowest across all projects.

## Changes

- Add staff-only `GET /api/debug_ch_queries/slowest_queries/` endpoint that returns the 100 slowest experiment queries from `system.query_log`, with configurable time range (`?hours=`)
- Add "Slowest experiment queries" table to the query performance page with time range selector (1h/6h/24h/7d), expandable rows showing full SQL and errors
- Each row shows: timestamp, duration, team ID, experiment name, metric name, execution path, status

## How did you test this code?
Manually tested:

<img width="1290" height="969" alt="image" src="https://github.com/user-attachments/assets/2d4e9bf3-e3e2-4dc5-bd37-477902838173" />