### PR TITLE
fix(hog): Fixes a stack pop issue with async functions

### DIFF
--- a/nodejs/src/cdp/async-functions/example.ts
+++ b/nodejs/src/cdp/async-functions/example.ts
@@ -8,6 +8,20 @@ import { registerAsyncFunction } from '../async-function-registry'
  * If you're trying to add a new realtime destination or workflow action that will use your async function, these are defined in nodejs/src/cdp/templates/_destinations.
  *
  * IMPORTANT: For your async function to become registered, it MUST be imported in the index.ts file in this directory (nodejs/src/cdp/async-functions/index.ts)
+ *
+ * RETURN-VALUE CONTRACT: when the VM hits an async function call it pops the args, advances the
+ * instruction pointer, and pauses. By the time the VM resumes, `vmState.stack` MUST contain the
+ * function's return value (so the bytecode compiler's trailing POP for expression statements has
+ * something to consume). Handlers satisfy this in one of two ways:
+ *
+ * 1. Synchronous handlers (like this example, and `produceToWarehouseWebhooks`) finish their work
+ *    inside `execute()` and push their return value directly onto `result.invocation.state.vmState.stack`.
+ * 2. Queueing handlers (`fetch`, `sendEmail`, `postHogGetTicket`, `postHogUpdateTicket`) stage
+ *    `result.invocation.queueParameters` and let the matching `executeFetch` / `executeSendEmail`
+ *    worker push the response once the real I/O completes.
+ *
+ * Forgetting to push leaves the resumed VM with an empty stack and crashes with
+ * "Invalid HogQL bytecode, stack is empty, can not pop".
  */
 registerAsyncFunction('foobar', {
     /**
@@ -15,7 +29,7 @@ registerAsyncFunction('foobar', {
      * @param args the arguments passed from the Hog code, for example `foobar('i am foo', {'key': 200}, 'i am baz')`
      * @param _context includes the invocation details, any global variables attached to the invocation, and a reference to
      *   the AsyncFunctionContext which provides access to other services and data (e.g. teamManager, siteUrl, etc.)
-     * @param _result the current state of the invocation result, which can be modified by the async function and serves as a place to store
+     * @param result the current state of the invocation result, which can be modified by the async function and serves as a place to store
      *   its return value and/or modify the invocation.
      *   For example, you can set a value for a key on result.invocation, and that value would then be accessible in subsequent async functions.
      *   You can stop execution after an error by setting result.finished = true + result.error, and you can log messages to the
@@ -32,6 +46,10 @@ registerAsyncFunction('foobar', {
             timestamp: DateTime.now(),
             message: `Executed async function 'foobar' with arguments: foo=${foo}, bar=${JSON.stringify(bar)}, baz=${baz}`,
         })
+
+        // See the RETURN-VALUE CONTRACT comment above the registration. We finished our work
+        // synchronously, so we push our return value onto the resumed VM stack right here.
+        result.invocation.state.vmState?.stack.push(null)
     },
     /**
      * A mock implementation of the async function used in destinations and workflows Test tooling, when "Make real HTTP requests" is disabled.

--- a/nodejs/src/cdp/async-functions/warehouse-webhooks.ts
+++ b/nodejs/src/cdp/async-functions/warehouse-webhooks.ts
@@ -29,6 +29,12 @@ registerAsyncFunction('produceToWarehouseWebhooks', {
             schema_id: schemaId,
             payload,
         })
+
+        // Async handlers must leave a return value on the resumed VM stack so the trailing
+        // POP from the expression statement has something to pop. fetch / sendEmail defer this
+        // push to executeFetch / executeSendEmail once the real I/O completes; we finish our
+        // work synchronously here, so we push immediately.
+        result.invocation.state.vmState?.stack.push(null)
     },
 
     mock: (args, logs) => {

--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -15,6 +15,7 @@ import { Hub } from '../../../src/types'
 import { createHub } from '../../../src/utils/db/hub'
 import { parseJSON } from '../../utils/json-parse'
 import { promisifyCallback } from '../../utils/utils'
+import { compileHog } from '../templates/compiler'
 import { HOG_EXAMPLES, HOG_FILTERS_EXAMPLES, HOG_INPUTS_EXAMPLES } from '../_tests/examples'
 import { createExampleInvocation, createHogExecutionGlobals, createHogFunction } from '../_tests/fixtures'
 import { EXTEND_OBJECT_KEY, isConnectionLevelError } from './hog-executor.service'
@@ -911,6 +912,47 @@ describe('Hog Executor', () => {
 
             const result = await executor.execute(createTicketInvocation())
             expect(result.error).toContain('Team 1 not found')
+        })
+    })
+
+    describe('produceToWarehouseWebhooks', () => {
+        const buildInvocation = async (code: string): Promise<CyclotronJobInvocationHogFunction> => {
+            const bytecode = await compileHog(code)
+            return createExampleInvocation(createHogFunction({ bytecode }), { inputs: {} })
+        }
+
+        // Regression test for a stack-empty crash when an async function with no
+        // meaningful return value is called as an expression statement.
+        // The bytecode compiler emits a trailing POP after every expression
+        // statement, but the generic async function path in execute() never pushed
+        // a return value onto the resumed VM stack — so when the cyclotron worker
+        // resumed the invocation, the POP fired against an empty stack and raised
+        // "Invalid HogQL bytecode, stack is empty, can not pop".
+        it('finishes cleanly when called as an expression statement', async () => {
+            const invocation = await buildInvocation(`produceToWarehouseWebhooks({'foo': 'bar'}, 'test-schema-id')`)
+
+            const result = await executor.executeWithAsyncFunctions(invocation)
+
+            expect(result.error).toBeUndefined()
+            expect(result.finished).toBe(true)
+            expect(result.warehouseWebhookPayloads).toHaveLength(1)
+            expect(result.warehouseWebhookPayloads[0]).toMatchObject({
+                schema_id: 'test-schema-id',
+                payload: { foo: 'bar' },
+            })
+        })
+
+        it('finishes cleanly when followed by another statement', async () => {
+            const invocation = await buildInvocation(
+                `produceToWarehouseWebhooks({'foo': 'bar'}, 'test-schema-id')
+                 print('after produce')`
+            )
+
+            const result = await executor.executeWithAsyncFunctions(invocation)
+
+            expect(result.error).toBeUndefined()
+            expect(result.finished).toBe(true)
+            expect(result.warehouseWebhookPayloads).toHaveLength(1)
         })
     })
 

--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -559,6 +559,11 @@ export class HogExecutorService {
                     if (!handler) {
                         throw new Error(`Unknown async function '${execRes.asyncFunctionName}'`)
                     }
+                    // Async handlers are responsible for ensuring the resumed VM stack contains
+                    // their return value before it next runs - either by pushing directly onto
+                    // result.invocation.state.vmState.stack (synchronous handlers) or by deferring
+                    // the push to executeFetch / executeSendEmail (queueing handlers). See the
+                    // RETURN-VALUE CONTRACT comment in cdp/async-functions/example.ts.
                     await handler.execute(
                         args,
                         { invocation: result.invocation, globals, ...this.asyncContext },


### PR DESCRIPTION
## Problem

Warehouse source webhooks (e.g. Stripe via `produceToWarehouseWebhooks`) were intermittently failing in the cyclotron worker with:

> Invalid HogQL bytecode, stack is empty, can not pop

The payload itself was still landing on the warehouse webhooks Kafka topic, but every "valid" webhook (one whose `objectType` matched the schema mapping) finished with `result.error` set, polluting failure metrics and producing confusing log noise on the happy path.

The bug was a contract violation in the hog async-function dispatch path, not in the hog code of the Stripe template:

1. The bytecode compiler emits a trailing `POP` after every expression statement (`produceToWarehouseWebhooks(request.body, schemaId)` is one such statement).
2. When the VM hits an async function call it pops the args, advances the instruction pointer past `CALL_GLOBAL`, and pauses with `finished: false`. The args are gone, but no return value has been pushed yet.
3. `fetch` / `sendEmail` / `postHogGetTicket` / `postHogUpdateTicket` handle this correctly: their handler stages `result.invocation.queueParameters`, the dispatch loop routes to `executeFetch` / `executeSendEmail`, and that worker pushes the response onto `vmState.stack` before the VM is resumed.
4. `produceToWarehouseWebhooks` (and the `foobar` example) are synchronous side-effect handlers — they finish their work inside `execute()` and there is no follow-up worker. Nothing ever pushed a return value, so when the cyclotron worker resumed the invocation the very first opcode (`POP`) hit an empty stack and threw.

The existing `cdp-dwh-source-webhooks.consumer` test missed this because it only exercises the HTTP entry point, where the side effect is flushed straight to Kafka before the cyclotron worker ever picks the queued invocation back up.

## Changes

Tighten and document the contract for async function handlers:

> Every async handler must ensure `vmState.stack` contains its return value before the VM resumes — either directly (synchronous handlers push it themselves) or by deferring to a downstream worker (`executeFetch` / `executeSendEmail`) that pushes the response once the real I/O completes.

- `produceToWarehouseWebhooks` now pushes `null` onto `result.invocation.state.vmState.stack` after recording the payload, mirroring how `executeFetch` pushes the HTTP response at the end of its work.
- The `foobar` example async function does the same and gains a top-level `RETURN-VALUE CONTRACT` docstring explaining the two valid ways to satisfy the contract, so the next handler author copies the right pattern instead of tripping the same bug.
- The dispatch site in `hog-executor.service.ts` is back to a plain `await handler.execute(...)` — no magic-string `null`-push fallback, no special-casing of `queueParameters.type`. The contract lives with the handlers, not with the dispatcher.

## How did you test this code?

- Added two unit tests in `hog-executor.service.test.ts` under a new `produceToWarehouseWebhooks` describe block that drive `executor.executeWithAsyncFunctions` end-to-end against a real compiled hog program. Both reproduce the `"Invalid HogQL bytecode, stack is empty, can not pop"` failure on master and pass after the fix:
  - `produceToWarehouseWebhooks({...}, 'schema-id')` as the only statement (the original Stripe template shape)
  - `produceToWarehouseWebhooks({...}, 'schema-id')` followed by another statement, to confirm the resumed VM continues normally

## Publish to changelog?

no

## Docs update

n/a