### PR TITLE
chore(error-tracking): update suppression rule create schema

### DIFF
--- a/products/error_tracking/backend/api/suppression_rules.py
+++ b/products/error_tracking/backend/api/suppression_rules.py
@@ -40,7 +40,8 @@ class ErrorTrackingSuppressionRuleFiltersField(serializers.JSONField):
             try:
                 PropertyGroupFilterValue(**value)
             except (PydanticValidationError, TypeError) as err:
-                raise serializers.ValidationError(str(err)) from err
+                logger.warning("Invalid suppression rule filters payload", exc_info=err)
+                raise serializers.ValidationError("Invalid filters payload.") from err
         elif "values" not in value:
             raise serializers.ValidationError("Invalid filters")
 

--- a/products/error_tracking/backend/api/suppression_rules.py
+++ b/products/error_tracking/backend/api/suppression_rules.py
@@ -2,12 +2,14 @@ from typing import override
 
 import structlog
 import posthoganalytics
+from drf_spectacular.utils import OpenApiResponse, extend_schema_field
 from pydantic import ValidationError as PydanticValidationError
 from rest_framework import serializers, status, viewsets
 from rest_framework.response import Response
 
 from posthog.schema import PropertyGroupFilterValue
 
+from posthog.api.mixins import ValidatedRequest, validated_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.event_usage import groups
 from posthog.models.team.team import Team
@@ -24,6 +26,42 @@ class ErrorTrackingSuppressionRuleSerializer(serializers.ModelSerializer):
         model = ErrorTrackingSuppressionRule
         fields = ["id", "filters", "order_key", "disabled_data", "sampling_rate", "created_at", "updated_at"]
         read_only_fields = ["team_id", "created_at", "updated_at"]
+
+
+@extend_schema_field(PropertyGroupFilterValue)  # type: ignore[arg-type]
+class ErrorTrackingSuppressionRuleFiltersField(serializers.JSONField):
+    def to_internal_value(self, data):
+        value = super().to_internal_value(data)
+
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Expected an object.")
+
+        if _has_filter_values(value):
+            try:
+                PropertyGroupFilterValue(**value)
+            except (PydanticValidationError, TypeError) as err:
+                raise serializers.ValidationError(str(err)) from err
+        elif "values" not in value:
+            raise serializers.ValidationError("Invalid filters")
+
+        return value
+
+
+class ErrorTrackingSuppressionRuleCreateRequestSerializer(serializers.Serializer):
+    filters = ErrorTrackingSuppressionRuleFiltersField(
+        required=False,
+        help_text=(
+            "Optional property-group filters that define which incoming error events should be suppressed. "
+            "Omit this field or provide an empty `values` array to create a match-all suppression rule."
+        ),
+    )
+    sampling_rate = serializers.FloatField(
+        required=False,
+        default=1.0,
+        min_value=0.0,
+        max_value=1.0,
+        help_text="Fraction of matching events to suppress. Use `1.0` to suppress all matching events.",
+    )
 
 
 class ErrorTrackingSuppressionRuleViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet, RuleReorderingMixin):
@@ -84,31 +122,22 @@ class ErrorTrackingSuppressionRuleViewSet(TeamAndOrgViewSetMixin, viewsets.Model
 
         return response
 
-    @override
-    def create(self, request, *args, **kwargs) -> Response:
-        json_filters = request.data.get("filters")
+    @validated_request(
+        request_serializer=ErrorTrackingSuppressionRuleCreateRequestSerializer,
+        responses={201: OpenApiResponse(response=ErrorTrackingSuppressionRuleSerializer)},
+    )
+    def create(self, request: ValidatedRequest, *args, **kwargs) -> Response:
+        json_filters = request.validated_data.get("filters")
 
-        if json_filters is not None:
-            if _has_filter_values(json_filters):
-                try:
-                    parsed_filters = PropertyGroupFilterValue(**json_filters)
-                except (PydanticValidationError, TypeError):
-                    return Response({"error": "Invalid filters"}, status=status.HTTP_400_BAD_REQUEST)
-                bytecode = generate_byte_code(self.team, parsed_filters)
-            elif "values" not in json_filters:
-                return Response({"error": "Invalid filters"}, status=status.HTTP_400_BAD_REQUEST)
-            else:
-                bytecode = generate_match_all_bytecode()
-        else:
+        if json_filters is None:
             json_filters = {"type": "AND", "values": []}
+
+        if _has_filter_values(json_filters):
+            bytecode = generate_byte_code(self.team, PropertyGroupFilterValue(**json_filters))
+        else:
             bytecode = generate_match_all_bytecode()
 
-        sampling_rate = request.data.get("sampling_rate", 1.0)
-        if not isinstance(sampling_rate, (int, float)) or not (0.0 <= sampling_rate <= 1.0):
-            return Response(
-                {"error": "sampling_rate must be a number between 0 and 1"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        sampling_rate = request.validated_data["sampling_rate"]
 
         suppression_rule = ErrorTrackingSuppressionRule.objects.create(
             team=self.team,

--- a/products/error_tracking/backend/api/test/test_suppression_rules.py
+++ b/products/error_tracking/backend/api/test/test_suppression_rules.py
@@ -432,6 +432,19 @@ class TestSuppressionRuleAPI(APIBaseTest):
         assert response.json()["attr"] == "filters"
         assert response.json()["detail"] == "Invalid filters"
 
+    def test_create_rejects_invalid_filters_shape_without_leaking_exception(self) -> None:
+        response = self.client.post(
+            self._url(),
+            data={"filters": {"type": "NOT_A_VALID_OPERATOR", "values": [{"key": "x"}]}},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert body["type"] == "validation_error"
+        assert body["attr"] == "filters"
+        assert body["detail"] == "Invalid filters payload."
+
     def test_update_changes_bytecode(self) -> None:
         create_response = self.client.post(
             self._url(),

--- a/products/error_tracking/backend/api/test/test_suppression_rules.py
+++ b/products/error_tracking/backend/api/test/test_suppression_rules.py
@@ -429,7 +429,8 @@ class TestSuppressionRuleAPI(APIBaseTest):
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json()["error"] == "Invalid filters"
+        assert response.json()["attr"] == "filters"
+        assert response.json()["detail"] == "Invalid filters"
 
     def test_update_changes_bytecode(self) -> None:
         create_response = self.client.post(
@@ -557,7 +558,8 @@ class TestSuppressionRuleAPI(APIBaseTest):
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "sampling_rate" in response.json()["error"]
+        assert response.json()["attr"] == "sampling_rate"
+        assert "less than or equal to 1.0" in response.json()["detail"]
 
     def test_update_sampling_rate(self) -> None:
         create_response = self.client.post(

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -915,6 +915,17 @@ export interface PaginatedErrorTrackingSuppressionRuleListApi {
     results: ErrorTrackingSuppressionRuleApi[]
 }
 
+export interface ErrorTrackingSuppressionRuleCreateRequestApi {
+    /** Optional property-group filters that define which incoming error events should be suppressed. Omit this field or provide an empty `values` array to create a match-all suppression rule. */
+    filters?: PropertyGroupFilterValueApi
+    /**
+     * Fraction of matching events to suppress. Use `1.0` to suppress all matching events.
+     * @minimum 0
+     * @maximum 1
+     */
+    sampling_rate?: number
+}
+
 export interface PatchedErrorTrackingSuppressionRuleApi {
     readonly id?: string
     filters?: unknown

--- a/products/error_tracking/frontend/generated/api.ts
+++ b/products/error_tracking/frontend/generated/api.ts
@@ -35,6 +35,7 @@ import type {
     ErrorTrackingStackFrameApi,
     ErrorTrackingStackFramesListParams,
     ErrorTrackingSuppressionRuleApi,
+    ErrorTrackingSuppressionRuleCreateRequestApi,
     ErrorTrackingSuppressionRulesListParams,
     ErrorTrackingSymbolSetApi,
     ErrorTrackingSymbolSetsList2Params,
@@ -1126,14 +1127,14 @@ export const getErrorTrackingSuppressionRulesCreateUrl = (projectId: string) => 
 
 export const errorTrackingSuppressionRulesCreate = async (
     projectId: string,
-    errorTrackingSuppressionRuleApi: NonReadonly<ErrorTrackingSuppressionRuleApi>,
+    errorTrackingSuppressionRuleCreateRequestApi: ErrorTrackingSuppressionRuleCreateRequestApi,
     options?: RequestInit
 ): Promise<ErrorTrackingSuppressionRuleApi> => {
     return apiMutator<ErrorTrackingSuppressionRuleApi>(getErrorTrackingSuppressionRulesCreateUrl(projectId), {
         ...options,
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(errorTrackingSuppressionRuleApi),
+        body: JSON.stringify(errorTrackingSuppressionRuleCreateRequestApi),
     })
 }
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14809,6 +14809,17 @@ export namespace Schemas {
       readonly updated_at: string;
     }
 
+    export interface ErrorTrackingSuppressionRuleCreateRequest {
+      /** Optional property-group filters that define which incoming error events should be suppressed. Omit this field or provide an empty `values` array to create a match-all suppression rule. */
+      filters?: PropertyGroupFilterValue;
+      /**
+       * Fraction of matching events to suppress. Use `1.0` to suppress all matching events.
+       * @minimum 0
+       * @maximum 1
+       */
+      sampling_rate?: number;
+    }
+
     /**
      * Release associated with this symbol set
      * @nullable


### PR DESCRIPTION
## Problem

The error tracking suppression rule create endpoint used manual validation and lacked proper OpenAPI serializers, preventing accurate type generation.

## Changes

- Add `ErrorTrackingSuppressionRuleCreateRequestSerializer` with typed `filters` (optional, defaults to match-all) and `sampling_rate` (0.0–1.0, defaults to 1.0)
- Add custom `ErrorTrackingSuppressionRuleFiltersField` with Pydantic validation
- Replace manual validation with `@validated_request` decorator, simplifying the create method
- Regenerate frontend and MCP types
- Update existing tests to match new DRF validation error format

## How did you test this code?

Existing backend tests in `test_suppression_rules.py` updated for new error response format.

## Publish to changelog?

No