### PR TITLE
feat(replay): add ai session summary viewed event

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummaryTab.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummaryTab.tsx
@@ -1,6 +1,18 @@
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 import { PlayerSidebarSessionSummary } from 'scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary'
+import { sessionRecordingEventUsageLogic } from 'scenes/session-recordings/sessionRecordingEventUsageLogic'
 
 export function PlayerSidebarSessionSummaryTab(): JSX.Element {
+    const { logicProps } = useValues(sessionRecordingPlayerLogic)
+    const { reportAISessionSummaryViewed } = useActions(sessionRecordingEventUsageLogic)
+
+    useEffect(() => {
+        reportAISessionSummaryViewed(logicProps.sessionRecordingId, 'tab')
+    }, [logicProps.sessionRecordingId, reportAISessionSummaryViewed])
+
     return (
         <div className="flex flex-col overflow-auto bg-primary px-2 py-1 h-full">
             <PlayerSidebarSessionSummary />

--- a/frontend/src/scenes/session-recordings/sessionRecordingEventUsageLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingEventUsageLogic.ts
@@ -72,6 +72,7 @@ export const sessionRecordingEventUsageLogic = kea<sessionRecordingEventUsageLog
         reportRecordingPinnedToList: (pinned: boolean) => ({ pinned }),
         reportRecordingPlaylistCreated: (source: 'filters' | 'new' | 'pin' | 'duplicate') => ({ source }),
         reportRecordingOpenedFromRecentRecordingList: true,
+        reportAISessionSummaryViewed: (recording_id: string, source: 'tab') => ({ recording_id, source }),
     }),
     listeners(() => ({
         reportRecordingLoaded: ({ playerData, metadata }) => {
@@ -154,6 +155,9 @@ export const sessionRecordingEventUsageLogic = kea<sessionRecordingEventUsageLog
         },
         reportRecordingPlaylistCreated: (properties) => {
             posthog.capture('recording playlist created', properties)
+        },
+        reportAISessionSummaryViewed: ({ recording_id, source }) => {
+            posthog.capture('ai session summary viewed', { recording_id, source })
         },
     })),
 ])


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- adding a new event `ai session summary viewed` for tracking

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
