### PR TITLE
feat(cloud-agent): pass create_pr policy into sandboxes

### DIFF
--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -580,6 +580,7 @@ class DockerSandbox(SandboxBase):
         task_id: str,
         run_id: str,
         mode: str,
+        create_pr: bool,
         interaction_origin: str | None = None,
         branch: str | None = None,
         mcp_servers_arg: str = "",
@@ -588,13 +589,14 @@ class DockerSandbox(SandboxBase):
         env_prefix = (
             f"env POSTHOG_CODE_INTERACTION_ORIGIN={shlex.quote(interaction_origin)} " if interaction_origin else ""
         )
+        create_pr_flag = f" --createPr {shlex.quote('true' if create_pr else 'false')}"
         branch_flag = f" --baseBranch {shlex.quote(branch)}" if branch else ""
         repo_flag = f" --repositoryPath {shlex.quote(repo_path)}" if repo_path else ""
         domains_flag = f" --allowedDomains {shlex.quote(','.join(allowed_domains))}" if allowed_domains else ""
         server_cmd = (
             f"{env_prefix}./node_modules/.bin/agent-server --port {AGENT_SERVER_PORT}{repo_flag} "
             f"--taskId {shlex.quote(task_id)} --runId {shlex.quote(run_id)} --mode {shlex.quote(mode)}"
-            f"{branch_flag}{mcp_servers_arg}{domains_flag}"
+            f"{create_pr_flag}{branch_flag}{mcp_servers_arg}{domains_flag}"
         )
 
         inner = f"cd /scripts && {server_cmd} > /tmp/agent-server.log 2>&1"
@@ -624,6 +626,7 @@ class DockerSandbox(SandboxBase):
         task_id: str,
         run_id: str,
         mode: str = "background",
+        create_pr: bool = True,
         interaction_origin: str | None = None,
         branch: str | None = None,
         mcp_configs: list[McpServerConfig] | None = None,
@@ -661,6 +664,7 @@ class DockerSandbox(SandboxBase):
             task_id,
             run_id,
             mode,
+            create_pr,
             interaction_origin,
             branch,
             mcp_servers_arg,
@@ -688,6 +692,7 @@ class DockerSandbox(SandboxBase):
                 task_id,
                 run_id,
                 mode,
+                create_pr,
                 interaction_origin,
                 branch=None,
                 mcp_servers_arg=mcp_servers_arg,

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -540,6 +540,7 @@ class ModalSandbox(SandboxBase):
         task_id: str,
         run_id: str,
         mode: str,
+        create_pr: bool,
         interaction_origin: str | None = None,
         branch: str | None = None,
         mcp_servers_arg: str = "",
@@ -548,13 +549,14 @@ class ModalSandbox(SandboxBase):
         env_prefix = (
             f"env POSTHOG_CODE_INTERACTION_ORIGIN={shlex.quote(interaction_origin)} " if interaction_origin else ""
         )
+        create_pr_flag = f" --createPr {shlex.quote('true' if create_pr else 'false')}"
         repo_flag = f" --repositoryPath {shlex.quote(repo_path)}" if repo_path else ""
         branch_flag = f" --baseBranch {shlex.quote(branch)}" if branch else ""
         domains_flag = f" --allowedDomains {shlex.quote(','.join(allowed_domains))}" if allowed_domains else ""
         server_cmd = (
             f"{env_prefix}./node_modules/.bin/agent-server --port {AGENT_SERVER_PORT}{repo_flag} "
             f"--taskId {shlex.quote(task_id)} --runId {shlex.quote(run_id)} --mode {shlex.quote(mode)}"
-            f"{branch_flag}{mcp_servers_arg}{domains_flag}"
+            f"{create_pr_flag}{branch_flag}{mcp_servers_arg}{domains_flag}"
         )
 
         inner = f"cd /scripts && {server_cmd} > /tmp/agent-server.log 2>&1"
@@ -580,6 +582,7 @@ class ModalSandbox(SandboxBase):
         task_id: str,
         run_id: str,
         mode: str = "background",
+        create_pr: bool = True,
         interaction_origin: str | None = None,
         branch: str | None = None,
         mcp_configs: list[McpServerConfig] | None = None,
@@ -612,6 +615,7 @@ class ModalSandbox(SandboxBase):
             task_id,
             run_id,
             mode,
+            create_pr,
             interaction_origin,
             branch,
             mcp_servers_arg,

--- a/products/tasks/backend/services/sandbox.py
+++ b/products/tasks/backend/services/sandbox.py
@@ -149,7 +149,11 @@ class SandboxBase(ABC):
 
     @abstractmethod
     def execute_task(
-        self, task_id: str, run_id: str, repository: str | None = None, create_pr: bool = True
+        self,
+        task_id: str,
+        run_id: str,
+        repository: str | None = None,
+        create_pr: bool = True,
     ) -> ExecutionResult: ...
 
     @abstractmethod
@@ -168,6 +172,7 @@ class SandboxBase(ABC):
         task_id: str,
         run_id: str,
         mode: str = "background",
+        create_pr: bool = True,
         interaction_origin: str | None = None,
         branch: str | None = None,
         mcp_configs: list[McpServerConfig] | None = None,

--- a/products/tasks/backend/services/test_docker_sandbox.py
+++ b/products/tasks/backend/services/test_docker_sandbox.py
@@ -241,6 +241,7 @@ class TestDockerSandboxUnit:
                 assert shlex.quote(task_id) in command
                 assert shlex.quote(run_id) in command
                 assert shlex.quote(mode) in command
+                assert "--createPr true" in command
 
     def test_parse_repo_mount_map_empty(self):
         with patch.dict(os.environ, {}, clear=True):
@@ -331,6 +332,7 @@ class TestDockerSandboxUnit:
 
         mock_setup_agentsh.assert_not_called()
         command = mock_execute.call_args_list[0][0][0]
+        assert "--createPr true" in command
         assert "agentsh exec" not in command
         assert "nohup" in command
         assert "./node_modules/.bin/agent-server" in command
@@ -360,8 +362,40 @@ class TestDockerSandboxUnit:
 
         mock_setup_agentsh.assert_not_called()
         command = mock_execute.call_args_list[0][0][0]
+        assert "--createPr true" in command
         assert "--allowedDomains" not in command
         assert "agentsh exec" not in command
+
+    @pytest.mark.parametrize(
+        ("create_pr", "expected_flag"),
+        [
+            (True, "--createPr true"),
+            (False, "--createPr false"),
+        ],
+    )
+    def test_start_agent_server_passes_create_pr_flag(self, create_pr: bool, expected_flag: str):
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        sandbox._container_id = "abc123"
+        sandbox.id = "abc123"
+        sandbox.config = SandboxConfig(name="test")
+        sandbox._host_port = 12345
+
+        with patch.object(sandbox, "is_running", return_value=True):
+            with patch.object(sandbox, "execute") as mock_execute:
+                mock_execute.side_effect = [
+                    ExecutionResult(stdout="", stderr="", exit_code=0, error=None),
+                    ExecutionResult(stdout="ok:1", stderr="", exit_code=0, error=None),
+                ]
+                sandbox.start_agent_server(
+                    "posthog/posthog",
+                    "task-123",
+                    "run-456",
+                    "background",
+                    create_pr=create_pr,
+                )
+
+        command = mock_execute.call_args_list[0][0][0]
+        assert expected_flag in command
 
 
 @pytest.mark.skipif(is_ci() or not docker_available(), reason="Docker sandbox tests only run locally, not in CI")

--- a/products/tasks/backend/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/services/tests/test_modal_sandbox.py
@@ -206,6 +206,7 @@ class TestModalSandboxAgentServer:
         assert f"--taskId {shlex.quote('task-123')}" in command
         assert f"--runId {shlex.quote('run-456')}" in command
         assert f"--mode {shlex.quote('background')}" in command
+        assert "--createPr true" in command
         assert "agentsh exec" not in command
         assert "nohup" in command
 
@@ -231,10 +232,38 @@ class TestModalSandboxAgentServer:
             ["example.com"],
         )
         command = mock_sandbox.execute.call_args_list[0][0][0]
+        assert "--createPr true" in command
         assert "agentsh exec --client-timeout 2h --timeout 2h" in command
         assert "env -0 > /tmp/agent-env" in command
         assert "/tmp/agentsh-env-wrapper.sh" in command
         assert "./node_modules/.bin/agent-server" in command
+
+    @pytest.mark.parametrize(
+        ("create_pr", "expected_flag"),
+        [
+            (True, "--createPr true"),
+            (False, "--createPr false"),
+        ],
+    )
+    def test_start_agent_server_passes_create_pr_flag(self, mock_sandbox: Any, create_pr: bool, expected_flag: str):
+        mock_sandbox.execute = MagicMock(
+            side_effect=[
+                ExecutionResult(stdout="", stderr="", exit_code=0, error=None),
+                ExecutionResult(stdout="ok:1", stderr="", exit_code=0, error=None),
+            ]
+        )
+
+        with patch.object(mock_sandbox, "_setup_agentsh"):
+            mock_sandbox.start_agent_server(
+                repository="posthog/posthog",
+                task_id="task-123",
+                run_id="run-456",
+                mode="background",
+                create_pr=create_pr,
+            )
+
+        command = mock_sandbox.execute.call_args_list[0][0][0]
+        assert expected_flag in command
 
     def test_start_agent_server_raises_when_not_running(self, mock_sandbox: Any):
         mock_sandbox._sandbox.poll.return_value = 0

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -143,7 +143,6 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
             project_id=ctx.team_id,
             scopes=scopes,
         )
-
         if task.created_by_id:
             user_mcp_configs = get_user_mcp_server_configs(
                 token=access_token,
@@ -152,6 +151,19 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
             )
             if user_mcp_configs:
                 mcp_configs = mcp_configs + user_mcp_configs
+
+        if mcp_configs:
+            emit_agent_log(
+                ctx.run_id,
+                "debug",
+                f"Resolved {len(mcp_configs)} MCP config(s) for agent server: {', '.join(config.name for config in mcp_configs)}",
+            )
+        else:
+            emit_agent_log(
+                ctx.run_id,
+                "warn",
+                "No MCP configs were resolved for this run. PostHog MCP tools will be unavailable in the agent session.",
+            )
 
         if ctx.allowed_domains:
             environment_name = ctx.sandbox_environment_name or ctx.sandbox_environment_id or "selected environment"
@@ -174,6 +186,7 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
                 task_id=ctx.task_id,
                 run_id=ctx.run_id,
                 mode=ctx.mode,
+                create_pr=ctx.create_pr,
                 interaction_origin=ctx.interaction_origin,
                 branch=ctx.branch,
                 mcp_configs=mcp_configs or None,

--- a/products/tasks/backend/tests/test_agentsh.py
+++ b/products/tasks/backend/tests/test_agentsh.py
@@ -177,6 +177,7 @@ class TestModalSandboxAgentShWrapping(TestCase):
             task_id="test-task",
             run_id="test-run",
             mode="background",
+            create_pr=True,
         )
         self.assertNotIn("agentsh exec --client-timeout 2h --timeout 2h", cmd)
         self.assertNotIn("env -0 > /tmp/agent-env", cmd)
@@ -192,6 +193,7 @@ class TestModalSandboxAgentShWrapping(TestCase):
             task_id="test-task",
             run_id="test-run",
             mode="background",
+            create_pr=True,
             allowed_domains=["example.com", "api.example.com"],
         )
         self.assertIn("agentsh exec --client-timeout 2h --timeout 2h", cmd)


### PR DESCRIPTION
## Problem

PR policy was not being passed explicitly into the sandbox agent process, which we kinda need to better have a more "review first" experience, in some flows.

Since I was here, added some MCP logging as well on startup.

## Changes

- passed `create_pr` through sandbox startup into `agent-server` as `--createPr true|false`
- updated both Docker and Modal sandbox startup paths to include the explicit publish policy
- added sandbox tests covering both `--createPr true` and `--createPr false`
- added MCP resolution logging during agent-server startup to make missing-MCP runs easier to diagnose
- restored `_should_forward_pending_user_message()` in the task workflow
- switched startup pending-message forwarding back to that helper so only non-interactive, non-resume runs auto-forward