### PR TITLE
feat(mcp): include email and country in persons-list response

### DIFF
--- a/products/persons/mcp/tools.yaml
+++ b/products/persons/mcp/tools.yaml
@@ -33,6 +33,9 @@ tools:
                 - uuid
                 - name
                 - distinct_ids
+                - properties.email
+                - properties.$email
+                - properties.$geoip_country_code
                 - created_at
                 - last_seen_at
     persons-retrieve:

--- a/services/mcp/src/tools/generated/persons.ts
+++ b/services/mcp/src/tools/generated/persons.ts
@@ -37,7 +37,17 @@ const personsList = (): ToolBase<typeof PersonsListSchema, WithPostHogUrl<Schema
         const filtered = {
             ...result,
             results: (result.results ?? []).map((item: any) =>
-                pickResponseFields(item, ['id', 'uuid', 'name', 'distinct_ids', 'created_at', 'last_seen_at'])
+                pickResponseFields(item, [
+                    'id',
+                    'uuid',
+                    'name',
+                    'distinct_ids',
+                    'properties.email',
+                    'properties.$email',
+                    'properties.$geoip_country_code',
+                    'created_at',
+                    'last_seen_at',
+                ])
             ),
         } as typeof result
         return await withPostHogUrl(context, filtered, '/persons')

--- a/services/mcp/tests/tools/persons.integration.test.ts
+++ b/services/mcp/tests/tools/persons.integration.test.ts
@@ -32,6 +32,13 @@ describe('Persons', { concurrent: false }, () => {
             expect(response.results).toBeTruthy()
             expect(Array.isArray(response.results)).toBe(true)
             expect(response._posthogUrl).toContain('/persons')
+
+            if (response.results.length > 0) {
+                const person = response.results[0]
+                expect(Object.keys(person).sort()).toEqual(
+                    ['created_at', 'distinct_ids', 'id', 'last_seen_at', 'name', 'properties', 'uuid'].sort()
+                )
+            }
         })
 
         it('should support pagination with limit and offset', async () => {
@@ -43,10 +50,29 @@ describe('Persons', { concurrent: false }, () => {
         })
 
         it('should support search by email', async () => {
-            const result = await listTool.handler(context, { search: 'test@' })
+            // Find a person with an email property to use as a search term
+            const allResult = await listTool.handler(context, { limit: 100 })
+            const allResponse = parseToolResponse(allResult)
+            const personWithEmail = allResponse.results.find((p: any) => p.properties?.email || p.properties?.$email)
+
+            if (!personWithEmail) {
+                console.warn('No persons with email found in project, skipping search by email test')
+                return
+            }
+
+            const email = personWithEmail.properties.email ?? personWithEmail.properties.$email
+            const result = await listTool.handler(context, { search: email })
             const response = parseToolResponse(result)
 
             expect(Array.isArray(response.results)).toBe(true)
+            expect(response.results.length).toBeGreaterThan(0)
+
+            // Verify only the dot-notation picked properties are present (no full properties blob leaked)
+            const allowedProps = new Set(['email', '$email', '$geoip_country_code'])
+            const person = response.results[0]
+            for (const key of Object.keys(person.properties)) {
+                expect(allowedProps).toContain(key)
+            }
         })
     })
 


### PR DESCRIPTION
## Problem

PR #54440 optimized the persons-list MCP tool by stripping the full `properties` object from list responses to save tokens. However, this made the tool less practical — agents need to call persons-retrieve for every person just to see their email, which is the most commonly needed identifier.

## Changes

Added a small allowlist of commonly useful person properties to the persons-list response using the existing dot-path notation in `pickResponseFields`:

- `properties.email` — most common person identifier
- `properties.$email` — system variant (some customers use this instead)
- `properties.$geoip_country_code` — auto-enriched by PostHog GeoIP, compact 2-char code, available for nearly all customers

Only these specific properties are extracted from the full properties map, keeping token usage low while making the list view practical.

## How did you test this code?

- Verified the generated `pickResponseFields` call includes the new dot-paths in `services/mcp/src/tools/generated/persons.ts`
- Ran MCP unit tests (`utils.test.ts`, `generate-tools.test.ts`) — all pass
- The `pickResponseFields` utility already has comprehensive test coverage for dot-path extraction
- Manual test

## Publish to changelog?

No

## Docs update

No docs update needed.
