### PR TITLE
fix(mcp-store): permission incorrectly set

### DIFF
--- a/products/mcp_store/frontend/McpStoreSettings.tsx
+++ b/products/mcp_store/frontend/McpStoreSettings.tsx
@@ -81,7 +81,7 @@ function ConnectOAuthButton({
 export function McpStoreSettings(): JSX.Element {
     const restrictedReason = useRestrictedArea({
         scope: RestrictionScope.Project,
-        minimumAccessLevel: TeamMembershipLevel.Admin,
+        minimumAccessLevel: TeamMembershipLevel.Member,
     })
     const { installations, installationsLoading, installedServerUrls, recommendedServers, serversLoading } =
         useValues(mcpStoreLogic)


### PR DESCRIPTION
## Problem

This was incorrectly set to require Admin privileges in another PR; it only requires Member privileges.

## Changes

- Changed role 

## How did you test this code?

- tested locally

## Publish to changelog?

no

## Docs update

n/a