### PR TITLE
fix(docs): point coder devbox link to GitHub

### DIFF
--- a/docs/internal/coder-workspaces.md
+++ b/docs/internal/coder-workspaces.md
@@ -16,7 +16,7 @@ Use this when you want a remote PostHog dev environment instead of running the f
 Open the workspace in VS Code (`hogli devbox:open --vscode`), Cursor (`--cursor`), or a browser-based editor (`--web`).
 
 **Sharing a workspace** —
-Grant a teammate access for pair debugging or to pick up where you (or Claude) left off:
+Grant a teammate access for pair debugging or to pick up where you left off:
 
 ```bash
 hogli devbox:users                                        # list Coder usernames

--- a/docs/internal/coder-workspaces.md
+++ b/docs/internal/coder-workspaces.md
@@ -10,9 +10,26 @@ Use this when you want a remote PostHog dev environment instead of running the f
 - You want a persistent remote workspace that is easy to stop and resume
 - You are working from a machine where local Docker setup is inconvenient
 
+## Common scenarios
+
+**Connecting your IDE** —
+Open the workspace in VS Code (`hogli devbox:open --vscode`), Cursor (`--cursor`), or a browser-based editor (`--web`).
+
+**Sharing a workspace** —
+Grant a teammate access for pair debugging or to pick up where you (or Claude) left off:
+
+```bash
+hogli devbox:users                                        # list Coder usernames
+hogli devbox:share --name mybox --user alice               # grant access (default role: use)
+hogli devbox:share --name mybox --user alice --remove      # revoke access
+hogli devbox:share --name mybox --list                     # see who has access
+```
+
+Once shared, the teammate can target your workspace with `@user` syntax (e.g. `hogli devbox:ssh @you/mybox`).
+
 ## Prerequisites
 
-- Access to the PostHog Tailscale tailnet
+- Access to the PostHog Tailscale tailnet (on macOS, the Tailscale app bundle CLI is detected automatically if `tailscale` isn't on PATH)
 - Access to the internal Coder deployment at `https://coder.hedgehog-kitefin.ts.net`
 - `hogli` available locally
 
@@ -27,30 +44,24 @@ hogli devbox:setup
 This does the host-side setup only:
 
 - verifies Tailscale connectivity
-- installs the `coder` CLI with Homebrew if needed
+- installs the `coder` CLI at the version matching the server
 - logs you into the Coder deployment
-- optionally runs `coder config-ssh` for local SSH/editor access
+- configures `~/.ssh/config` with Coder workspace entries (use `--skip-configure-ssh` to skip)
+- prompts for Git identity, an optional dotfiles repo, and an optional Claude OAuth token (cached in macOS Keychain)
+
+To reconfigure individual settings later, pass `--configure-git-identity`, `--configure-dotfiles`, or `--configure-claude`.
 
 ## Available commands
 
-Run:
-
-```bash
-hogli devbox
-```
-
-Then use `hogli <command> --help` for command-specific options.
-If your template includes the Claude module, `hogli devbox:start` can prompt for a Claude OAuth token when the workspace is created.
-After connecting with `hogli devbox:ssh`, run `claude` directly in the workspace terminal.
+Run `hogli devbox` to see all available commands, and `hogli <command> --help` for options.
 
 Runtime commands assume setup is already complete.
 If they fail with `Run hogli devbox:setup`, rerun setup on your laptop first.
 
 ## Auth model
 
-- Laptop to workspace access uses `coder ssh` and optional `coder config-ssh`
-- Git inside the workspace should use HTTPS via Coder external auth
-- Do not set up SSH Git inside the workspace
-- Claude auth for the workspace is passed through the `claude_oauth_token` Coder parameter, not AI Bridge
+- Laptop to workspace access uses `coder ssh` and `coder config-ssh` (configured automatically during setup)
+- Git inside the workspace should use HTTPS via Coder external auth — do not set up SSH Git inside the workspace
+- Claude auth is passed through the `claude_oauth_token` Coder parameter, not AI Bridge. On macOS, the token is cached in Keychain.
 
 `go/coder` is a convenient shortcut for humans, but the canonical deployment URL is `https://coder.hedgehog-kitefin.ts.net`.

--- a/docs/internal/coder-workspaces.md
+++ b/docs/internal/coder-workspaces.md
@@ -19,18 +19,18 @@ Open the workspace in VS Code (`hogli devbox:open --vscode`), Cursor (`--cursor`
 Grant a teammate access for pair debugging or to pick up where you left off:
 
 ```bash
-hogli devbox:users                                        # list Coder usernames
-hogli devbox:share --name mybox --user alice               # grant access (default role: use)
-hogli devbox:share --name mybox --user alice --remove      # revoke access
-hogli devbox:share --name mybox --list                     # see who has access
+hogli devbox:users                          # list Coder usernames
+hogli devbox:share bob-box --user alice     # grant access (default role: use)
+hogli devbox:unshare bob-box --user alice   # revoke access
+hogli devbox:share bob-box --list           # see who has access
 ```
 
-Once shared, the teammate can target your workspace with `@user` syntax (e.g. `hogli devbox:ssh @you/mybox`).
+Once shared, the teammate can target your workspace with `@user[/label]` syntax (e.g. `hogli devbox:ssh @bob/bob-box`).
 
 ## Prerequisites
 
 - Access to the PostHog Tailscale tailnet (on macOS, the Tailscale app bundle CLI is detected automatically if `tailscale` isn't on PATH)
-- Access to the internal Coder deployment at `https://coder.hedgehog-kitefin.ts.net`
+- Access to the internal Coder deployment at `https://coder.dev.posthog.dev`
 - `hogli` available locally
 
 ## First-time setup
@@ -64,4 +64,4 @@ If they fail with `Run hogli devbox:setup`, rerun setup on your laptop first.
 - Git inside the workspace should use HTTPS via Coder external auth — do not set up SSH Git inside the workspace
 - Claude auth is passed through the `claude_oauth_token` Coder parameter, not AI Bridge. On macOS, the token is cached in Keychain.
 
-`go/coder` is a convenient shortcut for humans, but the canonical deployment URL is `https://coder.hedgehog-kitefin.ts.net`.
+`go/coder` is a convenient shortcut for humans, but the canonical deployment URL is `https://coder.dev.posthog.dev`.

--- a/docs/published/handbook/engineering/developing-locally.md
+++ b/docs/published/handbook/engineering/developing-locally.md
@@ -211,7 +211,7 @@ When running `uv sync`, you may see a `Failed to parse` warning related to `pypr
 
 ## Option 2: Developing with Coder workspaces (PostHog employees only)
 
-If you work at PostHog and want a remote workspace instead of running the stack on your laptop, see the [internal Coder workspaces guide](../../../internal/coder-workspaces.md).
+If you work at PostHog and want a remote workspace instead of running the stack on your laptop, see the [internal Coder workspaces guide](https://github.com/PostHog/posthog/blob/master/docs/internal/coder-workspaces.md).
 
 ## Testing
 


### PR DESCRIPTION
## Problem

The published docs page for "Developing with Coder workspaces" links to `../../../internal/coder-workspaces.md`, which resolves to a broken `https://posthog.com/internal/coder-workspaces` URL on the website. The internal doc itself was also outdated — missing common scenarios, stale setup instructions, and no mention of workspace sharing or IDE support.

Depends on some `hogli devbox` CLI changes from https://github.com/PostHog/posthog/pull/54311 which should be merged first.

## Changes

- Fix the Coder workspaces link in `developing-locally.md` to point to the GitHub file directly
- Add common scenarios section (IDE connection, workspace sharing)
- Update setup instructions to reflect current `hogli devbox:setup` behavior (version-pinned CLI, SSH config, git identity, dotfiles, Claude token)
- Streamline the available commands and auth model sections

## How did you test this code?

Docs-only change. Verified the GitHub link resolves correctly.

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored PR. No manual testing beyond verifying link resolution.