### PR TITLE
perf(tasks): Fix task list query N+1

### DIFF
--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -9,7 +9,7 @@ from typing import cast
 
 from django.conf import settings
 from django.db import models, transaction
-from django.db.models import F, Prefetch
+from django.db.models import F
 from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
 from django.utils import timezone
 
@@ -195,9 +195,8 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             else:
                 qs = qs.filter(internal=False)
 
-        # Defer the large `state` blob from runs, and select_related to avoid N+1 on created_by/team
-        runs_qs = TaskRun.objects.defer("state")
-        qs = qs.select_related("created_by", "team").prefetch_related(Prefetch("runs", queryset=runs_qs))
+        # select_related to avoid N+1 on created_by (UserBasicSerializer) and team (slug property)
+        qs = qs.select_related("created_by", "team").prefetch_related("runs")
 
         return qs
 

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -9,7 +9,7 @@ from typing import cast
 
 from django.conf import settings
 from django.db import models, transaction
-from django.db.models import F
+from django.db.models import F, Prefetch
 from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
 from django.utils import timezone
 
@@ -195,8 +195,9 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             else:
                 qs = qs.filter(internal=False)
 
-        # Prefetch runs to avoid N+1 queries when fetching latest_run
-        qs = qs.prefetch_related("runs")
+        # Prefetch runs deferring the large `state` blob, and select_related to avoid N+1 on created_by/team
+        latest_runs_qs = TaskRun.objects.order_by("-created_at").defer("state")
+        qs = qs.select_related("created_by", "team").prefetch_related(Prefetch("runs", queryset=latest_runs_qs))
 
         return qs
 

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -195,9 +195,9 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             else:
                 qs = qs.filter(internal=False)
 
-        # Prefetch runs deferring the large `state` blob, and select_related to avoid N+1 on created_by/team
-        latest_runs_qs = TaskRun.objects.order_by("-created_at").defer("state")
-        qs = qs.select_related("created_by", "team").prefetch_related(Prefetch("runs", queryset=latest_runs_qs))
+        # Defer the large `state` blob from runs, and select_related to avoid N+1 on created_by/team
+        runs_qs = TaskRun.objects.defer("state")
+        qs = qs.select_related("created_by", "team").prefetch_related(Prefetch("runs", queryset=runs_qs))
 
         return qs
 


### PR DESCRIPTION
## Problem

The tasks list endpoint (`/api/projects/:team_id/tasks/`) takes ~6 seconds even with only 36 tasks. Why?

## Changes

Well. An optimization in `TaskViewSet.safely_get_queryset`:

Adding `select_related("created_by", "team")` as `UserBasicSerializer` on each task's `created_by` and the `slug` property accessing `self.team.name` were causing N+1 queries (i.e. 72 extra queries for 36 tasks).

This seems to have been most of the time wasted.

## How did you test this code?

Relying on `test_list_tasks`.