### PR TITLE
feat(insights): preserve filters when switching from data table to other insight types

### DIFF
--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -8,7 +8,7 @@ import { insightNavLogic } from 'scenes/insights/InsightNav/insightNavLogic'
 import { useMocks } from '~/mocks/jest'
 import { examples } from '~/queries/examples'
 import { nodeKindToDefaultQuery } from '~/queries/nodes/InsightQuery/defaults'
-import { FunnelsQuery, InsightVizNode, NodeKind, TrendsQuery, Node } from '~/queries/schema/schema-general'
+import { EventsQuery, FunnelsQuery, InsightVizNode, NodeKind, TrendsQuery, Node } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import {
     ChartDisplayType,
@@ -1220,12 +1220,15 @@ describe('insightNavLogic', () => {
                 })
             })
 
-            it('seeds cache from a DataTable EventsQuery and preserves filters when switching to trends', async () => {
-                const dataTableQuery: Node = {
-                    kind: NodeKind.DataTableNode,
+            const dataTableSeedingCases: {
+                label: string
+                source: Partial<EventsQuery>
+                targetView: InsightType
+                expectedSource: Record<string, any>
+            }[] = [
+                {
+                    label: 'single event + date range + properties',
                     source: {
-                        kind: NodeKind.EventsQuery,
-                        select: ['*'],
                         event: '$pageview',
                         after: '-180d',
                         properties: [
@@ -1237,19 +1240,8 @@ describe('insightNavLogic', () => {
                             },
                         ],
                     },
-                } as Node
-
-                await expectLogic(logic, () => {
-                    builtInsightDataLogic.actions.setQuery(dataTableQuery)
-                }).toFinishAllListeners()
-
-                await expectLogic(builtInsightDataLogic, () => {
-                    logic.actions.setActiveView(InsightType.TRENDS)
-                }).toFinishAllListeners()
-
-                expect(builtInsightDataLogic.values.query).toMatchObject({
-                    kind: NodeKind.InsightVizNode,
-                    source: {
+                    targetView: InsightType.TRENDS,
+                    expectedSource: {
                         kind: NodeKind.TrendsQuery,
                         dateRange: { date_from: '-180d' },
                         properties: [
@@ -1262,37 +1254,49 @@ describe('insightNavLogic', () => {
                         ],
                         series: [{ kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' }],
                     },
-                })
-            })
-
-            it('seeds multi-event series when DataTable EventsQuery uses events[]', async () => {
-                const dataTableQuery: Node = {
-                    kind: NodeKind.DataTableNode,
-                    source: {
-                        kind: NodeKind.EventsQuery,
-                        select: ['*'],
-                        events: ['$pageview', '$autocapture'],
-                    },
-                } as Node
-
-                await expectLogic(logic, () => {
-                    builtInsightDataLogic.actions.setQuery(dataTableQuery)
-                }).toFinishAllListeners()
-
-                await expectLogic(builtInsightDataLogic, () => {
-                    logic.actions.setActiveView(InsightType.TRENDS)
-                }).toFinishAllListeners()
-
-                expect(builtInsightDataLogic.values.query).toMatchObject({
-                    source: {
+                },
+                {
+                    label: 'events[] seeds multi-series',
+                    source: { events: ['$pageview', '$autocapture'] },
+                    targetView: InsightType.TRENDS,
+                    expectedSource: {
                         kind: NodeKind.TrendsQuery,
                         series: [
                             { kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' },
                             { kind: NodeKind.EventsNode, event: '$autocapture', name: '$autocapture' },
                         ],
                     },
-                })
-            })
+                },
+                {
+                    label: 'before-only seeds date_to',
+                    source: { before: '2026-01-01T00:00:00Z' },
+                    targetView: InsightType.TRENDS,
+                    expectedSource: { dateRange: { date_to: '2026-01-01T00:00:00Z' } },
+                },
+            ]
+
+            it.each(dataTableSeedingCases)(
+                'seeds cache from DataTable EventsQuery: $label',
+                async ({ source, targetView, expectedSource }) => {
+                    const dataTableQuery: Node = {
+                        kind: NodeKind.DataTableNode,
+                        source: { kind: NodeKind.EventsQuery, select: ['*'], ...source },
+                    } as Node
+
+                    await expectLogic(logic, () => {
+                        builtInsightDataLogic.actions.setQuery(dataTableQuery)
+                    }).toFinishAllListeners()
+
+                    await expectLogic(builtInsightDataLogic, () => {
+                        logic.actions.setActiveView(targetView)
+                    }).toFinishAllListeners()
+
+                    expect(builtInsightDataLogic.values.query).toMatchObject({
+                        kind: NodeKind.InsightVizNode,
+                        source: expectedSource,
+                    })
+                }
+            )
 
             it('cleans seeded series through the funnels capability cleaner', async () => {
                 const dataTableQuery: Node = {
@@ -1318,32 +1322,6 @@ describe('insightNavLogic', () => {
                         series: [{ kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' }],
                     },
                 })
-            })
-
-            it('seeds only date_to when DataTable EventsQuery has only before', async () => {
-                const dataTableQuery: Node = {
-                    kind: NodeKind.DataTableNode,
-                    source: {
-                        kind: NodeKind.EventsQuery,
-                        select: ['*'],
-                        before: '2026-01-01T00:00:00Z',
-                    },
-                } as Node
-
-                await expectLogic(logic, () => {
-                    builtInsightDataLogic.actions.setQuery(dataTableQuery)
-                }).toFinishAllListeners()
-
-                await expectLogic(builtInsightDataLogic, () => {
-                    logic.actions.setActiveView(InsightType.TRENDS)
-                }).toFinishAllListeners()
-
-                expect(builtInsightDataLogic.values.query).toMatchObject({
-                    source: { dateRange: { date_to: '2026-01-01T00:00:00Z' } },
-                })
-                expect(
-                    (builtInsightDataLogic.values.query as InsightVizNode).source.dateRange?.date_from
-                ).toBeUndefined()
             })
 
             it('is a no-op when DataTable EventsQuery has no filters', async () => {

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -1219,6 +1219,51 @@ describe('insightNavLogic', () => {
                     source: expectedSource,
                 })
             })
+
+            it('seeds cache from a DataTable EventsQuery and preserves filters when switching to trends', async () => {
+                const dataTableQuery: Node = {
+                    kind: NodeKind.DataTableNode,
+                    source: {
+                        kind: NodeKind.EventsQuery,
+                        select: ['*'],
+                        event: '$pageview',
+                        after: '-180d',
+                        properties: [
+                            {
+                                key: 'email',
+                                value: 'test@example.com',
+                                operator: PropertyOperator.Exact,
+                                type: PropertyFilterType.Event,
+                            },
+                        ],
+                    },
+                } as Node
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(dataTableQuery)
+                }).toFinishAllListeners()
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.TRENDS)
+                }).toFinishAllListeners()
+
+                expect(builtInsightDataLogic.values.query).toMatchObject({
+                    kind: NodeKind.InsightVizNode,
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        dateRange: { date_from: '-180d' },
+                        properties: [
+                            {
+                                key: 'email',
+                                value: 'test@example.com',
+                                operator: PropertyOperator.Exact,
+                                type: PropertyFilterType.Event,
+                            },
+                        ],
+                        series: [{ kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' }],
+                    },
+                })
+            })
         })
     })
 })

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.test.ts
@@ -1264,6 +1264,124 @@ describe('insightNavLogic', () => {
                     },
                 })
             })
+
+            it('seeds multi-event series when DataTable EventsQuery uses events[]', async () => {
+                const dataTableQuery: Node = {
+                    kind: NodeKind.DataTableNode,
+                    source: {
+                        kind: NodeKind.EventsQuery,
+                        select: ['*'],
+                        events: ['$pageview', '$autocapture'],
+                    },
+                } as Node
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(dataTableQuery)
+                }).toFinishAllListeners()
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.TRENDS)
+                }).toFinishAllListeners()
+
+                expect(builtInsightDataLogic.values.query).toMatchObject({
+                    source: {
+                        kind: NodeKind.TrendsQuery,
+                        series: [
+                            { kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' },
+                            { kind: NodeKind.EventsNode, event: '$autocapture', name: '$autocapture' },
+                        ],
+                    },
+                })
+            })
+
+            it('cleans seeded series through the funnels capability cleaner', async () => {
+                const dataTableQuery: Node = {
+                    kind: NodeKind.DataTableNode,
+                    source: {
+                        kind: NodeKind.EventsQuery,
+                        select: ['*'],
+                        event: '$pageview',
+                    },
+                } as Node
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(dataTableQuery)
+                }).toFinishAllListeners()
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.FUNNELS)
+                }).toFinishAllListeners()
+
+                expect(builtInsightDataLogic.values.query).toMatchObject({
+                    source: {
+                        kind: NodeKind.FunnelsQuery,
+                        series: [{ kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' }],
+                    },
+                })
+            })
+
+            it('seeds only date_to when DataTable EventsQuery has only before', async () => {
+                const dataTableQuery: Node = {
+                    kind: NodeKind.DataTableNode,
+                    source: {
+                        kind: NodeKind.EventsQuery,
+                        select: ['*'],
+                        before: '2026-01-01T00:00:00Z',
+                    },
+                } as Node
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(dataTableQuery)
+                }).toFinishAllListeners()
+
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.TRENDS)
+                }).toFinishAllListeners()
+
+                expect(builtInsightDataLogic.values.query).toMatchObject({
+                    source: { dateRange: { date_to: '2026-01-01T00:00:00Z' } },
+                })
+                expect(
+                    (builtInsightDataLogic.values.query as InsightVizNode).source.dateRange?.date_from
+                ).toBeUndefined()
+            })
+
+            it('is a no-op when DataTable EventsQuery has no filters', async () => {
+                const dataTableQuery: Node = {
+                    kind: NodeKind.DataTableNode,
+                    source: { kind: NodeKind.EventsQuery, select: ['*'] },
+                } as Node
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(dataTableQuery)
+                }).toFinishAllListeners()
+
+                // Subsequent tab switch should not blow up and should not carry any filters
+                await expectLogic(builtInsightDataLogic, () => {
+                    logic.actions.setActiveView(InsightType.TRENDS)
+                }).toFinishAllListeners()
+
+                const trendsSource = (builtInsightDataLogic.values.query as InsightVizNode).source as TrendsQuery
+                expect(trendsSource.dateRange).toBeUndefined()
+                expect(trendsSource.properties).toBeUndefined()
+            })
+
+            it('does not seed cache when DataTable source is not an EventsQuery', async () => {
+                const cacheBefore = logic.values.queryPropertyCache
+                const dataTableQuery: Node = {
+                    kind: NodeKind.DataTableNode,
+                    source: {
+                        kind: NodeKind.HogQLQuery,
+                        query: 'SELECT * FROM events',
+                    },
+                } as Node
+
+                await expectLogic(logic, () => {
+                    builtInsightDataLogic.actions.setQuery(dataTableQuery)
+                }).toFinishAllListeners()
+
+                expect(logic.values.queryPropertyCache).toEqual(cacheBefore)
+            })
         })
     })
 })

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -19,6 +19,7 @@ import {
     AnyEntityNode,
     BreakdownFilter,
     CalendarHeatmapFilter,
+    DataTableNode,
     DataWarehouseNode,
     EntityNode,
     EventsNode,
@@ -51,6 +52,7 @@ import {
     isDataVisualizationNode,
     isDataWarehouseNode,
     isEndpointsUsageQuery,
+    isEventsQuery,
     isFunnelsQuery,
     isFunnelsDataWarehouseNode,
     isHogQuery,
@@ -529,15 +531,54 @@ export const insightNavLogic = kea<insightNavLogicType>([
         setQuery: ({ query }) => {
             if (isInsightVizNode(query)) {
                 actions.updateQueryPropertyCache(cachePropertiesFromQuery(query.source, values.queryPropertyCache))
+            } else if (isDataTableNode(query)) {
+                const seeded = cachePropertiesFromDataTable(query)
+                if (seeded) {
+                    actions.updateQueryPropertyCache(seeded)
+                }
             }
         },
     })),
     afterMount(({ values, actions }) => {
         if (values.query && isInsightVizNode(values.query)) {
             actions.updateQueryPropertyCache(cachePropertiesFromQuery(values.query.source, values.queryPropertyCache))
+        } else if (values.query && isDataTableNode(values.query)) {
+            const seeded = cachePropertiesFromDataTable(values.query)
+            if (seeded) {
+                actions.updateQueryPropertyCache(seeded)
+            }
         }
     }),
 ])
+
+const cachePropertiesFromDataTable = (query: DataTableNode): QueryPropertyCache | null => {
+    if (!isEventsQuery(query.source)) {
+        return null
+    }
+    const source = query.source
+    const cache: QueryPropertyCache = { commonFilter: {} }
+
+    if (source.properties?.length) {
+        cache.properties = JSON.parse(JSON.stringify(source.properties))
+    }
+    if (source.after || source.before) {
+        cache.dateRange = {
+            ...(source.after ? { date_from: source.after } : {}),
+            ...(source.before ? { date_to: source.before } : {}),
+        }
+    }
+
+    const seriesEvents = source.events?.length ? source.events : source.event ? [source.event] : []
+    if (seriesEvents.length) {
+        cache.series = seriesEvents.map((event) => ({
+            kind: NodeKind.EventsNode,
+            event,
+            name: event,
+        }))
+    }
+
+    return cache
+}
 
 const cachePropertiesFromQuery = (query: InsightQueryNode, cache: QueryPropertyCache | null): QueryPropertyCache => {
     const newCache = JSON.parse(JSON.stringify(query)) as QueryPropertyCache

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -556,7 +556,7 @@ const cachePropertiesFromDataTable = (query: DataTableNode): QueryPropertyCache 
         return null
     }
     const source = query.source
-    const cache: QueryPropertyCache = { commonFilter: {} }
+    const cache: Partial<QueryPropertyCache> = {}
 
     if (source.properties?.length) {
         cache.properties = JSON.parse(JSON.stringify(source.properties))
@@ -577,7 +577,7 @@ const cachePropertiesFromDataTable = (query: DataTableNode): QueryPropertyCache 
         }))
     }
 
-    return cache
+    return cache as QueryPropertyCache
 }
 
 const cachePropertiesFromQuery = (query: InsightQueryNode, cache: QueryPropertyCache | null): QueryPropertyCache => {

--- a/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
+++ b/frontend/src/scenes/insights/InsightNav/insightNavLogic.tsx
@@ -577,7 +577,7 @@ const cachePropertiesFromDataTable = (query: DataTableNode): QueryPropertyCache 
         }))
     }
 
-    return cache as QueryPropertyCache
+    return Object.keys(cache).length > 0 ? (cache as QueryPropertyCache) : null
 }
 
 const cachePropertiesFromQuery = (query: InsightQueryNode, cache: QueryPropertyCache | null): QueryPropertyCache => {


### PR DESCRIPTION
## Problem

When you open an event from the activity Data Table via "Open as new insight", you land on a Data Table insight with your filters (date range, event, property filters) applied. Switching to any other insight type tab (Trends, Funnels, Retention, etc.) wiped those filters and you had to re-apply them.

## Changes

- Add `cachePropertiesFromDataTable` in `insightNavLogic.tsx` that extracts `properties`, `dateRange` (from `EventsQuery.after`/`before`), and a single-entry `series` (from `EventsQuery.event`/`events`) out of a `DataTableNode` wrapping an `EventsQuery`.
- Seed the query property cache with those values on mount and on `setQuery` when the incoming query is a `DataTableNode`. The existing `mergeCachedProperties` machinery takes it from there — applying the cached values to the new insight type's query shape.
- New jest test covering DataTable → Trends preservation of date range, property filter, and event series.

## How did you test this code?

I'm an agent — no manual testing. I ran `pnpm --dir frontend exec jest src/scenes/insights/InsightNav/insightNavLogic.test.ts` (35 tests passing, including the new one).

## Publish to changelog?

<!-- For features only -->

## 🤖 LLM context

Authored by Claude (Opus 4.6). Starting point was a customer request to preserve Data Table filters when clicking over to other insight type tabs. The existing `queryPropertyCache` in `insightNavLogic` already supported cross-type filter preservation for `InsightVizNode` queries — the gap was that it never got seeded from `DataTableNode` queries, which is what "Open as new insight" from the activity page produces.