### PR TITLE
fix(visual-review): remove deleted snapshots from baseline on approval

### DIFF
--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -1029,6 +1029,11 @@ def _commit_baseline_to_github(run: Run, repo: Repo, approved_snapshots: list[di
 
     current_baselines, file_sha = _fetch_baseline_file(github, repo.repo_full_name, baseline_path, pr_info["head_ref"])
 
+    # Remove entries for snapshots detected as removed in this run
+    removed_identifiers = set(run.snapshots.filter(result=SnapshotResult.REMOVED).values_list("identifier", flat=True))
+    for identifier in removed_identifiers:
+        current_baselines.pop(identifier, None)
+
     updates = [{"identifier": s["identifier"], "new_hash": s["new_hash"]} for s in approved_snapshots]
     new_content = _build_snapshots_yaml(repo, current_baselines, updates)
 


### PR DESCRIPTION
**Problem**
When approving a VR run, `_commit_baseline_to_github` applied the approved changed/new hashes but never removed entries for snapshots detected as REMOVED. The auto-approve path already handled this, the manual approval path didn't.

**Fix**
Prune REMOVED identifiers from the baseline before building the YAML, matching the auto-approve behavior. Stale entries for deleted stories now get cleaned up on approval.