### PR TITLE
chore(experiments): remove [New] tag from user feedback tab

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconSparkles } from '@posthog/icons'
-import { LemonBanner, LemonTabs, LemonTag } from '@posthog/lemon-ui'
+import { LemonBanner, LemonTabs } from '@posthog/lemon-ui'
 
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { DebugCHQueries } from 'lib/components/AppShortcuts/utils/DebugCHQueries'
@@ -361,14 +361,7 @@ export function ExperimentView({ tabId }: Pick<ExperimentSceneLogicProps, 'tabId
                                 ? [
                                       {
                                           key: 'feedback',
-                                          label: (
-                                              <div className="flex flex-row">
-                                                  <div>User feedback</div>
-                                                  <LemonTag className="ml-2 float-right uppercase" type="primary">
-                                                      New
-                                                  </LemonTag>
-                                              </div>
-                                          ),
+                                          label: 'User feedback',
                                           content: <ExperimentFeedbackTab experiment={experiment} />,
                                       },
                                   ]


### PR DESCRIPTION
## Problem

The user feedback tab in experiments still shows a [New] tag, but the feature is no longer new.

## Changes

Removed the [New] `LemonTag` from the user feedback tab label and cleaned up the unused import.

## How did you test this code?

Visual change only — removed a tag component.

## 🤖 LLM context

Agent-authored PR.