### PR TITLE
chore(error-tracking): update grouping rule list schema

### DIFF
--- a/products/error_tracking/backend/api/grouping_rules.py
+++ b/products/error_tracking/backend/api/grouping_rules.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import structlog
 import posthoganalytics
-from drf_spectacular.utils import extend_schema_field
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_field, extend_schema_serializer
 from rest_framework import serializers, status, viewsets
 from rest_framework.response import Response
 
@@ -24,7 +24,17 @@ class ErrorTrackingGroupingRuleSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = ErrorTrackingGroupingRule
-        fields = ["id", "filters", "assignee", "issue", "order_key", "disabled_data", "created_at", "updated_at"]
+        fields = [
+            "id",
+            "filters",
+            "assignee",
+            "description",
+            "issue",
+            "order_key",
+            "disabled_data",
+            "created_at",
+            "updated_at",
+        ]
         read_only_fields = ["team_id", "created_at", "updated_at"]
 
     @extend_schema_field(
@@ -55,6 +65,11 @@ class ErrorTrackingGroupingRuleSerializer(serializers.ModelSerializer):
         return None
 
 
+@extend_schema_serializer(many=False)
+class ErrorTrackingGroupingRuleListResponseSerializer(serializers.Serializer):
+    results = ErrorTrackingGroupingRuleSerializer(many=True)
+
+
 def _build_issue_map(team_id: int, rule_ids: list[str]) -> dict:
     """Build a mapping of rule_id -> ErrorTrackingIssue for grouping rules."""
     if not rule_ids:
@@ -74,10 +89,12 @@ class ErrorTrackingGroupingRuleViewSet(TeamAndOrgViewSetMixin, viewsets.ModelVie
     scope_object = "error_tracking"
     queryset = ErrorTrackingGroupingRule.objects.order_by("order_key").all()
     serializer_class = ErrorTrackingGroupingRuleSerializer
+    pagination_class = None
 
     def safely_get_queryset(self, queryset):
         return queryset.filter(team_id=self.team.id)
 
+    @extend_schema(responses={200: OpenApiResponse(response=ErrorTrackingGroupingRuleListResponseSerializer)})
     def list(self, request, *args, **kwargs) -> Response:
         queryset = list(self.filter_queryset(self.get_queryset()))
         rule_ids = [str(r.id) for r in queryset]

--- a/products/error_tracking/backend/api/test/test_grouping_rules.py
+++ b/products/error_tracking/backend/api/test/test_grouping_rules.py
@@ -1,0 +1,30 @@
+from posthog.test.base import APIBaseTest
+
+from rest_framework import status
+
+from products.error_tracking.backend.models import ErrorTrackingGroupingRule
+
+
+class TestGroupingRuleAPI(APIBaseTest):
+    def _url(self, rule_id: str | None = None) -> str:
+        base = f"/api/environments/{self.team.id}/error_tracking/grouping_rules/"
+        if rule_id:
+            return f"{base}{rule_id}/"
+        return base
+
+    def test_list_returns_results_wrapper_without_pagination_fields(self) -> None:
+        ErrorTrackingGroupingRule.objects.create(
+            team=self.team,
+            filters={"type": "AND", "values": []},
+            bytecode=[],
+            order_key=0,
+            description="Group similar TypeErrors together",
+        )
+
+        response = self.client.get(self._url())
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert list(data.keys()) == ["results"]
+        assert len(data["results"]) == 1
+        assert data["results"][0]["description"] == "Group similar TypeErrors together"

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -650,6 +650,8 @@ export interface ErrorTrackingGroupingRuleApi {
     filters: unknown
     /** @nullable */
     readonly assignee: ErrorTrackingGroupingRuleApiAssignee
+    /** @nullable */
+    description?: string | null
     /**
      * Issue linked to this rule
      * @nullable
@@ -665,12 +667,7 @@ export interface ErrorTrackingGroupingRuleApi {
     readonly updated_at: string
 }
 
-export interface PaginatedErrorTrackingGroupingRuleListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
+export interface ErrorTrackingGroupingRuleListResponseApi {
     results: ErrorTrackingGroupingRuleApi[]
 }
 
@@ -693,6 +690,8 @@ export interface PatchedErrorTrackingGroupingRuleApi {
     filters?: unknown
     /** @nullable */
     readonly assignee?: PatchedErrorTrackingGroupingRuleApiAssignee
+    /** @nullable */
+    description?: string | null
     /**
      * Issue linked to this rule
      * @nullable
@@ -1030,17 +1029,6 @@ export type ErrorTrackingExternalReferencesListParams = {
 }
 
 export type ErrorTrackingFingerprintsListParams = {
-    /**
-     * Number of results to return per page.
-     */
-    limit?: number
-    /**
-     * The initial index from which to return the results.
-     */
-    offset?: number
-}
-
-export type ErrorTrackingGroupingRulesListParams = {
     /**
      * Number of results to return per page.
      */

--- a/products/error_tracking/frontend/generated/api.ts
+++ b/products/error_tracking/frontend/generated/api.ts
@@ -18,7 +18,7 @@ import type {
     ErrorTrackingFingerprintApi,
     ErrorTrackingFingerprintsListParams,
     ErrorTrackingGroupingRuleApi,
-    ErrorTrackingGroupingRulesListParams,
+    ErrorTrackingGroupingRuleListResponseApi,
     ErrorTrackingIssueFullApi,
     ErrorTrackingIssueMergeRequestApi,
     ErrorTrackingIssueMergeResponseApi,
@@ -41,7 +41,6 @@ import type {
     PaginatedErrorTrackingAssignmentRuleListApi,
     PaginatedErrorTrackingExternalReferenceListApi,
     PaginatedErrorTrackingFingerprintListApi,
-    PaginatedErrorTrackingGroupingRuleListApi,
     PaginatedErrorTrackingIssueFullListApi,
     PaginatedErrorTrackingRecommendationListApi,
     PaginatedErrorTrackingReleaseListApi,
@@ -425,37 +424,18 @@ export const errorTrackingGitProviderFileLinksResolveGitlabRetrieve = async (
     })
 }
 
-export const getErrorTrackingGroupingRulesListUrl = (
-    projectId: string,
-    params?: ErrorTrackingGroupingRulesListParams
-) => {
-    const normalizedParams = new URLSearchParams()
-
-    Object.entries(params || {}).forEach(([key, value]) => {
-        if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : value.toString())
-        }
-    })
-
-    const stringifiedParams = normalizedParams.toString()
-
-    return stringifiedParams.length > 0
-        ? `/api/environments/${projectId}/error_tracking/grouping_rules/?${stringifiedParams}`
-        : `/api/environments/${projectId}/error_tracking/grouping_rules/`
+export const getErrorTrackingGroupingRulesListUrl = (projectId: string) => {
+    return `/api/environments/${projectId}/error_tracking/grouping_rules/`
 }
 
 export const errorTrackingGroupingRulesList = async (
     projectId: string,
-    params?: ErrorTrackingGroupingRulesListParams,
     options?: RequestInit
-): Promise<PaginatedErrorTrackingGroupingRuleListApi> => {
-    return apiMutator<PaginatedErrorTrackingGroupingRuleListApi>(
-        getErrorTrackingGroupingRulesListUrl(projectId, params),
-        {
-            ...options,
-            method: 'GET',
-        }
-    )
+): Promise<ErrorTrackingGroupingRuleListResponseApi> => {
+    return apiMutator<ErrorTrackingGroupingRuleListResponseApi>(getErrorTrackingGroupingRulesListUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
 }
 
 export const getErrorTrackingGroupingRulesCreateUrl = (projectId: string) => {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14527,6 +14527,8 @@ export namespace Schemas {
       filters: unknown;
       /** @nullable */
       readonly assignee: ErrorTrackingGroupingRuleAssignee;
+      /** @nullable */
+      description?: string | null;
       /**
        * Issue linked to this rule
        * @nullable
@@ -14540,6 +14542,10 @@ export namespace Schemas {
       disabled_data?: unknown | null;
       readonly created_at: string;
       readonly updated_at: string;
+    }
+
+    export interface ErrorTrackingGroupingRuleListResponse {
+      results: ErrorTrackingGroupingRule[];
     }
 
     export interface ErrorTrackingIssueAssignment {
@@ -21014,15 +21020,6 @@ export namespace Schemas {
       results: ErrorTrackingFingerprint[];
     }
 
-    export interface PaginatedErrorTrackingGroupingRuleList {
-      count: number;
-      /** @nullable */
-      next?: string | null;
-      /** @nullable */
-      previous?: string | null;
-      results: ErrorTrackingGroupingRule[];
-    }
-
     export interface PaginatedErrorTrackingIssueFullList {
       count: number;
       /** @nullable */
@@ -24641,6 +24638,8 @@ export namespace Schemas {
       filters?: unknown;
       /** @nullable */
       readonly assignee?: PatchedErrorTrackingGroupingRuleAssignee;
+      /** @nullable */
+      description?: string | null;
       /**
        * Issue linked to this rule
        * @nullable
@@ -34519,17 +34518,6 @@ export namespace Schemas {
     };
 
     export type ErrorTrackingFingerprintsListParams = {
-    /**
-     * Number of results to return per page.
-     */
-    limit?: number;
-    /**
-     * The initial index from which to return the results.
-     */
-    offset?: number;
-    };
-
-    export type ErrorTrackingGroupingRulesListParams = {
     /**
      * Number of results to return per page.
      */


### PR DESCRIPTION
## Problem

The grouping rules list endpoint returned a paginated response but the endpoint doesn't actually paginate. It also didn't expose the `description` field, and lacked an explicit response serializer for the OpenAPI spec.

## Changes

- Remove pagination from the grouping rules list endpoint (set `pagination_class = None`)
- Add `description` field to `ErrorTrackingGroupingRuleSerializer`
- Add `ErrorTrackingGroupingRuleListResponseSerializer` as the explicit response schema
- Regenerate frontend types (removes pagination params, adds `description` field)
- Add backend test verifying the response shape

## How did you test this code?

Backend unit test in `test_grouping_rules.py`.

## Publish to changelog?

No