### PR TITLE
fix(cymbal): limit apply_func concurrency

### DIFF
--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -49,6 +49,7 @@ pub struct AppContext {
     pub catalog: Arc<Catalog>,
     pub symbol_resolver: Arc<dyn SymbolResolver>,
     pub symbol_resolution_limiter: Arc<Semaphore>,
+    pub process_request_limiter: Arc<Semaphore>,
     pub config: Config,
     pub geoip_client: GeoIpClient,
 
@@ -264,6 +265,8 @@ impl AppContext {
         ));
         let symbol_resolution_limiter =
             Arc::new(Semaphore::new(config.symbol_resolution_concurrency.max(1)));
+        let process_request_limiter =
+            Arc::new(Semaphore::new(config.process_max_in_flight_requests.max(1)));
 
         Ok(Self {
             health_registry,
@@ -276,6 +279,7 @@ impl AppContext {
             catalog,
             config: config.clone(),
             symbol_resolution_limiter,
+            process_request_limiter,
             team_manager,
             geoip_client,
             billing_limiter,

--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -10,7 +10,7 @@ use limiters::redis::{QuotaResource, RedisLimiter, ServiceName, QUOTA_LIMITER_CA
 use rdkafka::producer::FutureProducer;
 use sqlx::{postgres::PgPoolOptions, PgPool};
 use std::{sync::Arc, time::Duration};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Semaphore};
 use tracing::info;
 use uuid::Uuid;
 
@@ -48,6 +48,7 @@ pub struct AppContext {
     pub persons_pool: PgPool,
     pub catalog: Arc<Catalog>,
     pub symbol_resolver: Arc<dyn SymbolResolver>,
+    pub symbol_resolution_limiter: Arc<Semaphore>,
     pub config: Config,
     pub geoip_client: GeoIpClient,
 
@@ -261,6 +262,8 @@ impl AppContext {
             catalog.clone(),
             posthog_pool.clone(),
         ));
+        let symbol_resolution_limiter =
+            Arc::new(Semaphore::new(config.symbol_resolution_concurrency.max(1)));
 
         Ok(Self {
             health_registry,
@@ -272,6 +275,7 @@ impl AppContext {
             persons_pool,
             catalog,
             config: config.clone(),
+            symbol_resolution_limiter,
             team_manager,
             geoip_client,
             billing_limiter,

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -131,6 +131,11 @@ pub struct Config {
     #[envconfig(default = "1000")]
     pub max_events_per_batch: usize,
 
+    // Maximum number of in-flight /process requests accepted by the API.
+    // Requests above this limit are rejected with 429 to apply backpressure.
+    #[envconfig(default = "128")]
+    pub process_max_in_flight_requests: usize,
+
     #[envconfig(default = "10")]
     pub max_event_batch_wait_seconds: u64,
 

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -118,10 +118,15 @@ pub struct Config {
     #[envconfig(default = "15")]
     pub context_line_count: usize,
 
-    // Maximum number of in-flight futures while processing a Batch with apply_func.
-    // This bounds nested fanout across events -> exceptions -> frames.
+    // Maximum number of in-flight futures for a single `Batch::apply_func` call.
+    // This is a per-call-site limit, not a global pipeline-wide concurrency cap.
     #[envconfig(default = "64")]
     pub batch_apply_concurrency: usize,
+
+    // Global maximum number of concurrent symbol resolution operations.
+    // This limiter is shared across frame and exception symbol resolution paths.
+    #[envconfig(default = "64")]
+    pub symbol_resolution_concurrency: usize,
 
     #[envconfig(default = "1000")]
     pub max_events_per_batch: usize,

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -11,6 +11,7 @@ use tracing::{info, warn};
 
 // TODO - I'm just too lazy to pipe this all the way through the resolve call stack
 pub static FRAME_CONTEXT_LINES: AtomicUsize = AtomicUsize::new(15);
+pub static BATCH_APPLY_CONCURRENCY: AtomicUsize = AtomicUsize::new(64);
 
 #[derive(Envconfig, Clone)]
 pub struct Config {
@@ -117,6 +118,11 @@ pub struct Config {
     #[envconfig(default = "15")]
     pub context_line_count: usize,
 
+    // Maximum number of in-flight futures while processing a Batch with apply_func.
+    // This bounds nested fanout across events -> exceptions -> frames.
+    #[envconfig(default = "64")]
+    pub batch_apply_concurrency: usize,
+
     #[envconfig(default = "1000")]
     pub max_events_per_batch: usize,
 
@@ -210,6 +216,7 @@ impl Config {
 
 pub fn init_global_state(config: &Config) {
     FRAME_CONTEXT_LINES.store(config.context_line_count, Ordering::Relaxed);
+    BATCH_APPLY_CONCURRENCY.store(config.batch_apply_concurrency.max(1), Ordering::Relaxed);
 }
 
 fn default_maxmind_db_path() -> PathBuf {

--- a/rust/cymbal/src/router/event.rs
+++ b/rust/cymbal/src/router/event.rs
@@ -16,7 +16,7 @@ use crate::{
     app_context::AppContext,
     error::UnhandledError,
     metric_consts::{
-        PROCESS_BATCH_EVENTS, PROCESS_IN_FLIGHT, PROCESS_REQUESTS_TOTAL,
+        ERRORS, PROCESS_BATCH_EVENTS, PROCESS_IN_FLIGHT, PROCESS_REQUESTS_TOTAL,
         PROCESS_REQUEST_DURATION_SECONDS,
     },
     stages::http_pipeline::HttpEventPipeline,
@@ -47,16 +47,37 @@ fn get_request_id(headers: &HeaderMap) -> String {
         .unwrap_or_else(|| Uuid::now_v7().to_string())
 }
 
-impl IntoResponse for UnhandledError {
+pub enum ProcessEventsError {
+    Unhandled(UnhandledError),
+    Backpressure,
+}
+
+impl From<UnhandledError> for ProcessEventsError {
+    fn from(value: UnhandledError) -> Self {
+        Self::Unhandled(value)
+    }
+}
+
+impl IntoResponse for ProcessEventsError {
     fn into_response(self) -> axum::response::Response {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({
-                "error": "An unexpected error occurred while processing the events",
-                "details": self.to_string(),
-            })),
-        )
-            .into_response()
+        match self {
+            ProcessEventsError::Unhandled(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({
+                    "error": "An unexpected error occurred while processing the events",
+                    "details": err.to_string(),
+                })),
+            )
+                .into_response(),
+            ProcessEventsError::Backpressure => (
+                StatusCode::TOO_MANY_REQUESTS,
+                Json(json!({
+                    "error": "Too many in-flight /process requests",
+                    "details": "Backpressure limit reached, retry later",
+                })),
+            )
+                .into_response(),
+        }
     }
 }
 
@@ -84,7 +105,7 @@ pub async fn process_events(
     State(ctx): State<Arc<AppContext>>,
     headers: HeaderMap,
     Json(events): Json<Vec<AnyEvent>>,
-) -> Result<Batch<Option<AnyEvent>>, UnhandledError> {
+) -> Result<Batch<Option<AnyEvent>>, ProcessEventsError> {
     let _in_flight = ProcessInFlightGuard::start();
     let request_id = get_request_id(&headers);
     let started_at = Instant::now();
@@ -104,6 +125,27 @@ pub async fn process_events(
         team_count,
         "Started /process request"
     );
+
+    let _permit = ctx
+        .process_request_limiter
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_| {
+            metrics::counter!(ERRORS, "cause" => "process_backpressure").increment(1);
+            metrics::counter!(
+                PROCESS_REQUESTS_TOTAL,
+                "outcome" => "error",
+                "status_class" => "4xx"
+            )
+            .increment(1);
+            warn!(
+                request_id = %request_id,
+                batch_event_count,
+                team_count,
+                "Rejected /process request due to backpressure"
+            );
+            ProcessEventsError::Backpressure
+        })?;
 
     let slow_log_threshold_ms = ctx.config.process_slow_log_threshold_ms;
     let pipeline = HttpEventPipeline::new(ctx.clone());
@@ -174,5 +216,5 @@ pub async fn process_events(
         }
     }
 
-    output
+    output.map_err(ProcessEventsError::from)
 }

--- a/rust/cymbal/src/stages/resolution/exception.rs
+++ b/rust/cymbal/src/stages/resolution/exception.rs
@@ -52,10 +52,12 @@ impl ValueOperator for ExceptionResolver {
                 move |exc, ctx| async move {
                     let ctx = ctx.clone();
                     if ExceptionResolver::is_java_exception(&exc) {
+                        let _permit = ctx.acquire_symbol_resolution_permit().await?;
                         ctx.symbol_resolver
                             .resolve_java_exception(evt.team_id, exc)
                             .await
                     } else if ExceptionResolver::is_dart_exception(&exc) {
+                        let _permit = ctx.acquire_symbol_resolution_permit().await?;
                         ctx.symbol_resolver
                             .resolve_dart_exception(evt.team_id, exc)
                             .await

--- a/rust/cymbal/src/stages/resolution/frame.rs
+++ b/rust/cymbal/src/stages/resolution/frame.rs
@@ -75,6 +75,8 @@ impl FrameResolver {
         debug_images: &[AppleDebugImage],
         ctx: ResolutionStage,
     ) -> Result<Vec<Frame>, UnhandledError> {
+        let _permit = ctx.acquire_symbol_resolution_permit().await?;
+
         ctx.symbol_resolver
             .resolve_raw_frame(team_id, frame, debug_images)
             .await

--- a/rust/cymbal/src/stages/resolution/mod.rs
+++ b/rust/cymbal/src/stages/resolution/mod.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
 pub mod exception;
 pub mod frame;
 pub mod properties;
@@ -7,6 +9,7 @@ pub mod symbol;
 
 use crate::{
     app_context::AppContext,
+    error::UnhandledError,
     metric_consts::RESOLUTION_STAGE,
     stages::pipeline::ExceptionEventPipelineItem,
     stages::resolution::{
@@ -22,13 +25,27 @@ use crate::{
 #[derive(Clone)]
 pub struct ResolutionStage {
     pub symbol_resolver: Arc<dyn SymbolResolver>,
+    pub symbol_resolution_limiter: Arc<Semaphore>,
 }
 
 impl From<&Arc<AppContext>> for ResolutionStage {
     fn from(app_context: &Arc<AppContext>) -> Self {
         Self {
             symbol_resolver: app_context.as_ref().symbol_resolver.clone(),
+            symbol_resolution_limiter: app_context.as_ref().symbol_resolution_limiter.clone(),
         }
+    }
+}
+
+impl ResolutionStage {
+    pub async fn acquire_symbol_resolution_permit(
+        &self,
+    ) -> Result<OwnedSemaphorePermit, UnhandledError> {
+        self.symbol_resolution_limiter
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| UnhandledError::Other("Symbol resolution limiter is closed".to_string()))
     }
 }
 

--- a/rust/cymbal/src/types/batch.rs
+++ b/rust/cymbal/src/types/batch.rs
@@ -1,6 +1,9 @@
-use std::future::Future;
+use std::{future::Future, sync::atomic::Ordering};
+
+use futures::{StreamExt, TryStreamExt};
 
 use crate::{
+    config::BATCH_APPLY_CONCURRENCY,
     error::UnhandledError,
     types::{
         operator::Operator,
@@ -85,18 +88,16 @@ impl<T> Batch<T> {
         O: Send + 'static,
         E: Send + 'static,
     {
-        let mut handles = vec![];
-        for item in self.0.into_iter() {
-            let future = func(item, ctx.clone());
-            handles.push(tokio::spawn(future));
-        }
         async move {
-            futures::future::try_join_all(handles)
-                .await
-                .unwrap_or_else(|e| panic!("task panicked during batch processing: {:?}", e))
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .map(|value| value.into())
+            let concurrency_limit = BATCH_APPLY_CONCURRENCY.load(Ordering::Relaxed).max(1);
+            futures::stream::iter(self.0.into_iter().map(|item| {
+                let future = func(item, ctx.clone());
+                async move { future.await }
+            }))
+            .buffered(concurrency_limit)
+            .try_collect::<Vec<_>>()
+            .await
+            .map(Batch::from)
         }
     }
 

--- a/rust/cymbal/src/types/batch.rs
+++ b/rust/cymbal/src/types/batch.rs
@@ -76,11 +76,7 @@ impl<T> Batch<T> {
         Ok(Batch(result))
     }
 
-    pub async fn apply_func<Ctx, O, F, Fu, E>(
-        self,
-        mut func: F,
-        ctx: Ctx,
-    ) -> Result<Batch<O>, E>
+    pub async fn apply_func<Ctx, O, F, Fu, E>(self, mut func: F, ctx: Ctx) -> Result<Batch<O>, E>
     where
         Ctx: Clone + Send,
         F: FnMut(T, Ctx) -> Fu + 'static,

--- a/rust/cymbal/src/types/batch.rs
+++ b/rust/cymbal/src/types/batch.rs
@@ -76,11 +76,11 @@ impl<T> Batch<T> {
         Ok(Batch(result))
     }
 
-    pub fn apply_func<Ctx, O, F, Fu, E>(
+    pub async fn apply_func<Ctx, O, F, Fu, E>(
         self,
         mut func: F,
         ctx: Ctx,
-    ) -> impl Future<Output = Result<Batch<O>, E>>
+    ) -> Result<Batch<O>, E>
     where
         Ctx: Clone + Send,
         F: FnMut(T, Ctx) -> Fu + 'static,
@@ -88,17 +88,12 @@ impl<T> Batch<T> {
         O: Send + 'static,
         E: Send + 'static,
     {
-        async move {
-            let concurrency_limit = BATCH_APPLY_CONCURRENCY.load(Ordering::Relaxed).max(1);
-            futures::stream::iter(self.0.into_iter().map(|item| {
-                let future = func(item, ctx.clone());
-                async move { future.await }
-            }))
+        let concurrency_limit = BATCH_APPLY_CONCURRENCY.load(Ordering::Relaxed).max(1);
+        futures::stream::iter(self.0.into_iter().map(|item| func(item, ctx.clone())))
             .buffered(concurrency_limit)
             .try_collect::<Vec<_>>()
             .await
             .map(Batch::from)
-        }
     }
 
     #[allow(clippy::manual_async_fn)]


### PR DESCRIPTION
https://posthog.slack.com/archives/C08JQTX5RRP/p1776154289065489

## Problem

`Batch::apply_func` in cymbal spawned one Tokio task per batch item with no concurrency bound.
Because frame resolution fanout can be nested (events -> exceptions -> frames), large batches could create too many in-flight tasks and increase memory and scheduler pressure.

## Changes

- Reworked `Batch::apply_func` to use bounded in-flight concurrency with buffered streams instead of unbounded `tokio::spawn` fanout.
- Added a configurable concurrency limit via `batch_apply_concurrency` (default `64`).
- Wired `batch_apply_concurrency` into global runtime state as `BATCH_APPLY_CONCURRENCY`.

## How did you test this code?

- `cd rust && cargo check -p cymbal`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update required.

## 🤖 LLM context

- Focused follow-up change to make batch operator fanout bounded and configurable.
- Validation run: `cargo check -p cymbal`.
