### PR TITLE
feat(ch_migrate): add desired-state command foundation

### DIFF
--- a/posthog/clickhouse/migration_tools/README.md
+++ b/posthog/clickhouse/migration_tools/README.md
@@ -1,0 +1,77 @@
+# ClickHouse migration tools
+
+Declarative, Terraform-style schema management for ClickHouse.
+
+## Architecture
+
+```text
+schema/*.yaml          desired state (what you want)
+     |
+     v
+desired_state.py       parse YAML into DesiredState objects
+     |
+     v
+state_diff.py          diff desired vs current -> list[StateDiff]
+     |
+     v
+plan_generator.py      StateDiff -> human-readable plan + ManifestStep list
+     |
+     v
+runner.py              route each ManifestStep to correct ClickHouse nodes
+```
+
+Supporting modules:
+
+- `schema_introspect.py` -- query live ClickHouse for current schema, detect drift
+- `schema_graph.py` -- table ecosystem definitions (which tables form a pipeline)
+- `tracking.py` -- advisory locking for concurrent apply prevention
+- `manifest.py` -- ManifestStep dataclass and node role mapping
+- `templates.py` -- generate schema YAML dicts from named templates
+- `validator.py` -- lint schema YAML for ecosystem completeness and targeting
+
+## Developer flow
+
+```bash
+# Generate schema YAML from a template
+python manage.py ch_migrate generate --template ingestion_pipeline --table sessions_v4
+
+# Edit the generated YAML
+$EDITOR posthog/clickhouse/schema/sessions_v4.yaml
+
+# Diff desired vs current
+python manage.py ch_migrate plan
+
+# Execute the plan
+python manage.py ch_migrate apply
+```
+
+## Available templates
+
+| Template                 | Objects created                                |
+| ------------------------ | ---------------------------------------------- |
+| `ingestion_pipeline`     | kafka + sharded + writable + readable + MV (5) |
+| `sharded_table`          | sharded + writable + readable (3)              |
+| `cross_cluster_readable` | distributed table for cross-cluster reads      |
+| `materialized_view`      | single MV                                      |
+| `add_column`             | guidance to edit existing YAML directly        |
+| `drop_table`             | guidance to remove from existing YAML          |
+
+## Modules
+
+- `desired_state.py` -- parses `schema/*.yaml` into DesiredState objects
+- `state_diff.py` -- diffs desired state against live ClickHouse schema
+- `plan_generator.py` -- generates human-readable plan + executable SQL steps
+- `schema_introspect.py` -- queries `system.tables`/`system.columns` across all hosts
+- `schema_graph.py` -- models table ecosystems (events, sessions, person, replay)
+- `templates.py` -- generates desired-state YAML from template configs
+- `runner.py` -- executes SQL steps via ClickhouseCluster + legacy migration support
+- `tracking.py` -- per-host step tracking, advisory locking
+- `validator.py` -- validates desired-state YAML (ecosystem completeness, cross-cluster targeting)
+- `manifest.py` -- ManifestStep dataclass + node role mapping
+
+## Running tests
+
+```bash
+uv run python -m pytest posthog/clickhouse/test/test_reconcile.py -v
+uv run python -m pytest posthog/clickhouse/test/test_advisory_lock.py -v
+```

--- a/posthog/clickhouse/migration_tools/__init__.py
+++ b/posthog/clickhouse/migration_tools/__init__.py
@@ -1,0 +1,1 @@
+# ClickHouse desired-state reconciliation engine.

--- a/posthog/clickhouse/migration_tools/desired_state.py
+++ b/posthog/clickhouse/migration_tools/desired_state.py
@@ -1,0 +1,207 @@
+"""Parse desired-state YAML files into typed Python objects.
+
+Each YAML file declares the complete desired schema for one table ecosystem
+(e.g. events, sessions_v3, person). The system reads these files, diffs them
+against live ClickHouse state, and generates migration plans.
+
+This is the "terraform plan" equivalent for ClickHouse schema management.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class ColumnDef:
+    name: str
+    type: str
+    default_kind: str = ""
+    default_expression: str = ""
+    codec: str = ""
+
+
+@dataclass
+class DesiredTable:
+    name: str
+    engine: str
+    columns: list[ColumnDef]
+    on_nodes: list[str]
+    order_by: list[str] | None = None
+    partition_by: str | None = None
+    sharded: bool = False
+    sharding_key: str | None = None
+    source: str | None = None  # for Distributed: the local table
+    target: str | None = None  # for MV: the target table
+    select: str | None = None  # for MV: the SELECT statement
+    settings: dict[str, str] | None = None  # for Kafka: engine settings
+    inherit_columns_from: str | None = None
+    # Dictionary-only fields. All three (dict_source/dict_layout/dict_lifetime)
+    # are required alongside primary_key when engine == "Dictionary".
+    primary_key: str | None = None
+    dict_source: dict[str, Any] | None = None  # {"type": "CLICKHOUSE", "table": "...", ...}
+    dict_layout: dict[str, Any] | None = None  # {"type": "COMPLEX_KEY_HASHED", "params": {...}}
+    dict_lifetime: dict[str, int] | None = None  # {"min": 3000, "max": 3600}
+    # RANGE(MIN x MAX y) clause — only populated for RANGE_HASHED layouts where
+    # the dictionary holds per-range values (exchange_rate_dict being the
+    # canonical example). Kept separate from dict_layout because RANGE is a
+    # top-level DDL clause, not a LAYOUT parameter.
+    dict_range: dict[str, str] | None = None  # {"min": "start_date", "max": "end_date"}
+
+
+@dataclass
+class DesiredState:
+    ecosystem: str
+    cluster: str
+    tables: dict[str, DesiredTable]
+    database: str = "posthog"
+
+
+def _parse_column(raw: dict[str, Any]) -> ColumnDef:
+    return ColumnDef(
+        name=raw["name"],
+        type=raw["type"],
+        default_kind=raw.get("default_kind", ""),
+        default_expression=raw.get("default_expression", raw.get("default", "")),
+        codec=raw.get("codec", ""),
+    )
+
+
+def _parse_columns(raw: Any, all_tables: dict[str, Any], _visited: frozenset[str] | None = None) -> list[ColumnDef]:
+    """Parse columns, handling 'inherit <table_name>' syntax.
+
+    Tracks visited tables via _visited to detect circular inheritance.
+    """
+    if _visited is None:
+        _visited = frozenset()
+    if isinstance(raw, str) and raw.startswith("inherit "):
+        source_table = raw.split(" ", 1)[1].strip()
+        if source_table in _visited:
+            cycle = " -> ".join([*sorted(_visited), source_table])
+            raise ValueError(f"Circular column inheritance detected: {cycle}")
+        source_raw = all_tables.get(source_table)
+        if source_raw is None:
+            raise ValueError(f"Cannot inherit columns from unknown table '{source_table}'")
+        source_cols = source_raw.get("columns")
+        if isinstance(source_cols, str) and source_cols.startswith("inherit "):
+            return _parse_columns(source_cols, all_tables, _visited | {source_table})
+        if not isinstance(source_cols, list):
+            raise ValueError(f"Source table '{source_table}' has no column list to inherit from")
+        return [_parse_column(c) for c in source_cols]
+    if isinstance(raw, list):
+        return [_parse_column(c) for c in raw]
+    raise ValueError(f"'columns' must be a list of column defs or 'inherit <table_name>', got {type(raw).__name__}")
+
+
+def _parse_table(name: str, raw: dict[str, Any], all_tables: dict[str, Any]) -> DesiredTable:
+    engine = raw.get("engine", "")
+    if not engine:
+        raise ValueError(f"Table '{name}' must have an 'engine' field")
+
+    columns_raw = raw.get("columns", [])
+    inherit_from: str | None = None
+    if isinstance(columns_raw, str) and columns_raw.startswith("inherit "):
+        inherit_from = columns_raw.split(" ", 1)[1].strip()
+    columns = _parse_columns(columns_raw, all_tables)
+
+    # Use `or` instead of a dict default so that an explicit `None`
+    # (from YAML `on_nodes:` with no value) also falls back to ["ALL"].
+    on_nodes_raw = raw.get("on_nodes") or ["ALL"]
+    if isinstance(on_nodes_raw, str):
+        on_nodes_raw = [on_nodes_raw]
+
+    order_by = raw.get("order_by")
+    if isinstance(order_by, str):
+        order_by = [order_by]
+
+    settings = raw.get("settings")
+    if settings and isinstance(settings, dict):
+        settings = {k: str(v) for k, v in settings.items()}
+
+    # Dictionary engines read `source`/`layout`/`lifetime` as nested mappings,
+    # not the scalar `source` used by Distributed (which is a table name string).
+    # Route the Dictionary form into dict_* fields so the two don't collide.
+    dict_source: dict[str, Any] | None = None
+    dict_layout: dict[str, Any] | None = None
+    dict_lifetime: dict[str, int] | None = None
+    dict_range: dict[str, str] | None = None
+    primary_key = raw.get("primary_key")
+    source_raw = raw.get("source")
+    if engine.lower() == "dictionary":
+        if isinstance(source_raw, dict):
+            dict_source = source_raw
+            source_raw = None  # don't leak the mapping into DesiredTable.source
+        layout_raw = raw.get("layout")
+        if isinstance(layout_raw, dict):
+            dict_layout = layout_raw
+        lifetime_raw = raw.get("lifetime")
+        if isinstance(lifetime_raw, dict):
+            dict_lifetime = {k: int(v) for k, v in lifetime_raw.items()}
+        range_raw = raw.get("range")
+        if isinstance(range_raw, dict):
+            dict_range = {k: str(v) for k, v in range_raw.items()}
+
+    return DesiredTable(
+        name=name,
+        engine=engine,
+        columns=columns,
+        on_nodes=on_nodes_raw,
+        order_by=order_by,
+        partition_by=raw.get("partition_by"),
+        sharded=raw.get("sharded", False),
+        sharding_key=raw.get("sharding_key"),
+        source=source_raw if isinstance(source_raw, str) else None,
+        target=raw.get("target"),
+        select=raw.get("select"),
+        settings=settings,
+        inherit_columns_from=inherit_from,
+        primary_key=primary_key,
+        dict_source=dict_source,
+        dict_layout=dict_layout,
+        dict_lifetime=dict_lifetime,
+        dict_range=dict_range,
+    )
+
+
+def parse_desired_state(yaml_path: Path) -> DesiredState:
+    """Parse a single desired-state YAML file into a DesiredState object."""
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Desired state YAML must be a mapping, got {type(data).__name__}")
+
+    ecosystem = data.get("ecosystem", "")
+    if not ecosystem:
+        raise ValueError("Desired state YAML must have an 'ecosystem' field")
+
+    cluster = data.get("cluster", "main")
+    database = data.get("database", "posthog")
+
+    raw_tables = data.get("tables", {})
+    if not isinstance(raw_tables, dict):
+        raise ValueError(f"'tables' must be a mapping, got {type(raw_tables).__name__}")
+
+    tables: dict[str, DesiredTable] = {}
+    for table_name, table_raw in raw_tables.items():
+        tables[table_name] = _parse_table(table_name, table_raw, raw_tables)
+
+    return DesiredState(
+        ecosystem=ecosystem,
+        cluster=cluster,
+        tables=tables,
+        database=database,
+    )
+
+
+def parse_desired_state_dir(schema_dir: Path) -> list[DesiredState]:
+    """Parse all YAML files in a directory into DesiredState objects."""
+    states: list[DesiredState] = []
+    yaml_files = sorted(schema_dir.glob("*.yaml")) + sorted(schema_dir.glob("*.yml"))
+    for yaml_path in yaml_files:
+        states.append(parse_desired_state(yaml_path))
+    return states

--- a/posthog/clickhouse/migration_tools/manifest.py
+++ b/posthog/clickhouse/migration_tools/manifest.py
@@ -1,0 +1,34 @@
+"""Shared data types for ClickHouse migration steps."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+ROLE_MAP: dict[str, str] = {
+    "DATA": "data",
+    "COORDINATOR": "coordinator",
+    "INGESTION_EVENTS": "events",
+    "INGESTION_SMALL": "small",
+    "INGESTION_MEDIUM": "medium",
+    "SHUFFLEHOG": "shufflehog",
+    "ENDPOINTS": "endpoints",
+    "LOGS": "logs",
+    "ALL": "all",
+    "OPS": "ops",
+    "AI_EVENTS": "ai_events",
+    "AUX": "aux",
+    "SESSIONS": "sessions",
+}
+
+
+@dataclass
+class ManifestStep:
+    sql: str
+    node_roles: list[str]
+    comment: str = ""
+    sharded: bool = False
+    is_alter_on_replicated_table: bool = False
+    # Logical cluster name this step targets. Empty string means the caller
+    # should use the default migrations cluster. Propagated from StateDiff
+    # so the runner can resolve the correct physical cluster per step.
+    cluster: str = ""

--- a/posthog/clickhouse/migration_tools/runner.py
+++ b/posthog/clickhouse/migration_tools/runner.py
@@ -1,0 +1,151 @@
+"""Step execution engine -- routes SQL to correct ClickHouse nodes by role.
+
+Also provides legacy migration support: discover_migrations, get_pending_migrations,
+run_migration_down.
+"""
+
+from __future__ import annotations
+
+import os
+import importlib
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from posthog.clickhouse.migration_tools.manifest import ROLE_MAP, ManifestStep
+
+if TYPE_CHECKING:
+    from posthog.clickhouse.cluster import ClickhouseCluster
+
+# Legacy migrations live here
+MIGRATIONS_DIR = Path(__file__).resolve().parent.parent / "migrations"
+
+
+def _map_node_roles(manifest_roles: list[str]) -> list:
+    from posthog.clickhouse.client.connection import NodeRole
+
+    result = []
+    for role in manifest_roles:
+        role_value = ROLE_MAP.get(role)
+        if role_value is None:
+            raise ValueError(f"Unknown node role '{role}'. Valid roles: {sorted(ROLE_MAP.keys())}")
+        result.append(NodeRole(role_value))
+    return result
+
+
+def execute_migration_step(
+    cluster: ClickhouseCluster,
+    step: ManifestStep,
+    rendered_sql: str,
+) -> dict[Any, Any]:
+    """Routing: sharded+alter_replicated -> one_host_per_shard, alter_replicated -> any_host, else -> all hosts."""
+    from posthog.clickhouse.cluster import Query
+
+    query = Query(rendered_sql)
+    node_roles = _map_node_roles(step.node_roles)
+
+    if step.sharded and step.is_alter_on_replicated_table:
+        futures_map = cluster.map_one_host_per_shard(query)
+        return futures_map.result()
+    elif step.is_alter_on_replicated_table:
+        future = cluster.any_host_by_roles(query, node_roles=node_roles)
+        result = future.result()
+        return {"single_host": result}
+    else:
+        futures_map = cluster.map_hosts_by_roles(query, node_roles=node_roles)
+        return futures_map.result()
+
+
+# ------------------------------------------------------------------
+# Legacy migration support
+# ------------------------------------------------------------------
+
+
+def discover_migrations() -> list[str]:
+    """Find all legacy .py migration modules in the migrations directory.
+
+    Returns sorted module names like ['0001_initial', '0002_add_events', ...].
+    """
+    if not MIGRATIONS_DIR.exists():
+        return []
+
+    migrations = []
+    for entry in sorted(os.listdir(MIGRATIONS_DIR)):
+        # Match NNNN_name.py or NNNN_name/ (directory migrations)
+        if entry.startswith("0") and not entry.startswith("__"):
+            name = entry.removesuffix(".py")
+            # Accept .py files, legacy dir migrations with __init__.py, and
+            # new-style manifest directories with a manifest.yaml. Earlier
+            # this only matched __init__.py, so manifest-only migrations
+            # silently disappeared from legacy discovery.
+            entry_path = MIGRATIONS_DIR / entry
+            if entry_path.is_file() and entry.endswith(".py"):
+                migrations.append(name)
+            elif entry_path.is_dir() and (
+                (entry_path / "__init__.py").exists() or (entry_path / "manifest.yaml").exists()
+            ):
+                migrations.append(name)
+
+    return migrations
+
+
+def get_pending_migrations() -> list[str]:
+    """Return legacy migrations that haven't been applied yet.
+
+    Checks the infi clickhouse_orm migration tracking.
+    """
+    all_migrations = discover_migrations()
+    if not all_migrations:
+        return []
+
+    try:
+        from posthog.clickhouse.client.migration_tools import get_migrations_cluster
+
+        cluster = get_migrations_cluster()
+        client = cluster.any_host(lambda c: c).result()
+
+        # Check what's been recorded in the infi tracking system
+        rows = client.execute(
+            "SELECT name FROM system.tables WHERE database = 'default' AND name = 'infi_clickhouse_orm_migrations'"
+        )
+        if not rows:
+            return all_migrations  # no tracking table = everything is pending
+
+        applied_rows = client.execute("SELECT package_name FROM default.infi_clickhouse_orm_migrations")
+        applied = {row[0] for row in applied_rows}
+
+        return [m for m in all_migrations if m not in applied]
+    except Exception:
+        return all_migrations
+
+
+def run_migration_down(migration_number: int) -> None:
+    """Roll back a legacy migration by number."""
+    migrations = discover_migrations()
+    target = None
+    for m in migrations:
+        if m.startswith(f"{migration_number:04d}_"):
+            target = m
+            break
+
+    if target is None:
+        raise ValueError(f"Migration {migration_number} not found")
+
+    module_path = f"posthog.clickhouse.migrations.{target}"
+    module = importlib.import_module(module_path)
+    rollback_ops = getattr(module, "rollback_operations", [])
+
+    if not rollback_ops:
+        raise ValueError(f"Migration {target} has no rollback_operations")
+
+    from posthog.clickhouse.client.migration_tools import get_migrations_cluster
+
+    cluster = get_migrations_cluster()
+
+    for op in rollback_ops:
+        if hasattr(op, "sql"):
+            from posthog.clickhouse.cluster import Query
+
+            cluster.map_all_hosts(Query(op.sql)).result()
+        elif hasattr(op, "fn"):
+            client = cluster.any_host(lambda c: c).result()
+            op.fn(client)

--- a/posthog/clickhouse/migration_tools/runner.py
+++ b/posthog/clickhouse/migration_tools/runner.py
@@ -7,6 +7,7 @@ run_migration_down.
 from __future__ import annotations
 
 import os
+import logging
 import importlib
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -18,6 +19,7 @@ if TYPE_CHECKING:
 
 # Legacy migrations live here
 MIGRATIONS_DIR = Path(__file__).resolve().parent.parent / "migrations"
+logger = logging.getLogger(__name__)
 
 
 def _map_node_roles(manifest_roles: list[str]) -> list:
@@ -114,7 +116,8 @@ def get_pending_migrations() -> list[str]:
         applied = {row[0] for row in applied_rows}
 
         return [m for m in all_migrations if m not in applied]
-    except Exception:
+    except Exception as exc:
+        logger.warning("Could not read applied legacy migrations from ClickHouse: %s", exc)
         return all_migrations
 
 

--- a/posthog/clickhouse/migrations/README.md
+++ b/posthog/clickhouse/migrations/README.md
@@ -1,109 +1,172 @@
-## Creating ClickHouse schema changes
+# ClickHouse migrations
 
-**Important:** ClickHouse schema changes should be created as a separate PR from application code changes. This allows for:
+This directory contains ClickHouse schema migrations for PostHog.
 
-- Independent review and testing of schema migrations
-- Safer rollout of database changes
-- Clear separation between infrastructure and application logic changes
+## How it works
 
-## About migrations
+The old migration system (`run_sql_with_exceptions`) asks you to pick from 12 node roles,
+know whether a table is sharded, remember to set `is_alter_on_replicated_table`,
+and get the execution order right for companion tables (Kafka, MV, Distributed).
+Miss any of these and your migration runs on the wrong nodes, silently.
 
-Not all migrations are intended to run on all nodes every time, because of the topologies we run. Some nodes are intended to only perform compute operations and do not contain sharded tables.
+The new system works like Terraform for ClickHouse.
+You declare the schema you want in YAML, diff it against what's actually running, and apply the difference.
 
-Some tables are meant to run only on a couple of nodes, like some Kafka tables, to prevent the whole cluster to run too many insertions in ClickHouse.
+```bash
+# Scaffold a new table ecosystem
+python manage.py ch_migrate generate --template ingestion_pipeline --table sessions_v4
 
-And, in some other cases, we want to only create one table (like a unique Kafka consumer) in one node.
+# See what would change
+python manage.py ch_migrate plan
 
-Because of the above, take the following advice into consideration when manipulating schemas for ClickHouse.
+# Do it
+python manage.py ch_migrate apply
+```
 
-### When to run a migration ONLY on a data node
+```mermaid
+graph LR
+    YAML["schema/X.yaml"] -->|plan| Diff["Diff vs live CH"]
+    Diff -->|apply| CH["ClickHouse"]
+```
 
-- When adding / updating a sharded data table
+The plan output shows every SQL statement, which hosts it targets, and the execution order.
+Review it the same way you'd review a Terraform plan before hitting apply.
 
-In the above cases, create a migration and call the `run_sql_with_exceptions` function with the `node_roles` set to `[NodeRole.DATA]`.
+## Migration approaches
 
-<details>
+### Desired-state YAML (new)
 
-<summary>Example</summary>
-For example, the `sharded_events` table is a sharded table. Thus, it should only be added on data nodes.
+Schema is declared in `posthog/clickhouse/schema/*.yaml`.
+The system diffs desired state against live ClickHouse and generates a plan.
 
-Also, since to fill this table we need to consume events from Kafka, we need to run Kafka consumers on the data nodes, which would include the materialized view and the writable distributed table. So the `kafka_events_json`, `events_json_mv` and `writable_events` tables should also be added on them.
+Developer flow:
 
-</details>
+```bash
+# Generate a schema YAML from a template
+python manage.py ch_migrate generate --template ingestion_pipeline --table sessions_v4
 
-### When to run a migration on DATA nodes (non-sharded)
+# Diff desired vs current, show plan
+python manage.py ch_migrate plan
 
-- Basically when the migration does not include any of the above listed in the previous section.
-- When adding / updating a distributed table for reading
-- When adding / updating a replicated table
-- When adding / updating a view
-- When adding / updating a dictionary
-- And so on
+# Execute the plan
+python manage.py ch_migrate apply
+```
 
-In the above cases, create a migration and call the `run_sql_with_exceptions` function with the `node_roles` set to `[NodeRole.DATA]`.
+### Legacy .py migrations
 
-<details>
+The numbered `.py` files (0001 through 0223) are legacy migrations
+managed by `migrate_clickhouse`.
+They are untouched and still discoverable by `ch_migrate check`.
 
-<summary>Example</summary>
+## Schema YAML format
 
-Following the previous section example, the sharded events table along with the Kafka tables, materialized views and writable distributed table would be added to the data nodes. The `distributed_events`, which is the table used for the read path, would also be added to data nodes.
+Each YAML file declares one table ecosystem:
 
-</details>
+```yaml
+ecosystem: events
+cluster: main
 
-## When to use NodeRole.INGESTION_SMALL or NodeRole.INGESTION_MEDIUM
+tables:
+  sharded_events:
+    engine: ReplicatedReplacingMergeTree
+    sharded: true
+    on_nodes: DATA
+    order_by: [team_id, 'toDate(timestamp)', event]
+    partition_by: 'toYYYYMM(timestamp)'
+    columns:
+      - name: uuid
+        type: UUID
+      - name: event
+        type: String
 
-We have extra nodes with a sole purpose of ingesting the data from Kafka topics into ClickHouse tables. These nodes don't contain any data perse, only Kafka tables and Distributed ones, along with the materialized views that connect them.
+  writable_events:
+    engine: Distributed
+    source: sharded_events
+    on_nodes: COORDINATOR
+    columns: inherit sharded_events
 
-Use these node roles exclusively when you need to ingest data from Kafka into ClickHouse.
+  events:
+    engine: Distributed
+    source: sharded_events
+    on_nodes: ALL
+    columns: inherit sharded_events
+```
 
-When you want to pull data from Kafka into ClickHouse, you should:
+## `ch_migrate` subcommands
 
-1. Create a Kafka table.
-2. Create a writable table only on ingestion nodes. It should be a Distributed table with your data table.
-   1. If your data table is non-sharded, you should point it to one shard: `Distributed(..., cluster=settings.CLICKHOUSE_SINGLE_SHARD_CLUSTER)`, without using any sharding key.
-   2. If your data table is sharded, you should point it to all shards: `Distributed(..., cluster=settings.CLICKHOUSE_CLUSTER, sharding_key="...")`, using a sharding key.
-3. Create a materialized view between Kafka table and the writable table.
+| Command     | Description                              |
+| ----------- | ---------------------------------------- |
+| `plan`      | Diff schema YAML vs live ClickHouse      |
+| `apply`     | Execute the reconciliation plan          |
+| `generate`  | Scaffold a schema YAML from a template   |
+| `drift`     | Detect per-host schema divergence        |
+| `schema`    | Dump current live schema                 |
+| `status`    | Show per-host migration tracking records |
+| `bootstrap` | Create the tracking table                |
+| `check`     | Show pending legacy migrations           |
+| `lint`      | Validate schema YAML files               |
+| `down`      | Roll back a legacy migration by number   |
 
-Example PR for non-sharded table: https://github.com/PostHog/posthog/pull/38890/files
-Example PR for sharded table: https://github.com/PostHog/posthog/issues/38668/files
+## Schema safety
 
-`Medium` tier contains 4 consumers, while `Small` tier contain just one. Depending on the throughput of the Kafka topic, you should choose the appropriate tier, in case of doubts choose `Small` and you can later upgrade to `Medium` if lag is too high.
+The diff engine respects ClickHouse ecosystem rules:
 
-## When to use NodeRole.ALL
+- DROP MV before altering source tables
+- CREATE local tables before Distributed tables
+- CREATE Kafka tables before MVs
+- ALTER all ecosystem tables when adding a column
 
-We are introducing changes to our ClickHouse topology frequently, introducing new types of nodes.
+The `lint` command checks for ecosystem completeness
+and cross-cluster targeting mismatches.
 
-Rarely, you'll need to run a migration on all nodes. In that case, you can use the `NodeRole.ALL` role. You should only use it when you're sure that the change is safe to apply to all nodes.
+## Node roles
 
-In the vast majority of cases, just follow the [previous](#when-to-run-a-migration-only-on-a-data-node) [sections](#when-to-run-a-migration-on-data-nodes-non-sharded).
+| Role             | Meaning                                         |
+| ---------------- | ----------------------------------------------- |
+| DATA             | Data storage nodes (sharded local tables)       |
+| COORDINATOR      | Coordinator nodes (writable distributed tables) |
+| ALL              | All nodes in the cluster                        |
+| INGESTION_EVENTS | Events ingestion nodes (Kafka tables, MVs)      |
+| INGESTION_SMALL  | Small ingestion pipeline nodes                  |
+| INGESTION_MEDIUM | Medium ingestion pipeline nodes                 |
+| SHUFFLEHOG       | Shufflehog nodes                                |
+| ENDPOINTS        | Endpoint nodes                                  |
+| LOGS             | Log nodes                                       |
 
-### The ON CLUSTER clause
+## FAQ
 
-**Do not use the `ON CLUSTER` clause**, since the DDL statement will be run on all nodes anyway through the `run_sql_with_exceptions` function, and, by default, the `ON CLUSTER` clause makes the DDL statement run on nodes specified for the default cluster, which may not include all target nodes.
-This may cause lots of troubles and block migrations.
+**What happens to live writes during ALTER TABLE on sharded_events?**
 
-The `ON CLUSTER` clause is used to specify the cluster to run the DDL statement on. By default, the `posthog` cluster is used. That cluster only includes the data nodes.
+Nothing. `ALTER ADD COLUMN` on ReplicatedMergeTree is metadata-only -- it completes in milliseconds regardless of table size.
+Writes keep going. Same behavior as the old system.
 
-### Testing
+**What about ALTER MODIFY COLUMN (type changes)?**
 
-To re-run a migration, you'll need to delete the entry from the `infi_clickhouse_orm_migrations` table.
+That rewrites data parts and can take hours on large tables.
+The plan flags it with a warning. Schedule these carefully and coordinate with whoever's on-call.
 
-## Ingestion layer
+**What happens during the MV drop/recreate gap?**
 
-We have extra nodes with a sole purpose of ingesting the data from Kafka topics into ClickHouse tables. The way to do that is to:
+There's a sub-second window where Kafka messages aren't consumed by that MV.
+Kafka retains them, and the new MV picks up from the last committed offset.
+Same window the old system had.
 
-1. Create your data table in ClickHouse main cluster.
-2. Create a writable table only on ingestion nodes: `node_roles=[NodeRole.INGESTION_SMALL]`. It should be Distributed table with your data table. If your data table is non-sharded, you should point it to one shard: `Distributed(..., cluster=settings.CLICKHOUSE_SINGLE_SHARD_CLUSTER)`.
-3. Create a Kafka table in ingestion nodes: `node_roles=[NodeRole.INGESTION_SMALL]`.
-4. Create materialized view between Kafka table and writable table on ingestion nodes.
+**What if a shard fails during apply?**
 
-Example PR for non-sharded table: https://github.com/PostHog/posthog/pull/38890/files
+Apply halts immediately. The tracking table records which steps succeeded on which hosts.
+Re-running is safe -- all generated SQL uses `IF NOT EXISTS` / `IF EXISTS`.
 
-**How and why?**
+**How do the 231 legacy migrations coexist?**
 
-Our main cluster (`posthog`) nodes were overwhelmed with ingestion and sometimes the query load
-was interfering with ingestion. This was causing delays and at the end incidents.
+They're untouched. `migrate_clickhouse` still runs them in order.
+The two systems coexist. `run_sql_with_exceptions` has a deprecation warning pointing here.
 
-We added new nodes that are not part of our regular cluster setup, we run them on Kubernetes.
+**What about drift between hosts?**
 
-ClickHouse cluster as defined in it is a logical concept and one may add nodes that are running in different places, this is how we created a new cluster that has all workers and our new ingestion nodes.
+`ch_migrate drift` queries `system.tables` on every host across all registered clusters and compares.
+Run it before apply to check for host divergence.
+
+**How do I roll back?**
+
+Edit the schema YAML (revert your change), run `plan`, run `apply`.
+Git history of the YAML files is your rollback mechanism.

--- a/posthog/clickhouse/test/_stubs.py
+++ b/posthog/clickhouse/test/_stubs.py
@@ -1,0 +1,244 @@
+"""Shared Django/ClickHouse stubs for standalone migration tool tests.
+
+WHY STUBS INSTEAD OF DJANGO TEST RUNNER:
+PostHog's Django startup (posthog/__init__.py, settings, celery) triggers
+ClickHouse client connections, Kafka configuration, and celery app setup.
+Running these tests via `DJANGO_SETTINGS_MODULE=posthog.settings.test pytest`
+requires a full Django environment with live ClickHouse — impractical for
+unit tests that only exercise YAML parsing, diff logic, and plan generation.
+These stubs isolate the migration_tools package from Django/CH/celery so
+tests run fast with zero infrastructure.
+
+Usage at the top of each test file (BEFORE any posthog imports):
+
+    import posthog.clickhouse.test._stubs as _stubs  # noqa: F401
+
+    # _stubs installs itself on import — now posthog.* is safe to import.
+
+Or for standalone execution:
+
+    _BASE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+    sys.path.insert(0, _BASE)
+    import posthog.clickhouse.test._stubs  # noqa: F401
+
+This module installs all stubs on import — no need to call install_stubs() explicitly.
+The stubs are idempotent and safe to import multiple times.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+from unittest.mock import MagicMock
+
+_BASE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if _BASE not in sys.path:
+    sys.path.insert(0, _BASE)
+
+
+def _django_is_configured() -> bool:
+    try:
+        from django.conf import settings
+
+        val = getattr(settings, "USE_I18N", None)
+        return isinstance(val, bool)
+    except Exception:
+        return False
+
+
+class _NodeRole:
+    DATA = "DATA"
+    COORDINATOR = "COORDINATOR"
+    ALL = "ALL"
+
+    def __init__(self, value: str = "data") -> None:
+        self.value = value
+
+
+class _FakeQuery:
+    def __init__(self, sql: str) -> None:
+        self.sql = sql
+
+
+class _FakeRunPython:
+    def __init__(self, fn: object) -> None:
+        self.fn = fn
+
+
+def _fake_get_cluster(*args: object, **kwargs: object) -> MagicMock:
+    mock = MagicMock()
+    mock.any_host.return_value.result.return_value = {}
+    return mock
+
+
+def _install() -> None:
+    if _django_is_configured():
+        return
+
+    # posthog package — prevent __init__.py from running
+    if "posthog" not in sys.modules:
+        pkg = types.ModuleType("posthog")
+        pkg.__path__ = [os.path.join(_BASE, "posthog")]
+        pkg.__package__ = "posthog"
+        pkg.celery_app = None  # type: ignore[attr-defined]
+        sys.modules["posthog"] = pkg
+
+    # posthog.celery
+    _celery = types.ModuleType("posthog.celery")
+    _celery.app = types.SimpleNamespace()  # type: ignore[attr-defined]
+    sys.modules.setdefault("posthog.celery", _celery)
+
+    # posthog.clickhouse (package)
+    ch_pkg = types.ModuleType("posthog.clickhouse")
+    ch_pkg.__path__ = [os.path.join(_BASE, "posthog/clickhouse")]
+    ch_pkg.__package__ = "posthog.clickhouse"
+    sys.modules.setdefault("posthog.clickhouse", ch_pkg)
+
+    # posthog.clickhouse.client
+    fake_client = types.ModuleType("posthog.clickhouse.client")
+    fake_client.__path__ = [os.path.join(_BASE, "posthog/clickhouse/client")]
+    fake_client.__package__ = "posthog.clickhouse.client"
+    sys.modules.setdefault("posthog.clickhouse.client", fake_client)
+
+    # posthog.clickhouse.client.connection
+    fake_conn = types.ModuleType("posthog.clickhouse.client.connection")
+    fake_conn.NodeRole = _NodeRole  # type: ignore[attr-defined]
+    sys.modules.setdefault("posthog.clickhouse.client.connection", fake_conn)
+
+    # posthog.clickhouse.cluster
+    fake_cluster = types.ModuleType("posthog.clickhouse.cluster")
+    fake_cluster.Query = _FakeQuery  # type: ignore[attr-defined]
+    fake_cluster.get_cluster = _fake_get_cluster  # type: ignore[attr-defined]
+    fake_cluster.ClickhouseCluster = MagicMock  # type: ignore[attr-defined]
+
+    # HostInfo is a NamedTuple used by schema_introspect — provide a lightweight stand-in
+    from collections import namedtuple as _nt
+
+    fake_cluster.HostInfo = _nt(  # type: ignore[attr-defined]
+        "HostInfo",
+        ["connection_info", "shard_num", "replica_num", "host_cluster_type", "host_cluster_role"],
+    )
+    # _CLUSTER_REGISTRY is needed by state_diff._resolve_physical_cluster.
+    # Mirrors the real registry in posthog/clickhouse/cluster.py — maps YAML
+    # logical names to (host_attr, cluster_attr) tuples.
+    fake_cluster._CLUSTER_REGISTRY = {  # type: ignore[attr-defined]
+        "main": ("CLICKHOUSE_HOST", "CLICKHOUSE_CLUSTER"),
+        "logs": ("CLICKHOUSE_LOGS_CLUSTER_HOST", "CLICKHOUSE_LOGS_CLUSTER"),
+        "migrations": ("CLICKHOUSE_MIGRATIONS_HOST", "CLICKHOUSE_MIGRATIONS_CLUSTER"),
+        "sessions": ("CLICKHOUSE_HOST", "CLICKHOUSE_SESSIONS_CLUSTER"),
+        "ops": ("CLICKHOUSE_HOST", "CLICKHOUSE_OPS_CLUSTER"),
+        "ai_events": ("CLICKHOUSE_HOST", "CLICKHOUSE_AI_EVENTS_CLUSTER"),
+        "aux": ("CLICKHOUSE_HOST", "CLICKHOUSE_AUX_CLUSTER"),
+    }
+    sys.modules.setdefault("posthog.clickhouse.cluster", fake_cluster)
+
+    # infi.clickhouse_orm
+    for mod_name in ("infi", "infi.clickhouse_orm"):
+        m = types.ModuleType(mod_name)
+        m.__path__ = ["/fake"]
+        sys.modules.setdefault(mod_name, m)
+
+    infi_migrations = types.ModuleType("infi.clickhouse_orm.migrations")
+    infi_migrations.__path__ = ["/fake"]
+    infi_migrations.RunPython = _FakeRunPython  # type: ignore[attr-defined]
+    sys.modules.setdefault("infi.clickhouse_orm.migrations", infi_migrations)
+
+    # posthog.settings
+    fake_settings = types.ModuleType("posthog.settings")
+    fake_settings.E2E_TESTING = False  # type: ignore[attr-defined]
+    fake_settings.DEBUG = True  # type: ignore[attr-defined]
+    fake_settings.CLOUD_DEPLOYMENT = False  # type: ignore[attr-defined]
+    sys.modules.setdefault("posthog.settings", fake_settings)
+
+    fake_ds = types.ModuleType("posthog.settings.data_stores")
+    fake_ds.CLICKHOUSE_MIGRATIONS_CLUSTER = "default"  # type: ignore[attr-defined]
+    fake_ds.CLICKHOUSE_MIGRATIONS_HOST = "localhost"  # type: ignore[attr-defined]
+    sys.modules.setdefault("posthog.settings.data_stores", fake_ds)
+
+    # posthog.clickhouse.client.migration_tools
+    fake_mt = types.ModuleType("posthog.clickhouse.client.migration_tools")
+    fake_mt.get_migrations_cluster = _fake_get_cluster  # type: ignore[attr-defined]
+    sys.modules.setdefault("posthog.clickhouse.client.migration_tools", fake_mt)
+
+    # posthog.clickhouse.migration_tools.cluster_registry — let real module load
+    # (its only dependency is posthog.clickhouse.cluster which is already stubbed above)
+
+    # yaml (for manifest.py)
+
+    _yaml_stub = types.ModuleType("yaml")
+    try:
+        import yaml as _real_yaml
+
+        _yaml_stub.safe_load = _real_yaml.safe_load  # type: ignore[attr-defined]
+        _yaml_stub.dump = _real_yaml.dump  # type: ignore[attr-defined]
+    except ImportError:
+        _yaml_stub.safe_load = lambda f: None  # type: ignore[attr-defined]
+        _yaml_stub.dump = lambda *a, **kw: None  # type: ignore[attr-defined]
+    sys.modules.setdefault("yaml", _yaml_stub)
+
+    # posthog.clickhouse.test (package)
+    test_pkg = types.ModuleType("posthog.clickhouse.test")
+    test_pkg.__path__ = [os.path.join(_BASE, "posthog/clickhouse/test")]
+    test_pkg.__package__ = "posthog.clickhouse.test"
+    sys.modules.setdefault("posthog.clickhouse.test", test_pkg)
+
+    # django stubs (for ch_migrate command tests)
+    for mod_name in ("django", "django.conf", "django.core", "django.core.management", "django.core.management.base"):
+        m = types.ModuleType(mod_name)
+        m.__path__ = ["/fake"]
+        sys.modules.setdefault(mod_name, m)
+
+    if not hasattr(sys.modules.get("django.conf"), "settings"):
+        settings_ns = types.SimpleNamespace(
+            CLICKHOUSE_DATABASE="default",
+            CLICKHOUSE_HOST="localhost",
+            CLICKHOUSE_CLUSTER="posthog",
+            CLICKHOUSE_LOGS_CLUSTER_HOST="localhost",
+            CLICKHOUSE_LOGS_CLUSTER="posthog_single_shard",
+            CLICKHOUSE_MIGRATIONS_HOST="localhost",
+            CLICKHOUSE_MIGRATIONS_CLUSTER="posthog_migrations",
+            # Satellite cluster names resolved by _CLUSTER_REGISTRY via state_diff
+            CLICKHOUSE_SESSIONS_CLUSTER="posthog_sessions",
+            CLICKHOUSE_OPS_CLUSTER="posthog_ops",
+            CLICKHOUSE_AI_EVENTS_CLUSTER="posthog_ai_events",
+            CLICKHOUSE_AUX_CLUSTER="posthog_aux",
+        )
+        sys.modules["django.conf"].settings = settings_ns  # type: ignore[attr-defined]
+
+    class _FakeBaseCommand:
+        def __init__(self) -> None:
+            self.stdout = __import__("io").StringIO()
+            self.stderr = __import__("io").StringIO()
+
+        def print_help(self, *args: object) -> None:
+            pass
+
+    class _FakeCommandError(Exception):
+        """Stand-in for django.core.management.base.CommandError.
+
+        Used by ch_migrate.handle_apply to signal non-zero exit on step failure.
+        Real Django raises this and Django's management runner catches it to
+        print a clean error and exit with code 1.
+        """
+
+    if not hasattr(sys.modules.get("django.core.management.base"), "BaseCommand"):
+        sys.modules["django.core.management.base"].BaseCommand = _FakeBaseCommand  # type: ignore[attr-defined]
+    if not hasattr(sys.modules.get("django.core.management.base"), "CommandError"):
+        sys.modules["django.core.management.base"].CommandError = _FakeCommandError  # type: ignore[attr-defined]
+
+    # Wire submodule attributes so `from posthog import settings` works
+    sys.modules["posthog"].settings = sys.modules["posthog.settings"]  # type: ignore[attr-defined]
+    sys.modules["posthog.settings"].data_stores = sys.modules["posthog.settings.data_stores"]  # type: ignore[attr-defined]
+
+    # posthog.management.commands — make it a resolvable package
+    for mod_name in ("posthog.management", "posthog.management.commands"):
+        if mod_name not in sys.modules:
+            m = types.ModuleType(mod_name)
+            m.__path__ = [os.path.join(_BASE, mod_name.replace(".", "/"))]
+            m.__package__ = mod_name
+            sys.modules[mod_name] = m
+
+
+_install()

--- a/posthog/clickhouse/test/conftest.py
+++ b/posthog/clickhouse/test/conftest.py
@@ -1,0 +1,24 @@
+"""Pytest conftest — loads Django/ClickHouse stubs before test modules are imported.
+
+This replaces the importlib.util bootstrap that was duplicated across every
+test file in this directory.  Stubs install themselves on load and are
+idempotent, so re-importing _stubs in a test file is safe but unnecessary.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import importlib.util
+
+_BASE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if _BASE not in sys.path:
+    sys.path.insert(0, _BASE)
+
+_spec = importlib.util.spec_from_file_location(
+    "posthog.clickhouse.test._stubs",
+    os.path.join(_BASE, "posthog", "clickhouse", "test", "_stubs.py"),
+)
+assert _spec and _spec.loader
+_stubs_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_stubs_mod)

--- a/posthog/management/commands/ch_migrate.py
+++ b/posthog/management/commands/ch_migrate.py
@@ -18,7 +18,6 @@ Modules: desired_state, state_diff, plan_generator, schema_graph,
 schema_introspect, tracking.
 """
 
-import sys
 from typing import Any
 
 from django.conf import settings
@@ -289,7 +288,6 @@ class Command(BaseCommand):
                     or "Code: 210" in exc_str
                     or "Connection refused" in exc_str
                     or "Name or service not known" in exc_str
-                    or "not found" in exc_str.lower()
                 )
                 if is_unreachable:
                     # Fall back to the migrations-cluster union so we still
@@ -644,7 +642,7 @@ class Command(BaseCommand):
             print("No schema drift detected across all clusters.")
             return
 
-        sys.exit(1)
+        raise CommandError(f"Schema drift detected across {len(all_diffs)} host(s).")
 
     # ------------------------------------------------------------------
     # schema
@@ -795,7 +793,7 @@ class Command(BaseCommand):
         print(f"Lint errors ({len(errors)}):\n")
         for err in errors:
             print(f"  - {err}")
-        sys.exit(1)
+        raise CommandError(f"Schema lint failed with {len(errors)} error(s).")
 
     # ------------------------------------------------------------------
     # orphans -- find undeclared tables
@@ -844,7 +842,6 @@ class Command(BaseCommand):
                     or "Code: 210" in exc_str
                     or "Connection refused" in exc_str
                     or "Name or service not known" in exc_str
-                    or "not found" in exc_str.lower()
                 )
                 if is_unreachable:
                     unreachable.append((cluster_name, exc_str[:200]))

--- a/posthog/management/commands/ch_migrate.py
+++ b/posthog/management/commands/ch_migrate.py
@@ -1,0 +1,910 @@
+# ruff: noqa: T201 allow print statements
+"""
+ClickHouse schema management -- declarative, Terraform-style.
+
+Subcommands (10):
+  plan       -- diff schema/*.yaml vs live ClickHouse, show plan
+  apply      -- execute the diff (plan + apply)
+  generate   -- scaffold a new schema YAML from a template
+  drift      -- detect per-host schema divergence
+  schema     -- dump current live schema
+  status     -- show per-host migration state
+  bootstrap  -- create the tracking table
+  check      -- show pending legacy migrations
+  lint       -- lint schema YAML files
+  down       -- roll back a legacy migration
+
+Modules: desired_state, state_diff, plan_generator, schema_graph,
+schema_introspect, tracking.
+"""
+
+import sys
+from typing import Any
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from posthog.clickhouse.cluster import get_all_logical_clusters, get_cluster_by_name, is_known_cluster
+from posthog.clickhouse.migration_tools.schema_introspect import detect_drift, dump_schema
+
+MAX_DRIFT_DISPLAY = 10
+DEFAULT_SCHEMA_DIR = "posthog/clickhouse/schema"
+
+
+def _any_client(cluster: Any) -> Any:
+    return cluster.any_host(lambda c: c).result()
+
+
+class Command(BaseCommand):
+    help = "ClickHouse schema management -- plan, apply, generate, drift, schema, status, bootstrap, check, lint, down, orphans, version"
+
+    def add_arguments(self, parser: Any) -> None:
+        subparsers = parser.add_subparsers(dest="subcommand")
+
+        # plan -- diff desired vs current
+        plan_parser = subparsers.add_parser("plan", help="Diff desired-state YAML vs live ClickHouse")
+        plan_parser.add_argument(
+            "--schema-dir",
+            type=str,
+            default=DEFAULT_SCHEMA_DIR,
+            help="Directory with desired-state YAML files",
+        )
+        plan_parser.add_argument(
+            "--cluster",
+            type=str,
+            default=None,
+            help="Filter to a specific cluster (e.g. main, logs). Default: all clusters.",
+        )
+
+        # apply -- execute the diff
+        apply_parser = subparsers.add_parser("apply", help="Execute the reconciliation plan")
+        apply_parser.add_argument(
+            "--schema-dir",
+            type=str,
+            default=DEFAULT_SCHEMA_DIR,
+            help="Directory with desired-state YAML files",
+        )
+        apply_parser.add_argument("--force", action="store_true", default=False)
+        apply_parser.add_argument("--yes", "-y", action="store_true", default=False, help="Skip confirmation prompt")
+        apply_parser.add_argument("--cluster", type=str, default=None, help="Filter to a specific cluster")
+        apply_parser.add_argument(
+            "--continue-on-error",
+            action="store_true",
+            default=False,
+            help="Continue applying remaining steps after a failure instead of halting. "
+            "Prints a per-step failure summary at the end and still raises CommandError "
+            "if any step failed. Useful for surfacing all YAML data issues in one pass.",
+        )
+
+        # generate -- scaffold schema YAML from template
+        gen_parser = subparsers.add_parser("generate", help="Generate a schema YAML file from a template")
+        gen_parser.add_argument("--template", type=str, required=True, help="Template name (e.g. ingestion_pipeline)")
+        gen_parser.add_argument("--table", type=str, required=True, help="Base table name")
+        gen_parser.add_argument("--cluster", type=str, default="main", help="Target cluster (default: main)")
+        gen_parser.add_argument(
+            "--output-dir",
+            type=str,
+            default=DEFAULT_SCHEMA_DIR,
+            help="Output directory for YAML file",
+        )
+
+        # drift
+        subparsers.add_parser("drift", help="Detect schema drift between cluster hosts")
+
+        # schema
+        subparsers.add_parser("schema", help="Dump current schema state from ClickHouse")
+
+        # status
+        status_parser = subparsers.add_parser("status", help="Show per-host migration state")
+        status_parser.add_argument("--node", type=str, default=None, help="Filter by hostname")
+
+        # bootstrap
+        subparsers.add_parser("bootstrap", help="Create the tracking table on all nodes")
+
+        # check
+        subparsers.add_parser("check", help="Show pending legacy migrations")
+
+        # lint
+        lint_parser = subparsers.add_parser("lint", help="Lint schema YAML files")
+        lint_parser.add_argument(
+            "--schema-dir",
+            type=str,
+            default=DEFAULT_SCHEMA_DIR,
+            help="Directory with desired-state YAML files",
+        )
+
+        # orphans
+        orphans_parser = subparsers.add_parser("orphans", help="List production tables not declared in any YAML")
+        orphans_parser.add_argument(
+            "--schema-dir",
+            type=str,
+            default=DEFAULT_SCHEMA_DIR,
+            help="Directory with desired-state YAML files",
+        )
+        orphans_parser.add_argument(
+            "--exclude",
+            type=str,
+            nargs="*",
+            default=[],
+            help="Additional table names to exclude",
+        )
+
+        # version
+        subparsers.add_parser("version", help="Show the last applied schema version (git commit)")
+
+        # down (legacy)
+        down_parser = subparsers.add_parser("down", help="Roll back a legacy migration by number")
+        down_parser.add_argument("migration_number", type=int, help="Migration number to roll back")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        subcommand = options.get("subcommand")
+        handlers: dict[str, Any] = {
+            "plan": self.handle_plan,
+            "apply": self.handle_apply,
+            "generate": self.handle_generate,
+            "drift": self.handle_drift,
+            "schema": self.handle_schema,
+            "status": self.handle_status,
+            "bootstrap": self.handle_bootstrap,
+            "check": self.handle_check,
+            "lint": self.handle_lint,
+            "orphans": self.handle_orphans,
+            "version": self.handle_version,
+            "down": self.handle_down,
+        }
+        handler = handlers.get(subcommand or "")
+        if handler:
+            handler(options)
+        else:
+            self.print_help("manage.py", "ch_migrate")
+
+    # ------------------------------------------------------------------
+    # plan / apply -- desired-state reconciliation
+    # ------------------------------------------------------------------
+
+    def _compute_diffs(
+        self, database: str, schema_dir: Any, cluster_filter: str | None = None
+    ) -> tuple[list, str | None]:
+        """Compute desired-vs-current diffs. Returns (diffs, error_message).
+
+        Connects to the correct ClickHouse host for each logical cluster
+        declared in the YAML files. When *cluster_filter* is set, only YAML
+        files matching that cluster are diffed.
+        """
+        from collections import defaultdict
+
+        from posthog.clickhouse.migration_tools.desired_state import parse_desired_state_dir
+        from posthog.clickhouse.migration_tools.state_diff import (
+            TRACKING_TABLES,
+            StateDiff,
+            _drop_stmt,
+            diff_state,
+            has_placeholder_select,
+        )
+
+        desired_states = parse_desired_state_dir(schema_dir)
+        if not desired_states:
+            return [], f"No YAML files found in {schema_dir}"
+
+        if cluster_filter:
+            desired_states = [ds for ds in desired_states if ds.cluster == cluster_filter]
+            if not desired_states:
+                return [], f"No YAML files for cluster '{cluster_filter}' in {schema_dir}"
+
+        # Validate cluster names
+        for ds in desired_states:
+            if not is_known_cluster(ds.cluster):
+                known = ", ".join(get_all_logical_clusters())
+                return [], (
+                    f"Schema file for ecosystem '{ds.ecosystem}' references cluster "
+                    f"'{ds.cluster}' which is not in the cluster registry. "
+                    f"Known clusters: {known}. "
+                    f"Add '{ds.cluster}' to _REGISTRY in posthog/clickhouse/cluster.py with the "
+                    f"appropriate CLICKHOUSE_*_HOST and CLICKHOUSE_*_CLUSTER settings."
+                )
+
+        # Group desired states by cluster so we connect once per cluster
+        by_cluster: dict[str, list] = defaultdict(list)
+        for ds in desired_states:
+            by_cluster[ds.cluster].append(ds)
+
+        # Global desired-name and placeholder sets across all clusters.
+        # Pass 2's orphan scan uses these instead of per-cluster sets so a
+        # table owned by one logical cluster isn't emitted as an orphan
+        # against another that shares the same physical ClickHouse host
+        # (common in dev stacks where `main`, `aux`, `ops`, etc. all resolve
+        # to the same CLICKHOUSE_HOST). In production every logical cluster
+        # has a distinct physical host, so a table declared for `logs`
+        # wouldn't appear in `main`'s introspection at all — this global
+        # check is a no-op there. True orphans (live, declared nowhere) are
+        # still dropped.
+        all_desired_names: set[str] = set()
+        all_placeholder_names: set[str] = set()
+        for ds in desired_states:
+            for name, t in ds.tables.items():
+                all_desired_names.add(name)
+                if has_placeholder_select(t):
+                    all_placeholder_names.add(name)
+
+        # Introspect each target cluster independently. Earlier versions
+        # introspected only the migrations cluster once and reused that union
+        # for every logical cluster — that's wrong when YAMLs target separate
+        # ecosystems (`logs`, `sessions`, etc.) because their tables don't
+        # exist on the main migrations cluster, so diff_state emits spurious
+        # `create` actions and misses real drift on the satellite.
+        #
+        # The migrations cluster union is used only as a fallback when the
+        # per-cluster introspection fails with an unreachable error — in CI
+        # dev stacks not every satellite is provisioned.
+        from posthog.clickhouse.client.migration_tools import get_migrations_cluster
+        from posthog.clickhouse.migration_tools.schema_introspect import dump_schema_all_hosts
+
+        def _union_from_cluster(cluster_obj: Any) -> dict[str, Any]:
+            per_host = dump_schema_all_hosts(cluster_obj, database)
+            union: dict[str, Any] = {}
+            for _host_info, host_schema in per_host.items():
+                for tbl_name, tbl_schema in host_schema.items():
+                    # First-wins union across all nodes in the cluster.
+                    # Replicated tables have identical DDL across replicas;
+                    # for node-role-specific tables (Distributed, MV) only
+                    # one node has them at all, so there's no conflict.
+                    if tbl_name not in union:
+                        union[tbl_name] = tbl_schema
+            return union
+
+        # Lazy fallback union from the migrations cluster — only computed if
+        # a per-cluster scan fails for an unreachable reason.
+        _migrations_union: dict[str, Any] | None = None
+
+        def _fallback_union() -> dict[str, Any]:
+            nonlocal _migrations_union
+            if _migrations_union is None:
+                _migrations_union = _union_from_cluster(get_migrations_cluster())
+            return _migrations_union
+
+        all_diffs = []
+        for cluster_name, states in by_cluster.items():
+            used_fallback = False
+            try:
+                cluster_obj = get_cluster_by_name(cluster_name)
+                current = _union_from_cluster(cluster_obj)
+            except Exception as exc:
+                # A satellite cluster named in the YAML may be unreachable from the
+                # current runtime for several expected reasons — skip with a warning
+                # instead of crashing the whole plan/apply:
+                #   - CLUSTER_DOESNT_EXIST (code 701): YAML declares a cluster the
+                #     current stack doesn't have. Common on dev stacks running a
+                #     subset of production clusters.
+                #   - Connection refused / Code: 210: satellite host not resolvable
+                #     from the current container (dev stack test harness, or the
+                #     satellite deployment not yet provisioned).
+                #   - Name or service not known: DNS failure when the satellite host
+                #     is pointed at something the runner can't resolve.
+                # In production all declared clusters are reachable, so these
+                # markers never fire. Unexpected errors still propagate.
+                exc_str = str(exc)
+                is_unreachable = (
+                    "CLUSTER_DOESNT_EXIST" in exc_str
+                    or "Code: 701" in exc_str
+                    or "Code: 210" in exc_str
+                    or "Connection refused" in exc_str
+                    or "Name or service not known" in exc_str
+                    or "not found" in exc_str.lower()
+                )
+                if is_unreachable:
+                    # Fall back to the migrations-cluster union so we still
+                    # produce something useful — if the table doesn't exist
+                    # there either, diff_state correctly emits a create.
+                    ecosystem_names = ", ".join(s.ecosystem for s in states)
+                    print(
+                        f"Warning: cluster '{cluster_name}' "
+                        f"(ecosystems: {ecosystem_names}) unreachable; "
+                        f"falling back to migrations-cluster schema. Details: {exc_str[:200]}"
+                    )
+                    try:
+                        current = _fallback_union()
+                        used_fallback = True
+                    except Exception as fallback_exc:
+                        print(
+                            f"Warning: fallback to migrations cluster also failed for "
+                            f"'{cluster_name}': {fallback_exc!s:.200}. Skipping."
+                        )
+                        continue
+                else:
+                    raise
+
+            # Pass 1: per-ecosystem diff on a filtered slice of `current`.
+            # Filtering to `desired.tables` prevents spurious DROPs for tables
+            # owned by a sibling ecosystem on the same physical cluster
+            # (e.g. heatmaps tables don't appear in the events ecosystem diff).
+            # Because the slice always covers all of `desired.tables`, this
+            # pass produces only creates / alters / recreates — never drops —
+            # which is what makes apply converge to zero.
+            #
+            # When `current` came from the migrations-cluster fallback, the
+            # introspected tables belong to a *different* physical cluster.
+            # Matching a desired table name against that set would suppress
+            # a legitimate create — e.g. `logs` ecosystem falling back to
+            # the `main` cluster's tables would see `events` on main, and a
+            # desired `logs`-exclusive table sharing a name with any
+            # main-cluster table would skip creation. Treat the introspected
+            # state as empty when falling back so every desired table on the
+            # unreachable cluster is emitted as a create.
+            for desired in states:
+                if used_fallback:
+                    ecosystem_current = {}
+                else:
+                    ecosystem_current = {name: table for name, table in current.items() if name in desired.tables}
+                diffs = diff_state(desired, ecosystem_current, database=database)
+                for d in diffs:
+                    d.cluster = cluster_name
+                    all_diffs.append(d)
+
+            # Pass 2: cluster-wide orphan scan. A live table is a real orphan
+            # only when no ecosystem on this cluster claims it. Tracking tables
+            # and placeholder MVs are managed elsewhere — never drop them.
+            #
+            # Skip pass 2 when `current` came from the migrations-cluster
+            # fallback — those tables represent a different cluster's live
+            # state, so no ecosystem on *this* cluster claims any of them
+            # and every table would become a spurious DROP. The fallback is
+            # still useful for pass 1 (diff_state correctly emits creates for
+            # tables missing from the fallback union too), just not for
+            # cluster-scoped orphan detection.
+            if used_fallback:
+                continue
+
+            for table_name in sorted(current.keys()):
+                if table_name in all_desired_names:
+                    continue
+                if table_name in TRACKING_TABLES:
+                    continue
+                if table_name in all_placeholder_names:
+                    continue
+                current_table = current[table_name]
+                all_diffs.append(
+                    StateDiff(
+                        action="drop",
+                        table=table_name,
+                        detail=(
+                            f"Orphan: table {table_name} exists but is not declared in any "
+                            f"YAML on cluster {cluster_name}"
+                        ),
+                        sql=_drop_stmt(current_table.engine, database, table_name),
+                        node_roles=["ALL"],
+                        cluster=cluster_name,
+                    )
+                )
+
+        return all_diffs, None
+
+    def handle_plan(self, options: dict[str, Any]) -> None:
+        from pathlib import Path
+
+        from posthog.clickhouse.migration_tools.plan_generator import generate_plan_text
+
+        database: str = settings.CLICKHOUSE_DATABASE
+        schema_dir = Path(options.get("schema_dir", DEFAULT_SCHEMA_DIR))
+
+        if not schema_dir.exists():
+            print(f"Schema directory not found: {schema_dir}")
+            print("Run 'ch_migrate generate' to create schema YAML files.")
+            return
+
+        cluster_filter = options.get("cluster")
+        all_diffs, err = self._compute_diffs(database, schema_dir, cluster_filter=cluster_filter)
+        if err:
+            print(err)
+            return
+
+        if cluster_filter:
+            print(f"Filtering to cluster: {cluster_filter}\n")
+        print(generate_plan_text(all_diffs))
+
+    def handle_apply(self, options: dict[str, Any]) -> None:
+        import time
+        import socket
+        import hashlib
+        import subprocess
+        from pathlib import Path
+
+        from posthog.clickhouse.client.migration_tools import get_migrations_cluster
+        from posthog.clickhouse.migration_tools.plan_generator import generate_manifest_steps, generate_plan_text
+        from posthog.clickhouse.migration_tools.runner import execute_migration_step
+        from posthog.clickhouse.migration_tools.tracking import (
+            StepRecord,
+            _record_step,
+            acquire_apply_lock,
+            record_schema_version,
+            release_apply_lock,
+        )
+
+        database: str = settings.CLICKHOUSE_DATABASE
+        force: bool = options.get("force", False)
+        schema_dir = Path(options.get("schema_dir", DEFAULT_SCHEMA_DIR))
+
+        if not schema_dir.exists():
+            print(f"Schema directory not found: {schema_dir}")
+            return
+
+        cluster_obj = get_migrations_cluster()
+        client = _any_client(cluster_obj)
+        hostname = socket.gethostname()
+
+        cluster_filter = options.get("cluster")
+        all_diffs, err = self._compute_diffs(database, schema_dir, cluster_filter=cluster_filter)
+        if err:
+            print(err)
+            return
+
+        if not all_diffs:
+            print("No changes. Infrastructure is up to date.")
+            return
+
+        print(generate_plan_text(all_diffs))
+        print()
+
+        auto_approve: bool = options.get("yes", False)
+        if not auto_approve:
+            answer = input(f"Apply {len(all_diffs)} change(s)? [y/N] ")
+            if answer.lower() not in ("y", "yes"):
+                print("Aborted.")
+                return
+
+        cluster_name = getattr(settings, "CLICKHOUSE_MIGRATIONS_CLUSTER", "posthog_migrations")
+        acquired, reason = acquire_apply_lock(client, database, hostname, force=force, cluster=cluster_name)
+        if not acquired:
+            print(reason)
+            return
+
+        continue_on_error: bool = options.get("continue_on_error", False)
+        failures: list[tuple[int, str, str]] = []  # (step_index, step_name, error)
+
+        # Per-step cluster resolution cache — avoid rebuilding the same
+        # ClickhouseCluster object on every step. Keyed by logical cluster
+        # name; the empty key maps to the default migrations cluster.
+        cluster_cache: dict[str, Any] = {"": cluster_obj}
+
+        def _resolve_step_cluster(step_cluster_name: str) -> Any:
+            key = step_cluster_name or ""
+            if key in cluster_cache:
+                return cluster_cache[key]
+            try:
+                resolved = get_cluster_by_name(step_cluster_name)
+            except Exception:
+                # If the cluster isn't reachable from this runtime (dev stack
+                # missing a satellite) fall back to the migrations cluster —
+                # the same policy _compute_diffs applies when introspecting.
+                resolved = cluster_obj
+            cluster_cache[key] = resolved
+            return resolved
+
+        try:
+            steps = generate_manifest_steps(all_diffs)
+            print(f"Applying {len(steps)} step(s)...\n")
+
+            max_retries = 3
+            for i, (step, rendered_sql) in enumerate(steps):
+                print(f"  Step {i}: {step.comment}...", end=" ", flush=True)
+                checksum = hashlib.sha256(rendered_sql.encode()).hexdigest()
+                step_cluster = _resolve_step_cluster(step.cluster)
+                success = False
+                last_exc: Exception | None = None
+                for attempt in range(max_retries):
+                    try:
+                        execute_migration_step(step_cluster, step, rendered_sql)
+                        success = True
+                        break
+                    except Exception as exc:
+                        last_exc = exc
+                        if attempt < max_retries - 1:
+                            wait = 2**attempt
+                            print(f"\n    Retry {attempt + 1}/{max_retries} in {wait}s: {exc}", flush=True)
+                            time.sleep(wait)
+
+                if not success:
+                    assert last_exc is not None
+                    print(f"FAILED after {max_retries} attempts: {last_exc}")
+                    _record_step(
+                        client=client,
+                        record=StepRecord(
+                            migration_number=0,
+                            migration_name=step.comment or "reconcile",
+                            step_index=i,
+                            host=hostname,
+                            node_role="*",
+                            direction="up",
+                            checksum=checksum,
+                            success=False,
+                        ),
+                        database=database,
+                    )
+                    failures.append((i, step.comment or "reconcile", str(last_exc)))
+
+                    if not continue_on_error:
+                        print(
+                            "\nApply halted. Review the error and retry, "
+                            "or pass --continue-on-error to surface all failures."
+                        )
+                        # Raise CommandError so the process exits non-zero.
+                        # The finally block still runs and releases the apply lock.
+                        raise CommandError(f"Apply failed on step {i} ({step.comment or 'reconcile'}): {last_exc}")
+                    # continue-on-error: keep going to the next step
+                    continue
+
+                print("OK")
+                _record_step(
+                    client=client,
+                    record=StepRecord(
+                        migration_number=0,
+                        migration_name=step.comment or "reconcile",
+                        step_index=i,
+                        host=hostname,
+                        node_role="*",
+                        direction="up",
+                        checksum=checksum,
+                        success=True,
+                    ),
+                    database=database,
+                )
+        finally:
+            release_apply_lock(client, database, hostname)
+
+        if failures:
+            # --continue-on-error path: print a grouped summary of every failure.
+            print(f"\n=== APPLY SUMMARY: {len(steps) - len(failures)} OK, {len(failures)} FAILED ===")
+            for idx, name, err in failures:
+                # Truncate very long CH stack traces to the first line of the exception
+                first_line = err.split("\n", 1)[0][:300]
+                print(f"  step {idx} {name}: {first_line}")
+            raise CommandError(f"Apply finished with {len(failures)} failure(s) out of {len(steps)} step(s)")
+
+        # Record the git commit hash of the schema that was applied
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                record_schema_version(client, database, result.stdout.strip(), hostname)
+                print(f"Schema version recorded: {result.stdout.strip()[:12]}")
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass  # git not available — skip version recording
+
+        print("\nApply completed successfully.")
+
+    # ------------------------------------------------------------------
+    # generate -- scaffold schema YAML from template
+    # ------------------------------------------------------------------
+
+    def handle_generate(self, options: dict[str, Any]) -> None:
+        from pathlib import Path
+
+        from posthog.clickhouse.migration_tools.templates import generate_schema_yaml
+
+        template_name = options["template"]
+        table_name = options["table"]
+        cluster_name = options.get("cluster", "main")
+        output_dir = Path(options.get("output_dir", DEFAULT_SCHEMA_DIR))
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = output_dir / f"{table_name}.yaml"
+
+        if output_path.exists():
+            print(f"Schema file already exists: {output_path}")
+            print("Edit it directly or delete it first.")
+            return
+
+        yaml_data = generate_schema_yaml(template_name, table_name, cluster_name)
+        if yaml_data is None:
+            return
+
+        import yaml as yaml_lib
+
+        with open(output_path, "w") as f:
+            yaml_lib.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+
+        table_count = len(yaml_data.get("tables", {}))
+        print(f"Generated: {output_path} ({table_count} table(s))")
+        print(f"Edit the YAML, then run: ch_migrate plan")
+
+    # ------------------------------------------------------------------
+    # drift
+    # ------------------------------------------------------------------
+
+    def handle_drift(self, options: dict[str, Any]) -> None:
+        database: str = settings.CLICKHOUSE_DATABASE
+
+        print(f"Checking schema drift across all registered clusters (database={database})...")
+
+        all_diffs = []
+        for name in get_all_logical_clusters():
+            try:
+                cluster = get_cluster_by_name(name)
+                diffs = detect_drift(cluster, database)
+                if diffs:
+                    print(f"\nDrift detected on cluster '{name}':")
+                    for diff in diffs:
+                        host_label = f" [{diff.host}]" if diff.host else ""
+                        if diff.column:
+                            print(f"  {diff.diff_type}: {diff.table}.{diff.column}{host_label}")
+                        else:
+                            print(f"  {diff.diff_type}: {diff.table}{host_label}")
+                        if diff.expected:
+                            print(f"    expected: {diff.expected}")
+                        if diff.actual:
+                            print(f"    actual:   {diff.actual}")
+                    all_diffs.extend(diffs)
+            except Exception as e:
+                print(f"  Warning: could not connect to cluster '{name}': {e}")
+
+        if not all_diffs:
+            print("No schema drift detected across all clusters.")
+            return
+
+        sys.exit(1)
+
+    # ------------------------------------------------------------------
+    # schema
+    # ------------------------------------------------------------------
+
+    def handle_schema(self, options: dict[str, Any]) -> None:
+        database: str = settings.CLICKHOUSE_DATABASE
+        cluster = get_cluster_by_name("main")
+
+        client = _any_client(cluster)
+        schema = dump_schema(client, database)
+
+        if not schema:
+            print("No tables found.")
+            return
+
+        print(f"Schema for database '{database}' ({len(schema)} table(s)):\n")
+        for table_name in sorted(schema.keys()):
+            table = schema[table_name]
+            print(f"  {table_name} (engine={table.engine})")
+            if table.sorting_key:
+                print(f"    ORDER BY {table.sorting_key}")
+            if table.partition_key:
+                print(f"    PARTITION BY {table.partition_key}")
+            for col in table.columns:
+                default_str = f" DEFAULT {col.default_expression}" if col.default_expression else ""
+                print(f"    - {col.name}: {col.type}{default_str}")
+            print()
+
+    # ------------------------------------------------------------------
+    # status
+    # ------------------------------------------------------------------
+
+    def handle_status(self, options: dict[str, Any]) -> None:
+        database: str = settings.CLICKHOUSE_DATABASE
+        cluster = get_cluster_by_name("main")
+        client = _any_client(cluster)
+
+        from posthog.clickhouse.migration_tools.tracking import TRACKING_TABLE_NAME, _ensure_tracking_table
+
+        cluster_name = getattr(settings, "CLICKHOUSE_MIGRATIONS_CLUSTER", "posthog_migrations")
+        _ensure_tracking_table(client, database, cluster_name)
+
+        node_filter = options.get("node")
+
+        if node_filter:
+            import re
+
+            if not re.match(r"^[a-zA-Z0-9._:-]+$", node_filter):
+                print(f"Invalid node filter: {node_filter!r}")
+                return
+            rows = client.execute(
+                f"SELECT migration_number, migration_name, host, direction, applied_at, success "
+                f"FROM {database}.{TRACKING_TABLE_NAME} "
+                f"WHERE host = %(host)s "
+                f"ORDER BY applied_at DESC LIMIT 50",
+                {"host": node_filter},
+            )
+        else:
+            rows = client.execute(
+                f"SELECT migration_number, migration_name, host, direction, applied_at, success "
+                f"FROM {database}.{TRACKING_TABLE_NAME} "
+                f"ORDER BY applied_at DESC LIMIT 50"
+            )
+
+        if not rows:
+            print("No migration records found.")
+            return
+
+        print(f"Recent migration records (database={database}):\n")
+        for number, name, host, direction, applied_at, success in rows:
+            status = "OK" if success else "FAILED"
+            print(f"  {number:04d} {name:40s} {direction:4s} {host:20s} {applied_at} {status}")
+
+    # ------------------------------------------------------------------
+    # bootstrap
+    # ------------------------------------------------------------------
+
+    def handle_bootstrap(self, options: dict[str, Any]) -> None:
+        database: str = settings.CLICKHOUSE_DATABASE
+
+        from posthog.clickhouse.client.connection import default_client
+        from posthog.clickhouse.migration_tools.tracking import _ensure_tracking_table
+
+        cluster_name = getattr(settings, "CLICKHOUSE_MIGRATIONS_CLUSTER", "posthog_migrations")
+
+        # Create the database itself before anything else tries to connect to it.
+        # On a fresh stack `posthog_test` doesn't exist, and the ClickHouse native
+        # driver sends the target database in its "Hello" frame on connect. If the
+        # database doesn't exist, CH rejects the connection with "Database
+        # posthog_test does not exist" before any query runs — so we can't use a
+        # cluster client that was constructed with `database=posthog_test`.
+        #
+        # `default_client` connects to the `system` database (see its docstring)
+        # which always exists, so it can run the CREATE DATABASE statement.
+        with default_client() as bootstrap_client:
+            bootstrap_client.execute(f"CREATE DATABASE IF NOT EXISTS {database} ON CLUSTER {cluster_name}")
+
+        # Now that the database exists, build the cluster client and create the
+        # tracking table on every migrations node via ON CLUSTER.
+        cluster = get_cluster_by_name("main")
+        client = _any_client(cluster)
+
+        _ensure_tracking_table(client, database, cluster_name)
+        print(f"Tracking table ensured in database '{database}' on cluster '{cluster_name}'.")
+
+    # ------------------------------------------------------------------
+    # check -- pending legacy migrations
+    # ------------------------------------------------------------------
+
+    def handle_check(self, options: dict[str, Any]) -> None:
+        from posthog.clickhouse.migration_tools.runner import get_pending_migrations
+
+        pending = get_pending_migrations()
+        if not pending:
+            print("No pending legacy migrations.")
+            return
+
+        print(f"{len(pending)} pending legacy migration(s):\n")
+        for m in pending:
+            print(f"  {m}")
+
+    # ------------------------------------------------------------------
+    # lint -- validate schema YAML files
+    # ------------------------------------------------------------------
+
+    def handle_lint(self, options: dict[str, Any]) -> None:
+        from pathlib import Path
+
+        from posthog.clickhouse.migration_tools.desired_state import parse_desired_state_dir
+        from posthog.clickhouse.migration_tools.validator import validate_desired_states
+
+        schema_dir = Path(options.get("schema_dir", DEFAULT_SCHEMA_DIR))
+        if not schema_dir.exists():
+            print(f"Schema directory not found: {schema_dir}")
+            return
+
+        desired_states = parse_desired_state_dir(schema_dir)
+        if not desired_states:
+            print(f"No YAML files found in {schema_dir}")
+            return
+
+        errors = validate_desired_states(desired_states)
+        if not errors:
+            print(f"All {len(desired_states)} schema file(s) passed lint.")
+            return
+
+        print(f"Lint errors ({len(errors)}):\n")
+        for err in errors:
+            print(f"  - {err}")
+        sys.exit(1)
+
+    # ------------------------------------------------------------------
+    # orphans -- find undeclared tables
+    # ------------------------------------------------------------------
+
+    def handle_orphans(self, options: dict[str, Any]) -> None:
+        from pathlib import Path
+
+        from posthog.clickhouse.migration_tools.desired_state import parse_desired_state_dir
+        from posthog.clickhouse.migration_tools.schema_introspect import dump_schema
+        from posthog.clickhouse.migration_tools.state_diff import detect_orphans
+
+        database: str = settings.CLICKHOUSE_DATABASE
+        schema_dir = Path(options.get("schema_dir", DEFAULT_SCHEMA_DIR))
+
+        if not schema_dir.exists():
+            print(f"Schema directory not found: {schema_dir}")
+            return
+
+        desired_states = parse_desired_state_dir(schema_dir)
+        if not desired_states:
+            print(f"No YAML files found in {schema_dir}")
+            return
+
+        exclude = options.get("exclude") or []
+
+        # Orphan scan must walk every registered logical cluster — satellite
+        # tables live on separate CH hosts, so a main-cluster scan alone
+        # misses them and risks reporting false positives when a table owned
+        # by e.g. `logs` isn't declared in `main`'s YAML. Merge the per-cluster
+        # current schemas into a single introspection map before calling
+        # detect_orphans, mirroring the global-name semantics used in
+        # _compute_diffs.
+        current_union: dict[str, Any] = {}
+        unreachable: list[tuple[str, str]] = []
+        for cluster_name in get_all_logical_clusters():
+            try:
+                cluster = get_cluster_by_name(cluster_name)
+                client = _any_client(cluster)
+                current = dump_schema(client, database)
+            except Exception as exc:
+                exc_str = str(exc)
+                is_unreachable = (
+                    "CLUSTER_DOESNT_EXIST" in exc_str
+                    or "Code: 701" in exc_str
+                    or "Code: 210" in exc_str
+                    or "Connection refused" in exc_str
+                    or "Name or service not known" in exc_str
+                    or "not found" in exc_str.lower()
+                )
+                if is_unreachable:
+                    unreachable.append((cluster_name, exc_str[:200]))
+                    continue
+                raise
+            for tbl_name, tbl_schema in current.items():
+                # First-wins union — replicated tables have identical DDL
+                # across nodes, and for node-role-specific tables (Distributed,
+                # MV) only one cluster host has them anyway.
+                current_union.setdefault(tbl_name, tbl_schema)
+
+        if unreachable:
+            for cluster_name, detail in unreachable:
+                print(f"Warning: cluster '{cluster_name}' unreachable; skipping. Details: {detail}")
+
+        orphans = detect_orphans(desired_states, current_union, exclude)
+
+        if not orphans:
+            print("No orphan tables found. All production tables are declared in YAML.")
+            return
+
+        print(f"Orphan tables ({len(orphans)}) — in production but not declared in any YAML:\n")
+        for name in orphans:
+            engine = current_union[name].engine if name in current_union else "?"
+            print(f"  {name} (engine={engine})")
+        print("\nThese tables may be leftover from old migrations or manual creation.")
+
+    # ------------------------------------------------------------------
+    # version -- show last applied schema version
+    # ------------------------------------------------------------------
+
+    def handle_version(self, options: dict[str, Any]) -> None:
+        from posthog.clickhouse.migration_tools.tracking import _ensure_tracking_table, get_latest_schema_version
+
+        database: str = settings.CLICKHOUSE_DATABASE
+        cluster = get_cluster_by_name("main")
+        client = _any_client(cluster)
+
+        cluster_name = getattr(settings, "CLICKHOUSE_MIGRATIONS_CLUSTER", "posthog_migrations")
+        _ensure_tracking_table(client, database, cluster_name)
+        version = get_latest_schema_version(client, database)
+
+        if version is None:
+            print("No schema version recorded. Run 'ch_migrate apply' to record one.")
+            return
+
+        commit_hash, host, applied_at = version
+        print(f"Last applied schema version:")
+        print(f"  Commit:     {commit_hash}")
+        print(f"  Applied by: {host}")
+        print(f"  Applied at: {applied_at}")
+
+    # ------------------------------------------------------------------
+    # down -- legacy rollback
+    # ------------------------------------------------------------------
+
+    def handle_down(self, options: dict[str, Any]) -> None:
+        from posthog.clickhouse.migration_tools.runner import run_migration_down
+
+        migration_number = options["migration_number"]
+        print(f"Rolling back migration {migration_number}...")
+        run_migration_down(migration_number)
+        print("Done.")


### PR DESCRIPTION
## Summary
- Introduce foundational `ch_migrate` command plumbing and desired-state parser/manifest/runner scaffolding.
- Include base docs and test scaffolding required for follow-on vertical slices.
- Keeps this PR focused on foundation only, without diff/locking/routing hardening.

## Test plan
- [x] `bin/hogli lint`
- [ ] stacked CI suites