### PR TITLE
fix(data-imports): avoid full scans on partitioned postgres re-syncs

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -945,13 +945,7 @@ def _get_partition_settings_for_partitioned_table(
         return None
 
     avg_row_size = total_size / total_rows
-    if avg_row_size <= 0:
-        return None
-
     partition_size = round(DEFAULT_PARTITION_TARGET_SIZE_IN_BYTES / avg_row_size)
-    if partition_size <= 0:
-        return None
-
     partition_count = max(1, math.floor(total_rows / partition_size))
     logger.debug(
         f"_get_partition_settings_for_partitioned_table: partition_count={partition_count}, "

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -847,6 +847,15 @@ def _get_rows_to_sync(cursor: psycopg.Cursor, count_query: sql.Composed, logger:
 def _get_partition_settings(
     cursor: psycopg.Cursor, schema: str, table_name: str, logger: FilteringBoundLogger
 ) -> PartitionSettings | None:
+    # For partitioned tables, a plain COUNT(*) and pg_table_size on the
+    # parent would scan every child partition / return 0. Use catalog
+    # estimates instead.
+    try:
+        if _is_partitioned_table(cursor, schema, table_name):
+            return _get_partition_settings_for_partitioned_table(cursor, schema, table_name, logger)
+    except Exception as e:
+        logger.debug(f"_get_partition_settings: partition detection failed, falling back: {e}")
+
     query = sql.SQL("""
         SELECT
             CASE WHEN count(*) = 0 OR pg_table_size({schema_table_name_literal}) = 0 THEN NULL
@@ -885,6 +894,69 @@ def _get_partition_settings(
         return PartitionSettings(partition_count=1, partition_size=partition_size)
 
     logger.debug(f"_get_partition_settings: partition_count={partition_count}, partition_size={partition_size}")
+    return PartitionSettings(partition_count=partition_count, partition_size=partition_size)
+
+
+def _get_partition_settings_for_partitioned_table(
+    cursor: psycopg.Cursor, schema: str, table_name: str, logger: FilteringBoundLogger
+) -> PartitionSettings | None:
+    """Compute PartitionSettings for a partitioned table via catalog stats.
+
+    Summing pg_table_size and reltuples across child partitions avoids the
+    full-table scan that COUNT(*) + pg_table_size on the parent would incur.
+    Returns None if catalog stats are unreliable (any partition unanalyzed),
+    letting the caller skip partitioning rather than use bad numbers.
+    """
+    cursor.execute(
+        """
+        SELECT
+            COALESCE(SUM(pg_table_size(c.oid)), 0)::bigint,
+            COALESCE(SUM(CASE WHEN c.reltuples >= 0 THEN c.reltuples ELSE 0 END), 0)::bigint,
+            COALESCE(SUM(CASE WHEN c.reltuples < 0 THEN 1 ELSE 0 END), 0)::bigint,
+            COUNT(*)::bigint
+        FROM pg_inherits i
+        JOIN pg_class c ON c.oid = i.inhrelid
+        WHERE i.inhparent = (
+            SELECT c2.oid
+            FROM pg_class c2
+            JOIN pg_namespace n ON n.oid = c2.relnamespace
+            WHERE n.nspname = %(schema)s AND c2.relname = %(table)s
+        )
+        """,
+        {"schema": schema, "table": table_name},
+    )
+    row = cursor.fetchone()
+    if row is None:
+        return None
+
+    total_size, total_rows, unanalyzed_count, partition_count_children = (
+        int(row[0]),
+        int(row[1]),
+        int(row[2]),
+        int(row[3]),
+    )
+
+    if partition_count_children == 0 or total_size == 0 or total_rows == 0 or unanalyzed_count > 0:
+        logger.debug(
+            f"_get_partition_settings_for_partitioned_table: no reliable estimate "
+            f"(children={partition_count_children}, size={total_size}, rows={total_rows}, "
+            f"unanalyzed={unanalyzed_count}), returning None"
+        )
+        return None
+
+    avg_row_size = total_size / total_rows
+    if avg_row_size <= 0:
+        return None
+
+    partition_size = round(DEFAULT_PARTITION_TARGET_SIZE_IN_BYTES / avg_row_size)
+    if partition_size <= 0:
+        return None
+
+    partition_count = max(1, math.floor(total_rows / partition_size))
+    logger.debug(
+        f"_get_partition_settings_for_partitioned_table: partition_count={partition_count}, "
+        f"partition_size={partition_size} (total_rows={total_rows}, total_size={total_size})"
+    )
     return PartitionSettings(partition_count=partition_count, partition_size=partition_size)
 
 
@@ -1159,13 +1231,22 @@ def postgres_source(
                     else:
                         chunk_size = _get_table_chunk_size(cursor, inner_query_with_limit, logger)
                     logger.debug("Getting rows to sync...")
-                    # For partitioned tables on initial sync, use pg_class.reltuples
+                    # For partitioned tables without an incremental cursor (initial
+                    # sync, re-sync, or non-incremental), use pg_class.reltuples
                     # estimate to avoid scanning all partitions with a COUNT(*).
+                    # `is_initial_sync` only reflects the first-ever sync; a forced
+                    # re-sync keeps initial_sync_complete=True but still scans the
+                    # whole table, so we gate on the filter actually being a full
+                    # scan (no incremental cursor value).
                     rows_to_sync: int | None = None
-                    if is_initial_sync:
+                    full_table_scan = db_incremental_field_last_value is None
+                    if is_initial_sync or full_table_scan:
                         try:
                             if _is_partitioned_table(cursor, schema, table_name):
-                                logger.debug("Partitioned table detected, using estimated row count")
+                                logger.debug(
+                                    f"Partitioned table detected (is_initial_sync={is_initial_sync}, "
+                                    f"full_table_scan={full_table_scan}), using estimated row count"
+                                )
                                 rows_to_sync = _get_estimated_row_count_for_partitioned_table(
                                     cursor, schema, table_name, logger
                                 )

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -19,6 +19,8 @@ from posthog.temporal.data_imports.sources.postgres.postgres import (
     _build_count_query,
     _build_query,
     _get_estimated_row_count_for_partitioned_table,
+    _get_partition_settings,
+    _get_partition_settings_for_partitioned_table,
     _get_primary_keys,
     _get_sslmode,
     _get_table,
@@ -476,6 +478,100 @@ class TestGetEstimatedRowCountForPartitionedTable:
                 cast(Any, dj_cursor), "public", "test_est_count_empty", logger
             )
             assert result is None
+
+
+class TestGetPartitionSettings:
+    @pytest.mark.django_db
+    def test_partitioned_table_uses_catalog_fast_path(self):
+        """On a partitioned parent, settings come from pg_inherits/reltuples,
+        not a COUNT(*) + pg_table_size on the parent.
+        """
+        logger = structlog.get_logger()
+
+        with django_connection.cursor() as dj_cursor:
+            dj_cursor.execute("""
+                CREATE TABLE test_ps_partitioned (
+                    id BIGSERIAL,
+                    created_at DATE NOT NULL,
+                    payload TEXT,
+                    PRIMARY KEY (id, created_at)
+                ) PARTITION BY RANGE (created_at)
+            """)
+            dj_cursor.execute("""
+                CREATE TABLE test_ps_partitioned_q1
+                PARTITION OF test_ps_partitioned
+                FOR VALUES FROM ('2026-01-01') TO ('2026-04-01')
+            """)
+            dj_cursor.execute("""
+                CREATE TABLE test_ps_partitioned_q2
+                PARTITION OF test_ps_partitioned
+                FOR VALUES FROM ('2026-04-01') TO ('2026-07-01')
+            """)
+            dj_cursor.execute("""
+                INSERT INTO test_ps_partitioned (created_at, payload)
+                SELECT '2026-01-15'::date + (g % 2) * interval '3 months',
+                       repeat('x', 256)
+                FROM generate_series(1, 500) g
+            """)
+            dj_cursor.execute("ANALYZE test_ps_partitioned")
+
+            result = _get_partition_settings(cast(Any, dj_cursor), "public", "test_ps_partitioned", logger)
+            assert result is not None
+            assert result.partition_count >= 1
+            assert result.partition_size > 0
+
+    @pytest.mark.django_db
+    def test_partitioned_table_returns_none_when_any_partition_unanalyzed(self):
+        """Mixed analyzed + unanalyzed partitions must not produce a setting —
+        the catalog numbers are stale, so fall through to exact scan.
+        """
+        logger = structlog.get_logger()
+
+        with django_connection.cursor() as dj_cursor:
+            dj_cursor.execute("""
+                CREATE TABLE test_ps_partial (
+                    id BIGSERIAL,
+                    created_at DATE NOT NULL,
+                    PRIMARY KEY (id, created_at)
+                ) PARTITION BY RANGE (created_at)
+            """)
+            dj_cursor.execute("""
+                CREATE TABLE test_ps_partial_q1
+                PARTITION OF test_ps_partial
+                FOR VALUES FROM ('2026-01-01') TO ('2026-04-01')
+            """)
+            dj_cursor.execute("""
+                CREATE TABLE test_ps_partial_q2
+                PARTITION OF test_ps_partial
+                FOR VALUES FROM ('2026-04-01') TO ('2026-07-01')
+            """)
+            dj_cursor.execute("""
+                INSERT INTO test_ps_partial (created_at)
+                SELECT '2026-01-15'::date + (g % 2) * interval '3 months'
+                FROM generate_series(1, 200) g
+            """)
+            dj_cursor.execute("ANALYZE test_ps_partial_q1")
+
+            result = _get_partition_settings_for_partitioned_table(
+                cast(Any, dj_cursor), "public", "test_ps_partial", logger
+            )
+            assert result is None
+
+    @pytest.mark.django_db
+    def test_non_partitioned_table_still_uses_legacy_query(self):
+        """Regular tables must skip the catalog fast path and go through the
+        original COUNT(*) + pg_table_size query.
+        """
+        logger = structlog.get_logger()
+
+        with django_connection.cursor() as dj_cursor:
+            dj_cursor.execute("CREATE TABLE test_ps_regular (id SERIAL PRIMARY KEY, data TEXT)")
+            dj_cursor.execute("INSERT INTO test_ps_regular (data) SELECT repeat('x', 128) FROM generate_series(1, 200)")
+            dj_cursor.execute("ANALYZE test_ps_regular")
+
+            result = _get_partition_settings(cast(Any, dj_cursor), "public", "test_ps_regular", logger)
+            assert result is not None
+            assert result.partition_size > 0
 
 
 class TestPostgreSQLColumnToArrowField:


### PR DESCRIPTION
## Problem

Follow-up to #54460. The row-count fast path for partitioned postgres tables was not firing in two important cases, sending us right back to a full-table scan:

1. **Forced re-syncs / retries after a failed initial sync.** The fast path was gated on `is_initial_sync` (which is `not schema.initial_sync_complete`). Once an initial sync eventually succeeds — or when the caller is a non-incremental schema without a cursor — the gate closes even though the query being counted still has no narrowing filter (`WHERE created_at > '1970-01-01'`), so `COUNT(*)` scans every child partition.
2. **`_get_partition_settings` runs `COUNT(*)` + `pg_table_size(parent)` directly on the partitioned parent.** On a declarative partitioned table that expands to a parallel append across every child partition, and `pg_table_size` on the parent is effectively 0. Observed on a ~90-partition / ~65M-row table where this query dominated the sync start-up time.

## Changes

- Gate the row-count fast path on `is_initial_sync or db_incremental_field_last_value is None` — i.e. whenever the effective filter is a full scan, not just the very first sync attempt.
- Add `_get_partition_settings_for_partitioned_table`, a catalog-based fast path that sums `pg_table_size(child)` and `reltuples` via `pg_inherits`. Reuses the same "all partitions must be analyzed" safety check as the row-count estimator; returns `None` on stale stats so the caller falls through to the legacy query.
- Route `_get_partition_settings` through the new helper when `_is_partitioned_table` returns true.

## How did you test this code?

- Existing unit tests pass (`hogli test posthog/temporal/data_imports/sources/postgres/test_postgres.py`, 131 passed).
- I am an agent-assisted change; I did not manually run a sync against production postgres. The symptom this addresses (full `COUNT(*)` + parallel-append `pg_table_size` plan at sync start) was captured from live Temporal logs on a partitioned source that #54460 alone did not fix because the gate and the partition-settings query both still triggered full scans.

## Publish to changelog?

no

## 🤖 LLM context

Co-authored with Claude Opus 4.6. The diagnosis came from reading live sync logs on a partitioned source where #54460 had deployed but the fast path never ran (`is_initial_sync = False` on a retry), followed by noticing `_get_partition_settings` independently issued a full-table `COUNT(*) + pg_table_size(parent)` query.