### PR TITLE
fix(capture-logs): parse string timestamps in datadog logs endpoint

### DIFF
--- a/rust/capture-logs/src/endpoints/datadog.rs
+++ b/rust/capture-logs/src/endpoints/datadog.rs
@@ -9,7 +9,7 @@ use axum::{
 use base64::{engine::general_purpose::STANDARD as base64_standard, Engine};
 use bytes::Bytes;
 use chrono::{TimeZone, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use serde_json::json;
 use std::collections::HashMap;
 use tracing::{debug, error, instrument};
@@ -29,10 +29,50 @@ pub struct DatadogLog {
     pub service: Option<String>,
     #[serde(default)]
     pub status: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_timestamp")]
     pub timestamp: Option<i64>,
     #[serde(flatten)]
     pub extra: HashMap<String, serde_json::Value>,
+}
+
+fn deserialize_timestamp<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de;
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum TimestampValue {
+        Integer(i64),
+        Str(String),
+    }
+
+    let opt: Option<TimestampValue> = Option::deserialize(deserializer)?;
+    match opt {
+        None => Ok(None),
+        Some(TimestampValue::Integer(n)) => Ok(Some(n)),
+        Some(TimestampValue::Str(s)) => {
+            if s.is_empty() {
+                return Ok(None);
+            }
+            // Try parsing as plain integer string first
+            if let Ok(n) = s.parse::<i64>() {
+                return Ok(Some(n));
+            }
+            // Try parsing as RFC 3339 / ISO 8601 datetime
+            if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(&s) {
+                return Ok(Some(dt.timestamp_millis()));
+            }
+            if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(&s, "%Y-%m-%dT%H:%M:%S%.f") {
+                return Ok(Some(dt.and_utc().timestamp_millis()));
+            }
+            Err(de::Error::custom(format!(
+                "invalid timestamp string: {}",
+                s
+            )))
+        }
+    }
 }
 
 pub fn normalize_datadog_severity(status: Option<&str>) -> (String, i32) {

--- a/rust/capture-logs/tests/datadog_test.rs
+++ b/rust/capture-logs/tests/datadog_test.rs
@@ -739,3 +739,18 @@ fn test_datadog_log_overridden_timestamp_tracking() {
     // User's originalTimestamp should still be in attributes
     assert!(row_user_attr.attributes.contains_key("originalTimestamp"));
 }
+
+#[test]
+fn test_datadog_log_timestamp_as_numeric_string() {
+    let json_data = r#"{"timestamp": "1700000000000", "message": "hello"}"#;
+    let log: DatadogLog = serde_json::from_str(json_data).unwrap();
+    assert_eq!(log.timestamp, Some(1700000000000));
+}
+
+#[test]
+fn test_datadog_log_timestamp_as_rfc3339_string() {
+    let json_data = r#"{"timestamp": "2024-01-15T10:30:00Z", "message": "hello"}"#;
+    let log: DatadogLog = serde_json::from_str(json_data).unwrap();
+    // 2024-01-15T10:30:00Z in milliseconds
+    assert_eq!(log.timestamp, Some(1705312200000));
+}

--- a/rust/capture-logs/tests/datadog_test.rs
+++ b/rust/capture-logs/tests/datadog_test.rs
@@ -752,5 +752,5 @@ fn test_datadog_log_timestamp_as_rfc3339_string() {
     let json_data = r#"{"timestamp": "2024-01-15T10:30:00Z", "message": "hello"}"#;
     let log: DatadogLog = serde_json::from_str(json_data).unwrap();
     // 2024-01-15T10:30:00Z in milliseconds
-    assert_eq!(log.timestamp, Some(1705312200000));
+    assert_eq!(log.timestamp, Some(1705314600000));
 }


### PR DESCRIPTION
## Problem

capture logs for datadog format is too restrictive, only accepting int timestamps. 

## Changes
Parse string timestamps too
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
unit tests
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
