### PR TITLE
feat(tracing): fetch all spans on modal open

### DIFF
--- a/products/tracing/backend/presentation/views.py
+++ b/products/tracing/backend/presentation/views.py
@@ -151,6 +151,7 @@ class SpansViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
             dateRange=date_range,
             traceId=trace_id,
             limit=1000,
+            prefetchSpans=2000,
             rootSpans=False,
         )
 

--- a/products/tracing/frontend/TracingScene.tsx
+++ b/products/tracing/frontend/TracingScene.tsx
@@ -2,6 +2,7 @@ import { useActions, useValues } from 'kea'
 
 import { LemonModal, LemonTable, LemonTableColumns, LemonTag } from '@posthog/lemon-ui'
 
+import { SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
 import { SceneExport } from 'scenes/sceneTypes'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
@@ -82,13 +83,14 @@ const columns: LemonTableColumns<Span> = [
 export default function TracingScene(): JSX.Element {
     const {
         rootSpans,
-        spans,
         spansLoading,
         isTraceModalOpen,
         selectedTraceId,
         sparklineData,
         sparklineLoading,
         totalSpansMatchingFilters,
+        modalSpans,
+        isLoadingFullTrace,
     } = useValues(tracingSceneLogic)
     const { openTraceModal, closeTraceModal, setDateRange } = useActions(tracingSceneLogic)
 
@@ -132,7 +134,8 @@ export default function TracingScene(): JSX.Element {
                 width="90vw"
             >
                 <div className="relative min-h-32">
-                    <TraceFlameChart spans={spans.filter((s) => s.trace_id === selectedTraceId)} />
+                    {isLoadingFullTrace && <SpinnerOverlay />}
+                    <TraceFlameChart spans={modalSpans} />
                 </div>
             </LemonModal>
         </SceneContent>

--- a/products/tracing/frontend/tracingDataLogic.ts
+++ b/products/tracing/frontend/tracingDataLogic.ts
@@ -45,7 +45,6 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
         runQuery: true,
         fetchNextPage: true,
         clearSpans: true,
-        clearTraceSpans: true,
         cancelInProgressSpans: (controller: AbortController | null) => ({ controller }),
         cancelInProgressSparkline: (controller: AbortController | null) => ({ controller }),
         setSpansAbortController: (controller: AbortController | null) => ({ controller }),
@@ -155,7 +154,6 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
         traceSpans: [
             [] as Span[],
             {
-                clearTraceSpans: () => [],
                 loadTraceSpans: async (traceId: string): Promise<Span[]> => {
                     const response = await api.tracing.getTrace(traceId, {
                         date_from: values.utcDateRange.date_from ?? '-24h',

--- a/products/tracing/frontend/tracingDataLogic.ts
+++ b/products/tracing/frontend/tracingDataLogic.ts
@@ -26,6 +26,7 @@ export interface TracingSparklineData {
 }
 
 const DEFAULT_PAGE_SIZE = 100
+export const PREFETCH_SPANS = 20
 const NEW_QUERY_STARTED_ERROR_MESSAGE = 'new query started' as const
 
 function isUserInitiatedError(error: unknown): boolean {
@@ -44,6 +45,7 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
         runQuery: true,
         fetchNextPage: true,
         clearSpans: true,
+        clearTraceSpans: true,
         cancelInProgressSpans: (controller: AbortController | null) => ({ controller }),
         cancelInProgressSparkline: (controller: AbortController | null) => ({ controller }),
         setSpansAbortController: (controller: AbortController | null) => ({ controller }),
@@ -117,7 +119,7 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
                         orderBy: values.filters.orderBy,
                         serviceNames: values.filters.serviceNames.length > 0 ? values.filters.serviceNames : undefined,
                         filterGroup: values.filters.filterGroup as PropertyGroupFilter,
-                        prefetchSpans: 20,
+                        prefetchSpans: PREFETCH_SPANS,
                         limit: DEFAULT_PAGE_SIZE,
                     })
 
@@ -153,8 +155,12 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
         traceSpans: [
             [] as Span[],
             {
+                clearTraceSpans: () => [],
                 loadTraceSpans: async (traceId: string): Promise<Span[]> => {
-                    const response = await api.tracing.getTrace(traceId, { date_from: '-24h' })
+                    const response = await api.tracing.getTrace(traceId, {
+                        date_from: values.utcDateRange.date_from ?? '-24h',
+                        date_to: values.utcDateRange.date_to ?? undefined,
+                    })
                     return response.results as Span[]
                 },
             },

--- a/products/tracing/frontend/tracingSceneLogic.ts
+++ b/products/tracing/frontend/tracingSceneLogic.ts
@@ -34,7 +34,7 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
         ],
         actions: [
             tracingDataLogic,
-            ['runQuery', 'fetchNextPage', 'loadTraceSpans', 'clearTraceSpans'],
+            ['runQuery', 'fetchNextPage', 'loadTraceSpans'],
             tracingFiltersLogic,
             ['setDateRange', 'setServiceNames', 'setFilterGroup', 'setOrderBy', 'setFilters'],
         ],
@@ -83,9 +83,6 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
             if (prefetchedSpans.length >= PREFETCH_SPANS) {
                 actions.loadTraceSpans(traceId)
             }
-        },
-        closeTraceModal: () => {
-            actions.clearTraceSpans()
         },
         setDateRange: () => {
             actions.syncUrlAndRunQuery()

--- a/products/tracing/frontend/tracingSceneLogic.ts
+++ b/products/tracing/frontend/tracingSceneLogic.ts
@@ -67,8 +67,9 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
                 if (!selectedTraceId) {
                     return []
                 }
-                if (traceSpans.length > 0) {
-                    return traceSpans
+                const filteredTraceSpans = traceSpans.filter((s) => s.trace_id === selectedTraceId)
+                if (filteredTraceSpans.length > 0) {
+                    return filteredTraceSpans
                 }
                 return spans.filter((s) => s.trace_id === selectedTraceId)
             },

--- a/products/tracing/frontend/tracingSceneLogic.ts
+++ b/products/tracing/frontend/tracingSceneLogic.ts
@@ -6,9 +6,10 @@ import { DEFAULT_UNIVERSAL_GROUP_FILTER } from 'lib/components/UniversalFilters/
 import { parseTagsFilter } from 'lib/utils'
 import { Params } from 'scenes/sceneTypes'
 
-import { tracingDataLogic } from './tracingDataLogic'
+import { PREFETCH_SPANS, tracingDataLogic } from './tracingDataLogic'
 import { DEFAULT_DATE_RANGE, DEFAULT_ORDER_BY, DEFAULT_SERVICE_NAMES, tracingFiltersLogic } from './tracingFiltersLogic'
 import type { tracingSceneLogicType } from './tracingSceneLogicType'
+import type { Span } from './types'
 
 export const tracingSceneLogic = kea<tracingSceneLogicType>([
     path(['products', 'tracing', 'frontend', 'tracingSceneLogic']),
@@ -25,6 +26,7 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
                 'hasMoreToLoad',
                 'hasRunQuery',
                 'totalSpansMatchingFilters',
+                'traceSpans',
                 'traceSpansLoading',
             ],
             tracingFiltersLogic,
@@ -32,7 +34,7 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
         ],
         actions: [
             tracingDataLogic,
-            ['runQuery', 'fetchNextPage', 'loadTraceSpans'],
+            ['runQuery', 'fetchNextPage', 'loadTraceSpans', 'clearTraceSpans'],
             tracingFiltersLogic,
             ['setDateRange', 'setServiceNames', 'setFilterGroup', 'setOrderBy', 'setFilters'],
         ],
@@ -59,11 +61,30 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
             (s) => [s.selectedTraceId],
             (selectedTraceId: string | null): boolean => selectedTraceId !== null,
         ],
+        modalSpans: [
+            (s) => [s.selectedTraceId, s.spans, s.traceSpans],
+            (selectedTraceId: string | null, spans: Span[], traceSpans: Span[]): Span[] => {
+                if (!selectedTraceId) {
+                    return []
+                }
+                if (traceSpans.length > 0) {
+                    return traceSpans
+                }
+                return spans.filter((s) => s.trace_id === selectedTraceId)
+            },
+        ],
+        isLoadingFullTrace: [(s) => [s.traceSpansLoading], (traceSpansLoading: boolean): boolean => traceSpansLoading],
     }),
 
-    listeners(({ actions }) => ({
+    listeners(({ actions, values }) => ({
         openTraceModal: ({ traceId }) => {
-            actions.loadTraceSpans(traceId)
+            const prefetchedSpans = values.spans.filter((s: Span) => s.trace_id === traceId)
+            if (prefetchedSpans.length >= PREFETCH_SPANS) {
+                actions.loadTraceSpans(traceId)
+            }
+        },
+        closeTraceModal: () => {
+            actions.clearTraceSpans()
         },
         setDateRange: () => {
             actions.syncUrlAndRunQuery()


### PR DESCRIPTION
## Problem

we currently prefetch and only show 20 spans per trace

if we have 20 spans we need to try to fetch them all
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
