### PR TITLE
feat(api): Fix missing /github_login & /signal_processing scope

### DIFF
--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -488,6 +488,8 @@ class UserViewSet(
     scope_object = "user"
     # None = derive scopes from scope_object per HTTP method; individual actions can override via @action(required_scopes=...)
     required_scopes: list[str] | None = None
+    # Custom @action GETs that should map to user:read for OAuth / personal API keys
+    scope_object_read_actions = ["list", "retrieve", "github_login"]
     throttle_classes = [UserAuthenticationThrottle]
     serializer_class = UserSerializer
     authentication_classes = [

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -702,7 +702,17 @@ class PauseStateResponseSerializer(serializers.Serializer):
 class SignalProcessingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     """View and control signal processing pipeline state for a team."""
 
-    scope_object = "INTERNAL"
+    # Same scope family as other signals team APIs (SignalSourceConfigViewSet, etc.)
+    scope_object = "task"
+    scope_object_write_actions = [
+        "create",
+        "update",
+        "partial_update",
+        "patch",
+        "destroy",
+        "pause",
+        "unpause",
+    ]
 
     @extend_schema(request=None, responses={200: PauseStateResponseSerializer})
     def list(self, request: Request, *args, **kwargs) -> Response:


### PR DESCRIPTION
## Problem

OAuth access tokens and personal API keys were rejected on `GET /api/users/.../github_login/` and the signals `signal_processing` endpoints. `APIScopePermission` had no required scopes for the `github_login` custom action, and `SignalProcessingViewSet` used `scope_object = "INTERNAL"`, which never allows keyed access.

## Changes

Added `github_login` to `scope_object_read_actions` on `UserViewSet` so the action requires `user:read`.
Set `SignalProcessingViewSet` to `scope_object = "task"` (aligned with other signals project APIs) and listed `pause` / `unpause` under `scope_object_write_actions` so retrieval uses `task:read` and pause/unpause use `task:write`.

Think we should move over all the inbox&signals endpoints to new distinct `inbox:read`/`inbox:write` scopes, but that's for another PR.

## How did you test this code?

Ran `hogli test posthog/test/test_permissions.py`.

## Publish to changelog?

do not publish to changelog

## Docs update

N/A