### PR TITLE
feat(experiments): precompute funnel metric events for ordered funnels

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -293,6 +293,7 @@ export const FEATURE_FLAGS = {
     EXPERIMENT_SESSION_REPLAYS_SKILL: 'experiment-session-replays-skill', // owner: @rodrigoi #team-experiments
     EXPERIMENT_SIGNIFICANCE_ALERTS: 'experiment-significance-alerts', // owner: @jurajmajerik #team-experiments
     EXPERIMENT_QUERY_PREAGGREGATION: 'experiment-query-preaggregation', // owner: @jurajmajerik #team-experiments
+    EXPERIMENTS_METRIC_EVENTS_PRECOMPUTATION: 'experiments-metric-events-precomputation', // owner: @jurajmajerik #team-experiments
     EXPERIMENT_FUNNEL_ACTORS_QUERY: 'experiment-funnel-actors-query', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_DW_AA_TEST: 'experiments-dw-aa-test', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -17061,6 +17061,9 @@
                 "metric": {
                     "$ref": "#/definitions/ExperimentMetric"
                 },
+                "metric_events_precomputation": {
+                    "type": "boolean"
+                },
                 "modifiers": {
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3482,6 +3482,7 @@ export interface ExperimentQuery extends DataNode<ExperimentQueryResponse> {
     experiment_id?: integer
     name?: string
     precomputation_mode?: 'precomputed' | 'direct'
+    metric_events_precomputation?: boolean
 }
 
 export interface ExperimentExposureQuery extends DataNode<ExperimentExposureQueryResponse> {

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -5,6 +5,7 @@ import { router } from 'kea-router'
 
 import api from 'lib/api'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -196,6 +197,7 @@ interface MetricLoadingConfig {
     isRetry: boolean
     metricIndexOffset: number
     orderedUuids?: string[] | null
+    metricEventsPrecomputation?: boolean
     onSetLegacyResults: (
         results: (
             | CachedLegacyExperimentQueryResponse
@@ -325,6 +327,7 @@ const loadMetrics = async ({
     isRetry,
     metricIndexOffset,
     orderedUuids,
+    metricEventsPrecomputation,
     onSetLegacyResults,
     onSetResults,
     onSetErrors,
@@ -362,6 +365,7 @@ const loadMetrics = async ({
                         kind: NodeKind.ExperimentQuery,
                         metric: metric,
                         experiment_id: experimentId,
+                        ...(metricEventsPrecomputation ? { metric_events_precomputation: true } : {}),
                     }
                 } else {
                     queryWithExperimentId = {
@@ -2012,6 +2016,8 @@ export const experimentLogic = kea<experimentLogicType>([
                 isRetry: false,
                 metricIndexOffset: 0,
                 orderedUuids: values.experiment?.primary_metrics_ordered_uuids,
+                metricEventsPrecomputation:
+                    !!values.featureFlags[FEATURE_FLAGS.EXPERIMENTS_METRIC_EVENTS_PRECOMPUTATION],
                 onSetLegacyResults: actions.setLegacyPrimaryMetricsResults,
                 onSetResults: actions.setPrimaryMetricsResults,
                 onSetErrors: actions.setPrimaryMetricsResultsErrors,
@@ -2051,6 +2057,8 @@ export const experimentLogic = kea<experimentLogicType>([
                 isRetry: false,
                 metricIndexOffset: 0,
                 orderedUuids: values.experiment?.secondary_metrics_ordered_uuids,
+                metricEventsPrecomputation:
+                    !!values.featureFlags[FEATURE_FLAGS.EXPERIMENTS_METRIC_EVENTS_PRECOMPUTATION],
                 onSetLegacyResults: actions.setLegacySecondaryMetricsResults,
                 onSetResults: actions.setSecondaryMetricsResults,
                 onSetErrors: actions.setSecondaryMetricsResultsErrors,
@@ -2098,6 +2106,8 @@ export const experimentLogic = kea<experimentLogicType>([
                 isPrimary: true,
                 isRetry: true,
                 metricIndexOffset: index,
+                metricEventsPrecomputation:
+                    !!values.featureFlags[FEATURE_FLAGS.EXPERIMENTS_METRIC_EVENTS_PRECOMPUTATION],
                 onSetLegacyResults: (results) => {
                     currentLegacyResults[index] = results[0]
                     actions.setLegacyPrimaryMetricsResults(currentLegacyResults)
@@ -2146,6 +2156,8 @@ export const experimentLogic = kea<experimentLogicType>([
                 isPrimary: false,
                 isRetry: true,
                 metricIndexOffset: index,
+                metricEventsPrecomputation:
+                    !!values.featureFlags[FEATURE_FLAGS.EXPERIMENTS_METRIC_EVENTS_PRECOMPUTATION],
                 onSetLegacyResults: (results) => {
                     currentLegacyResults[index] = results[0]
                     actions.setLegacySecondaryMetricsResults(currentLegacyResults)

--- a/posthog/hogql_queries/experiments/METRIC_EVENTS_PRECOMPUTATION.md
+++ b/posthog/hogql_queries/experiments/METRIC_EVENTS_PRECOMPUTATION.md
@@ -1,0 +1,213 @@
+# Funnel metric events precomputation
+
+## Problem
+
+An experiment funnel query has three CTEs: `exposures`, `metric_events`, and `entity_metrics`. The `exposures` CTE is already precomputed (see `LAZY_COMPUTATION.md`). The `metric_events` CTE still scans the events table on every query:
+
+```sql
+metric_events AS (
+    SELECT
+        person_id AS entity_id,
+        properties.$feature_flag_response AS variant,
+        timestamp,
+        uuid,
+        properties.$session_id AS session_id,
+        step_0,  -- 1 if this is an exposure event, else 0
+        step_1,  -- 1 if this matches funnel step 1, else 0
+        step_2   -- 1 if this matches funnel step 2, else 0
+    FROM events
+    WHERE (exposure_predicate OR funnel_steps_filter)
+)
+```
+
+This scans every event that matches the exposure criteria OR any funnel step (e.g. `pageview`, `purchase`). For high-traffic experiments, this is millions of rows — and it runs on every query.
+
+## Solution
+
+Scan the events table once, store matching events in `experiment_metric_events_preaggregated`, and read from there on subsequent queries.
+
+## What gets stored
+
+One row per matching event. The step indicators are packed into an `Array(UInt8)`:
+
+```text
+┌──────────┬──────────┬───────────┬─────────────────────┬───────────┬────────────┬───────────┐
+│ team_id  │ job_id   │ entity_id │ timestamp           │ event_uuid│ session_id │ steps     │
+├──────────┼──────────┼───────────┼─────────────────────┼───────────┼────────────┼───────────┤
+│ 123      │ job-A    │ user-1    │ 2026-01-02 10:00:00 │ evt-111   │ sess-1     │ [1, 0, 0] │  ← exposure
+│ 123      │ job-A    │ user-1    │ 2026-01-02 11:00:00 │ evt-222   │ sess-1     │ [0, 1, 0] │  ← pageview
+│ 123      │ job-A    │ user-1    │ 2026-01-02 12:00:00 │ evt-333   │ sess-1     │ [0, 0, 1] │  ← purchase
+│ 123      │ job-A    │ user-2    │ 2026-01-02 14:00:00 │ evt-444   │ sess-2     │ [1, 0, 0] │  ← exposure
+│ 123      │ job-A    │ user-2    │ 2026-01-02 15:00:00 │ evt-555   │ sess-2     │ [0, 1, 0] │  ← pageview
+│ ...      │          │           │                     │           │            │           │
+└──────────┴──────────┴───────────┴─────────────────────┴───────────┴────────────┴───────────┘
+```
+
+`steps = [1, 0, 0]` means: this event matches step_0 (exposure) but not step_1 or step_2.
+
+## Data flow
+
+### Without precomputation
+
+```text
+┌────────────────────────────────┐
+│         events table           │
+│       (millions of rows)       │
+└───────┬───────────────┬────────┘
+        │               │
+        │ scan for      │ scan for pageview,
+        │ exposures     │ purchase, etc.
+        │               │
+        ▼               ▼
+  exposures CTE   metric_events CTE ◄── THIS IS THE EXPENSIVE PART
+        │               │
+        └───────┬───────┘
+                │ LEFT JOIN
+                ▼
+        entity_metrics CTE
+        (aggregate_funnel_array UDF)
+                │
+                ▼
+          Final result
+```
+
+### With precomputation
+
+```text
+  FIRST QUERY (precomputes):
+
+  events table ──scan──▶ experiment_metric_events_preaggregated
+                         (stores matching events with step indicators)
+
+
+  SUBSEQUENT QUERIES (reads from cache):
+
+  ┌─────────────────────────┐    ┌───────────────────────────────────┐
+  │ experiment_exposures    │    │ experiment_metric_events          │
+  │ _preaggregated          │    │ _preaggregated                   │
+  │ (already cached)        │    │ (newly cached)                   │
+  └──────────┬──────────────┘    └────────────────┬──────────────────┘
+             │                                    │
+             ▼                                    ▼
+       exposures CTE                      metric_events CTE
+             │                                    │
+             └──────────┬─────────────────────────┘
+                        │ LEFT JOIN
+                        ▼
+                entity_metrics CTE        ← same UDF, same logic
+                        │
+                        ▼
+                  Final result            ← identical output
+```
+
+## How it works
+
+### Write path: `get_funnel_metric_events_query_for_precomputation()`
+
+The builder produces a query template with `{time_window_min}` and `{time_window_max}` placeholders:
+
+```sql
+SELECT
+    person_id AS entity_id,
+    timestamp AS timestamp,
+    uuid AS event_uuid,
+    `$session_id` AS session_id,
+    [toUInt8(if(exposure_pred, 1, 0)),
+     toUInt8(if(step_1_pred, 1, 0)),
+     toUInt8(if(step_2_pred, 1, 0))] AS steps
+FROM events
+WHERE timestamp >= {time_window_min}
+    AND timestamp < {time_window_max}
+    AND (exposure_predicate OR funnel_steps_filter)
+```
+
+The lazy computation system (`ensure_precomputed()`) splits the experiment date range into daily windows, fills in the time placeholders, and wraps the SELECT in an INSERT:
+
+```sql
+INSERT INTO experiment_metric_events_preaggregated
+    (team_id, job_id, entity_id, timestamp, event_uuid, session_id, steps, expires_at)
+SELECT
+    123 AS team_id,
+    'job-uuid' AS job_id,
+    ... -- the SELECT from above
+```
+
+Each daily window becomes a separate job. Already-computed windows are skipped.
+
+### Read path: `_build_funnel_query_legacy()`
+
+When `metric_events_preaggregation_job_ids` is set, the metric_events CTE reads from the precomputed table instead of scanning events:
+
+```sql
+metric_events AS (
+    SELECT
+        toUUID(t.entity_id) AS entity_id,
+        t.timestamp AS timestamp,
+        t.event_uuid AS uuid,
+        t.session_id AS session_id,
+        arrayElement(t.steps, 1) AS step_0,
+        arrayElement(t.steps, 2) AS step_1,
+        arrayElement(t.steps, 3) AS step_2
+    FROM experiment_metric_events_preaggregated AS t
+    WHERE t.job_id IN ('job-A', 'job-B')
+        AND t.team_id = 123
+)
+```
+
+`arrayElement(t.steps, N)` extracts individual step indicators from the packed array. The rest of the query (entity_metrics CTE, `aggregate_funnel_array` UDF, final aggregation) is unchanged.
+
+### Wiring: `_get_experiment_query()`
+
+The runner orchestrates both precomputations:
+
+```python
+if should_precompute and not is_data_warehouse_query:
+    # 1. Precompute exposures (already existed)
+    result = self._ensure_exposures_precomputed(builder)
+    if result.ready:
+        builder.preaggregation_job_ids = result.job_ids
+
+    # 2. Precompute metric events (new — ordered funnels only)
+    if is_ordered_funnel:
+        result = self._ensure_metric_events_precomputed(builder)
+        if result.ready:
+            builder.metric_events_preaggregation_job_ids = result.job_ids
+```
+
+Both use the same lazy computation system (daily windows, job management, TTL).
+
+## Conversion window
+
+Funnel steps can occur after the experiment end date (within the conversion window). Example: experiment ends Jan 15, conversion window is 7 days, a purchase on Jan 20 still counts.
+
+The runner extends `time_range_end` by the conversion window when precomputing metric events:
+
+```python
+date_to = experiment.end_date + timedelta(seconds=conversion_window_seconds)
+```
+
+The exposure precomputation does NOT need this extension — exposures only occur within the experiment date range.
+
+## Key differences from exposure precomputation
+
+|                            | Exposures                              | Metric events                              |
+| -------------------------- | -------------------------------------- | ------------------------------------------ |
+| **Granularity**            | 1 row per user per job                 | 1 row per event per job                    |
+| **Re-aggregation on read** | Yes — `argMin`/`min`/`max` across jobs | No — events are unique per daily window    |
+| **Table**                  | `experiment_exposures_preaggregated`   | `experiment_metric_events_preaggregated`   |
+| **Time range**             | Experiment start → end                 | Experiment start → end + conversion window |
+| **Stores variant**         | Yes                                    | No — variant comes from exposures CTE      |
+
+## Scope
+
+Currently implemented for **ordered funnels only**. Unordered funnels, mean, ratio, and retention metrics are not yet precomputed.
+
+## Key files
+
+| File                                        | Purpose                                                                                                                 |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `experiment_query_builder.py`               | `get_funnel_metric_events_query_for_precomputation()` (write), precomputed CTE in `_build_funnel_query_legacy()` (read) |
+| `experiment_query_runner.py`                | `_ensure_metric_events_precomputed()`, wiring in `_get_experiment_query()`                                              |
+| `lazy_computation_executor.py`              | Core lazy computation: `ensure_precomputed()`, job management                                                           |
+| `experiment_metric_events_sql.py`           | ClickHouse table definition                                                                                             |
+| `experiment_metric_events_preaggregated.py` | HogQL schema for the table                                                                                              |

--- a/posthog/hogql_queries/experiments/experiment_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_query_builder.py
@@ -103,6 +103,7 @@ class ExperimentQueryBuilder:
         self.breakdowns = breakdowns or []
         self.breakdown_injector = BreakdownInjector(self.breakdowns, metric) if metric else None
         self.preaggregation_job_ids: list[str] | None = None
+        self.metric_events_preaggregation_job_ids: list[str] | None = None
 
     # Experiment queries group by (variant, breakdown_values), so the row count is
     # bounded by num_variants × num_breakdown_values.  The HogQL executor injects
@@ -317,7 +318,31 @@ class ExperimentQueryBuilder:
         # Determine which query pattern to use
         has_dw_steps = self._has_datawarehouse_steps()
 
-        if has_dw_steps:
+        # Track whether step columns need to be injected after parsing.
+        # Precomputed metric events already have steps extracted from the array.
+        inject_step_columns = True
+
+        if self.metric_events_preaggregation_job_ids and not has_dw_steps:
+            # Read from precomputed table instead of scanning events
+            inject_step_columns = False
+            step_extracts = ", ".join(f"arrayElement(t.steps, {i + 1}) AS step_{i}" for i in range(num_steps))
+            entity_id_cast = "toUUID(t.entity_id)" if self.entity_key == "person_id" else "t.entity_id"
+            session_id_col = "t.session_id AS session_id," if not self.funnel_steps_data_disabled else ""
+
+            metric_events_cte_str = f"""
+                    metric_events AS (
+                        SELECT
+                            {entity_id_cast} AS entity_id,
+                            t.timestamp AS timestamp,
+                            t.event_uuid AS uuid,
+                            {session_id_col}
+                            {step_extracts}
+                        FROM experiment_metric_events_preaggregated AS t
+                        WHERE t.job_id IN {{metric_events_job_ids}}
+                            AND t.team_id = {{metric_events_team_id}}
+                    )
+            """
+        elif has_dw_steps:
             # UNION ALL pattern for heterogeneous sources
             metric_events_cte_str = self._build_funnel_metric_events_cte_with_union()
         else:
@@ -409,6 +434,10 @@ class ExperimentQueryBuilder:
             placeholders["uuid_to_session_map"] = self._build_uuid_to_session_map()
             placeholders["uuid_to_timestamp_map"] = self._build_uuid_to_timestamp_map()
 
+        if self.metric_events_preaggregation_job_ids:
+            placeholders["metric_events_job_ids"] = ast.Constant(value=self.metric_events_preaggregation_job_ids)
+            placeholders["metric_events_team_id"] = ast.Constant(value=self.team.id)
+
         query = parse_select(
             f"""
             WITH
@@ -439,12 +468,10 @@ class ExperimentQueryBuilder:
         if self.breakdown_injector:
             self.breakdown_injector.inject_funnel_breakdown_columns(query)
 
-        # Inject step columns into the metric_events CTE
-        # Find the metric_events CTE in the query
-        if query.ctes and "metric_events" in query.ctes:
+        # Inject step columns into the metric_events CTE (skip when precomputed — already extracted)
+        if inject_step_columns and query.ctes and "metric_events" in query.ctes:
             metric_events_cte = query.ctes["metric_events"]
             if isinstance(metric_events_cte, ast.CTE) and isinstance(metric_events_cte.expr, ast.SelectQuery):
-                # Add step columns to the SELECT
                 step_columns = self._build_funnel_step_columns()
                 metric_events_cte.expr.select.extend(step_columns)
 
@@ -1620,6 +1647,63 @@ class ExperimentQueryBuilder:
             "variants": ast.Constant(value=self.variants),
             "experiment_date_from": self.date_range_query.date_from_as_hogql(),
             "experiment_date_to": self.date_range_query.date_to_as_hogql(),
+        }
+
+        return query_string, placeholders
+
+    def get_funnel_metric_events_query_for_precomputation(self) -> tuple[str, dict[str, ast.Expr]]:
+        """
+        Returns the funnel metric events query and placeholders for lazy computation.
+
+        Stores one row per event with step indicators packed into an Array(UInt8).
+        The query uses {time_window_min} and {time_window_max} placeholders filled
+        by the lazy computation system for each daily bucket.
+
+        Returns:
+            Tuple of (query_string, placeholders_dict)
+        """
+        assert isinstance(self.metric, ExperimentFunnelMetric)
+
+        # Build step indicator expressions for the steps array.
+        # step_0 = exposure predicate, step_1..N = funnel step filters.
+        # These are the same expressions used in build_boolean_columns().
+        exposure_filter = self._build_exposure_predicate()
+        step_exprs: list[ast.Expr] = [exposure_filter]
+
+        step_builder = FunnelStepBuilder(self.metric.series, self.team)
+        for _step_index, step_source in enumerate(self.metric.series, start=1):
+            step_filter = step_builder._build_step_filter(step_source)
+            step_exprs.append(step_filter)
+
+        # Pack into Array(UInt8): [toUInt8(if(step_0, 1, 0)), toUInt8(if(step_1, 1, 0)), ...]
+        steps_array = ast.Array(
+            exprs=[
+                ast.Call(
+                    name="toUInt8",
+                    args=[ast.Call(name="if", args=[expr, ast.Constant(value=1), ast.Constant(value=0)])],
+                )
+                for expr in step_exprs
+            ]
+        )
+
+        query_string = """
+            SELECT
+                {entity_key} AS entity_id,
+                timestamp AS timestamp,
+                uuid AS event_uuid,
+                `$session_id` AS session_id,
+                {steps_array} AS steps
+            FROM events
+            WHERE timestamp >= {time_window_min}
+                AND timestamp < {time_window_max}
+                AND ({exposure_predicate} OR {funnel_steps_filter})
+        """
+
+        placeholders: dict[str, ast.Expr] = {
+            "entity_key": parse_expr(self.entity_key),
+            "steps_array": steps_array,
+            "exposure_predicate": self._build_exposure_predicate(),
+            "funnel_steps_filter": self._build_funnel_steps_filter(),
         }
 
         return query_string, placeholders

--- a/posthog/hogql_queries/experiments/experiment_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_query_builder.py
@@ -1702,7 +1702,7 @@ class ExperimentQueryBuilder:
         placeholders: dict[str, ast.Expr] = {
             "entity_key": parse_expr(self.entity_key),
             "steps_array": steps_array,
-            "exposure_predicate": self._build_exposure_predicate(),
+            "exposure_predicate": exposure_filter,
             "funnel_steps_filter": self._build_funnel_steps_filter(),
         }
 

--- a/posthog/hogql_queries/experiments/experiment_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_query_builder.py
@@ -304,8 +304,10 @@ class ExperimentQueryBuilder:
 
     def _build_funnel_query_legacy(self) -> ast.SelectQuery:
         """
-        Legacy funnel query: 3 CTEs (exposures, metric_events, entity_metrics).
-        Used when precomputed exposures are available.
+        3-CTE funnel query: exposures, metric_events, entity_metrics.
+        Called "legacy" because it predates the single-scan optimized path,
+        but this is the primary path for precomputed queries — both exposures
+        and metric_events CTEs can read from precomputed tables here.
 
         Supports two patterns:
         1. Events-only: Single query with boolean step columns

--- a/posthog/hogql_queries/experiments/experiment_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_query_builder.py
@@ -1669,9 +1669,11 @@ class ExperimentQueryBuilder:
 
     def get_funnel_metric_events_query_for_precomputation(self) -> tuple[str, dict[str, ast.Expr]]:
         """
-        Returns the funnel metric events query and placeholders for lazy computation.
+        Returns the SELECT query that the lazy computation system wraps in an
+        INSERT INTO experiment_metric_events_preaggregated. This is the write
+        path — it scans the events table and stores one row per matching event
+        with step indicators packed into an Array(UInt8).
 
-        Stores one row per event with step indicators packed into an Array(UInt8).
         The query uses {time_window_min} and {time_window_max} placeholders filled
         by the lazy computation system for each daily bucket.
 

--- a/posthog/hogql_queries/experiments/experiment_query_builder.py
+++ b/posthog/hogql_queries/experiments/experiment_query_builder.py
@@ -329,6 +329,16 @@ class ExperimentQueryBuilder:
             entity_id_cast = "toUUID(t.entity_id)" if self.entity_key == "person_id" else "t.entity_id"
             session_id_col = "t.session_id AS session_id," if not self.funnel_steps_data_disabled else ""
 
+            # Filter by experiment date range: jobs can cover broader time ranges
+            # than the experiment for cache reusability, so we must filter on read.
+            # Upper bound includes conversion window since funnel step events can
+            # occur after experiment end.
+            conversion_window_seconds = self._get_conversion_window_seconds()
+            if conversion_window_seconds > 0:
+                upper_bound = f"{{metric_events_date_to}} + toIntervalSecond({conversion_window_seconds})"
+            else:
+                upper_bound = "{metric_events_date_to}"
+
             metric_events_cte_str = f"""
                     metric_events AS (
                         SELECT
@@ -340,6 +350,8 @@ class ExperimentQueryBuilder:
                         FROM experiment_metric_events_preaggregated AS t
                         WHERE t.job_id IN {{metric_events_job_ids}}
                             AND t.team_id = {{metric_events_team_id}}
+                            AND t.timestamp >= {{metric_events_date_from}}
+                            AND t.timestamp <= {upper_bound}
                     )
             """
         elif has_dw_steps:
@@ -437,6 +449,8 @@ class ExperimentQueryBuilder:
         if self.metric_events_preaggregation_job_ids:
             placeholders["metric_events_job_ids"] = ast.Constant(value=self.metric_events_preaggregation_job_ids)
             placeholders["metric_events_team_id"] = ast.Constant(value=self.team.id)
+            placeholders["metric_events_date_from"] = self.date_range_query.date_from_as_hogql()
+            placeholders["metric_events_date_to"] = self.date_range_query.date_to_as_hogql()
 
         query = parse_select(
             f"""

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -279,13 +279,11 @@ class ExperimentQueryRunner(QueryRunner):
                 logger.exception("exposure_lazy_computation_failed", experiment_id=self.experiment.id)
 
             # Precompute metric events for ordered funnel metrics
-            # Temporary: restrict to specific teams while validating correctness
-            _METRIC_EVENTS_PRECOMPUTATION_TEAM_IDS: set[int] = {2}
             if (
                 isinstance(self.metric, ExperimentFunnelMetric)
                 and (self.metric.funnel_order_type or "ordered") == "ordered"
                 and not self._get_breakdowns_for_builder()
-                and self.team.id in _METRIC_EVENTS_PRECOMPUTATION_TEAM_IDS
+                and self.query.metric_events_precomputation
             ):
                 try:
                     metric_result = self._ensure_metric_events_precomputed(builder)

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -190,6 +190,36 @@ class ExperimentQueryRunner(QueryRunner):
             placeholders=placeholders,
         )
 
+    def _ensure_metric_events_precomputed(self, builder: ExperimentQueryBuilder) -> LazyComputationResult:
+        """
+        Ensures lazy-computed funnel metric event data exists for this experiment.
+
+        Stores one row per matching event with step indicators in the
+        experiment_metric_events_preaggregated table.
+        """
+        query_string, placeholders = builder.get_funnel_metric_events_query_for_precomputation()
+
+        if not self.experiment.start_date:
+            raise ValidationError("Experiment must have a start date for lazy computation")
+
+        date_from = self.experiment.start_date
+        date_to = self.override_end_date or self.experiment.end_date or datetime.now(UTC)
+
+        # Extend time range by conversion window — funnel step events can occur after experiment end
+        conversion_window_seconds = builder._get_conversion_window_seconds()
+        if conversion_window_seconds > 0:
+            date_to = date_to + timedelta(seconds=conversion_window_seconds)
+
+        return ensure_precomputed(
+            team=self.team,
+            insert_query=query_string,
+            time_range_start=date_from,
+            time_range_end=date_to,
+            ttl_seconds=DEFAULT_EXPOSURE_TTL_SECONDS,
+            table=LazyComputationTable.EXPERIMENT_METRIC_EVENTS_PREAGGREGATED,
+            placeholders=placeholders,
+        )
+
     def _should_precompute(self) -> bool:
         """Resolve whether to use precomputation: query-level override > team-level default."""
         if self.query.precomputation_mode == PrecomputationMode.PRECOMPUTED:
@@ -247,6 +277,20 @@ class ExperimentQueryRunner(QueryRunner):
                     logger.warning("exposure_lazy_computation_not_ready", experiment_id=self.experiment.id)
             except Exception:
                 logger.exception("exposure_lazy_computation_failed", experiment_id=self.experiment.id)
+
+            # Precompute metric events for ordered funnel metrics
+            if (
+                isinstance(self.metric, ExperimentFunnelMetric)
+                and (self.metric.funnel_order_type or "ordered") == "ordered"
+            ):
+                try:
+                    metric_result = self._ensure_metric_events_precomputed(builder)
+                    if metric_result.ready:
+                        builder.metric_events_preaggregation_job_ids = [str(job_id) for job_id in metric_result.job_ids]
+                    else:
+                        logger.warning("metric_events_lazy_computation_not_ready", experiment_id=self.experiment.id)
+                except Exception:
+                    logger.exception("metric_events_lazy_computation_failed", experiment_id=self.experiment.id)
 
         return builder.build_query()
 

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -284,6 +284,7 @@ class ExperimentQueryRunner(QueryRunner):
             if (
                 isinstance(self.metric, ExperimentFunnelMetric)
                 and (self.metric.funnel_order_type or "ordered") == "ordered"
+                and not self._get_breakdowns_for_builder()
                 and self.team.id in _METRIC_EVENTS_PRECOMPUTATION_TEAM_IDS
             ):
                 try:

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -279,9 +279,12 @@ class ExperimentQueryRunner(QueryRunner):
                 logger.exception("exposure_lazy_computation_failed", experiment_id=self.experiment.id)
 
             # Precompute metric events for ordered funnel metrics
+            # Temporary: restrict to specific teams while validating correctness
+            _METRIC_EVENTS_PRECOMPUTATION_TEAM_IDS: set[int] = {2}
             if (
                 isinstance(self.metric, ExperimentFunnelMetric)
                 and (self.metric.funnel_order_type or "ordered") == "ordered"
+                and self.team.id in _METRIC_EVENTS_PRECOMPUTATION_TEAM_IDS
             ):
                 try:
                     metric_result = self._ensure_metric_events_precomputed(builder)

--- a/posthog/hogql_queries/experiments/test/experiment_query_runner/base.py
+++ b/posthog/hogql_queries/experiments/test/experiment_query_runner/base.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 
 from posthog.clickhouse.client.execute import sync_execute
 from posthog.clickhouse.preaggregation.experiment_exposures_sql import TRUNCATE_EXPERIMENT_EXPOSURES_TABLE_SQL
+from posthog.clickhouse.preaggregation.experiment_metric_events_sql import TRUNCATE_EXPERIMENT_METRIC_EVENTS_TABLE_SQL
 from posthog.models.feature_flag.feature_flag import FeatureFlag
 from posthog.models.team.extensions import get_or_create_team_extension
 
@@ -36,6 +37,7 @@ class ExperimentQueryRunnerBaseTest(ClickhouseTestMixin, APIBaseTest):
     def _clean_preaggregation_data(self):
         """Clean precomputation data from ClickHouse and PostgreSQL"""
         sync_execute(TRUNCATE_EXPERIMENT_EXPOSURES_TABLE_SQL())
+        sync_execute(TRUNCATE_EXPERIMENT_METRIC_EVENTS_TABLE_SQL())
         PreaggregationJob.objects.all().delete()
 
     def _setup_precomputation_test(self, use_precomputation: bool):

--- a/posthog/hogql_queries/experiments/test/test_experiment_funnel_metric_events_preaggregation.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_funnel_metric_events_preaggregation.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import cast
 
 from posthog.test.base import _create_event, _create_person
@@ -287,8 +287,6 @@ class TestExperimentFunnelMetricEventsPreaggregation(ExperimentQueryRunnerBaseTe
         )
 
         # Precompute metric events — extend end date by conversion window
-        from datetime import timedelta
-
         metric_query_string, metric_placeholders = builder.get_funnel_metric_events_query_for_precomputation()
         conversion_window_seconds = builder._get_conversion_window_seconds()
         metric_end_date = experiment.end_date + timedelta(seconds=conversion_window_seconds)

--- a/posthog/hogql_queries/experiments/test/test_experiment_funnel_metric_events_preaggregation.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_funnel_metric_events_preaggregation.py
@@ -1,0 +1,321 @@
+from datetime import UTC, datetime
+from typing import cast
+
+from posthog.test.base import _create_event, _create_person
+
+from django.test import override_settings
+
+from posthog.schema import (
+    EventsNode,
+    ExperimentFunnelMetric,
+    ExperimentQuery,
+    ExperimentQueryResponse,
+    FunnelConversionWindowTimeUnit,
+    IntervalType,
+)
+
+from posthog.hogql_queries.experiments.base_query_utils import get_experiment_date_range
+from posthog.hogql_queries.experiments.experiment_query_builder import (
+    ExperimentQueryBuilder,
+    get_exposure_config_params_for_builder,
+)
+from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
+from posthog.hogql_queries.experiments.exposure_query_logic import get_entity_key
+from posthog.hogql_queries.experiments.test.experiment_query_runner.base import ExperimentQueryRunnerBaseTest
+from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+
+from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import (
+    LazyComputationTable,
+    ensure_precomputed,
+)
+
+
+@override_settings(IN_UNIT_TESTING=True)
+class TestExperimentFunnelMetricEventsPreaggregation(ExperimentQueryRunnerBaseTest):
+    def _create_exposure_event(self, distinct_id, feature_flag, variant, timestamp):
+        _create_event(
+            team=self.team,
+            event="$feature_flag_called",
+            distinct_id=distinct_id,
+            timestamp=timestamp,
+            properties={
+                f"$feature/{feature_flag.key}": variant,
+                "$feature_flag_response": variant,
+                "$feature_flag": feature_flag.key,
+            },
+        )
+
+    def _run_experiment(self, experiment, metric) -> ExperimentQueryResponse:
+        query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+        runner = ExperimentQueryRunner(query=query, team=self.team)
+        return cast(ExperimentQueryResponse, runner.calculate())
+
+    def _build_lazy_computation_builder(self, experiment, feature_flag, metric) -> ExperimentQueryBuilder:
+        exposure_config, multiple_variant_handling, filter_test_accounts = get_exposure_config_params_for_builder(
+            experiment.exposure_criteria
+        )
+        date_range = get_experiment_date_range(experiment, self.team, None)
+        return ExperimentQueryBuilder(
+            team=self.team,
+            feature_flag_key=feature_flag.key,
+            exposure_config=exposure_config,
+            filter_test_accounts=filter_test_accounts,
+            multiple_variant_handling=multiple_variant_handling,
+            variants=[v["key"] for v in feature_flag.variants],
+            date_range_query=QueryDateRange(
+                date_range=date_range, team=self.team, interval=IntervalType.DAY, now=datetime.now()
+            ),
+            entity_key=get_entity_key(feature_flag.filters.get("aggregation_group_type_index")),
+            metric=metric,
+        )
+
+    def _precompute_and_compare(
+        self, experiment, feature_flag, metric
+    ) -> tuple[ExperimentQueryResponse, ExperimentQueryResponse]:
+        """Run the same experiment through both paths and assert identical results."""
+        # Path A: direct events scan
+        self._disable_precomputation()
+        experiment.save()
+        direct_result = self._run_experiment(experiment, metric)
+
+        builder = self._build_lazy_computation_builder(experiment, feature_flag, metric)
+
+        # Precompute exposures
+        exposure_query_string, exposure_placeholders = builder.get_exposure_query_for_precomputation()
+        ensure_precomputed(
+            team=self.team,
+            insert_query=exposure_query_string,
+            time_range_start=experiment.start_date,
+            time_range_end=experiment.end_date,
+            table=LazyComputationTable.EXPERIMENT_EXPOSURES_PREAGGREGATED,
+            placeholders=exposure_placeholders,
+        )
+
+        # Precompute metric events
+        metric_query_string, metric_placeholders = builder.get_funnel_metric_events_query_for_precomputation()
+        ensure_precomputed(
+            team=self.team,
+            insert_query=metric_query_string,
+            time_range_start=experiment.start_date,
+            time_range_end=experiment.end_date,
+            table=LazyComputationTable.EXPERIMENT_METRIC_EVENTS_PREAGGREGATED,
+            placeholders=metric_placeholders,
+        )
+
+        # Path B: precomputed
+        self._enable_precomputation()
+        experiment.save()
+        precomputed_result = self._run_experiment(experiment, metric)
+
+        assert direct_result.baseline is not None
+        assert precomputed_result.baseline is not None
+        assert direct_result.baseline.key == precomputed_result.baseline.key
+        assert direct_result.baseline.number_of_samples == precomputed_result.baseline.number_of_samples
+        assert direct_result.baseline.sum == precomputed_result.baseline.sum
+
+        assert direct_result.variant_results is not None
+        assert precomputed_result.variant_results is not None
+        assert len(direct_result.variant_results) == len(precomputed_result.variant_results)
+        for i in range(len(direct_result.variant_results)):
+            assert direct_result.variant_results[i].key == precomputed_result.variant_results[i].key
+            assert (
+                direct_result.variant_results[i].number_of_samples
+                == precomputed_result.variant_results[i].number_of_samples
+            )
+            assert direct_result.variant_results[i].sum == precomputed_result.variant_results[i].sum
+
+        return direct_result, precomputed_result
+
+    def test_basic_two_step_funnel(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(
+            feature_flag=feature_flag,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 10),
+        )
+
+        metric = ExperimentFunnelMetric(series=[EventsNode(event="purchase")])
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        # Control: 3 exposed, 2 convert
+        for i in range(3):
+            _create_person(distinct_ids=[f"control_{i}"], team_id=self.team.pk)
+            self._create_exposure_event(
+                f"control_{i}", feature_flag, "control", datetime(2024, 1, 2, 12, 0, tzinfo=UTC)
+            )
+            if i < 2:
+                _create_event(
+                    team=self.team,
+                    event="purchase",
+                    distinct_id=f"control_{i}",
+                    timestamp=datetime(2024, 1, 3, 12, 0, tzinfo=UTC),
+                )
+
+        # Test: 4 exposed, 3 convert
+        for i in range(4):
+            _create_person(distinct_ids=[f"test_{i}"], team_id=self.team.pk)
+            self._create_exposure_event(f"test_{i}", feature_flag, "test", datetime(2024, 1, 2, 14, 0, tzinfo=UTC))
+            if i < 3:
+                _create_event(
+                    team=self.team,
+                    event="purchase",
+                    distinct_id=f"test_{i}",
+                    timestamp=datetime(2024, 1, 3, 14, 0, tzinfo=UTC),
+                )
+
+        direct_result, precomputed_result = self._precompute_and_compare(experiment, feature_flag, metric)
+        assert direct_result.baseline is not None
+        assert direct_result.baseline.number_of_samples == 3
+        assert direct_result.baseline.sum == 2.0
+
+    def test_three_step_funnel(self):
+        feature_flag = self.create_feature_flag(key="three-step-test")
+        experiment = self.create_experiment(
+            feature_flag=feature_flag,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 10),
+        )
+
+        metric = ExperimentFunnelMetric(
+            series=[
+                EventsNode(event="pageview"),
+                EventsNode(event="purchase"),
+            ],
+        )
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        # Control: 4 exposed, 3 reach pageview, 2 reach purchase
+        for i in range(4):
+            _create_person(distinct_ids=[f"control_{i}"], team_id=self.team.pk)
+            self._create_exposure_event(
+                f"control_{i}", feature_flag, "control", datetime(2024, 1, 2, 10, 0, tzinfo=UTC)
+            )
+            if i < 3:
+                _create_event(
+                    team=self.team,
+                    event="pageview",
+                    distinct_id=f"control_{i}",
+                    timestamp=datetime(2024, 1, 2, 11, 0, tzinfo=UTC),
+                )
+            if i < 2:
+                _create_event(
+                    team=self.team,
+                    event="purchase",
+                    distinct_id=f"control_{i}",
+                    timestamp=datetime(2024, 1, 2, 12, 0, tzinfo=UTC),
+                )
+
+        # Test: 5 exposed, 4 reach pageview, 3 reach purchase
+        for i in range(5):
+            _create_person(distinct_ids=[f"test_{i}"], team_id=self.team.pk)
+            self._create_exposure_event(f"test_{i}", feature_flag, "test", datetime(2024, 1, 2, 14, 0, tzinfo=UTC))
+            if i < 4:
+                _create_event(
+                    team=self.team,
+                    event="pageview",
+                    distinct_id=f"test_{i}",
+                    timestamp=datetime(2024, 1, 2, 15, 0, tzinfo=UTC),
+                )
+            if i < 3:
+                _create_event(
+                    team=self.team,
+                    event="purchase",
+                    distinct_id=f"test_{i}",
+                    timestamp=datetime(2024, 1, 2, 16, 0, tzinfo=UTC),
+                )
+
+        direct_result, precomputed_result = self._precompute_and_compare(experiment, feature_flag, metric)
+        assert direct_result.baseline is not None
+        assert direct_result.baseline.number_of_samples == 4
+        assert direct_result.baseline.sum == 2.0
+
+    def test_funnel_with_conversion_window(self):
+        feature_flag = self.create_feature_flag(key="conv-window-test")
+        experiment = self.create_experiment(
+            feature_flag=feature_flag,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 5),
+        )
+
+        metric = ExperimentFunnelMetric(
+            series=[EventsNode(event="purchase")],
+            conversion_window=7,
+            conversion_window_unit=FunnelConversionWindowTimeUnit.DAY,
+        )
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        # User exposed on Jan 3, purchases on Jan 8 (within 7-day window, after experiment end)
+        _create_person(distinct_ids=["user_late"], team_id=self.team.pk)
+        self._create_exposure_event("user_late", feature_flag, "test", datetime(2024, 1, 3, 12, 0, tzinfo=UTC))
+        _create_event(
+            team=self.team,
+            event="purchase",
+            distinct_id="user_late",
+            timestamp=datetime(2024, 1, 8, 12, 0, tzinfo=UTC),
+        )
+
+        # User exposed on Jan 2, purchases on Jan 3 (within window, within experiment)
+        _create_person(distinct_ids=["user_early"], team_id=self.team.pk)
+        self._create_exposure_event("user_early", feature_flag, "control", datetime(2024, 1, 2, 12, 0, tzinfo=UTC))
+        _create_event(
+            team=self.team,
+            event="purchase",
+            distinct_id="user_early",
+            timestamp=datetime(2024, 1, 3, 12, 0, tzinfo=UTC),
+        )
+
+        # For precomputation, we need to extend time_range_end by conversion window
+        builder = self._build_lazy_computation_builder(experiment, feature_flag, metric)
+
+        # Path A: direct
+        self._disable_precomputation()
+        experiment.save()
+        direct_result = self._run_experiment(experiment, metric)
+
+        # Precompute exposures
+        exposure_query_string, exposure_placeholders = builder.get_exposure_query_for_precomputation()
+        ensure_precomputed(
+            team=self.team,
+            insert_query=exposure_query_string,
+            time_range_start=experiment.start_date,
+            time_range_end=experiment.end_date,
+            table=LazyComputationTable.EXPERIMENT_EXPOSURES_PREAGGREGATED,
+            placeholders=exposure_placeholders,
+        )
+
+        # Precompute metric events — extend end date by conversion window
+        from datetime import timedelta
+
+        metric_query_string, metric_placeholders = builder.get_funnel_metric_events_query_for_precomputation()
+        conversion_window_seconds = builder._get_conversion_window_seconds()
+        metric_end_date = experiment.end_date + timedelta(seconds=conversion_window_seconds)
+        ensure_precomputed(
+            team=self.team,
+            insert_query=metric_query_string,
+            time_range_start=experiment.start_date,
+            time_range_end=metric_end_date,
+            table=LazyComputationTable.EXPERIMENT_METRIC_EVENTS_PREAGGREGATED,
+            placeholders=metric_placeholders,
+        )
+
+        # Path B: precomputed
+        self._enable_precomputation()
+        experiment.save()
+        precomputed_result = self._run_experiment(experiment, metric)
+
+        assert direct_result.baseline is not None
+        assert precomputed_result.baseline is not None
+        assert direct_result.baseline.number_of_samples == precomputed_result.baseline.number_of_samples
+        assert direct_result.baseline.sum == precomputed_result.baseline.sum
+
+        assert direct_result.variant_results is not None
+        assert precomputed_result.variant_results is not None
+        for i in range(len(direct_result.variant_results)):
+            assert (
+                direct_result.variant_results[i].number_of_samples
+                == precomputed_result.variant_results[i].number_of_samples
+            )
+            assert direct_result.variant_results[i].sum == precomputed_result.variant_results[i].sum

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -20874,6 +20874,7 @@ class ExperimentQuery(BaseModel):
     experiment_id: int | None = None
     kind: Literal["ExperimentQuery"] = "ExperimentQuery"
     metric: ExperimentMeanMetric | ExperimentFunnelMetric | ExperimentRatioMetric | ExperimentRetentionMetric
+    metric_events_precomputation: bool | None = None
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     name: str | None = None
     precomputation_mode: PrecomputationMode | None = None

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -6201,6 +6201,8 @@ export interface ExperimentQueryApi {
         | ExperimentFunnelMetricApi
         | ExperimentRatioMetricApi
         | ExperimentRetentionMetricApi
+    /** @nullable */
+    metric_events_precomputation?: boolean | null
     /** Modifiers used when performing the query */
     modifiers?: HogQLQueryModifiersApi | null
     /** @nullable */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -4580,6 +4580,8 @@ export namespace Schemas {
       experiment_id?: number | null;
       kind?: ExperimentQueryKind;
       metric: ExperimentMeanMetric | ExperimentFunnelMetric | ExperimentRatioMetric | ExperimentRetentionMetric;
+      /** @nullable */
+      metric_events_precomputation?: boolean | null;
       /** Modifiers used when performing the query */
       modifiers?: HogQLQueryModifiers | null;
       /** @nullable */


### PR DESCRIPTION
## Problem

Experiment funnel queries scan the events table twice: once for exposures (already precomputed), once for metric events (funnel steps like `pageview`, `purchase`, etc). The metric events scan is the remaining expensive part.

## Changes

Extend the lazy precomputation system to also cache the `metric_events` CTE for ordered funnel experiments.

**Write path** (`get_funnel_metric_events_query_for_precomputation()`): Scan events once, store each matching event with step indicators packed into `Array(UInt8)` in `experiment_metric_events_preaggregated`.

**Read path** (modified `_build_funnel_query_legacy()`): When precomputed data is available, the `metric_events` CTE reads from the precomputed table and extracts step indicators with `arrayElement()` instead of scanning events.

Everything downstream (exposures JOIN, `aggregate_funnel_array` UDF, final aggregation) is unchanged.

**Scope**: Ordered funnels only for now.

See `METRIC_EVENTS_PRECOMPUTATION.md` for the full mechanism with diagrams.

## How did you test this code?

- 3 new tests comparing direct scan vs precomputed results and asserting identical output:
	- Basic 2-step funnel
	- 3-step funnel
	- Funnel with conversion window (events after experiment end date)
- All existing funnel tests pass