### PR TITLE
test(ch_migrate): decompose oversized reconciliation/state-diff tests

### DIFF
--- a/posthog/clickhouse/test/test_reconcile_diff.py
+++ b/posthog/clickhouse/test/test_reconcile_diff.py
@@ -1,4 +1,30 @@
 """Split from a larger legacy test module for review-size control."""
 
-
 # Re-exported test classes are intentionally imported for pytest discovery.
+from posthog.clickhouse.test.test_reconcile_shared import (
+    TestCheckLegacyMigrations,
+    TestClusterRegistry,
+    TestDetectDrift,
+    TestDetectOrphans,
+    TestDistributedClusterResolution,
+    TestKafkaRecreateWarning,
+    TestMvSelectChange,
+    TestMvSelectNormalization,
+    TestReplicatedEngineExplicitZkPath,
+    TestStructuralFieldDiffs,
+    TestTemplates,
+)
+
+__all__ = [
+    "TestMvSelectChange",
+    "TestDetectOrphans",
+    "TestClusterRegistry",
+    "TestStructuralFieldDiffs",
+    "TestReplicatedEngineExplicitZkPath",
+    "TestDistributedClusterResolution",
+    "TestKafkaRecreateWarning",
+    "TestMvSelectNormalization",
+    "TestCheckLegacyMigrations",
+    "TestTemplates",
+    "TestDetectDrift",
+]

--- a/posthog/clickhouse/test/test_reconcile_diff.py
+++ b/posthog/clickhouse/test/test_reconcile_diff.py
@@ -1,0 +1,4 @@
+"""Split from a larger legacy test module for review-size control."""
+
+
+# Re-exported test classes are intentionally imported for pytest discovery.

--- a/posthog/clickhouse/test/test_reconcile_edge_cases.py
+++ b/posthog/clickhouse/test/test_reconcile_edge_cases.py
@@ -1,4 +1,38 @@
 """Split from a larger legacy test module for review-size control."""
 
-
 # Re-exported test classes are intentionally imported for pytest discovery.
+from posthog.clickhouse.test.test_reconcile_shared import (
+    TestApplyRoutesStepsToCorrectCluster,
+    TestCircularInheritance,
+    TestComputeDiffsConvergencePreserved,
+    TestComputeDiffsEmitsDropsForRemovedTables,
+    TestComputeDiffsPerCluster,
+    TestComputeDiffsSharedPhysicalHost,
+    TestComputeDiffsSkipsOrphanScanOnFallback,
+    TestComputeDiffsTagsClusterOnDiffs,
+    TestDiffStatePlaceholderMvNotDropped,
+    TestDriftComparesKeyFields,
+    TestEngineRequiredFieldsLint,
+    TestKafkaFallbackWarning,
+    TestManifestStepCarriesCluster,
+    TestMergetreeOrderByLint,
+    TestSatelliteRoleLint,
+)
+
+__all__ = [
+    "TestCircularInheritance",
+    "TestKafkaFallbackWarning",
+    "TestMergetreeOrderByLint",
+    "TestEngineRequiredFieldsLint",
+    "TestSatelliteRoleLint",
+    "TestDriftComparesKeyFields",
+    "TestComputeDiffsPerCluster",
+    "TestComputeDiffsEmitsDropsForRemovedTables",
+    "TestComputeDiffsTagsClusterOnDiffs",
+    "TestManifestStepCarriesCluster",
+    "TestDiffStatePlaceholderMvNotDropped",
+    "TestComputeDiffsConvergencePreserved",
+    "TestApplyRoutesStepsToCorrectCluster",
+    "TestComputeDiffsSkipsOrphanScanOnFallback",
+    "TestComputeDiffsSharedPhysicalHost",
+]

--- a/posthog/clickhouse/test/test_reconcile_edge_cases.py
+++ b/posthog/clickhouse/test/test_reconcile_edge_cases.py
@@ -1,0 +1,4 @@
+"""Split from a larger legacy test module for review-size control."""
+
+
+# Re-exported test classes are intentionally imported for pytest discovery.

--- a/posthog/clickhouse/test/test_reconcile_foundation.py
+++ b/posthog/clickhouse/test/test_reconcile_foundation.py
@@ -1,4 +1,28 @@
 """Split from a larger legacy test module for review-size control."""
 
-
 # Re-exported test classes are intentionally imported for pytest discovery.
+from posthog.clickhouse.test.test_reconcile_shared import (
+    TestDiffDependencyOrder,
+    TestDiffStateExtraColumn,
+    TestDiffStateMissingColumn,
+    TestDiffStateMissingTable,
+    TestDiffStateMvChange,
+    TestDiffStateTypeChange,
+    TestManifestStepGeneration,
+    TestParseDesiredState,
+    TestPlanGeneratorHumanReadable,
+    TestReconcileImportYamlRoundTrip,
+)
+
+__all__ = [
+    "TestParseDesiredState",
+    "TestDiffStateMissingTable",
+    "TestDiffStateExtraColumn",
+    "TestDiffStateMissingColumn",
+    "TestDiffStateTypeChange",
+    "TestDiffStateMvChange",
+    "TestDiffDependencyOrder",
+    "TestPlanGeneratorHumanReadable",
+    "TestManifestStepGeneration",
+    "TestReconcileImportYamlRoundTrip",
+]

--- a/posthog/clickhouse/test/test_reconcile_foundation.py
+++ b/posthog/clickhouse/test/test_reconcile_foundation.py
@@ -1,0 +1,4 @@
+"""Split from a larger legacy test module for review-size control."""
+
+
+# Re-exported test classes are intentionally imported for pytest discovery.

--- a/posthog/clickhouse/test/test_reconcile_shared.py
+++ b/posthog/clickhouse/test/test_reconcile_shared.py
@@ -1,0 +1,2419 @@
+"""Unit tests for desired-state reconciliation (desired_state, state_diff, plan_generator).
+
+No Django or ClickHouse connection required.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import textwrap
+from pathlib import Path
+
+import unittest
+
+import posthog.clickhouse.test._stubs  # noqa: F401
+from posthog.clickhouse.migration_tools.desired_state import (
+    ColumnDef,
+    DesiredState,
+    DesiredTable,
+    parse_desired_state,
+    parse_desired_state_dir,
+)
+from posthog.clickhouse.migration_tools.plan_generator import generate_manifest_steps, generate_plan_text
+from posthog.clickhouse.migration_tools.schema_introspect import ColumnSchema, TableSchema
+from posthog.clickhouse.migration_tools.state_diff import StateDiff, diff_state
+
+
+def _write_yaml(content: str) -> Path:
+    d = tempfile.mkdtemp()
+    p = Path(d) / "test_ecosystem.yaml"
+    p.write_text(textwrap.dedent(content))
+    return p
+
+
+def _make_desired_state(tables: dict[str, DesiredTable]) -> DesiredState:
+    return DesiredState(ecosystem="test", cluster="main", tables=tables)
+
+
+def _make_desired_table(
+    name: str,
+    engine: str = "ReplicatedMergeTree",
+    columns: list[ColumnDef] | None = None,
+    on_nodes: list[str] | None = None,
+    **kwargs: object,
+) -> DesiredTable:
+    return DesiredTable(
+        name=name,
+        engine=engine,
+        columns=columns or [],
+        on_nodes=on_nodes or ["DATA"],
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def _make_table_schema(
+    name: str,
+    engine: str = "ReplicatedMergeTree",
+    columns: list[ColumnSchema] | None = None,
+) -> TableSchema:
+    return TableSchema(name=name, engine=engine, columns=columns or [])
+
+
+class TestParseDesiredState(unittest.TestCase):
+    def test_parse_basic_yaml(self) -> None:
+        p = _write_yaml("""\
+            ecosystem: events
+            cluster: main
+            tables:
+              sharded_events:
+                engine: ReplicatedMergeTree
+                sharded: true
+                on_nodes: DATA
+                order_by: [team_id, id]
+                columns:
+                  - name: id
+                    type: UUID
+                  - name: team_id
+                    type: Int64
+        """)
+        state = parse_desired_state(p)
+        self.assertEqual(state.ecosystem, "events")
+        self.assertEqual(state.cluster, "main")
+        self.assertIn("sharded_events", state.tables)
+        table = state.tables["sharded_events"]
+        self.assertEqual(table.engine, "ReplicatedMergeTree")
+        self.assertTrue(table.sharded)
+        self.assertEqual(len(table.columns), 2)
+        self.assertEqual(table.columns[0].name, "id")
+        self.assertEqual(table.columns[0].type, "UUID")
+        self.assertEqual(table.order_by, ["team_id", "id"])
+
+    def test_parse_column_inheritance(self) -> None:
+        p = _write_yaml("""\
+            ecosystem: test
+            cluster: main
+            tables:
+              sharded_t:
+                engine: ReplicatedMergeTree
+                on_nodes: DATA
+                columns:
+                  - name: id
+                    type: UUID
+                  - name: name
+                    type: String
+              distributed_t:
+                engine: Distributed
+                source: sharded_t
+                on_nodes: ALL
+                columns: inherit sharded_t
+        """)
+        state = parse_desired_state(p)
+        dist = state.tables["distributed_t"]
+        self.assertEqual(len(dist.columns), 2)
+        self.assertEqual(dist.columns[0].name, "id")
+        self.assertEqual(dist.inherit_columns_from, "sharded_t")
+
+    def test_parse_missing_ecosystem(self) -> None:
+        p = _write_yaml("""\
+            cluster: main
+            tables: {}
+        """)
+        with self.assertRaises(ValueError) as ctx:
+            parse_desired_state(p)
+        self.assertIn("ecosystem", str(ctx.exception))
+
+    def test_parse_mv_table(self) -> None:
+        p = _write_yaml("""\
+            ecosystem: test
+            cluster: main
+            tables:
+              my_mv:
+                engine: MaterializedView
+                source: kafka_t
+                target: writable_t
+                select: "SELECT * FROM posthog.kafka_t"
+                on_nodes: ALL
+                columns: []
+        """)
+        state = parse_desired_state(p)
+        mv = state.tables["my_mv"]
+        self.assertEqual(mv.engine, "MaterializedView")
+        self.assertEqual(mv.target, "writable_t")
+        self.assertEqual(mv.source, "kafka_t")
+
+    def test_parse_dir(self) -> None:
+        d = tempfile.mkdtemp()
+        (Path(d) / "eco1.yaml").write_text(
+            textwrap.dedent("""\
+            ecosystem: eco1
+            cluster: main
+            tables:
+              t1:
+                engine: MergeTree
+                on_nodes: DATA
+                columns:
+                  - name: id
+                    type: UInt64
+        """)
+        )
+        (Path(d) / "eco2.yaml").write_text(
+            textwrap.dedent("""\
+            ecosystem: eco2
+            cluster: main
+            tables:
+              t2:
+                engine: MergeTree
+                on_nodes: DATA
+                columns:
+                  - name: id
+                    type: UInt64
+        """)
+        )
+        states = parse_desired_state_dir(Path(d))
+        self.assertEqual(len(states), 2)
+        ecosystems = {s.ecosystem for s in states}
+        self.assertEqual(ecosystems, {"eco1", "eco2"})
+
+
+class TestDiffStateMissingTable(unittest.TestCase):
+    def test_missing_table_creates(self) -> None:
+        desired = _make_desired_state(
+            {
+                "new_table": _make_desired_table(
+                    "new_table",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                ),
+            }
+        )
+        current: dict[str, TableSchema] = {}
+        diffs = diff_state(desired, current)
+        self.assertEqual(len(diffs), 1)
+        self.assertEqual(diffs[0].action, "create")
+        self.assertEqual(diffs[0].table, "new_table")
+        self.assertIn("CREATE TABLE", diffs[0].sql)
+
+
+class TestDiffStateExtraColumn(unittest.TestCase):
+    def test_extra_column_adds(self) -> None:
+        desired = _make_desired_state(
+            {
+                "t": _make_desired_table(
+                    "t",
+                    columns=[
+                        ColumnDef(name="id", type="UUID"),
+                        ColumnDef(name="new_col", type="String"),
+                    ],
+                ),
+            }
+        )
+        current = {
+            "t": _make_table_schema(
+                "t",
+                columns=[
+                    ColumnSchema(name="id", type="UUID"),
+                ],
+            ),
+        }
+        diffs = diff_state(desired, current)
+        add_diffs = [d for d in diffs if d.action == "alter_add_column"]
+        self.assertEqual(len(add_diffs), 1)
+        self.assertEqual(add_diffs[0].table, "t")
+        self.assertIn("new_col", add_diffs[0].sql)
+        self.assertIn("ADD COLUMN", add_diffs[0].sql)
+
+
+class TestDiffStateMissingColumn(unittest.TestCase):
+    def test_missing_column_drops(self) -> None:
+        desired = _make_desired_state(
+            {
+                "t": _make_desired_table(
+                    "t",
+                    columns=[
+                        ColumnDef(name="id", type="UUID"),
+                    ],
+                ),
+            }
+        )
+        current = {
+            "t": _make_table_schema(
+                "t",
+                columns=[
+                    ColumnSchema(name="id", type="UUID"),
+                    ColumnSchema(name="old_col", type="String"),
+                ],
+            ),
+        }
+        diffs = diff_state(desired, current)
+        drop_diffs = [d for d in diffs if d.action == "alter_drop_column"]
+        self.assertEqual(len(drop_diffs), 1)
+        self.assertIn("old_col", drop_diffs[0].sql)
+        self.assertIn("DROP COLUMN", drop_diffs[0].sql)
+
+
+class TestDiffStateTypeChange(unittest.TestCase):
+    def test_type_change_modifies(self) -> None:
+        desired = _make_desired_state(
+            {
+                "t": _make_desired_table(
+                    "t",
+                    columns=[
+                        ColumnDef(name="val", type="Int64"),
+                    ],
+                ),
+            }
+        )
+        current = {
+            "t": _make_table_schema(
+                "t",
+                columns=[
+                    ColumnSchema(name="val", type="Int32"),
+                ],
+            ),
+        }
+        diffs = diff_state(desired, current)
+        modify_diffs = [d for d in diffs if d.action == "alter_modify_column"]
+        self.assertEqual(len(modify_diffs), 1)
+        self.assertIn("MODIFY COLUMN", modify_diffs[0].sql)
+        self.assertIn("Int64", modify_diffs[0].sql)
+
+
+class TestDiffStateMvChange(unittest.TestCase):
+    def test_mv_engine_change_recreates(self) -> None:
+        desired = _make_desired_state(
+            {
+                "my_mv": DesiredTable(
+                    name="my_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["ALL"],
+                    target="writable_t",
+                    select="SELECT * FROM kafka_t",
+                ),
+            }
+        )
+        current = {
+            "my_mv": _make_table_schema("my_mv", engine="MergeTree"),
+        }
+        diffs = diff_state(desired, current)
+        recreate_diffs = [d for d in diffs if d.action == "recreate_mv"]
+        self.assertEqual(len(recreate_diffs), 1)
+        self.assertIn("DROP TABLE", recreate_diffs[0].sql)
+        self.assertIn("CREATE MATERIALIZED VIEW", recreate_diffs[0].sql)
+
+
+class TestDiffDependencyOrder(unittest.TestCase):
+    def test_mv_dropped_before_source_altered(self) -> None:
+        """When a MV exists in current but not desired, and its source table
+        is being altered, the MV drop should come before the alter."""
+        desired = _make_desired_state(
+            {
+                "source_t": _make_desired_table(
+                    "source_t",
+                    columns=[
+                        ColumnDef(name="id", type="UUID"),
+                        ColumnDef(name="new_col", type="String"),
+                    ],
+                ),
+            }
+        )
+        current = {
+            "source_t": _make_table_schema(
+                "source_t",
+                columns=[
+                    ColumnSchema(name="id", type="UUID"),
+                ],
+            ),
+            "my_mv": _make_table_schema("my_mv", engine="MaterializedView"),
+        }
+        diffs = diff_state(desired, current)
+
+        # Find positions
+        drop_idx = next(i for i, d in enumerate(diffs) if d.action == "drop" and d.table == "my_mv")
+        alter_idx = next(i for i, d in enumerate(diffs) if d.action == "alter_add_column")
+
+        self.assertLess(drop_idx, alter_idx, "MV drop should come before source table alter")
+
+    def test_create_local_before_distributed(self) -> None:
+        """Local tables should be created before distributed tables."""
+        desired = _make_desired_state(
+            {
+                "sharded_t": _make_desired_table(
+                    "sharded_t",
+                    columns=[
+                        ColumnDef(name="id", type="UUID"),
+                    ],
+                ),
+                "dist_t": DesiredTable(
+                    name="dist_t",
+                    engine="Distributed",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    on_nodes=["ALL"],
+                    source="sharded_t",
+                ),
+            }
+        )
+        current: dict[str, TableSchema] = {}
+        diffs = diff_state(desired, current)
+        creates = [d for d in diffs if d.action == "create"]
+        self.assertEqual(len(creates), 2)
+
+        local_idx = next(i for i, d in enumerate(creates) if d.table == "sharded_t")
+        dist_idx = next(i for i, d in enumerate(creates) if d.table == "dist_t")
+        self.assertLess(local_idx, dist_idx, "Local table should be created before distributed")
+
+
+class TestPlanGeneratorHumanReadable(unittest.TestCase):
+    def test_plan_includes_symbols(self) -> None:
+        diffs = [
+            StateDiff(
+                action="alter_add_column",
+                table="sharded_events",
+                detail="Add column foo String to sharded_events",
+                sql="ALTER TABLE ...",
+                node_roles=["DATA"],
+            ),
+            StateDiff(
+                action="drop",
+                table="old_mv",
+                detail="Table old_mv exists but is not in desired state",
+                sql="DROP TABLE ...",
+                node_roles=["ALL"],
+            ),
+            StateDiff(
+                action="create",
+                table="new_table",
+                detail="Create MergeTree table new_table",
+                sql="CREATE TABLE ...",
+                node_roles=["DATA"],
+            ),
+        ]
+        plan = generate_plan_text(diffs)
+        self.assertIn("~", plan)  # modify symbol
+        self.assertIn("-", plan)  # drop symbol
+        self.assertIn("+", plan)  # create symbol
+        self.assertIn("sharded_events", plan)
+        self.assertIn("old_mv", plan)
+        self.assertIn("new_table", plan)
+        self.assertIn("Plan:", plan)
+        self.assertIn("ch_migrate plan:", plan)
+
+    def test_no_changes_plan(self) -> None:
+        plan = generate_plan_text([])
+        self.assertIn("No changes", plan)
+
+
+class TestManifestStepGeneration(unittest.TestCase):
+    def test_generates_manifest_steps(self) -> None:
+        diffs = [
+            StateDiff(
+                action="alter_add_column",
+                table="t",
+                detail="Add col",
+                sql="ALTER TABLE posthog.t ADD COLUMN IF NOT EXISTS foo String",
+                node_roles=["DATA"],
+                sharded=True,
+                is_alter_on_replicated_table=True,
+            ),
+        ]
+        steps = generate_manifest_steps(diffs)
+        self.assertEqual(len(steps), 1)
+        step, sql = steps[0]
+        self.assertEqual(step.node_roles, ["DATA"])
+        self.assertTrue(step.sharded)
+        self.assertTrue(step.is_alter_on_replicated_table)
+        self.assertIn("ALTER TABLE", sql)
+
+    def test_recreate_splits_into_drop_create(self) -> None:
+        diffs = [
+            StateDiff(
+                action="recreate_mv",
+                table="my_mv",
+                detail="Recreate MV",
+                sql="DROP TABLE IF EXISTS posthog.my_mv;\nCREATE MATERIALIZED VIEW ...",
+                node_roles=["ALL"],
+            ),
+        ]
+        steps = generate_manifest_steps(diffs)
+        self.assertEqual(len(steps), 2)
+        self.assertIn("drop", steps[0][0].sql)
+        self.assertIn("create", steps[1][0].sql)
+
+
+class TestReconcileImportYamlRoundTrip(unittest.TestCase):
+    def test_import_roundtrip(self) -> None:
+        """Write a YAML file, parse it, verify it round-trips through the parser."""
+        import yaml
+
+        yaml_content = textwrap.dedent("""\
+            ecosystem: roundtrip_test
+            cluster: main
+            tables:
+              sharded_t:
+                engine: ReplicatedMergeTree
+                sharded: true
+                on_nodes: DATA
+                order_by: [team_id, id]
+                partition_by: "toYYYYMM(timestamp)"
+                columns:
+                  - name: id
+                    type: UUID
+                  - name: team_id
+                    type: Int64
+                  - name: timestamp
+                    type: DateTime64(6, 'UTC')
+              writable_t:
+                engine: Distributed
+                source: sharded_t
+                sharding_key: "cityHash64(id)"
+                on_nodes: COORDINATOR
+                columns: inherit sharded_t
+        """)
+
+        d = tempfile.mkdtemp()
+        p = Path(d) / "roundtrip_test.yaml"
+        p.write_text(yaml_content)
+
+        state = parse_desired_state(p)
+        self.assertEqual(state.ecosystem, "roundtrip_test")
+        self.assertEqual(len(state.tables), 2)
+
+        sharded = state.tables["sharded_t"]
+        self.assertEqual(sharded.order_by, ["team_id", "id"])
+        self.assertEqual(sharded.partition_by, "toYYYYMM(timestamp)")
+        self.assertEqual(len(sharded.columns), 3)
+
+        writable = state.tables["writable_t"]
+        self.assertEqual(writable.source, "sharded_t")
+        self.assertEqual(len(writable.columns), 3)  # inherited
+
+        # Write back out as YAML and re-parse
+        tables_out: dict[str, dict] = {}
+        for tname, tbl in state.tables.items():
+            tdata: dict = {"engine": tbl.engine, "on_nodes": tbl.on_nodes}
+            if tbl.order_by:
+                tdata["order_by"] = tbl.order_by
+            if tbl.partition_by:
+                tdata["partition_by"] = tbl.partition_by
+            if tbl.source:
+                tdata["source"] = tbl.source
+            if tbl.sharding_key:
+                tdata["sharding_key"] = tbl.sharding_key
+            if tbl.sharded:
+                tdata["sharded"] = True
+            tdata["columns"] = [{"name": c.name, "type": c.type} for c in tbl.columns]
+            tables_out[tname] = tdata
+        out_data = {
+            "ecosystem": state.ecosystem,
+            "cluster": state.cluster,
+            "tables": tables_out,
+        }
+
+        out_path = Path(d) / "roundtrip_out.yaml"
+        with open(out_path, "w") as f:
+            yaml.dump(out_data, f, default_flow_style=False, sort_keys=False)
+
+        state2 = parse_desired_state(out_path)
+        self.assertEqual(state2.ecosystem, state.ecosystem)
+        self.assertEqual(len(state2.tables), len(state.tables))
+        for tname in state.tables:
+            self.assertEqual(
+                len(state2.tables[tname].columns),
+                len(state.tables[tname].columns),
+            )
+
+
+class TestMvSelectChange(unittest.TestCase):
+    def test_mv_select_change_detected(self) -> None:
+        """When an MV's SELECT changes, state_diff should generate DROP + CREATE."""
+        desired = _make_desired_state(
+            {
+                "my_mv": DesiredTable(
+                    name="my_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["ALL"],
+                    target="writable_t",
+                    select="SELECT id, new_col FROM posthog.kafka_t",
+                ),
+            }
+        )
+        current = {
+            "my_mv": TableSchema(
+                name="my_mv",
+                engine="MaterializedView",
+                as_select="SELECT * FROM posthog.kafka_t",
+            ),
+        }
+        diffs = diff_state(desired, current)
+
+        drop_diffs = [d for d in diffs if d.action == "drop"]
+        create_diffs = [d for d in diffs if d.action == "create"]
+
+        self.assertEqual(len(drop_diffs), 1, "Should generate a DROP for the old MV")
+        self.assertEqual(drop_diffs[0].table, "my_mv")
+        self.assertEqual(len(create_diffs), 1, "Should generate a CREATE for the new MV")
+        self.assertEqual(create_diffs[0].table, "my_mv")
+        self.assertIn("CREATE MATERIALIZED VIEW", create_diffs[0].sql)
+
+    def test_mv_select_unchanged_no_diff(self) -> None:
+        """When an MV's SELECT matches, no diff should be generated."""
+        select_stmt = "SELECT * FROM posthog.kafka_t"
+        desired = _make_desired_state(
+            {
+                "my_mv": DesiredTable(
+                    name="my_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["ALL"],
+                    target="writable_t",
+                    select=select_stmt,
+                ),
+            }
+        )
+        current = {
+            "my_mv": TableSchema(
+                name="my_mv",
+                engine="MaterializedView",
+                as_select=select_stmt,
+            ),
+        }
+        diffs = diff_state(desired, current)
+        self.assertEqual(len(diffs), 0, "No diffs when MV SELECT is unchanged")
+
+
+class TestDetectOrphans(unittest.TestCase):
+    def test_finds_undeclared_tables(self) -> None:
+        from posthog.clickhouse.migration_tools.state_diff import detect_orphans
+
+        desired_states = [
+            _make_desired_state({"t1": _make_desired_table("t1", columns=[ColumnDef(name="id", type="UUID")])}),
+        ]
+        current = {
+            "t1": _make_table_schema("t1"),
+            "orphan_table": _make_table_schema("orphan_table"),
+        }
+        orphans = detect_orphans(desired_states, current)
+        self.assertEqual(orphans, ["orphan_table"])
+
+    def test_excludes_system_tables(self) -> None:
+        from posthog.clickhouse.migration_tools.state_diff import detect_orphans
+
+        desired_states = [
+            _make_desired_state({"t1": _make_desired_table("t1", columns=[ColumnDef(name="id", type="UUID")])}),
+        ]
+        current = {
+            "t1": _make_table_schema("t1"),
+            "clickhouse_schema_migrations": _make_table_schema("clickhouse_schema_migrations"),
+            "_tmp_backup": _make_table_schema("_tmp_backup"),
+        }
+        orphans = detect_orphans(desired_states, current)
+        self.assertEqual(orphans, [])
+
+    def test_excludes_custom_patterns(self) -> None:
+        from posthog.clickhouse.migration_tools.state_diff import detect_orphans
+
+        desired_states = [
+            _make_desired_state({"t1": _make_desired_table("t1", columns=[ColumnDef(name="id", type="UUID")])}),
+        ]
+        current = {
+            "t1": _make_table_schema("t1"),
+            "legacy_table": _make_table_schema("legacy_table"),
+        }
+        orphans = detect_orphans(desired_states, current, exclude_patterns=["legacy_table"])
+        self.assertEqual(orphans, [])
+
+
+class TestClusterRegistry(unittest.TestCase):
+    """Tests for cluster registry in cluster.py."""
+
+    def test_cluster_registry_maps_main(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        mock_settings = MagicMock()
+        mock_settings.CLICKHOUSE_HOST = "main-host"
+        mock_settings.CLICKHOUSE_CLUSTER = "posthog"
+
+        with (
+            patch("posthog.clickhouse.cluster.get_cluster") as mock_get_cluster,
+            patch("posthog.clickhouse.cluster.settings", mock_settings),
+        ):
+            from posthog.clickhouse.cluster import get_cluster_by_name
+
+            get_cluster_by_name("main")
+            mock_get_cluster.assert_called_once_with(host="main-host", cluster="posthog")
+
+    def test_cluster_registry_maps_logs(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        mock_settings = MagicMock()
+        mock_settings.CLICKHOUSE_LOGS_CLUSTER_HOST = "logs-host"
+        mock_settings.CLICKHOUSE_LOGS_CLUSTER = "posthog_single_shard"
+
+        with (
+            patch("posthog.clickhouse.cluster.get_cluster") as mock_get_cluster,
+            patch("posthog.clickhouse.cluster.settings", mock_settings),
+        ):
+            from posthog.clickhouse.cluster import get_cluster_by_name
+
+            get_cluster_by_name("logs")
+            mock_get_cluster.assert_called_once_with(host="logs-host", cluster="posthog_single_shard")
+
+    def test_cluster_registry_unknown_raises(self) -> None:
+        """Unknown logical cluster names must raise instead of silently
+        falling back — silent fallback masks bugs where callers mis-spell
+        or forget to register a new cluster."""
+        from posthog.clickhouse.cluster import get_cluster_by_name
+
+        with self.assertRaises(ValueError) as cm:
+            get_cluster_by_name("unknown_cluster")
+        self.assertIn("unknown_cluster", str(cm.exception))
+        self.assertIn("Known clusters:", str(cm.exception))
+
+    def test_plan_groups_by_cluster(self) -> None:
+        """Desired states with different clusters should each connect to their own cluster host."""
+        ds_main = _make_desired_state({"t1": _make_desired_table("t1", columns=[ColumnDef(name="id", type="UUID")])})
+        ds_main.cluster = "main"
+
+        ds_logs = DesiredState(
+            ecosystem="logs_eco",
+            cluster="logs",
+            tables={"t2": _make_desired_table("t2", columns=[ColumnDef(name="id", type="UUID")])},
+        )
+
+        # Both clusters exist in the registry
+        from posthog.clickhouse.cluster import is_known_cluster
+
+        self.assertTrue(is_known_cluster("main"))
+        self.assertTrue(is_known_cluster("logs"))
+        # And they produce separate groupings
+        from collections import defaultdict
+
+        by_cluster: dict[str, list] = defaultdict(list)
+        for ds in [ds_main, ds_logs]:
+            by_cluster[ds.cluster].append(ds)
+
+        self.assertEqual(sorted(by_cluster.keys()), ["logs", "main"])
+        self.assertEqual(len(by_cluster["main"]), 1)
+        self.assertEqual(len(by_cluster["logs"]), 1)
+
+    def test_unknown_cluster_in_yaml_errors(self) -> None:
+        """A YAML referencing a truly unknown cluster should produce a clear
+        error. `sessions`, `aux`, `ops`, and `ai_events` are now registered
+        as satellite clusters, so this test uses a synthetic name."""
+        from posthog.clickhouse.cluster import get_all_logical_clusters, is_known_cluster
+
+        # Satellite clusters are now registered — they must resolve.
+        self.assertTrue(is_known_cluster("sessions"))
+        self.assertTrue(is_known_cluster("aux"))
+
+        # A name that is NOT registered must still be flagged.
+        self.assertFalse(is_known_cluster("definitely_not_a_cluster"))
+
+        known = ", ".join(get_all_logical_clusters())
+        self.assertIn("logs", known)
+        self.assertIn("main", known)
+        self.assertIn("migrations", known)
+        self.assertIn("sessions", known)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestStructuralFieldDiffs(unittest.TestCase):
+    """Tests for High #1 fix: state_diff compares structural fields."""
+
+    def test_order_by_change_triggers_recreate(self) -> None:
+        desired = _make_desired_state(
+            {
+                "t": _make_desired_table(
+                    "t",
+                    engine="ReplicatedMergeTree",
+                    order_by=["a", "b"],
+                    columns=[ColumnDef(name="a", type="String"), ColumnDef(name="b", type="String")],
+                ),
+            }
+        )
+        current = {
+            "t": TableSchema(name="t", engine="ReplicatedMergeTree", sorting_key="a"),
+        }
+        diffs = diff_state(desired, current)
+        recreate_diffs = [d for d in diffs if d.action == "recreate"]
+        self.assertEqual(len(recreate_diffs), 1)
+        self.assertIn("ORDER BY", recreate_diffs[0].detail)
+
+    def test_partition_by_change_triggers_recreate(self) -> None:
+        desired = _make_desired_state(
+            {
+                "t": _make_desired_table(
+                    "t",
+                    engine="ReplicatedMergeTree",
+                    partition_by="toYYYYMM(created_at)",
+                    columns=[ColumnDef(name="created_at", type="DateTime")],
+                ),
+            }
+        )
+        current = {
+            "t": TableSchema(name="t", engine="ReplicatedMergeTree", partition_key="toYYYYMMDD(created_at)"),
+        }
+        diffs = diff_state(desired, current)
+        recreate_diffs = [d for d in diffs if d.action == "recreate"]
+        self.assertEqual(len(recreate_diffs), 1)
+        self.assertIn("PARTITION BY", recreate_diffs[0].detail)
+
+    def test_distributed_source_change_triggers_recreate(self) -> None:
+        desired = _make_desired_state(
+            {
+                "dist_t": DesiredTable(
+                    name="dist_t",
+                    engine="Distributed",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    on_nodes=["ALL"],
+                    source="new_sharded_t",
+                    sharding_key="rand()",
+                ),
+            }
+        )
+        current = {
+            "dist_t": TableSchema(
+                name="dist_t",
+                engine="Distributed",
+                engine_full="Distributed('posthog', 'posthog', 'old_sharded_t', rand())",
+            ),
+        }
+        diffs = diff_state(desired, current)
+        recreate_diffs = [d for d in diffs if d.action == "recreate"]
+        self.assertEqual(len(recreate_diffs), 1)
+        self.assertIn("source table changed", recreate_diffs[0].detail)
+
+    def test_kafka_setting_change_triggers_recreate(self) -> None:
+        desired = _make_desired_state(
+            {
+                "kafka_t": _make_desired_table(
+                    "kafka_t",
+                    engine="Kafka",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    settings={"kafka_broker_list": "new-broker:9092", "kafka_topic_list": "events"},
+                ),
+            }
+        )
+        current = {
+            "kafka_t": TableSchema(
+                name="kafka_t",
+                engine="Kafka",
+                engine_full="Kafka('old-broker:9092', 'events', 'group1', 'JSONEachRow')",
+            ),
+        }
+        diffs = diff_state(desired, current)
+        # Kafka column changes trigger drop+create, but structural changes trigger recreate
+        recreate_diffs = [d for d in diffs if d.action == "recreate"]
+        self.assertEqual(len(recreate_diffs), 1)
+        self.assertIn("kafka_broker_list", recreate_diffs[0].detail)
+
+    def test_column_default_change_triggers_modify(self) -> None:
+        desired = _make_desired_state(
+            {
+                "t": _make_desired_table(
+                    "t",
+                    columns=[
+                        ColumnDef(name="val", type="Int64", default_kind="DEFAULT", default_expression="0"),
+                    ],
+                ),
+            }
+        )
+        current = {
+            "t": _make_table_schema(
+                "t",
+                columns=[
+                    ColumnSchema(name="val", type="Int64", default_kind="DEFAULT", default_expression="42"),
+                ],
+            ),
+        }
+        diffs = diff_state(desired, current)
+        modify_diffs = [d for d in diffs if d.action == "alter_modify_column"]
+        self.assertEqual(len(modify_diffs), 1)
+        self.assertIn("default", modify_diffs[0].detail.lower())
+
+    def test_column_default_removal_emits_remove_default(self) -> None:
+        """Dropping `default:` from YAML while the live column still has a
+        default must emit a MODIFY COLUMN ... REMOVE DEFAULT. Previously the
+        comparison short-circuited on an empty desired default and silently
+        ignored removals, so live DEFAULT clauses lingered after YAML changes.
+        """
+        desired = _make_desired_state(
+            {
+                "t": _make_desired_table(
+                    "t",
+                    columns=[
+                        ColumnDef(name="val", type="Int64"),  # no default
+                    ],
+                ),
+            }
+        )
+        current = {
+            "t": _make_table_schema(
+                "t",
+                columns=[
+                    ColumnSchema(name="val", type="Int64", default_kind="DEFAULT", default_expression="42"),
+                ],
+            ),
+        }
+        diffs = diff_state(desired, current)
+        modify_diffs = [d for d in diffs if d.action == "alter_modify_column"]
+        self.assertEqual(len(modify_diffs), 1)
+        self.assertIn("REMOVE DEFAULT", modify_diffs[0].sql)
+        self.assertIn("val", modify_diffs[0].sql)
+
+    def test_no_recreate_when_structural_fields_match(self) -> None:
+        """No structural diff when order_by/partition_by match current."""
+        desired = _make_desired_state(
+            {
+                "t": _make_desired_table(
+                    "t",
+                    engine="ReplicatedMergeTree",
+                    order_by=["a"],
+                    partition_by="toYYYYMM(ts)",
+                    columns=[ColumnDef(name="a", type="String"), ColumnDef(name="ts", type="DateTime")],
+                ),
+            }
+        )
+        current = {
+            "t": TableSchema(
+                name="t",
+                engine="ReplicatedMergeTree",
+                sorting_key="a",
+                partition_key="toYYYYMM(ts)",
+            ),
+        }
+        diffs = diff_state(desired, current)
+        # Only column adds since current has no columns defined
+        recreate_diffs = [d for d in diffs if d.action in ("recreate", "recreate_mv")]
+        self.assertEqual(len(recreate_diffs), 0)
+
+
+class TestReplicatedEngineExplicitZkPath(unittest.TestCase):
+    """Regression tests for the P0 `{uuid}` macro bug found in 2026-04-10 e2e run.
+
+    Before the fix, `_generate_create_sql` emitted zero-arg Replicated* engines
+    like `ReplicatedReplacingMergeTree()`. ClickHouse falls back to a default
+    zk_path containing `{uuid}`, which only resolves inside `ON CLUSTER` queries
+    or Replicated database engines. Since the runner sends CREATE statements
+    directly to each host via `map_hosts_by_roles()`, the macro was unresolvable
+    and apply failed on the very first table with:
+
+        Code: 36. DB::Exception: Macro 'uuid' in engine arguments is only
+        supported when the UUID is explicitly specified, used within an ON
+        CLUSTER query, or when using the Replicated database engine.
+
+    The fix emits explicit (zk_path, replica_name) args for every Replicated*
+    engine, matching the convention used by `tracking.py` and legacy PostHog
+    migrations.
+    """
+
+    def _make_table(self, name: str, engine: str) -> DesiredTable:
+        return DesiredTable(
+            name=name,
+            engine=engine,
+            columns=[ColumnDef(name="id", type="UUID"), ColumnDef(name="team_id", type="Int64")],
+            on_nodes=["DATA"],
+            order_by=["team_id", "id"],
+        )
+
+    def test_replicated_merge_tree_has_explicit_zk_path(self) -> None:
+        from posthog.clickhouse.migration_tools.state_diff import _generate_create_sql
+
+        table = self._make_table("events_raw", "ReplicatedMergeTree")
+        sql = _generate_create_sql(table, database="posthog", cluster="main")
+        self.assertIn("ReplicatedMergeTree(", sql)
+        self.assertIn("'/clickhouse/tables/{shard}/posthog/events_raw'", sql)
+        self.assertIn("'{replica}'", sql)
+        self.assertNotIn("ReplicatedMergeTree()", sql)
+
+    def test_replicated_replacing_merge_tree_has_explicit_zk_path(self) -> None:
+        """The actual engine/table that broke on 2026-04-10 — adhoc_events_deletion."""
+        from posthog.clickhouse.migration_tools.state_diff import _generate_create_sql
+
+        table = self._make_table("adhoc_events_deletion", "ReplicatedReplacingMergeTree")
+        sql = _generate_create_sql(table, database="posthog_test", cluster="main")
+        self.assertIn("ReplicatedReplacingMergeTree(", sql)
+        self.assertIn("'/clickhouse/tables/{shard}/posthog_test/adhoc_events_deletion'", sql)
+        self.assertIn("'{replica}'", sql)
+        self.assertNotIn("ReplicatedReplacingMergeTree()", sql)
+
+    def test_replicated_variants_all_emit_explicit_zk_path(self) -> None:
+        from posthog.clickhouse.migration_tools.state_diff import _generate_create_sql
+
+        for engine in (
+            "ReplicatedAggregatingMergeTree",
+            "ReplicatedSummingMergeTree",
+            "ReplicatedCollapsingMergeTree",
+        ):
+            sql = _generate_create_sql(
+                self._make_table("t", engine),
+                database="posthog",
+                cluster="main",
+            )
+            self.assertIn(
+                "'/clickhouse/tables/{shard}/posthog/t'",
+                sql,
+                f"{engine} missing explicit zk_path",
+            )
+            self.assertIn("'{replica}'", sql, f"{engine} missing replica macro")
+            self.assertNotIn(f"{engine}()", sql, f"{engine} still emits zero-arg form")
+
+    def test_non_replicated_merge_tree_has_no_zk_path(self) -> None:
+        """Plain (unreplicated) MergeTree must stay zero-arg — no zk_path."""
+        from posthog.clickhouse.migration_tools.state_diff import _generate_create_sql
+
+        table = self._make_table("local_t", "MergeTree")
+        sql = _generate_create_sql(table, database="posthog", cluster="main")
+        self.assertIn("ENGINE = MergeTree()", sql)
+        self.assertNotIn("/clickhouse/tables/", sql)
+        self.assertNotIn("{replica}", sql)
+
+
+class TestDistributedClusterResolution(unittest.TestCase):
+    """Regression tests for the P1 Distributed cluster name mismatch found in
+    Round 4 e2e (2026-04-10). Before the fix, `_generate_create_sql` embedded
+    the YAML logical cluster name (e.g. 'main') directly into the Distributed
+    engine SQL. On dev stacks where the physical CH cluster is named
+    'posthog_migrations' (not 'main'), apply failed with:
+        Code: 701. DB::Exception: Requested cluster 'main' not found.
+    The fix resolves logical -> physical cluster name via _CLUSTER_REGISTRY.
+    """
+
+    def test_distributed_uses_physical_cluster_name(self) -> None:
+        from posthog.clickhouse.migration_tools.state_diff import _generate_create_sql
+
+        table = DesiredTable(
+            name="events_dist",
+            engine="Distributed",
+            columns=[ColumnDef(name="id", type="UUID")],
+            on_nodes=["ALL"],
+            source="sharded_events",
+            sharding_key="cityHash64(distinct_id)",
+        )
+        sql = _generate_create_sql(table, database="posthog", cluster="main")
+        # 'main' should resolve to settings.CLICKHOUSE_CLUSTER (test stub: 'posthog')
+        self.assertIn("Distributed('posthog',", sql)
+        self.assertNotIn("Distributed('main',", sql)
+
+    def test_distributed_unknown_cluster_passes_through(self) -> None:
+        from posthog.clickhouse.migration_tools.state_diff import _generate_create_sql
+
+        table = DesiredTable(
+            name="events_dist",
+            engine="Distributed",
+            columns=[ColumnDef(name="id", type="UUID")],
+            on_nodes=["ALL"],
+            source="sharded_events",
+            sharding_key="rand()",
+        )
+        sql = _generate_create_sql(table, database="posthog", cluster="unknown_thing")
+        self.assertIn("Distributed('unknown_thing',", sql)
+
+    def test_distributed_satellite_cluster_resolves(self) -> None:
+        from unittest.mock import patch
+
+        from django.conf import settings as _settings
+
+        from posthog.clickhouse.migration_tools.state_diff import _generate_create_sql
+
+        table = DesiredTable(
+            name="sessions_dist",
+            engine="Distributed",
+            columns=[ColumnDef(name="id", type="UUID")],
+            on_nodes=["ALL"],
+            source="sharded_sessions",
+            sharding_key="rand()",
+        )
+        # Patch setting so the test is deterministic regardless of whether the
+        # Django-free _stubs module installed its SimpleNamespace (stubs skip
+        # when Django is already configured).
+        with patch.object(_settings, "CLICKHOUSE_SESSIONS_CLUSTER", "posthog_sessions"):
+            sql = _generate_create_sql(table, database="posthog", cluster="sessions")
+        self.assertIn("Distributed('posthog_sessions',", sql)
+
+
+class TestKafkaRecreateWarning(unittest.TestCase):
+    """Tests for High #2 fix: Kafka DROP+CREATE operator warning."""
+
+    def test_plan_emits_kafka_warning_on_recreate(self) -> None:
+        diffs = [
+            StateDiff(
+                action="recreate",
+                table="kafka_events_json",
+                detail="Recreate kafka_events_json (Kafka setting changed)",
+                sql="DROP TABLE IF EXISTS posthog.kafka_events_json;\nCREATE TABLE ...",
+                node_roles=["ALL"],
+            ),
+        ]
+        plan = generate_plan_text(diffs)
+        self.assertIn("KAFKA TABLE RECREATE WARNING", plan)
+        self.assertIn("ingestion will pause", plan)
+        self.assertIn("kafka_events_json", plan)
+
+    def test_plan_no_kafka_warning_for_non_kafka_table(self) -> None:
+        diffs = [
+            StateDiff(
+                action="recreate",
+                table="sharded_events",
+                detail="Recreate sharded_events",
+                sql="DROP TABLE IF EXISTS posthog.sharded_events;\nCREATE TABLE ...",
+                node_roles=["DATA"],
+            ),
+        ]
+        plan = generate_plan_text(diffs)
+        self.assertNotIn("KAFKA TABLE RECREATE WARNING", plan)
+
+    def test_plan_kafka_warning_on_drop(self) -> None:
+        diffs = [
+            StateDiff(
+                action="drop",
+                table="kafka_session_recording",
+                detail="Drop Kafka table for recreation",
+                sql="DROP TABLE IF EXISTS posthog.kafka_session_recording",
+                node_roles=["ALL"],
+            ),
+        ]
+        plan = generate_plan_text(diffs)
+        self.assertIn("KAFKA TABLE RECREATE WARNING", plan)
+
+
+class TestMvSelectNormalization(unittest.TestCase):
+    """Tests for High #3 fix: MV SELECT normalization."""
+
+    def test_mv_select_whitespace_only_no_diff(self) -> None:
+        """Whitespace-only differences should not trigger a recreate."""
+        desired = _make_desired_state(
+            {
+                "my_mv": DesiredTable(
+                    name="my_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["ALL"],
+                    target="writable_t",
+                    select="SELECT * FROM posthog.kafka_t",
+                ),
+            }
+        )
+        current = {
+            "my_mv": TableSchema(
+                name="my_mv",
+                engine="MaterializedView",
+                as_select="SELECT *\n  FROM   posthog.kafka_t\n",
+            ),
+        }
+        diffs = diff_state(desired, current)
+        drop_diffs = [d for d in diffs if d.action == "drop"]
+        create_diffs = [d for d in diffs if d.action == "create"]
+        self.assertEqual(len(drop_diffs), 0, "No DROP for whitespace-only MV SELECT change")
+        self.assertEqual(len(create_diffs), 0, "No CREATE for whitespace-only MV SELECT change")
+
+    def test_mv_select_keyword_case_no_diff(self) -> None:
+        """Keyword case differences should not trigger a recreate."""
+        desired = _make_desired_state(
+            {
+                "my_mv": DesiredTable(
+                    name="my_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["ALL"],
+                    target="writable_t",
+                    select="select a, b from t where c = 1",
+                ),
+            }
+        )
+        current = {
+            "my_mv": TableSchema(
+                name="my_mv",
+                engine="MaterializedView",
+                as_select="SELECT a, b FROM t WHERE c = 1",
+            ),
+        }
+        diffs = diff_state(desired, current)
+        self.assertEqual(len(diffs), 0, "No diffs for keyword case changes in MV SELECT")
+
+    def test_mv_select_real_change_still_detected(self) -> None:
+        """Actual semantic changes should still trigger a recreate."""
+        desired = _make_desired_state(
+            {
+                "my_mv": DesiredTable(
+                    name="my_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["ALL"],
+                    target="writable_t",
+                    select="SELECT a, b, c FROM posthog.kafka_t",
+                ),
+            }
+        )
+        current = {
+            "my_mv": TableSchema(
+                name="my_mv",
+                engine="MaterializedView",
+                as_select="SELECT a, b FROM posthog.kafka_t",
+            ),
+        }
+        diffs = diff_state(desired, current)
+        drop_diffs = [d for d in diffs if d.action == "drop"]
+        create_diffs = [d for d in diffs if d.action == "create"]
+        self.assertEqual(len(drop_diffs), 1, "Should DROP old MV")
+        self.assertEqual(len(create_diffs), 1, "Should CREATE new MV")
+
+    def test_normalize_mv_select_function(self) -> None:
+        """Direct test of the normalization function."""
+        from posthog.clickhouse.migration_tools.state_diff import _normalize_mv_select
+
+        a = "SELECT a, b\nFROM t\nWHERE c = 1"
+        b = "SELECT a, b FROM t WHERE c = 1"
+        self.assertEqual(_normalize_mv_select(a), _normalize_mv_select(b))
+
+        c = "select a from t"
+        d = "SELECT a FROM t"
+        self.assertEqual(_normalize_mv_select(c), _normalize_mv_select(d))
+
+        e = "SELECT a FROM t -- comment\nWHERE 1=1"
+        f = "SELECT a FROM t WHERE 1=1"
+        self.assertEqual(_normalize_mv_select(e), _normalize_mv_select(f))
+
+
+class TestCheckLegacyMigrations(unittest.TestCase):
+    def test_check_queries_correct_legacy_table(self) -> None:
+        import inspect
+
+        from posthog.clickhouse.migration_tools import runner
+
+        source = inspect.getsource(runner)
+        assert "infi_clickhouse_orm_migrations" in source
+        assert "name = 'clickhouseorm_migrations'" not in source
+
+
+class TestTemplates(unittest.TestCase):
+    def test_ingestion_pipeline_uses_database_placeholder(self) -> None:
+        from posthog.clickhouse.migration_tools.templates import generate_schema_yaml
+
+        result = generate_schema_yaml("ingestion_pipeline", "my_events", "main")
+        assert result is not None
+        mv_table = result["tables"]["my_events_mv"]
+        assert "posthog.kafka_" not in mv_table["select"]
+        assert "{{ database }}" in mv_table["select"]
+
+    def test_materialized_view_uses_database_placeholder(self) -> None:
+        from posthog.clickhouse.migration_tools.templates import generate_schema_yaml
+
+        result = generate_schema_yaml("materialized_view", "my_events", "main")
+        assert result is not None
+        mv_table = result["tables"]["my_events_mv"]
+        assert "posthog.kafka_" not in mv_table["select"]
+        assert "{{ database }}" in mv_table["select"]
+
+
+class TestDetectDrift(unittest.TestCase):
+    def test_drift_groups_by_role(self) -> None:
+        """detect_drift should compare hosts within the same role, not across roles."""
+        import inspect
+
+        from posthog.clickhouse.migration_tools import schema_introspect
+
+        source = inspect.getsource(schema_introspect.detect_drift)
+        assert "host_cluster_role" in source, "detect_drift must group hosts by role"
+
+
+class TestCircularInheritance(unittest.TestCase):
+    """F13: _parse_columns must detect circular inheritance and raise ValueError."""
+
+    def test_circular_inheritance_raises_value_error(self) -> None:
+        """A -> B -> A should raise ValueError, not RecursionError."""
+        p = _write_yaml("""\
+            ecosystem: test
+            cluster: main
+            tables:
+              table_a:
+                engine: ReplicatedMergeTree
+                on_nodes: DATA
+                order_by: [id]
+                columns: inherit table_b
+              table_b:
+                engine: ReplicatedMergeTree
+                on_nodes: DATA
+                order_by: [id]
+                columns: inherit table_a
+        """)
+        with self.assertRaises(ValueError) as ctx:
+            parse_desired_state(p)
+        self.assertIn("Circular", str(ctx.exception))
+
+    def test_non_circular_chain_works(self) -> None:
+        """A -> B (no cycle) should resolve columns normally."""
+        p = _write_yaml("""\
+            ecosystem: test
+            cluster: main
+            tables:
+              base:
+                engine: ReplicatedMergeTree
+                on_nodes: DATA
+                order_by: [id]
+                columns:
+                  - name: id
+                    type: UUID
+              derived:
+                engine: Distributed
+                source: base
+                on_nodes: ALL
+                columns: inherit base
+        """)
+        state = parse_desired_state(p)
+        self.assertEqual(len(state.tables["derived"].columns), 1)
+        self.assertEqual(state.tables["derived"].columns[0].name, "id")
+
+
+class TestKafkaFallbackWarning(unittest.TestCase):
+    """F5: _resolve_setting must log a warning when Django setting is unset."""
+
+    def setUp(self) -> None:
+        # posthog/settings/logs.py sets ``disable_existing_loggers: True`` on
+        # Django's LOGGING config. When Django initializes after state_diff is
+        # imported (order depends on pytest discovery), the "migrations"
+        # logger gets disabled and assertLogs can never capture records.
+        # Re-enable + ensure WARNING level for this test.
+        import logging
+
+        migrations_logger = logging.getLogger("migrations")
+        migrations_logger.disabled = False
+        migrations_logger.setLevel(logging.WARNING)
+
+    def test_warning_when_kafka_setting_unset(self) -> None:
+        from unittest.mock import patch
+
+        from posthog.clickhouse.migration_tools.state_diff import _resolve_setting
+
+        with patch("posthog.clickhouse.migration_tools.state_diff.django_settings") as mock_settings:
+            # Simulate missing KAFKA_HOSTS_FOR_CLICKHOUSE
+            del mock_settings.KAFKA_HOSTS_FOR_CLICKHOUSE
+            mock_settings.configure_mock(**{})
+            with self.assertLogs("migrations", level="WARNING") as cm:
+                result = _resolve_setting("kafka_broker_list")
+        self.assertEqual(result, "kafka:9092")
+        self.assertTrue(any("unset" in msg for msg in cm.output))
+
+    def test_no_warning_when_setting_configured(self) -> None:
+        from unittest.mock import patch
+
+        from posthog.clickhouse.migration_tools.state_diff import _resolve_setting
+
+        with patch("posthog.clickhouse.migration_tools.state_diff.django_settings") as mock_settings:
+            mock_settings.KAFKA_HOSTS_FOR_CLICKHOUSE = ["broker1:9092", "broker2:9092"]
+            result = _resolve_setting("kafka_broker_list")
+        self.assertEqual(result, "broker1:9092,broker2:9092")
+
+
+class TestMergetreeOrderByLint(unittest.TestCase):
+    """F7: MergeTree tables without ORDER BY must produce a lint error."""
+
+    def test_mergetree_without_order_by_errors(self) -> None:
+        from posthog.clickhouse.migration_tools.validator import validate_desired_states
+
+        state = DesiredState(
+            ecosystem="test",
+            cluster="main",
+            tables={
+                "bad_table": DesiredTable(
+                    name="bad_table",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    on_nodes=["DATA"],
+                    order_by=None,
+                ),
+            },
+        )
+        errors = validate_desired_states([state])
+        order_by_errors = [e for e in errors if "ORDER BY" in e]
+        self.assertTrue(len(order_by_errors) > 0, f"Expected ORDER BY error, got: {errors}")
+
+    def test_mergetree_with_order_by_passes(self) -> None:
+        from posthog.clickhouse.migration_tools.validator import validate_desired_states
+
+        state = DesiredState(
+            ecosystem="test",
+            cluster="main",
+            tables={
+                "good_table": DesiredTable(
+                    name="good_table",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    on_nodes=["DATA"],
+                    order_by=["id"],
+                ),
+            },
+        )
+        errors = validate_desired_states([state])
+        order_by_errors = [e for e in errors if "ORDER BY" in e]
+        self.assertEqual(len(order_by_errors), 0, f"Unexpected ORDER BY error: {errors}")
+
+
+class TestEngineRequiredFieldsLint(unittest.TestCase):
+    """Distributed tables need a source; materialized views need a target."""
+
+    def _validate(self, tables: dict[str, DesiredTable]) -> list[str]:
+        from posthog.clickhouse.migration_tools.validator import validate_desired_states
+
+        state = DesiredState(ecosystem="test", cluster="main", tables=tables)
+        return validate_desired_states([state])
+
+    def test_distributed_without_source_rejected(self) -> None:
+        errors = self._validate(
+            {
+                "dist_no_source": DesiredTable(
+                    name="dist_no_source",
+                    engine="Distributed",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    on_nodes=["COORDINATOR"],
+                ),
+            }
+        )
+        self.assertTrue(any("source" in e.lower() for e in errors), f"Expected source error, got: {errors}")
+
+    def test_mv_without_target_rejected(self) -> None:
+        errors = self._validate(
+            {
+                "mv_no_target": DesiredTable(
+                    name="mv_no_target",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["DATA"],
+                    select="SELECT 1",
+                ),
+            }
+        )
+        self.assertTrue(any("target" in e.lower() for e in errors), f"Expected target error, got: {errors}")
+
+
+class TestSatelliteRoleLint(unittest.TestCase):
+    """P1-D: Satellite roles (LOGS, AUX, SESSIONS, OPS, AI_EVENTS, SHUFFLEHOG,
+    ENDPOINTS) must pass cross-cluster targeting lint for Distributed, Kafka,
+    and MV engines. Earlier `_EXPECTED_ROLES` only listed COORDINATOR/ALL +
+    ingestion roles, so valid YAMLs on satellite ecosystems failed lint.
+    """
+
+    def _state_with_engine(self, engine: str, on_nodes: list[str]) -> DesiredState:
+        return DesiredState(
+            ecosystem="test",
+            cluster="logs",
+            tables={
+                "some_table": DesiredTable(
+                    name="some_table",
+                    engine=engine,
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    on_nodes=on_nodes,
+                    order_by=["id"],
+                    source="sharded_some",  # used by Distributed
+                    target="sharded_some",  # used by MV
+                    settings={  # used by Kafka
+                        "kafka_broker_list": "localhost:9092",
+                        "kafka_topic_list": "t",
+                    },
+                ),
+            },
+        )
+
+    def test_distributed_on_logs_passes_lint(self) -> None:
+        from posthog.clickhouse.migration_tools.validator import _check_cross_cluster_targeting
+
+        errors = _check_cross_cluster_targeting(self._state_with_engine("Distributed", ["LOGS"]))
+        self.assertEqual(errors, [], f"LOGS on Distributed should be valid: {errors}")
+
+    def test_distributed_accepts_ingestion_and_data_roles(self) -> None:
+        """P1-5 (Codex round 2): Distributed tables can live on DATA,
+        INGESTION_SMALL, and INGESTION_MEDIUM — existing YAMLs
+        (document_embeddings, heatmaps, session_replay) target those roles
+        for writable passthrough tables. The earlier lint rejected them."""
+        from posthog.clickhouse.migration_tools.validator import _check_cross_cluster_targeting
+
+        for role in ("DATA", "INGESTION_SMALL", "INGESTION_MEDIUM", "INGESTION_EVENTS"):
+            errors = _check_cross_cluster_targeting(self._state_with_engine("Distributed", [role]))
+            self.assertEqual(errors, [], f"{role} on Distributed should be valid: {errors}")
+
+    def test_kafka_on_aux_passes_lint(self) -> None:
+        from posthog.clickhouse.migration_tools.validator import _check_cross_cluster_targeting
+
+        errors = _check_cross_cluster_targeting(self._state_with_engine("Kafka", ["AUX"]))
+        self.assertEqual(errors, [], f"AUX on Kafka should be valid: {errors}")
+
+    def test_mv_on_sessions_passes_lint(self) -> None:
+        from posthog.clickhouse.migration_tools.validator import _check_cross_cluster_targeting
+
+        errors = _check_cross_cluster_targeting(self._state_with_engine("MaterializedView", ["SESSIONS"]))
+        self.assertEqual(errors, [], f"SESSIONS on MaterializedView should be valid: {errors}")
+
+    def test_invalid_role_still_rejected(self) -> None:
+        """Ensure we didn't broaden the set so far that garbage roles pass."""
+        from posthog.clickhouse.migration_tools.validator import _check_cross_cluster_targeting
+
+        errors = _check_cross_cluster_targeting(self._state_with_engine("Distributed", ["GARBAGE"]))
+        self.assertTrue(len(errors) > 0, "Unknown role should still fail lint")
+
+    def test_expected_roles_covers_node_role_enum(self) -> None:
+        """Every role advertised by NodeRole should be accepted by at least
+        one engine category — otherwise a new role would silently break lint
+        on ecosystems that target it."""
+        from posthog.clickhouse.migration_tools.validator import _EXPECTED_ROLES
+
+        # Names we expect to see in _EXPECTED_ROLES (some union).
+        # Source: NodeRole enum in posthog/clickhouse/client/connection.py.
+        # DATA is excluded — Distributed/Kafka/MV don't run on DATA nodes.
+        expected_named = {
+            "ALL",
+            "COORDINATOR",
+            "INGESTION_EVENTS",
+            "INGESTION_SMALL",
+            "INGESTION_MEDIUM",
+            "SHUFFLEHOG",
+            "ENDPOINTS",
+            "LOGS",
+            "AI_EVENTS",
+            "AUX",
+            "OPS",
+            "SESSIONS",
+        }
+        union_of_allowed: set[str] = set()
+        for allowed in _EXPECTED_ROLES.values():
+            union_of_allowed |= allowed
+        missing = expected_named - union_of_allowed
+        self.assertEqual(missing, set(), f"_EXPECTED_ROLES union missing roles: {sorted(missing)}")
+
+
+class TestDriftComparesKeyFields(unittest.TestCase):
+    """P2: compare_schemas must detect drift on partition_key, primary_key,
+    engine_full — not just engine + sorting_key + columns.
+    """
+
+    def _base(self, **overrides):
+        from posthog.clickhouse.migration_tools.schema_introspect import TableSchema
+
+        kwargs: dict[str, object] = {
+            "name": "sharded_events",
+            "engine": "ReplicatedMergeTree",
+            "engine_full": "ReplicatedMergeTree('/clickhouse/tables/{shard}/events', '{replica}')",
+            "sorting_key": "team_id, id",
+            "partition_key": "toStartOfMonth(timestamp)",
+            "primary_key": "team_id, id",
+        }
+        kwargs.update(overrides)
+        return TableSchema(**kwargs)  # type: ignore[arg-type]
+
+    def test_partition_key_drift_detected(self) -> None:
+        from posthog.clickhouse.migration_tools.schema_introspect import compare_schemas
+
+        expected = {"t": self._base(partition_key="toStartOfMonth(timestamp)")}
+        actual = {"t": self._base(partition_key="toStartOfWeek(timestamp)")}
+        diffs = compare_schemas(expected, actual)
+        partition_diffs = [d for d in diffs if d.diff_type == "partition_key_mismatch"]
+        self.assertEqual(len(partition_diffs), 1, f"Expected partition drift; got {diffs}")
+
+    def test_primary_key_drift_detected(self) -> None:
+        from posthog.clickhouse.migration_tools.schema_introspect import compare_schemas
+
+        expected = {"t": self._base(primary_key="team_id, id")}
+        actual = {"t": self._base(primary_key="team_id")}
+        diffs = compare_schemas(expected, actual)
+        pk_diffs = [d for d in diffs if d.diff_type == "primary_key_mismatch"]
+        self.assertEqual(len(pk_diffs), 1, f"Expected primary-key drift; got {diffs}")
+
+    def test_engine_full_drift_detected(self) -> None:
+        from posthog.clickhouse.migration_tools.schema_introspect import compare_schemas
+
+        expected = {"t": self._base(engine_full="ReplicatedMergeTree('/tables/{shard}/events', '{replica}')")}
+        actual = {"t": self._base(engine_full="ReplicatedMergeTree('/tables/{shard}/OTHER', '{replica}')")}
+        diffs = compare_schemas(expected, actual)
+        engine_diffs = [d for d in diffs if d.diff_type == "engine_full_mismatch"]
+        self.assertEqual(len(engine_diffs), 1, f"Expected engine_full drift; got {diffs}")
+
+    def test_no_drift_when_all_fields_match(self) -> None:
+        from posthog.clickhouse.migration_tools.schema_introspect import compare_schemas
+
+        expected = {"t": self._base()}
+        actual = {"t": self._base()}
+        diffs = compare_schemas(expected, actual)
+        self.assertEqual(diffs, [], f"Unexpected drift on identical schemas: {diffs}")
+
+    def test_engine_full_skipped_when_actual_empty(self) -> None:
+        """Some system tables leave engine_full empty — don't flag as drift."""
+        from posthog.clickhouse.migration_tools.schema_introspect import compare_schemas
+
+        expected = {"t": self._base(engine_full="ReplicatedMergeTree('/x', '{replica}')")}
+        actual = {"t": self._base(engine_full="")}
+        diffs = compare_schemas(expected, actual)
+        engine_diffs = [d for d in diffs if d.diff_type == "engine_full_mismatch"]
+        self.assertEqual(len(engine_diffs), 0, "engine_full drift should skip when either side is empty")
+
+
+class TestComputeDiffsPerCluster(unittest.TestCase):
+    """P1-A: _compute_diffs must introspect each declared cluster separately.
+    Earlier it used the migrations-cluster union for every target, which
+    produced spurious diffs on satellite ecosystems (their tables don't
+    exist on the main migrations cluster).
+    """
+
+    def test_dump_schema_called_per_cluster(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from posthog.management.commands.ch_migrate import Command
+
+        logs_state = DesiredState(
+            ecosystem="logs",
+            cluster="logs",
+            tables={
+                "logs_table": _make_desired_table(
+                    "logs_table",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+        main_state = DesiredState(
+            ecosystem="events",
+            cluster="main",
+            tables={
+                "sharded_events": _make_desired_table(
+                    "sharded_events",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+
+        # Fake cluster objects — distinguishable by id()
+        main_cluster = MagicMock(name="main-cluster")
+        logs_cluster = MagicMock(name="logs-cluster")
+
+        def fake_get_cluster_by_name(name: str, **_kw):
+            if name == "logs":
+                return logs_cluster
+            return main_cluster
+
+        dump_calls: list[object] = []
+
+        def fake_dump(cluster_obj, _database):
+            dump_calls.append(cluster_obj)
+            return {}  # empty live schema → every desired table becomes a create
+
+        with (
+            patch(
+                "posthog.clickhouse.migration_tools.desired_state.parse_desired_state_dir",
+                return_value=[main_state, logs_state],
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.get_cluster_by_name",
+                side_effect=fake_get_cluster_by_name,
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.is_known_cluster",
+                return_value=True,
+            ),
+            patch(
+                "posthog.clickhouse.migration_tools.schema_introspect.dump_schema_all_hosts",
+                side_effect=fake_dump,
+            ),
+        ):
+            cmd = Command()
+            diffs, err = cmd._compute_diffs("posthog", "/tmp/fake_schema_dir")
+
+        self.assertIsNone(err, f"Expected no error; got: {err}")
+
+        # Both clusters should have been introspected — not just migrations.
+        self.assertIn(main_cluster, dump_calls, "main cluster not introspected")
+        self.assertIn(logs_cluster, dump_calls, "logs cluster not introspected")
+
+        # No migrations-cluster fallback since both per-cluster scans succeeded.
+        migration_scans = [c for c in dump_calls if c is not main_cluster and c is not logs_cluster]
+        self.assertEqual(migration_scans, [], f"Unexpected fallback scans: {migration_scans}")
+
+    def test_unreachable_cluster_falls_back_to_migrations(self) -> None:
+        """When a satellite cluster is unreachable (dev stack), fall back
+        to the migrations cluster schema instead of crashing."""
+        from unittest.mock import MagicMock, patch
+
+        from posthog.management.commands.ch_migrate import Command
+
+        logs_state = DesiredState(
+            ecosystem="logs",
+            cluster="logs",
+            tables={
+                "logs_table": _make_desired_table(
+                    "logs_table",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+
+        migrations_cluster = MagicMock(name="migrations-cluster")
+
+        def fake_get_cluster_by_name(name: str, **_kw):
+            raise Exception("Code: 701 CLUSTER_DOESNT_EXIST: Cluster 'logs' not found")
+
+        # Track call args separately since migrations cluster and the failing
+        # logs cluster both route through dump_schema_all_hosts.
+        calls: list[object] = []
+
+        def fake_dump(cluster_obj, _database):
+            calls.append(cluster_obj)
+            return {}
+
+        with (
+            patch(
+                "posthog.clickhouse.migration_tools.desired_state.parse_desired_state_dir",
+                return_value=[logs_state],
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.get_cluster_by_name",
+                side_effect=fake_get_cluster_by_name,
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.is_known_cluster",
+                return_value=True,
+            ),
+            patch(
+                "posthog.clickhouse.client.migration_tools.get_migrations_cluster",
+                return_value=migrations_cluster,
+            ),
+            patch(
+                "posthog.clickhouse.migration_tools.schema_introspect.dump_schema_all_hosts",
+                side_effect=fake_dump,
+            ),
+        ):
+            cmd = Command()
+            diffs, err = cmd._compute_diffs("posthog", "/tmp/fake_schema_dir")
+
+        self.assertIsNone(err)
+        # Fallback to migrations cluster should have been taken
+        self.assertIn(migrations_cluster, calls, f"Migrations-cluster fallback not used: {calls}")
+
+
+class TestComputeDiffsEmitsDropsForRemovedTables(unittest.TestCase):
+    """P1-2 (Codex round 2): _compute_diffs earlier filtered `current` to the
+    intersection with `desired.tables`, which hid every drop. Removing a table
+    from YAML silently left it live. The fix passes the full `current` dict
+    into diff_state while still avoiding spurious drops from other ecosystems
+    sharing the same physical cluster.
+    """
+
+    def test_drop_emitted_when_table_missing_from_yaml(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from posthog.management.commands.ch_migrate import Command
+
+        # Only ecosystem `events` — no one claims `legacy_orphan`.
+        events_state = DesiredState(
+            ecosystem="events",
+            cluster="main",
+            tables={
+                "sharded_events": _make_desired_table(
+                    "sharded_events",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+
+        main_cluster = MagicMock(name="main-cluster")
+
+        def fake_dump(_cluster_obj, _database):
+            # dump_schema_all_hosts returns {HostInfo: {table_name: TableSchema}}.
+            # Use a simple string key — _union_from_cluster only iterates values.
+            return {
+                "host1": {
+                    "sharded_events": _make_table_schema(
+                        "sharded_events",
+                        engine="ReplicatedMergeTree",
+                        columns=[ColumnSchema(name="id", type="UUID")],
+                    ),
+                    # Live but not in YAML — must emit drop.
+                    "legacy_orphan": _make_table_schema(
+                        "legacy_orphan",
+                        engine="MergeTree",
+                        columns=[ColumnSchema(name="id", type="UUID")],
+                    ),
+                }
+            }
+
+        with (
+            patch(
+                "posthog.clickhouse.migration_tools.desired_state.parse_desired_state_dir",
+                return_value=[events_state],
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.get_cluster_by_name",
+                return_value=main_cluster,
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.is_known_cluster",
+                return_value=True,
+            ),
+            patch(
+                "posthog.clickhouse.migration_tools.schema_introspect.dump_schema_all_hosts",
+                side_effect=fake_dump,
+            ),
+        ):
+            cmd = Command()
+            diffs, err = cmd._compute_diffs("posthog", "/tmp/fake_schema_dir")
+
+        self.assertIsNone(err)
+        drops = [d for d in diffs if d.action == "drop"]
+        self.assertEqual([d.table for d in drops], ["legacy_orphan"])
+
+    def test_no_drops_for_tables_owned_by_sibling_ecosystems(self) -> None:
+        """heatmaps and events both live on cluster `main`. An events-only
+        diff should not drop the heatmaps table (which is present in `current`
+        but only claimed by the heatmaps ecosystem)."""
+        from unittest.mock import MagicMock, patch
+
+        from posthog.management.commands.ch_migrate import Command
+
+        events_state = DesiredState(
+            ecosystem="events",
+            cluster="main",
+            tables={
+                "sharded_events": _make_desired_table(
+                    "sharded_events",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+        heatmaps_state = DesiredState(
+            ecosystem="heatmaps",
+            cluster="main",
+            tables={
+                "sharded_heatmaps": _make_desired_table(
+                    "sharded_heatmaps",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+
+        main_cluster = MagicMock(name="main-cluster")
+
+        def fake_dump(_cluster_obj, _database):
+            return {
+                "host1": {
+                    "sharded_events": _make_table_schema(
+                        "sharded_events",
+                        engine="ReplicatedMergeTree",
+                        columns=[ColumnSchema(name="id", type="UUID")],
+                    ),
+                    "sharded_heatmaps": _make_table_schema(
+                        "sharded_heatmaps",
+                        engine="ReplicatedMergeTree",
+                        columns=[ColumnSchema(name="id", type="UUID")],
+                    ),
+                }
+            }
+
+        with (
+            patch(
+                "posthog.clickhouse.migration_tools.desired_state.parse_desired_state_dir",
+                return_value=[events_state, heatmaps_state],
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.get_cluster_by_name",
+                return_value=main_cluster,
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.is_known_cluster",
+                return_value=True,
+            ),
+            patch(
+                "posthog.clickhouse.migration_tools.schema_introspect.dump_schema_all_hosts",
+                side_effect=fake_dump,
+            ),
+        ):
+            cmd = Command()
+            diffs, err = cmd._compute_diffs("posthog", "/tmp/fake_schema_dir")
+
+        self.assertIsNone(err)
+        drops = [d for d in diffs if d.action == "drop"]
+        self.assertEqual(drops, [], f"Unexpected drops: {[d.table for d in drops]}")
+
+
+class TestComputeDiffsTagsClusterOnDiffs(unittest.TestCase):
+    """P1-3 (Codex round 2): each StateDiff must carry the cluster it targets
+    so handle_apply can route steps to the correct physical cluster instead of
+    funneling everything through the main migrations cluster."""
+
+    def test_diffs_tagged_with_source_cluster(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from posthog.management.commands.ch_migrate import Command
+
+        logs_state = DesiredState(
+            ecosystem="logs",
+            cluster="logs",
+            tables={
+                "logs_table": _make_desired_table(
+                    "logs_table",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+        main_state = DesiredState(
+            ecosystem="events",
+            cluster="main",
+            tables={
+                "sharded_events": _make_desired_table(
+                    "sharded_events",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+
+        def fake_get_cluster_by_name(name: str, **_kw):
+            return MagicMock(name=f"{name}-cluster")
+
+        def fake_dump(_cluster_obj, _database):
+            return {}  # empty live state → every table becomes a create
+
+        with (
+            patch(
+                "posthog.clickhouse.migration_tools.desired_state.parse_desired_state_dir",
+                return_value=[logs_state, main_state],
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.get_cluster_by_name",
+                side_effect=fake_get_cluster_by_name,
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.is_known_cluster",
+                return_value=True,
+            ),
+            patch(
+                "posthog.clickhouse.migration_tools.schema_introspect.dump_schema_all_hosts",
+                side_effect=fake_dump,
+            ),
+        ):
+            cmd = Command()
+            diffs, err = cmd._compute_diffs("posthog", "/tmp/fake_schema_dir")
+
+        self.assertIsNone(err)
+        by_cluster = {d.table: d.cluster for d in diffs}
+        self.assertEqual(by_cluster.get("logs_table"), "logs")
+        self.assertEqual(by_cluster.get("sharded_events"), "main")
+
+
+class TestManifestStepCarriesCluster(unittest.TestCase):
+    """P1-3 (Codex round 2): cluster tag propagates from StateDiff to
+    ManifestStep so the apply loop can resolve the per-step cluster."""
+
+    def test_generate_manifest_steps_copies_cluster(self) -> None:
+        from posthog.clickhouse.migration_tools.plan_generator import generate_manifest_steps
+
+        diff = StateDiff(
+            action="create",
+            table="foo",
+            detail="create foo",
+            sql="CREATE TABLE foo (id UInt64) ENGINE = MergeTree ORDER BY id",
+            node_roles=["ALL"],
+            cluster="logs",
+        )
+        steps = generate_manifest_steps([diff])
+        self.assertEqual(len(steps), 1)
+        step, _sql = steps[0]
+        self.assertEqual(step.cluster, "logs")
+
+
+class TestDiffStatePlaceholderMvNotDropped(unittest.TestCase):
+    """P1-4 (Codex round 2): placeholder-select MVs are excluded from
+    desired_names but must also be excluded from current_names. Otherwise
+    diff_state emits a DROP against every legacy MV the YAML stubbed out."""
+
+    def test_placeholder_mv_present_in_live_is_not_dropped(self) -> None:
+        desired = _make_desired_state(
+            {
+                "stub_mv": _make_desired_table(
+                    "stub_mv",
+                    engine="MaterializedView",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    on_nodes=["ALL"],
+                    target="target_table",
+                    select="SELECT ... FROM source",  # placeholder sentinel
+                ),
+            }
+        )
+        current = {
+            "stub_mv": _make_table_schema(
+                "stub_mv",
+                engine="MaterializedView",
+                columns=[ColumnSchema(name="id", type="UUID")],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        drops = [d for d in diffs if d.action == "drop"]
+        self.assertEqual(drops, [], f"Placeholder MV should not be dropped: {[d.table for d in drops]}")
+
+    def test_placeholder_mv_trailing_dots_variant(self) -> None:
+        """The `, ...` trailing-cols placeholder must also be exempt."""
+        desired = _make_desired_state(
+            {
+                "stub_mv": _make_desired_table(
+                    "stub_mv",
+                    engine="MaterializedView",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    on_nodes=["ALL"],
+                    target="target_table",
+                    select="SELECT id, timestamp, ... FROM source",
+                ),
+            }
+        )
+        current = {
+            "stub_mv": _make_table_schema(
+                "stub_mv",
+                engine="MaterializedView",
+                columns=[ColumnSchema(name="id", type="UUID")],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        drops = [d for d in diffs if d.action == "drop"]
+        self.assertEqual(drops, [], f"Trailing-dots placeholder MV should not be dropped: {[d.table for d in drops]}")
+
+
+class TestComputeDiffsConvergencePreserved(unittest.TestCase):
+    """Regression guard: when every desired table is already present in the
+    live cluster and there are no orphans, _compute_diffs must return an
+    empty diff list. The previous round-2 attempt to detect orphans across
+    ecosystems leaked spurious DROPs and broke this property."""
+
+    def test_no_diffs_when_desired_matches_current_no_orphans(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from posthog.management.commands.ch_migrate import Command
+
+        events_state = DesiredState(
+            ecosystem="events",
+            cluster="main",
+            tables={
+                "sharded_events": _make_desired_table(
+                    "sharded_events",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+        heatmaps_state = DesiredState(
+            ecosystem="heatmaps",
+            cluster="main",
+            tables={
+                "sharded_heatmaps": _make_desired_table(
+                    "sharded_heatmaps",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+
+        main_cluster = MagicMock(name="main-cluster")
+
+        def fake_dump(_cluster_obj, _database):
+            return {
+                "host1": {
+                    "sharded_events": _make_table_schema(
+                        "sharded_events",
+                        engine="ReplicatedMergeTree",
+                        columns=[ColumnSchema(name="id", type="UUID")],
+                    ),
+                    "sharded_heatmaps": _make_table_schema(
+                        "sharded_heatmaps",
+                        engine="ReplicatedMergeTree",
+                        columns=[ColumnSchema(name="id", type="UUID")],
+                    ),
+                    # Tracking tables exist in live but should never trigger drops.
+                    "clickhouse_schema_migrations": _make_table_schema(
+                        "clickhouse_schema_migrations",
+                        engine="ReplicatedMergeTree",
+                        columns=[ColumnSchema(name="id", type="UUID")],
+                    ),
+                }
+            }
+
+        with (
+            patch(
+                "posthog.clickhouse.migration_tools.desired_state.parse_desired_state_dir",
+                return_value=[events_state, heatmaps_state],
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.get_cluster_by_name",
+                return_value=main_cluster,
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.is_known_cluster",
+                return_value=True,
+            ),
+            patch(
+                "posthog.clickhouse.migration_tools.schema_introspect.dump_schema_all_hosts",
+                side_effect=fake_dump,
+            ),
+        ):
+            cmd = Command()
+            diffs, err = cmd._compute_diffs("posthog", "/tmp/fake_schema_dir")
+
+        self.assertIsNone(err)
+        self.assertEqual(diffs, [], f"Expected no diffs, got: {[(d.action, d.table) for d in diffs]}")
+
+
+class TestApplyRoutesStepsToCorrectCluster(unittest.TestCase):
+    """P1-3 (Codex round 2): handle_apply must call execute_migration_step
+    with the cluster object that matches the StateDiff.cluster tag, not
+    always with the migrations cluster. Without this, every step runs against
+    the main cluster — including logs-cluster steps that target tables which
+    don't exist there."""
+
+    def test_step_executes_against_step_cluster(self) -> None:
+        import tempfile
+
+        from unittest.mock import MagicMock, patch
+
+        from posthog.clickhouse.migration_tools.manifest import ManifestStep
+        from posthog.management.commands.ch_migrate import Command
+
+        # Two steps: one for `main`, one for `logs`.
+        steps = [
+            (
+                ManifestStep(
+                    sql="_reconcile:create_main_t",
+                    node_roles=["ALL"],
+                    comment="create main_t",
+                    cluster="main",
+                ),
+                "CREATE TABLE main_t (id UInt64) ENGINE = MergeTree ORDER BY id",
+            ),
+            (
+                ManifestStep(
+                    sql="_reconcile:create_logs_t",
+                    node_roles=["ALL"],
+                    comment="create logs_t",
+                    cluster="logs",
+                ),
+                "CREATE TABLE logs_t (id UInt64) ENGINE = MergeTree ORDER BY id",
+            ),
+        ]
+
+        # Drive _compute_diffs to produce one diff so handle_apply takes the
+        # apply path. The actual diff content gets replaced by `steps` via the
+        # generate_manifest_steps patch.
+        diffs = [
+            StateDiff(
+                action="create",
+                table="main_t",
+                detail="create main_t",
+                sql="CREATE TABLE main_t (id UInt64) ENGINE = MergeTree ORDER BY id",
+                node_roles=["ALL"],
+                cluster="main",
+            )
+        ]
+
+        migrations_cluster = MagicMock(name="migrations-cluster")
+        main_cluster = MagicMock(name="main-cluster")
+        logs_cluster = MagicMock(name="logs-cluster")
+        cluster_lookup = {"main": main_cluster, "logs": logs_cluster}
+
+        executed: list[tuple[object, str]] = []
+
+        def fake_execute(cluster_obj, step, _sql):
+            executed.append((cluster_obj, step.cluster))
+
+        def fake_get_cluster_by_name(name: str, **_kw):
+            return cluster_lookup[name]
+
+        # handle_apply checks `schema_dir.exists()` and returns early if not —
+        # use a real temp dir so the apply flow runs.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with (
+                patch(
+                    "posthog.clickhouse.client.migration_tools.get_migrations_cluster",
+                    return_value=migrations_cluster,
+                ),
+                patch(
+                    "posthog.management.commands.ch_migrate._any_client",
+                    return_value=MagicMock(),
+                ),
+                patch(
+                    "posthog.management.commands.ch_migrate.get_cluster_by_name",
+                    side_effect=fake_get_cluster_by_name,
+                ),
+                patch.object(Command, "_compute_diffs", return_value=(diffs, None)),
+                patch(
+                    "posthog.clickhouse.migration_tools.plan_generator.generate_manifest_steps",
+                    return_value=steps,
+                ),
+                patch(
+                    "posthog.clickhouse.migration_tools.runner.execute_migration_step",
+                    side_effect=fake_execute,
+                ),
+                patch(
+                    "posthog.clickhouse.migration_tools.tracking.acquire_apply_lock",
+                    return_value=(True, ""),
+                ),
+                patch(
+                    "posthog.clickhouse.migration_tools.tracking.release_apply_lock",
+                ),
+                patch("posthog.clickhouse.migration_tools.tracking._record_step"),
+                patch("posthog.clickhouse.migration_tools.tracking.record_schema_version"),
+            ):
+                cmd = Command()
+                cmd.handle_apply({"yes": True, "schema_dir": tmpdir})
+
+        self.assertEqual(len(executed), 2, f"Expected 2 executions, got: {executed}")
+        # Step 0 went through the main cluster.
+        self.assertIs(executed[0][0], main_cluster, "main step routed to wrong cluster")
+        # Step 1 went through the logs cluster, NOT the migrations cluster.
+        self.assertIs(executed[1][0], logs_cluster, "logs step routed to wrong cluster")
+        self.assertIsNot(executed[1][0], migrations_cluster, "logs step incorrectly hit migrations cluster")
+
+
+class TestComputeDiffsSkipsOrphanScanOnFallback(unittest.TestCase):
+    """Pass 2 (cluster-wide orphan scan) must be skipped when the satellite
+    cluster was unreachable and `current` came from the migrations-cluster
+    fallback. Otherwise every main-cluster table becomes a spurious DROP
+    orphan against the unreachable satellite (since the satellite's
+    ecosystem doesn't claim main's tables).
+    """
+
+    def test_no_orphan_drops_when_satellite_falls_back_to_migrations(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from posthog.management.commands.ch_migrate import Command
+
+        logs_state = DesiredState(
+            ecosystem="logs",
+            cluster="logs",
+            tables={
+                "logs_table": _make_desired_table(
+                    "logs_table",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+
+        def fake_get_cluster_by_name(name: str, **_kw):
+            # Only `logs` is unreachable; migrations cluster resolves fine.
+            if name == "logs":
+                raise Exception("Code: 701 CLUSTER_DOESNT_EXIST: Cluster 'logs' not found")
+            return MagicMock(name=f"{name}-cluster")
+
+        # Fallback introspection returns main-cluster tables. None of these
+        # belong to the logs ecosystem — the guard must prevent them being
+        # emitted as orphan drops against the `logs` cluster.
+        def fake_dump(_cluster_obj, _database):
+            return {
+                "host1": {
+                    "sharded_events": _make_table_schema(
+                        "sharded_events",
+                        engine="ReplicatedMergeTree",
+                        columns=[ColumnSchema(name="id", type="UUID")],
+                    ),
+                    "sharded_heatmaps": _make_table_schema(
+                        "sharded_heatmaps",
+                        engine="ReplicatedMergeTree",
+                        columns=[ColumnSchema(name="id", type="UUID")],
+                    ),
+                }
+            }
+
+        with (
+            patch(
+                "posthog.clickhouse.migration_tools.desired_state.parse_desired_state_dir",
+                return_value=[logs_state],
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.get_cluster_by_name",
+                side_effect=fake_get_cluster_by_name,
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.is_known_cluster",
+                return_value=True,
+            ),
+            patch(
+                "posthog.clickhouse.client.migration_tools.get_migrations_cluster",
+                return_value=MagicMock(name="migrations-cluster"),
+            ),
+            patch(
+                "posthog.clickhouse.migration_tools.schema_introspect.dump_schema_all_hosts",
+                side_effect=fake_dump,
+            ),
+        ):
+            cmd = Command()
+            diffs, err = cmd._compute_diffs("posthog", "/tmp/fake_schema_dir")
+
+        self.assertIsNone(err)
+        drops = [d for d in diffs if d.action == "drop"]
+        self.assertEqual(
+            drops,
+            [],
+            f"Fallback must not emit orphan drops (would drop main tables): {[d.table for d in drops]}",
+        )
+
+
+class TestComputeDiffsSharedPhysicalHost(unittest.TestCase):
+    """On dev stacks several logical clusters (`main`, `aux`, `ops`) share
+    the same physical CLICKHOUSE_HOST — so `dump_schema_all_hosts(aux)`
+    returns main's tables too. The orphan scan must NOT emit drops for
+    tables owned by a sibling logical cluster, even though that logical
+    cluster's ecosystems don't claim them.
+
+    In production each logical cluster has a distinct physical host, so the
+    introspection would only return that cluster's tables — this check is
+    a no-op there.
+    """
+
+    def test_aux_does_not_drop_main_owned_tables(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from posthog.management.commands.ch_migrate import Command
+
+        main_state = DesiredState(
+            ecosystem="events",
+            cluster="main",
+            tables={
+                "sharded_events": _make_desired_table(
+                    "sharded_events",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+        aux_state = DesiredState(
+            ecosystem="error_tracking_fingerprint_issue_state",
+            cluster="aux",
+            tables={
+                "error_tracking_fingerprint_issue_state": _make_desired_table(
+                    "error_tracking_fingerprint_issue_state",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+
+        # Both clusters' introspection returns the same shared-host schema.
+        def fake_dump(_cluster_obj, _database):
+            return {
+                "host1": {
+                    "sharded_events": _make_table_schema(
+                        "sharded_events",
+                        engine="ReplicatedMergeTree",
+                        columns=[ColumnSchema(name="id", type="UUID")],
+                    ),
+                    "error_tracking_fingerprint_issue_state": _make_table_schema(
+                        "error_tracking_fingerprint_issue_state",
+                        engine="ReplicatedMergeTree",
+                        columns=[ColumnSchema(name="id", type="UUID")],
+                    ),
+                }
+            }
+
+        with (
+            patch(
+                "posthog.clickhouse.migration_tools.desired_state.parse_desired_state_dir",
+                return_value=[main_state, aux_state],
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.get_cluster_by_name",
+                side_effect=lambda name, **_kw: MagicMock(name=f"{name}-cluster"),
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.is_known_cluster",
+                return_value=True,
+            ),
+            patch(
+                "posthog.clickhouse.migration_tools.schema_introspect.dump_schema_all_hosts",
+                side_effect=fake_dump,
+            ),
+        ):
+            cmd = Command()
+            diffs, err = cmd._compute_diffs("posthog", "/tmp/fake_schema_dir")
+
+        self.assertIsNone(err)
+        drops = [d for d in diffs if d.action == "drop"]
+        self.assertEqual(
+            drops,
+            [],
+            f"No drops expected — every live table is claimed by some ecosystem: {[d.table for d in drops]}",
+        )
+
+    def test_shared_host_still_drops_tables_claimed_nowhere(self) -> None:
+        """A table that no ecosystem on ANY cluster claims is still a real
+        orphan and must be dropped (when encountered on its cluster)."""
+        from unittest.mock import MagicMock, patch
+
+        from posthog.management.commands.ch_migrate import Command
+
+        main_state = DesiredState(
+            ecosystem="events",
+            cluster="main",
+            tables={
+                "sharded_events": _make_desired_table(
+                    "sharded_events",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+
+        def fake_dump(_cluster_obj, _database):
+            return {
+                "host1": {
+                    "sharded_events": _make_table_schema(
+                        "sharded_events",
+                        engine="ReplicatedMergeTree",
+                        columns=[ColumnSchema(name="id", type="UUID")],
+                    ),
+                    # Not in any YAML on any cluster — real orphan.
+                    "truly_orphan": _make_table_schema(
+                        "truly_orphan",
+                        engine="MergeTree",
+                        columns=[ColumnSchema(name="id", type="UUID")],
+                    ),
+                }
+            }
+
+        with (
+            patch(
+                "posthog.clickhouse.migration_tools.desired_state.parse_desired_state_dir",
+                return_value=[main_state],
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.get_cluster_by_name",
+                side_effect=lambda name, **_kw: MagicMock(name=f"{name}-cluster"),
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.is_known_cluster",
+                return_value=True,
+            ),
+            patch(
+                "posthog.clickhouse.migration_tools.schema_introspect.dump_schema_all_hosts",
+                side_effect=fake_dump,
+            ),
+        ):
+            cmd = Command()
+            diffs, err = cmd._compute_diffs("posthog", "/tmp/fake_schema_dir")
+
+        self.assertIsNone(err)
+        drops = [d for d in diffs if d.action == "drop"]
+        self.assertEqual([d.table for d in drops], ["truly_orphan"])

--- a/posthog/clickhouse/test/test_reconcile_shared.py
+++ b/posthog/clickhouse/test/test_reconcile_shared.py
@@ -5,6 +5,7 @@ No Django or ClickHouse connection required.
 
 from __future__ import annotations
 
+import atexit
 import tempfile
 import textwrap
 from pathlib import Path
@@ -23,10 +24,20 @@ from posthog.clickhouse.migration_tools.plan_generator import generate_manifest_
 from posthog.clickhouse.migration_tools.schema_introspect import ColumnSchema, TableSchema
 from posthog.clickhouse.migration_tools.state_diff import StateDiff, diff_state
 
+_TEMP_DIRS: list[tempfile.TemporaryDirectory[str]] = []
+
+
+@atexit.register
+def _cleanup_temp_dirs() -> None:
+    for tmp_dir in _TEMP_DIRS:
+        tmp_dir.cleanup()
+    _TEMP_DIRS.clear()
+
 
 def _write_yaml(content: str) -> Path:
-    d = tempfile.mkdtemp()
-    p = Path(d) / "test_ecosystem.yaml"
+    tmp_dir = tempfile.TemporaryDirectory()
+    _TEMP_DIRS.append(tmp_dir)
+    p = Path(tmp_dir.name) / "test_ecosystem.yaml"
     p.write_text(textwrap.dedent(content))
     return p
 
@@ -142,9 +153,9 @@ class TestParseDesiredState(unittest.TestCase):
         self.assertEqual(mv.source, "kafka_t")
 
     def test_parse_dir(self) -> None:
-        d = tempfile.mkdtemp()
-        (Path(d) / "eco1.yaml").write_text(
-            textwrap.dedent("""\
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "eco1.yaml").write_text(
+                textwrap.dedent("""\
             ecosystem: eco1
             cluster: main
             tables:
@@ -155,9 +166,9 @@ class TestParseDesiredState(unittest.TestCase):
                   - name: id
                     type: UInt64
         """)
-        )
-        (Path(d) / "eco2.yaml").write_text(
-            textwrap.dedent("""\
+            )
+            (Path(d) / "eco2.yaml").write_text(
+                textwrap.dedent("""\
             ecosystem: eco2
             cluster: main
             tables:
@@ -168,11 +179,11 @@ class TestParseDesiredState(unittest.TestCase):
                   - name: id
                     type: UInt64
         """)
-        )
-        states = parse_desired_state_dir(Path(d))
-        self.assertEqual(len(states), 2)
-        ecosystems = {s.ecosystem for s in states}
-        self.assertEqual(ecosystems, {"eco1", "eco2"})
+            )
+            states = parse_desired_state_dir(Path(d))
+            self.assertEqual(len(states), 2)
+            ecosystems = {s.ecosystem for s in states}
+            self.assertEqual(ecosystems, {"eco1", "eco2"})
 
 
 class TestDiffStateMissingTable(unittest.TestCase):
@@ -469,57 +480,57 @@ class TestReconcileImportYamlRoundTrip(unittest.TestCase):
                 columns: inherit sharded_t
         """)
 
-        d = tempfile.mkdtemp()
-        p = Path(d) / "roundtrip_test.yaml"
-        p.write_text(yaml_content)
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "roundtrip_test.yaml"
+            p.write_text(yaml_content)
 
-        state = parse_desired_state(p)
-        self.assertEqual(state.ecosystem, "roundtrip_test")
-        self.assertEqual(len(state.tables), 2)
+            state = parse_desired_state(p)
+            self.assertEqual(state.ecosystem, "roundtrip_test")
+            self.assertEqual(len(state.tables), 2)
 
-        sharded = state.tables["sharded_t"]
-        self.assertEqual(sharded.order_by, ["team_id", "id"])
-        self.assertEqual(sharded.partition_by, "toYYYYMM(timestamp)")
-        self.assertEqual(len(sharded.columns), 3)
+            sharded = state.tables["sharded_t"]
+            self.assertEqual(sharded.order_by, ["team_id", "id"])
+            self.assertEqual(sharded.partition_by, "toYYYYMM(timestamp)")
+            self.assertEqual(len(sharded.columns), 3)
 
-        writable = state.tables["writable_t"]
-        self.assertEqual(writable.source, "sharded_t")
-        self.assertEqual(len(writable.columns), 3)  # inherited
+            writable = state.tables["writable_t"]
+            self.assertEqual(writable.source, "sharded_t")
+            self.assertEqual(len(writable.columns), 3)  # inherited
 
-        # Write back out as YAML and re-parse
-        tables_out: dict[str, dict] = {}
-        for tname, tbl in state.tables.items():
-            tdata: dict = {"engine": tbl.engine, "on_nodes": tbl.on_nodes}
-            if tbl.order_by:
-                tdata["order_by"] = tbl.order_by
-            if tbl.partition_by:
-                tdata["partition_by"] = tbl.partition_by
-            if tbl.source:
-                tdata["source"] = tbl.source
-            if tbl.sharding_key:
-                tdata["sharding_key"] = tbl.sharding_key
-            if tbl.sharded:
-                tdata["sharded"] = True
-            tdata["columns"] = [{"name": c.name, "type": c.type} for c in tbl.columns]
-            tables_out[tname] = tdata
-        out_data = {
-            "ecosystem": state.ecosystem,
-            "cluster": state.cluster,
-            "tables": tables_out,
-        }
+            # Write back out as YAML and re-parse
+            tables_out: dict[str, dict] = {}
+            for tname, tbl in state.tables.items():
+                tdata: dict = {"engine": tbl.engine, "on_nodes": tbl.on_nodes}
+                if tbl.order_by:
+                    tdata["order_by"] = tbl.order_by
+                if tbl.partition_by:
+                    tdata["partition_by"] = tbl.partition_by
+                if tbl.source:
+                    tdata["source"] = tbl.source
+                if tbl.sharding_key:
+                    tdata["sharding_key"] = tbl.sharding_key
+                if tbl.sharded:
+                    tdata["sharded"] = True
+                tdata["columns"] = [{"name": c.name, "type": c.type} for c in tbl.columns]
+                tables_out[tname] = tdata
+            out_data = {
+                "ecosystem": state.ecosystem,
+                "cluster": state.cluster,
+                "tables": tables_out,
+            }
 
-        out_path = Path(d) / "roundtrip_out.yaml"
-        with open(out_path, "w") as f:
-            yaml.dump(out_data, f, default_flow_style=False, sort_keys=False)
+            out_path = Path(d) / "roundtrip_out.yaml"
+            with open(out_path, "w") as f:
+                yaml.dump(out_data, f, default_flow_style=False, sort_keys=False)
 
-        state2 = parse_desired_state(out_path)
-        self.assertEqual(state2.ecosystem, state.ecosystem)
-        self.assertEqual(len(state2.tables), len(state.tables))
-        for tname in state.tables:
-            self.assertEqual(
-                len(state2.tables[tname].columns),
-                len(state.tables[tname].columns),
-            )
+            state2 = parse_desired_state(out_path)
+            self.assertEqual(state2.ecosystem, state.ecosystem)
+            self.assertEqual(len(state2.tables), len(state.tables))
+            for tname in state.tables:
+                self.assertEqual(
+                    len(state2.tables[tname].columns),
+                    len(state.tables[tname].columns),
+                )
 
 
 class TestMvSelectChange(unittest.TestCase):

--- a/posthog/clickhouse/test/test_state_diff_cluster_routing.py
+++ b/posthog/clickhouse/test/test_state_diff_cluster_routing.py
@@ -1,4 +1,24 @@
 """Split from a larger legacy test module for review-size control."""
 
-
 # Re-exported test classes are intentionally imported for pytest discovery.
+from posthog.clickhouse.test.test_state_diff_shared import (
+    TestDiffConvergenceDistributedEmptyColumns,
+    TestDiffConvergenceEnum8,
+    TestDiffConvergenceKafkaMVStability,
+    TestDiffConvergenceKafkaVirtualColumns,
+    TestDistributedSourceWithDbPrefix,
+    TestKafkaCascadeOnSelectChange,
+    TestKafkaMVCascadePrevention,
+    TestKafkaVirtualColumns,
+)
+
+__all__ = [
+    "TestKafkaVirtualColumns",
+    "TestDiffConvergenceKafkaVirtualColumns",
+    "TestDiffConvergenceDistributedEmptyColumns",
+    "TestDiffConvergenceKafkaMVStability",
+    "TestDiffConvergenceEnum8",
+    "TestKafkaMVCascadePrevention",
+    "TestDistributedSourceWithDbPrefix",
+    "TestKafkaCascadeOnSelectChange",
+]

--- a/posthog/clickhouse/test/test_state_diff_cluster_routing.py
+++ b/posthog/clickhouse/test/test_state_diff_cluster_routing.py
@@ -1,0 +1,4 @@
+"""Split from a larger legacy test module for review-size control."""
+
+
+# Re-exported test classes are intentionally imported for pytest discovery.

--- a/posthog/clickhouse/test/test_state_diff_dictionary.py
+++ b/posthog/clickhouse/test/test_state_diff_dictionary.py
@@ -1,4 +1,24 @@
 """Split from a larger legacy test module for review-size control."""
 
-
 # Re-exported test classes are intentionally imported for pytest discovery.
+from posthog.clickhouse.test.test_state_diff_shared import (
+    TestDictionaryEngine,
+    TestDictionaryRangeInCreateSql,
+    TestDictionaryRecreateExtended,
+    TestDumpDictionaries,
+    TestRenderDictLayout,
+    TestRenderDictLifetime,
+    TestRenderDictRange,
+    TestRenderDictSource,
+)
+
+__all__ = [
+    "TestRenderDictSource",
+    "TestRenderDictLayout",
+    "TestRenderDictLifetime",
+    "TestDictionaryEngine",
+    "TestDumpDictionaries",
+    "TestDictionaryRecreateExtended",
+    "TestRenderDictRange",
+    "TestDictionaryRangeInCreateSql",
+]

--- a/posthog/clickhouse/test/test_state_diff_dictionary.py
+++ b/posthog/clickhouse/test/test_state_diff_dictionary.py
@@ -1,0 +1,4 @@
+"""Split from a larger legacy test module for review-size control."""
+
+
+# Re-exported test classes are intentionally imported for pytest discovery.

--- a/posthog/clickhouse/test/test_state_diff_normalization.py
+++ b/posthog/clickhouse/test/test_state_diff_normalization.py
@@ -1,0 +1,4 @@
+"""Split from a larger legacy test module for review-size control."""
+
+
+# Re-exported test classes are intentionally imported for pytest discovery.

--- a/posthog/clickhouse/test/test_state_diff_normalization.py
+++ b/posthog/clickhouse/test/test_state_diff_normalization.py
@@ -1,4 +1,34 @@
 """Split from a larger legacy test module for review-size control."""
 
-
 # Re-exported test classes are intentionally imported for pytest discovery.
+from posthog.clickhouse.test.test_state_diff_shared import (
+    TestDiffConvergenceDateTime64,
+    TestDiffConvergenceIntervalDefault,
+    TestDiffConvergenceMvSelect,
+    TestNormalizeDateTime64,
+    TestNormalizeDecimal,
+    TestNormalizeDefault,
+    TestNormalizeDefaultNestedLambdaParens,
+    TestNormalizeIntervalFuncs,
+    TestNormalizeLambdaParens,
+    TestNormalizeMvSelect,
+    TestNormalizeQuoteEscaping,
+    TestNormalizeType,
+    TestStripRedundantParens,
+)
+
+__all__ = [
+    "TestNormalizeIntervalFuncs",
+    "TestNormalizeDefault",
+    "TestDiffConvergenceIntervalDefault",
+    "TestNormalizeLambdaParens",
+    "TestNormalizeType",
+    "TestNormalizeQuoteEscaping",
+    "TestNormalizeDateTime64",
+    "TestNormalizeDecimal",
+    "TestDiffConvergenceDateTime64",
+    "TestNormalizeDefaultNestedLambdaParens",
+    "TestNormalizeMvSelect",
+    "TestDiffConvergenceMvSelect",
+    "TestStripRedundantParens",
+]

--- a/posthog/clickhouse/test/test_state_diff_shared.py
+++ b/posthog/clickhouse/test/test_state_diff_shared.py
@@ -1,5 +1,6 @@
 """Tests for state_diff convergence — verifying idempotent apply (second run = 0 diffs)."""
 
+import pytest
 from unittest.mock import patch
 
 from posthog.clickhouse.migration_tools.desired_state import ColumnDef, DesiredState, DesiredTable
@@ -22,26 +23,20 @@ from posthog.clickhouse.migration_tools.state_diff import (
 
 
 class TestNormalizeIntervalFuncs:
-    def test_toIntervalDay(self):
-        assert _normalize_interval_funcs("today() + toIntervalDay(7)") == "today() + INTERVAL 7 DAY"
-
-    def test_toIntervalHour(self):
-        assert _normalize_interval_funcs("now() + toIntervalHour(24)") == "now() + INTERVAL 24 HOUR"
-
-    def test_toIntervalMinute(self):
-        assert _normalize_interval_funcs("toIntervalMinute(30)") == "INTERVAL 30 MINUTE"
-
-    def test_toIntervalSecond(self):
-        assert _normalize_interval_funcs("toIntervalSecond(60)") == "INTERVAL 60 SECOND"
-
-    def test_toIntervalWeek(self):
-        assert _normalize_interval_funcs("toIntervalWeek(2)") == "INTERVAL 2 WEEK"
-
-    def test_toIntervalMonth(self):
-        assert _normalize_interval_funcs("toIntervalMonth(1)") == "INTERVAL 1 MONTH"
-
-    def test_toIntervalYear(self):
-        assert _normalize_interval_funcs("toIntervalYear(1)") == "INTERVAL 1 YEAR"
+    @pytest.mark.parametrize(
+        "input_expr,expected",
+        [
+            ("today() + toIntervalDay(7)", "today() + INTERVAL 7 DAY"),
+            ("now() + toIntervalHour(24)", "now() + INTERVAL 24 HOUR"),
+            ("toIntervalMinute(30)", "INTERVAL 30 MINUTE"),
+            ("toIntervalSecond(60)", "INTERVAL 60 SECOND"),
+            ("toIntervalWeek(2)", "INTERVAL 2 WEEK"),
+            ("toIntervalMonth(1)", "INTERVAL 1 MONTH"),
+            ("toIntervalYear(1)", "INTERVAL 1 YEAR"),
+        ],
+    )
+    def test_to_interval_functions(self, input_expr: str, expected: str):
+        assert _normalize_interval_funcs(input_expr) == expected
 
     def test_no_change_for_interval_literal(self):
         s = "INTERVAL 7 DAY"
@@ -371,31 +366,31 @@ class TestNormalizeQuoteEscaping:
 
 
 class TestNormalizeDateTime64:
-    def test_datetime64_default_precision(self):
-        assert _normalize_type("DateTime64") == "DateTime64(3)"
-
-    def test_datetime64_explicit_3(self):
-        assert _normalize_type("DateTime64(3)") == "DateTime64(3)"
-
-    def test_datetime64_explicit_6(self):
-        assert _normalize_type("DateTime64(6)") == "DateTime64(6)"
-
-    def test_nullable_datetime64(self):
-        assert _normalize_type("Nullable(DateTime64)") == "Nullable(DateTime64(3))"
+    @pytest.mark.parametrize(
+        "input_type,expected",
+        [
+            ("DateTime64", "DateTime64(3)"),
+            ("DateTime64(3)", "DateTime64(3)"),
+            ("DateTime64(6)", "DateTime64(6)"),
+            ("Nullable(DateTime64)", "Nullable(DateTime64(3))"),
+        ],
+    )
+    def test_datetime64_variants(self, input_type: str, expected: str):
+        assert _normalize_type(input_type) == expected
 
 
 class TestNormalizeDecimal:
-    def test_decimal_18_10_to_decimal64(self):
-        assert _normalize_type("Decimal(18, 10)") == "Decimal64(10)"
-
-    def test_decimal_9_2_to_decimal32(self):
-        assert _normalize_type("Decimal(9, 2)") == "Decimal32(2)"
-
-    def test_decimal_38_10_to_decimal128(self):
-        assert _normalize_type("Decimal(38, 10)") == "Decimal128(10)"
-
-    def test_decimal64_unchanged(self):
-        assert _normalize_type("Decimal64(10)") == "Decimal64(10)"
+    @pytest.mark.parametrize(
+        "input_type,expected",
+        [
+            ("Decimal(18, 10)", "Decimal64(10)"),
+            ("Decimal(9, 2)", "Decimal32(2)"),
+            ("Decimal(38, 10)", "Decimal128(10)"),
+            ("Decimal64(10)", "Decimal64(10)"),
+        ],
+    )
+    def test_decimal_variants(self, input_type: str, expected: str):
+        assert _normalize_type(input_type) == expected
 
 
 class TestDiffConvergenceDateTime64:

--- a/posthog/clickhouse/test/test_state_diff_shared.py
+++ b/posthog/clickhouse/test/test_state_diff_shared.py
@@ -1,0 +1,1366 @@
+"""Tests for state_diff convergence — verifying idempotent apply (second run = 0 diffs)."""
+
+from unittest.mock import patch
+
+from posthog.clickhouse.migration_tools.desired_state import ColumnDef, DesiredState, DesiredTable
+from posthog.clickhouse.migration_tools.schema_introspect import ColumnSchema, TableSchema
+from posthog.clickhouse.migration_tools.state_diff import (
+    _generate_create_sql,
+    _is_kafka_virtual_column,
+    _normalize_default,
+    _normalize_interval_funcs,
+    _normalize_mv_select,
+    _normalize_type,
+    _render_dict_layout,
+    _render_dict_lifetime,
+    _render_dict_source,
+    _strip_redundant_parens,
+    diff_state,
+)
+
+# -- Fix 1: Interval normalization --
+
+
+class TestNormalizeIntervalFuncs:
+    def test_toIntervalDay(self):
+        assert _normalize_interval_funcs("today() + toIntervalDay(7)") == "today() + INTERVAL 7 DAY"
+
+    def test_toIntervalHour(self):
+        assert _normalize_interval_funcs("now() + toIntervalHour(24)") == "now() + INTERVAL 24 HOUR"
+
+    def test_toIntervalMinute(self):
+        assert _normalize_interval_funcs("toIntervalMinute(30)") == "INTERVAL 30 MINUTE"
+
+    def test_toIntervalSecond(self):
+        assert _normalize_interval_funcs("toIntervalSecond(60)") == "INTERVAL 60 SECOND"
+
+    def test_toIntervalWeek(self):
+        assert _normalize_interval_funcs("toIntervalWeek(2)") == "INTERVAL 2 WEEK"
+
+    def test_toIntervalMonth(self):
+        assert _normalize_interval_funcs("toIntervalMonth(1)") == "INTERVAL 1 MONTH"
+
+    def test_toIntervalYear(self):
+        assert _normalize_interval_funcs("toIntervalYear(1)") == "INTERVAL 1 YEAR"
+
+    def test_no_change_for_interval_literal(self):
+        s = "INTERVAL 7 DAY"
+        assert _normalize_interval_funcs(s) == s
+
+    def test_whitespace_in_parens(self):
+        assert _normalize_interval_funcs("toIntervalDay(  7  )") == "INTERVAL 7 DAY"
+
+    def test_multiple_intervals(self):
+        s = "toIntervalDay(1) + toIntervalHour(2)"
+        assert _normalize_interval_funcs(s) == "INTERVAL 1 DAY + INTERVAL 2 HOUR"
+
+
+class TestNormalizeDefault:
+    def test_interval_forms_equivalent(self):
+        a = "DEFAULT today() + toIntervalDay(7)"
+        b = "DEFAULT today() + INTERVAL 7 DAY"
+        assert _normalize_default(a) == _normalize_default(b)
+
+    def test_case_insensitive(self):
+        assert _normalize_default("DEFAULT NOW()") == _normalize_default("DEFAULT now()")
+
+    def test_whitespace_collapse(self):
+        assert _normalize_default("DEFAULT  now(  )") == _normalize_default("DEFAULT now( )")
+
+    def test_empty_string(self):
+        assert _normalize_default("") == ""
+
+    def test_preserves_string_literals(self):
+        a = "DEFAULT 'UTC'"
+        assert _normalize_default(a) == "default 'utc'"
+
+
+# -- Fix 2: Kafka virtual columns --
+
+
+class TestKafkaVirtualColumns:
+    def test_known_virtual_columns(self):
+        for col in ("_topic", "_key", "_offset", "_partition", "_timestamp", "_headers"):
+            assert _is_kafka_virtual_column(col), f"{col} should be virtual"
+
+    def test_headers_dot_prefix(self):
+        assert _is_kafka_virtual_column("_headers.name")
+        assert _is_kafka_virtual_column("_headers.value")
+
+    def test_regular_column_not_virtual(self):
+        assert not _is_kafka_virtual_column("team_id")
+        assert not _is_kafka_virtual_column("event")
+        assert not _is_kafka_virtual_column("timestamp")
+
+
+# -- Integration: diff_state convergence --
+
+
+def _make_desired(tables: dict[str, DesiredTable]) -> DesiredState:
+    return DesiredState(ecosystem="test", cluster="test_cluster", tables=tables)
+
+
+def _col(name: str, type: str, default_kind: str = "", default_expression: str = "") -> ColumnDef:
+    return ColumnDef(name=name, type=type, default_kind=default_kind, default_expression=default_expression)
+
+
+def _live_col(name: str, type: str, default_kind: str = "", default_expression: str = "") -> ColumnSchema:
+    return ColumnSchema(name=name, type=type, default_kind=default_kind, default_expression=default_expression)
+
+
+# Patch _resolve_physical_cluster and _resolve_setting to avoid Django settings dependency
+_PATCH_RESOLVE = patch(
+    "posthog.clickhouse.migration_tools.state_diff._resolve_physical_cluster",
+    return_value="test_cluster",
+)
+_PATCH_SETTING = patch(
+    "posthog.clickhouse.migration_tools.state_diff._resolve_setting",
+    side_effect=lambda k: k,
+)
+
+
+class TestDiffConvergenceIntervalDefault:
+    """Fix 1: toIntervalDay(7) in YAML should match INTERVAL 7 DAY from system.columns."""
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_no_spurious_alter_for_interval_default(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "test_table": DesiredTable(
+                    name="test_table",
+                    engine="ReplacingMergeTree",
+                    columns=[
+                        _col("id", "UInt64"),
+                        _col(
+                            "expires", "Date", default_kind="DEFAULT", default_expression="today() + toIntervalDay(7)"
+                        ),
+                    ],
+                    on_nodes=["all"],
+                    order_by=["id"],
+                ),
+            }
+        )
+        current = {
+            "test_table": TableSchema(
+                name="test_table",
+                engine="ReplacingMergeTree",
+                columns=[
+                    _live_col("id", "UInt64"),
+                    _live_col("expires", "Date", default_kind="DEFAULT", default_expression="today() + INTERVAL 7 DAY"),
+                ],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        assert len(diffs) == 0, f"Expected 0 diffs but got: {[d.detail for d in diffs]}"
+
+
+class TestDiffConvergenceKafkaVirtualColumns:
+    """Fix 2: Kafka virtual columns should not trigger recreate."""
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_no_recreate_when_only_virtual_columns_differ(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "kafka_events": DesiredTable(
+                    name="kafka_events",
+                    engine="Kafka",
+                    columns=[
+                        _col("event", "String"),
+                        _col("timestamp", "DateTime"),
+                    ],
+                    on_nodes=["all"],
+                    settings={"kafka_broker_list": "localhost:9092", "kafka_topic_list": "events"},
+                ),
+            }
+        )
+        # Live schema includes virtual columns injected by CH
+        current = {
+            "kafka_events": TableSchema(
+                name="kafka_events",
+                engine="Kafka",
+                columns=[
+                    _live_col("event", "String"),
+                    _live_col("timestamp", "DateTime"),
+                    _live_col("_topic", "LowCardinality(String)"),
+                    _live_col("_key", "String"),
+                    _live_col("_offset", "UInt64"),
+                    _live_col("_partition", "UInt64"),
+                    _live_col("_timestamp", "Nullable(DateTime)"),
+                    _live_col("_headers", "Map(String, String)"),
+                ],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        assert len(diffs) == 0, f"Expected 0 diffs but got: {[d.detail for d in diffs]}"
+
+
+class TestDiffConvergenceDistributedEmptyColumns:
+    """Fix 4: Distributed tables with columns: [] should not generate column diffs."""
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_no_drop_columns_for_empty_desired(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "events_dist": DesiredTable(
+                    name="events_dist",
+                    engine="Distributed",
+                    columns=[],  # inherit from source
+                    on_nodes=["all"],
+                    source="sharded_events",
+                ),
+            }
+        )
+        # Live schema has real columns (inherited from source at creation time)
+        current = {
+            "events_dist": TableSchema(
+                name="events_dist",
+                engine="Distributed",
+                columns=[
+                    _live_col("uuid", "UUID"),
+                    _live_col("event", "String"),
+                    _live_col("timestamp", "DateTime"),
+                ],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        # Should not produce DROP COLUMN diffs
+        drop_diffs = [d for d in diffs if "drop_column" in d.action.lower() or "Drop column" in d.detail]
+        assert len(drop_diffs) == 0, f"Expected no column drops but got: {[d.detail for d in drop_diffs]}"
+
+
+class TestDiffConvergenceKafkaMVStability:
+    """Fix 3: Kafka table not being recreated means its MV stays stable too."""
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_kafka_and_mv_stable_on_second_apply(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "kafka_events": DesiredTable(
+                    name="kafka_events",
+                    engine="Kafka",
+                    columns=[
+                        _col("event", "String"),
+                    ],
+                    on_nodes=["all"],
+                    settings={"kafka_broker_list": "localhost:9092", "kafka_topic_list": "events"},
+                ),
+                "kafka_events_mv": DesiredTable(
+                    name="kafka_events_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["all"],
+                    target="sharded_events",
+                    select="SELECT event FROM posthog.kafka_events",
+                ),
+            }
+        )
+        current = {
+            "kafka_events": TableSchema(
+                name="kafka_events",
+                engine="Kafka",
+                columns=[
+                    _live_col("event", "String"),
+                    _live_col("_topic", "LowCardinality(String)"),
+                    _live_col("_offset", "UInt64"),
+                ],
+            ),
+            "kafka_events_mv": TableSchema(
+                name="kafka_events_mv",
+                engine="MaterializedView",
+                as_select="SELECT event FROM posthog.kafka_events",
+                columns=[
+                    _live_col("event", "String"),
+                ],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        assert len(diffs) == 0, f"Expected 0 diffs but got: {[d.detail for d in diffs]}"
+
+
+# -- Fix 1: Lambda condition parenthesization normalization --
+
+
+class TestNormalizeLambdaParens:
+    def test_lambda_parens_stripped(self):
+        a = "mapFilter((key, _) -> (key NOT LIKE '$%'), m)"
+        b = "mapFilter((key, _) -> key NOT LIKE '$%', m)"
+        assert _normalize_default(a) == _normalize_default(b)
+
+    def test_lambda_nested_parens_preserved(self):
+        a = "arrayMap((x) -> (toInt64(x) + 1), arr)"
+        b = "arrayMap((x) -> toInt64(x) + 1, arr)"
+        assert _normalize_default(a) == _normalize_default(b)
+
+    def test_lambda_no_parens_unchanged(self):
+        a = "arrayMap((x) -> x + 1, arr)"
+        assert _normalize_default(a) == _normalize_default(a)
+
+
+# -- Fix 2: Enum8/Enum16 type normalization --
+
+
+class TestNormalizeType:
+    def test_enum8_to_enum(self):
+        assert _normalize_type("Enum8('a' = 1, 'button' = 2)") == "Enum('a', 'button')"
+
+    def test_enum16_to_enum(self):
+        assert _normalize_type("Enum16('x' = 100, 'y' = 200)") == "Enum('x', 'y')"
+
+    def test_array_enum8(self):
+        assert _normalize_type("Array(Enum8('a' = 1, 'button' = 2))") == "Array(Enum('a', 'button'))"
+
+    def test_plain_enum_unchanged(self):
+        assert _normalize_type("Enum('a', 'b')") == "Enum('a', 'b')"
+
+    def test_non_enum_unchanged(self):
+        assert _normalize_type("String") == "String"
+
+
+class TestDiffConvergenceEnum8:
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_no_alter_for_enum8_vs_enum(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "test_table": DesiredTable(
+                    name="test_table",
+                    engine="ReplacingMergeTree",
+                    columns=[
+                        _col("id", "UInt64"),
+                        _col("status", "Enum('active', 'deleted')"),
+                    ],
+                    on_nodes=["all"],
+                    order_by=["id"],
+                ),
+            }
+        )
+        current = {
+            "test_table": TableSchema(
+                name="test_table",
+                engine="ReplacingMergeTree",
+                columns=[
+                    _live_col("id", "UInt64"),
+                    _live_col("status", "Enum8('active' = 1, 'deleted' = 2)"),
+                ],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        assert len(diffs) == 0, f"Expected 0 diffs but got: {[d.detail for d in diffs]}"
+
+
+# -- Fix 3: Quote escaping normalization --
+
+
+class TestNormalizeQuoteEscaping:
+    def test_double_backslash_quote(self):
+        a = 'DEFAULT \\\\"hello\\\\"'
+        b = 'DEFAULT "hello"'
+        assert _normalize_default(a) == _normalize_default(b)
+
+    def test_single_backslash_quote(self):
+        a = 'DEFAULT \\"hello\\"'
+        b = 'DEFAULT "hello"'
+        assert _normalize_default(a) == _normalize_default(b)
+
+
+# -- Fix 4: DateTime64 precision and Decimal type aliases --
+
+
+class TestNormalizeDateTime64:
+    def test_datetime64_default_precision(self):
+        assert _normalize_type("DateTime64") == "DateTime64(3)"
+
+    def test_datetime64_explicit_3(self):
+        assert _normalize_type("DateTime64(3)") == "DateTime64(3)"
+
+    def test_datetime64_explicit_6(self):
+        assert _normalize_type("DateTime64(6)") == "DateTime64(6)"
+
+    def test_nullable_datetime64(self):
+        assert _normalize_type("Nullable(DateTime64)") == "Nullable(DateTime64(3))"
+
+
+class TestNormalizeDecimal:
+    def test_decimal_18_10_to_decimal64(self):
+        assert _normalize_type("Decimal(18, 10)") == "Decimal64(10)"
+
+    def test_decimal_9_2_to_decimal32(self):
+        assert _normalize_type("Decimal(9, 2)") == "Decimal32(2)"
+
+    def test_decimal_38_10_to_decimal128(self):
+        assert _normalize_type("Decimal(38, 10)") == "Decimal128(10)"
+
+    def test_decimal64_unchanged(self):
+        assert _normalize_type("Decimal64(10)") == "Decimal64(10)"
+
+
+class TestDiffConvergenceDateTime64:
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_no_alter_datetime64_vs_datetime64_3(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "test_table": DesiredTable(
+                    name="test_table",
+                    engine="ReplacingMergeTree",
+                    columns=[
+                        _col("id", "UInt64"),
+                        _col("created_at", "DateTime64(3)"),
+                    ],
+                    on_nodes=["all"],
+                    order_by=["id"],
+                ),
+            }
+        )
+        current = {
+            "test_table": TableSchema(
+                name="test_table",
+                engine="ReplacingMergeTree",
+                columns=[
+                    _live_col("id", "UInt64"),
+                    _live_col("created_at", "DateTime64"),
+                ],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        assert len(diffs) == 0, f"Expected 0 diffs but got: {[d.detail for d in diffs]}"
+
+
+# -- Fix 5: Kafka/MV recreate cascade prevention --
+
+
+class TestKafkaMVCascadePrevention:
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_kafka_recreated_after_mv_recreate(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "kafka_events": DesiredTable(
+                    name="kafka_events",
+                    engine="Kafka",
+                    columns=[_col("event", "String")],
+                    on_nodes=["all"],
+                    settings={"kafka_broker_list": "localhost:9092", "kafka_topic_list": "events"},
+                ),
+                "sharded_events": DesiredTable(
+                    name="sharded_events",
+                    engine="ReplacingMergeTree",
+                    columns=[_col("event", "String")],
+                    on_nodes=["all"],
+                    order_by=["event"],
+                ),
+                "kafka_events_mv": DesiredTable(
+                    name="kafka_events_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["all"],
+                    target="sharded_events",
+                    select="SELECT event FROM posthog.kafka_events",
+                ),
+            }
+        )
+        # Current state: MV target changed → triggers recreate_mv
+        current = {
+            "kafka_events": TableSchema(
+                name="kafka_events",
+                engine="Kafka",
+                columns=[_live_col("event", "String")],
+            ),
+            "sharded_events": TableSchema(
+                name="sharded_events",
+                engine="ReplacingMergeTree",
+                columns=[_live_col("event", "String")],
+            ),
+            "kafka_events_mv": TableSchema(
+                name="kafka_events_mv",
+                engine="MaterializedView",
+                engine_full="MaterializedView TO posthog.old_target",
+                as_select="SELECT event FROM posthog.kafka_events",
+                columns=[_live_col("event", "String")],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        # Should have a recreate_mv for the MV
+        mv_recreates = [d for d in diffs if d.action == "recreate_mv"]
+        assert len(mv_recreates) == 1, f"Expected 1 MV recreate but got: {[d.detail for d in mv_recreates]}"
+        # Should have a create step for the Kafka table (cascade prevention)
+        kafka_creates = [d for d in diffs if d.action == "create" and d.table == "kafka_events"]
+        assert len(kafka_creates) == 1, f"Expected Kafka re-create but got: {[d.detail for d in kafka_creates]}"
+        assert "cascade" in kafka_creates[0].detail.lower()
+
+
+# -- Bug A: Nested AND/OR parens in lambda bodies --
+
+
+class TestStripRedundantParens:
+    def test_outer_lambda_parens(self):
+        assert _strip_redundant_parens("-> (x + 1)") == "-> x + 1"
+
+    def test_nested_and_operand_parens(self):
+        s = "-> ((key like '$ai_%') and (key not in ('a', 'b')))"
+        result = _strip_redundant_parens(s)
+        assert "(" not in result.split("->")[1].split("not in")[0], f"Redundant parens remain: {result}"
+        assert "key like '$ai_%' and key not in" in result
+
+    def test_or_operand_parens(self):
+        s = "-> ((a > 1) or (b < 2))"
+        result = _strip_redundant_parens(s)
+        assert result == "-> a > 1 or b < 2"
+
+    def test_preserves_function_call_parens(self):
+        s = "-> toInt64(x) + 1"
+        assert _strip_redundant_parens(s) == s
+
+    def test_stable_on_already_clean(self):
+        s = "-> key like '$ai_%' and key not in ('a', 'b')"
+        assert _strip_redundant_parens(s) == s
+
+
+class TestNormalizeDefaultNestedLambdaParens:
+    def test_ch_style_vs_yaml_style(self):
+        ch = "DEFAULT mapFilter((key, _) -> ((key LIKE '$ai_%') AND (key NOT IN ('$ai_generation_id'))), m)"
+        yaml = "DEFAULT mapFilter((key, _) -> key LIKE '$ai_%' AND key NOT IN ('$ai_generation_id'), m)"
+        assert _normalize_default(ch) == _normalize_default(yaml)
+
+    def test_triple_and(self):
+        ch = "DEFAULT mapFilter((k, v) -> ((k LIKE 'a%') AND (k NOT LIKE 'b%') AND (v != '')), m)"
+        yaml = "DEFAULT mapFilter((k, v) -> k LIKE 'a%' AND k NOT LIKE 'b%' AND v != '', m)"
+        assert _normalize_default(ch) == _normalize_default(yaml)
+
+
+# -- Bug B: MV SELECT body normalization --
+
+
+class TestNormalizeMvSelect:
+    def test_database_prefix_stripped(self):
+        ch = "SELECT event FROM posthog_test.kafka_events"
+        yaml = "SELECT event FROM kafka_events"
+        assert _normalize_mv_select(ch, database="posthog_test") == _normalize_mv_select(yaml, database="posthog_test")
+
+    def test_keyword_case_normalized(self):
+        ch = "SELECT event FROM kafka_events WHERE team_id = 1"
+        yaml = "select event from kafka_events where team_id = 1"
+        assert _normalize_mv_select(ch) == _normalize_mv_select(yaml)
+
+    def test_trailing_settings_stripped(self):
+        ch = "SELECT event FROM kafka_events SETTINGS max_threads = 4"
+        yaml = "SELECT event FROM kafka_events"
+        assert _normalize_mv_select(ch) == _normalize_mv_select(yaml)
+
+    def test_whitespace_collapsed(self):
+        ch = "SELECT  event\n  FROM   kafka_events"
+        yaml = "SELECT event FROM kafka_events"
+        assert _normalize_mv_select(ch) == _normalize_mv_select(yaml)
+
+    def test_combined_differences(self):
+        ch = "SELECT event, timestamp AS ts FROM posthog_test.kafka_events WHERE team_id = 1 SETTINGS max_threads = 4"
+        yaml = "select event, timestamp as ts from kafka_events where team_id = 1"
+        assert _normalize_mv_select(ch, database="posthog_test") == _normalize_mv_select(yaml, database="posthog_test")
+
+    def test_multiple_db_prefixes(self):
+        ch = "SELECT a FROM posthog.t1 JOIN posthog.t2 ON t1.id = t2.id"
+        yaml = "SELECT a FROM t1 JOIN t2 ON t1.id = t2.id"
+        assert _normalize_mv_select(ch, database="posthog") == _normalize_mv_select(yaml, database="posthog")
+
+    def test_join_aliases_preserved(self):
+        """``a.col``/``b.col`` in JOIN must not be stripped — they are table aliases, not DB prefixes."""
+        sql = "SELECT a.x, b.y FROM t1 AS a JOIN t2 AS b ON a.id = b.id"
+        out = _normalize_mv_select(sql, database="posthog")
+        assert "a.x" in out and "b.y" in out and "a.id" in out and "b.id" in out
+
+    def test_settings_inside_subquery_preserved(self):
+        """Trailing SETTINGS strip must not chop a subquery's SETTINGS clause."""
+        sql = "SELECT x FROM (SELECT y FROM t SETTINGS max_threads = 4) z SETTINGS insert_quorum = 2"
+        out = _normalize_mv_select(sql)
+        assert "insert_quorum" not in out, "outer SETTINGS should be stripped"
+        assert "max_threads" in out, "subquery SETTINGS must survive"
+
+    def test_settings_inside_subquery_only(self):
+        """When only the subquery has SETTINGS, it must survive."""
+        sql = "SELECT x FROM (SELECT y FROM t SETTINGS max_threads = 4) z"
+        out = _normalize_mv_select(sql)
+        assert "max_threads" in out
+
+
+class TestDiffConvergenceMvSelect:
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_no_recreate_when_only_db_prefix_differs(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "events_mv": DesiredTable(
+                    name="events_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["all"],
+                    target="sharded_events",
+                    select="SELECT event FROM kafka_events",
+                ),
+            }
+        )
+        current = {
+            "events_mv": TableSchema(
+                name="events_mv",
+                engine="MaterializedView",
+                as_select="SELECT event FROM posthog_test.kafka_events",
+                columns=[_live_col("event", "String")],
+            ),
+        }
+        # `database` arg must match what CH stored (posthog_test); the prefix
+        # strip is scoped to that DB so JOIN aliases and other-DB references
+        # (other_db.t) survive. See `_normalize_mv_select` docstring.
+        diffs = diff_state(desired, current, database="posthog_test", cluster="test_cluster")
+        assert len(diffs) == 0, f"Expected 0 diffs but got: {[d.detail for d in diffs]}"
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_no_recreate_when_keyword_case_and_settings_differ(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "events_mv": DesiredTable(
+                    name="events_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["all"],
+                    target="sharded_events",
+                    select="SELECT event FROM kafka_events WHERE team_id = 1",
+                ),
+            }
+        )
+        current = {
+            "events_mv": TableSchema(
+                name="events_mv",
+                engine="MaterializedView",
+                as_select="SELECT event FROM posthog.kafka_events WHERE team_id = 1 SETTINGS max_threads = 4",
+                columns=[_live_col("event", "String")],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        assert len(diffs) == 0, f"Expected 0 diffs but got: {[d.detail for d in diffs]}"
+
+
+# -- Dictionary engine support --
+
+
+def _dict_table(
+    name: str = "channel_definition_dict",
+    primary_key: str = "domain, kind",
+) -> DesiredTable:
+    return DesiredTable(
+        name=name,
+        engine="Dictionary",
+        columns=[
+            _col("domain", "String"),
+            _col("kind", "String"),
+            _col("domain_type", "Nullable(String)"),
+        ],
+        on_nodes=["ALL"],
+        primary_key=primary_key,
+        dict_source={"type": "CLICKHOUSE", "table": "channel_definition", "password": "secret"},
+        dict_layout={"type": "COMPLEX_KEY_HASHED"},
+        dict_lifetime={"min": 3000, "max": 3600},
+    )
+
+
+class TestRenderDictSource:
+    def test_clickhouse_source(self):
+        s = _render_dict_source({"type": "CLICKHOUSE", "table": "channel_definition", "password": "secret"})
+        assert s == "SOURCE(CLICKHOUSE(table 'channel_definition' password 'secret'))"
+
+    def test_http_source(self):
+        s = _render_dict_source({"type": "HTTP", "url": "https://example.com/x.csv", "format": "CSVWithNames"})
+        assert s == "SOURCE(HTTP(url 'https://example.com/x.csv' format 'CSVWithNames'))"
+
+    def test_from_settings_sentinel_resolves(self):
+        with patch(
+            "posthog.clickhouse.migration_tools.state_diff._resolve_setting",
+            side_effect=lambda k: f"RESOLVED_{k}",
+        ):
+            s = _render_dict_source({"type": "CLICKHOUSE", "table": "x", "password": "__from_settings__"})
+        assert "password 'RESOLVED_password'" in s
+
+    def test_settings_resolution_keys_match_yaml_param_names(self):
+        """Regression: `password`/`user` keys in `_SETTINGS_RESOLUTION` must equal the
+        YAML parameter names. Otherwise `_resolve_setting('password')` misses the map
+        and falls back to the kafka placeholder, leaking that into the SOURCE clause.
+        """
+        from posthog.clickhouse.migration_tools.state_diff import _SETTINGS_RESOLUTION
+
+        assert "password" in _SETTINGS_RESOLUTION, "YAML key 'password' must be a resolution-map key"
+        assert "user" in _SETTINGS_RESOLUTION, "YAML key 'user' must be a resolution-map key"
+
+    def test_missing_type_raises(self):
+        try:
+            _render_dict_source({"table": "x"})
+        except ValueError as e:
+            assert "type" in str(e)
+        else:
+            raise AssertionError("expected ValueError")
+
+
+class TestRenderDictLayout:
+    def test_no_params(self):
+        assert _render_dict_layout({"type": "COMPLEX_KEY_HASHED"}) == "LAYOUT(COMPLEX_KEY_HASHED())"
+
+    def test_with_params(self):
+        s = _render_dict_layout({"type": "RANGE_HASHED", "params": {"range_lookup_strategy": "max"}})
+        assert s == "LAYOUT(RANGE_HASHED(range_lookup_strategy 'max'))"
+
+    def test_missing_type_raises(self):
+        try:
+            _render_dict_layout({})
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("expected ValueError")
+
+
+class TestRenderDictLifetime:
+    def test_basic(self):
+        assert _render_dict_lifetime({"min": 3000, "max": 3600}) == "LIFETIME(MIN 3000 MAX 3600)"
+
+    def test_missing_raises(self):
+        try:
+            _render_dict_lifetime({"min": 10})
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("expected ValueError")
+
+
+class TestDictionaryEngine:
+    def test_parse_dictionary_yaml(self, tmp_path):
+        """YAML with full Dictionary metadata parses into DesiredTable."""
+        yaml_path = tmp_path / "test_dict.yaml"
+        yaml_path.write_text(
+            """
+ecosystem: test
+cluster: main
+tables:
+  channel_definition_dict:
+    engine: Dictionary
+    on_nodes: ALL
+    primary_key: domain, kind
+    columns:
+      - name: domain
+        type: String
+      - name: kind
+        type: String
+    source:
+      type: CLICKHOUSE
+      table: channel_definition
+      password: __from_settings__
+    layout:
+      type: COMPLEX_KEY_HASHED
+    lifetime:
+      min: 3000
+      max: 3600
+"""
+        )
+        from posthog.clickhouse.migration_tools.desired_state import parse_desired_state
+
+        state = parse_desired_state(yaml_path)
+        t = state.tables["channel_definition_dict"]
+        assert t.engine == "Dictionary"
+        assert t.primary_key == "domain, kind"
+        assert t.dict_source == {"type": "CLICKHOUSE", "table": "channel_definition", "password": "__from_settings__"}
+        assert t.dict_layout == {"type": "COMPLEX_KEY_HASHED"}
+        assert t.dict_lifetime == {"min": 3000, "max": 3600}
+        # Dictionary `source` must not leak into the Distributed `source` field
+        assert t.source is None
+
+    def test_generate_dictionary_create_sql(self):
+        sql = _generate_create_sql(_dict_table(), "posthog", "main")
+        assert sql.startswith("CREATE DICTIONARY IF NOT EXISTS posthog.channel_definition_dict")
+        assert "PRIMARY KEY domain, kind" in sql
+        assert "SOURCE(CLICKHOUSE(table 'channel_definition' password 'secret'))" in sql
+        assert "LAYOUT(COMPLEX_KEY_HASHED())" in sql
+        assert "LIFETIME(MIN 3000 MAX 3600)" in sql
+
+    def test_generate_dictionary_sql_missing_primary_key_raises(self):
+        t = _dict_table()
+        t.primary_key = None
+        try:
+            _generate_create_sql(t, "posthog", "main")
+        except ValueError as e:
+            assert "primary_key" in str(e)
+        else:
+            raise AssertionError("expected ValueError")
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_dictionary_create_emitted_when_missing(self, _mock_setting, _mock_cluster):
+        """Dictionary in desired but not in current produces a CREATE DICTIONARY diff."""
+        desired = _make_desired({"channel_definition_dict": _dict_table()})
+        diffs = diff_state(desired, {}, database="posthog", cluster="test_cluster")
+        creates = [d for d in diffs if d.action == "create"]
+        assert len(creates) == 1
+        assert creates[0].table == "channel_definition_dict"
+        assert "CREATE DICTIONARY" in creates[0].sql
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_dictionary_drop_uses_drop_dictionary_verb(self, _mock_setting, _mock_cluster):
+        """Extraneous Dictionary in current → drops with DROP DICTIONARY IF EXISTS."""
+        desired = _make_desired({})
+        current = {
+            "stray_dict": TableSchema(
+                name="stray_dict",
+                engine="Dictionary",
+                columns=[_live_col("k", "String")],
+            )
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        drops = [d for d in diffs if d.action == "drop"]
+        assert len(drops) == 1
+        assert "DROP DICTIONARY IF EXISTS posthog.stray_dict" in drops[0].sql
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_dictionary_diff_generates_drop_create_on_column_change(self, _mock_setting, _mock_cluster):
+        """Dictionaries can't ALTER — a column change must emit DROP DICTIONARY + CREATE DICTIONARY."""
+        desired = _make_desired({"channel_definition_dict": _dict_table()})
+        current = {
+            "channel_definition_dict": TableSchema(
+                name="channel_definition_dict",
+                engine="Dictionary",
+                engine_full=(
+                    "Dictionary PRIMARY KEY domain, kind "
+                    "SOURCE(CLICKHOUSE(TABLE 'channel_definition' PASSWORD 'x')) "
+                    "LAYOUT(COMPLEX_KEY_HASHED()) LIFETIME(MIN 3000 MAX 3600)"
+                ),
+                columns=[
+                    _live_col("domain", "String"),
+                    _live_col("kind", "String"),
+                    # Missing `domain_type` → triggers DROP + CREATE
+                ],
+            )
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        drops = [d for d in diffs if d.action == "drop"]
+        creates = [d for d in diffs if d.action == "create"]
+        assert len(drops) == 1
+        assert "DROP DICTIONARY IF EXISTS posthog.channel_definition_dict" in drops[0].sql
+        assert len(creates) == 1
+        assert "CREATE DICTIONARY" in creates[0].sql
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_dictionary_stable_when_matching(self, _mock_setting, _mock_cluster):
+        """Dictionary with matching columns + engine_full metadata → 0 diffs (convergence)."""
+        desired = _make_desired({"channel_definition_dict": _dict_table()})
+        current = {
+            "channel_definition_dict": TableSchema(
+                name="channel_definition_dict",
+                engine="Dictionary",
+                engine_full=(
+                    "Dictionary PRIMARY KEY domain, kind "
+                    "SOURCE(CLICKHOUSE(TABLE 'channel_definition' PASSWORD 'x')) "
+                    "LAYOUT(COMPLEX_KEY_HASHED()) LIFETIME(MIN 3000 MAX 3600)"
+                ),
+                columns=[
+                    _live_col("domain", "String"),
+                    _live_col("kind", "String"),
+                    _live_col("domain_type", "Nullable(String)"),
+                ],
+            )
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        assert len(diffs) == 0, f"Expected 0 diffs but got: {[d.detail for d in diffs]}"
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_dictionary_recreate_on_lifetime_change(self, _mock_setting, _mock_cluster):
+        """LIFETIME metadata change forces DROP + CREATE (Dictionaries don't ALTER)."""
+        desired = _make_desired({"channel_definition_dict": _dict_table()})
+        current = {
+            "channel_definition_dict": TableSchema(
+                name="channel_definition_dict",
+                engine="Dictionary",
+                # Stored lifetime differs from desired (300/600 vs 3000/3600)
+                engine_full=(
+                    "Dictionary PRIMARY KEY domain, kind "
+                    "SOURCE(CLICKHOUSE(TABLE 'channel_definition' PASSWORD 'x')) "
+                    "LAYOUT(COMPLEX_KEY_HASHED()) LIFETIME(MIN 300 MAX 600)"
+                ),
+                columns=[
+                    _live_col("domain", "String"),
+                    _live_col("kind", "String"),
+                    _live_col("domain_type", "Nullable(String)"),
+                ],
+            )
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        recreates = [d for d in diffs if d.action == "recreate"]
+        assert len(recreates) == 1
+        assert "DROP DICTIONARY IF EXISTS posthog.channel_definition_dict" in recreates[0].sql
+        assert "CREATE DICTIONARY" in recreates[0].sql
+        assert "LIFETIME" in recreates[0].detail
+
+
+# -- P1-C: Distributed source with database prefix --------------------------
+
+
+class TestDistributedSourceWithDbPrefix:
+    """P1-C: Distributed(..., '<db>', '<table>', ...) must split source on '.'.
+
+    YAML `source: system.processes` must produce `Distributed(..., 'system',
+    'processes', ...)`. Passing the full string as the table name makes CH
+    resolve `system.processes` in the local database, which fails.
+    """
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_system_processes_split_into_db_and_table(self, _mock_setting, _mock_cluster):
+        table = DesiredTable(
+            name="distributed_system_processes",
+            engine="Distributed",
+            columns=[],
+            on_nodes=["all"],
+            source="system.processes",
+        )
+        sql = _generate_create_sql(table, "posthog_test", "test_cluster")
+
+        assert "'system', 'processes'" in sql, f"Expected 'system', 'processes' in: {sql}"
+        # Must NOT emit the un-split form that CH resolves to the current DB.
+        assert "'posthog_test', 'system.processes'" not in sql
+        # AS clause still references the qualified source so columns inherit.
+        assert "AS system.processes" in sql
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_undotted_source_uses_current_database(self, _mock_setting, _mock_cluster):
+        table = DesiredTable(
+            name="events_dist",
+            engine="Distributed",
+            columns=[_col("uuid", "UUID")],
+            on_nodes=["all"],
+            source="sharded_events",
+        )
+        sql = _generate_create_sql(table, "posthog", "test_cluster")
+
+        assert "'posthog', 'sharded_events'" in sql
+
+
+# -- P1-B: Kafka cascade on MV drop+create pair -----------------------------
+
+
+class TestKafkaCascadeOnSelectChange:
+    """P1-B: When an MV's SELECT changes, the diff emits drop+create rather
+    than recreate_mv. The cascade fix must still re-create the Kafka source.
+    """
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_kafka_recreated_on_mv_select_change(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "kafka_events": DesiredTable(
+                    name="kafka_events",
+                    engine="Kafka",
+                    columns=[_col("event", "String")],
+                    on_nodes=["all"],
+                    settings={"kafka_broker_list": "localhost:9092", "kafka_topic_list": "events"},
+                ),
+                "kafka_events_mv": DesiredTable(
+                    name="kafka_events_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["all"],
+                    target="sharded_events",
+                    select="SELECT event, toUnixTimestamp(timestamp) AS ts FROM posthog.kafka_events",
+                ),
+            }
+        )
+        current = {
+            "kafka_events": TableSchema(
+                name="kafka_events",
+                engine="Kafka",
+                columns=[
+                    _live_col("event", "String"),
+                    _live_col("_topic", "LowCardinality(String)"),
+                ],
+            ),
+            "kafka_events_mv": TableSchema(
+                name="kafka_events_mv",
+                engine="MaterializedView",
+                # Old SELECT — triggers the drop+create path (not recreate_mv)
+                as_select="SELECT event FROM posthog.kafka_events",
+                columns=[_live_col("event", "String")],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+
+        # Verify MV got a drop+create (not recreate_mv)
+        mv_drops = [d for d in diffs if d.action == "drop" and d.table == "kafka_events_mv"]
+        mv_creates = [d for d in diffs if d.action == "create" and d.table == "kafka_events_mv"]
+        assert len(mv_drops) == 1, f"Expected MV drop; got {[d.detail for d in diffs]}"
+        assert len(mv_creates) == 1, f"Expected MV create; got {[d.detail for d in diffs]}"
+
+        # Cascade fix must add a create for the Kafka source
+        kafka_creates = [d for d in diffs if d.action == "create" and d.table == "kafka_events"]
+        assert len(kafka_creates) == 1, (
+            f"Expected Kafka source to be re-added after MV recreate; got {[d.detail for d in diffs]}"
+        )
+        assert "cascade-dropped" in kafka_creates[0].detail.lower()
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_no_cascade_when_mv_stable(self, _mock_setting, _mock_cluster):
+        """Regression: Kafka is not re-added when the MV isn't being recreated."""
+        desired = _make_desired(
+            {
+                "kafka_events": DesiredTable(
+                    name="kafka_events",
+                    engine="Kafka",
+                    columns=[_col("event", "String")],
+                    on_nodes=["all"],
+                    settings={"kafka_broker_list": "localhost:9092", "kafka_topic_list": "events"},
+                ),
+                "kafka_events_mv": DesiredTable(
+                    name="kafka_events_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["all"],
+                    target="sharded_events",
+                    select="SELECT event FROM posthog.kafka_events",
+                ),
+            }
+        )
+        current = {
+            "kafka_events": TableSchema(
+                name="kafka_events",
+                engine="Kafka",
+                columns=[
+                    _live_col("event", "String"),
+                    _live_col("_topic", "LowCardinality(String)"),
+                ],
+            ),
+            "kafka_events_mv": TableSchema(
+                name="kafka_events_mv",
+                engine="MaterializedView",
+                as_select="SELECT event FROM posthog.kafka_events",
+                columns=[_live_col("event", "String")],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        kafka_creates = [d for d in diffs if d.action == "create" and d.table == "kafka_events"]
+        assert len(kafka_creates) == 0, f"Unexpected Kafka recreate: {[d.detail for d in diffs]}"
+
+
+# -- Dictionary introspection + extended recreate checks --
+
+
+class TestDumpDictionaries:
+    def test_enriches_existing_table_schema(self):
+        """dump_dictionaries populates dict_* fields on the matching TableSchema."""
+        from posthog.clickhouse.migration_tools.schema_introspect import TableSchema, dump_dictionaries
+
+        schema = {
+            "channel_definition_dict": TableSchema(
+                name="channel_definition_dict",
+                engine="Dictionary",
+            )
+        }
+
+        class _FakeClient:
+            def execute(self, query, params):
+                assert "system.dictionaries" in query
+                assert params == {"database": "posthog"}
+                return [
+                    (
+                        "channel_definition_dict",
+                        "ClickHouse: posthog.channel_definition",
+                        "ComplexKeyHashed",
+                        3000,
+                        3600,
+                    )
+                ]
+
+        dump_dictionaries(_FakeClient(), "posthog", schema)
+        t = schema["channel_definition_dict"]
+        assert t.dict_source_type == "ClickHouse"
+        assert t.dict_source_raw == "ClickHouse: posthog.channel_definition"
+        assert t.dict_layout_type == "COMPLEXKEYHASHED"
+        assert t.dict_lifetime_min == 3000
+        assert t.dict_lifetime_max == 3600
+
+    def test_skips_rows_without_system_tables_entry(self):
+        """Rows in system.dictionaries with no system.tables counterpart are skipped."""
+        from posthog.clickhouse.migration_tools.schema_introspect import dump_dictionaries
+
+        schema: dict = {}
+
+        class _FakeClient:
+            def execute(self, query, params):
+                return [("orphan_dict", "HTTP: https://x", "Hashed", 60, 120)]
+
+        dump_dictionaries(_FakeClient(), "posthog", schema)
+        # No TableSchema was in schema, so dump_dictionaries adds nothing.
+        assert schema == {}
+
+
+class TestDictionaryRecreateExtended:
+    """Covers the new source/layout param checks in the recreate path."""
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_recreate_on_source_type_change(self, _mock_setting, _mock_cluster):
+        """Changing SOURCE type (CLICKHOUSE -> HTTP) triggers recreate."""
+        desired = _make_desired({"channel_definition_dict": _dict_table()})
+        current = {
+            "channel_definition_dict": TableSchema(
+                name="channel_definition_dict",
+                engine="Dictionary",
+                engine_full=(
+                    "Dictionary PRIMARY KEY domain, kind "
+                    "SOURCE(HTTP(url 'https://x' format 'CSVWithNames')) "
+                    "LAYOUT(COMPLEX_KEY_HASHED()) LIFETIME(MIN 3000 MAX 3600)"
+                ),
+                dict_source_type="HTTP",
+                dict_layout_type="COMPLEX_KEY_HASHED",
+                dict_lifetime_min=3000,
+                dict_lifetime_max=3600,
+                columns=[
+                    _live_col("domain", "String"),
+                    _live_col("kind", "String"),
+                    _live_col("domain_type", "Nullable(String)"),
+                ],
+            )
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        recreates = [d for d in diffs if d.action == "recreate"]
+        assert len(recreates) == 1
+        assert "SOURCE type changed" in recreates[0].detail
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_complex_key_layout_normalization(self, _mock_setting, _mock_cluster):
+        """YAML `HASHED` and live `COMPLEX_KEY_HASHED` are semantically equal.
+
+        CH auto-upgrades HASHED → COMPLEX_KEY_HASHED when the primary key is
+        a String or composite. Without normalization the diff would re-create
+        the dict every apply.
+        """
+        desired_table = _dict_table()
+        desired_table.dict_layout = {"type": "HASHED"}
+        desired = _make_desired({"channel_definition_dict": desired_table})
+        current = {
+            "channel_definition_dict": TableSchema(
+                name="channel_definition_dict",
+                engine="Dictionary",
+                engine_full=(
+                    "CREATE DICTIONARY posthog.channel_definition_dict "
+                    "(`domain` String, `kind` String, `domain_type` Nullable(String)) "
+                    "PRIMARY KEY domain, kind "
+                    "SOURCE(CLICKHOUSE(TABLE 'channel_definition' PASSWORD '[HIDDEN]')) "
+                    "LAYOUT(COMPLEX_KEY_HASHED()) "
+                    "LIFETIME(MIN 3000 MAX 3600)"
+                ),
+                dict_source_type="ClickHouse",
+                dict_layout_type="COMPLEX_KEY_HASHED",
+                dict_lifetime_min=3000,
+                dict_lifetime_max=3600,
+                columns=[
+                    _live_col("domain", "String"),
+                    _live_col("kind", "String"),
+                    _live_col("domain_type", "Nullable(String)"),
+                ],
+            )
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        recreates = [d for d in diffs if d.action == "recreate"]
+        assert recreates == []
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_not_loaded_dict_uses_engine_full_fallback(self, _mock_setting, _mock_cluster):
+        """NOT_LOADED dicts return empty system.dictionaries rows — diff reads from engine_full.
+
+        schema_introspect populates engine_full from create_table_query for
+        Dictionary engines, which is always available regardless of load state.
+        """
+        desired_table = _dict_table()
+        desired_table.primary_key = "domain"
+        desired_table.dict_layout = {"type": "RANGE_HASHED", "params": {"range_lookup_strategy": "max"}}
+        desired_table.dict_range = {"min": "start_date", "max": "end_date"}
+        desired_table.columns = [
+            ColumnDef(name="domain", type="String"),
+            ColumnDef(name="start_date", type="Date"),
+            ColumnDef(name="end_date", type="Nullable(Date)"),
+            ColumnDef(name="rate", type="Decimal64(10)"),
+        ]
+        desired = _make_desired({"channel_definition_dict": desired_table})
+        current = {
+            "channel_definition_dict": TableSchema(
+                name="channel_definition_dict",
+                engine="Dictionary",
+                # Dictionary not loaded yet — system.dictionaries columns empty/0.
+                engine_full=(
+                    "CREATE DICTIONARY posthog.channel_definition_dict "
+                    "(`domain` String, `start_date` Date, `end_date` Nullable(Date), `rate` Decimal64(10)) "
+                    "PRIMARY KEY domain "
+                    "SOURCE(CLICKHOUSE(QUERY 'SELECT ...' USER 'default' PASSWORD '[HIDDEN]')) "
+                    "LIFETIME(MIN 3000 MAX 3600) "
+                    "LAYOUT(COMPLEX_KEY_RANGE_HASHED(RANGE_LOOKUP_STRATEGY 'max')) "
+                    "RANGE(MIN start_date MAX end_date)"
+                ),
+                dict_source_type="",
+                dict_layout_type="",
+                dict_lifetime_min=0,
+                dict_lifetime_max=0,
+                columns=[
+                    _live_col("domain", "String"),
+                    _live_col("start_date", "Date"),
+                    _live_col("end_date", "Nullable(Date)"),
+                    _live_col("rate", "Decimal64(10)"),
+                ],
+            )
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        assert len(diffs) == 0, f"Expected 0 diffs but got: {[d.detail for d in diffs]}"
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_source_param_change_does_not_trigger_recreate(self, _mock_setting, _mock_cluster):
+        """SOURCE param diffs (table, URL, query text) do NOT trigger recreate.
+
+        CH stores DDL with password masked as [HIDDEN], uppercases param keys,
+        and reformats query text — substring matching false-positives on these
+        normalizations. Users who truly need to rewrite the SOURCE change the
+        dict name or force-drop manually.
+        """
+        desired = _make_desired({"channel_definition_dict": _dict_table()})
+        current = {
+            "channel_definition_dict": TableSchema(
+                name="channel_definition_dict",
+                engine="Dictionary",
+                engine_full=(
+                    "Dictionary PRIMARY KEY domain, kind "
+                    "SOURCE(CLICKHOUSE(TABLE 'old_table' PASSWORD 'secret')) "
+                    "LAYOUT(COMPLEX_KEY_HASHED()) LIFETIME(MIN 3000 MAX 3600)"
+                ),
+                dict_source_type="ClickHouse",
+                dict_layout_type="COMPLEX_KEY_HASHED",
+                dict_lifetime_min=3000,
+                dict_lifetime_max=3600,
+                columns=[
+                    _live_col("domain", "String"),
+                    _live_col("kind", "String"),
+                    _live_col("domain_type", "Nullable(String)"),
+                ],
+            )
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        recreates = [d for d in diffs if d.action == "recreate"]
+        assert recreates == []
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_layout_param_change_does_not_trigger_recreate(self, _mock_setting, _mock_cluster):
+        """LAYOUT param diffs (PREALLOCATE, SHARDS, size_in_cells) do NOT trigger recreate.
+
+        CH normalizes param casing and ordering; substring comparison false-
+        positives on formatting. Only the LAYOUT type (HASHED vs
+        COMPLEX_KEY_HASHED vs RANGE_HASHED etc.) is checked.
+        """
+        desired_table = _dict_table()
+        desired_table.dict_layout = {"type": "COMPLEX_KEY_HASHED", "params": {"PREALLOCATE": 1}}
+        desired = _make_desired({"channel_definition_dict": desired_table})
+        current = {
+            "channel_definition_dict": TableSchema(
+                name="channel_definition_dict",
+                engine="Dictionary",
+                engine_full=(
+                    "Dictionary PRIMARY KEY domain, kind "
+                    "SOURCE(CLICKHOUSE(TABLE 'channel_definition' PASSWORD 'secret')) "
+                    "LAYOUT(COMPLEX_KEY_HASHED()) LIFETIME(MIN 3000 MAX 3600)"
+                ),
+                dict_source_type="ClickHouse",
+                dict_layout_type="COMPLEX_KEY_HASHED",
+                dict_lifetime_min=3000,
+                dict_lifetime_max=3600,
+                columns=[
+                    _live_col("domain", "String"),
+                    _live_col("kind", "String"),
+                    _live_col("domain_type", "Nullable(String)"),
+                ],
+            )
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        recreates = [d for d in diffs if d.action == "recreate"]
+        assert recreates == []
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_stable_when_source_and_layout_match(self, _mock_setting, _mock_cluster):
+        """Structured fields matching desired -> 0 diffs (convergence)."""
+        desired = _make_desired({"channel_definition_dict": _dict_table()})
+        current = {
+            "channel_definition_dict": TableSchema(
+                name="channel_definition_dict",
+                engine="Dictionary",
+                engine_full=(
+                    "Dictionary PRIMARY KEY domain, kind "
+                    "SOURCE(CLICKHOUSE(TABLE 'channel_definition' PASSWORD 'secret')) "
+                    "LAYOUT(COMPLEX_KEY_HASHED()) LIFETIME(MIN 3000 MAX 3600)"
+                ),
+                dict_source_type="ClickHouse",
+                dict_layout_type="COMPLEX_KEY_HASHED",
+                dict_lifetime_min=3000,
+                dict_lifetime_max=3600,
+                columns=[
+                    _live_col("domain", "String"),
+                    _live_col("kind", "String"),
+                    _live_col("domain_type", "Nullable(String)"),
+                ],
+            )
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        assert len(diffs) == 0, f"Expected 0 diffs but got: {[d.detail for d in diffs]}"
+
+
+class TestRenderDictRange:
+    def test_renders_min_max_columns(self):
+        from posthog.clickhouse.migration_tools.state_diff import _render_dict_range
+
+        assert _render_dict_range({"min": "start_date", "max": "end_date"}) == "RANGE(MIN start_date MAX end_date)"
+
+    def test_none_returns_empty(self):
+        from posthog.clickhouse.migration_tools.state_diff import _render_dict_range
+
+        assert _render_dict_range(None) == ""
+
+    def test_missing_keys_raises(self):
+        from posthog.clickhouse.migration_tools.state_diff import _render_dict_range
+
+        try:
+            _render_dict_range({"min": "x"})
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("expected ValueError")
+
+
+class TestDictionaryRangeInCreateSql:
+    def test_range_appears_after_lifetime(self):
+        """CREATE DICTIONARY with dict_range emits RANGE(MIN x MAX y) after LIFETIME."""
+        t = _dict_table()
+        t.dict_layout = {"type": "RANGE_HASHED", "params": {"range_lookup_strategy": "max"}}
+        t.dict_range = {"min": "start_date", "max": "end_date"}
+        sql = _generate_create_sql(t, "posthog", "main")
+        # RANGE must come after LIFETIME line. Use "RANGE(MIN" to avoid
+        # matching the "RANGE_HASHED" token inside the LAYOUT clause.
+        assert "LIFETIME(MIN 3000 MAX 3600)" in sql
+        assert "RANGE(MIN start_date MAX end_date)" in sql
+        assert sql.index("RANGE(MIN") > sql.index("LIFETIME")
+
+    def test_no_range_when_none(self):
+        """CREATE DICTIONARY without dict_range emits no RANGE clause."""
+        t = _dict_table()
+        sql = _generate_create_sql(t, "posthog", "main")
+        assert "RANGE(" not in sql


### PR DESCRIPTION
## Summary
- Split oversized reconciliation and state-diff tests into focused files to reduce review size pressure.
- Preserve behavior while making subsequent functional PRs stay below the 2k line cap.
- Establishes the split-test baseline for the vertical PR stack.

## Test plan
- [x] python syntax compile for new split test modules
- [ ] full CI on stacked branch