### PR TITLE
chore(signals): track signal reports in pr events

### DIFF
--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -491,6 +491,9 @@ class TaskRun(models.Model):
                 "run_id": str(self.id),
                 "team_id": self.team_id,
                 "repository": self.task.repository,
+                "origin_product": self.task.origin_product,
+                "title": self.task.title,
+                "signal_report_id": str(self.task.signal_report_id) if self.task.signal_report_id else None,
                 "environment": self.environment,
                 "mode": self.mode,
             }


### PR DESCRIPTION
We are tracking which PRs are opened, merged and closed from PostHog Code, lets include signal data there so that we can determine how well the signals pipeline is generating tasks that are mergeable