### PR TITLE
fix(dags): route OPTIMIZE to online replica in deletes_job cleanup

### DIFF
--- a/posthog/dags/deletes.py
+++ b/posthog/dags/deletes.py
@@ -23,6 +23,7 @@ from posthog.clickhouse.cluster import (
     Query,
 )
 from posthog.clickhouse.plugin_log_entries import PLUGIN_LOG_ENTRIES_TABLE
+from posthog.clickhouse.workload import Workload
 from posthog.dags.common import JobOwners
 from posthog.dags.person_overrides import squash_person_overrides
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
@@ -758,7 +759,9 @@ def cleanup_delete_assets(
     cluster.map_all_hosts(resources.pending_deletions_dictionary.source.drop).result()
 
     cluster.map_all_hosts(resources.adhoc_event_deletes_dictionary.drop).result()
-    cluster.any_host(resources.adhoc_event_deletes_dictionary.source.optimize).result()
+    cluster.any_host_by_role(
+        resources.adhoc_event_deletes_dictionary.source.optimize, NodeRole.DATA, Workload.ONLINE
+    ).result()
 
     return True
 

--- a/posthog/dags/deletes.py
+++ b/posthog/dags/deletes.py
@@ -21,9 +21,9 @@ from posthog.clickhouse.cluster import (
     MutationWaiter,
     NodeRole,
     Query,
+    Workload,
 )
 from posthog.clickhouse.plugin_log_entries import PLUGIN_LOG_ENTRIES_TABLE
-from posthog.clickhouse.workload import Workload
 from posthog.dags.common import JobOwners
 from posthog.dags.person_overrides import squash_person_overrides
 from posthog.models.async_deletion import AsyncDeletion, DeletionType

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -451,6 +451,7 @@
   list([
     'DoesNotExist',
     'MultipleObjectsReturned',
+    '__annotations__',
     '__doc__',
     '__module__',
     '__repr__',


### PR DESCRIPTION
## Problem

Follow-up to #54182.

`cleanup_delete_assets` in `deletes_job` fails with:

```
DB::Exception: OPTIMIZE cannot be done on this replica because it is not a leader
```

`cluster.any_host(...)` picks a random host, including replicas that aren't leader-eligible for the target table. `OPTIMIZE TABLE ... FINAL` is leader-only, so it fails when routed there. The op is the final step, so everything upstream succeeds but the job reports as FAILED and staging assets aren't dropped.

## Changes

Swap `cluster.any_host(...)` for `cluster.any_host_by_role(..., NodeRole.DATA, Workload.ONLINE)` in `cleanup_delete_assets`. Constrains host selection to leader-eligible replicas.

## How did you test this code?

Agent-authored. Validation:

- Directly observed `NOT_A_LEADER` failure in the latest run.
- `system.replicas` for the target table confirms only online data replicas are leader-eligible.

Next run confirms end-to-end.

## Publish to changelog?

No.

## Docs update

No docs update needed.