### PR TITLE
chore: Use Warpstream producer in CDP services

### DIFF
--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -88,6 +88,8 @@ export interface CdpCoreServicesDeps {
     teamManager: TeamManager
     integrationManager: IntegrationManagerService
     kafkaProducer: KafkaProducerWrapper
+    /** Producer targeting the ingestion WarpStream cluster for monitoring outputs (app metrics, log entries). */
+    monitoringKafkaProducer: KafkaProducerWrapper
     internalCaptureService: InternalCaptureService
 }
 
@@ -177,13 +179,13 @@ export function createCdpCoreServices(
             [APP_METRICS_OUTPUT]: new SingleIngestionOutput(
                 APP_METRICS_OUTPUT,
                 config.HOG_FUNCTION_MONITORING_APP_METRICS_TOPIC,
-                deps.kafkaProducer,
+                deps.monitoringKafkaProducer,
                 'default'
             ),
             [LOG_ENTRIES_OUTPUT]: new SingleIngestionOutput(
                 LOG_ENTRIES_OUTPUT,
                 config.HOG_FUNCTION_MONITORING_LOG_ENTRIES_TOPIC,
-                deps.kafkaProducer,
+                deps.monitoringKafkaProducer,
                 'default'
             ),
         }),

--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -89,7 +89,7 @@ export interface CdpCoreServicesDeps {
     integrationManager: IntegrationManagerService
     kafkaProducer: KafkaProducerWrapper
     /** Producer targeting the ingestion WarpStream cluster for monitoring outputs (app metrics, log entries). */
-    monitoringKafkaProducer: KafkaProducerWrapper
+    hogTransformerProducer: KafkaProducerWrapper
     internalCaptureService: InternalCaptureService
 }
 
@@ -179,13 +179,13 @@ export function createCdpCoreServices(
             [APP_METRICS_OUTPUT]: new SingleIngestionOutput(
                 APP_METRICS_OUTPUT,
                 config.HOG_FUNCTION_MONITORING_APP_METRICS_TOPIC,
-                deps.monitoringKafkaProducer,
+                deps.hogTransformerProducer,
                 'default'
             ),
             [LOG_ENTRIES_OUTPUT]: new SingleIngestionOutput(
                 LOG_ENTRIES_OUTPUT,
                 config.HOG_FUNCTION_MONITORING_LOG_ENTRIES_TOPIC,
-                deps.monitoringKafkaProducer,
+                deps.hogTransformerProducer,
                 'default'
             ),
         }),

--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -89,7 +89,7 @@ export interface CdpCoreServicesDeps {
     integrationManager: IntegrationManagerService
     kafkaProducer: KafkaProducerWrapper
     /** Producer targeting the ingestion WarpStream cluster for monitoring outputs (app metrics, log entries). */
-    hogTransformerProducer: KafkaProducerWrapper
+    monitoringProducer: KafkaProducerWrapper
     internalCaptureService: InternalCaptureService
 }
 
@@ -179,13 +179,13 @@ export function createCdpCoreServices(
             [APP_METRICS_OUTPUT]: new SingleIngestionOutput(
                 APP_METRICS_OUTPUT,
                 config.HOG_FUNCTION_MONITORING_APP_METRICS_TOPIC,
-                deps.hogTransformerProducer,
+                deps.monitoringProducer,
                 'default'
             ),
             [LOG_ENTRIES_OUTPUT]: new SingleIngestionOutput(
                 LOG_ENTRIES_OUTPUT,
                 config.HOG_FUNCTION_MONITORING_LOG_ENTRIES_TOPIC,
-                deps.hogTransformerProducer,
+                deps.monitoringProducer,
                 'default'
             ),
         }),

--- a/nodejs/src/cdp/consumers/cdp-base.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-base.consumer.ts
@@ -119,7 +119,7 @@ export abstract class CdpConsumerBase<TConfig extends CdpConsumerBaseConfig = Cd
     public async start(): Promise<void> {
         // NOTE: This is only for starting shared services
         await Promise.all([
-            KafkaProducerWrapper.create(this.config.KAFKA_CLIENT_RACK, 'CDP_PRODUCER').then((producer) => {
+            KafkaProducerWrapper.create(this.config.KAFKA_CLIENT_RACK).then((producer) => {
                 this.kafkaProducer = producer
             }),
             KafkaProducerWrapper.create(this.config.KAFKA_CLIENT_RACK, 'WAREHOUSE_PRODUCER').then((producer) => {

--- a/nodejs/src/cdp/consumers/cdp-base.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-base.consumer.ts
@@ -119,7 +119,7 @@ export abstract class CdpConsumerBase<TConfig extends CdpConsumerBaseConfig = Cd
     public async start(): Promise<void> {
         // NOTE: This is only for starting shared services
         await Promise.all([
-            KafkaProducerWrapper.create(this.config.KAFKA_CLIENT_RACK).then((producer) => {
+            KafkaProducerWrapper.create(this.config.KAFKA_CLIENT_RACK, 'CDP_PRODUCER').then((producer) => {
                 this.kafkaProducer = producer
             }),
             KafkaProducerWrapper.create(this.config.KAFKA_CLIENT_RACK, 'WAREHOUSE_PRODUCER').then((producer) => {

--- a/nodejs/src/kafka/config.ts
+++ b/nodejs/src/kafka/config.ts
@@ -15,7 +15,7 @@ export type KafkaConfigTarget =
     | 'CONSUMER'
     | 'CDP_PRODUCER'
     | 'WARPSTREAM_PRODUCER'
-    | 'HOGTRANSFORMER_PRODUCER'
+    | 'MONITORING_PRODUCER'
     | 'METRICS_PRODUCER'
     | 'WAREHOUSE_PRODUCER'
 

--- a/nodejs/src/kafka/config.ts
+++ b/nodejs/src/kafka/config.ts
@@ -15,6 +15,7 @@ export type KafkaConfigTarget =
     | 'CONSUMER'
     | 'CDP_PRODUCER'
     | 'WARPSTREAM_PRODUCER'
+    | 'HOGTRANSFORMER_PRODUCER'
     | 'METRICS_PRODUCER'
     | 'WAREHOUSE_PRODUCER'
 

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -49,6 +49,7 @@ export class PluginServer implements NodeServer {
 
     // Infrastructure resources (tracked for shutdown cleanup)
     private kafkaProducer?: KafkaProducerWrapper
+    private monitoringKafkaProducer?: KafkaProducerWrapper
     private postgres?: PostgresRouter
     private redisPool?: RedisPool
     private posthogRedisPool?: RedisPool
@@ -112,6 +113,7 @@ export class PluginServer implements NodeServer {
                   teamManager,
                   integrationManager: cdpServices!.integrationManager,
                   kafkaProducer: this.kafkaProducer!,
+                  monitoringKafkaProducer: this.monitoringKafkaProducer!,
                   internalCaptureService: cdpServices!.internalCaptureService,
                   personRepository: cdpServices!.personRepository,
                   geoipService: cdpServices!.geoipService,
@@ -267,7 +269,9 @@ export class PluginServer implements NodeServer {
 
     private getCleanupResources(): CleanupResources {
         return {
-            kafkaProducers: [this.kafkaProducer].filter(Boolean) as KafkaProducerWrapper[],
+            kafkaProducers: [this.kafkaProducer, this.monitoringKafkaProducer].filter(
+                Boolean
+            ) as KafkaProducerWrapper[],
             redisPools: [this.redisPool, this.posthogRedisPool].filter(Boolean) as RedisPool[],
             postgres: this.postgres,
             pubsub: this.pubsub,
@@ -286,6 +290,10 @@ export class PluginServer implements NodeServer {
 
         logger.info('🤔', 'Connecting to Kafka...')
         this.kafkaProducer = await KafkaProducerWrapper.create(this.config.KAFKA_CLIENT_RACK)
+        this.monitoringKafkaProducer = await KafkaProducerWrapper.create(
+            this.config.KAFKA_CLIENT_RACK,
+            'WARPSTREAM_PRODUCER'
+        )
         logger.info('👍', 'Kafka ready')
 
         logger.info('🤔', 'Connecting to ingestion Redis...')

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -49,7 +49,7 @@ export class PluginServer implements NodeServer {
 
     // Infrastructure resources (tracked for shutdown cleanup)
     private kafkaProducer?: KafkaProducerWrapper
-    private monitoringKafkaProducer?: KafkaProducerWrapper
+    private hogTransformerProducer?: KafkaProducerWrapper
     private postgres?: PostgresRouter
     private redisPool?: RedisPool
     private posthogRedisPool?: RedisPool
@@ -113,7 +113,7 @@ export class PluginServer implements NodeServer {
                   teamManager,
                   integrationManager: cdpServices!.integrationManager,
                   kafkaProducer: this.kafkaProducer!,
-                  monitoringKafkaProducer: this.monitoringKafkaProducer!,
+                  hogTransformerProducer: this.hogTransformerProducer!,
                   internalCaptureService: cdpServices!.internalCaptureService,
                   personRepository: cdpServices!.personRepository,
                   geoipService: cdpServices!.geoipService,
@@ -269,9 +269,7 @@ export class PluginServer implements NodeServer {
 
     private getCleanupResources(): CleanupResources {
         return {
-            kafkaProducers: [this.kafkaProducer, this.monitoringKafkaProducer].filter(
-                Boolean
-            ) as KafkaProducerWrapper[],
+            kafkaProducers: [this.kafkaProducer, this.hogTransformerProducer].filter(Boolean) as KafkaProducerWrapper[],
             redisPools: [this.redisPool, this.posthogRedisPool].filter(Boolean) as RedisPool[],
             postgres: this.postgres,
             pubsub: this.pubsub,
@@ -290,9 +288,9 @@ export class PluginServer implements NodeServer {
 
         logger.info('🤔', 'Connecting to Kafka...')
         this.kafkaProducer = await KafkaProducerWrapper.create(this.config.KAFKA_CLIENT_RACK)
-        this.monitoringKafkaProducer = await KafkaProducerWrapper.create(
+        this.hogTransformerProducer = await KafkaProducerWrapper.create(
             this.config.KAFKA_CLIENT_RACK,
-            'WARPSTREAM_PRODUCER'
+            'HOGTRANSFORMER_PRODUCER'
         )
         logger.info('👍', 'Kafka ready')
 

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -49,7 +49,7 @@ export class PluginServer implements NodeServer {
 
     // Infrastructure resources (tracked for shutdown cleanup)
     private kafkaProducer?: KafkaProducerWrapper
-    private hogTransformerProducer?: KafkaProducerWrapper
+    private monitoringProducer?: KafkaProducerWrapper
     private postgres?: PostgresRouter
     private redisPool?: RedisPool
     private posthogRedisPool?: RedisPool
@@ -113,7 +113,7 @@ export class PluginServer implements NodeServer {
                   teamManager,
                   integrationManager: cdpServices!.integrationManager,
                   kafkaProducer: this.kafkaProducer!,
-                  hogTransformerProducer: this.hogTransformerProducer!,
+                  monitoringProducer: this.monitoringProducer!,
                   internalCaptureService: cdpServices!.internalCaptureService,
                   personRepository: cdpServices!.personRepository,
                   geoipService: cdpServices!.geoipService,
@@ -269,7 +269,7 @@ export class PluginServer implements NodeServer {
 
     private getCleanupResources(): CleanupResources {
         return {
-            kafkaProducers: [this.kafkaProducer, this.hogTransformerProducer].filter(Boolean) as KafkaProducerWrapper[],
+            kafkaProducers: [this.kafkaProducer, this.monitoringProducer].filter(Boolean) as KafkaProducerWrapper[],
             redisPools: [this.redisPool, this.posthogRedisPool].filter(Boolean) as RedisPool[],
             postgres: this.postgres,
             pubsub: this.pubsub,
@@ -288,9 +288,9 @@ export class PluginServer implements NodeServer {
 
         logger.info('🤔', 'Connecting to Kafka...')
         this.kafkaProducer = await KafkaProducerWrapper.create(this.config.KAFKA_CLIENT_RACK)
-        this.hogTransformerProducer = await KafkaProducerWrapper.create(
+        this.monitoringProducer = await KafkaProducerWrapper.create(
             this.config.KAFKA_CLIENT_RACK,
-            'HOGTRANSFORMER_PRODUCER'
+            'MONITORING_PRODUCER'
         )
         logger.info('👍', 'Kafka ready')
 

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -127,6 +127,7 @@ export interface HubServices {
     posthogRedisPool: GenericPool<Redis>
     cookielessRedisPool: GenericPool<Redis>
     kafkaProducer: KafkaProducerWrapper
+    monitoringKafkaProducer: KafkaProducerWrapper
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
     groupRepository: GroupRepository

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -127,7 +127,7 @@ export interface HubServices {
     posthogRedisPool: GenericPool<Redis>
     cookielessRedisPool: GenericPool<Redis>
     kafkaProducer: KafkaProducerWrapper
-    hogTransformerProducer: KafkaProducerWrapper
+    monitoringProducer: KafkaProducerWrapper
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
     groupRepository: GroupRepository

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -127,7 +127,7 @@ export interface HubServices {
     posthogRedisPool: GenericPool<Redis>
     cookielessRedisPool: GenericPool<Redis>
     kafkaProducer: KafkaProducerWrapper
-    monitoringKafkaProducer: KafkaProducerWrapper
+    hogTransformerProducer: KafkaProducerWrapper
     teamManager: TeamManager
     groupTypeManager: GroupTypeManager
     groupRepository: GroupRepository

--- a/nodejs/src/utils/db/hub.ts
+++ b/nodejs/src/utils/db/hub.ts
@@ -131,6 +131,7 @@ export async function createHub(config: Partial<PluginsServerConfig> = {}): Prom
         posthogRedisPool,
         cookielessRedisPool,
         kafkaProducer,
+        monitoringKafkaProducer: kafkaProducer,
         groupTypeManager,
         teamManager,
         groupRepository,

--- a/nodejs/src/utils/db/hub.ts
+++ b/nodejs/src/utils/db/hub.ts
@@ -131,7 +131,7 @@ export async function createHub(config: Partial<PluginsServerConfig> = {}): Prom
         posthogRedisPool,
         cookielessRedisPool,
         kafkaProducer,
-        hogTransformerProducer: kafkaProducer,
+        monitoringProducer: kafkaProducer,
         groupTypeManager,
         teamManager,
         groupRepository,

--- a/nodejs/src/utils/db/hub.ts
+++ b/nodejs/src/utils/db/hub.ts
@@ -131,7 +131,7 @@ export async function createHub(config: Partial<PluginsServerConfig> = {}): Prom
         posthogRedisPool,
         cookielessRedisPool,
         kafkaProducer,
-        monitoringKafkaProducer: kafkaProducer,
+        hogTransformerProducer: kafkaProducer,
         groupTypeManager,
         teamManager,
         groupRepository,

--- a/nodejs/tests/helpers/cdp.ts
+++ b/nodejs/tests/helpers/cdp.ts
@@ -10,6 +10,7 @@ export function createCdpConsumerDeps(hub: Hub): CdpConsumerBaseDeps {
         teamManager: hub.teamManager,
         integrationManager: hub.integrationManager,
         kafkaProducer: hub.kafkaProducer,
+        monitoringKafkaProducer: hub.monitoringKafkaProducer,
         internalCaptureService: hub.internalCaptureService,
         personRepository: hub.personRepository,
         geoipService: hub.geoipService,

--- a/nodejs/tests/helpers/cdp.ts
+++ b/nodejs/tests/helpers/cdp.ts
@@ -10,7 +10,7 @@ export function createCdpConsumerDeps(hub: Hub): CdpConsumerBaseDeps {
         teamManager: hub.teamManager,
         integrationManager: hub.integrationManager,
         kafkaProducer: hub.kafkaProducer,
-        hogTransformerProducer: hub.hogTransformerProducer,
+        monitoringProducer: hub.monitoringProducer,
         internalCaptureService: hub.internalCaptureService,
         personRepository: hub.personRepository,
         geoipService: hub.geoipService,

--- a/nodejs/tests/helpers/cdp.ts
+++ b/nodejs/tests/helpers/cdp.ts
@@ -10,7 +10,7 @@ export function createCdpConsumerDeps(hub: Hub): CdpConsumerBaseDeps {
         teamManager: hub.teamManager,
         integrationManager: hub.integrationManager,
         kafkaProducer: hub.kafkaProducer,
-        monitoringKafkaProducer: hub.monitoringKafkaProducer,
+        hogTransformerProducer: hub.hogTransformerProducer,
         internalCaptureService: hub.internalCaptureService,
         personRepository: hub.personRepository,
         geoipService: hub.geoipService,


### PR DESCRIPTION
## Problem

We want to move the CDP monitoring outputs (`clickhouse_app_metrics2` and `log_entries`) produced by `HogFunctionMonitoringService` to the ingestion Warpstream cluster instead of the MSK cluster.

## Changes

- Added `monitoringKafkaProducer` to `CdpCoreServicesDeps` and wired it to the `HogFunctionMonitoringService` outputs in `createCdpCoreServices`
- Created a `WARPSTREAM_PRODUCER` instance in `PluginServer` and passed it through to CDP deps
- Added `monitoringKafkaProducer` to `HubServices` so test hubs satisfy the new dep automatically


## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
