### PR TITLE
fix(workflows): Show per-record DKIM status instead of all-or-nothing

### DIFF
--- a/products/workflows/backend/providers/ses.py
+++ b/products/workflows/backend/providers/ses.py
@@ -226,6 +226,26 @@ class SESProvider:
             for r in dns_records:
                 if r["type"] == "dkim":
                     r["status"] = "success"
+        else:
+            # SES reports aggregate DKIM status, but individual CNAMEs may already
+            # be present.  Do per-record DNS lookups so the UI can show which
+            # specific records are still missing.
+            resolver = dns.resolver.Resolver()
+            resolver.lifetime = 5
+            for r in dns_records:
+                if r["type"] != "dkim":
+                    continue
+                try:
+                    answers = resolver.resolve(r["recordHostname"], "CNAME")
+                    expected = r["recordValue"].rstrip(".") + "."
+                    for rdata in answers:
+                        if str(rdata.target) == expected:
+                            r["status"] = "success"
+                            break
+                except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer, dns.resolver.NoNameservers, dns.resolver.Timeout):
+                    pass
+                except Exception:
+                    logger.exception("Unexpected error during DKIM CNAME lookup for %s", r["recordHostname"])
         if mail_from_status == "Success":
             for r in dns_records:
                 if r["type"] == "mail_from":

--- a/products/workflows/backend/providers/ses.py
+++ b/products/workflows/backend/providers/ses.py
@@ -4,6 +4,7 @@ import logging
 from django.conf import settings
 
 import boto3
+import dns.name
 import dns.resolver
 from botocore.exceptions import BotoCoreError, ClientError
 from rest_framework import exceptions
@@ -237,9 +238,10 @@ class SESProvider:
                     continue
                 try:
                     answers = resolver.resolve(r["recordHostname"], "CNAME")
-                    expected = r["recordValue"].rstrip(".") + "."
+                    expected = dns.name.from_text(r["recordValue"])
                     for rdata in answers:
-                        if str(rdata.target) == expected:
+                        # Use dnspython Name comparison, case-insensitive per RFC 1035
+                        if rdata.target == expected:
                             r["status"] = "success"
                             break
                 except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer, dns.resolver.NoNameservers, dns.resolver.Timeout):

--- a/products/workflows/backend/test/test_ses_provider.py
+++ b/products/workflows/backend/test/test_ses_provider.py
@@ -292,40 +292,43 @@ class TestSESProvider(TestCase):
             assert dmarc_records[0]["recordValue"] == expected_record_value
             assert result["status"] == "pending"  # SES statuses are Pending, so overall stays pending
 
-    @patch("products.workflows.backend.providers.ses.dns.resolver.Resolver")
-    def test_verify_dkim_partial_shows_per_record_status(self, mock_resolver_cls):
+    @parameterized.expand(
+        [
+            ("all_missing", set()),
+            ("partial_present", {"token2", "token3"}),
+            ("all_present", {"token1", "token2", "token3"}),
+        ]
+    )
+    def test_verify_dkim_partial_shows_per_record_status(self, _name, present_tokens):
         """When DKIM is not fully verified, individual CNAME lookups show which records are present."""
         provider = SESProvider()
 
         def resolve_side_effect(hostname, rdtype=None):
-            # token2 and token3 are present, token1 is missing
-            if rdtype == "CNAME" and "token2._domainkey" in hostname:
-                rdata = MagicMock()
-                rdata.target = dns.name.from_text("token2.dkim.amazonses.com.")
-                return [rdata]
-            if rdtype == "CNAME" and "token3._domainkey" in hostname:
-                rdata = MagicMock()
-                rdata.target = dns.name.from_text("token3.dkim.amazonses.com.")
-                return [rdata]
-            # token1 CNAME and DMARC TXT both missing
+            for token in present_tokens:
+                if rdtype == "CNAME" and f"{token}._domainkey" in hostname:
+                    rdata = MagicMock()
+                    rdata.target = dns.name.from_text(f"{token}.dkim.amazonses.com.")
+                    return [rdata]
             raise dns.resolver.NXDOMAIN()
-
-        mock_resolver_cls.return_value.resolve.side_effect = resolve_side_effect
 
         with (
             patch.object(provider.ses_client, "get_identity_verification_attributes") as mock_verif,
             patch.object(provider.ses_client, "get_identity_dkim_attributes") as mock_dkim,
             patch.object(provider.ses_client, "get_identity_mail_from_domain_attributes") as mock_mail,
+            patch("products.workflows.backend.providers.ses.dns.resolver.Resolver") as mock_resolver_cls,
         ):
+            mock_resolver_cls.return_value.resolve.side_effect = resolve_side_effect
             mock_verif.return_value = {"VerificationAttributes": {TEST_DOMAIN: {"VerificationStatus": "Success"}}}
             mock_dkim.return_value = {"DkimAttributes": {TEST_DOMAIN: {"DkimVerificationStatus": "Failed"}}}
             mock_mail.return_value = {"MailFromDomainAttributes": {TEST_DOMAIN: {"MailFromDomainStatus": "Success"}}}
 
             result = provider.verify_email_domain(TEST_DOMAIN, mail_from_subdomain="mail", team_id=1)
 
+        # DkimVerificationStatus=Failed always produces overall "failed", regardless of per-record DNS state
+        assert result["status"] == "failed"
         dkim_records = [r for r in result["dnsRecords"] if r["type"] == "dkim"]
         assert len(dkim_records) == 3
         statuses = {r["recordHostname"].split(".")[0]: r["status"] for r in dkim_records}
-        assert statuses["token1"] == "pending"
-        assert statuses["token2"] == "success"
-        assert statuses["token3"] == "success"
+        for token in ("token1", "token2", "token3"):
+            expected = "success" if token in present_tokens else "pending"
+            assert statuses[token] == expected, f"{token}: expected {expected}, got {statuses[token]}"

--- a/products/workflows/backend/test/test_ses_provider.py
+++ b/products/workflows/backend/test/test_ses_provider.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 
+import dns.name
 import dns.resolver
 from parameterized import parameterized
 
@@ -290,3 +291,41 @@ class TestSESProvider(TestCase):
             assert dmarc_records[0]["status"] == expected_dmarc_status
             assert dmarc_records[0]["recordValue"] == expected_record_value
             assert result["status"] == "pending"  # SES statuses are Pending, so overall stays pending
+
+    @patch("products.workflows.backend.providers.ses.dns.resolver.Resolver")
+    def test_verify_dkim_partial_shows_per_record_status(self, mock_resolver_cls):
+        """When DKIM is not fully verified, individual CNAME lookups show which records are present."""
+        provider = SESProvider()
+
+        def resolve_side_effect(hostname, rdtype=None):
+            # token2 and token3 are present, token1 is missing
+            if rdtype == "CNAME" and "token2._domainkey" in hostname:
+                rdata = MagicMock()
+                rdata.target = dns.name.from_text("token2.dkim.amazonses.com.")
+                return [rdata]
+            if rdtype == "CNAME" and "token3._domainkey" in hostname:
+                rdata = MagicMock()
+                rdata.target = dns.name.from_text("token3.dkim.amazonses.com.")
+                return [rdata]
+            # token1 CNAME and DMARC TXT both missing
+            raise dns.resolver.NXDOMAIN()
+
+        mock_resolver_cls.return_value.resolve.side_effect = resolve_side_effect
+
+        with (
+            patch.object(provider.ses_client, "get_identity_verification_attributes") as mock_verif,
+            patch.object(provider.ses_client, "get_identity_dkim_attributes") as mock_dkim,
+            patch.object(provider.ses_client, "get_identity_mail_from_domain_attributes") as mock_mail,
+        ):
+            mock_verif.return_value = {"VerificationAttributes": {TEST_DOMAIN: {"VerificationStatus": "Success"}}}
+            mock_dkim.return_value = {"DkimAttributes": {TEST_DOMAIN: {"DkimVerificationStatus": "Failed"}}}
+            mock_mail.return_value = {"MailFromDomainAttributes": {TEST_DOMAIN: {"MailFromDomainStatus": "Success"}}}
+
+            result = provider.verify_email_domain(TEST_DOMAIN, mail_from_subdomain="mail", team_id=1)
+
+        dkim_records = [r for r in result["dnsRecords"] if r["type"] == "dkim"]
+        assert len(dkim_records) == 3
+        statuses = {r["recordHostname"].split(".")[0]: r["status"] for r in dkim_records}
+        assert statuses["token1"] == "pending"
+        assert statuses["token2"] == "success"
+        assert statuses["token3"] == "success"


### PR DESCRIPTION
## Problem

Customer [reported](https://posthoghelp.zendesk.com/agent/tickets/55279) setting up email channels in Workflows and seeing "Not present" for all 3 DKIM CNAME records even when some are correctly configured. This is because `SESProvider.verify_email_domain` uses the aggregate SES DKIM status (success/failed/pending) to set the status of all 3 records at once. If even one CNAME is missing, SES reports `Failed` and the UI marks all 3 as "Not present" - giving the customer no indication of which record is actually wrong.

A real customer had 2 of 3 CNAMEs correctly in DNS but spent over a week unable to resolve the issue because the UI kept telling them all 3 were broken.

## Changes

When SES reports DKIM as not fully verified, the provider now does individual DNS lookups for each DKIM CNAME record (same pattern already used for DMARC verification) and marks each one as `success` or `pending` independently.

**Before:**
<img width="1026" height="1152" alt="cname-display-fix-before" src="https://github.com/user-attachments/assets/d6212cd8-d08a-48ec-bf26-4de682abb129" />

**After:**
<img width="1013" height="1167" alt="cname-display-fix-after" src="https://github.com/user-attachments/assets/13d6bef0-f07f-460c-967d-2341191dfc35" />

## How did you test this code?

- Added test that mocks SES with `DkimVerificationStatus: "Failed"`, sets up DNS so 2 of 3 CNAMEs resolve, and asserts per-record status is correct
- End-to-end against real DNS: ran the fixed `verify_email_domain` locally against the affected domain. Confirmed the fix correctly identifies 2 of 3 CNAMEs as already present and pinpoints the single missing record - matching what `dig` returns directly. The current production response on the same domain still flags all 3 as "Not present", reproducing the bug.

## Publish to changelog?

No