### PR TITLE
chore(mcp): Optimize persons MCP tools token usage

### DIFF
--- a/products/persons/mcp/tools.yaml
+++ b/products/persons/mcp/tools.yaml
@@ -27,6 +27,14 @@ tools:
         exclude_params:
             - format
             - properties
+        response:
+            include:
+                - id
+                - uuid
+                - name
+                - distinct_ids
+                - created_at
+                - last_seen_at
     persons-retrieve:
         operation: persons_retrieve
         enabled: true
@@ -42,6 +50,15 @@ tools:
             Retrieve a single person by numeric ID or UUID. Returns the person's properties, distinct IDs, and metadata.
         exclude_params:
             - format
+        response:
+            include:
+                - id
+                - uuid
+                - name
+                - properties
+                - distinct_ids
+                - created_at
+                - last_seen_at
     persons-update:
         operation: persons_update
         enabled: false

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -523,7 +523,7 @@ function buildResponseFilter(config: ToolConfig): {
         const paths = config.response?.include.map((f) => `'${f}'`).join(', ')
         if (config.list) {
             return {
-                code: `        const filtered = { ...result, results: result.results.map((item: any) => pickResponseFields(item, [${paths}])) } as typeof result\n`,
+                code: `        const filtered = { ...result, results: (result.results ?? []).map((item: any) => pickResponseFields(item, [${paths}])) } as typeof result\n`,
                 helperImport: 'pickResponseFields',
             }
         }
@@ -536,7 +536,7 @@ function buildResponseFilter(config: ToolConfig): {
         const paths = config.response?.exclude.map((f) => `'${f}'`).join(', ')
         if (config.list) {
             return {
-                code: `        const filtered = { ...result, results: result.results.map((item: any) => omitResponseFields(item, [${paths}])) } as typeof result\n`,
+                code: `        const filtered = { ...result, results: (result.results ?? []).map((item: any) => omitResponseFields(item, [${paths}])) } as typeof result\n`,
                 helperImport: 'omitResponseFields',
             }
         }
@@ -560,7 +560,7 @@ function buildEnrichment(config: ToolConfig, category: CategoryConfig, resultVar
         return [
             `        return await withPostHogUrl(context, {`,
             `            ...${resultVar},`,
-            `            results: await Promise.all(${resultVar}.results.map((item) => withPostHogUrl(context, item, \`${baseUrl}/${prefix}\${item.${field}}\`))),`,
+            `            results: await Promise.all((${resultVar}.results ?? []).map((item) => withPostHogUrl(context, item, \`${baseUrl}/${prefix}\${item.${field}}\`))),`,
             `        }, '${baseUrl}')`,
             ``,
         ].join('\n')

--- a/services/mcp/src/tools/generated/actions.ts
+++ b/services/mcp/src/tools/generated/actions.ts
@@ -35,7 +35,7 @@ const actionsGetAll = (): ToolBase<typeof ActionsGetAllSchema, WithPostHogUrl<Sc
                 {
                     ...result,
                     results: await Promise.all(
-                        result.results.map((item) =>
+                        (result.results ?? []).map((item) =>
                             withPostHogUrl(context, item, `/data-management/actions/${item.id}`)
                         )
                     ),

--- a/services/mcp/src/tools/generated/cohorts.ts
+++ b/services/mcp/src/tools/generated/cohorts.ts
@@ -35,7 +35,7 @@ const cohortsList = (): ToolBase<typeof CohortsListSchema, WithPostHogUrl<Schema
             })
             const filtered = {
                 ...result,
-                results: result.results.map((item: any) =>
+                results: (result.results ?? []).map((item: any) =>
                     pickResponseFields(item, ['id', 'name', 'description', 'count', 'is_static', 'created_at'])
                 ),
             } as typeof result
@@ -44,7 +44,7 @@ const cohortsList = (): ToolBase<typeof CohortsListSchema, WithPostHogUrl<Schema
                 {
                     ...filtered,
                     results: await Promise.all(
-                        filtered.results.map((item) => withPostHogUrl(context, item, `/cohorts/${item.id}`))
+                        (filtered.results ?? []).map((item) => withPostHogUrl(context, item, `/cohorts/${item.id}`))
                     ),
                 },
                 '/cohorts'

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -38,7 +38,7 @@ const dashboardsGetAll = (): ToolBase<
             {
                 ...result,
                 results: await Promise.all(
-                    result.results.map((item) => withPostHogUrl(context, item, `/dashboard/${item.id}`))
+                    (result.results ?? []).map((item) => withPostHogUrl(context, item, `/dashboard/${item.id}`))
                 ),
             },
             '/dashboard'

--- a/services/mcp/src/tools/generated/data_warehouse.ts
+++ b/services/mcp/src/tools/generated/data_warehouse.ts
@@ -43,7 +43,7 @@ const viewList = (): ToolBase<
             {
                 ...result,
                 results: await Promise.all(
-                    result.results.map((item) => withPostHogUrl(context, item, `/sql/?open_view=${item.id}`))
+                    (result.results ?? []).map((item) => withPostHogUrl(context, item, `/sql/?open_view=${item.id}`))
                 ),
             },
             '/sql'

--- a/services/mcp/src/tools/generated/endpoints.ts
+++ b/services/mcp/src/tools/generated/endpoints.ts
@@ -45,7 +45,7 @@ const endpointsGetAll = (): ToolBase<
             {
                 ...result,
                 results: await Promise.all(
-                    result.results.map((item) => withPostHogUrl(context, item, `/endpoints/${item.name}`))
+                    (result.results ?? []).map((item) => withPostHogUrl(context, item, `/endpoints/${item.name}`))
                 ),
             },
             '/endpoints'
@@ -228,7 +228,7 @@ const endpointVersions = (): ToolBase<
             {
                 ...result,
                 results: await Promise.all(
-                    result.results.map((item) => withPostHogUrl(context, item, `/endpoints/${item.name}`))
+                    (result.results ?? []).map((item) => withPostHogUrl(context, item, `/endpoints/${item.name}`))
                 ),
             },
             '/endpoints'

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -39,7 +39,9 @@ const errorTrackingIssuesList = (): ToolBase<
                 {
                     ...result,
                     results: await Promise.all(
-                        result.results.map((item) => withPostHogUrl(context, item, `/error_tracking/${item.id}`))
+                        (result.results ?? []).map((item) =>
+                            withPostHogUrl(context, item, `/error_tracking/${item.id}`)
+                        )
                     ),
                 },
                 '/error_tracking'

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -41,7 +41,7 @@ const experimentGetAll = (): ToolBase<typeof ExperimentGetAllSchema, WithPostHog
             })
             const filtered = {
                 ...result,
-                results: result.results.map((item: any) =>
+                results: (result.results ?? []).map((item: any) =>
                     pickResponseFields(item, [
                         'id',
                         'name',
@@ -62,7 +62,7 @@ const experimentGetAll = (): ToolBase<typeof ExperimentGetAllSchema, WithPostHog
                 {
                     ...filtered,
                     results: await Promise.all(
-                        filtered.results.map((item) => withPostHogUrl(context, item, `/experiments/${item.id}`))
+                        (filtered.results ?? []).map((item) => withPostHogUrl(context, item, `/experiments/${item.id}`))
                     ),
                 },
                 '/experiments'

--- a/services/mcp/src/tools/generated/feature_flags.ts
+++ b/services/mcp/src/tools/generated/feature_flags.ts
@@ -58,7 +58,7 @@ const featureFlagGetAll = (): ToolBase<
         })
         const filtered = {
             ...result,
-            results: result.results.map((item: any) =>
+            results: (result.results ?? []).map((item: any) =>
                 pickResponseFields(item, ['id', 'key', 'name', 'updated_at', 'status', 'tags'])
             ),
         } as typeof result
@@ -67,7 +67,7 @@ const featureFlagGetAll = (): ToolBase<
             {
                 ...filtered,
                 results: await Promise.all(
-                    filtered.results.map((item) => withPostHogUrl(context, item, `/feature_flags/${item.id}`))
+                    (filtered.results ?? []).map((item) => withPostHogUrl(context, item, `/feature_flags/${item.id}`))
                 ),
             },
             '/feature_flags'

--- a/services/mcp/src/tools/generated/persons.ts
+++ b/services/mcp/src/tools/generated/persons.ts
@@ -36,7 +36,7 @@ const personsList = (): ToolBase<typeof PersonsListSchema, WithPostHogUrl<Schema
         })
         const filtered = {
             ...result,
-            results: result.results.map((item: any) =>
+            results: (result.results ?? []).map((item: any) =>
                 pickResponseFields(item, ['id', 'uuid', 'name', 'distinct_ids', 'created_at', 'last_seen_at'])
             ),
         } as typeof result

--- a/services/mcp/src/tools/generated/persons.ts
+++ b/services/mcp/src/tools/generated/persons.ts
@@ -13,7 +13,7 @@ import {
     PersonsUpdatePropertyCreateParams,
     PersonsValuesRetrieveQueryParams,
 } from '@/generated/persons/api'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const PersonsListSchema = PersonsListQueryParams.omit({ format: true, properties: true })
@@ -34,7 +34,13 @@ const personsList = (): ToolBase<typeof PersonsListSchema, WithPostHogUrl<Schema
                 search: params.search,
             },
         })
-        return await withPostHogUrl(context, result, '/persons')
+        const filtered = {
+            ...result,
+            results: result.results.map((item: any) =>
+                pickResponseFields(item, ['id', 'uuid', 'name', 'distinct_ids', 'created_at', 'last_seen_at'])
+            ),
+        } as typeof result
+        return await withPostHogUrl(context, filtered, '/persons')
     },
 })
 
@@ -49,7 +55,16 @@ const personsRetrieve = (): ToolBase<typeof PersonsRetrieveSchema, WithPostHogUr
             method: 'GET',
             path: `/api/projects/${projectId}/persons/${params.id}/`,
         })
-        return await withPostHogUrl(context, result, `/persons/${result.id}`)
+        const filtered = pickResponseFields(result, [
+            'id',
+            'uuid',
+            'name',
+            'properties',
+            'distinct_ids',
+            'created_at',
+            'last_seen_at',
+        ]) as typeof result
+        return await withPostHogUrl(context, filtered, `/persons/${filtered.id}`)
     },
 })
 

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -112,7 +112,7 @@ const insightsList = (): ToolBase<typeof InsightsListSchema, WithPostHogUrl<Sche
         })
         const filtered = {
             ...result,
-            results: result.results.map((item: any) =>
+            results: (result.results ?? []).map((item: any) =>
                 pickResponseFields(item, [
                     'id',
                     'short_id',
@@ -135,7 +135,7 @@ const insightsList = (): ToolBase<typeof InsightsListSchema, WithPostHogUrl<Sche
             {
                 ...filtered,
                 results: await Promise.all(
-                    filtered.results.map((item) => withPostHogUrl(context, item, `/insights/${item.short_id}`))
+                    (filtered.results ?? []).map((item) => withPostHogUrl(context, item, `/insights/${item.short_id}`))
                 ),
             },
             '/insights'

--- a/services/mcp/src/tools/generated/surveys.ts
+++ b/services/mcp/src/tools/generated/surveys.ts
@@ -40,7 +40,7 @@ const surveysGetAll = (): ToolBase<typeof SurveysGetAllSchema, WithPostHogUrl<Sc
                 {
                     ...result,
                     results: await Promise.all(
-                        result.results.map((item) => withPostHogUrl(context, item, `/surveys/${item.id}`))
+                        (result.results ?? []).map((item) => withPostHogUrl(context, item, `/surveys/${item.id}`))
                     ),
                 },
                 '/surveys'

--- a/services/mcp/tests/unit/__snapshots__/generate-tools.test.ts.snap
+++ b/services/mcp/tests/unit/__snapshots__/generate-tools.test.ts.snap
@@ -38,7 +38,7 @@ const thingsList = (): ToolBase<typeof ThingsListSchema, unknown> => ({
         })
         return await withPostHogUrl(context, {
             ...result,
-            results: await Promise.all(result.results.map((item) => withPostHogUrl(context, item, \`/things/\${item.id}\`))),
+            results: await Promise.all((result.results ?? []).map((item) => withPostHogUrl(context, item, \`/things/\${item.id}\`))),
         }, '/things')
     },
 })

--- a/services/mcp/tests/unit/generate-tools.test.ts
+++ b/services/mcp/tests/unit/generate-tools.test.ts
@@ -703,7 +703,7 @@ describe('buildResponseFilter', () => {
             response: { include: ['id', 'key'] },
         }
         const result = buildResponseFilter(config)
-        expect(result.code).toContain('result.results.map')
+        expect(result.code).toContain('(result.results ?? []).map')
         expect(result.code).toContain('pickResponseFields(item, ')
         expect(result.helperImport).toBe('pickResponseFields')
     })
@@ -716,7 +716,7 @@ describe('buildResponseFilter', () => {
             response: { exclude: ['large_blob'] },
         }
         const result = buildResponseFilter(config)
-        expect(result.code).toContain('result.results.map')
+        expect(result.code).toContain('(result.results ?? []).map')
         expect(result.code).toContain('omitResponseFields(item, ')
         expect(result.helperImport).toBe('omitResponseFields')
     })
@@ -832,9 +832,9 @@ describe('generateToolCode with response filtering', () => {
             stubGetQuerySchema
         )
 
-        expect(result.code).toContain('result.results.map((item: any) => omitResponseFields(item, ')
+        expect(result.code).toContain('(result.results ?? []).map((item: any) => omitResponseFields(item, ')
         expect(result.code).toContain('...filtered,')
-        expect(result.code).toContain('filtered.results.map')
+        expect(result.code).toContain('(filtered.results ?? []).map')
         expect(result.responseFilterImport).toBe('omitResponseFields')
     })
 })


### PR DESCRIPTION
## Summary

- Filter `properties` from `persons-list`MCP tool responses using `response.include`

## Token impact

| Field | Avg size per person | Included |
|---|---|---|
| `id` | ~5 bytes | Yes |
| `uuid` | ~36 bytes | Yes |
| `name` | ~20 bytes | Yes |
| `distinct_ids` | ~50-200 bytes | Yes |
| `created_at` | ~24 bytes | Yes |
| `last_seen_at` | ~24 bytes | Yes |
| **`properties`** | **~300-1500 bytes** | **No (dropped)** |

For a typical `persons-list` call (100 results), this reduces response size by an estimated **~70-85%** by removing the `properties` field, which is the dominant payload.

## Test plan

- [x] Manually verify `persons-list` and `persons-retrieve` via MCP client