### PR TITLE
fix(surveys): use property access in survey queries

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -739,7 +739,7 @@ export const surveyLogic = kea<surveyLogicType>([
                     FROM events
                     WHERE team_id = ${teamLogic.values.currentTeamId}
                         AND event IN ('${SurveyEventName.SHOWN}', '${SurveyEventName.DISMISSED}', '${SurveyEventName.SENT}')
-                        AND properties.${SurveyEventProperties.SURVEY_ID} = '${props.id}'
+                        AND properties.\`${SurveyEventProperties.SURVEY_ID}\` = '${props.id}'
                         ${values.timestampFilter}
                         ${values.archivedResponsesFilter}
                         AND {filters} -- Apply property filters here to the main query
@@ -747,7 +747,7 @@ export const surveyLogic = kea<surveyLogicType>([
                         AND (
                             event != '${SurveyEventName.DISMISSED}'
                             OR
-                            COALESCE(JSONExtractBool(properties, '${SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED}'), False) = False
+                            coalesce(properties.\`${SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED}\` = true, false) = false
                         )
                         AND (
                             -- Include non-'sent' events directly
@@ -794,13 +794,13 @@ export const surveyLogic = kea<surveyLogicType>([
                         FROM events
                         WHERE team_id = ${teamLogic.values.currentTeamId}
                             AND event IN ('${SurveyEventName.DISMISSED}', '${SurveyEventName.SENT}')
-                            AND properties.${SurveyEventProperties.SURVEY_ID} = '${props.id}'
+                            AND properties.\`${SurveyEventProperties.SURVEY_ID}\` = '${props.id}'
                             ${values.timestampFilter}
                             ${values.archivedResponsesFilter}
                             AND (
                             event != '${SurveyEventName.DISMISSED}'
                             OR
-                            COALESCE(JSONExtractBool(properties, '${SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED}'), False) = False
+                            coalesce(properties.\`${SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED}\` = true, false) = false
                             )
                             AND {filters} -- Apply property filters here to reduce initial events
                         GROUP BY person_id
@@ -1576,10 +1576,7 @@ export const surveyLogic = kea<surveyLogicType>([
                  * So we return all responses that don't have it.
                  * For posthog-js > 1.240, we use the $survey_completed property.
                  */
-                return `AND (
-                            NOT JSONHas(properties, '${SurveyEventProperties.SURVEY_COMPLETED}')
-                            OR JSONExtractBool(properties, '${SurveyEventProperties.SURVEY_COMPLETED}') = true
-                        )`
+                return `AND coalesce(properties.\`${SurveyEventProperties.SURVEY_COMPLETED}\` = true, true)`
             },
         ],
         archivedResponsesFilter: [

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -863,6 +863,17 @@ describe('survey utils', () => {
             expect(result).toContain(`timestamp >= '2024-08-27T00:00:00'`) // Survey start date
             expect(result).toContain(`timestamp <= '2024-08-30T23:59:59'`) // Survey end date
         })
+
+        it('prefers survey start_date over created_at for the lower bound', () => {
+            const survey = {
+                created_at: '2024-08-20T15:30:00Z',
+                start_date: '2024-08-27T09:00:00Z',
+                end_date: '2024-08-30T10:00:00Z',
+            }
+            const result = buildSurveyTimestampFilter(survey)
+
+            expect(result).toContain(`timestamp >= '2024-08-27T00:00:00'`)
+        })
     })
 
     describe('getResolvedSurveyDateRange', () => {
@@ -896,6 +907,21 @@ describe('survey utils', () => {
 
             expect(partialFilter).toContain(`greaterOrEquals(timestamp, '${fromMatch?.[1]}')`)
             expect(partialFilter).toContain(`lessOrEquals(timestamp, '${toMatch?.[1]}')`)
+        })
+
+        it('uses direct property access for fixed survey properties', () => {
+            const survey = {
+                id: 'test-survey-id',
+                created_at: '2024-11-19T00:00:00Z',
+                end_date: null,
+                enable_partial_responses: true,
+            } as Survey
+
+            const partialFilter = buildPartialResponsesFilter(survey)
+
+            expect(partialFilter).toContain('properties.`$survey_id`')
+            expect(partialFilter).toContain('properties.`$survey_submission_id`')
+            expect(partialFilter).not.toContain('JSONExtractString')
         })
     })
 })

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -1277,9 +1277,14 @@ describe('createAnswerFilterHogQLExpression', () => {
 })
 
 describe('timezone handling in survey date queries', () => {
-    const createMockSurvey = (createdAt: string, endDate?: string): Pick<Survey, 'created_at' | 'end_date'> => ({
+    const createMockSurvey = (
+        createdAt: string,
+        endDate?: string,
+        startDate?: string
+    ): Pick<Survey, 'created_at' | 'end_date'> & Partial<Pick<Survey, 'start_date'>> => ({
         created_at: createdAt,
         end_date: endDate || null,
+        start_date: startDate,
     })
 
     afterEach(() => {

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -875,7 +875,7 @@ export interface SurveyDateRange {
 }
 
 export function getResolvedSurveyDateRange(
-    survey: Pick<Survey, 'created_at' | 'start_date' | 'end_date'>,
+    survey: Pick<Survey, 'created_at' | 'end_date'> & Partial<Pick<Survey, 'start_date'>>,
     dateRange?: SurveyDateRange | null
 ): { fromDate: string; toDate: string } {
     let fromDate = getSurveyStartDateForQuery(survey)
@@ -896,7 +896,7 @@ export function getResolvedSurveyDateRange(
 }
 
 export function buildSurveyTimestampFilter(
-    survey: Pick<Survey, 'created_at' | 'start_date' | 'end_date'>,
+    survey: Pick<Survey, 'created_at' | 'end_date'> & Partial<Pick<Survey, 'start_date'>>,
     dateRange?: SurveyDateRange | null
 ): string {
     const { fromDate, toDate } = getResolvedSurveyDateRange(survey, dateRange)

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -852,7 +852,9 @@ function getTeamTimezone(): string {
     return getAppContext()?.current_team?.timezone || 'UTC'
 }
 
-export function getSurveyStartDateForQuery(survey: Pick<Survey, 'created_at' | 'start_date'>): string {
+export function getSurveyStartDateForQuery(
+    survey: Pick<Survey, 'created_at'> & Partial<Pick<Survey, 'start_date'>>
+): string {
     const tz = getTeamTimezone()
     return dayjs
         .tz(survey.start_date ?? survey.created_at, tz)

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -381,8 +381,8 @@ export function getSurveyResponse(question: SurveyQuestion, index: number): stri
     }
 
     return `COALESCE(
-        NULLIF(JSONExtractString(events.properties, '${idBasedKey}'), ''),
-        NULLIF(JSONExtractString(events.properties, '${indexBasedKey}'), '')
+        NULLIF(events.properties['${idBasedKey}'], ''),
+        NULLIF(events.properties['${indexBasedKey}'], '')
     )`
 }
 
@@ -583,10 +583,7 @@ export function doesSurveyHaveDisplayConditions(survey: Survey | NewSurvey): boo
 
 export function buildPartialResponsesFilter(survey: Survey, dateRange?: SurveyDateRange | null): string {
     if (!survey.enable_partial_responses) {
-        return `AND (
-        NOT JSONHas(properties, '${SurveyEventProperties.SURVEY_COMPLETED}')
-        OR JSONExtractBool(properties, '${SurveyEventProperties.SURVEY_COMPLETED}') = true
-    )`
+        return `AND coalesce(properties.\`${SurveyEventProperties.SURVEY_COMPLETED}\` = true, true)`
     }
 
     const { fromDate, toDate } = getResolvedSurveyDateRange(survey, dateRange)
@@ -597,14 +594,15 @@ export function buildPartialResponsesFilter(survey: Survey, dateRange?: SurveyDa
         FROM events
         WHERE and(
             equals(event, '${SurveyEventName.SENT}'),
-            equals(JSONExtractString(properties, '${SurveyEventProperties.SURVEY_ID}'), '${survey.id}'),
+            equals(properties.\`${SurveyEventProperties.SURVEY_ID}\`, '${survey.id}'),
             greaterOrEquals(timestamp, '${fromDate}'),
             lessOrEquals(timestamp, '${toDate}')
         )
         GROUP BY
             if(
-                JSONHas(properties, '${SurveyEventProperties.SURVEY_SUBMISSION_ID}'),
-                JSONExtractString(properties, '${SurveyEventProperties.SURVEY_SUBMISSION_ID}'),
+                isNotNull(properties.\`${SurveyEventProperties.SURVEY_SUBMISSION_ID}\`)
+                    AND properties.\`${SurveyEventProperties.SURVEY_SUBMISSION_ID}\` != '',
+                properties.\`${SurveyEventProperties.SURVEY_SUBMISSION_ID}\`,
                 toString(uuid)
             )
     ) --- Filter to ensure we only get one response per ${SurveyEventProperties.SURVEY_SUBMISSION_ID}`
@@ -633,7 +631,7 @@ export function buildAggregateQuery(
     const branches: string[] = []
 
     const baseWhere = `event = '${SurveyEventName.SENT}'
-        AND properties.${SurveyEventProperties.SURVEY_ID} = '${survey.id}'
+        AND properties.\`${SurveyEventProperties.SURVEY_ID}\` = '${survey.id}'
         ${filters.timestampFilter}
         ${filters.answerFilterHogQLExpression}
         ${filters.archivedResponsesFilter}
@@ -854,9 +852,12 @@ function getTeamTimezone(): string {
     return getAppContext()?.current_team?.timezone || 'UTC'
 }
 
-export function getSurveyStartDateForQuery(survey: Pick<Survey, 'created_at'>): string {
+export function getSurveyStartDateForQuery(survey: Pick<Survey, 'created_at' | 'start_date'>): string {
     const tz = getTeamTimezone()
-    return dayjs.tz(survey.created_at, tz).startOf('day').format(DATE_FORMAT)
+    return dayjs
+        .tz(survey.start_date ?? survey.created_at, tz)
+        .startOf('day')
+        .format(DATE_FORMAT)
 }
 
 export function getSurveyEndDateForQuery(survey: Pick<Survey, 'end_date'>): string {
@@ -872,7 +873,7 @@ export interface SurveyDateRange {
 }
 
 export function getResolvedSurveyDateRange(
-    survey: Pick<Survey, 'created_at' | 'end_date'>,
+    survey: Pick<Survey, 'created_at' | 'start_date' | 'end_date'>,
     dateRange?: SurveyDateRange | null
 ): { fromDate: string; toDate: string } {
     let fromDate = getSurveyStartDateForQuery(survey)
@@ -893,7 +894,7 @@ export function getResolvedSurveyDateRange(
 }
 
 export function buildSurveyTimestampFilter(
-    survey: Pick<Survey, 'created_at' | 'end_date'>,
+    survey: Pick<Survey, 'created_at' | 'start_date' | 'end_date'>,
     dateRange?: SurveyDateRange | null
 ): string {
     const { fromDate, toDate } = getResolvedSurveyDateRange(survey, dateRange)

--- a/posthog/api/test/__snapshots__/test_survey.ambr
+++ b/posthog/api/test/__snapshots__/test_survey.ambr
@@ -2,7 +2,7 @@
 # name: TestResponsesCount.test_responses_count
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT JSONExtractString(properties, '$survey_id') as survey_id,
+  SELECT replaceRegexpAll(JSONExtractRaw(properties, '$survey_id'), '^"|"$', '') as survey_id,
          count()
   FROM events
   WHERE team_id = 99999
@@ -14,10 +14,10 @@
        WHERE team_id = 99999
          AND timestamp >= '2024-01-21 14:40:09'
          AND event = 'survey sent'
-       GROUP BY JSONExtractString(properties, '$survey_id'),
+       GROUP BY replaceRegexpAll(JSONExtractRaw(properties, '$survey_id'), '^"|"$', ''),
                 CASE
-                    WHEN COALESCE(JSONExtractString(properties, '$survey_submission_id'), '') = '' THEN toString(uuid)
-                    ELSE JSONExtractString(properties, '$survey_submission_id')
+                    WHEN COALESCE(replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', ''), '') = '' THEN toString(uuid)
+                    ELSE replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', '')
                 END)
   GROUP BY survey_id
   '''
@@ -25,7 +25,7 @@
 # name: TestResponsesCount.test_responses_count_only_after_first_survey_started
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT JSONExtractString(properties, '$survey_id') as survey_id,
+  SELECT replaceRegexpAll(JSONExtractRaw(properties, '$survey_id'), '^"|"$', '') as survey_id,
          count()
   FROM events
   WHERE team_id = 99999
@@ -37,10 +37,10 @@
        WHERE team_id = 99999
          AND timestamp >= '2024-04-25 14:40:09'
          AND event = 'survey sent'
-       GROUP BY JSONExtractString(properties, '$survey_id'),
+       GROUP BY replaceRegexpAll(JSONExtractRaw(properties, '$survey_id'), '^"|"$', ''),
                 CASE
-                    WHEN COALESCE(JSONExtractString(properties, '$survey_submission_id'), '') = '' THEN toString(uuid)
-                    ELSE JSONExtractString(properties, '$survey_submission_id')
+                    WHEN COALESCE(replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', ''), '') = '' THEN toString(uuid)
+                    ELSE replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', '')
                 END)
   GROUP BY survey_id
   '''
@@ -48,7 +48,7 @@
 # name: TestResponsesCount.test_responses_count_with_partial_responses
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT JSONExtractString(properties, '$survey_id') as survey_id,
+  SELECT replaceRegexpAll(JSONExtractRaw(properties, '$survey_id'), '^"|"$', '') as survey_id,
          count()
   FROM events
   WHERE team_id = 99999
@@ -60,10 +60,10 @@
        WHERE team_id = 99999
          AND timestamp >= '2024-06-10 11:00:00'
          AND event = 'survey sent'
-       GROUP BY JSONExtractString(properties, '$survey_id'),
+       GROUP BY replaceRegexpAll(JSONExtractRaw(properties, '$survey_id'), '^"|"$', ''),
                 CASE
-                    WHEN COALESCE(JSONExtractString(properties, '$survey_submission_id'), '') = '' THEN toString(uuid)
-                    ELSE JSONExtractString(properties, '$survey_submission_id')
+                    WHEN COALESCE(replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', ''), '') = '' THEN toString(uuid)
+                    ELSE replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', '')
                 END)
   GROUP BY survey_id
   '''

--- a/posthog/hogql/functions/posthog.py
+++ b/posthog/hogql/functions/posthog.py
@@ -62,7 +62,14 @@ HOGQL_POSTHOG_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
         "getSurveyResponse", 1, 3, signatures=[((IntegerType(), StringType(), BooleanType()), StringType())]
     ),
     "uniqueSurveySubmissionsFilter": HogQLFunctionMeta(
-        "uniqueSurveySubmissionsFilter", 1, 1, signatures=[((StringType(),), StringType())]
+        "uniqueSurveySubmissionsFilter",
+        1,
+        3,
+        signatures=[
+            ((StringType(),), StringType()),
+            ((StringType(), StringType()), StringType()),
+            ((StringType(), StringType(), StringType()), StringType()),
+        ],
     ),
     # traffic type classification functions (experimental)
     "__preview_getTrafficType": HogQLFunctionMeta(

--- a/posthog/hogql/functions/posthog.py
+++ b/posthog/hogql/functions/posthog.py
@@ -68,7 +68,11 @@ HOGQL_POSTHOG_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
         signatures=[
             ((StringType(),), StringType()),
             ((StringType(), StringType()), StringType()),
+            ((StringType(), DateTimeType()), StringType()),
             ((StringType(), StringType(), StringType()), StringType()),
+            ((StringType(), StringType(), DateTimeType()), StringType()),
+            ((StringType(), DateTimeType(), StringType()), StringType()),
+            ((StringType(), DateTimeType(), DateTimeType()), StringType()),
         ],
     ),
     # traffic type classification functions (experimental)

--- a/posthog/hogql/functions/survey.py
+++ b/posthog/hogql/functions/survey.py
@@ -163,7 +163,7 @@ def unique_survey_submissions_filter(node: ast.Call, args: list[ast.Expr], team_
     Args:
         node: The AST Call node for uniqueSurveySubmissionsFilter
         args: The function arguments
-        team_id: The team ID for filtering
+        team_id: The team ID from the outer query context
 
     Returns:
         ast.Expr representing the unique survey submissions filter
@@ -176,40 +176,43 @@ def unique_survey_submissions_filter(node: ast.Call, args: list[ast.Expr], team_
     start_timestamp_arg = args[1] if len(args) > 1 else None
     end_timestamp_arg = args[2] if len(args) > 2 else None
 
-    # Build the subquery using parse_expr
-    # uuid IN (SELECT argMax(uuid, timestamp) FROM events WHERE event = 'survey sent' AND ... GROUP BY ...)
-    submission_id_expr = "properties.`$survey_submission_id`"
-    grouping_key = f"if(coalesce({submission_id_expr}, '') = '', toString(uuid), {submission_id_expr})"
-
-    team_filter = f" AND team_id = {team_id}" if team_id is not None else ""
-    date_filter = ""
+    # The subquery inherits the outer team filter from HogQL's normal events resolution,
+    # so we only need to describe the survey/datetime predicates here.
     placeholders: dict[str, ast.Expr] = {"survey_id": ast.Constant(value=survey_id)}
+    where_expr = parse_expr(
+        "event = 'survey sent' AND properties.$survey_id = {survey_id}",
+        placeholders=placeholders,
+    )
 
     if start_timestamp_arg is not None:
         normalized_start_timestamp_arg = _normalize_timestamp_constant(start_timestamp_arg)
         if normalized_start_timestamp_arg is None:
             raise QueryError("uniqueSurveySubmissionsFilter second argument must be a constant")
-        date_filter += " AND timestamp >= {start_timestamp}"
         placeholders["start_timestamp"] = normalized_start_timestamp_arg
+        where_expr = parse_expr(
+            "{where} AND timestamp >= {start_timestamp}",
+            placeholders={"where": where_expr, "start_timestamp": normalized_start_timestamp_arg},
+        )
 
     if end_timestamp_arg is not None:
         normalized_end_timestamp_arg = _normalize_timestamp_constant(end_timestamp_arg)
         if normalized_end_timestamp_arg is None:
             raise QueryError("uniqueSurveySubmissionsFilter third argument must be a constant")
-        date_filter += " AND timestamp <= {end_timestamp}"
         placeholders["end_timestamp"] = normalized_end_timestamp_arg
+        where_expr = parse_expr(
+            "{where} AND timestamp <= {end_timestamp}",
+            placeholders={"where": where_expr, "end_timestamp": normalized_end_timestamp_arg},
+        )
 
-    hogql = f"""uuid IN (
-        SELECT argMax(uuid, timestamp)
-        FROM events
-        WHERE event = 'survey sent'
-          AND properties.`$survey_id` = {{survey_id}}
-          {team_filter}
-          {date_filter}
-        GROUP BY {grouping_key}
-    )"""
+    grouping_key = parse_expr(
+        "if(coalesce(properties.$survey_submission_id, '') = '', toString(uuid), properties.$survey_submission_id)"
+    )
 
-    return parse_expr(hogql, placeholders=placeholders, start=None)
+    return parse_expr(
+        "uuid IN (SELECT argMax(uuid, timestamp) FROM events WHERE {where} GROUP BY {grouping_key})",
+        placeholders={"where": where_expr, "grouping_key": grouping_key},
+        start=None,
+    )
 
 
 def _normalize_timestamp_constant(timestamp_arg: ast.Expr) -> ast.Constant | None:

--- a/posthog/hogql/functions/survey.py
+++ b/posthog/hogql/functions/survey.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from posthog.hogql import ast
 from posthog.hogql.errors import QueryError
 from posthog.hogql.parser import parse_expr
@@ -184,16 +186,18 @@ def unique_survey_submissions_filter(node: ast.Call, args: list[ast.Expr], team_
     placeholders: dict[str, ast.Expr] = {"survey_id": ast.Constant(value=survey_id)}
 
     if start_timestamp_arg is not None:
-        if not isinstance(start_timestamp_arg, ast.Constant):
+        normalized_start_timestamp_arg = _normalize_timestamp_constant(start_timestamp_arg)
+        if normalized_start_timestamp_arg is None:
             raise QueryError("uniqueSurveySubmissionsFilter second argument must be a constant")
         date_filter += " AND timestamp >= {start_timestamp}"
-        placeholders["start_timestamp"] = start_timestamp_arg
+        placeholders["start_timestamp"] = normalized_start_timestamp_arg
 
     if end_timestamp_arg is not None:
-        if not isinstance(end_timestamp_arg, ast.Constant):
+        normalized_end_timestamp_arg = _normalize_timestamp_constant(end_timestamp_arg)
+        if normalized_end_timestamp_arg is None:
             raise QueryError("uniqueSurveySubmissionsFilter third argument must be a constant")
         date_filter += " AND timestamp <= {end_timestamp}"
-        placeholders["end_timestamp"] = end_timestamp_arg
+        placeholders["end_timestamp"] = normalized_end_timestamp_arg
 
     hogql = f"""uuid IN (
         SELECT argMax(uuid, timestamp)
@@ -206,3 +210,13 @@ def unique_survey_submissions_filter(node: ast.Call, args: list[ast.Expr], team_
     )"""
 
     return parse_expr(hogql, placeholders=placeholders, start=None)
+
+
+def _normalize_timestamp_constant(timestamp_arg: ast.Expr) -> ast.Constant | None:
+    if not isinstance(timestamp_arg, ast.Constant):
+        return None
+
+    if isinstance(timestamp_arg.value, datetime):
+        return ast.Constant(value=timestamp_arg.value.strftime("%Y-%m-%d %H:%M:%S"))
+
+    return timestamp_arg

--- a/posthog/hogql/functions/survey.py
+++ b/posthog/hogql/functions/survey.py
@@ -171,21 +171,38 @@ def unique_survey_submissions_filter(node: ast.Call, args: list[ast.Expr], team_
         raise QueryError("uniqueSurveySubmissionsFilter first argument must be a constant")
 
     survey_id = survey_id_arg.value
+    start_timestamp_arg = args[1] if len(args) > 1 else None
+    end_timestamp_arg = args[2] if len(args) > 2 else None
 
     # Build the subquery using parse_expr
     # uuid IN (SELECT argMax(uuid, timestamp) FROM events WHERE event = 'survey sent' AND ... GROUP BY ...)
-    submission_id_expr = "JSONExtractString(properties, '$survey_submission_id')"
+    submission_id_expr = "properties.`$survey_submission_id`"
     grouping_key = f"if(coalesce({submission_id_expr}, '') = '', toString(uuid), {submission_id_expr})"
 
     team_filter = f" AND team_id = {team_id}" if team_id is not None else ""
+    date_filter = ""
+    placeholders: dict[str, ast.Expr] = {"survey_id": ast.Constant(value=survey_id)}
+
+    if start_timestamp_arg is not None:
+        if not isinstance(start_timestamp_arg, ast.Constant):
+            raise QueryError("uniqueSurveySubmissionsFilter second argument must be a constant")
+        date_filter += " AND timestamp >= {start_timestamp}"
+        placeholders["start_timestamp"] = start_timestamp_arg
+
+    if end_timestamp_arg is not None:
+        if not isinstance(end_timestamp_arg, ast.Constant):
+            raise QueryError("uniqueSurveySubmissionsFilter third argument must be a constant")
+        date_filter += " AND timestamp <= {end_timestamp}"
+        placeholders["end_timestamp"] = end_timestamp_arg
 
     hogql = f"""uuid IN (
         SELECT argMax(uuid, timestamp)
         FROM events
         WHERE event = 'survey sent'
-          AND JSONExtractString(properties, '$survey_id') = {{survey_id}}
+          AND properties.`$survey_id` = {{survey_id}}
           {team_filter}
+          {date_filter}
         GROUP BY {grouping_key}
     )"""
 
-    return parse_expr(hogql, placeholders={"survey_id": ast.Constant(value=survey_id)}, start=None)
+    return parse_expr(hogql, placeholders=placeholders, start=None)

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -3038,7 +3038,17 @@ class TestPrinter(BaseTest):
         self.assertIn("SELECT argMax(events.uuid", printed)
         self.assertIn("FROM events WHERE", printed)
         self.assertIn("GROUP BY", printed)
-        self.assertIn("JSONExtractString", printed)
+        self.assertIn("JSONExtractRaw(events.properties", printed)
+
+    def test_unique_survey_submissions_filter_with_timestamps(self):
+        printed = self._print(
+            "select uuid from events where uniqueSurveySubmissionsFilter('survey123', '2025-01-01', '2025-01-31')",
+            settings=HogQLGlobalSettings(max_execution_time=10),
+        )
+
+        self.assertIn("events.timestamp", printed)
+        self.assertIn("greaterOrEquals", printed)
+        self.assertIn("lessOrEquals", printed)
 
     def test_override_timezone(self):
         context = HogQLContext(

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -1,5 +1,6 @@
 import json
 from collections.abc import Mapping
+from datetime import datetime
 from typing import Any, Literal, Optional, cast
 
 import pytest
@@ -3043,6 +3044,20 @@ class TestPrinter(BaseTest):
     def test_unique_survey_submissions_filter_with_timestamps(self):
         printed = self._print(
             "select uuid from events where uniqueSurveySubmissionsFilter('survey123', '2025-01-01', '2025-01-31')",
+            settings=HogQLGlobalSettings(max_execution_time=10),
+        )
+
+        self.assertIn("events.timestamp", printed)
+        self.assertIn("greaterOrEquals", printed)
+        self.assertIn("lessOrEquals", printed)
+
+    def test_unique_survey_submissions_filter_with_datetime_placeholders(self):
+        printed = self._print(
+            "select uuid from events where uniqueSurveySubmissionsFilter('survey123', {start_date}, {end_date})",
+            placeholders={
+                "start_date": ast.Constant(value=datetime(2025, 1, 1, 0, 0, 0)),
+                "end_date": ast.Constant(value=datetime(2025, 1, 31, 23, 59, 59)),
+            },
             settings=HogQLGlobalSettings(max_execution_time=10),
         )
 

--- a/posthog/tasks/llm_analytics_usage_report.py
+++ b/posthog/tasks/llm_analytics_usage_report.py
@@ -597,17 +597,18 @@ def get_llm_feedback_survey_metrics(
         dict mapping team_id to TeamLLMSurveyMetrics
     """
     ai_trace_id_expr, _ = get_property_string_expr("events", "$ai_trace_id", "'$ai_trace_id'", "properties")
+    survey_id_expr, _ = get_property_string_expr("events", "$survey_id", "'$survey_id'", "properties")
 
     query_template = f"""
         SELECT
             team_id,
-            JSONExtractString(properties, '$survey_id') as survey_id,
+            {survey_id_expr} as survey_id,
             countIf(event = 'survey sent') as response_count
         FROM events
         WHERE team_id IN %(team_ids)s
           AND event IN ('survey sent', 'survey shown')
           AND {ai_trace_id_expr} != ''
-          AND JSONExtractString(properties, '$survey_id') != ''
+          AND {survey_id_expr} != ''
           AND timestamp >= %(begin)s
           AND timestamp < %(end)s
         GROUP BY team_id, survey_id

--- a/posthog/tasks/stop_surveys_reached_target.py
+++ b/posthog/tasks/stop_surveys_reached_target.py
@@ -22,6 +22,7 @@ def _get_surveys_response_counts(
     submission_id_expr = get_survey_property_string_expr(SurveyEventProperties.SURVEY_SUBMISSION_ID)
 
     tag_queries(product=ProductKey.SURVEYS, feature=Feature.QUERY)
+    # nosemgrep: clickhouse-fstring-param-audit - survey property expressions come from internal helper output
     data = sync_execute(
         f"""
         SELECT

--- a/posthog/tasks/stop_surveys_reached_target.py
+++ b/posthog/tasks/stop_surveys_reached_target.py
@@ -12,19 +12,23 @@ from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.models.utils import UUIDT
 
 from products.surveys.backend.models import Survey
+from products.surveys.backend.util import SurveyEventProperties, get_survey_property_string_expr
 
 
 def _get_surveys_response_counts(
     surveys_ids: list[UUIDT], team_id: int, earliest_survey_creation_date: datetime
 ) -> dict[str, int]:
+    survey_id_expr = get_survey_property_string_expr(SurveyEventProperties.SURVEY_ID)
+    submission_id_expr = get_survey_property_string_expr(SurveyEventProperties.SURVEY_SUBMISSION_ID)
+
     tag_queries(product=ProductKey.SURVEYS, feature=Feature.QUERY)
     data = sync_execute(
-        """
+        f"""
         SELECT
-            JSONExtractString(properties, '$survey_id') as survey_id,
+            {survey_id_expr} as survey_id,
             count(DISTINCT
-                if(JSONHas(properties, '$survey_submission_id'),
-                   JSONExtractString(properties, '$survey_submission_id'),
+                if(coalesce({submission_id_expr}, '') != '',
+                   {submission_id_expr},
                    toString(uuid))
             ) as unique_responses
         FROM events

--- a/posthog/tasks/test/__snapshots__/test_stop_surveys_reached_target.ambr
+++ b/posthog/tasks/test/__snapshots__/test_stop_surveys_reached_target.ambr
@@ -2,8 +2,8 @@
 # name: TestStopSurveysReachedTarget.test_stop_surveys_with_enough_responses
   '''
   
-  SELECT JSONExtractString(properties, '$survey_id') as survey_id,
-         count(DISTINCT if(JSONHas(properties, '$survey_submission_id'), JSONExtractString(properties, '$survey_submission_id'), toString(uuid))) as unique_responses
+  SELECT replaceRegexpAll(JSONExtractRaw(properties, '$survey_id'), '^"|"$', '') as survey_id,
+         count(DISTINCT if(coalesce(replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', ''), '') != '', replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', ''), toString(uuid))) as unique_responses
   FROM events
   WHERE event = 'survey sent'
     AND team_id = 99999
@@ -15,8 +15,8 @@
 # name: TestStopSurveysReachedTarget.test_stop_surveys_with_enough_responses.1
   '''
   
-  SELECT JSONExtractString(properties, '$survey_id') as survey_id,
-         count(DISTINCT if(JSONHas(properties, '$survey_submission_id'), JSONExtractString(properties, '$survey_submission_id'), toString(uuid))) as unique_responses
+  SELECT replaceRegexpAll(JSONExtractRaw(properties, '$survey_id'), '^"|"$', '') as survey_id,
+         count(DISTINCT if(coalesce(replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', ''), '') != '', replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', ''), toString(uuid))) as unique_responses
   FROM events
   WHERE event = 'survey sent'
     AND team_id = 99999

--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -867,10 +867,10 @@
          AND timestamp < '2022-01-10 23:59:59'
          AND event = 'survey sent'
        GROUP BY team_id,
-                survey_id,
+                replaceRegexpAll(JSONExtractRaw(properties, '$survey_id'), '^"|"$', ''),
                 CASE
-                    WHEN COALESCE(survey_submission_id, '') = '' THEN toString(uuid)
-                    ELSE survey_submission_id
+                    WHEN COALESCE(replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', ''), '') = '' THEN toString(uuid)
+                    ELSE replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', '')
                 END)
   GROUP BY team_id
   '''

--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -867,10 +867,10 @@
          AND timestamp < '2022-01-10 23:59:59'
          AND event = 'survey sent'
        GROUP BY team_id,
-                JSONExtractString(properties, '$survey_id'),
+                survey_id,
                 CASE
-                    WHEN COALESCE(JSONExtractString(properties, '$survey_submission_id'), '') = '' THEN toString(uuid)
-                    ELSE JSONExtractString(properties, '$survey_submission_id')
+                    WHEN COALESCE(survey_submission_id, '') = '' THEN toString(uuid)
+                    ELSE survey_submission_id
                 END)
   GROUP BY team_id
   '''

--- a/posthog/tasks/update_survey_adaptive_sampling.py
+++ b/posthog/tasks/update_survey_adaptive_sampling.py
@@ -6,6 +6,7 @@ from django.utils.timezone import now
 from posthog.clickhouse.client import sync_execute
 
 from products.surveys.backend.models import Survey
+from products.surveys.backend.util import SurveyEventProperties, get_survey_property_string_expr
 
 
 def _update_survey_adaptive_sampling(survey: Survey) -> None:
@@ -41,12 +42,14 @@ def _update_survey_adaptive_sampling(survey: Survey) -> None:
 
 
 def _get_survey_responses_count(survey_id: int) -> int:
+    survey_id_expr = get_survey_property_string_expr(SurveyEventProperties.SURVEY_ID)
+
     # nosemgrep: clickhouse-fstring-param-audit - no interpolation, only parameterized values
     data = sync_execute(
         f"""
-                SELECT JSONExtractString(properties, '$survey_id') as survey_id, count()
+                SELECT {survey_id_expr} as survey_id, count()
                 FROM events
-                WHERE event = 'survey sent' AND survey_id = %(survey_id)s
+                WHERE event = 'survey sent' AND {survey_id_expr} = %(survey_id)s
             """,
         {"survey_id": survey_id},
     )

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -55,7 +55,11 @@ from products.data_warehouse.backend.models import (
 )
 from products.error_tracking.backend.models import ErrorTrackingIssue, ErrorTrackingSymbolSet
 from products.surveys.backend.models import Survey
-from products.surveys.backend.util import get_unique_survey_event_uuids_sql_subquery
+from products.surveys.backend.util import (
+    SurveyEventProperties,
+    get_survey_property_string_expr,
+    get_unique_survey_event_uuids_sql_subquery,
+)
 
 logger = structlog.get_logger(__name__)
 logger.setLevel(logging.INFO)
@@ -978,6 +982,8 @@ def get_teams_with_survey_responses_count_in_period(
     begin: datetime,
     end: datetime,
 ) -> list[tuple[int, int]]:
+    survey_id_expr = get_survey_property_string_expr(SurveyEventProperties.SURVEY_ID)
+
     # Get survey IDs that are linked to product tours (these are free and shouldn't be billed)
     product_tour_survey_ids = list(
         Survey.objects.filter(product_tour__isnull=False).values_list("id", flat=True).distinct()
@@ -990,14 +996,14 @@ def get_teams_with_survey_responses_count_in_period(
         ],
         group_by_prefix_expressions=[
             "team_id",
-            "JSONExtractString(properties, '$survey_id')",  # Deduplicate per team_id, per survey_id
+            survey_id_expr,  # Deduplicate per team_id, per survey_id
         ],
     )
 
     # Build exclusion clause for product tour surveys
     product_tour_exclusion = ""
     if product_tour_survey_ids:
-        product_tour_exclusion = "AND JSONExtractString(properties, '$survey_id') NOT IN %(product_tour_survey_ids)s"
+        product_tour_exclusion = f"AND {survey_id_expr} NOT IN %(product_tour_survey_ids)s"
 
     query = f"""
         SELECT

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -77,6 +77,7 @@ from products.surveys.backend.util import (
     SurveyEventName,
     SurveyEventProperties,
     get_archived_response_uuids,
+    get_survey_property_string_expr,
     get_unique_survey_event_uuids_sql_subquery,
 )
 
@@ -1598,6 +1599,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
             return Response({})
 
         params = {"team_id": self.team_id, "timestamp": earliest_survey_start_date}
+        survey_id_expr = get_survey_property_string_expr(SurveyEventProperties.SURVEY_ID)
 
         partial_responses_filter = self._get_partial_responses_filter(
             base_conditions_sql=[
@@ -1617,14 +1619,12 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
         if survey_ids_param:
             survey_ids = [sid.strip() for sid in survey_ids_param.split(",") if sid.strip()]
             if survey_ids:
-                survey_ids_filter = (
-                    f"AND JSONExtractString(properties, '{SurveyEventProperties.SURVEY_ID}') IN %(survey_ids)s"
-                )
+                survey_ids_filter = f"AND {survey_id_expr} IN %(survey_ids)s"
                 params["survey_ids"] = survey_ids
 
         query = f"""
             SELECT
-                JSONExtractString(properties, '{SurveyEventProperties.SURVEY_ID}') as survey_id,
+                {survey_id_expr} as survey_id,
                 count()
             FROM events
             WHERE
@@ -1794,6 +1794,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
         # Build query parameters
         params: dict[str, Any] = {"team_id": str(self.team_id)}
         date_filter = ""
+        survey_id_expr = get_survey_property_string_expr(SurveyEventProperties.SURVEY_ID)
 
         if parsed_from:
             date_filter += " AND timestamp >= %(date_from)s"
@@ -1813,7 +1814,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
         # Add survey filter if specific survey
         survey_filter = ""
         if survey_id:
-            survey_filter = f"AND JSONExtractString(properties, '{SurveyEventProperties.SURVEY_ID}') = %(survey_id)s"
+            survey_filter = f"AND {survey_id_expr} = %(survey_id)s"
             params["survey_id"] = str(survey_id)
         else:
             # For global stats, only include non-archived surveys
@@ -1830,13 +1831,17 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
                         "unique_users_dismissal_rate": 0.0,
                     },
                 }
-            survey_filter = f"AND JSONExtractString(properties, '{SurveyEventProperties.SURVEY_ID}') IN %(survey_ids)s"
+            survey_filter = f"AND {survey_id_expr} IN %(survey_ids)s"
             params["survey_ids"] = [str(id) for id in active_survey_ids]
 
+        partial_responses_base_conditions = ["team_id = %(team_id)s"]
+        if parsed_from:
+            partial_responses_base_conditions.append("timestamp >= %(date_from)s")
+        if parsed_to:
+            partial_responses_base_conditions.append("timestamp <= %(date_to)s")
+
         partial_responses_filter = self._get_partial_responses_filter(
-            base_conditions_sql=[
-                "team_id = %(team_id)s",
-            ],
+            base_conditions_sql=partial_responses_base_conditions,
         )
 
         # Query 1: Base Stats (Similar to original query)
@@ -1852,14 +1857,14 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
             AND event IN (%(shown)s, %(dismissed)s, %(sent)s)
             {survey_filter}
             {date_filter}
-            {archive_filter}
-            AND (
-                event != %(dismissed)s
-                OR
-                COALESCE(JSONExtractBool(properties, '{SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED}'), False) = False
-            )
-            AND (
-                event != %(sent)s
+                {archive_filter}
+                AND (
+                    event != %(dismissed)s
+                    OR
+                    COALESCE(JSONExtractBool(properties, '{SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED}'), False) = False
+                )
+                AND (
+                    event != %(sent)s
                 OR
                 {partial_responses_filter}
             )

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -77,6 +77,7 @@ from products.surveys.backend.util import (
     SurveyEventName,
     SurveyEventProperties,
     get_archived_response_uuids,
+    get_survey_property_bool_expr,
     get_survey_property_string_expr,
     get_unique_survey_event_uuids_sql_subquery,
 )
@@ -1795,13 +1796,35 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
         params: dict[str, Any] = {"team_id": str(self.team_id)}
         date_filter = ""
         survey_id_expr = get_survey_property_string_expr(SurveyEventProperties.SURVEY_ID)
+        survey_partially_completed_expr = get_survey_property_bool_expr(
+            SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED
+        )
+        effective_from = parsed_from
+        effective_to = parsed_to
 
-        if parsed_from:
+        if survey_id:
+            survey_dates = (
+                Survey.objects.filter(team_id=self.team_id, id=survey_id)
+                .values("start_date", "created_at", "end_date")
+                .first()
+            )
+
+            if survey_dates:
+                survey_start = survey_dates["start_date"]
+                survey_end = survey_dates["end_date"]
+
+                if survey_start:
+                    effective_from = max(filter(None, [parsed_from, survey_start]), default=survey_start)
+
+                if survey_end:
+                    effective_to = min(filter(None, [parsed_to, survey_end]), default=survey_end)
+
+        if effective_from:
             date_filter += " AND timestamp >= %(date_from)s"
-            params["date_from"] = parsed_from
-        if parsed_to:
+            params["date_from"] = effective_from
+        if effective_to:
             date_filter += " AND timestamp <= %(date_to)s"
-            params["date_to"] = parsed_to
+            params["date_to"] = effective_to
 
         # Add archive filter if needed
         archive_filter = ""
@@ -1835,9 +1858,9 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
             params["survey_ids"] = [str(id) for id in active_survey_ids]
 
         partial_responses_base_conditions = ["team_id = %(team_id)s"]
-        if parsed_from:
+        if effective_from:
             partial_responses_base_conditions.append("timestamp >= %(date_from)s")
-        if parsed_to:
+        if effective_to:
             partial_responses_base_conditions.append("timestamp <= %(date_to)s")
 
         partial_responses_filter = self._get_partial_responses_filter(
@@ -1861,7 +1884,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
                 AND (
                     event != %(dismissed)s
                     OR
-                    COALESCE(JSONExtractBool(properties, '{SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED}'), False) = False
+                    COALESCE({survey_partially_completed_expr}, False) = False
                 )
                 AND (
                     event != %(sent)s
@@ -1893,7 +1916,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
                 AND (
                     event != %(dismissed)s
                     OR
-                    COALESCE(JSONExtractBool(properties, '{SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED}'), False) = False
+                    COALESCE({survey_partially_completed_expr}, False) = False
                 )
                 GROUP BY person_id
                 HAVING sum(if(event = %(dismissed)s, 1, 0)) > 0

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -1810,7 +1810,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
             )
 
             if survey_dates:
-                survey_start = survey_dates["start_date"]
+                survey_start = survey_dates["start_date"] or survey_dates["created_at"]
                 survey_end = survey_dates["end_date"]
 
                 if survey_start:

--- a/products/surveys/backend/api/test/__snapshots__/test_survey.ambr
+++ b/products/surveys/backend/api/test/__snapshots__/test_survey.ambr
@@ -2,7 +2,7 @@
 # name: TestResponsesCount.test_responses_count
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT JSONExtractString(properties, '$survey_id') as survey_id,
+  SELECT replaceRegexpAll(JSONExtractRaw(properties, '$survey_id'), '^"|"$', '') as survey_id,
          count()
   FROM events
   WHERE team_id = 99999
@@ -14,10 +14,10 @@
        WHERE team_id = 99999
          AND timestamp >= '2024-01-21 14:40:09'
          AND event = 'survey sent'
-       GROUP BY JSONExtractString(properties, '$survey_id'),
+       GROUP BY replaceRegexpAll(JSONExtractRaw(properties, '$survey_id'), '^"|"$', ''),
                 CASE
-                    WHEN COALESCE(JSONExtractString(properties, '$survey_submission_id'), '') = '' THEN toString(uuid)
-                    ELSE JSONExtractString(properties, '$survey_submission_id')
+                    WHEN COALESCE(replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', ''), '') = '' THEN toString(uuid)
+                    ELSE replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', '')
                 END)
   GROUP BY survey_id
   '''
@@ -25,7 +25,7 @@
 # name: TestResponsesCount.test_responses_count_only_after_first_survey_started
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT JSONExtractString(properties, '$survey_id') as survey_id,
+  SELECT replaceRegexpAll(JSONExtractRaw(properties, '$survey_id'), '^"|"$', '') as survey_id,
          count()
   FROM events
   WHERE team_id = 99999
@@ -37,10 +37,10 @@
        WHERE team_id = 99999
          AND timestamp >= '2024-04-25 14:40:09'
          AND event = 'survey sent'
-       GROUP BY JSONExtractString(properties, '$survey_id'),
+       GROUP BY replaceRegexpAll(JSONExtractRaw(properties, '$survey_id'), '^"|"$', ''),
                 CASE
-                    WHEN COALESCE(JSONExtractString(properties, '$survey_submission_id'), '') = '' THEN toString(uuid)
-                    ELSE JSONExtractString(properties, '$survey_submission_id')
+                    WHEN COALESCE(replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', ''), '') = '' THEN toString(uuid)
+                    ELSE replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', '')
                 END)
   GROUP BY survey_id
   '''
@@ -48,7 +48,7 @@
 # name: TestResponsesCount.test_responses_count_with_partial_responses
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT JSONExtractString(properties, '$survey_id') as survey_id,
+  SELECT replaceRegexpAll(JSONExtractRaw(properties, '$survey_id'), '^"|"$', '') as survey_id,
          count()
   FROM events
   WHERE team_id = 99999
@@ -60,10 +60,10 @@
        WHERE team_id = 99999
          AND timestamp >= '2024-06-10 11:00:00'
          AND event = 'survey sent'
-       GROUP BY JSONExtractString(properties, '$survey_id'),
+       GROUP BY replaceRegexpAll(JSONExtractRaw(properties, '$survey_id'), '^"|"$', ''),
                 CASE
-                    WHEN COALESCE(JSONExtractString(properties, '$survey_submission_id'), '') = '' THEN toString(uuid)
-                    ELSE JSONExtractString(properties, '$survey_submission_id')
+                    WHEN COALESCE(replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', ''), '') = '' THEN toString(uuid)
+                    ELSE replaceRegexpAll(JSONExtractRaw(properties, '$survey_submission_id'), '^"|"$', '')
                 END)
   GROUP BY survey_id
   '''

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -5069,6 +5069,7 @@ class TestSurveyStats(ClickhouseTestMixin, APIBaseTest):
             name="Archive Test Survey",
             type="popover",
             questions=[{"type": "open", "question": "What?"}],
+            start_date=datetime(2024, 5, 1, 9, 0, 0, tzinfo=UTC),
         )
 
         response_uuid = str(uuid.uuid4())

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -4911,6 +4911,7 @@ class TestSurveyStats(ClickhouseTestMixin, APIBaseTest):
             name="Partial Response Survey",
             type="popover",
             questions=[{"type": "open", "question": "How are you?"}],
+            start_date=datetime(2024, 6, 10, 8, 0, 0, tzinfo=UTC),
             enable_partial_responses=True,  # Enable partial responses
         )
         sub_id_1 = str(uuid.uuid4())
@@ -5026,6 +5027,40 @@ class TestSurveyStats(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(rates_reassigned["response_rate"], 100.0)
         # (Unique persons dismissed / Unique persons shown) * 100 = (1 / 3) * 100 = 33.33
         self.assertEqual(rates_reassigned["dismissal_rate"], 33.33)
+
+    @freeze_time("2024-06-10 10:00:00")
+    def test_survey_stats_uses_created_at_when_start_date_is_missing(self):
+        survey = Survey.objects.create(
+            team=self.team,
+            name="Created At Fallback Survey",
+            type="popover",
+            questions=[{"type": "open", "question": "How are you?"}],
+        )
+        user = Person.objects.create(team=self.team, distinct_ids=[str(uuid.uuid4())])
+
+        _create_event(
+            team=self.team,
+            event="survey sent",
+            distinct_id=user.distinct_ids[0],
+            timestamp="2024-06-09 23:59:00",
+            properties={"$survey_id": str(survey.id)},
+        )
+        _create_event(
+            team=self.team,
+            event="survey sent",
+            distinct_id=user.distinct_ids[0],
+            timestamp="2024-06-10 10:01:00",
+            properties={"$survey_id": str(survey.id)},
+        )
+
+        flush_persons_and_events()
+
+        response = self.client.get(f"/api/projects/{self.team.id}/surveys/{survey.id}/stats/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        self.assertEqual(data["stats"]["survey sent"]["total_count"], 1)
+        self.assertEqual(data["stats"]["survey sent"]["unique_persons"], 1)
 
     @freeze_time("2024-05-01 12:00:00")
     def test_survey_stats_excludes_archived_responses(self):

--- a/products/surveys/backend/summarization/fetch.py
+++ b/products/surveys/backend/summarization/fetch.py
@@ -47,11 +47,11 @@ def fetch_responses(
         SELECT getSurveyResponse({question_index}, {question_id})
         FROM events
         WHERE event == 'survey sent'
-            AND properties.$survey_id = {survey_id}
-            AND uniqueSurveySubmissionsFilter({survey_id})
-            AND trim(getSurveyResponse({question_index}, {question_id})) != ''
             AND timestamp >= {start_date}
             AND timestamp <= {end_date}
+            AND properties.`$survey_id` = {survey_id}
+            AND uniqueSurveySubmissionsFilter({survey_id}, {start_date}, {end_date})
+            AND trim(getSurveyResponse({question_index}, {question_id})) != ''
     """
 
     # Add archived response filter if there are UUIDs to exclude

--- a/products/surveys/backend/util.py
+++ b/products/surveys/backend/util.py
@@ -3,6 +3,8 @@ from uuid import UUID
 
 from posthog.hogql.escape_sql import escape_clickhouse_string
 
+from posthog.models.property.util import get_property_string_expr
+
 from products.surveys.backend.models import SurveyResponseArchive
 
 
@@ -22,6 +24,17 @@ class SurveyEventProperties(StrEnum):
     SURVEY_DISMISSED = "$survey_dismissed"
     SURVEY_COMPLETED = "$survey_completed"
     SURVEY_LAST_SEEN_DATE = "$last_seen_survey_date"
+
+
+def get_survey_property_string_expr(property_name: SurveyEventProperties, table_alias: str | None = None) -> str:
+    expression, _ = get_property_string_expr(
+        "events",
+        str(property_name),
+        escape_clickhouse_string(str(property_name)),
+        "properties",
+        table_alias=table_alias,
+    )
+    return expression
 
 
 def get_survey_response_clickhouse_query(
@@ -78,7 +91,7 @@ def _build_multiple_choice_query(_DANGEROUS_id_based_key: str, index_based_key: 
 def filter_survey_sent_events_by_unique_submission(survey_id: str, team_id: int | None = None) -> str:
     """
     Generates a SQL condition string to filter 'survey sent' events, ensuring uniqueness based on submission ID,
-    using an optimized approach with argMax(). Usage with uniqueSurveySubmissionsFilter(survey_id, team_id).
+    using an optimized approach with argMax().
 
     This handles two scenarios for identifying relevant 'survey sent' events:
     1. Events recorded before the introduction of `$survey_submission_id` (submission_id is empty/null):
@@ -95,7 +108,7 @@ def filter_survey_sent_events_by_unique_submission(survey_id: str, team_id: int 
         Example: "uuid IN (SELECT argMax(uuid, timestamp) FROM ... GROUP BY ...)"
     """
     # Define the column for submission ID to avoid repetition and enhance readability
-    submission_id_col = f"JSONExtractString(properties, '{SurveyEventProperties.SURVEY_SUBMISSION_ID}')"
+    submission_id_col = get_survey_property_string_expr(SurveyEventProperties.SURVEY_SUBMISSION_ID)
 
     # Define the grouping key expression. This determines how events are grouped for deduplication.
     # If $survey_submission_id is present, group by it. Otherwise, group by uuid (making each old event unique).
@@ -112,11 +125,10 @@ def filter_survey_sent_events_by_unique_submission(survey_id: str, team_id: int 
             argMax(uuid, timestamp) -- Selects the UUID of the event with the latest timestamp within each group
         FROM events
         WHERE event = '{SurveyEventName.SENT}' -- Filter for 'survey sent' events
-          AND JSONExtractString(properties, '{SurveyEventProperties.SURVEY_ID}') = {escape_clickhouse_string(survey_id)} -- Filter for the specific survey
+          AND {get_survey_property_string_expr(SurveyEventProperties.SURVEY_ID)} = {escape_clickhouse_string(survey_id)} -- Filter for the specific survey
           {extra_filters}
-          -- Date range filters from the outer query are intentionally NOT included here.
-          -- This ensures we find the globally latest unique submission, which is then
-          -- filtered by the outer query's date range.
+          -- Callers that need bounded deduplication should add the same timestamp filters
+          -- to the outer query and this subquery.
         GROUP BY {grouping_key_expr} -- Group events by the effective submission identifier
     )"""
     return query
@@ -138,7 +150,7 @@ def get_unique_survey_event_uuids_sql_subquery(
                              Callers should ensure "event = 'survey sent'" is included if that's the target.
         group_by_prefix_expressions: A list of SQL expressions to prefix the GROUP BY clause.
                                      These define the segments within which deduplication occurs.
-                                     Example: ['team_id', "JSONExtractString(properties, '$survey_id')"]
+                                     Example: ['team_id', "replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$survey_id'), ''), 'null'), '^\"|\"$', '')"]
                                      If empty, deduplication is based purely on submission ID / UUID across
                                      all events matching base_conditions_sql.
 
@@ -159,12 +171,13 @@ def get_unique_survey_event_uuids_sql_subquery(
         sql_conditions = base_conditions_sql
 
     # Always include the survey_id in the group by
-    if group_by_prefix_expressions.count(f"JSONExtractString(properties, '{SurveyEventProperties.SURVEY_ID}')") == 0:
-        group_by_prefix_expressions.append(f"JSONExtractString(properties, '{SurveyEventProperties.SURVEY_ID}')")
+    survey_id_expr = get_survey_property_string_expr(SurveyEventProperties.SURVEY_ID)
+    if survey_id_expr not in group_by_prefix_expressions:
+        group_by_prefix_expressions.append(survey_id_expr)
 
     where_clause = " AND ".join(sql_conditions)
 
-    submission_id_col = f"JSONExtractString(properties, '{SurveyEventProperties.SURVEY_SUBMISSION_ID}')"
+    submission_id_col = get_survey_property_string_expr(SurveyEventProperties.SURVEY_SUBMISSION_ID)
     deduplication_group_by_key = (
         f"CASE WHEN COALESCE({submission_id_col}, '') = '' THEN toString(uuid) ELSE {submission_id_col} END"
     )

--- a/products/surveys/backend/util.py
+++ b/products/surveys/backend/util.py
@@ -37,6 +37,12 @@ def get_survey_property_string_expr(property_name: SurveyEventProperties, table_
     return expression
 
 
+def get_survey_property_bool_expr(property_name: SurveyEventProperties, table_alias: str | None = None) -> str:
+    expression = get_survey_property_string_expr(property_name, table_alias)
+    normalized_expression = f"toString(nullIf(nullIf({expression}, ''), 'null'))"
+    return f"toBool(transform({normalized_expression}, ['true', 'false'], [1, 0], NULL))"
+
+
 def get_survey_response_clickhouse_query(
     question_index: int, question_id: str | None = None, is_multiple_choice: bool = False
 ) -> str:


### PR DESCRIPTION
## Problem

Survey query paths still hardcode JSON extraction for fixed survey properties, which bypasses property access planning and leaves a few survey-related query builders on slower access patterns. The partial-response dedupe subqueries also needed to respect the same outer timestamp windows so we don't widen the work for bounded survey queries.

## Changes

- Switched the survey HogQL helper and summarization query to direct property access for fixed fields, following the same ``properties.`$survey_id` `` / ``properties.`$survey_submission_id` `` pattern used in #53791.
- Reworked the shared raw SQL survey helpers to stop using `JSONExtractString` for fixed survey fields, while keeping dynamic question-key access untouched.
- Updated survey API/task query builders and their snapshots so the partial-response dedupe logic uses the shared helper output and applies the same timestamp bounds as the outer survey queries.
- Extended `uniqueSurveySubmissionsFilter` to optionally take start/end timestamps for bounded dedupe in summarization paths, and updated the focused printer assertions.

## How did you test this code?

- `pytest products/surveys/backend/summarization/test_fetch.py products/surveys/backend/api/test/test_survey.py::TestResponsesCount::test_responses_count products/surveys/backend/api/test/test_survey.py::TestResponsesCount::test_responses_count_only_after_first_survey_started products/surveys/backend/api/test/test_survey.py::TestResponsesCount::test_responses_count_with_partial_responses products/surveys/backend/api/test/test_survey.py::TestSurveyStats::test_survey_stats_partial_responses posthog/tasks/test/test_stop_surveys_reached_target.py::TestStopSurveysReachedTarget::test_stop_surveys_with_enough_responses posthog/tasks/test/test_usage_report.py::TestSurveysUsageReport::test_usage_report_survey_responses posthog/tasks/test/test_llm_analytics_usage_report.py::TestLLMAnalyticsUsageReport::test_get_llm_feedback_survey_metrics posthog/tasks/test/test_update_survey_adaptive_sampling.py`
- `pytest posthog/hogql/printer/test/test_printer.py -k "unique_survey_submissions_filter"`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Agent-authored. This change was aligned to the property-access pattern already introduced in #53791 for survey HogQL, and expanded to the remaining survey API/task query paths plus the bounded partial-response dedupe subqueries.