### PR TITLE
fix(ws): stop reprocessing DLQ'd messages in pipeline_v3

### DIFF
--- a/posthog/temporal/data_imports/README.md
+++ b/posthog/temporal/data_imports/README.md
@@ -104,30 +104,51 @@ Run this on a `temporal-worker-data-warehouse` pod via `manage.py shell_plus`:
 
 ```python
 from posthog.temporal.data_imports.pipelines.pipeline_v3.s3 import list_parquet_files, read_parquet
-from posthog.temporal.data_imports.pipelines.pipeline_v3.s3.common import get_base_folder, get_data_folder
+from posthog.temporal.data_imports.pipelines.pipeline_v3.s3.common import get_base_folder, get_data_folder, strip_s3_protocol
 from posthog.temporal.data_imports.pipelines.pipeline_v3.kafka.common import ExportSignalMessage, get_warpstream_kafka_producer
 from posthog.temporal.data_imports.pipelines.pipeline_v3.load.retry_tracker import clear_retry_info
 from posthog.temporal.data_imports.pipelines.pipeline_v3.load.idempotency import is_batch_already_processed
 from posthog.kafka_client.topics import KAFKA_WAREHOUSE_SOURCES_JOBS
 from products.data_warehouse.backend.models import ExternalDataJob, ExternalDataSchema
+from products.data_warehouse.backend.s3 import get_s3_client
 
 schema_id = '...'  # UUID of the schema to replay
 dry_run = True  # Set to False to actually send messages
+skip_job_check = False  # If True, ignore job status in DB and replay whatever is in S3
 
 schema = ExternalDataSchema.objects.select_related('source').get(id=schema_id)
 source = schema.source
 team_id = schema.team_id
 
-# Find the latest failed or running job for this schema
-job = (
-    ExternalDataJob.objects
-    .filter(schema_id=schema_id, status__in=[ExternalDataJob.Status.FAILED, ExternalDataJob.Status.RUNNING])
-    .order_by('-created_at')
-    .first()
-)
+if skip_job_check:
+    # Discover the latest run_uuid folder directly from S3 — strip the trailing run_uuid
+    # segment from get_base_folder to get the schema-level prefix
+    schema_base = get_base_folder(team_id, str(schema.id), '').rstrip('/')
+    schema_prefix = strip_s3_protocol(schema_base)
+    s3 = get_s3_client()
+    try:
+        run_folders = sorted(f.rstrip('/').split('/')[-1] for f in s3.ls(schema_prefix))
+    except FileNotFoundError:
+        run_folders = []
+    if not run_folders:
+        print(f"No S3 run folders found under {schema_prefix}")
+        job = None
+    else:
+        run_uuid = run_folders[-1]
+        job = ExternalDataJob.objects.filter(schema_id=schema_id, workflow_run_id=run_uuid).order_by('-created_at').first()
+        if job is None:
+            print(f"Found S3 run_uuid={run_uuid} but no matching ExternalDataJob")
+else:
+    # Find the latest failed or running job for this schema
+    job = (
+        ExternalDataJob.objects
+        .filter(schema_id=schema_id, status__in=[ExternalDataJob.Status.FAILED, ExternalDataJob.Status.RUNNING])
+        .order_by('-created_at')
+        .first()
+    )
 
 if job is None:
-    print(f"No failed/running job found for schema {schema_id}")
+    print(f"No job available for schema {schema_id}")
 else:
     run_uuid = job.workflow_run_id
     print(f"Found job {job.id} (status={job.status}, run_uuid={run_uuid})")

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py
@@ -214,7 +214,7 @@ class KafkaConsumerService:
                     timeout=self._config.batch_timeout_seconds,
                 )
 
-                messages: list[Any] = []
+                messages: list[tuple[Any, dict]] = []
                 for msg in raw_messages:
                     err = msg.error()
                     if err is not None:
@@ -225,7 +225,7 @@ class KafkaConsumerService:
                     raw = msg.value()
                     if raw is None:
                         continue
-                    messages.append(json.loads(raw.decode("utf-8")))
+                    messages.append((msg, json.loads(raw.decode("utf-8"))))
 
                 if not messages:
                     continue
@@ -243,8 +243,24 @@ class KafkaConsumerService:
         finally:
             self._cleanup()
 
+    def _commit_message(self, raw_msg: Any) -> None:
+        """Commit the offset for a single Kafka message synchronously.
+
+        Used on DLQ paths so a stuck message doesn't block the offset commit of
+        its healthy siblings in the same batch. Failures are logged but swallowed
+        so a commit blip doesn't prevent continued processing — redelivery will
+        hit the is_retry_exhausted branch and re-DLQ idempotently.
+        """
+        assert self._consumer is not None
+        try:
+            self._consumer.commit(message=raw_msg, asynchronous=False)
+            OFFSET_COMMITS_TOTAL.labels(status="success").inc()
+        except Exception as e:
+            OFFSET_COMMITS_TOTAL.labels(status="failure").inc()
+            logger.warning("per_message_commit_failed", error=str(e))
+
     def _process_batch_with_retry(
-        self, messages: list[Any], health_reporter: Optional[Callable[[], None]] = None
+        self, messages: list[tuple[Any, dict]], health_reporter: Optional[Callable[[], None]] = None
     ) -> None:
         """Process a batch of messages with persistent retry tracking.
 
@@ -261,7 +277,7 @@ class KafkaConsumerService:
 
         dlq_count = 0
 
-        for message in messages:
+        for raw_msg, message in messages:
             team_id = str(message.get("team_id") or "unknown")
             schema_id = str(message.get("schema_id") or "unknown")
 
@@ -290,7 +306,12 @@ class KafkaConsumerService:
                 )
                 self._send_to_dlq(message, error)
                 self._mark_job_failed_from_message(message, error)
-                clear_retry_info(*msg_key)
+                # Deliberately keep retry_info in Redis: if this per-message
+                # commit or the trailing batch commit fails, redelivery must
+                # still observe the exhausted state and re-DLQ idempotently
+                # rather than starting a fresh retry cycle. Cleanup relies on
+                # the 72h TTL.
+                self._commit_message(raw_msg)
                 MESSAGES_PROCESSED_TOTAL.labels(team_id=team_id, schema_id=schema_id, status="dlq").inc()
                 DLQ_MESSAGES_TOTAL.labels(team_id=team_id, schema_id=schema_id, error_type="RetryExhausted").inc()
                 BATCH_RETRY_EXHAUSTED_TOTAL.labels(error_type=retry_info.error_type or "unknown").inc()
@@ -323,10 +344,14 @@ class KafkaConsumerService:
                 BATCH_RETRY_TOTAL.labels(attempt=str(retry_info.count), error_type=type(e).__name__).inc()
 
                 if is_retry_exhausted(retry_info):
-                    # Exhausted after this attempt — DLQ and mark failed
+                    # Exhausted after this attempt — DLQ and mark failed.
+                    # Retry state stays in Redis (72h TTL) so that if the
+                    # per-message commit or a sibling failure prevents the
+                    # trailing batch commit, redelivery will re-DLQ via the
+                    # is_retry_exhausted branch rather than retrying from zero.
                     self._send_to_dlq(message, e)
                     self._mark_job_failed_from_message(message, e)
-                    clear_retry_info(*msg_key)
+                    self._commit_message(raw_msg)
                     MESSAGES_PROCESSED_TOTAL.labels(team_id=team_id, schema_id=schema_id, status="dlq").inc()
                     DLQ_MESSAGES_TOTAL.labels(team_id=team_id, schema_id=schema_id, error_type=type(e).__name__).inc()
                     BATCH_RETRY_EXHAUSTED_TOTAL.labels(error_type=error_class).inc()

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/test_consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/test_consumer.py
@@ -206,6 +206,11 @@ class TestExtractMessageKey:
         assert _extract_message_key(msg) is None
 
 
+def _wrap(*messages: dict) -> list[tuple[Any, dict]]:
+    """Pair each message dict with a MagicMock standing in for a confluent_kafka.Message."""
+    return [(MagicMock(name=f"raw_msg_{i}"), m) for i, m in enumerate(messages)]
+
+
 class TestProcessBatchPersistentRetry:
     def _setup_service(self, process_message: Any = None) -> KafkaConsumerService:
         service = _make_service(process_message=process_message or MagicMock())
@@ -219,11 +224,13 @@ class TestProcessBatchPersistentRetry:
         service = self._setup_service()
         msg = _make_message()
 
-        service._process_batch_with_retry([msg])
+        service._process_batch_with_retry(_wrap(msg))
 
         mock_inc.assert_called_once_with(1, "schema-1", "run-1", 0)
         mock_clear.assert_called_once_with(1, "schema-1", "run-1", 0)
-        cast(MagicMock, service._consumer).commit.assert_called_once()
+        consumer = cast(MagicMock, service._consumer)
+        # Success path: exactly one trailing batch commit, no per-message commit.
+        consumer.commit.assert_called_once_with()
 
     @patch(f"{RETRY_TRACKER_PATH}.update_retry_error_type")
     @patch(f"{RETRY_TRACKER_PATH}.increment_retry_count", return_value=RetryInfo(count=1))
@@ -234,7 +241,7 @@ class TestProcessBatchPersistentRetry:
         msg = _make_message()
 
         with pytest.raises(ValueError, match="bad data"):
-            service._process_batch_with_retry([msg])
+            service._process_batch_with_retry(_wrap(msg))
 
         mock_update.assert_called_once_with(
             1, "schema-1", "run-1", 0, error_type="non_transient", last_error="bad data"
@@ -249,17 +256,25 @@ class TestProcessBatchPersistentRetry:
         process_fn = MagicMock(side_effect=ValueError("bad data"))
         service = self._setup_service(process_message=process_fn)
         msg = _make_message()
+        wrapped = _wrap(msg)
+        raw_msg = wrapped[0][0]
 
         with (
             patch.object(service, "_send_to_dlq") as mock_dlq,
             patch.object(service, "_mark_job_failed_from_message") as mock_fail,
         ):
-            service._process_batch_with_retry([msg])
+            service._process_batch_with_retry(wrapped)
 
             mock_dlq.assert_called_once()
             mock_fail.assert_called_once()
-            mock_clear.assert_called_once_with(1, "schema-1", "run-1", 0)
-            cast(MagicMock, service._consumer).commit.assert_called_once()
+            # Retry state must NOT be cleared — redelivery relies on it to re-DLQ
+            # idempotently if any commit fails after DLQ'ing.
+            mock_clear.assert_not_called()
+            consumer = cast(MagicMock, service._consumer)
+            # Per-message commit fires right after DLQ, trailing batch commit after the loop.
+            assert consumer.commit.call_count == 2
+            consumer.commit.assert_any_call(message=raw_msg, asynchronous=False)
+            consumer.commit.assert_any_call()
 
     @patch(f"{RETRY_TRACKER_PATH}.clear_retry_info")
     @patch(f"{RETRY_TRACKER_PATH}.increment_retry_count")
@@ -271,19 +286,24 @@ class TestProcessBatchPersistentRetry:
         process_fn = MagicMock()
         service = self._setup_service(process_message=process_fn)
         msg = _make_message()
+        wrapped = _wrap(msg)
+        raw_msg = wrapped[0][0]
 
         with (
             patch.object(service, "_send_to_dlq") as mock_dlq,
             patch.object(service, "_mark_job_failed_from_message") as mock_fail,
         ):
-            service._process_batch_with_retry([msg])
+            service._process_batch_with_retry(wrapped)
 
             process_fn.assert_not_called()
             mock_inc.assert_not_called()
             mock_dlq.assert_called_once()
             mock_fail.assert_called_once()
-            mock_clear.assert_called_once()
-            cast(MagicMock, service._consumer).commit.assert_called_once()
+            mock_clear.assert_not_called()
+            consumer = cast(MagicMock, service._consumer)
+            assert consumer.commit.call_count == 2
+            consumer.commit.assert_any_call(message=raw_msg, asynchronous=False)
+            consumer.commit.assert_any_call()
 
     @patch(f"{RETRY_TRACKER_PATH}.clear_retry_info")
     @patch(f"{RETRY_TRACKER_PATH}.increment_retry_count", return_value=RetryInfo(count=1))
@@ -303,7 +323,7 @@ class TestProcessBatchPersistentRetry:
         service = self._setup_service(process_message=track_process)
         msg = _make_message()
 
-        service._process_batch_with_retry([msg])
+        service._process_batch_with_retry(_wrap(msg))
 
         assert call_order == ["increment", "process"]
 
@@ -316,7 +336,7 @@ class TestProcessBatchPersistentRetry:
         msg = _make_message()
 
         with pytest.raises(ConnectionError):
-            service._process_batch_with_retry([msg])
+            service._process_batch_with_retry(_wrap(msg))
 
         mock_update.assert_called_once_with(1, "schema-1", "run-1", 0, error_type="transient", last_error="reset")
 
@@ -340,8 +360,99 @@ class TestProcessBatchPersistentRetry:
         msg2 = _make_message(batch_index=1)
 
         with pytest.raises(ValueError):
-            service._process_batch_with_retry([msg1, msg2])
+            service._process_batch_with_retry(_wrap(msg1, msg2))
 
         # Only the first message was attempted
         assert call_count == 1
         cast(MagicMock, service._consumer).commit.assert_not_called()
+
+    @patch(f"{RETRY_TRACKER_PATH}.clear_retry_info")
+    @patch(f"{RETRY_TRACKER_PATH}.increment_retry_count")
+    @patch(
+        f"{RETRY_TRACKER_PATH}.get_retry_info",
+        return_value=RetryInfo(count=4, error_type="non_transient", last_error="previous error"),
+    )
+    def test_redelivered_exhausted_message_redlqs_idempotently(self, mock_get, mock_inc, mock_clear):
+        """On redelivery of a message that was DLQ'd but whose offset never advanced,
+        the exhausted retry state in Redis must cause a fresh DLQ + per-message commit
+        rather than a new retry cycle. Two deliveries → two DLQ sends, two per-message
+        commits, zero process_message calls, zero clear_retry_info calls."""
+        process_fn = MagicMock()
+        service = self._setup_service(process_message=process_fn)
+        msg = _make_message()
+
+        with (
+            patch.object(service, "_send_to_dlq") as mock_dlq,
+            patch.object(service, "_mark_job_failed_from_message") as mock_fail,
+        ):
+            first = _wrap(msg)
+            service._process_batch_with_retry(first)
+
+            second = _wrap(msg)
+            service._process_batch_with_retry(second)
+
+            process_fn.assert_not_called()
+            mock_inc.assert_not_called()
+            mock_clear.assert_not_called()
+            assert mock_dlq.call_count == 2
+            assert mock_fail.call_count == 2
+
+            consumer = cast(MagicMock, service._consumer)
+            # Each delivery: 1 per-message commit on DLQ + 1 trailing batch commit = 2.
+            assert consumer.commit.call_count == 4
+            consumer.commit.assert_any_call(message=first[0][0], asynchronous=False)
+            consumer.commit.assert_any_call(message=second[0][0], asynchronous=False)
+
+    @patch(f"{RETRY_TRACKER_PATH}.clear_retry_info")
+    @patch(f"{RETRY_TRACKER_PATH}.update_retry_error_type")
+    @patch(f"{RETRY_TRACKER_PATH}.increment_retry_count", return_value=RetryInfo(count=1))
+    def test_sibling_failure_does_not_unwind_dlq_offset(self, mock_inc, mock_update, mock_clear):
+        """Batch [A exhausted-on-arrival, B raises non-exhausted]. A must be DLQ'd and
+        its offset committed via per-message commit *before* B's raise propagates out.
+        The trailing batch commit is skipped — but A's offset has already advanced, so
+        on redelivery A is no longer in the batch."""
+        with patch(f"{RETRY_TRACKER_PATH}.get_retry_info") as mock_get:
+            # A is exhausted on arrival; B starts fresh.
+            mock_get.side_effect = [
+                RetryInfo(count=4, error_type="non_transient", last_error="earlier"),
+                RetryInfo(count=0),
+            ]
+
+            process_fn = MagicMock(side_effect=ValueError("B fails"))
+            service = self._setup_service(process_message=process_fn)
+            msg_a = _make_message(batch_index=0)
+            msg_b = _make_message(batch_index=1)
+            wrapped = _wrap(msg_a, msg_b)
+            raw_a = wrapped[0][0]
+
+            with (
+                patch.object(service, "_send_to_dlq") as mock_dlq,
+                patch.object(service, "_mark_job_failed_from_message") as mock_fail,
+                pytest.raises(ValueError, match="B fails"),
+            ):
+                service._process_batch_with_retry(wrapped)
+
+            # A was DLQ'd, B was attempted and failed.
+            mock_dlq.assert_called_once()
+            mock_fail.assert_called_once()
+            process_fn.assert_called_once()
+            mock_clear.assert_not_called()
+
+            consumer = cast(MagicMock, service._consumer)
+            # Only A's per-message commit — B's raise aborts the trailing batch commit.
+            consumer.commit.assert_called_once_with(message=raw_a, asynchronous=False)
+
+    @patch(f"{RETRY_TRACKER_PATH}.clear_retry_info")
+    @patch(f"{RETRY_TRACKER_PATH}.increment_retry_count", return_value=RetryInfo(count=1))
+    @patch(f"{RETRY_TRACKER_PATH}.get_retry_info", return_value=RetryInfo(count=0))
+    def test_success_path_uses_batch_commit_not_per_message(self, mock_get, mock_inc, mock_clear):
+        service = self._setup_service()
+        msgs = [_make_message(batch_index=i) for i in range(3)]
+
+        service._process_batch_with_retry(_wrap(*msgs))
+
+        consumer = cast(MagicMock, service._consumer)
+        consumer.commit.assert_called_once_with()
+        # No per-message commit was issued on any message.
+        for call in consumer.commit.call_args_list:
+            assert call.kwargs.get("message") is None

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -235,6 +235,21 @@ def _mark_job_completed(export_signal: ExportSignalMessage) -> None:
 
 
 def _mark_job_failed(export_signal: ExportSignalMessage, error: Exception) -> None:
+    # Short-circuit if the job is already FAILED: redelivered DLQ'd messages
+    # (the retry state stays in Redis until its 72h TTL) would otherwise spam
+    # status updates and latest_error rewrites for a terminal job.
+    existing = ExternalDataJob.objects.filter(
+        id=export_signal.job_id, team_id=export_signal.team_id, status=ExternalDataJob.Status.FAILED
+    ).first()
+    if existing is not None:
+        logger.info(
+            "job_already_marked_failed",
+            job_id=export_signal.job_id,
+            team_id=export_signal.team_id,
+            schema_id=export_signal.schema_id,
+        )
+        return
+
     job = update_external_job_status(
         job_id=export_signal.job_id,
         team_id=export_signal.team_id,


### PR DESCRIPTION
## Problem

The `pipeline_v3` Kafka consumer's `_process_batch_with_retry` had a race condition where DLQ'd messages could be reprocessed and re-DLQ'd indefinitely. Both DLQ branches in `consumer.py` called `clear_retry_info()` **before** the batch-level`consumer.commit()`. If anything between those points failed — a sibling message in the same batch raising non-exhausted, or the worker OOM'ing / SIGKILL'ing... the  DLQ'd message's Redis retry state was wiped but its Kafka offset never advanced. On redelivery the message started a fresh retry cycle, got DLQ'd again, and so on.

## Changes

### `posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py`

- `run()` deserialize loop now carries `(raw_msg, parsed_dict)` tuples.
- New `_commit_message(raw_msg)` helper.
- Both DLQ paths (exhausted-on-arrival, exhausted-after-attempt): removed `clear_retry_info`, added `self._commit_message(raw_msg)`.
- Success path's `clear_retry_info` and the trailing batch commit are unchanged.

### `posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py`

- `_mark_job_failed` short-circuits if the job is already `FAILED`, so redelivered DLQ events don't spam DB writes for a terminal job.

### `posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/test_consumer.py`

- Updated DLQ-path tests: `clear_retry_info` assertions changed to `assert_not_called()`, added per-message commit assertions.
- New tests covering the race:
  - `test_redelivered_exhausted_message_redlqs_idempotently`
  - `test_sibling_failure_does_not_unwind_dlq_offset`
  - `test_success_path_uses_batch_commit_not_per_message`Opus 4.6Extended

## How did you test this code?

 * Test pass
 * Can't run locally this 

## Publish to changelog?

NO


