### PR TITLE
fix(logs): open alert modal from alertId deep link

### DIFF
--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -14,6 +14,7 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
+import { LogsAlertingSection } from 'products/logs/frontend/components/LogsAlerting/LogsAlertingSection'
 import { LogsServices } from 'products/logs/frontend/components/LogsServices/LogsServices'
 import { LogsViewer } from 'products/logs/frontend/components/LogsViewer'
 import { LogsViewerModal } from 'products/logs/frontend/components/LogsViewer/LogsViewerModal'
@@ -90,10 +91,12 @@ const LogsSceneTabbedContent = (): JSX.Element => {
     const { setActiveTab } = useActions(logsSceneLogic)
     const { hasLogs, teamHasLogsCheckFailed } = useValues(logsIngestionLogic)
     const showServicesView = useFeatureFlag('LOGS_SERVICES_VIEW')
+    const showAlerting = useFeatureFlag('LOGS_ALERTING')
 
     const tabs: { key: LogsSceneActiveTab; label: string }[] = [
         { key: 'viewer', label: 'Viewer' },
         ...(showServicesView ? [{ key: 'services' as const, label: 'Services' }] : []),
+        ...(showAlerting ? [{ key: 'alerts' as const, label: 'Alerts' }] : []),
         { key: 'configuration', label: 'Configuration' },
     ]
 
@@ -138,6 +141,7 @@ const LogsSceneTabbedContent = (): JSX.Element => {
                     <LogsViewerModal />
                 </>
             )}
+            {activeTab === 'alerts' && showAlerting && <LogsAlertingSection />}
             {activeTab === 'configuration' && (
                 <Settings logicKey={LOGS_LOGIC_KEY} sectionId="environment-logs" settingId="logs" handleLocally />
             )}

--- a/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
@@ -1,5 +1,6 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
+import { router } from 'kea-router'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
@@ -57,6 +58,18 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
     })),
 
     listeners(({ actions, values }) => ({
+        loadAlertsSuccess: () => {
+            const params = router.values.searchParams
+            if (params.alertId && typeof params.alertId === 'string') {
+                const alert = values.alerts.find((a) => a.id === params.alertId)
+                if (alert) {
+                    actions.setEditingAlert(alert)
+                }
+                // Clear alertId from URL regardless of whether we found the alert
+                const { alertId: _, ...rest } = router.values.searchParams
+                router.actions.replace(router.values.location.pathname, rest, router.values.hashParams)
+            }
+        },
         deleteAlert: async ({ id }) => {
             const projectId = String(values.currentTeamId)
             try {

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -33,9 +33,19 @@ import { logsViewerLogic } from 'products/logs/frontend/components/LogsViewer/lo
 
 import type { logsSceneLogicType } from './logsSceneLogicType'
 
-export type LogsSceneActiveTab = 'viewer' | 'services' | 'configuration'
-const VALID_ACTIVE_TABS: LogsSceneActiveTab[] = ['viewer', 'services', 'configuration']
+export type LogsSceneActiveTab = 'viewer' | 'services' | 'alerts' | 'configuration'
+const VALID_ACTIVE_TABS: LogsSceneActiveTab[] = ['viewer', 'services', 'alerts', 'configuration']
 export const DEFAULT_ACTIVE_TAB: LogsSceneActiveTab = 'viewer'
+
+const resolveActiveTabFromParams = (params: Params): LogsSceneActiveTab | null => {
+    if (typeof params.alertId === 'string' && params.alertId.length > 0) {
+        return 'alerts'
+    }
+    if (typeof params.activeTab === 'string' && VALID_ACTIVE_TABS.includes(params.activeTab as LogsSceneActiveTab)) {
+        return params.activeTab as LogsSceneActiveTab
+    }
+    return null
+}
 
 export interface LogsLogicProps {
     tabId: string
@@ -76,12 +86,9 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             if (cache.isSyncingUrl) {
                 return
             }
-            if (
-                typeof params.activeTab === 'string' &&
-                VALID_ACTIVE_TABS.includes(params.activeTab as LogsSceneActiveTab) &&
-                params.activeTab !== values.activeTab
-            ) {
-                actions.setActiveTab(params.activeTab as LogsSceneActiveTab)
+            const requestedTab = resolveActiveTabFromParams(params)
+            if (requestedTab && requestedTab !== values.activeTab) {
+                actions.setActiveTab(requestedTab)
             }
 
             const filtersFromUrl: Partial<LogsViewerFilters> = {}


### PR DESCRIPTION
## Problem

Users need to be able to navigate directly to specific alerts in the logs alerting interface via URL parameters. Currently, there's no way to deep-link to a specific alert or automatically open the alerts tab when an alert ID is provided in the URL.

## Changes

- Added a new "Alerts" tab to the logs scene interface behind the `LOGS_ALERTING` feature flag
- Implemented URL parameter handling to automatically switch to the alerts tab when `alertId` is present in the URL
- Added logic to automatically open the specified alert for editing when navigating via URL with an `alertId` parameter
- Enhanced the active tab resolution logic to prioritize alert navigation over generic tab selection
- Added automatic URL cleanup to remove the `alertId` parameter after processing

## How did you test this code?

manual testing of the url and ensuring the tab is still hidden behind the feature flag

## Publish to changelog?

no

## Docs update

no