### PR TITLE
feat(mcp): add error tracking grouping rule create tool

### DIFF
--- a/products/error_tracking/mcp/tools.yaml
+++ b/products/error_tracking/mcp/tools.yaml
@@ -84,7 +84,17 @@ tools:
             their filters, optional assignee, description, and linked issue when available.
     error-tracking-grouping-rules-create:
         operation: error_tracking_grouping_rules_create
-        enabled: false
+        enabled: true
+        scopes:
+            - error_tracking:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Create error tracking grouping rule
+        description: >
+            Create an error tracking grouping rule for the current project. Provide required `filters`, and
+            optionally set `assignee` and `description` for the issues this rule creates.
     error-tracking-grouping-rules-reorder-partial-update:
         operation: error_tracking_grouping_rules_reorder_partial_update
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1064,6 +1064,21 @@
             "readOnlyHint": true
         }
     },
+    "error-tracking-grouping-rules-create": {
+        "description": "Create an error tracking grouping rule for the current project. Provide required `filters`, and optionally set `assignee` and `description` for the issues this rule creates.",
+        "category": "Error tracking",
+        "feature": "error_tracking",
+        "summary": "Create error tracking grouping rule",
+        "title": "Create error tracking grouping rule",
+        "required_scopes": ["error_tracking:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "error-tracking-issues-list": {
         "description": "List all error tracking issues in the project. Returns issues with id, status, name, first seen timestamp, and assignee info.",
         "category": "Error tracking",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1543,6 +1543,21 @@
             "readOnlyHint": true
         }
     },
+    "error-tracking-grouping-rules-create": {
+        "description": "Create an error tracking grouping rule for the current project. Provide required `filters`, and optionally set `assignee` and `description` for the issues this rule creates.",
+        "category": "Error tracking",
+        "feature": "error_tracking",
+        "summary": "Create error tracking grouping rule",
+        "title": "Create error tracking grouping rule",
+        "required_scopes": ["error_tracking:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "error-tracking-issues-list": {
         "description": "List all error tracking issues in the project. Returns issues with id, status, name, first seen timestamp, and assignee info.",
         "category": "Error tracking",

--- a/services/mcp/src/generated/error_tracking/api.ts
+++ b/services/mcp/src/generated/error_tracking/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 8 enabled ops
+ * PostHog API - MCP 9 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -985,6 +985,969 @@ export const ErrorTrackingGroupingRulesListParams = /* @__PURE__ */ zod.object({
         .describe(
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
         ),
+})
+
+export const ErrorTrackingGroupingRulesCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwoTypeDefault = `event`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemThreeTypeDefault = `person`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemFourTypeDefault = `element`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemFiveTypeDefault = `event_metadata`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSixTypeDefault = `session`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSevenKeyDefault = `id`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSevenTypeDefault = `cohort`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemEightTypeDefault = `recording`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemNineTypeDefault = `log_entry`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnezeroTypeDefault = `group`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOneoneTypeDefault = `feature`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnetwoOperatorDefault = `flag_evaluates_to`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnetwoTypeDefault = `flag`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnethreeTypeDefault = `hogql`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnefourTypeDefault = `empty`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnefiveTypeDefault = `data_warehouse`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnesixTypeDefault = `data_warehouse_person_property`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnesevenTypeDefault = `error_tracking_issue`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwozeroTypeDefault = `revenue_analytics`
+export const errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwooneTypeDefault = `workflow_variable`
+
+export const ErrorTrackingGroupingRulesCreateBody = /* @__PURE__ */ zod.object({
+    filters: zod
+        .object({
+            type: zod.enum(['AND', 'OR']),
+            values: zod.array(
+                zod.union([
+                    zod.unknown(),
+                    zod.object({
+                        key: zod.string(),
+                        label: zod.string().nullish(),
+                        operator: zod
+                            .enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'gte',
+                                'lt',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'between',
+                                'not_between',
+                                'min',
+                                'max',
+                                'in',
+                                'not_in',
+                                'is_cleaned_path_exact',
+                                'flag_evaluates_to',
+                                'semver_eq',
+                                'semver_neq',
+                                'semver_gt',
+                                'semver_gte',
+                                'semver_lt',
+                                'semver_lte',
+                                'semver_tilde',
+                                'semver_caret',
+                                'semver_wildcard',
+                                'icontains_multi',
+                                'not_icontains_multi',
+                            ])
+                            .nullish(),
+                        type: zod
+                            .enum(['event'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwoTypeDefault)
+                            .describe('Event properties'),
+                        value: zod
+                            .union([
+                                zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                zod.string(),
+                                zod.number(),
+                                zod.boolean(),
+                            ])
+                            .nullish(),
+                    }),
+                    zod.object({
+                        key: zod.string(),
+                        label: zod.string().nullish(),
+                        operator: zod.enum([
+                            'exact',
+                            'is_not',
+                            'icontains',
+                            'not_icontains',
+                            'regex',
+                            'not_regex',
+                            'gt',
+                            'gte',
+                            'lt',
+                            'lte',
+                            'is_set',
+                            'is_not_set',
+                            'is_date_exact',
+                            'is_date_before',
+                            'is_date_after',
+                            'between',
+                            'not_between',
+                            'min',
+                            'max',
+                            'in',
+                            'not_in',
+                            'is_cleaned_path_exact',
+                            'flag_evaluates_to',
+                            'semver_eq',
+                            'semver_neq',
+                            'semver_gt',
+                            'semver_gte',
+                            'semver_lt',
+                            'semver_lte',
+                            'semver_tilde',
+                            'semver_caret',
+                            'semver_wildcard',
+                            'icontains_multi',
+                            'not_icontains_multi',
+                        ]),
+                        type: zod
+                            .enum(['person'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemThreeTypeDefault)
+                            .describe('Person properties'),
+                        value: zod
+                            .union([
+                                zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                zod.string(),
+                                zod.number(),
+                                zod.boolean(),
+                            ])
+                            .nullish(),
+                    }),
+                    zod.object({
+                        key: zod.enum(['tag_name', 'text', 'href', 'selector']),
+                        label: zod.string().nullish(),
+                        operator: zod.enum([
+                            'exact',
+                            'is_not',
+                            'icontains',
+                            'not_icontains',
+                            'regex',
+                            'not_regex',
+                            'gt',
+                            'gte',
+                            'lt',
+                            'lte',
+                            'is_set',
+                            'is_not_set',
+                            'is_date_exact',
+                            'is_date_before',
+                            'is_date_after',
+                            'between',
+                            'not_between',
+                            'min',
+                            'max',
+                            'in',
+                            'not_in',
+                            'is_cleaned_path_exact',
+                            'flag_evaluates_to',
+                            'semver_eq',
+                            'semver_neq',
+                            'semver_gt',
+                            'semver_gte',
+                            'semver_lt',
+                            'semver_lte',
+                            'semver_tilde',
+                            'semver_caret',
+                            'semver_wildcard',
+                            'icontains_multi',
+                            'not_icontains_multi',
+                        ]),
+                        type: zod
+                            .enum(['element'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemFourTypeDefault),
+                        value: zod
+                            .union([
+                                zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                zod.string(),
+                                zod.number(),
+                                zod.boolean(),
+                            ])
+                            .nullish(),
+                    }),
+                    zod.object({
+                        key: zod.string(),
+                        label: zod.string().nullish(),
+                        operator: zod.enum([
+                            'exact',
+                            'is_not',
+                            'icontains',
+                            'not_icontains',
+                            'regex',
+                            'not_regex',
+                            'gt',
+                            'gte',
+                            'lt',
+                            'lte',
+                            'is_set',
+                            'is_not_set',
+                            'is_date_exact',
+                            'is_date_before',
+                            'is_date_after',
+                            'between',
+                            'not_between',
+                            'min',
+                            'max',
+                            'in',
+                            'not_in',
+                            'is_cleaned_path_exact',
+                            'flag_evaluates_to',
+                            'semver_eq',
+                            'semver_neq',
+                            'semver_gt',
+                            'semver_gte',
+                            'semver_lt',
+                            'semver_lte',
+                            'semver_tilde',
+                            'semver_caret',
+                            'semver_wildcard',
+                            'icontains_multi',
+                            'not_icontains_multi',
+                        ]),
+                        type: zod
+                            .enum(['event_metadata'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemFiveTypeDefault),
+                        value: zod
+                            .union([
+                                zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                zod.string(),
+                                zod.number(),
+                                zod.boolean(),
+                            ])
+                            .nullish(),
+                    }),
+                    zod.object({
+                        key: zod.string(),
+                        label: zod.string().nullish(),
+                        operator: zod.enum([
+                            'exact',
+                            'is_not',
+                            'icontains',
+                            'not_icontains',
+                            'regex',
+                            'not_regex',
+                            'gt',
+                            'gte',
+                            'lt',
+                            'lte',
+                            'is_set',
+                            'is_not_set',
+                            'is_date_exact',
+                            'is_date_before',
+                            'is_date_after',
+                            'between',
+                            'not_between',
+                            'min',
+                            'max',
+                            'in',
+                            'not_in',
+                            'is_cleaned_path_exact',
+                            'flag_evaluates_to',
+                            'semver_eq',
+                            'semver_neq',
+                            'semver_gt',
+                            'semver_gte',
+                            'semver_lt',
+                            'semver_lte',
+                            'semver_tilde',
+                            'semver_caret',
+                            'semver_wildcard',
+                            'icontains_multi',
+                            'not_icontains_multi',
+                        ]),
+                        type: zod
+                            .enum(['session'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSixTypeDefault),
+                        value: zod
+                            .union([
+                                zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                zod.string(),
+                                zod.number(),
+                                zod.boolean(),
+                            ])
+                            .nullish(),
+                    }),
+                    zod.object({
+                        cohort_name: zod.string().nullish(),
+                        key: zod
+                            .enum(['id'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSevenKeyDefault),
+                        label: zod.string().nullish(),
+                        operator: zod
+                            .enum([
+                                'exact',
+                                'is_not',
+                                'icontains',
+                                'not_icontains',
+                                'regex',
+                                'not_regex',
+                                'gt',
+                                'gte',
+                                'lt',
+                                'lte',
+                                'is_set',
+                                'is_not_set',
+                                'is_date_exact',
+                                'is_date_before',
+                                'is_date_after',
+                                'between',
+                                'not_between',
+                                'min',
+                                'max',
+                                'in',
+                                'not_in',
+                                'is_cleaned_path_exact',
+                                'flag_evaluates_to',
+                                'semver_eq',
+                                'semver_neq',
+                                'semver_gt',
+                                'semver_gte',
+                                'semver_lt',
+                                'semver_lte',
+                                'semver_tilde',
+                                'semver_caret',
+                                'semver_wildcard',
+                                'icontains_multi',
+                                'not_icontains_multi',
+                            ])
+                            .nullish(),
+                        type: zod
+                            .enum(['cohort'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemSevenTypeDefault),
+                        value: zod.number(),
+                    }),
+                    zod.object({
+                        key: zod.union([zod.enum(['duration', 'active_seconds', 'inactive_seconds']), zod.string()]),
+                        label: zod.string().nullish(),
+                        operator: zod.enum([
+                            'exact',
+                            'is_not',
+                            'icontains',
+                            'not_icontains',
+                            'regex',
+                            'not_regex',
+                            'gt',
+                            'gte',
+                            'lt',
+                            'lte',
+                            'is_set',
+                            'is_not_set',
+                            'is_date_exact',
+                            'is_date_before',
+                            'is_date_after',
+                            'between',
+                            'not_between',
+                            'min',
+                            'max',
+                            'in',
+                            'not_in',
+                            'is_cleaned_path_exact',
+                            'flag_evaluates_to',
+                            'semver_eq',
+                            'semver_neq',
+                            'semver_gt',
+                            'semver_gte',
+                            'semver_lt',
+                            'semver_lte',
+                            'semver_tilde',
+                            'semver_caret',
+                            'semver_wildcard',
+                            'icontains_multi',
+                            'not_icontains_multi',
+                        ]),
+                        type: zod
+                            .enum(['recording'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemEightTypeDefault),
+                        value: zod
+                            .union([
+                                zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                zod.string(),
+                                zod.number(),
+                                zod.boolean(),
+                            ])
+                            .nullish(),
+                    }),
+                    zod.object({
+                        key: zod.string(),
+                        label: zod.string().nullish(),
+                        operator: zod.enum([
+                            'exact',
+                            'is_not',
+                            'icontains',
+                            'not_icontains',
+                            'regex',
+                            'not_regex',
+                            'gt',
+                            'gte',
+                            'lt',
+                            'lte',
+                            'is_set',
+                            'is_not_set',
+                            'is_date_exact',
+                            'is_date_before',
+                            'is_date_after',
+                            'between',
+                            'not_between',
+                            'min',
+                            'max',
+                            'in',
+                            'not_in',
+                            'is_cleaned_path_exact',
+                            'flag_evaluates_to',
+                            'semver_eq',
+                            'semver_neq',
+                            'semver_gt',
+                            'semver_gte',
+                            'semver_lt',
+                            'semver_lte',
+                            'semver_tilde',
+                            'semver_caret',
+                            'semver_wildcard',
+                            'icontains_multi',
+                            'not_icontains_multi',
+                        ]),
+                        type: zod
+                            .enum(['log_entry'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemNineTypeDefault),
+                        value: zod
+                            .union([
+                                zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                zod.string(),
+                                zod.number(),
+                                zod.boolean(),
+                            ])
+                            .nullish(),
+                    }),
+                    zod.object({
+                        group_key_names: zod.record(zod.string(), zod.string()).nullish(),
+                        group_type_index: zod.number().nullish(),
+                        key: zod.string(),
+                        label: zod.string().nullish(),
+                        operator: zod.enum([
+                            'exact',
+                            'is_not',
+                            'icontains',
+                            'not_icontains',
+                            'regex',
+                            'not_regex',
+                            'gt',
+                            'gte',
+                            'lt',
+                            'lte',
+                            'is_set',
+                            'is_not_set',
+                            'is_date_exact',
+                            'is_date_before',
+                            'is_date_after',
+                            'between',
+                            'not_between',
+                            'min',
+                            'max',
+                            'in',
+                            'not_in',
+                            'is_cleaned_path_exact',
+                            'flag_evaluates_to',
+                            'semver_eq',
+                            'semver_neq',
+                            'semver_gt',
+                            'semver_gte',
+                            'semver_lt',
+                            'semver_lte',
+                            'semver_tilde',
+                            'semver_caret',
+                            'semver_wildcard',
+                            'icontains_multi',
+                            'not_icontains_multi',
+                        ]),
+                        type: zod
+                            .enum(['group'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnezeroTypeDefault),
+                        value: zod
+                            .union([
+                                zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                zod.string(),
+                                zod.number(),
+                                zod.boolean(),
+                            ])
+                            .nullish(),
+                    }),
+                    zod.object({
+                        key: zod.string(),
+                        label: zod.string().nullish(),
+                        operator: zod.enum([
+                            'exact',
+                            'is_not',
+                            'icontains',
+                            'not_icontains',
+                            'regex',
+                            'not_regex',
+                            'gt',
+                            'gte',
+                            'lt',
+                            'lte',
+                            'is_set',
+                            'is_not_set',
+                            'is_date_exact',
+                            'is_date_before',
+                            'is_date_after',
+                            'between',
+                            'not_between',
+                            'min',
+                            'max',
+                            'in',
+                            'not_in',
+                            'is_cleaned_path_exact',
+                            'flag_evaluates_to',
+                            'semver_eq',
+                            'semver_neq',
+                            'semver_gt',
+                            'semver_gte',
+                            'semver_lt',
+                            'semver_lte',
+                            'semver_tilde',
+                            'semver_caret',
+                            'semver_wildcard',
+                            'icontains_multi',
+                            'not_icontains_multi',
+                        ]),
+                        type: zod
+                            .enum(['feature'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOneoneTypeDefault)
+                            .describe('Event property with "$feature/" prepended'),
+                        value: zod
+                            .union([
+                                zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                zod.string(),
+                                zod.number(),
+                                zod.boolean(),
+                            ])
+                            .nullish(),
+                    }),
+                    zod.object({
+                        key: zod.string().describe('The key should be the flag ID'),
+                        label: zod.string().nullish(),
+                        operator: zod
+                            .enum(['flag_evaluates_to'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnetwoOperatorDefault)
+                            .describe('Only flag_evaluates_to operator is allowed for flag dependencies'),
+                        type: zod
+                            .enum(['flag'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnetwoTypeDefault)
+                            .describe('Feature flag dependency'),
+                        value: zod
+                            .union([zod.boolean(), zod.string()])
+                            .describe('The value can be true, false, or a variant name'),
+                    }),
+                    zod.object({
+                        key: zod.string(),
+                        label: zod.string().nullish(),
+                        type: zod
+                            .enum(['hogql'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnethreeTypeDefault),
+                        value: zod
+                            .union([
+                                zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                zod.string(),
+                                zod.number(),
+                                zod.boolean(),
+                            ])
+                            .nullish(),
+                    }),
+                    zod.object({
+                        type: zod
+                            .enum(['empty'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnefourTypeDefault),
+                    }),
+                    zod.object({
+                        key: zod.string(),
+                        label: zod.string().nullish(),
+                        operator: zod.enum([
+                            'exact',
+                            'is_not',
+                            'icontains',
+                            'not_icontains',
+                            'regex',
+                            'not_regex',
+                            'gt',
+                            'gte',
+                            'lt',
+                            'lte',
+                            'is_set',
+                            'is_not_set',
+                            'is_date_exact',
+                            'is_date_before',
+                            'is_date_after',
+                            'between',
+                            'not_between',
+                            'min',
+                            'max',
+                            'in',
+                            'not_in',
+                            'is_cleaned_path_exact',
+                            'flag_evaluates_to',
+                            'semver_eq',
+                            'semver_neq',
+                            'semver_gt',
+                            'semver_gte',
+                            'semver_lt',
+                            'semver_lte',
+                            'semver_tilde',
+                            'semver_caret',
+                            'semver_wildcard',
+                            'icontains_multi',
+                            'not_icontains_multi',
+                        ]),
+                        type: zod
+                            .enum(['data_warehouse'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnefiveTypeDefault),
+                        value: zod
+                            .union([
+                                zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                zod.string(),
+                                zod.number(),
+                                zod.boolean(),
+                            ])
+                            .nullish(),
+                    }),
+                    zod.object({
+                        key: zod.string(),
+                        label: zod.string().nullish(),
+                        operator: zod.enum([
+                            'exact',
+                            'is_not',
+                            'icontains',
+                            'not_icontains',
+                            'regex',
+                            'not_regex',
+                            'gt',
+                            'gte',
+                            'lt',
+                            'lte',
+                            'is_set',
+                            'is_not_set',
+                            'is_date_exact',
+                            'is_date_before',
+                            'is_date_after',
+                            'between',
+                            'not_between',
+                            'min',
+                            'max',
+                            'in',
+                            'not_in',
+                            'is_cleaned_path_exact',
+                            'flag_evaluates_to',
+                            'semver_eq',
+                            'semver_neq',
+                            'semver_gt',
+                            'semver_gte',
+                            'semver_lt',
+                            'semver_lte',
+                            'semver_tilde',
+                            'semver_caret',
+                            'semver_wildcard',
+                            'icontains_multi',
+                            'not_icontains_multi',
+                        ]),
+                        type: zod
+                            .enum(['data_warehouse_person_property'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnesixTypeDefault),
+                        value: zod
+                            .union([
+                                zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                zod.string(),
+                                zod.number(),
+                                zod.boolean(),
+                            ])
+                            .nullish(),
+                    }),
+                    zod.object({
+                        key: zod.string(),
+                        label: zod.string().nullish(),
+                        operator: zod.enum([
+                            'exact',
+                            'is_not',
+                            'icontains',
+                            'not_icontains',
+                            'regex',
+                            'not_regex',
+                            'gt',
+                            'gte',
+                            'lt',
+                            'lte',
+                            'is_set',
+                            'is_not_set',
+                            'is_date_exact',
+                            'is_date_before',
+                            'is_date_after',
+                            'between',
+                            'not_between',
+                            'min',
+                            'max',
+                            'in',
+                            'not_in',
+                            'is_cleaned_path_exact',
+                            'flag_evaluates_to',
+                            'semver_eq',
+                            'semver_neq',
+                            'semver_gt',
+                            'semver_gte',
+                            'semver_lt',
+                            'semver_lte',
+                            'semver_tilde',
+                            'semver_caret',
+                            'semver_wildcard',
+                            'icontains_multi',
+                            'not_icontains_multi',
+                        ]),
+                        type: zod
+                            .enum(['error_tracking_issue'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemOnesevenTypeDefault),
+                        value: zod
+                            .union([
+                                zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                zod.string(),
+                                zod.number(),
+                                zod.boolean(),
+                            ])
+                            .nullish(),
+                    }),
+                    zod.object({
+                        key: zod.string(),
+                        label: zod.string().nullish(),
+                        operator: zod.enum([
+                            'exact',
+                            'is_not',
+                            'icontains',
+                            'not_icontains',
+                            'regex',
+                            'not_regex',
+                            'gt',
+                            'gte',
+                            'lt',
+                            'lte',
+                            'is_set',
+                            'is_not_set',
+                            'is_date_exact',
+                            'is_date_before',
+                            'is_date_after',
+                            'between',
+                            'not_between',
+                            'min',
+                            'max',
+                            'in',
+                            'not_in',
+                            'is_cleaned_path_exact',
+                            'flag_evaluates_to',
+                            'semver_eq',
+                            'semver_neq',
+                            'semver_gt',
+                            'semver_gte',
+                            'semver_lt',
+                            'semver_lte',
+                            'semver_tilde',
+                            'semver_caret',
+                            'semver_wildcard',
+                            'icontains_multi',
+                            'not_icontains_multi',
+                        ]),
+                        type: zod.enum(['log', 'log_attribute', 'log_resource_attribute']),
+                        value: zod
+                            .union([
+                                zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                zod.string(),
+                                zod.number(),
+                                zod.boolean(),
+                            ])
+                            .nullish(),
+                    }),
+                    zod.object({
+                        key: zod.string(),
+                        label: zod.string().nullish(),
+                        operator: zod.enum([
+                            'exact',
+                            'is_not',
+                            'icontains',
+                            'not_icontains',
+                            'regex',
+                            'not_regex',
+                            'gt',
+                            'gte',
+                            'lt',
+                            'lte',
+                            'is_set',
+                            'is_not_set',
+                            'is_date_exact',
+                            'is_date_before',
+                            'is_date_after',
+                            'between',
+                            'not_between',
+                            'min',
+                            'max',
+                            'in',
+                            'not_in',
+                            'is_cleaned_path_exact',
+                            'flag_evaluates_to',
+                            'semver_eq',
+                            'semver_neq',
+                            'semver_gt',
+                            'semver_gte',
+                            'semver_lt',
+                            'semver_lte',
+                            'semver_tilde',
+                            'semver_caret',
+                            'semver_wildcard',
+                            'icontains_multi',
+                            'not_icontains_multi',
+                        ]),
+                        type: zod.enum(['span', 'span_attribute', 'span_resource_attribute']),
+                        value: zod
+                            .union([
+                                zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                zod.string(),
+                                zod.number(),
+                                zod.boolean(),
+                            ])
+                            .nullish(),
+                    }),
+                    zod.object({
+                        key: zod.string(),
+                        label: zod.string().nullish(),
+                        operator: zod.enum([
+                            'exact',
+                            'is_not',
+                            'icontains',
+                            'not_icontains',
+                            'regex',
+                            'not_regex',
+                            'gt',
+                            'gte',
+                            'lt',
+                            'lte',
+                            'is_set',
+                            'is_not_set',
+                            'is_date_exact',
+                            'is_date_before',
+                            'is_date_after',
+                            'between',
+                            'not_between',
+                            'min',
+                            'max',
+                            'in',
+                            'not_in',
+                            'is_cleaned_path_exact',
+                            'flag_evaluates_to',
+                            'semver_eq',
+                            'semver_neq',
+                            'semver_gt',
+                            'semver_gte',
+                            'semver_lt',
+                            'semver_lte',
+                            'semver_tilde',
+                            'semver_caret',
+                            'semver_wildcard',
+                            'icontains_multi',
+                            'not_icontains_multi',
+                        ]),
+                        type: zod
+                            .enum(['revenue_analytics'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwozeroTypeDefault),
+                        value: zod
+                            .union([
+                                zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                zod.string(),
+                                zod.number(),
+                                zod.boolean(),
+                            ])
+                            .nullish(),
+                    }),
+                    zod.object({
+                        key: zod.string(),
+                        label: zod.string().nullish(),
+                        operator: zod.enum([
+                            'exact',
+                            'is_not',
+                            'icontains',
+                            'not_icontains',
+                            'regex',
+                            'not_regex',
+                            'gt',
+                            'gte',
+                            'lt',
+                            'lte',
+                            'is_set',
+                            'is_not_set',
+                            'is_date_exact',
+                            'is_date_before',
+                            'is_date_after',
+                            'between',
+                            'not_between',
+                            'min',
+                            'max',
+                            'in',
+                            'not_in',
+                            'is_cleaned_path_exact',
+                            'flag_evaluates_to',
+                            'semver_eq',
+                            'semver_neq',
+                            'semver_gt',
+                            'semver_gte',
+                            'semver_lt',
+                            'semver_lte',
+                            'semver_tilde',
+                            'semver_caret',
+                            'semver_wildcard',
+                            'icontains_multi',
+                            'not_icontains_multi',
+                        ]),
+                        type: zod
+                            .enum(['workflow_variable'])
+                            .default(errorTrackingGroupingRulesCreateBodyFiltersOneValuesItemTwooneTypeDefault),
+                        value: zod
+                            .union([
+                                zod.array(zod.union([zod.string(), zod.number(), zod.boolean()])),
+                                zod.string(),
+                                zod.number(),
+                                zod.boolean(),
+                            ])
+                            .nullish(),
+                    }),
+                ])
+            ),
+        })
+        .describe('Property-group filters that define which exceptions should be grouped into the same issue.'),
+    assignee: zod
+        .object({
+            type: zod
+                .enum(['user', 'role'])
+                .describe('* `user` - user\n* `role` - role')
+                .describe(
+                    'Assignee type. Use `user` for a user ID or `role` for a role UUID.\n\n* `user` - user\n* `role` - role'
+                ),
+            id: zod
+                .union([zod.number(), zod.string()])
+                .describe('User ID when `type` is `user`, or role UUID when `type` is `role`.'),
+        })
+        .nullish()
+        .describe('Optional user or role to assign to issues created by this grouping rule.'),
+    description: zod
+        .string()
+        .nullish()
+        .describe('Optional human-readable description of what this grouping rule is for.'),
 })
 
 export const ErrorTrackingIssuesListParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -109,7 +109,7 @@ const errorTrackingGroupingRulesCreate = (): ToolBase<
         }
         const result = await context.api.request<Schemas.ErrorTrackingGroupingRule>({
             method: 'POST',
-            path: `/api/environments/${projectId}/error_tracking/grouping_rules/`,
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/error_tracking/grouping_rules/`,
             body,
         })
         return result

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -5,6 +5,7 @@ import type { Schemas } from '@/api/generated'
 import {
     ErrorTrackingAssignmentRulesCreateBody,
     ErrorTrackingAssignmentRulesListQueryParams,
+    ErrorTrackingGroupingRulesCreateBody,
     ErrorTrackingIssuesListQueryParams,
     ErrorTrackingIssuesMergeCreateBody,
     ErrorTrackingIssuesMergeCreateParams,
@@ -81,6 +82,35 @@ const errorTrackingGroupingRulesList = (): ToolBase<
         const result = await context.api.request<Schemas.ErrorTrackingGroupingRuleListResponse>({
             method: 'GET',
             path: `/api/environments/${encodeURIComponent(String(projectId))}/error_tracking/grouping_rules/`,
+        })
+        return result
+    },
+})
+
+const ErrorTrackingGroupingRulesCreateSchema = ErrorTrackingGroupingRulesCreateBody
+
+const errorTrackingGroupingRulesCreate = (): ToolBase<
+    typeof ErrorTrackingGroupingRulesCreateSchema,
+    Schemas.ErrorTrackingGroupingRule
+> => ({
+    name: 'error-tracking-grouping-rules-create',
+    schema: ErrorTrackingGroupingRulesCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof ErrorTrackingGroupingRulesCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.filters !== undefined) {
+            body['filters'] = params.filters
+        }
+        if (params.assignee !== undefined) {
+            body['assignee'] = params.assignee
+        }
+        if (params.description !== undefined) {
+            body['description'] = params.description
+        }
+        const result = await context.api.request<Schemas.ErrorTrackingGroupingRule>({
+            method: 'POST',
+            path: `/api/environments/${projectId}/error_tracking/grouping_rules/`,
+            body,
         })
         return result
     },
@@ -564,6 +594,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'error-tracking-assignment-rules-list': errorTrackingAssignmentRulesList,
     'error-tracking-assignment-rules-create': errorTrackingAssignmentRulesCreate,
     'error-tracking-grouping-rules-list': errorTrackingGroupingRulesList,
+    'error-tracking-grouping-rules-create': errorTrackingGroupingRulesCreate,
     'error-tracking-issues-list': errorTrackingIssuesList,
     'error-tracking-issues-retrieve': errorTrackingIssuesRetrieve,
     'error-tracking-issues-partial-update': errorTrackingIssuesPartialUpdate,

--- a/services/mcp/tests/tools/errorTracking.integration.test.ts
+++ b/services/mcp/tests/tools/errorTracking.integration.test.ts
@@ -27,6 +27,7 @@ describe('Error Tracking', { concurrent: false }, () => {
     let currentUserId: number
     const queryTool = GENERATED_TOOLS['query-error-tracking-issues']!()
     const createdAssignmentRuleIds: string[] = []
+    const createdGroupingRuleIds: string[] = []
     const createdResources: CreatedResources = {
         featureFlags: [],
         insights: [],
@@ -60,6 +61,17 @@ describe('Error Tracking', { concurrent: false }, () => {
             }
         }
         createdAssignmentRuleIds.length = 0
+        for (const id of createdGroupingRuleIds) {
+            try {
+                await context.api.request({
+                    method: 'DELETE',
+                    path: `/api/environments/${TEST_PROJECT_ID}/error_tracking/grouping_rules/${id}/`,
+                })
+            } catch {
+                // best effort — rule may already be deleted
+            }
+        }
+        createdGroupingRuleIds.length = 0
         await cleanupResources(context.api, TEST_PROJECT_ID!, createdResources)
     })
 
@@ -230,6 +242,41 @@ describe('Error Tracking', { concurrent: false }, () => {
 
             expect(result).toBeTruthy()
             expect(Array.isArray(result.results)).toBe(true)
+        })
+    })
+
+    describe('grouping-rules create tool', () => {
+        const groupingRulesCreateTool = GENERATED_TOOLS['error-tracking-grouping-rules-create']!()
+
+        it('should create a grouping rule', async () => {
+            const result = (await groupingRulesCreateTool.handler(context, {
+                filters: {
+                    type: 'AND',
+                    values: [
+                        {
+                            type: 'AND',
+                            values: [
+                                {
+                                    key: '$exception_type',
+                                    type: 'event',
+                                    value: ['TypeError'],
+                                    operator: 'exact',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                assignee: { type: 'user', id: currentUserId },
+                description: 'Group TypeErrors from MCP integration test',
+            })) as { id: string; filters: unknown; assignee: { type: string; id: number | string } | null; description?: string | null }
+
+            createdGroupingRuleIds.push(result.id)
+
+            expect(result).toBeTruthy()
+            expect(typeof result.id).toBe('string')
+            expect(result.filters).toBeTruthy()
+            expect(result.assignee).toEqual({ type: 'user', id: currentUserId })
+            expect(result.description).toBe('Group TypeErrors from MCP integration test')
         })
     })
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-grouping-rules-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/error-tracking-grouping-rules-create.json
@@ -1,0 +1,1892 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "assignee": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "id": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ],
+                            "description": "User ID when `type` is `user`, or role UUID when `type` is `role`."
+                        },
+                        "type": {
+                            "description": "Assignee type. Use `user` for a user ID or `role` for a role UUID.\n\n* `user` - user\n* `role` - role",
+                            "enum": ["user", "role"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["type", "id"],
+                    "type": "object"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Optional user or role to assign to issues created by this grouping rule."
+        },
+        "description": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Optional human-readable description of what this grouping rule is for."
+        },
+        "filters": {
+            "description": "Property-group filters that define which exceptions should be grouped into the same issue.",
+            "properties": {
+                "type": {
+                    "enum": ["AND", "OR"],
+                    "type": "string"
+                },
+                "values": {
+                    "items": {
+                        "anyOf": [
+                            {},
+                            {
+                                "properties": {
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "anyOf": [
+                                            {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "type": {
+                                        "default": "event",
+                                        "description": "Event properties",
+                                        "enum": ["event"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["key"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "enum": [
+                                            "exact",
+                                            "is_not",
+                                            "icontains",
+                                            "not_icontains",
+                                            "regex",
+                                            "not_regex",
+                                            "gt",
+                                            "gte",
+                                            "lt",
+                                            "lte",
+                                            "is_set",
+                                            "is_not_set",
+                                            "is_date_exact",
+                                            "is_date_before",
+                                            "is_date_after",
+                                            "between",
+                                            "not_between",
+                                            "min",
+                                            "max",
+                                            "in",
+                                            "not_in",
+                                            "is_cleaned_path_exact",
+                                            "flag_evaluates_to",
+                                            "semver_eq",
+                                            "semver_neq",
+                                            "semver_gt",
+                                            "semver_gte",
+                                            "semver_lt",
+                                            "semver_lte",
+                                            "semver_tilde",
+                                            "semver_caret",
+                                            "semver_wildcard",
+                                            "icontains_multi",
+                                            "not_icontains_multi"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "default": "person",
+                                        "description": "Person properties",
+                                        "enum": ["person"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["key", "operator"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "enum": ["tag_name", "text", "href", "selector"],
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "enum": [
+                                            "exact",
+                                            "is_not",
+                                            "icontains",
+                                            "not_icontains",
+                                            "regex",
+                                            "not_regex",
+                                            "gt",
+                                            "gte",
+                                            "lt",
+                                            "lte",
+                                            "is_set",
+                                            "is_not_set",
+                                            "is_date_exact",
+                                            "is_date_before",
+                                            "is_date_after",
+                                            "between",
+                                            "not_between",
+                                            "min",
+                                            "max",
+                                            "in",
+                                            "not_in",
+                                            "is_cleaned_path_exact",
+                                            "flag_evaluates_to",
+                                            "semver_eq",
+                                            "semver_neq",
+                                            "semver_gt",
+                                            "semver_gte",
+                                            "semver_lt",
+                                            "semver_lte",
+                                            "semver_tilde",
+                                            "semver_caret",
+                                            "semver_wildcard",
+                                            "icontains_multi",
+                                            "not_icontains_multi"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "default": "element",
+                                        "enum": ["element"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["key", "operator"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "enum": [
+                                            "exact",
+                                            "is_not",
+                                            "icontains",
+                                            "not_icontains",
+                                            "regex",
+                                            "not_regex",
+                                            "gt",
+                                            "gte",
+                                            "lt",
+                                            "lte",
+                                            "is_set",
+                                            "is_not_set",
+                                            "is_date_exact",
+                                            "is_date_before",
+                                            "is_date_after",
+                                            "between",
+                                            "not_between",
+                                            "min",
+                                            "max",
+                                            "in",
+                                            "not_in",
+                                            "is_cleaned_path_exact",
+                                            "flag_evaluates_to",
+                                            "semver_eq",
+                                            "semver_neq",
+                                            "semver_gt",
+                                            "semver_gte",
+                                            "semver_lt",
+                                            "semver_lte",
+                                            "semver_tilde",
+                                            "semver_caret",
+                                            "semver_wildcard",
+                                            "icontains_multi",
+                                            "not_icontains_multi"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "default": "event_metadata",
+                                        "enum": ["event_metadata"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["key", "operator"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "enum": [
+                                            "exact",
+                                            "is_not",
+                                            "icontains",
+                                            "not_icontains",
+                                            "regex",
+                                            "not_regex",
+                                            "gt",
+                                            "gte",
+                                            "lt",
+                                            "lte",
+                                            "is_set",
+                                            "is_not_set",
+                                            "is_date_exact",
+                                            "is_date_before",
+                                            "is_date_after",
+                                            "between",
+                                            "not_between",
+                                            "min",
+                                            "max",
+                                            "in",
+                                            "not_in",
+                                            "is_cleaned_path_exact",
+                                            "flag_evaluates_to",
+                                            "semver_eq",
+                                            "semver_neq",
+                                            "semver_gt",
+                                            "semver_gte",
+                                            "semver_lt",
+                                            "semver_lte",
+                                            "semver_tilde",
+                                            "semver_caret",
+                                            "semver_wildcard",
+                                            "icontains_multi",
+                                            "not_icontains_multi"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "default": "session",
+                                        "enum": ["session"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["key", "operator"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "cohort_name": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "key": {
+                                        "default": "id",
+                                        "enum": ["id"],
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "anyOf": [
+                                            {
+                                                "enum": [
+                                                    "exact",
+                                                    "is_not",
+                                                    "icontains",
+                                                    "not_icontains",
+                                                    "regex",
+                                                    "not_regex",
+                                                    "gt",
+                                                    "gte",
+                                                    "lt",
+                                                    "lte",
+                                                    "is_set",
+                                                    "is_not_set",
+                                                    "is_date_exact",
+                                                    "is_date_before",
+                                                    "is_date_after",
+                                                    "between",
+                                                    "not_between",
+                                                    "min",
+                                                    "max",
+                                                    "in",
+                                                    "not_in",
+                                                    "is_cleaned_path_exact",
+                                                    "flag_evaluates_to",
+                                                    "semver_eq",
+                                                    "semver_neq",
+                                                    "semver_gt",
+                                                    "semver_gte",
+                                                    "semver_lt",
+                                                    "semver_lte",
+                                                    "semver_tilde",
+                                                    "semver_caret",
+                                                    "semver_wildcard",
+                                                    "icontains_multi",
+                                                    "not_icontains_multi"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "type": {
+                                        "default": "cohort",
+                                        "enum": ["cohort"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "number"
+                                    }
+                                },
+                                "required": ["value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "anyOf": [
+                                            {
+                                                "enum": ["duration", "active_seconds", "inactive_seconds"],
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ]
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "enum": [
+                                            "exact",
+                                            "is_not",
+                                            "icontains",
+                                            "not_icontains",
+                                            "regex",
+                                            "not_regex",
+                                            "gt",
+                                            "gte",
+                                            "lt",
+                                            "lte",
+                                            "is_set",
+                                            "is_not_set",
+                                            "is_date_exact",
+                                            "is_date_before",
+                                            "is_date_after",
+                                            "between",
+                                            "not_between",
+                                            "min",
+                                            "max",
+                                            "in",
+                                            "not_in",
+                                            "is_cleaned_path_exact",
+                                            "flag_evaluates_to",
+                                            "semver_eq",
+                                            "semver_neq",
+                                            "semver_gt",
+                                            "semver_gte",
+                                            "semver_lt",
+                                            "semver_lte",
+                                            "semver_tilde",
+                                            "semver_caret",
+                                            "semver_wildcard",
+                                            "icontains_multi",
+                                            "not_icontains_multi"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "default": "recording",
+                                        "enum": ["recording"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["key", "operator"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "enum": [
+                                            "exact",
+                                            "is_not",
+                                            "icontains",
+                                            "not_icontains",
+                                            "regex",
+                                            "not_regex",
+                                            "gt",
+                                            "gte",
+                                            "lt",
+                                            "lte",
+                                            "is_set",
+                                            "is_not_set",
+                                            "is_date_exact",
+                                            "is_date_before",
+                                            "is_date_after",
+                                            "between",
+                                            "not_between",
+                                            "min",
+                                            "max",
+                                            "in",
+                                            "not_in",
+                                            "is_cleaned_path_exact",
+                                            "flag_evaluates_to",
+                                            "semver_eq",
+                                            "semver_neq",
+                                            "semver_gt",
+                                            "semver_gte",
+                                            "semver_lt",
+                                            "semver_lte",
+                                            "semver_tilde",
+                                            "semver_caret",
+                                            "semver_wildcard",
+                                            "icontains_multi",
+                                            "not_icontains_multi"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "default": "log_entry",
+                                        "enum": ["log_entry"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["key", "operator"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "group_key_names": {
+                                        "anyOf": [
+                                            {
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                },
+                                                "propertyNames": {
+                                                    "type": "string"
+                                                },
+                                                "type": "object"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "group_type_index": {
+                                        "anyOf": [
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "enum": [
+                                            "exact",
+                                            "is_not",
+                                            "icontains",
+                                            "not_icontains",
+                                            "regex",
+                                            "not_regex",
+                                            "gt",
+                                            "gte",
+                                            "lt",
+                                            "lte",
+                                            "is_set",
+                                            "is_not_set",
+                                            "is_date_exact",
+                                            "is_date_before",
+                                            "is_date_after",
+                                            "between",
+                                            "not_between",
+                                            "min",
+                                            "max",
+                                            "in",
+                                            "not_in",
+                                            "is_cleaned_path_exact",
+                                            "flag_evaluates_to",
+                                            "semver_eq",
+                                            "semver_neq",
+                                            "semver_gt",
+                                            "semver_gte",
+                                            "semver_lt",
+                                            "semver_lte",
+                                            "semver_tilde",
+                                            "semver_caret",
+                                            "semver_wildcard",
+                                            "icontains_multi",
+                                            "not_icontains_multi"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "default": "group",
+                                        "enum": ["group"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["key", "operator"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "enum": [
+                                            "exact",
+                                            "is_not",
+                                            "icontains",
+                                            "not_icontains",
+                                            "regex",
+                                            "not_regex",
+                                            "gt",
+                                            "gte",
+                                            "lt",
+                                            "lte",
+                                            "is_set",
+                                            "is_not_set",
+                                            "is_date_exact",
+                                            "is_date_before",
+                                            "is_date_after",
+                                            "between",
+                                            "not_between",
+                                            "min",
+                                            "max",
+                                            "in",
+                                            "not_in",
+                                            "is_cleaned_path_exact",
+                                            "flag_evaluates_to",
+                                            "semver_eq",
+                                            "semver_neq",
+                                            "semver_gt",
+                                            "semver_gte",
+                                            "semver_lt",
+                                            "semver_lte",
+                                            "semver_tilde",
+                                            "semver_caret",
+                                            "semver_wildcard",
+                                            "icontains_multi",
+                                            "not_icontains_multi"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "default": "feature",
+                                        "description": "Event property with \"$feature/\" prepended",
+                                        "enum": ["feature"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["key", "operator"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "description": "The key should be the flag ID",
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "default": "flag_evaluates_to",
+                                        "description": "Only flag_evaluates_to operator is allowed for flag dependencies",
+                                        "enum": ["flag_evaluates_to"],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "default": "flag",
+                                        "description": "Feature flag dependency",
+                                        "enum": ["flag"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "type": "boolean"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "description": "The value can be true, false, or a variant name"
+                                    }
+                                },
+                                "required": ["key", "value"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "type": {
+                                        "default": "hogql",
+                                        "enum": ["hogql"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["key"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "type": {
+                                        "default": "empty",
+                                        "enum": ["empty"],
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "enum": [
+                                            "exact",
+                                            "is_not",
+                                            "icontains",
+                                            "not_icontains",
+                                            "regex",
+                                            "not_regex",
+                                            "gt",
+                                            "gte",
+                                            "lt",
+                                            "lte",
+                                            "is_set",
+                                            "is_not_set",
+                                            "is_date_exact",
+                                            "is_date_before",
+                                            "is_date_after",
+                                            "between",
+                                            "not_between",
+                                            "min",
+                                            "max",
+                                            "in",
+                                            "not_in",
+                                            "is_cleaned_path_exact",
+                                            "flag_evaluates_to",
+                                            "semver_eq",
+                                            "semver_neq",
+                                            "semver_gt",
+                                            "semver_gte",
+                                            "semver_lt",
+                                            "semver_lte",
+                                            "semver_tilde",
+                                            "semver_caret",
+                                            "semver_wildcard",
+                                            "icontains_multi",
+                                            "not_icontains_multi"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "default": "data_warehouse",
+                                        "enum": ["data_warehouse"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["key", "operator"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "enum": [
+                                            "exact",
+                                            "is_not",
+                                            "icontains",
+                                            "not_icontains",
+                                            "regex",
+                                            "not_regex",
+                                            "gt",
+                                            "gte",
+                                            "lt",
+                                            "lte",
+                                            "is_set",
+                                            "is_not_set",
+                                            "is_date_exact",
+                                            "is_date_before",
+                                            "is_date_after",
+                                            "between",
+                                            "not_between",
+                                            "min",
+                                            "max",
+                                            "in",
+                                            "not_in",
+                                            "is_cleaned_path_exact",
+                                            "flag_evaluates_to",
+                                            "semver_eq",
+                                            "semver_neq",
+                                            "semver_gt",
+                                            "semver_gte",
+                                            "semver_lt",
+                                            "semver_lte",
+                                            "semver_tilde",
+                                            "semver_caret",
+                                            "semver_wildcard",
+                                            "icontains_multi",
+                                            "not_icontains_multi"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "default": "data_warehouse_person_property",
+                                        "enum": ["data_warehouse_person_property"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["key", "operator"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "enum": [
+                                            "exact",
+                                            "is_not",
+                                            "icontains",
+                                            "not_icontains",
+                                            "regex",
+                                            "not_regex",
+                                            "gt",
+                                            "gte",
+                                            "lt",
+                                            "lte",
+                                            "is_set",
+                                            "is_not_set",
+                                            "is_date_exact",
+                                            "is_date_before",
+                                            "is_date_after",
+                                            "between",
+                                            "not_between",
+                                            "min",
+                                            "max",
+                                            "in",
+                                            "not_in",
+                                            "is_cleaned_path_exact",
+                                            "flag_evaluates_to",
+                                            "semver_eq",
+                                            "semver_neq",
+                                            "semver_gt",
+                                            "semver_gte",
+                                            "semver_lt",
+                                            "semver_lte",
+                                            "semver_tilde",
+                                            "semver_caret",
+                                            "semver_wildcard",
+                                            "icontains_multi",
+                                            "not_icontains_multi"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "default": "error_tracking_issue",
+                                        "enum": ["error_tracking_issue"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["key", "operator"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "enum": [
+                                            "exact",
+                                            "is_not",
+                                            "icontains",
+                                            "not_icontains",
+                                            "regex",
+                                            "not_regex",
+                                            "gt",
+                                            "gte",
+                                            "lt",
+                                            "lte",
+                                            "is_set",
+                                            "is_not_set",
+                                            "is_date_exact",
+                                            "is_date_before",
+                                            "is_date_after",
+                                            "between",
+                                            "not_between",
+                                            "min",
+                                            "max",
+                                            "in",
+                                            "not_in",
+                                            "is_cleaned_path_exact",
+                                            "flag_evaluates_to",
+                                            "semver_eq",
+                                            "semver_neq",
+                                            "semver_gt",
+                                            "semver_gte",
+                                            "semver_lt",
+                                            "semver_lte",
+                                            "semver_tilde",
+                                            "semver_caret",
+                                            "semver_wildcard",
+                                            "icontains_multi",
+                                            "not_icontains_multi"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": ["log", "log_attribute", "log_resource_attribute"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["key", "operator", "type"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "enum": [
+                                            "exact",
+                                            "is_not",
+                                            "icontains",
+                                            "not_icontains",
+                                            "regex",
+                                            "not_regex",
+                                            "gt",
+                                            "gte",
+                                            "lt",
+                                            "lte",
+                                            "is_set",
+                                            "is_not_set",
+                                            "is_date_exact",
+                                            "is_date_before",
+                                            "is_date_after",
+                                            "between",
+                                            "not_between",
+                                            "min",
+                                            "max",
+                                            "in",
+                                            "not_in",
+                                            "is_cleaned_path_exact",
+                                            "flag_evaluates_to",
+                                            "semver_eq",
+                                            "semver_neq",
+                                            "semver_gt",
+                                            "semver_gte",
+                                            "semver_lt",
+                                            "semver_lte",
+                                            "semver_tilde",
+                                            "semver_caret",
+                                            "semver_wildcard",
+                                            "icontains_multi",
+                                            "not_icontains_multi"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "enum": ["span", "span_attribute", "span_resource_attribute"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["key", "operator", "type"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "enum": [
+                                            "exact",
+                                            "is_not",
+                                            "icontains",
+                                            "not_icontains",
+                                            "regex",
+                                            "not_regex",
+                                            "gt",
+                                            "gte",
+                                            "lt",
+                                            "lte",
+                                            "is_set",
+                                            "is_not_set",
+                                            "is_date_exact",
+                                            "is_date_before",
+                                            "is_date_after",
+                                            "between",
+                                            "not_between",
+                                            "min",
+                                            "max",
+                                            "in",
+                                            "not_in",
+                                            "is_cleaned_path_exact",
+                                            "flag_evaluates_to",
+                                            "semver_eq",
+                                            "semver_neq",
+                                            "semver_gt",
+                                            "semver_gte",
+                                            "semver_lt",
+                                            "semver_lte",
+                                            "semver_tilde",
+                                            "semver_caret",
+                                            "semver_wildcard",
+                                            "icontains_multi",
+                                            "not_icontains_multi"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "default": "revenue_analytics",
+                                        "enum": ["revenue_analytics"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["key", "operator"],
+                                "type": "object"
+                            },
+                            {
+                                "properties": {
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "label": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    },
+                                    "operator": {
+                                        "enum": [
+                                            "exact",
+                                            "is_not",
+                                            "icontains",
+                                            "not_icontains",
+                                            "regex",
+                                            "not_regex",
+                                            "gt",
+                                            "gte",
+                                            "lt",
+                                            "lte",
+                                            "is_set",
+                                            "is_not_set",
+                                            "is_date_exact",
+                                            "is_date_before",
+                                            "is_date_after",
+                                            "between",
+                                            "not_between",
+                                            "min",
+                                            "max",
+                                            "in",
+                                            "not_in",
+                                            "is_cleaned_path_exact",
+                                            "flag_evaluates_to",
+                                            "semver_eq",
+                                            "semver_neq",
+                                            "semver_gt",
+                                            "semver_gte",
+                                            "semver_lt",
+                                            "semver_lte",
+                                            "semver_tilde",
+                                            "semver_caret",
+                                            "semver_wildcard",
+                                            "icontains_multi",
+                                            "not_icontains_multi"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "default": "workflow_variable",
+                                        "enum": ["workflow_variable"],
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "anyOf": [
+                                            {
+                                                "anyOf": [
+                                                    {
+                                                        "items": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string"
+                                                                },
+                                                                {
+                                                                    "type": "number"
+                                                                },
+                                                                {
+                                                                    "type": "boolean"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "number"
+                                                    },
+                                                    {
+                                                        "type": "boolean"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": ["key", "operator"],
+                                "type": "object"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["type", "values"],
+            "type": "object"
+        }
+    },
+    "required": ["filters"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

MCP clients had no way to create error tracking grouping rules.

## Changes

- Enable `error-tracking-grouping-rules-create` in `tools.yaml` with write scope
- Add generated MCP tool handler with `filters`, optional `assignee`, and optional `description` parameters
- Add integration test with cleanup and unit snapshot for the tool schema

## How did you test this code?

MCP integration test (creates rule, validates response, cleans up) and unit snapshot.

## Publish to changelog?

No