### PR TITLE
feat: expose email_* fields to workflow

### DIFF
--- a/nodejs/src/cdp/async-functions/conversations.ts
+++ b/nodejs/src/cdp/async-functions/conversations.ts
@@ -63,6 +63,10 @@ registerAsyncFunction('postHogGetTicket', {
                 slack_channel_id: null,
                 slack_thread_ts: null,
                 slack_team_id: null,
+                email_subject: null,
+                email_from: null,
+                email_to: null,
+                cc_participants: [],
                 tags: [],
             },
         }

--- a/products/conversations/backend/api/external.py
+++ b/products/conversations/backend/api/external.py
@@ -102,9 +102,9 @@ class ExternalTicketView(APIView):
         assert team is not None
 
         try:
-            ticket = Ticket.objects.select_related("assignment", "assignment__user", "assignment__role").get(
-                id=ticket_id, team_id=team.id
-            )
+            ticket = Ticket.objects.select_related(
+                "assignment", "assignment__user", "assignment__role", "email_config"
+            ).get(id=ticket_id, team_id=team.id)
         except Ticket.DoesNotExist:
             return Response({"error": "Ticket not found"}, status=status.HTTP_404_NOT_FOUND)
 
@@ -147,6 +147,10 @@ class ExternalTicketView(APIView):
                 "slack_channel_id": ticket.slack_channel_id,
                 "slack_thread_ts": ticket.slack_thread_ts,
                 "slack_team_id": ticket.slack_team_id,
+                "email_subject": ticket.email_subject,
+                "email_from": ticket.email_from,
+                "email_to": ticket.email_config.from_email if ticket.email_config else None,
+                "cc_participants": ticket.cc_participants,
                 "tags": tags,
             }
         )

--- a/products/conversations/backend/api/tests/test_external.py
+++ b/products/conversations/backend/api/tests/test_external.py
@@ -298,15 +298,22 @@ class TestExternalTicketAPI(BaseTest):
         self.assertEqual(data["slack_team_id"], "T0987654321")
 
     def test_get_ticket_returns_email_fields(self):
+        from products.conversations.backend.models.team_conversations_email_config import EmailChannel
+
+        channel = EmailChannel.objects.create(
+            team=self.team, inbound_token="abc123", from_email="support@example.com", from_name="Support"
+        )
+        self.ticket.email_config = channel
         self.ticket.email_subject = "Need help with billing"
         self.ticket.email_from = "customer@example.com"
         self.ticket.cc_participants = ["cc1@example.com", "cc2@example.com"]
-        self.ticket.save(update_fields=["email_subject", "email_from", "cc_participants"])
+        self.ticket.save(update_fields=["email_config", "email_subject", "email_from", "cc_participants"])
         response = self.client.get(self.url, **self._auth_headers())
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         self.assertEqual(data["email_subject"], "Need help with billing")
         self.assertEqual(data["email_from"], "customer@example.com")
+        self.assertEqual(data["email_to"], "support@example.com")
         self.assertEqual(data["cc_participants"], ["cc1@example.com", "cc2@example.com"])
 
     def test_get_ticket_returns_tags(self):

--- a/products/conversations/backend/api/tests/test_external.py
+++ b/products/conversations/backend/api/tests/test_external.py
@@ -96,6 +96,10 @@ class TestExternalTicketAPI(BaseTest):
         self.assertIsNone(data["slack_channel_id"])
         self.assertIsNone(data["slack_thread_ts"])
         self.assertIsNone(data["slack_team_id"])
+        self.assertIsNone(data["email_subject"])
+        self.assertIsNone(data["email_from"])
+        self.assertIsNone(data["email_to"])
+        self.assertEqual(data["cc_participants"], [])
         self.assertEqual(data["tags"], [])
         self.assertIn("created_at", data)
         self.assertIn("updated_at", data)
@@ -292,6 +296,18 @@ class TestExternalTicketAPI(BaseTest):
         self.assertEqual(data["slack_channel_id"], "C1234567890")
         self.assertEqual(data["slack_thread_ts"], "1234567890.123456")
         self.assertEqual(data["slack_team_id"], "T0987654321")
+
+    def test_get_ticket_returns_email_fields(self):
+        self.ticket.email_subject = "Need help with billing"
+        self.ticket.email_from = "customer@example.com"
+        self.ticket.cc_participants = ["cc1@example.com", "cc2@example.com"]
+        self.ticket.save(update_fields=["email_subject", "email_from", "cc_participants"])
+        response = self.client.get(self.url, **self._auth_headers())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["email_subject"], "Need help with billing")
+        self.assertEqual(data["email_from"], "customer@example.com")
+        self.assertEqual(data["cc_participants"], ["cc1@example.com", "cc2@example.com"])
 
     def test_get_ticket_returns_tags(self):
         from posthog.models import Tag

--- a/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/hogFlowEditorLogic.tsx
@@ -774,6 +774,10 @@ export const hogFlowEditorLogic = kea<hogFlowEditorLogicType>([
                                 ['slack_channel_id', 'Slack channel ID'],
                                 ['slack_thread_ts', 'Slack thread timestamp'],
                                 ['slack_team_id', 'Slack team ID'],
+                                ['email_subject', 'Email subject'],
+                                ['email_from', 'Email from'],
+                                ['email_to', 'Email to'],
+                                ['cc_participants', 'CC participants'],
                             ]
 
                             const newVars = spreadFields


### PR DESCRIPTION
Email fields to workflow

<img width="592" height="155" alt="Screenshot 2026-04-15 at 13 01 30" src="https://github.com/user-attachments/assets/46d855f8-58b4-4995-b6dd-2ab6a17d4685" />
