### PR TITLE
chore: migrate from posthog-js/react to @posthog/react

### DIFF
--- a/docs/onboarding/experiments/_snippets/experiment-implementation.tsx
+++ b/docs/onboarding/experiments/_snippets/experiment-implementation.tsx
@@ -23,7 +23,7 @@ export const ExperimentImplementationSnippet = memo(
             // or you can use the feature flags component - https://posthog.com/docs/libraries/react#feature-flags-react-component
 
             // Method one: using the useFeatureFlagVariantKey hook
-            import { useFeatureFlagVariantKey } from 'posthog-js/react'
+            import { useFeatureFlagVariantKey } from '@posthog/react'
 
             function App() {
                 const variant = useFeatureFlagVariantKey('your-experiment-feature-flag')
@@ -33,7 +33,7 @@ export const ExperimentImplementationSnippet = memo(
             }
 
             // Method two: using the feature flags component
-            import { PostHogFeature } from 'posthog-js/react'
+            import { PostHogFeature } from '@posthog/react'
 
             function App() {
                 return (

--- a/docs/onboarding/product-analytics/nextjs.tsx
+++ b/docs/onboarding/product-analytics/nextjs.tsx
@@ -119,7 +119,7 @@ export const getNextJSClientSteps = (ctx: OnboardingComponentsContext): StepDefi
                                                 import { useEffect } from "react"
 
                                                 import posthog from 'posthog-js'
-                                                import { PostHogProvider as PHProvider } from 'posthog-js/react'
+                                                import { PostHogProvider as PHProvider } from '@posthog/react'
 
                                                 export function PostHogProvider({ children }: { children: React.ReactNode }) {
                                                   useEffect(() => {
@@ -181,7 +181,7 @@ export const getNextJSClientSteps = (ctx: OnboardingComponentsContext): StepDefi
                                                 import { useEffect } from 'react'
                                                 import { Router } from 'next/router'
                                                 import posthog from 'posthog-js'
-                                                import { PostHogProvider } from 'posthog-js/react'
+                                                import { PostHogProvider } from '@posthog/react'
                                                 import type { AppProps } from 'next/app'
 
                                                 export default function App({ Component, pageProps }: AppProps) {
@@ -268,7 +268,7 @@ export const getNextJSClientSteps = (ctx: OnboardingComponentsContext): StepDefi
                                             code: dedent`
                                                 'use client'
 
-                                                import { usePostHog } from 'posthog-js/react'
+                                                import { usePostHog } from '@posthog/react'
 
                                                 export default function CheckoutPage() {
                                                     const posthog = usePostHog()

--- a/docs/onboarding/product-analytics/remix.tsx
+++ b/docs/onboarding/product-analytics/remix.tsx
@@ -54,7 +54,7 @@ export const getRemixSteps = (ctx: OnboardingComponentsContext): StepDefinition[
             content: (
                 <>
                     <Markdown>
-                        Add `posthog-js` and `posthog-js/react` to `ssr.noExternal` in your `vite.config.ts` so they get
+                        Add `posthog-js` and `@posthog/react` to `ssr.noExternal` in your `vite.config.ts` so they get
                         bundled for SSR:
                     </Markdown>
                     <CodeBlock
@@ -79,7 +79,7 @@ export const getRemixSteps = (ctx: OnboardingComponentsContext): StepDefinition[
                                         tsconfigPaths(),
                                       ],
                                       ssr: {
-                                        noExternal: ["posthog-js", "posthog-js/react"],
+                                        noExternal: ["posthog-js", "@posthog/react"],
                                       },
                                     });
                                 `,
@@ -106,7 +106,7 @@ export const getRemixSteps = (ctx: OnboardingComponentsContext): StepDefinition[
                                 code: dedent`
                                     import { useEffect, useState } from "react";
                                     import posthog from "posthog-js";
-                                    import { PostHogProvider } from "posthog-js/react";
+                                    import { PostHogProvider } from "@posthog/react";
 
                                     export function PHProvider({ children }: { children: React.ReactNode }) {
                                       const [hydrated, setHydrated] = useState(false);

--- a/docs/onboarding/product-analytics/tanstack.tsx
+++ b/docs/onboarding/product-analytics/tanstack.tsx
@@ -82,7 +82,7 @@ export const getTanStackSteps = (ctx: OnboardingComponentsContext): StepDefiniti
                                     import { createRoot } from 'react-dom/client'
                                     import './index.css'
                                     import App from './App.jsx'
-                                    import { PostHogProvider } from 'posthog-js/react'
+                                    import { PostHogProvider } from '@posthog/react'
 
                                     const options = {
                                       api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -105,6 +105,7 @@
         "@posthog/products-visual-review": "workspace:*",
         "@posthog/products-web-analytics": "workspace:*",
         "@posthog/products-workflows": "workspace:*",
+        "@posthog/react": "catalog:",
         "@posthog/replay-shared": "workspace:*",
         "@posthog/rrweb": "0.0.26",
         "@posthog/rrweb-plugin-console-record": "0.0.26",

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -6,8 +6,9 @@ import { Tooltip as BaseTooltip } from '@base-ui/react/tooltip'
 import { polyfillCountryFlagEmojis } from 'country-flag-emoji-polyfill'
 import { getContext } from 'kea'
 import posthog from 'posthog-js'
-import { PostHogProvider } from 'posthog-js/react'
 import { createRoot } from 'react-dom/client'
+
+import { PostHogProvider } from '@posthog/react'
 
 import { App } from 'scenes/App'
 

--- a/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/src/layout/ErrorBoundary/ErrorBoundary.tsx
@@ -2,7 +2,8 @@ import './ErrorBoundary.scss'
 
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { PostHogErrorBoundary, type PostHogErrorBoundaryFallbackProps } from 'posthog-js/react'
+
+import { PostHogErrorBoundary, type PostHogErrorBoundaryFallbackProps } from '@posthog/react'
 
 import { SupportTicketExceptionEvent, supportLogic } from 'lib/components/Support/supportLogic'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'

--- a/frontend/src/scenes/experiments/ExperimentCodeSnippets.tsx
+++ b/frontend/src/scenes/experiments/ExperimentCodeSnippets.tsx
@@ -98,7 +98,7 @@ export function ReactSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
 // or you can use the feature flags component - https://posthog.com/docs/libraries/react#feature-flags-react-component
 
 // Method one: using the useFeatureFlagVariantKey hook
-import { useFeatureFlagVariantKey } from 'posthog-js/react'
+import { useFeatureFlagVariantKey } from '@posthog/react'
 
 function App() {
     const variant = useFeatureFlagVariantKey('${flagKey}')
@@ -108,7 +108,7 @@ function App() {
 }
 
 // Method two: using the feature flags component
-import { PostHogFeature } from 'posthog-js/react'
+import { PostHogFeature } from '@posthog/react'
 
 function App() {
     return (

--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -747,7 +747,7 @@ export function ReactSnippet({ flagKey, multivariant, payload }: FeatureFlagSnip
     return (
         <CodeSnippet language={Language.JSX} wrap>
             {`
-import { ${flagFunction} } from 'posthog-js/react'
+import { ${flagFunction} } from '@posthog/react'
 
 function App() {
     const ${variable} = ${flagFunction}('${flagKey}')

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -1,6 +1,7 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { router } from 'kea-router'
-import { useFeatureFlagVariantKey } from 'posthog-js/react'
+
+import { useFeatureFlagVariantKey } from '@posthog/react'
 
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { NotFound } from 'lib/components/NotFound'

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePlaylist.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePlaylist.tsx
@@ -1,6 +1,7 @@
 import { BuiltLogic, useActions, useValues } from 'kea'
-import { PostHogErrorBoundary } from 'posthog-js/react'
 import { useEffect, useMemo } from 'react'
+
+import { PostHogErrorBoundary } from '@posthog/react'
 
 import { JSONContent } from 'lib/components/RichContentEditor/types'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/js-web.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/js-web.tsx
@@ -14,6 +14,20 @@ export function JSInstallSnippet(): JSX.Element {
     )
 }
 
+export function ReactInstallSnippet(): JSX.Element {
+    return (
+        <CodeSnippet language={Language.Bash}>
+            {[
+                'npm install posthog-js @posthog/react',
+                '# OR',
+                'yarn add posthog-js @posthog/react',
+                '# OR',
+                'pnpm add posthog-js @posthog/react',
+            ].join('\n')}
+        </CodeSnippet>
+    )
+}
+
 export function JSSetupSnippet(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
     const { featureFlags } = useValues(featureFlagLogic)

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/next-js.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/next-js.tsx
@@ -12,7 +12,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { SDK_DEFAULTS_DATE } from '~/loadPostHogJS'
 
 import SetupWizardBanner from './components/SetupWizardBanner'
-import { JSInstallSnippet } from './js-web'
+import { ReactInstallSnippet } from './js-web'
 import { type NextJSRouter, nextJsInstructionsLogic } from './nextJsInstructionsLogic'
 
 function NextEnvVarsSnippet(): JSX.Element {
@@ -37,7 +37,7 @@ function NextPagesRouterPageViewSnippet(): JSX.Element {
 import { useEffect } from 'react'
 import { Router } from 'next/router'
 import posthog from 'posthog-js'
-import { PostHogProvider } from 'posthog-js/react'
+import { PostHogProvider } from '@posthog/react'
 import type { AppProps } from 'next/app'
 
 export default function App({ Component, pageProps }: AppProps) {
@@ -101,10 +101,10 @@ function NextAppRouterPageViewProviderSnippet(): JSX.Element {
 
 import { usePathname, useSearchParams } from "next/navigation"
 import { useEffect } from "react"
-import { usePostHog } from 'posthog-js/react'
+import { usePostHog } from '@posthog/react'
 
 import posthog from 'posthog-js'
-import { PostHogProvider as PHProvider } from 'posthog-js/react'
+import { PostHogProvider as PHProvider } from '@posthog/react'
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
@@ -152,8 +152,8 @@ export function SDKInstallNextJSInstructions({ hideWizard }: { hideWizard?: bool
     return (
         <>
             <SetupWizardBanner integrationName="Next.js" hide={hideWizard} />
-            <h3>Install posthog-js using your package manager</h3>
-            <JSInstallSnippet />
+            <h3>Install posthog-js and @posthog/react using your package manager</h3>
+            <ReactInstallSnippet />
             <h3>Add environment variables</h3>
             <p>
                 Add your environment variables to your .env.local file and to your hosting provider (e.g. Vercel,

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react.tsx
@@ -7,7 +7,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { SDK_DEFAULTS_DATE } from '~/loadPostHogJS'
 
 import SetupWizardBanner from './components/SetupWizardBanner'
-import { JSInstallSnippet } from './js-web'
+import { ReactInstallSnippet } from './js-web'
 
 function ReactEnvVarsSnippet(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
@@ -29,7 +29,7 @@ function ReactSetupSnippet(): JSX.Element {
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
-import { PostHogProvider } from 'posthog-js/react'
+import { PostHogProvider } from '@posthog/react'
 
 const options = {
   api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
@@ -52,7 +52,7 @@ export function SDKInstallReactInstructions({ hideWizard }: { hideWizard?: boole
         <>
             <SetupWizardBanner integrationName="React" hide={hideWizard} />
             <h3>Install the package</h3>
-            <JSInstallSnippet />
+            <ReactInstallSnippet />
             <h3>Add environment variables</h3>
             <ReactEnvVarsSnippet />
             <h3>Initialize</h3>

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/remix.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/remix.tsx
@@ -8,7 +8,7 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import { SDK_DEFAULTS_DATE } from '~/loadPostHogJS'
 
-import { JSInstallSnippet } from './js-web'
+import { ReactInstallSnippet } from './js-web'
 
 function RemixExternalImportSnippet(): JSX.Element {
     return (
@@ -30,7 +30,7 @@ export default defineConfig({
     tsconfigPaths(),
   ],
   ssr: {
-    noExternal: ["posthog-js", "posthog-js/react"],
+    noExternal: ["posthog-js", "@posthog/react"],
   },
 });`}
         </CodeSnippet>
@@ -45,7 +45,7 @@ function RemixPHProviderSnippet(): JSX.Element {
         <CodeSnippet language={Language.JavaScript}>
             {`import { useEffect, useState } from "react";
 import posthog from "posthog-js";
-import { PostHogProvider } from "posthog-js/react";
+import { PostHogProvider } from "@posthog/react";
 
 export function PHProvider({ children }: { children: React.ReactNode }) {
   const [hydrated, setHydrated] = useState(false);
@@ -110,11 +110,11 @@ export default function App() {
 export function SDKInstallRemixJSInstructions(): JSX.Element {
     return (
         <>
-            <h3>Install posthog-js using your package manager</h3>
-            <JSInstallSnippet />
+            <h3>Install posthog-js and @posthog/react using your package manager</h3>
+            <ReactInstallSnippet />
             <h3>Add PostHog to your app</h3>
             <p>
-                Start by setting <code>posthog-js</code> and <code>posthog-js/react</code> as external packages in your{' '}
+                Start by setting <code>posthog-js</code> and <code>@posthog/react</code> as external packages in your{' '}
                 <code>vite.config.ts</code> file.
             </p>
             <RemixExternalImportSnippet />

--- a/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionSummaryV2.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/OpenQuestionSummaryV2.tsx
@@ -1,5 +1,4 @@
 import { useValues } from 'kea'
-import { useThumbSurvey } from 'posthog-js/react/surveys'
 import { useCallback, useEffect, useState } from 'react'
 
 import {
@@ -12,6 +11,7 @@ import {
     IconThumbsUpFilled,
 } from '@posthog/icons'
 import { LemonButton, LemonSkeleton } from '@posthog/lemon-ui'
+import { useThumbSurvey } from '@posthog/react/surveys'
 
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@parcel/transformer-typescript-types':
       specifier: 2.13.3
       version: 2.13.3
+    '@posthog/react':
+      specifier: ^1.9.0
+      version: 1.9.0
     '@storybook/addon-actions':
       specifier: ^7.6.4
       version: 7.6.4
@@ -710,6 +713,9 @@ importers:
       '@posthog/products-workflows':
         specifier: workspace:*
         version: link:../products/workflows
+      '@posthog/react':
+        specifier: 'catalog:'
+        version: 1.9.0(@types/react@18.3.27)(posthog-js@1.369.0)(react@18.3.1)
       '@posthog/replay-shared':
         specifier: workspace:*
         version: link:../common/replay-shared
@@ -8628,6 +8634,16 @@ packages:
       kea-router: '*'
       react: 18.3.1
       react-dom: 18.3.1
+
+  '@posthog/react@1.9.0':
+    resolution: {integrity: sha512-lVdTsWT5+PtHBu44gSQ7QohbLjAYqHkFAIGAQ+HV8Eh9yj+OcnQ7mXCmyhaMlTBD3z7D0H1eWMp4vQaFnsIyWQ==}
+    peerDependencies:
+      '@types/react': 18.3.27
+      posthog-js: '>=1.257.2'
+      react: 18.3.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@posthog/rrdom@0.0.4':
     resolution: {integrity: sha512-hUZOgnIxzB6ZWgKBbuf79oHko+7x1+sQMVtovY0k6fO67e5SwhKkLq3Y/Tn2ayIyUqEKqL8971wP1cmIeIVO+A==}
@@ -31456,6 +31472,13 @@ snapshots:
       kea-router: 3.4.1(kea@4.0.0-pre.5(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@posthog/react@1.9.0(@types/react@18.3.27)(posthog-js@1.369.0)(react@18.3.1)':
+    dependencies:
+      posthog-js: 1.369.0
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.27
 
   '@posthog/rrdom@0.0.4':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,6 +36,7 @@ catalog:
     kea-waitfor: ^0.2.1
     kea-window-values: ^3.0.1
     # PostHog packages
+    '@posthog/react': ^1.9.0
     posthog-js: ^1.369.0
     # Build tools
     '@parcel/packager-ts': 2.13.3

--- a/products/llm_analytics/frontend/feedback-view/wizard/codeExamples.ts
+++ b/products/llm_analytics/frontend/feedback-view/wizard/codeExamples.ts
@@ -5,7 +5,7 @@ interface CodeExampleParams {
 
 export function getReactExample({ surveyId = 'your-survey-id', followUpEnabled }: CodeExampleParams): string {
     return `// requires @posthog/react 1.7.1+ (bundled with posthog-js 1.345.1+)
-import { useThumbSurvey } from 'posthog-js/react/surveys'
+import { useThumbSurvey } from '@posthog/react/surveys'
 
 function HedgehogBotResponse({ traceId }: { traceId: string }) {
   const { respond, response${followUpEnabled ? ', triggerRef' : ''} } = useThumbSurvey({


### PR DESCRIPTION
## Problem

The codebase was using the old import path `posthog-js/react` for PostHog React components and hooks, which should be updated to use the new dedicated package `@posthog/react` for better maintainability and clearer separation of concerns.

## Changes

- Updated all import statements from `posthog-js/react` to `@posthog/react` across documentation and frontend code
- Added `@posthog/react` package dependency to the frontend package.json and pnpm workspace catalog
- Updated import statements for:
  - `PostHogProvider`
  - `usePostHog`
  - `useFeatureFlagVariantKey`
  - `PostHogFeature`
  - `PostHogErrorBoundary`
- Updated documentation examples in onboarding guides for Next.js, Remix, and TanStack
- Updated experiment and feature flag code snippets to use the new import path

## How did you test this code?

This change updates import paths across the codebase. The functionality remains identical as we're importing the same components from a different package location. Testing should verify:

1. All React components using PostHog hooks and components still function correctly
2. Documentation examples compile and work as expected
3. No broken imports or missing dependencies

As an agent, I have verified the import path consistency across all affected files but have not performed manual testing of the application functionality.

## Publish to changelog?

No - this is an internal refactoring that doesn't change user-facing functionality.

## Docs update

The documentation examples have been updated as part of this PR to reflect the new import paths.