### PR TITLE
feat: Allow publishing to team scoped outputs in ingestion-events

### DIFF
--- a/nodejs/src/ingestion/common/event-filters/batch-app-metrics.ts
+++ b/nodejs/src/ingestion/common/event-filters/batch-app-metrics.ts
@@ -47,6 +47,7 @@ export class EventFiltersBatchAppMetrics {
                 })
             ),
             key: Buffer.from(`${teamId}`),
+            teamId,
         }))
 
         this.counts.clear()

--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -362,6 +362,11 @@ export type IngestionOutputsConfig = {
     INGESTION_OUTPUT_TOPHOG_PRODUCER: ProducerName
     INGESTION_OUTPUT_TOPHOG_SECONDARY_TOPIC: string
     INGESTION_OUTPUT_TOPHOG_SECONDARY_PRODUCER: ProducerName
+
+    /** Comma-separated team IDs whose output should be routed to a different producer. */
+    INGESTION_TEAM_ROUTING_TEAM_IDS: string
+    /** Producer name to use for team-routed messages. Must match a registered producer. */
+    INGESTION_TEAM_ROUTING_PRODUCER: ProducerName
 }
 
 export function getDefaultIngestionOutputsConfig(): IngestionOutputsConfig {
@@ -418,5 +423,8 @@ export function getDefaultIngestionOutputsConfig(): IngestionOutputsConfig {
         INGESTION_OUTPUT_TOPHOG_PRODUCER: DEFAULT_PRODUCER,
         INGESTION_OUTPUT_TOPHOG_SECONDARY_TOPIC: '',
         INGESTION_OUTPUT_TOPHOG_SECONDARY_PRODUCER: DEFAULT_PRODUCER,
+
+        INGESTION_TEAM_ROUTING_TEAM_IDS: '',
+        INGESTION_TEAM_ROUTING_PRODUCER: DEFAULT_PRODUCER,
     }
 }

--- a/nodejs/src/ingestion/event-processing/emit-event-step.ts
+++ b/nodejs/src/ingestion/event-processing/emit-event-step.ts
@@ -34,7 +34,7 @@ export function createEmitEventStep<O extends string, T extends EmitEventStepInp
     config: EmitEventStepConfig<O>
 ): ProcessingStep<T, void> {
     return function emitEventStep(input) {
-        const { eventsToEmit, headers, message } = input
+        const { eventsToEmit, teamId, headers, message } = input
         const { outputs, groupId } = config
 
         // Record ingestion lag metric if we have the required data
@@ -57,6 +57,7 @@ export function createEmitEventStep<O extends string, T extends EmitEventStepInp
                     key: serialized.uuid,
                     value: Buffer.from(JSON.stringify(serialized)),
                     headers: { productTrack: productTrackHeader(event) },
+                    teamId,
                 })
                 .then((result) => {
                     eventProcessedAndIngestedCounter.inc()

--- a/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.ts
+++ b/nodejs/src/ingestion/event-processing/extract-heatmap-data-step.ts
@@ -46,6 +46,7 @@ export function createExtractHeatmapDataStep<TInput extends ExtractHeatmapDataSt
                         heatmapEvents.map((rawEvent) => ({
                             key: eventUuid,
                             value: Buffer.from(JSON.stringify(rawEvent)),
+                            teamId: preparedEvent.teamId,
                         }))
                     )
                 )

--- a/nodejs/src/ingestion/event-processing/flush-batch-stores-step.ts
+++ b/nodejs/src/ingestion/event-processing/flush-batch-stores-step.ts
@@ -89,6 +89,7 @@ function createProducePromises(personsStoreMessages: FlushResult[], outputs: Per
                 .produce(message.output, {
                     key: null,
                     value: message.value,
+                    teamId: record.teamId,
                 })
                 .catch((error) => {
                     // Handle message size errors gracefully by capturing a warning

--- a/nodejs/src/ingestion/outputs/ingestion-outputs.ts
+++ b/nodejs/src/ingestion/outputs/ingestion-outputs.ts
@@ -50,6 +50,20 @@ export class IngestionOutputs<O extends string> {
      * @param timeoutMs - Timeout for each topic metadata check.
      * @returns Output names whose topics failed the check.
      */
+    /**
+     * Return a new `IngestionOutputs` where each output has been passed through `fn`.
+     *
+     * Useful for wrapping outputs with team-based routing or other decorators
+     * without changing the builder or the callers.
+     */
+    wrapOutputs(fn: (name: string, output: IngestionOutput) => IngestionOutput): IngestionOutputs<O> {
+        const wrapped: Record<string, IngestionOutput> = {}
+        for (const name in this.outputs) {
+            wrapped[name] = fn(name, this.outputs[name])
+        }
+        return new IngestionOutputs<O>(wrapped as Record<O, IngestionOutput>)
+    }
+
     async checkTopics(timeoutMs = 10000): Promise<string[]> {
         const failures: string[] = []
         for (const outputName in this.outputs) {

--- a/nodejs/src/ingestion/outputs/team-routed-ingestion-output.test.ts
+++ b/nodejs/src/ingestion/outputs/team-routed-ingestion-output.test.ts
@@ -1,0 +1,121 @@
+import { KafkaProducerWrapper } from '../../kafka/producer'
+import { SingleIngestionOutput } from './single-ingestion-output'
+import { TeamRoutedIngestionOutput } from './team-routed-ingestion-output'
+
+function createMockProducer(): jest.Mocked<KafkaProducerWrapper> {
+    return {
+        checkConnection: jest.fn().mockResolvedValue(undefined),
+        checkTopicExists: jest.fn().mockResolvedValue(undefined),
+        produce: jest.fn().mockResolvedValue(undefined),
+        queueMessages: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<KafkaProducerWrapper>
+}
+
+describe('TeamRoutedIngestionOutput', () => {
+    let defaultProducer: jest.Mocked<KafkaProducerWrapper>
+    let teamProducer: jest.Mocked<KafkaProducerWrapper>
+    let defaultOutput: SingleIngestionOutput
+    let teamOutput: SingleIngestionOutput
+    let routed: TeamRoutedIngestionOutput
+
+    beforeEach(() => {
+        defaultProducer = createMockProducer()
+        teamProducer = createMockProducer()
+        defaultOutput = new SingleIngestionOutput('events', 'events_json', defaultProducer, 'DEFAULT')
+        teamOutput = new SingleIngestionOutput('events', 'events_json', teamProducer, 'WARPSTREAM')
+        routed = new TeamRoutedIngestionOutput(defaultOutput, teamOutput, new Set([2, 42]))
+    })
+
+    describe('produce', () => {
+        it('routes to team output when teamId matches', async () => {
+            await routed.produce({ key: Buffer.from('k'), value: Buffer.from('v'), teamId: 2 })
+
+            expect(teamProducer.produce).toHaveBeenCalledTimes(1)
+            expect(defaultProducer.produce).not.toHaveBeenCalled()
+        })
+
+        it('routes to default output when teamId does not match', async () => {
+            await routed.produce({ key: Buffer.from('k'), value: Buffer.from('v'), teamId: 99 })
+
+            expect(defaultProducer.produce).toHaveBeenCalledTimes(1)
+            expect(teamProducer.produce).not.toHaveBeenCalled()
+        })
+
+        it('routes to default output when teamId is undefined', async () => {
+            await routed.produce({ key: Buffer.from('k'), value: Buffer.from('v') })
+
+            expect(defaultProducer.produce).toHaveBeenCalledTimes(1)
+            expect(teamProducer.produce).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('queueMessages', () => {
+        it('splits batch by team membership', async () => {
+            await routed.queueMessages([
+                { value: Buffer.from('default-1'), teamId: 1 },
+                { value: Buffer.from('team-2'), teamId: 2 },
+                { value: Buffer.from('default-3'), teamId: 3 },
+                { value: Buffer.from('team-42'), teamId: 42 },
+            ])
+
+            expect(defaultProducer.queueMessages).toHaveBeenCalledTimes(1)
+            expect(teamProducer.queueMessages).toHaveBeenCalledTimes(1)
+
+            // Default producer gets messages for non-matching teams
+            const defaultCall = defaultProducer.queueMessages.mock.calls[0][0] as { messages: unknown[] }
+            expect(defaultCall.messages).toHaveLength(2)
+
+            // Team producer gets messages for matching teams
+            const teamCall = teamProducer.queueMessages.mock.calls[0][0] as { messages: unknown[] }
+            expect(teamCall.messages).toHaveLength(2)
+        })
+
+        it('sends all to default when no teamId matches', async () => {
+            await routed.queueMessages([{ value: Buffer.from('a'), teamId: 99 }, { value: Buffer.from('b') }])
+
+            expect(defaultProducer.queueMessages).toHaveBeenCalledTimes(1)
+            expect(teamProducer.queueMessages).not.toHaveBeenCalled()
+        })
+
+        it('sends all to team output when all teamIds match', async () => {
+            await routed.queueMessages([
+                { value: Buffer.from('a'), teamId: 2 },
+                { value: Buffer.from('b'), teamId: 42 },
+            ])
+
+            expect(teamProducer.queueMessages).toHaveBeenCalledTimes(1)
+            expect(defaultProducer.queueMessages).not.toHaveBeenCalled()
+        })
+
+        it('handles empty batch', async () => {
+            await routed.queueMessages([])
+
+            expect(defaultProducer.queueMessages).not.toHaveBeenCalled()
+            expect(teamProducer.queueMessages).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('checkHealth', () => {
+        it('checks both outputs', async () => {
+            await routed.checkHealth(5000)
+
+            expect(defaultProducer.checkConnection).toHaveBeenCalledTimes(1)
+            expect(teamProducer.checkConnection).toHaveBeenCalledTimes(1)
+        })
+
+        it('propagates failure from either output', async () => {
+            teamProducer.checkConnection.mockRejectedValue(new Error('WS down'))
+
+            await expect(routed.checkHealth(5000)).rejects.toThrow('WS down')
+        })
+    })
+
+    describe('checkTopicExists', () => {
+        it('checks both outputs', async () => {
+            await routed.checkTopicExists(5000)
+
+            expect(defaultProducer.checkTopicExists).toHaveBeenCalledTimes(1)
+            expect(teamProducer.checkTopicExists).toHaveBeenCalledTimes(1)
+        })
+    })
+})

--- a/nodejs/src/ingestion/outputs/team-routed-ingestion-output.ts
+++ b/nodejs/src/ingestion/outputs/team-routed-ingestion-output.ts
@@ -1,0 +1,58 @@
+import { MessageKey } from '../../kafka/producer'
+import { IngestionOutput } from './ingestion-output'
+import { IngestionOutputMessage } from './types'
+
+/**
+ * Routes messages to different outputs based on team ID.
+ *
+ * Messages whose `teamId` is in the configured set are sent to the
+ * `teamOutput`; everything else goes to `defaultOutput`. For `queueMessages`,
+ * the batch is split by team membership and each sub-batch is sent to the
+ * appropriate output in parallel.
+ *
+ * Health checks and topic checks cover both outputs.
+ */
+export class TeamRoutedIngestionOutput implements IngestionOutput {
+    constructor(
+        private readonly defaultOutput: IngestionOutput,
+        private readonly teamOutput: IngestionOutput,
+        private readonly teamIds: ReadonlySet<number>
+    ) {}
+
+    async produce(message: IngestionOutputMessage & { key: MessageKey }): Promise<void> {
+        if (message.teamId !== undefined && this.teamIds.has(message.teamId)) {
+            return this.teamOutput.produce(message)
+        }
+        return this.defaultOutput.produce(message)
+    }
+
+    async queueMessages(messages: IngestionOutputMessage[]): Promise<void> {
+        const defaultMessages: IngestionOutputMessage[] = []
+        const teamMessages: IngestionOutputMessage[] = []
+
+        for (const msg of messages) {
+            if (msg.teamId !== undefined && this.teamIds.has(msg.teamId)) {
+                teamMessages.push(msg)
+            } else {
+                defaultMessages.push(msg)
+            }
+        }
+
+        const promises: Promise<void>[] = []
+        if (defaultMessages.length > 0) {
+            promises.push(this.defaultOutput.queueMessages(defaultMessages))
+        }
+        if (teamMessages.length > 0) {
+            promises.push(this.teamOutput.queueMessages(teamMessages))
+        }
+        await Promise.all(promises)
+    }
+
+    async checkHealth(timeoutMs: number): Promise<void> {
+        await Promise.all([this.defaultOutput.checkHealth(timeoutMs), this.teamOutput.checkHealth(timeoutMs)])
+    }
+
+    async checkTopicExists(timeoutMs: number): Promise<void> {
+        await Promise.all([this.defaultOutput.checkTopicExists(timeoutMs), this.teamOutput.checkTopicExists(timeoutMs)])
+    }
+}

--- a/nodejs/src/ingestion/outputs/team-routing.test.ts
+++ b/nodejs/src/ingestion/outputs/team-routing.test.ts
@@ -1,0 +1,122 @@
+import { KafkaProducerWrapper } from '../../kafka/producer'
+import { IngestionOutputs } from './ingestion-outputs'
+import { KafkaProducerRegistry } from './kafka-producer-registry'
+import { SingleIngestionOutput } from './single-ingestion-output'
+import { applyTeamRouting, parseTeamIds } from './team-routing'
+
+function createMockProducer(): jest.Mocked<KafkaProducerWrapper> {
+    return {
+        checkConnection: jest.fn().mockResolvedValue(undefined),
+        checkTopicExists: jest.fn().mockResolvedValue(undefined),
+        produce: jest.fn().mockResolvedValue(undefined),
+        queueMessages: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<KafkaProducerWrapper>
+}
+
+describe('parseTeamIds', () => {
+    it('parses comma-separated team IDs', () => {
+        expect(parseTeamIds('1,2,3')).toEqual(new Set([1, 2, 3]))
+    })
+
+    it('handles whitespace', () => {
+        expect(parseTeamIds(' 1 , 2 , 3 ')).toEqual(new Set([1, 2, 3]))
+    })
+
+    it('returns empty set for empty string', () => {
+        expect(parseTeamIds('')).toEqual(new Set())
+    })
+
+    it('returns empty set for whitespace-only string', () => {
+        expect(parseTeamIds('   ')).toEqual(new Set())
+    })
+
+    it('filters out NaN values', () => {
+        expect(parseTeamIds('1,abc,3')).toEqual(new Set([1, 3]))
+    })
+
+    it('handles single value', () => {
+        expect(parseTeamIds('42')).toEqual(new Set([42]))
+    })
+})
+
+describe('applyTeamRouting', () => {
+    it('returns outputs unchanged when teamIds is empty', () => {
+        const producer = createMockProducer()
+        const outputs = new IngestionOutputs({
+            events: new SingleIngestionOutput('events', 'events_json', producer, 'DEFAULT'),
+        })
+        const registry = new KafkaProducerRegistry({ DEFAULT: producer } as Record<string, KafkaProducerWrapper>)
+
+        const result = applyTeamRouting(outputs, registry, new Set(), 'WARPSTREAM', {})
+
+        expect(result).toBe(outputs)
+    })
+
+    it('wraps outputs with TeamRoutedIngestionOutput when teamIds are set', async () => {
+        const defaultProducer = createMockProducer()
+        const wsProducer = createMockProducer()
+        const outputs = new IngestionOutputs({
+            events: new SingleIngestionOutput('events', 'events_json', defaultProducer, 'DEFAULT'),
+        })
+        const registry = new KafkaProducerRegistry({
+            DEFAULT: defaultProducer,
+            WARPSTREAM: wsProducer,
+        } as Record<string, KafkaProducerWrapper>)
+
+        const result = applyTeamRouting(outputs, registry, new Set([2]), 'WARPSTREAM', {
+            INGESTION_OUTPUT_EVENTS_TOPIC: 'events_json',
+        })
+
+        // Produce for team 2 should go to WS
+        await result.produce('events', { key: Buffer.from('k'), value: Buffer.from('v'), teamId: 2 })
+        expect(wsProducer.produce).toHaveBeenCalledTimes(1)
+        expect(defaultProducer.produce).not.toHaveBeenCalled()
+
+        // Produce for other teams should go to default
+        defaultProducer.produce.mockClear()
+        wsProducer.produce.mockClear()
+        await result.produce('events', { key: Buffer.from('k'), value: Buffer.from('v'), teamId: 99 })
+        expect(defaultProducer.produce).toHaveBeenCalledTimes(1)
+        expect(wsProducer.produce).not.toHaveBeenCalled()
+    })
+
+    it('uses the specified producer name', async () => {
+        const defaultProducer = createMockProducer()
+        const customProducer = createMockProducer()
+        const outputs = new IngestionOutputs({
+            events: new SingleIngestionOutput('events', 'events_json', defaultProducer, 'DEFAULT'),
+        })
+        const registry = new KafkaProducerRegistry({
+            DEFAULT: defaultProducer,
+            CUSTOM: customProducer,
+        } as Record<string, KafkaProducerWrapper>)
+
+        const result = applyTeamRouting(outputs, registry, new Set([2]), 'CUSTOM', {
+            INGESTION_OUTPUT_EVENTS_TOPIC: 'events_json',
+        })
+
+        await result.produce('events', { key: Buffer.from('k'), value: Buffer.from('v'), teamId: 2 })
+        expect(customProducer.produce).toHaveBeenCalledTimes(1)
+        expect(defaultProducer.produce).not.toHaveBeenCalled()
+    })
+
+    it('skips wrapping outputs without a topic in config', async () => {
+        const defaultProducer = createMockProducer()
+        const wsProducer = createMockProducer()
+        const outputs = new IngestionOutputs({
+            events: new SingleIngestionOutput('events', 'events_json', defaultProducer, 'DEFAULT'),
+        })
+        const registry = new KafkaProducerRegistry({
+            DEFAULT: defaultProducer,
+            WARPSTREAM: wsProducer,
+        } as Record<string, KafkaProducerWrapper>)
+
+        // No INGESTION_OUTPUT_EVENTS_TOPIC in config
+        const result = applyTeamRouting(outputs, registry, new Set([2]), 'WARPSTREAM', {})
+
+        // Should still go to default even for team 2 (not wrapped)
+        await result.produce('events', { key: Buffer.from('k'), value: Buffer.from('v'), teamId: 2 })
+        expect(defaultProducer.produce).toHaveBeenCalledTimes(1)
+        expect(wsProducer.produce).not.toHaveBeenCalled()
+    })
+})

--- a/nodejs/src/ingestion/outputs/team-routing.ts
+++ b/nodejs/src/ingestion/outputs/team-routing.ts
@@ -1,0 +1,56 @@
+import { IngestionOutputs } from './ingestion-outputs'
+import { KafkaProducerRegistry } from './kafka-producer-registry'
+import { SingleIngestionOutput } from './single-ingestion-output'
+import { TeamRoutedIngestionOutput } from './team-routed-ingestion-output'
+
+/**
+ * Parse a comma-separated string of team IDs into a Set.
+ * Empty or whitespace-only strings return an empty set.
+ */
+export function parseTeamIds(raw: string): Set<number> {
+    if (!raw.trim()) {
+        return new Set()
+    }
+    return new Set(
+        raw
+            .split(',')
+            .map((s) => parseInt(s.trim(), 10))
+            .filter((n) => !isNaN(n))
+    )
+}
+
+/**
+ * Wrap each output in a `TeamRoutedIngestionOutput` so messages for the
+ * specified teams are produced via a different producer.
+ *
+ * The topic stays the same — only the producer (broker connection) changes.
+ * If `teamIds` is empty the outputs are returned unchanged.
+ */
+export function applyTeamRouting<O extends string>(
+    outputs: IngestionOutputs<O>,
+    producerRegistry: KafkaProducerRegistry<string>,
+    teamIds: Set<number>,
+    producerName: string,
+    config: Record<string, string>
+): IngestionOutputs<O> {
+    if (teamIds.size === 0) {
+        return outputs
+    }
+
+    const teamProducer = producerRegistry.getProducer(producerName)
+
+    return outputs.wrapOutputs((name, defaultOutput) => {
+        // Look up the topic for this output from config.
+        // Convention: INGESTION_OUTPUT_<NAME>_TOPIC
+        const topicKey = `INGESTION_OUTPUT_${name.toUpperCase()}_TOPIC`
+        const topic = config[topicKey]
+
+        if (!topic) {
+            // Output has no known topic config (shouldn't happen) — skip routing
+            return defaultOutput
+        }
+
+        const teamOutput = new SingleIngestionOutput(name, topic, teamProducer, producerName)
+        return new TeamRoutedIngestionOutput(defaultOutput, teamOutput, teamIds)
+    })
+}

--- a/nodejs/src/ingestion/outputs/types.ts
+++ b/nodejs/src/ingestion/outputs/types.ts
@@ -5,4 +5,12 @@ export type IngestionOutputMessage = {
     value: Buffer | null
     key?: MessageKey
     headers?: Record<string, string>
+    /**
+     * Optional team ID for team-based producer routing.
+     *
+     * When set, `TeamRoutedIngestionOutput` uses this to decide which producer
+     * handles the message (e.g. WarpStream for specific teams, default for the rest).
+     * Ignored by producers — not sent as a Kafka header or included in the message payload.
+     */
+    teamId?: number
 }

--- a/nodejs/src/servers/ingestion-general-server.ts
+++ b/nodejs/src/servers/ingestion-general-server.ts
@@ -39,6 +39,7 @@ import { CookielessManager } from '../ingestion/cookieless/cookieless-manager'
 import { IngestionConsumer, IngestionConsumerDeps } from '../ingestion/ingestion-consumer'
 import { IngestionTestingConsumer } from '../ingestion/ingestion-testing-consumer'
 import { KafkaProducerRegistry } from '../ingestion/outputs/kafka-producer-registry'
+import { applyTeamRouting, parseTeamIds } from '../ingestion/outputs/team-routing'
 import { buildGroupRepository, buildPersonRepository, createPersonHogClient } from '../ingestion/personhog'
 import { KafkaProducerWrapper } from '../kafka/producer'
 import { PluginServerService, RedisPool } from '../types'
@@ -219,7 +220,14 @@ export class IngestionGeneralServer implements NodeServer {
             this.ingestionProducerRegistry = await createProducerRegistry(this.config.KAFKA_CLIENT_RACK).build(
                 this.config
             )
-            const ingestionOutputs = createOutputsRegistry().build(this.ingestionProducerRegistry, this.config)
+            const teamRoutingTeamIds = parseTeamIds(this.config.INGESTION_TEAM_ROUTING_TEAM_IDS)
+            const ingestionOutputs = applyTeamRouting(
+                createOutputsRegistry().build(this.ingestionProducerRegistry, this.config),
+                this.ingestionProducerRegistry,
+                teamRoutingTeamIds,
+                this.config.INGESTION_TEAM_ROUTING_PRODUCER,
+                this.config as unknown as Record<string, string>
+            )
             const clickhouseGroupRepository = new ClickhouseGroupRepository(ingestionOutputs)
 
             const hogTransformerDeps: HogTransformerServiceDeps = {

--- a/nodejs/src/worker/ingestion/groups/repositories/clickhouse-group-repository.ts
+++ b/nodejs/src/worker/ingestion/groups/repositories/clickhouse-group-repository.ts
@@ -30,6 +30,7 @@ export class ClickhouseGroupRepository {
                         version,
                     })
                 ),
+                teamId,
             },
         ])
     }


### PR DESCRIPTION
## Problem

The ingestion-general pipeline currently produces all output to a single Kafka cluster (MSK via the DEFAULT producer). We need to progressively migrate traffic to WarpStream, starting with specific teams, without duplicating the entire pipeline.

## Changes

- Added a `TeamRoutedIngestionOutput` that wraps any `IngestionOutput` and routes messages to a different producer based on `message.teamId`
- Added optional `teamId` field to `IngestionOutputMessage` so pipeline steps can tag messages for routing
- Added `wrapOutputs` method to `IngestionOutputs` for post-build output decoration
- Added `INGESTION_TEAM_ROUTING_TEAM_IDS` (comma-separated team IDs) and `INGESTION_TEAM_ROUTING_PRODUCER` (target producer name) config keys
- Wired team routing into `IngestionGeneralServer` after building outputs
- Updated data output callers (events, heatmaps, persons, groups, app metrics) to pass `teamId`
- DLQ, redirect, overflow, and ingestion warnings always use the default producer

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
