### PR TITLE
feat: add margin to "Add condition" button in conditional branch step

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
@@ -127,7 +127,7 @@ export function StepConditionalBranchConfiguration({
                 </div>
             ))}
 
-            <LemonButton type="secondary" icon={<IconPlus />} onClick={() => addCondition()}>
+            <LemonButton type="secondary" icon={<IconPlus />} onClick={() => addCondition()} className="mt-2">
                 Add condition
             </LemonButton>
         </>


### PR DESCRIPTION
## Problem

The "Add condition" button in the StepConditionalBranch component lacks top margin spacing, causing it to appear too close to the conditions list above it.

## Changes

Added `className="mt-2"` to the "Add condition" button to provide consistent spacing between the conditions list and the button.

## How did you test this code?

This is a straightforward styling change. Visual verification in the UI would confirm the button now has appropriate top margin spacing relative to the conditions above it.

## Publish to changelog?

No

https://claude.ai/code/session_012ramR4Lxq2mFLXjFyzx4kn