### PR TITLE
fix(cohorts): sanitize experiment actors queries for cohort creation

### DIFF
--- a/posthog/hogql_queries/experiments/test/test_experiment_actors_query.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_actors_query.py
@@ -472,33 +472,49 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
         assert len(response.results) == 1
         assert response.results[0][1]["distinct_ids"][0] == "user_after_exposure"
 
+    @parameterized.expand(
+        [
+            (
+                "strips_recordings",
+                True,
+                ["actor", "matched_recordings"],
+                "",
+                ["matching_events", "matched_recordings"],
+            ),
+            (
+                "strips_search",
+                False,
+                ["actor"],
+                "some-email@example.com",
+                ["some-email@example.com"],
+            ),
+        ]
+    )
     @freeze_time("2020-01-01T12:00:00Z")
-    def test_experiment_funnel_actors_cohort_creation(self):
-        """
-        Reproduce #24037: "Save as cohort" from experiment persons modal creates empty cohort.
-
-        The frontend sends ActorsQuery { source: ExperimentActorsQuery, select: ["actor", "matched_recordings"] }
-        to the cohort API. print_cohort_hogql_query must produce valid SQL that returns actor_id values.
-        """
+    def test_experiment_funnel_actors_cohort_sanitization(
+        self,
+        _name: str,
+        include_recordings: bool,
+        select: list[str],
+        search: str,
+        forbidden_in_sql: list[str],
+    ):
         feature_flag, experiment, experiment_query = self._create_experiment_with_funnel()
-        self._create_funnel_data_both_variants(f"$feature/{feature_flag.key}")
-        flush_persons_and_events()
 
         experiment_actors_query = ExperimentActorsQuery(
             kind="ExperimentActorsQuery",
             source=experiment_query,
             funnelStep=1,
             funnelStepBreakdown="control",
-            includeRecordings=True,
+            includeRecordings=include_recordings,
             featureFlagKey=feature_flag.key,
         )
 
-        # This mirrors what personsModalLogic.ts sends to the cohort API
         actors_query = ActorsQuery(
             source=experiment_actors_query,
-            select=["actor", "matched_recordings"],
+            select=select,
             orderBy=[],
-            search="",
+            search=search,
         )
 
         cohort = Cohort.objects.create(
@@ -512,80 +528,5 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
         sql = print_cohort_hogql_query(cohort, context, team=self.team)
 
         assert "actor_id" in sql
-
-    @freeze_time("2020-01-01T12:00:00Z")
-    def test_experiment_funnel_actors_cohort_sanitizes_recordings(self):
-        """
-        Verify that cohort creation strips includeRecordings and matched_recordings
-        from the query, avoiding the aggregate_funnel_array UDF in cohort SQL.
-        """
-        feature_flag, experiment, experiment_query = self._create_experiment_with_funnel()
-
-        experiment_actors_query = ExperimentActorsQuery(
-            kind="ExperimentActorsQuery",
-            source=experiment_query,
-            funnelStep=1,
-            funnelStepBreakdown="control",
-            includeRecordings=True,
-            featureFlagKey=feature_flag.key,
-        )
-
-        actors_query = ActorsQuery(
-            source=experiment_actors_query,
-            select=["actor", "matched_recordings"],
-            orderBy=[],
-            search="",
-        )
-
-        cohort = Cohort.objects.create(
-            team=self.team,
-            name="Test cohort from experiment",
-            is_static=True,
-            query=actors_query.model_dump(mode="json"),
-        )
-
-        context = HogQLContext(team_id=self.team.id, enable_select_queries=True)
-        sql = print_cohort_hogql_query(cohort, context, team=self.team)
-
-        assert "actor_id" in sql
-        # matched_recordings / matching_events should be stripped from cohort SQL
-        assert "matching_events" not in sql
-        assert "matched_recordings" not in sql
-
-    @freeze_time("2020-01-01T12:00:00Z")
-    def test_experiment_funnel_actors_cohort_strips_search(self):
-        """
-        Verify that search terms are stripped from cohort queries so all matching
-        persons are included, not just those matching a modal search filter.
-        """
-        feature_flag, experiment, experiment_query = self._create_experiment_with_funnel()
-
-        experiment_actors_query = ExperimentActorsQuery(
-            kind="ExperimentActorsQuery",
-            source=experiment_query,
-            funnelStep=1,
-            funnelStepBreakdown="control",
-            includeRecordings=False,
-            featureFlagKey=feature_flag.key,
-        )
-
-        actors_query = ActorsQuery(
-            source=experiment_actors_query,
-            select=["actor"],
-            orderBy=[],
-            search="some-email@example.com",
-        )
-
-        cohort = Cohort.objects.create(
-            team=self.team,
-            name="Test cohort with search",
-            is_static=True,
-            query=actors_query.model_dump(mode="json"),
-        )
-
-        context = HogQLContext(team_id=self.team.id, enable_select_queries=True)
-        sql = print_cohort_hogql_query(cohort, context, team=self.team)
-
-        assert "actor_id" in sql
-        # Search term should NOT appear in cohort SQL
-        assert "some-email@example.com" not in sql
+        for forbidden in forbidden_in_sql:
+            assert forbidden not in sql, f"Expected '{forbidden}' to be stripped from cohort SQL"

--- a/posthog/hogql_queries/experiments/test/test_experiment_actors_query.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_actors_query.py
@@ -21,8 +21,12 @@ from parameterized import parameterized
 
 from posthog.schema import ActorsQuery, EventsNode, ExperimentActorsQuery, ExperimentFunnelMetric, ExperimentQuery
 
+from posthog.hogql.context import HogQLContext
+
 from posthog.hogql_queries.actors_query_runner import ActorsQueryRunner
 from posthog.hogql_queries.experiments.test.experiment_query_runner.base import ExperimentQueryRunnerBaseTest
+from posthog.models.cohort import Cohort
+from posthog.models.cohort.util import print_cohort_hogql_query
 
 
 @override_settings(IN_UNIT_TESTING=True)
@@ -467,3 +471,121 @@ class TestExperimentActorsQuery(ExperimentQueryRunnerBaseTest, ClickhouseTestMix
         # user_before_exposure should NOT be counted because their signup was before exposure
         assert len(response.results) == 1
         assert response.results[0][1]["distinct_ids"][0] == "user_after_exposure"
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_experiment_funnel_actors_cohort_creation(self):
+        """
+        Reproduce #24037: "Save as cohort" from experiment persons modal creates empty cohort.
+
+        The frontend sends ActorsQuery { source: ExperimentActorsQuery, select: ["actor", "matched_recordings"] }
+        to the cohort API. print_cohort_hogql_query must produce valid SQL that returns actor_id values.
+        """
+        feature_flag, experiment, experiment_query = self._create_experiment_with_funnel()
+        self._create_funnel_data_both_variants(f"$feature/{feature_flag.key}")
+        flush_persons_and_events()
+
+        experiment_actors_query = ExperimentActorsQuery(
+            kind="ExperimentActorsQuery",
+            source=experiment_query,
+            funnelStep=1,
+            funnelStepBreakdown="control",
+            includeRecordings=True,
+            featureFlagKey=feature_flag.key,
+        )
+
+        # This mirrors what personsModalLogic.ts sends to the cohort API
+        actors_query = ActorsQuery(
+            source=experiment_actors_query,
+            select=["actor", "matched_recordings"],
+            orderBy=[],
+            search="",
+        )
+
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Test cohort from experiment",
+            is_static=True,
+            query=actors_query.model_dump(mode="json"),
+        )
+
+        context = HogQLContext(team_id=self.team.id, enable_select_queries=True)
+        sql = print_cohort_hogql_query(cohort, context, team=self.team)
+
+        assert "actor_id" in sql
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_experiment_funnel_actors_cohort_sanitizes_recordings(self):
+        """
+        Verify that cohort creation strips includeRecordings and matched_recordings
+        from the query, avoiding the aggregate_funnel_array UDF in cohort SQL.
+        """
+        feature_flag, experiment, experiment_query = self._create_experiment_with_funnel()
+
+        experiment_actors_query = ExperimentActorsQuery(
+            kind="ExperimentActorsQuery",
+            source=experiment_query,
+            funnelStep=1,
+            funnelStepBreakdown="control",
+            includeRecordings=True,
+            featureFlagKey=feature_flag.key,
+        )
+
+        actors_query = ActorsQuery(
+            source=experiment_actors_query,
+            select=["actor", "matched_recordings"],
+            orderBy=[],
+            search="",
+        )
+
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Test cohort from experiment",
+            is_static=True,
+            query=actors_query.model_dump(mode="json"),
+        )
+
+        context = HogQLContext(team_id=self.team.id, enable_select_queries=True)
+        sql = print_cohort_hogql_query(cohort, context, team=self.team)
+
+        assert "actor_id" in sql
+        # matched_recordings / matching_events should be stripped from cohort SQL
+        assert "matching_events" not in sql
+        assert "matched_recordings" not in sql
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_experiment_funnel_actors_cohort_strips_search(self):
+        """
+        Verify that search terms are stripped from cohort queries so all matching
+        persons are included, not just those matching a modal search filter.
+        """
+        feature_flag, experiment, experiment_query = self._create_experiment_with_funnel()
+
+        experiment_actors_query = ExperimentActorsQuery(
+            kind="ExperimentActorsQuery",
+            source=experiment_query,
+            funnelStep=1,
+            funnelStepBreakdown="control",
+            includeRecordings=False,
+            featureFlagKey=feature_flag.key,
+        )
+
+        actors_query = ActorsQuery(
+            source=experiment_actors_query,
+            select=["actor"],
+            orderBy=[],
+            search="some-email@example.com",
+        )
+
+        cohort = Cohort.objects.create(
+            team=self.team,
+            name="Test cohort with search",
+            is_static=True,
+            query=actors_query.model_dump(mode="json"),
+        )
+
+        context = HogQLContext(team_id=self.team.id, enable_select_queries=True)
+        sql = print_cohort_hogql_query(cohort, context, team=self.team)
+
+        assert "actor_id" in sql
+        # Search term should NOT appear in cohort SQL
+        assert "some-email@example.com" not in sql

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -294,15 +294,42 @@ def format_person_query(cohort: Cohort, index: int, hogql_context: HogQLContext)
     return query, params
 
 
+def _sanitize_query_for_cohort(query_dict: dict) -> dict:
+    """Strip fields unnecessary for cohort population.
+
+    Cohort population only needs person IDs, so we remove recordings data
+    (which can use complex UDFs like aggregate_funnel_array that may not
+    be available or are needlessly expensive) and search terms (the cohort
+    should include all matching persons, not just those matching a search).
+    """
+    import copy
+
+    query_dict = copy.deepcopy(query_dict)
+
+    if query_dict.get("kind") == "ActorsQuery":
+        select = query_dict.get("select", [])
+        query_dict["select"] = [s for s in select if s != "matched_recordings"]
+        if not query_dict["select"]:
+            query_dict["select"] = ["actor"]
+
+        query_dict.pop("search", None)
+
+        source = query_dict.get("source", {})
+        if isinstance(source, dict) and source.get("includeRecordings"):
+            source["includeRecordings"] = False
+
+    return query_dict
+
+
 def print_cohort_hogql_query(cohort: Cohort, hogql_context: HogQLContext, *, team: Team) -> str:
     from posthog.hogql_queries.query_runner import get_query_runner
 
     if not cohort.query:
         raise ValueError("Cohort has no query")
 
-    query = get_query_runner(
-        cast(dict, cohort.query), team=team, limit_context=LimitContext.COHORT_CALCULATION
-    ).to_query()
+    query_dict = _sanitize_query_for_cohort(cast(dict, cohort.query))
+
+    query = get_query_runner(query_dict, team=team, limit_context=LimitContext.COHORT_CALCULATION).to_query()
 
     uses_distinct_id = False
     uses_actor_id = False

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -311,6 +311,8 @@ def _sanitize_query_for_cohort(query_dict: dict) -> dict:
         if not query_dict["select"]:
             query_dict["select"] = ["actor"]
 
+        # Intentionally strip search: the cohort should capture all persons matching
+        # the query, not just those matching an ad-hoc search in the persons modal.
         query_dict.pop("search", None)
 
         source = query_dict.get("source", {})

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -1,3 +1,4 @@
+import copy
 import uuid
 from datetime import datetime, timedelta
 from enum import StrEnum
@@ -302,8 +303,6 @@ def _sanitize_query_for_cohort(query_dict: dict) -> dict:
     be available or are needlessly expensive) and search terms (the cohort
     should include all matching persons, not just those matching a search).
     """
-    import copy
-
     query_dict = copy.deepcopy(query_dict)
 
     if query_dict.get("kind") == "ActorsQuery":


### PR DESCRIPTION
## Problem

Closes #24037

When a user clicks on an experiment funnel chart, opens the persons modal, and clicks "Save as cohort", the resulting static cohort has 0 persons. The cohort appears saved but is empty.

The root cause: the frontend sends `ActorsQuery { source: ExperimentActorsQuery, select: ["actor", "matched_recordings"] }` to the cohort API. The `includeRecordings=true` flag causes the experiment actors query to use the `aggregate_funnel_array` UDF for recording matching, producing complex SQL that fails during cohort population. The Celery task (`insert_cohort_from_query`) catches the error and persists it via `errors_calculating` / `last_error_at`, but the cohort ends up empty.

## Changes

Added `_sanitize_query_for_cohort()` in `posthog/models/cohort/util.py` that runs before `print_cohort_hogql_query` generates SQL. It:

- Strips `matched_recordings` from the ActorsQuery select list (cohort population only needs person IDs)
- Sets `includeRecordings=False` on the source query to avoid the expensive UDF
- Removes `search` terms so the cohort includes all matching persons, not just those matching a modal search filter (intentional -- commented in code)

### Not addressed in this PR

The Celery task error handling already logs at error level (`logger.exception`), captures to error tracking, and persists `errors_calculating` + `last_error_at` on the cohort. However, it does not store the actual error message text on the model (would require a Django migration to add a field). This could be a follow-up if we want the UI to surface the specific error message.

## How did you test this code?

Added a parameterized test `test_experiment_funnel_actors_cohort_sanitization` in `posthog/hogql_queries/experiments/test/test_experiment_actors_query.py` with two cases:

- `strips_recordings` -- verifies `matched_recordings` and `matching_events` are stripped from cohort SQL
- `strips_search` -- verifies search terms are not included in cohort SQL

I am an agent and have not tested this manually. The fix should be verified end-to-end by:
1. Creating an experiment with a funnel metric
2. Clicking a funnel chart bar to open the persons modal
3. Clicking "Save as cohort" and verifying the cohort has the expected persons

## Publish to changelog?

no

## LLM context

Agent-authored PR. The fix was identified by tracing the full code path from frontend click through the Celery task to ClickHouse SQL generation, writing a reproducing test, and confirming the root cause was the aggregate_funnel_array UDF usage in recording-enabled experiment actors queries.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*