### PR TITLE
fix(mcp): rebuild ApiClient on inbound token rotation

### DIFF
--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -176,6 +176,8 @@ export class MCP extends McpAgent<Env> {
     }
 
     async api(): Promise<ApiClient> {
+        // The mcp-session-id can stay the same across requests while the inbound OAuth token rotates,
+        // so we must rebuild the cached client whenever the token changes.
         if (!this._api || this._api.config.apiToken !== this.requestProperties.apiToken) {
             const baseUrl = await this.getBaseUrl()
             await this.resolveClientInfo()

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -176,7 +176,7 @@ export class MCP extends McpAgent<Env> {
     }
 
     async api(): Promise<ApiClient> {
-        if (!this._api) {
+        if (!this._api || this._api.config.apiToken !== this.requestProperties.apiToken) {
             const baseUrl = await this.getBaseUrl()
             await this.resolveClientInfo()
             this._api = new ApiClient({

--- a/services/mcp/tests/unit/mcp-api-caching.test.ts
+++ b/services/mcp/tests/unit/mcp-api-caching.test.ts
@@ -26,6 +26,10 @@ vi.mock('@modelcontextprotocol/ext-apps/server', () => ({
     RESOURCE_URI_META_KEY: 'resource-uri',
 }))
 
+vi.mock('@shared/guidelines.md', () => ({
+    default: '',
+}))
+
 import { MCP } from '@/mcp'
 
 function buildMcp(initialToken: string): MCP {

--- a/services/mcp/tests/unit/mcp-api-caching.test.ts
+++ b/services/mcp/tests/unit/mcp-api-caching.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ApiClientCtor = vi.fn()
+
+vi.mock('@/api/client', () => ({
+    ApiClient: class {
+        config: { apiToken: string; baseUrl: string }
+        baseUrl: string
+        constructor(config: any) {
+            this.config = config
+            this.baseUrl = config.baseUrl
+            ApiClientCtor(config)
+        }
+    },
+}))
+
+vi.mock('agents/mcp', () => ({
+    McpAgent: class {},
+}))
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+    McpServer: class {},
+}))
+
+vi.mock('@modelcontextprotocol/ext-apps/server', () => ({
+    RESOURCE_URI_META_KEY: 'resource-uri',
+}))
+
+import { MCP } from '@/mcp'
+
+function buildMcp(initialToken: string): MCP {
+    const mcp = Object.create(MCP.prototype) as MCP
+    ;(mcp as any).props = {
+        userHash: 'user-hash',
+        apiToken: initialToken,
+        clientUserAgent: 'test-agent',
+    }
+    ;(mcp as any).getBaseUrl = async () => 'https://us.posthog.com'
+    ;(mcp as any).resolveClientInfo = async () => {}
+    return mcp
+}
+
+describe('MCP.api() token-aware caching', () => {
+    beforeEach(() => {
+        ApiClientCtor.mockClear()
+    })
+
+    it('constructs an ApiClient with the current token on first call', async () => {
+        const mcp = buildMcp('token-A')
+        const api = await mcp.api()
+
+        expect(ApiClientCtor).toHaveBeenCalledTimes(1)
+        expect(ApiClientCtor).toHaveBeenLastCalledWith(expect.objectContaining({ apiToken: 'token-A' }))
+        expect(api.config.apiToken).toBe('token-A')
+    })
+
+    it('returns the cached instance when the token is unchanged', async () => {
+        const mcp = buildMcp('token-A')
+        const first = await mcp.api()
+        const second = await mcp.api()
+
+        expect(ApiClientCtor).toHaveBeenCalledTimes(1)
+        expect(second).toBe(first)
+    })
+
+    it('rebuilds the client when the token rotates', async () => {
+        const mcp = buildMcp('token-A')
+        await mcp.api()
+        ;(mcp as any).props.apiToken = 'token-B'
+        const rebuilt = await mcp.api()
+
+        expect(ApiClientCtor).toHaveBeenCalledTimes(2)
+        expect(ApiClientCtor).toHaveBeenLastCalledWith(expect.objectContaining({ apiToken: 'token-B' }))
+        expect(rebuilt.config.apiToken).toBe('token-B')
+    })
+
+    it('rebuilds when rotating back to a previously-used token', async () => {
+        const mcp = buildMcp('token-A')
+        await mcp.api()
+        ;(mcp as any).props.apiToken = 'token-B'
+        await mcp.api()
+        ;(mcp as any).props.apiToken = 'token-A'
+        await mcp.api()
+
+        expect(ApiClientCtor).toHaveBeenCalledTimes(3)
+    })
+})


### PR DESCRIPTION
## Problem

Consumers of the PostHog MCP server (the desktop app, and any other client that refreshes OAuth tokens mid-session) were hitting `authentication_failed: Invalid access token` on tool calls like `execute-sql` after a mid-session token rotation, even though the transport layer was receiving a fresh `Authorization: Bearer <new-token>` header.

Root cause: `MCP.api()` in `services/mcp/src/mcp.ts` lazy-initialized `this._api` on the first call and never rebuilt it, so the cached `ApiClient` kept using whichever token first landed on the Durable Object — which eventually got revoked upstream by OAuth rotation, permanently breaking the DO instance.

## Changes

- `services/mcp/src/mcp.ts` — `api()` now also rebuilds the cached `ApiClient` when `this._api.config.apiToken !== this.requestProperties.apiToken`. `ApiClient`'s constructor is lightweight (no async init), so rebuilding on rotation is effectively free.
- `services/mcp/tests/unit/mcp-api-caching.test.ts` — new Vitest unit file covering: first-call construct, cached reuse when the token is unchanged, rebuild on token rotation (regression test), and rebuild when rotating back to a previously-used token.

Other caches on the `MCP` class (`_cache`, `_clientInfoPromise`, MCP protocol metadata fields) are intentionally left alone — they're either user-scoped or protocol-scoped and don't depend on the inbound token.

## How did you test this code?

- Added four Vitest unit tests in `services/mcp/tests/unit/mcp-api-caching.test.ts` and ran them against the patched `api()` — all pass.
- Verified the regression tests fail on the unpatched method: temporarily reverted the condition, re-ran, and confirmed tests 3 and 4 fail with `expected spy to be called 2/3 times, but got 1`.

## Publish to changelog?

no

## 🤖 LLM context

Co-authored with Claude Code; scope limited to the `api()` caching bug described above. No changes to `src/index.ts`, `src/api/client.ts`, or wrangler config.