### PR TITLE
feat(cohorts): inline cohort creation in TaxonomicFilter

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
@@ -23,15 +23,19 @@ const COHORT_GROUP_TYPES: readonly TaxonomicFilterGroupType[] = [
     TaxonomicFilterGroupType.CohortsWithAllUsers,
 ]
 
+// Stable element for the "+ New cohort" button icon so each TaxonomicFilter
+// render doesn't allocate a fresh ReactElement.
+const PLUS_ICON = <IconPlusSmall />
+
 export interface InfiniteSelectResultsProps {
     focusInput: () => void
     taxonomicFilterLogicProps: TaxonomicFilterLogicProps
     popupAnchorElement: HTMLDivElement | null
     definitionPopoverRenderer?: DefinitionPopoverRenderer
     /**
-     * When provided, a "+ Create new cohort" button is rendered above the list
-     * for cohort-typed groups. Firing this callback typically opens a modal
-     * hosted by the parent TaxonomicFilter.
+     * When provided, a "+ New cohort" button is rendered above the list for
+     * the active cohort-typed tab. Firing this callback typically opens a
+     * modal hosted by the parent TaxonomicFilter.
      */
     openCohortCreateModal?: () => void
 }
@@ -214,7 +218,11 @@ export function InfiniteSelectResults({
 
             <div className={cn('flex-1 overflow-hidden min-h-0')}>
                 {taxonomicGroupTypes.map((groupType) => {
-                    const showCohortCreateButton = !!openCohortCreateModal && COHORT_GROUP_TYPES.includes(groupType)
+                    // Only render the create button on the active tab — otherwise
+                    // the button sits in a `hidden` subtree but is still in the
+                    // DOM and reachable via keyboard tab navigation.
+                    const showCohortCreateButton =
+                        !!openCohortCreateModal && groupType === openTab && COHORT_GROUP_TYPES.includes(groupType)
                     return (
                         <div key={groupType} className={cn(groupType === openTab ? 'flex flex-col h-full' : 'hidden')}>
                             <BindLogic
@@ -227,11 +235,11 @@ export function InfiniteSelectResults({
                                             type="tertiary"
                                             size="small"
                                             fullWidth
-                                            icon={<IconPlusSmall />}
+                                            icon={PLUS_ICON}
                                             onClick={openCohortCreateModal}
                                             data-attr={`taxonomic-create-cohort-${groupType}`}
                                         >
-                                            Create new cohort
+                                            New cohort
                                         </LemonButton>
                                     </div>
                                 )}

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
@@ -1,7 +1,8 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { useRef } from 'react'
 
-import { LemonTag } from '@posthog/lemon-ui'
+import { IconPlusSmall } from '@posthog/icons'
+import { LemonButton, LemonTag } from '@posthog/lemon-ui'
 
 import { InfiniteList } from 'lib/components/TaxonomicFilter/InfiniteList'
 import { infiniteListLogic } from 'lib/components/TaxonomicFilter/infiniteListLogic'
@@ -17,11 +18,22 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { TaxonomicFilterEmptyState, taxonomicFilterGroupTypesWithEmptyStates } from './TaxonomicFilterEmptyState'
 import { taxonomicFilterLogic } from './taxonomicFilterLogic'
 
+const COHORT_GROUP_TYPES: readonly TaxonomicFilterGroupType[] = [
+    TaxonomicFilterGroupType.Cohorts,
+    TaxonomicFilterGroupType.CohortsWithAllUsers,
+]
+
 export interface InfiniteSelectResultsProps {
     focusInput: () => void
     taxonomicFilterLogicProps: TaxonomicFilterLogicProps
     popupAnchorElement: HTMLDivElement | null
     definitionPopoverRenderer?: DefinitionPopoverRenderer
+    /**
+     * When provided, a "+ Create new cohort" button is rendered above the list
+     * for cohort-typed groups. Firing this callback typically opens a modal
+     * hosted by the parent TaxonomicFilter.
+     */
+    openCohortCreateModal?: () => void
 }
 
 // CategoryPillContent uses useValues(infiniteListLogic) without props, relying on BindLogic context
@@ -122,6 +134,7 @@ export function InfiniteSelectResults({
     taxonomicFilterLogicProps,
     popupAnchorElement,
     definitionPopoverRenderer,
+    openCohortCreateModal,
 }: InfiniteSelectResultsProps): JSX.Element {
     const { activeTab, taxonomicGroups, taxonomicGroupTypes, activeTaxonomicGroup, value } =
         useValues(taxonomicFilterLogic)
@@ -201,12 +214,27 @@ export function InfiniteSelectResults({
 
             <div className={cn('flex-1 overflow-hidden min-h-0')}>
                 {taxonomicGroupTypes.map((groupType) => {
+                    const showCohortCreateButton = !!openCohortCreateModal && COHORT_GROUP_TYPES.includes(groupType)
                     return (
                         <div key={groupType} className={cn(groupType === openTab ? 'flex flex-col h-full' : 'hidden')}>
                             <BindLogic
                                 logic={infiniteListLogic}
                                 props={{ ...taxonomicFilterLogicProps, listGroupType: groupType }}
                             >
+                                {showCohortCreateButton && (
+                                    <div className="px-1 pb-1">
+                                        <LemonButton
+                                            type="tertiary"
+                                            size="small"
+                                            fullWidth
+                                            icon={<IconPlusSmall />}
+                                            onClick={openCohortCreateModal}
+                                            data-attr={`taxonomic-create-cohort-${groupType}`}
+                                        >
+                                            Create new cohort
+                                        </LemonButton>
+                                    </div>
+                                )}
                                 {(showDataWarehouseLoadingState || showEmptyState) && (
                                     <TaxonomicFilterEmptyState
                                         groupType={groupType}

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -8,6 +8,7 @@ import { IconKeyboard } from '@posthog/icons'
 import { Link } from '@posthog/lemon-ui'
 
 import {
+    TaxonomicFilterGroup,
     TaxonomicFilterGroupType,
     TaxonomicFilterLogicProps,
     TaxonomicFilterProps,
@@ -15,7 +16,10 @@ import {
 import { Icon123 } from 'lib/lemon-ui/icons'
 import { LemonInput, LemonInputPropsText } from 'lib/lemon-ui/LemonInput/LemonInput'
 import { Tooltip, TooltipProps } from 'lib/lemon-ui/Tooltip'
+import { CohortCreateModal } from 'scenes/cohorts/CohortCreateModal'
 import { urls } from 'scenes/urls'
+
+import { CohortType } from '~/types'
 
 import { InfiniteSelectResults } from './InfiniteSelectResults'
 import { defaultDataWarehousePopoverFields, taxonomicFilterLogic } from './taxonomicFilterLogic'
@@ -51,7 +55,9 @@ export function TaxonomicFilter({
     definitionPopoverRenderer,
     minSearchQueryLength,
     suggestedFiltersLabel,
+    enableInlineCohortCreation = true,
 }: TaxonomicFilterProps): JSX.Element {
+    const [isCohortCreateModalOpen, setIsCohortCreateModalOpen] = useState(false)
     // Generate a unique key for each unique TaxonomicFilter that's rendered
     const taxonomicFilterLogicKey = useMemo(
         () => taxonomicFilterLogicKeyInput || `taxonomic-filter-${uniqueMemoizedIndex++}`,
@@ -90,8 +96,16 @@ export function TaxonomicFilter({
     }
 
     const logic = taxonomicFilterLogic(taxonomicFilterLogicProps)
-    const { activeTab } = useValues(logic)
+    const { activeTab, taxonomicGroups } = useValues(logic)
+    const { selectItem } = useActions(logic)
     const [refReady, setRefReady] = useState(false)
+
+    const cohortCreationEnabled =
+        enableInlineCohortCreation &&
+        (taxonomicGroupTypes.includes(TaxonomicFilterGroupType.Cohorts) ||
+            taxonomicGroupTypes.includes(TaxonomicFilterGroupType.CohortsWithAllUsers))
+
+    const openCohortCreateModal = useMemo(() => () => setIsCohortCreateModalOpen(true), [])
 
     useEffect(() => {
         if (groupType !== TaxonomicFilterGroupType.HogQLExpression) {
@@ -135,9 +149,32 @@ export function TaxonomicFilter({
                         taxonomicFilterLogicProps={taxonomicFilterLogicProps}
                         popupAnchorElement={taxonomicFilterRef.current}
                         definitionPopoverRenderer={definitionPopoverRenderer}
+                        openCohortCreateModal={cohortCreationEnabled ? openCohortCreateModal : undefined}
                     />
                 )}
             </div>
+            {cohortCreationEnabled && (
+                <CohortCreateModal
+                    isOpen={isCohortCreateModalOpen}
+                    onClose={() => setIsCohortCreateModalOpen(false)}
+                    onSaved={(cohort: CohortType) => {
+                        // Prefer the breakdown-friendly "CohortsWithAllUsers" group if present,
+                        // otherwise use the plain Cohorts group. Both groups share `getValue`
+                        // returning the cohort id, so either works with downstream consumers.
+                        const cohortGroup =
+                            taxonomicGroups.find(
+                                (g: TaxonomicFilterGroup) => g.type === TaxonomicFilterGroupType.Cohorts
+                            ) ??
+                            taxonomicGroups.find(
+                                (g: TaxonomicFilterGroup) => g.type === TaxonomicFilterGroupType.CohortsWithAllUsers
+                            )
+                        if (cohortGroup) {
+                            selectItem(cohortGroup, cohort.id, cohort)
+                        }
+                    }}
+                    modalKey={taxonomicFilterLogicKey}
+                />
+            )}
         </BindLogic>
     )
 }

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -2,7 +2,7 @@ import './TaxonomicFilter.scss'
 
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
-import { forwardRef, useEffect, useMemo, useRef, useState } from 'react'
+import { Suspense, forwardRef, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { IconKeyboard } from '@posthog/icons'
 import { Link } from '@posthog/lemon-ui'
@@ -16,13 +16,20 @@ import {
 import { Icon123 } from 'lib/lemon-ui/icons'
 import { LemonInput, LemonInputPropsText } from 'lib/lemon-ui/LemonInput/LemonInput'
 import { Tooltip, TooltipProps } from 'lib/lemon-ui/Tooltip'
-import { CohortCreateModal } from 'scenes/cohorts/CohortCreateModal'
 import { urls } from 'scenes/urls'
 
 import { CohortType } from '~/types'
 
 import { InfiniteSelectResults } from './InfiniteSelectResults'
 import { defaultDataWarehousePopoverFields, taxonomicFilterLogic } from './taxonomicFilterLogic'
+
+// Lazy-load the cohort creation modal so the cohort editor subtree
+// (cohortEditLogic, CohortCriteriaGroups, kea-forms, etc.) is not in the
+// TaxonomicFilter's initial bundle — TaxonomicFilter renders on almost every
+// analytics page.
+const CohortCreateModal = lazy(() =>
+    import('scenes/cohorts/CohortCreateModal').then((m) => ({ default: m.CohortCreateModal }))
+)
 
 let uniqueMemoizedIndex = 0
 
@@ -96,8 +103,10 @@ export function TaxonomicFilter({
     }
 
     const logic = taxonomicFilterLogic(taxonomicFilterLogicProps)
-    const { activeTab, taxonomicGroups } = useValues(logic)
-    const { selectItem } = useActions(logic)
+    // Only subscribe to `activeTab`. `taxonomicGroups` is a heavy selector with
+    // many upstream deps — reading it via `logic.findMounted()` inside the
+    // save callback avoids re-rendering TaxonomicFilter on every group change.
+    const { activeTab } = useValues(logic)
     const [refReady, setRefReady] = useState(false)
 
     const cohortCreationEnabled =
@@ -105,7 +114,28 @@ export function TaxonomicFilter({
         (taxonomicGroupTypes.includes(TaxonomicFilterGroupType.Cohorts) ||
             taxonomicGroupTypes.includes(TaxonomicFilterGroupType.CohortsWithAllUsers))
 
-    const openCohortCreateModal = useMemo(() => () => setIsCohortCreateModalOpen(true), [])
+    const openCohortCreateModal = useCallback(() => setIsCohortCreateModalOpen(true), [])
+    const closeCohortCreateModal = useCallback(() => setIsCohortCreateModalOpen(false), [])
+    const onCohortSaved = useCallback(
+        (cohort: CohortType) => {
+            const mounted = taxonomicFilterLogic.findMounted(taxonomicFilterLogicProps)
+            if (!mounted) {
+                return
+            }
+            const groups: TaxonomicFilterGroup[] = mounted.values.taxonomicGroups
+            // Prefer the breakdown-friendly CohortsWithAllUsers group if present,
+            // otherwise fall back to the plain Cohorts group — both use `cohort.id`
+            // as the selected value.
+            const cohortGroup =
+                groups.find((g) => g.type === TaxonomicFilterGroupType.Cohorts) ??
+                groups.find((g) => g.type === TaxonomicFilterGroupType.CohortsWithAllUsers)
+            if (cohortGroup) {
+                mounted.actions.selectItem(cohortGroup, cohort.id, cohort)
+            }
+            // oxlint-disable-next-line react-hooks/exhaustive-deps
+        },
+        [taxonomicFilterLogicKey]
+    )
 
     useEffect(() => {
         if (groupType !== TaxonomicFilterGroupType.HogQLExpression) {
@@ -153,27 +183,15 @@ export function TaxonomicFilter({
                     />
                 )}
             </div>
-            {cohortCreationEnabled && (
-                <CohortCreateModal
-                    isOpen={isCohortCreateModalOpen}
-                    onClose={() => setIsCohortCreateModalOpen(false)}
-                    onSaved={(cohort: CohortType) => {
-                        // Prefer the breakdown-friendly "CohortsWithAllUsers" group if present,
-                        // otherwise use the plain Cohorts group. Both groups share `getValue`
-                        // returning the cohort id, so either works with downstream consumers.
-                        const cohortGroup =
-                            taxonomicGroups.find(
-                                (g: TaxonomicFilterGroup) => g.type === TaxonomicFilterGroupType.Cohorts
-                            ) ??
-                            taxonomicGroups.find(
-                                (g: TaxonomicFilterGroup) => g.type === TaxonomicFilterGroupType.CohortsWithAllUsers
-                            )
-                        if (cohortGroup) {
-                            selectItem(cohortGroup, cohort.id, cohort)
-                        }
-                    }}
-                    modalKey={taxonomicFilterLogicKey}
-                />
+            {cohortCreationEnabled && isCohortCreateModalOpen && (
+                <Suspense fallback={null}>
+                    <CohortCreateModal
+                        isOpen={isCohortCreateModalOpen}
+                        onClose={closeCohortCreateModal}
+                        onSaved={onCohortSaved}
+                        modalKey={taxonomicFilterLogicKey}
+                    />
+                </Suspense>
             )}
         </BindLogic>
     )

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -102,6 +102,11 @@ export interface TaxonomicFilterProps {
     minSearchQueryLength?: number
     /** Override the "Suggested filters" tab label for specific contexts. */
     suggestedFiltersLabel?: string
+    /**
+     * Set to `false` to hide the inline "+ Create new cohort" row that appears
+     * above the Cohorts and CohortsWithAllUsers lists. Defaults to enabled.
+     */
+    enableInlineCohortCreation?: boolean
 }
 
 export interface DataWarehousePopoverField {

--- a/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
+++ b/frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.tsx
@@ -50,6 +50,8 @@ export interface TaxonomicPopoverProps<ValueType extends TaxonomicFilterValue = 
     sideIcon?: React.ReactElement | null
     definitionPopoverRenderer?: DefinitionPopoverRenderer
     suggestedFiltersLabel?: string
+    /** Forwarded to the inner TaxonomicFilter — disable to hide the inline "+ New cohort" button. */
+    enableInlineCohortCreation?: boolean
 }
 
 /** Like TaxonomicPopover, but convenient when you know you will only use string values */
@@ -90,6 +92,7 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
         allowNonCapturedEvents,
         definitionPopoverRenderer,
         suggestedFiltersLabel,
+        enableInlineCohortCreation,
         width,
         placement,
         sideIcon,
@@ -147,6 +150,7 @@ export const TaxonomicPopover = forwardRef(function TaxonomicPopover_<
                     allowNonCapturedEvents={allowNonCapturedEvents}
                     definitionPopoverRenderer={definitionPopoverRenderer}
                     suggestedFiltersLabel={suggestedFiltersLabel}
+                    enableInlineCohortCreation={enableInlineCohortCreation}
                     width={width}
                 />
             }

--- a/frontend/src/scenes/cohorts/CohortCreateModal.tsx
+++ b/frontend/src/scenes/cohorts/CohortCreateModal.tsx
@@ -1,0 +1,140 @@
+import { BindLogic, useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
+import { useMemo } from 'react'
+
+import { LemonButton, LemonInput, LemonModal } from '@posthog/lemon-ui'
+
+import { CohortTypeEnum } from 'lib/constants'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
+import { Link } from 'lib/lemon-ui/Link'
+import { cohortEditLogic } from 'scenes/cohorts/cohortEditLogic'
+import { CohortCriteriaGroups } from 'scenes/cohorts/CohortFilters/CohortCriteriaGroups'
+import { COHORT_TYPE_OPTIONS } from 'scenes/cohorts/CohortFilters/constants'
+
+import { AndOrFilterSelect } from '~/queries/nodes/InsightViz/PropertyGroupFilters/AndOrFilterSelect'
+import { CohortType } from '~/types'
+
+export interface CohortCreateModalProps {
+    isOpen: boolean
+    onClose: () => void
+    onSaved: (cohort: CohortType) => void
+    /**
+     * Unique key used to isolate this modal's `cohortEditLogic` instance from the
+     * cohort scene (which keys by `id` + `tabId`). Typically the parent's
+     * taxonomicFilterLogicKey.
+     */
+    modalKey: string
+}
+
+/**
+ * Inline "Create new cohort" modal for use inside the TaxonomicFilter. Reuses
+ * `cohortEditLogic` so the form, validation, and API save path are identical to
+ * the cohort creation scene at `/cohorts/new` — only the chrome is different.
+ */
+export function CohortCreateModal({ isOpen, onClose, onSaved, modalKey }: CohortCreateModalProps): JSX.Element | null {
+    const logicProps = useMemo(
+        () => ({
+            id: 'new' as const,
+            tabId: `cohort-create-modal-${modalKey}`,
+            disableNavigation: true,
+            onSaved: (cohort: CohortType) => {
+                onSaved(cohort)
+                onClose()
+            },
+        }),
+        [modalKey, onSaved, onClose]
+    )
+
+    // Only mount the cohort edit logic while the modal is open — keeps the
+    // logic isolated and avoids accidentally seeding the NEW_COHORT state when
+    // the TaxonomicFilter is rendered but the modal is closed.
+    if (!isOpen) {
+        return null
+    }
+
+    return (
+        <BindLogic logic={cohortEditLogic} props={logicProps}>
+            <CohortCreateModalInner onClose={onClose} />
+        </BindLogic>
+    )
+}
+
+function CohortCreateModalInner({ onClose }: { onClose: () => void }): JSX.Element {
+    const { cohort, cohortLoading } = useValues(cohortEditLogic)
+    const { setCohortValue, setOuterGroupsType, submitCohort } = useActions(cohortEditLogic)
+
+    return (
+        <LemonModal
+            title="Create new cohort"
+            isOpen
+            onClose={onClose}
+            width={720}
+            closable={!cohortLoading}
+            footer={
+                <div className="flex items-center justify-end gap-2">
+                    <LemonButton type="secondary" onClick={onClose} disabled={cohortLoading}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        onClick={() => submitCohort()}
+                        loading={cohortLoading}
+                        data-attr="save-cohort-modal"
+                        disabledReason={
+                            cohort.is_static ? 'Static cohorts must be created from the cohorts page' : undefined
+                        }
+                    >
+                        Create cohort
+                    </LemonButton>
+                </div>
+            }
+        >
+            <Form logic={cohortEditLogic} formKey="cohort" enableFormOnSubmit className="deprecated-space-y-4">
+                <LemonField name="name" label="Name">
+                    <LemonInput
+                        placeholder="e.g. Active users"
+                        data-attr="cohort-name-modal"
+                        autoFocus
+                        onChange={(value) => setCohortValue('name', value)}
+                        value={cohort.name ?? ''}
+                    />
+                </LemonField>
+                <LemonField name="is_static" label="Type">
+                    {({ value, onChange }) => (
+                        <LemonSelect
+                            options={COHORT_TYPE_OPTIONS}
+                            value={value ? CohortTypeEnum.Static : CohortTypeEnum.Dynamic}
+                            onChange={(cohortType) => {
+                                onChange(cohortType === CohortTypeEnum.Static)
+                            }}
+                            fullWidth
+                            data-attr="cohort-type-modal"
+                        />
+                    )}
+                </LemonField>
+                {cohort.is_static ? (
+                    <div className="text-secondary">
+                        Static cohorts require a CSV upload or persons picker. Please use the{' '}
+                        <Link to="/cohorts/new" target="_blank">
+                            full cohort editor
+                        </Link>{' '}
+                        to create a static cohort.
+                    </div>
+                ) : (
+                    <div className="flex flex-col gap-2">
+                        <AndOrFilterSelect
+                            value={cohort.filters.properties.type}
+                            onChange={(value) => setOuterGroupsType(value)}
+                            topLevelFilter
+                            suffix={['criterion', 'criteria']}
+                        />
+                        <div className="[&>div]:my-0 [&>div]:w-full">
+                            <CohortCriteriaGroups id="new" />
+                        </div>
+                    </div>
+                )}
+            </Form>
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/cohorts/CohortCreateModal.tsx
+++ b/frontend/src/scenes/cohorts/CohortCreateModal.tsx
@@ -4,13 +4,11 @@ import { useMemo } from 'react'
 
 import { LemonButton, LemonInput, LemonModal } from '@posthog/lemon-ui'
 
-import { CohortTypeEnum } from 'lib/constants'
+import { CLICK_OUTSIDE_BLOCK_CLASS } from 'lib/hooks/useOutsideClickHandler'
 import { LemonField } from 'lib/lemon-ui/LemonField'
-import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
 import { Link } from 'lib/lemon-ui/Link'
 import { cohortEditLogic } from 'scenes/cohorts/cohortEditLogic'
 import { CohortCriteriaGroups } from 'scenes/cohorts/CohortFilters/CohortCriteriaGroups'
-import { COHORT_TYPE_OPTIONS } from 'scenes/cohorts/CohortFilters/constants'
 
 import { AndOrFilterSelect } from '~/queries/nodes/InsightViz/PropertyGroupFilters/AndOrFilterSelect'
 import { CohortType } from '~/types'
@@ -28,11 +26,14 @@ export interface CohortCreateModalProps {
 }
 
 /**
- * Inline "Create new cohort" modal for use inside the TaxonomicFilter. Reuses
+ * Inline "New cohort" modal for use inside the TaxonomicFilter. Reuses
  * `cohortEditLogic` so the form, validation, and API save path are identical to
  * the cohort creation scene at `/cohorts/new` — only the chrome is different.
+ *
+ * This modal only supports dynamic cohorts. Static cohorts require a CSV upload
+ * or persons picker and are handled by the full cohort scene.
  */
-export function CohortCreateModal({ isOpen, onClose, onSaved, modalKey }: CohortCreateModalProps): JSX.Element | null {
+export function CohortCreateModal({ isOpen, onClose, onSaved, modalKey }: CohortCreateModalProps): JSX.Element {
     const logicProps = useMemo(
         () => ({
             id: 'new' as const,
@@ -46,44 +47,44 @@ export function CohortCreateModal({ isOpen, onClose, onSaved, modalKey }: Cohort
         [modalKey, onSaved, onClose]
     )
 
-    // Only mount the cohort edit logic while the modal is open — keeps the
-    // logic isolated and avoids accidentally seeding the NEW_COHORT state when
-    // the TaxonomicFilter is rendered but the modal is closed.
-    if (!isOpen) {
-        return null
-    }
-
+    // Always render the modal (use LemonModal's isOpen to toggle visibility)
+    // so a mid-save close never unmounts `cohortEditLogic` and orphans the
+    // in-flight API call.
     return (
         <BindLogic logic={cohortEditLogic} props={logicProps}>
-            <CohortCreateModalInner onClose={onClose} />
+            <CohortCreateModalInner isOpen={isOpen} onClose={onClose} />
         </BindLogic>
     )
 }
 
-function CohortCreateModalInner({ onClose }: { onClose: () => void }): JSX.Element {
+function CohortCreateModalInner({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }): JSX.Element {
     const { cohort, cohortLoading } = useValues(cohortEditLogic)
-    const { setCohortValue, setOuterGroupsType, submitCohort } = useActions(cohortEditLogic)
+    const { setOuterGroupsType, submitCohort } = useActions(cohortEditLogic)
+
+    const savingDisabledReason = cohortLoading ? 'Saving…' : undefined
 
     return (
         <LemonModal
-            title="Create new cohort"
-            isOpen
+            title="New cohort"
+            isOpen={isOpen}
             onClose={onClose}
             width={720}
-            closable={!cohortLoading}
+            // `.click-outside-block` prevents clicks inside the modal content
+            // from closing a surrounding Popover (e.g. TaxonomicPopover) via its
+            // click-outside handler. Without this, clicking any control in the
+            // modal would dismiss the host filter popover and unmount the modal.
+            overlayClassName={CLICK_OUTSIDE_BLOCK_CLASS}
             footer={
                 <div className="flex items-center justify-end gap-2">
-                    <LemonButton type="secondary" onClick={onClose} disabled={cohortLoading}>
+                    <LemonButton type="secondary" onClick={onClose}>
                         Cancel
                     </LemonButton>
                     <LemonButton
                         type="primary"
                         onClick={() => submitCohort()}
                         loading={cohortLoading}
+                        disabledReason={savingDisabledReason}
                         data-attr="save-cohort-modal"
-                        disabledReason={
-                            cohort.is_static ? 'Static cohorts must be created from the cohorts page' : undefined
-                        }
                     >
                         Create cohort
                     </LemonButton>
@@ -92,48 +93,34 @@ function CohortCreateModalInner({ onClose }: { onClose: () => void }): JSX.Eleme
         >
             <Form logic={cohortEditLogic} formKey="cohort" enableFormOnSubmit className="deprecated-space-y-4">
                 <LemonField name="name" label="Name">
-                    <LemonInput
-                        placeholder="e.g. Active users"
-                        data-attr="cohort-name-modal"
-                        autoFocus
-                        onChange={(value) => setCohortValue('name', value)}
-                        value={cohort.name ?? ''}
-                    />
-                </LemonField>
-                <LemonField name="is_static" label="Type">
                     {({ value, onChange }) => (
-                        <LemonSelect
-                            options={COHORT_TYPE_OPTIONS}
-                            value={value ? CohortTypeEnum.Static : CohortTypeEnum.Dynamic}
-                            onChange={(cohortType) => {
-                                onChange(cohortType === CohortTypeEnum.Static)
-                            }}
-                            fullWidth
-                            data-attr="cohort-type-modal"
+                        <LemonInput
+                            placeholder="e.g. Active users"
+                            data-attr="cohort-name-modal"
+                            autoFocus
+                            value={value ?? ''}
+                            onChange={onChange}
                         />
                     )}
                 </LemonField>
-                {cohort.is_static ? (
-                    <div className="text-secondary">
-                        Static cohorts require a CSV upload or persons picker. Please use the{' '}
-                        <Link to="/cohorts/new" target="_blank">
-                            full cohort editor
-                        </Link>{' '}
-                        to create a static cohort.
+                <div className="text-xs text-secondary">
+                    Need a static cohort (uploaded from a CSV)?{' '}
+                    <Link to="/cohorts/new" target="_blank">
+                        Use the full cohort editor
+                    </Link>
+                    .
+                </div>
+                <div className="flex flex-col gap-2">
+                    <AndOrFilterSelect
+                        value={cohort.filters.properties.type}
+                        onChange={(value) => setOuterGroupsType(value)}
+                        topLevelFilter
+                        suffix={['criterion', 'criteria']}
+                    />
+                    <div className="[&>div]:my-0 [&>div]:w-full">
+                        <CohortCriteriaGroups id="new" />
                     </div>
-                ) : (
-                    <div className="flex flex-col gap-2">
-                        <AndOrFilterSelect
-                            value={cohort.filters.properties.type}
-                            onChange={(value) => setOuterGroupsType(value)}
-                            topLevelFilter
-                            suffix={['criterion', 'criteria']}
-                        />
-                        <div className="[&>div]:my-0 [&>div]:w-full">
-                            <CohortCriteriaGroups id="new" />
-                        </div>
-                    </div>
-                )}
+                </div>
             </Form>
         </LemonModal>
     )

--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
@@ -167,6 +167,9 @@ export function CohortTaxonomicField({
             groupTypes={taxonomicGroupTypes}
             placeholder={placeholder}
             data-attr={`cohort-taxonomic-field-${fieldKey}`}
+            // Avoid offering inline cohort creation inside the cohort criteria
+            // picker itself — would trigger a recursive create-cohort modal.
+            enableInlineCohortCreation={false}
             renderValue={(value) =>
                 value ? (
                     <PropertyKeyInfo value={value as string} type={groupType} />

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -50,6 +50,14 @@ import type { cohortEditLogicType } from './cohortEditLogicType'
 export type CohortLogicProps = {
     id?: CohortType['id']
     tabId?: string
+    /**
+     * When true, successful creation of a new cohort does NOT navigate to
+     * `/cohorts/:id`. Used when `cohortEditLogic` is mounted inside a modal
+     * (e.g. the inline creation modal in TaxonomicFilter).
+     */
+    disableNavigation?: boolean
+    /** Called after a new cohort is successfully created. */
+    onSaved?: (cohort: CohortType) => void
 }
 
 const checkIsPendingCalculation = (cohort: CohortType): boolean =>
@@ -317,7 +325,7 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
         },
     })),
 
-    loaders(({ actions, values, key }) => ({
+    loaders(({ actions, values, key, props }) => ({
         cohort: [
             NEW_COHORT,
             {
@@ -426,7 +434,11 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                         actions.refreshPersonsData()
                     }
                     if (existingCohort.id === 'new') {
-                        router.actions.push(urls.cohort(cohort.id))
+                        if (props.disableNavigation) {
+                            props.onSaved?.(cohort)
+                        } else {
+                            router.actions.push(urls.cohort(cohort.id))
+                        }
                         if (existingCohort.is_static) {
                             actions.resetPersonsToCreateStaticCohort()
                         }


### PR DESCRIPTION
## Problem

When building an insight, users who realize mid-flow that the cohort they need doesn't exist yet have to navigate away to `/cohorts/new`, create it, then come back and re-open the filter. This is friction in a common flow — breakdowns, property filters, retention, surveys, anywhere cohorts are selectable.

Mixpanel solves this with an inline "+ Create new cohort" affordance directly inside the cohort picker; this PR ports that pattern to PostHog.

## Changes

- **New `CohortCreateModal`** (`frontend/src/scenes/cohorts/CohortCreateModal.tsx`) — a lightweight wrapper around the existing `cohortEditLogic` that reuses the same form/validation/API path as `/cohorts/new`. Only the chrome is different.
- **`cohortEditLogic`** gains two optional props — `disableNavigation` and `onSaved(cohort)` — so the save path can fire a callback instead of pushing to the cohort detail scene.
- **`TaxonomicFilter`** hosts the modal behind a new `enableInlineCohortCreation` prop (defaults to on). On save it calls `selectItem` through `taxonomicFilterLogic.findMounted()`, so the new cohort flows out through the normal `onChange` path — every consumer (trends/funnels breakdowns, property filters, retention, surveys, etc.) picks it up without per-consumer wiring.
- **`InfiniteSelectResults`** renders a "+ New cohort" button above the active cohort tab only (keyboard-reachable, not in hidden tabs).
- **`TaxonomicPopover` + `CohortTaxonomicField`** — the prop is threaded through the popover and explicitly disabled inside the cohort criteria picker to avoid a recursive create-cohort modal.
- The modal deliberately only supports dynamic cohorts; static cohorts require CSV upload / person picker flows that belong in the full editor, and a link sends users there.

Architectural notes for reviewers:
- `LemonModal` is rendered with `.click-outside-block` on its overlay so clicks inside the modal don't dismiss the host Popover.
- `CohortCreateModal` is lazy-loaded (`React.lazy`) so the cohort editor subtree stays out of the TaxonomicFilter bundle.
- The modal stays mounted (visibility toggled via `LemonModal`'s `isOpen`) so a mid-save close never unmounts `cohortEditLogic` and orphans the API call.
- `taxonomicGroups` is read lazily via `findMounted()` rather than subscribed at the top of `TaxonomicFilter` to avoid regressing the hot path.

## How did you test this code?

I'm an agent — no manual browser testing. Verified:

- `pnpm --filter=@posthog/frontend typescript:check` introduces zero new errors vs. `master` baseline for the touched files.
- `oxlint` / `oxfmt` clean.
- A separate multi-agent QA review pass (`QAREPORT.md` was produced then acted on in a follow-up commit) surfaced several issues around modal lifecycle, click-outside handling, LemonField double-wiring, and recursive cohort creation — all addressed.

Suggested manual verification:

- [ ] Open a trend insight → Breakdown → Cohorts tab → click "+ New cohort" → create a dynamic cohort → confirm modal closes and the new cohort is auto-selected as the breakdown value.
- [ ] Repeat for a property filter and a retention breakdown (CohortsWithAllUsers).
- [ ] Open `/cohorts/new` simultaneously and confirm the scene still navigates on save (prop-gated behavior).
- [ ] Inside the cohort criteria picker, click a cohort field — confirm the inner TaxonomicFilter does **not** show the "+ New cohort" button (recursive-modal guard).

## Publish to changelog?

Yes — user-facing quality-of-life improvement for anyone building insights that segment by cohort.

## Docs update

No — no documentation changes required; the affordance is discoverable in-product.

## 🤖 LLM context

Authored by Claude Code (claude-opus-4-6[1m]). Session: https://claude.ai/code/session_01ERxZbKjzdALEyoYksbvVq3

Workflow: planned in plan mode → implemented → reviewed by a multi-agent QA team (`QAREPORT.md`) → follow-up commit addresses findings including modal-inside-popover click-outside handling, mid-save unmount safety, kea-forms field wiring, callback memoization, lazy `taxonomicGroups` read, double-submit prevention, and a recursive create-cohort guard in `CohortTaxonomicField`.

The review report from the agent team is committed as `QAREPORT.md` on the branch for reviewer context — safe to delete before merge.