### PR TITLE
fix(ch_migrate): add locking and apply-safety protections

### DIFF
--- a/posthog/clickhouse/migration_tools/tracking.py
+++ b/posthog/clickhouse/migration_tools/tracking.py
@@ -1,0 +1,270 @@
+"""Advisory locking for concurrent apply prevention.
+
+The tracking table is ReplicatedMergeTree ON CLUSTER so that every node
+in the cluster sees the same lock/history rows. This prevents two
+concurrent ``ch_migrate apply`` calls on different hosts from both
+acquiring the advisory lock.
+"""
+
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+TRACKING_TABLE_NAME = "clickhouse_schema_migrations"
+
+TRACKING_TABLE_DDL = """
+CREATE TABLE IF NOT EXISTS {database}.clickhouse_schema_migrations ON CLUSTER {cluster} (
+    migration_number UInt32,
+    migration_name String,
+    step_index Int32,
+    host String,
+    node_role String,
+    direction Enum8('up' = 1, 'down' = 2),
+    checksum String,
+    applied_at DateTime64(3),
+    success Bool
+) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{{shard}}/{database}/clickhouse_schema_migrations', '{{replica}}')
+ORDER BY (migration_number, step_index, host, direction, applied_at)
+"""
+
+# Advisory lock constants.
+LOCK_MIGRATION_NUMBER = 0
+LOCK_STEP_INDEX = -999
+LOCK_TIMEOUT_MINUTES = 30
+
+
+@dataclass
+class StepRecord:
+    migration_number: int
+    migration_name: str
+    step_index: int
+    host: str
+    node_role: str
+    direction: str
+    checksum: str
+    success: bool
+
+
+def _ensure_tracking_table(client: Any, database: str, cluster: str = "posthog_migrations") -> None:
+    """Create the tracking table on every node via ON CLUSTER (idempotent)."""
+    client.execute(TRACKING_TABLE_DDL.format(database=database, cluster=cluster))
+
+
+def _record_step(
+    client: Any,
+    record: StepRecord,
+    database: str = "",
+) -> None:
+    table_ref = f"{database}.{TRACKING_TABLE_NAME}" if database else TRACKING_TABLE_NAME
+    sql = f"""
+        INSERT INTO {table_ref}
+        (migration_number, migration_name, step_index, host, node_role, direction, checksum, applied_at, success)
+        VALUES
+    """
+    now = datetime.now(tz=UTC)
+    params = [
+        (
+            record.migration_number,
+            record.migration_name,
+            record.step_index,
+            record.host,
+            record.node_role,
+            record.direction,
+            record.checksum,
+            now,
+            record.success,
+        )
+    ]
+    client.execute(sql, params)
+
+
+def acquire_apply_lock(
+    client: Any,
+    database: str,
+    hostname: str,
+    *,
+    force: bool = False,
+    cluster: str = "posthog_migrations",
+) -> tuple[bool, str]:
+    """Cluster-wide advisory lock via ReplicatedMergeTree INSERT.
+
+    The tracking table is replicated across all nodes, so a lock row
+    inserted on any host is visible to every other host after replication
+    converges. We INSERT a lock row, wait briefly for replication, then
+    verify no other host also acquired — if so, we back off.
+    """
+    _ensure_tracking_table(client, database, cluster)
+    table_ref = f"{database}.{TRACKING_TABLE_NAME}"
+
+    if force:
+        _record_step(
+            client=client,
+            record=StepRecord(
+                migration_number=LOCK_MIGRATION_NUMBER,
+                migration_name="__lock__",
+                step_index=LOCK_STEP_INDEX,
+                host=hostname,
+                node_role="*",
+                direction="up",
+                checksum="lock",
+                success=True,
+            ),
+            database=database,
+        )
+        return (True, "")
+
+    # Check for an existing active lock before attempting to insert.
+    # A lock is "active" when there is an 'up' row with no subsequent 'down' row.
+    check_sql = f"""
+        SELECT host, applied_at
+        FROM {table_ref}
+        WHERE migration_number = {LOCK_MIGRATION_NUMBER}
+          AND step_index = {LOCK_STEP_INDEX}
+          AND direction = 'up'
+          AND success = 1
+          AND applied_at > now() - INTERVAL {LOCK_TIMEOUT_MINUTES} MINUTE
+          AND host != %(hostname)s
+          AND applied_at > (
+              SELECT coalesce(max(applied_at), toDateTime64('1970-01-01', 3))
+              FROM {table_ref}
+              WHERE migration_number = {LOCK_MIGRATION_NUMBER}
+                AND step_index = {LOCK_STEP_INDEX}
+                AND direction = 'down'
+          )
+        ORDER BY applied_at DESC
+        LIMIT 1
+    """
+    existing = client.execute(check_sql, {"hostname": hostname})
+    if existing:
+        return (
+            False,
+            f"Another ch_migrate apply is running on {existing[0][0]} (started {existing[0][1]}). Use --force to override.",
+        )
+
+    # Insert the acquire record
+    _record_step(
+        client=client,
+        record=StepRecord(
+            migration_number=LOCK_MIGRATION_NUMBER,
+            migration_name="__lock__",
+            step_index=LOCK_STEP_INDEX,
+            host=hostname,
+            node_role="*",
+            direction="up",
+            checksum="lock",
+            success=True,
+        ),
+        database=database,
+    )
+
+    # Force replication convergence before the double-lock check. A fixed
+    # sleep (0.5s, 5s, ...) is not a correctness barrier — under replication
+    # lag each host can still see only its own insert. SYSTEM SYNC REPLICA
+    # STRICT blocks until the local replica has drained its ZooKeeper
+    # replication queue, so when we then SELECT we observe all peer inserts
+    # that beat ours to the leader. Hosts that INSERT simultaneously will
+    # disagree on the tie-break (applied_at, host) but both observe the same
+    # sorted set and agree on the winner.
+    try:
+        client.execute(f"SYSTEM SYNC REPLICA {table_ref} STRICT")
+    except Exception:
+        # SYNC REPLICA is only valid on Replicated engines; fall back to a
+        # short sleep for local-only dev stacks where the tracking table is
+        # plain MergeTree. This path is not safe under real concurrency but
+        # matches the single-host dev environment.
+        time.sleep(1)
+    # Deterministic tie-break: earliest-applied wins, then lexicographic
+    # hostname. Both callers sort the same rows identically regardless of
+    # which one landed in the driver result first, so they agree on the
+    # winner. Prior `ORDER BY applied_at DESC` let the winner flip when two
+    # inserts landed in the same millisecond.
+    verify_sql = f"""
+        SELECT host, applied_at
+        FROM {table_ref}
+        WHERE migration_number = {LOCK_MIGRATION_NUMBER}
+          AND step_index = {LOCK_STEP_INDEX}
+          AND direction = 'up'
+          AND success = 1
+          AND applied_at > now() - INTERVAL {LOCK_TIMEOUT_MINUTES} MINUTE
+          AND applied_at > (
+              SELECT coalesce(max(applied_at), toDateTime64('1970-01-01', 3))
+              FROM {table_ref}
+              WHERE migration_number = {LOCK_MIGRATION_NUMBER}
+                AND step_index = {LOCK_STEP_INDEX}
+                AND direction = 'down'
+          )
+        ORDER BY applied_at ASC, host ASC
+    """
+    active = client.execute(verify_sql)
+    if len(active) > 1 and active[0][0] != hostname:
+        # Race: another host won. Release and back off.
+        release_apply_lock(client, database, hostname)
+        return (
+            False,
+            f"Race detected — lock held by {active[0][0]}. Use --force to override.",
+        )
+
+    return (True, "")
+
+
+# Schema version sentinel: records which git commit was last applied.
+VERSION_STEP_INDEX = -2
+
+
+def record_schema_version(client: Any, database: str, commit_hash: str, hostname: str) -> None:
+    """Record the git commit hash of the schema YAML that was just applied."""
+    _record_step(
+        client=client,
+        record=StepRecord(
+            migration_number=LOCK_MIGRATION_NUMBER,
+            migration_name=commit_hash,
+            step_index=VERSION_STEP_INDEX,
+            host=hostname,
+            node_role="*",
+            direction="up",
+            checksum="version",
+            success=True,
+        ),
+        database=database,
+    )
+
+
+def get_latest_schema_version(client: Any, database: str) -> tuple[str, str, str] | None:
+    """Return (commit_hash, host, applied_at) of the last applied schema version, or None."""
+    table_ref = f"{database}.{TRACKING_TABLE_NAME}"
+    sql = f"""
+        SELECT migration_name, host, applied_at
+        FROM {table_ref}
+        WHERE migration_number = {LOCK_MIGRATION_NUMBER}
+          AND step_index = {VERSION_STEP_INDEX}
+          AND success = 1
+        ORDER BY applied_at DESC
+        LIMIT 1
+    """
+    rows = client.execute(sql)
+    if rows:
+        return (rows[0][0], rows[0][1], str(rows[0][2]))
+    return None
+
+
+def release_apply_lock(client: Any, database: str, hostname: str) -> None:
+    """Release the advisory lock by inserting a direction='down' row.
+
+    The acquire logic checks for 'up' rows whose applied_at exceeds the
+    latest 'down' row — this release row makes the lock invisible.
+    """
+    _record_step(
+        client=client,
+        record=StepRecord(
+            migration_number=LOCK_MIGRATION_NUMBER,
+            migration_name="__lock__",
+            step_index=LOCK_STEP_INDEX,
+            host=hostname,
+            node_role="*",
+            direction="down",
+            checksum="unlock",
+            success=True,
+        ),
+        database=database,
+    )

--- a/posthog/clickhouse/migration_tools/validator.py
+++ b/posthog/clickhouse/migration_tools/validator.py
@@ -1,0 +1,227 @@
+"""Validate desired-state YAML schemas for ecosystem completeness and targeting."""
+
+from __future__ import annotations
+
+from posthog.clickhouse.migration_tools.desired_state import DesiredState
+from posthog.clickhouse.migration_tools.schema_graph import DictRef, TableEcosystem, lookup_ecosystem
+from posthog.clickhouse.migration_tools.state_diff import _is_distributed, _is_kafka, _is_mergetree, _is_mv
+
+# Expected node roles by engine type.
+#
+# Source of truth: `NodeRole` enum in posthog/clickhouse/client/connection.py.
+# Every satellite cluster (LOGS, AUX, SESSIONS, OPS, AI_EVENTS, SHUFFLEHOG,
+# ENDPOINTS) can host its own Distributed, Kafka, and MV tables in its own
+# topology, so all three engine categories accept those roles in addition to
+# the main-cluster roles.
+_SATELLITE_ROLES: frozenset[str] = frozenset({"LOGS", "AUX", "SESSIONS", "OPS", "AI_EVENTS", "SHUFFLEHOG", "ENDPOINTS"})
+
+_EXPECTED_ROLES: dict[str, set[str]] = {
+    # Distributed routing is logical, not physical — a Distributed table can
+    # legitimately live on any role (DATA for read paths, INGESTION_* for
+    # writable passthroughs on ingestion hosts, COORDINATOR for query
+    # coordination, satellite roles for per-ecosystem hosts).
+    "distributed": {
+        "COORDINATOR",
+        "ALL",
+        "DATA",
+        "INGESTION_EVENTS",
+        "INGESTION_SMALL",
+        "INGESTION_MEDIUM",
+        *_SATELLITE_ROLES,
+    },
+    "kafka": {"INGESTION_EVENTS", "INGESTION_SMALL", "INGESTION_MEDIUM", "ALL", *_SATELLITE_ROLES},
+    # DATA is valid for MVs that feed tables living on the main data nodes —
+    # e.g. events_recent, sessions, query_log_archive — where the MV runs on
+    # the same role as its destination MergeTree table.
+    "materializedview": {
+        "DATA",
+        "INGESTION_EVENTS",
+        "INGESTION_SMALL",
+        "INGESTION_MEDIUM",
+        "ALL",
+        *_SATELLITE_ROLES,
+    },
+}
+
+
+def _is_dictionary(engine: str) -> bool:
+    return engine.lower() == "dictionary"
+
+
+def build_ecosystems_from_yaml(desired_states: list[DesiredState]) -> list[TableEcosystem]:
+    """Build ecosystem objects from desired-state YAML definitions.
+
+    Scans all DesiredState objects and identifies ecosystems. Each MergeTree
+    local table anchors one ecosystem — companion tables are matched by
+    name prefix (after stripping a leading `sharded_`). Any combination of
+    Distributed, Kafka, MV, or Dictionary companions triggers an ecosystem.
+    This catches dictionary-only and local-only pipelines (exchange_rate,
+    channel_definition, person_overrides, web_preaggregated) that were
+    previously silently skipped because they lacked a Distributed pair.
+    """
+    ecosystems: list[TableEcosystem] = []
+
+    for state in desired_states:
+        tables = state.tables
+
+        local_tables = {n: t for n, t in tables.items() if _is_mergetree(t.engine)}
+        distributed = {n: t for n, t in tables.items() if _is_distributed(t.engine)}
+        kafka = {n: t for n, t in tables.items() if _is_kafka(t.engine)}
+        mvs = {n: t for n, t in tables.items() if _is_mv(t.engine)}
+        dicts = {n: t for n, t in tables.items() if _is_dictionary(t.engine)}
+
+        for local_name in local_tables:
+            writable = next(
+                (n for n, t in distributed.items() if t.source == local_name and "writable" in n),
+                None,
+            )
+            readable = next(
+                (n for n, t in distributed.items() if t.source == local_name and "writable" not in n),
+                None,
+            )
+
+            base_name = local_name.replace("sharded_", "")
+
+            kafka_tbl = next(
+                (n for n in kafka if base_name in n),
+                None,
+            )
+            mv_tbl = next(
+                (n for n in mvs if base_name in n),
+                None,
+            )
+            dict_tbl = next(
+                (n for n in dicts if base_name in n),
+                None,
+            )
+
+            if writable or readable or kafka_tbl or mv_tbl or dict_tbl:
+                ecosystems.append(
+                    TableEcosystem(
+                        base_name=base_name,
+                        sharded_table=local_name,
+                        distributed_writable=writable,
+                        distributed_readable=readable,
+                        kafka_table=kafka_tbl,
+                        materialized_view=mv_tbl,
+                        dictionaries=[DictRef(dict_name=dict_tbl, source_table=local_name)] if dict_tbl else [],
+                    )
+                )
+
+    return ecosystems
+
+
+def validate_desired_states(desired_states: list[DesiredState]) -> list[str]:
+    """Validate a list of desired states. Returns a list of error strings (empty = valid)."""
+    errors: list[str] = []
+
+    # Build dynamic ecosystems from YAML for completeness checking
+    dynamic_ecosystems = build_ecosystems_from_yaml(desired_states)
+    dynamic_lookup: dict[str, TableEcosystem] = {}
+    for eco in dynamic_ecosystems:
+        for tbl in eco.all_tables():
+            dynamic_lookup[tbl] = eco
+
+    for state in desired_states:
+        errors.extend(_check_ecosystem_completeness(state, dynamic_lookup))
+        errors.extend(_check_cross_cluster_targeting(state))
+        errors.extend(_check_engine_required_fields(state))
+        errors.extend(_check_mergetree_order_by(state))
+
+    return errors
+
+
+def _check_ecosystem_completeness(
+    state: DesiredState,
+    dynamic_lookup: dict[str, TableEcosystem] | None = None,
+) -> list[str]:
+    """Warn if an ecosystem is partially declared (e.g. sharded without distributed).
+
+    Uses dynamic ecosystems built from YAML when available, falls back to
+    the hardcoded registry in schema_graph.py.
+    """
+    errors: list[str] = []
+
+    for table_name in state.tables:
+        # Try dynamic lookup first, then hardcoded
+        eco = None
+        if dynamic_lookup:
+            eco = dynamic_lookup.get(table_name)
+        if eco is None:
+            eco = lookup_ecosystem(table_name)
+        if eco is None:
+            continue
+
+        expected_tables = eco.all_tables()
+        declared_tables = set(state.tables.keys())
+        missing = expected_tables - declared_tables
+
+        if missing:
+            errors.append(
+                f"[{state.ecosystem}] Table '{table_name}' belongs to ecosystem "
+                f"'{eco.base_name}' but companion tables are missing: {sorted(missing)}"
+            )
+            break  # one warning per ecosystem is enough
+
+    return errors
+
+
+def _check_cross_cluster_targeting(state: DesiredState) -> list[str]:
+    """Check that engine types target appropriate node roles."""
+    errors: list[str] = []
+
+    for table_name, table in state.tables.items():
+        engine_lower = table.engine.lower()
+        expected = None
+        for engine_key, roles in _EXPECTED_ROLES.items():
+            if engine_key in engine_lower:
+                expected = roles
+                break
+
+        if expected is None:
+            continue
+
+        on_nodes_set = set(table.on_nodes)
+        if not on_nodes_set & expected:
+            errors.append(
+                f"[{state.ecosystem}] Table '{table_name}' (engine={table.engine}) "
+                f"targets {table.on_nodes} but expected one of {sorted(expected)}"
+            )
+
+    return errors
+
+
+def _check_mergetree_order_by(state: DesiredState) -> list[str]:
+    """MergeTree-family tables must have an ORDER BY clause.
+
+    ClickHouse rejects CREATE TABLE for MergeTree engines without ORDER BY.
+    Catching this at lint time prevents silent failures at apply time.
+    """
+    errors: list[str] = []
+    for table_name, table in state.tables.items():
+        if _is_mergetree(table.engine) and not table.order_by:
+            errors.append(
+                f"[{state.ecosystem}] Table '{table_name}' (engine={table.engine}) "
+                f"is missing ORDER BY \u2014 ClickHouse will reject this CREATE"
+            )
+    return errors
+
+
+def _check_engine_required_fields(state: DesiredState) -> list[str]:
+    """Catch engine-specific required fields before apply-time failures."""
+    errors: list[str] = []
+
+    for table_name, table in state.tables.items():
+        if _is_distributed(table.engine) and not table.source:
+            errors.append(
+                f"[{state.ecosystem}] Table '{table_name}' (engine={table.engine}) "
+                "is missing source — Distributed tables must declare a source table"
+            )
+
+        if _is_mv(table.engine) and not table.target:
+            errors.append(
+                f"[{state.ecosystem}] Table '{table_name}' (engine={table.engine}) "
+                "is missing target — MaterializedView tables must declare a target table"
+            )
+
+    return errors

--- a/posthog/clickhouse/migration_tools/validator.py
+++ b/posthog/clickhouse/migration_tools/validator.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 from posthog.clickhouse.migration_tools.desired_state import DesiredState
 from posthog.clickhouse.migration_tools.schema_graph import DictRef, TableEcosystem, lookup_ecosystem
 from posthog.clickhouse.migration_tools.state_diff import _is_distributed, _is_kafka, _is_mergetree, _is_mv
@@ -81,17 +83,18 @@ def build_ecosystems_from_yaml(desired_states: list[DesiredState]) -> list[Table
             )
 
             base_name = local_name.replace("sharded_", "")
+            base_name_pattern = re.compile(rf"(^|_){re.escape(base_name)}($|_)")
 
             kafka_tbl = next(
-                (n for n in kafka if base_name in n),
+                (n for n in kafka if base_name_pattern.search(n)),
                 None,
             )
             mv_tbl = next(
-                (n for n in mvs if base_name in n),
+                (n for n in mvs if base_name_pattern.search(n)),
                 None,
             )
             dict_tbl = next(
-                (n for n in dicts if base_name in n),
+                (n for n in dicts if base_name_pattern.search(n)),
                 None,
             )
 
@@ -141,6 +144,7 @@ def _check_ecosystem_completeness(
     the hardcoded registry in schema_graph.py.
     """
     errors: list[str] = []
+    reported_ecosystems: set[str] = set()
 
     for table_name in state.tables:
         # Try dynamic lookup first, then hardcoded
@@ -156,12 +160,12 @@ def _check_ecosystem_completeness(
         declared_tables = set(state.tables.keys())
         missing = expected_tables - declared_tables
 
-        if missing:
+        if missing and eco.base_name not in reported_ecosystems:
             errors.append(
                 f"[{state.ecosystem}] Table '{table_name}' belongs to ecosystem "
                 f"'{eco.base_name}' but companion tables are missing: {sorted(missing)}"
             )
-            break  # one warning per ecosystem is enough
+            reported_ecosystems.add(eco.base_name)
 
     return errors
 

--- a/posthog/clickhouse/test/test_advisory_lock.py
+++ b/posthog/clickhouse/test/test_advisory_lock.py
@@ -1,0 +1,147 @@
+"""Unit tests for advisory locking in tracking.py.
+
+Tests acquire_apply_lock and release_apply_lock with mocked ClickHouse
+client — no Django or ClickHouse connection required.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import posthog.clickhouse.test._stubs  # noqa: F401
+from posthog.clickhouse.migration_tools.tracking import acquire_apply_lock, release_apply_lock
+
+
+class TestAdvisoryLock(unittest.TestCase):
+    """Tests for the advisory lock mechanism."""
+
+    @patch("posthog.clickhouse.migration_tools.tracking.time.sleep")
+    def test_advisory_lock_prevents_concurrent_apply(self, mock_sleep: MagicMock) -> None:
+        """An active lock from another host prevents acquisition."""
+        client = MagicMock()
+        now = datetime.now(tz=UTC)
+        # Flow: ensure table, check for existing lock (found -> reject)
+        client.execute.side_effect = [
+            None,  # CREATE TABLE ON CLUSTER (ensure tracking table)
+            [("other-pod", now)],  # Check SELECT -- another host holds the lock
+        ]
+
+        acquired, reason = acquire_apply_lock(client, "default", "my-pod")
+
+        self.assertFalse(acquired)
+        self.assertIn("other-pod", reason)
+        self.assertIn("--force", reason)
+
+    @patch("posthog.clickhouse.migration_tools.tracking.time.sleep")
+    def test_advisory_lock_expired_allows_apply(self, mock_sleep: MagicMock) -> None:
+        """No active lock (expired or absent) allows acquisition."""
+        client = MagicMock()
+        now = datetime.now(tz=UTC)
+        client.execute.side_effect = [
+            None,  # CREATE TABLE ON CLUSTER (ensure tracking table)
+            [],  # Check SELECT -- no active lock
+            None,  # INSERT lock row (via _record_step)
+            None,  # SYSTEM SYNC REPLICA (replication barrier)
+            [("my-pod", now)],  # Post-replication verify -- only our lock
+        ]
+
+        acquired, reason = acquire_apply_lock(client, "default", "my-pod")
+
+        self.assertTrue(acquired)
+        self.assertEqual(reason, "")
+        # Five calls: CREATE ON CLUSTER + check SELECT + INSERT + SYNC REPLICA + verify SELECT
+        self.assertEqual(client.execute.call_count, 5)
+        # SYNC REPLICA succeeded, so no sleep fallback
+        mock_sleep.assert_not_called()
+        sync_sql = client.execute.call_args_list[3].args[0]
+        self.assertIn("SYSTEM SYNC REPLICA", sync_sql)
+        self.assertIn("STRICT", sync_sql)
+        verify_sql = client.execute.call_args_list[4].args[0]
+        self.assertIn("ORDER BY applied_at ASC, host ASC", verify_sql)
+
+    @patch("posthog.clickhouse.migration_tools.tracking.time.sleep")
+    def test_advisory_lock_same_host_allows_reacquire(self, mock_sleep: MagicMock) -> None:
+        """A lock from the same host allows re-acquisition (idempotent)."""
+        client = MagicMock()
+        now = datetime.now(tz=UTC)
+        client.execute.side_effect = [
+            None,  # CREATE TABLE ON CLUSTER
+            [],  # Check SELECT -- no lock from OTHER hosts
+            None,  # INSERT lock row
+            None,  # SYSTEM SYNC REPLICA
+            [("my-pod", now)],  # Verify -- our own host holds the lock
+        ]
+
+        acquired, reason = acquire_apply_lock(client, "default", "my-pod")
+
+        self.assertTrue(acquired)
+        self.assertEqual(reason, "")
+
+    def test_advisory_lock_force_overrides_other_host(self) -> None:
+        """force=True acquires even when another host holds the lock."""
+        client = MagicMock()
+        client.execute.side_effect = [
+            None,  # CREATE TABLE ON CLUSTER (ensure tracking table)
+            None,  # INSERT lock row directly (no check with force=True)
+        ]
+
+        acquired, reason = acquire_apply_lock(client, "default", "my-pod", force=True)
+
+        self.assertTrue(acquired)
+        self.assertEqual(reason, "")
+        # Two calls: CREATE ON CLUSTER + INSERT (via _record_step). No verify needed.
+        self.assertEqual(client.execute.call_count, 2)
+
+    @patch("posthog.clickhouse.migration_tools.tracking.time.sleep")
+    def test_advisory_lock_race_detected(self, mock_sleep: MagicMock) -> None:
+        """When two hosts both insert before replication, the loser backs off."""
+        client = MagicMock()
+        now = datetime.now(tz=UTC)
+        client.execute.side_effect = [
+            None,  # CREATE TABLE ON CLUSTER
+            [],  # Check SELECT -- no lock (race window)
+            None,  # INSERT lock row
+            None,  # SYSTEM SYNC REPLICA
+            [("other-pod", now), ("my-pod", now)],  # Verify -- two locks! other-pod won
+            None,  # release_apply_lock INSERT (direction=down)
+        ]
+
+        acquired, reason = acquire_apply_lock(client, "default", "my-pod")
+
+        self.assertFalse(acquired)
+        self.assertIn("Race detected", reason)
+        self.assertIn("other-pod", reason)
+
+    def test_release_apply_lock_inserts_down_row(self) -> None:
+        """Release inserts a direction='down', success=True row."""
+        client = MagicMock()
+        client.execute.return_value = None
+
+        release_apply_lock(client, "default", "my-pod")
+
+        # Should have inserted a row (via _record_step which calls client.execute)
+        client.execute.assert_called_once()
+        # Verify the INSERT contains direction='down'
+        call_args = client.execute.call_args
+        params = call_args[0][1][0]  # positional: (sql, params_list)
+        # direction is at index 5 in the tuple
+        self.assertEqual(params[5], "down")
+        # success is at index 8
+        self.assertTrue(params[8])
+
+    def test_tracking_table_ddl_uses_replicated_engine(self) -> None:
+        """The tracking table DDL must use ReplicatedMergeTree and ON CLUSTER."""
+        from posthog.clickhouse.migration_tools.tracking import TRACKING_TABLE_DDL
+
+        self.assertIn("ReplicatedMergeTree", TRACKING_TABLE_DDL)
+        self.assertIn("ON CLUSTER", TRACKING_TABLE_DDL)
+        self.assertIn("{cluster}", TRACKING_TABLE_DDL)
+        self.assertIn("{{shard}}", TRACKING_TABLE_DDL)
+        self.assertIn("{{replica}}", TRACKING_TABLE_DDL)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/posthog/management/commands/test_ch_migrations_are_safe.py
+++ b/posthog/management/commands/test_ch_migrations_are_safe.py
@@ -29,13 +29,29 @@ IGNORED_DUPLICATE_MIGRATION_NUMBERS = frozenset(
 
 
 def get_all_migrations() -> list[tuple[str, str]]:
-    """Get all migrations as (index, name) tuples."""
+    """Get all migrations as (index, name) tuples.
+
+    Matches both legacy .py files and new-style directory-based migrations
+    (directories containing a manifest.yaml).
+    """
     migrations: list[tuple[str, str]] = []
-    for filename in os.listdir(MIGRATIONS_DIR):
-        match = re.match(r"([0-9]+)_([a-zA-Z_0-9]+)\.py", filename)
+    for entry in os.listdir(MIGRATIONS_DIR):
+        full_path = os.path.join(MIGRATIONS_DIR, entry)
+
+        # Legacy .py file migrations
+        match = re.match(r"([0-9]+)_([a-zA-Z_0-9]+)\.py", entry)
         if match:
             groups = match.groups()
             migrations.append((groups[0], groups[1]))
+            continue
+
+        # New-style directory-based migrations (contain manifest.yaml)
+        if os.path.isdir(full_path):
+            dir_match = re.match(r"([0-9]+)_([a-zA-Z_0-9]+)", entry)
+            if dir_match and os.path.isfile(os.path.join(full_path, "manifest.yaml")):
+                groups = dir_match.groups()
+                migrations.append((groups[0], groups[1]))
+
     return sorted(migrations, key=lambda x: (int(x[0]), x[1]))
 
 
@@ -89,7 +105,19 @@ class Command(BaseCommand):
             logger.warning("Not running migration-specific checks. See .github/workflows/ci-backend.yml for usage.")
             return
 
-        migrations = [m.strip() for m in sys.stdin.readlines() if m.strip()]
+        raw_paths = [m.strip() for m in sys.stdin.readlines() if m.strip()]
+
+        # Deduplicate directory-based migrations: multiple files (up.sql, down.sql,
+        # manifest.yaml) in the same directory represent one migration.
+        seen: dict[str, str] = {}
+        for path in raw_paths:
+            dir_match = re.search(r"clickhouse/migrations/([0-9]+_[a-zA-Z_0-9]+)/", path)
+            if dir_match:
+                key = dir_match.group(1)
+                seen.setdefault(key, path)
+            else:
+                seen[path] = path
+        migrations = list(seen.values())
 
         if len(migrations) > 1:
             logger.error("Multiple migrations in PR. Please limit to one migration per PR.")
@@ -121,14 +149,29 @@ class Command(BaseCommand):
 
         old_migrations = []
         for filename in master_migrations:
+            # Match both .py files and directories
             match = re.findall(r"([0-9]+)_([a-zA-Z_0-9]+)\.py", filename)
             if match:
                 old_migrations.append(match[0])
+            else:
+                dir_match = re.match(r"([0-9]+)_([a-zA-Z_0-9]+)$", filename)
+                if dir_match and os.path.isdir(os.path.join(MIGRATIONS_DIR, filename)):
+                    old_migrations.append(dir_match.groups())
 
         try:
-            _, index, name = re.findall(r"([a-z]+)/clickhouse/migrations/([0-9]+)_([a-zA-Z_0-9]+)\.py", new_migration)[
-                0
-            ]
+            # Try .py file pattern first, then directory pattern
+            py_match = re.findall(r"([a-z]+)/clickhouse/migrations/([0-9]+)_([a-zA-Z_0-9]+)\.py", new_migration)
+            if py_match:
+                _, index, name = py_match[0]
+            else:
+                # Directory-based migration: path like posthog/clickhouse/migrations/0224_name/manifest.yaml
+                dir_match_result = re.findall(
+                    r"([a-z]+)/clickhouse/migrations/([0-9]+)_([a-zA-Z_0-9]+)/", new_migration
+                )
+                if dir_match_result:
+                    _, index, name = dir_match_result[0]
+                else:
+                    raise IndexError(f"No match for path: {new_migration}")
         except (IndexError, CommandError) as exc:
             logger.warning("Could not parse migration path '%s': %s", new_migration, exc)
             return

--- a/posthog/management/commands/test_ch_migrations_are_safe.py
+++ b/posthog/management/commands/test_ch_migrations_are_safe.py
@@ -155,7 +155,7 @@ class Command(BaseCommand):
                 old_migrations.append(match[0])
             else:
                 dir_match = re.match(r"([0-9]+)_([a-zA-Z_0-9]+)$", filename)
-                if dir_match and os.path.isdir(os.path.join(MIGRATIONS_DIR, filename)):
+                if dir_match:
                     old_migrations.append(dir_match.groups())
 
         try:


### PR DESCRIPTION
## Summary
- Add advisory lock tracking and apply-safety guardrails.
- Include validator protections and safety-oriented command tests.
- Keeps locking/failure semantics isolated from routing/schema changes.

## Test plan
- [x] `bin/hogli test:python posthog/clickhouse/test/test_advisory_lock.py`
- [ ] stacked CI suites