### PR TITLE
fix: skip interactive prompts in flox when POSTHOG_CODE is set

### DIFF
--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -155,8 +155,15 @@ warn_step() {
   printf "  ${C_YELLOW}⚠${C_RESET} %s\n" "$label"
 }
 
+# ── Interactive mode detection ────────────────────────────────────
+# Skip all interactive prompts when running under PostHog Code (automated agent).
+_interactive=false
+if [[ -t 0 ]] && [[ -z "${POSTHOG_CODE:-}" ]]; then
+  _interactive=true
+fi
+
 # ── Direnv first-time setup (interactive only) ─────────────────────
-if [[ -t 0 ]] && ! command -v direnv >/dev/null 2>&1 && [[ ! -f "$FLOX_ENV_CACHE/.hush-direnv" ]]; then
+if [[ "$_interactive" == true ]] && ! command -v direnv >/dev/null 2>&1 && [[ ! -f "$FLOX_ENV_CACHE/.hush-direnv" ]]; then
   read -p "$(echo -e "${C_BOLD}direnv${C_RESET} recommended for auto-activation. Set up now? (Y/n) ")" -n 1 -r
   echo
   if [[ $REPLY =~ ^[Yy]$ || -z $REPLY ]]; then
@@ -174,7 +181,7 @@ fi
 if [[ "$(uname -s)" == "Darwin" ]] && command -v xcodebuild >/dev/null 2>&1 \
    && [[ "$(xcode-select -p 2>/dev/null)" == /Applications/Xcode*.app/* ]]; then
   if ! xcodebuild -license check >/dev/null 2>&1; then
-    if [[ -t 0 ]] && [[ ! -f "$FLOX_ENV_CACHE/.hush-xcode-license" ]]; then
+    if [[ "$_interactive" == true ]] && [[ ! -f "$FLOX_ENV_CACHE/.hush-xcode-license" ]]; then
       warn_step "Xcode license not accepted. Native builds may fail."
       read -p "$(echo -e "   Accept Xcode license now? (Y/n) ")" -n 1 -r
       echo
@@ -255,7 +262,7 @@ else
   echo -e "  ${C_YELLOW}┃${C_RESET}   ${C_DIM}sudo sed -i.bak '/clickhouse-coordinator objectstorage/d' /etc/hosts; echo '${POSTHOG_HOSTS}' | sudo tee -a /etc/hosts${C_RESET}"
   echo -e "  ${C_YELLOW}┃${C_RESET}"
   echo ""
-  if [[ -t 0 ]]; then
+  if [[ "$_interactive" == true ]]; then
     read -n 1 -s -r -p "  Press any key to continue..."
     echo ""
   fi
@@ -300,7 +307,7 @@ _activation_time=$(( _activation_end - _activation_start ))
 echo -e "\n${C_DIM}Ready in ${_activation_time}s${C_RESET}"
 
 # ── Interactive welcome ─────────────────────────────────────────────
-if [[ -t 0 ]]; then
+if [[ "$_interactive" == true ]]; then
   quotes=(
     "At PostHog, we don't follow trends, we set them, like records."
     "Be bold, be fearless, and let's lead the way in tech innovation with beast mode."

--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -156,7 +156,7 @@ warn_step() {
 }
 
 # ── Interactive mode detection ────────────────────────────────────
-# Skip all interactive prompts when running under PostHog Code (automated agent).
+# Skip all interactive prompts in non-interactive terminals or when running under PostHog Code (automated agent).
 _interactive=false
 if [[ -t 0 ]] && [[ -z "${POSTHOG_CODE:-}" ]]; then
   _interactive=true


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C09G8Q32R6F/p1776162290960399

When PostHog Code (automated agent) runs `flox activate`, the on-activate script blocks waiting for user input at interactive prompts — most notably "Press any key to continue..." for `/etc/hosts`. This prevents automated environment setup from completing.

## Changes

Introduces an `_interactive` variable in `.flox/env/on-activate.sh` that is `true` only when both stdin is a TTY (`-t 0`) and `POSTHOG_CODE` env var is not set. All four interactive prompts now use this variable instead of raw `-t 0` checks:

- Direnv setup prompt
- Xcode license acceptance prompt
- `/etc/hosts` "Press any key" prompt
- Welcome message with quotes and tips

## How did you test this code?

This is a shell script change authored by an agent. I verified the diff is correct and that the only remaining raw `-t 0` check is the non-interactive Xcode warning fallback (`elif [[ ! -t 0 ]]`), which does not use `read` and is correct to keep.

To test manually:
- `POSTHOG_CODE=1 flox activate` — should not block on any prompt
- `flox activate` without `POSTHOG_CODE` — interactive prompts appear as before

## Publish to changelog?

No

## Docs update

N/A

## LLM context

Authored entirely by PostHog Code agent. Single-file change to `.flox/env/on-activate.sh`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*