### PR TITLE
feat(marketing-analytics): capture query performance telemetry

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -1,9 +1,11 @@
+import time
 from abc import ABC, abstractmethod
 from datetime import datetime
 from functools import cached_property
 from typing import Generic, Optional, TypeVar
 
 import structlog
+import posthoganalytics
 
 from posthog.schema import (
     ConversionGoalFilter1,
@@ -19,6 +21,7 @@ from posthog.hogql.database.schema.channel_type import ChannelTypeExprs, create_
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_select
 
+from posthog.event_usage import groups
 from posthog.hogql_queries.query_runner import AnalyticsQueryResponseProtocol, AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_compare_to_date_range import QueryCompareToDateRange
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
@@ -47,6 +50,42 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
         super().__init__(*args, **kwargs)
         self.config = MarketingAnalyticsConfig()
         self._conversion_goal_warnings: list[str] = []
+
+    def calculate(self) -> ResponseType:
+        start = time.perf_counter()
+        try:
+            response = self._calculate()
+            self._capture_query_event("marketing analytics query performed", start)
+            return response
+        except Exception as e:
+            self._capture_query_event("marketing analytics query failed", start, error=e)
+            raise
+
+    def _capture_query_event(self, event: str, start: float, error: Optional[BaseException] = None) -> None:
+        try:
+            duration_ms = (time.perf_counter() - start) * 1000
+            props: dict = {
+                "query_kind": getattr(self.query, "kind", None),
+                "duration_ms": round(duration_ms, 2),
+                "drill_down_level": getattr(self.config, "drill_down_level", None),
+                "attribution_mode": getattr(self.query, "attributionMode", None),
+                "conversion_goals_count": len(getattr(self.query, "conversionGoals", None) or []),
+                "has_compare": getattr(self.query, "compareFilter", None) is not None,
+                "team_id": self.team.pk,
+            }
+            if error is None:
+                props["timings"] = [{"k": t.k, "t": t.t} for t in self.timings.to_list()]
+            else:
+                props["error_name"] = type(error).__name__
+                props["error_message"] = str(error)[:500]
+            posthoganalytics.capture(
+                distinct_id=str(self.team.uuid),
+                event=event,
+                properties=props,
+                groups=groups(self.team.organization, self.team),
+            )
+        except Exception:
+            logger.exception("Failed to capture marketing analytics telemetry event", event=event)
 
     @cached_property
     def query_date_range(self):

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -85,7 +85,7 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
                 groups=groups(self.team.organization, self.team),
             )
         except Exception:
-            logger.exception("Failed to capture marketing analytics telemetry event", event=event)
+            logger.exception("Failed to capture marketing analytics telemetry event", event_name=event)
 
     @cached_property
     def query_date_range(self):

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_telemetry.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_telemetry.py
@@ -1,6 +1,8 @@
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
+from parameterized import parameterized
+
 from posthog.schema import DateRange, MarketingAnalyticsTableQuery
 
 from products.marketing_analytics.backend.hogql_queries.marketing_analytics_table_query_runner import (
@@ -47,13 +49,21 @@ class TestMarketingAnalyticsTelemetry(BaseTest):
         assert "timings" in props
         assert "error_message" not in props
 
+    @parameterized.expand(
+        [
+            ("short_message", ValueError, "boom", "boom"),
+            ("long_message_is_truncated", RuntimeError, "x" * 5000, "x" * 500),
+        ]
+    )
     @patch.object(MarketingAnalyticsTableQueryRunner, "_calculate")
     @patch(TELEMETRY_PATH)
-    def test_emits_failed_event_on_error_and_reraises(self, mock_capture, mock_calculate):
-        mock_calculate.side_effect = ValueError("boom")
+    def test_emits_failed_event_on_error_and_reraises(
+        self, _name, exc_class, message, expected_message, mock_capture, mock_calculate
+    ):
+        mock_calculate.side_effect = exc_class(message)
         runner = self._runner()
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(exc_class):
             runner.calculate()
 
         mock_capture.assert_called_once()
@@ -61,22 +71,9 @@ class TestMarketingAnalyticsTelemetry(BaseTest):
         assert kwargs["event"] == "marketing analytics query failed"
         props = kwargs["properties"]
         assert props["query_kind"] == "MarketingAnalyticsTableQuery"
-        assert props["error_name"] == "ValueError"
-        assert props["error_message"] == "boom"
+        assert props["error_name"] == exc_class.__name__
+        assert props["error_message"] == expected_message
         assert "timings" not in props
-
-    @patch.object(MarketingAnalyticsTableQueryRunner, "_calculate")
-    @patch(TELEMETRY_PATH)
-    def test_error_message_is_truncated(self, mock_capture, mock_calculate):
-        long_msg = "x" * 5000
-        mock_calculate.side_effect = RuntimeError(long_msg)
-        runner = self._runner()
-
-        with self.assertRaises(RuntimeError):
-            runner.calculate()
-
-        props = mock_capture.call_args.kwargs["properties"]
-        assert len(props["error_message"]) == 500
 
     @patch.object(MarketingAnalyticsTableQueryRunner, "_calculate")
     @patch(TELEMETRY_PATH)

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_telemetry.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_telemetry.py
@@ -1,0 +1,92 @@
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from posthog.schema import DateRange, MarketingAnalyticsTableQuery
+
+from products.marketing_analytics.backend.hogql_queries.marketing_analytics_table_query_runner import (
+    MarketingAnalyticsTableQueryRunner,
+)
+
+TELEMETRY_PATH = (
+    "products.marketing_analytics.backend.hogql_queries.marketing_analytics_base_query_runner.posthoganalytics.capture"
+)
+
+
+class TestMarketingAnalyticsTelemetry(BaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUp(self):
+        super().setUp()
+        self.query = MarketingAnalyticsTableQuery(
+            dateRange=DateRange(date_from="2023-01-01", date_to="2023-01-31"),
+            properties=[],
+        )
+
+    def _runner(self) -> MarketingAnalyticsTableQueryRunner:
+        return MarketingAnalyticsTableQueryRunner(query=self.query, team=self.team)
+
+    @patch.object(MarketingAnalyticsTableQueryRunner, "_calculate")
+    @patch(TELEMETRY_PATH)
+    def test_emits_performed_event_on_success(self, mock_capture, mock_calculate):
+        mock_calculate.return_value = MagicMock()
+        runner = self._runner()
+
+        runner.calculate()
+
+        mock_capture.assert_called_once()
+        kwargs = mock_capture.call_args.kwargs
+        assert kwargs["event"] == "marketing analytics query performed"
+        assert kwargs["distinct_id"] == str(self.team.uuid)
+        props = kwargs["properties"]
+        assert props["query_kind"] == "MarketingAnalyticsTableQuery"
+        assert props["team_id"] == self.team.pk
+        assert props["conversion_goals_count"] == 0
+        assert props["has_compare"] is False
+        assert isinstance(props["duration_ms"], (int, float))
+        assert props["duration_ms"] >= 0
+        assert "timings" in props
+        assert "error_message" not in props
+
+    @patch.object(MarketingAnalyticsTableQueryRunner, "_calculate")
+    @patch(TELEMETRY_PATH)
+    def test_emits_failed_event_on_error_and_reraises(self, mock_capture, mock_calculate):
+        mock_calculate.side_effect = ValueError("boom")
+        runner = self._runner()
+
+        with self.assertRaises(ValueError):
+            runner.calculate()
+
+        mock_capture.assert_called_once()
+        kwargs = mock_capture.call_args.kwargs
+        assert kwargs["event"] == "marketing analytics query failed"
+        props = kwargs["properties"]
+        assert props["query_kind"] == "MarketingAnalyticsTableQuery"
+        assert props["error_name"] == "ValueError"
+        assert props["error_message"] == "boom"
+        assert "timings" not in props
+
+    @patch.object(MarketingAnalyticsTableQueryRunner, "_calculate")
+    @patch(TELEMETRY_PATH)
+    def test_error_message_is_truncated(self, mock_capture, mock_calculate):
+        long_msg = "x" * 5000
+        mock_calculate.side_effect = RuntimeError(long_msg)
+        runner = self._runner()
+
+        with self.assertRaises(RuntimeError):
+            runner.calculate()
+
+        props = mock_capture.call_args.kwargs["properties"]
+        assert len(props["error_message"]) == 500
+
+    @patch.object(MarketingAnalyticsTableQueryRunner, "_calculate")
+    @patch(TELEMETRY_PATH)
+    def test_capture_failure_does_not_break_query(self, mock_capture, mock_calculate):
+        mock_capture.side_effect = Exception("analytics down")
+        expected_response = MagicMock()
+        mock_calculate.return_value = expected_response
+        runner = self._runner()
+
+        # Should not raise even though telemetry capture fails
+        response = runner.calculate()
+
+        assert response is expected_response


### PR DESCRIPTION
## Problem

Marketing analytics queries can be slow (p95 ~26s on production over the last 7 days) but we don't have structured telemetry to understand what configurations are slow, what stages dominate the runtime, or what causes failures. Without this we can't measure the impact of optimizations like lazy computation of intermediate results.

## Changes

Override `calculate()` in `MarketingAnalyticsBaseQueryRunner` to emit two events through `posthoganalytics.capture`:

- `marketing analytics query performed` on success, with `query_kind`, `duration_ms`, `drill_down_level`, `attribution_mode`, `conversion_goals_count`, `has_compare`, `team_id`, and the full `HogQLTimings` breakdown (including the downstream `execute_hogql_query` stage from ClickHouse).
- `marketing analytics query failed` on exception, with the same metadata plus `error_name` and `error_message` (truncated to 500 chars).

The capture is wrapped in `try/except` so telemetry never breaks a query. No PII is emitted — no SQL text, no user filter values. Scoped entirely to `products/marketing_analytics/`.

## How did you test this code?

- Existing runner tests pass: `hogli test products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_table_query_runner.py` (23 passed) and `test_marketing_analytics_aggregated_query_runner.py` (1 passed).
- No changes to public interfaces; the override calls `_calculate()` which is the existing abstract method subclasses implement.
- Lint + format clean.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs