### PR TITLE
fix(storybook): make shard partitioning deterministic across CI runners

### DIFF
--- a/common/storybook/storybook-timings.json
+++ b/common/storybook/storybook-timings.json
@@ -1,1085 +1,1285 @@
 {
     "frontend/src/exporter/stories/ExporterFunnels.stories.tsx": {
-        "chromium": 27.8,
-        "webkit": 3.6
+        "chromium": 30.938,
+        "webkit": 6.401
     },
     "frontend/src/exporter/stories/ExporterOther.stories.tsx": {
-        "chromium": 27.5,
-        "webkit": 4.8
+        "chromium": 30.621,
+        "webkit": 5.97
     },
     "frontend/src/exporter/stories/ExporterTrends.stories.tsx": {
-        "chromium": 28.0,
-        "webkit": 3.9
+        "chromium": 30.7,
+        "webkit": 5.505
     },
     "frontend/src/layout/ErrorProjectUnavailable.stories.tsx": {
-        "chromium": 11.9,
-        "webkit": 2.7
+        "chromium": 12.435,
+        "webkit": 3.491
     },
     "frontend/src/layout/FeaturePreviews/FeaturePreviews.stories.tsx": {
-        "chromium": 9.9,
-        "webkit": 2.6
+        "chromium": 10.737,
+        "webkit": 2.788
     },
     "frontend/src/layout/navigation-3000/components/KeyboardShortcut.stories.tsx": {
-        "chromium": 8.7,
-        "webkit": 2.7
+        "chromium": 9.89,
+        "webkit": 3.264
     },
     "frontend/src/layout/navigation-3000/sidepanel/SidePanel.stories.tsx": {
-        "chromium": 53.5,
-        "webkit": 5.5
+        "chromium": 49.554,
+        "webkit": 18.815
     },
     "frontend/src/layout/panel-layout/PinnedFolder/EditCustomProductsModal.stories.tsx": {
-        "chromium": 2.5,
-        "webkit": 2.4
+        "chromium": 2.156,
+        "webkit": 2.142
     },
     "frontend/src/layout/panel-layout/ProjectTree/ProjectTree.stories.tsx": {
-        "chromium": 13.2,
-        "webkit": 3.5
+        "chromium": 14.621,
+        "webkit": 3.75
     },
     "frontend/src/lib/components/ActivityLog/ActivityLog.stories.tsx": {
-        "chromium": 29.4,
-        "webkit": 3.1
+        "chromium": 32.917,
+        "webkit": 5.135
     },
     "frontend/src/lib/components/ActivityLog/SentenceList.stories.tsx": {
-        "chromium": 14.1,
-        "webkit": 2.7
+        "chromium": 16.052,
+        "webkit": 3.514
+    },
+    "frontend/src/lib/components/Alerts/views/QuietHoursFields.stories.tsx": {
+        "chromium": 6.379,
+        "webkit": 2.374
     },
     "frontend/src/lib/components/BaseCurrency/CurrencyDropdown.stories.tsx": {
-        "chromium": 6.3,
-        "webkit": 2.6
+        "chromium": 6.748,
+        "webkit": 2.634
+    },
+    "frontend/src/lib/components/Cards/ButtonTileCard/ButtonTileCard.stories.tsx": {
+        "chromium": 16.082,
+        "webkit": 3.083
     },
     "frontend/src/lib/components/Cards/InsightCard/InsightCard.stories.tsx": {
-        "chromium": 40.5,
-        "webkit": 5.6
+        "chromium": 43.199,
+        "webkit": 10.417
     },
     "frontend/src/lib/components/Cards/InsightCard/InsightDetails.stories.tsx": {
-        "chromium": 47.7,
-        "webkit": 4.5
+        "chromium": 54.666,
+        "webkit": 7.066
     },
     "frontend/src/lib/components/Cards/InsightCard/RecordingsUniversalFiltersDisplay.stories.tsx": {
-        "chromium": 48.6,
-        "webkit": 4.0
+        "chromium": 56.263,
+        "webkit": 6.276
     },
     "frontend/src/lib/components/Cards/TextCard/TextCard.stories.tsx": {
-        "chromium": 11.8,
-        "webkit": 2.9
+        "chromium": 14.156,
+        "webkit": 4.607
     },
     "frontend/src/lib/components/CodeSnippet/CodeSnippet.stories.tsx": {
-        "chromium": 26.7,
-        "webkit": 3.1
+        "chromium": 30.34,
+        "webkit": 5.412
     },
     "frontend/src/lib/components/CompactList/CompactList.stories.tsx": {
-        "chromium": 6.5,
-        "webkit": 2.6
+        "chromium": 6.914,
+        "webkit": 3.097
     },
     "frontend/src/lib/components/CopyToClipboardInline.stories.tsx": {
-        "chromium": 22.7,
-        "webkit": 2.7
+        "chromium": 26.111,
+        "webkit": 4.401
+    },
+    "frontend/src/lib/components/DefinitionPopover/DefinitionPopover.stories.tsx": {
+        "chromium": 25.618,
+        "webkit": 4.805
     },
     "frontend/src/lib/components/EditableField/EditableField.stories.tsx": {
-        "chromium": 9.0,
-        "webkit": 2.7
+        "chromium": 9.492,
+        "webkit": 2.769
     },
     "frontend/src/lib/components/EmojiPicker/EmojiPickerPopover.stories.tsx": {
-        "chromium": 8.9,
-        "webkit": 2.5
+        "chromium": 9.695,
+        "webkit": 2.804
     },
     "frontend/src/lib/components/EmptyMessage/EmptyMessage.stories.tsx": {
-        "chromium": 6.3,
-        "webkit": 2.5
+        "chromium": 6.515,
+        "webkit": 3.093
     },
     "frontend/src/lib/components/Errors/ErrorDisplay.stories.tsx": {
-        "chromium": 26.4,
-        "webkit": 3.1
+        "chromium": 30.516,
+        "webkit": 4.367
+    },
+    "frontend/src/lib/components/Errors/Frame/CollapsibleFrame.stories.tsx": {
+        "chromium": 26.589,
+        "webkit": 4.13
     },
     "frontend/src/lib/components/EventSelect/EventSelect.stories.tsx": {
-        "chromium": 5.8,
-        "webkit": 2.4
+        "chromium": 6.135,
+        "webkit": 2.35
     },
     "frontend/src/lib/components/HTMLElementsDisplay/HTMLElementsDisplay.stories.tsx": {
-        "chromium": 34.8,
-        "webkit": 3.3
+        "chromium": 39.251,
+        "webkit": 5.053
     },
-    "frontend/src/lib/components/HedgehogBuddy/HedgehogBuddy.stories.tsx": {
-        "chromium": 2.4,
-        "webkit": 2.5
+    "frontend/src/lib/components/HedgehogMode/HedgehogMode.stories.tsx": {
+        "chromium": 11.343,
+        "webkit": 3.153
     },
     "frontend/src/lib/components/HogQLEditor/HogQLEditor.stories.tsx": {
-        "chromium": 12.4,
-        "webkit": 2.9
+        "chromium": 14.06,
+        "webkit": 3.632
     },
     "frontend/src/lib/components/Hogfetti/Hogfetti.stories.tsx": {
-        "chromium": 5.9,
-        "webkit": 2.4
+        "chromium": 6.125,
+        "webkit": 2.59
+    },
+    "frontend/src/lib/components/ImageCarousel/ImageCarousel.stories.tsx": {
+        "chromium": 13.269,
+        "webkit": 2.783
+    },
+    "frontend/src/lib/components/JSSnippet.stories.tsx": {
+        "chromium": 2.488,
+        "webkit": 2.287
     },
     "frontend/src/lib/components/Map/Map.stories.tsx": {
-        "chromium": 2.6,
-        "webkit": 2.2
+        "chromium": 2.525,
+        "webkit": 2.136
+    },
+    "frontend/src/lib/components/MarkdownEditor/inline/InlineRichMarkdownEditor.stories.tsx": {
+        "chromium": 13.139
+    },
+    "frontend/src/lib/components/MarkdownEditor/rich/RichMarkdownEditor.stories.tsx": {
+        "webkit": 2.616
     },
     "frontend/src/lib/components/MonacoDiffEditor.stories.tsx": {
-        "chromium": 2.6,
-        "webkit": 2.5
+        "chromium": 2.159,
+        "webkit": 2.168
     },
     "frontend/src/lib/components/NotFound/NotFound.stories.tsx": {
-        "chromium": 6.3,
-        "webkit": 2.5
+        "chromium": 6.398,
+        "webkit": 2.784
     },
     "frontend/src/lib/components/ObjectTags/ObjectTags.stories.tsx": {
-        "chromium": 8.9,
-        "webkit": 2.4
+        "chromium": 9.615,
+        "webkit": 2.664
     },
     "frontend/src/lib/components/PathCleanFilters/PathCleanFilters.stories.tsx": {
-        "chromium": 11.9,
-        "webkit": 2.7
+        "chromium": 13.225,
+        "webkit": 3.038
     },
     "frontend/src/lib/components/PathCleanFilters/PathCleaningRulesDebugger.stories.tsx": {
-        "chromium": 5.8,
-        "webkit": 2.4
+        "chromium": 6.087,
+        "webkit": 2.48
     },
     "frontend/src/lib/components/PayGateMini/PayGateMini.stories.tsx": {
-        "chromium": 36.1,
-        "webkit": 3.2
+        "chromium": 40.688,
+        "webkit": 5.041
     },
     "frontend/src/lib/components/ProductIntroduction/ProductIntroduction.stories.tsx": {
-        "chromium": 15.1,
-        "webkit": 2.6
+        "chromium": 23.475,
+        "webkit": 3.943
     },
     "frontend/src/lib/components/ProductSetup/ProductSetupPopover.stories.tsx": {
-        "chromium": 7.2,
-        "webkit": 2.5
+        "chromium": 7.16,
+        "webkit": 2.282
     },
     "frontend/src/lib/components/PropertiesTable/PropertiesTable.stories.tsx": {
-        "chromium": 15.1,
-        "webkit": 3.0
+        "chromium": 17.201,
+        "webkit": 3.561
     },
     "frontend/src/lib/components/PropertiesTimeline/PropertiesTimeline.stories.tsx": {
-        "chromium": 12.1,
-        "webkit": 2.6
+        "chromium": 13.072,
+        "webkit": 3.678
     },
     "frontend/src/lib/components/PropertyFilters/PropertyFilters.stories.tsx": {
-        "chromium": 9.4,
-        "webkit": 3.0
+        "chromium": 15.574,
+        "webkit": 4.86
     },
     "frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.stories.tsx": {
-        "chromium": 26.2,
-        "webkit": 3.1
+        "chromium": 30.242,
+        "webkit": 4.193
     },
     "frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.stories.tsx": {
-        "chromium": 9.4,
-        "webkit": 2.7
+        "chromium": 13.211,
+        "webkit": 4.492
     },
     "frontend/src/lib/components/PropertyIcon/PropertyIcon.stories.tsx": {
-        "chromium": 6.0,
-        "webkit": 2.7
+        "webkit": 2.491
     },
     "frontend/src/lib/components/PropertyKeyInfo.stories.tsx": {
-        "chromium": 5.9,
-        "webkit": 2.3
+        "chromium": 6.228,
+        "webkit": 2.326
     },
     "frontend/src/lib/components/PropertySelect/PropertySelect.stories.tsx": {
-        "chromium": 9.1,
-        "webkit": 2.6
+        "chromium": 10.038,
+        "webkit": 2.772
     },
     "frontend/src/lib/components/ScrollableShadows/ScrollableShadows.stories.tsx": {
-        "chromium": 8.8,
-        "webkit": 2.6
+        "chromium": 9.567,
+        "webkit": 3.376
+    },
+    "frontend/src/lib/components/Search/Search.stories.tsx": {
+        "chromium": 11.732,
+        "webkit": 4.653
     },
     "frontend/src/lib/components/SearchAutocomplete/SearchAutocomplete.stories.tsx": {
-        "chromium": 5.8,
-        "webkit": 2.4
+        "chromium": 6.152,
+        "webkit": 3.287
     },
     "frontend/src/lib/components/Sharing/SharingModal.stories.tsx": {
-        "chromium": 28.0,
-        "webkit": 3.5
+        "chromium": 31.001,
+        "webkit": 4.022
     },
     "frontend/src/lib/components/Sparkline.stories.tsx": {
-        "chromium": 8.8,
-        "webkit": 2.5
+        "chromium": 9.594,
+        "webkit": 3.099
     },
     "frontend/src/lib/components/Subscriptions/SubscriptionsModal.stories.tsx": {
-        "chromium": 23.8,
-        "webkit": 3.3
+        "chromium": 25.948,
+        "webkit": 4.69
     },
     "frontend/src/lib/components/TZLabel/TZLabel.stories.tsx": {
-        "chromium": 19.8,
-        "webkit": 2.8
+        "chromium": 23.037,
+        "webkit": 3.768
+    },
+    "frontend/src/lib/components/TablePreview/TablePreview.stories.tsx": {
+        "chromium": 16.06,
+        "webkit": 3.469
     },
     "frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.stories.tsx": {
-        "chromium": 30.5,
-        "webkit": 3.6
+        "chromium": 51.237,
+        "webkit": 8.204
     },
     "frontend/src/lib/components/TaxonomicPopover/TaxonomicPopover.stories.tsx": {
-        "chromium": 8.8,
-        "webkit": 2.4
+        "chromium": 9.447,
+        "webkit": 2.616
     },
     "frontend/src/lib/components/UniversalFilters/UniversalFilters.stories.tsx": {
-        "chromium": 6.0,
-        "webkit": 2.7
+        "chromium": 6.392,
+        "webkit": 2.498
     },
     "frontend/src/lib/components/VerticalNestedDND/VerticalNestedDND.stories.tsx": {
-        "chromium": 6.2,
-        "webkit": 2.5
+        "chromium": 6.424,
+        "webkit": 2.499
     },
     "frontend/src/lib/components/ViewRecordingButton/ViewRecordingButton.stories.tsx": {
-        "chromium": 8.8,
-        "webkit": 2.6
+        "chromium": 9.379,
+        "webkit": 2.719
+    },
+    "frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.stories.tsx": {
+        "chromium": 14.418,
+        "webkit": 3.159
     },
     "frontend/src/lib/components/hedgehogs.stories.tsx": {
-        "chromium": 2.6,
-        "webkit": 2.4
+        "chromium": 2.181,
+        "webkit": 2.152
     },
-    "frontend/src/lib/lemon-ui/ClampedText/ClampedText.stories.tsx": {
-        "webkit": 2.8
+    "frontend/src/lib/hog-charts/ReferenceLine.stories.tsx": {
+        "chromium": 20.109,
+        "webkit": 3.433
     },
     "frontend/src/lib/lemon-ui/LemonBadge/LemonBadge.stories.tsx": {
-        "chromium": 17.0,
-        "webkit": 2.8
+        "chromium": 19.359,
+        "webkit": 3.59
     },
     "frontend/src/lib/lemon-ui/LemonBadge/LemonBadgeNumber.stories.tsx": {
-        "chromium": 11.6,
-        "webkit": 2.7
+        "chromium": 12.674,
+        "webkit": 2.954
     },
     "frontend/src/lib/lemon-ui/LemonBanner/LemonBanner.stories.tsx": {
-        "chromium": 31.3,
-        "webkit": 3.0
+        "chromium": 36.163,
+        "webkit": 4.628
     },
     "frontend/src/lib/lemon-ui/LemonButton/LemonButton.stories.tsx": {
-        "chromium": 71.7,
-        "webkit": 4.2
+        "chromium": 79.864,
+        "webkit": 8.412
     },
     "frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendar.stories.tsx": {
-        "chromium": 40.6,
-        "webkit": 3.1
+        "chromium": 47.31,
+        "webkit": 5.945
     },
     "frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendarSelect.stories.tsx": {
-        "chromium": 33.7,
-        "webkit": 3.3
+        "chromium": 39.061,
+        "webkit": 6.323
     },
     "frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendarSelectInput.stories.tsx": {
-        "chromium": 11.4,
-        "webkit": 2.8
+        "chromium": 12.784,
+        "webkit": 3.398
     },
     "frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRange.stories.tsx": {
-        "chromium": 6.6,
-        "webkit": 2.7
+        "chromium": 6.622,
+        "webkit": 3.839
     },
     "frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRangeInline.stories.tsx": {
-        "chromium": 6.1,
-        "webkit": 2.6
+        "chromium": 6.351,
+        "webkit": 2.423
     },
     "frontend/src/lib/lemon-ui/LemonCard/LemonCard.stories.tsx": {
-        "chromium": 14.1,
-        "webkit": 2.7
+        "chromium": 16.008,
+        "webkit": 3.146
     },
     "frontend/src/lib/lemon-ui/LemonCheckbox/LemonCheckbox.stories.tsx": {
-        "chromium": 20.0,
-        "webkit": 2.8
+        "chromium": 22.945,
+        "webkit": 4.918
     },
     "frontend/src/lib/lemon-ui/LemonCollapse/LemonCollapse.stories.tsx": {
-        "chromium": 17.0,
-        "webkit": 2.8
+        "chromium": 19.295,
+        "webkit": 3.661
     },
     "frontend/src/lib/lemon-ui/LemonColor/LemonColorButton.stories.tsx": {
-        "chromium": 23.2,
-        "webkit": 3.4
+        "chromium": 26.466,
+        "webkit": 4.423
     },
     "frontend/src/lib/lemon-ui/LemonColor/LemonColorGlyph.stories.tsx": {
-        "chromium": 18.0,
-        "webkit": 2.8
+        "chromium": 20.154,
+        "webkit": 3.581
     },
     "frontend/src/lib/lemon-ui/LemonColor/LemonColorList.stories.tsx": {
-        "chromium": 12.4,
-        "webkit": 2.7
+        "chromium": 13.327,
+        "webkit": 3.177
     },
     "frontend/src/lib/lemon-ui/LemonColor/LemonColorPicker.stories.tsx": {
-        "chromium": 14.7,
-        "webkit": 2.8
+        "chromium": 16.909,
+        "webkit": 3.468
     },
     "frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.stories.tsx": {
-        "chromium": 14.7,
-        "webkit": 2.8
+        "webkit": 4.255
     },
     "frontend/src/lib/lemon-ui/LemonDivider/LemonDivider.stories.tsx": {
-        "chromium": 17.0,
-        "webkit": 2.7
+        "chromium": 19.419,
+        "webkit": 3.326
+    },
+    "frontend/src/lib/lemon-ui/LemonDrawer/LemonDrawer.stories.tsx": {
+        "chromium": 19.442,
+        "webkit": 3.456
     },
     "frontend/src/lib/lemon-ui/LemonField/LemonField.stories.tsx": {
-        "chromium": 9.7,
-        "webkit": 2.6
+        "chromium": 10.209,
+        "webkit": 2.594
     },
     "frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.stories.tsx": {
-        "chromium": 17.1,
-        "webkit": 2.8
+        "chromium": 19.553,
+        "webkit": 3.328
     },
     "frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.stories.tsx": {
-        "chromium": 59.7,
-        "webkit": 3.7
+        "chromium": 76.333,
+        "webkit": 8.273
     },
     "frontend/src/lib/lemon-ui/LemonLabel/LemonLabel.stories.tsx": {
-        "webkit": 2.6
+        "chromium": 9.384,
+        "webkit": 4.013
     },
     "frontend/src/lib/lemon-ui/LemonMarkdown/LemonMarkdown.stories.tsx": {
-        "chromium": 23.9,
-        "webkit": 3.3
+        "chromium": 27.699,
+        "webkit": 4.203
     },
     "frontend/src/lib/lemon-ui/LemonMenu/LemonMenu.stories.tsx": {
-        "chromium": 11.3,
-        "webkit": 2.8
+        "chromium": 13.127,
+        "webkit": 2.833
     },
     "frontend/src/lib/lemon-ui/LemonModal/LemonModal.stories.tsx": {
-        "chromium": 14.5,
-        "webkit": 2.7
+        "chromium": 16.774,
+        "webkit": 3.304
     },
     "frontend/src/lib/lemon-ui/LemonProgress/LemonProgress.stories.tsx": {
-        "chromium": 6.0,
-        "webkit": 2.4
+        "chromium": 6.201,
+        "webkit": 2.443
     },
     "frontend/src/lib/lemon-ui/LemonProgressCircle/LemonProgressCircle.stories.tsx": {
-        "chromium": 12.1,
-        "webkit": 2.6
+        "chromium": 9.475,
+        "webkit": 2.678
     },
     "frontend/src/lib/lemon-ui/LemonRadio/LemonRadio.stories.tsx": {
-        "chromium": 11.6,
-        "webkit": 2.7
+        "chromium": 12.923,
+        "webkit": 4.367
     },
     "frontend/src/lib/lemon-ui/LemonRichContent/LemonRichContentEditor.stories.tsx": {
-        "chromium": 6.0,
-        "webkit": 2.4
+        "chromium": 6.446,
+        "webkit": 2.499
     },
     "frontend/src/lib/lemon-ui/LemonRow/LemonRow.stories.tsx": {
-        "chromium": 47.4,
-        "webkit": 3.2
+        "chromium": 55.094,
+        "webkit": 7.178
     },
     "frontend/src/lib/lemon-ui/LemonSegmentedButton/LemonSegmentedButton.stories.tsx": {
-        "chromium": 11.9,
-        "webkit": 2.8
+        "chromium": 16.304,
+        "webkit": 3.22
     },
     "frontend/src/lib/lemon-ui/LemonSegmentedButton/LemonSegmentedDropdown.stories.tsx": {
-        "chromium": 17.3,
-        "webkit": 2.9
+        "chromium": 19.435,
+        "webkit": 3.515
     },
     "frontend/src/lib/lemon-ui/LemonSegmentedSelect/LemonSegmentedSelect.stories.tsx": {
-        "chromium": 11.6,
-        "webkit": 2.7
+        "chromium": 13.215,
+        "webkit": 2.928
     },
     "frontend/src/lib/lemon-ui/LemonSelect/LemonSearchableSelect.stories.tsx": {
-        "chromium": 9.0,
-        "webkit": 2.9
+        "chromium": 9.946,
+        "webkit": 3.018
     },
     "frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.stories.tsx": {
-        "chromium": 28.4,
-        "webkit": 3.2
+        "chromium": 32.848,
+        "webkit": 4.551
     },
     "frontend/src/lib/lemon-ui/LemonSkeleton/LemonSkeleton.stories.tsx": {
-        "chromium": 14.5,
-        "webkit": 3.0
+        "chromium": 16.49,
+        "webkit": 3.527
     },
     "frontend/src/lib/lemon-ui/LemonSlider/LemonSlider.stories.tsx": {
-        "webkit": 2.5
+        "chromium": 6.175,
+        "webkit": 2.784
     },
     "frontend/src/lib/lemon-ui/LemonSnack/LemonSnack.stories.tsx": {
-        "chromium": 14.7,
-        "webkit": 2.7
+        "chromium": 15.901,
+        "webkit": 2.974
     },
     "frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.stories.tsx": {
-        "chromium": 25.4,
-        "webkit": 2.8
+        "chromium": 29.235,
+        "webkit": 5.583
     },
     "frontend/src/lib/lemon-ui/LemonTable/LemonTable.stories.tsx": {
-        "chromium": 62.5,
-        "webkit": 4.1
+        "chromium": 83.813,
+        "webkit": 9.163
     },
     "frontend/src/lib/lemon-ui/LemonTabs/LemonTabs.stories.tsx": {
-        "chromium": 11.5,
-        "webkit": 2.7
+        "chromium": 12.862,
+        "webkit": 3.172
     },
     "frontend/src/lib/lemon-ui/LemonTag/LemonTag.stories.tsx": {
-        "chromium": 8.7,
-        "webkit": 2.5
+        "chromium": 9.505,
+        "webkit": 3.08
     },
     "frontend/src/lib/lemon-ui/LemonTextArea/LemonTextArea.stories.tsx": {
-        "chromium": 17.2,
-        "webkit": 2.8
+        "chromium": 19.566,
+        "webkit": 3.325
     },
     "frontend/src/lib/lemon-ui/LemonTextArea/LemonTextAreaMarkdown.stories.tsx": {
-        "chromium": 12.1,
-        "webkit": 2.5
+        "chromium": 13.084,
+        "webkit": 2.911
     },
     "frontend/src/lib/lemon-ui/LemonToast/LemonToast.stories.tsx": {
-        "chromium": 14.7,
-        "webkit": 2.7
+        "chromium": 19.659,
+        "webkit": 4.497
     },
     "frontend/src/lib/lemon-ui/LemonTree/LemonTree.stories.tsx": {
-        "chromium": 6.6,
-        "webkit": 3.0
+        "chromium": 7.028,
+        "webkit": 2.549
     },
     "frontend/src/lib/lemon-ui/LemonWidget/LemonWidget.stories.tsx": {
-        "chromium": 14.2,
-        "webkit": 2.7
+        "chromium": 16.01,
+        "webkit": 3.53
     },
     "frontend/src/lib/lemon-ui/Lettermark/Lettermark.stories.tsx": {
-        "chromium": 25.2,
-        "webkit": 2.8
+        "chromium": 29.421,
+        "webkit": 4.242
     },
     "frontend/src/lib/lemon-ui/Link/Link.stories.tsx": {
-        "chromium": 11.3,
-        "webkit": 2.7
+        "chromium": 12.896,
+        "webkit": 2.794
     },
     "frontend/src/lib/lemon-ui/PaginationControl/PaginationControl.stories.tsx": {
-        "chromium": 8.6,
-        "webkit": 2.5
+        "chromium": 9.424,
+        "webkit": 2.742
     },
     "frontend/src/lib/lemon-ui/Popover/Popover.stories.tsx": {
-        "chromium": 2.5,
-        "webkit": 2.4
+        "webkit": 2.238
     },
     "frontend/src/lib/lemon-ui/ProfilePicture/ProfileBubbles.stories.tsx": {
-        "chromium": 19.6,
-        "webkit": 2.8
+        "chromium": 22.408,
+        "webkit": 3.854
     },
     "frontend/src/lib/lemon-ui/Spinner/Spinner.stories.tsx": {
-        "chromium": 20.8
+        "chromium": 23.099,
+        "webkit": 3.677
     },
     "frontend/src/lib/lemon-ui/Splotch/Splotch.stories.tsx": {
-        "chromium": 5.7,
-        "webkit": 2.4
+        "chromium": 6.441,
+        "webkit": 2.327
     },
     "frontend/src/lib/lemon-ui/UploadedLogo/UploadedLogo.stories.tsx": {
-        "chromium": 19.7,
-        "webkit": 2.8
+        "chromium": 22.423,
+        "webkit": 3.862
     },
     "frontend/src/lib/lemon-ui/colors.stories.tsx": {
-        "chromium": 17.9,
-        "webkit": 2.9
+        "chromium": 19.827,
+        "webkit": 3.434
     },
     "frontend/src/lib/lemon-ui/icons/icons3000.stories.tsx": {
-        "chromium": 2.7,
-        "webkit": 2.3
+        "chromium": 2.302,
+        "webkit": 1.842
     },
     "frontend/src/lib/lemon-ui/icons/stories/Icons1.stories.tsx": {
-        "chromium": 29.7,
-        "webkit": 3.2
+        "chromium": 33.439,
+        "webkit": 5.211
     },
     "frontend/src/lib/lemon-ui/icons/stories/Icons2.stories.tsx": {
-        "chromium": 28.7,
-        "webkit": 2.9
+        "chromium": 33.164,
+        "webkit": 4.61
     },
     "frontend/src/lib/lemon-ui/icons/stories/Icons3.stories.tsx": {
-        "chromium": 40.7,
-        "webkit": 3.7
+        "chromium": 47.004,
+        "webkit": 5.822
     },
     "frontend/src/lib/ui/Button/ButtonPrimitives.stories.tsx": {
-        "chromium": 9.0,
-        "webkit": 2.8
+        "chromium": 9.744,
+        "webkit": 2.798
+    },
+    "frontend/src/lib/ui/Collapsible/Collapsible.stories.tsx": {
+        "chromium": 19.716,
+        "webkit": 4.831
     },
     "frontend/src/lib/ui/Colors/Colors.stories.tsx": {
-        "chromium": 14.9,
-        "webkit": 3.3
+        "chromium": 15.767,
+        "webkit": 3.107
     },
     "frontend/src/lib/ui/Combobox/Combobox.stories.tsx": {
-        "chromium": 9.1,
-        "webkit": 2.9
+        "chromium": 9.853,
+        "webkit": 2.756
     },
     "frontend/src/lib/ui/ContextMenu/ContextMenu.stories.tsx": {
-        "chromium": 6.2,
-        "webkit": 2.7
+        "chromium": 6.047,
+        "webkit": 2.512
     },
     "frontend/src/lib/ui/DropdownMenu/DropdownMenu.stories.tsx": {
-        "chromium": 5.9,
-        "webkit": 2.8
+        "chromium": 6.255,
+        "webkit": 2.282
     },
     "frontend/src/lib/ui/ListBox/ListBox.stories.tsx": {
-        "chromium": 9.2,
-        "webkit": 2.6
+        "chromium": 10.009,
+        "webkit": 3.165
     },
     "frontend/src/lib/ui/SelectPrimitive/SelectPrimitive.stories.tsx": {
-        "chromium": 5.8,
-        "webkit": 2.4
+        "chromium": 6.224,
+        "webkit": 2.312
     },
     "frontend/src/lib/ui/TabsPrimitive/TabsPrimitive.stories.tsx": {
-        "chromium": 6.2,
-        "webkit": 2.5
+        "chromium": 6.164,
+        "webkit": 3.72
     },
     "frontend/src/lib/ui/WrappingLoadingSkeleton/WrappingLoadingSkeleton.stories.tsx": {
-        "chromium": 6.0,
-        "webkit": 2.5
+        "chromium": 6.447,
+        "webkit": 2.247
     },
     "frontend/src/lib/utils/AutocapturePreviewImage.stories.tsx": {
-        "chromium": 39.1,
-        "webkit": 3.4
+        "chromium": 44.743,
+        "webkit": 5.501
     },
     "frontend/src/queries/nodes/DataNode/DataNode.stories.tsx": {
-        "chromium": 2.5,
-        "webkit": 2.6
+        "chromium": 2.514,
+        "webkit": 1.922
     },
     "frontend/src/queries/nodes/DataTable/DataTable.stories.tsx": {
-        "chromium": 2.5,
-        "webkit": 2.5
+        "chromium": 2.431,
+        "webkit": 2.001
     },
     "frontend/src/queries/nodes/InsightViz/EditorFilters.stories.tsx": {
-        "chromium": 12.3,
-        "webkit": 2.6
+        "chromium": 12.197,
+        "webkit": 2.915
     },
     "frontend/src/queries/nodes/InsightViz/PropertyGroupFilters/AndOrFilterSelect.stories.tsx": {
-        "chromium": 5.8,
-        "webkit": 2.4
+        "chromium": 6.218,
+        "webkit": 2.95
     },
     "frontend/src/queries/nodes/WebVitals/WebVitals.stories.tsx": {
-        "chromium": 7.1,
-        "webkit": 2.8
+        "chromium": 7.274,
+        "webkit": 2.872
     },
     "frontend/src/queries/nodes/WebVitals/WebVitalsPathBreakdown.stories.tsx": {
-        "chromium": 6.4,
-        "webkit": 2.5
+        "chromium": 6.818,
+        "webkit": 2.431
     },
     "frontend/src/scenes/PreflightCheck/PreflightCheck.stories.tsx": {
-        "chromium": 6.5,
-        "webkit": 2.5
+        "chromium": 6.577,
+        "webkit": 2.387
     },
     "frontend/src/scenes/Unsubscribe/Unsubscribe.stories.tsx": {
-        "chromium": 6.8,
-        "webkit": 2.7
+        "chromium": 6.665,
+        "webkit": 2.425
     },
     "frontend/src/scenes/activity/explore/Events.stories.tsx": {
-        "chromium": 8.0,
-        "webkit": 2.6
+        "chromium": 8.501,
+        "webkit": 2.618
     },
     "frontend/src/scenes/annotations/Annotations.stories.tsx": {
-        "chromium": 10.1,
-        "webkit": 2.5
+        "chromium": 10.973,
+        "webkit": 2.4
     },
     "frontend/src/scenes/authentication/InviteSignup.stories.tsx": {
-        "chromium": 39.3,
-        "webkit": 2.9
+        "chromium": 40.085,
+        "webkit": 4.831
     },
     "frontend/src/scenes/authentication/Login.stories.tsx": {
-        "chromium": 30.1,
-        "webkit": 3.2
+        "chromium": 29.751,
+        "webkit": 5.477
     },
     "frontend/src/scenes/authentication/PasswordReset.stories.tsx": {
-        "chromium": 19.5,
-        "webkit": 2.8
+        "chromium": 22.195,
+        "webkit": 5.037
     },
     "frontend/src/scenes/authentication/PasswordResetComplete.stories.tsx": {
-        "chromium": 9.9,
-        "webkit": 2.6
+        "chromium": 10.575,
+        "webkit": 2.644
     },
     "frontend/src/scenes/authentication/signup/Signup.stories.tsx": {
-        "chromium": 14.7,
-        "webkit": 3.0
+        "chromium": 14.836,
+        "webkit": 3.644
     },
     "frontend/src/scenes/authentication/signup/verify-email/VerifyEmail.stories.tsx": {
-        "chromium": 18.4,
-        "webkit": 2.7
+        "chromium": 18.576,
+        "webkit": 3.445
     },
     "frontend/src/scenes/billing/Billing.stories.tsx": {
-        "chromium": 32.3,
-        "webkit": 3.5
+        "chromium": 35.52,
+        "webkit": 6.209
     },
     "frontend/src/scenes/billing/BillingProduct.stories.tsx": {
-        "chromium": 19.4,
-        "webkit": 3.3
+        "chromium": 21.604,
+        "webkit": 3.865
     },
     "frontend/src/scenes/cohorts/AddPersonToCohortModal.stories.tsx": {
-        "chromium": 12.6,
-        "webkit": 2.6
+        "chromium": 13.808,
+        "webkit": 3.734
     },
     "frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaRowBuilder.stories.tsx": {
-        "chromium": 6.0,
-        "webkit": 2.4
+        "chromium": 6.428,
+        "webkit": 2.788
     },
     "frontend/src/scenes/cohorts/CohortFilters/CohortNumberField.stories.tsx": {
-        "chromium": 6.1,
-        "webkit": 2.5
+        "chromium": 6.267,
+        "webkit": 2.765
     },
     "frontend/src/scenes/cohorts/CohortFilters/CohortPersonPropertiesValuesField.stories.tsx": {
-        "chromium": 6.0,
-        "webkit": 2.5
+        "chromium": 6.186,
+        "webkit": 2.876
     },
     "frontend/src/scenes/cohorts/CohortFilters/CohortSelectorField.stories.tsx": {
-        "chromium": 22.9,
-        "webkit": 3.0
+        "chromium": 25.85,
+        "webkit": 3.979
     },
     "frontend/src/scenes/cohorts/CohortFilters/CohortTaxonomicField.stories.tsx": {
-        "chromium": 8.8,
-        "webkit": 2.9
+        "chromium": 9.861,
+        "webkit": 3.823
     },
     "frontend/src/scenes/cohorts/CohortFilters/CohortTextField.stories.tsx": {
-        "chromium": 5.8,
-        "webkit": 2.8
+        "chromium": 5.993,
+        "webkit": 2.439
     },
     "frontend/src/scenes/cohorts/Cohorts.stories.tsx": {
-        "chromium": 31.5,
-        "webkit": 3.9
+        "chromium": 37.367,
+        "webkit": 8.643
     },
     "frontend/src/scenes/dashboard/DashboardInsightCardLegend.stories.tsx": {
-        "chromium": 2.7,
-        "webkit": 2.4
-    },
-    "frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplateModal.stories.tsx": {
-        "chromium": 10.1,
-        "webkit": 2.9
+        "chromium": 2.475,
+        "webkit": 3.346
     },
     "frontend/src/scenes/dashboard/Dashboards.stories.tsx": {
-        "chromium": 73.8,
-        "webkit": 4.6
+        "chromium": 73.248,
+        "webkit": 15.6
+    },
+    "frontend/src/scenes/dashboard/addInsightToDashboardModal/AddInsightToDashboardModal.stories.tsx": {
+        "chromium": 15.777,
+        "webkit": 6.803
+    },
+    "frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplateItem.stories.tsx": {
+        "webkit": 2.265
+    },
+    "frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplateModal.stories.tsx": {
+        "chromium": 14.891,
+        "webkit": 4.829
+    },
+    "frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplatesTable.stories.tsx": {
+        "chromium": 7.714,
+        "webkit": 3.792
     },
     "frontend/src/scenes/data-management/comments/Comments.stories.tsx": {
-        "chromium": 10.0,
-        "webkit": 2.4
+        "chromium": 10.654,
+        "webkit": 2.876
+    },
+    "frontend/src/scenes/data-management/events/DefinitionHeader.stories.tsx": {
+        "chromium": 13.613
+    },
+    "frontend/src/scenes/data-management/events/EventDefinitionsTable.stories.tsx": {
+        "chromium": 17.891,
+        "webkit": 5.153
     },
     "frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.stories.tsx": {
-        "chromium": 7.8,
-        "webkit": 2.8
+        "chromium": 7.92,
+        "webkit": 3.195
     },
     "frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetsScene.stories.tsx": {
-        "chromium": 7.1,
-        "webkit": 2.6
+        "chromium": 7.946,
+        "webkit": 2.739
+    },
+    "frontend/src/scenes/data-management/properties/PropertyDefinitionsTable.stories.tsx": {
+        "chromium": 17.917,
+        "webkit": 4.938
     },
     "frontend/src/scenes/data-pipelines/batch-exports/BatchExportScene.stories.tsx": {
-        "chromium": 45.0,
-        "webkit": 14.0
+        "chromium": 56.398,
+        "webkit": 13.473
+    },
+    "frontend/src/scenes/data-warehouse/editor/QueryHistoryModal.stories.tsx": {
+        "chromium": 10.491,
+        "webkit": 3.495
+    },
+    "frontend/src/scenes/data-warehouse/editor/sidebar/graph/UpstreamGraph.stories.tsx": {
+        "chromium": 14.53,
+        "webkit": 3.325
     },
     "frontend/src/scenes/data-warehouse/settings/source/Schemas.stories.tsx": {
-        "chromium": 6.9,
-        "webkit": 2.6
+        "chromium": 7.313,
+        "webkit": 2.797
     },
     "frontend/src/scenes/experiments/stories/DraftExperiment.stories.tsx": {
-        "chromium": 8.7,
-        "webkit": 2.5
+        "chromium": 10.238,
+        "webkit": 2.394
     },
     "frontend/src/scenes/experiments/stories/ExperimentAsymmetricIntervals.stories.tsx": {
-        "chromium": 10.6,
-        "webkit": 2.9
+        "chromium": 11.065,
+        "webkit": 3.086
     },
     "frontend/src/scenes/experiments/stories/ExperimentFrequentistFiveVariants.stories.tsx": {
-        "chromium": 11.7,
-        "webkit": 3.5
+        "chromium": 12.408,
+        "webkit": 3.445
     },
     "frontend/src/scenes/experiments/stories/ExperimentFrequentistTwoVariants.stories.tsx": {
-        "chromium": 11.0,
-        "webkit": 3.3
+        "chromium": 17.973,
+        "webkit": 3.478
     },
     "frontend/src/scenes/experiments/stories/ExperimentWithFunnelMetric.stories.tsx": {
-        "chromium": 10.7,
-        "webkit": 3.1
+        "chromium": 11.23,
+        "webkit": 3.349
     },
     "frontend/src/scenes/experiments/stories/ExperimentWithLegacyFunnelsQuery.stories.tsx": {
-        "chromium": 11.2,
-        "webkit": 3.3
+        "chromium": 12.134,
+        "webkit": 4.562
     },
     "frontend/src/scenes/experiments/stories/ExperimentWithLegacyTrendsQuery.stories.tsx": {
-        "chromium": 11.1,
-        "webkit": 3.5
+        "chromium": 12.304,
+        "webkit": 4.741
     },
     "frontend/src/scenes/experiments/stories/ExperimentWithMeanMetric.stories.tsx": {
-        "chromium": 9.9,
-        "webkit": 3.6
+        "chromium": 10.954,
+        "webkit": 4.774
     },
     "frontend/src/scenes/experiments/stories/ExperimentWithMultipleMetrics.stories.tsx": {
-        "chromium": 11.1,
-        "webkit": 3.3
+        "chromium": 11.582,
+        "webkit": 3.024
     },
     "frontend/src/scenes/experiments/stories/ExperimentWithMultipleMetricsReordered.stories.tsx": {
-        "chromium": 10.7,
-        "webkit": 3.3
+        "chromium": 11.105,
+        "webkit": 3.254
     },
     "frontend/src/scenes/experiments/stories/ExperimentWithRatioMetric.stories.tsx": {
-        "chromium": 10.9,
-        "webkit": 3.6
+        "chromium": 11.186,
+        "webkit": 2.836
     },
     "frontend/src/scenes/experiments/stories/Experiments.stories.tsx": {
-        "chromium": 9.4,
-        "webkit": 2.4
+        "webkit": 2.543
     },
     "frontend/src/scenes/feature-flags/FeatureFlagCodeInstructions.stories.tsx": {
-        "chromium": 23.4,
-        "webkit": 3.1
+        "chromium": 25.866,
+        "webkit": 4.632
     },
     "frontend/src/scenes/feature-flags/FeatureFlags.stories.tsx": {
-        "chromium": 43.2,
-        "webkit": 3.2
+        "chromium": 47.306,
+        "webkit": 10.527
     },
     "frontend/src/scenes/feature-flags/NewFeatureFlagMenu.stories.tsx": {
-        "chromium": 6.4,
-        "webkit": 2.5
+        "chromium": 7.013,
+        "webkit": 2.422
     },
     "frontend/src/scenes/funnels/FunnelFlowGraph/BuilderPathFlowNode.stories.tsx": {
-        "chromium": 8.0,
-        "webkit": 3.0
+        "chromium": 12.861,
+        "webkit": 3.337
     },
     "frontend/src/scenes/funnels/FunnelFlowGraph/BuilderStepNode.stories.tsx": {
-        "chromium": 8.0,
-        "webkit": 3.0
+        "chromium": 20.445,
+        "webkit": 3.735
     },
     "frontend/src/scenes/funnels/FunnelFlowGraph/FunnelFlowGraph.stories.tsx": {
-        "chromium": 30.0,
-        "webkit": 8.0
+        "chromium": 24.984,
+        "webkit": 4.554
     },
     "frontend/src/scenes/funnels/FunnelFlowGraph/JourneyFlowNode.stories.tsx": {
-        "chromium": 8.0,
-        "webkit": 3.0
+        "chromium": 27.25
     },
     "frontend/src/scenes/funnels/FunnelFlowGraph/PathFlowNode.stories.tsx": {
-        "chromium": 10.0,
-        "webkit": 3.5
+        "chromium": 22.951,
+        "webkit": 3.734
     },
     "frontend/src/scenes/funnels/FunnelFlowGraph/ProfileFlowNode.stories.tsx": {
-        "chromium": 8.0,
-        "webkit": 3.0
+        "chromium": 23.103,
+        "webkit": 3.642
     },
     "frontend/src/scenes/funnels/FunnelTooltip.stories.tsx": {
-        "chromium": 8.9,
-        "webkit": 2.9
+        "chromium": 9.538,
+        "webkit": 2.713
     },
     "frontend/src/scenes/groups/Groups.stories.tsx": {
-        "chromium": 7.7,
-        "webkit": 2.5
+        "chromium": 7.716,
+        "webkit": 2.835
+    },
+    "frontend/src/scenes/health/components/HealthTables.stories.tsx": {
+        "chromium": 47.094,
+        "webkit": 5.965
     },
     "frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapNewScene.stories.tsx": {
-        "chromium": 8.3,
-        "webkit": 2.5
+        "chromium": 8.714,
+        "webkit": 2.401
     },
     "frontend/src/scenes/heatmaps/scenes/heatmap/HeatmapScene.stories.tsx": {
-        "chromium": 21.6,
-        "webkit": 2.7
+        "chromium": 23.552,
+        "webkit": 5.095
     },
     "frontend/src/scenes/heatmaps/scenes/heatmaps/HeatmapsScene.stories.tsx": {
-        "chromium": 7.3,
-        "webkit": 2.7
+        "chromium": 7.755,
+        "webkit": 2.527
+    },
+    "frontend/src/scenes/hog-functions/HogFunctionScene.stories.tsx": {
+        "chromium": 37.683,
+        "webkit": 8.834
     },
     "frontend/src/scenes/insights/EmptyStates/EmptyStates.stories.tsx": {
-        "chromium": 52.2,
-        "webkit": 4.0
+        "chromium": 58.589,
+        "webkit": 9.306
     },
     "frontend/src/scenes/insights/EmptyStates/LoadingMessages.stories.tsx": {
-        "chromium": 6.2,
-        "webkit": 2.7
+        "chromium": 6.69,
+        "webkit": 2.599
     },
     "frontend/src/scenes/insights/Funnels.stories.tsx": {
-        "chromium": 86.0,
-        "webkit": 4.1
+        "chromium": 138.086,
+        "webkit": 27.737
     },
     "frontend/src/scenes/insights/InsightQuickStart/InsightQuickStart.stories.tsx": {
-        "chromium": 8.8,
-        "webkit": 2.5
+        "chromium": 9.0,
+        "webkit": 2.495
     },
     "frontend/src/scenes/insights/InsightTooltip/InsightTooltip.stories.tsx": {
-        "chromium": 2.8,
-        "webkit": 2.4
+        "chromium": 2.497,
+        "webkit": 1.994
     },
     "frontend/src/scenes/insights/Lifecycle.stories.tsx": {
-        "chromium": 15.7,
-        "webkit": 2.9
+        "chromium": 38.873,
+        "webkit": 6.248
     },
     "frontend/src/scenes/insights/Retention.stories.tsx": {
-        "chromium": 17.7,
-        "webkit": 2.8
+        "chromium": 42.019,
+        "webkit": 6.576
+    },
+    "frontend/src/scenes/insights/SidePanel/InsightPanelActions.stories.tsx": {
+        "webkit": 6.086
+    },
+    "frontend/src/scenes/insights/Stickiness.stories.tsx": {
+        "chromium": 40.39,
+        "webkit": 7.183
     },
     "frontend/src/scenes/insights/UserPaths.stories.tsx": {
-        "chromium": 10.4,
-        "webkit": 2.6
+        "chromium": 43.824,
+        "webkit": 11.161
     },
     "frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.stories.tsx": {
-        "chromium": 21.1,
-        "webkit": 3.7
+        "chromium": 23.548,
+        "webkit": 4.37
     },
     "frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.stories.tsx": {
-        "chromium": 6.4,
-        "webkit": 2.5
+        "chromium": 6.788,
+        "webkit": 2.197
+    },
+    "frontend/src/scenes/insights/stories/SQLLineChart.stories.tsx": {
+        "webkit": 4.448
+    },
+    "frontend/src/scenes/insights/stories/TrendsBoxPlot.stories.tsx": {
+        "chromium": 18.776
     },
     "frontend/src/scenes/insights/stories/TrendsLine.stories.tsx": {
-        "chromium": 101.0,
-        "webkit": 6.1
+        "chromium": 129.058,
+        "webkit": 21.346
     },
     "frontend/src/scenes/insights/stories/TrendsPie.stories.tsx": {
-        "chromium": 59.3,
-        "webkit": 4.5
+        "chromium": 88.882,
+        "webkit": 11.089
     },
     "frontend/src/scenes/insights/stories/TrendsValue.stories.tsx": {
-        "chromium": 97.9,
-        "webkit": 5.2
+        "chromium": 146.784,
+        "webkit": 22.686
+    },
+    "frontend/src/scenes/insights/views/BoldNumber/BoldNumber.stories.tsx": {
+        "chromium": 19.936,
+        "webkit": 6.752
     },
     "frontend/src/scenes/insights/views/BoldNumber/Textfit.stories.tsx": {
-        "chromium": 6.2,
-        "webkit": 2.8
+        "chromium": 6.056,
+        "webkit": 2.351
     },
     "frontend/src/scenes/insights/views/Funnels/FunnelCorrelationTable.stories.tsx": {
-        "chromium": 6.5,
-        "webkit": 2.6
+        "chromium": 6.703,
+        "webkit": 2.518
     },
     "frontend/src/scenes/insights/views/Funnels/FunnelPropertyCorrelationTable.stories.tsx": {
-        "chromium": 6.7,
-        "webkit": 2.7
+        "chromium": 6.795,
+        "webkit": 3.969
     },
     "frontend/src/scenes/insights/views/InsightsTable/InsightsTable.stories.tsx": {
-        "chromium": 19.3,
-        "webkit": 3.3
+        "chromium": 24.642,
+        "webkit": 4.695
+    },
+    "frontend/src/scenes/insights/views/RegionMap/RegionMap.stories.tsx": {
+        "chromium": 16.128,
+        "webkit": 2.653
+    },
+    "frontend/src/scenes/insights/views/WorldMap/WorldMap.stories.tsx": {
+        "webkit": 2.271
     },
     "frontend/src/scenes/max/Max.stories.tsx": {
-        "chromium": 176.6,
-        "webkit": 13.5
+        "chromium": 215.227,
+        "webkit": 41.945
     },
     "frontend/src/scenes/notebooks/Nodes/NotebookNodeCustomerJourney/NotebookNodeCustomerJourney.stories.tsx": {
-        "chromium": 40.0,
-        "webkit": 10.0
+        "chromium": 25.824,
+        "webkit": 6.13
+    },
+    "frontend/src/scenes/notebooks/Nodes/NotebookNodeSupportTickets.stories.tsx": {
+        "chromium": 14.579,
+        "webkit": 3.423
     },
     "frontend/src/scenes/notebooks/Notebook/Notebook.stories.tsx": {
-        "chromium": 49.1,
-        "webkit": 4.6
+        "chromium": 55.253,
+        "webkit": 14.308
     },
     "frontend/src/scenes/notebooks/NotebookSelectButton/NotebookSelectButton.stories.tsx": {
-        "chromium": 20.7,
-        "webkit": 3.2
+        "chromium": 23.829,
+        "webkit": 3.996
     },
     "frontend/src/scenes/oauth/OAuthAuthorize.stories.tsx": {
-        "chromium": 11.8,
-        "webkit": 2.6
+        "chromium": 12.798,
+        "webkit": 4.108
     },
     "frontend/src/scenes/onboarding/Onboarding.stories.tsx": {
-        "chromium": 57.5,
-        "webkit": 5.1
+        "chromium": 59.737,
+        "webkit": 13.58
+    },
+    "frontend/src/scenes/onboarding/PostOnboardingModal.stories.tsx": {
+        "chromium": 78.088,
+        "webkit": 6.074
     },
     "frontend/src/scenes/onboarding/productSelection/ProductSelection.stories.tsx": {
-        "chromium": 14.7,
-        "webkit": 2.7
+        "chromium": 7.438,
+        "webkit": 2.547
     },
     "frontend/src/scenes/persons-management/Persons.stories.tsx": {
-        "chromium": 12.6,
-        "webkit": 2.6
+        "chromium": 13.49,
+        "webkit": 3.76
     },
     "frontend/src/scenes/persons/PersonScene.stories.tsx": {
-        "chromium": 16.8,
-        "webkit": 2.8
+        "chromium": 17.821,
+        "webkit": 4.144
     },
     "frontend/src/scenes/project-homepage/ProjectHomepage.stories.tsx": {
-        "chromium": 15.8,
-        "webkit": 2.6
+        "chromium": 21.252,
+        "webkit": 4.664
     },
     "frontend/src/scenes/saved-insights/SavedInsights.stories.tsx": {
-        "chromium": 12.4,
-        "webkit": 2.7
+        "chromium": 14.063,
+        "webkit": 3.859
     },
     "frontend/src/scenes/session-recordings/SessionsRecordings-activity-modal.stories.tsx": {
-        "chromium": 8.3,
-        "webkit": 2.4
+        "webkit": 2.451
     },
     "frontend/src/scenes/session-recordings/SessionsRecordings-group-scene.stories.tsx": {
-        "chromium": 19.3,
-        "webkit": 3.2
+        "chromium": 21.612,
+        "webkit": 5.269
     },
     "frontend/src/scenes/session-recordings/SessionsRecordings-person-scene.stories.tsx": {
-        "chromium": 13.1,
-        "webkit": 3.4
+        "chromium": 14.92,
+        "webkit": 5.235
     },
     "frontend/src/scenes/session-recordings/SessionsRecordings-player-failure.stories.tsx": {
-        "chromium": 8.1,
-        "webkit": 2.6
+        "chromium": 9.081,
+        "webkit": 2.62
     },
     "frontend/src/scenes/session-recordings/SessionsRecordings-player-success.stories.tsx": {
-        "chromium": 47.1,
-        "webkit": 5.0
+        "chromium": 58.644,
+        "webkit": 12.61
     },
     "frontend/src/scenes/session-recordings/SessionsRecordings-playlist-listing.stories.tsx": {
-        "chromium": 8.3,
-        "webkit": 2.8
+        "chromium": 8.266,
+        "webkit": 3.84
+    },
+    "frontend/src/scenes/session-recordings/apm/NetworkView.stories.tsx": {
+        "chromium": 6.598,
+        "webkit": 2.411
     },
     "frontend/src/scenes/session-recordings/apm/playerInspector/ItemPerformanceEvent.stories.tsx": {
-        "chromium": 15.1,
-        "webkit": 3.2
+        "chromium": 16.61,
+        "webkit": 4.821
     },
     "frontend/src/scenes/session-recordings/components/RecordingsRow.stories.tsx": {
-        "chromium": 6.1,
-        "webkit": 2.5
+        "chromium": 6.43,
+        "webkit": 3.964
+    },
+    "frontend/src/scenes/session-recordings/player/RecordingDeleted.stories.tsx": {
+        "chromium": 9.489
     },
     "frontend/src/scenes/session-recordings/player/commenting/PlayerCommentModal.stories.tsx": {
-        "webkit": 2.6
+        "chromium": 6.727,
+        "webkit": 2.36
     },
     "frontend/src/scenes/session-recordings/player/controller/PlayerController.stories.tsx": {
-        "chromium": 25.0,
-        "webkit": 3.3
+        "chromium": 21.836,
+        "webkit": 4.161
     },
     "frontend/src/scenes/session-recordings/player/inspector/PlayerInspector.stories.tsx": {
-        "chromium": 6.8,
-        "webkit": 2.6
+        "chromium": 6.942,
+        "webkit": 2.5
     },
     "frontend/src/scenes/session-recordings/player/inspector/components/ItemAppState.stories.tsx": {
-        "chromium": 12.4,
-        "webkit": 2.9
+        "chromium": 14.136,
+        "webkit": 3.337
     },
     "frontend/src/scenes/session-recordings/player/inspector/components/ItemComment.stories.tsx": {
-        "chromium": 9.3,
-        "webkit": 2.7
+        "chromium": 10.632,
+        "webkit": 3.318
     },
     "frontend/src/scenes/session-recordings/player/inspector/components/ItemConsoleLog.stories.tsx": {
-        "chromium": 6.4,
-        "webkit": 2.7
+        "chromium": 6.558,
+        "webkit": 2.445
+    },
+    "frontend/src/scenes/session-recordings/player/inspector/components/ItemDoctor.stories.tsx": {
+        "chromium": 34.059,
+        "webkit": 4.768
     },
     "frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.stories.tsx": {
-        "chromium": 35.2,
-        "webkit": 4.4
+        "chromium": 39.752,
+        "webkit": 5.544
     },
     "frontend/src/scenes/session-recordings/player/inspector/components/ItemSessionChange.stories.tsx": {
-        "chromium": 8.8,
-        "webkit": 2.7
+        "chromium": 9.677,
+        "webkit": 2.84
     },
     "frontend/src/scenes/session-recordings/player/inspector/components/NavigationItem.stories.tsx": {
-        "chromium": 40.3,
-        "webkit": 3.5
+        "chromium": 46.743,
+        "webkit": 5.773
     },
     "frontend/src/scenes/session-recordings/player/inspector/components/Timing/NetworkRequestTiming.stories.tsx": {
-        "chromium": 6.0,
-        "webkit": 2.6
+        "chromium": 6.789,
+        "webkit": 3.286
     },
     "frontend/src/scenes/session-recordings/player/share/PlayerShareDialog.stories.tsx": {
-        "chromium": 22.2,
-        "webkit": 3.0
+        "chromium": 13.722,
+        "webkit": 2.904
     },
     "frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarOverviewOtherWatchers.stories.tsx": {
-        "chromium": 15.5,
-        "webkit": 2.8
+        "chromium": 16.537,
+        "webkit": 4.382
     },
     "frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarOverviewTab.stories.tsx": {
-        "chromium": 17.0,
-        "webkit": 3.2
+        "chromium": 18.523,
+        "webkit": 3.525
     },
     "frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.stories.tsx": {
-        "chromium": 22.4,
-        "webkit": 2.7
+        "chromium": 25.13,
+        "webkit": 3.642
     },
     "frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistScene.stories.tsx": {
-        "chromium": 2.6,
-        "webkit": 2.3
+        "chromium": 2.395,
+        "webkit": 2.021
     },
     "frontend/src/scenes/settings/environment/SlackIntegration.stories.tsx": {
-        "chromium": 12.2,
-        "webkit": 2.9
+        "chromium": 13.163,
+        "webkit": 2.844
     },
     "frontend/src/scenes/settings/organization/Invites.stories.tsx": {
-        "chromium": 20.7,
-        "webkit": 3.3
+        "chromium": 24.664,
+        "webkit": 5.407
+    },
+    "frontend/src/scenes/settings/organization/OAuthApps.stories.tsx": {
+        "chromium": 9.487,
+        "webkit": 2.713
     },
     "frontend/src/scenes/settings/organization/VerifiedDomains/SSOSelect.stories.tsx": {
-        "chromium": 5.9,
-        "webkit": 2.5
+        "chromium": 6.368,
+        "webkit": 2.397
+    },
+    "frontend/src/scenes/settings/organization/VerifiedDomains/VerifiedDomains.stories.tsx": {
+        "chromium": 27.216,
+        "webkit": 6.617
     },
     "frontend/src/scenes/settings/stories/SettingsEnvironment.stories.tsx": {
-        "chromium": 84.1,
-        "webkit": 6.7
+        "chromium": 126.802,
+        "webkit": 29.871
     },
     "frontend/src/scenes/settings/stories/SettingsOrganization.stories.tsx": {
-        "chromium": 39.8,
-        "webkit": 4.3
+        "chromium": 47.794,
+        "webkit": 11.723
     },
     "frontend/src/scenes/settings/stories/SettingsProject.stories.tsx": {
-        "chromium": 49.4,
-        "webkit": 4.9
+        "chromium": 57.4,
+        "webkit": 11.978
     },
     "frontend/src/scenes/settings/stories/SettingsUser.stories.tsx": {
-        "chromium": 27.5,
-        "webkit": 3.9
+        "chromium": 35.061,
+        "webkit": 8.416
+    },
+    "frontend/src/scenes/subscriptions/SubscriptionsTable.stories.tsx": {
+        "chromium": 6.615,
+        "webkit": 2.396
     },
     "frontend/src/scenes/surveys/Surveys.stories.tsx": {
-        "chromium": 55.8,
-        "webkit": 5.5
+        "chromium": 62.814,
+        "webkit": 12.386
+    },
+    "frontend/src/scenes/surveys/components/SurveyResponseKeysReference.stories.tsx": {
+        "chromium": 35.162,
+        "webkit": 7.311
     },
     "frontend/src/scenes/toolbar-launch/ToolbarLaunch.stories.tsx": {
-        "chromium": 16.8,
-        "webkit": 3.4
+        "chromium": 19.031,
+        "webkit": 3.888
     },
     "frontend/src/scenes/trends/persons-modal/PersonsModal.stories.tsx": {
-        "chromium": 17.1,
-        "webkit": 2.7
+        "chromium": 21.851,
+        "webkit": 4.077
     },
     "frontend/src/scenes/web-analytics/CalendarHeatMap/CalendarHeatMap.stories.tsx": {
-        "chromium": 22.2,
-        "webkit": 2.8
+        "chromium": 25.385,
+        "webkit": 4.002
     },
     "frontend/src/scenes/web-analytics/SessionAttributionExplorer/sessionAttributionExplorer.stories.tsx": {
-        "chromium": 7.4,
-        "webkit": 2.6
+        "chromium": 7.909,
+        "webkit": 2.401
     },
     "frontend/src/scenes/web-analytics/WebAnalyticsDashboard.stories.tsx": {
-        "chromium": 10.9,
-        "webkit": 2.5
+        "chromium": 11.009,
+        "webkit": 2.447
     },
     "frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/NonIntegratedConversionsTable/CellActionsMenu.stories.tsx": {
-        "chromium": 23.3,
-        "webkit": 3.6
+        "chromium": 26.635,
+        "webkit": 4.443
     },
     "frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.stories.tsx": {
-        "chromium": 21.4,
-        "webkit": 3.3
+        "chromium": 23.269,
+        "webkit": 5.701
     },
     "frontend/src/toolbar/Toolbar.stories.tsx": {
-        "chromium": 72.4,
-        "webkit": 2.4
+        "chromium": 83.483,
+        "webkit": 2.863
+    },
+    "mosaic/storybook/Components.stories.tsx": {
+        "chromium": 26.569,
+        "webkit": 7.556
     },
     "products/actions/frontend/pages/Action.stories.tsx": {
-        "chromium": 26.4,
-        "webkit": 3.4
+        "chromium": 34.078,
+        "webkit": 7.216
+    },
+    "products/actions/mcp/apps/Actions.stories.tsx": {
+        "chromium": 10.891,
+        "webkit": 3.829
+    },
+    "products/cohorts/mcp/apps/Cohorts.stories.tsx": {
+        "chromium": 10.751,
+        "webkit": 3.571
+    },
+    "products/customer_analytics/frontend/CustomerAnalyticsScene.stories.tsx": {
+        "chromium": 27.564,
+        "webkit": 6.135
     },
     "products/customer_analytics/frontend/components/CustomerJourneys/CustomerJourneys.stories.tsx": {
-        "chromium": 25.0,
-        "webkit": 7.0
+        "chromium": 7.773,
+        "webkit": 2.303
+    },
+    "products/customer_analytics/frontend/scenes/CustomerJourneyBuilderScene/CustomerJourneyBuilderScene.stories.tsx": {
+        "chromium": 10.589,
+        "webkit": 2.494
+    },
+    "products/customer_analytics/frontend/scenes/CustomerJourneyTemplatesScene/CustomerJourneyTemplatesScene.stories.tsx": {
+        "chromium": 12.804
     },
     "products/early_access_features/frontend/EarlyAccessFeatures.stories.tsx": {
-        "chromium": 17.0,
-        "webkit": 3.3
+        "chromium": 18.366,
+        "webkit": 6.615
     },
     "products/error_tracking/frontend/ErrorTracking.stories.tsx": {
-        "chromium": 12.2,
-        "webkit": 2.6
+        "chromium": 13.034,
+        "webkit": 4.989
     },
     "products/error_tracking/frontend/components/Assignee/AssigneeDisplay.stories.tsx": {
-        "chromium": 14.3,
-        "webkit": 2.9
+        "chromium": 16.304,
+        "webkit": 3.421
     },
     "products/error_tracking/frontend/components/ContextDisplay/ContextDisplay.stories.tsx": {
-        "chromium": 13.6,
-        "webkit": 2.8
+        "chromium": 15.272,
+        "webkit": 3.888
     },
     "products/error_tracking/frontend/components/ExceptionCard/ExceptionCard.stories.tsx": {
-        "chromium": 15.2,
-        "webkit": 3.1
+        "chromium": 16.745,
+        "webkit": 4.289
     },
     "products/error_tracking/frontend/components/ExceptionCard/Tabs/StackTraceTab/StackTraceDisplay.stories.tsx": {
-        "chromium": 37.9,
-        "webkit": 4.2
+        "chromium": 49.347,
+        "webkit": 7.025
+    },
+    "products/error_tracking/frontend/components/VolumeSparkline/VolumeSparkline.stories.tsx": {
+        "chromium": 24.117,
+        "webkit": 4.429
+    },
+    "products/error_tracking/mcp/apps/ErrorTracking.stories.tsx": {
+        "chromium": 18.987,
+        "webkit": 4.586
+    },
+    "products/experiments/mcp/apps/Experiments.stories.tsx": {
+        "chromium": 13.593,
+        "webkit": 3.43
+    },
+    "products/feature_flags/mcp/apps/FeatureFlags.stories.tsx": {
+        "webkit": 3.343
     },
     "products/links/frontend/LinksScene.stories.tsx": {
-        "chromium": 16.3,
-        "webkit": 3.0
+        "chromium": 18.949,
+        "webkit": 5.295
     },
     "products/llm_analytics/frontend/ConversationDisplay/ConversationDisplay.stories.tsx": {
-        "chromium": 18.5,
-        "webkit": 3.5
+        "chromium": 20.73,
+        "webkit": 5.229
     },
     "products/llm_analytics/frontend/LLMAnalyticsTraceScene.stories.tsx": {
-        "chromium": 18.4,
-        "webkit": 3.1
+        "chromium": 19.139,
+        "webkit": 4.13
+    },
+    "products/llm_analytics/frontend/components/SentimentTag.stories.tsx": {
+        "chromium": 48.501,
+        "webkit": 5.731
+    },
+    "products/llm_analytics/mcp/apps/LLMAnalytics.stories.tsx": {
+        "chromium": 8.714,
+        "webkit": 3.396
     },
     "products/logs/frontend/LogsScene.stories.tsx": {
-        "chromium": 3.1,
-        "webkit": 2.3
+        "chromium": 2.785,
+        "webkit": 1.845
     },
     "products/revenue_analytics/frontend/Onboarding/Onboarding.stories.tsx": {
-        "chromium": 14.0,
-        "webkit": 2.9
+        "chromium": 15.08,
+        "webkit": 3.327
     },
     "products/revenue_analytics/frontend/RevenueAnalyticsScene.stories.tsx": {
-        "chromium": 19.4,
-        "webkit": 3.2
+        "chromium": 20.034,
+        "webkit": 4.012
     },
     "products/revenue_analytics/frontend/nodes/modals/MRRBreakdownModal.stories.tsx": {
-        "chromium": 7.1,
-        "webkit": 2.4
+        "chromium": 7.277,
+        "webkit": 2.526
     },
     "products/revenue_analytics/frontend/settings/EventConfigurationModal.stories.tsx": {
-        "chromium": 6.6,
-        "webkit": 2.6
+        "chromium": 6.998,
+        "webkit": 2.878
     },
     "products/revenue_analytics/frontend/settings/RevenueAnalyticsSettings.stories.tsx": {
-        "chromium": 10.2,
-        "webkit": 2.4
+        "chromium": 11.503,
+        "webkit": 2.455
+    },
+    "products/surveys/mcp/apps/Surveys.stories.tsx": {
+        "chromium": 12.865,
+        "webkit": 3.504
+    },
+    "products/workflows/mcp/apps/Workflows.stories.tsx": {
+        "chromium": 10.739,
+        "webkit": 4.572
     }
 }

--- a/common/storybook/test-sequencer.js
+++ b/common/storybook/test-sequencer.js
@@ -44,7 +44,11 @@ function getDuration(timings, relativePath, browser) {
 function binPackShard(tests, shardCount, shardIndex, timings, browser) {
     // Canonical path order upfront — makes the entire partition deterministic
     // regardless of readdir order on the CI runner's filesystem.
-    const sorted = [...tests].sort((a, b) => getRelativePath(a).localeCompare(getRelativePath(b)))
+    const sorted = [...tests].sort((a, b) => {
+        const pa = getRelativePath(a)
+        const pb = getRelativePath(b)
+        return pa < pb ? -1 : pa > pb ? 1 : 0
+    })
 
     const known = []
     const unknown = []

--- a/common/storybook/test-sequencer.js
+++ b/common/storybook/test-sequencer.js
@@ -42,10 +42,14 @@ function getDuration(timings, relativePath, browser) {
 // Tests without timing data go into a separate pool and are spread evenly
 // after the known tests are placed.
 function binPackShard(tests, shardCount, shardIndex, timings, browser) {
+    // Canonical path order upfront — makes the entire partition deterministic
+    // regardless of readdir order on the CI runner's filesystem.
+    const sorted = [...tests].sort((a, b) => getRelativePath(a).localeCompare(getRelativePath(b)))
+
     const known = []
     const unknown = []
 
-    for (const test of tests) {
+    for (const test of sorted) {
         const rel = getRelativePath(test)
         const duration = getDuration(timings, rel, browser)
         if (duration !== null) {
@@ -55,7 +59,7 @@ function binPackShard(tests, shardCount, shardIndex, timings, browser) {
         }
     }
 
-    // Sort known tests longest-first
+    // Sort known tests longest-first. Stable sort preserves path order for ties.
     known.sort((a, b) => b.duration - a.duration)
 
     const shardTotals = new Array(shardCount).fill(0)

--- a/common/storybook/update-storybook-timings.sh
+++ b/common/storybook/update-storybook-timings.sh
@@ -72,7 +72,7 @@ for xml_file in sorted(tmpdir.rglob('junit.xml')):
 
         if filepath not in timings:
             timings[filepath] = {}
-        timings[filepath][browser] = round(time_s, 1)
+        timings[filepath][browser] = round(time_s, 3)
 
 if not timings:
     print('ERROR: No test timings found in JUnit artifacts', file=sys.stderr)


### PR DESCRIPTION
**Problem**
The storybook bin-packing sequencer produces different partitions on different CI runners. Each shard job discovers files via `readdir` (non-deterministic order across Linux filesystems), and since `Array.sort` is stable, duration ties preserve whatever `readdir` order each runner happened to use. With 58% of files sharing a duration value (from rounding to 0.1s), the greedy placement diverges across runners — different shards disagree on which files belong where.

Simulated impact per CI run: ~22% of story files missed entirely, ~15% duplicated across shards, only ~59% landing on exactly one shard. This was masked before because all shards uploaded all committed PNGs.

**Changes**
- Sort the input array by path at the top of `binPackShard` so the partition is deterministic regardless of filesystem discovery order
- Increase timing precision from 1 to 3 decimal places in `update-storybook-timings.sh` (reduces duration ties from 182 files to 4)
- Refresh `storybook-timings.json` from latest master CI run (coverage 80% → 96%)

**How did you test this code?**
Wrote a simulation that runs 100 trials of 16 independent shard jobs, each with randomly shuffled input. Before the fix: ~75 files missed, ~50 duplicated per trial. After the fix: all 336 files on exactly 1 shard, every trial.

## 🤖 LLM context
Agent-authored. Root cause identified by simulating the bin-packing algorithm with randomized input orders matching what different CI runners would see.