### PR TITLE
fix: Retry in inner loop on ServerDisconnectedError.

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
@@ -144,7 +144,12 @@ class WorkflowsConsumer(Consumer):
     async def consume_chunk(self, data: bytes) -> None:
         post = make_retryable_with_exponential_backoff(
             self.post,
-            retryable_exceptions=(InternalServerError, ServiceUnavailable, TooManyRequests),
+            retryable_exceptions=(
+                InternalServerError,
+                ServiceUnavailable,
+                TooManyRequests,
+                aiohttp.ServerDisconnectedError,
+            ),
             # Retry forever on retryable errors
             max_attempts=None,
         )


### PR DESCRIPTION
## Problem

Occasionally, we can get disconnected by our API server. We should retry these errors as the API will become available shortly.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Retry on `ServerDisconnectedError`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

I haven't 

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
