### PR TITLE
fix(sql-editor): show errors in viz panel

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -803,6 +803,19 @@ const Content = ({
             return 0
         })
     }, [rows, sortColumns])
+    const hasError = queryCancelled || !!responseError || !!(response && 'error' in response && !!response.error)
+
+    if (hasError) {
+        return (
+            <ErrorState
+                responseError={responseError}
+                sourceQuery={sourceQuery}
+                queryCancelled={queryCancelled}
+                response={response}
+            />
+        )
+    }
+
     if (activeTab === OutputTab.Visualization) {
         if (!response && !responseLoading && !insightLoading) {
             return (
@@ -843,17 +856,6 @@ const Content = ({
                     progress={progress}
                 />
             </div>
-        )
-    }
-
-    if (responseError) {
-        return (
-            <ErrorState
-                responseError={responseError}
-                sourceQuery={sourceQuery}
-                queryCancelled={queryCancelled}
-                response={response}
-            />
         )
     }
 


### PR DESCRIPTION
## Problem

error messages were only shown in the Results panel, not the Visualization panel, so if there was an error it was not visible to the user. 

## Changes

Moved the error state check to execute earlier in the render logic, before any tab-specific rendering. This ensures that if a query has been cancelled, returned an error, or the response contains an error, the `ErrorState` component is displayed immediately rather than attempting to render other content.


## How did you test this code?

it works more better locally now

<img width="675" height="616" alt="image" src="https://github.com/user-attachments/assets/d55fcc15-a042-4ae0-bc03-88e30ab2e8b2" />

claude helped with this but wrote a garbage PR description so I made it better
https://claude.ai/code/session_014QjxoGWKzzDbLqbwgA869z