### PR TITLE
chore(error-tracking): update issue split schema

### DIFF
--- a/products/error_tracking/backend/api/issues.py
+++ b/products/error_tracking/backend/api/issues.py
@@ -133,6 +133,37 @@ class ErrorTrackingIssueMergeResponseSerializer(serializers.Serializer):
     success = serializers.BooleanField(help_text="Whether the merge completed successfully.")
 
 
+class ErrorTrackingIssueSplitFingerprintSerializer(serializers.Serializer):
+    fingerprint = serializers.CharField(help_text="Fingerprint to split into a new issue.")
+    name = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text="Optional name for the new issue created from this fingerprint.",
+    )
+    description = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text="Optional description for the new issue created from this fingerprint.",
+    )
+
+
+class ErrorTrackingIssueSplitRequestSerializer(serializers.Serializer):
+    fingerprints = serializers.ListField(
+        child=ErrorTrackingIssueSplitFingerprintSerializer(),
+        required=False,
+        default=list,
+        help_text="Fingerprints to split into new issues. Each fingerprint becomes its own new issue.",
+    )
+
+
+class ErrorTrackingIssueSplitResponseSerializer(serializers.Serializer):
+    success = serializers.BooleanField(help_text="Whether the split completed successfully.")
+    new_issue_ids = serializers.ListField(
+        child=serializers.UUIDField(),
+        help_text="IDs of the new issues created by the split.",
+    )
+
+
 @extend_schema(tags=[ProductKey.ERROR_TRACKING])
 class ErrorTrackingIssueViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelViewSet):
     scope_object = "error_tracking"
@@ -203,14 +234,14 @@ class ErrorTrackingIssueViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, view
         sync_issues_to_clickhouse(issue_ids=[issue.id], team_id=issue.team_id)
         return Response({"success": True})
 
+    @validated_request(
+        request_serializer=ErrorTrackingIssueSplitRequestSerializer,
+        responses={200: OpenApiResponse(response=ErrorTrackingIssueSplitResponseSerializer)},
+    )
     @action(methods=["POST"], detail=True)
-    def split(self, request, **kwargs):
+    def split(self, request: ValidatedRequest, **kwargs):
         issue: ErrorTrackingIssue = self.get_object()
-        fingerprints = request.data.get("fingerprints", [])
-        if not isinstance(fingerprints, list) or not all(
-            isinstance(entry, dict) and isinstance(entry.get("fingerprint"), str) for entry in fingerprints
-        ):
-            raise ValidationError("fingerprints must be a list of objects with a 'fingerprint' string field")
+        fingerprints = request.validated_data["fingerprints"]
         new_issues = issue.split(fingerprints=fingerprints)
         sync_issues_to_clickhouse(issue_ids=[issue.id] + [i.id for i in new_issues], team_id=issue.team_id)
         return Response({"success": True, "new_issue_ids": [str(i.id) for i in new_issues]})

--- a/products/error_tracking/backend/api/test/test_error_tracking_api.py
+++ b/products/error_tracking/backend/api/test/test_error_tracking_api.py
@@ -188,6 +188,37 @@ class TestErrorTracking(APIBaseTest):
             "attr": "ids",
         }
 
+    def test_issue_split(self):
+        issue = self.create_issue(fingerprints=["fingerprint_one", "fingerprint_two"])
+
+        assert ErrorTrackingIssue.objects.count() == 1
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/split",
+            data={"fingerprints": [{"fingerprint": "fingerprint_two", "name": "Split issue"}]},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+        assert len(response.json()["new_issue_ids"]) == 1
+        assert ErrorTrackingIssueFingerprintV2.objects.filter(issue_id=issue.id).count() == 1
+        assert ErrorTrackingIssueFingerprintV2.objects.filter(issue_id=issue.id, fingerprint="fingerprint_one").exists()
+        assert ErrorTrackingIssue.objects.count() == 2
+
+    def test_issue_split_requires_fingerprint_on_each_entry(self):
+        issue = self.create_issue(fingerprints=["fingerprint_one"])
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/split",
+            data={"fingerprints": [{"name": "Missing fingerprint"}]},
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert response.json()["type"] == "validation_error"
+        assert response.json()["code"] == "required"
+
     def test_can_start_symbol_set_upload(self) -> None:
         chunk_id = uuid7()
         response = self.client.post(

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -306,6 +306,27 @@ export interface ErrorTrackingIssueMergeResponseApi {
     success: boolean
 }
 
+export interface ErrorTrackingIssueSplitFingerprintApi {
+    /** Fingerprint to split into a new issue. */
+    fingerprint: string
+    /** Optional name for the new issue created from this fingerprint. */
+    name?: string
+    /** Optional description for the new issue created from this fingerprint. */
+    description?: string
+}
+
+export interface ErrorTrackingIssueSplitRequestApi {
+    /** Fingerprints to split into new issues. Each fingerprint becomes its own new issue. */
+    fingerprints?: ErrorTrackingIssueSplitFingerprintApi[]
+}
+
+export interface ErrorTrackingIssueSplitResponseApi {
+    /** Whether the split completed successfully. */
+    success: boolean
+    /** IDs of the new issues created by the split. */
+    new_issue_ids: string[]
+}
+
 export interface ErrorTrackingReleaseApi {
     readonly id: string
     hash_id: string

--- a/products/error_tracking/frontend/generated/api.ts
+++ b/products/error_tracking/frontend/generated/api.ts
@@ -20,6 +20,8 @@ import type {
     ErrorTrackingIssueFullApi,
     ErrorTrackingIssueMergeRequestApi,
     ErrorTrackingIssueMergeResponseApi,
+    ErrorTrackingIssueSplitRequestApi,
+    ErrorTrackingIssueSplitResponseApi,
     ErrorTrackingIssuesListParams,
     ErrorTrackingReleaseApi,
     ErrorTrackingReleasesList2Params,
@@ -739,14 +741,14 @@ export const getErrorTrackingIssuesSplitCreateUrl = (projectId: string, id: stri
 export const errorTrackingIssuesSplitCreate = async (
     projectId: string,
     id: string,
-    errorTrackingIssueFullApi: NonReadonly<ErrorTrackingIssueFullApi>,
+    errorTrackingIssueSplitRequestApi: ErrorTrackingIssueSplitRequestApi,
     options?: RequestInit
-): Promise<void> => {
-    return apiMutator<void>(getErrorTrackingIssuesSplitCreateUrl(projectId, id), {
+): Promise<ErrorTrackingIssueSplitResponseApi> => {
+    return apiMutator<ErrorTrackingIssueSplitResponseApi>(getErrorTrackingIssuesSplitCreateUrl(projectId, id), {
         ...options,
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(errorTrackingIssueFullApi),
+        body: JSON.stringify(errorTrackingIssueSplitRequestApi),
     })
 }
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14334,6 +14334,27 @@ export namespace Schemas {
       success: boolean;
     }
 
+    export interface ErrorTrackingIssueSplitFingerprint {
+      /** Fingerprint to split into a new issue. */
+      fingerprint: string;
+      /** Optional name for the new issue created from this fingerprint. */
+      name?: string;
+      /** Optional description for the new issue created from this fingerprint. */
+      description?: string;
+    }
+
+    export interface ErrorTrackingIssueSplitRequest {
+      /** Fingerprints to split into new issues. Each fingerprint becomes its own new issue. */
+      fingerprints?: ErrorTrackingIssueSplitFingerprint[];
+    }
+
+    export interface ErrorTrackingIssueSplitResponse {
+      /** Whether the split completed successfully. */
+      success: boolean;
+      /** IDs of the new issues created by the split. */
+      new_issue_ids: string[];
+    }
+
     export interface ErrorTrackingRelease {
       readonly id: string;
       hash_id: string;


### PR DESCRIPTION
## Problem

The error tracking issue split endpoint lacked proper request/response serializer annotations, making it invisible to the OpenAPI spec and preventing accurate type generation for frontend and MCP consumers.

## Changes

- Add `ErrorTrackingIssueSplitRequestSerializer` and `ErrorTrackingIssueSplitResponseSerializer` with `help_text` annotations
- Replace manual validation with `@validated_request` decorator on the `split` action
- Regenerate frontend TypeScript types and update the generated API client to use the new typed request/response
- Add tests for the split endpoint (success path and validation error)

## How did you test this code?

Backend unit tests added in `test_error_tracking_api.py` covering the split action and validation.

## Publish to changelog?

No