### PR TITLE
fix(webhooks): enable TLS certificate verification on webhook test en…

### DIFF
--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -17,6 +17,7 @@ from django.test import override_settings
 from django.utils import timezone
 from django.utils.text import slugify
 
+import responses
 from django_otp.plugins.otp_static.models import StaticDevice
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from rest_framework import status
@@ -1573,6 +1574,30 @@ class TestUserSlackWebhook(APIBaseTest):
         response = self.send_request({"webhook": "http://localhost/bla"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["error"], "invalid webhook URL")
+
+    @responses.activate
+    def test_slack_webhook_success(self):
+        responses.post("https://hooks.slack.com/services/test", body="ok", status=200)
+
+        response = self.send_request({"webhook": "https://hooks.slack.com/services/test"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+
+    @responses.activate
+    def test_slack_webhook_ssl_error(self):
+        from requests.exceptions import SSLError
+
+        webhook_url = "https://hooks.slack.com/services/ssl-test"
+        responses.post(webhook_url, body=SSLError("certificate verify failed"))
+
+        response = self.send_request({"webhook": webhook_url})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()["error"],
+            "TLS certificate verification failed",
+        )
 
 
 class TestSessionAuthEndpoints(APIBaseTest):

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -20,6 +20,7 @@ from django.utils.text import slugify
 import responses
 from django_otp.plugins.otp_static.models import StaticDevice
 from django_otp.plugins.otp_totp.models import TOTPDevice
+from requests.exceptions import SSLError
 from rest_framework import status
 
 from posthog.api.email_verification import email_verification_token_generator
@@ -1586,8 +1587,6 @@ class TestUserSlackWebhook(APIBaseTest):
 
     @responses.activate
     def test_slack_webhook_ssl_error(self):
-        from requests.exceptions import SSLError
-
         webhook_url = "https://hooks.slack.com/services/ssl-test"
         responses.post(webhook_url, body=SSLError("certificate verify failed"))
 

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -30,6 +30,7 @@ from django_otp.util import random_hex
 from drf_spectacular.utils import extend_schema
 from loginas.utils import is_impersonated_session
 from prometheus_client import Counter
+from requests.exceptions import SSLError
 from rest_framework import exceptions, mixins, serializers, viewsets
 from rest_framework.exceptions import NotFound
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -1229,11 +1230,13 @@ def test_slack_webhook(request):
             session.mount("https://", PublicIPOnlyHttpAdapter())
             session.mount("http://", PublicIPOnlyHttpAdapter())
 
-        response = session.post(webhook, verify=False, json=message)
+        response = session.post(webhook, json=message)
 
         if response.ok:
             return JsonResponse({"success": True})
         else:
             return JsonResponse({"error": response.text})
-    except:
+    except SSLError:
+        return JsonResponse({"error": "TLS certificate verification failed"})
+    except Exception:
         return JsonResponse({"error": "invalid webhook URL"})


### PR DESCRIPTION
## Problem

The `test_slack_webhook` endpoint in `posthog/api/user.py` uses `verify=False` when POSTing to user-provided webhook URLs, disabling TLS certificate verification. This was introduced in the original Slack integration (#460) and was left in place when SSRF protections were added in #22037.

While the payload is a static test message and the SSRF protections mitigate the most severe risks, disabling TLS verification seems unnecessary and goes against best practices for outbound requests to user-controlled URLs. 

If there are cases we should ignore the TLS verification (e.g. self-signed certificates) I think we should have an UI input for that.

## Changes

- Removed `verify=False` from `session.post()` so TLS verification uses the default (`True`)
- Added an explicit `except SSLError` handler that returns a descriptive error message to the user when their webhook endpoint has an invalid certificate
- Added tests covering the success path and the TLS error path

## How did you test this code?

- Automated tests
- Manual verification against `https://self-signed.badssl.com/` confirmed the `SSLError` is raised and caught correctly

## Publish to changelog?

Do not publish to changelog.

## Docs update

No docs update needed.

## LLM context

Co-authored with Claude Code.
