### PR TITLE
perf(flags): avoid double deserialization

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2162,6 +2162,7 @@ dependencies = [
  "common-s3",
  "common-types",
  "mockall",
+ "serde",
  "serde-pickle",
  "serde_json",
  "sha2",

--- a/rust/common/hypercache/Cargo.toml
+++ b/rust/common/hypercache/Cargo.toml
@@ -15,6 +15,7 @@ common-metrics = { path = "../metrics" }
 common-redis = { path = "../redis" }
 common-s3 = { path = "../s3" }
 common-types = { path = "../types" }
+serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 serde-pickle = "1.2.0"

--- a/rust/common/hypercache/src/lib.rs
+++ b/rust/common/hypercache/src/lib.rs
@@ -153,13 +153,6 @@ enum RawJsonResult {
     Empty,
 }
 
-/// Deserialized cache value, or the `__missing__` sentinel.
-#[derive(Debug)]
-enum TypedCacheResult<T> {
-    Value(T),
-    Empty,
-}
-
 #[derive(Debug, Clone, PartialEq)]
 pub enum CacheSource {
     Redis,
@@ -472,7 +465,7 @@ impl HyperCacheReader {
         )
         .await
         {
-            Ok(Ok(TypedCacheResult::Value(data))) => {
+            Ok(Ok(Some(data))) => {
                 debug!(
                     cache_key = %redis_cache_key,
                     namespace = %self.config.namespace,
@@ -489,7 +482,7 @@ impl HyperCacheReader {
                 );
                 return Ok((Some(data), CacheSource::Redis));
             }
-            Ok(Ok(TypedCacheResult::Empty)) => {
+            Ok(Ok(None)) => {
                 debug!(
                     cache_key = %redis_cache_key,
                     namespace = %self.config.namespace,
@@ -749,9 +742,9 @@ impl HyperCacheReader {
     async fn try_get_typed_from_redis<T: DeserializeOwned>(
         &self,
         cache_key: &str,
-    ) -> Result<TypedCacheResult<T>, HyperCacheError> {
+    ) -> Result<Option<T>, HyperCacheError> {
         match self.try_get_json_string_from_redis(cache_key).await? {
-            RawJsonResult::Empty => Ok(TypedCacheResult::Empty),
+            RawJsonResult::Empty => Ok(None),
             RawJsonResult::Json(json_string) => {
                 let value = serde_json::from_str::<T>(&json_string).map_err(|e| {
                     debug!(
@@ -769,7 +762,7 @@ impl HyperCacheReader {
                     );
                     HyperCacheError::Json(e)
                 })?;
-                Ok(TypedCacheResult::Value(value))
+                Ok(Some(value))
             }
         }
     }

--- a/rust/common/hypercache/src/lib.rs
+++ b/rust/common/hypercache/src/lib.rs
@@ -147,17 +147,13 @@ pub enum HyperCacheError {
     Timeout(String),
 }
 
-/// Result of fetching a raw JSON string from a cache tier.
-/// Used internally to separate pickle/S3 decoding from JSON deserialization.
+/// Raw JSON string before deserialization, or the `__missing__` sentinel.
 enum RawJsonResult {
-    /// Valid JSON string ready for deserialization.
     Json(String),
-    /// The `__missing__` sentinel was found — the key exists but has no data.
     Empty,
 }
 
-/// Result of a typed deserialization from a cache tier.
-/// Distinguishes a successfully deserialized value from the `__missing__` sentinel.
+/// Deserialized cache value, or the `__missing__` sentinel.
 #[derive(Debug)]
 enum TypedCacheResult<T> {
     Value(T),
@@ -329,10 +325,6 @@ impl HyperCacheReader {
         }
     }
 
-    /// Fetch a value from cache (Redis → S3 cascade) and return it as a
-    /// `serde_json::Value`. The `__missing__` sentinel is mapped to `Value::Null`.
-    ///
-    /// Delegates to [`get_typed_with_source`] with `T = Value`.
     pub async fn get_with_source(
         &self,
         key: &KeyType,
@@ -346,12 +338,24 @@ impl HyperCacheReader {
         Ok(data)
     }
 
-    /// Get a value from cache with fallback support.
+    /// Get a value from cache with fallback support
     ///
-    /// Tries Redis, then S3, then the provided fallback function.
-    /// Does NOT write the fallback result back to the cache.
+    /// This method tries to get data from cache (Redis first, then S3), and if both
+    /// cache tiers miss, calls the provided fallback function to retrieve the data
+    /// from an alternative source (e.g., database, API, computation, etc.).
     ///
-    /// Delegates to [`get_typed_with_source_or_fallback`] with `T = Value`.
+    /// Unlike a read-through cache pattern, this method does NOT write the fallback
+    /// result back to the cache. This is intentional to handle catastrophic cache
+    /// miss scenarios without potentially corrupting the cache with data that may
+    /// not match the expected format or freshness requirements.
+    ///
+    /// # Arguments
+    /// * `key` - The key to look up
+    /// * `fallback` - Function to call if both cache tiers miss
+    ///
+    /// # Returns
+    /// * `Ok((Value, CacheSource))` - The value and its source (Redis, S3, or Fallback)
+    /// * `Err(E)` - Error from the fallback function, or HyperCacheError if fallback returns None
     pub async fn get_with_source_or_fallback<F, Fut, E>(
         &self,
         key: &KeyType,
@@ -373,17 +377,10 @@ impl HyperCacheReader {
         &self.config
     }
 
-    // ── Generic cache access — Redis → S3 cascade with typed deserialization ──
-    //
-    // These methods deserialize the JSON string directly into `T: DeserializeOwned`,
-    // skipping the intermediate `serde_json::Value` tree. The `Value`-based public
-    // methods above delegate here with `T = Value`.
+    // ── Core cache access — Redis → S3 cascade with generic deserialization ──
 
-    /// Like [`get_typed_with_source`](Self::get_typed_with_source), but calls `fallback` on
-    /// cache miss or infrastructure error.
-    ///
-    /// Returns `Ok((None, CacheSource::Redis))` when the `__missing__` sentinel is found.
-    /// The fallback closure returns `Option<T>` directly — no `serde_json::Value` round-trip.
+    /// Like [`get_typed_with_source`], but calls `fallback` on cache miss or infrastructure error.
+    /// Returns `Ok((None, _))` for the `__missing__` sentinel (fallback is not called).
     pub async fn get_typed_with_source_or_fallback<T, F, Fut, E>(
         &self,
         key: &KeyType,
@@ -457,11 +454,8 @@ impl HyperCacheReader {
         }
     }
 
-    /// Like [`get_with_source`](Self::get_with_source), but deserializes the JSON string
-    /// directly into `T` instead of building an intermediate `serde_json::Value` tree.
-    ///
-    /// Returns `Ok((None, source))` when the `__missing__` sentinel is found in Redis.
-    /// Returns `Ok((Some(T), source))` for valid data.
+    /// Fetch from cache (Redis → S3), deserializing directly into `T`.
+    /// Returns `Ok((None, source))` for the `__missing__` sentinel.
     pub async fn get_typed_with_source<T: DeserializeOwned>(
         &self,
         key: &KeyType,
@@ -655,8 +649,7 @@ impl HyperCacheReader {
         }
     }
 
-    /// Like [`get`](Self::get), but deserializes directly into `T`.
-    /// Returns `None` for the `__missing__` sentinel.
+    /// Like [`get`], but deserializes directly into `T`. Returns `None` for sentinel.
     pub async fn get_typed<T: DeserializeOwned>(
         &self,
         key: &KeyType,
@@ -665,11 +658,9 @@ impl HyperCacheReader {
         Ok(data)
     }
 
-    // ── Internal helpers: extract raw JSON strings from cache tiers ──
+    // ── Internal helpers ──
 
-    /// Fetch from Redis and return the raw JSON string (after pickle decoding
-    /// and sentinel detection). The caller is responsible for deserializing
-    /// the JSON string into the desired type.
+    /// Pickle-decode the Redis value and detect the `__missing__` sentinel.
     async fn try_get_json_string_from_redis(
         &self,
         cache_key: &str,
@@ -737,8 +728,7 @@ impl HyperCacheReader {
         }
     }
 
-    /// Fetch from S3 and return the raw JSON string.
-    /// S3 does not use the `__missing__` sentinel — a missing key is an S3 NotFound error.
+    /// Fetch the raw JSON string from S3.
     async fn try_get_json_string_from_s3(
         &self,
         cache_key: &str,
@@ -755,8 +745,6 @@ impl HyperCacheReader {
             }
         }
     }
-
-    // ── Typed internal helpers: deserialize directly from JSON strings ──
 
     async fn try_get_typed_from_redis<T: DeserializeOwned>(
         &self,

--- a/rust/common/hypercache/src/lib.rs
+++ b/rust/common/hypercache/src/lib.rs
@@ -40,6 +40,7 @@ use common_s3::{S3Client, S3Error, S3Impl};
 use common_types::{TeamId, TeamIdentifier};
 #[cfg(all(test, feature = "mock-client"))]
 use mockall::predicate;
+use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::fmt::{self, Display};
 use std::sync::Arc;
@@ -144,6 +145,23 @@ pub enum HyperCacheError {
 
     #[error("Timeout error: {0}")]
     Timeout(String),
+}
+
+/// Result of fetching a raw JSON string from a cache tier.
+/// Used internally to separate pickle/S3 decoding from JSON deserialization.
+enum RawJsonResult {
+    /// Valid JSON string ready for deserialization.
+    Json(String),
+    /// The `__missing__` sentinel was found — the key exists but has no data.
+    Empty,
+}
+
+/// Result of a typed deserialization from a cache tier.
+/// Distinguishes a successfully deserialized value from the `__missing__` sentinel.
+#[derive(Debug)]
+enum TypedCacheResult<T> {
+    Value(T),
+    Empty,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -593,7 +611,274 @@ impl HyperCacheReader {
         &self.config
     }
 
-    async fn try_get_from_redis(&self, cache_key: &str) -> Result<Value, HyperCacheError> {
+    // ── Typed (generic) cache access — deserializes directly into `T` ──
+    //
+    // These methods skip the intermediate `serde_json::Value` tree entirely,
+    // deserializing the JSON string straight into the target type. Use these
+    // when the caller knows the concrete type at compile time (e.g.,
+    // `HypercacheFlagsWrapper`, `Team`).
+
+    /// Like [`get_typed_with_source`](Self::get_typed_with_source), but calls `fallback` on
+    /// cache miss or infrastructure error.
+    ///
+    /// Returns `Ok((None, CacheSource::Redis))` when the `__missing__` sentinel is found.
+    /// The fallback closure returns `Option<T>` directly — no `serde_json::Value` round-trip.
+    pub async fn get_typed_with_source_or_fallback<T, F, Fut, E>(
+        &self,
+        key: &KeyType,
+        fallback: F,
+    ) -> Result<(Option<T>, CacheSource), E>
+    where
+        T: DeserializeOwned,
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<Option<T>, E>>,
+        E: From<HyperCacheError>,
+    {
+        match self.get_typed_with_source::<T>(key).await {
+            Ok((data, source)) => Ok((data, source)),
+            Err(HyperCacheError::CacheMiss) => {
+                debug!("Cache miss for key {}, trying fallback", key);
+
+                match fallback().await? {
+                    Some(value) => {
+                        inc(
+                            HYPERCACHE_COUNTER_NAME,
+                            &[
+                                ("result".to_string(), "hit_fallback".to_string()),
+                                ("namespace".to_string(), self.config.namespace.clone()),
+                                ("value".to_string(), self.config.object_name.clone()),
+                            ],
+                            1,
+                        );
+                        Ok((Some(value), CacheSource::Fallback))
+                    }
+                    None => {
+                        inc(
+                            TOMBSTONE_COUNTER_NAME,
+                            &[
+                                ("namespace".to_string(), self.config.namespace.clone()),
+                                (
+                                    "operation".to_string(),
+                                    "hypercache_fallback_miss".to_string(),
+                                ),
+                                ("component".to_string(), self.config.object_name.clone()),
+                            ],
+                            1,
+                        );
+
+                        Err(HyperCacheError::CacheMiss.into())
+                    }
+                }
+            }
+            Err(e) => {
+                // Infrastructure error — try the fallback as a resilience measure.
+                debug!(
+                    "Cache infrastructure error for key {}: {}, trying fallback",
+                    key, e
+                );
+
+                match fallback().await? {
+                    Some(value) => {
+                        inc(
+                            HYPERCACHE_COUNTER_NAME,
+                            &[
+                                ("result".to_string(), "hit_fallback".to_string()),
+                                ("namespace".to_string(), self.config.namespace.clone()),
+                                ("value".to_string(), self.config.object_name.clone()),
+                            ],
+                            1,
+                        );
+                        Ok((Some(value), CacheSource::Fallback))
+                    }
+                    None => Err(e.into()),
+                }
+            }
+        }
+    }
+
+    /// Like [`get_with_source`](Self::get_with_source), but deserializes the JSON string
+    /// directly into `T` instead of building an intermediate `serde_json::Value` tree.
+    ///
+    /// Returns `Ok((None, source))` when the `__missing__` sentinel is found in Redis.
+    /// Returns `Ok((Some(T), source))` for valid data.
+    pub async fn get_typed_with_source<T: DeserializeOwned>(
+        &self,
+        key: &KeyType,
+    ) -> Result<(Option<T>, CacheSource), HyperCacheError> {
+        let redis_cache_key = self.config.get_redis_cache_key(key);
+
+        let mut s3_confirmed_miss = false;
+        let mut infra_error: Option<HyperCacheError> = None;
+
+        // Try Redis first
+        match timeout(
+            self.config.redis_timeout,
+            self.try_get_typed_from_redis::<T>(&redis_cache_key),
+        )
+        .await
+        {
+            Ok(Ok(TypedCacheResult::Value(data))) => {
+                debug!(
+                    cache_key = %redis_cache_key,
+                    namespace = %self.config.namespace,
+                    "HyperCache hit: Redis (typed)"
+                );
+                inc(
+                    HYPERCACHE_COUNTER_NAME,
+                    &[
+                        ("result".to_string(), "hit_redis".to_string()),
+                        ("namespace".to_string(), self.config.namespace.clone()),
+                        ("value".to_string(), self.config.object_name.clone()),
+                    ],
+                    1,
+                );
+                return Ok((Some(data), CacheSource::Redis));
+            }
+            Ok(Ok(TypedCacheResult::Empty)) => {
+                debug!(
+                    cache_key = %redis_cache_key,
+                    namespace = %self.config.namespace,
+                    "HyperCache hit: Redis (sentinel)"
+                );
+                inc(
+                    HYPERCACHE_COUNTER_NAME,
+                    &[
+                        ("result".to_string(), "hit_redis".to_string()),
+                        ("namespace".to_string(), self.config.namespace.clone()),
+                        ("value".to_string(), self.config.object_name.clone()),
+                    ],
+                    1,
+                );
+                return Ok((None, CacheSource::Redis));
+            }
+            Ok(Err(HyperCacheError::CacheMiss)) => {
+                debug!(
+                    cache_key = %redis_cache_key,
+                    "HyperCache Redis miss, trying S3 (typed)"
+                );
+            }
+            Ok(Err(e)) => {
+                debug!(
+                    cache_key = %redis_cache_key,
+                    error = %e,
+                    "HyperCache Redis error, trying S3 (typed)"
+                );
+                infra_error = Some(e);
+            }
+            Err(_) => {
+                debug!(
+                    cache_key = %redis_cache_key,
+                    "HyperCache Redis timeout, trying S3 (typed)"
+                );
+                inc(
+                    HYPERCACHE_REDIS_MISS_REASON_COUNTER_NAME,
+                    &[
+                        ("reason".to_string(), "timeout".to_string()),
+                        ("namespace".to_string(), self.config.namespace.clone()),
+                        ("value".to_string(), self.config.object_name.clone()),
+                    ],
+                    1,
+                );
+                infra_error = Some(HyperCacheError::Timeout("redis timeout".to_string()));
+            }
+        }
+
+        // Try S3 fallback
+        let s3_cache_key = self.config.get_s3_cache_key(key);
+        match timeout(
+            self.config.s3_timeout,
+            self.try_get_typed_from_s3::<T>(&s3_cache_key),
+        )
+        .await
+        {
+            Ok(Ok(data)) => {
+                debug!(
+                    cache_key = %s3_cache_key,
+                    namespace = %self.config.namespace,
+                    "HyperCache hit: S3 (typed)"
+                );
+                inc(
+                    HYPERCACHE_COUNTER_NAME,
+                    &[
+                        ("result".to_string(), "hit_s3".to_string()),
+                        ("namespace".to_string(), self.config.namespace.clone()),
+                        ("value".to_string(), self.config.object_name.clone()),
+                    ],
+                    1,
+                );
+                return Ok((Some(data), CacheSource::S3));
+            }
+            Ok(Err(HyperCacheError::S3(S3Error::NotFound(_)))) => {
+                debug!(
+                    cache_key = %s3_cache_key,
+                    "HyperCache S3 confirmed miss (typed)"
+                );
+                s3_confirmed_miss = true;
+            }
+            Ok(Err(e)) => {
+                debug!(
+                    cache_key = %s3_cache_key,
+                    error = %e,
+                    "HyperCache S3 error (typed)"
+                );
+                if infra_error.is_none() {
+                    infra_error = Some(e);
+                }
+            }
+            Err(_) => {
+                debug!(
+                    cache_key = %s3_cache_key,
+                    "HyperCache S3 timeout (typed)"
+                );
+                if infra_error.is_none() {
+                    infra_error = Some(HyperCacheError::Timeout("s3 timeout".to_string()));
+                }
+            }
+        }
+
+        // Both tiers failed
+        if s3_confirmed_miss {
+            return Err(HyperCacheError::CacheMiss);
+        }
+        if let Some(e) = infra_error {
+            return Err(e);
+        }
+
+        // Should not reach here, but handle gracefully
+        inc(
+            TOMBSTONE_COUNTER_NAME,
+            &[
+                ("namespace".to_string(), self.config.namespace.clone()),
+                (
+                    "operation".to_string(),
+                    "hypercache_impossible_miss".to_string(),
+                ),
+                ("component".to_string(), self.config.object_name.clone()),
+            ],
+            1,
+        );
+        Err(HyperCacheError::CacheMiss)
+    }
+
+    /// Like [`get`](Self::get), but deserializes directly into `T`.
+    /// Returns `None` for the `__missing__` sentinel.
+    pub async fn get_typed<T: DeserializeOwned>(
+        &self,
+        key: &KeyType,
+    ) -> Result<Option<T>, HyperCacheError> {
+        let (data, _source) = self.get_typed_with_source::<T>(key).await?;
+        Ok(data)
+    }
+
+    // ── Internal helpers: extract raw JSON strings from cache tiers ──
+
+    /// Fetch from Redis and return the raw JSON string (after pickle decoding
+    /// and sentinel detection). The caller is responsible for deserializing
+    /// the JSON string into the desired type.
+    async fn try_get_json_string_from_redis(
+        &self,
+        cache_key: &str,
+    ) -> Result<RawJsonResult, HyperCacheError> {
         // The Redis client's get_raw_bytes already handles zstd decompression,
         // so we receive Pickle(JSON) data directly.
         match self.redis_client.get_raw_bytes(cache_key.to_string()).await {
@@ -601,27 +886,9 @@ impl HyperCacheReader {
                 match serde_pickle::from_slice::<String>(&raw_bytes, Default::default()) {
                     Ok(json_string) => {
                         if json_string == HYPER_CACHE_EMPTY_VALUE {
-                            return Ok(Value::String(json_string));
+                            return Ok(RawJsonResult::Empty);
                         }
-                        match serde_json::from_str(&json_string) {
-                            Ok(value) => return Ok(value),
-                            Err(e) => {
-                                debug!(
-                                    "Failed to parse JSON from Redis data for key '{}': {}",
-                                    cache_key, e
-                                );
-                                inc(
-                                    HYPERCACHE_REDIS_MISS_REASON_COUNTER_NAME,
-                                    &[
-                                        ("reason".to_string(), "json_error".to_string()),
-                                        ("namespace".to_string(), self.config.namespace.clone()),
-                                        ("value".to_string(), self.config.object_name.clone()),
-                                    ],
-                                    1,
-                                );
-                                return Err(HyperCacheError::Json(e));
-                            }
-                        }
+                        Ok(RawJsonResult::Json(json_string))
                     }
                     Err(e) => {
                         debug!(
@@ -637,7 +904,7 @@ impl HyperCacheReader {
                             ],
                             1,
                         );
-                        return Err(HyperCacheError::Pickle(e.to_string()));
+                        Err(HyperCacheError::Pickle(e.to_string()))
                     }
                 }
             }
@@ -652,6 +919,7 @@ impl HyperCacheReader {
                     ],
                     1,
                 );
+                Err(HyperCacheError::CacheMiss)
             }
             Err(e) => {
                 // Infrastructure error — surface it so callers can distinguish
@@ -669,34 +937,107 @@ impl HyperCacheReader {
                     ],
                     1,
                 );
-                return Err(HyperCacheError::Redis(e));
+                Err(HyperCacheError::Redis(e))
             }
         }
-
-        Err(HyperCacheError::CacheMiss)
     }
 
-    pub(crate) async fn try_get_from_s3(&self, cache_key: &str) -> Result<Value, HyperCacheError> {
+    /// Fetch from S3 and return the raw JSON string.
+    /// S3 does not use the `__missing__` sentinel — a missing key is an S3 NotFound error.
+    async fn try_get_json_string_from_s3(
+        &self,
+        cache_key: &str,
+    ) -> Result<String, HyperCacheError> {
         match self
             .s3_client
             .get_string(&self.config.s3_bucket, cache_key)
             .await
         {
-            Ok(body_str) => match serde_json::from_str(&body_str) {
-                Ok(value) => Ok(value),
-                Err(e) => {
-                    debug!(
-                        "Failed to parse JSON from S3 data for key '{}': {}",
-                        cache_key, e
-                    );
-                    Err(HyperCacheError::Json(e))
-                }
-            },
+            Ok(body_str) => Ok(body_str),
             Err(e) => {
                 debug!("Failed to get data from S3 for key '{}': {}", cache_key, e);
                 Err(HyperCacheError::S3(e))
             }
         }
+    }
+
+    // ── Untyped (Value-based) cache access — used by config pass-through ──
+
+    async fn try_get_from_redis(&self, cache_key: &str) -> Result<Value, HyperCacheError> {
+        match self.try_get_json_string_from_redis(cache_key).await? {
+            RawJsonResult::Empty => Ok(Value::String(HYPER_CACHE_EMPTY_VALUE.to_string())),
+            RawJsonResult::Json(json_string) => serde_json::from_str(&json_string).map_err(|e| {
+                debug!(
+                    "Failed to parse JSON from Redis data for key '{}': {}",
+                    cache_key, e
+                );
+                inc(
+                    HYPERCACHE_REDIS_MISS_REASON_COUNTER_NAME,
+                    &[
+                        ("reason".to_string(), "json_error".to_string()),
+                        ("namespace".to_string(), self.config.namespace.clone()),
+                        ("value".to_string(), self.config.object_name.clone()),
+                    ],
+                    1,
+                );
+                HyperCacheError::Json(e)
+            }),
+        }
+    }
+
+    pub(crate) async fn try_get_from_s3(&self, cache_key: &str) -> Result<Value, HyperCacheError> {
+        let body_str = self.try_get_json_string_from_s3(cache_key).await?;
+        serde_json::from_str(&body_str).map_err(|e| {
+            debug!(
+                "Failed to parse JSON from S3 data for key '{}': {}",
+                cache_key, e
+            );
+            HyperCacheError::Json(e)
+        })
+    }
+
+    // ── Typed internal helpers: deserialize directly from JSON strings ──
+
+    async fn try_get_typed_from_redis<T: DeserializeOwned>(
+        &self,
+        cache_key: &str,
+    ) -> Result<TypedCacheResult<T>, HyperCacheError> {
+        match self.try_get_json_string_from_redis(cache_key).await? {
+            RawJsonResult::Empty => Ok(TypedCacheResult::Empty),
+            RawJsonResult::Json(json_string) => {
+                let value = serde_json::from_str::<T>(&json_string).map_err(|e| {
+                    debug!(
+                        "Failed to parse typed JSON from Redis data for key '{}': {}",
+                        cache_key, e
+                    );
+                    inc(
+                        HYPERCACHE_REDIS_MISS_REASON_COUNTER_NAME,
+                        &[
+                            ("reason".to_string(), "json_error".to_string()),
+                            ("namespace".to_string(), self.config.namespace.clone()),
+                            ("value".to_string(), self.config.object_name.clone()),
+                        ],
+                        1,
+                    );
+                    HyperCacheError::Json(e)
+                })?;
+                Ok(TypedCacheResult::Value(value))
+            }
+        }
+    }
+
+    async fn try_get_typed_from_s3<T: DeserializeOwned>(
+        &self,
+        cache_key: &str,
+    ) -> Result<T, HyperCacheError> {
+        let body_str = self.try_get_json_string_from_s3(cache_key).await?;
+        serde_json::from_str::<T>(&body_str).map_err(|e| {
+            debug!(
+                "Failed to parse typed JSON from S3 data for key '{}': {}",
+                cache_key, e
+            );
+            HyperCacheError::Json(e)
+        })
     }
 }
 
@@ -1529,5 +1870,242 @@ mod tests {
             ),
             "should surface the original infrastructure error, not CacheMiss"
         );
+    }
+
+    // ── Tests for typed deserialization methods ──
+
+    #[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
+    struct TestFlags {
+        flags: Vec<TestFlag>,
+        team_id: i32,
+    }
+
+    #[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
+    struct TestFlag {
+        id: i32,
+        key: String,
+        active: bool,
+    }
+
+    fn make_test_flags() -> TestFlags {
+        TestFlags {
+            flags: vec![
+                TestFlag {
+                    id: 1,
+                    key: "beta-feature".to_string(),
+                    active: true,
+                },
+                TestFlag {
+                    id: 2,
+                    key: "dark-mode".to_string(),
+                    active: false,
+                },
+            ],
+            team_id: 42,
+        }
+    }
+
+    fn pickle_json(value: &impl serde::Serialize) -> Vec<u8> {
+        let json_string = serde_json::to_string(value).unwrap();
+        serde_pickle::to_vec(&json_string, Default::default()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_get_typed_with_source_redis_hit() {
+        let expected = make_test_flags();
+        let pickled = pickle_json(&expected);
+
+        let mut mock_redis = MockRedisClient::new();
+        let cache_key = create_test_config().get_redis_cache_key(&KeyType::int(42));
+        mock_redis.get_raw_bytes_ret(&cache_key, Ok(pickled));
+
+        let reader = create_test_reader_with_mocks(mock_redis, create_dummy_s3_client());
+        let (data, source) = reader
+            .get_typed_with_source::<TestFlags>(&KeyType::int(42))
+            .await
+            .unwrap();
+
+        assert_eq!(source, CacheSource::Redis);
+        assert_eq!(data, Some(expected));
+    }
+
+    #[tokio::test]
+    async fn test_get_typed_with_source_sentinel_returns_none() {
+        let sentinel_pickled =
+            serde_pickle::to_vec(&HYPER_CACHE_EMPTY_VALUE, Default::default()).unwrap();
+
+        let mut mock_redis = MockRedisClient::new();
+        let cache_key = create_test_config().get_redis_cache_key(&KeyType::int(99));
+        mock_redis.get_raw_bytes_ret(&cache_key, Ok(sentinel_pickled));
+
+        let reader = create_test_reader_with_mocks(mock_redis, create_dummy_s3_client());
+        let (data, source) = reader
+            .get_typed_with_source::<TestFlags>(&KeyType::int(99))
+            .await
+            .unwrap();
+
+        assert_eq!(source, CacheSource::Redis);
+        assert!(data.is_none(), "sentinel should return None");
+    }
+
+    #[cfg(feature = "mock-client")]
+    #[tokio::test]
+    async fn test_get_typed_with_source_redis_miss_s3_hit() {
+        let expected = make_test_flags();
+        let json_string = serde_json::to_string(&expected).unwrap();
+
+        let mut mock_redis = MockRedisClient::new();
+        let cache_key = create_test_config().get_redis_cache_key(&KeyType::int(42));
+        mock_redis.get_raw_bytes_ret(&cache_key, Err(CustomRedisError::NotFound));
+
+        let mut mock_s3 = MockS3Client::new();
+        let s3_key = create_test_config().get_s3_cache_key(&KeyType::int(42));
+        let json_clone = json_string.clone();
+        mock_s3
+            .expect_get_string()
+            .with(
+                predicate::eq("test-bucket".to_string()),
+                predicate::eq(s3_key),
+            )
+            .returning(move |_, _| {
+                let val = json_clone.clone();
+                Box::pin(async move { Ok(val) })
+            });
+
+        let reader = create_test_reader_with_mocks(mock_redis, Arc::new(mock_s3));
+        let (data, source) = reader
+            .get_typed_with_source::<TestFlags>(&KeyType::int(42))
+            .await
+            .unwrap();
+
+        assert_eq!(source, CacheSource::S3);
+        assert_eq!(data, Some(expected));
+    }
+
+    #[tokio::test]
+    async fn test_get_typed_with_source_json_parse_error_falls_to_s3() {
+        // When Redis returns invalid JSON, the reader falls through to S3.
+        // With dummy S3 (always NotFound), this results in a confirmed CacheMiss.
+        let invalid_json = "not valid json {{{";
+        let pickled = serde_pickle::to_vec(&invalid_json, Default::default()).unwrap();
+
+        let mut mock_redis = MockRedisClient::new();
+        let cache_key = create_test_config().get_redis_cache_key(&KeyType::int(42));
+        mock_redis.get_raw_bytes_ret(&cache_key, Ok(pickled));
+
+        let reader = create_test_reader_with_mocks(mock_redis, create_dummy_s3_client());
+        let result = reader
+            .get_typed_with_source::<TestFlags>(&KeyType::int(42))
+            .await;
+
+        assert!(result.is_err());
+        // S3 confirms miss → CacheMiss takes priority over the Redis JSON error
+        assert!(
+            matches!(result.unwrap_err(), HyperCacheError::CacheMiss),
+            "should be CacheMiss when S3 confirms NotFound"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_typed_from_redis_json_parse_error() {
+        // Test the internal helper directly to verify JSON errors surface correctly
+        let invalid_json = "not valid json {{{";
+        let pickled = serde_pickle::to_vec(&invalid_json, Default::default()).unwrap();
+
+        let mut mock_redis = MockRedisClient::new();
+        let cache_key = create_test_config().get_redis_cache_key(&KeyType::int(42));
+        mock_redis.get_raw_bytes_ret(&cache_key, Ok(pickled));
+
+        let reader = create_test_reader_with_mocks(mock_redis, create_dummy_s3_client());
+        let result = reader
+            .try_get_typed_from_redis::<TestFlags>(&cache_key)
+            .await;
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), HyperCacheError::Json(_)));
+    }
+
+    #[tokio::test]
+    async fn test_get_typed_with_source_or_fallback_cache_hit() {
+        let expected = make_test_flags();
+        let pickled = pickle_json(&expected);
+
+        let mut mock_redis = MockRedisClient::new();
+        let cache_key = create_test_config().get_redis_cache_key(&KeyType::int(42));
+        mock_redis.get_raw_bytes_ret(&cache_key, Ok(pickled));
+
+        let reader = create_test_reader_with_mocks(mock_redis, create_dummy_s3_client());
+        let (data, source) = reader
+            .get_typed_with_source_or_fallback::<TestFlags, _, _, HyperCacheError>(
+                &KeyType::int(42),
+                || async { panic!("fallback should not be called") },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(source, CacheSource::Redis);
+        assert_eq!(data, Some(expected));
+    }
+
+    #[tokio::test]
+    async fn test_get_typed_with_source_or_fallback_uses_fallback() {
+        let expected = make_test_flags();
+        let expected_clone = expected.clone();
+
+        let mut mock_redis = MockRedisClient::new();
+        let cache_key = create_test_config().get_redis_cache_key(&KeyType::int(42));
+        mock_redis.get_raw_bytes_ret(&cache_key, Err(CustomRedisError::NotFound));
+
+        let reader = create_test_reader_with_mocks(mock_redis, create_dummy_s3_client());
+        let (data, source) = reader
+            .get_typed_with_source_or_fallback::<TestFlags, _, _, HyperCacheError>(
+                &KeyType::int(42),
+                || async move { Ok(Some(expected_clone)) },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(source, CacheSource::Fallback);
+        assert_eq!(data, Some(expected));
+    }
+
+    #[tokio::test]
+    async fn test_get_typed_with_source_or_fallback_sentinel_no_fallback() {
+        let sentinel_pickled =
+            serde_pickle::to_vec(&HYPER_CACHE_EMPTY_VALUE, Default::default()).unwrap();
+
+        let mut mock_redis = MockRedisClient::new();
+        let cache_key = create_test_config().get_redis_cache_key(&KeyType::int(99));
+        mock_redis.get_raw_bytes_ret(&cache_key, Ok(sentinel_pickled));
+
+        let reader = create_test_reader_with_mocks(mock_redis, create_dummy_s3_client());
+        let (data, source) = reader
+            .get_typed_with_source_or_fallback::<TestFlags, _, _, HyperCacheError>(
+                &KeyType::int(99),
+                || async { panic!("fallback should not be called for sentinel") },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(source, CacheSource::Redis);
+        assert!(data.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_typed_simple() {
+        let expected = make_test_flags();
+        let pickled = pickle_json(&expected);
+
+        let mut mock_redis = MockRedisClient::new();
+        let cache_key = create_test_config().get_redis_cache_key(&KeyType::int(42));
+        mock_redis.get_raw_bytes_ret(&cache_key, Ok(pickled));
+
+        let reader = create_test_reader_with_mocks(mock_redis, create_dummy_s3_client());
+        let data = reader
+            .get_typed::<TestFlags>(&KeyType::int(42))
+            .await
+            .unwrap();
+
+        assert_eq!(data, Some(expected));
     }
 }

--- a/rust/common/hypercache/src/lib.rs
+++ b/rust/common/hypercache/src/lib.rs
@@ -329,27 +329,156 @@ impl HyperCacheReader {
         }
     }
 
+    /// Fetch a value from cache (Redis → S3 cascade) and return it as a
+    /// `serde_json::Value`. The `__missing__` sentinel is mapped to `Value::Null`.
+    ///
+    /// Delegates to [`get_typed_with_source`] with `T = Value`.
     pub async fn get_with_source(
         &self,
         key: &KeyType,
     ) -> Result<(Value, CacheSource), HyperCacheError> {
+        let (data, source) = self.get_typed_with_source::<Value>(key).await?;
+        Ok((data.unwrap_or(Value::Null), source))
+    }
+
+    pub async fn get(&self, key: &KeyType) -> Result<Value, HyperCacheError> {
+        let (data, _source) = self.get_with_source(key).await?;
+        Ok(data)
+    }
+
+    /// Get a value from cache with fallback support.
+    ///
+    /// Tries Redis, then S3, then the provided fallback function.
+    /// Does NOT write the fallback result back to the cache.
+    ///
+    /// Delegates to [`get_typed_with_source_or_fallback`] with `T = Value`.
+    pub async fn get_with_source_or_fallback<F, Fut, E>(
+        &self,
+        key: &KeyType,
+        fallback: F,
+    ) -> Result<(Value, CacheSource), E>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<Option<Value>, E>>,
+        E: From<HyperCacheError>,
+    {
+        let (data, source) = self
+            .get_typed_with_source_or_fallback::<Value, _, _, E>(key, fallback)
+            .await?;
+        Ok((data.unwrap_or(Value::Null), source))
+    }
+
+    /// Get access to the configuration (useful for testing)
+    pub fn config(&self) -> &HyperCacheConfig {
+        &self.config
+    }
+
+    // ── Generic cache access — Redis → S3 cascade with typed deserialization ──
+    //
+    // These methods deserialize the JSON string directly into `T: DeserializeOwned`,
+    // skipping the intermediate `serde_json::Value` tree. The `Value`-based public
+    // methods above delegate here with `T = Value`.
+
+    /// Like [`get_typed_with_source`](Self::get_typed_with_source), but calls `fallback` on
+    /// cache miss or infrastructure error.
+    ///
+    /// Returns `Ok((None, CacheSource::Redis))` when the `__missing__` sentinel is found.
+    /// The fallback closure returns `Option<T>` directly — no `serde_json::Value` round-trip.
+    pub async fn get_typed_with_source_or_fallback<T, F, Fut, E>(
+        &self,
+        key: &KeyType,
+        fallback: F,
+    ) -> Result<(Option<T>, CacheSource), E>
+    where
+        T: DeserializeOwned,
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<Option<T>, E>>,
+        E: From<HyperCacheError>,
+    {
+        match self.get_typed_with_source::<T>(key).await {
+            Ok((data, source)) => Ok((data, source)),
+            Err(HyperCacheError::CacheMiss) => {
+                debug!("Cache miss for key {}, trying fallback", key);
+
+                match fallback().await? {
+                    Some(value) => {
+                        inc(
+                            HYPERCACHE_COUNTER_NAME,
+                            &[
+                                ("result".to_string(), "hit_fallback".to_string()),
+                                ("namespace".to_string(), self.config.namespace.clone()),
+                                ("value".to_string(), self.config.object_name.clone()),
+                            ],
+                            1,
+                        );
+                        Ok((Some(value), CacheSource::Fallback))
+                    }
+                    None => {
+                        inc(
+                            TOMBSTONE_COUNTER_NAME,
+                            &[
+                                ("namespace".to_string(), self.config.namespace.clone()),
+                                (
+                                    "operation".to_string(),
+                                    "hypercache_fallback_miss".to_string(),
+                                ),
+                                ("component".to_string(), self.config.object_name.clone()),
+                            ],
+                            1,
+                        );
+
+                        Err(HyperCacheError::CacheMiss.into())
+                    }
+                }
+            }
+            Err(e) => {
+                // Infrastructure error — try the fallback as a resilience measure.
+                debug!(
+                    "Cache infrastructure error for key {}: {}, trying fallback",
+                    key, e
+                );
+
+                match fallback().await? {
+                    Some(value) => {
+                        inc(
+                            HYPERCACHE_COUNTER_NAME,
+                            &[
+                                ("result".to_string(), "hit_fallback_infra_error".to_string()),
+                                ("namespace".to_string(), self.config.namespace.clone()),
+                                ("value".to_string(), self.config.object_name.clone()),
+                            ],
+                            1,
+                        );
+                        Ok((Some(value), CacheSource::Fallback))
+                    }
+                    None => Err(e.into()),
+                }
+            }
+        }
+    }
+
+    /// Like [`get_with_source`](Self::get_with_source), but deserializes the JSON string
+    /// directly into `T` instead of building an intermediate `serde_json::Value` tree.
+    ///
+    /// Returns `Ok((None, source))` when the `__missing__` sentinel is found in Redis.
+    /// Returns `Ok((Some(T), source))` for valid data.
+    pub async fn get_typed_with_source<T: DeserializeOwned>(
+        &self,
+        key: &KeyType,
+    ) -> Result<(Option<T>, CacheSource), HyperCacheError> {
         let redis_cache_key = self.config.get_redis_cache_key(key);
 
-        // S3 NotFound is the best miss signal on the read path — not truly
-        // authoritative, but sufficient for negative-cache tombstoning.
-        // Infrastructure errors are tracked separately so callers don't
-        // tombstone keys that may exist once the backing store recovers.
         let mut s3_confirmed_miss = false;
         let mut infra_error: Option<HyperCacheError> = None;
 
         // Try Redis first
         match timeout(
             self.config.redis_timeout,
-            self.try_get_from_redis(&redis_cache_key),
+            self.try_get_typed_from_redis::<T>(&redis_cache_key),
         )
         .await
         {
-            Ok(Ok(data)) => {
+            Ok(Ok(TypedCacheResult::Value(data))) => {
                 debug!(
                     cache_key = %redis_cache_key,
                     namespace = %self.config.namespace,
@@ -364,13 +493,24 @@ impl HyperCacheReader {
                     ],
                     1,
                 );
-
-                if let Value::String(s) = &data {
-                    if s == HYPER_CACHE_EMPTY_VALUE {
-                        return Ok((Value::Null, CacheSource::Redis));
-                    }
-                }
-                return Ok((data, CacheSource::Redis));
+                return Ok((Some(data), CacheSource::Redis));
+            }
+            Ok(Ok(TypedCacheResult::Empty)) => {
+                debug!(
+                    cache_key = %redis_cache_key,
+                    namespace = %self.config.namespace,
+                    "HyperCache hit: Redis (sentinel)"
+                );
+                inc(
+                    HYPERCACHE_COUNTER_NAME,
+                    &[
+                        ("result".to_string(), "hit_redis".to_string()),
+                        ("namespace".to_string(), self.config.namespace.clone()),
+                        ("value".to_string(), self.config.object_name.clone()),
+                    ],
+                    1,
+                );
+                return Ok((None, CacheSource::Redis));
             }
             Ok(Err(HyperCacheError::CacheMiss)) => {
                 debug!(
@@ -406,7 +546,12 @@ impl HyperCacheReader {
 
         // Try S3 fallback
         let s3_cache_key = self.config.get_s3_cache_key(key);
-        match timeout(self.config.s3_timeout, self.try_get_from_s3(&s3_cache_key)).await {
+        match timeout(
+            self.config.s3_timeout,
+            self.try_get_typed_from_s3::<T>(&s3_cache_key),
+        )
+        .await
+        {
             Ok(Ok(data)) => {
                 debug!(
                     cache_key = %s3_cache_key,
@@ -422,7 +567,7 @@ impl HyperCacheReader {
                     ],
                     1,
                 );
-                return Ok((data, CacheSource::S3));
+                return Ok((Some(data), CacheSource::S3));
             }
             Ok(Err(HyperCacheError::S3(S3Error::NotFound(_)))) => {
                 debug!(
@@ -508,356 +653,6 @@ impl HyperCacheReader {
                 "unexpected: no tier set s3_confirmed_miss or infra_error".to_string(),
             ))
         }
-    }
-
-    pub async fn get(&self, key: &KeyType) -> Result<Value, HyperCacheError> {
-        let (data, _source) = self.get_with_source(key).await?;
-        Ok(data)
-    }
-
-    /// Get a value from cache with fallback support
-    ///
-    /// This method tries to get data from cache (Redis first, then S3), and if both
-    /// cache tiers miss, calls the provided fallback function to retrieve the data
-    /// from an alternative source (e.g., database, API, computation, etc.).
-    ///
-    /// Unlike a read-through cache pattern, this method does NOT write the fallback
-    /// result back to the cache. This is intentional to handle catastrophic cache
-    /// miss scenarios without potentially corrupting the cache with data that may
-    /// not match the expected format or freshness requirements.
-    ///
-    /// # Arguments
-    /// * `key` - The key to look up
-    /// * `fallback` - Function to call if both cache tiers miss
-    ///
-    /// # Returns
-    /// * `Ok((Value, CacheSource))` - The value and its source (Redis, S3, or Fallback)
-    /// * `Err(E)` - Error from the fallback function, or HyperCacheError if fallback returns None
-    pub async fn get_with_source_or_fallback<F, Fut, E>(
-        &self,
-        key: &KeyType,
-        fallback: F,
-    ) -> Result<(Value, CacheSource), E>
-    where
-        F: FnOnce() -> Fut,
-        Fut: std::future::Future<Output = Result<Option<Value>, E>>,
-        E: From<HyperCacheError>,
-    {
-        match self.get_with_source(key).await {
-            Ok((data, source)) => Ok((data, source)),
-            Err(HyperCacheError::CacheMiss) => {
-                debug!("Cache miss for key {}, trying fallback", key);
-
-                match fallback().await? {
-                    Some(value) => {
-                        inc(
-                            HYPERCACHE_COUNTER_NAME,
-                            &[
-                                ("result".to_string(), "hit_fallback".to_string()),
-                                ("namespace".to_string(), self.config.namespace.clone()),
-                                ("value".to_string(), self.config.object_name.clone()),
-                            ],
-                            1,
-                        );
-                        Ok((value, CacheSource::Fallback))
-                    }
-                    None => {
-                        // Tombstone metric - cache and database both miss is really unusual
-                        inc(
-                            TOMBSTONE_COUNTER_NAME,
-                            &[
-                                ("namespace".to_string(), self.config.namespace.clone()),
-                                (
-                                    "operation".to_string(),
-                                    "hypercache_fallback_miss".to_string(),
-                                ),
-                                ("component".to_string(), self.config.object_name.clone()),
-                            ],
-                            1,
-                        );
-
-                        Err(HyperCacheError::CacheMiss.into())
-                    }
-                }
-            }
-            Err(e) => {
-                // Infrastructure error — try the fallback as a resilience measure.
-                debug!(
-                    "Cache infrastructure error for key {}: {}, trying fallback",
-                    key, e
-                );
-
-                match fallback().await? {
-                    Some(value) => {
-                        inc(
-                            HYPERCACHE_COUNTER_NAME,
-                            &[
-                                ("result".to_string(), "hit_fallback_infra_error".to_string()),
-                                ("namespace".to_string(), self.config.namespace.clone()),
-                                ("value".to_string(), self.config.object_name.clone()),
-                            ],
-                            1,
-                        );
-                        Ok((value, CacheSource::Fallback))
-                    }
-                    None => Err(e.into()),
-                }
-            }
-        }
-    }
-
-    /// Get access to the configuration (useful for testing)
-    pub fn config(&self) -> &HyperCacheConfig {
-        &self.config
-    }
-
-    // ── Typed (generic) cache access — deserializes directly into `T` ──
-    //
-    // These methods skip the intermediate `serde_json::Value` tree entirely,
-    // deserializing the JSON string straight into the target type. Use these
-    // when the caller knows the concrete type at compile time (e.g.,
-    // `HypercacheFlagsWrapper`, `Team`).
-
-    /// Like [`get_typed_with_source`](Self::get_typed_with_source), but calls `fallback` on
-    /// cache miss or infrastructure error.
-    ///
-    /// Returns `Ok((None, CacheSource::Redis))` when the `__missing__` sentinel is found.
-    /// The fallback closure returns `Option<T>` directly — no `serde_json::Value` round-trip.
-    pub async fn get_typed_with_source_or_fallback<T, F, Fut, E>(
-        &self,
-        key: &KeyType,
-        fallback: F,
-    ) -> Result<(Option<T>, CacheSource), E>
-    where
-        T: DeserializeOwned,
-        F: FnOnce() -> Fut,
-        Fut: std::future::Future<Output = Result<Option<T>, E>>,
-        E: From<HyperCacheError>,
-    {
-        match self.get_typed_with_source::<T>(key).await {
-            Ok((data, source)) => Ok((data, source)),
-            Err(HyperCacheError::CacheMiss) => {
-                debug!("Cache miss for key {}, trying fallback", key);
-
-                match fallback().await? {
-                    Some(value) => {
-                        inc(
-                            HYPERCACHE_COUNTER_NAME,
-                            &[
-                                ("result".to_string(), "hit_fallback".to_string()),
-                                ("namespace".to_string(), self.config.namespace.clone()),
-                                ("value".to_string(), self.config.object_name.clone()),
-                            ],
-                            1,
-                        );
-                        Ok((Some(value), CacheSource::Fallback))
-                    }
-                    None => {
-                        inc(
-                            TOMBSTONE_COUNTER_NAME,
-                            &[
-                                ("namespace".to_string(), self.config.namespace.clone()),
-                                (
-                                    "operation".to_string(),
-                                    "hypercache_fallback_miss".to_string(),
-                                ),
-                                ("component".to_string(), self.config.object_name.clone()),
-                            ],
-                            1,
-                        );
-
-                        Err(HyperCacheError::CacheMiss.into())
-                    }
-                }
-            }
-            Err(e) => {
-                // Infrastructure error — try the fallback as a resilience measure.
-                debug!(
-                    "Cache infrastructure error for key {}: {}, trying fallback",
-                    key, e
-                );
-
-                match fallback().await? {
-                    Some(value) => {
-                        inc(
-                            HYPERCACHE_COUNTER_NAME,
-                            &[
-                                ("result".to_string(), "hit_fallback".to_string()),
-                                ("namespace".to_string(), self.config.namespace.clone()),
-                                ("value".to_string(), self.config.object_name.clone()),
-                            ],
-                            1,
-                        );
-                        Ok((Some(value), CacheSource::Fallback))
-                    }
-                    None => Err(e.into()),
-                }
-            }
-        }
-    }
-
-    /// Like [`get_with_source`](Self::get_with_source), but deserializes the JSON string
-    /// directly into `T` instead of building an intermediate `serde_json::Value` tree.
-    ///
-    /// Returns `Ok((None, source))` when the `__missing__` sentinel is found in Redis.
-    /// Returns `Ok((Some(T), source))` for valid data.
-    pub async fn get_typed_with_source<T: DeserializeOwned>(
-        &self,
-        key: &KeyType,
-    ) -> Result<(Option<T>, CacheSource), HyperCacheError> {
-        let redis_cache_key = self.config.get_redis_cache_key(key);
-
-        let mut s3_confirmed_miss = false;
-        let mut infra_error: Option<HyperCacheError> = None;
-
-        // Try Redis first
-        match timeout(
-            self.config.redis_timeout,
-            self.try_get_typed_from_redis::<T>(&redis_cache_key),
-        )
-        .await
-        {
-            Ok(Ok(TypedCacheResult::Value(data))) => {
-                debug!(
-                    cache_key = %redis_cache_key,
-                    namespace = %self.config.namespace,
-                    "HyperCache hit: Redis (typed)"
-                );
-                inc(
-                    HYPERCACHE_COUNTER_NAME,
-                    &[
-                        ("result".to_string(), "hit_redis".to_string()),
-                        ("namespace".to_string(), self.config.namespace.clone()),
-                        ("value".to_string(), self.config.object_name.clone()),
-                    ],
-                    1,
-                );
-                return Ok((Some(data), CacheSource::Redis));
-            }
-            Ok(Ok(TypedCacheResult::Empty)) => {
-                debug!(
-                    cache_key = %redis_cache_key,
-                    namespace = %self.config.namespace,
-                    "HyperCache hit: Redis (sentinel)"
-                );
-                inc(
-                    HYPERCACHE_COUNTER_NAME,
-                    &[
-                        ("result".to_string(), "hit_redis".to_string()),
-                        ("namespace".to_string(), self.config.namespace.clone()),
-                        ("value".to_string(), self.config.object_name.clone()),
-                    ],
-                    1,
-                );
-                return Ok((None, CacheSource::Redis));
-            }
-            Ok(Err(HyperCacheError::CacheMiss)) => {
-                debug!(
-                    cache_key = %redis_cache_key,
-                    "HyperCache Redis miss, trying S3 (typed)"
-                );
-            }
-            Ok(Err(e)) => {
-                debug!(
-                    cache_key = %redis_cache_key,
-                    error = %e,
-                    "HyperCache Redis error, trying S3 (typed)"
-                );
-                infra_error = Some(e);
-            }
-            Err(_) => {
-                debug!(
-                    cache_key = %redis_cache_key,
-                    "HyperCache Redis timeout, trying S3 (typed)"
-                );
-                inc(
-                    HYPERCACHE_REDIS_MISS_REASON_COUNTER_NAME,
-                    &[
-                        ("reason".to_string(), "timeout".to_string()),
-                        ("namespace".to_string(), self.config.namespace.clone()),
-                        ("value".to_string(), self.config.object_name.clone()),
-                    ],
-                    1,
-                );
-                infra_error = Some(HyperCacheError::Timeout("redis timeout".to_string()));
-            }
-        }
-
-        // Try S3 fallback
-        let s3_cache_key = self.config.get_s3_cache_key(key);
-        match timeout(
-            self.config.s3_timeout,
-            self.try_get_typed_from_s3::<T>(&s3_cache_key),
-        )
-        .await
-        {
-            Ok(Ok(data)) => {
-                debug!(
-                    cache_key = %s3_cache_key,
-                    namespace = %self.config.namespace,
-                    "HyperCache hit: S3 (typed)"
-                );
-                inc(
-                    HYPERCACHE_COUNTER_NAME,
-                    &[
-                        ("result".to_string(), "hit_s3".to_string()),
-                        ("namespace".to_string(), self.config.namespace.clone()),
-                        ("value".to_string(), self.config.object_name.clone()),
-                    ],
-                    1,
-                );
-                return Ok((Some(data), CacheSource::S3));
-            }
-            Ok(Err(HyperCacheError::S3(S3Error::NotFound(_)))) => {
-                debug!(
-                    cache_key = %s3_cache_key,
-                    "HyperCache S3 confirmed miss (typed)"
-                );
-                s3_confirmed_miss = true;
-            }
-            Ok(Err(e)) => {
-                debug!(
-                    cache_key = %s3_cache_key,
-                    error = %e,
-                    "HyperCache S3 error (typed)"
-                );
-                if infra_error.is_none() {
-                    infra_error = Some(e);
-                }
-            }
-            Err(_) => {
-                debug!(
-                    cache_key = %s3_cache_key,
-                    "HyperCache S3 timeout (typed)"
-                );
-                if infra_error.is_none() {
-                    infra_error = Some(HyperCacheError::Timeout("s3 timeout".to_string()));
-                }
-            }
-        }
-
-        // Both tiers failed
-        if s3_confirmed_miss {
-            return Err(HyperCacheError::CacheMiss);
-        }
-        if let Some(e) = infra_error {
-            return Err(e);
-        }
-
-        // Should not reach here, but handle gracefully
-        inc(
-            TOMBSTONE_COUNTER_NAME,
-            &[
-                ("namespace".to_string(), self.config.namespace.clone()),
-                (
-                    "operation".to_string(),
-                    "hypercache_impossible_miss".to_string(),
-                ),
-                ("component".to_string(), self.config.object_name.clone()),
-            ],
-            1,
-        );
-        Err(HyperCacheError::CacheMiss)
     }
 
     /// Like [`get`](Self::get), but deserializes directly into `T`.
@@ -961,41 +756,6 @@ impl HyperCacheReader {
         }
     }
 
-    // ── Untyped (Value-based) cache access — used by config pass-through ──
-
-    async fn try_get_from_redis(&self, cache_key: &str) -> Result<Value, HyperCacheError> {
-        match self.try_get_json_string_from_redis(cache_key).await? {
-            RawJsonResult::Empty => Ok(Value::String(HYPER_CACHE_EMPTY_VALUE.to_string())),
-            RawJsonResult::Json(json_string) => serde_json::from_str(&json_string).map_err(|e| {
-                debug!(
-                    "Failed to parse JSON from Redis data for key '{}': {}",
-                    cache_key, e
-                );
-                inc(
-                    HYPERCACHE_REDIS_MISS_REASON_COUNTER_NAME,
-                    &[
-                        ("reason".to_string(), "json_error".to_string()),
-                        ("namespace".to_string(), self.config.namespace.clone()),
-                        ("value".to_string(), self.config.object_name.clone()),
-                    ],
-                    1,
-                );
-                HyperCacheError::Json(e)
-            }),
-        }
-    }
-
-    pub(crate) async fn try_get_from_s3(&self, cache_key: &str) -> Result<Value, HyperCacheError> {
-        let body_str = self.try_get_json_string_from_s3(cache_key).await?;
-        serde_json::from_str(&body_str).map_err(|e| {
-            debug!(
-                "Failed to parse JSON from S3 data for key '{}': {}",
-                cache_key, e
-            );
-            HyperCacheError::Json(e)
-        })
-    }
-
     // ── Typed internal helpers: deserialize directly from JSON strings ──
 
     async fn try_get_typed_from_redis<T: DeserializeOwned>(
@@ -1007,7 +767,7 @@ impl HyperCacheReader {
             RawJsonResult::Json(json_string) => {
                 let value = serde_json::from_str::<T>(&json_string).map_err(|e| {
                     debug!(
-                        "Failed to parse typed JSON from Redis data for key '{}': {}",
+                        "Failed to parse JSON from Redis data for key '{}': {}",
                         cache_key, e
                     );
                     inc(
@@ -1033,7 +793,7 @@ impl HyperCacheReader {
         let body_str = self.try_get_json_string_from_s3(cache_key).await?;
         serde_json::from_str::<T>(&body_str).map_err(|e| {
             debug!(
-                "Failed to parse typed JSON from S3 data for key '{}': {}",
+                "Failed to parse JSON from S3 data for key '{}': {}",
                 cache_key, e
             );
             HyperCacheError::Json(e)
@@ -1247,116 +1007,6 @@ mod tests {
         assert_eq!(result, Value::Null);
     }
 
-    #[tokio::test]
-    async fn test_try_get_from_redis_success() {
-        let mut mock_redis = MockRedisClient::new();
-        let test_data = json!({"flags": [], "group_type_mapping": {}});
-        let test_data_str = serde_json::to_string(&test_data).unwrap();
-
-        // Simulate Django's pickle format (uncompressed)
-        let pickled_bytes = serde_pickle::to_vec(&test_data_str, Default::default()).unwrap();
-        mock_redis = mock_redis.get_raw_bytes_ret("test_key", Ok(pickled_bytes));
-
-        let config = HyperCacheConfig::new(
-            "test".to_string(),
-            "test".to_string(),
-            "us-east-1".to_string(),
-            "test-bucket".to_string(),
-        );
-        let reader = HyperCacheReader {
-            redis_client: Arc::new(mock_redis) as Arc<dyn RedisClient + Send + Sync>,
-            s3_client: create_dummy_s3_client(),
-            config,
-        };
-
-        let result = reader.try_get_from_redis("test_key").await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), test_data);
-    }
-
-    #[tokio::test]
-    async fn test_try_get_from_redis_compressed_data() {
-        // The real RedisClient auto-decompresses zstd data in get_raw_bytes,
-        // so HyperCache receives already-decompressed pickled bytes.
-        // This test verifies HyperCache handles pickled data correctly
-        // (which is what it receives after Redis client decompression).
-        let mut mock_redis = MockRedisClient::new();
-        let test_data = json!({"flags": [], "group_type_mapping": {}});
-        let test_data_str = serde_json::to_string(&test_data).unwrap();
-
-        // Simulate what the real Redis client returns after auto-decompression:
-        // Pickle(JSON) - the zstd layer is already removed by the Redis client
-        let pickled_bytes = serde_pickle::to_vec(&test_data_str, Default::default()).unwrap();
-
-        mock_redis = mock_redis.get_raw_bytes_ret("test_key", Ok(pickled_bytes));
-
-        let config = HyperCacheConfig::new(
-            "test".to_string(),
-            "test".to_string(),
-            "us-east-1".to_string(),
-            "test-bucket".to_string(),
-        );
-        let reader = HyperCacheReader {
-            redis_client: Arc::new(mock_redis) as Arc<dyn RedisClient + Send + Sync>,
-            s3_client: create_dummy_s3_client(),
-            config,
-        };
-
-        let result = reader.try_get_from_redis("test_key").await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), test_data);
-    }
-
-    #[tokio::test]
-    async fn test_try_get_from_redis_pickled_uncompressed_data() {
-        let mut mock_redis = MockRedisClient::new();
-        let test_data = json!({"small": "data"});
-        let test_data_str = serde_json::to_string(&test_data).unwrap();
-
-        // Simulate Django's pipeline for small data: JSON string -> Pickle (no compression)
-        let pickled_bytes = serde_pickle::to_vec(&test_data_str, Default::default()).unwrap();
-
-        // Use the raw bytes method to provide the pickled (but uncompressed) bytes
-        mock_redis = mock_redis.get_raw_bytes_ret("test_key", Ok(pickled_bytes));
-
-        let config = HyperCacheConfig::new(
-            "test".to_string(),
-            "test".to_string(),
-            "us-east-1".to_string(),
-            "test-bucket".to_string(),
-        );
-        let reader = HyperCacheReader {
-            redis_client: Arc::new(mock_redis) as Arc<dyn RedisClient + Send + Sync>,
-            s3_client: create_dummy_s3_client(),
-            config,
-        };
-
-        let result = reader.try_get_from_redis("test_key").await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), test_data);
-    }
-
-    #[tokio::test]
-    async fn test_try_get_from_redis_not_found() {
-        let mut mock_redis = MockRedisClient::new();
-        mock_redis = mock_redis.get_ret("test_key", Err(CustomRedisError::NotFound));
-
-        let config = HyperCacheConfig::new(
-            "test".to_string(),
-            "test".to_string(),
-            "us-east-1".to_string(),
-            "test-bucket".to_string(),
-        );
-        let reader = HyperCacheReader {
-            redis_client: Arc::new(mock_redis) as Arc<dyn RedisClient + Send + Sync>,
-            s3_client: create_dummy_s3_client(),
-            config,
-        };
-
-        let result = reader.try_get_from_redis("test_key").await;
-        assert!(matches!(result, Err(HyperCacheError::CacheMiss)));
-    }
-
     #[test]
     fn test_hypercache_error_conversion() {
         let cache_miss = HyperCacheError::CacheMiss;
@@ -1477,46 +1127,6 @@ mod tests {
         let result = reader.get_with_source(&team_key).await;
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), HyperCacheError::CacheMiss));
-    }
-
-    #[tokio::test]
-    async fn test_redis_json_parsing_error() {
-        let cache_key = "cache/teams/123/test_namespace/test_value";
-        let invalid_json = "invalid json data";
-
-        let mut mock_redis = MockRedisClient::new();
-        mock_redis = mock_redis.get_ret(cache_key, Ok(invalid_json.to_string()));
-
-        let config = HyperCacheConfig::new(
-            "test".to_string(),
-            "test".to_string(),
-            "us-east-1".to_string(),
-            "test-bucket".to_string(),
-        );
-        let reader = HyperCacheReader {
-            redis_client: Arc::new(mock_redis) as Arc<dyn RedisClient + Send + Sync>,
-            s3_client: create_dummy_s3_client(),
-            config,
-        };
-
-        let result = reader.try_get_from_redis(cache_key).await;
-        assert!(result.is_err());
-        // The mock returns raw bytes that fail pickle deserialization before
-        // reaching the JSON parse stage.
-        assert!(matches!(result.unwrap_err(), HyperCacheError::Pickle(_)));
-    }
-
-    #[tokio::test]
-    async fn test_invalid_data_handling() {
-        let mut mock_redis = MockRedisClient::new();
-        // Provide invalid data that can't be deserialized as pickle
-        let invalid_bytes = vec![0xFF, 0xFE, 0xFD, 0xFC];
-        mock_redis = mock_redis.get_raw_bytes_ret("test_key", Ok(invalid_bytes));
-
-        let reader = create_test_reader_with_mocks(mock_redis, create_dummy_s3_client());
-
-        let result = reader.try_get_from_redis("test_key").await;
-        assert!(matches!(result, Err(HyperCacheError::Pickle(_))));
     }
 
     #[tokio::test]

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -1,4 +1,4 @@
-use crate::api::errors::{simplify_serde_error, FlagError};
+use crate::api::errors::FlagError;
 use crate::cohorts::cohort_models::Cohort;
 use crate::database::get_connection_with_metrics;
 use crate::flags::flag_models::{
@@ -7,7 +7,6 @@ use crate::flags::flag_models::{
 };
 use crate::metrics::consts::TOMBSTONE_COUNTER;
 use common_database::PostgresReader;
-use common_hypercache::HYPER_CACHE_EMPTY_VALUE;
 use common_types::TeamId;
 use metrics::counter;
 
@@ -44,72 +43,6 @@ impl FeatureFlagList {
                 }
             }
         }
-    }
-
-    /// Parses a JSON Value from hypercache into flags, evaluation metadata,
-    /// and optional preloaded cohort definitions.
-    ///
-    /// Handles:
-    /// - Null values (returns empty vec with default metadata)
-    /// - Sentinel "__missing__" value (returns empty vec with default metadata)
-    /// - Standard hypercache format `{"flags": [...], "evaluation_metadata": {...}, "cohorts": [...]}`
-    pub fn parse_hypercache_value(
-        data: serde_json::Value,
-        team_id: TeamId,
-    ) -> Result<HypercacheParseResult, FlagError> {
-        // Handle null (can happen when hypercache returns empty)
-        if data.is_null() {
-            return Ok((vec![], EvaluationMetadata::default(), None));
-        }
-
-        // Check for the sentinel value indicating no flags for this team
-        if data.as_str() == Some(HYPER_CACHE_EMPTY_VALUE) {
-            tracing::debug!("Hypercache sentinel (no flags) for team {}", team_id);
-            return Ok((vec![], EvaluationMetadata::default(), None));
-        }
-
-        // Parse the hypercache format: {"flags": [...], "evaluation_metadata": {...}}
-        let wrapper: HypercacheFlagsWrapper = serde_json::from_value(data).map_err(|e| {
-            tracing::error!(
-                "Failed to parse hypercache data for team {}: {}",
-                team_id,
-                e
-            );
-            counter!(
-                TOMBSTONE_COUNTER,
-                "failure_type" => "hypercache_parse_error",
-                "team_id" => team_id.to_string(),
-            )
-            .increment(1);
-            FlagError::DataParsingErrorWithContext(format!(
-                "Failed to parse feature flags for team {team_id}: {}",
-                simplify_serde_error(&e.to_string())
-            ))
-        })?;
-
-        tracing::debug!(
-            "Parsed {} flags and {} cohorts for team {}",
-            wrapper.flags.len(),
-            wrapper.cohorts.as_ref().map_or(0, |c| c.len()),
-            team_id,
-        );
-
-        let evaluation_metadata = wrapper.evaluation_metadata;
-        if evaluation_metadata.dependency_stages.is_empty() && !wrapper.flags.is_empty() {
-            // Every valid cache entry and PG fallback must populate dependency_stages.
-            // Empty stages with non-empty flags means something went wrong upstream.
-            tracing::error!(
-                "evaluation_metadata.dependency_stages is empty but {} flags present for team {}",
-                wrapper.flags.len(),
-                team_id
-            );
-            return Err(FlagError::DataParsingErrorWithContext(format!(
-                "evaluation_metadata.dependency_stages is empty but {} flags present for team {team_id}",
-                wrapper.flags.len()
-            )));
-        }
-
-        Ok((wrapper.flags, evaluation_metadata, wrapper.cohorts))
     }
 
     /// Validates and extracts flags from a deserialized `HypercacheFlagsWrapper`.
@@ -702,14 +635,14 @@ mod tests {
     }
 
     // =========================================================================
-    // Tests for parse_hypercache_value()
+    // Tests for from_wrapper()
     // =========================================================================
 
     use serde_json::json;
 
     #[test]
-    fn test_parse_hypercache_value_valid_flags() {
-        let data = json!({
+    fn test_from_wrapper_valid_flags() {
+        let wrapper: HypercacheFlagsWrapper = serde_json::from_value(json!({
             "flags": [
                 {
                     "id": 1,
@@ -733,11 +666,11 @@ mod tests {
                 "flags_with_missing_deps": [],
                 "transitive_deps": {}
             }
-        });
+        }))
+        .unwrap();
 
-        let result = FeatureFlagList::parse_hypercache_value(data, 123);
-        assert!(result.is_ok());
-        let (flags, metadata, _cohorts) = result.unwrap();
+        let (flags, metadata, _cohorts) =
+            FeatureFlagList::from_wrapper(Some(wrapper), 123).unwrap();
         assert_eq!(metadata.dependency_stages, vec![vec![1, 2]]);
         assert!(metadata.flags_with_missing_deps.is_empty());
         assert!(metadata.transitive_deps.is_empty());
@@ -749,8 +682,8 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_hypercache_value_with_evaluation_context_valid_flags() {
-        let data = json!({
+    fn test_from_wrapper_with_evaluation_context_valid_flags() {
+        let wrapper: HypercacheFlagsWrapper = serde_json::from_value(json!({
             "evaluation_metadata": {
                 "dependency_stages": [
                     [766, 768, 769],
@@ -890,11 +823,11 @@ mod tests {
                     "version": 1
                 }
             ]
-        });
+        }))
+        .unwrap();
 
-        let result = FeatureFlagList::parse_hypercache_value(data, 123);
-        assert!(result.is_ok());
-        let (flags, evaluation_metadata, _cohorts) = result.unwrap();
+        let (flags, evaluation_metadata, _cohorts) =
+            FeatureFlagList::from_wrapper(Some(wrapper), 123).unwrap();
         assert_eq!(evaluation_metadata.dependency_stages.len(), 2);
         assert_eq!(
             evaluation_metadata.dependency_stages[0],
@@ -920,85 +853,33 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_hypercache_value_null_returns_empty() {
-        let data = serde_json::Value::Null;
-        let result = FeatureFlagList::parse_hypercache_value(data, 123);
-        assert!(result.is_ok());
-        let (flags, metadata, _cohorts) = result.unwrap();
+    fn test_from_wrapper_none_returns_empty() {
+        let (flags, metadata, cohorts) = FeatureFlagList::from_wrapper(None, 123).unwrap();
         assert!(flags.is_empty());
         assert_eq!(metadata, EvaluationMetadata::default());
+        assert!(cohorts.is_none());
     }
 
     #[test]
-    fn test_parse_hypercache_value_sentinel_returns_empty() {
-        let data = json!("__missing__");
-        let result = FeatureFlagList::parse_hypercache_value(data, 123);
-        assert!(result.is_ok());
-        let (flags, metadata, _cohorts) = result.unwrap();
-        assert!(flags.is_empty());
-        assert_eq!(metadata, EvaluationMetadata::default());
-    }
-
-    #[test]
-    fn test_parse_hypercache_value_empty_flags_array() {
-        let data = json!({
+    fn test_from_wrapper_empty_flags_array() {
+        let wrapper: HypercacheFlagsWrapper = serde_json::from_value(json!({
             "flags": [],
             "evaluation_metadata": {
                 "dependency_stages": [],
                 "flags_with_missing_deps": [],
                 "transitive_deps": {}
             }
-        });
-        let result = FeatureFlagList::parse_hypercache_value(data, 123);
-        assert!(result.is_ok());
-        let (flags, metadata, _cohorts) = result.unwrap();
+        }))
+        .unwrap();
+        let (flags, metadata, _cohorts) =
+            FeatureFlagList::from_wrapper(Some(wrapper), 123).unwrap();
         assert!(flags.is_empty());
         assert_eq!(metadata, EvaluationMetadata::default());
     }
 
     #[test]
-    fn test_parse_hypercache_value_missing_flags_wrapper() {
-        // Data is an array instead of {"flags": [...]} wrapper
-        let data = json!([{"id": 1, "key": "test"}]);
-        let result = FeatureFlagList::parse_hypercache_value(data, 123);
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-    }
-
-    #[test]
-    fn test_parse_hypercache_value_invalid_json_structure() {
-        // Data has wrong structure - flags is not an array
-        let data = json!({"flags": "not an array"});
-        let result = FeatureFlagList::parse_hypercache_value(data, 123);
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-    }
-
-    #[test]
-    fn test_parse_hypercache_value_invalid_flag_fields() {
-        // Missing required fields in flag
-        let data = json!({
-            "flags": [
-                {
-                    "id": 1
-                    // missing required fields: key, team_id, active, deleted, filters
-                }
-            ]
-        });
-        let result = FeatureFlagList::parse_hypercache_value(data, 123);
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-    }
-
-    #[test]
-    fn test_parse_hypercache_value_with_all_optional_fields() {
-        let data = json!({
+    fn test_from_wrapper_with_all_optional_fields() {
+        let wrapper: HypercacheFlagsWrapper = serde_json::from_value(json!({
             "flags": [
                 {
                     "id": 42,
@@ -1028,11 +909,11 @@ mod tests {
                 "flags_with_missing_deps": [],
                 "transitive_deps": {}
             }
-        });
+        }))
+        .unwrap();
 
-        let result = FeatureFlagList::parse_hypercache_value(data, 123);
-        assert!(result.is_ok());
-        let (flags, metadata, _cohorts) = result.unwrap();
+        let (flags, metadata, _cohorts) =
+            FeatureFlagList::from_wrapper(Some(wrapper), 123).unwrap();
         assert_eq!(metadata.dependency_stages, vec![vec![42]]);
         assert!(metadata.flags_with_missing_deps.is_empty());
         assert!(metadata.transitive_deps.is_empty());
@@ -1049,8 +930,8 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_hypercache_value_with_cohorts() {
-        let data = json!({
+    fn test_from_wrapper_with_cohorts() {
+        let wrapper: HypercacheFlagsWrapper = serde_json::from_value(json!({
             "flags": [],
             "evaluation_metadata": {
                 "dependency_stages": [],
@@ -1075,10 +956,10 @@ mod tests {
                 "created_by_id": null,
                 "cohort_type": null
             }]
-        });
-        let result = FeatureFlagList::parse_hypercache_value(data, 123);
-        assert!(result.is_ok());
-        let (_flags, _metadata, cohorts) = result.unwrap();
+        }))
+        .unwrap();
+        let (_flags, _metadata, cohorts) =
+            FeatureFlagList::from_wrapper(Some(wrapper), 123).unwrap();
         let cohorts = cohorts.expect("cohorts should be Some");
         assert_eq!(cohorts.len(), 1);
         assert_eq!(cohorts[0].id, 42);
@@ -1088,8 +969,8 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_hypercache_value_without_cohorts_defaults_to_none() {
-        let data = json!({
+    fn test_from_wrapper_without_cohorts_defaults_to_none() {
+        let wrapper: HypercacheFlagsWrapper = serde_json::from_value(json!({
             "flags": [{
                 "id": 1,
                 "team_id": 123,
@@ -1102,17 +983,16 @@ mod tests {
                 "flags_with_missing_deps": [],
                 "transitive_deps": {}
             }
-        });
-        let result = FeatureFlagList::parse_hypercache_value(data, 123);
-        assert!(result.is_ok());
-        let (_flags, _metadata, cohorts) = result.unwrap();
+        }))
+        .unwrap();
+        let (_flags, _metadata, cohorts) =
+            FeatureFlagList::from_wrapper(Some(wrapper), 123).unwrap();
         assert!(cohorts.is_none());
     }
 
     #[test]
-    fn test_parse_hypercache_value_empty_stages_with_flags_is_error() {
-        // dependency_stages must not be empty when flags are present
-        let data = json!({
+    fn test_from_wrapper_empty_stages_with_flags_is_error() {
+        let wrapper: HypercacheFlagsWrapper = serde_json::from_value(json!({
             "flags": [
                 {"id": 10, "key": "a", "team_id": 1, "active": true, "deleted": false, "filters": {"groups": []}},
                 {"id": 20, "key": "b", "team_id": 1, "active": true, "deleted": false, "filters": {"groups": []}}
@@ -1122,23 +1002,9 @@ mod tests {
                 "flags_with_missing_deps": [],
                 "transitive_deps": {}
             }
-        });
-        let result = FeatureFlagList::parse_hypercache_value(data, 1);
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-    }
-
-    #[test]
-    fn test_parse_hypercache_value_missing_evaluation_metadata_fails() {
-        // evaluation_metadata is required in cache entries; missing field must fail
-        let data = json!({
-            "flags": [
-                {"id": 1, "key": "flag", "team_id": 1, "active": true, "deleted": false, "filters": {"groups": []}}
-            ]
-        });
-        let result = FeatureFlagList::parse_hypercache_value(data, 1);
+        }))
+        .unwrap();
+        let result = FeatureFlagList::from_wrapper(Some(wrapper), 1);
         assert!(matches!(
             result,
             Err(FlagError::DataParsingErrorWithContext(_))
@@ -1170,28 +1036,6 @@ mod tests {
         assert!(meta.transitive_deps.is_empty()); // no flags → genuinely empty
     }
 
-    #[test]
-    fn test_parse_hypercache_value_random_string_is_not_sentinel() {
-        // A random string that's not the sentinel should fail parsing
-        let data = json!("some_random_string");
-        let result = FeatureFlagList::parse_hypercache_value(data, 123);
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-    }
-
-    #[test]
-    fn test_parse_hypercache_value_empty_object() {
-        // Empty object (no flags key)
-        let data = json!({});
-        let result = FeatureFlagList::parse_hypercache_value(data, 123);
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-    }
-
     /// Golden fixture contract test: verifies that Rust can deserialize the hypercache
     /// format that Python produces. If this test fails, you've changed the cache schema
     /// in a way that breaks deserialization.
@@ -1202,12 +1046,12 @@ mod tests {
     #[test]
     fn test_hypercache_contract() {
         let fixture = include_str!("../../tests/fixtures/hypercache_contract.json");
-        let data: serde_json::Value = serde_json::from_str(fixture).expect(
-            "Failed to parse hypercache_contract.json as JSON. \
-             The fixture file must be valid JSON.",
+        let wrapper: HypercacheFlagsWrapper = serde_json::from_str(fixture).expect(
+            "Failed to deserialize hypercache_contract.json as HypercacheFlagsWrapper. \
+             The fixture file must be valid JSON matching the wrapper schema.",
         );
 
-        let result = FeatureFlagList::parse_hypercache_value(data, 99);
+        let result = FeatureFlagList::from_wrapper(Some(wrapper), 99);
         let (flags, metadata, cohorts) = result.expect(
             "\n\
              ==============================================================================\n\

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -112,11 +112,8 @@ impl FeatureFlagList {
         Ok((wrapper.flags, evaluation_metadata, wrapper.cohorts))
     }
 
-    /// Extracts flags, evaluation metadata, and cohorts from a pre-deserialized
-    /// `HypercacheFlagsWrapper`. Used with the typed deserialization path where
-    /// `HyperCacheReader` deserializes directly into the wrapper type.
-    ///
-    /// `None` means the `__missing__` sentinel was found (team has no flags).
+    /// Validates and extracts flags from a deserialized `HypercacheFlagsWrapper`.
+    /// `None` means the `__missing__` sentinel (team has no flags).
     pub fn from_wrapper(
         wrapper: Option<HypercacheFlagsWrapper>,
         team_id: TeamId,

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -112,6 +112,46 @@ impl FeatureFlagList {
         Ok((wrapper.flags, evaluation_metadata, wrapper.cohorts))
     }
 
+    /// Extracts flags, evaluation metadata, and cohorts from a pre-deserialized
+    /// `HypercacheFlagsWrapper`. Used with the typed deserialization path where
+    /// `HyperCacheReader` deserializes directly into the wrapper type.
+    ///
+    /// `None` means the `__missing__` sentinel was found (team has no flags).
+    pub fn from_wrapper(
+        wrapper: Option<HypercacheFlagsWrapper>,
+        team_id: TeamId,
+    ) -> Result<HypercacheParseResult, FlagError> {
+        let wrapper = match wrapper {
+            None => {
+                tracing::debug!("Hypercache sentinel (no flags) for team {}", team_id);
+                return Ok((vec![], EvaluationMetadata::default(), None));
+            }
+            Some(w) => w,
+        };
+
+        tracing::debug!(
+            "Parsed {} flags and {} cohorts for team {}",
+            wrapper.flags.len(),
+            wrapper.cohorts.as_ref().map_or(0, |c| c.len()),
+            team_id,
+        );
+
+        let evaluation_metadata = wrapper.evaluation_metadata;
+        if evaluation_metadata.dependency_stages.is_empty() && !wrapper.flags.is_empty() {
+            tracing::error!(
+                "evaluation_metadata.dependency_stages is empty but {} flags present for team {}",
+                wrapper.flags.len(),
+                team_id
+            );
+            return Err(FlagError::DataParsingErrorWithContext(format!(
+                "evaluation_metadata.dependency_stages is empty but {} flags present for team {team_id}",
+                wrapper.flags.len()
+            )));
+        }
+
+        Ok((wrapper.flags, evaluation_metadata, wrapper.cohorts))
+    }
+
     /// Returns feature flags from postgres given a team_id
     pub async fn from_pg(
         client: PostgresReader,

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -1,6 +1,6 @@
 use crate::{
     api::errors::FlagError,
-    flags::flag_models::FeatureFlagList,
+    flags::flag_models::{FeatureFlagList, HypercacheFlagsWrapper},
     handler::canonical_log::with_canonical_log,
     metrics::consts::{
         DB_TEAM_READS_COUNTER, PG_TEAM_FALLBACK_SKIPPED_COUNTER, TEAM_CACHE_HIT_COUNTER,
@@ -118,7 +118,7 @@ impl FlagService {
 
         let (data, source) = self
             .team_hypercache_reader
-            .get_with_source_or_fallback(&key, || async move {
+            .get_typed_with_source_or_fallback::<Team, _, _, FlagError>(&key, || async move {
                 // This closure runs on cache miss (key not found in Redis and
                 // S3) or infrastructure errors (timeouts, connection failures)
                 // as a resilience fallback.
@@ -127,21 +127,16 @@ impl FlagService {
                     return Err(FlagError::TokenValidationError);
                 }
 
-                // Fallback: load from PostgreSQL and convert to JSON Value
+                // Fallback: load directly from PostgreSQL — no serialization round-trip
                 let team = Team::from_pg(pg_client, &token_owned).await?;
                 inc(DB_TEAM_READS_COUNTER, &[], 1);
 
-                // Convert team to JSON value for consistency with cache format
-                let value = serde_json::to_value(&team).map_err(|e| {
-                    tracing::error!("Failed to serialize team from PG: {}", e);
-                    FlagError::Internal(format!("Failed to serialize team: {e}"))
-                })?;
-                Ok::<Option<serde_json::Value>, FlagError>(Some(value))
+                Ok::<Option<Team>, FlagError>(Some(team))
             })
             .await?;
 
-        // Parse the result (from cache or fallback)
-        let team = Team::from_hypercache_value(data)?;
+        // Sentinel (None) means the token exists in cache but has no team
+        let team = data.ok_or(FlagError::TokenValidationError)?;
         let cache_hit = !matches!(source, CacheSource::Fallback);
 
         with_canonical_log(|log| log.team_cache_source = Some(source.as_log_str()));
@@ -171,34 +166,28 @@ impl FlagService {
 
         let (data, source) = self
             .flags_hypercache_reader
-            .get_with_source_or_fallback(&key, || async move {
-                // Fallback: load from PostgreSQL and convert to JSON Value.
-                // PG has no dependency metadata, so place all flags in a
-                // single evaluation stage — they will be evaluated but
-                // without guaranteed dependency ordering.
-                let flags = FeatureFlagList::from_pg(pg_client, team_id).await?;
-                let evaluation_metadata =
-                    crate::flags::flag_models::EvaluationMetadata::single_stage(&flags);
-                let wrapper = crate::flags::flag_models::HypercacheFlagsWrapper {
-                    flags,
-                    cohorts: None,
-                    evaluation_metadata,
-                };
-                let value = serde_json::to_value(&wrapper).map_err(|e| {
-                    tracing::error!(
-                        "Failed to serialize flags from PG for team {}: {}",
-                        team_id,
-                        e
-                    );
-                    FlagError::Internal(format!("Failed to serialize flags: {e}"))
-                })?;
-                Ok::<Option<serde_json::Value>, FlagError>(Some(value))
-            })
+            .get_typed_with_source_or_fallback::<HypercacheFlagsWrapper, _, _, FlagError>(
+                &key,
+                || async move {
+                    // Fallback: load from PostgreSQL directly — no serialization round-trip.
+                    // PG has no dependency metadata, so place all flags in a
+                    // single evaluation stage — they will be evaluated but
+                    // without guaranteed dependency ordering.
+                    let flags = FeatureFlagList::from_pg(pg_client, team_id).await?;
+                    let evaluation_metadata =
+                        crate::flags::flag_models::EvaluationMetadata::single_stage(&flags);
+                    let wrapper = HypercacheFlagsWrapper {
+                        flags,
+                        cohorts: None,
+                        evaluation_metadata,
+                    };
+                    Ok::<Option<HypercacheFlagsWrapper>, FlagError>(Some(wrapper))
+                },
+            )
             .await?;
 
-        // Parse the result (from cache or fallback)
-        let (flags, evaluation_metadata, cohorts) =
-            FeatureFlagList::parse_hypercache_value(data, team_id)?;
+        // Validate and extract from the wrapper (or handle sentinel)
+        let (flags, evaluation_metadata, cohorts) = FeatureFlagList::from_wrapper(data, team_id)?;
 
         Ok(FlagResult {
             flag_list: FeatureFlagList {

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -127,7 +127,6 @@ impl FlagService {
                     return Err(FlagError::TokenValidationError);
                 }
 
-                // Fallback: load directly from PostgreSQL — no serialization round-trip
                 let team = Team::from_pg(pg_client, &token_owned).await?;
                 inc(DB_TEAM_READS_COUNTER, &[], 1);
 
@@ -135,7 +134,6 @@ impl FlagService {
             })
             .await?;
 
-        // Sentinel (None) means the token exists in cache but has no team
         let team = data.ok_or(FlagError::TokenValidationError)?;
         let cache_hit = !matches!(source, CacheSource::Fallback);
 
@@ -169,10 +167,7 @@ impl FlagService {
             .get_typed_with_source_or_fallback::<HypercacheFlagsWrapper, _, _, FlagError>(
                 &key,
                 || async move {
-                    // Fallback: load from PostgreSQL directly — no serialization round-trip.
-                    // PG has no dependency metadata, so place all flags in a
-                    // single evaluation stage — they will be evaluated but
-                    // without guaranteed dependency ordering.
+                    // PG has no dependency metadata, so all flags go in a single stage.
                     let flags = FeatureFlagList::from_pg(pg_client, team_id).await?;
                     let evaluation_metadata =
                         crate::flags::flag_models::EvaluationMetadata::single_stage(&flags);
@@ -186,7 +181,6 @@ impl FlagService {
             )
             .await?;
 
-        // Validate and extract from the wrapper (or handle sentinel)
         let (flags, evaluation_metadata, cohorts) = FeatureFlagList::from_wrapper(data, team_id)?;
 
         Ok(FlagResult {

--- a/rust/feature-flags/src/team/team_operations.rs
+++ b/rust/feature-flags/src/team/team_operations.rs
@@ -1,10 +1,7 @@
 use crate::{
-    api::errors::{simplify_serde_error, FlagError},
-    database::get_connection_with_metrics,
-    team::team_models::Team,
+    api::errors::FlagError, database::get_connection_with_metrics, team::team_models::Team,
 };
 use common_database::PostgresReader;
-use serde_json::Value;
 
 /// SQL fragment for selecting all Team columns
 const TEAM_COLUMNS: &str = "
@@ -48,17 +45,6 @@ const TEAM_COLUMNS: &str = "
 ";
 
 impl Team {
-    /// Parse team from HyperCache JSON value (team_metadata cache format).
-    pub fn from_hypercache_value(value: Value) -> Result<Team, FlagError> {
-        serde_json::from_value(value).map_err(|e| {
-            tracing::error!("Failed to deserialize team from HyperCache: {e}");
-            FlagError::DataParsingErrorWithContext(format!(
-                "Failed to parse team configuration: {}",
-                simplify_serde_error(&e.to_string())
-            ))
-        })
-    }
-
     pub async fn from_pg(client: PostgresReader, token: &str) -> Result<Team, FlagError> {
         let mut conn =
             get_connection_with_metrics(&client, "non_persons_reader", "fetch_team").await?;
@@ -94,8 +80,6 @@ impl Team {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
-
     use super::*;
     use crate::utils::test_utils::{
         insert_new_team_in_redis, setup_redis_client, setup_team_hypercache_reader, TestContext,
@@ -109,12 +93,15 @@ mod tests {
             .await
             .expect("Failed to insert team in redis");
 
-        // Verify we can fetch team from HyperCache
+        // Verify we can fetch team from HyperCache using typed deserialization
         let team_hypercache_reader = setup_team_hypercache_reader(client.clone()).await;
         let key = common_hypercache::KeyType::string(&team.api_token);
-        let (data, _source) = team_hypercache_reader.get_with_source(&key).await.unwrap();
+        let (data, _source) = team_hypercache_reader
+            .get_typed_with_source::<Team>(&key)
+            .await
+            .unwrap();
 
-        let team_from_cache = Team::from_hypercache_value(data).unwrap();
+        let team_from_cache = data.expect("Expected team data, got sentinel");
         assert_eq!(team_from_cache.api_token, team.api_token);
         assert_eq!(team_from_cache.id, team.id);
     }
@@ -284,188 +271,5 @@ mod tests {
         let config = team_from_pg.extra_settings.unwrap();
         let recorder_script = config.get("recorder_script").and_then(|v| v.as_str());
         assert_eq!(recorder_script, Some(""));
-    }
-
-    #[tokio::test]
-    async fn test_from_hypercache_value_parses_extra_settings() {
-        let extra_settings = json!({
-            "recorder_script": "posthog-recorder",
-            "something_else": 123
-        });
-
-        let team_data = json!({
-            "id": 12345,
-            "name": "Test Team",
-            "api_token": "phc_test123",
-            "uuid": "00000000-0000-0000-0000-000000012345",
-            "timezone": "America/New_York",
-            "extra_settings": extra_settings,
-        });
-
-        let team = Team::from_hypercache_value(team_data).expect("Failed to parse team");
-        assert_eq!(team.id, 12345);
-        assert_eq!(team.api_token, "phc_test123");
-        assert_eq!(team.timezone, "America/New_York");
-        assert!(team.extra_settings.is_some());
-
-        let config = team.extra_settings.unwrap();
-        assert_eq!(
-            config.get("recorder_script").and_then(|v| v.as_str()),
-            Some("posthog-recorder")
-        );
-    }
-
-    #[tokio::test]
-    async fn test_from_hypercache_value_handles_all_optional_fields() {
-        let team_data = json!({
-            "id": 99999,
-            "name": "Minimal Team",
-            "api_token": "phc_minimal",
-            "uuid": "00000000-0000-0000-0000-000000000001",
-            "organization_id": "00000000-0000-0000-0000-000000000002",
-            "autocapture_opt_out": true,
-            "session_recording_opt_in": false,
-            "session_recording_sample_rate": "0.75",
-            "cookieless_server_hash_mode": 1,
-            "timezone": "Europe/London",
-        });
-
-        let team = Team::from_hypercache_value(team_data).expect("Failed to parse team");
-        assert_eq!(team.id, 99999);
-        assert_eq!(team.api_token, "phc_minimal");
-        assert_eq!(team.autocapture_opt_out, Some(true));
-        assert!(!team.session_recording_opt_in);
-        assert_eq!(team.cookieless_server_hash_mode, Some(1));
-        assert_eq!(team.timezone, "Europe/London");
-    }
-
-    #[tokio::test]
-    async fn test_from_hypercache_value_rejects_non_object() {
-        // Test with array
-        let result = Team::from_hypercache_value(json!(["not", "an", "object"]));
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-
-        // Test with string
-        let result = Team::from_hypercache_value(json!("just a string"));
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-
-        // Test with number
-        let result = Team::from_hypercache_value(json!(42));
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-
-        // Test with null
-        let result = Team::from_hypercache_value(json!(null));
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_from_hypercache_value_rejects_missing_required_fields() {
-        // Missing id
-        let result = Team::from_hypercache_value(json!({
-            "api_token": "phc_test",
-            "uuid": "00000000-0000-0000-0000-000000000001"
-        }));
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-
-        // Missing api_token
-        let result = Team::from_hypercache_value(json!({
-            "id": 123,
-            "uuid": "00000000-0000-0000-0000-000000000001"
-        }));
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-
-        // Missing uuid
-        let result = Team::from_hypercache_value(json!({
-            "id": 123,
-            "api_token": "phc_test"
-        }));
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-
-        // Empty object
-        let result = Team::from_hypercache_value(json!({}));
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_from_hypercache_value_rejects_invalid_uuid() {
-        let result = Team::from_hypercache_value(json!({
-            "id": 123,
-            "api_token": "phc_test",
-            "uuid": "not-a-valid-uuid"
-        }));
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-
-        let result = Team::from_hypercache_value(json!({
-            "id": 123,
-            "api_token": "phc_test",
-            "uuid": ""
-        }));
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_from_hypercache_value_rejects_wrong_field_types() {
-        // id as string instead of number
-        let result = Team::from_hypercache_value(json!({
-            "id": "not-a-number",
-            "api_token": "phc_test",
-            "uuid": "00000000-0000-0000-0000-000000000001"
-        }));
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-
-        // api_token as number instead of string
-        let result = Team::from_hypercache_value(json!({
-            "id": 123,
-            "api_token": 12345,
-            "uuid": "00000000-0000-0000-0000-000000000001"
-        }));
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
-
-        // uuid as number instead of string
-        let result = Team::from_hypercache_value(json!({
-            "id": 123,
-            "api_token": "phc_test",
-            "uuid": 12345
-        }));
-        assert!(matches!(
-            result,
-            Err(FlagError::DataParsingErrorWithContext(_))
-        ));
     }
 }


### PR DESCRIPTION
## Problem

The `HyperCacheReader` returns `serde_json::Value` from all its public methods. Every request to the Feature Flags service deserializes cached data twice: first from the JSON string into an intermediate `serde_json::Value` tree (backed by `BTreeMap`), then from that `Value` tree into the actual typed structs (`HypercacheFlagsWrapper`, `Team`). The intermediate tree is immediately discarded after the second pass.

A 15 minute Pyroscope CPU profile shows this pattern accounts for roughly 19% of total CPU: 11.2% in `Value::deserialize` dispatch, 4.95% in `BTreeMap` operations (the `Value::Object` backing store), and additional costs in allocator pressure and drop overhead. On top of this, the PG fallback path does the reverse: it serializes a typed struct into `serde_json::Value` via `to_value`, only for the caller to immediately deserialize it back.

## Changes

Add generic typed deserialization methods to `HyperCacheReader` that deserialize the JSON string directly into the target type via `serde_json::from_str::<T>()`, bypassing the `serde_json::Value` intermediate.

**`common-hypercache`:**

The existing `try_get_from_redis` and `try_get_from_s3` methods are refactored into two layers. New internal helpers (`try_get_json_string_from_redis`, `try_get_json_string_from_s3`) handle pickle decoding, sentinel detection, and S3 fetching, returning the raw JSON string. The existing `Value` methods and the new typed methods both call these helpers, then apply their respective deserialization (`from_str::<Value>` vs `from_str::<T>`).

Three new public methods are added: `get_typed_with_source`, `get_typed`, and `get_typed_with_source_or_fallback`. They mirror the existing `Value` API but are generic over `T: DeserializeOwned`. The `__missing__` sentinel is handled at the string level and surfaced as `None` to callers, matching the existing `Value::Null` semantics. The fallback closure now returns `Option<T>` instead of `Option<Value>`.

All existing `Value` methods remain untouched for backward compatibility. The `hypercache-server` and `config_cache.rs` continue using the `Value` API with no changes required.

**`feature-flags`:**

`FlagService::get_flags_from_cache_or_pg` now calls `get_typed_with_source_or_fallback::<HypercacheFlagsWrapper>`. The PG fallback closure returns the wrapper struct directly instead of serializing it to `Value`. A new `FeatureFlagList::from_wrapper` method handles validation (empty dependency stages check) without any deserialization step.

`FlagService::get_team_from_cache_or_pg` now calls `get_typed_with_source_or_fallback::<Team>`. The PG fallback returns the `Team` struct directly, eliminating the `serde_json::to_value` round trip.

## How did you test this code?

All 46 `common-hypercache` unit tests, 10 integration tests, and 1 doc test pass. 9 new unit tests cover the typed methods: Redis hit, sentinel handling, Redis miss with S3 fallback, JSON parse errors (both at the reader level and the composed `get_typed_with_source` level), cache hit with fallback (verifying fallback is not called), fallback invocation on miss, sentinel with fallback (verifying fallback is not called), and the simple `get_typed` wrapper.

All 1140 `feature-flags` unit tests pass. Zero clippy warnings on both crates. `hypercache-server` compiles with no changes.

## Publish to changelog?

no

## Docs update

no