### PR TITLE
chore(sig): Add ingest_report_json command

### DIFF
--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -1054,7 +1054,7 @@ def _resume_task_with_new_run(
         return True
 
     extra_state: dict[str, Any] = {
-        "interaction_origin": "slack",
+        "interaction_origin": "slack",  # Makes the agent auto-push and open a draft PR
     }
 
     previous_state = previous_run.state or {}

--- a/products/signals/backend/management/AGENTS.md
+++ b/products/signals/backend/management/AGENTS.md
@@ -45,6 +45,28 @@ python manage.py list_signal_reports --team-id 1 --signals --json
 Reports that aren't `ready` still appear in the output with their `error` field
 explaining why they were filtered, plus `artefacts` containing the full judge reasoning.
 
+## Seeding a pre-researched report
+
+Use `ingest_report_json` to short-circuit the research flow and drop a fully-researched
+`SignalReport` into the database, so you can test the autostart path without the sandbox.
+
+```bash
+# 1. Make sure the team has autonomy configured and at least one opted-in user
+python manage.py enable_signals_autonomy 1 P2 alice@posthog.com
+
+# 2. Ingest a research-output fixture — creates a SignalReport, persists artefacts,
+#    triggers `_maybe_autostart_task_for_report`, then marks the report READY.
+python manage.py ingest_report_json \
+    products/signals/backend/report_generation/fixtures/insight_scene_logic_mode_property_bug.json \
+    --team-id 1
+```
+
+The fixture must match the shape in `report_generation/fixtures/` — a JSON object with
+`repository`, `signal_ids`, and a `result` that parses as `ReportResearchOutput`. Autostart
+still requires a working GitHub integration (for reviewer resolution) and the commit authors
+in `relevant_commit_hashes` to map to an opted-in user, otherwise the report will be saved but
+no `Task` will be created.
+
 ## Session summary (video-based)
 
 Test the SummarizeSingleSessionWorkflow with full video validation:

--- a/products/signals/backend/management/AGENTS.md
+++ b/products/signals/backend/management/AGENTS.md
@@ -51,8 +51,9 @@ Use `ingest_report_json` to short-circuit the research flow and drop a fully-res
 `SignalReport` into the database, so you can test the autostart path without the sandbox.
 
 ```bash
-# 1. Make sure the team has autonomy configured and at least one opted-in user
-python manage.py enable_signals_autonomy 1 P2 alice@posthog.com
+# 1. Make sure at least one team user has opted into autonomy. Either set a default
+#    threshold for the team via SignalTeamConfig, or have a user POST to
+#    /api/users/<id>/signal_autonomy/ with their personal autostart_priority.
 
 # 2. Ingest a research-output fixture — creates a SignalReport, persists artefacts,
 #    triggers `_maybe_autostart_task_for_report`, then marks the report READY.
@@ -64,8 +65,9 @@ python manage.py ingest_report_json \
 The fixture must match the shape in `report_generation/fixtures/` — a JSON object with
 `repository`, `signal_ids`, and a `result` that parses as `ReportResearchOutput`. Autostart
 still requires a working GitHub integration (for reviewer resolution) and the commit authors
-in `relevant_commit_hashes` to map to an opted-in user, otherwise the report will be saved but
-no `Task` will be created.
+in `relevant_commit_hashes` to map to a user with a `SignalUserAutonomyConfig` whose effective
+priority threshold (personal or team default) covers the report's priority — otherwise the
+report will be saved but no `Task` will be created.
 
 ## Session summary (video-based)
 

--- a/products/signals/backend/management/commands/ingest_report_json.py
+++ b/products/signals/backend/management/commands/ingest_report_json.py
@@ -139,10 +139,15 @@ class Command(BaseCommand):
             report.save(update_fields=ready_fields)
 
     def _warn_if_autonomy_not_configured(self, team: Team) -> None:
-        opted_in_exists = SignalUserAutonomyConfig.objects.filter(
-            user__organization_memberships__organization_id=team.organization_id,
-        ).exists()
-        if not opted_in_exists:
+        from posthog.models import OrganizationMembership
+
+        org_member_user_ids = OrganizationMembership.objects.filter(
+            organization_id=team.organization_id,
+        ).values_list("user_id", flat=True)
+        opted_in_user_count = SignalUserAutonomyConfig.objects.filter(
+            user_id__in=org_member_user_ids,
+        ).count()
+        if not opted_in_user_count:
             self.stdout.write(
                 self.style.WARNING(
                     "No org users have a SignalUserAutonomyConfig — autostart will not trigger. "

--- a/products/signals/backend/management/commands/ingest_report_json.py
+++ b/products/signals/backend/management/commands/ingest_report_json.py
@@ -26,9 +26,8 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
 from posthog.models import Team
-from posthog.models.team.extensions import get_or_create_team_extension
 
-from products.signals.backend.models import SignalAutonomyConfig, SignalReport
+from products.signals.backend.models import SignalReport, SignalUserAutonomyConfig
 from products.signals.backend.report_generation.research import ReportResearchOutput
 from products.signals.backend.report_generation.select_repo import RepoSelectionResult
 from products.signals.backend.temporal.agentic.report import _persist_agentic_report_artefacts
@@ -140,11 +139,13 @@ class Command(BaseCommand):
             report.save(update_fields=ready_fields)
 
     def _warn_if_autonomy_not_configured(self, team: Team) -> None:
-        config = get_or_create_team_extension(team, SignalAutonomyConfig)
-        if not config.opted_in_user_ids:
+        opted_in_exists = SignalUserAutonomyConfig.objects.filter(
+            user__organization_memberships__organization_id=team.organization_id,
+        ).exists()
+        if not opted_in_exists:
             self.stdout.write(
                 self.style.WARNING(
-                    "Team has no opted-in autonomy users — autostart will not trigger. "
-                    "Run `python manage.py enable_signals_autonomy <team_id> <priority> <emails>` first."
+                    "No org users have a SignalUserAutonomyConfig — autostart will not trigger. "
+                    "Opt in via POST /api/users/<id>/signal_autonomy/ first."
                 )
             )

--- a/products/signals/backend/management/commands/ingest_report_json.py
+++ b/products/signals/backend/management/commands/ingest_report_json.py
@@ -1,0 +1,150 @@
+"""Local dev tool: ingest a saved SignalReport research output as if the agentic flow had just produced it.
+
+Creates a SignalReport row, transitions it through candidate -> in_progress, persists the fixture's
+artefacts via `_persist_agentic_report_artefacts` (which is what triggers `_maybe_autostart_task_for_report`),
+then transitions the report to READY. Useful for testing the autostart path end-to-end without
+running the sandbox research flow.
+
+The fixture shape matches `report_generation/fixtures/analyze_report_funnel_research_output.json`:
+
+    {
+      "name": "<human label>",
+      "report_id": "<ignored, a fresh UUID is created>",
+      "generated_at": "<iso timestamp>",
+      "repository": "owner/repo",
+      "signal_ids": ["uuid", ...],
+      "result": { ReportResearchOutput JSON }
+    }
+"""
+
+import json
+import asyncio
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from posthog.models import Team
+from posthog.models.team.extensions import get_or_create_team_extension
+
+from products.signals.backend.models import SignalAutonomyConfig, SignalReport
+from products.signals.backend.report_generation.research import ReportResearchOutput
+from products.signals.backend.report_generation.select_repo import RepoSelectionResult
+from products.signals.backend.temporal.agentic.report import _persist_agentic_report_artefacts
+
+
+class Command(BaseCommand):
+    help = (
+        "Ingest a saved SignalReport research output as if the agentic flow had just produced it.\n"
+        "Creates a SignalReport, writes the report_generation artefacts, triggers autostart, and marks it READY."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "file",
+            type=str,
+            help="Path to the report JSON fixture to ingest",
+        )
+        parser.add_argument(
+            "--team-id",
+            type=int,
+            required=True,
+            help="Team ID to attach the report to",
+        )
+        parser.add_argument(
+            "--repository",
+            type=str,
+            default=None,
+            help="Override the repository from the fixture (org/repo)",
+        )
+
+    def handle(self, *args, **options):
+        if not settings.DEBUG:
+            raise CommandError("This command can only be run with DEBUG=True")
+
+        file_path = Path(options["file"])
+        if not file_path.exists():
+            raise CommandError(f"File does not exist: {file_path}")
+
+        try:
+            payload = json.loads(file_path.read_text())
+        except json.JSONDecodeError as e:
+            raise CommandError(f"Fixture is not valid JSON: {file_path}: {e}") from e
+
+        if not isinstance(payload, dict):
+            raise CommandError(f"Fixture root must be a JSON object: {file_path}")
+
+        result_payload = payload.get("result")
+        if result_payload is None:
+            raise CommandError(f"Fixture missing 'result': {file_path}")
+
+        try:
+            result = ReportResearchOutput.model_validate(result_payload)
+        except Exception as e:
+            raise CommandError(f"Fixture 'result' is not a valid ReportResearchOutput: {e}") from e
+
+        repository = options["repository"] or payload.get("repository")
+        if not repository:
+            raise CommandError("Fixture is missing 'repository' and --repository was not provided")
+
+        try:
+            team = Team.objects.select_related("organization").get(id=options["team_id"])
+        except Team.DoesNotExist:
+            raise CommandError(f"Team {options['team_id']} not found")
+
+        signal_ids = payload.get("signal_ids") or []
+        signal_count = max(len(signal_ids), len(result.findings))
+
+        report = self._create_and_advance_report(team, signal_count)
+
+        self.stdout.write(f"Created SignalReport {report.id} for team {team.id} in state {report.status}")
+        self.stdout.write(f"Repository: {repository}")
+        self.stdout.write(f"Actionability: {result.actionability.actionability.value}")
+        if result.priority:
+            self.stdout.write(f"Priority: {result.priority.priority.value}")
+        else:
+            self.stdout.write("Priority: N/A (not actionable)")
+
+        repo_selection = RepoSelectionResult(
+            repository=repository,
+            reason="ingest_report_json: repository provided by fixture",
+        )
+
+        asyncio.run(_persist_agentic_report_artefacts(team.id, str(report.id), result, repo_selection))
+
+        self._finalize_report(report, result)
+
+        self.stdout.write(self.style.SUCCESS(f"Ingested report {report.id} and persisted artefacts."))
+
+        self._warn_if_autonomy_not_configured(team)
+
+    def _create_and_advance_report(self, team: Team, signal_count: int) -> SignalReport:
+        with transaction.atomic():
+            report = SignalReport.objects.create(
+                team=team,
+                status=SignalReport.Status.POTENTIAL,
+                signal_count=signal_count,
+                total_weight=float(signal_count),
+            )
+            candidate_fields = report.transition_to(SignalReport.Status.CANDIDATE)
+            report.save(update_fields=candidate_fields)
+            in_progress_fields = report.transition_to(SignalReport.Status.IN_PROGRESS, signals_at_run_increment=3)
+            report.save(update_fields=in_progress_fields)
+        return report
+
+    def _finalize_report(self, report: SignalReport, result: ReportResearchOutput) -> None:
+        with transaction.atomic():
+            report.refresh_from_db()
+            ready_fields = report.transition_to(SignalReport.Status.READY, title=result.title, summary=result.summary)
+            report.save(update_fields=ready_fields)
+
+    def _warn_if_autonomy_not_configured(self, team: Team) -> None:
+        config = get_or_create_team_extension(team, SignalAutonomyConfig)
+        if not config.opted_in_user_ids:
+            self.stdout.write(
+                self.style.WARNING(
+                    "Team has no opted-in autonomy users — autostart will not trigger. "
+                    "Run `python manage.py enable_signals_autonomy <team_id> <priority> <emails>` first."
+                )
+            )

--- a/products/signals/backend/report_generation/AGENTS.md
+++ b/products/signals/backend/report_generation/AGENTS.md
@@ -28,6 +28,10 @@ the safety judge first, then calls into this flow via a Temporal activity if the
     The repository used for research is tracked separately via the `repo_selection` artefact.
 - `fixtures/analyze_report_funnel_research_output.json`
   Saved previous research output used by local `update` testing.
+- `fixtures/insight_scene_logic_mode_property_bug.json`
+  Saved research output for a single-signal, `immediately_actionable` P1 report.
+  Used by the `ingest_report_json` management command to exercise the autostart
+  path without running the sandbox research flow.
 
 ## Mental model
 

--- a/products/signals/backend/report_generation/fixtures/insight_scene_logic_mode_property_bug.json
+++ b/products/signals/backend/report_generation/fixtures/insight_scene_logic_mode_property_bug.json
@@ -1,33 +1,30 @@
 {
-  "name": "insight_scene_logic_mode_property_bug",
-  "report_id": "test-insight-scene-logic-report-001",
-  "generated_at": "2026-04-14T10:25:00Z",
-  "repository": "posthog/posthog",
-  "signal_ids": ["64824815-db30-466d-a412-043050cb1f94"],
+  "name": "backups_succesful_typo",
+  "report_id": "test-backups-succesful-typo-001",
+  "generated_at": "2026-04-17T10:00:00Z",
+  "repository": "PostHog/posthog",
+  "signal_ids": ["7e000000-0000-0000-0000-000000000001"],
   "result": {
-    "title": "fix(insights): Correct property name in scene-change guard",
-    "summary": "The one-sentence tl;dr: Loading an insight can trigger an infinite setInsight loop because the scene-change guard in insightSceneLogic checks a property that does not exist.\n\n**What's happening:** The urlToAction handler in frontend/src/scenes/insights/insightSceneLogic.tsx has an early-return optimization meant to skip reprocessing when the insight scene hasn't changed. The guard reads `currentScene.activeSceneLogic?.values.mode`, but the logic exposes `insightMode`, not `mode`. Because `values.mode` is always `undefined`, the equality check never matches, the early return never fires, and any query upgrade triggers setInsight, which retriggers the handler.\n\n**Root cause:** A property-name typo introduced with the guard reads a non-existent value. The equality compares `undefined === insightMode`, so the guard can never short-circuit, and the handler re-enters itself via query upgrades.\n\n**How to resolve:** Update the guard to compare `values.insightMode` instead of `values.mode`, cast through the generated logic type, and add an explicit null check so the guard is strict. No new tests required for the loop itself, but the change should be covered by an existing urlToAction behavior test to ensure the early return fires when insight and mode match.",
+    "title": "fix(backups): correct 'succesful' typo in docstring",
+    "summary": "The docstring of the `_get_base_backup` function in `posthog/dags/backups.py` (line 346) misspells 'successful' as 'succesful'. This is a single-word typo in a docstring — no code behavior is affected.",
     "findings": [
       {
-        "signal_id": "64824815-db30-466d-a412-043050cb1f94",
+        "signal_id": "7e000000-0000-0000-0000-000000000001",
         "relevant_code_paths": [
-          "frontend/src/scenes/insights/insightSceneLogic.tsx",
-          "frontend/src/scenes/insights/insightSceneLogicType.ts"
+          "posthog/dags/backups.py"
         ],
-        "relevant_commit_hashes": {
-          "a469426": "Fix commit that corrected `values.mode` to `values.insightMode` in the urlToAction scene-change guard and added an explicit null check (the commit referenced in the signal description)."
-        },
-        "data_queried": "No PostHog MCP queries were run. The signal is a code-level bug in frontend logic, and the evidence is purely in the source file and git history. Inspected frontend/src/scenes/insights/insightSceneLogic.tsx — the reducer declares `insightMode` at line 130 and there is no `mode` value on the logic. The urlToAction guard at ~line 487-489 now correctly reads `values.insightMode === insightMode`, matching the fix described in the signal. `git log -- frontend/src/scenes/insights/insightSceneLogic.tsx` shows the fix commit landed on 2025-07-30.",
+        "relevant_commit_hashes": {},
+        "data_queried": "Verified via source that posthog/dags/backups.py line 346 reads 'Checks the latest succesful backup to use it as a base backup.' — the correct spelling is 'successful'.",
         "verified": true
       }
     ],
     "actionability": {
-      "explanation": "The signal pinpoints a single file, a single guard, and a single property-name typo, with the corrected line visible in the current source. A coding agent can reproduce the old buggy condition from the signal, confirm the current fix is present, and either close this as already-addressed or port the same guard pattern if any sibling scene logic (replay, experiment) inherited the same mistake.",
+      "explanation": "Single docstring typo fix in a single file. One word to change. Pure docstring, so zero test/behavior impact. An agent can perform this end to end without any human input.",
       "actionability": "immediately_actionable",
       "already_addressed": false
     },
     "priority": {
-      "explanation": "The original bug caused an infinite setInsight loop whenever a query upgrade ran on insight load — a user-visible hang in one of PostHog's core scenes. The fix is mechanical and contained to one file, with no architectural trade-offs. That combination (high user impact, low implementation risk) fits P1.",
+      "explanation": "Low-risk, low-impact, but immediately actionable and suitable for agent autonomy testing.",
       "priority": "P1"
     }
   }

--- a/products/signals/backend/report_generation/fixtures/insight_scene_logic_mode_property_bug.json
+++ b/products/signals/backend/report_generation/fixtures/insight_scene_logic_mode_property_bug.json
@@ -1,0 +1,34 @@
+{
+  "name": "insight_scene_logic_mode_property_bug",
+  "report_id": "test-insight-scene-logic-report-001",
+  "generated_at": "2026-04-14T10:25:00Z",
+  "repository": "posthog/posthog",
+  "signal_ids": ["64824815-db30-466d-a412-043050cb1f94"],
+  "result": {
+    "title": "fix(insights): Correct property name in scene-change guard",
+    "summary": "The one-sentence tl;dr: Loading an insight can trigger an infinite setInsight loop because the scene-change guard in insightSceneLogic checks a property that does not exist.\n\n**What's happening:** The urlToAction handler in frontend/src/scenes/insights/insightSceneLogic.tsx has an early-return optimization meant to skip reprocessing when the insight scene hasn't changed. The guard reads `currentScene.activeSceneLogic?.values.mode`, but the logic exposes `insightMode`, not `mode`. Because `values.mode` is always `undefined`, the equality check never matches, the early return never fires, and any query upgrade triggers setInsight, which retriggers the handler.\n\n**Root cause:** A property-name typo introduced with the guard reads a non-existent value. The equality compares `undefined === insightMode`, so the guard can never short-circuit, and the handler re-enters itself via query upgrades.\n\n**How to resolve:** Update the guard to compare `values.insightMode` instead of `values.mode`, cast through the generated logic type, and add an explicit null check so the guard is strict. No new tests required for the loop itself, but the change should be covered by an existing urlToAction behavior test to ensure the early return fires when insight and mode match.",
+    "findings": [
+      {
+        "signal_id": "64824815-db30-466d-a412-043050cb1f94",
+        "relevant_code_paths": [
+          "frontend/src/scenes/insights/insightSceneLogic.tsx",
+          "frontend/src/scenes/insights/insightSceneLogicType.ts"
+        ],
+        "relevant_commit_hashes": {
+          "a469426": "Fix commit that corrected `values.mode` to `values.insightMode` in the urlToAction scene-change guard and added an explicit null check (the commit referenced in the signal description)."
+        },
+        "data_queried": "No PostHog MCP queries were run. The signal is a code-level bug in frontend logic, and the evidence is purely in the source file and git history. Inspected frontend/src/scenes/insights/insightSceneLogic.tsx — the reducer declares `insightMode` at line 130 and there is no `mode` value on the logic. The urlToAction guard at ~line 487-489 now correctly reads `values.insightMode === insightMode`, matching the fix described in the signal. `git log -- frontend/src/scenes/insights/insightSceneLogic.tsx` shows the fix commit landed on 2025-07-30.",
+        "verified": true
+      }
+    ],
+    "actionability": {
+      "explanation": "The signal pinpoints a single file, a single guard, and a single property-name typo, with the corrected line visible in the current source. A coding agent can reproduce the old buggy condition from the signal, confirm the current fix is present, and either close this as already-addressed or port the same guard pattern if any sibling scene logic (replay, experiment) inherited the same mistake.",
+      "actionability": "immediately_actionable",
+      "already_addressed": false
+    },
+    "priority": {
+      "explanation": "The original bug caused an infinite setInsight loop whenever a query upgrade ran on insight load — a user-visible hang in one of PostHog's core scenes. The fix is mechanical and contained to one file, with no architectural trade-offs. That combination (high user impact, low implementation risk) fits P1.",
+      "priority": "P1"
+    }
+  }
+}

--- a/products/signals/backend/temporal/agentic/report.py
+++ b/products/signals/backend/temporal/agentic/report.py
@@ -301,6 +301,7 @@ async def _maybe_autostart_task_for_report(
         repository=repository,
         signal_report_id=report_id,
         posthog_mcp_scopes="read_only",
+        interaction_origin="signal_report",  # Makes the agent auto-push and open a draft PR
     )
     task_run = await task.runs.order_by("-created_at").afirst()
     if task_run is None:

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -257,6 +257,7 @@ class Task(DeletedMetaFields, models.Model):
         sandbox_environment_id: str | None = None,
         internal: bool = False,
         output_schema: type[BaseModel] | dict | None = None,
+        interaction_origin: str | None = None,
     ) -> "Task":
         from products.tasks.backend.temporal.client import execute_task_processing_workflow
 
@@ -292,7 +293,9 @@ class Task(DeletedMetaFields, models.Model):
         extra_state: dict[str, str] = {}
         if slack_thread_url:
             extra_state["slack_thread_url"] = slack_thread_url
-        if slack_thread_context:
+        if interaction_origin:
+            extra_state["interaction_origin"] = interaction_origin
+        elif slack_thread_context:
             extra_state["interaction_origin"] = "slack"
 
         if sandbox_env is not None:


### PR DESCRIPTION
## Problem

Testing the Signal autostart path end-to-end requires running the full agentic research flow in the sandbox – slow, complex, costly, finicky. We need a faster way to seed`SignalReport` records for local testing.

## Changes

Adding a new Django management command `ingest_report_json` that:

1. Loads a research-output fixture from a JSON file matching the `ReportResearchOutput` schema
2. Creates a `SignalReport` and transitions it through `POTENTIAL` → `CANDIDATE` → `IN_PROGRESS`
3. Persists report artefacts via `_persist_agentic_report_artefacts`, which triggers the autostart logic
4. Finalizes the report to `READY` status with title and summary from the fixture

Also: sample input `backups_succesful_typo.json` with the expected JSON shape.

## How did you test this code?

Two steps:
1. Set up a team with autonomy enabled: `python manage.py enable_signals_autonomy 1 P2 user@example.com`
2. Also manually enable the error tracking source in local PH Code
3. Then run `python manage.py ingest_report_json products/signals/backend/report_generation/fixtures/backups_succesful_typo.json --team-id 1`

## Publish to changelog?

No.