### PR TITLE
feat(tasks): Add plan mode support for cloud runs with permission relay

### DIFF
--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -256,10 +256,14 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         run_source = request.validated_data.get("run_source")
         signal_report_id = request.validated_data.get("signal_report_id")
         github_user_token = request.validated_data.get("github_user_token")
+        initial_permission_mode = request.validated_data.get("initial_permission_mode")
 
         extra_state = None
         if pending_user_message is not None:
             extra_state = {"pending_user_message": pending_user_message}
+        if initial_permission_mode is not None:
+            extra_state = extra_state or {}
+            extra_state["initial_permission_mode"] = initial_permission_mode
 
         if resume_from_run_id:
             # prevent cross-task resume

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -415,6 +415,12 @@ class TaskRunCreateRequestSerializer(serializers.Serializer):
         write_only=True,
         help_text="Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests.",
     )
+    initial_permission_mode = serializers.ChoiceField(
+        choices=["default", "acceptEdits", "plan", "bypassPermissions"],
+        required=False,
+        default=None,
+        help_text="Initial permission mode for the agent session (e.g., 'plan' to start in plan mode).",
+    )
 
 
 class TaskRunCommandRequestSerializer(serializers.Serializer):
@@ -424,6 +430,8 @@ class TaskRunCommandRequestSerializer(serializers.Serializer):
         "user_message",
         "cancel",
         "close",
+        "permission_response",
+        "set_config_option",
     ]
 
     jsonrpc = serializers.ChoiceField(

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -259,6 +259,22 @@ export const RunSourceEnumApi = {
 } as const
 
 /**
+ * * `default` - default
+ * `acceptEdits` - acceptEdits
+ * `plan` - plan
+ * `bypassPermissions` - bypassPermissions
+ */
+export type InitialPermissionModeEnumApi =
+    (typeof InitialPermissionModeEnumApi)[keyof typeof InitialPermissionModeEnumApi]
+
+export const InitialPermissionModeEnumApi = {
+    Default: 'default',
+    AcceptEdits: 'acceptEdits',
+    Plan: 'plan',
+    BypassPermissions: 'bypassPermissions',
+} as const
+
+/**
  * Request body for creating a new task run
  */
 export interface TaskRunCreateRequestApi {
@@ -293,6 +309,13 @@ export interface TaskRunCreateRequestApi {
     signal_report_id?: string
     /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
     github_user_token?: string
+    /** Initial permission mode for the agent session (e.g., 'plan' to start in plan mode).
+
+* `default` - default
+* `acceptEdits` - acceptEdits
+* `plan` - plan
+* `bypassPermissions` - bypassPermissions */
+    initial_permission_mode?: InitialPermissionModeEnumApi
 }
 
 /**
@@ -535,6 +558,8 @@ export const JsonrpcEnumApi = {
  * * `user_message` - user_message
  * `cancel` - cancel
  * `close` - close
+ * `permission_response` - permission_response
+ * `set_config_option` - set_config_option
  */
 export type MethodEnumApi = (typeof MethodEnumApi)[keyof typeof MethodEnumApi]
 
@@ -542,6 +567,8 @@ export const MethodEnumApi = {
     UserMessage: 'user_message',
     Cancel: 'cancel',
     Close: 'close',
+    PermissionResponse: 'permission_response',
+    SetConfigOption: 'set_config_option',
 } as const
 
 /**
@@ -556,7 +583,9 @@ export interface TaskRunCommandRequestApi {
 
 * `user_message` - user_message
 * `cancel` - cancel
-* `close` - close */
+* `close` - close
+* `permission_response` - permission_response
+* `set_config_option` - set_config_option */
     method: MethodEnumApi
     /** Parameters for the command */
     params?: TaskRunCommandRequestApiParams

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -18567,6 +18567,22 @@ export namespace Schemas {
     }
 
     /**
+     * * `default` - default
+    * `acceptEdits` - acceptEdits
+    * `plan` - plan
+    * `bypassPermissions` - bypassPermissions
+     */
+    export type InitialPermissionModeEnum = typeof InitialPermissionModeEnum[keyof typeof InitialPermissionModeEnum];
+
+
+    export const InitialPermissionModeEnum = {
+      Default: 'default',
+      AcceptEdits: 'acceptEdits',
+      Plan: 'plan',
+      BypassPermissions: 'bypassPermissions',
+    } as const;
+
+    /**
      * @nullable
      */
     export type InsightResolvedDateRange = {
@@ -19572,6 +19588,8 @@ export namespace Schemas {
      * * `user_message` - user_message
     * `cancel` - cancel
     * `close` - close
+    * `permission_response` - permission_response
+    * `set_config_option` - set_config_option
      */
     export type MethodEnum = typeof MethodEnum[keyof typeof MethodEnum];
 
@@ -19580,6 +19598,8 @@ export namespace Schemas {
       UserMessage: 'user_message',
       Cancel: 'cancel',
       Close: 'close',
+      PermissionResponse: 'permission_response',
+      SetConfigOption: 'set_config_option',
     } as const;
 
     export interface MinimalPerson {
@@ -31108,7 +31128,9 @@ export namespace Schemas {
 
     * `user_message` - user_message
     * `cancel` - cancel
-    * `close` - close */
+    * `close` - close
+    * `permission_response` - permission_response
+    * `set_config_option` - set_config_option */
       method: MethodEnum;
       /** Parameters for the command */
       params?: TaskRunCommandRequestParams;
@@ -31187,6 +31209,13 @@ export namespace Schemas {
       signal_report_id?: string;
       /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
       github_user_token?: string;
+      /** Initial permission mode for the agent session (e.g., 'plan' to start in plan mode).
+
+    * `default` - default
+    * `acceptEdits` - acceptEdits
+    * `plan` - plan
+    * `bypassPermissions` - bypassPermissions */
+      initial_permission_mode?: InitialPermissionModeEnum;
     }
 
     export interface TaskRunRelayMessageRequest {


### PR DESCRIPTION
## Problem

  Plan mode doesn't work in cloud runs — the cloud agent auto-approves all permissions instantly, so plans are never reviewed. There's also no mode switcher UI for cloud sessions.

  ## Changes

  - Relay permission requests (plan approvals, edits, bash) to connected PostHog Code desktop app via SSE instead of auto-approving
  - Enforce plan mode tool restrictions so the agent must plan before acting
  - Pass `initial_permission_mode` through the task run API so cloud sessions start in the correct mode (defaults to `bypassPermissions` when not set — web app/Slack tasks unaffected)
  - Show mode switcher in cloud session chat UI with all modes including bypass permissions
  - Backend: add `initial_permission_mode` field and `permission_response`/`set_config_option` commands

## How did you test this code?

- [x] Tested manually with the [Posthog Code changes](https://github.com/PostHog/code/pull/1645)

## Publish to changelog?

  No