### PR TITLE
chore(batch-exports): reduce run failure threshold from 10 to 3

### DIFF
--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -496,7 +496,7 @@ class FinishBatchExportRunInputs:
     latest_error: str | None = None
     records_completed: int | None = None
     records_total_count: int | None = None
-    failure_threshold: int = 10
+    failure_threshold: int = 3
     failure_check_window: int = 50
     bytes_exported: int | None = None
     records_failed: int | None = None

--- a/products/batch_exports/backend/tests/temporal/test_run_updates.py
+++ b/products/batch_exports/backend/tests/temporal/test_run_updates.py
@@ -240,7 +240,7 @@ async def test_finish_batch_export_run_pauses_if_reaching_failure_threshold(acti
     )
 
     batch_export_id = str(batch_export.id)
-    failure_threshold = 10
+    failure_threshold = 3
 
     for run_number in range(1, failure_threshold * 2):
         run_id = await activity_environment.run(start_batch_export_run, inputs)


### PR DESCRIPTION
## Problem

At the moment, we pause a batch export and cancel any running backfills after 10 failed runs. This is a bit too high, since we aim to only fail batch exports if there is a client error (we retry on all internal or transient errors as much as possible).

## Changes

Reduce the run failure threshold from 10 to 3.

## How did you test this code?

Risk should be minimal, so will rely on existing automated tests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No

## Docs update

Not sure if we actually reference the value of our failure threshold in our docs.
