### PR TITLE
feat(experiments): add bucketing identifier selector to experiment wizard

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm/BucketingIdentifierSelector.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/BucketingIdentifierSelector.tsx
@@ -1,0 +1,224 @@
+import { useValues } from 'kea'
+import { groupsModel } from 'models/groupsModel'
+import { useRef } from 'react'
+
+import { IconCheckCircle, IconLaptop, IconPeople, IconPerson } from '@posthog/icons'
+import { LemonLabel, LemonSelect } from '@posthog/lemon-ui'
+
+import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
+import { Link } from 'lib/lemon-ui/Link'
+
+export type BucketingOption = 'user' | 'device' | 'group'
+
+export interface BucketingIdentifierValue {
+    option: BucketingOption
+    aggregationGroupTypeIndex?: number | null
+}
+
+interface BucketingIdentifierSelectorProps {
+    value: BucketingIdentifierValue
+    onChange: (value: BucketingIdentifierValue) => void
+    disabled?: boolean
+}
+
+export function BucketingIdentifierSelector({
+    value,
+    onChange,
+    disabled = false,
+}: BucketingIdentifierSelectorProps): JSX.Element | null {
+    const { groupTypes, showGroupsOptions } = useValues(groupsModel)
+    const optionRefs = useRef<Record<string, HTMLDivElement | null>>({})
+
+    const groupTypeValues = Array.from(groupTypes.values())
+    const hasGroups = showGroupsOptions && groupTypeValues.length > 0
+
+    const options: {
+        value: BucketingOption
+        icon: JSX.Element
+        label: string
+        description: string
+        badge?: { type: 'warning' | 'highlight'; text: string }
+        learnMoreUrl?: string
+    }[] = [
+        {
+            value: 'user',
+            icon: <IconPerson className="text-base shrink-0" />,
+            label: 'User',
+            description: 'Stable assignment for logged-in users based on their distinct ID.',
+        },
+        {
+            value: 'device',
+            icon: <IconLaptop className="text-base shrink-0" />,
+            label: 'Device',
+            description: 'Stable assignment per device. Good fit for experiments on anonymous users.',
+            badge: { type: 'warning', text: 'BETA' },
+            learnMoreUrl: 'https://posthog.com/docs/feature-flags/device-bucketing',
+        },
+        ...(hasGroups
+            ? [
+                  {
+                      value: 'group' as const,
+                      icon: <IconPeople className="text-base shrink-0" />,
+                      label: 'Group',
+                      description:
+                          'Stable assignment for everyone in an organization, company, or other custom group type.',
+                  },
+              ]
+            : []),
+    ]
+
+    const selectOption = (optionValue: BucketingOption): void => {
+        if (disabled) {
+            return
+        }
+        if (optionValue === 'group') {
+            const firstGroupType = groupTypeValues[0]
+            onChange({
+                option: 'group',
+                aggregationGroupTypeIndex: firstGroupType?.group_type_index ?? null,
+            })
+        } else {
+            onChange({
+                option: optionValue,
+                aggregationGroupTypeIndex: null,
+            })
+        }
+    }
+
+    return (
+        <div>
+            <LemonLabel className="mb-2" id="experiment-bucketing-label">
+                Bucketing identifier
+            </LemonLabel>
+            <div
+                role="radiogroup"
+                aria-labelledby="experiment-bucketing-label"
+                className="flex flex-wrap gap-2"
+                data-attr="experiment-bucketing-identifier"
+                onKeyDown={(e) => {
+                    if (disabled) {
+                        return
+                    }
+                    if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+                        e.preventDefault()
+                        const optionValues = options.map((o) => o.value)
+                        const currentIndex = optionValues.indexOf(value.option)
+                        let nextIndex = currentIndex
+
+                        if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+                            nextIndex = currentIndex > 0 ? currentIndex - 1 : optionValues.length - 1
+                        } else if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+                            nextIndex = currentIndex < optionValues.length - 1 ? currentIndex + 1 : 0
+                        }
+
+                        selectOption(optionValues[nextIndex])
+                        optionRefs.current[optionValues[nextIndex]]?.focus()
+                    }
+                }}
+            >
+                {options.map((option) => {
+                    const isSelected = option.value === value.option
+
+                    return (
+                        <div
+                            key={option.value}
+                            ref={(el) => {
+                                optionRefs.current[option.value] = el
+                            }}
+                            role="radio"
+                            aria-checked={isSelected}
+                            tabIndex={isSelected ? 0 : -1}
+                            className={`rounded p-3 cursor-pointer transition-colors flex-1 min-w-0 ${
+                                disabled
+                                    ? 'opacity-50 cursor-not-allowed'
+                                    : isSelected
+                                      ? 'bg-accent-highlight-light border-2 border-accent'
+                                      : 'border bg-surface-primary border-primary hover:bg-fill-button-tertiary-hover'
+                            }`}
+                            onClick={() => selectOption(option.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                    e.preventDefault()
+                                    selectOption(option.value)
+                                }
+                            }}
+                            data-attr={`experiment-bucketing-${option.value}`}
+                        >
+                            <div className="flex flex-col gap-1">
+                                <div className="flex items-center gap-1.5">
+                                    {option.icon}
+                                    <span className="text-sm font-medium flex-1 truncate" title={option.label}>
+                                        {option.label}
+                                    </span>
+                                    {option.badge && (
+                                        <LemonTag type={option.badge.type} size="small">
+                                            {option.badge.text}
+                                        </LemonTag>
+                                    )}
+                                    {isSelected && <IconCheckCircle className="text-accent text-sm shrink-0" />}
+                                </div>
+                                <div className="text-xs text-muted">
+                                    {option.description}
+                                    {option.learnMoreUrl && (
+                                        <>
+                                            {' '}
+                                            <Link
+                                                to={option.learnMoreUrl}
+                                                target="_blank"
+                                                onClick={(e) => e.stopPropagation()}
+                                            >
+                                                Learn more
+                                            </Link>
+                                        </>
+                                    )}
+                                </div>
+                                {option.value === 'group' &&
+                                    isSelected &&
+                                    value.aggregationGroupTypeIndex != null &&
+                                    (groupTypeValues.length > 1 ? (
+                                        <div onClick={(e) => e.stopPropagation()}>
+                                            <LemonSelect
+                                                size="xsmall"
+                                                dropdownMatchSelectWidth={false}
+                                                data-attr="experiment-bucketing-group-type-select"
+                                                value={value.aggregationGroupTypeIndex}
+                                                onChange={(v) => {
+                                                    if (v != null) {
+                                                        onChange({
+                                                            option: 'group',
+                                                            aggregationGroupTypeIndex: v,
+                                                        })
+                                                    }
+                                                }}
+                                                options={groupTypeValues.map((groupType) => ({
+                                                    value: groupType.group_type_index,
+                                                    label: groupType.group_type,
+                                                }))}
+                                                disabledReason={disabled ? 'Cannot change while editing' : undefined}
+                                            />
+                                        </div>
+                                    ) : (
+                                        <span className="text-xs font-medium">{groupTypeValues[0]?.group_type}</span>
+                                    ))}
+                            </div>
+                        </div>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}
+
+/** Derive the BucketingOption from experiment parameters */
+export function bucketingValueFromExperiment(params: {
+    aggregation_group_type_index?: number | null
+    bucketing_identifier?: string | null
+}): BucketingIdentifierValue {
+    if (params.aggregation_group_type_index != null) {
+        return { option: 'group', aggregationGroupTypeIndex: params.aggregation_group_type_index }
+    }
+    if (params.bucketing_identifier === 'device_id') {
+        return { option: 'device', aggregationGroupTypeIndex: null }
+    }
+    return { option: 'user', aggregationGroupTypeIndex: null }
+}

--- a/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
@@ -21,6 +21,11 @@ import type { Experiment, MultivariateFlagVariant } from '~/types'
 import { NEW_EXPERIMENT } from '../constants'
 import { ensureIsPercent, isEvenlyDistributed } from '../utils'
 import {
+    BucketingIdentifierSelector,
+    BucketingIdentifierValue,
+    bucketingValueFromExperiment,
+} from './BucketingIdentifierSelector'
+import {
     computeUpdatedVariantSplit,
     distributeVariantsEvenly,
     parseVariantPercentage,
@@ -38,6 +43,8 @@ interface VariantsPanelCreateFeatureFlagProps {
             feature_flag_variants?: MultivariateFlagVariant[]
             ensure_experience_continuity?: boolean
             rollout_percentage?: number
+            aggregation_group_type_index?: number | null
+            bucketing_identifier?: string | null
         }
     }) => void
     disabled?: boolean
@@ -105,12 +112,30 @@ export const VariantsPanelCreateFeatureFlag = ({
     const rolloutPercentage =
         experiment.parameters?.rollout_percentage ?? NEW_EXPERIMENT.parameters.rollout_percentage ?? 100
 
+    const aggregationGroupTypeIndex = experiment.parameters?.aggregation_group_type_index ?? null
+    const bucketingIdentifier =
+        (experiment.parameters as { bucketing_identifier?: string | null })?.bucketing_identifier ?? null
+
     const updateRolloutPercentage = (value: number): void => {
         onChange({
             parameters: {
                 feature_flag_variants: variants,
                 ensure_experience_continuity: ensureExperienceContinuity,
                 rollout_percentage: value,
+                aggregation_group_type_index: aggregationGroupTypeIndex,
+                bucketing_identifier: bucketingIdentifier,
+            },
+        })
+    }
+
+    const updateBucketingIdentifier = (bucketingValue: BucketingIdentifierValue): void => {
+        onChange({
+            parameters: {
+                feature_flag_variants: variants,
+                ensure_experience_continuity: ensureExperienceContinuity,
+                rollout_percentage: rolloutPercentage,
+                aggregation_group_type_index: bucketingValue.aggregationGroupTypeIndex ?? null,
+                bucketing_identifier: bucketingValue.option === 'device' ? 'device_id' : null,
             },
         })
     }
@@ -325,6 +350,15 @@ export const VariantsPanelCreateFeatureFlag = ({
                 </div>
             </div>
 
+            <BucketingIdentifierSelector
+                value={bucketingValueFromExperiment({
+                    aggregation_group_type_index: aggregationGroupTypeIndex,
+                    bucketing_identifier: bucketingIdentifier,
+                })}
+                onChange={updateBucketingIdentifier}
+                disabled={disabled}
+            />
+
             <div>
                 <LemonCheckbox
                     label="Persist flag across authentication steps"
@@ -334,6 +368,8 @@ export const VariantsPanelCreateFeatureFlag = ({
                                 feature_flag_variants: variants,
                                 ensure_experience_continuity: checked,
                                 rollout_percentage: rolloutPercentage,
+                                aggregation_group_type_index: aggregationGroupTypeIndex,
+                                bucketing_identifier: bucketingIdentifier,
                             },
                         })
                     }}

--- a/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm/VariantsPanelCreateFeatureFlag.tsx
@@ -113,8 +113,7 @@ export const VariantsPanelCreateFeatureFlag = ({
         experiment.parameters?.rollout_percentage ?? NEW_EXPERIMENT.parameters.rollout_percentage ?? 100
 
     const aggregationGroupTypeIndex = experiment.parameters?.aggregation_group_type_index ?? null
-    const bucketingIdentifier =
-        (experiment.parameters as { bucketing_identifier?: string | null })?.bucketing_identifier ?? null
+    const bucketingIdentifier = experiment.parameters?.bucketing_identifier ?? null
 
     const updateRolloutPercentage = (value: number): void => {
         onChange({

--- a/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentForm/createExperimentLogic.ts
@@ -113,6 +113,8 @@ export const createExperimentLogic = kea<createExperimentLogicType>([
             parameters?: {
                 feature_flag_variants?: MultivariateFlagVariant[]
                 ensure_experience_continuity?: boolean
+                aggregation_group_type_index?: number | null
+                bucketing_identifier?: string | null
             }
         }) => ({ config }),
         saveExperiment: true,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4502,6 +4502,7 @@ export interface Experiment {
         feature_flag_variants: MultivariateFlagVariant[]
         custom_exposure_filter?: FilterType
         aggregation_group_type_index?: integer
+        bucketing_identifier?: string | null
         variant_screenshot_media_ids?: Record<string, string[]>
         rollout_percentage?: number
     }

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -599,6 +599,8 @@ class ExperimentService:
             feature_flag_data["ensure_experience_continuity"] = params["ensure_experience_continuity"]
         else:
             feature_flag_data["ensure_experience_continuity"] = self.team.flags_persistence_default or False
+        if params.get("bucketing_identifier") is not None:
+            feature_flag_data["bucketing_identifier"] = params["bucketing_identifier"]
         if create_in_folder is not None:
             feature_flag_data["_create_in_folder"] = create_in_folder
 
@@ -1324,9 +1326,14 @@ class ExperimentService:
                     holdout_filters_for_flag(holdout.id if holdout else None, holdout.filters if holdout else None)
                 )
 
+                flag_update_data: dict[str, Any] = {"filters": feature_flag_filters}
+                bucketing_identifier = update_data["parameters"].get("bucketing_identifier")
+                if bucketing_identifier is not None:
+                    flag_update_data["bucketing_identifier"] = bucketing_identifier
+
                 existing_flag_serializer = FeatureFlagSerializer(
                     feature_flag,
-                    data={"filters": feature_flag_filters},
+                    data=flag_update_data,
                     partial=True,
                     context=context,
                 )

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -599,7 +599,7 @@ class ExperimentService:
             feature_flag_data["ensure_experience_continuity"] = params["ensure_experience_continuity"]
         else:
             feature_flag_data["ensure_experience_continuity"] = self.team.flags_persistence_default or False
-        if params.get("bucketing_identifier") is not None:
+        if "bucketing_identifier" in params:
             feature_flag_data["bucketing_identifier"] = params["bucketing_identifier"]
         if create_in_folder is not None:
             feature_flag_data["_create_in_folder"] = create_in_folder
@@ -1327,9 +1327,8 @@ class ExperimentService:
                 )
 
                 flag_update_data: dict[str, Any] = {"filters": feature_flag_filters}
-                bucketing_identifier = update_data["parameters"].get("bucketing_identifier")
-                if bucketing_identifier is not None:
-                    flag_update_data["bucketing_identifier"] = bucketing_identifier
+                if "bucketing_identifier" in update_data["parameters"]:
+                    flag_update_data["bucketing_identifier"] = update_data["parameters"]["bucketing_identifier"]
 
                 existing_flag_serializer = FeatureFlagSerializer(
                     feature_flag,


### PR DESCRIPTION
## Problem

When creating an experiment, users have no way to choose the bucketing identifier (user, device, or group). The feature flag form already has a "Match by" selector with these options, but the experiment wizard doesn't expose this setting — forcing users to manually edit the linked feature flag after creation.

## Changes

- **New `BucketingIdentifierSelector` component** — a reusable radio-card selector (User / Device / Group) that mirrors the visual pattern from the feature flag "Match by" UI in `FeatureFlagReleaseConditionsCollapsible`. Includes keyboard navigation, group type dropdown, and BETA badge for device bucketing.
- **Integrated into the experiment wizard's Variants step** — appears in `VariantsPanelCreateFeatureFlag` between the rollout/variants section and the "Persist flag" checkbox.
- **Updated `createExperimentLogic`** — extended `setFeatureFlagConfig` action types to accept `aggregation_group_type_index` and `bucketing_identifier`.
- **Backend: `ExperimentService`** — now passes `bucketing_identifier` from experiment parameters to the feature flag serializer on both create and update paths.

## How did you test this code?

This was authored by an agent. TypeScript checks pass (no new errors introduced). Python lint passes. Manual testing in a browser has not been performed.

Reviewers should:
1. Navigate to the experiment creation wizard
2. Go to the Variants step
3. Verify the "Bucketing identifier" selector appears with User (default), Device (beta), and Group options (Group only if group types are configured)
4. Select each option and confirm it persists through step navigation
5. Save the experiment and verify the linked feature flag has the correct `aggregation_group_type_index` / `bucketing_identifier`

## Publish to changelog?

no

## Docs update

No docs changes needed — this adds UI for an existing backend capability.

## 🤖 LLM context

Authored by PostHog Code agent. The `BucketingIdentifierSelector` component extracts and simplifies the radio-card pattern from `FeatureFlagReleaseConditionsCollapsible.tsx` for use in the experiment context. The "User & Group" mixed targeting option from the feature flag form was intentionally excluded as it adds complexity not needed for experiments.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*