### PR TITLE
feat(ingestion): implement new ClickHouse Kafka Engine and Materialized View tables

### DIFF
--- a/posthog/clickhouse/kafka_engine.py
+++ b/posthog/clickhouse/kafka_engine.py
@@ -29,6 +29,12 @@ CONSUMER_GROUP_APP_METRICS2_WS = "clickhouse_app_metrics2_ws"
 CONSUMER_GROUP_TOPHOG_WS = "clickhouse_tophog_ws"
 CONSUMER_GROUP_PRECALCULATED_EVENTS_WS = "clickhouse_precalculated_events_ws"
 CONSUMER_GROUP_PRECALCULATED_PERSON_PROPERTIES_WS = "clickhouse_precalculated_person_properties_ws"
+CONSUMER_GROUP_EVENTS_JSON_WS = "clickhouse_events_json_ws"
+CONSUMER_GROUP_GROUPS_WS = "clickhouse_groups_ws"
+CONSUMER_GROUP_PERSON_WS = "clickhouse_person_ws"
+CONSUMER_GROUP_PERSON_DISTINCT_ID2_WS = "clickhouse_person_distinct_id2_ws"
+CONSUMER_GROUP_AI_EVENTS_WS = "clickhouse_ai_events_ws"
+CONSUMER_GROUP_HEATMAPS_WS = "clickhouse_heatmaps_ws"
 
 STORAGE_POLICY = lambda: "SETTINGS storage_policy = 'hot_to_cold'" if settings.CLICKHOUSE_ENABLE_STORAGE_POLICY else ""
 

--- a/posthog/clickhouse/migrations/0232_warpstream_ingestion_kafka_engines.py
+++ b/posthog/clickhouse/migrations/0232_warpstream_ingestion_kafka_engines.py
@@ -1,7 +1,12 @@
 from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.heatmaps.sql import HEATMAPS_WS_TABLE_MV_SQL, KAFKA_HEATMAPS_WS_TABLE_SQL
-from posthog.models.ai_events.sql import AI_EVENTS_WS_MV_SQL, KAFKA_AI_EVENTS_WS_TABLE_SQL
+from posthog.models.ai_events.sql import (
+    AI_EVENTS_DATA_TABLE_SQL,
+    AI_EVENTS_WS_MV_SQL,
+    DISTRIBUTED_AI_EVENTS_TABLE_SQL,
+    KAFKA_AI_EVENTS_WS_TABLE_SQL,
+)
 from posthog.models.event.sql import EVENTS_TABLE_JSON_WS_MV_SQL, KAFKA_EVENTS_TABLE_JSON_WS_SQL
 from posthog.models.group.sql import GROUPS_WS_TABLE_MV_SQL, KAFKA_GROUPS_WS_TABLE_SQL
 from posthog.models.person.sql import (
@@ -63,6 +68,17 @@ operations = [
         node_roles=[NodeRole.INGESTION_SMALL],
     ),
     # ai_events (AI_EVENTS satellite cluster, matching existing MSK table)
+    # Ensure sharded + distributed ai_events tables exist — they were originally
+    # created only in schema.py (not a numbered migration), so the MV target
+    # may be missing when migrate_clickhouse runs before test conftest setup.
+    run_sql_with_exceptions(
+        AI_EVENTS_DATA_TABLE_SQL(),
+        node_roles=[NodeRole.AI_EVENTS],
+    ),
+    run_sql_with_exceptions(
+        DISTRIBUTED_AI_EVENTS_TABLE_SQL(),
+        node_roles=[NodeRole.AI_EVENTS],
+    ),
     run_sql_with_exceptions(
         KAFKA_AI_EVENTS_WS_TABLE_SQL(),
         node_roles=[NodeRole.AI_EVENTS],

--- a/posthog/clickhouse/migrations/0232_warpstream_ingestion_kafka_engines.py
+++ b/posthog/clickhouse/migrations/0232_warpstream_ingestion_kafka_engines.py
@@ -1,3 +1,4 @@
+from posthog import settings
 from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.heatmaps.sql import HEATMAPS_WS_TABLE_MV_SQL, KAFKA_HEATMAPS_WS_TABLE_SQL
@@ -22,6 +23,10 @@ from posthog.models.person.sql import (
 # the same topics but via the warpstream_ingestion named collection. Each has its own
 # consumer group to avoid conflicts with the MSK tables.
 #
+# CLOUD-ONLY: In non-cloud environments (CI, dev, hobby) there is only one ClickHouse
+# node, so both the MSK and WS materialized views would consume the same Kafka topic
+# and write to the same target table, causing every event to be counted twice.
+#
 # New tables:
 # - kafka_events_json_ws + events_json_ws_mv (INGESTION_EVENTS)
 # - kafka_groups_ws + groups_ws_mv (INGESTION_SMALL)
@@ -30,70 +35,74 @@ from posthog.models.person.sql import (
 # - kafka_ai_events_json_ws + ai_events_json_ws_mv (AI_EVENTS)
 # - kafka_heatmaps_ws + heatmaps_ws_mv (INGESTION_MEDIUM)
 
-operations = [
-    # events_json (INGESTION_EVENTS — WS tables go to events ingestion nodes)
-    run_sql_with_exceptions(
-        KAFKA_EVENTS_TABLE_JSON_WS_SQL(),
-        node_roles=[NodeRole.INGESTION_EVENTS],
-    ),
-    run_sql_with_exceptions(
-        EVENTS_TABLE_JSON_WS_MV_SQL(),
-        node_roles=[NodeRole.INGESTION_EVENTS],
-    ),
-    # groups (INGESTION_SMALL, matching existing MSK table)
-    run_sql_with_exceptions(
-        KAFKA_GROUPS_WS_TABLE_SQL(),
-        node_roles=[NodeRole.INGESTION_SMALL],
-    ),
-    run_sql_with_exceptions(
-        GROUPS_WS_TABLE_MV_SQL(),
-        node_roles=[NodeRole.INGESTION_SMALL],
-    ),
-    # person (INGESTION_SMALL, matching existing MSK table)
-    run_sql_with_exceptions(
-        KAFKA_PERSONS_WS_TABLE_SQL(),
-        node_roles=[NodeRole.INGESTION_SMALL],
-    ),
-    run_sql_with_exceptions(
-        PERSONS_WS_TABLE_MV_SQL(),
-        node_roles=[NodeRole.INGESTION_SMALL],
-    ),
-    # person_distinct_id2 (INGESTION_SMALL, matching existing MSK table)
-    run_sql_with_exceptions(
-        KAFKA_PERSON_DISTINCT_ID2_WS_TABLE_SQL(),
-        node_roles=[NodeRole.INGESTION_SMALL],
-    ),
-    run_sql_with_exceptions(
-        PERSON_DISTINCT_ID2_WS_MV_SQL(),
-        node_roles=[NodeRole.INGESTION_SMALL],
-    ),
-    # ai_events (AI_EVENTS satellite cluster, matching existing MSK table)
-    # Ensure sharded + distributed ai_events tables exist — they were originally
-    # created only in schema.py (not a numbered migration), so the MV target
-    # may be missing when migrate_clickhouse runs before test conftest setup.
-    run_sql_with_exceptions(
-        AI_EVENTS_DATA_TABLE_SQL(),
-        node_roles=[NodeRole.AI_EVENTS],
-    ),
-    run_sql_with_exceptions(
-        DISTRIBUTED_AI_EVENTS_TABLE_SQL(),
-        node_roles=[NodeRole.AI_EVENTS],
-    ),
-    run_sql_with_exceptions(
-        KAFKA_AI_EVENTS_WS_TABLE_SQL(),
-        node_roles=[NodeRole.AI_EVENTS],
-    ),
-    run_sql_with_exceptions(
-        AI_EVENTS_WS_MV_SQL(),
-        node_roles=[NodeRole.AI_EVENTS],
-    ),
-    # heatmaps (INGESTION_MEDIUM, matching existing MSK table)
-    run_sql_with_exceptions(
-        KAFKA_HEATMAPS_WS_TABLE_SQL(),
-        node_roles=[NodeRole.INGESTION_MEDIUM],
-    ),
-    run_sql_with_exceptions(
-        HEATMAPS_WS_TABLE_MV_SQL(),
-        node_roles=[NodeRole.INGESTION_MEDIUM],
-    ),
-]
+operations = (
+    []
+    if not settings.CLOUD_DEPLOYMENT
+    else [
+        # events_json (INGESTION_EVENTS — WS tables go to events ingestion nodes)
+        run_sql_with_exceptions(
+            KAFKA_EVENTS_TABLE_JSON_WS_SQL(),
+            node_roles=[NodeRole.INGESTION_EVENTS],
+        ),
+        run_sql_with_exceptions(
+            EVENTS_TABLE_JSON_WS_MV_SQL(),
+            node_roles=[NodeRole.INGESTION_EVENTS],
+        ),
+        # groups (INGESTION_SMALL, matching existing MSK table)
+        run_sql_with_exceptions(
+            KAFKA_GROUPS_WS_TABLE_SQL(),
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        run_sql_with_exceptions(
+            GROUPS_WS_TABLE_MV_SQL(),
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        # person (INGESTION_SMALL, matching existing MSK table)
+        run_sql_with_exceptions(
+            KAFKA_PERSONS_WS_TABLE_SQL(),
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        run_sql_with_exceptions(
+            PERSONS_WS_TABLE_MV_SQL(),
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        # person_distinct_id2 (INGESTION_SMALL, matching existing MSK table)
+        run_sql_with_exceptions(
+            KAFKA_PERSON_DISTINCT_ID2_WS_TABLE_SQL(),
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        run_sql_with_exceptions(
+            PERSON_DISTINCT_ID2_WS_MV_SQL(),
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        # ai_events (AI_EVENTS satellite cluster, matching existing MSK table)
+        # Ensure sharded + distributed ai_events tables exist — they were originally
+        # created only in schema.py (not a numbered migration), so the MV target
+        # may be missing when migrate_clickhouse runs before test conftest setup.
+        run_sql_with_exceptions(
+            AI_EVENTS_DATA_TABLE_SQL(),
+            node_roles=[NodeRole.AI_EVENTS],
+        ),
+        run_sql_with_exceptions(
+            DISTRIBUTED_AI_EVENTS_TABLE_SQL(),
+            node_roles=[NodeRole.AI_EVENTS],
+        ),
+        run_sql_with_exceptions(
+            KAFKA_AI_EVENTS_WS_TABLE_SQL(),
+            node_roles=[NodeRole.AI_EVENTS],
+        ),
+        run_sql_with_exceptions(
+            AI_EVENTS_WS_MV_SQL(),
+            node_roles=[NodeRole.AI_EVENTS],
+        ),
+        # heatmaps (INGESTION_MEDIUM, matching existing MSK table)
+        run_sql_with_exceptions(
+            KAFKA_HEATMAPS_WS_TABLE_SQL(),
+            node_roles=[NodeRole.INGESTION_MEDIUM],
+        ),
+        run_sql_with_exceptions(
+            HEATMAPS_WS_TABLE_MV_SQL(),
+            node_roles=[NodeRole.INGESTION_MEDIUM],
+        ),
+    ]
+)

--- a/posthog/clickhouse/migrations/0232_warpstream_ingestion_kafka_engines.py
+++ b/posthog/clickhouse/migrations/0232_warpstream_ingestion_kafka_engines.py
@@ -1,0 +1,83 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.heatmaps.sql import HEATMAPS_WS_TABLE_MV_SQL, KAFKA_HEATMAPS_WS_TABLE_SQL
+from posthog.models.ai_events.sql import AI_EVENTS_WS_MV_SQL, KAFKA_AI_EVENTS_WS_TABLE_SQL
+from posthog.models.event.sql import EVENTS_TABLE_JSON_WS_MV_SQL, KAFKA_EVENTS_TABLE_JSON_WS_SQL
+from posthog.models.group.sql import GROUPS_WS_TABLE_MV_SQL, KAFKA_GROUPS_WS_TABLE_SQL
+from posthog.models.person.sql import (
+    KAFKA_PERSON_DISTINCT_ID2_WS_TABLE_SQL,
+    KAFKA_PERSONS_WS_TABLE_SQL,
+    PERSON_DISTINCT_ID2_WS_MV_SQL,
+    PERSONS_WS_TABLE_MV_SQL,
+)
+
+# Migration to create WarpStream Kafka engine tables for core ingestion topics.
+#
+# These tables coexist alongside the existing MSK Kafka engine tables, reading from
+# the same topics but via the warpstream_ingestion named collection. Each has its own
+# consumer group to avoid conflicts with the MSK tables.
+#
+# New tables:
+# - kafka_events_json_ws + events_json_ws_mv (DATA)
+# - kafka_groups_ws + groups_ws_mv (INGESTION_SMALL)
+# - kafka_person_ws + person_ws_mv (INGESTION_SMALL)
+# - kafka_person_distinct_id2_ws + person_distinct_id2_ws_mv (INGESTION_SMALL)
+# - kafka_ai_events_json_ws + ai_events_json_ws_mv (AI_EVENTS)
+# - kafka_heatmaps_ws + heatmaps_ws_mv (INGESTION_MEDIUM)
+
+operations = [
+    # events_json (DATA, matching existing MSK table)
+    run_sql_with_exceptions(
+        KAFKA_EVENTS_TABLE_JSON_WS_SQL(),
+        node_roles=[NodeRole.DATA],
+    ),
+    run_sql_with_exceptions(
+        EVENTS_TABLE_JSON_WS_MV_SQL(),
+        node_roles=[NodeRole.DATA],
+    ),
+    # groups (INGESTION_SMALL, matching existing MSK table)
+    run_sql_with_exceptions(
+        KAFKA_GROUPS_WS_TABLE_SQL(),
+        node_roles=[NodeRole.INGESTION_SMALL],
+    ),
+    run_sql_with_exceptions(
+        GROUPS_WS_TABLE_MV_SQL(),
+        node_roles=[NodeRole.INGESTION_SMALL],
+    ),
+    # person (INGESTION_SMALL, matching existing MSK table)
+    run_sql_with_exceptions(
+        KAFKA_PERSONS_WS_TABLE_SQL(),
+        node_roles=[NodeRole.INGESTION_SMALL],
+    ),
+    run_sql_with_exceptions(
+        PERSONS_WS_TABLE_MV_SQL(),
+        node_roles=[NodeRole.INGESTION_SMALL],
+    ),
+    # person_distinct_id2 (INGESTION_SMALL, matching existing MSK table)
+    run_sql_with_exceptions(
+        KAFKA_PERSON_DISTINCT_ID2_WS_TABLE_SQL(),
+        node_roles=[NodeRole.INGESTION_SMALL],
+    ),
+    run_sql_with_exceptions(
+        PERSON_DISTINCT_ID2_WS_MV_SQL(),
+        node_roles=[NodeRole.INGESTION_SMALL],
+    ),
+    # ai_events (AI_EVENTS satellite cluster, matching existing MSK table)
+    run_sql_with_exceptions(
+        KAFKA_AI_EVENTS_WS_TABLE_SQL(),
+        node_roles=[NodeRole.AI_EVENTS],
+    ),
+    run_sql_with_exceptions(
+        AI_EVENTS_WS_MV_SQL(),
+        node_roles=[NodeRole.AI_EVENTS],
+    ),
+    # heatmaps (INGESTION_MEDIUM, matching existing MSK table)
+    run_sql_with_exceptions(
+        KAFKA_HEATMAPS_WS_TABLE_SQL(),
+        node_roles=[NodeRole.INGESTION_MEDIUM],
+    ),
+    run_sql_with_exceptions(
+        HEATMAPS_WS_TABLE_MV_SQL(),
+        node_roles=[NodeRole.INGESTION_MEDIUM],
+    ),
+]

--- a/posthog/clickhouse/migrations/0232_warpstream_ingestion_kafka_engines.py
+++ b/posthog/clickhouse/migrations/0232_warpstream_ingestion_kafka_engines.py
@@ -18,7 +18,7 @@ from posthog.models.person.sql import (
 # consumer group to avoid conflicts with the MSK tables.
 #
 # New tables:
-# - kafka_events_json_ws + events_json_ws_mv (DATA)
+# - kafka_events_json_ws + events_json_ws_mv (INGESTION_EVENTS)
 # - kafka_groups_ws + groups_ws_mv (INGESTION_SMALL)
 # - kafka_person_ws + person_ws_mv (INGESTION_SMALL)
 # - kafka_person_distinct_id2_ws + person_distinct_id2_ws_mv (INGESTION_SMALL)
@@ -26,14 +26,14 @@ from posthog.models.person.sql import (
 # - kafka_heatmaps_ws + heatmaps_ws_mv (INGESTION_MEDIUM)
 
 operations = [
-    # events_json (DATA, matching existing MSK table)
+    # events_json (INGESTION_EVENTS — WS tables go to events ingestion nodes)
     run_sql_with_exceptions(
         KAFKA_EVENTS_TABLE_JSON_WS_SQL(),
-        node_roles=[NodeRole.DATA],
+        node_roles=[NodeRole.INGESTION_EVENTS],
     ),
     run_sql_with_exceptions(
         EVENTS_TABLE_JSON_WS_MV_SQL(),
-        node_roles=[NodeRole.DATA],
+        node_roles=[NodeRole.INGESTION_EVENTS],
     ),
     # groups (INGESTION_SMALL, matching existing MSK table)
     run_sql_with_exceptions(

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0231_add_ai_columns_to_session_replay_events
+0232_warpstream_ingestion_kafka_engines

--- a/posthog/heatmaps/sql.py
+++ b/posthog/heatmaps/sql.py
@@ -1,7 +1,12 @@
 from django.conf import settings
 
 from posthog.clickhouse.cluster import ON_CLUSTER_CLAUSE
-from posthog.clickhouse.kafka_engine import CONSUMER_GROUP_HEATMAPS, kafka_engine, ttl_period
+from posthog.clickhouse.kafka_engine import (
+    CONSUMER_GROUP_HEATMAPS,
+    CONSUMER_GROUP_HEATMAPS_WS,
+    kafka_engine,
+    ttl_period,
+)
 from posthog.clickhouse.table_engines import Distributed, MergeTreeEngine, ReplicationScheme
 from posthog.kafka_client.topics import KAFKA_CLICKHOUSE_HEATMAP_EVENTS
 
@@ -164,4 +169,51 @@ TRUNCATE_HEATMAPS_TABLE_SQL = lambda: (f"TRUNCATE TABLE IF EXISTS {HEATMAPS_DATA
 
 ALTER_TABLE_ADD_TTL_PERIOD = lambda: (
     f"ALTER TABLE {HEATMAPS_DATA_TABLE()} MODIFY {ttl_period('timestamp', 90, unit='DAY')}"
+)
+
+
+# WarpStream Kafka engine tables (coexist alongside MSK tables, same target)
+
+KAFKA_HEATMAPS_WS_TABLE = "kafka_heatmaps_ws"
+HEATMAPS_WS_MV = "heatmaps_ws_mv"
+
+DROP_KAFKA_HEATMAPS_WS_TABLE_SQL = f"DROP TABLE IF EXISTS {KAFKA_HEATMAPS_WS_TABLE}"
+DROP_HEATMAPS_WS_MV_SQL = f"DROP TABLE IF EXISTS {HEATMAPS_WS_MV}"
+
+KAFKA_HEATMAPS_WS_TABLE_SQL = lambda: KAFKA_HEATMAPS_TABLE_BASE_SQL.format(
+    table_name=KAFKA_HEATMAPS_WS_TABLE,
+    engine=kafka_engine(
+        topic=KAFKA_CLICKHOUSE_HEATMAP_EVENTS,
+        group=CONSUMER_GROUP_HEATMAPS_WS,
+        named_collection=settings.CLICKHOUSE_KAFKA_WARPSTREAM_INGESTION_NAMED_COLLECTION,
+    ),
+)
+
+HEATMAPS_WS_TABLE_MV_SQL = (
+    lambda: """
+CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name}
+TO {database}.{target_table}
+AS SELECT
+    session_id,
+    team_id,
+    distinct_id,
+    timestamp,
+    x,
+    y,
+    scale_factor,
+    viewport_width,
+    viewport_height,
+    pointer_target_fixed,
+    current_url,
+    type,
+    _timestamp,
+    _offset,
+    _partition
+FROM {database}.{from_table}
+""".format(
+        mv_name=HEATMAPS_WS_MV,
+        target_table="writable_heatmaps",
+        from_table=KAFKA_HEATMAPS_WS_TABLE,
+        database=settings.CLICKHOUSE_DATABASE,
+    )
 )

--- a/posthog/heatmaps/sql.py
+++ b/posthog/heatmaps/sql.py
@@ -101,14 +101,21 @@ HEATMAPS_TABLE_SQL = lambda on_cluster=True: (
     ttl_period=ttl_period("timestamp", 90, unit="DAY"),
 )
 
+HEATMAPS_WRITABLE_TABLE = "writable_heatmaps"
+
 KAFKA_HEATMAPS_TABLE_SQL = lambda: KAFKA_HEATMAPS_TABLE_BASE_SQL.format(
     table_name="kafka_heatmaps",
     engine=kafka_engine(topic=KAFKA_CLICKHOUSE_HEATMAP_EVENTS, group=CONSUMER_GROUP_HEATMAPS),
 )
 
-HEATMAPS_TABLE_MV_SQL = (
-    lambda: """
-CREATE MATERIALIZED VIEW IF NOT EXISTS heatmaps_mv
+
+def HEATMAPS_TABLE_MV_SQL(
+    mv_name="heatmaps_mv",
+    kafka_table="kafka_heatmaps",
+    target_table=HEATMAPS_WRITABLE_TABLE,
+):
+    return """
+CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name}
 TO {database}.{target_table}
 AS SELECT
     session_id,
@@ -130,18 +137,20 @@ AS SELECT
     _timestamp,
     _offset,
     _partition
-FROM {database}.kafka_heatmaps
+FROM {database}.{kafka_table}
 """.format(
-        target_table="writable_heatmaps",
+        mv_name=mv_name,
+        target_table=target_table,
+        kafka_table=kafka_table,
         database=settings.CLICKHOUSE_DATABASE,
     )
-)
+
 
 # Distributed engine tables are only created if CLICKHOUSE_REPLICATED
 
 # This table is responsible for writing to sharded_heatmaps based on a sharding key.
 WRITABLE_HEATMAPS_TABLE_SQL = lambda: HEATMAPS_TABLE_BASE_SQL.format(
-    table_name="writable_heatmaps",
+    table_name=HEATMAPS_WRITABLE_TABLE,
     engine=Distributed(
         data_table=HEATMAPS_DATA_TABLE(),
         sharding_key="cityHash64(concat(toString(team_id), '-', session_id, '-', toString(toDate(timestamp))))",
@@ -159,7 +168,7 @@ DISTRIBUTED_HEATMAPS_TABLE_SQL = lambda: HEATMAPS_TABLE_BASE_SQL.format(
 
 DROP_HEATMAPS_TABLE_SQL = lambda: (f"DROP TABLE IF EXISTS {HEATMAPS_DATA_TABLE()}")
 
-DROP_WRITABLE_HEATMAPS_TABLE_SQL = lambda: (f"DROP TABLE IF EXISTS writable_heatmaps")
+DROP_WRITABLE_HEATMAPS_TABLE_SQL = lambda: (f"DROP TABLE IF EXISTS {HEATMAPS_WRITABLE_TABLE}")
 
 DROP_HEATMAPS_TABLE_MV_SQL = lambda: (f"DROP TABLE IF EXISTS heatmaps_mv")
 
@@ -189,31 +198,10 @@ KAFKA_HEATMAPS_WS_TABLE_SQL = lambda: KAFKA_HEATMAPS_TABLE_BASE_SQL.format(
     ),
 )
 
-HEATMAPS_WS_TABLE_MV_SQL = (
-    lambda: """
-CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name}
-TO {database}.{target_table}
-AS SELECT
-    session_id,
-    team_id,
-    distinct_id,
-    timestamp,
-    x,
-    y,
-    scale_factor,
-    viewport_width,
-    viewport_height,
-    pointer_target_fixed,
-    current_url,
-    type,
-    _timestamp,
-    _offset,
-    _partition
-FROM {database}.{from_table}
-""".format(
+
+def HEATMAPS_WS_TABLE_MV_SQL():
+    return HEATMAPS_TABLE_MV_SQL(
         mv_name=HEATMAPS_WS_MV,
-        target_table="writable_heatmaps",
-        from_table=KAFKA_HEATMAPS_WS_TABLE,
-        database=settings.CLICKHOUSE_DATABASE,
+        kafka_table=KAFKA_HEATMAPS_WS_TABLE,
+        target_table=HEATMAPS_WRITABLE_TABLE,
     )
-)

--- a/posthog/models/ai_events/sql.py
+++ b/posthog/models/ai_events/sql.py
@@ -1,4 +1,6 @@
-from posthog.clickhouse.kafka_engine import CONSUMER_GROUP_AI_EVENTS, kafka_engine
+from django.conf import settings
+
+from posthog.clickhouse.kafka_engine import CONSUMER_GROUP_AI_EVENTS, CONSUMER_GROUP_AI_EVENTS_WS, kafka_engine
 from posthog.clickhouse.table_engines import Distributed, MergeTreeEngine, ReplicationScheme
 from posthog.kafka_client.topics import KAFKA_CLICKHOUSE_AI_EVENTS_JSON
 
@@ -201,7 +203,11 @@ def KAFKA_AI_EVENTS_TABLE_SQL():
     )
 
 
-def AI_EVENTS_MV_SQL(target_table: str = TABLE_BASE_NAME):
+def AI_EVENTS_MV_SQL(
+    target_table: str = TABLE_BASE_NAME,
+    mv_name: str = MV_NAME,
+    kafka_table: str = KAFKA_TABLE_NAME,
+):
     # AI events do not have a dedicated writable table today, so the MV
     # writes straight to the distributed ai_events table.
     # Use src.properties to avoid alias shadowing — the stripped_properties
@@ -290,10 +296,37 @@ AS SELECT
     _partition
 FROM {kafka_table} AS src
 """.format(
-        mv_name=MV_NAME,
+        mv_name=mv_name,
         target_table=target_table,
-        kafka_table=KAFKA_TABLE_NAME,
+        kafka_table=kafka_table,
         stripped_properties=stripped_properties,
+    )
+
+
+# WarpStream Kafka engine tables (coexist alongside MSK tables, same target)
+
+KAFKA_AI_EVENTS_WS_TABLE = "kafka_ai_events_json_ws"
+AI_EVENTS_WS_MV = "ai_events_json_ws_mv"
+
+DROP_KAFKA_AI_EVENTS_WS_TABLE_SQL = f"DROP TABLE IF EXISTS {KAFKA_AI_EVENTS_WS_TABLE}"
+DROP_AI_EVENTS_WS_MV_SQL = f"DROP TABLE IF EXISTS {AI_EVENTS_WS_MV}"
+
+
+def KAFKA_AI_EVENTS_WS_TABLE_SQL():
+    return KAFKA_AI_EVENTS_TABLE_BASE_SQL.format(
+        table_name=KAFKA_AI_EVENTS_WS_TABLE,
+        engine=kafka_engine(
+            topic=KAFKA_CLICKHOUSE_AI_EVENTS_JSON,
+            group=CONSUMER_GROUP_AI_EVENTS_WS,
+            named_collection=settings.CLICKHOUSE_KAFKA_WARPSTREAM_INGESTION_NAMED_COLLECTION,
+        ),
+    )
+
+
+def AI_EVENTS_WS_MV_SQL():
+    return AI_EVENTS_MV_SQL(
+        mv_name=AI_EVENTS_WS_MV,
+        kafka_table=KAFKA_AI_EVENTS_WS_TABLE,
     )
 
 

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -5,6 +5,7 @@ from posthog.clickhouse.cluster import ON_CLUSTER_CLAUSE
 from posthog.clickhouse.indexes import index_by_kafka_timestamp
 from posthog.clickhouse.kafka_engine import (
     CONSUMER_GROUP_EVENTS_JSON,
+    CONSUMER_GROUP_EVENTS_JSON_WS,
     KAFKA_COLUMNS,
     STORAGE_POLICY,
     kafka_engine,
@@ -297,6 +298,44 @@ FROM {database}.{kafka_table}
         dynamically_materialized_columns=MV_DYNAMICALLY_MATERIALIZED_COLUMNS(),
         on_cluster_clause=f"ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'" if on_cluster else "",
         database=settings.CLICKHOUSE_DATABASE,
+    )
+
+
+# WarpStream Kafka engine tables (coexist alongside MSK tables, same target)
+
+KAFKA_EVENTS_JSON_WS_TABLE = "kafka_events_json_ws"
+EVENTS_JSON_WS_MV = "events_json_ws_mv"
+
+DROP_KAFKA_EVENTS_JSON_WS_TABLE_SQL = f"DROP TABLE IF EXISTS {KAFKA_EVENTS_JSON_WS_TABLE}"
+DROP_EVENTS_JSON_WS_MV_SQL = f"DROP TABLE IF EXISTS {EVENTS_JSON_WS_MV}"
+
+
+def KAFKA_EVENTS_TABLE_JSON_WS_SQL():
+    return (
+        EVENTS_TABLE_BASE_SQL
+        + """
+    SETTINGS kafka_skip_broken_messages = 100
+"""
+    ).format(
+        table_name=KAFKA_EVENTS_JSON_WS_TABLE,
+        on_cluster_clause=ON_CLUSTER_CLAUSE(False),
+        engine=kafka_engine(
+            topic=KAFKA_EVENTS_JSON,
+            group=CONSUMER_GROUP_EVENTS_JSON_WS,
+            named_collection=settings.CLICKHOUSE_KAFKA_WARPSTREAM_INGESTION_NAMED_COLLECTION,
+        ),
+        extra_fields="",
+        dynamically_materialized_columns=EVENTS_TABLE_DYNAMICALLY_MATERIALIZED_COLUMNS(),
+        materialized_columns="",
+        indexes="",
+    )
+
+
+def EVENTS_TABLE_JSON_WS_MV_SQL():
+    return EVENTS_TABLE_JSON_MV_SQL(
+        mv_name=EVENTS_JSON_WS_MV,
+        kafka_table=KAFKA_EVENTS_JSON_WS_TABLE,
+        on_cluster=False,
     )
 
 

--- a/posthog/models/group/sql.py
+++ b/posthog/models/group/sql.py
@@ -68,9 +68,14 @@ def GROUPS_WRITABLE_TABLE_SQL():
     )
 
 
-def GROUPS_TABLE_MV_SQL(target_table=GROUPS_WRITABLE_TABLE, on_cluster=True):
+def GROUPS_TABLE_MV_SQL(
+    target_table=GROUPS_WRITABLE_TABLE,
+    on_cluster=True,
+    mv_name=GROUPS_TABLE_MV,
+    kafka_table=KAFKA_GROUPS_TABLE,
+):
     return f"""
-CREATE MATERIALIZED VIEW IF NOT EXISTS {GROUPS_TABLE_MV} {ON_CLUSTER_CLAUSE(on_cluster)}
+CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name} {ON_CLUSTER_CLAUSE(on_cluster)}
 TO {target_table}
 AS SELECT
 group_type_index,
@@ -80,7 +85,7 @@ team_id,
 group_properties,
 _timestamp,
 _offset
-FROM {KAFKA_GROUPS_TABLE}
+FROM {kafka_table}
 """
 
 
@@ -107,19 +112,12 @@ def KAFKA_GROUPS_WS_TABLE_SQL():
 
 
 def GROUPS_WS_TABLE_MV_SQL(target_table=GROUPS_WRITABLE_TABLE):
-    return f"""
-CREATE MATERIALIZED VIEW IF NOT EXISTS {GROUPS_WS_MV}
-TO {target_table}
-AS SELECT
-group_type_index,
-group_key,
-created_at,
-team_id,
-group_properties,
-_timestamp,
-_offset
-FROM {KAFKA_GROUPS_WS_TABLE}
-"""
+    return GROUPS_TABLE_MV_SQL(
+        target_table=target_table,
+        on_cluster=False,
+        mv_name=GROUPS_WS_MV,
+        kafka_table=KAFKA_GROUPS_WS_TABLE,
+    )
 
 
 # { ..., "group_0": 1325 }

--- a/posthog/models/group/sql.py
+++ b/posthog/models/group/sql.py
@@ -1,7 +1,7 @@
 from posthog import settings
 from posthog.clickhouse.base_sql import COPY_ROWS_BETWEEN_TEAMS_BASE_SQL
 from posthog.clickhouse.cluster import ON_CLUSTER_CLAUSE
-from posthog.clickhouse.kafka_engine import KAFKA_COLUMNS, STORAGE_POLICY, kafka_engine
+from posthog.clickhouse.kafka_engine import CONSUMER_GROUP_GROUPS_WS, KAFKA_COLUMNS, STORAGE_POLICY, kafka_engine
 from posthog.clickhouse.table_engines import Distributed, ReplacingMergeTree
 from posthog.kafka_client.topics import KAFKA_GROUPS
 from posthog.settings import CLICKHOUSE_CLUSTER
@@ -81,6 +81,44 @@ group_properties,
 _timestamp,
 _offset
 FROM {KAFKA_GROUPS_TABLE}
+"""
+
+
+# WarpStream Kafka engine tables (coexist alongside MSK tables, same target)
+
+KAFKA_GROUPS_WS_TABLE = "kafka_groups_ws"
+GROUPS_WS_MV = "groups_ws_mv"
+
+DROP_KAFKA_GROUPS_WS_TABLE_SQL = f"DROP TABLE IF EXISTS {KAFKA_GROUPS_WS_TABLE}"
+DROP_GROUPS_WS_MV_SQL = f"DROP TABLE IF EXISTS {GROUPS_WS_MV}"
+
+
+def KAFKA_GROUPS_WS_TABLE_SQL():
+    return GROUPS_TABLE_BASE_SQL.format(
+        table_name=KAFKA_GROUPS_WS_TABLE,
+        on_cluster_clause=ON_CLUSTER_CLAUSE(False),
+        engine=kafka_engine(
+            topic=KAFKA_GROUPS,
+            group=CONSUMER_GROUP_GROUPS_WS,
+            named_collection=settings.CLICKHOUSE_KAFKA_WARPSTREAM_INGESTION_NAMED_COLLECTION,
+        ),
+        extra_fields="",
+    )
+
+
+def GROUPS_WS_TABLE_MV_SQL(target_table=GROUPS_WRITABLE_TABLE):
+    return f"""
+CREATE MATERIALIZED VIEW IF NOT EXISTS {GROUPS_WS_MV}
+TO {target_table}
+AS SELECT
+group_type_index,
+group_key,
+created_at,
+team_id,
+group_properties,
+_timestamp,
+_offset
+FROM {KAFKA_GROUPS_WS_TABLE}
 """
 
 

--- a/posthog/models/person/sql.py
+++ b/posthog/models/person/sql.py
@@ -3,7 +3,14 @@ from django.conf import settings
 from posthog.clickhouse.base_sql import COPY_ROWS_BETWEEN_TEAMS_BASE_SQL
 from posthog.clickhouse.cluster import ON_CLUSTER_CLAUSE
 from posthog.clickhouse.indexes import index_by_kafka_timestamp
-from posthog.clickhouse.kafka_engine import KAFKA_COLUMNS, KAFKA_COLUMNS_WITH_PARTITION, STORAGE_POLICY, kafka_engine
+from posthog.clickhouse.kafka_engine import (
+    CONSUMER_GROUP_PERSON_DISTINCT_ID2_WS,
+    CONSUMER_GROUP_PERSON_WS,
+    KAFKA_COLUMNS,
+    KAFKA_COLUMNS_WITH_PARTITION,
+    STORAGE_POLICY,
+    kafka_engine,
+)
 from posthog.clickhouse.table_engines import CollapsingMergeTree, Distributed, ReplacingMergeTree
 from posthog.kafka_client.topics import KAFKA_PERSON, KAFKA_PERSON_DISTINCT_ID, KAFKA_PERSON_UNIQUE_ID
 
@@ -100,6 +107,51 @@ def PERSONS_WRITABLE_TABLE_SQL():
         on_cluster_clause=ON_CLUSTER_CLAUSE(False),
         engine=Distributed(data_table=PERSONS_TABLE, cluster=settings.CLICKHOUSE_SINGLE_SHARD_CLUSTER),
         extra_fields=KAFKA_COLUMNS,
+    )
+
+
+# WarpStream Kafka engine tables (coexist alongside MSK tables, same target)
+
+KAFKA_PERSONS_WS_TABLE = "kafka_person_ws"
+PERSONS_WS_MV = "person_ws_mv"
+
+DROP_KAFKA_PERSONS_WS_TABLE_SQL = f"DROP TABLE IF EXISTS {KAFKA_PERSONS_WS_TABLE}"
+DROP_PERSONS_WS_MV_SQL = f"DROP TABLE IF EXISTS {PERSONS_WS_MV}"
+
+
+def KAFKA_PERSONS_WS_TABLE_SQL():
+    return PERSONS_TABLE_BASE_SQL.format(
+        table_name=KAFKA_PERSONS_WS_TABLE,
+        on_cluster_clause=ON_CLUSTER_CLAUSE(False),
+        engine=kafka_engine(
+            topic=KAFKA_PERSON,
+            group=CONSUMER_GROUP_PERSON_WS,
+            named_collection=settings.CLICKHOUSE_KAFKA_WARPSTREAM_INGESTION_NAMED_COLLECTION,
+        ),
+        extra_fields="",
+    )
+
+
+def PERSONS_WS_TABLE_MV_SQL(target_table=PERSONS_WRITABLE_TABLE):
+    return """
+CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name}
+TO {target_table}
+AS SELECT
+id,
+created_at,
+team_id,
+properties,
+is_identified,
+is_deleted,
+version,
+last_seen_at,
+_timestamp,
+_offset
+FROM {kafka_table}
+""".format(
+        mv_name=PERSONS_WS_MV,
+        target_table=target_table,
+        kafka_table=KAFKA_PERSONS_WS_TABLE,
     )
 
 
@@ -286,6 +338,49 @@ def PERSON_DISTINCT_ID2_WRITABLE_TABLE_SQL():
         extra_fields=f"""
     {KAFKA_COLUMNS_WITH_PARTITION}
     """,
+    )
+
+
+# WarpStream Kafka engine tables for person_distinct_id2 (coexist alongside MSK tables, same target)
+
+KAFKA_PERSON_DISTINCT_ID2_WS_TABLE = "kafka_person_distinct_id2_ws"
+PERSON_DISTINCT_ID2_WS_MV = "person_distinct_id2_ws_mv"
+
+DROP_KAFKA_PERSON_DISTINCT_ID2_WS_TABLE_SQL = f"DROP TABLE IF EXISTS {KAFKA_PERSON_DISTINCT_ID2_WS_TABLE}"
+DROP_PERSON_DISTINCT_ID2_WS_MV_SQL = f"DROP TABLE IF EXISTS {PERSON_DISTINCT_ID2_WS_MV}"
+
+
+def KAFKA_PERSON_DISTINCT_ID2_WS_TABLE_SQL():
+    return PERSON_DISTINCT_ID2_TABLE_BASE_SQL.format(
+        table_name=KAFKA_PERSON_DISTINCT_ID2_WS_TABLE,
+        on_cluster_clause=ON_CLUSTER_CLAUSE(False),
+        engine=kafka_engine(
+            topic=KAFKA_PERSON_DISTINCT_ID,
+            group=CONSUMER_GROUP_PERSON_DISTINCT_ID2_WS,
+            named_collection=settings.CLICKHOUSE_KAFKA_WARPSTREAM_INGESTION_NAMED_COLLECTION,
+        ),
+        extra_fields="",
+    )
+
+
+def PERSON_DISTINCT_ID2_WS_MV_SQL(target_table=PERSON_DISTINCT_ID2_WRITABLE_TABLE):
+    return """
+CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name}
+TO {target_table}
+AS SELECT
+team_id,
+distinct_id,
+person_id,
+is_deleted,
+version,
+_timestamp,
+_offset,
+_partition
+FROM {kafka_table}
+""".format(
+        mv_name=PERSON_DISTINCT_ID2_WS_MV,
+        target_table=target_table,
+        kafka_table=KAFKA_PERSON_DISTINCT_ID2_WS_TABLE,
     )
 
 

--- a/posthog/models/person/sql.py
+++ b/posthog/models/person/sql.py
@@ -77,7 +77,12 @@ def KAFKA_PERSONS_TABLE_SQL(on_cluster=True):
     )
 
 
-def PERSONS_TABLE_MV_SQL(on_cluster=True, target_table=PERSONS_WRITABLE_TABLE):
+def PERSONS_TABLE_MV_SQL(
+    on_cluster=True,
+    target_table=PERSONS_WRITABLE_TABLE,
+    mv_name=PERSONS_TABLE_MV,
+    kafka_table=KAFKA_PERSONS_TABLE,
+):
     return """
 CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name} {on_cluster_clause}
 TO {target_table}
@@ -94,10 +99,10 @@ _timestamp,
 _offset
 FROM {kafka_table}
 """.format(
-        mv_name=PERSONS_TABLE_MV,
+        mv_name=mv_name,
         on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster),
         target_table=target_table,
-        kafka_table=KAFKA_PERSONS_TABLE,
+        kafka_table=kafka_table,
     )
 
 
@@ -133,24 +138,10 @@ def KAFKA_PERSONS_WS_TABLE_SQL():
 
 
 def PERSONS_WS_TABLE_MV_SQL(target_table=PERSONS_WRITABLE_TABLE):
-    return """
-CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name}
-TO {target_table}
-AS SELECT
-id,
-created_at,
-team_id,
-properties,
-is_identified,
-is_deleted,
-version,
-last_seen_at,
-_timestamp,
-_offset
-FROM {kafka_table}
-""".format(
-        mv_name=PERSONS_WS_MV,
+    return PERSONS_TABLE_MV_SQL(
+        on_cluster=False,
         target_table=target_table,
+        mv_name=PERSONS_WS_MV,
         kafka_table=KAFKA_PERSONS_WS_TABLE,
     )
 
@@ -307,7 +298,12 @@ def KAFKA_PERSON_DISTINCT_ID2_TABLE_SQL(on_cluster=True):
     )
 
 
-def PERSON_DISTINCT_ID2_MV_SQL(on_cluster=True, target_table=PERSON_DISTINCT_ID2_WRITABLE_TABLE):
+def PERSON_DISTINCT_ID2_MV_SQL(
+    on_cluster=True,
+    target_table=PERSON_DISTINCT_ID2_WRITABLE_TABLE,
+    mv_name=PERSON_DISTINCT_ID2_TABLE_MV,
+    kafka_table=KAFKA_PERSON_DISTINCT_ID2_TABLE,
+):
     return """
 CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name} {on_cluster_clause}
 TO {target_table}
@@ -322,10 +318,10 @@ _offset,
 _partition
 FROM {kafka_table}
 """.format(
-        mv_name=PERSON_DISTINCT_ID2_TABLE_MV,
+        mv_name=mv_name,
         on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster),
         target_table=target_table,
-        kafka_table=KAFKA_PERSON_DISTINCT_ID2_TABLE,
+        kafka_table=kafka_table,
     )
 
 
@@ -364,22 +360,10 @@ def KAFKA_PERSON_DISTINCT_ID2_WS_TABLE_SQL():
 
 
 def PERSON_DISTINCT_ID2_WS_MV_SQL(target_table=PERSON_DISTINCT_ID2_WRITABLE_TABLE):
-    return """
-CREATE MATERIALIZED VIEW IF NOT EXISTS {mv_name}
-TO {target_table}
-AS SELECT
-team_id,
-distinct_id,
-person_id,
-is_deleted,
-version,
-_timestamp,
-_offset,
-_partition
-FROM {kafka_table}
-""".format(
-        mv_name=PERSON_DISTINCT_ID2_WS_MV,
+    return PERSON_DISTINCT_ID2_MV_SQL(
+        on_cluster=False,
         target_table=target_table,
+        mv_name=PERSON_DISTINCT_ID2_WS_MV,
         kafka_table=KAFKA_PERSON_DISTINCT_ID2_WS_TABLE,
     )
 


### PR DESCRIPTION
## Problem
`#team-ingestion` is experimenting with moving all our MSK topics to WarpStream. As part of this, we want to selectively move candidate teams over to being smoke testing the new pipelines.

This requires dual-source ClickHouse Kafka Engine and MV tables scoped to our `vcn_ingestion_prod_*` WarpStream clusters mirroring the existing CH tables currently sourcing from the ingestion MSK cluster.

The new WS tables will share the write and sharded tables the existing MSK counterparts do. They will be near identical to the MSK counterparts other than sourcing from WarpStream, and the diverging recommended consumer configs this requires.

**Disclaimer: first time creating tables for ClickHouse like this. Please review with care (suspicion!)** 🙇 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Add new CH Kafka Engine and MV tables for the following WS ingestion topics:
* `clickhouse_events_json`
* `clickhouse_person`
* `clickhouse_person_distinct_id`
* `clickhouse_groups`
* `clickhouse_heatmap_events`
* `clickhouse_ai_events_json`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
