### PR TITLE
feat(llma): add error status for system-disabled evaluations

### DIFF
--- a/posthog/templates/email/llm_analytics_evaluation_disabled.html
+++ b/posthog/templates/email/llm_analytics_evaluation_disabled.html
@@ -1,0 +1,32 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% block preheader %}Your evaluation "{{ evaluation_name }}" has been disabled{% endblock %}
+{% block heading %}Your evaluation has been disabled{% endblock %}
+{% block section %}
+<p>
+    Your evaluation <strong>{{ evaluation_name }}</strong> has been automatically disabled:
+</p>
+<p style="padding: 12px; background-color: #f8f8f8; border-left: 4px solid #e5484d; border-radius: 4px;">
+    {{ disabled_reason }}
+</p>
+<p>
+    To fix this, go to the <a href="{% absolute_uri settings_url %}">LLM analytics settings</a> and add your own provider API key. Once added, you can re-enable the evaluation.
+</p>
+<div class="mb mt text-center">
+    <a class="button" href="{% absolute_uri evaluation_url %}">View evaluation</a>
+</div>
+<div class="mt">
+    <p>
+        If the button above doesn't work, paste this link into your browser:<br />
+        <a href="{% absolute_uri evaluation_url %}">{% absolute_uri evaluation_url %}</a>
+    </p>
+</div>
+{% endblock %}
+
+{% block footer %}
+Need help?
+<a href="https://posthog.com/questions?{{ utm_tags }}"
+    target="_blank"><b>Visit support</b></a>
+or
+<a href="https://posthog.com/docs/ai-engineering?{{ utm_tags }}"
+    target="_blank"><b>read our documentation</b></a>.
+{% endblock %}

--- a/posthog/temporal/llm_analytics/__init__.py
+++ b/posthog/temporal/llm_analytics/__init__.py
@@ -8,6 +8,7 @@ from posthog.temporal.llm_analytics.run_evaluation import (
     execute_llm_judge_activity,
     fetch_evaluation_activity,
     increment_trial_eval_count_activity,
+    send_evaluation_disabled_email_activity,
     send_trial_usage_email_activity,
     update_key_state_activity,
 )
@@ -44,6 +45,7 @@ EVAL_ACTIVITIES = [
     increment_trial_eval_count_activity,
     disable_evaluation_activity,
     send_trial_usage_email_activity,
+    send_evaluation_disabled_email_activity,
     update_key_state_activity,
     execute_llm_judge_activity,
     execute_hog_eval_activity,
@@ -93,6 +95,7 @@ ACTIVITIES = [
     increment_trial_eval_count_activity,
     disable_evaluation_activity,
     send_trial_usage_email_activity,
+    send_evaluation_disabled_email_activity,
     update_key_state_activity,
     execute_llm_judge_activity,
     execute_hog_eval_activity,

--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -249,6 +249,66 @@ async def disable_evaluation_activity(evaluation_id: str, team_id: int, reason: 
 
 
 @dataclass
+class SendEvaluationDisabledEmailInputs:
+    team_id: int
+    evaluation_id: str
+    evaluation_name: str
+    disabled_reason: str
+
+
+@temporalio.activity.defn
+async def send_evaluation_disabled_email_activity(inputs: SendEvaluationDisabledEmailInputs) -> None:
+    """Send an email to org members when an evaluation is automatically disabled by the system."""
+
+    def _send():
+        from posthog.email import EmailMessage, is_email_available
+
+        if not is_email_available(with_absolute_urls=True):
+            logger.info(
+                "Email not available, skipping evaluation disabled notification",
+                team_id=inputs.team_id,
+                evaluation_id=inputs.evaluation_id,
+            )
+            return
+
+        try:
+            team = Team.objects.select_related("organization").get(id=inputs.team_id)
+        except Team.DoesNotExist:
+            logger.warning("Team not found for evaluation disabled email", team_id=inputs.team_id)
+            return
+
+        settings_url = f"/project/{team.pk}/settings/environment-llm-analytics#llm-analytics-byok"
+        evaluation_url = f"/project/{team.pk}/llm-analytics/evaluations/{inputs.evaluation_id}"
+        campaign_key = f"llm_analytics_eval_disabled_{inputs.evaluation_id}"
+
+        message = EmailMessage(
+            campaign_key=campaign_key,
+            subject=f'Your evaluation "{inputs.evaluation_name}" has been disabled',
+            template_name="llm_analytics_evaluation_disabled",
+            template_context={
+                "evaluation_name": inputs.evaluation_name,
+                "disabled_reason": inputs.disabled_reason,
+                "settings_url": settings_url,
+                "evaluation_url": evaluation_url,
+            },
+        )
+
+        for user in team.organization.members.all():
+            message.add_user_recipient(user)
+
+        if message.to:
+            message.send()
+            logger.info(
+                "Sent evaluation disabled email",
+                team_id=inputs.team_id,
+                evaluation_id=inputs.evaluation_id,
+                recipient_count=len(message.to),
+            )
+
+    await database_sync_to_async(_send)()
+
+
+@dataclass
 class SendTrialUsageEmailInputs:
     team_id: int
     threshold_pct: int
@@ -934,20 +994,42 @@ class RunEvaluationWorkflow(PostHogWorkflow):
                                 schedule_to_close_timeout=timedelta(seconds=30),
                                 retry_policy=RetryPolicy(maximum_attempts=2),
                             )
-                            if temporalio.workflow.patched("trial-usage-email"):
-                                try:
-                                    await temporalio.workflow.execute_activity(
-                                        send_trial_usage_email_activity,
-                                        SendTrialUsageEmailInputs(team_id=evaluation["team_id"], threshold_pct=100),
-                                        activity_id=f"send-trial-usage-email-100pct-{evaluation['team_id']}",
-                                        schedule_to_close_timeout=timedelta(seconds=30),
-                                        retry_policy=RetryPolicy(maximum_attempts=2),
-                                    )
-                                except Exception:
-                                    temporalio.workflow.logger.exception(
-                                        "Failed to send trial exhausted email",
-                                        team_id=evaluation["team_id"],
-                                    )
+                            if error_type == "trial_limit_reached":
+                                if temporalio.workflow.patched("trial-usage-email"):
+                                    try:
+                                        await temporalio.workflow.execute_activity(
+                                            send_trial_usage_email_activity,
+                                            SendTrialUsageEmailInputs(team_id=evaluation["team_id"], threshold_pct=100),
+                                            activity_id=f"send-trial-usage-email-100pct-{evaluation['team_id']}",
+                                            schedule_to_close_timeout=timedelta(seconds=30),
+                                            retry_policy=RetryPolicy(maximum_attempts=2),
+                                        )
+                                    except Exception:
+                                        temporalio.workflow.logger.exception(
+                                            "Failed to send trial exhausted email",
+                                            team_id=evaluation["team_id"],
+                                        )
+                            else:
+                                if temporalio.workflow.patched("eval-disabled-email"):
+                                    try:
+                                        await temporalio.workflow.execute_activity(
+                                            send_evaluation_disabled_email_activity,
+                                            SendEvaluationDisabledEmailInputs(
+                                                team_id=evaluation["team_id"],
+                                                evaluation_id=evaluation["id"],
+                                                evaluation_name=evaluation.get("name", "Unknown evaluation"),
+                                                disabled_reason=disable_reason,
+                                            ),
+                                            activity_id=f"send-eval-disabled-email-{evaluation['id']}",
+                                            schedule_to_close_timeout=timedelta(seconds=30),
+                                            retry_policy=RetryPolicy(maximum_attempts=2),
+                                        )
+                                    except Exception:
+                                        temporalio.workflow.logger.exception(
+                                            "Failed to send evaluation disabled email",
+                                            evaluation_id=evaluation["id"],
+                                            team_id=evaluation["team_id"],
+                                        )
                         return {
                             "verdict": None,
                             "skipped": True,

--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -236,11 +236,14 @@ async def increment_trial_eval_count_activity(team_id: int) -> int | None:
 
 
 @temporalio.activity.defn
-async def disable_evaluation_activity(evaluation_id: str, team_id: int) -> None:
-    """Disable an evaluation when trial limit is reached"""
+async def disable_evaluation_activity(evaluation_id: str, team_id: int, reason: str = "") -> None:
+    """Disable an evaluation when trial limit is reached or model not allowed"""
 
     def _disable():
-        Evaluation.objects.filter(id=evaluation_id, team_id=team_id).update(enabled=False)
+        Evaluation.objects.filter(id=evaluation_id, team_id=team_id).update(
+            enabled=False,
+            disabled_reason=reason or "Disabled by system",
+        )
 
     await database_sync_to_async(_disable)()
 
@@ -920,9 +923,14 @@ class RunEvaluationWorkflow(PostHogWorkflow):
                     # Handle skippable errors - return success with skip info
                     if error_type in ("trial_limit_reached", "key_invalid", "parse_error", "model_not_allowed"):
                         if error_type in ("trial_limit_reached", "model_not_allowed"):
+                            disable_reason = (
+                                "Trial evaluation limit reached"
+                                if error_type == "trial_limit_reached"
+                                else f"Model '{details.get('model', 'unknown')}' is not available on the trial plan"
+                            )
                             await temporalio.workflow.execute_activity(
                                 disable_evaluation_activity,
-                                args=[evaluation["id"], evaluation["team_id"]],
+                                args=[evaluation["id"], evaluation["team_id"], disable_reason],
                                 schedule_to_close_timeout=timedelta(seconds=30),
                                 retry_policy=RetryPolicy(maximum_attempts=2),
                             )

--- a/products/llm_analytics/backend/api/evaluations.py
+++ b/products/llm_analytics/backend/api/evaluations.py
@@ -65,6 +65,7 @@ class EvaluationSerializer(serializers.ModelSerializer):
             "name",
             "description",
             "enabled",
+            "disabled_reason",
             "evaluation_type",
             "evaluation_config",
             "output_type",
@@ -76,7 +77,7 @@ class EvaluationSerializer(serializers.ModelSerializer):
             "created_by",
             "deleted",
         ]
-        read_only_fields = ["id", "created_at", "updated_at", "created_by"]
+        read_only_fields = ["id", "created_at", "updated_at", "created_by", "disabled_reason"]
 
     def validate(self, data):
         if "evaluation_config" in data and "output_config" in data:
@@ -168,6 +169,10 @@ class EvaluationSerializer(serializers.ModelSerializer):
             validated_data["model_configuration"] = self._create_or_update_model_configuration(
                 model_config_data, instance.team_id
             )
+
+        # Clear disabled_reason when re-enabling
+        if validated_data.get("enabled") and not instance.enabled:
+            validated_data["disabled_reason"] = None
 
         return super().update(instance, validated_data)
 

--- a/products/llm_analytics/backend/api/provider_keys.py
+++ b/products/llm_analytics/backend/api/provider_keys.py
@@ -346,7 +346,7 @@ class LLMProviderKeyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, v
                     team_id=self.team_id,
                     deleted=False,
                     enabled=False,
-                ).update(enabled=True)
+                ).update(enabled=True, disabled_reason=None)
 
         report_user_action(
             request.user,
@@ -395,7 +395,7 @@ class LLMProviderKeyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, v
             with transaction.atomic():
                 Evaluation.objects.filter(
                     model_configuration_id__in=model_config_ids, team_id=self.team_id, deleted=False
-                ).update(enabled=False)
+                ).update(enabled=False, disabled_reason="Provider API key was deleted")
                 return super().destroy(request, *args, **kwargs)
 
 

--- a/products/llm_analytics/backend/migrations/0023_evaluation_disabled_reason.py
+++ b/products/llm_analytics/backend/migrations/0023_evaluation_disabled_reason.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("llm_analytics", "0022_reviewqueue_reviewqueueitem_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="evaluation",
+            name="disabled_reason",
+            field=models.CharField(max_length=200, null=True, blank=True),
+        ),
+    ]

--- a/products/llm_analytics/backend/migrations/max_migration.txt
+++ b/products/llm_analytics/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0022_reviewqueue_reviewqueueitem_and_more
+0023_evaluation_disabled_reason

--- a/products/llm_analytics/backend/models/evaluations.py
+++ b/products/llm_analytics/backend/models/evaluations.py
@@ -26,6 +26,7 @@ class Evaluation(UUIDTModel):
     name = models.CharField(max_length=400)
     description = models.TextField(blank=True, default="")
     enabled = models.BooleanField(default=False)
+    disabled_reason = models.CharField(max_length=200, null=True, blank=True)
 
     evaluation_type = models.CharField(max_length=50, choices=EvaluationType.choices)
     evaluation_config = models.JSONField(default=dict)

--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
@@ -3,7 +3,7 @@ import { Field, Form } from 'kea-forms'
 import { combineUrl, router } from 'kea-router'
 import { useRef } from 'react'
 
-import { IconArrowLeft, IconInfo, IconPlay, IconTrends } from '@posthog/icons'
+import { IconArrowLeft, IconInfo, IconPlay, IconTrends, IconWarning } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
@@ -183,9 +183,17 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
                             <LemonTag type="primary">New</LemonTag>
                         ) : (
                             <>
-                                <LemonTag type={evaluation.enabled ? 'success' : 'default'}>
-                                    {evaluation.enabled ? 'Enabled' : 'Disabled'}
-                                </LemonTag>
+                                {!evaluation.enabled && evaluation.disabled_reason ? (
+                                    <Tooltip title={evaluation.disabled_reason}>
+                                        <LemonTag type="danger" icon={<IconWarning />}>
+                                            Error
+                                        </LemonTag>
+                                    </Tooltip>
+                                ) : (
+                                    <LemonTag type={evaluation.enabled ? 'success' : 'default'}>
+                                        {evaluation.enabled ? 'Enabled' : 'Disabled'}
+                                    </LemonTag>
+                                )}
                                 {hasUnsavedChanges && <LemonTag type="warning">Unsaved changes</LemonTag>}
                             </>
                         )}
@@ -233,6 +241,15 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
                     )}
                 </div>
             </div>
+
+            {!evaluation.enabled && evaluation.disabled_reason && (
+                <LemonBanner type="danger">
+                    <div className="space-y-1">
+                        <p className="font-semibold">This evaluation was disabled by the system</p>
+                        <p>{evaluation.disabled_reason}</p>
+                    </div>
+                </LemonBanner>
+            )}
 
             {evaluationProviderKeyIssue && (
                 <LemonBanner type="warning">

--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
@@ -1,7 +1,7 @@
 import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 
-import { IconCopy, IconPencil, IconPlus, IconSearch, IconTrash } from '@posthog/icons'
+import { IconCopy, IconPencil, IconPlus, IconSearch, IconTrash, IconWarning } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
@@ -119,6 +119,7 @@ function LLMAnalyticsEvaluationsContent({ tabId }: { tabId?: string }): JSX.Elem
             render: (_, evaluation) => {
                 const canEnable = canEnableEvaluation(evaluation)
                 const isBlocked = !canEnable && !evaluation.enabled
+                const isSystemDisabled = !evaluation.enabled && !!evaluation.disabled_reason
                 return (
                     <div className="flex items-center gap-2">
                         <AccessControlAction
@@ -129,7 +130,9 @@ function LLMAnalyticsEvaluationsContent({ tabId }: { tabId?: string }): JSX.Elem
                                 title={
                                     isBlocked
                                         ? 'Trial evaluation limit reached. Add a provider API key to re-enable.'
-                                        : undefined
+                                        : isSystemDisabled
+                                          ? evaluation.disabled_reason
+                                          : undefined
                                 }
                             >
                                 <span>
@@ -143,9 +146,18 @@ function LLMAnalyticsEvaluationsContent({ tabId }: { tabId?: string }): JSX.Elem
                                 </span>
                             </Tooltip>
                         </AccessControlAction>
-                        <span className={evaluation.enabled ? 'text-success' : 'text-muted'}>
-                            {evaluation.enabled ? 'Enabled' : 'Disabled'}
-                        </span>
+                        {isSystemDisabled ? (
+                            <Tooltip title={evaluation.disabled_reason}>
+                                <span className="flex items-center gap-1 text-danger">
+                                    <IconWarning className="text-sm" />
+                                    Error
+                                </span>
+                            </Tooltip>
+                        ) : (
+                            <span className={evaluation.enabled ? 'text-success' : 'text-muted'}>
+                                {evaluation.enabled ? 'Enabled' : 'Disabled'}
+                            </span>
+                        )}
                     </div>
                 )
             },

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.ts
@@ -85,7 +85,11 @@ export const llmEvaluationsLogic = kea<llmEvaluationsLogicType>([
                 deleteEvaluationSuccess: (state, { id }) => state.filter((e: EvaluationConfig) => e.id !== id),
                 duplicateEvaluationSuccess: (state, { evaluation }) => [...state, evaluation],
                 toggleEvaluationEnabledSuccess: (state, { id }) =>
-                    state.map((e: EvaluationConfig) => (e.id === id ? { ...e, enabled: !e.enabled } : e)),
+                    state.map((e: EvaluationConfig) =>
+                        e.id === id
+                            ? { ...e, enabled: !e.enabled, disabled_reason: !e.enabled ? null : e.disabled_reason }
+                            : e
+                    ),
             },
         ],
         evaluationsLoading: [

--- a/products/llm_analytics/frontend/evaluations/types.ts
+++ b/products/llm_analytics/frontend/evaluations/types.ts
@@ -30,6 +30,7 @@ export interface BaseEvaluationConfig {
     name: string
     description?: string
     enabled: boolean
+    disabled_reason?: string | null
     output_type: EvaluationOutputType
     output_config: EvaluationOutputConfig
     conditions: EvaluationConditionSet[]

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -122,6 +122,8 @@ export interface EvaluationApi {
     name: string
     description?: string
     enabled?: boolean
+    /** @nullable */
+    readonly disabled_reason: string | null
     evaluation_type: EvaluationTypeEnumApi
     evaluation_config?: unknown
     output_type: OutputTypeEnumApi

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14451,6 +14451,8 @@ export namespace Schemas {
       name: string;
       description?: string;
       enabled?: boolean;
+      /** @nullable */
+      readonly disabled_reason: string | null;
       evaluation_type: EvaluationTypeEnum;
       evaluation_config?: unknown;
       output_type: OutputTypeEnum;
@@ -23917,6 +23919,8 @@ export namespace Schemas {
       name?: string;
       description?: string;
       enabled?: boolean;
+      /** @nullable */
+      readonly disabled_reason?: string | null;
       evaluation_type?: EvaluationTypeEnum;
       evaluation_config?: unknown;
       output_type?: OutputTypeEnum;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When an evaluation is disabled by the system (e.g. trial limit reached, model not allowed on trial plan, provider API key deleted), the evaluations table just shows "Disabled" — the same as if the user manually toggled it off. There is no indication that something went wrong or needs attention. Users click "Save Changes" and get an infinite loading state with no explanation (the API rejects re-enabling but the UI doesn't surface why).

Additionally, when `model_not_allowed` triggered the system disable, it incorrectly sent the "trial exhausted" email — which is misleading since the trial isn't actually exhausted.

## Changes

### Backend — `disabled_reason` field
- Added `disabled_reason` (`CharField`, nullable, max 200 chars) to the `Evaluation` model
- Set when the system disables an evaluation:
  - **Temporal workflow**: "Trial evaluation limit reached" or "Model 'X' is not available on the trial plan"
  - **Provider key deletion**: "Provider API key was deleted"
- Cleared automatically when re-enabling (via PATCH or assign-key endpoint)
- Exposed as a read-only field in the API serializer
- Django migration `0023_evaluation_disabled_reason`

### Backend — email split
- `trial_limit_reached` → still sends the trial exhausted email (existing behavior, unchanged)
- `model_not_allowed` → now sends a **new** evaluation-disabled email (`llm_analytics_evaluation_disabled` template) with the specific evaluation name, reason, and links to settings/eval page
- New `send_evaluation_disabled_email_activity` + `SendEvaluationDisabledEmailInputs` dataclass
- New email template `llm_analytics_evaluation_disabled.html`
- Activity registered in both `EVAL_ACTIVITIES` and `ACTIVITIES` lists

### Frontend
- **Evaluations table**: System-disabled evaluations show a red "Error" status with warning icon instead of plain "Disabled". Hovering shows the reason tooltip.
- **Evaluation detail page**: Danger banner + "Error" tag when system-disabled.
- Toggle still works — re-enabling clears the error state.

## How did you test this code?

I am an agent and was unable to run the full backend test suite (requires `sqlx` binary). I verified:
- Migration generates correct SQL (`ALTER TABLE ... ADD COLUMN "disabled_reason" varchar(200) NULL`)
- Python linting passes (`ruff check` + `ruff format`)
- TypeScript check shows no new errors in modified files
- Reviewed all code paths where `enabled=False` is set by the system
- Verified email template follows existing template patterns

## Publish to changelog?

No

## Docs update

No docs changes needed.

## 🤖 LLM context

This PR was authored by a cloud agent in response to a Slack thread where users reported system-disabled evaluations had no visual indicator. Follow-up from Richard requested splitting the email notification so `model_not_allowed` doesn't incorrectly send a trial exhausted email.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1776237532844509?thread_ts=1776237532.844509&cid=C087XQ7K9K7)

<div><a href="https://cursor.com/agents/bc-9af1c01a-d2ba-521d-9c78-0386ed406a0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9af1c01a-d2ba-521d-9c78-0386ed406a0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

