### PR TITLE
feat(mcp): add error tracking grouping rules list tool

### DIFF
--- a/products/error_tracking/mcp/tools.yaml
+++ b/products/error_tracking/mcp/tools.yaml
@@ -71,7 +71,17 @@ tools:
         enabled: false
     error-tracking-grouping-rules-list:
         operation: error_tracking_grouping_rules_list
-        enabled: false
+        enabled: true
+        scopes:
+            - error_tracking:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: List error tracking grouping rules
+        description: >
+            List error tracking grouping rules for the current project. Returns rules in evaluation order with
+            their filters, optional assignee, description, and linked issue when available.
     error-tracking-grouping-rules-create:
         operation: error_tracking_grouping_rules_create
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1049,6 +1049,21 @@
             "readOnlyHint": false
         }
     },
+    "error-tracking-grouping-rules-list": {
+        "description": "List error tracking grouping rules for the current project. Returns rules in evaluation order with their filters, optional assignee, description, and linked issue when available.",
+        "category": "Error tracking",
+        "feature": "error_tracking",
+        "summary": "List error tracking grouping rules",
+        "title": "List error tracking grouping rules",
+        "required_scopes": ["error_tracking:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "error-tracking-issues-list": {
         "description": "List all error tracking issues in the project. Returns issues with id, status, name, first seen timestamp, and assignee info.",
         "category": "Error tracking",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1528,6 +1528,21 @@
             "readOnlyHint": false
         }
     },
+    "error-tracking-grouping-rules-list": {
+        "description": "List error tracking grouping rules for the current project. Returns rules in evaluation order with their filters, optional assignee, description, and linked issue when available.",
+        "category": "Error tracking",
+        "feature": "error_tracking",
+        "summary": "List error tracking grouping rules",
+        "title": "List error tracking grouping rules",
+        "required_scopes": ["error_tracking:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "error-tracking-issues-list": {
         "description": "List all error tracking issues in the project. Returns issues with id, status, name, first seen timestamp, and assignee info.",
         "category": "Error tracking",

--- a/services/mcp/src/generated/error_tracking/api.ts
+++ b/services/mcp/src/generated/error_tracking/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 7 enabled ops
+ * PostHog API - MCP 8 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -977,6 +977,14 @@ export const ErrorTrackingAssignmentRulesCreateBody = /* @__PURE__ */ zod.object
                 .describe('User ID when `type` is `user`, or role UUID when `type` is `role`.'),
         })
         .describe('User or role to assign matching issues to.'),
+})
+
+export const ErrorTrackingGroupingRulesListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
 })
 
 export const ErrorTrackingIssuesListParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -67,6 +67,25 @@ const errorTrackingAssignmentRulesCreate = (): ToolBase<
     },
 })
 
+const ErrorTrackingGroupingRulesListSchema = z.object({})
+
+const errorTrackingGroupingRulesList = (): ToolBase<
+    typeof ErrorTrackingGroupingRulesListSchema,
+    Schemas.ErrorTrackingGroupingRuleListResponse
+> => ({
+    name: 'error-tracking-grouping-rules-list',
+    schema: ErrorTrackingGroupingRulesListSchema,
+    // eslint-disable-next-line no-unused-vars
+    handler: async (context: Context, params: z.infer<typeof ErrorTrackingGroupingRulesListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.ErrorTrackingGroupingRuleListResponse>({
+            method: 'GET',
+            path: `/api/environments/${projectId}/error_tracking/grouping_rules/`,
+        })
+        return result
+    },
+})
+
 const ErrorTrackingIssuesListSchema = ErrorTrackingIssuesListQueryParams
 
 const errorTrackingIssuesList = (): ToolBase<
@@ -544,6 +563,7 @@ const QueryErrorTrackingIssuesSchema = AssistantErrorTrackingQuery.extend({
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'error-tracking-assignment-rules-list': errorTrackingAssignmentRulesList,
     'error-tracking-assignment-rules-create': errorTrackingAssignmentRulesCreate,
+    'error-tracking-grouping-rules-list': errorTrackingGroupingRulesList,
     'error-tracking-issues-list': errorTrackingIssuesList,
     'error-tracking-issues-retrieve': errorTrackingIssuesRetrieve,
     'error-tracking-issues-partial-update': errorTrackingIssuesPartialUpdate,

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -80,7 +80,7 @@ const errorTrackingGroupingRulesList = (): ToolBase<
         const projectId = await context.stateManager.getProjectId()
         const result = await context.api.request<Schemas.ErrorTrackingGroupingRuleListResponse>({
             method: 'GET',
-            path: `/api/environments/${projectId}/error_tracking/grouping_rules/`,
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/error_tracking/grouping_rules/`,
         })
         return result
     },

--- a/services/mcp/tests/tools/errorTracking.integration.test.ts
+++ b/services/mcp/tests/tools/errorTracking.integration.test.ts
@@ -220,6 +220,19 @@ describe('Error Tracking', { concurrent: false }, () => {
         })
     })
 
+    describe('grouping-rules list tool', () => {
+        const groupingRulesListTool = GENERATED_TOOLS['error-tracking-grouping-rules-list']!()
+
+        it('should list grouping rules', async () => {
+            const result = (await groupingRulesListTool.handler(context, {})) as {
+                results: unknown[]
+            }
+
+            expect(result).toBeTruthy()
+            expect(Array.isArray(result.results)).toBe(true)
+        })
+    })
+
     describe('update-issue-status tool', () => {
         const updateTool = GENERATED_TOOLS['error-tracking-issues-partial-update']!()
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-grouping-rules-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-grouping-rules-list.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {},
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

MCP clients had no way to list error tracking grouping rules for a project.

## Changes

- Enable `error-tracking-grouping-rules-list` in `tools.yaml` with read scope and read-only annotation
- Add generated MCP tool handler (no pagination params since the endpoint returns all rules)
- Add integration test and unit snapshot for the tool schema

## How did you test this code?

MCP integration test and unit snapshot.

## Publish to changelog?

No