### PR TITLE
fix(oauth-proxy): catch async handler rejections that cause Error 1101

### DIFF
--- a/services/oauth-proxy/src/handlers/metadata.ts
+++ b/services/oauth-proxy/src/handlers/metadata.ts
@@ -45,8 +45,19 @@ async function fetchAuthoritativeMetadata(): Promise<WellKnownOAuthAuthorization
 
 export async function handleMetadata(request: Request): Promise<Response> {
     if (!authoritativeMetadataCache || !cachedUntil || cachedUntil < new Date()) {
-        authoritativeMetadataCache = await fetchAuthoritativeMetadata()
-        cachedUntil = new Date(Date.now() + 600 * 1000) // cache for 10 minutes (600 seconds)
+        try {
+            authoritativeMetadataCache = await fetchAuthoritativeMetadata()
+            cachedUntil = new Date(Date.now() + 600 * 1000) // cache for 10 minutes (600 seconds)
+        } catch (error) {
+            console.error('Failed to fetch metadata:', error)
+            return new Response(
+                JSON.stringify({
+                    error: 'server_error',
+                    error_description: 'Unable to fetch authorization server metadata',
+                }),
+                { status: 502, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } }
+            )
+        }
     }
 
     const url = new URL(request.url)

--- a/services/oauth-proxy/src/handlers/passthrough.ts
+++ b/services/oauth-proxy/src/handlers/passthrough.ts
@@ -75,8 +75,15 @@ async function routeByClientId(request: Request, kv: KVNamespace, path: string):
     let clientId: string | null = null
 
     if (contentType.includes('application/json')) {
-        const json = JSON.parse(body) as Record<string, unknown>
-        clientId = (json.client_id as string) || null
+        try {
+            const json = JSON.parse(body) as Record<string, unknown>
+            clientId = (json.client_id as string) || null
+        } catch {
+            return new Response(
+                JSON.stringify({ error: 'invalid_request', error_description: 'Malformed JSON body' }),
+                { status: 400, headers: { 'Content-Type': 'application/json' } }
+            )
+        }
     } else {
         const params = new URLSearchParams(body)
         clientId = params.get('client_id')

--- a/services/oauth-proxy/src/handlers/token.ts
+++ b/services/oauth-proxy/src/handlers/token.ts
@@ -18,9 +18,16 @@ export async function handleToken(request: Request, kv: KVNamespace): Promise<Re
     let grantType: string | null = null
 
     if (contentType.includes('application/json')) {
-        const json = JSON.parse(body) as Record<string, unknown>
-        clientId = (json.client_id as string) || null
-        grantType = (json.grant_type as string) || null
+        try {
+            const json = JSON.parse(body) as Record<string, unknown>
+            clientId = (json.client_id as string) || null
+            grantType = (json.grant_type as string) || null
+        } catch {
+            return new Response(
+                JSON.stringify({ error: 'invalid_request', error_description: 'Malformed JSON body' }),
+                { status: 400, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } }
+            )
+        }
     } else {
         const formParams = new URLSearchParams(body)
         clientId = formParams.get('client_id')

--- a/services/oauth-proxy/src/index.ts
+++ b/services/oauth-proxy/src/index.ts
@@ -84,7 +84,7 @@ export default {
                     continue
                 }
                 if (route.paths.some((p) => normalizePath(p) === normalized)) {
-                    return route.handler(request, env.AUTH_KV)
+                    return await route.handler(request, env.AUTH_KV)
                 }
             }
 

--- a/services/oauth-proxy/tests/metadata.test.ts
+++ b/services/oauth-proxy/tests/metadata.test.ts
@@ -93,7 +93,7 @@ describe('handleMetadata', () => {
         vi.useRealTimers()
     })
 
-    it('throws when authoritative metadata fetch fails', async () => {
+    it('returns 502 when authoritative metadata fetch fails and no cache exists', async () => {
         vi.stubGlobal(
             'fetch',
             vi.fn().mockResolvedValue({
@@ -105,6 +105,38 @@ describe('handleMetadata', () => {
         const { handleMetadata } = await import('@/handlers/metadata')
         const request = new Request('https://oauth.posthog.com/.well-known/oauth-authorization-server')
 
-        await expect(handleMetadata(request)).rejects.toThrow('Failed to fetch authoritative metadata')
+        const response = await handleMetadata(request)
+        expect(response.status).toBe(502)
+        const data = (await response.json()) as Record<string, unknown>
+        expect(data.error).toBe('server_error')
+    })
+
+    it('returns 502 when metadata refresh fails after cache expires', async () => {
+        vi.useFakeTimers()
+        const { handleMetadata } = await import('@/handlers/metadata')
+        const request = new Request('https://oauth.posthog.com/.well-known/oauth-authorization-server')
+
+        // Populate cache with a successful fetch
+        const response1 = await handleMetadata(request)
+        expect(response1.status).toBe(200)
+
+        // Expire cache
+        vi.advanceTimersByTime(601 * 1000)
+
+        // Make fetch fail
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: false,
+                statusText: 'Service Unavailable',
+            })
+        )
+
+        const response2 = await handleMetadata(request)
+        expect(response2.status).toBe(502)
+        const data = (await response2.json()) as Record<string, unknown>
+        expect(data.error).toBe('server_error')
+
+        vi.useRealTimers()
     })
 })

--- a/services/oauth-proxy/tests/router.test.ts
+++ b/services/oauth-proxy/tests/router.test.ts
@@ -1,10 +1,42 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import worker from '@/index'
 
 const mockEnv = {
     AUTH_KV: {} as KVNamespace,
 }
+
+beforeEach(() => {
+    vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+            ok: true,
+            json: () =>
+                Promise.resolve({
+                    issuer: 'https://us.posthog.com',
+                    authorization_endpoint: 'https://us.posthog.com/oauth/authorize/',
+                    token_endpoint: 'https://us.posthog.com/oauth/token/',
+                    revocation_endpoint: 'https://us.posthog.com/oauth/revoke/',
+                    introspection_endpoint: 'https://us.posthog.com/oauth/introspect/',
+                    userinfo_endpoint: 'https://us.posthog.com/oauth/userinfo/',
+                    jwks_uri: 'https://us.posthog.com/.well-known/jwks.json',
+                    registration_endpoint: 'https://us.posthog.com/oauth/register/',
+                    scopes_supported: ['openid'],
+                    response_types_supported: ['code'],
+                    response_modes_supported: ['query'],
+                    grant_types_supported: ['authorization_code', 'refresh_token'],
+                    token_endpoint_auth_methods_supported: ['none'],
+                    code_challenge_methods_supported: ['S256'],
+                    service_documentation: 'https://posthog.com/docs/api',
+                    client_id_metadata_document_supported: true,
+                }),
+        })
+    )
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
 
 describe('router', () => {
     it.each([
@@ -28,5 +60,45 @@ describe('router', () => {
         const response = await worker.fetch(request, mockEnv)
         const text = await response.text()
         expect(text).toContain('PostHog OAuth Proxy')
+    })
+
+    it('catches async handler rejections and returns 500 instead of crashing', async () => {
+        // This is the core regression test for the `return await` fix in the router.
+        // Without `await`, a rejected handler promise bypasses the try/catch and becomes
+        // an unhandled rejection (Cloudflare Error 1101). With `await`, the catch block
+        // intercepts it and returns a structured 500 response.
+        vi.resetModules()
+
+        // Mock handleAuthorize to return a rejected promise (simulates any async failure)
+        vi.doMock('@/handlers/authorize', () => ({
+            handleAuthorize: () => Promise.reject(new Error('KV transient failure')),
+        }))
+
+        const { default: freshWorker } = await import('@/index')
+        const request = new Request('https://oauth.posthog.com/oauth/authorize/?client_id=abc')
+        const response = await freshWorker.fetch(request, mockEnv)
+
+        expect(response.status).toBe(500)
+        const data = (await response.json()) as Record<string, unknown>
+        expect(data.error).toBe('server_error')
+        expect(data.error_description).toBe('An internal error occurred')
+    })
+
+    it('catches synchronous handler throws and returns 500', async () => {
+        vi.resetModules()
+
+        vi.doMock('@/handlers/authorize', () => ({
+            handleAuthorize: () => {
+                throw new Error('unexpected null')
+            },
+        }))
+
+        const { default: freshWorker } = await import('@/index')
+        const request = new Request('https://oauth.posthog.com/oauth/authorize/?client_id=abc')
+        const response = await freshWorker.fetch(request, mockEnv)
+
+        expect(response.status).toBe(500)
+        const data = (await response.json()) as Record<string, unknown>
+        expect(data.error).toBe('server_error')
     })
 })

--- a/services/oauth-proxy/tests/token.test.ts
+++ b/services/oauth-proxy/tests/token.test.ts
@@ -164,6 +164,20 @@ describe('handleToken', () => {
         expect(data.error).toBe('invalid_request')
     })
 
+    it('returns 400 for malformed JSON body', async () => {
+        const request = new Request('https://oauth.posthog.com/oauth/token/', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{invalid json',
+        })
+
+        const response = await handleToken(request, mockKV)
+        expect(response.status).toBe(400)
+        const data = (await response.json()) as Record<string, unknown>
+        expect(data.error).toBe('invalid_request')
+        expect(data.error_description).toBe('Malformed JSON body')
+    })
+
     it('falls back to try-both for refresh_token grants', async () => {
         mockKVGetValue(mockKV, null)
 


### PR DESCRIPTION
## Problem

  MCP clients that dynamically register via RFC 7591 DCR get a valid client_id back from the registration endpoint, but when they use it at the authorization endpoint, the OAuth proxy Cloudflare Worker crashes with HTTP Error 1101 ("Worker threw exception"). The authorization flow never completes.

  The root cause is a missing `await` in the router's try/catch block. All route handlers are async, and returning a promise without awaiting it doesn't unwrap it inside the try block — so rejected promises bypass the catch entirely and become unhandled rejections, which Cloudflare surfaces as Error 1101 instead of a proper error response.

  ## Changes

  The critical fix is a one-line change: awaiting the handler promise in the router so the catch block can intercept async rejections. Previously, any async failure in any handler would crash the worker; now it returns a structured JSON error response.

  On top of that, a few secondary throw sites that were relying on the (broken) router catch have been hardened:
  - The metadata handler now returns a 502 response instead of throwing when the upstream fetch fails
  - Unguarded JSON parsing in the token and revoke handlers now returns 400 for malformed bodies instead of throwing

  ## How did you test this code?

- Added tests

## Publish to changelog?

  no

## Docs update

  No docs changes needed.