### PR TITLE
feat(quill): scroll area shadow + button props

### DIFF
--- a/packages/quill/packages/primitives/src/index.ts
+++ b/packages/quill/packages/primitives/src/index.ts
@@ -158,7 +158,7 @@ export { Popover, PopoverContent, PopoverTrigger } from './popover'
 export { Progress } from './progress'
 export { RadioGroup, RadioGroupItem, RadioIndicator } from './radio-group'
 export { ResizableHandle, ResizablePanel, ResizablePanelGroup } from './resizable'
-export { ScrollArea, ScrollBar } from './scroll-area'
+export { ScrollArea, ScrollBar, scrollShadowsCss, SCROLL_SHADOWS_STYLE_ID } from './scroll-area'
 export {
     Select,
     SelectContent,

--- a/packages/quill/packages/primitives/src/scroll-area.stories.tsx
+++ b/packages/quill/packages/primitives/src/scroll-area.stories.tsx
@@ -27,9 +27,43 @@ export const Default: Story = {
     ),
 } satisfies Story
 
+export const Horizontal: Story = {
+    render: () => (
+        <ScrollArea className="h-28 w-80 max-w-[calc(100vw-8rem)]">
+            <ul className="m-0 flex list-none gap-3 p-0">
+                {Array.from({ length: 20 }, (_, i) => (
+                    <li
+                        key={i}
+                        className="flex h-20 w-20 shrink-0 items-center justify-center rounded-lg bg-muted text-sm font-bold text-gray-600 dark:text-gray-400"
+                    >
+                        {i + 1}
+                    </li>
+                ))}
+            </ul>
+        </ScrollArea>
+    ),
+} satisfies Story
+
 export const AllDirections: Story = {
     render: () => (
         <ScrollArea className="h-80 w-80 max-w-[calc(100vw-8rem)]">
+            <ul className="m-0 grid list-none grid-cols-[repeat(10,6.25rem)] grid-rows-[repeat(10,6.25rem)] gap-3 p-0">
+                {Array.from({ length: 100 }, (_, i) => (
+                    <li
+                        key={i}
+                        className="flex items-center justify-center rounded-lg bg-muted text-sm font-bold text-gray-600 dark:text-gray-400"
+                    >
+                        {i + 1}
+                    </li>
+                ))}
+            </ul>
+        </ScrollArea>
+    ),
+} satisfies Story
+
+export const AlwaysShowScrollbars: Story = {
+    render: () => (
+        <ScrollArea alwaysShowScrollbars className="h-80 w-80 max-w-[calc(100vw-8rem)]">
             <ul className="m-0 grid list-none grid-cols-[repeat(10,6.25rem)] grid-rows-[repeat(10,6.25rem)] gap-3 p-0">
                 {Array.from({ length: 100 }, (_, i) => (
                     <li

--- a/packages/quill/packages/primitives/src/scroll-area.stories.tsx
+++ b/packages/quill/packages/primitives/src/scroll-area.stories.tsx
@@ -78,6 +78,39 @@ export const AlwaysShowScrollbars: Story = {
     ),
 } satisfies Story
 
+export const ScrollToButtonVertical: Story = {
+    render: () => (
+        <ScrollArea showScrollToButton={['top', 'bottom']} className="h-[50vh] px-4">
+            {Array.from({ length: 10 }).map((_, index) => (
+                <p key={index} className="mb-4 leading-normal">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+                    aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+                    cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+                    culpa qui officia deserunt mollit anim id est laborum.
+                </p>
+            ))}
+        </ScrollArea>
+    ),
+} satisfies Story
+
+export const ScrollToButtonAllDirections: Story = {
+    render: () => (
+        <ScrollArea showScrollToButton="all" className="h-80 w-80 max-w-[calc(100vw-8rem)]">
+            <ul className="m-0 grid list-none grid-cols-[repeat(10,6.25rem)] grid-rows-[repeat(10,6.25rem)] gap-3 p-0">
+                {Array.from({ length: 100 }, (_, i) => (
+                    <li
+                        key={i}
+                        className="flex items-center justify-center rounded-lg bg-muted text-sm font-bold text-gray-600 dark:text-gray-400"
+                    >
+                        {i + 1}
+                    </li>
+                ))}
+            </ul>
+        </ScrollArea>
+    ),
+} satisfies Story
+
 export const HideScrollbarsAllDirections: Story = {
     render: () => (
         <ScrollArea hideScrollbars className="h-80 w-80 max-w-[calc(100vw-8rem)]">

--- a/packages/quill/packages/primitives/src/scroll-area.stories.tsx
+++ b/packages/quill/packages/primitives/src/scroll-area.stories.tsx
@@ -34,7 +34,7 @@ export const Horizontal: Story = {
                 {Array.from({ length: 100 }, (_, i) => (
                     <li
                         key={i}
-                        className="flex items-center justify-center rounded-lg bg-gray-100 text-sm font-bold text-gray-600"
+                        className="flex items-center justify-center rounded-lg bg-muted text-sm font-bold text-gray-600 dark:text-gray-400"
                     >
                         {i + 1}
                     </li>

--- a/packages/quill/packages/primitives/src/scroll-area.stories.tsx
+++ b/packages/quill/packages/primitives/src/scroll-area.stories.tsx
@@ -27,9 +27,26 @@ export const Default: Story = {
     ),
 } satisfies Story
 
-export const Horizontal: Story = {
+export const AllDirections: Story = {
     render: () => (
         <ScrollArea className="h-80 w-80 max-w-[calc(100vw-8rem)]">
+            <ul className="m-0 grid list-none grid-cols-[repeat(10,6.25rem)] grid-rows-[repeat(10,6.25rem)] gap-3 p-0">
+                {Array.from({ length: 100 }, (_, i) => (
+                    <li
+                        key={i}
+                        className="flex items-center justify-center rounded-lg bg-muted text-sm font-bold text-gray-600 dark:text-gray-400"
+                    >
+                        {i + 1}
+                    </li>
+                ))}
+            </ul>
+        </ScrollArea>
+    ),
+} satisfies Story
+
+export const HideScrollbarsAllDirections: Story = {
+    render: () => (
+        <ScrollArea hideScrollbars className="h-80 w-80 max-w-[calc(100vw-8rem)]">
             <ul className="m-0 grid list-none grid-cols-[repeat(10,6.25rem)] grid-rows-[repeat(10,6.25rem)] gap-3 p-0">
                 {Array.from({ length: 100 }, (_, i) => (
                     <li

--- a/packages/quill/packages/primitives/src/scroll-area.tsx
+++ b/packages/quill/packages/primitives/src/scroll-area.tsx
@@ -72,8 +72,13 @@ function ScrollArea({
     children,
     scrollShadows = true,
     hideScrollbars = false,
+    alwaysShowScrollbars = false,
     ...props
-}: ScrollAreaPrimitive.Root.Props & { scrollShadows?: boolean; hideScrollbars?: boolean }): React.ReactElement {
+}: ScrollAreaPrimitive.Root.Props & {
+    scrollShadows?: boolean
+    hideScrollbars?: boolean
+    alwaysShowScrollbars?: boolean
+}): React.ReactElement {
     return (
         <ScrollAreaPrimitive.Root
             data-slot="scroll-area"
@@ -91,8 +96,8 @@ function ScrollArea({
             </ScrollAreaPrimitive.Viewport>
             {!hideScrollbars && (
                 <>
-                    <ScrollBar orientation="horizontal" />
-                    <ScrollBar orientation="vertical" />
+                    <ScrollBar orientation="horizontal" alwaysVisible={alwaysShowScrollbars} />
+                    <ScrollBar orientation="vertical" alwaysVisible={alwaysShowScrollbars} />
                     <ScrollAreaPrimitive.Corner
                         data-slot="scroll-area-corner"
                         className="bg-transparent rounded-br-sm z-1"
@@ -106,8 +111,9 @@ function ScrollArea({
 function ScrollBar({
     className,
     orientation = 'vertical',
+    alwaysVisible = false,
     ...props
-}: ScrollAreaPrimitive.Scrollbar.Props): React.ReactElement {
+}: ScrollAreaPrimitive.Scrollbar.Props & { alwaysVisible?: boolean }): React.ReactElement {
     return (
         <ScrollAreaPrimitive.Scrollbar
             data-slot="scroll-area-scrollbar"
@@ -115,9 +121,11 @@ function ScrollBar({
             orientation={orientation}
             className={cn(
                 'group/scrollbar bg-input/50 flex touch-none p-px transition-colors select-none z-1 rounded-sm',
-                'data-[orientation=horizontal]:w-[calc(100%-0.625rem)] data-[orientation=horizontal]:h-2.5 data-[orientation=horizontal]:flex-row',
-                'data-[orientation=vertical]:h-[calc(100%-0.625rem)] data-[orientation=vertical]:w-2.5 data-[orientation=vertical]:flex-col',
-                'opacity-0 transition-opacity pointer-events-none data-[hovering]:opacity-100 data-[hovering]:delay-0 data-[hovering]:pointer-events-auto data-[scrolling]:opacity-100 data-[scrolling]:duration-0 data-[scrolling]:pointer-events-auto',
+                'data-[orientation=horizontal]:w-full data-[orientation=horizontal]:data-[has-overflow-y]:w-[calc(100%-0.625rem)] data-[orientation=horizontal]:h-2.5 data-[orientation=horizontal]:flex-row',
+                'data-[orientation=vertical]:h-full data-[orientation=vertical]:data-[has-overflow-x]:h-[calc(100%-0.625rem)] data-[orientation=vertical]:w-2.5 data-[orientation=vertical]:flex-col',
+                alwaysVisible
+                    ? 'opacity-100 pointer-events-auto'
+                    : 'opacity-0 transition-opacity pointer-events-none data-[hovering]:opacity-100 data-[hovering]:delay-0 data-[hovering]:pointer-events-auto data-[scrolling]:opacity-100 data-[scrolling]:duration-0 data-[scrolling]:pointer-events-auto',
                 className
             )}
             {...props}

--- a/packages/quill/packages/primitives/src/scroll-area.tsx
+++ b/packages/quill/packages/primitives/src/scroll-area.tsx
@@ -120,8 +120,12 @@ function ScrollToEdgeButton({
 // Injected once at module load rather than authored as Tailwind arbitrary values —
 // the box-shadow syntax with nested commas and var() interactions is unreliable in
 // Tailwind's arbitrary-property parser.
-const SCROLL_SHADOWS_STYLE_ID = 'quill-scroll-area-shadows'
-const scrollShadowsCss = `
+//
+// Both the CSS string and ID are exported so consumers with strict CSP (nonce-based
+// style-src) can inject themselves via `<style nonce={...}>{scrollShadowsCss}</style>`
+// before the default auto-injection runs. Match the ID to dedupe.
+export const SCROLL_SHADOWS_STYLE_ID = 'quill-scroll-area-shadows'
+export const scrollShadowsCss = `
 [data-component="scroll-area"][data-scroll-shadows="true"] {
     --shadow-x-start: 0 0 0 0 transparent;
     --shadow-x-end: 0 0 0 0 transparent;
@@ -193,6 +197,12 @@ function ScrollArea({
 }): React.ReactElement {
     const viewportRef = React.useRef<HTMLDivElement | null>(null)
     const edges = resolveEdges(showScrollToButton)
+    if (process.env.NODE_ENV !== 'production' && hideScrollbars && alwaysShowScrollbars) {
+        // eslint-disable-next-line no-console
+        console.warn(
+            '[ScrollArea] `hideScrollbars` and `alwaysShowScrollbars` are mutually exclusive; `alwaysShowScrollbars` will be ignored.'
+        )
+    }
     return (
         <ScrollAreaPrimitive.Root
             data-slot="scroll-area"

--- a/packages/quill/packages/primitives/src/scroll-area.tsx
+++ b/packages/quill/packages/primitives/src/scroll-area.tsx
@@ -71,8 +71,9 @@ function ScrollArea({
     className,
     children,
     scrollShadows = true,
+    hideScrollbars = false,
     ...props
-}: ScrollAreaPrimitive.Root.Props & { scrollShadows?: boolean }): React.ReactElement {
+}: ScrollAreaPrimitive.Root.Props & { scrollShadows?: boolean; hideScrollbars?: boolean }): React.ReactElement {
     return (
         <ScrollAreaPrimitive.Root
             data-slot="scroll-area"
@@ -88,12 +89,16 @@ function ScrollArea({
             >
                 {children}
             </ScrollAreaPrimitive.Viewport>
-            <ScrollBar orientation="horizontal" />
-            <ScrollBar orientation="vertical" />
-            <ScrollAreaPrimitive.Corner
-                data-slot="scroll-area-corner"
-                className="bg-transparent rounded-br-sm z-1"
-            />
+            {!hideScrollbars && (
+                <>
+                    <ScrollBar orientation="horizontal" />
+                    <ScrollBar orientation="vertical" />
+                    <ScrollAreaPrimitive.Corner
+                        data-slot="scroll-area-corner"
+                        className="bg-transparent rounded-br-sm z-1"
+                    />
+                </>
+            )}
         </ScrollAreaPrimitive.Root>
     )
 }

--- a/packages/quill/packages/primitives/src/scroll-area.tsx
+++ b/packages/quill/packages/primitives/src/scroll-area.tsx
@@ -3,6 +3,70 @@ import * as React from 'react'
 
 import { cn } from './lib/utils'
 
+// Base-UI sets data-overflow-{x,y}-{start,end} attributes on the Root when the
+// viewport has scrollable content remaining in that direction. Two pseudos on Root
+// (::before = start edges left+top, ::after = end edges right+bottom) each stack two
+// inset box-shadows driven by CSS custom properties, toggled via the data attrs.
+// Injected once at module load rather than authored as Tailwind arbitrary values —
+// the box-shadow syntax with nested commas and var() interactions is unreliable in
+// Tailwind's arbitrary-property parser.
+const SCROLL_SHADOWS_STYLE_ID = 'quill-scroll-area-shadows'
+const scrollShadowsCss = `
+[data-component="scroll-area"][data-scroll-shadows="true"] {
+    --shadow-x-start: 0 0 0 0 transparent;
+    --shadow-x-end: 0 0 0 0 transparent;
+    --shadow-y-start: 0 0 0 0 transparent;
+    --shadow-y-end: 0 0 0 0 transparent;
+}
+[data-component="scroll-area"][data-scroll-shadows="true"][data-overflow-x-start] {
+    --shadow-x-start: 16px 0 16px -16px rgb(0 0 0 / 25%);
+}
+[data-component="scroll-area"][data-scroll-shadows="true"][data-overflow-x-end] {
+    --shadow-x-end: -16px 0 16px -16px rgb(0 0 0 / 25%);
+}
+[data-component="scroll-area"][data-scroll-shadows="true"][data-overflow-y-start] {
+    --shadow-y-start: 0 16px 16px -16px rgb(0 0 0 / 25%);
+}
+[data-component="scroll-area"][data-scroll-shadows="true"][data-overflow-y-end] {
+    --shadow-y-end: 0 -16px 16px -16px rgb(0 0 0 / 25%);
+}
+[data-component="scroll-area"][data-scroll-shadows="true"]::before,
+[data-component="scroll-area"][data-scroll-shadows="true"]::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 2;
+    border-radius: inherit;
+    transition: box-shadow 200ms ease;
+}
+[data-component="scroll-area"][data-scroll-shadows="true"]::before {
+    box-shadow: var(--shadow-x-start) inset, var(--shadow-y-start) inset;
+}
+[data-component="scroll-area"][data-scroll-shadows="true"]::after {
+    box-shadow: var(--shadow-x-end) inset, var(--shadow-y-end) inset;
+}
+.dark [data-component="scroll-area"][data-scroll-shadows="true"][data-overflow-x-start] {
+    --shadow-x-start: 28px 0 24px -16px rgb(0 0 0 / 100%);
+}
+.dark [data-component="scroll-area"][data-scroll-shadows="true"][data-overflow-x-end] {
+    --shadow-x-end: -28px 0 24px -16px rgb(0 0 0 / 100%);
+}
+.dark [data-component="scroll-area"][data-scroll-shadows="true"][data-overflow-y-start] {
+    --shadow-y-start: 0 28px 24px -16px rgb(0 0 0 / 100%);
+}
+.dark [data-component="scroll-area"][data-scroll-shadows="true"][data-overflow-y-end] {
+    --shadow-y-end: 0 -28px 24px -16px rgb(0 0 0 / 100%);
+}
+`
+
+if (typeof document !== 'undefined' && !document.getElementById(SCROLL_SHADOWS_STYLE_ID)) {
+    const styleEl = document.createElement('style')
+    styleEl.id = SCROLL_SHADOWS_STYLE_ID
+    styleEl.textContent = scrollShadowsCss
+    document.head.appendChild(styleEl)
+}
+
 function ScrollArea({
     className,
     children,
@@ -20,13 +84,7 @@ function ScrollArea({
         >
             <ScrollAreaPrimitive.Viewport
                 data-slot="scroll-area-viewport"
-                className={cn(
-                    'size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1',
-                    '[[data-scroll-shadows=true]_&]:before:content-[""] [[data-scroll-shadows=true]_&]:before:block [[data-scroll-shadows=true]_&]:before:left-0 [[data-scroll-shadows=true]_&]:before:w-full [[data-scroll-shadows=true]_&]:before:absolute [[data-scroll-shadows=true]_&]:before:pointer-events-none [[data-scroll-shadows=true]_&]:before:transition-[height] [[data-scroll-shadows=true]_&]:before:duration-100 [[data-scroll-shadows=true]_&]:before:ease-out [[data-scroll-shadows=true]_&]:before:top-0 [[data-scroll-shadows=true]_&]:before:z-1 [[data-scroll-shadows=true]_&]:before:[--scroll-area-overflow-y-start:inherit] [[data-scroll-shadows=true]_&]:before:h-[min(20px,var(--scroll-area-overflow-y-start))] ',
-                    '[[data-scroll-shadows=true]_&]:after:content-[""] [[data-scroll-shadows=true]_&]:after:block [[data-scroll-shadows=true]_&]:after:left-0 [[data-scroll-shadows=true]_&]:after:w-full [[data-scroll-shadows=true]_&]:after:absolute [[data-scroll-shadows=true]_&]:after:pointer-events-none [[data-scroll-shadows=true]_&]:after:transition-[height] [[data-scroll-shadows=true]_&]:after:duration-100 [[data-scroll-shadows=true]_&]:after:ease-out [[data-scroll-shadows=true]_&]:after:bottom-0 [[data-scroll-shadows=true]_&]:after:z-1 [[data-scroll-shadows=true]_&]:after:[--scroll-area-overflow-y-end:inherit] [[data-scroll-shadows=true]_&]:after:h-[min(20px,var(--scroll-area-overflow-y-end,20px))]',
-                    '[[data-scroll-shadows=true]_&]:before:bg-linear-to-b [[data-scroll-shadows=true]_&]:before:from-background [[data-scroll-shadows=true]_&]:before:to-transparent',
-                    '[[data-scroll-shadows=true]_&]:after:bg-linear-to-t [[data-scroll-shadows=true]_&]:after:from-background [[data-scroll-shadows=true]_&]:after:to-transparent'
-                )}
+                className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
             >
                 {children}
             </ScrollAreaPrimitive.Viewport>

--- a/packages/quill/packages/primitives/src/scroll-area.tsx
+++ b/packages/quill/packages/primitives/src/scroll-area.tsx
@@ -1,7 +1,117 @@
 import { ScrollArea as ScrollAreaPrimitive } from '@base-ui/react/scroll-area'
+import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp } from 'lucide-react'
 import * as React from 'react'
 
 import { cn } from './lib/utils'
+import { Button } from './button'
+
+type ScrollEdge = 'top' | 'right' | 'bottom' | 'left'
+type ShowScrollToButton = ScrollEdge | 'all' | ReadonlyArray<ScrollEdge>
+
+const ALL_EDGES: ReadonlyArray<ScrollEdge> = ['top', 'right', 'bottom', 'left']
+
+function resolveEdges(value: ShowScrollToButton | undefined): ReadonlyArray<ScrollEdge> {
+    if (!value) {
+        return []
+    }
+    if (value === 'all') {
+        return ALL_EDGES
+    }
+    if (Array.isArray(value)) {
+        return value
+    }
+    return [value as ScrollEdge]
+}
+
+// Each button is gated on the Root having a matching base-ui overflow data attribute
+// via Tailwind's `group-data-*` variants — no React state, no scroll listeners, no
+// effects. Visibility is pure CSS driven by base-ui's internal scroll tracking.
+const EDGE_CONFIG: Record<
+    ScrollEdge,
+    {
+        label: string
+        Icon: React.ComponentType<{ className?: string }>
+        positionClasses: string
+        visibleClasses: string
+        getScrollTarget: (viewport: HTMLElement) => ScrollToOptions
+    }
+> = {
+    top: {
+        label: 'Scroll to top',
+        Icon: ArrowUp,
+        positionClasses: 'top-2 left-1/2 -translate-x-1/2',
+        visibleClasses:
+            'group-data-[overflow-y-start]/scroll-area:opacity-100 group-data-[overflow-y-start]/scroll-area:scale-100 group-data-[overflow-y-start]/scroll-area:pointer-events-auto',
+        getScrollTarget: () => ({ top: 0 }),
+    },
+    bottom: {
+        label: 'Scroll to bottom',
+        Icon: ArrowDown,
+        positionClasses: 'bottom-2 left-1/2 -translate-x-1/2',
+        visibleClasses:
+            'group-data-[overflow-y-end]/scroll-area:opacity-100 group-data-[overflow-y-end]/scroll-area:scale-100 group-data-[overflow-y-end]/scroll-area:pointer-events-auto',
+        getScrollTarget: (viewport) => ({ top: viewport.scrollHeight }),
+    },
+    left: {
+        label: 'Scroll to start',
+        Icon: ArrowLeft,
+        positionClasses: 'left-2 top-1/2 -translate-y-1/2 not-disabled:active:-translate-y-1/2',
+        visibleClasses:
+            'group-data-[overflow-x-start]/scroll-area:opacity-100 group-data-[overflow-x-start]/scroll-area:scale-100 group-data-[overflow-x-start]/scroll-area:pointer-events-auto',
+        getScrollTarget: () => ({ left: 0 }),
+    },
+    right: {
+        label: 'Scroll to end',
+        Icon: ArrowRight,
+        positionClasses: 'right-2 top-1/2 -translate-y-1/2 not-disabled:active:-translate-y-1/2',
+        visibleClasses:
+            'group-data-[overflow-x-end]/scroll-area:opacity-100 group-data-[overflow-x-end]/scroll-area:scale-100 group-data-[overflow-x-end]/scroll-area:pointer-events-auto',
+        getScrollTarget: (viewport) => ({ left: viewport.scrollWidth }),
+    },
+}
+
+function ScrollToEdgeButton({
+    edge,
+    viewportRef,
+}: {
+    edge: ScrollEdge
+    viewportRef: React.RefObject<HTMLDivElement | null>
+}): React.ReactElement {
+    const config = EDGE_CONFIG[edge]
+    const { Icon } = config
+    const handleClick = (): void => {
+        const viewport = viewportRef.current
+        if (!viewport) {
+            return
+        }
+        const prefersReducedMotion =
+            typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        viewport.scrollTo({
+            ...config.getScrollTarget(viewport),
+            behavior: prefersReducedMotion ? 'auto' : 'smooth',
+        })
+    }
+    return (
+        <Button
+            type="button"
+            size="icon"
+            variant="outline"
+            aria-label={config.label}
+            onClick={handleClick}
+            className={cn(
+                'bg-background not-disabled:hover:bg-accent absolute z-10 grid place-items-center rounded-full shadow-md',
+                'opacity-0 scale-95 pointer-events-none',
+                'transition-[opacity,transform,background-color] duration-150 ease-out',
+                'motion-reduce:transition-none',
+                'focus-visible:opacity-100 focus-visible:scale-100 focus-visible:pointer-events-auto',
+                config.positionClasses,
+                config.visibleClasses
+            )}
+        >
+            <Icon className="size-4" />
+        </Button>
+    )
+}
 
 // Base-UI sets data-overflow-{x,y}-{start,end} attributes on the Root when the
 // viewport has scrollable content remaining in that direction. Two pseudos on Root
@@ -73,22 +183,27 @@ function ScrollArea({
     scrollShadows = true,
     hideScrollbars = false,
     alwaysShowScrollbars = false,
+    showScrollToButton,
     ...props
 }: ScrollAreaPrimitive.Root.Props & {
     scrollShadows?: boolean
     hideScrollbars?: boolean
     alwaysShowScrollbars?: boolean
+    showScrollToButton?: ShowScrollToButton
 }): React.ReactElement {
+    const viewportRef = React.useRef<HTMLDivElement | null>(null)
+    const edges = resolveEdges(showScrollToButton)
     return (
         <ScrollAreaPrimitive.Root
             data-slot="scroll-area"
             // Just to keep around so we know it's a scroll area in case we merge props with another component
             data-component="scroll-area"
             data-scroll-shadows={scrollShadows}
-            className={cn('relative', className)}
+            className={cn('group/scroll-area relative', className)}
             {...props}
         >
             <ScrollAreaPrimitive.Viewport
+                ref={viewportRef}
                 data-slot="scroll-area-viewport"
                 className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
             >
@@ -104,6 +219,9 @@ function ScrollArea({
                     />
                 </>
             )}
+            {edges.map((edge) => (
+                <ScrollToEdgeButton key={edge} edge={edge} viewportRef={viewportRef} />
+            ))}
         </ScrollAreaPrimitive.Root>
     )
 }

--- a/packages/quill/packages/quill/package.json
+++ b/packages/quill/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill",
-    "version": "0.1.0-alpha.4",
+    "version": "0.1.0-alpha.5",
     "description": "PostHog's unified design system — primitives, components, and blocks designed to be compiled by the consumer's Tailwind v4.",
     "license": "MIT",
     "repository": {


### PR DESCRIPTION
## Problem

The quill ScrollArea was missing polish that the legacy `frontend/src/lib/components/ScrollableShadows` component provided: shadows only covered two edges, scrollbars wasted space reserving a corner when only one axis overflowed, and there was no way to surface a scroll-to-edge affordance for long content.

## Changes

- **Scroll shadows on all four edges**, matching the reference `ScrollableShadows.scss` pattern — inset box-shadows on Root `::before`/`::after` pseudos, driven by Base-UI's existing `data-overflow-{x,y}-{start,end}` attributes. Light mode uses 25% opacity, dark mode a more prominent version. Injected once at module load so the CSS sidesteps Tailwind's arbitrary-value parser which choked on the nested box-shadow comma syntax.
- **`hideScrollbars` prop** (default `false`) — skips rendering both `ScrollBar`s and the `Corner`; Base-UI's default native-scrollbar hiding takes over.
- **`alwaysShowScrollbars` prop** (default `false`) — swaps the hover/scrolling opacity cycle for `opacity-100 pointer-events-auto` so the tracks stay visible.
- **Single-axis scrollbar length fix** — scrollbars previously reserved 0.625rem for the perpendicular scrollbar even when that axis didn't overflow, leaving a visible gap. Now `data-[has-overflow-*]` gates the `calc(100% - 0.625rem)` subtraction, so single-axis (or `hideScrollbars`) cases get full-length scrollbars.
- **`showScrollToButton` prop** accepting `'top' | 'right' | 'bottom' | 'left' | 'all' | ScrollEdge[]` — renders floating scroll-to-edge buttons. Visibility is 100% CSS via `group-data-[overflow-*]/scroll-area:*` variants on the already-existing Base-UI data attrs — no scroll listeners, no `useEffect`, no React state. Click handlers use a single `useRef` to the Viewport and call `scrollTo({ behavior: 'smooth' })`, falling back to `'auto'` when the user prefers reduced motion.
- Uses quill's `Button` primitive with `variant=\"outline\"`; left/right button position classes re-assert `not-disabled:active:-translate-y-1/2` to beat the Button base's active press translate that was breaking their vertical centering.
- Bumped `@posthog/quill` to `0.1.0-alpha.5`.

Storybook stories added: `Horizontal`, `AllDirections`, `AlwaysShowScrollbars`, `HideScrollbarsAllDirections`, `ScrollToButtonVertical`, `ScrollToButtonAllDirections`.

## How did you test this code?

Verified visually in quill Storybook across light and dark themes — all-directions grid, single-axis horizontal, hidden scrollbars, always-visible scrollbars, and the new scroll-to-edge buttons. No automated tests added.

## Publish to changelog?

no

## 🤖 LLM context

Authored with Claude Code. No `useEffect` or scroll listeners — the scroll-to-edge button visibility relies entirely on Base-UI's pre-existing `data-overflow-*` attributes being flipped internally, surfaced via Tailwind `group-data-*` variants.