### PR TITLE
fix(dashboards): snapshot relative dates before refreshing tiles

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -102,6 +102,7 @@ import {
     layoutsByTile,
     parseURLFilters,
     parseURLVariables,
+    isTileDateRangeStale,
     runWithLimit,
     snapshotDashboardFilterDates,
 } from './dashboardUtils'
@@ -2068,7 +2069,12 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         forceRefresh ||
                         !isInitialLoadOrUpdate ||
                         !t.insight.cache_target_age ||
-                        dayjs(t.insight.cache_target_age).isBefore(dayjs())
+                        dayjs(t.insight.cache_target_age).isBefore(dayjs()) ||
+                        // Also refresh tiles whose cached data has a shifted date range
+                        // due to relative dates resolving differently since the tile
+                        // was last computed (e.g. tile cached yesterday shows "-7d" as
+                        // starting 8 days ago instead of 7)
+                        isTileDateRangeStale(values.effectiveRefreshFilters, t.insight.last_refresh, values.timezone)
                 )
 
             const tilesStaleCount = sortedTilesToRefresh.length

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -104,7 +104,6 @@ import {
     parseURLVariables,
     isTileDateRangeStale,
     runWithLimit,
-    snapshotDashboardFilterDates,
 } from './dashboardUtils'
 import { TileFiltersOverride } from './TileFiltersOverride'
 import { tileLogic } from './tileLogic'
@@ -2004,8 +2003,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             }
 
             // Cache values before the long-running await — the logic may unmount
-            const { currentTeamId, urlFilters, urlVariables, timezone } = values
-            const effectiveRefreshFilters = snapshotDashboardFilterDates(values.effectiveRefreshFilters, timezone)
+            const { currentTeamId, effectiveRefreshFilters, urlFilters, urlVariables } = values
 
             actions.setRefreshStatus(insight.short_id, true, true)
 
@@ -2103,6 +2101,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 // only cancels on newer invocations, not on unmount).
                 const {
                     currentTeamId,
+                    effectiveRefreshFilters,
                     urlFilters,
                     urlVariables,
                     dashboardLoadData,
@@ -2110,14 +2109,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     lastDashboardRefresh,
                     isAnalyzing,
                     refreshAnalysisCacheKey,
-                    timezone,
                 } = values
-
-                // Snapshot relative dates (e.g. "-7d") to absolute dates once for the
-                // entire refresh batch so every tile resolves the same date boundaries.
-                // Without this, tiles computed concurrently or across a day boundary
-                // could end up with different absolute date ranges.
-                const effectiveRefreshFilters = snapshotDashboardFilterDates(values.effectiveRefreshFilters, timezone)
 
                 const fetchSyncInsightFunctions = sortedTilesToRefresh.map((tile) => async () => {
                     const insight = tile.insight

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -103,6 +103,7 @@ import {
     parseURLFilters,
     parseURLVariables,
     runWithLimit,
+    snapshotDashboardFilterDates,
 } from './dashboardUtils'
 import { TileFiltersOverride } from './TileFiltersOverride'
 import { tileLogic } from './tileLogic'
@@ -163,7 +164,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
     connect(() => ({
         values: [
             teamLogic,
-            ['currentTeamId'],
+            ['currentTeamId', 'timezone'],
             featureFlagLogic,
             ['featureFlags'],
             variableDataLogic,
@@ -2002,7 +2003,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
             }
 
             // Cache values before the long-running await — the logic may unmount
-            const { currentTeamId, effectiveRefreshFilters, urlFilters, urlVariables } = values
+            const { currentTeamId, urlFilters, urlVariables, timezone } = values
+            const effectiveRefreshFilters = snapshotDashboardFilterDates(values.effectiveRefreshFilters, timezone)
 
             actions.setRefreshStatus(insight.short_id, true, true)
 
@@ -2095,7 +2097,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 // only cancels on newer invocations, not on unmount).
                 const {
                     currentTeamId,
-                    effectiveRefreshFilters,
                     urlFilters,
                     urlVariables,
                     dashboardLoadData,
@@ -2103,7 +2104,14 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     lastDashboardRefresh,
                     isAnalyzing,
                     refreshAnalysisCacheKey,
+                    timezone,
                 } = values
+
+                // Snapshot relative dates (e.g. "-7d") to absolute dates once for the
+                // entire refresh batch so every tile resolves the same date boundaries.
+                // Without this, tiles computed concurrently or across a day boundary
+                // could end up with different absolute date ranges.
+                const effectiveRefreshFilters = snapshotDashboardFilterDates(values.effectiveRefreshFilters, timezone)
 
                 const fetchSyncInsightFunctions = sortedTilesToRefresh.map((tile) => async () => {
                     const insight = tile.insight

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -2068,10 +2068,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         !isInitialLoadOrUpdate ||
                         !t.insight.cache_target_age ||
                         dayjs(t.insight.cache_target_age).isBefore(dayjs()) ||
-                        // Also refresh tiles whose cached data has a shifted date range
-                        // due to relative dates resolving differently since the tile
-                        // was last computed (e.g. tile cached yesterday shows "-7d" as
-                        // starting 8 days ago instead of 7)
                         isTileDateRangeStale(values.effectiveRefreshFilters, t.insight.last_refresh, values.timezone)
                 )
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1089,9 +1089,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
             {
                 setDates: (state, { date_from, date_to, explicitDate }) => ({
                     ...state,
-                    date_from,
-                    date_to,
-                    explicitDate,
+                    date_from: date_from ?? undefined,
+                    date_to: date_to ?? undefined,
+                    explicitDate: explicitDate || undefined,
                 }),
                 setProperties: (state, { properties }) => ({
                     ...state,

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1089,9 +1089,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
             {
                 setDates: (state, { date_from, date_to, explicitDate }) => ({
                     ...state,
-                    date_from: date_from ?? undefined,
-                    date_to: date_to ?? undefined,
-                    explicitDate: explicitDate || undefined,
+                    date_from,
+                    date_to,
+                    explicitDate,
                 }),
                 setProperties: (state, { properties }) => ({
                     ...state,

--- a/frontend/src/scenes/dashboard/dashboardUtils.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.test.ts
@@ -3,6 +3,7 @@ import {
     parseURLVariables,
     SEARCH_PARAM_FILTERS_KEY,
     SEARCH_PARAM_QUERY_VARIABLES_KEY,
+    snapshotDashboardFilterDates,
 } from './dashboardUtils'
 
 describe('parseURLVariables', () => {
@@ -56,5 +57,50 @@ describe('parseURLFilters', () => {
         }
         expect(parseURLFilters(searchParams)).toEqual({})
         consoleSpy.mockRestore()
+    })
+})
+
+describe('snapshotDashboardFilterDates', () => {
+    it('resolves relative date_from to absolute YYYY-MM-DD', () => {
+        const result = snapshotDashboardFilterDates({ date_from: '-7d' }, 'UTC')
+        expect(result.date_from).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+        expect(result.date_to).toBeUndefined()
+    })
+
+    it('resolves relative date_to to absolute YYYY-MM-DD', () => {
+        const result = snapshotDashboardFilterDates({ date_from: '-7d', date_to: '-1d' }, 'UTC')
+        expect(result.date_from).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+        expect(result.date_to).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    })
+
+    it('does not modify already-absolute date strings', () => {
+        const filters = { date_from: '2024-01-15', date_to: '2024-01-22' }
+        const result = snapshotDashboardFilterDates(filters, 'UTC')
+        expect(result.date_from).toBe('2024-01-15')
+        expect(result.date_to).toBe('2024-01-22')
+    })
+
+    it('returns filters unchanged when no dates are set', () => {
+        const filters = { properties: [] }
+        const result = snapshotDashboardFilterDates(filters, 'UTC')
+        expect(result).toEqual(filters)
+    })
+
+    it('does not resolve "all" date_from', () => {
+        const filters = { date_from: 'all' }
+        const result = snapshotDashboardFilterDates(filters, 'UTC')
+        expect(result.date_from).toBe('all')
+    })
+
+    it('preserves other filter properties unchanged', () => {
+        const result = snapshotDashboardFilterDates({ date_from: '-7d', date_to: null }, 'UTC')
+        expect(result.date_from).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+        expect(result.date_to).toBeNull()
+    })
+
+    it('produces consistent results when called multiple times at the same moment', () => {
+        const a = snapshotDashboardFilterDates({ date_from: '-7d' }, 'UTC')
+        const b = snapshotDashboardFilterDates({ date_from: '-7d' }, 'UTC')
+        expect(a.date_from).toBe(b.date_from)
     })
 })

--- a/frontend/src/scenes/dashboard/dashboardUtils.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.test.ts
@@ -1,5 +1,4 @@
 import {
-    combineDashboardFilters,
     isTileDateRangeStale,
     parseURLFilters,
     parseURLVariables,
@@ -58,37 +57,6 @@ describe('parseURLFilters', () => {
         }
         expect(parseURLFilters(searchParams)).toEqual({})
         consoleSpy.mockRestore()
-    })
-})
-
-describe('combineDashboardFilters', () => {
-    it('strips null values from the combined result', () => {
-        const result = combineDashboardFilters({ date_from: '-7d' }, { date_to: null })
-        expect(result).toEqual({ date_from: '-7d' })
-        expect('date_to' in result).toBe(false)
-    })
-
-    it('strips explicitDate: false (default value)', () => {
-        const result = combineDashboardFilters({ date_from: '-7d', explicitDate: false })
-        expect(result).toEqual({ date_from: '-7d' })
-        expect('explicitDate' in result).toBe(false)
-    })
-
-    it('preserves explicitDate: true', () => {
-        const result = combineDashboardFilters({ date_from: '-7d', explicitDate: true })
-        expect(result).toEqual({ date_from: '-7d', explicitDate: true })
-    })
-
-    it('produces identical output regardless of null/undefined in input', () => {
-        const a = combineDashboardFilters({ date_from: '-7d' })
-        const b = combineDashboardFilters({ date_from: '-7d', date_to: null, explicitDate: false })
-        expect(a).toEqual(b)
-        expect(JSON.stringify(a)).toBe(JSON.stringify(b))
-    })
-
-    it('later filters override earlier ones', () => {
-        const result = combineDashboardFilters({ date_from: '-7d' }, { date_from: 'dStart' })
-        expect(result).toEqual({ date_from: 'dStart' })
     })
 })
 

--- a/frontend/src/scenes/dashboard/dashboardUtils.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.test.ts
@@ -1,4 +1,5 @@
 import {
+    isTileDateRangeStale,
     parseURLFilters,
     parseURLVariables,
     SEARCH_PARAM_FILTERS_KEY,
@@ -102,5 +103,41 @@ describe('snapshotDashboardFilterDates', () => {
         const a = snapshotDashboardFilterDates({ date_from: '-7d' }, 'UTC')
         const b = snapshotDashboardFilterDates({ date_from: '-7d' }, 'UTC')
         expect(a.date_from).toBe(b.date_from)
+    })
+})
+
+describe('isTileDateRangeStale', () => {
+    it('returns true when last_refresh is from a different calendar day', () => {
+        const yesterday = new Date(Date.now() - 86400000).toISOString()
+        expect(isTileDateRangeStale({ date_from: '-7d' }, yesterday, 'UTC')).toBe(true)
+    })
+
+    it('returns false when last_refresh is from today', () => {
+        const justNow = new Date().toISOString()
+        expect(isTileDateRangeStale({ date_from: '-7d' }, justNow, 'UTC')).toBe(false)
+    })
+
+    it('returns false for absolute date filters', () => {
+        const yesterday = new Date(Date.now() - 86400000).toISOString()
+        expect(isTileDateRangeStale({ date_from: '2024-01-15' }, yesterday, 'UTC')).toBe(false)
+    })
+
+    it('returns false for "all" date_from', () => {
+        const yesterday = new Date(Date.now() - 86400000).toISOString()
+        expect(isTileDateRangeStale({ date_from: 'all' }, yesterday, 'UTC')).toBe(false)
+    })
+
+    it('returns true when last_refresh is null', () => {
+        expect(isTileDateRangeStale({ date_from: '-7d' }, null, 'UTC')).toBe(true)
+    })
+
+    it('returns false when no date_from in filters', () => {
+        const yesterday = new Date(Date.now() - 86400000).toISOString()
+        expect(isTileDateRangeStale({}, yesterday, 'UTC')).toBe(false)
+    })
+
+    it('returns true when last_refresh is from two days ago', () => {
+        const twoDaysAgo = new Date(Date.now() - 2 * 86400000).toISOString()
+        expect(isTileDateRangeStale({ date_from: '-7d' }, twoDaysAgo, 'UTC')).toBe(true)
     })
 })

--- a/frontend/src/scenes/dashboard/dashboardUtils.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.test.ts
@@ -1,10 +1,10 @@
 import {
+    combineDashboardFilters,
     isTileDateRangeStale,
     parseURLFilters,
     parseURLVariables,
     SEARCH_PARAM_FILTERS_KEY,
     SEARCH_PARAM_QUERY_VARIABLES_KEY,
-    snapshotDashboardFilterDates,
 } from './dashboardUtils'
 
 describe('parseURLVariables', () => {
@@ -61,48 +61,34 @@ describe('parseURLFilters', () => {
     })
 })
 
-describe('snapshotDashboardFilterDates', () => {
-    it('resolves relative date_from to absolute YYYY-MM-DD', () => {
-        const result = snapshotDashboardFilterDates({ date_from: '-7d' }, 'UTC')
-        expect(result.date_from).toMatch(/^\d{4}-\d{2}-\d{2}$/)
-        expect(result.date_to).toBeUndefined()
+describe('combineDashboardFilters', () => {
+    it('strips null values from the combined result', () => {
+        const result = combineDashboardFilters({ date_from: '-7d' }, { date_to: null })
+        expect(result).toEqual({ date_from: '-7d' })
+        expect('date_to' in result).toBe(false)
     })
 
-    it('resolves relative date_to to absolute YYYY-MM-DD', () => {
-        const result = snapshotDashboardFilterDates({ date_from: '-7d', date_to: '-1d' }, 'UTC')
-        expect(result.date_from).toMatch(/^\d{4}-\d{2}-\d{2}$/)
-        expect(result.date_to).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    it('strips explicitDate: false (default value)', () => {
+        const result = combineDashboardFilters({ date_from: '-7d', explicitDate: false })
+        expect(result).toEqual({ date_from: '-7d' })
+        expect('explicitDate' in result).toBe(false)
     })
 
-    it('does not modify already-absolute date strings', () => {
-        const filters = { date_from: '2024-01-15', date_to: '2024-01-22' }
-        const result = snapshotDashboardFilterDates(filters, 'UTC')
-        expect(result.date_from).toBe('2024-01-15')
-        expect(result.date_to).toBe('2024-01-22')
+    it('preserves explicitDate: true', () => {
+        const result = combineDashboardFilters({ date_from: '-7d', explicitDate: true })
+        expect(result).toEqual({ date_from: '-7d', explicitDate: true })
     })
 
-    it('returns filters unchanged when no dates are set', () => {
-        const filters = { properties: [] }
-        const result = snapshotDashboardFilterDates(filters, 'UTC')
-        expect(result).toEqual(filters)
+    it('produces identical output regardless of null/undefined in input', () => {
+        const a = combineDashboardFilters({ date_from: '-7d' })
+        const b = combineDashboardFilters({ date_from: '-7d', date_to: null, explicitDate: false })
+        expect(a).toEqual(b)
+        expect(JSON.stringify(a)).toBe(JSON.stringify(b))
     })
 
-    it('does not resolve "all" date_from', () => {
-        const filters = { date_from: 'all' }
-        const result = snapshotDashboardFilterDates(filters, 'UTC')
-        expect(result.date_from).toBe('all')
-    })
-
-    it('preserves other filter properties unchanged', () => {
-        const result = snapshotDashboardFilterDates({ date_from: '-7d', date_to: null }, 'UTC')
-        expect(result.date_from).toMatch(/^\d{4}-\d{2}-\d{2}$/)
-        expect(result.date_to).toBeNull()
-    })
-
-    it('produces consistent results when called multiple times at the same moment', () => {
-        const a = snapshotDashboardFilterDates({ date_from: '-7d' }, 'UTC')
-        const b = snapshotDashboardFilterDates({ date_from: '-7d' }, 'UTC')
-        expect(a.date_from).toBe(b.date_from)
+    it('later filters override earlier ones', () => {
+        const result = combineDashboardFilters({ date_from: '-7d' }, { date_from: 'dStart' })
+        expect(result).toEqual({ date_from: 'dStart' })
     })
 })
 

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -366,57 +366,32 @@ export const encodeURLFilters = (filters: DashboardFilter): Record<string, strin
 }
 
 export function combineDashboardFilters(...filters: DashboardFilter[]): DashboardFilter {
-    return filters.reduce((combined, filter) => {
+    const combined = filters.reduce((acc, filter) => {
         Object.keys(filter).forEach((key) => {
             const value = (filter as Record<string, any>)[key]
             if (value !== undefined) {
-                ;(combined as Record<string, any>)[key] = value
+                ;(acc as Record<string, any>)[key] = value
             }
         })
-        return combined
+        return acc
     }, {} as DashboardFilter)
-}
 
-/**
- * Resolve relative date strings (e.g. "-7d", "dStart") in dashboard filters to absolute
- * ISO date strings using a single "now" reference point. This ensures all dashboard tiles
- * in the same refresh batch use identical date boundaries, preventing visual
- * inconsistencies when tiles resolve relative dates independently at slightly different
- * times (e.g. across a midnight boundary).
- *
- * Only `date_from` and `date_to` are resolved — `date_to` being null/undefined means
- * "now" and is left for the backend to handle (it rounds to end-of-day for daily+
- * intervals anyway).
- */
-export function snapshotDashboardFilterDates(filters: DashboardFilter, timezone: string): DashboardFilter {
-    if (!filters.date_from && !filters.date_to) {
-        return filters
-    }
-
-    // "all" is a special value meaning "all time" — don't resolve it
-    if (filters.date_from === 'all') {
-        return filters
-    }
-
-    const snapshotted = { ...filters }
-
-    if (filters.date_from && !isDate.test(filters.date_from)) {
-        const resolved = dateStringToDayJs(filters.date_from, timezone)
-        if (resolved) {
-            // Format as YYYY-MM-DD so the backend still applies its own truncation logic
-            // (relative_date_parse treats YYYY-MM-DD as absolute but preserves the time component)
-            snapshotted.date_from = resolved.format('YYYY-MM-DD')
+    // Strip null values and default-false explicitDate so the serialized
+    // output is stable across code paths. Without this, switching date filters
+    // can produce {date_from: "-7d", date_to: null, explicitDate: false}
+    // instead of just {date_from: "-7d"}, leading to different JSON payloads
+    // sent to the backend and potentially different cache key lookups.
+    const cleaned: Record<string, any> = {}
+    for (const [key, value] of Object.entries(combined)) {
+        if (value === null || value === undefined) {
+            continue
         }
-    }
-
-    if (filters.date_to && !isDate.test(filters.date_to)) {
-        const resolved = dateStringToDayJs(filters.date_to, timezone)
-        if (resolved) {
-            snapshotted.date_to = resolved.format('YYYY-MM-DD')
+        if (key === 'explicitDate' && value === false) {
+            continue
         }
+        cleaned[key] = value
     }
-
-    return snapshotted
+    return cleaned as DashboardFilter
 }
 
 /**

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -3,6 +3,7 @@ import { ResponsiveLayouts } from 'react-grid-layout'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api, { ApiMethodOptions, getJSONOrNull } from 'lib/api'
+import { dayjs } from 'lib/dayjs'
 import { currentSessionId } from 'lib/internalMetrics'
 import { dateStringToDayJs, isDate, objectClean, shouldCancelQuery, toParams } from 'lib/utils'
 import { accessLevelSatisfied } from 'lib/utils/accessControlUtils'
@@ -416,4 +417,50 @@ export function snapshotDashboardFilterDates(filters: DashboardFilter, timezone:
     }
 
     return snapshotted
+}
+
+/**
+ * Check whether a cached tile's data is date-stale — i.e. its `last_refresh` is old enough
+ * that relative date filters (e.g. "-7d") would now resolve to a different calendar day.
+ *
+ * The normal cache staleness check (`cache_target_age`) only considers how old the cache is
+ * relative to the query interval (e.g. 6 hours for daily). But for dashboards with relative
+ * date filters, a cache from 6 hours ago can still show data starting from a different day
+ * than "now" would produce — causing tiles to briefly display mismatched date ranges.
+ *
+ * Returns true if the tile should be refreshed because the date range has shifted.
+ */
+export function isTileDateRangeStale(
+    filters: DashboardFilter,
+    tileLastRefresh: string | null | undefined,
+    timezone: string
+): boolean {
+    // Only relevant when date_from is a relative date string
+    if (!filters.date_from || isDate.test(filters.date_from) || filters.date_from === 'all') {
+        return false
+    }
+
+    if (!tileLastRefresh) {
+        return true // No last_refresh means the tile has never been computed
+    }
+
+    // Resolve what date_from meant at the time the tile was last refreshed vs now.
+    // If they land on different calendar days, the tile's data is showing a shifted range.
+    const now = dayjs().tz(timezone)
+    const lastRefreshTime = dayjs(tileLastRefresh).tz(timezone)
+
+    const currentDateFrom = dateStringToDayJs(filters.date_from, timezone)
+    if (!currentDateFrom) {
+        return false
+    }
+
+    // Re-resolve the same relative date string but using the tile's last_refresh time as "now".
+    // dateStringToDayJs uses dayjs().tz(timezone).startOf('day') as the offset,
+    // so we compare by checking if the last_refresh day differs from today's day — which would
+    // cause the resolved date_from to shift.
+    const lastRefreshDay = lastRefreshTime.startOf('day')
+    const currentDay = now.startOf('day')
+
+    // If last_refresh is from a different calendar day, relative dates will resolve differently
+    return !lastRefreshDay.isSame(currentDay, 'day')
 }

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -366,30 +366,15 @@ export const encodeURLFilters = (filters: DashboardFilter): Record<string, strin
 }
 
 export function combineDashboardFilters(...filters: DashboardFilter[]): DashboardFilter {
-    const combined = filters.reduce((acc, filter) => {
+    return filters.reduce((combined, filter) => {
         Object.keys(filter).forEach((key) => {
             const value = (filter as Record<string, any>)[key]
             if (value !== undefined) {
-                ;(acc as Record<string, any>)[key] = value
+                ;(combined as Record<string, any>)[key] = value
             }
         })
-        return acc
+        return combined
     }, {} as DashboardFilter)
-
-    // Strip nulls and default-false explicitDate so the serialized output matches
-    // the persisted shape — otherwise the same logical filter produces different
-    // filters_override JSON depending on code path, and can miss the cache entry.
-    const cleaned: Record<string, any> = {}
-    for (const [key, value] of Object.entries(combined)) {
-        if (value === null || value === undefined) {
-            continue
-        }
-        if (key === 'explicitDate' && value === false) {
-            continue
-        }
-        cleaned[key] = value
-    }
-    return cleaned as DashboardFilter
 }
 
 // Relative date filters (e.g. "-7d") resolve against "now", so a tile cached yesterday

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -4,7 +4,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api, { ApiMethodOptions, getJSONOrNull } from 'lib/api'
 import { currentSessionId } from 'lib/internalMetrics'
-import { objectClean, shouldCancelQuery, toParams } from 'lib/utils'
+import { dateStringToDayJs, isDate, objectClean, shouldCancelQuery, toParams } from 'lib/utils'
 import { accessLevelSatisfied } from 'lib/utils/accessControlUtils'
 
 import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
@@ -374,4 +374,46 @@ export function combineDashboardFilters(...filters: DashboardFilter[]): Dashboar
         })
         return combined
     }, {} as DashboardFilter)
+}
+
+/**
+ * Resolve relative date strings (e.g. "-7d", "dStart") in dashboard filters to absolute
+ * ISO date strings using a single "now" reference point. This ensures all dashboard tiles
+ * in the same refresh batch use identical date boundaries, preventing visual
+ * inconsistencies when tiles resolve relative dates independently at slightly different
+ * times (e.g. across a midnight boundary).
+ *
+ * Only `date_from` and `date_to` are resolved — `date_to` being null/undefined means
+ * "now" and is left for the backend to handle (it rounds to end-of-day for daily+
+ * intervals anyway).
+ */
+export function snapshotDashboardFilterDates(filters: DashboardFilter, timezone: string): DashboardFilter {
+    if (!filters.date_from && !filters.date_to) {
+        return filters
+    }
+
+    // "all" is a special value meaning "all time" — don't resolve it
+    if (filters.date_from === 'all') {
+        return filters
+    }
+
+    const snapshotted = { ...filters }
+
+    if (filters.date_from && !isDate.test(filters.date_from)) {
+        const resolved = dateStringToDayJs(filters.date_from, timezone)
+        if (resolved) {
+            // Format as YYYY-MM-DD so the backend still applies its own truncation logic
+            // (relative_date_parse treats YYYY-MM-DD as absolute but preserves the time component)
+            snapshotted.date_from = resolved.format('YYYY-MM-DD')
+        }
+    }
+
+    if (filters.date_to && !isDate.test(filters.date_to)) {
+        const resolved = dateStringToDayJs(filters.date_to, timezone)
+        if (resolved) {
+            snapshotted.date_to = resolved.format('YYYY-MM-DD')
+        }
+    }
+
+    return snapshotted
 }

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -5,7 +5,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 import api, { ApiMethodOptions, getJSONOrNull } from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 import { currentSessionId } from 'lib/internalMetrics'
-import { dateStringToDayJs, isDate, objectClean, shouldCancelQuery, toParams } from 'lib/utils'
+import { isDate, objectClean, shouldCancelQuery, toParams } from 'lib/utils'
 import { accessLevelSatisfied } from 'lib/utils/accessControlUtils'
 
 import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
@@ -376,11 +376,9 @@ export function combineDashboardFilters(...filters: DashboardFilter[]): Dashboar
         return acc
     }, {} as DashboardFilter)
 
-    // Strip null values and default-false explicitDate so the serialized
-    // output is stable across code paths. Without this, switching date filters
-    // can produce {date_from: "-7d", date_to: null, explicitDate: false}
-    // instead of just {date_from: "-7d"}, leading to different JSON payloads
-    // sent to the backend and potentially different cache key lookups.
+    // Strip nulls and default-false explicitDate so the serialized output matches
+    // the persisted shape — otherwise the same logical filter produces different
+    // filters_override JSON depending on code path, and can miss the cache entry.
     const cleaned: Record<string, any> = {}
     for (const [key, value] of Object.entries(combined)) {
         if (value === null || value === undefined) {
@@ -394,48 +392,21 @@ export function combineDashboardFilters(...filters: DashboardFilter[]): Dashboar
     return cleaned as DashboardFilter
 }
 
-/**
- * Check whether a cached tile's data is date-stale — i.e. its `last_refresh` is old enough
- * that relative date filters (e.g. "-7d") would now resolve to a different calendar day.
- *
- * The normal cache staleness check (`cache_target_age`) only considers how old the cache is
- * relative to the query interval (e.g. 6 hours for daily). But for dashboards with relative
- * date filters, a cache from 6 hours ago can still show data starting from a different day
- * than "now" would produce — causing tiles to briefly display mismatched date ranges.
- *
- * Returns true if the tile should be refreshed because the date range has shifted.
- */
+// Relative date filters (e.g. "-7d") resolve against "now", so a tile cached yesterday
+// holds data for a date range that has since shifted. cache_target_age doesn't catch
+// this — a 6h-old cache is still "fresh" even if those 6h crossed midnight.
 export function isTileDateRangeStale(
     filters: DashboardFilter,
     tileLastRefresh: string | null | undefined,
     timezone: string
 ): boolean {
-    // Only relevant when date_from is a relative date string
     if (!filters.date_from || isDate.test(filters.date_from) || filters.date_from === 'all') {
         return false
     }
-
     if (!tileLastRefresh) {
-        return true // No last_refresh means the tile has never been computed
+        return true
     }
-
-    // Resolve what date_from meant at the time the tile was last refreshed vs now.
-    // If they land on different calendar days, the tile's data is showing a shifted range.
-    const now = dayjs().tz(timezone)
-    const lastRefreshTime = dayjs(tileLastRefresh).tz(timezone)
-
-    const currentDateFrom = dateStringToDayJs(filters.date_from, timezone)
-    if (!currentDateFrom) {
-        return false
-    }
-
-    // Re-resolve the same relative date string but using the tile's last_refresh time as "now".
-    // dateStringToDayJs uses dayjs().tz(timezone).startOf('day') as the offset,
-    // so we compare by checking if the last_refresh day differs from today's day — which would
-    // cause the resolved date_from to shift.
-    const lastRefreshDay = lastRefreshTime.startOf('day')
-    const currentDay = now.startOf('day')
-
-    // If last_refresh is from a different calendar day, relative dates will resolve differently
-    return !lastRefreshDay.isSame(currentDay, 'day')
+    const today = dayjs().tz(timezone).startOf('day')
+    const lastRefreshDay = dayjs(tileLastRefresh).tz(timezone).startOf('day')
+    return !lastRefreshDay.isSame(today, 'day')
 }


### PR DESCRIPTION
## Problem

Dashboard tiles show stale/old data after switching date filters and coming back. Repro:

1. Be on "Last 7 days", bulk refresh, wait for completion
2. Switch to "Today", wait for data
3. Switch back to "Last 7 days"
4. Some tiles show old (pre-bulk-refresh) data

Behavior is inconsistent — browser refresh sometimes shows fresh data, sometimes stale. Individual tile refresh sometimes sticks, sometimes reverts.

**Root cause: cache key instability across code paths.**

When switching date filters, `combineDashboardFilters` produces filter objects with extra null/false values that weren't present during the bulk refresh. For example:

- Bulk refresh sends: `{date_from: "-7d"}`
- After Today→Last 7 days switch sends: `{date_from: "-7d", date_to: null, explicitDate: false}`

These serialize to different `filters_override` JSON in the API request. On the backend, this can produce subtly different `DashboardFilter` objects, which flow into the query and may generate a different cache key — causing the backend to return an older cache entry instead of the fresh bulk-refreshed one.

Additionally, tiles cached overnight can pass the `cache_target_age` freshness check (6h threshold for daily intervals) but have shifted date ranges because `-7d` resolves to a different day.

## Changes

**Fix 1 — Stabilize combined filter output** (`combineDashboardFilters`):
- Strip null values and default-false `explicitDate` from the combined result
- Ensures the `filters_override` JSON is identical regardless of whether the user navigated directly or switched between date presets
- Tests verify `{date_from: "-7d"}` and `{date_from: "-7d", date_to: null, explicitDate: false}` produce identical output

**Fix 2 — Force refresh date-stale tiles** (`isTileDateRangeStale`):
- Checks if a cached tile's `last_refresh` is from a different calendar day than today
- Added to the staleness filter so tiles with shifted date ranges are refreshed even when `cache_target_age` hasn't expired
- Prevents tiles cached overnight from briefly showing data starting from the wrong day

**Other:**
- Connected `timezone` from `teamLogic` to `dashboardLogic` for timezone-aware staleness checks
- Added tests for both `combineDashboardFilters` cleanup and `isTileDateRangeStale`

## How did you test this code?

This PR was authored by an agent. Unit tests verify filter stabilization and date-stale detection. Manual testing was not performed.

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code agent. An earlier approach (snapshotting relative dates to absolute) was reverted because it made the cache key problem worse by converting `-7d` to `2024-04-07`, which never matched the bulk refresh's cache entry. The final fix addresses the root cause: ensuring filter serialization is stable across code paths.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*