### PR TITLE
chore: second attempt prevent high-cardinality metric labels in metrics

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1721,6 +1721,7 @@ dependencies = [
  "chrono",
  "common-alloc",
  "common-continuous-profiling",
+ "common-metrics",
  "common-redis",
  "common-types",
  "envconfig",
@@ -8781,6 +8782,7 @@ name = "serve-metrics"
 version = "0.1.0"
 dependencies = [
  "axum 0.7.9",
+ "common-metrics",
  "metrics",
  "metrics-exporter-prometheus",
  "tokio",

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -22,6 +22,7 @@ lifecycle = { path = "../common/lifecycle" }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
 common-alloc = { path = "../common/alloc" }
+common-metrics = { path = "../common/metrics" }
 common-continuous-profiling = { path = "../common/continuous_profiling" }
 common-redis = { path = "../common/redis" }
 common-types = { path = "../common/types" }

--- a/rust/capture/src/metrics_middleware.rs
+++ b/rust/capture/src/metrics_middleware.rs
@@ -9,6 +9,7 @@ use axum::{
     response::IntoResponse,
     routing::Router,
 };
+use common_metrics::normalize_unmatched_path;
 use metrics::gauge;
 
 // Global atomic counter for active connections
@@ -40,7 +41,7 @@ pub async fn track_metrics(req: Request<Body>, next: Next) -> impl IntoResponse 
     let path = if let Some(matched_path) = req.extensions().get::<MatchedPath>() {
         matched_path.as_str().to_owned()
     } else {
-        req.uri().path().to_owned()
+        normalize_unmatched_path(req.uri().path())
     };
 
     let method = req.method().clone();

--- a/rust/capture/src/metrics_middleware.rs
+++ b/rust/capture/src/metrics_middleware.rs
@@ -87,7 +87,11 @@ where
             move |req: axum::extract::Request, next: axum::middleware::Next| async move {
                 let start = std::time::Instant::now();
                 let method = req.method().to_string();
-                let path = req.uri().path().to_string();
+                let path = if let Some(matched) = req.extensions().get::<MatchedPath>() {
+                    matched.as_str().to_owned()
+                } else {
+                    normalize_unmatched_path(req.uri().path())
+                };
                 let client_ip = req
                     .headers()
                     .get("X-Forwarded-For")

--- a/rust/common/metrics/src/lib.rs
+++ b/rust/common/metrics/src/lib.rs
@@ -56,6 +56,17 @@ pub fn setup_metrics_recorder() -> PrometheusHandle {
         .unwrap()
 }
 
+/// Normalize an unmatched path to its first segment to avoid high-cardinality
+/// metric labels from arbitrary 404 paths (tokens, locales, scanner probes, etc.).
+///
+/// Examples: `/array/phc_xxx/config.js` → `/array/`, `/metrics` → `/metrics`
+pub fn normalize_unmatched_path(raw: &str) -> String {
+    match raw.find('/').and_then(|_| raw[1..].find('/')) {
+        Some(i) => raw[..i + 2].to_owned(),
+        None => raw.to_owned(),
+    }
+}
+
 /// Middleware to record some common HTTP metrics
 /// Someday tower-http might provide a metrics middleware: https://github.com/tower-rs/tower-http/issues/57
 pub async fn track_metrics(req: Request<Body>, next: Next) -> impl IntoResponse {
@@ -64,7 +75,7 @@ pub async fn track_metrics(req: Request<Body>, next: Next) -> impl IntoResponse 
     let path = if let Some(matched_path) = req.extensions().get::<MatchedPath>() {
         matched_path.as_str().to_owned()
     } else {
-        req.uri().path().to_owned()
+        normalize_unmatched_path(req.uri().path())
     };
 
     let method = req.method().clone();
@@ -198,5 +209,29 @@ impl<'a> TimingGuardLabels<'a> {
                 labels.push((key.to_string(), value.to_string()));
             }
         };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_unmatched_path;
+
+    #[test]
+    fn test_normalize_unmatched_path() {
+        let cases = [
+            // (input, expected)
+            ("/array/phc_xxx/config.js", "/array/"),
+            ("/array/phc_xxx/en_GB/config.js", "/array/"),
+            ("/array/N/A/config", "/array/"),
+            ("/array/https:/us.i.posthog.com/config", "/array/"),
+            ("/api/surveys/blah", "/api/"),
+            ("/array/env", "/array/"),
+            ("/array/package.json", "/array/"),
+            ("/metrics", "/metrics"),
+            ("/", "/"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(normalize_unmatched_path(input), expected, "input: {input}");
+        }
     }
 }

--- a/rust/common/metrics/src/lib.rs
+++ b/rust/common/metrics/src/lib.rs
@@ -229,6 +229,13 @@ mod tests {
             ("/array/package.json", "/array/"),
             ("/metrics", "/metrics"),
             ("/", "/"),
+            // Edge cases from scanner/malformed input
+            ("/foo/", "/foo/"),
+            ("//", "//"),
+            ("/array/", "/array/"),
+            ("/a/b", "/a/"),
+            ("/array/phc_xxx/", "/array/"),
+            ("", ""),
         ];
         for (input, expected) in cases {
             assert_eq!(normalize_unmatched_path(input), expected, "input: {input}");

--- a/rust/common/serve_metrics/Cargo.toml
+++ b/rust/common/serve_metrics/Cargo.toml
@@ -11,3 +11,4 @@ axum = { workspace = true }
 tokio = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 metrics = { workspace = true }
+common-metrics = { path = "../metrics" }

--- a/rust/common/serve_metrics/src/lib.rs
+++ b/rust/common/serve_metrics/src/lib.rs
@@ -48,7 +48,7 @@ pub async fn track_metrics(req: Request<Body>, next: Next) -> impl IntoResponse 
     let path = if let Some(matched_path) = req.extensions().get::<MatchedPath>() {
         matched_path.as_str().to_owned()
     } else {
-        req.uri().path().to_owned()
+        common_metrics::normalize_unmatched_path(req.uri().path())
     };
 
     let method = req.method().clone();

--- a/rust/hypercache-server/src/router.rs
+++ b/rust/hypercache-server/src/router.rs
@@ -61,11 +61,11 @@ pub fn router(
             "/array/:token/config.js",
             any(remote_config::config_js_endpoint),
         )
-        // Explicit 404 for sourcemap requests to avoid high-cardinality unmatched paths in metrics
-        .route(
-            "/array/:token/config.js.map",
-            any(|| ready(StatusCode::NOT_FOUND)),
-        )
+        // Catch-all 404s for known prefixes to avoid high-cardinality unmatched paths in metrics.
+        // Without these, unmatched requests fall through with the raw URI as the metric label,
+        // creating a unique time series for every distinct 404 path (tokens, locales, probes, etc.).
+        // With explicit routes, axum sets MatchedPath so metrics get clean parameterized labels.
+        .route("/array/:token/*rest", any(|| ready(StatusCode::NOT_FOUND)))
         .layer(ConcurrencyLimitLayer::new(config.max_concurrency));
 
     let router = Router::new()


### PR DESCRIPTION
second attempt for #54271 (it was reverted in #54308)