### PR TITLE
feat(cli): add `api` subcommand with auto-generated OpenAPI operations

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -113,6 +113,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,10 +386,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -443,7 +475,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio 0.8.11",
- "parking_lot",
+ "parking_lot 0.12.5",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -458,7 +490,7 @@ dependencies = [
  "bitflags 2.10.0",
  "crossterm_winapi",
  "mio 1.1.0",
- "parking_lot",
+ "parking_lot 0.12.5",
  "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
@@ -659,6 +691,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +791,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +819,21 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-channel"
@@ -784,10 +852,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -807,8 +897,10 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1094,6 +1186,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1414,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,6 +1437,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1626,6 +1756,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,6 +1867,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "openapi-to-rust"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9568367e014e68cf4b250d87d7db590bbc9cf114ac2d10f774a62b3731279b10"
+dependencies = [
+ "clap",
+ "heck",
+ "insta",
+ "once_cell",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "reqwest 0.11.27",
+ "reqwest-middleware",
+ "reqwest-retry",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "syn",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "toml",
+ "url",
+ "validator",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,12 +1958,37 @@ checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.12",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -1755,7 +1999,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1864,6 +2108,7 @@ dependencies = [
  "magic_string",
  "miette",
  "open",
+ "openapi-to-rust",
  "plist",
  "posthog-rs",
  "posthog-symbol-data",
@@ -1949,6 +2194,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,7 +2284,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls 0.23.35",
@@ -2056,12 +2333,33 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2071,7 +2369,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2133,6 +2440,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2200,10 +2516,12 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.32",
  "hyper-rustls 0.24.2",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -2215,11 +2533,14 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.24.1",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 0.25.4",
  "winreg",
@@ -2264,6 +2585,52 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 1.0.4",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.3.1",
+ "reqwest 0.12.24",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.16",
+ "http 1.3.1",
+ "hyper 1.8.1",
+ "parking_lot 0.11.2",
+ "reqwest 0.12.24",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "wasm-timer",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2406,6 +2773,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2445,6 +2821,29 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2494,6 +2893,15 @@ dependencies = [
  "ryu",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2675,7 +3083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
- "parking_lot",
+ "parking_lot 0.12.5",
  "phf_shared",
  "precomputed-hash",
  "serde",
@@ -2774,7 +3182,7 @@ dependencies = [
  "nom",
  "nom-supreme",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.5",
  "pdb-addr2line",
  "regex",
  "scroll 0.12.0",
@@ -2850,7 +3258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -3039,9 +3447,33 @@ dependencies = [
  "bytes",
  "libc",
  "mio 1.1.0",
+ "parking_lot 0.12.5",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.1",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3076,6 +3508,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3320,6 +3793,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "validator"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
+dependencies = [
+ "idna",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
+dependencies = [
+ "darling",
+ "once_cell",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3439,6 +3942,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3830,6 +4361,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -61,6 +61,10 @@ zstd = "0.13"
 symbolic = { version = "12.12", features = ["debuginfo"] }
 plist = "1"
 
+[build-dependencies]
+openapi-to-rust = "0.1.7"
+serde_json = "1.0"
+
 [dev-dependencies]
 test-log = "0.2.17"
 

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,12 +1,159 @@
+use std::path::{Path, PathBuf};
+
 // Debug token, used to get metrics for debug builds - team 89529
 const DEBUG_POSTHOG_API_TOKEN: &str = "phc_raG2H9V246hkNZk6K89DZGG98qQyPrKKlicifGlpOXA";
 
-// This build file just sets this token for debug builds - for production builds, we use the token from our CI's secrets
+fn generate_api_registry(out_dir: &Path, spec_path: &Path) {
+    use openapi_to_rust::{CodeGenerator, GeneratorConfig, SchemaAnalyzer};
+
+    eprintln!("cargo:warning=Generating API registry from {}", spec_path.display());
+
+    let spec_content = std::fs::read_to_string(spec_path)
+        .unwrap_or_else(|e| panic!("Failed to read OpenAPI spec at {}: {}", spec_path.display(), e));
+
+    // openapi-to-rust expects 3.1 but PostHog generates 3.0.3.
+    // The structural differences that matter (nullable, etc.) don't affect the registry,
+    // so patch the version string before parsing.
+    let spec_content = spec_content.replacen("\"3.0.3\"", "\"3.1.0\"", 1);
+
+    let spec: serde_json::Value = serde_json::from_str(&spec_content)
+        .unwrap_or_else(|e| panic!("Failed to parse OpenAPI spec: {}", e));
+
+    let mut analyzer = SchemaAnalyzer::new(spec)
+        .unwrap_or_else(|e| panic!("Failed to analyze OpenAPI spec: {:?}", e));
+    let analysis = analyzer.analyze()
+        .unwrap_or_else(|e| panic!("Failed to analyze schemas: {:?}", e));
+
+    let config = GeneratorConfig {
+        spec_path: spec_path.to_path_buf(),
+        output_dir: out_dir.to_path_buf(),
+        module_name: "posthog_api".to_string(),
+        enable_registry: true,
+        registry_only: true,
+        enable_async_client: false,
+        enable_sse_client: false,
+        ..Default::default()
+    };
+
+    let generator = CodeGenerator::new(config);
+    let registry_code = generator.generate_registry(&analysis)
+        .unwrap_or_else(|e| panic!("Failed to generate registry: {:?}", e));
+
+    // The generated code uses //! inner doc comments which don't work inside include!().
+    let registry_code = registry_code.replace("//!", "//");
+
+    // The generated code derives serde::Deserialize on structs with &'static [ParamDef]
+    // which doesn't implement Deserialize. Strip the Deserialize derive since we only need
+    // Serialize for the registry (it's all static data).
+    let registry_code = registry_code.replace(
+        "serde::Serialize, serde::Deserialize",
+        "serde::Serialize",
+    );
+
+    let registry_path = out_dir.join("registry.rs");
+    std::fs::write(&registry_path, &registry_code)
+        .unwrap_or_else(|e| panic!("Failed to write registry to {}: {}", registry_path.display(), e));
+
+    eprintln!(
+        "cargo:warning=Generated API registry with {} operations",
+        analysis.operations.len()
+    );
+}
+
+fn generate_empty_registry(out_dir: &Path) {
+    let stub = r#"
+//! Empty API registry stub — no OpenAPI spec was found at build time.
+//! Run `hogli build:openapi-schema` to generate the spec, then rebuild.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum HttpMethod { Get, Post, Put, Patch, Delete }
+
+impl HttpMethod {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Get => "GET", Self::Post => "POST", Self::Put => "PUT",
+            Self::Patch => "PATCH", Self::Delete => "DELETE",
+        }
+    }
+}
+
+impl std::fmt::Display for HttpMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum ParamLocation { Path, Query, Header }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum ParamType { String, Integer, Number, Boolean }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum BodyContentType { Json, FormUrlEncoded, Multipart, OctetStream, TextPlain }
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ParamDef {
+    pub name: &'static str,
+    pub location: ParamLocation,
+    pub required: bool,
+    pub param_type: ParamType,
+    pub description: Option<&'static str>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BodyDef {
+    pub content_type: BodyContentType,
+    pub schema_name: Option<&'static str>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct OperationDef {
+    pub id: &'static str,
+    pub method: HttpMethod,
+    pub path: &'static str,
+    pub summary: Option<&'static str>,
+    pub description: Option<&'static str>,
+    pub params: &'static [ParamDef],
+    pub body: Option<BodyDef>,
+    pub response_schema: Option<&'static str>,
+}
+
+pub fn find_operation(id: &str) -> Option<&'static OperationDef> {
+    OPERATIONS.iter().find(|op| op.id == id)
+}
+
+pub fn operation_ids() -> impl Iterator<Item = &'static str> {
+    OPERATIONS.iter().map(|op| op.id)
+}
+
+pub static OPERATIONS: [OperationDef; 0] = [];
+"#;
+    let registry_path = out_dir.join("registry.rs");
+    std::fs::write(&registry_path, stub)
+        .unwrap_or_else(|e| panic!("Failed to write stub registry: {}", e));
+
+    eprintln!("cargo:warning=No OpenAPI spec found. Run `hogli build:openapi-schema` then rebuild.");
+}
+
 pub fn main() {
     let profile = std::env::var("PROFILE").expect("Profile variable is set by cargo");
     if profile == "debug" {
         println!("cargo:rustc-env=POSTHOG_API_TOKEN={DEBUG_POSTHOG_API_TOKEN}");
     } else {
         eprintln!("Not setting debug posthog api token");
+    }
+
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR is set by cargo"));
+
+    // Look for the OpenAPI spec in the standard location (generated by `hogli build:openapi-schema`)
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set"));
+    let spec_path = manifest_dir.join("../frontend/tmp/openapi.json");
+
+    if spec_path.exists() {
+        println!("cargo:rerun-if-changed={}", spec_path.display());
+        generate_api_registry(&out_dir, &spec_path);
+    } else {
+        generate_empty_registry(&out_dir);
     }
 }

--- a/cli/src/api_cmd.rs
+++ b/cli/src/api_cmd.rs
@@ -1,0 +1,248 @@
+use clap::Subcommand;
+
+use crate::error::CapturedError;
+use crate::invocation_context::context;
+
+// Include the build-time generated registry from openapi-to-rust
+#[allow(dead_code)]
+mod registry {
+    include!(concat!(env!("OUT_DIR"), "/registry.rs"));
+}
+
+use registry::{HttpMethod, OperationDef, ParamLocation, OPERATIONS};
+
+#[derive(Subcommand)]
+pub enum ApiCommand {
+    /// List all available API operations
+    List {
+        /// Filter operations by tag/resource name (e.g. "feature_flags", "dashboards")
+        #[arg(short, long)]
+        filter: Option<String>,
+    },
+
+    /// Call an API operation by its operation ID
+    Call {
+        /// Operation ID (e.g. "feature_flags_list", "dashboards_retrieve")
+        /// Use `posthog-cli api list` to see all available operations.
+        operation_id: String,
+
+        /// JSON object with parameters and request body.
+        /// Path/query params are extracted by name, remaining fields become the request body.
+        /// Example: '{"project_id": "12345", "limit": "10"}'
+        #[arg(default_value = "{}")]
+        params_json: String,
+    },
+}
+
+impl ApiCommand {
+    pub fn run(self) -> Result<(), CapturedError> {
+        match self {
+            ApiCommand::List { filter } => list_operations(filter),
+            ApiCommand::Call {
+                operation_id,
+                params_json,
+            } => call_operation(&operation_id, &params_json),
+        }
+    }
+}
+
+fn list_operations(filter: Option<String>) -> Result<(), CapturedError> {
+    if OPERATIONS.is_empty() {
+        eprintln!("No API operations available.");
+        eprintln!("Run `hogli build:openapi-schema` then rebuild the CLI.");
+        return Ok(());
+    }
+
+    let filter_lower = filter.as_deref().map(|s| s.to_lowercase());
+
+    let mut printed = 0;
+    for op in OPERATIONS.iter() {
+        if let Some(ref f) = filter_lower {
+            let id_lower = op.id.to_lowercase();
+            let path_lower = op.path.to_lowercase();
+            if !id_lower.contains(f) && !path_lower.contains(f) {
+                continue;
+            }
+        }
+
+        let summary = op.summary.unwrap_or("");
+        println!(
+            "  {:<8} {:<55} {}",
+            op.method.as_str(),
+            op.id,
+            summary
+        );
+        printed += 1;
+    }
+
+    if printed == 0 {
+        eprintln!(
+            "No operations matched filter {:?}. Try `posthog-cli api list` to see all.",
+            filter.unwrap_or_default()
+        );
+    } else {
+        eprintln!("\n{printed} operations");
+    }
+    Ok(())
+}
+
+fn call_operation(operation_id: &str, params_json: &str) -> Result<(), CapturedError> {
+    let op = find_operation(operation_id)?;
+
+    let params: serde_json::Value = serde_json::from_str(params_json)
+        .map_err(|e| anyhow::anyhow!("Invalid JSON params: {e}"))?;
+    let params_map = params.as_object().cloned().unwrap_or_default();
+
+    // Build the URL by substituting path parameters
+    let mut path = op.path.to_string();
+    let mut query_params: Vec<(String, String)> = Vec::new();
+    let mut consumed_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for param in op.params.iter() {
+        let value = params_map.get(param.name).and_then(|v| match v {
+            serde_json::Value::String(s) => Some(s.clone()),
+            other => Some(other.to_string()),
+        });
+
+        match param.location {
+            ParamLocation::Path => {
+                if let Some(val) = &value {
+                    path = path.replace(&format!("{{{}}}", param.name), val);
+                    consumed_keys.insert(param.name.to_string());
+                } else if param.required {
+                    return Err(anyhow::anyhow!(
+                        "Missing required path parameter: '{}'\nUsage: posthog-cli api call {} '{{\"{}\":\"...\"}}'",
+                        param.name, operation_id, param.name
+                    )
+                    .into());
+                }
+            }
+            ParamLocation::Query => {
+                if let Some(val) = &value {
+                    query_params.push((param.name.to_string(), val.clone()));
+                    consumed_keys.insert(param.name.to_string());
+                }
+            }
+            ParamLocation::Header => {
+                // Headers are handled separately if needed; skip for now
+                if value.is_some() {
+                    consumed_keys.insert(param.name.to_string());
+                }
+            }
+        }
+    }
+
+    // Remaining (unconsumed) params become the request body for POST/PUT/PATCH
+    let body: Option<serde_json::Value> = if op.body.is_some() {
+        let body_map: serde_json::Map<String, serde_json::Value> = params_map
+            .into_iter()
+            .filter(|(k, _)| !consumed_keys.contains(k))
+            .collect();
+        if body_map.is_empty() {
+            None
+        } else {
+            Some(serde_json::Value::Object(body_map))
+        }
+    } else {
+        None
+    };
+
+    // Build the full URL
+    let ctx = context();
+    let host = &ctx.config.host;
+    let mut url = reqwest::Url::parse(host)
+        .map_err(|e| anyhow::anyhow!("Invalid host URL: {e}"))?
+        .join(&path)
+        .map_err(|e| anyhow::anyhow!("Failed to build URL: {e}"))?;
+
+    for (key, value) in &query_params {
+        url.query_pairs_mut().append_pair(key, value);
+    }
+
+    // Make the request
+    let method = match op.method {
+        HttpMethod::Get => reqwest::Method::GET,
+        HttpMethod::Post => reqwest::Method::POST,
+        HttpMethod::Put => reqwest::Method::PUT,
+        HttpMethod::Patch => reqwest::Method::PATCH,
+        HttpMethod::Delete => reqwest::Method::DELETE,
+    };
+
+    let response = ctx.client.send_request(method, url, |req| {
+        if let Some(ref body_json) = body {
+            req.json(body_json)
+        } else {
+            req
+        }
+    });
+
+    match response {
+        Ok(resp) => {
+            let text = resp.text().map_err(|e| anyhow::anyhow!("Failed to read response: {e}"))?;
+            // Try to pretty-print JSON, fall back to raw text
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json)
+                        .unwrap_or(text)
+                );
+            } else {
+                println!("{text}");
+            }
+            Ok(())
+        }
+        Err(e) => Err(anyhow::anyhow!("API request failed: {e}").into()),
+    }
+}
+
+fn find_operation(id: &str) -> Result<&'static OperationDef, CapturedError> {
+    // Exact match first
+    if let Some(op) = registry::find_operation(id) {
+        return Ok(op);
+    }
+
+    // Fuzzy match: try matching the end of operation IDs
+    let candidates: Vec<&OperationDef> = OPERATIONS
+        .iter()
+        .filter(|op| op.id.ends_with(id) || op.id.contains(id))
+        .collect();
+
+    match candidates.len() {
+        0 => {
+            // Suggest similar operations
+            let suggestions: Vec<&str> = OPERATIONS
+                .iter()
+                .filter(|op| {
+                    let id_lower = op.id.to_lowercase();
+                    let search_lower = id.to_lowercase();
+                    id_lower
+                        .split('_')
+                        .any(|part| part.starts_with(&search_lower))
+                        || search_lower
+                            .split('_')
+                            .any(|part| id_lower.contains(part))
+                })
+                .map(|op| op.id)
+                .take(5)
+                .collect();
+
+            let mut msg = format!("Unknown operation: '{id}'");
+            if !suggestions.is_empty() {
+                msg.push_str("\n\nDid you mean one of these?");
+                for s in suggestions {
+                    msg.push_str(&format!("\n  {s}"));
+                }
+            }
+            msg.push_str("\n\nUse `posthog-cli api list` to see all available operations.");
+            Err(anyhow::anyhow!("{msg}").into())
+        }
+        1 => Ok(candidates[0]),
+        _ => {
+            let mut msg = format!("Ambiguous operation '{id}'. Matches:");
+            for c in &candidates {
+                msg.push_str(&format!("\n  {} {} {}", c.method.as_str(), c.id, c.path));
+            }
+            Err(anyhow::anyhow!("{msg}").into())
+        }
+    }
+}

--- a/cli/src/api_cmd.rs
+++ b/cli/src/api_cmd.rs
@@ -20,7 +20,21 @@ pub enum ApiCommand {
         filter: Option<String>,
     },
 
-    /// Call an API operation by its operation ID
+    /// Show details for an API operation (path, params, body)
+    Inspect {
+        /// Operation ID (supports fuzzy matching)
+        operation_id: String,
+    },
+
+    /// Call an API operation by its operation ID.
+    ///
+    /// Path params like project_id and environment_id are auto-filled from
+    /// your login context. Pass any overrides or extra params as JSON.
+    ///
+    /// Examples:
+    ///   posthog-cli api call feature_flags_list
+    ///   posthog-cli api call feature_flags_list '{"limit": "10"}'
+    ///   posthog-cli api call feature_flags_retrieve '{"id": "42"}'
     Call {
         /// Operation ID (e.g. "feature_flags_list", "dashboards_retrieve")
         /// Use `posthog-cli api list` to see all available operations.
@@ -28,7 +42,7 @@ pub enum ApiCommand {
 
         /// JSON object with parameters and request body.
         /// Path/query params are extracted by name, remaining fields become the request body.
-        /// Example: '{"project_id": "12345", "limit": "10"}'
+        /// project_id and environment_id are auto-filled from your login context.
         #[arg(default_value = "{}")]
         params_json: String,
     },
@@ -38,6 +52,7 @@ impl ApiCommand {
     pub fn run(self) -> Result<(), CapturedError> {
         match self {
             ApiCommand::List { filter } => list_operations(filter),
+            ApiCommand::Inspect { operation_id } => inspect_operation(&operation_id),
             ApiCommand::Call {
                 operation_id,
                 params_json,
@@ -65,12 +80,20 @@ fn list_operations(filter: Option<String>) -> Result<(), CapturedError> {
             }
         }
 
-        let summary = op.summary.unwrap_or("");
+        let desc = op
+            .summary
+            .or(op.description.map(|d| {
+                // Truncate long descriptions to first sentence
+                d.split('\n').next().unwrap_or(d)
+            }))
+            .unwrap_or("");
+        // Truncate to fit terminal
+        let desc_truncated: String = desc.chars().take(60).collect();
         println!(
             "  {:<8} {:<55} {}",
             op.method.as_str(),
             op.id,
-            summary
+            desc_truncated
         );
         printed += 1;
     }
@@ -86,12 +109,112 @@ fn list_operations(filter: Option<String>) -> Result<(), CapturedError> {
     Ok(())
 }
 
+fn inspect_operation(operation_id: &str) -> Result<(), CapturedError> {
+    let op = find_operation(operation_id)?;
+
+    println!("Operation: {}", op.id);
+    println!("Method:    {}", op.method.as_str());
+    println!("Path:      {}", op.path);
+
+    if let Some(desc) = op.description.or(op.summary) {
+        println!();
+        // Print first paragraph only
+        for line in desc.split('\n') {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                break;
+            }
+            println!("  {trimmed}");
+        }
+    }
+
+    let path_params: Vec<_> = op
+        .params
+        .iter()
+        .filter(|p| p.location == ParamLocation::Path)
+        .collect();
+    let query_params: Vec<_> = op
+        .params
+        .iter()
+        .filter(|p| p.location == ParamLocation::Query)
+        .collect();
+
+    if !path_params.is_empty() {
+        println!("\nPath parameters:");
+        for p in &path_params {
+            let req = if p.required { " (required)" } else { "" };
+            let auto = if p.name == "project_id" || p.name == "environment_id" {
+                " [auto-filled from login]"
+            } else {
+                ""
+            };
+            let desc = p.description.unwrap_or("");
+            println!("  {:<25} {}{}{}", p.name, desc, req, auto);
+        }
+    }
+
+    if !query_params.is_empty() {
+        println!("\nQuery parameters:");
+        for p in &query_params {
+            let req = if p.required { " (required)" } else { "" };
+            let desc = p.description.unwrap_or("");
+            println!("  {:<25} {}{}", p.name, desc, req);
+        }
+    }
+
+    if op.body.is_some() {
+        println!("\nAccepts request body (JSON)");
+        if let Some(schema) = op.body.as_ref().and_then(|b| b.schema_name) {
+            println!("  Schema: {schema}");
+        }
+    }
+
+    // Show example usage
+    println!("\nExample:");
+    let mut example_json = serde_json::Map::new();
+    for p in op.params.iter() {
+        if p.location == ParamLocation::Path
+            && p.name != "project_id"
+            && p.name != "environment_id"
+        {
+            example_json.insert(
+                p.name.to_string(),
+                serde_json::Value::String("...".to_string()),
+            );
+        }
+    }
+    if example_json.is_empty() {
+        println!("  posthog-cli api call {}", op.id);
+    } else {
+        let json_str = serde_json::to_string(&example_json).unwrap_or_default();
+        println!("  posthog-cli api call {} '{}'", op.id, json_str);
+    }
+
+    Ok(())
+}
+
 fn call_operation(operation_id: &str, params_json: &str) -> Result<(), CapturedError> {
     let op = find_operation(operation_id)?;
 
     let params: serde_json::Value = serde_json::from_str(params_json)
         .map_err(|e| anyhow::anyhow!("Invalid JSON params: {e}"))?;
-    let params_map = params.as_object().cloned().unwrap_or_default();
+    let mut params_map = params.as_object().cloned().unwrap_or_default();
+
+    // Auto-fill project_id and environment_id from the login context
+    let ctx = context();
+    let env_id = ctx.client.get_env_id().clone();
+    if !params_map.contains_key("project_id") {
+        params_map.insert(
+            "project_id".to_string(),
+            serde_json::Value::String(env_id.clone()),
+        );
+    }
+    if !params_map.contains_key("environment_id") {
+        params_map.insert(
+            "environment_id".to_string(),
+            serde_json::Value::String(env_id),
+        );
+    }
 
     // Build the URL by substituting path parameters
     let mut path = op.path.to_string();
@@ -111,8 +234,8 @@ fn call_operation(operation_id: &str, params_json: &str) -> Result<(), CapturedE
                     consumed_keys.insert(param.name.to_string());
                 } else if param.required {
                     return Err(anyhow::anyhow!(
-                        "Missing required path parameter: '{}'\nUsage: posthog-cli api call {} '{{\"{}\":\"...\"}}'",
-                        param.name, operation_id, param.name
+                        "Missing required path parameter: '{}'\n\nRun `posthog-cli api inspect {}` to see all parameters.",
+                        param.name, operation_id
                     )
                     .into());
                 }
@@ -124,7 +247,6 @@ fn call_operation(operation_id: &str, params_json: &str) -> Result<(), CapturedE
                 }
             }
             ParamLocation::Header => {
-                // Headers are handled separately if needed; skip for now
                 if value.is_some() {
                     consumed_keys.insert(param.name.to_string());
                 }
@@ -148,7 +270,6 @@ fn call_operation(operation_id: &str, params_json: &str) -> Result<(), CapturedE
     };
 
     // Build the full URL
-    let ctx = context();
     let host = &ctx.config.host;
     let mut url = reqwest::Url::parse(host)
         .map_err(|e| anyhow::anyhow!("Invalid host URL: {e}"))?
@@ -178,13 +299,14 @@ fn call_operation(operation_id: &str, params_json: &str) -> Result<(), CapturedE
 
     match response {
         Ok(resp) => {
-            let text = resp.text().map_err(|e| anyhow::anyhow!("Failed to read response: {e}"))?;
+            let text = resp
+                .text()
+                .map_err(|e| anyhow::anyhow!("Failed to read response: {e}"))?;
             // Try to pretty-print JSON, fall back to raw text
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
                 println!(
                     "{}",
-                    serde_json::to_string_pretty(&json)
-                        .unwrap_or(text)
+                    serde_json::to_string_pretty(&json).unwrap_or(text)
                 );
             } else {
                 println!("{text}");

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 use tracing::error;
 
 use crate::{
+    api_cmd::ApiCommand,
     dsym::DsymSubcommand,
     error::CapturedError,
     experimental::{endpoints::EndpointCommand, query::command::QueryCommand, tasks::TaskCommand},
@@ -66,6 +67,12 @@ pub enum Commands {
     Proguard {
         #[command(subcommand)]
         cmd: ProguardSubcommand,
+    },
+
+    /// Call any PostHog API endpoint directly. Operations are auto-generated from the OpenAPI spec.
+    Api {
+        #[command(subcommand)]
+        cmd: ApiCommand,
     },
 }
 
@@ -155,7 +162,7 @@ impl Cli {
     }
 
     fn run_impl(self) -> Result<(), CapturedError> {
-        if !matches!(self.command, Commands::Login) {
+        if !matches!(self.command, Commands::Login | Commands::Api { cmd: ApiCommand::List { .. } }) {
             init_context(
                 self.host.clone(),
                 self.skip_ssl_verification,
@@ -202,6 +209,9 @@ impl Cli {
                     crate::proguard::upload::upload(&args)?;
                 }
             },
+            Commands::Api { cmd } => {
+                cmd.run()?;
+            }
             Commands::Exp { cmd } => match cmd {
                 ExpCommand::Task {
                     cmd,
@@ -248,7 +258,9 @@ impl Cli {
             },
         }
 
-        context().finish();
+        if crate::invocation_context::INVOCATION_CONTEXT.get().is_some() {
+            context().finish();
+        }
 
         Ok(())
     }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -162,7 +162,16 @@ impl Cli {
     }
 
     fn run_impl(self) -> Result<(), CapturedError> {
-        if !matches!(self.command, Commands::Login | Commands::Api { cmd: ApiCommand::List { .. } }) {
+        if !matches!(
+            self.command,
+            Commands::Login
+                | Commands::Api {
+                    cmd: ApiCommand::List { .. }
+                }
+                | Commands::Api {
+                    cmd: ApiCommand::Inspect { .. }
+                }
+        ) {
             init_context(
                 self.host.clone(),
                 self.skip_ssl_verification,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod api_cmd;
 pub mod commands;
 pub mod dsym;
 pub mod error;


### PR DESCRIPTION
## Problem

The PostHog CLI has manually-coded API endpoints for specific features (sourcemaps, tasks, etc.), but there's no way to call arbitrary API endpoints from the CLI. Adding new endpoints requires writing manual Rust code for each one.

## Changes

Uses [openapi-to-rust](https://github.com/gpu-cli/openapi-to-rust) to auto-generate a static operation registry from the PostHog OpenAPI spec at build time. This exposes every Django viewset endpoint (1331 operations) as a CLI command.

### How it works

1. **Build time**: `build.rs` reads `frontend/tmp/openapi.json` (produced by `hogli build:openapi-schema`) and uses `openapi-to-rust`'s `SchemaAnalyzer` + `CodeGenerator` with `registry_only: true` to generate a static `OPERATIONS` array containing operation metadata (ID, HTTP method, URL path template, parameters with location/type, body info, summary text).

2. **Runtime**: `api_cmd.rs` provides three subcommands that consume the generated registry:
   - `api list [--filter <term>]` — browse/search all operations (no auth needed)
   - `api inspect <operation_id>` — show full details for one operation (no auth needed)
   - `api call <operation_id> [json]` — execute the operation

3. **Graceful fallback**: When the spec is absent at build time, the CLI compiles with an empty registry and tells users to run `hogli build:openapi-schema`.

### How auth works

`api call` uses the **exact same auth flow** as every other CLI command:

- Credentials come from `posthog-cli login` (stored in `~/.posthog/credentials.json`) or the env vars `POSTHOG_CLI_API_KEY` and `POSTHOG_CLI_PROJECT_ID`
- Requests go through the existing `PHClient`, which sends a `Bearer` token via the `Authorization` header
- `project_id` and `environment_id` path params are **auto-filled** from your login context (the env ID stored during `posthog-cli login`), so you don't need to pass them manually
- `api list` and `api inspect` skip auth entirely since they only read the compiled-in registry

### Usage examples

```bash
# Browse operations
posthog-cli api list
posthog-cli api list --filter feature_flag
posthog-cli api list --filter survey

# Inspect an operation before calling it
posthog-cli api inspect feature_flags_list

# Call operations (project_id auto-filled from login)
posthog-cli api call feature_flags_list
posthog-cli api call feature_flags_list '{"active": "true", "limit": "10"}'
posthog-cli api call feature_flags_retrieve '{"id": "12345"}'
posthog-cli api call dashboards_list
posthog-cli api call experiments_list
```

### Files changed

- `cli/build.rs` — registry generation from OpenAPI spec via `openapi-to-rust`
- `cli/src/api_cmd.rs` — new `api` subcommand module (list, inspect, call)
- `cli/src/commands.rs` — wire up `Api` variant, skip auth for list/inspect
- `cli/src/lib.rs` — register module
- `cli/Cargo.toml` — add `openapi-to-rust` build dependency

## How to build and test

### Prerequisites

- Rust 1.85+ (the `openapi-to-rust` crate requires this)
- The OpenAPI spec at `frontend/tmp/openapi.json`

### Step 1: Generate the OpenAPI spec

Either run the full pipeline (requires Django + databases):

```bash
hogli build:openapi-schema
```

Or fetch it directly from a running PostHog instance (no local services needed):

```bash
mkdir -p frontend/tmp
curl -sS "https://us.posthog.com/api/schema/" -H "Accept: application/json" -o frontend/tmp/openapi.json
```

### Step 2: Build the CLI

```bash
cd cli
cargo build
```

You should see build warnings like:
```
warning: Generating API registry from .../frontend/tmp/openapi.json
warning: Generated API registry with 1331 operations
```

### Step 3: Test (no auth needed)

```bash
# List all operations
cargo run -- api list

# Filter by resource
cargo run -- api list --filter feature_flag

# Inspect a specific operation
cargo run -- api inspect feature_flags_list
cargo run -- api inspect dashboards_retrieve
```

### Step 4: Test API calls (requires auth)

```bash
# Log in first
cargo run -- login

# Call any endpoint
cargo run -- api call feature_flags_list
cargo run -- api call feature_flags_list '{"limit": "5"}'
```

### Without the spec (fallback)

If you skip step 1 and build without the spec, everything still compiles — you just get an empty registry:

```bash
cd cli
cargo build  # warns "No OpenAPI spec found"
cargo run -- api list  # prints "No API operations available."
```

## Publish to changelog?

No

## Docs update

No docs needed for this experimental feature.

## LLM context

Agent-authored PR proving out the viability of using `openapi-to-rust` to auto-generate CLI commands from the Django OpenAPI spec. The approach trades compile-time code generation for manual endpoint maintenance — when the OpenAPI spec changes, rebuilding the CLI picks up all new/changed endpoints automatically.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*