### PR TITLE
chore(quill): bump quill and quill-tokens to 0.1.0-alpha.6

### DIFF
--- a/packages/quill/packages/quill/package.json
+++ b/packages/quill/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill",
-    "version": "0.1.0-alpha.5",
+    "version": "0.1.0-alpha.6",
     "description": "PostHog's unified design system — primitives, components, and blocks designed to be compiled by the consumer's Tailwind v4.",
     "license": "MIT",
     "repository": {

--- a/packages/quill/packages/tokens/package.json
+++ b/packages/quill/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/quill-tokens",
-    "version": "0.1.0-alpha.4",
+    "version": "0.1.0-alpha.6",
     "license": "MIT",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Problem

Rolls up recent ScrollArea primitive changes into a new quill prerelease for consumers.

## Changes

- \`@posthog/quill\`: \`0.1.0-alpha.5\` → \`0.1.0-alpha.6\`
- \`@posthog/quill-tokens\`: \`0.1.0-alpha.4\` → \`0.1.0-alpha.6\`

## How did you test this code?

Version-only bump. No functional changes in this PR.

## Publish to changelog?

no

## 🤖 LLM context

Authored with Claude Code. Version bump after ScrollArea feature PR #54583.