### PR TITLE
chore(mcp): reduce error-tracking-issues-list response with response.include

### DIFF
--- a/products/error_tracking/mcp/tools.yaml
+++ b/products/error_tracking/mcp/tools.yaml
@@ -71,8 +71,15 @@ tools:
         list: true
         title: List error tracking issues
         description: >
-            List all error tracking issues in the project. Returns issues with status, volume, first/last seen
-            timestamps, and assignee info.
+            List all error tracking issues in the project. Returns issues with id, status, name, first seen
+            timestamp, and assignee info.
+        response:
+            include:
+                - id
+                - status
+                - name
+                - first_seen
+                - assignee
         ui_app: error-issue-list
     error-tracking-issues-create:
         operation: error_tracking_issues_create

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -915,7 +915,7 @@
         }
     },
     "error-tracking-issues-list": {
-        "description": "List all error tracking issues in the project. Returns issues with status, volume, first/last seen timestamps, and assignee info.",
+        "description": "List all error tracking issues in the project. Returns issues with id, status, name, first seen timestamp, and assignee info.",
         "category": "Error tracking",
         "feature": "error_tracking",
         "summary": "List error tracking issues",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1424,7 +1424,7 @@
         }
     },
     "error-tracking-issues-list": {
-        "description": "List all error tracking issues in the project. Returns issues with status, volume, first/last seen timestamps, and assignee info.",
+        "description": "List all error tracking issues in the project. Returns issues with id, status, name, first seen timestamp, and assignee info.",
         "category": "Error tracking",
         "feature": "error_tracking",
         "summary": "List error tracking issues",

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -12,7 +12,7 @@ import {
 } from '@/generated/error_tracking/api'
 import { withUiApp } from '@/resources/ui-apps'
 import { createQueryWrapper } from '@/tools/query-wrapper-factory'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ErrorTrackingIssuesListSchema = ErrorTrackingIssuesListQueryParams
@@ -34,12 +34,18 @@ const errorTrackingIssuesList = (): ToolBase<
                     offset: params.offset,
                 },
             })
+            const filtered = {
+                ...result,
+                results: (result.results ?? []).map((item: any) =>
+                    pickResponseFields(item, ['id', 'status', 'name', 'first_seen', 'assignee'])
+                ),
+            } as typeof result
             return await withPostHogUrl(
                 context,
                 {
-                    ...result,
+                    ...filtered,
                     results: await Promise.all(
-                        (result.results ?? []).map((item) =>
+                        (filtered.results ?? []).map((item) =>
                             withPostHogUrl(context, item, `/error_tracking/${item.id}`)
                         )
                     ),


### PR DESCRIPTION
## Problem

  The `error-tracking-issues-list` MCP tool returns full stack traces in the `description` field for every issue. With ~981K issues and most being ClickHouse `ServerException` errors with 1,000–1,500 character stack traces each, a single 10-result page consumes ~4,000–4,500 tokens. Only ~500 tokens of that is useful for a list view — the rest is stack trace noise.

  This wastes ~85-90% of tokens on data that an LLM agent doesn't need when browsing issues. The agent can always call `error-tracking-issues-retrieve` to get full details on a specific issue.

  ## Changes

  - Added `response.include` to the `error-tracking-issues-list` tool config in `products/error_tracking/mcp/tools.yaml`, limiting response fields to: `id`, `status`, `name`, `first_seen`, `assignee`
  - Updated the generated handler in `services/mcp/src/tools/generated/error_tracking.ts` to use `pickResponseFields` to strip heavy fields (primarily `description`) before returning results

## How did you test this code?

- Manual test

## Publish to changelog?

  No

## Docs update

  N/A — internal MCP tool optimization, no user-facing API change.