### PR TITLE
feat(replay): add ai_tags and ai_highlighted columns to session_replay_events

### DIFF
--- a/posthog/clickhouse/migrations/0231_add_ai_columns_to_session_replay_events.py
+++ b/posthog/clickhouse/migrations/0231_add_ai_columns_to_session_replay_events.py
@@ -20,7 +20,7 @@ operations = [
     run_sql_with_exceptions(
         DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False), node_roles=[NodeRole.INGESTION_SMALL]
     ),
-    # Add ai_tags and ai_is_interesting columns to the target tables
+    # Add ai_tags and ai_highlighted columns to the target tables
     # Writable table - Distributed engine (not replicated MergeTree)
     run_sql_with_exceptions(
         ADD_AI_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL(),

--- a/posthog/clickhouse/migrations/0231_add_ai_columns_to_session_replay_events.py
+++ b/posthog/clickhouse/migrations/0231_add_ai_columns_to_session_replay_events.py
@@ -20,27 +20,27 @@ operations = [
     run_sql_with_exceptions(
         DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False), node_roles=[NodeRole.INGESTION_SMALL]
     ),
-    # Add ai_tags and ai_highlighted columns to the target tables
-    # Writable table - Distributed engine (not replicated MergeTree)
+    # Add columns to the target tables — source (sharded) table first, then distributed
+    # Sharded table - ReplicatedAggregatingMergeTree (source of truth)
     run_sql_with_exceptions(
-        ADD_AI_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL(),
-        sharded=False,
-        is_alter_on_replicated_table=False,
-        node_roles=[NodeRole.INGESTION_SMALL],
+        ADD_AI_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL(),
+        node_roles=[NodeRole.DATA],
+        sharded=True,
+        is_alter_on_replicated_table=True,
     ),
-    # Distributed table for reads - Distributed engine
+    # Distributed table for reads
     run_sql_with_exceptions(
         ADD_AI_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL(),
         node_roles=[NodeRole.DATA],
         sharded=False,
         is_alter_on_replicated_table=False,
     ),
-    # Sharded table - ReplicatedAggregatingMergeTree
+    # Writable table - Distributed engine
     run_sql_with_exceptions(
-        ADD_AI_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL(),
-        node_roles=[NodeRole.DATA],
-        sharded=True,
-        is_alter_on_replicated_table=True,
+        ADD_AI_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL(),
+        sharded=False,
+        is_alter_on_replicated_table=False,
+        node_roles=[NodeRole.INGESTION_SMALL],
     ),
     # Recreate the Kafka table and MV (these live on ingestion nodes)
     run_sql_with_exceptions(

--- a/posthog/clickhouse/migrations/0231_add_ai_columns_to_session_replay_events.py
+++ b/posthog/clickhouse/migrations/0231_add_ai_columns_to_session_replay_events.py
@@ -1,0 +1,52 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.session_recordings.sql.session_replay_event_migrations_sql import (
+    ADD_AI_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    ADD_AI_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    ADD_AI_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+)
+from posthog.session_recordings.sql.session_replay_event_sql import (
+    KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+)
+
+operations = [
+    # Drop the MV and Kafka table first (these live on ingestion nodes)
+    run_sql_with_exceptions(
+        DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=False), node_roles=[NodeRole.INGESTION_SMALL]
+    ),
+    run_sql_with_exceptions(
+        DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False), node_roles=[NodeRole.INGESTION_SMALL]
+    ),
+    # Add ai_tags and ai_is_interesting columns to the target tables
+    # Writable table - Distributed engine (not replicated MergeTree)
+    run_sql_with_exceptions(
+        ADD_AI_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL(),
+        sharded=False,
+        is_alter_on_replicated_table=False,
+        node_roles=[NodeRole.INGESTION_SMALL],
+    ),
+    # Distributed table for reads - Distributed engine
+    run_sql_with_exceptions(
+        ADD_AI_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL(),
+        node_roles=[NodeRole.DATA],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+    # Sharded table - ReplicatedAggregatingMergeTree
+    run_sql_with_exceptions(
+        ADD_AI_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL(),
+        node_roles=[NodeRole.DATA],
+        sharded=True,
+        is_alter_on_replicated_table=True,
+    ),
+    # Recreate the Kafka table and MV (these live on ingestion nodes)
+    run_sql_with_exceptions(
+        KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL(on_cluster=False), node_roles=[NodeRole.INGESTION_SMALL]
+    ),
+    run_sql_with_exceptions(
+        SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=False), node_roles=[NodeRole.INGESTION_SMALL]
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0230_fix_metric_events_order_by
+0231_add_ai_columns_to_session_replay_events

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -620,6 +620,8 @@
       snapshot_library Nullable(String),
       retention_period_days Nullable(Int64),
       is_deleted UInt8,
+      ai_tags Array(String),
+      ai_highlighted UInt8,
   ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_session_replay_events_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
@@ -2277,6 +2279,8 @@
       snapshot_library Nullable(String),
       retention_period_days Nullable(Int64),
       is_deleted UInt8,
+      ai_tags Array(String),
+      ai_highlighted UInt8,
   ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_session_replay_events_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
   '''
@@ -4156,6 +4160,10 @@
       retention_period_days SimpleAggregateFunction(max, Nullable(Int64)),
       -- marks the recording as deleted for crypto shredding; once 1, merges keep it as 1
       is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
+      -- AI-generated session tags from the summarization pipeline
+      ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      -- AI-generated flag indicating the session is especially interesting or worth watching
+      ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
   '''
@@ -4183,6 +4191,8 @@
   `_timestamp` Nullable(DateTime)
   ,`retention_period_days` SimpleAggregateFunction(max, Nullable(Int64))
   ,`is_deleted` SimpleAggregateFunction(max, UInt8)
+  ,`ai_tags` SimpleAggregateFunction(groupUniqArrayArray, Array(String))
+  ,`ai_highlighted` SimpleAggregateFunction(max, UInt8)
   )
   AS SELECT
   session_id,
@@ -4220,6 +4230,8 @@
   max(_timestamp) as _timestamp
   ,max(retention_period_days) as retention_period_days
   ,max(is_deleted) as is_deleted
+  ,groupUniqArrayArray(ai_tags) as ai_tags
+  ,max(ai_highlighted) as ai_highlighted
   FROM posthog_test.kafka_session_replay_events
   group by session_id, team_id
   
@@ -5303,6 +5315,10 @@
       retention_period_days SimpleAggregateFunction(max, Nullable(Int64)),
       -- marks the recording as deleted for crypto shredding; once 1, merges keep it as 1
       is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
+      -- AI-generated session tags from the summarization pipeline
+      ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      -- AI-generated flag indicating the session is especially interesting or worth watching
+      ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   
       PARTITION BY toYYYYMM(min_first_timestamp)
@@ -6377,6 +6393,10 @@
       retention_period_days SimpleAggregateFunction(max, Nullable(Int64)),
       -- marks the recording as deleted for crypto shredding; once 1, merges keep it as 1
       is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
+      -- AI-generated session tags from the summarization pipeline
+      ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      -- AI-generated flag indicating the session is especially interesting or worth watching
+      ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
   '''
@@ -8229,6 +8249,10 @@
       retention_period_days SimpleAggregateFunction(max, Nullable(Int64)),
       -- marks the recording as deleted for crypto shredding; once 1, merges keep it as 1
       is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
+      -- AI-generated session tags from the summarization pipeline
+      ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      -- AI-generated flag indicating the session is especially interesting or worth watching
+      ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   
       PARTITION BY toYYYYMM(min_first_timestamp)
@@ -8528,6 +8552,10 @@
       retention_period_days SimpleAggregateFunction(max, Nullable(Int64)),
       -- marks the recording as deleted for crypto shredding; once 1, merges keep it as 1
       is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
+      -- AI-generated session tags from the summarization pipeline
+      ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      -- AI-generated flag indicating the session is especially interesting or worth watching
+      ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
   '''

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -620,7 +620,8 @@
       snapshot_library Nullable(String),
       retention_period_days Nullable(Int64),
       is_deleted UInt8,
-      ai_tags Array(String),
+      ai_tags_fixed Array(String),
+      ai_tags_freeform Array(String),
       ai_highlighted UInt8,
   ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_session_replay_events_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
@@ -2279,7 +2280,8 @@
       snapshot_library Nullable(String),
       retention_period_days Nullable(Int64),
       is_deleted UInt8,
-      ai_tags Array(String),
+      ai_tags_fixed Array(String),
+      ai_tags_freeform Array(String),
       ai_highlighted UInt8,
   ) ENGINE = Kafka(msk_cluster, kafka_topic_list = 'clickhouse_session_replay_events_test', kafka_group_name = 'group1', kafka_format = 'JSONEachRow')
   
@@ -4160,8 +4162,10 @@
       retention_period_days SimpleAggregateFunction(max, Nullable(Int64)),
       -- marks the recording as deleted for crypto shredding; once 1, merges keep it as 1
       is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
-      -- AI-generated session tags from the summarization pipeline
-      ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      -- AI-generated session tags from the summarization pipeline (fixed taxonomy)
+      ai_tags_fixed SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      -- AI-generated session tags from the summarization pipeline (free-form)
+      ai_tags_freeform SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
       -- AI-generated flag indicating the session is highlighted / worth watching
       ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
@@ -4191,7 +4195,8 @@
   `_timestamp` Nullable(DateTime)
   ,`retention_period_days` SimpleAggregateFunction(max, Nullable(Int64))
   ,`is_deleted` SimpleAggregateFunction(max, UInt8)
-  ,`ai_tags` SimpleAggregateFunction(groupUniqArrayArray, Array(String))
+  ,`ai_tags_fixed` SimpleAggregateFunction(groupUniqArrayArray, Array(String))
+  ,`ai_tags_freeform` SimpleAggregateFunction(groupUniqArrayArray, Array(String))
   ,`ai_highlighted` SimpleAggregateFunction(max, UInt8)
   )
   AS SELECT
@@ -4230,7 +4235,8 @@
   max(_timestamp) as _timestamp
   ,max(retention_period_days) as retention_period_days
   ,max(is_deleted) as is_deleted
-  ,groupUniqArrayArray(ai_tags) as ai_tags
+  ,groupUniqArrayArray(ai_tags_fixed) as ai_tags_fixed
+  ,groupUniqArrayArray(ai_tags_freeform) as ai_tags_freeform
   ,max(ai_highlighted) as ai_highlighted
   FROM posthog_test.kafka_session_replay_events
   group by session_id, team_id
@@ -5315,8 +5321,10 @@
       retention_period_days SimpleAggregateFunction(max, Nullable(Int64)),
       -- marks the recording as deleted for crypto shredding; once 1, merges keep it as 1
       is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
-      -- AI-generated session tags from the summarization pipeline
-      ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      -- AI-generated session tags from the summarization pipeline (fixed taxonomy)
+      ai_tags_fixed SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      -- AI-generated session tags from the summarization pipeline (free-form)
+      ai_tags_freeform SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
       -- AI-generated flag indicating the session is highlighted / worth watching
       ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
@@ -6393,8 +6401,10 @@
       retention_period_days SimpleAggregateFunction(max, Nullable(Int64)),
       -- marks the recording as deleted for crypto shredding; once 1, merges keep it as 1
       is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
-      -- AI-generated session tags from the summarization pipeline
-      ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      -- AI-generated session tags from the summarization pipeline (fixed taxonomy)
+      ai_tags_fixed SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      -- AI-generated session tags from the summarization pipeline (free-form)
+      ai_tags_freeform SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
       -- AI-generated flag indicating the session is highlighted / worth watching
       ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
@@ -8249,8 +8259,10 @@
       retention_period_days SimpleAggregateFunction(max, Nullable(Int64)),
       -- marks the recording as deleted for crypto shredding; once 1, merges keep it as 1
       is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
-      -- AI-generated session tags from the summarization pipeline
-      ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      -- AI-generated session tags from the summarization pipeline (fixed taxonomy)
+      ai_tags_fixed SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      -- AI-generated session tags from the summarization pipeline (free-form)
+      ai_tags_freeform SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
       -- AI-generated flag indicating the session is highlighted / worth watching
       ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
@@ -8552,8 +8564,10 @@
       retention_period_days SimpleAggregateFunction(max, Nullable(Int64)),
       -- marks the recording as deleted for crypto shredding; once 1, merges keep it as 1
       is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
-      -- AI-generated session tags from the summarization pipeline
-      ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      -- AI-generated session tags from the summarization pipeline (fixed taxonomy)
+      ai_tags_fixed SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+      -- AI-generated session tags from the summarization pipeline (free-form)
+      ai_tags_freeform SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
       -- AI-generated flag indicating the session is highlighted / worth watching
       ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -4162,7 +4162,7 @@
       is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
       -- AI-generated session tags from the summarization pipeline
       ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
-      -- AI-generated flag indicating the session is especially interesting or worth watching
+      -- AI-generated flag indicating the session is highlighted / worth watching
       ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
@@ -5317,7 +5317,7 @@
       is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
       -- AI-generated session tags from the summarization pipeline
       ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
-      -- AI-generated flag indicating the session is especially interesting or worth watching
+      -- AI-generated flag indicating the session is highlighted / worth watching
       ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   
@@ -6395,7 +6395,7 @@
       is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
       -- AI-generated session tags from the summarization pipeline
       ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
-      -- AI-generated flag indicating the session is especially interesting or worth watching
+      -- AI-generated flag indicating the session is highlighted / worth watching
       ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   
@@ -8251,7 +8251,7 @@
       is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
       -- AI-generated session tags from the summarization pipeline
       ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
-      -- AI-generated flag indicating the session is especially interesting or worth watching
+      -- AI-generated flag indicating the session is highlighted / worth watching
       ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.session_replay_events', '{replica}')
   
@@ -8554,7 +8554,7 @@
       is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
       -- AI-generated session tags from the summarization pipeline
       ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
-      -- AI-generated flag indicating the session is especially interesting or worth watching
+      -- AI-generated flag indicating the session is highlighted / worth watching
       ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_session_replay_events', sipHash64(distinct_id))
   

--- a/posthog/hogql/database/schema/session_replay_events.py
+++ b/posthog/hogql/database/schema/session_replay_events.py
@@ -209,6 +209,8 @@ SESSION_REPLAY_EVENTS_COMMON_FIELDS: dict[str, FieldOrTable] = {
     "snapshot_library": StringDatabaseField(name="snapshot_library", nullable=True),
     "retention_period_days": IntegerDatabaseField(name="retention_period_days", nullable=True),
     "is_deleted": IntegerDatabaseField(name="is_deleted", nullable=False),
+    "ai_tags": DatabaseField(name="ai_tags", nullable=True),
+    "ai_highlighted": IntegerDatabaseField(name="ai_highlighted", nullable=False),
     "events": LazyJoin(
         from_field=["session_id"],
         join_table=EventsTable(),
@@ -278,6 +280,8 @@ def select_from_session_replay_events_table(requested_fields: dict[str, list[str
         "event_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "event_count"])]),
         "message_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "message_count"])]),
         "is_deleted": ast.Call(name="max", args=[ast.Field(chain=[table_name, "is_deleted"])]),
+        "ai_tags": ast.Call(name="groupUniqArrayArray", args=[ast.Field(chain=[table_name, "ai_tags"])]),
+        "ai_highlighted": ast.Call(name="max", args=[ast.Field(chain=[table_name, "ai_highlighted"])]),
     }
 
     select_fields: list[ast.Expr] = []

--- a/posthog/hogql/database/schema/session_replay_events.py
+++ b/posthog/hogql/database/schema/session_replay_events.py
@@ -209,7 +209,8 @@ SESSION_REPLAY_EVENTS_COMMON_FIELDS: dict[str, FieldOrTable] = {
     "snapshot_library": StringDatabaseField(name="snapshot_library", nullable=True),
     "retention_period_days": IntegerDatabaseField(name="retention_period_days", nullable=True),
     "is_deleted": IntegerDatabaseField(name="is_deleted", nullable=False),
-    "ai_tags": DatabaseField(name="ai_tags", nullable=True),
+    "ai_tags_fixed": DatabaseField(name="ai_tags_fixed", nullable=True),
+    "ai_tags_freeform": DatabaseField(name="ai_tags_freeform", nullable=True),
     "ai_highlighted": IntegerDatabaseField(name="ai_highlighted", nullable=False),
     "events": LazyJoin(
         from_field=["session_id"],
@@ -280,7 +281,10 @@ def select_from_session_replay_events_table(requested_fields: dict[str, list[str
         "event_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "event_count"])]),
         "message_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "message_count"])]),
         "is_deleted": ast.Call(name="max", args=[ast.Field(chain=[table_name, "is_deleted"])]),
-        "ai_tags": ast.Call(name="groupUniqArrayArray", args=[ast.Field(chain=[table_name, "ai_tags"])]),
+        "ai_tags_fixed": ast.Call(name="groupUniqArrayArray", args=[ast.Field(chain=[table_name, "ai_tags_fixed"])]),
+        "ai_tags_freeform": ast.Call(
+            name="groupUniqArrayArray", args=[ast.Field(chain=[table_name, "ai_tags_freeform"])]
+        ),
         "ai_highlighted": ast.Call(name="max", args=[ast.Field(chain=[table_name, "ai_highlighted"])]),
     }
 

--- a/posthog/hogql/test/__snapshots__/test_resolver.ambr
+++ b/posthog/hogql/test/__snapshots__/test_resolver.ambr
@@ -3834,6 +3834,15 @@
                     active_milliseconds: {
                       hidden: False
                     },
+                    ai_highlighted: {
+                      hidden: False
+                    },
+                    ai_tags_fixed: {
+                      hidden: False
+                    },
+                    ai_tags_freeform: {
+                      hidden: False
+                    },
                     all_urls: {
                       hidden: False
                     },
@@ -4273,6 +4282,66 @@
         }
       },
       {
+        alias: "ai_tags_fixed"
+        expr: {
+          chain: [
+            "e",
+            "ai_tags_fixed"
+          ]
+          from_asterisk: True
+          type: {
+            name: "ai_tags_fixed"
+            table_type: <recursion ...>
+          }
+        }
+        from_asterisk: False
+        hidden: True
+        type: {
+          alias: "ai_tags_fixed"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "ai_tags_freeform"
+        expr: {
+          chain: [
+            "e",
+            "ai_tags_freeform"
+          ]
+          from_asterisk: True
+          type: {
+            name: "ai_tags_freeform"
+            table_type: <recursion ...>
+          }
+        }
+        from_asterisk: False
+        hidden: True
+        type: {
+          alias: "ai_tags_freeform"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "ai_highlighted"
+        expr: {
+          chain: [
+            "e",
+            "ai_highlighted"
+          ]
+          from_asterisk: True
+          type: {
+            name: "ai_highlighted"
+            table_type: <recursion ...>
+          }
+        }
+        from_asterisk: False
+        hidden: True
+        type: {
+          alias: "ai_highlighted"
+          type: <recursion ...>
+        }
+      },
+      {
         alias: "start_time"
         expr: {
           chain: [
@@ -4550,6 +4619,9 @@
       anonymous_tables: []
       columns: {
         active_milliseconds: <recursion ...>,
+        ai_highlighted: <recursion ...>,
+        ai_tags_fixed: <recursion ...>,
+        ai_tags_freeform: <recursion ...>,
         all_urls: <recursion ...>,
         click_count: <recursion ...>,
         console_error_count: <recursion ...>,

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -360,7 +360,8 @@ ADD_IS_DELETED_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSI
 
 ALTER_SESSION_REPLAY_ADD_AI_COLUMNS = """
     ALTER TABLE {table_name}
-        ADD COLUMN IF NOT EXISTS ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+        ADD COLUMN IF NOT EXISTS ai_tags_fixed SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+        ADD COLUMN IF NOT EXISTS ai_tags_freeform SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
         ADD COLUMN IF NOT EXISTS ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0
 """
 

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -354,7 +354,7 @@ ADD_IS_DELETED_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSI
 
 # =========================
 # MIGRATION: Add AI-generated columns for session tagging
-# The summarization pipeline produces tags and an "interesting" flag per session.
+# The summarization pipeline produces tags and a "highlighted" flag per session.
 # These are written back to Kafka and merged via the MV, same pattern as is_deleted.
 # =========================
 

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -359,7 +359,7 @@ ADD_IS_DELETED_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSI
 # =========================
 
 ALTER_SESSION_REPLAY_ADD_AI_COLUMNS = """
-    ALTER TABLE IF EXISTS {table_name}
+    ALTER TABLE {table_name}
         ADD COLUMN IF NOT EXISTS ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
         ADD COLUMN IF NOT EXISTS ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0
 """

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -351,3 +351,27 @@ ADD_IS_DELETED_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_
 ADD_IS_DELETED_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_IS_DELETED_COLUMN.format(
     table_name="session_replay_events",
 )
+
+# =========================
+# MIGRATION: Add AI-generated columns for session tagging
+# The summarization pipeline produces tags and an "interesting" flag per session.
+# These are written back to Kafka and merged via the MV, same pattern as is_deleted.
+# =========================
+
+ALTER_SESSION_REPLAY_ADD_AI_COLUMNS = """
+    ALTER TABLE IF EXISTS {table_name}
+        ADD COLUMN IF NOT EXISTS ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+        ADD COLUMN IF NOT EXISTS ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0
+"""
+
+ADD_AI_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_AI_COLUMNS.format(
+    table_name=SESSION_REPLAY_EVENTS_DATA_TABLE(),
+)
+
+ADD_AI_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_AI_COLUMNS.format(
+    table_name="writable_session_replay_events",
+)
+
+ADD_AI_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_AI_COLUMNS.format(
+    table_name="session_replay_events",
+)

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -40,7 +40,8 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     snapshot_library Nullable(String),
     retention_period_days Nullable(Int64),
     is_deleted UInt8,
-    ai_tags Array(String),
+    ai_tags_fixed Array(String),
+    ai_tags_freeform Array(String),
     ai_highlighted UInt8,
 ) ENGINE = {engine}
 """
@@ -94,8 +95,10 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     retention_period_days SimpleAggregateFunction(max, Nullable(Int64)),
     -- marks the recording as deleted for crypto shredding; once 1, merges keep it as 1
     is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
-    -- AI-generated session tags from the summarization pipeline
-    ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+    -- AI-generated session tags from the summarization pipeline (fixed taxonomy)
+    ai_tags_fixed SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+    -- AI-generated session tags from the summarization pipeline (free-form)
+    ai_tags_freeform SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
     -- AI-generated flag indicating the session is highlighted / worth watching
     ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
 ) ENGINE = {engine}
@@ -168,7 +171,8 @@ def SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=True, exclude_columns=None):
 `_timestamp` Nullable(DateTime)
 {",`retention_period_days` SimpleAggregateFunction(max, Nullable(Int64))" if "retention_period_days" not in exclude_columns else ""}
 {",`is_deleted` SimpleAggregateFunction(max, UInt8)" if "is_deleted" not in exclude_columns else ""}
-{",`ai_tags` SimpleAggregateFunction(groupUniqArrayArray, Array(String))" if "ai_tags" not in exclude_columns else ""}
+{",`ai_tags_fixed` SimpleAggregateFunction(groupUniqArrayArray, Array(String))" if "ai_tags_fixed" not in exclude_columns else ""}
+{",`ai_tags_freeform` SimpleAggregateFunction(groupUniqArrayArray, Array(String))" if "ai_tags_freeform" not in exclude_columns else ""}
 {",`ai_highlighted` SimpleAggregateFunction(max, UInt8)" if "ai_highlighted" not in exclude_columns else ""}
 )"""
 
@@ -211,7 +215,8 @@ argMinState(snapshot_library, first_timestamp) as snapshot_library,
 max(_timestamp) as _timestamp
 {",max(retention_period_days) as retention_period_days" if "retention_period_days" not in exclude_columns else ""}
 {",max(is_deleted) as is_deleted" if "is_deleted" not in exclude_columns else ""}
-{",groupUniqArrayArray(ai_tags) as ai_tags" if "ai_tags" not in exclude_columns else ""}
+{",groupUniqArrayArray(ai_tags_fixed) as ai_tags_fixed" if "ai_tags_fixed" not in exclude_columns else ""}
+{",groupUniqArrayArray(ai_tags_freeform) as ai_tags_freeform" if "ai_tags_freeform" not in exclude_columns else ""}
 {",max(ai_highlighted) as ai_highlighted" if "ai_highlighted" not in exclude_columns else ""}
 FROM {database}.kafka_session_replay_events
 group by session_id, team_id

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -40,6 +40,8 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     snapshot_library Nullable(String),
     retention_period_days Nullable(Int64),
     is_deleted UInt8,
+    ai_tags Array(String),
+    ai_highlighted UInt8,
 ) ENGINE = {engine}
 """
 
@@ -92,6 +94,10 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     retention_period_days SimpleAggregateFunction(max, Nullable(Int64)),
     -- marks the recording as deleted for crypto shredding; once 1, merges keep it as 1
     is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
+    -- AI-generated session tags from the summarization pipeline
+    ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+    -- AI-generated flag indicating the session is especially interesting or worth watching
+    ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
 ) ENGINE = {engine}
 """
 
@@ -162,6 +168,8 @@ def SESSION_REPLAY_EVENTS_TABLE_MV_SQL(on_cluster=True, exclude_columns=None):
 `_timestamp` Nullable(DateTime)
 {",`retention_period_days` SimpleAggregateFunction(max, Nullable(Int64))" if "retention_period_days" not in exclude_columns else ""}
 {",`is_deleted` SimpleAggregateFunction(max, UInt8)" if "is_deleted" not in exclude_columns else ""}
+{",`ai_tags` SimpleAggregateFunction(groupUniqArrayArray, Array(String))" if "ai_tags" not in exclude_columns else ""}
+{",`ai_highlighted` SimpleAggregateFunction(max, UInt8)" if "ai_highlighted" not in exclude_columns else ""}
 )"""
 
     return f"""
@@ -203,6 +211,8 @@ argMinState(snapshot_library, first_timestamp) as snapshot_library,
 max(_timestamp) as _timestamp
 {",max(retention_period_days) as retention_period_days" if "retention_period_days" not in exclude_columns else ""}
 {",max(is_deleted) as is_deleted" if "is_deleted" not in exclude_columns else ""}
+{",groupUniqArrayArray(ai_tags) as ai_tags" if "ai_tags" not in exclude_columns else ""}
+{",max(ai_highlighted) as ai_highlighted" if "ai_highlighted" not in exclude_columns else ""}
 FROM {database}.kafka_session_replay_events
 group by session_id, team_id
 """

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -96,7 +96,7 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     is_deleted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
     -- AI-generated session tags from the summarization pipeline
     ai_tags SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
-    -- AI-generated flag indicating the session is especially interesting or worth watching
+    -- AI-generated flag indicating the session is highlighted / worth watching
     ai_highlighted SimpleAggregateFunction(max, UInt8) DEFAULT 0,
 ) ENGINE = {engine}
 """


### PR DESCRIPTION
## Problem

We want to be able to filter and sort session recordings by AI-generated metadata (tags, highlighted sessions). This requires new columns in the `session_replay_events` ClickHouse table before the summarization pipeline can start writing this data.

## Changes

Adds two new columns to the `session_replay_events` ClickHouse table:

- **`ai_tags`** — `SimpleAggregateFunction(groupUniqArrayArray, Array(String))` — for AI-generated session tags
- **`ai_highlighted`** — `SimpleAggregateFunction(max, UInt8)` — flag for sessions worth watching

Both columns follow the same pattern as `is_deleted`: designed to be written back via Kafka and merged by the AggregatingMergeTree engine. The migration updates all 4 table layers (sharded, writable, distributed, Kafka) and recreates the MV.

This is schema-only prep work — no data is written to these columns yet.

## How did you test this code?

- Schema snapshot tests updated and passing

## Publish to changelog?

No

## 🤖 LLM context

Agent-authored PR. Schema-only migration preparing for follow-up work to wire up the summarization pipeline.