### PR TITLE
chore: auto-detect Secretive SSH agent for commit signing

### DIFF
--- a/.claude/hooks/setup-code-signing.sh
+++ b/.claude/hooks/setup-code-signing.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# SessionStart hook: detect Secretive SSH agent for git commit signing.
+#
+# If SSH_AUTH_SOCK is unset (or still the default macOS launchd agent) and the
+# Secretive agent socket exists, point SSH_AUTH_SOCK at it so git commit
+# signing works out of the box on macOS.
+
+if [ -z "$CLAUDE_ENV_FILE" ]; then
+  exit 0
+fi
+
+SECRETIVE_SOCKET="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+if [ -S "$SECRETIVE_SOCKET" ]; then
+  # Treat empty or default macOS launchd agent as "no custom agent configured"
+  if [ -z "$SSH_AUTH_SOCK" ] || [[ "$SSH_AUTH_SOCK" == /var/run/com.apple.launchd.*/Listeners ]]; then
+    printf 'export SSH_AUTH_SOCK=%q\n' "$SECRETIVE_SOCKET" >> "$CLAUDE_ENV_FILE"
+  fi
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,10 @@
                     },
                     {
                         "type": "command",
+                        "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/setup-code-signing.sh"
+                    },
+                    {
+                        "type": "command",
                         "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/setup-flox.sh"
                     }
                 ]


### PR DESCRIPTION
## Problem

Claude Code sessions on macOS don't inherit `SSH_AUTH_SOCK` pointing to the [Secretive](https://github.com/maxgoedjen/secretive) agent, so git commit signing fails with "No private key found for public key".

Developers using Secretive for SSH key management hit this every session.

## Changes

In the `SessionStart` hook (`setup-flox.sh`), if `SSH_AUTH_SOCK` is unset and the Secretive agent socket exists at `~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh`, export it for the session.

The check runs before the flox setup so it works even if flox isn't installed. It's a no-op on Linux or if Secretive isn't present.

## How did you test this code?
Using this branch as a base, I was able to make https://github.com/PostHog/posthog/pull/54449. code signing with Secretive just worked

## Publish to changelog?

No

## Docs update

N/A

## LLM context

Agent-authored PR. The signing issue was discovered while pushing commits for PR #52978.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*