### PR TITLE
fix(experiments): extend metric events preaggregation ORDER BY for per-event storage

### DIFF
--- a/posthog/clickhouse/migrations/0230_fix_metric_events_order_by.py
+++ b/posthog/clickhouse/migrations/0230_fix_metric_events_order_by.py
@@ -1,0 +1,42 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.preaggregation.experiment_metric_events_sql import (
+    DISTRIBUTED_EXPERIMENT_METRIC_EVENTS_TABLE_SQL,
+    DROP_EXPERIMENT_METRIC_EVENTS_TABLE_SQL,
+    DROP_SHARDED_EXPERIMENT_METRIC_EVENTS_TABLE_SQL,
+    SHARDED_EXPERIMENT_METRIC_EVENTS_TABLE_SQL,
+)
+
+# The table was created in 0228 with ORDER BY (team_id, job_id, entity_id).
+# ReplacingMergeTree deduplicates by the ORDER BY key, so after background
+# merges only one row per (team_id, job_id, entity_id) survives. That works
+# for mean/ratio metrics (one value per user), but breaks funnel metrics
+# which store one row per event — a user with a pageview and a purchase
+# needs both rows kept.
+#
+# Fix: extend ORDER BY to (team_id, job_id, entity_id, timestamp, event_uuid)
+# so each event is a distinct key. No data loss — nothing writes to this
+# table yet.
+
+operations = [
+    # Drop distributed table first (depends on sharded)
+    run_sql_with_exceptions(
+        DROP_EXPERIMENT_METRIC_EVENTS_TABLE_SQL(),
+        node_roles=[NodeRole.AUX, NodeRole.DATA],
+    ),
+    # Drop sharded table
+    run_sql_with_exceptions(
+        DROP_SHARDED_EXPERIMENT_METRIC_EVENTS_TABLE_SQL(),
+        node_roles=[NodeRole.AUX],
+    ),
+    # Recreate sharded table with fixed ORDER BY
+    run_sql_with_exceptions(
+        SHARDED_EXPERIMENT_METRIC_EVENTS_TABLE_SQL(),
+        node_roles=[NodeRole.AUX],
+    ),
+    # Recreate distributed table
+    run_sql_with_exceptions(
+        DISTRIBUTED_EXPERIMENT_METRIC_EVENTS_TABLE_SQL(),
+        node_roles=[NodeRole.AUX, NodeRole.DATA],
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0229_warpstream_calculated_events
+0230_fix_metric_events_order_by

--- a/posthog/clickhouse/preaggregation/experiment_metric_events_sql.py
+++ b/posthog/clickhouse/preaggregation/experiment_metric_events_sql.py
@@ -5,7 +5,9 @@
 # and store it here. Subsequent queries read from this table instead of
 # scanning events.
 #
-# One row per entity per job, deduplicated by ReplacingMergeTree.
+# For funnels: one row per event per entity per job.
+# For mean/ratio: one row per entity per job.
+# Deduplicated by ReplacingMergeTree on the full ORDER BY key.
 #
 # Supported metric types:
 # - Funnel: uses `steps` array for step indicators
@@ -67,7 +69,7 @@ def SHARDED_EXPERIMENT_METRIC_EVENTS_TABLE_SQL():
         EXPERIMENT_METRIC_EVENTS_TABLE_BASE_SQL
         + """
 PARTITION BY toYYYYMMDD(expires_at)
-ORDER BY (team_id, job_id, entity_id)
+ORDER BY (team_id, job_id, entity_id, timestamp, event_uuid)
 TTL expires_at
 SETTINGS index_granularity=8192, ttl_only_drop_parts = 1
 """

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -4765,7 +4765,7 @@
   ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_noshard/posthog.experiment_metric_events_preaggregated', '{replica}-{shard}', computed_at)
   
   PARTITION BY toYYYYMMDD(expires_at)
-  ORDER BY (team_id, job_id, entity_id)
+  ORDER BY (team_id, job_id, entity_id, timestamp, event_uuid)
   TTL expires_at
   SETTINGS index_granularity=8192, ttl_only_drop_parts = 1
   
@@ -7691,7 +7691,7 @@
   ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_noshard/posthog.experiment_metric_events_preaggregated', '{replica}-{shard}', computed_at)
   
   PARTITION BY toYYYYMMDD(expires_at)
-  ORDER BY (team_id, job_id, entity_id)
+  ORDER BY (team_id, job_id, entity_id, timestamp, event_uuid)
   TTL expires_at
   SETTINGS index_granularity=8192, ttl_only_drop_parts = 1
   


### PR DESCRIPTION
## Problem

The `experiment_metric_events_preaggregated` table (#50033) has `ORDER BY (team_id, job_id, entity_id)`. ReplacingMergeTree deduplicates by the ORDER BY key, keeping one row per entity per job after background merges.

While implementing funnel metric precomputation, I realized the order by key set up like this would drop events - funnels need to store every matching event per user (e.g. a pageview at T1, a purchase at T2), not just one aggregated row.

## Changes

Extend ORDER BY to `(team_id, job_id, entity_id, timestamp, event_uuid)` so each event gets its own key. The table will be dropped and recreated with a migration - this is fine as the table is not populated yet.