### PR TITLE
fix(phai): allow create_insight to generate sql insights

### DIFF
--- a/ee/hogai/tools/create_insight.py
+++ b/ee/hogai/tools/create_insight.py
@@ -511,7 +511,7 @@ The agent has encountered an unknown error while creating an insight.
 {{{system_reminder}}}
 """.strip()
 
-InsightType = Literal["trends", "funnel", "retention"]
+InsightType = Literal["trends", "funnel", "retention", "sql"]
 
 
 class CreateInsightToolArgs(BaseModel):
@@ -569,6 +569,8 @@ class CreateInsightTool(MaxTool):
                 graph_builder.add_retention_generator().add_edge(
                     AssistantNodeName.START, AssistantNodeName.RETENTION_GENERATOR
                 )
+            case "sql":
+                graph_builder.add_sql_generator().add_edge(AssistantNodeName.START, AssistantNodeName.SQL_GENERATOR)
 
         graph = graph_builder.add_query_executor().compile()
         new_state = self._state.model_copy(

--- a/ee/hogai/tools/test/test_create_insight.py
+++ b/ee/hogai/tools/test/test_create_insight.py
@@ -186,6 +186,47 @@ class TestCreateInsightTool(ClickhouseTestMixin, NonAtomicBaseTest):
         mock_graph_builder.add_retention_generator.assert_called_once()
         mock_graph_builder.add_edge.assert_called_with(AssistantNodeName.START, AssistantNodeName.RETENTION_GENERATOR)
 
+    async def test_successful_sql_insight_creation_returns_messages(self):
+        """Test successful SQL insight creation uses correct generator node."""
+        tool = await self._create_tool()
+
+        query = AssistantTrendsQuery(series=[])
+        artifact = await AgentArtifact.objects.acreate(
+            team=self.team,
+            conversation=self.conversation,
+            name="Test Artifact",
+            type=AgentArtifact.Type.VISUALIZATION,
+            data=VisualizationArtifactContent(query=query, name="Query 1", description="Plan 1").model_dump(),
+        )
+        artifact_message = ArtifactRefMessage(
+            content_type=ArtifactContentType.VISUALIZATION,
+            source=ArtifactSource.ARTIFACT,
+            artifact_id=artifact.short_id,
+            id="123",
+        )
+        tool_call_message = AssistantToolCallMessage(content="Results", tool_call_id=self.tool_call_id)
+        mock_state = AssistantState(messages=[artifact_message, tool_call_message])
+
+        with patch("ee.hogai.tools.create_insight.InsightsGraph") as mock_graph_class:
+            mock_graph_builder = mock_graph_class.return_value
+            mock_graph_builder.add_sql_generator.return_value = mock_graph_builder
+            mock_graph_builder.add_edge.return_value = mock_graph_builder
+            mock_graph_builder.add_query_executor.return_value = mock_graph_builder
+
+            mock_compiled_graph = AsyncMock()
+            mock_compiled_graph.ainvoke = AsyncMock(return_value=mock_state.model_dump())
+            mock_graph_builder.compile.return_value = mock_compiled_graph
+
+            await tool._arun_impl(
+                viz_title="Test SQL",
+                viz_description="Test description",
+                query_description="test sql",
+                insight_type="sql",
+            )
+
+        mock_graph_builder.add_sql_generator.assert_called_once()
+        mock_graph_builder.add_edge.assert_called_with(AssistantNodeName.START, AssistantNodeName.SQL_GENERATOR)
+
     async def test_schema_generation_exception_returns_formatted_error(self):
         """Test SchemaGenerationException is caught and returns formatted error message."""
         tool = await self._create_tool()


### PR DESCRIPTION
## Problem

Max's `create_insight` tool prompt already instructs the model to "choose the SQL type" for queries that can't be answered by trends/funnels/retention, but `"sql"` was missing from the `InsightType` literal and the `match` statement. So when Max tried to create or update a SQL insight, the tool call was rejected.

## Changes

- Add `"sql"` to the `InsightType` literal in `ee/hogai/tools/create_insight.py`
- Add a `case "sql"` branch that wires up `InsightsGraph.add_sql_generator()` → `AssistantNodeName.SQL_GENERATOR` (both already exist)
- Add a unit test mirroring the existing trends/funnel/retention coverage

## How did you test this code?

I'm an agent. Ran the new unit test (`test_successful_sql_insight_creation_returns_messages`) — passes. No manual end-to-end testing.

## Publish to changelog?

## 🤖 LLM context

Authored by Claude Opus 4.6 via Claude Code. Fix was sketched by the user before an IDE crash; I confirmed the wiring (`add_sql_generator`, `SQL_GENERATOR` node) already exists in `ee/hogai/chat_agent/insights_graph/graph.py` and `ee/hogai/utils/types/base.py`, and ran the new test.