### PR TITLE
chore: add AI contributions policy

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,38 @@
+# AI contributions policy
+
+PostHog is built with plenty of AI assistance.
+This policy exists because of a growing volume of low-quality, AI-generated contributions that waste maintainer time.
+
+## The standard
+
+**You own what you submit.**
+Understand your code, test it, and be ready to explain why it's correct and how it interacts with the rest of the system (without re-prompting an LLM).
+This is no different from what we'd expect of any contribution.
+AI just makes it easier to skip the work.
+Don't skip the work.
+
+**Disclose AI usage.**
+Our [PR template](.github/pull_request_template.md) includes an LLM context section — please use it (most agents will pick it up automatically).
+If an LLM co-authored or authored your PR, say so and leave context about the tools and session.
+This helps reviewers calibrate.
+
+**Prefer PRs over AI-generated issues.**
+If AI helped you find a bug, fix it and open a pull request — don't paste the AI's output into an issue.
+Unreviewed, AI-generated bug reports and security disclosures will be closed without response.
+
+**Don't submit unsolicited AI-generated PR reviews.**
+If you didn't write the code and aren't a maintainer, don't point an LLM at someone else's PR and leave its output as a review comment.
+This is generally never helpful.
+
+## What happens when contributions don't meet this bar
+
+- **First time:** We'll close the PR/issue with a link to this policy and a brief explanation.
+- **Two or more closures:** We'll block the account.
+
+## Why we're not anti-AI
+
+We think the best contributions in 2026 often involve AI.
+A contributor who uses an LLM to help them understand unfamiliar code, draft a first pass, or catch edge cases they'd miss is probably _more_ productive than someone doing everything by hand.
+The key difference is that they're driving the AI, not the other way around.
+
+If you're new to open-source contributing and want to learn, we're genuinely happy to help — open an issue, ask questions, submit small PRs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ Before we do a full review, please:
 - Respond to automated review feedback (e.g. Greptile comments) where applicable.
 - Keep the change focused; add tests and docs where it meaningfully improves clarity.
 - Follow existing patterns and conventions in the areas you touch.
+- If AI helped write your contribution, read our [AI contributions policy](AI_POLICY.md) — we expect disclosure and full understanding of the code you submit.
 
 Escalation/deferral can happen for security-sensitive or critical paths, unclear product impact, or when support load is high—another engineer may pick it up later. We sometimes reward helpful contributions with merch even if a PR doesn’t merge.
 


### PR DESCRIPTION
## Problem

We're getting a growing volume of low-quality, AI-generated PRs and issues on the repo. Triaging, reviewing, and closing these takes real engineering time. A written AI policy gives us a linkable URL to point to when closing bad contributions and sets clear expectations for AI-assisted work.

## Changes

- Adds `AI_POLICY.md` at the repo root with our policy on AI-assisted contributions
- References the policy from the "before we review" checklist in `CONTRIBUTING.md`

## How did you test this code?

- Verified markdown renders correctly and links resolve
- Confirmed markdownlint passes (only pre-existing line-length warnings)

## Publish to changelog?

No

## Docs update

No docs update needed.

## 🤖 LLM context

PR authored by PostHog Code (Claude) based on Dylan's RFC for an AI contributions policy.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*