### PR TITLE
feat(devex): add import-linter for internal product facade enforcement

### DIFF
--- a/.agents/skills/isolating-product-facade-contracts/SKILL.md
+++ b/.agents/skills/isolating-product-facade-contracts/SKILL.md
@@ -93,5 +93,6 @@ Treat migration as complete only when:
 - Tests cover facade and presentation boundaries.
 - A global `[[interfaces]]` block in `tach.toml` restricts imports to facade + presentation views.
 - `tach check --interfaces` passes with no violations for this product.
+- `lint-imports` passes (import-linter verifies presentation doesn't bypass the facade internally).
 - `hogli product:lint <name>` shows no legacy leak warning.
 - `backend:contract-check` is present in `package.json` (enables isolated testing in CI).

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -486,6 +486,9 @@ jobs:
             - name: Check module boundaries (tach)
               run: tach check --dependencies --interfaces
 
+            - name: Check product facade enforcement (import-linter)
+              run: lint-imports
+
     # Migration validation and OpenAPI type generation.
     # This job needs Docker + DB — it checks out master first to run baseline
     # migrations, then checks out the PR branch. All steps after the PR checkout

--- a/common/hogli/product/checks.py
+++ b/common/hogli/product/checks.py
@@ -272,6 +272,21 @@ class MisplacedFilesCheck(ProductCheck):
     label = "misplaced backend files"
     for_lenient = False
 
+    # Directories allowed in backend/ for strict products.
+    # Anything else won't be covered by import-linter's wildcard contracts.
+    _KNOWN_DIRS = {
+        "facade",
+        "presentation",
+        "tasks",
+        "tests",
+        "test",
+        "migrations",
+        "management",
+        "models",
+        "logic",
+        "__pycache__",
+    }
+
     def run(self, ctx: CheckContext) -> CheckResult:
         if not ctx.backend_dir.exists():
             return CheckResult(skip=True)
@@ -285,6 +300,16 @@ class MisplacedFilesCheck(ProductCheck):
                     misplaced.append(f"'{filename}' at backend/ root conflicts with correct location '{correct_path}'")
                 else:
                     misplaced.append(f"backend/{filename} should be at backend/{correct_path}")
+
+        # Flag directories not in the canonical structure — these bypass
+        # import-linter's wildcard enforcement (presentation/facade/etc.)
+        for child in sorted(ctx.backend_dir.iterdir()):
+            if child.is_dir() and child.name not in self._KNOWN_DIRS:
+                misplaced.append(
+                    f"backend/{child.name}/ is not a recognized directory — "
+                    "import-linter only enforces canonical paths (presentation, facade, logic, models). "
+                    "Move code into an existing directory or update the product structure"
+                )
 
         if misplaced:
             return CheckResult(

--- a/common/hogli/product/checks.py
+++ b/common/hogli/product/checks.py
@@ -41,23 +41,33 @@ def check_file_exists(backend_dir: Path, path: str) -> bool:
 
 
 def has_legacy_interface_leaks(tach_content: str, module_path: str) -> bool:
-    """Check if a product has a TODO legacy leak [[interfaces]] block in tach.toml.
+    """Check if a product has legacy interface leak blocks in tach.toml.
 
     These are products where core (posthog/ee) still imports internals directly,
     so they can't safely be tested in isolation via contract-check.
 
-    Legacy leak blocks have a from = ["products.<name>"] and are preceded by
-    a TODO comment in the interfaces section.
+    Detected structurally: an [[interfaces]] block that exposes non-facade paths
+    (anything other than backend.facade or backend.presentation) and references
+    this specific module in its from = [...] field.
     """
     import re
 
-    todo_idx = tach_content.find("# TODO: legacy leaks")
-    if todo_idx == -1:
-        return False
-    leak_section = tach_content[todo_idx:]
-    # Match the exact module path in a from = [...] field to avoid substring
-    # false positives (e.g. products.mcp matching products.mcp_store).
-    return bool(re.search(rf'from\s*=\s*\["{re.escape(module_path)}"\]', leak_section))
+    # Find all [[interfaces]] blocks and check if any expose non-facade paths
+    # for this specific module.
+    for match in re.finditer(r"\[\[interfaces\]\]\s*\n(.*?)(?=\[\[|\Z)", tach_content, re.DOTALL):
+        block = match.group(1)
+        # Check if this block references our module in from = [...]
+        if not re.search(rf'from\s*=\s*\[\s*"{re.escape(module_path)}"\s*,?\s*\]', block):
+            continue
+        # Check if any expose pattern is NOT facade or presentation
+        expose_match = re.search(r"expose\s*=\s*\[(.*?)\]", block, re.DOTALL)
+        if not expose_match:
+            continue
+        patterns = re.findall(r'"(.*?)"', expose_match.group(1))
+        for pattern in patterns:
+            if not pattern.startswith("backend\\.facade") and not pattern.startswith("backend\\.presentation"):
+                return True
+    return False
 
 
 def get_tach_block(tach_content: str, module_path: str) -> str:

--- a/common/hogli/tests/test_checks.py
+++ b/common/hogli/tests/test_checks.py
@@ -13,6 +13,7 @@ from hogli.product.checks import (
     _has_test_files,
     _is_noop_script,
     _parse_pytest_paths,
+    has_legacy_interface_leaks,
 )
 
 # ---------------------------------------------------------------------------
@@ -368,3 +369,88 @@ class TestCombinedScenarios:
         result = check.run(ctx)
         # Should report: contract-check forbidden, || true, nonexistent path
         assert len(result.issues) >= 3
+
+
+# ---------------------------------------------------------------------------
+# has_legacy_interface_leaks
+# ---------------------------------------------------------------------------
+
+_TACH_SAMPLE = """\
+[[modules]]
+path = "products.visual_review"
+depends_on = ["posthog"]
+layer = "modules"
+
+[[modules]]
+path = "products.experiments"
+depends_on = ["ee", "posthog"]
+layer = "modules"
+
+[[modules]]
+path = "products.mcp_store"
+depends_on = ["ee", "posthog"]
+layer = "modules"
+
+# Facade + views: canonical public surface
+[[interfaces]]
+expose = [
+    "backend\\.facade.*",
+    "backend\\.presentation\\.views.*",
+]
+from = [
+    "products\\.(experiments|mcp_store|visual_review)",
+]
+
+# Legacy leaks — experiments
+[[interfaces]]
+expose = [
+    "backend\\.models.*",
+    "stats\\..*",
+]
+from = [
+    "products.experiments",
+]
+
+# Legacy leaks — mcp_store
+[[interfaces]]
+expose = [
+    "backend\\.models.*",
+    "backend\\.oauth.*",
+]
+from = [
+    "products.mcp_store",
+]
+"""
+
+
+class TestLegacyInterfaceLeaks:
+    @pytest.mark.parametrize(
+        "module_path, expected",
+        [
+            ("products.visual_review", False),
+            ("products.experiments", True),
+            ("products.mcp_store", True),
+            ("products.nonexistent", False),
+        ],
+    )
+    def test_detection(self, module_path: str, expected: bool) -> None:
+        assert has_legacy_interface_leaks(_TACH_SAMPLE, module_path) == expected
+
+    def test_empty_tach(self) -> None:
+        assert has_legacy_interface_leaks("", "products.anything") is False
+
+    def test_only_facade_block(self) -> None:
+        tach = """\
+[[interfaces]]
+expose = [
+    "backend\\.facade.*",
+    "backend\\.presentation\\.views.*",
+]
+from = [
+    "products.clean_product",
+]
+"""
+        assert has_legacy_interface_leaks(tach, "products.clean_product") is False
+
+    def test_regex_from_does_not_false_positive(self) -> None:
+        assert has_legacy_interface_leaks(_TACH_SAMPLE, "products.mcp") is False

--- a/products/architecture.md
+++ b/products/architecture.md
@@ -294,10 +294,16 @@ def process_artifact(artifact: Artifact) -> None:
 
 Global `[[interfaces]]` blocks in `tach.toml` control which paths inside a product other modules can import. All modules — including core (`posthog`, `ee`) — sit in a single `modules` layer, so interface enforcement applies everywhere. tach will reject any import that doesn't go through the declared `expose` patterns.
 
-Products with legacy interface leaks (where core still imports internals directly) get explicit TODO blocks in `tach.toml` and have `backend:contract-check` removed so CI doesn't treat them as safely isolated. Run `hogli product:lint` to see which products have leaks.
+Products with legacy interface leaks (where core still imports internals directly) get explicit blocks in `tach.toml` and have `backend:contract-check` removed so CI doesn't treat them as safely isolated. Run `hogli product:lint` to see which products have leaks.
+
+### What import-linter enforces
+
+[import-linter](https://github.com/seddonym/import-linter) enforces internal product architecture: presentation layers must not import models or logic directly — they must go through the facade. This is configured as a single wildcard-based forbidden contract in `pyproject.toml` that applies to all products automatically.
+
+tach handles _inter_-module boundaries (what can cross a product boundary). import-linter handles _intra_-product architecture (how code is structured within a product). Both run in CI.
 
 > [!TIP]
-> Use the `isolating-product-facade-contracts` skill for the full migration workflow — it covers contracts, facades, caller migration, and tach boundary enforcement step by step.
+> Use the `isolating-product-facade-contracts` skill for the full migration workflow — it covers contracts, facades, caller migration, and boundary enforcement step by step.
 
 During migration, existing cross-product model imports are tracked in `tach.toml` `depends_on`. The goal is to replace them with facade calls over time.
 

--- a/products/architecture.md
+++ b/products/architecture.md
@@ -225,6 +225,16 @@ Responsibilities:
 - Convert frozen dataclasses → JSON responses
 - No business logic
 
+Presentation may only import `facade` and other `presentation` modules within the same product. It must not import `models`, `logic`, or any other internal module directly — even utility modules like `cache.py` or `permissions.py`. This is enforced by import-linter in CI.
+
+### Where do cross-cutting utilities go?
+
+If both presentation and logic need the same utility (caching, permissions, etc.), putting it at `backend/cache.py` and importing from both layers creates an "accidental shared kernel" — a hidden coupling that bypasses the facade. Instead:
+
+- **Presentation concern** (response caching, rate limiting) → `presentation/`
+- **Business concern** (domain-level caching, permission checks) → `logic/`, exposed through the facade
+- **Both layers need it** → that's a signal the boundary is drawn wrong; refactor
+
 ### Why not mix with the facade?
 
 - Keeps HTTP concerns decoupled

--- a/products/architecture.md
+++ b/products/architecture.md
@@ -298,7 +298,7 @@ Products with legacy interface leaks (where core still imports internals directl
 
 ### What import-linter enforces
 
-[import-linter](https://github.com/seddonym/import-linter) enforces internal product architecture: presentation layers must not import models or logic directly — they must go through the facade. This is configured as a single wildcard-based forbidden contract in `pyproject.toml` that applies to all products automatically.
+[import-linter](https://github.com/seddonym/import-linter) enforces internal product architecture: presentation layers must not import any backend internals directly — they can only reach `facade` and other `presentation` modules. This is configured as a single forbidden contract in `pyproject.toml` that blocks `products.*.backend` from presentation, with allowlist ignores for facade and self-imports. Any new internal module (cache, helpers, etc.) is blocked automatically.
 
 tach handles _inter_-module boundaries (what can cross a product boundary). import-linter handles _intra_-product architecture (how code is structured within a product). Both run in CI.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -443,25 +443,32 @@ exclude = [
 [tool.importlinter]
 root_packages = ["products"]
 
-# Presentation must not bypass the facade to reach internals directly.
-# This is the key isolation rule: if presentation only imports facade,
-# changes to logic/models are invisible to external consumers.
+# Presentation must only reach product internals through the facade.
+# Forbid all backend imports, then allowlist facade + self-imports.
+# This catches any new internal modules (cache.py, helpers.py, etc.)
+# automatically — no blocklist to maintain.
 [[tool.importlinter.contracts]]
 name = "presentation must use facade"
 type = "forbidden"
 source_modules = ["products.*.backend.presentation"]
 forbidden_modules = [
-    "products.*.backend.models",
-    "products.*.backend.logic",
+    "products.*.backend",
 ]
 allow_indirect_imports = true
-# TODO: existing violations — fix by routing through facade
 ignore_imports = [
+    # Allowed: presentation can import facade and itself
+    "products.**.backend.presentation.** -> products.**.backend.facade.**",
+    "products.**.backend.presentation.** -> products.**.backend.presentation.**",
+    # TODO: existing violations — fix by routing through facade
     "products.mcp_analytics.backend.presentation.views -> products.mcp_analytics.backend.logic",
     "products.mcp_analytics.backend.presentation.serializers -> products.mcp_analytics.backend.models",
     "products.mcp_store.backend.presentation.views -> products.mcp_store.backend.models",
+    "products.mcp_store.backend.presentation.views -> products.mcp_store.backend.oauth",
+    "products.mcp_store.backend.presentation.views -> products.mcp_store.backend.proxy",
+    "products.notifications.backend.presentation.views -> products.notifications.backend.cache",
     "products.notifications.backend.presentation.views -> products.notifications.backend.models",
     "products.tracing.backend.presentation.views -> products.tracing.backend.logic",
+    "products.tracing.backend.presentation.views -> products.tracing.backend.sparkline_query_runner",
 ]
 
 [tool.ty.rules]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,7 +245,7 @@ dev = [
     "ruff~=0.14.11",
     "stpyv8==13.1.201.22; sys_platform != 'linux' or (platform_machine != 'aarch64' and platform_machine != 'arm64')",
     "syrupy~=4.9.1",
-    "tach~=0.20",
+    "tach~=0.34",
     "types-aioboto3[s3]~=14.3.0",
     "types-aiobotocore~=2.22.0",
     "types-boto3[essential]==1.37.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "google-cloud-iam==2.21",
     "google-genai==1.46.0",
     "granian[uvloop,reload,pname]==2.5.5",
-    "grimp==3.13",
+    "grimp~=3.14",
     "grpcio~=1.71.0",
     "gspread==6.2.1",
     "hogql-parser==1.3.38",
@@ -202,6 +202,7 @@ dev = [
     "dagster-dg-cli~=1.10.18",
     "datamodel-code-generator~=0.36.0",
     "debugpy~=1.8.0",
+    "import-linter~=2.11",
     "deepdiff~=8.6.1",
     "django-linear-migrations~=2.17.0",
     "django-stubs~=5.2.0",
@@ -244,7 +245,7 @@ dev = [
     "ruff~=0.14.11",
     "stpyv8==13.1.201.22; sys_platform != 'linux' or (platform_machine != 'aarch64' and platform_machine != 'arm64')",
     "syrupy~=4.9.1",
-    "tach~=0.20.0",
+    "tach~=0.20",
     "types-aioboto3[s3]~=14.3.0",
     "types-aiobotocore~=2.22.0",
     "types-boto3[essential]==1.37.6",
@@ -430,6 +431,37 @@ exclude = [
     "bin/**",
     "manage.py",
     "posthog/hogql/grammar/**",
+]
+
+# ---------------------------------------------------------------------------
+# import-linter: enforce internal product architecture
+# ---------------------------------------------------------------------------
+# Ensures products follow the facade pattern internally:
+# presentation → facade → logic/models (not shortcuts).
+# Complements tach (inter-module boundaries) with intra-product enforcement.
+
+[tool.importlinter]
+root_packages = ["products"]
+
+# Presentation must not bypass the facade to reach internals directly.
+# This is the key isolation rule: if presentation only imports facade,
+# changes to logic/models are invisible to external consumers.
+[[tool.importlinter.contracts]]
+name = "presentation must use facade"
+type = "forbidden"
+source_modules = ["products.*.backend.presentation"]
+forbidden_modules = [
+    "products.*.backend.models",
+    "products.*.backend.logic",
+]
+allow_indirect_imports = true
+# TODO: existing violations — fix by routing through facade
+ignore_imports = [
+    "products.mcp_analytics.backend.presentation.views -> products.mcp_analytics.backend.logic",
+    "products.mcp_analytics.backend.presentation.serializers -> products.mcp_analytics.backend.models",
+    "products.mcp_store.backend.presentation.views -> products.mcp_store.backend.models",
+    "products.notifications.backend.presentation.views -> products.notifications.backend.models",
+    "products.tracing.backend.presentation.views -> products.tracing.backend.logic",
 ]
 
 [tool.ty.rules]

--- a/tach.toml
+++ b/tach.toml
@@ -463,6 +463,7 @@ depends_on = [
 ]
 layer = "modules"
 
+# Facade + views: the canonical public surface for all isolated products.
 [[interfaces]]
 expose = [
     "backend\\.facade.*",
@@ -471,6 +472,11 @@ expose = [
 from = [
     "products\\.(experiments|mcp_store|notifications|visual_review|tracing|metrics|mcp_analytics|platform_features)",
 ]
+
+# Legacy leaks — core (posthog/ee) imports these internals directly.
+# Each block below should shrink as imports migrate to the facade.
+# These products have had backend:contract-check removed from package.json
+# so CI treats them as non-isolated until the leaks are cleaned up.
 
 [[interfaces]]
 expose = [

--- a/tach.toml
+++ b/tach.toml
@@ -2,8 +2,8 @@ layers = [
     "modules",
 ]
 exclude = [
-    ".*__pycache__",
-    ".*egg-info",
+    "**/*__pycache__",
+    "**/*egg-info",
     "docs",
     "tests",
 ]
@@ -280,6 +280,21 @@ depends_on = []
 layer = "modules"
 
 [[modules]]
+path = "products.marketing_analytics"
+depends_on = [
+    "posthog",
+    "products.data_warehouse",
+]
+layer = "modules"
+
+[[modules]]
+path = "products.mcp_analytics"
+depends_on = [
+    "posthog",
+]
+layer = "modules"
+
+[[modules]]
 path = "products.mcp_store"
 depends_on = [
     "ee",
@@ -288,10 +303,16 @@ depends_on = [
 layer = "modules"
 
 [[modules]]
-path = "products.marketing_analytics"
+path = "products.messaging"
 depends_on = [
     "posthog",
-    "products.data_warehouse",
+]
+layer = "modules"
+
+[[modules]]
+path = "products.metrics"
+depends_on = [
+    "posthog",
 ]
 layer = "modules"
 
@@ -313,8 +334,10 @@ depends_on = [
 layer = "modules"
 
 [[modules]]
-path = "products.product_analytics"
-depends_on = []
+path = "products.platform_features"
+depends_on = [
+    "posthog",
+]
 layer = "modules"
 
 [[modules]]
@@ -327,6 +350,11 @@ depends_on = [
     "products.llm_analytics",
     "products.logs",
 ]
+layer = "modules"
+
+[[modules]]
+path = "products.product_analytics"
+depends_on = []
 layer = "modules"
 
 [[modules]]
@@ -398,6 +426,13 @@ depends_on = [
 layer = "modules"
 
 [[modules]]
+path = "products.tracing"
+depends_on = [
+    "posthog",
+]
+layer = "modules"
+
+[[modules]]
 path = "products.user_interviews"
 depends_on = [
     "ee",
@@ -428,50 +463,14 @@ depends_on = [
 ]
 layer = "modules"
 
-
-[[modules]]
-path = "products.tracing"
-depends_on = ["posthog"]
-layer = "modules"
-
-[[modules]]
-path = "products.metrics"
-depends_on = ["posthog"]
-layer = "modules"
-
-[[modules]]
-path = "products.messaging"
-depends_on = ["posthog"]
-layer = "modules"
-
-[[modules]]
-path = "products.mcp_analytics"
-depends_on = ["posthog"]
-layer = "modules"
-
-[[modules]]
-path = "products.platform_features"
-depends_on = ["posthog"]
-layer = "modules"
-
-# ============================================================================
-# Interface definitions
-# ============================================================================
-# These enforce facade-only access: external consumers can only import from
-# the expose patterns listed here. Internal modules are hidden.
-#
-# The expose patterns are relative to the module path and support regex.
-# ============================================================================
-
-# Facade + views: the canonical public surface for all isolated products.
 [[interfaces]]
-expose = ["backend\\.facade.*", "backend\\.presentation\\.views.*"]
-from = ["products\\.(experiments|mcp_store|notifications|visual_review|tracing|metrics|mcp_analytics|platform_features)"]
-
-# TODO: legacy leaks — core (posthog/ee) imports these internals directly.
-# Each block below should shrink as imports migrate to the facade.
-# These products have had backend:contract-check removed from package.json
-# so CI treats them as non-isolated until the leaks are cleaned up.
+expose = [
+    "backend\\.facade.*",
+    "backend\\.presentation\\.views.*",
+]
+from = [
+    "products\\.(experiments|mcp_store|notifications|visual_review|tracing|metrics|mcp_analytics|platform_features)",
+]
 
 [[interfaces]]
 expose = [
@@ -482,12 +481,23 @@ expose = [
     "backend\\.models.*",
     "stats\\..*",
 ]
-from = ["products.experiments"]
+from = [
+    "products.experiments",
+]
 
 [[interfaces]]
-expose = ["backend\\.models.*", "backend\\.oauth.*"]
-from = ["products.mcp_store"]
+expose = [
+    "backend\\.models.*",
+    "backend\\.oauth.*",
+]
+from = [
+    "products.mcp_store",
+]
 
 [[interfaces]]
-expose = ["backend\\.logic.*"]
-from = ["products.tracing"]
+expose = [
+    "backend\\.logic.*",
+]
+from = [
+    "products.tracing",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-07T20:02:03.320662Z"
+exclude-newer = "2026-04-08T06:10:13.845708Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -5497,7 +5497,7 @@ dev = [
     { name = "ruff", specifier = "~=0.14.11" },
     { name = "stpyv8", marker = "(platform_machine != 'aarch64' and platform_machine != 'arm64') or sys_platform != 'linux'", specifier = "==13.1.201.22" },
     { name = "syrupy", specifier = "~=4.9.1" },
-    { name = "tach", specifier = "~=0.20" },
+    { name = "tach", specifier = "~=0.34" },
     { name = "ty", specifier = "==0.0.4" },
     { name = "types-aioboto3", extras = ["s3"], specifier = "~=14.3.0" },
     { name = "types-aiobotocore", specifier = "~=2.22.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-06T19:58:59.237620426Z"
+exclude-newer = "2026-04-07T20:02:03.320662Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -2755,27 +2755,27 @@ wheels = [
 
 [[package]]
 name = "grimp"
-version = "3.13"
+version = "3.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/b3/ff0d704cdc5cf399d74aabd2bf1694d4c4c3231d4d74b011b8f39f686a86/grimp-3.13.tar.gz", hash = "sha256:759bf6e05186e6473ee71af4119ec181855b2b324f4fcdd78dee9e5b59d87874", size = 847508, upload-time = "2025-10-29T13:04:57.704Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/46/79764cfb61a3ac80dadae5d94fb10acdb7800e31fecf4113cf3d345e4952/grimp-3.14.tar.gz", hash = "sha256:645fbd835983901042dae4e1b24fde3a89bf7ac152f9272dd17a97e55cb4f871", size = 830882, upload-time = "2025-12-10T17:55:01.287Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/06/ff7e3d72839f46f0fccdc79e1afe332318986751e20f65d7211a5e51366c/grimp-3.13-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3e715c56ffdd055e5c84d27b4c02d83369b733e6a24579d42bbbc284bd0664a9", size = 2070161, upload-time = "2025-10-29T13:03:59.755Z" },
-    { url = "https://files.pythonhosted.org/packages/58/2f/a95bdf8996db9400fd7e288f32628b2177b8840fe5f6b7cd96247b5fa173/grimp-3.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f794dea35a4728b948ab8fec970ffbdf2589b34209f3ab902cf8a9148cf1eaad", size = 1984365, upload-time = "2025-10-29T13:03:51.805Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/45/cc3d7f3b7b4d93e0b9d747dc45ed73a96203ba083dc857f24159eb6966b4/grimp-3.13-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69571270f2c27e8a64b968195aa7ecc126797112a9bf1e804ff39ba9f42d6f6d", size = 2145486, upload-time = "2025-10-29T13:02:36.591Z" },
-    { url = "https://files.pythonhosted.org/packages/16/92/a6e493b71cb5a9145ad414cc4790c3779853372b840a320f052b22879606/grimp-3.13-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f7b226398ae476762ef0afb5ef8f838d39c8e0e2f6d1a4378ce47059b221a4a", size = 2106747, upload-time = "2025-10-29T13:02:53.084Z" },
-    { url = "https://files.pythonhosted.org/packages/db/8d/36a09f39fe14ad8843ef3ff81090ef23abbd02984c1fcc1cef30e5713d82/grimp-3.13-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5498aeac4df0131a1787fcbe9bb460b52fc9b781ec6bba607fd6a7d6d3ea6fce", size = 2257027, upload-time = "2025-10-29T13:03:29.44Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/7a/90f78787f80504caeef501f1bff47e8b9f6058d45995f1d4c921df17bfef/grimp-3.13-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4be702bb2b5c001a6baf709c452358470881e15e3e074cfc5308903603485dcb", size = 2441208, upload-time = "2025-10-29T13:03:05.733Z" },
-    { url = "https://files.pythonhosted.org/packages/61/71/0fbd3a3e914512b9602fa24c8ebc85a8925b101f04f8a8c1d1e220e0a717/grimp-3.13-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fcf988f3e3d272a88f7be68f0c1d3719fee8624d902e9c0346b9015a0ea6a65", size = 2318758, upload-time = "2025-10-29T13:03:17.454Z" },
-    { url = "https://files.pythonhosted.org/packages/34/e9/29c685e88b3b0688f0a2e30c0825e02076ecdf22bc0e37b1468562eaa09a/grimp-3.13-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ede36d104ff88c208140f978de3345f439345f35b8ef2b4390c59ef6984deba", size = 2180523, upload-time = "2025-10-29T13:03:42.3Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bc/7cc09574b287b8850a45051e73272f365259d9b6ca58d7b8773265c6fe35/grimp-3.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b35e44bb8dc80e0bd909a64387f722395453593a1884caca9dc0748efea33764", size = 2328855, upload-time = "2025-10-29T13:04:08.111Z" },
-    { url = "https://files.pythonhosted.org/packages/34/86/3b0845900c8f984a57c6afe3409b20638065462d48b6afec0fd409fd6118/grimp-3.13-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:becb88e9405fc40896acd6e2b9bbf6f242a5ae2fd43a1ec0a32319ab6c10a227", size = 2367756, upload-time = "2025-10-29T13:04:22.736Z" },
-    { url = "https://files.pythonhosted.org/packages/06/2d/4e70e8c06542db92c3fffaecb43ebfc4114a411505bff574d4da7d82c7db/grimp-3.13-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a66585b4af46c3fbadbef495483514bee037e8c3075ed179ba4f13e494eb7899", size = 2358595, upload-time = "2025-10-29T13:04:35.595Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/06/c511d39eb6c73069af277f4e74991f1f29a05d90cab61f5416b9fc43932f/grimp-3.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:29f68c6e2ff70d782ca0e989ec4ec44df73ba847937bcbb6191499224a2f84e2", size = 2381464, upload-time = "2025-10-29T13:04:48.265Z" },
-    { url = "https://files.pythonhosted.org/packages/86/f5/42197d69e4c9e2e7eed091d06493da3824e07c37324155569aa895c3b5f7/grimp-3.13-cp312-cp312-win32.whl", hash = "sha256:cc996dcd1a44ae52d257b9a3e98838f8ecfdc42f7c62c8c82c2fcd3828155c98", size = 1758510, upload-time = "2025-10-29T13:05:11.74Z" },
-    { url = "https://files.pythonhosted.org/packages/30/dd/59c5f19f51e25f3dbf1c9e88067a88165f649ba1b8e4174dbaf1c950f78b/grimp-3.13-cp312-cp312-win_amd64.whl", hash = "sha256:e2966435947e45b11568f04a65863dcf836343c11ae44aeefdaa7f07eb1a0576", size = 1859530, upload-time = "2025-10-29T13:05:02.638Z" },
+    { url = "https://files.pythonhosted.org/packages/75/d6/a35ff62f35aa5fd148053506eddd7a8f2f6afaed31870dc608dd0eb38e4f/grimp-3.14-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ffabc6940301214753bad89ec0bfe275892fa1f64b999e9a101f6cebfc777133", size = 2178573, upload-time = "2025-12-10T17:53:42.836Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/bd2e80273da4d46110969fc62252e5372e0249feb872bc7fe76fdc7f1818/grimp-3.14-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:075d9a1c78d607792d0ed8d4d3d7754a621ef04c8a95eaebf634930dc9232bb2", size = 2110452, upload-time = "2025-12-10T17:53:19.831Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c3/7307249c657d34dca9d250d73ba027d6cfe15a98fb3119b6e5210bc388b7/grimp-3.14-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06ff52addeb20955a4d6aa097bee910573ffc9ef0d3c8a860844f267ad958156", size = 2283064, upload-time = "2025-12-10T17:52:07.673Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/d2/cae4cf32dc8d4188837cc4ab183300d655f898969b0f169e240f3b7c25be/grimp-3.14-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d10e0663e961fcbe8d0f54608854af31f911f164c96a44112d5173050132701f", size = 2235893, upload-time = "2025-12-10T17:52:20.418Z" },
+    { url = "https://files.pythonhosted.org/packages/04/92/3f58bc3064fc305dac107d08003ba65713a5bc89a6d327f1c06b30cce752/grimp-3.14-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ab874d7ddddc7a1291259cf7c31a4e7b5c612e9da2e24c67c0eb1a44a624e67", size = 2393376, upload-time = "2025-12-10T17:53:02.397Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b8/f476f30edf114f04cb58e8ae162cb4daf52bda0ab01919f3b5b7edb98430/grimp-3.14-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54fec672ec83355636a852177f5a470c964bede0f6730f9ba3c7b5c8419c9eab", size = 2571342, upload-time = "2025-12-10T17:52:35.214Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ae/2e44d3c4f591f95f86322a8f4dbb5aac17001d49e079f3a80e07e7caaf09/grimp-3.14-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b9e221b5e8070a916c780e88c877fee2a61c95a76a76a2a076396e459511b0bb", size = 2359022, upload-time = "2025-12-10T17:52:49.063Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ac/42b4d6bc0ea119ce2e91e1788feabf32c5433e9617dbb495c2a3d0dc7f12/grimp-3.14-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eea6b495f9b4a8d82f5ce544921e76d0d12017f5d1ac3a3bd2f5ac88ab055b1c", size = 2309424, upload-time = "2025-12-10T17:53:11.069Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c7/6a731989625c1790f4da7602dcbf9d6525512264e853cda77b3b3602d5e0/grimp-3.14-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:655e8d3f79cd99bb859e09c9dd633515150e9d850879ca71417d5ac31809b745", size = 2462754, upload-time = "2025-12-10T17:53:50.886Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4d/3d1571c0a39a59dd68be4835f766da64fe64cbab0d69426210b716a8bdf0/grimp-3.14-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a14f10b1b71c6c37647a76e6a49c226509648107abc0f48c1e3ecd158ba05531", size = 2501356, upload-time = "2025-12-10T17:54:06.014Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d1/8950b8229095ebda5c54c8784e4d1f0a6e19423f2847289ef9751f878798/grimp-3.14-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:81685111ee24d3e25f8ed9e77ed00b92b58b2414e1a1c2937236026900972744", size = 2504631, upload-time = "2025-12-10T17:54:34.441Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e6/23bed3da9206138d36d01890b656c7fb7adfb3a37daac8842d84d8777ade/grimp-3.14-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ce8352a8ea0e27b143136ea086582fc6653419aa8a7c15e28ed08c898c42b185", size = 2514751, upload-time = "2025-12-10T17:54:49.384Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/6f1f55c97ee982f133ec5ccb22fc99bf5335aee70c208f4fb86cd833b8d5/grimp-3.14-cp312-cp312-win32.whl", hash = "sha256:3fc0f98b3c60d88e9ffa08faff3200f36604930972f8b29155f323b76ea25a06", size = 1875041, upload-time = "2025-12-10T17:55:13.326Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cf/03ba01288e2a41a948bc8526f32c2eeaddd683ed34be1b895e31658d5a4c/grimp-3.14-cp312-cp312-win_amd64.whl", hash = "sha256:6bca77d1d50c8dc402c96af21f4e28e2f1e9938eeabd7417592a22bd83cde3c3", size = 2013868, upload-time = "2025-12-10T17:55:05.907Z" },
 ]
 
 [[package]]
@@ -3073,6 +3073,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "import-linter"
+version = "2.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "grimp" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/55b697a17bb15c6cb88d97d73716813f5427281527b90f02cc0a600abc6e/import_linter-2.11.tar.gz", hash = "sha256:5abc3394797a54f9bae315e7242dc98715ba485f840ac38c6d3192c370d0085e", size = 1153682, upload-time = "2026-03-06T12:11:38.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/aa/2ed2c89543632ded7196e0d93dcc6c7fe87769e88391a648c4a298ea864a/import_linter-2.11-py3-none-any.whl", hash = "sha256:3dc54cae933bae3430358c30989762b721c77aa99d424f56a08265be0eeaa465", size = 637315, upload-time = "2026-03-06T12:11:36.599Z" },
 ]
 
 [[package]]
@@ -5190,6 +5205,7 @@ dev = [
     { name = "freezegun" },
     { name = "grpcio-tools" },
     { name = "hypothesis" },
+    { name = "import-linter" },
     { name = "ipython" },
     { name = "mypy" },
     { name = "mypy-baseline" },
@@ -5331,7 +5347,7 @@ requires-dist = [
     { name = "google-genai", specifier = "==1.46.0" },
     { name = "google-re2", specifier = ">=1.1.20251105" },
     { name = "granian", extras = ["uvloop", "reload", "pname"], specifier = "==2.5.5" },
-    { name = "grimp", specifier = "==3.13" },
+    { name = "grimp", specifier = "~=3.14" },
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
     { name = "hogql-parser", specifier = "==1.3.38" },
@@ -5448,6 +5464,7 @@ dev = [
     { name = "freezegun", specifier = "==1.2.2" },
     { name = "grpcio-tools", specifier = "~=1.71.0" },
     { name = "hypothesis", specifier = "~=6.151.9" },
+    { name = "import-linter", specifier = "~=2.11" },
     { name = "ipython", specifier = "~=9.3.0" },
     { name = "mypy", specifier = "~=1.19.1" },
     { name = "mypy-baseline", specifier = "~=0.7.3" },
@@ -5480,7 +5497,7 @@ dev = [
     { name = "ruff", specifier = "~=0.14.11" },
     { name = "stpyv8", marker = "(platform_machine != 'aarch64' and platform_machine != 'arm64') or sys_platform != 'linux'", specifier = "==13.1.201.22" },
     { name = "syrupy", specifier = "~=4.9.1" },
-    { name = "tach", specifier = "~=0.20.0" },
+    { name = "tach", specifier = "~=0.20" },
     { name = "ty", specifier = "==0.0.4" },
     { name = "types-aioboto3", extras = ["s3"], specifier = "~=14.3.0" },
     { name = "types-aiobotocore", specifier = "~=2.22.0" },
@@ -6598,15 +6615,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "13.9.4"
+version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424, upload-time = "2024-11-01T16:43:55.817Z" },
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
 ]
 
 [[package]]
@@ -7255,7 +7272,7 @@ wheels = [
 
 [[package]]
 name = "tach"
-version = "0.20.0"
+version = "0.34.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitpython" },
@@ -7267,18 +7284,23 @@ dependencies = [
     { name = "tomli" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/c8/4064f6e97abeda0dd5a68a23a9cc46f236850d8247f124847ae3f03f86ff/tach-0.20.0.tar.gz", hash = "sha256:65ec25354c36c1305a7abfae33f138e9b6026266a19507ff4724f3dda9b55c67", size = 738845, upload-time = "2025-01-13T08:03:57.41Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/5b/a82de1482ede35e245951a6e039d608cdc86111aa8207344fffb8c927623/tach-0.34.1.tar.gz", hash = "sha256:58b5a8f9dd4f5c9fc9b1ade875aa0b31d3ac2f2f6802c655c05197a503d5acde", size = 765955, upload-time = "2026-04-03T06:12:28.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/ce/39fe1253b2141f72d290d64d0b4b47ebed99b15849b0b1c42827054f3590/tach-0.20.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:28b2869a3ec2b9a8f558f472d35ad1d237024361bc3137fbc3e1f0e5f42b0bf5", size = 3070560, upload-time = "2025-01-13T08:03:55.235Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ae/259dbb866ba38688e51a1da38d47c1da0878ea236e01486cddd7aed2b7cc/tach-0.20.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:c7bc8b325b41e2561cf9bace6a998fd391b45aeb37dd8011cfc311f4e6426f60", size = 2930725, upload-time = "2025-01-13T08:03:52.312Z" },
-    { url = "https://files.pythonhosted.org/packages/61/1b/c438601f76d3576200f4335c0d524377aebd20b18e09f07ef19e25fc338f/tach-0.20.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:49804f15b5a03b7b39d476f1b46330442c637ab908c693fa6b26c57f707ca070", size = 3265779, upload-time = "2025-01-13T08:03:32.231Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/36/56234b75760fa1ab02e83d16a7e75e0894266d8a9b4ea4e4d07a76b9be54/tach-0.20.0-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7051e2c5ccccd9d740bd7b33339117470aad7a0425fdd8c12a4f234a3f6d0896", size = 3233228, upload-time = "2025-01-13T08:03:37.296Z" },
-    { url = "https://files.pythonhosted.org/packages/92/77/01527cfa0f8c4c6cbf75f28d5a0316ceba44211ba9d949ca92068fdf77a7/tach-0.20.0-cp37-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:69e4a810e0f35565e523545f191b85123c207487fe7ad6df63b2e3b514bfd0ad", size = 3523062, upload-time = "2025-01-13T08:03:44.844Z" },
-    { url = "https://files.pythonhosted.org/packages/26/8a/bd9fb362c9638811660a19eaa7283850ed675f79ee0e082e83c8563c738a/tach-0.20.0-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:511af3a651e3cf5329162b008295296d25f3ad9b0713bc4a93b78958874b2b4b", size = 3529428, upload-time = "2025-01-13T08:03:39.296Z" },
-    { url = "https://files.pythonhosted.org/packages/92/c2/7e01d870a79d65e0cceb621eac43c925f0bd96748c4da0039f5594e64f89/tach-0.20.0-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7a80ba230299950493986dec04998a8ea231c9473c0d0b506cf67f139f640757", size = 3769550, upload-time = "2025-01-13T08:03:41.498Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/38/1ac3e633ddf775e2c76d6daa8f345f02db2252b02b83970ca15fbe8504bd/tach-0.20.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aba656fd46e89a236d9b30610851010b200e7ae25db3053d1d852f6cc0357640", size = 3387869, upload-time = "2025-01-13T08:03:48.117Z" },
-    { url = "https://files.pythonhosted.org/packages/59/74/3ebe4994b0569a4b53b5963ad4b63ca91277a543c841cc4934132030f325/tach-0.20.0-cp37-abi3-win32.whl", hash = "sha256:653455ff1da0aebfdd7408905aae13747a7144ee98490d93778447f56330fa4b", size = 2608869, upload-time = "2025-01-13T08:04:02.791Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/41/8d1d42e4de71e2894efe0e2ffd88e870252179df93335d0e7f04edd436b6/tach-0.20.0-cp37-abi3-win_amd64.whl", hash = "sha256:efdefa94bf899306fcb265ca603a419a24d2d81cc82d6547f4222077a37fa474", size = 2801132, upload-time = "2025-01-13T08:04:00.53Z" },
+    { url = "https://files.pythonhosted.org/packages/33/3f/d071b841bf634da94068b84d7a2098c99c18deb21b3418969f29e152d793/tach-0.34.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6dff869e7f8933be23055f407a751e6f9e4c8ecb0bf3a93a962a0815e106c313", size = 4100880, upload-time = "2026-04-03T06:12:20.276Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ae/aeb7f67c34b5a9ee43d1aa556b16c6e60424cafeb3f23e6fbf3298a968cd/tach-0.34.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:70d55ec38dfcc15f1fff9e420ba17d63c36bb1b27f92abb8e8c910ffb71fd233", size = 3969195, upload-time = "2026-04-03T06:12:18.54Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/de/12e565a0374436ba2b9c00ba68c3a9bf9999081ac546faf33da77162316e/tach-0.34.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:862d240a7fc297283a51c857eb269d8c56163f14b7e398f757b284bed1e3df4f", size = 4335854, upload-time = "2026-04-03T06:12:11.065Z" },
+    { url = "https://files.pythonhosted.org/packages/24/f7/3c75beb144017a22229808b497bfb22cd79acc11d836c9870dc8708185a7/tach-0.34.1-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fcb8ca825287160c1dd37b1cb164b88675e01ee97304ce14d50d7e8e1d3b853c", size = 4237244, upload-time = "2026-04-03T06:12:14.931Z" },
+    { url = "https://files.pythonhosted.org/packages/04/90/3459ce8c55a0aa4fa4533faf66cbbfef37eb5927aab1b87f8439c6db228b/tach-0.34.1-cp37-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b272ee726d8b0ef3887d3a3057f618922ab0f7471e1b1d6096f78f2ae93727e4", size = 4648719, upload-time = "2026-04-03T06:12:33.559Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d3/75b46da7c62a929ddde6c9eb4bb54f775693ee5a006f1b9a069a9aa2f5f2/tach-0.34.1-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6042b4f040c5941d28229963451b94a8cf2b08cdbb0ab0e338a04a46887c712f", size = 5203497, upload-time = "2026-04-03T06:12:21.997Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f7/838d3c2bc0972626eddb3f69d13fdf3eaa7cc46c6132ad965fe7839fe452/tach-0.34.1-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b52a70262f16b701aaa03781656d808f88a3eb6a263762f8cea726ea9ffb980", size = 4349388, upload-time = "2026-04-03T06:12:26.288Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a0/25ac1fb225aa07faacb29c2470dc49633583fed11214c9e128eae65dece9/tach-0.34.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1cba2d957371fde09c64cb1b70349844e33fae3d87f55e6b002929587c5c7826", size = 4593579, upload-time = "2026-04-03T06:12:39.73Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/54/29ffea4faf1c0c623bc2e97e8affc658fbaf38fcf8babf758fa63864dc1b/tach-0.34.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c600ea6f8748ea13183aaf802fb733c148238e252cc0e66a85ac8d6de9939906", size = 4513785, upload-time = "2026-04-03T06:12:13.145Z" },
+    { url = "https://files.pythonhosted.org/packages/66/5e/c716a12ed58a7cc23b27f61f52e31e60410914b2a4afdb0b1a88d16008a7/tach-0.34.1-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:7be15f69c99b89cdadc2835368fc3cfb3ad45e74c7a704a7d42bcdd2917608b2", size = 4512695, upload-time = "2026-04-03T06:12:16.831Z" },
+    { url = "https://files.pythonhosted.org/packages/44/f6/8538205bba54d77d8b5e3f4afe8203d705bc430578f59bf4d108b3b6da47/tach-0.34.1-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:d917fc81adae85e9b3f2d29e135ba572a69dc677661727012b3adf95e0216e9e", size = 4649718, upload-time = "2026-04-03T06:12:37.908Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/340e9ba6821d4e97f1bfeea5ad36a07c888f3422bb68f4805c74c1dc576c/tach-0.34.1-cp37-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:f94909630d699806e8682662962de0ac76ecc05dfcf7893af2c7e1a5c71de57e", size = 5333192, upload-time = "2026-04-03T06:12:24.289Z" },
+    { url = "https://files.pythonhosted.org/packages/04/c2/d0e46185745af3a3d4057fd73eeac9ec003f054d5591c54e2fd835f4cbe4/tach-0.34.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1246b2718cfffecd4e6d66d6e232323fc4b3f2c68b4c990af0063464808f85fa", size = 4641868, upload-time = "2026-04-03T06:12:44.163Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d5/0209e74d57b0d32057b6ea997b77db847e38d649bd27e6261a4bd58e1da5/tach-0.34.1-cp37-abi3-win32.whl", hash = "sha256:abd9d1e468a9b8bec1e0037c06797b31e9c23c62adf13bcfacf057a21310ad3f", size = 3431420, upload-time = "2026-04-03T06:12:31.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6c/51f1d58eb3ebd1f79d2944f4813806c18c9c715178956424a4528e8bd281/tach-0.34.1-cp37-abi3-win_amd64.whl", hash = "sha256:0220c002da4bf4656b121c6317313490e8660627e5200251e0bca3e00a27d0c4", size = 3737055, upload-time = "2026-04-03T06:12:29.714Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Problem**

tach enforces what external modules can import from a product (inter-module boundaries), but nothing enforces that a product's own presentation layer goes through the facade. A product can declare a facade, get the "isolated" badge for selective testing, and then have views that `from .models import Foo` directly. If core or another product then depends on something that leaks through presentation, changes to internals are no longer safe to test in isolation.

**Changes**

Add [import-linter](https://github.com/seddonym/import-linter) as a complementary tool to tach. It enforces intra-product architecture via a single wildcard-based forbidden contract:

```toml
[[tool.importlinter.contracts]]
name = "presentation must use facade"
type = "forbidden"
source_modules = ["products.*.backend.presentation"]
forbidden_modules = ["products.*.backend.models", "products.*.backend.logic"]
```

One rule, applies to every product automatically. New violations will be blocked in CI.

Existing violations in 4 products (mcp_analytics, mcp_store, notifications, tracing) are listed in `ignore_imports` — they pass CI but show up as known debt.

Also bumps tach 0.20 → 0.34 and adds `tach check --interfaces` to CI (companion to #54497).

**tach vs import-linter**
- tach: inter-module boundaries (what can product A import from product B → facades only)
- import-linter: intra-product architecture (within a product, presentation → facade, not shortcuts)

**How did you test this code?**

- `lint-imports` passes locally (1 contract kept, 0 broken)
- `tach check --dependencies --interfaces` still passes with bumped version
- `hogli product:lint --all` still passes

## 🤖 LLM context

Follow-up to #54465 (tach layer fix) and #54497 (tach --interfaces in CI). Discovered import-linter as a complement to tach for the internal enforcement gap.