### PR TITLE
chore(quill): bump quill alpha version

### DIFF
--- a/packages/quill/packages/quill/package.json
+++ b/packages/quill/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill",
-    "version": "0.1.0-alpha.3",
+    "version": "0.1.0-alpha.4",
     "description": "PostHog's unified design system — primitives, components, and blocks designed to be compiled by the consumer's Tailwind v4.",
     "license": "MIT",
     "repository": {

--- a/packages/quill/packages/tokens/package.json
+++ b/packages/quill/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-tokens",
-    "version": "0.1.0-alpha.3",
+    "version": "0.1.0-alpha.4",
     "license": "MIT",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Problem

Quill alpha packages need their prerelease version bumped for the next publish.

## Changes

- Bumped `@posthog/quill` from `0.1.0-alpha.3` to `0.1.0-alpha.4`
- Bumped `@posthog/quill-tokens` from `0.1.0-alpha.3` to `0.1.0-alpha.4`

## How did you test this code?

Verified the package manifest diffs locally. No automated tests were run because this is a package version bump only.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update needed.

## 🤖 LLM context

Authored with Codex in the local repository. Cleaned the branch to remove unrelated changes, recreated the Quill-only diff, force-pushed the branch, and updated this PR description.
