### PR TITLE
feat(mcp): add mcp-inspector as optional dev process

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -256,6 +256,12 @@ procs:
         capability: mcp_server
         ready_pattern: 'Initial build complete'
 
+    mcp-inspector:
+        shell: 'cd services/mcp && pnpm run inspector'
+        capability: mcp_server
+        autostart: false
+        ready_pattern: 'MCP Inspector'
+
     stripe-app:
         shell: 'bin/start-stripe-app'
         capability: stripe_app


### PR DESCRIPTION
## Problem

When working on MCP tools locally, you need to manually run the MCP Inspector from the services/mcp directory when wanting to use it.

## Changes

Adds `mcp-inspector` as a process in `bin/mprocs.yaml`:

- Gated behind `mcp_server` capability — only included when the `mcp` intent is active
- `autostart: false` — available but not started by default, start manually via phrocs
- Runs `@modelcontextprotocol/inspector` connected to `http://localhost:8787/mcp`

## How did you test this code?

Ran `hogli dev:generate` and verified the process appears in `.posthog/.generated/mprocs.yaml` with `autostart: false` and correct startup message. Manually verified the inspector starts and connects in phrocs.

## Publish to changelog?

No

## Docs update

N/A