### PR TITLE
fix(devex): enforce tach interface boundaries in CI

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -484,7 +484,7 @@ jobs:
               run: python .github/scripts/check-operator-parity.py
 
             - name: Check module boundaries (tach)
-              run: tach check
+              run: tach check --dependencies --interfaces
 
     # Migration validation and OpenAPI type generation.
     # This job needs Docker + DB — it checks out master first to run baseline


### PR DESCRIPTION
**Problem**

`tach check` without `--interfaces` only validates dependency directions between modules. It does not check whether imports go through declared `[[interfaces]]` expose patterns. This means a PR that bypasses a product's facade and imports internals directly would pass CI.

**Changes**

Add `--dependencies --interfaces` flags to the `tach check` step in `ci-backend.yml`. This is safe because #54465 already set up the global `[[interfaces]]` blocks with legacy leak exceptions — the command passes cleanly on master.

**How did you test this code?

Ran `tach check --dependencies --interfaces` locally — passes with no violations.

## 🤖 LLM context

Follow-up to #54465. One-line change.