### PR TITLE
feat(flags): implement cache builder for feature flag dependencies

### DIFF
--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -67,7 +67,7 @@ impl Cohort {
         client: &PostgresReader,
         team_id: TeamId,
         ids: &[CohortId],
-    ) -> Result<Vec<Cohort>, FlagError> {
+    ) -> Result<Vec<Cohort>, CohortFetchError> {
         if ids.is_empty() {
             return Ok(vec![]);
         }
@@ -81,7 +81,7 @@ impl Cohort {
                         team_id,
                         e
                     );
-                    FlagError::DatabaseUnavailable
+                    CohortFetchError::DatabaseUnavailable
                 })?;
 
         let query = format!(
@@ -100,7 +100,7 @@ impl Cohort {
                     team_id,
                     e
                 );
-                FlagError::Internal(format!("Database query error: {e}"))
+                CohortFetchError::QueryFailed(format!("Database query error: {e}"))
             })?;
 
         Ok(cohorts)

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -66,7 +66,7 @@ impl Cohort {
     pub async fn list_by_ids_from_pg(
         client: &PostgresReader,
         team_id: TeamId,
-        ids: &HashSet<CohortId>,
+        ids: &[CohortId],
     ) -> Result<Vec<Cohort>, FlagError> {
         if ids.is_empty() {
             return Ok(vec![]);
@@ -84,15 +84,13 @@ impl Cohort {
                     FlagError::DatabaseUnavailable
                 })?;
 
-        let ids_vec: Vec<CohortId> = ids.iter().copied().collect();
-
         let query = format!(
             "SELECT {COHORT_COLUMNS} FROM posthog_cohort AS c \
              WHERE c.id = ANY($1) AND c.deleted = false AND c.team_id = $2"
         );
 
         let cohorts = sqlx::query_as::<_, Cohort>(&query)
-            .bind(&ids_vec)
+            .bind(ids)
             .bind(team_id)
             .fetch_all(&mut *conn)
             .await

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -15,6 +15,14 @@ use crate::{api::errors::FlagError, properties::property_models::PropertyFilter}
 use common_database::PostgresReader;
 use common_types::TeamId;
 
+/// Column list for `posthog_cohort` queries. Must match the fields in `Cohort` (sqlx::FromRow).
+const COHORT_COLUMNS: &str = r#"
+    c.id, c.name, c.description, c.team_id, c.deleted, c.filters,
+    c.query, c.version, c.pending_version, c.count, c.is_calculating,
+    c.is_static, c.errors_calculating, c.groups, c.created_by_id,
+    c.cohort_type, c.last_backfill_person_properties_at
+"#;
+
 impl Cohort {
     /// Returns all cohorts for a given team
     pub async fn list_from_pg(
@@ -32,30 +40,12 @@ impl Cohort {
                 CohortFetchError::DatabaseUnavailable
             })?;
 
-        let query = r#"
-            SELECT c.id,
-                  c.name,
-                  c.description,
-                  c.team_id,
-                  c.deleted,
-                  c.filters,
-                  c.query,
-                  c.version,
-                  c.pending_version,
-                  c.count,
-                  c.is_calculating,
-                  c.is_static,
-                  c.errors_calculating,
-                  c.groups,
-                  c.created_by_id,
-                  c.cohort_type,
-                  c.last_backfill_person_properties_at
-              FROM posthog_cohort AS c
-              JOIN posthog_team AS t ON (c.team_id = t.id)
-            WHERE t.id = $1
-            AND c.deleted = false
-        "#;
-        let cohorts = sqlx::query_as::<_, Cohort>(query)
+        let query = format!(
+            "SELECT {COHORT_COLUMNS} FROM posthog_cohort AS c \
+             JOIN posthog_team AS t ON (c.team_id = t.id) \
+             WHERE t.id = $1 AND c.deleted = false"
+        );
+        let cohorts = sqlx::query_as::<_, Cohort>(&query)
             .bind(team_id)
             .fetch_all(&mut *conn)
             .await
@@ -66,6 +56,53 @@ impl Cohort {
                     e
                 );
                 CohortFetchError::QueryFailed(format!("Database query error: {e}"))
+            })?;
+
+        Ok(cohorts)
+    }
+
+    /// Fetch cohorts by a set of IDs, filtered to non-deleted cohorts for the given team.
+    /// Used by the cache builder for BFS cohort dependency resolution.
+    pub async fn list_by_ids_from_pg(
+        client: &PostgresReader,
+        team_id: TeamId,
+        ids: &HashSet<CohortId>,
+    ) -> Result<Vec<Cohort>, FlagError> {
+        if ids.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let mut conn =
+            get_connection_with_metrics(client, "non_persons_reader", "fetch_cohorts_for_cache")
+                .await
+                .map_err(|e| {
+                    tracing::error!(
+                        "Failed to get database connection for team {}: {}",
+                        team_id,
+                        e
+                    );
+                    FlagError::DatabaseUnavailable
+                })?;
+
+        let ids_vec: Vec<CohortId> = ids.iter().copied().collect();
+
+        let query = format!(
+            "SELECT {COHORT_COLUMNS} FROM posthog_cohort AS c \
+             WHERE c.id = ANY($1) AND c.deleted = false AND c.team_id = $2"
+        );
+
+        let cohorts = sqlx::query_as::<_, Cohort>(&query)
+            .bind(&ids_vec)
+            .bind(team_id)
+            .fetch_all(&mut *conn)
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    "Failed to fetch cohorts from database for team {}: {}",
+                    team_id,
+                    e
+                );
+                FlagError::Internal(format!("Database query error: {e}"))
             })?;
 
         Ok(cohorts)

--- a/rust/feature-flags/src/flags/cache_builder.rs
+++ b/rust/feature-flags/src/flags/cache_builder.rs
@@ -188,9 +188,11 @@ async fn load_cohorts_with_deps(
 
     while !ids_to_load.is_empty() {
         if depth >= MAX_COHORT_DEPENDENCY_DEPTH {
+            let sample: Vec<_> = ids_to_load.iter().take(10).copied().collect();
             tracing::warn!(
                 depth,
-                remaining_ids = ?ids_to_load,
+                remaining_count = ids_to_load.len(),
+                remaining_sample = ?sample,
                 "Cohort dependency depth limit reached"
             );
             break;

--- a/rust/feature-flags/src/flags/cache_builder.rs
+++ b/rust/feature-flags/src/flags/cache_builder.rs
@@ -22,8 +22,8 @@ use crate::utils::graph_utils::{DependencyGraph, DependencyProvider, DependencyT
 /// Matches Python's `_MAX_COHORT_DEPENDENCY_DEPTH`.
 const MAX_COHORT_DEPENDENCY_DEPTH: usize = 20;
 
-/// Newtype wrapper so we can implement `DependencyProvider` for flags
-/// without an orphan-rule conflict on `FeatureFlag`.
+/// Newtype adapter for `FeatureFlag` that implements `DependencyProvider`,
+/// keeping graph-specific trait impls separate from the domain model.
 #[derive(Debug, Clone)]
 struct FlagNode(FeatureFlag);
 
@@ -45,12 +45,6 @@ impl DependencyProvider for FlagNode {
 }
 
 /// Build the full flags cache payload for a team.
-///
-/// Orchestrates:
-/// 1. Fetch flags from Postgres via `FeatureFlagList::from_pg()`
-/// 2. Compute evaluation metadata (dependency stages, missing deps, transitive deps)
-/// 3. Fetch referenced cohorts with transitive dependency resolution
-/// 4. Assemble and return `HypercacheFlagsWrapper`
 pub async fn build_flags_cache(
     pg_reader: PostgresReader,
     team_id: TeamId,
@@ -199,7 +193,8 @@ async fn load_cohorts_with_deps(
         }
         depth += 1;
 
-        let newly_loaded = Cohort::list_by_ids_from_pg(&pg_reader, team_id, &ids_to_load).await?;
+        let ids_vec: Vec<CohortId> = ids_to_load.iter().copied().collect();
+        let newly_loaded = Cohort::list_by_ids_from_pg(&pg_reader, team_id, &ids_vec).await?;
 
         let mut ids_to_load_next: HashSet<CohortId> = HashSet::new();
         for cohort in newly_loaded {

--- a/rust/feature-flags/src/flags/cache_builder.rs
+++ b/rust/feature-flags/src/flags/cache_builder.rs
@@ -1,0 +1,803 @@
+//! Cache builder logic for producing the hypercache flags payload.
+//!
+//! Rust equivalent of Python's `_get_feature_flags_for_service()` in
+//! `posthog/models/feature_flag/flags_cache.py`. Reads flags and cohorts from
+//! Postgres, computes evaluation metadata (dependency stages via Kahn's algorithm),
+//! and produces the `HypercacheFlagsWrapper` JSON payload.
+
+use std::collections::{HashMap, HashSet};
+
+use common_database::PostgresReader;
+use common_types::TeamId;
+
+use crate::api::errors::FlagError;
+use crate::cohorts::cohort_models::{Cohort, CohortId};
+use crate::flags::flag_models::{
+    EvaluationMetadata, FeatureFlag, FeatureFlagId, FeatureFlagList, HypercacheFlagsWrapper,
+};
+use crate::properties::property_models::PropertyFilter;
+use crate::utils::graph_utils::{DependencyGraph, DependencyProvider, DependencyType};
+
+/// Maximum BFS depth when resolving transitive cohort-on-cohort dependencies.
+/// Matches Python's `_MAX_COHORT_DEPENDENCY_DEPTH`.
+const MAX_COHORT_DEPENDENCY_DEPTH: usize = 20;
+
+/// Newtype wrapper so we can implement `DependencyProvider` for flags
+/// without an orphan-rule conflict on `FeatureFlag`.
+#[derive(Debug, Clone)]
+struct FlagNode(FeatureFlag);
+
+impl DependencyProvider for FlagNode {
+    type Id = FeatureFlagId;
+    type Error = FlagError;
+
+    fn get_id(&self) -> Self::Id {
+        self.0.id
+    }
+
+    fn extract_dependencies(&self) -> Result<HashSet<Self::Id>, Self::Error> {
+        Ok(extract_direct_flag_dependency_ids(&self.0))
+    }
+
+    fn dependency_type() -> DependencyType {
+        DependencyType::Flag
+    }
+}
+
+/// Build the full flags cache payload for a team.
+///
+/// Orchestrates:
+/// 1. Fetch flags from Postgres via `FeatureFlagList::from_pg()`
+/// 2. Compute evaluation metadata (dependency stages, missing deps, transitive deps)
+/// 3. Fetch referenced cohorts with transitive dependency resolution
+/// 4. Assemble and return `HypercacheFlagsWrapper`
+pub async fn build_flags_cache(
+    pg_reader: PostgresReader,
+    team_id: TeamId,
+) -> Result<HypercacheFlagsWrapper, FlagError> {
+    let flags = FeatureFlagList::from_pg(pg_reader.clone(), team_id).await?;
+    let evaluation_metadata = compute_flag_dependencies(&flags)?;
+    let cohorts = fetch_referenced_cohorts(pg_reader, team_id, &flags).await?;
+
+    Ok(HypercacheFlagsWrapper {
+        flags,
+        evaluation_metadata,
+        cohorts: Some(cohorts),
+    })
+}
+
+/// Yields all property filters from an active, non-deleted flag's filter groups.
+///
+/// Only scans `groups` — `super_groups` are early-access enrollment gates
+/// using person properties, and `holdout` uses a different schema with no
+/// property filters.
+fn active_flag_properties(flag: &FeatureFlag) -> impl Iterator<Item = &PropertyFilter> {
+    let groups = if flag.active && !flag.deleted {
+        flag.filters.groups.as_slice()
+    } else {
+        &[]
+    };
+    groups.iter().flat_map(|g| g.properties.iter().flatten())
+}
+
+/// Extract direct flag dependency IDs from a single flag's filters.
+///
+/// Scans `filters.groups[*].properties` for `type == "flag"` properties and
+/// parses their `key` as an integer flag ID. Inactive/deleted flags return
+/// empty deps to match Python's `_extract_direct_dependency_ids()`.
+fn extract_direct_flag_dependency_ids(flag: &FeatureFlag) -> HashSet<FeatureFlagId> {
+    active_flag_properties(flag)
+        .filter_map(|p| p.get_feature_flag_id())
+        .collect()
+}
+
+/// Extract cohort IDs directly referenced in active flag filters.
+pub fn extract_cohort_ids_from_flag_filters(flags: &[FeatureFlag]) -> HashSet<CohortId> {
+    flags
+        .iter()
+        .flat_map(active_flag_properties)
+        .filter_map(|p| p.get_cohort_id())
+        .collect()
+}
+
+/// Compute flag dependency metadata via the shared `DependencyGraph` framework.
+///
+/// Produces output identical to Python's `_compute_flag_dependencies()`:
+/// - `dependency_stages`: flag IDs grouped by evaluation stage (stage 0 = no deps first),
+///   sorted within each stage
+/// - `flags_with_missing_deps`: sorted list of flag IDs with missing, cyclic, or
+///   transitively broken dependencies
+/// - `transitive_deps`: flag ID → set of all transitive dependency flag IDs
+pub fn compute_flag_dependencies(flags: &[FeatureFlag]) -> Result<EvaluationMetadata, FlagError> {
+    if flags.is_empty() {
+        return Ok(EvaluationMetadata::default());
+    }
+
+    let original_flag_ids: HashSet<FeatureFlagId> = flags.iter().map(|f| f.id).collect();
+    let nodes: Vec<FlagNode> = flags.iter().cloned().map(FlagNode).collect();
+
+    let mut edges: HashMap<FeatureFlagId, HashSet<FeatureFlagId>> =
+        HashMap::with_capacity(nodes.len());
+    for node in &nodes {
+        // FlagNode::extract_dependencies is infallible (always returns Ok),
+        // so unwrap_or_default is safe here.
+        edges.insert(
+            node.get_id(),
+            node.extract_dependencies().unwrap_or_default(),
+        );
+    }
+
+    // Build graph — tolerant of missing deps and cycles.
+    // from_nodes → finalize → remove_all_cycles strips cycle participants
+    // AND their dependents from the graph.
+    let (graph, _errors, mut nodes_with_missing_deps) = DependencyGraph::from_nodes(nodes, &edges)?;
+
+    // Nodes removed during cycle detection are also "missing"
+    let remaining_ids: HashSet<FeatureFlagId> = graph.iter_nodes().map(|n| n.get_id()).collect();
+    for &id in &original_flag_ids {
+        if !remaining_ids.contains(&id) {
+            nodes_with_missing_deps.insert(id);
+        }
+    }
+
+    // Compute evaluation stages, transitive deps, and missing-dep propagation
+    let result = graph.compute_evaluation_metadata(&nodes_with_missing_deps)?;
+
+    // Ensure all flags have entries in transitive_deps (cycle participants get empty sets)
+    let mut transitive_deps = result.transitive_deps;
+    for &fid in &original_flag_ids {
+        transitive_deps.entry(fid).or_default();
+    }
+
+    Ok(EvaluationMetadata {
+        dependency_stages: result.stages,
+        flags_with_missing_deps: result.nodes_with_missing_deps,
+        transitive_deps,
+    })
+}
+
+/// Fetch cohort definitions referenced by flags, including transitive
+/// cohort-on-cohort dependencies. BFS with depth limit of 20.
+///
+/// Matches Python's `_get_referenced_cohorts()` + `_load_cohorts_with_deps()`.
+pub async fn fetch_referenced_cohorts(
+    pg_reader: PostgresReader,
+    team_id: TeamId,
+    flags: &[FeatureFlag],
+) -> Result<Vec<Cohort>, FlagError> {
+    let seed_ids = extract_cohort_ids_from_flag_filters(flags);
+    if seed_ids.is_empty() {
+        return Ok(vec![]);
+    }
+
+    load_cohorts_with_deps(pg_reader, team_id, seed_ids).await
+}
+
+/// BFS-load cohorts by seed IDs, resolving transitive cohort-on-cohort deps.
+///
+/// Matches Python's `_load_cohorts_with_deps()` with depth limit of 20.
+async fn load_cohorts_with_deps(
+    pg_reader: PostgresReader,
+    team_id: TeamId,
+    seed_ids: HashSet<CohortId>,
+) -> Result<Vec<Cohort>, FlagError> {
+    let mut all_ids = seed_ids.clone();
+    let mut ids_to_load = seed_ids;
+    let mut loaded: HashMap<CohortId, Cohort> = HashMap::new();
+    let mut depth = 0;
+
+    while !ids_to_load.is_empty() {
+        if depth >= MAX_COHORT_DEPENDENCY_DEPTH {
+            tracing::warn!(
+                depth,
+                remaining_ids = ?ids_to_load,
+                "Cohort dependency depth limit reached"
+            );
+            break;
+        }
+        depth += 1;
+
+        let newly_loaded = Cohort::list_by_ids_from_pg(&pg_reader, team_id, &ids_to_load).await?;
+
+        let mut ids_to_load_next: HashSet<CohortId> = HashSet::new();
+        for cohort in newly_loaded {
+            let cohort_id = cohort.id;
+            match cohort.extract_dependencies() {
+                Ok(dep_ids) => {
+                    for dep_id in dep_ids {
+                        if !all_ids.contains(&dep_id) {
+                            all_ids.insert(dep_id);
+                            ids_to_load_next.insert(dep_id);
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        cohort_id = cohort_id,
+                        team_id = team_id,
+                        error = %e,
+                        "Failed to extract dependencies for cohort"
+                    );
+                }
+            }
+            loaded.insert(cohort_id, cohort);
+        }
+
+        ids_to_load = ids_to_load_next;
+    }
+
+    let mut cohorts: Vec<Cohort> = loaded.into_values().collect();
+    cohorts.sort_by_key(|c| c.id);
+    Ok(cohorts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::flags::flag_models::{FlagFilters, FlagPropertyGroup};
+    use crate::properties::property_models::{OperatorType, PropertyFilter, PropertyType};
+
+    fn make_flag(id: i32, key: &str, active: bool, groups: Vec<FlagPropertyGroup>) -> FeatureFlag {
+        FeatureFlag {
+            id,
+            team_id: 1,
+            name: Some(key.to_string()),
+            key: key.to_string(),
+            filters: FlagFilters {
+                groups,
+                ..Default::default()
+            },
+            active,
+            ..Default::default()
+        }
+    }
+
+    fn flag_dep_property(dep_flag_id: i32) -> PropertyFilter {
+        PropertyFilter {
+            key: dep_flag_id.to_string(),
+            value: Some(serde_json::json!("true")),
+            operator: Some(OperatorType::Exact),
+            prop_type: PropertyType::Flag,
+            ..Default::default()
+        }
+    }
+
+    fn cohort_property(cohort_id: i32) -> PropertyFilter {
+        PropertyFilter {
+            key: "$cohort".to_string(),
+            value: Some(serde_json::json!(cohort_id)),
+            operator: Some(OperatorType::Exact),
+            prop_type: PropertyType::Cohort,
+            ..Default::default()
+        }
+    }
+
+    fn group_with_properties(props: Vec<PropertyFilter>) -> FlagPropertyGroup {
+        FlagPropertyGroup {
+            properties: Some(props),
+            rollout_percentage: Some(100.0),
+            ..Default::default()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // extract_direct_flag_dependency_ids tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_extract_deps_no_dependencies() {
+        let flag = make_flag(1, "flag_a", true, vec![group_with_properties(vec![])]);
+        let deps = extract_direct_flag_dependency_ids(&flag);
+        assert!(deps.is_empty());
+    }
+
+    #[test]
+    fn test_extract_deps_with_flag_dependency() {
+        let flag = make_flag(
+            1,
+            "flag_a",
+            true,
+            vec![group_with_properties(vec![flag_dep_property(2)])],
+        );
+        let deps = extract_direct_flag_dependency_ids(&flag);
+        assert_eq!(deps, HashSet::from([2]));
+    }
+
+    #[test]
+    fn test_extract_deps_inactive_flag_returns_empty() {
+        let flag = make_flag(
+            1,
+            "flag_a",
+            false,
+            vec![group_with_properties(vec![flag_dep_property(2)])],
+        );
+        let deps = extract_direct_flag_dependency_ids(&flag);
+        assert!(deps.is_empty());
+    }
+
+    #[test]
+    fn test_extract_deps_deleted_flag_returns_empty() {
+        let mut flag = make_flag(
+            1,
+            "flag_a",
+            true,
+            vec![group_with_properties(vec![flag_dep_property(2)])],
+        );
+        flag.deleted = true;
+        let deps = extract_direct_flag_dependency_ids(&flag);
+        assert!(deps.is_empty());
+    }
+
+    // -------------------------------------------------------------------------
+    // extract_cohort_ids_from_flag_filters tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_extract_cohort_ids_empty_flags() {
+        let ids = extract_cohort_ids_from_flag_filters(&[]);
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn test_extract_cohort_ids_with_cohort_property() {
+        let flag = make_flag(
+            1,
+            "flag_a",
+            true,
+            vec![group_with_properties(vec![cohort_property(42)])],
+        );
+        let ids = extract_cohort_ids_from_flag_filters(&[flag]);
+        assert_eq!(ids, HashSet::from([42]));
+    }
+
+    #[test]
+    fn test_extract_cohort_ids_ignores_inactive() {
+        let flag = make_flag(
+            1,
+            "flag_a",
+            false,
+            vec![group_with_properties(vec![cohort_property(42)])],
+        );
+        let ids = extract_cohort_ids_from_flag_filters(&[flag]);
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn test_extract_cohort_ids_string_value() {
+        let flag = make_flag(
+            1,
+            "flag_a",
+            true,
+            vec![group_with_properties(vec![PropertyFilter {
+                key: "$cohort".to_string(),
+                value: Some(serde_json::json!("42")),
+                operator: Some(OperatorType::Exact),
+                prop_type: PropertyType::Cohort,
+                ..Default::default()
+            }])],
+        );
+        let ids = extract_cohort_ids_from_flag_filters(&[flag]);
+        assert_eq!(ids, HashSet::from([42]));
+    }
+
+    #[test]
+    fn test_extract_cohort_ids_multiple_flags_and_cohorts() {
+        let flag1 = make_flag(
+            1,
+            "flag_a",
+            true,
+            vec![group_with_properties(vec![cohort_property(10)])],
+        );
+        let flag2 = make_flag(
+            2,
+            "flag_b",
+            true,
+            vec![group_with_properties(vec![
+                cohort_property(20),
+                cohort_property(30),
+            ])],
+        );
+        let ids = extract_cohort_ids_from_flag_filters(&[flag1, flag2]);
+        assert_eq!(ids, HashSet::from([10, 20, 30]));
+    }
+
+    // -------------------------------------------------------------------------
+    // compute_flag_dependencies tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_compute_deps_empty_flags() {
+        let meta = compute_flag_dependencies(&[]).unwrap();
+        assert!(meta.dependency_stages.is_empty());
+        assert!(meta.flags_with_missing_deps.is_empty());
+        assert!(meta.transitive_deps.is_empty());
+    }
+
+    #[test]
+    fn test_compute_deps_no_dependencies() {
+        let flags = vec![
+            make_flag(1, "a", true, vec![group_with_properties(vec![])]),
+            make_flag(2, "b", true, vec![group_with_properties(vec![])]),
+            make_flag(3, "c", true, vec![group_with_properties(vec![])]),
+        ];
+        let meta = compute_flag_dependencies(&flags).unwrap();
+
+        // All flags in a single stage, sorted
+        assert_eq!(meta.dependency_stages.len(), 1);
+        assert_eq!(meta.dependency_stages[0], vec![1, 2, 3]);
+        assert!(meta.flags_with_missing_deps.is_empty());
+        // Each flag has empty transitive deps
+        for id in [1, 2, 3] {
+            assert!(meta.transitive_deps[&id].is_empty());
+        }
+    }
+
+    #[test]
+    fn test_compute_deps_linear_chain() {
+        // C depends on B, B depends on A
+        let flags = vec![
+            make_flag(1, "a", true, vec![group_with_properties(vec![])]),
+            make_flag(
+                2,
+                "b",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(1)])],
+            ),
+            make_flag(
+                3,
+                "c",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(2)])],
+            ),
+        ];
+        let meta = compute_flag_dependencies(&flags).unwrap();
+
+        assert_eq!(meta.dependency_stages.len(), 3);
+        assert_eq!(meta.dependency_stages[0], vec![1]); // A has no deps
+        assert_eq!(meta.dependency_stages[1], vec![2]); // B depends on A
+        assert_eq!(meta.dependency_stages[2], vec![3]); // C depends on B
+        assert!(meta.flags_with_missing_deps.is_empty());
+
+        // Transitive deps
+        assert!(meta.transitive_deps[&1].is_empty());
+        assert_eq!(meta.transitive_deps[&2], HashSet::from([1]));
+        assert_eq!(meta.transitive_deps[&3], HashSet::from([1, 2]));
+    }
+
+    #[test]
+    fn test_compute_deps_diamond() {
+        // D depends on B and C, B and C both depend on A
+        let flags = vec![
+            make_flag(1, "a", true, vec![group_with_properties(vec![])]),
+            make_flag(
+                2,
+                "b",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(1)])],
+            ),
+            make_flag(
+                3,
+                "c",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(1)])],
+            ),
+            make_flag(
+                4,
+                "d",
+                true,
+                vec![group_with_properties(vec![
+                    flag_dep_property(2),
+                    flag_dep_property(3),
+                ])],
+            ),
+        ];
+        let meta = compute_flag_dependencies(&flags).unwrap();
+
+        assert_eq!(meta.dependency_stages.len(), 3);
+        assert_eq!(meta.dependency_stages[0], vec![1]);
+        assert_eq!(meta.dependency_stages[1], vec![2, 3]); // B and C in same stage, sorted
+        assert_eq!(meta.dependency_stages[2], vec![4]);
+        assert!(meta.flags_with_missing_deps.is_empty());
+
+        assert_eq!(meta.transitive_deps[&4], HashSet::from([1, 2, 3]));
+    }
+
+    #[test]
+    fn test_compute_deps_missing_dependency() {
+        // Flag 1 depends on flag 99 which doesn't exist
+        let flags = vec![
+            make_flag(
+                1,
+                "a",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(99)])],
+            ),
+            make_flag(2, "b", true, vec![group_with_properties(vec![])]),
+        ];
+        let meta = compute_flag_dependencies(&flags).unwrap();
+
+        // Both flags still appear in stages (flag 1 has in_degree 0 because
+        // dep 99 is unknown, so the edge is ignored for in_degree counting)
+        assert_eq!(meta.dependency_stages.len(), 1);
+        assert_eq!(meta.dependency_stages[0], vec![1, 2]);
+        assert_eq!(meta.flags_with_missing_deps, vec![1]);
+    }
+
+    #[test]
+    fn test_compute_deps_cycle_detection() {
+        // A depends on B, B depends on A
+        let flags = vec![
+            make_flag(
+                1,
+                "a",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(2)])],
+            ),
+            make_flag(
+                2,
+                "b",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(1)])],
+            ),
+        ];
+        let meta = compute_flag_dependencies(&flags).unwrap();
+
+        // Cyclic flags are NOT in any stage
+        assert!(meta.dependency_stages.is_empty());
+        // Both flags are marked as having missing deps (cycled)
+        assert_eq!(meta.flags_with_missing_deps, vec![1, 2]);
+    }
+
+    #[test]
+    fn test_compute_deps_cycle_with_independent_flags() {
+        // Flags 1 and 2 form a cycle; flag 3 is independent
+        let flags = vec![
+            make_flag(
+                1,
+                "a",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(2)])],
+            ),
+            make_flag(
+                2,
+                "b",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(1)])],
+            ),
+            make_flag(3, "c", true, vec![group_with_properties(vec![])]),
+        ];
+        let meta = compute_flag_dependencies(&flags).unwrap();
+
+        // Only flag 3 appears in stages
+        assert_eq!(meta.dependency_stages.len(), 1);
+        assert_eq!(meta.dependency_stages[0], vec![3]);
+        assert_eq!(meta.flags_with_missing_deps, vec![1, 2]);
+    }
+
+    #[test]
+    fn test_compute_deps_transitive_missing_propagation() {
+        // A is fine, B depends on A, C depends on B and on 99 (missing)
+        // D depends on C, so D should also be flagged
+        let flags = vec![
+            make_flag(1, "a", true, vec![group_with_properties(vec![])]),
+            make_flag(
+                2,
+                "b",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(1)])],
+            ),
+            make_flag(
+                3,
+                "c",
+                true,
+                vec![group_with_properties(vec![
+                    flag_dep_property(2),
+                    flag_dep_property(99),
+                ])],
+            ),
+            make_flag(
+                4,
+                "d",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(3)])],
+            ),
+        ];
+        let meta = compute_flag_dependencies(&flags).unwrap();
+
+        // Stages: A (0), B (1), C (2), D (3)
+        assert_eq!(meta.dependency_stages.len(), 4);
+        // C and D are flagged as having missing deps
+        assert_eq!(meta.flags_with_missing_deps, vec![3, 4]);
+    }
+
+    #[test]
+    fn test_compute_deps_transitive_deps_string_keys_in_serialization() {
+        // Verify that serialization uses string keys (matching Python)
+        let flags = vec![
+            make_flag(1, "a", true, vec![group_with_properties(vec![])]),
+            make_flag(
+                2,
+                "b",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(1)])],
+            ),
+        ];
+        let meta = compute_flag_dependencies(&flags).unwrap();
+
+        // Serialize and verify string keys
+        let json = serde_json::to_value(&meta).unwrap();
+        let td = json["transitive_deps"].as_object().unwrap();
+        assert!(td.contains_key("1"));
+        assert!(td.contains_key("2"));
+        // Value for flag 2 should be [1]
+        assert_eq!(td["2"], serde_json::json!([1]));
+    }
+
+    #[test]
+    fn test_compute_deps_inactive_flag_deps_ignored() {
+        // Flag 2 (inactive) depends on flag 1, but since it's inactive
+        // its deps should be empty
+        let flags = vec![
+            make_flag(1, "a", true, vec![group_with_properties(vec![])]),
+            make_flag(
+                2,
+                "b",
+                false,
+                vec![group_with_properties(vec![flag_dep_property(1)])],
+            ),
+        ];
+        let meta = compute_flag_dependencies(&flags).unwrap();
+
+        // Both in stage 0 (flag 2's dep on flag 1 is ignored because inactive)
+        assert_eq!(meta.dependency_stages.len(), 1);
+        assert_eq!(meta.dependency_stages[0], vec![1, 2]);
+        assert!(meta.flags_with_missing_deps.is_empty());
+        assert!(meta.transitive_deps[&2].is_empty());
+    }
+
+    #[test]
+    fn test_compute_deps_self_cycle() {
+        // Flag depends on itself
+        let flags = vec![make_flag(
+            1,
+            "a",
+            true,
+            vec![group_with_properties(vec![flag_dep_property(1)])],
+        )];
+        let meta = compute_flag_dependencies(&flags).unwrap();
+
+        assert!(meta.dependency_stages.is_empty());
+        assert_eq!(meta.flags_with_missing_deps, vec![1]);
+        assert!(meta.transitive_deps[&1].is_empty());
+    }
+
+    #[test]
+    fn test_compute_deps_dependency_on_inactive_flag_not_missing() {
+        // Active flag 2 depends on inactive flag 1 — but inactive flag 1's deps
+        // are empty, so flag 2's edge to flag 1 is only based on its filter key.
+        // Since flag 1 exists in the graph, flag 2 is NOT missing.
+        let flags = vec![
+            make_flag(1, "a", false, vec![group_with_properties(vec![])]),
+            make_flag(
+                2,
+                "b",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(1)])],
+            ),
+        ];
+        let meta = compute_flag_dependencies(&flags).unwrap();
+
+        assert_eq!(meta.dependency_stages.len(), 2);
+        assert_eq!(meta.dependency_stages[0], vec![1]);
+        assert_eq!(meta.dependency_stages[1], vec![2]);
+        assert!(meta.flags_with_missing_deps.is_empty());
+        assert_eq!(meta.transitive_deps[&2], HashSet::from([1]));
+    }
+
+    #[test]
+    fn test_compute_deps_three_node_cycle_with_dependent() {
+        // A→B→C→A form a cycle; D depends on A
+        // All four should be flagged as missing
+        let flags = vec![
+            make_flag(
+                1,
+                "a",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(2)])],
+            ),
+            make_flag(
+                2,
+                "b",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(3)])],
+            ),
+            make_flag(
+                3,
+                "c",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(1)])],
+            ),
+            make_flag(
+                4,
+                "d",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(1)])],
+            ),
+        ];
+        let meta = compute_flag_dependencies(&flags).unwrap();
+
+        // Cycle participants and their dependents are all removed from the graph
+        assert!(meta.dependency_stages.is_empty());
+        assert_eq!(meta.flags_with_missing_deps, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_extract_cohort_ids_ignores_deleted() {
+        let mut flag = make_flag(
+            1,
+            "flag_a",
+            true,
+            vec![group_with_properties(vec![cohort_property(42)])],
+        );
+        flag.deleted = true;
+        let ids = extract_cohort_ids_from_flag_filters(&[flag]);
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn test_extract_deps_multiple_dependencies() {
+        // Flag with 2 dependencies
+        let flag = make_flag(
+            3,
+            "c",
+            true,
+            vec![group_with_properties(vec![
+                flag_dep_property(1),
+                flag_dep_property(2),
+            ])],
+        );
+        let deps = extract_direct_flag_dependency_ids(&flag);
+        assert_eq!(deps, HashSet::from([1, 2]));
+    }
+
+    #[test]
+    fn test_compute_deps_transitive_deps_serialization_empty_set() {
+        // Verify that a flag with no deps serializes as empty array
+        let flags = vec![
+            make_flag(1, "a", true, vec![group_with_properties(vec![])]),
+            make_flag(
+                2,
+                "b",
+                true,
+                vec![group_with_properties(vec![flag_dep_property(1)])],
+            ),
+        ];
+        let meta = compute_flag_dependencies(&flags).unwrap();
+        let json = serde_json::to_value(&meta).unwrap();
+        let td = json["transitive_deps"].as_object().unwrap();
+        assert_eq!(td["1"], serde_json::json!([]));
+        assert_eq!(td["2"], serde_json::json!([1]));
+    }
+
+    #[test]
+    fn test_compute_deps_matches_golden_fixture() {
+        let fixture = include_str!("../../tests/fixtures/hypercache_contract.json");
+        let wrapper: HypercacheFlagsWrapper =
+            serde_json::from_str(fixture).expect("fixture should deserialize");
+
+        let computed = compute_flag_dependencies(&wrapper.flags).unwrap();
+
+        assert_eq!(
+            computed.dependency_stages,
+            wrapper.evaluation_metadata.dependency_stages
+        );
+        assert_eq!(
+            computed.flags_with_missing_deps,
+            wrapper.evaluation_metadata.flags_with_missing_deps
+        );
+        assert_eq!(
+            computed.transitive_deps,
+            wrapper.evaluation_metadata.transitive_deps
+        );
+    }
+}

--- a/rust/feature-flags/src/flags/cache_builder.rs
+++ b/rust/feature-flags/src/flags/cache_builder.rs
@@ -61,10 +61,6 @@ pub async fn build_flags_cache(
 }
 
 /// Yields all property filters from an active, non-deleted flag's filter groups.
-///
-/// Only scans `groups` — `super_groups` are early-access enrollment gates
-/// using person properties, and `holdout` uses a different schema with no
-/// property filters.
 fn active_flag_properties(flag: &FeatureFlag) -> impl Iterator<Item = &PropertyFilter> {
     let groups = if flag.active && !flag.deleted {
         flag.filters.groups.as_slice()
@@ -113,7 +109,7 @@ pub fn compute_flag_dependencies(flags: &[FeatureFlag]) -> Result<EvaluationMeta
     let mut edges: HashMap<FeatureFlagId, HashSet<FeatureFlagId>> =
         HashMap::with_capacity(nodes.len());
     for node in &nodes {
-        // FlagNode::extract_dependencies is infallible (always returns Ok),
+        // FlagNode::extract_dependencies always returns Ok,
         // so unwrap_or_default is safe here.
         edges.insert(
             node.get_id(),
@@ -176,7 +172,7 @@ async fn load_cohorts_with_deps(
     seed_ids: HashSet<CohortId>,
 ) -> Result<Vec<Cohort>, FlagError> {
     let mut all_ids = seed_ids.clone();
-    let mut ids_to_load = seed_ids;
+    let mut ids_to_load: Vec<CohortId> = seed_ids.into_iter().collect();
     let mut loaded: HashMap<CohortId, Cohort> = HashMap::new();
     let mut depth = 0;
 
@@ -193,10 +189,9 @@ async fn load_cohorts_with_deps(
         }
         depth += 1;
 
-        let ids_vec: Vec<CohortId> = ids_to_load.iter().copied().collect();
-        let newly_loaded = Cohort::list_by_ids_from_pg(&pg_reader, team_id, &ids_vec).await?;
+        let newly_loaded = Cohort::list_by_ids_from_pg(&pg_reader, team_id, &ids_to_load).await?;
 
-        let mut ids_to_load_next: HashSet<CohortId> = HashSet::new();
+        let mut ids_to_load_next: Vec<CohortId> = Vec::new();
         for cohort in newly_loaded {
             let cohort_id = cohort.id;
             match cohort.extract_dependencies() {
@@ -204,7 +199,7 @@ async fn load_cohorts_with_deps(
                     for dep_id in dep_ids {
                         if !all_ids.contains(&dep_id) {
                             all_ids.insert(dep_id);
-                            ids_to_load_next.insert(dep_id);
+                            ids_to_load_next.push(dep_id);
                         }
                     }
                 }

--- a/rust/feature-flags/src/flags/cache_builder.rs
+++ b/rust/feature-flags/src/flags/cache_builder.rs
@@ -228,6 +228,7 @@ mod tests {
     use super::*;
     use crate::flags::flag_models::{FlagFilters, FlagPropertyGroup};
     use crate::properties::property_models::{OperatorType, PropertyFilter, PropertyType};
+    use test_case::test_case;
 
     fn make_flag(id: i32, key: &str, active: bool, groups: Vec<FlagPropertyGroup>) -> FeatureFlag {
         FeatureFlag {
@@ -295,27 +296,16 @@ mod tests {
         assert_eq!(deps, HashSet::from([2]));
     }
 
-    #[test]
-    fn test_extract_deps_inactive_flag_returns_empty() {
-        let flag = make_flag(
-            1,
-            "flag_a",
-            false,
-            vec![group_with_properties(vec![flag_dep_property(2)])],
-        );
-        let deps = extract_direct_flag_dependency_ids(&flag);
-        assert!(deps.is_empty());
-    }
-
-    #[test]
-    fn test_extract_deps_deleted_flag_returns_empty() {
+    #[test_case(false, false ; "inactive flag")]
+    #[test_case(true, true ; "deleted flag")]
+    fn test_extract_deps_skipped_flag_returns_empty(active: bool, deleted: bool) {
         let mut flag = make_flag(
             1,
             "flag_a",
-            true,
+            active,
             vec![group_with_properties(vec![flag_dep_property(2)])],
         );
-        flag.deleted = true;
+        flag.deleted = deleted;
         let deps = extract_direct_flag_dependency_ids(&flag);
         assert!(deps.is_empty());
     }
@@ -342,14 +332,16 @@ mod tests {
         assert_eq!(ids, HashSet::from([42]));
     }
 
-    #[test]
-    fn test_extract_cohort_ids_ignores_inactive() {
-        let flag = make_flag(
+    #[test_case(false, false ; "inactive flag")]
+    #[test_case(true, true ; "deleted flag")]
+    fn test_extract_cohort_ids_ignores_skipped(active: bool, deleted: bool) {
+        let mut flag = make_flag(
             1,
             "flag_a",
-            false,
+            active,
             vec![group_with_properties(vec![cohort_property(42)])],
         );
+        flag.deleted = deleted;
         let ids = extract_cohort_ids_from_flag_filters(&[flag]);
         assert!(ids.is_empty());
     }
@@ -721,19 +713,6 @@ mod tests {
         // Cycle participants and their dependents are all removed from the graph
         assert!(meta.dependency_stages.is_empty());
         assert_eq!(meta.flags_with_missing_deps, vec![1, 2, 3, 4]);
-    }
-
-    #[test]
-    fn test_extract_cohort_ids_ignores_deleted() {
-        let mut flag = make_flag(
-            1,
-            "flag_a",
-            true,
-            vec![group_with_properties(vec![cohort_property(42)])],
-        );
-        flag.deleted = true;
-        let ids = extract_cohort_ids_from_flag_filters(&[flag]);
-        assert!(ids.is_empty());
     }
 
     #[test]

--- a/rust/feature-flags/src/flags/mod.rs
+++ b/rust/feature-flags/src/flags/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod cache_builder;
 pub mod feature_flag_list;
 pub mod flag_analytics;
 pub mod flag_filters;

--- a/rust/feature-flags/src/flags/mod.rs
+++ b/rust/feature-flags/src/flags/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod cache_builder;
+pub mod cache_builder;
 pub mod feature_flag_list;
 pub mod flag_analytics;
 pub mod flag_filters;

--- a/rust/feature-flags/src/flags/property_filter.rs
+++ b/rust/feature-flags/src/flags/property_filter.rs
@@ -16,15 +16,17 @@ impl PropertyFilter {
     }
 
     /// Returns the cohort id if the filter is a cohort filter, or None if it's not a cohort filter
-    /// or if the value cannot be parsed as a cohort id
+    /// or if the value cannot be parsed as a cohort id.
+    /// Handles both JSON number and string representations (Python serializes both).
     pub fn get_cohort_id(&self) -> Option<CohortId> {
         if !self.is_cohort() {
             return None;
         }
-        self.value
-            .as_ref()
-            .and_then(|value| value.as_i64())
-            .map(|id| id as CohortId)
+        self.value.as_ref().and_then(|value| match value {
+            Value::Number(n) => n.as_i64().map(|id| id as CohortId),
+            Value::String(s) => s.parse::<CohortId>().ok(),
+            _ => None,
+        })
     }
 
     /// Checks if the filter depends on a feature flag
@@ -136,6 +138,11 @@ mod tests {
         // Non-cohort filter should return None
         let filter = mock!(crate::properties::property_models::PropertyFilter, key: "person".mock_into(), prop_type: PropertyType::Person, operator: Some(OperatorType::Exact));
         assert_eq!(filter.get_cohort_id(), None);
+
+        // Cohort filter with string-encoded numeric value should return the id
+        let mut filter = mock!(crate::properties::property_models::PropertyFilter, key: "cohort".mock_into(), prop_type: PropertyType::Cohort, operator: Some(OperatorType::Exact));
+        filter.value = Some(Value::String("123".to_string()));
+        assert_eq!(filter.get_cohort_id(), Some(123));
 
         // Cohort filter with non-numeric value should return None
         let mut filter = mock!(crate::properties::property_models::PropertyFilter, key: "cohort".mock_into(), prop_type: PropertyType::Cohort, operator: Some(OperatorType::Exact));

--- a/rust/feature-flags/src/flags/property_filter.rs
+++ b/rust/feature-flags/src/flags/property_filter.rs
@@ -23,7 +23,7 @@ impl PropertyFilter {
             return None;
         }
         self.value.as_ref().and_then(|value| match value {
-            Value::Number(n) => n.as_i64().map(|id| id as CohortId),
+            Value::Number(n) => n.as_i64().and_then(|id| CohortId::try_from(id).ok()),
             Value::String(s) => s.parse::<CohortId>().ok(),
             _ => None,
         })

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -40,6 +40,21 @@ impl<Id> GraphError<Id> {
     }
 }
 
+/// Result of computing evaluation metadata from a dependency graph.
+/// Contains staged evaluation order, transitive dependencies, and
+/// nodes with missing or broken dependencies.
+#[derive(Debug, Clone)]
+pub struct EvaluationResult<Id: Copy + Eq + std::hash::Hash> {
+    /// Node IDs grouped by evaluation stage. Stage 0 = leaves (no deps).
+    /// Each inner Vec is sorted by ID for determinism.
+    pub stages: Vec<Vec<Id>>,
+    /// Node ID → set of all transitive dependency node IDs.
+    /// Cycle participants get empty sets.
+    pub transitive_deps: HashMap<Id, HashSet<Id>>,
+    /// Sorted list of node IDs with missing, cyclic, or transitively broken deps.
+    pub nodes_with_missing_deps: Vec<Id>,
+}
+
 /// Trait for types that can provide their dependencies
 pub trait DependencyProvider {
     type Id: Copy + Eq + std::hash::Hash + std::fmt::Display + Into<i64>;
@@ -359,6 +374,72 @@ where
                     .collect()
             })
             .collect())
+    }
+
+    /// Computes evaluation stages, transitive dependencies, and missing-dep propagation
+    /// in a single pass over the topologically sorted stages.
+    ///
+    /// `nodes_with_missing_deps_set` contains IDs already known to have missing deps
+    /// (e.g. nodes removed during cycle detection, or nodes with external missing deps).
+    /// This method propagates that status: any node depending on a missing-dep node
+    /// is also marked as having missing deps.
+    pub fn compute_evaluation_metadata(
+        &self,
+        nodes_with_missing_deps_set: &HashSet<T::Id>,
+    ) -> Result<EvaluationResult<T::Id>, T::Error>
+    where
+        T::Id: Ord,
+    {
+        use petgraph::Direction::Outgoing;
+
+        let out_degree = self.build_evaluation_maps();
+        let stage_indices = Self::compute_stage_indices(&self.graph, out_degree)?;
+
+        // Build NodeIndex → Id lookup
+        let node_id = |idx: NodeIndex| -> T::Id { self.graph[idx].get_id() };
+
+        let mut transitive_deps: HashMap<T::Id, HashSet<T::Id>> =
+            HashMap::with_capacity(self.graph.node_count());
+        let mut has_missing: HashSet<T::Id> = nodes_with_missing_deps_set.clone();
+        let mut stages: Vec<Vec<T::Id>> = Vec::with_capacity(stage_indices.len());
+
+        for stage in &stage_indices {
+            let mut stage_ids: Vec<T::Id> = Vec::with_capacity(stage.len());
+
+            for &node_idx in stage {
+                let id = node_id(node_idx);
+                stage_ids.push(id);
+
+                // Collect transitive deps: union of {direct_dep} ∪ transitive_deps[direct_dep]
+                // This is safe because all deps appear in earlier stages.
+                let mut my_deps = HashSet::new();
+                for dep_idx in self.graph.neighbors_directed(node_idx, Outgoing) {
+                    let dep_id = node_id(dep_idx);
+                    my_deps.insert(dep_id);
+                    if let Some(dep_transitive) = transitive_deps.get(&dep_id) {
+                        my_deps.extend(dep_transitive);
+                    }
+                    // Propagate missing status
+                    if has_missing.contains(&dep_id) {
+                        has_missing.insert(id);
+                    }
+                }
+                transitive_deps.insert(id, my_deps);
+            }
+
+            // Sort each stage for determinism
+            stage_ids.sort();
+            stages.push(stage_ids);
+        }
+
+        let mut nodes_with_missing_deps: Vec<T::Id> = has_missing.into_iter().collect();
+        nodes_with_missing_deps.sort();
+
+        Ok(EvaluationResult {
+            stages,
+            transitive_deps,
+            nodes_with_missing_deps,
+        })
     }
 
     /// Returns an iterator over all nodes (items) in the graph.

--- a/rust/feature-flags/src/utils/graph_utils.rs
+++ b/rust/feature-flags/src/utils/graph_utils.rs
@@ -48,8 +48,9 @@ pub struct EvaluationResult<Id: Copy + Eq + std::hash::Hash> {
     /// Node IDs grouped by evaluation stage. Stage 0 = leaves (no deps).
     /// Each inner Vec is sorted by ID for determinism.
     pub stages: Vec<Vec<Id>>,
-    /// Node ID → set of all transitive dependency node IDs.
-    /// Cycle participants get empty sets.
+    /// Node ID → set of all transitive dependency node IDs for nodes remaining
+    /// in the graph. Nodes removed before evaluation (e.g. cycle participants)
+    /// will be absent — callers should backfill empty entries if needed.
     pub transitive_deps: HashMap<Id, HashSet<Id>>,
     /// Sorted list of node IDs with missing, cyclic, or transitively broken deps.
     pub nodes_with_missing_deps: Vec<Id>,

--- a/rust/feature-flags/src/utils/test_graph_utils.rs
+++ b/rust/feature-flags/src/utils/test_graph_utils.rs
@@ -917,6 +917,75 @@ mod tests {
             }
         }
     }
+
+    mod compute_evaluation_metadata {
+        use super::*;
+
+        #[test]
+        fn test_empty_graph() {
+            let nodes: Vec<TestItem> = vec![];
+            let (graph, _, missing) = build_graph_from_nodes(&nodes).unwrap();
+            let result = graph.compute_evaluation_metadata(&missing).unwrap();
+
+            assert!(result.stages.is_empty());
+            assert!(result.transitive_deps.is_empty());
+            assert!(result.nodes_with_missing_deps.is_empty());
+        }
+
+        #[test]
+        fn test_linear_chain() {
+            // 1 → 2 → 3 (1 depends on 2, 2 depends on 3)
+            let nodes = vec![
+                TestItem::new(1, HashSet::from([2])),
+                TestItem::new(2, HashSet::from([3])),
+                TestItem::new(3, HashSet::new()),
+            ];
+            let (graph, _, missing) = build_graph_from_nodes(&nodes).unwrap();
+            let result = graph.compute_evaluation_metadata(&missing).unwrap();
+
+            assert_eq!(result.stages, vec![vec![3], vec![2], vec![1]]);
+            assert!(result.transitive_deps[&3].is_empty());
+            assert_eq!(result.transitive_deps[&2], HashSet::from([3]));
+            assert_eq!(result.transitive_deps[&1], HashSet::from([2, 3]));
+            assert!(result.nodes_with_missing_deps.is_empty());
+        }
+
+        #[test]
+        fn test_diamond() {
+            // 4 depends on 2 and 3; both 2 and 3 depend on 1
+            let nodes = vec![
+                TestItem::new(1, HashSet::new()),
+                TestItem::new(2, HashSet::from([1])),
+                TestItem::new(3, HashSet::from([1])),
+                TestItem::new(4, HashSet::from([2, 3])),
+            ];
+            let (graph, _, missing) = build_graph_from_nodes(&nodes).unwrap();
+            let result = graph.compute_evaluation_metadata(&missing).unwrap();
+
+            assert_eq!(result.stages.len(), 3);
+            assert_eq!(result.stages[0], vec![1]);
+            assert_eq!(result.stages[1], vec![2, 3]);
+            assert_eq!(result.stages[2], vec![4]);
+            assert_eq!(result.transitive_deps[&4], HashSet::from([1, 2, 3]));
+            assert!(result.nodes_with_missing_deps.is_empty());
+        }
+
+        #[test]
+        fn test_missing_dep_propagation() {
+            // Node 1 has no deps, node 2 depends on 1, node 3 depends on 2
+            // Mark node 1 as having missing deps — should propagate to 2 and 3
+            let nodes = vec![
+                TestItem::new(1, HashSet::new()),
+                TestItem::new(2, HashSet::from([1])),
+                TestItem::new(3, HashSet::from([2])),
+            ];
+            let (graph, _, _) = build_graph_from_nodes(&nodes).unwrap();
+            let pre_missing = HashSet::from([1_i64]);
+            let result = graph.compute_evaluation_metadata(&pre_missing).unwrap();
+
+            assert_eq!(result.nodes_with_missing_deps, vec![1, 2, 3]);
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

We currently build the flags Hypercache entry in Django (`_get_feature_flags_for_service()` in `posthog/models/feature_flag/flags_cache.py`) and read it in Rust. This is a bit brittle in that we have to ensure that what's written in one platform can be read by another. Also, there's a lot of duplication of code and we have no good handling for cache misses. We rely on the cache to be 100% available.

By porting the cache building to Rust, we can use the same types for reading and writing. We also then have a path to rebuild the cache in the unlikely cache-miss case.

> [!NOTE]
> This code doesn't affect prod yet. There's nothing calling this code.

## Changes

- Add `cache_builder.rs` — the Rust equivalent of the Python cache builder. Orchestrates flag fetching, dependency computation via Kahn's algorithm, and BFS cohort resolution (depth-limited to 20 levels). Produces the `HypercacheFlagsWrapper` JSON payload.
- Add `Cohort::list_by_ids_from_pg()` for batch-fetching cohorts by ID set, used during BFS dependency resolution. Extract shared `COHORT_COLUMNS` constant to DRY up the existing `list_from_pg`.
- Extend `PropertyFilter::get_cohort_id()` to handle string-encoded numeric values (Python serializes cohort IDs as both numbers and strings).
- Add `DependencyGraph::compute_evaluation_metadata()` — computes staged evaluation order, transitive dependency maps, and missing-dep propagation in a single pass over topologically sorted stages. Returns a generic `EvaluationResult<Id>`.
- 26 unit tests covering the cache builder (dependency extraction, cohort resolution, cycle handling, inactive flag filtering) and 4 tests for the new graph evaluation metadata.

## How did you test this code?

All new functionality is covered by unit tests:
- `cargo test -p feature-flags` — 26 cache builder tests + 4 graph evaluation metadata tests all pass
- Tests cover: flag dependency extraction, cohort ID extraction, dependency stage computation, cycle detection and removal, BFS cohort resolution with depth limiting, inactive/deleted flag filtering, and string-encoded cohort ID parsing

## Publish to changelog?

No

## Docs update

No docs changes needed — this is internal Rust service implementation.
