### PR TITLE
feat(subscriptions): add custom prompt guide per subscription

### DIFF
--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -91,6 +91,7 @@ class SubscriptionSerializer(serializers.ModelSerializer):
             "integration_id",
             "invite_message",
             "summary_enabled",
+            "summary_prompt_guide",
         ]
         read_only_fields = [
             "id",
@@ -153,6 +154,10 @@ class SubscriptionSerializer(serializers.ModelSerializer):
                 raise ValidationError(
                     {"summary_enabled": ["AI change summaries are not available on your current plan."]}
                 )
+
+        prompt_guide = attrs.get("summary_prompt_guide")
+        if prompt_guide and len(prompt_guide) > 500:
+            raise ValidationError({"summary_prompt_guide": ["Prompt guide must be 500 characters or fewer."]})
 
         return attrs
 

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -438,6 +438,19 @@ export function EditSubscription({
                             </LemonField>
                         </PayGateMini>
 
+                        {subscription.summary_enabled && (
+                            <LemonField
+                                name="summary_prompt_guide"
+                                label="Context for the AI summary"
+                                showOptional
+                            >
+                                <LemonTextArea
+                                    placeholder="e.g. This is a daily revenue health check - focus on revenue drop-off and churn signals"
+                                    maxLength={500}
+                                />
+                            </LemonField>
+                        )}
+
                         {insightShortId && (
                             <div>
                                 <LemonLabel className="mb-2">Preview</LemonLabel>

--- a/posthog/models/subscription.py
+++ b/posthog/models/subscription.py
@@ -112,6 +112,7 @@ class Subscription(models.Model):
 
     # AI change summary
     summary_enabled = models.BooleanField(default=False)
+    summary_prompt_guide = models.CharField(max_length=500, blank=True, default="")
 
     class Meta:
         indexes = [


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
