### PR TITLE
chore(error-tracking): update assignment rule create schema

### DIFF
--- a/products/error_tracking/backend/api/assignment_rules.py
+++ b/products/error_tracking/backend/api/assignment_rules.py
@@ -80,6 +80,19 @@ class ErrorTrackingAssignmentRuleCreateRequestSerializer(serializers.Serializer)
     )
 
 
+class ErrorTrackingAssignmentRuleUpdateRequestSerializer(serializers.Serializer):
+    filters = ErrorTrackingAssignmentRuleFiltersField(
+        required=False,
+        allow_null=True,
+        help_text="Property-group filters that define when this rule matches incoming error events.",
+    )
+    assignee = ErrorTrackingAssignmentRuleAssigneeRequestSerializer(
+        required=False,
+        allow_null=True,
+        help_text="User or role to assign matching issues to.",
+    )
+
+
 class ErrorTrackingAssignmentRuleSerializer(serializers.ModelSerializer):
     assignee = serializers.SerializerMethodField()
 
@@ -114,10 +127,10 @@ class ErrorTrackingAssignmentRuleViewSet(TeamAndOrgViewSetMixin, viewsets.ModelV
     def safely_get_queryset(self, queryset):
         return queryset.filter(team_id=self.team.id)
 
-    def update(self, request, *args, **kwargs) -> Response:
+    def _apply_rule_update(self, request: ValidatedRequest) -> Response:
         assignment_rule = self.get_object()
-        assignee = request.data.get("assignee")
-        json_filters = request.data.get("filters")
+        json_filters = request.validated_data.get("filters")
+        assignee = request.validated_data.get("assignee")
 
         if json_filters:
             parsed_filters = PropertyGroupFilterValue(**json_filters)
@@ -138,8 +151,19 @@ class ErrorTrackingAssignmentRuleViewSet(TeamAndOrgViewSetMixin, viewsets.ModelV
 
         return Response({"ok": True}, status=status.HTTP_204_NO_CONTENT)
 
-    def partial_update(self, request, *args, **kwargs) -> Response:
-        return self.update(request, *args, **kwargs)
+    @validated_request(
+        request_serializer=ErrorTrackingAssignmentRuleUpdateRequestSerializer,
+        responses={204: None},
+    )
+    def update(self, request: ValidatedRequest, *args, **kwargs) -> Response:
+        return self._apply_rule_update(request)
+
+    @validated_request(
+        request_serializer=ErrorTrackingAssignmentRuleUpdateRequestSerializer,
+        responses={204: None},
+    )
+    def partial_update(self, request: ValidatedRequest, *args, **kwargs) -> Response:
+        return self._apply_rule_update(request)
 
     def destroy(self, request, *args, **kwargs) -> Response:
         response = super().destroy(request, *args, **kwargs)

--- a/products/error_tracking/backend/api/assignment_rules.py
+++ b/products/error_tracking/backend/api/assignment_rules.py
@@ -1,11 +1,15 @@
+from uuid import UUID
+
 import structlog
 import posthoganalytics
-from drf_spectacular.utils import extend_schema_field
+from drf_spectacular.utils import OpenApiResponse, extend_schema_field
+from pydantic import ValidationError as PydanticValidationError
 from rest_framework import serializers, status, viewsets
 from rest_framework.response import Response
 
 from posthog.schema import PropertyGroupFilterValue
 
+from posthog.api.mixins import ValidatedRequest, validated_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.event_usage import groups
 
@@ -14,6 +18,63 @@ from products.error_tracking.backend.models import ErrorTrackingAssignmentRule
 from .utils import RuleReorderingMixin, generate_byte_code
 
 logger = structlog.get_logger(__name__)
+
+
+@extend_schema_field(PropertyGroupFilterValue)  # type: ignore[arg-type]
+class ErrorTrackingAssignmentRuleFiltersField(serializers.JSONField):
+    def to_internal_value(self, data):
+        value = super().to_internal_value(data)
+        try:
+            PropertyGroupFilterValue(**value)
+        except PydanticValidationError as err:
+            raise serializers.ValidationError(str(err)) from err
+        return value
+
+
+@extend_schema_field({"oneOf": [{"type": "integer"}, {"type": "string", "format": "uuid"}]})
+class ErrorTrackingAssignmentRuleAssigneeIdField(serializers.Field):
+    def to_internal_value(self, data):
+        if isinstance(data, bool):
+            raise serializers.ValidationError("Expected an integer user ID or UUID role ID.")
+        if isinstance(data, int):
+            return data
+        if isinstance(data, str):
+            try:
+                return UUID(data)
+            except ValueError:
+                if data.isdigit():
+                    return int(data)
+        raise serializers.ValidationError("Expected an integer user ID or UUID role ID.")
+
+    def to_representation(self, value):
+        return value
+
+
+class ErrorTrackingAssignmentRuleAssigneeRequestSerializer(serializers.Serializer):
+    type = serializers.ChoiceField(
+        choices=["user", "role"],
+        help_text="Assignee type. Use `user` for a user ID or `role` for a role UUID.",
+    )
+    id = ErrorTrackingAssignmentRuleAssigneeIdField(
+        help_text="User ID when `type` is `user`, or role UUID when `type` is `role`."
+    )
+
+    def validate(self, attrs):
+        assignee_id = attrs["id"]
+        if attrs["type"] == "user" and not isinstance(assignee_id, int):
+            raise serializers.ValidationError({"id": "User assignee IDs must be integers."})
+        if attrs["type"] == "role" and not isinstance(assignee_id, UUID):
+            raise serializers.ValidationError({"id": "Role assignee IDs must be UUIDs."})
+        return attrs
+
+
+class ErrorTrackingAssignmentRuleCreateRequestSerializer(serializers.Serializer):
+    filters = ErrorTrackingAssignmentRuleFiltersField(
+        help_text="Property-group filters that define when this rule matches incoming error events."
+    )
+    assignee = ErrorTrackingAssignmentRuleAssigneeRequestSerializer(
+        help_text="User or role to assign matching issues to."
+    )
 
 
 class ErrorTrackingAssignmentRuleSerializer(serializers.ModelSerializer):
@@ -87,14 +148,13 @@ class ErrorTrackingAssignmentRuleViewSet(TeamAndOrgViewSetMixin, viewsets.ModelV
 
         return response
 
-    def create(self, request, *args, **kwargs) -> Response:
-        json_filters = request.data.get("filters")
-        assignee = request.data.get("assignee", None)
-
-        if not json_filters:
-            return Response({"error": "Filters are required"}, status=status.HTTP_400_BAD_REQUEST)
-        if not assignee:
-            return Response({"error": "Assignee is required"}, status=status.HTTP_400_BAD_REQUEST)
+    @validated_request(
+        request_serializer=ErrorTrackingAssignmentRuleCreateRequestSerializer,
+        responses={201: OpenApiResponse(response=ErrorTrackingAssignmentRuleSerializer)},
+    )
+    def create(self, request: ValidatedRequest, *args, **kwargs) -> Response:
+        json_filters = request.validated_data["filters"]
+        assignee = request.validated_data["assignee"]
 
         parsed_filters = PropertyGroupFilterValue(**json_filters)
 

--- a/products/error_tracking/backend/api/assignment_rules.py
+++ b/products/error_tracking/backend/api/assignment_rules.py
@@ -24,10 +24,13 @@ logger = structlog.get_logger(__name__)
 class ErrorTrackingAssignmentRuleFiltersField(serializers.JSONField):
     def to_internal_value(self, data):
         value = super().to_internal_value(data)
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Expected a JSON object.")
         try:
             PropertyGroupFilterValue(**value)
         except PydanticValidationError as err:
-            raise serializers.ValidationError(str(err)) from err
+            logger.warning("Invalid assignment rule filters payload", exc_info=err)
+            raise serializers.ValidationError("Invalid filters payload.") from err
         return value
 
 

--- a/products/error_tracking/backend/api/test/test_assignment_rules.py
+++ b/products/error_tracking/backend/api/test/test_assignment_rules.py
@@ -1,4 +1,5 @@
 from typing import Any
+from uuid import uuid4
 
 from posthog.test.base import APIBaseTest
 
@@ -50,6 +51,26 @@ class TestAssignmentRuleAPI(APIBaseTest):
         assert rule.bytecode is not None
         assert len(rule.bytecode) > 0
 
+    def test_create_accepts_frontend_payload_shape_with_extra_fields(self) -> None:
+        response = self.client.post(
+            self._url(),
+            data={
+                "filters": VALID_FILTERS,
+                "assignee": {"type": "user", "id": self.user.id},
+                "order_key": 123,
+                "disabled_data": {"reason": "frontend-local-state"},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        rule = ErrorTrackingAssignmentRule.objects.get(id=response.json()["id"])
+        assert rule.filters == VALID_FILTERS
+        assert rule.user_id == self.user.id
+        assert rule.order_key == 0
+        assert rule.disabled_data is None
+
     @parameterized.expand(
         [
             ("missing_filters", {"assignee": {"type": "user", "id": 1}}, "filters"),
@@ -98,3 +119,151 @@ class TestAssignmentRuleAPI(APIBaseTest):
         assert body["type"] == "validation_error"
         assert body["attr"] == "filters"
         assert body["detail"] == "Invalid filters payload."
+
+    @parameterized.expand(
+        [
+            ("user_type_with_uuid_id", {"type": "user", "id": str(uuid4())}, "User assignee IDs must be integers."),
+            ("role_type_with_int_id", {"type": "role", "id": 42}, "Role assignee IDs must be UUIDs."),
+        ]
+    )
+    def test_create_rejects_mismatched_assignee_type_and_id(
+        self, _name: str, assignee: dict[str, Any], expected_detail: str
+    ) -> None:
+        response = self.client.post(
+            self._url(),
+            data={"filters": VALID_FILTERS, "assignee": assignee},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert body["type"] == "validation_error"
+        assert body["attr"] == "assignee__id"
+        assert body["detail"] == expected_detail
+
+    @parameterized.expand(
+        [
+            ("bool_id", {"type": "user", "id": True}, "id", "Expected an integer user ID or UUID role ID."),
+            ("float_id", {"type": "user", "id": 1.5}, "id", "Expected an integer user ID or UUID role ID."),
+            (
+                "non_digit_string_id",
+                {"type": "user", "id": "abc"},
+                "id",
+                "Expected an integer user ID or UUID role ID.",
+            ),
+            ("invalid_type_enum", {"type": "group", "id": 1}, "type", '"group" is not a valid choice.'),
+        ]
+    )
+    def test_create_rejects_invalid_assignee_shape(
+        self, _name: str, assignee: dict[str, Any], sub_attr: str, expected_detail: str
+    ) -> None:
+        response = self.client.post(
+            self._url(),
+            data={"filters": VALID_FILTERS, "assignee": assignee},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert body["type"] == "validation_error"
+        assert body["attr"] == f"assignee__{sub_attr}"
+        assert body["detail"] == expected_detail
+
+    def _create_rule(self) -> ErrorTrackingAssignmentRule:
+        response = self.client.post(
+            self._url(),
+            data={"filters": VALID_FILTERS, "assignee": {"type": "user", "id": self.user.id}},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        return ErrorTrackingAssignmentRule.objects.get(id=response.json()["id"])
+
+    def test_update_rejects_invalid_filters_payload(self) -> None:
+        rule = self._create_rule()
+
+        response = self.client.patch(
+            self._url(str(rule.id)),
+            data={"filters": {"not": "a valid property group"}},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert body["type"] == "validation_error"
+        assert body["attr"] == "filters"
+        assert body["detail"] == "Invalid filters payload."
+
+    def test_update_rejects_mismatched_assignee(self) -> None:
+        rule = self._create_rule()
+
+        response = self.client.patch(
+            self._url(str(rule.id)),
+            data={"assignee": {"type": "role", "id": 42}},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert body["type"] == "validation_error"
+        assert body["attr"] == "assignee__id"
+
+    def test_update_allows_partial_filters_payload(self) -> None:
+        rule = self._create_rule()
+        new_filters = {
+            "type": "OR",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {"key": "$exception_type", "type": "event", "value": ["RangeError"], "operator": "exact"}
+                    ],
+                }
+            ],
+        }
+
+        response = self.client.patch(
+            self._url(str(rule.id)),
+            data={"filters": new_filters},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        rule.refresh_from_db()
+        assert rule.filters == new_filters
+        assert rule.user_id == self.user.id
+
+    def test_update_accepts_frontend_payload_shape_with_extra_fields(self) -> None:
+        rule = self._create_rule()
+        new_filters = {
+            "type": "OR",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {"key": "$exception_type", "type": "event", "value": ["RangeError"], "operator": "exact"}
+                    ],
+                }
+            ],
+        }
+
+        response = self.client.patch(
+            self._url(str(rule.id)),
+            data={
+                "filters": new_filters,
+                "assignee": {"type": "user", "id": self.user.id},
+                "order_key": 456,
+                "disabled_data": {"reason": "frontend-local-state"},
+                "created_at": rule.created_at.isoformat(),
+                "updated_at": rule.updated_at.isoformat(),
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        rule.refresh_from_db()
+        assert rule.filters == new_filters
+        assert rule.user_id == self.user.id
+        assert rule.order_key == 0
+        assert rule.disabled_data is None

--- a/products/error_tracking/backend/api/test/test_assignment_rules.py
+++ b/products/error_tracking/backend/api/test/test_assignment_rules.py
@@ -1,0 +1,78 @@
+from rest_framework import status
+
+from posthog.test.base import APIBaseTest
+
+from products.error_tracking.backend.models import ErrorTrackingAssignmentRule
+
+VALID_FILTERS = {
+    "type": "AND",
+    "values": [
+        {
+            "type": "AND",
+            "values": [
+                {
+                    "key": "$exception_type",
+                    "type": "event",
+                    "value": ["TypeError"],
+                    "operator": "exact",
+                }
+            ],
+        }
+    ],
+}
+
+
+class TestAssignmentRuleAPI(APIBaseTest):
+    def _url(self, rule_id: str | None = None) -> str:
+        base = f"/api/environments/{self.team.id}/error_tracking/assignment_rules/"
+        if rule_id:
+            return f"{base}{rule_id}/"
+        return base
+
+    def test_create_with_valid_user_assignee(self) -> None:
+        response = self.client.post(
+            self._url(),
+            data={"filters": VALID_FILTERS, "assignee": {"type": "user", "id": self.user.id}},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["filters"] == VALID_FILTERS
+        assert data["assignee"] == {"type": "user", "id": self.user.id}
+
+        rule = ErrorTrackingAssignmentRule.objects.get(id=data["id"])
+        assert rule.user_id == self.user.id
+        assert rule.role_id is None
+        assert rule.bytecode is not None
+        assert len(rule.bytecode) > 0
+
+    def test_create_requires_filters(self) -> None:
+        response = self.client.post(
+            self._url(),
+            data={"assignee": {"type": "user", "id": self.user.id}},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            "type": "validation_error",
+            "code": "required",
+            "detail": "This field is required.",
+            "attr": "filters",
+        }
+
+    def test_create_requires_assignee(self) -> None:
+        response = self.client.post(
+            self._url(),
+            data={"filters": VALID_FILTERS},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            "type": "validation_error",
+            "code": "required",
+            "detail": "This field is required.",
+            "attr": "assignee",
+        }

--- a/products/error_tracking/backend/api/test/test_assignment_rules.py
+++ b/products/error_tracking/backend/api/test/test_assignment_rules.py
@@ -1,5 +1,8 @@
+from typing import Any
+
 from posthog.test.base import APIBaseTest
 
+from parameterized import parameterized
 from rest_framework import status
 
 from products.error_tracking.backend.models import ErrorTrackingAssignmentRule
@@ -47,48 +50,41 @@ class TestAssignmentRuleAPI(APIBaseTest):
         assert rule.bytecode is not None
         assert len(rule.bytecode) > 0
 
-    def test_create_requires_filters(self) -> None:
-        response = self.client.post(
-            self._url(),
-            data={"assignee": {"type": "user", "id": self.user.id}},
-            format="json",
-        )
+    @parameterized.expand(
+        [
+            ("missing_filters", {"assignee": {"type": "user", "id": 1}}, "filters"),
+            ("missing_assignee", {"filters": VALID_FILTERS}, "assignee"),
+        ]
+    )
+    def test_create_requires_field(self, _name: str, payload: dict[str, Any], missing_attr: str) -> None:
+        response = self.client.post(self._url(), data=payload, format="json")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
             "type": "validation_error",
             "code": "required",
             "detail": "This field is required.",
-            "attr": "filters",
+            "attr": missing_attr,
         }
 
-    def test_create_requires_assignee(self) -> None:
+    @parameterized.expand(
+        [
+            ("list", []),
+            ("integer", 42),
+            ("string", "not-an-object"),
+        ]
+    )
+    def test_create_rejects_non_object_filters(self, _name: str, invalid_filters: Any) -> None:
         response = self.client.post(
             self._url(),
-            data={"filters": VALID_FILTERS},
+            data={"filters": invalid_filters, "assignee": {"type": "user", "id": self.user.id}},
             format="json",
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json() == {
-            "type": "validation_error",
-            "code": "required",
-            "detail": "This field is required.",
-            "attr": "assignee",
-        }
-
-    def test_create_rejects_non_object_filters(self) -> None:
-        for invalid_filters in ([], 42, "string"):
-            response = self.client.post(
-                self._url(),
-                data={"filters": invalid_filters, "assignee": {"type": "user", "id": self.user.id}},
-                format="json",
-            )
-
-            assert response.status_code == status.HTTP_400_BAD_REQUEST, invalid_filters
-            body = response.json()
-            assert body["type"] == "validation_error"
-            assert body["attr"] == "filters"
+        body = response.json()
+        assert body["type"] == "validation_error"
+        assert body["attr"] == "filters"
 
     def test_create_rejects_invalid_filters_shape_without_leaking_exception(self) -> None:
         response = self.client.post(

--- a/products/error_tracking/backend/api/test/test_assignment_rules.py
+++ b/products/error_tracking/backend/api/test/test_assignment_rules.py
@@ -1,6 +1,6 @@
-from rest_framework import status
-
 from posthog.test.base import APIBaseTest
+
+from rest_framework import status
 
 from products.error_tracking.backend.models import ErrorTrackingAssignmentRule
 
@@ -76,3 +76,29 @@ class TestAssignmentRuleAPI(APIBaseTest):
             "detail": "This field is required.",
             "attr": "assignee",
         }
+
+    def test_create_rejects_non_object_filters(self) -> None:
+        for invalid_filters in ([], 42, "string"):
+            response = self.client.post(
+                self._url(),
+                data={"filters": invalid_filters, "assignee": {"type": "user", "id": self.user.id}},
+                format="json",
+            )
+
+            assert response.status_code == status.HTTP_400_BAD_REQUEST, invalid_filters
+            body = response.json()
+            assert body["type"] == "validation_error"
+            assert body["attr"] == "filters"
+
+    def test_create_rejects_invalid_filters_shape_without_leaking_exception(self) -> None:
+        response = self.client.post(
+            self._url(),
+            data={"filters": {"not": "a valid property group"}, "assignee": {"type": "user", "id": self.user.id}},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert body["type"] == "validation_error"
+        assert body["attr"] == "filters"
+        assert body["detail"] == "Invalid filters payload."

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -513,6 +513,20 @@ export interface ErrorTrackingAssignmentRuleCreateRequestApi {
     assignee: ErrorTrackingAssignmentRuleAssigneeRequestApi
 }
 
+export interface ErrorTrackingAssignmentRuleUpdateRequestApi {
+    /** Property-group filters that define when this rule matches incoming error events. */
+    filters?: PropertyGroupFilterValueApi | null
+    /** User or role to assign matching issues to. */
+    assignee?: ErrorTrackingAssignmentRuleAssigneeRequestApi | null
+}
+
+export interface PatchedErrorTrackingAssignmentRuleUpdateRequestApi {
+    /** Property-group filters that define when this rule matches incoming error events. */
+    filters?: PropertyGroupFilterValueApi | null
+    /** User or role to assign matching issues to. */
+    assignee?: ErrorTrackingAssignmentRuleAssigneeRequestApi | null
+}
+
 /**
  * @nullable
  */

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -39,6 +39,480 @@ export interface PaginatedErrorTrackingAssignmentRuleListApi {
     results: ErrorTrackingAssignmentRuleApi[]
 }
 
+export type FilterLogicalOperatorApi = (typeof FilterLogicalOperatorApi)[keyof typeof FilterLogicalOperatorApi]
+
+export const FilterLogicalOperatorApi = {
+    And: 'AND',
+    Or: 'OR',
+} as const
+
+export type PropertyOperatorApi = (typeof PropertyOperatorApi)[keyof typeof PropertyOperatorApi]
+
+export const PropertyOperatorApi = {
+    Exact: 'exact',
+    IsNot: 'is_not',
+    Icontains: 'icontains',
+    NotIcontains: 'not_icontains',
+    Regex: 'regex',
+    NotRegex: 'not_regex',
+    Gt: 'gt',
+    Gte: 'gte',
+    Lt: 'lt',
+    Lte: 'lte',
+    IsSet: 'is_set',
+    IsNotSet: 'is_not_set',
+    IsDateExact: 'is_date_exact',
+    IsDateBefore: 'is_date_before',
+    IsDateAfter: 'is_date_after',
+    Between: 'between',
+    NotBetween: 'not_between',
+    Min: 'min',
+    Max: 'max',
+    In: 'in',
+    NotIn: 'not_in',
+    IsCleanedPathExact: 'is_cleaned_path_exact',
+    FlagEvaluatesTo: 'flag_evaluates_to',
+    SemverEq: 'semver_eq',
+    SemverNeq: 'semver_neq',
+    SemverGt: 'semver_gt',
+    SemverGte: 'semver_gte',
+    SemverLt: 'semver_lt',
+    SemverLte: 'semver_lte',
+    SemverTilde: 'semver_tilde',
+    SemverCaret: 'semver_caret',
+    SemverWildcard: 'semver_wildcard',
+    IcontainsMulti: 'icontains_multi',
+    NotIcontainsMulti: 'not_icontains_multi',
+} as const
+
+/**
+ * Event properties
+ */
+export type EventPropertyFilterApiType = (typeof EventPropertyFilterApiType)[keyof typeof EventPropertyFilterApiType]
+
+export const EventPropertyFilterApiType = {
+    Event: 'event',
+} as const
+
+export interface EventPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator?: PropertyOperatorApi | null
+    /** Event properties */
+    type?: EventPropertyFilterApiType
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+/**
+ * Person properties
+ */
+export type PersonPropertyFilterApiType = (typeof PersonPropertyFilterApiType)[keyof typeof PersonPropertyFilterApiType]
+
+export const PersonPropertyFilterApiType = {
+    Person: 'person',
+} as const
+
+export interface PersonPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    /** Person properties */
+    type?: PersonPropertyFilterApiType
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type Key10Api = (typeof Key10Api)[keyof typeof Key10Api]
+
+export const Key10Api = {
+    TagName: 'tag_name',
+    Text: 'text',
+    Href: 'href',
+    Selector: 'selector',
+} as const
+
+export type ElementPropertyFilterApiType =
+    (typeof ElementPropertyFilterApiType)[keyof typeof ElementPropertyFilterApiType]
+
+export const ElementPropertyFilterApiType = {
+    Element: 'element',
+} as const
+
+export interface ElementPropertyFilterApi {
+    key: Key10Api
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: ElementPropertyFilterApiType
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type EventMetadataPropertyFilterApiType =
+    (typeof EventMetadataPropertyFilterApiType)[keyof typeof EventMetadataPropertyFilterApiType]
+
+export const EventMetadataPropertyFilterApiType = {
+    EventMetadata: 'event_metadata',
+} as const
+
+export interface EventMetadataPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: EventMetadataPropertyFilterApiType
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type SessionPropertyFilterApiType =
+    (typeof SessionPropertyFilterApiType)[keyof typeof SessionPropertyFilterApiType]
+
+export const SessionPropertyFilterApiType = {
+    Session: 'session',
+} as const
+
+export interface SessionPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: SessionPropertyFilterApiType
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type CohortPropertyFilterApiKey = (typeof CohortPropertyFilterApiKey)[keyof typeof CohortPropertyFilterApiKey]
+
+export const CohortPropertyFilterApiKey = {
+    Id: 'id',
+} as const
+
+export type CohortPropertyFilterApiType = (typeof CohortPropertyFilterApiType)[keyof typeof CohortPropertyFilterApiType]
+
+export const CohortPropertyFilterApiType = {
+    Cohort: 'cohort',
+} as const
+
+export interface CohortPropertyFilterApi {
+    /** @nullable */
+    cohort_name?: string | null
+    key?: CohortPropertyFilterApiKey
+    /** @nullable */
+    label?: string | null
+    operator?: PropertyOperatorApi | null
+    type?: CohortPropertyFilterApiType
+    value: number
+}
+
+export type DurationTypeApi = (typeof DurationTypeApi)[keyof typeof DurationTypeApi]
+
+export const DurationTypeApi = {
+    Duration: 'duration',
+    ActiveSeconds: 'active_seconds',
+    InactiveSeconds: 'inactive_seconds',
+} as const
+
+export type RecordingPropertyFilterApiType =
+    (typeof RecordingPropertyFilterApiType)[keyof typeof RecordingPropertyFilterApiType]
+
+export const RecordingPropertyFilterApiType = {
+    Recording: 'recording',
+} as const
+
+export interface RecordingPropertyFilterApi {
+    key: DurationTypeApi | string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: RecordingPropertyFilterApiType
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type LogEntryPropertyFilterApiType =
+    (typeof LogEntryPropertyFilterApiType)[keyof typeof LogEntryPropertyFilterApiType]
+
+export const LogEntryPropertyFilterApiType = {
+    LogEntry: 'log_entry',
+} as const
+
+export interface LogEntryPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: LogEntryPropertyFilterApiType
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type GroupPropertyFilterApiType = (typeof GroupPropertyFilterApiType)[keyof typeof GroupPropertyFilterApiType]
+
+export const GroupPropertyFilterApiType = {
+    Group: 'group',
+} as const
+
+/**
+ * @nullable
+ */
+export type GroupPropertyFilterApiGroupKeyNames = { [key: string]: string } | null | null
+
+export interface GroupPropertyFilterApi {
+    /** @nullable */
+    group_key_names?: GroupPropertyFilterApiGroupKeyNames
+    /** @nullable */
+    group_type_index?: number | null
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: GroupPropertyFilterApiType
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+/**
+ * Event property with "$feature/" prepended
+ */
+export type FeaturePropertyFilterApiType =
+    (typeof FeaturePropertyFilterApiType)[keyof typeof FeaturePropertyFilterApiType]
+
+export const FeaturePropertyFilterApiType = {
+    Feature: 'feature',
+} as const
+
+export interface FeaturePropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    /** Event property with "$feature/" prepended */
+    type?: FeaturePropertyFilterApiType
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+/**
+ * Only flag_evaluates_to operator is allowed for flag dependencies
+ */
+export type FlagPropertyFilterApiOperator =
+    (typeof FlagPropertyFilterApiOperator)[keyof typeof FlagPropertyFilterApiOperator]
+
+export const FlagPropertyFilterApiOperator = {
+    FlagEvaluatesTo: 'flag_evaluates_to',
+} as const
+
+/**
+ * Feature flag dependency
+ */
+export type FlagPropertyFilterApiType = (typeof FlagPropertyFilterApiType)[keyof typeof FlagPropertyFilterApiType]
+
+export const FlagPropertyFilterApiType = {
+    Flag: 'flag',
+} as const
+
+export interface FlagPropertyFilterApi {
+    /** The key should be the flag ID */
+    key: string
+    /** @nullable */
+    label?: string | null
+    /** Only flag_evaluates_to operator is allowed for flag dependencies */
+    operator?: FlagPropertyFilterApiOperator
+    /** Feature flag dependency */
+    type?: FlagPropertyFilterApiType
+    /** The value can be true, false, or a variant name */
+    value: boolean | string
+}
+
+export type HogQLPropertyFilterApiType = (typeof HogQLPropertyFilterApiType)[keyof typeof HogQLPropertyFilterApiType]
+
+export const HogQLPropertyFilterApiType = {
+    Hogql: 'hogql',
+} as const
+
+export interface HogQLPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    type?: HogQLPropertyFilterApiType
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type EmptyPropertyFilterApiType = (typeof EmptyPropertyFilterApiType)[keyof typeof EmptyPropertyFilterApiType]
+
+export const EmptyPropertyFilterApiType = {
+    Empty: 'empty',
+} as const
+
+export interface EmptyPropertyFilterApi {
+    type?: EmptyPropertyFilterApiType
+}
+
+export type DataWarehousePropertyFilterApiType =
+    (typeof DataWarehousePropertyFilterApiType)[keyof typeof DataWarehousePropertyFilterApiType]
+
+export const DataWarehousePropertyFilterApiType = {
+    DataWarehouse: 'data_warehouse',
+} as const
+
+export interface DataWarehousePropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: DataWarehousePropertyFilterApiType
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type DataWarehousePersonPropertyFilterApiType =
+    (typeof DataWarehousePersonPropertyFilterApiType)[keyof typeof DataWarehousePersonPropertyFilterApiType]
+
+export const DataWarehousePersonPropertyFilterApiType = {
+    DataWarehousePersonProperty: 'data_warehouse_person_property',
+} as const
+
+export interface DataWarehousePersonPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: DataWarehousePersonPropertyFilterApiType
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type ErrorTrackingIssueFilterApiType =
+    (typeof ErrorTrackingIssueFilterApiType)[keyof typeof ErrorTrackingIssueFilterApiType]
+
+export const ErrorTrackingIssueFilterApiType = {
+    ErrorTrackingIssue: 'error_tracking_issue',
+} as const
+
+export interface ErrorTrackingIssueFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: ErrorTrackingIssueFilterApiType
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type LogPropertyFilterTypeApi = (typeof LogPropertyFilterTypeApi)[keyof typeof LogPropertyFilterTypeApi]
+
+export const LogPropertyFilterTypeApi = {
+    Log: 'log',
+    LogAttribute: 'log_attribute',
+    LogResourceAttribute: 'log_resource_attribute',
+} as const
+
+export interface LogPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type: LogPropertyFilterTypeApi
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type SpanPropertyFilterTypeApi = (typeof SpanPropertyFilterTypeApi)[keyof typeof SpanPropertyFilterTypeApi]
+
+export const SpanPropertyFilterTypeApi = {
+    Span: 'span',
+    SpanAttribute: 'span_attribute',
+    SpanResourceAttribute: 'span_resource_attribute',
+} as const
+
+export interface SpanPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type: SpanPropertyFilterTypeApi
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type RevenueAnalyticsPropertyFilterApiType =
+    (typeof RevenueAnalyticsPropertyFilterApiType)[keyof typeof RevenueAnalyticsPropertyFilterApiType]
+
+export const RevenueAnalyticsPropertyFilterApiType = {
+    RevenueAnalytics: 'revenue_analytics',
+} as const
+
+export interface RevenueAnalyticsPropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: RevenueAnalyticsPropertyFilterApiType
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export type WorkflowVariablePropertyFilterApiType =
+    (typeof WorkflowVariablePropertyFilterApiType)[keyof typeof WorkflowVariablePropertyFilterApiType]
+
+export const WorkflowVariablePropertyFilterApiType = {
+    WorkflowVariable: 'workflow_variable',
+} as const
+
+export interface WorkflowVariablePropertyFilterApi {
+    key: string
+    /** @nullable */
+    label?: string | null
+    operator: PropertyOperatorApi
+    type?: WorkflowVariablePropertyFilterApiType
+    value?: (string | number | boolean)[] | string | number | boolean | null
+}
+
+export interface PropertyGroupFilterValueApi {
+    type: FilterLogicalOperatorApi
+    values: (
+        | PropertyGroupFilterValueApi
+        | EventPropertyFilterApi
+        | PersonPropertyFilterApi
+        | ElementPropertyFilterApi
+        | EventMetadataPropertyFilterApi
+        | SessionPropertyFilterApi
+        | CohortPropertyFilterApi
+        | RecordingPropertyFilterApi
+        | LogEntryPropertyFilterApi
+        | GroupPropertyFilterApi
+        | FeaturePropertyFilterApi
+        | FlagPropertyFilterApi
+        | HogQLPropertyFilterApi
+        | EmptyPropertyFilterApi
+        | DataWarehousePropertyFilterApi
+        | DataWarehousePersonPropertyFilterApi
+        | ErrorTrackingIssueFilterApi
+        | LogPropertyFilterApi
+        | SpanPropertyFilterApi
+        | RevenueAnalyticsPropertyFilterApi
+        | WorkflowVariablePropertyFilterApi
+    )[]
+}
+
+/**
+ * * `user` - user
+ * `role` - role
+ */
+export type ErrorTrackingAssignmentRuleAssigneeRequestTypeEnumApi =
+    (typeof ErrorTrackingAssignmentRuleAssigneeRequestTypeEnumApi)[keyof typeof ErrorTrackingAssignmentRuleAssigneeRequestTypeEnumApi]
+
+export const ErrorTrackingAssignmentRuleAssigneeRequestTypeEnumApi = {
+    User: 'user',
+    Role: 'role',
+} as const
+
+export interface ErrorTrackingAssignmentRuleAssigneeRequestApi {
+    /** Assignee type. Use `user` for a user ID or `role` for a role UUID.
+
+* `user` - user
+* `role` - role */
+    type: ErrorTrackingAssignmentRuleAssigneeRequestTypeEnumApi
+    /** User ID when `type` is `user`, or role UUID when `type` is `role`. */
+    id: number | string
+}
+
+export interface ErrorTrackingAssignmentRuleCreateRequestApi {
+    /** Property-group filters that define when this rule matches incoming error events. */
+    filters: PropertyGroupFilterValueApi
+    /** User or role to assign matching issues to. */
+    assignee: ErrorTrackingAssignmentRuleAssigneeRequestApi
+}
+
 /**
  * @nullable
  */

--- a/products/error_tracking/frontend/generated/api.ts
+++ b/products/error_tracking/frontend/generated/api.ts
@@ -11,6 +11,7 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
 import type {
     ErrorTrackingAssignmentRuleApi,
     ErrorTrackingAssignmentRuleCreateRequestApi,
+    ErrorTrackingAssignmentRuleUpdateRequestApi,
     ErrorTrackingAssignmentRulesListParams,
     ErrorTrackingExternalReferenceApi,
     ErrorTrackingExternalReferencesListParams,
@@ -49,6 +50,7 @@ import type {
     PaginatedErrorTrackingSuppressionRuleListApi,
     PaginatedErrorTrackingSymbolSetListApi,
     PatchedErrorTrackingAssignmentRuleApi,
+    PatchedErrorTrackingAssignmentRuleUpdateRequestApi,
     PatchedErrorTrackingExternalReferenceApi,
     PatchedErrorTrackingGroupingRuleApi,
     PatchedErrorTrackingIssueFullApi,
@@ -146,14 +148,14 @@ export const getErrorTrackingAssignmentRulesUpdateUrl = (projectId: string, id: 
 export const errorTrackingAssignmentRulesUpdate = async (
     projectId: string,
     id: string,
-    errorTrackingAssignmentRuleApi: NonReadonly<ErrorTrackingAssignmentRuleApi>,
+    errorTrackingAssignmentRuleUpdateRequestApi: ErrorTrackingAssignmentRuleUpdateRequestApi,
     options?: RequestInit
-): Promise<ErrorTrackingAssignmentRuleApi> => {
-    return apiMutator<ErrorTrackingAssignmentRuleApi>(getErrorTrackingAssignmentRulesUpdateUrl(projectId, id), {
+): Promise<void> => {
+    return apiMutator<void>(getErrorTrackingAssignmentRulesUpdateUrl(projectId, id), {
         ...options,
         method: 'PUT',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(errorTrackingAssignmentRuleApi),
+        body: JSON.stringify(errorTrackingAssignmentRuleUpdateRequestApi),
     })
 }
 
@@ -164,14 +166,14 @@ export const getErrorTrackingAssignmentRulesPartialUpdateUrl = (projectId: strin
 export const errorTrackingAssignmentRulesPartialUpdate = async (
     projectId: string,
     id: string,
-    patchedErrorTrackingAssignmentRuleApi: NonReadonly<PatchedErrorTrackingAssignmentRuleApi>,
+    patchedErrorTrackingAssignmentRuleUpdateRequestApi: PatchedErrorTrackingAssignmentRuleUpdateRequestApi,
     options?: RequestInit
-): Promise<ErrorTrackingAssignmentRuleApi> => {
-    return apiMutator<ErrorTrackingAssignmentRuleApi>(getErrorTrackingAssignmentRulesPartialUpdateUrl(projectId, id), {
+): Promise<void> => {
+    return apiMutator<void>(getErrorTrackingAssignmentRulesPartialUpdateUrl(projectId, id), {
         ...options,
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(patchedErrorTrackingAssignmentRuleApi),
+        body: JSON.stringify(patchedErrorTrackingAssignmentRuleUpdateRequestApi),
     })
 }
 

--- a/products/error_tracking/frontend/generated/api.ts
+++ b/products/error_tracking/frontend/generated/api.ts
@@ -10,6 +10,7 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  */
 import type {
     ErrorTrackingAssignmentRuleApi,
+    ErrorTrackingAssignmentRuleCreateRequestApi,
     ErrorTrackingAssignmentRulesListParams,
     ErrorTrackingExternalReferenceApi,
     ErrorTrackingExternalReferencesListParams,
@@ -112,14 +113,14 @@ export const getErrorTrackingAssignmentRulesCreateUrl = (projectId: string) => {
 
 export const errorTrackingAssignmentRulesCreate = async (
     projectId: string,
-    errorTrackingAssignmentRuleApi: NonReadonly<ErrorTrackingAssignmentRuleApi>,
+    errorTrackingAssignmentRuleCreateRequestApi: ErrorTrackingAssignmentRuleCreateRequestApi,
     options?: RequestInit
 ): Promise<ErrorTrackingAssignmentRuleApi> => {
     return apiMutator<ErrorTrackingAssignmentRuleApi>(getErrorTrackingAssignmentRulesCreateUrl(projectId), {
         ...options,
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(errorTrackingAssignmentRuleApi),
+        body: JSON.stringify(errorTrackingAssignmentRuleCreateRequestApi),
     })
 }
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14424,6 +14424,13 @@ export namespace Schemas {
       assignee: ErrorTrackingAssignmentRuleAssigneeRequest;
     }
 
+    export interface ErrorTrackingAssignmentRuleUpdateRequest {
+      /** Property-group filters that define when this rule matches incoming error events. */
+      filters?: PropertyGroupFilterValue | null;
+      /** User or role to assign matching issues to. */
+      assignee?: ErrorTrackingAssignmentRuleAssigneeRequest | null;
+    }
+
     export type ErrorTrackingBreakdownsQueryKind = typeof ErrorTrackingBreakdownsQueryKind[keyof typeof ErrorTrackingBreakdownsQueryKind];
 
 
@@ -24535,6 +24542,13 @@ export namespace Schemas {
       disabled_data?: unknown | null;
       readonly created_at?: string;
       readonly updated_at?: string;
+    }
+
+    export interface PatchedErrorTrackingAssignmentRuleUpdateRequest {
+      /** Property-group filters that define when this rule matches incoming error events. */
+      filters?: PropertyGroupFilterValue | null;
+      /** User or role to assign matching issues to. */
+      assignee?: ErrorTrackingAssignmentRuleAssigneeRequest | null;
     }
 
     export interface PatchedErrorTrackingExternalReference {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14395,6 +14395,35 @@ export namespace Schemas {
       readonly updated_at: string;
     }
 
+    /**
+     * * `user` - user
+    * `role` - role
+     */
+    export type ErrorTrackingAssignmentRuleAssigneeRequestTypeEnum = typeof ErrorTrackingAssignmentRuleAssigneeRequestTypeEnum[keyof typeof ErrorTrackingAssignmentRuleAssigneeRequestTypeEnum];
+
+
+    export const ErrorTrackingAssignmentRuleAssigneeRequestTypeEnum = {
+      User: 'user',
+      Role: 'role',
+    } as const;
+
+    export interface ErrorTrackingAssignmentRuleAssigneeRequest {
+      /** Assignee type. Use `user` for a user ID or `role` for a role UUID.
+
+    * `user` - user
+    * `role` - role */
+      type: ErrorTrackingAssignmentRuleAssigneeRequestTypeEnum;
+      /** User ID when `type` is `user`, or role UUID when `type` is `role`. */
+      id: number | string;
+    }
+
+    export interface ErrorTrackingAssignmentRuleCreateRequest {
+      /** Property-group filters that define when this rule matches incoming error events. */
+      filters: PropertyGroupFilterValue;
+      /** User or role to assign matching issues to. */
+      assignee: ErrorTrackingAssignmentRuleAssigneeRequest;
+    }
+
     export type ErrorTrackingBreakdownsQueryKind = typeof ErrorTrackingBreakdownsQueryKind[keyof typeof ErrorTrackingBreakdownsQueryKind];
 
 


### PR DESCRIPTION
## Problem

The error tracking assignment rule create endpoint used manual validation and lacked OpenAPI-visible serializers, preventing accurate type generation.

## Changes

- Add `ErrorTrackingAssignmentRuleCreateRequestSerializer` with typed `filters` (validated via Pydantic) and `assignee` (user ID or role UUID)
- Add custom serializer fields for the assignee ID (integer or UUID) with cross-field validation
- Replace manual validation with `@validated_request` decorator
- Regenerate frontend TypeScript types and MCP API types
- Add backend tests for create (valid user assignee, missing filters, missing assignee)

## How did you test this code?

Backend unit tests in `test_assignment_rules.py`.

## Publish to changelog?

No