### PR TITLE
fix(devex): recreate hogli symlink when target is dangling

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -97,7 +97,7 @@ bash = '''
   if [ ! -f "$UV_PROJECT_ENVIRONMENT/bin/activate" ]; then
     uv sync
     ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
-  elif [ ! -L "$UV_PROJECT_ENVIRONMENT/bin/hogli" ]; then
+  elif [ ! -L "$UV_PROJECT_ENVIRONMENT/bin/hogli" ] || [ ! -e "$UV_PROJECT_ENVIRONMENT/bin/hogli" ]; then
     ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
   fi
   source $UV_PROJECT_ENVIRONMENT/bin/activate
@@ -116,7 +116,7 @@ zsh = '''
   if [[ ! -f "$UV_PROJECT_ENVIRONMENT/bin/activate" ]]; then
     uv sync
     ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
-  elif [[ ! -L "$UV_PROJECT_ENVIRONMENT/bin/hogli" ]]; then
+  elif [[ ! -L "$UV_PROJECT_ENVIRONMENT/bin/hogli" ]] || [[ ! -e "$UV_PROJECT_ENVIRONMENT/bin/hogli" ]]; then
     ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
   fi
   source $UV_PROJECT_ENVIRONMENT/bin/activate
@@ -131,7 +131,7 @@ fish = '''
   if not test -f "$UV_PROJECT_ENVIRONMENT/bin/activate.fish"
     uv sync
     ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
-  else if not test -L "$UV_PROJECT_ENVIRONMENT/bin/hogli"
+  else if not test -L "$UV_PROJECT_ENVIRONMENT/bin/hogli"; or not test -e "$UV_PROJECT_ENVIRONMENT/bin/hogli"
     ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
   end
   source $UV_PROJECT_ENVIRONMENT/bin/activate.fish
@@ -143,7 +143,7 @@ tcsh = '''
   if ( ! -f "$UV_PROJECT_ENVIRONMENT/bin/activate.csh" ) then
     uv sync
     ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
-  else if ( ! -l "$UV_PROJECT_ENVIRONMENT/bin/hogli" ) then
+  else if ( ! -l "$UV_PROJECT_ENVIRONMENT/bin/hogli" || ! -e "$UV_PROJECT_ENVIRONMENT/bin/hogli" ) then
     ln -sf "$FLOX_ENV_PROJECT/bin/hogli" "$UV_PROJECT_ENVIRONMENT/bin/hogli"
   endif
   source $UV_PROJECT_ENVIRONMENT/bin/activate.csh


### PR DESCRIPTION
## Problem

When a git worktree (e.g. from a Claude Code agent session) is cleaned up, the `hogli` symlink in `.flox/cache/venv/bin/` is left pointing at the deleted worktree path. Re-entering the flox environment doesn't fix it because the shell hook only checks if the symlink is missing (`-L` test), not if its target is valid. A dangling symlink passes `-L`, so the hook skips it and `hogli` stays broken.

## Changes

Added an `-e` check (follows symlinks to verify the target exists) alongside the existing `-L` check in all four shell hooks (bash, zsh, fish, tcsh) in the flox manifest. Now a dangling symlink is detected and recreated on environment activation.

## How did you test this code?

Reproduced the issue by observing a dangling symlink left by a worktree cleanup, confirmed the existing hook skipped it, and verified the new condition correctly catches it.

No publish to changelog

## 🤖 LLM context

Agent-authored PR. The root cause was identified by inspecting the symlink target and the flox manifest hook logic.