### PR TITLE
refactor(hogql): rename HogQLPrinter to BasePrinter, add dedicated HogQLPrinter

### DIFF
--- a/posthog/hogql/printer/__init__.py
+++ b/posthog/hogql/printer/__init__.py
@@ -1,5 +1,6 @@
-from posthog.hogql.printer.base import HogQLPrinter
+from posthog.hogql.printer.base import BasePrinter
 from posthog.hogql.printer.clickhouse import ClickHousePrinter
+from posthog.hogql.printer.hogql import HogQLPrinter
 from posthog.hogql.printer.postgres import PostgresPrinter
 from posthog.hogql.printer.utils import (
     prepare_and_print_ast,
@@ -13,6 +14,7 @@ __all__ = [
     "prepare_ast_for_printing",
     "print_prepared_ast",
     "to_printed_hogql",
+    "BasePrinter",
     "HogQLPrinter",
     "ClickHousePrinter",
     "PostgresPrinter",

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -73,8 +73,11 @@ def resolve_field_type(expr: ast.Expr) -> ast.Type | None:
     return expr_type
 
 
-class HogQLPrinter(Visitor[str]):
+class BasePrinter(Visitor[str]):
     # NOTE: Call "print_ast()", not this class directly.
+    # Shared AST walker for all dialect printers (HogQL, ClickHouse, Postgres).
+    # Dialect-specific behavior currently lives behind `self.dialect` checks
+    # and is being progressively moved into subclass overrides.
 
     def __init__(
         self,
@@ -384,7 +387,7 @@ class HogQLPrinter(Visitor[str]):
         node_type: ast.TableOrSelectType,
     ):
         if self.dialect != "hogql":
-            raise NotImplementedError("HogQLPrinter._ensure_team_id_where_clause not overridden")
+            raise NotImplementedError("BasePrinter._ensure_team_id_where_clause not overridden")
 
     def _get_table_predicates(
         self,

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -12,7 +12,8 @@ from posthog.hogql.database.models import DANGEROUS_NoTeamIdCheckTable, Database
 from posthog.hogql.database.s3_table import DataWarehouseTable, S3Table
 from posthog.hogql.errors import ImpossibleASTError, InternalHogQLError, QueryError
 from posthog.hogql.escape_sql import escape_clickhouse_identifier, escape_clickhouse_string, safe_identifier
-from posthog.hogql.printer.base import HogQLPrinter, resolve_field_type
+from posthog.hogql.printer.base import BasePrinter, resolve_field_type
+from posthog.hogql.printer.hogql import HogQLPrinter
 from posthog.hogql.printer.types import PrintableMaterializedColumn, PrintableMaterializedPropertyGroupItem
 from posthog.hogql.utils import ilike_matches, like_matches
 from posthog.hogql.visitor import GetFieldsTraverser, TraversingVisitor, clone_expr
@@ -77,7 +78,7 @@ COLUMNS_WITH_HACKY_OPTIMIZED_NULL_HANDLING = {
 }
 
 
-class ClickHousePrinter(HogQLPrinter):
+class ClickHousePrinter(BasePrinter):
     def __init__(
         self,
         context: HogQLContext,

--- a/posthog/hogql/printer/hogql.py
+++ b/posthog/hogql/printer/hogql.py
@@ -1,0 +1,12 @@
+from posthog.hogql.printer.base import BasePrinter
+
+
+class HogQLPrinter(BasePrinter):
+    """Prints a HogQL AST back out as HogQL text.
+
+    This is the ``dialect="hogql"`` output path — it preserves HogQL-native
+    syntax (nullish access, cohort ops, placeholder arguments) rather than
+    lowering the tree to a target SQL dialect.
+    """
+
+    pass

--- a/posthog/hogql/printer/postgres.py
+++ b/posthog/hogql/printer/postgres.py
@@ -10,7 +10,7 @@ from posthog.hogql.database.direct_postgres_table import DirectPostgresTable
 from posthog.hogql.database.models import StructDatabaseField
 from posthog.hogql.errors import ImpossibleASTError, QueryError
 from posthog.hogql.escape_sql import escape_postgres_identifier
-from posthog.hogql.printer.base import HogQLPrinter
+from posthog.hogql.printer.base import BasePrinter
 from posthog.hogql.printer.postgres_functions import (
     POSTGRES_FUNCTION_HANDLERS_LOWER,
     POSTGRES_FUNCTION_RENAMES_LOWER,
@@ -22,7 +22,7 @@ from posthog.hogql.printer.postgres_functions import (
 _SAFE_FUNCTION_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
-class PostgresPrinter(HogQLPrinter):
+class PostgresPrinter(BasePrinter):
     def __init__(
         self,
         context: HogQLContext,

--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -169,22 +169,35 @@ def print_prepared_ast(
     pretty: bool = False,
 ) -> str:
     with context.timings.measure("printer"):
-        printer_class: type[BasePrinter]
+        printer: BasePrinter
+        printer_stack = cast(list[ast.AST], stack or [])
 
         match dialect:
             case "clickhouse":
-                printer_class = ClickHousePrinter
+                printer = ClickHousePrinter(
+                    context=context,
+                    dialect=dialect,
+                    stack=printer_stack,
+                    settings=settings,
+                    pretty=pretty,
+                )
             case "postgres":
-                printer_class = PostgresPrinter
+                printer = PostgresPrinter(
+                    context=context,
+                    dialect=dialect,
+                    stack=printer_stack,
+                    settings=settings,
+                    pretty=pretty,
+                )
             case "hogql":
-                printer_class = HogQLPrinter
+                printer = HogQLPrinter(
+                    context=context,
+                    dialect=dialect,
+                    stack=printer_stack,
+                    settings=settings,
+                    pretty=pretty,
+                )
             case _:
                 raise InternalHogQLError(f"Invalid SQL dialect: {dialect}")
 
-        return printer_class(
-            context=context,
-            dialect=dialect,
-            stack=cast(list[ast.AST], stack or []),
-            settings=settings,
-            pretty=pretty,
-        ).visit(node)
+        return printer.visit(node)

--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -9,8 +9,9 @@ from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
 from posthog.hogql.errors import InternalHogQLError
 from posthog.hogql.modifiers import create_default_modifiers_for_team, set_default_in_cohort_via
-from posthog.hogql.printer.base import HogQLPrinter
+from posthog.hogql.printer.base import BasePrinter
 from posthog.hogql.printer.clickhouse import ClickHousePrinter
+from posthog.hogql.printer.hogql import HogQLPrinter
 from posthog.hogql.printer.postgres import PostgresPrinter
 from posthog.hogql.resolver import resolve_types
 from posthog.hogql.transforms.in_cohort import resolve_in_cohorts, resolve_in_cohorts_conjoined
@@ -168,7 +169,7 @@ def print_prepared_ast(
     pretty: bool = False,
 ) -> str:
     with context.timings.measure("printer"):
-        printer_class: type[HogQLPrinter]
+        printer_class: type[BasePrinter]
 
         match dialect:
             case "clickhouse":

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -46,7 +46,7 @@ from posthog.hogql.context import HogQLContext
 from posthog.hogql.errors import ExposedHogQLError, QueryError, ResolutionError
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.printer import to_printed_hogql
-from posthog.hogql.printer.base import HogQLPrinter
+from posthog.hogql.printer.hogql import HogQLPrinter
 from posthog.hogql.printer.utils import print_prepared_ast
 from posthog.hogql.visitor import CloningVisitor
 


### PR DESCRIPTION
## Problem

`HogQLPrinter` in `posthog/hogql/printer/base.py` currently plays three roles at once:

1. The shared AST visitor that walks every node.
2. The "print HogQL AST as HogQL text" output printer (`dialect="hogql"`).
3. The superclass for `ClickHousePrinter` and `PostgresPrinter`.

That conflation is why `base.py` is full of `self.dialect == "..."` branches — the same class has to behave differently for each output dialect. It also makes adding a new dialect (e.g. DuckDB) intrusive, because it means editing `base.py` rather than adding a new file.

This is the first PR in a 5-PR refactor that progressively moves each dialect's logic out of the shared base. This PR is purely a rename — no behavior changes — to give the next PRs somewhere to put things.

## Changes

- Renamed `HogQLPrinter` → `BasePrinter` in `posthog/hogql/printer/base.py`.
- Added `posthog/hogql/printer/hogql.py` with a new dedicated `HogQLPrinter(BasePrinter)` subclass (empty body — this will absorb the `dialect == "hogql"` branches in PR 3).
- `ClickHousePrinter` and `PostgresPrinter` now inherit directly from `BasePrinter` instead of going through `HogQLPrinter`.
- Updated the internal `HogQLPrinter(..., dialect="hogql")` call site in `clickhouse.py` and the `_PlaceholderPreservingPrinter` subclass in `products/endpoints/backend/api.py` to import from the new location.
- Exported `BasePrinter` from `posthog/hogql/printer/__init__.py`.

No dialect branches were moved yet — every `self.dialect == "..."` check still lives where it was. Follow-up PRs (2–5) migrate them into their respective subclasses and then delete the `self.dialect` field entirely.

## How did you test this code?

- `ruff check` clean.
- Import + instantiation smoke test confirms the inheritance graph (`ClickHousePrinter`, `PostgresPrinter`, `HogQLPrinter` all direct subclasses of `BasePrinter`; CH/PG no longer subclass `HogQLPrinter`).
- `HogQLPrinter(...).visit(parse_expr("1 + 2"))` still prints `plus(1, 2)`.
- Ran the printer test suite locally across all three dialects — green.

## Publish to changelog?

no

## 🤖 LLM context

Authored via Claude Code. Part of a planned 5-PR series to split dialect-specific logic out of the shared HogQL printer base so adding DuckDB (and keeping PG/CH optimal) doesn't require edits to the shared file. PR 1 is the rename/shell step; PRs 2–4 move branches out of `base.py` into the respective subclasses; PR 5 removes the `self.dialect` field entirely.
