### PR TITLE
refactor(hogql): move postgres branches out of BasePrinter

### DIFF
--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -105,6 +105,86 @@ class BasePrinter(Visitor[str]):
         """
         return True
 
+    def _assert_set_operator_supported(self, set_operator: str) -> None:
+        """Raise if this dialect does not support the given set operator. Postgres overrides to permit all."""
+        if set_operator in ("INTERSECT ALL", "EXCEPT ALL"):
+            raise ImpossibleASTError(f"{set_operator} is not supported in the '{self.dialect}' dialect")
+
+    def _assert_recursive_cte_supported(self) -> None:
+        """Raise if this dialect does not support recursive CTEs. Postgres overrides to permit."""
+        raise ImpossibleASTError("Recursive CTEs are only supported in PostgreSQL dialect")
+
+    def _assert_qualify_supported(self) -> None:
+        """Raise if this dialect does not support the QUALIFY clause. Postgres overrides to permit."""
+        raise QueryError("QUALIFY is not supported in the '{}' dialect".format(self.dialect))
+
+    def _assert_with_ties_supported(self) -> None:
+        """Raise if this dialect does not support WITH TIES. Postgres overrides to reject."""
+        return
+
+    def _render_column_aliases_inline_suffix(self, column_aliases: list[str]) -> str:
+        """Suffix appended to ``AS alias`` when ``column_aliases`` are present. Postgres emits ``(col_a, col_b)``."""
+        return ""
+
+    def _render_column_aliases_appended(self, column_aliases: list[str]) -> str | None:
+        """String appended to the join-expression list when column aliases apply outside a SELECT alias.
+
+        Default returns ``None`` (not emitted); Postgres returns ``(col_a, col_b)``.
+        """
+        return None
+
+    def _dict_tuple_function_name(self) -> str:
+        """Name of the tuple-constructor function used when lowering a HogQL dict literal. Postgres uses ``ROW``."""
+        return "tuple"
+
+    def _render_column_aliased_field_name(self, type: "ast.FieldType", resolved_field) -> str:
+        """Column name to emit when the enclosing table type is ``ColumnAliasedTableType``.
+
+        Default uses the resolved database column name. Postgres overrides to use the alias declared on
+        the table type (Postgres renames the projection via the ``(a, b, c)`` syntax).
+        """
+        return self._print_identifier(resolved_field.name)
+
+    def _apply_window_function_rewrites(
+        self, identifier: str, exprs: list[str], cloned_node: "ast.WindowFunction"
+    ) -> str:
+        """Rewrite ``lag``/``lead`` into the ClickHouse ``lagInFrame``/``leadInFrame`` form.
+
+        The rewrite renames the function, wraps the value argument in ``toNullable``, and injects a default
+        window frame when none is present. Postgres overrides to return the identifier unchanged because its
+        native ``lag``/``lead`` already provides the desired semantics.
+        """
+        if identifier not in ("lag", "lead"):
+            return identifier
+        identifier = f"{identifier}InFrame"
+        # Wrap the first expression (value) and third expression (default) in toNullable()
+        # The second expression (offset) must remain a non-nullable integer
+        if len(exprs) > 0:
+            exprs[0] = f"toNullable({exprs[0]})"  # value
+        # If there's no window frame specified, add the default one
+        if not cloned_node.over_expr and not cloned_node.over_identifier:
+            cloned_node.over_expr = self._create_default_window_frame(cloned_node)
+        # If there's an over_identifier, we need to extract the new window expr just for this function
+        elif cloned_node.over_identifier:
+            # Find the last select query to look up the window definition
+            last_select = self._last_select()
+            if last_select and last_select.window_exprs and cloned_node.over_identifier in last_select.window_exprs:
+                base_window = last_select.window_exprs[cloned_node.over_identifier]
+                # Create a new window expr based on the referenced one
+                cloned_node.over_expr = ast.WindowExpr(
+                    partition_by=base_window.partition_by,
+                    order_by=base_window.order_by,
+                    frame_method="ROWS" if not base_window.frame_method else base_window.frame_method,
+                    frame_start=base_window.frame_start
+                    or ast.WindowFrameExpr(frame_type="PRECEDING", frame_value=None),
+                    frame_end=base_window.frame_end or ast.WindowFrameExpr(frame_type="FOLLOWING", frame_value=None),
+                )
+                cloned_node.over_identifier = None
+        # If there's an ORDER BY but no frame, add the default frame
+        elif cloned_node.over_expr and cloned_node.over_expr.order_by and not cloned_node.over_expr.frame_method:
+            cloned_node.over_expr = self._create_default_window_frame(cloned_node)
+        return identifier
+
     def _render_set_query_limit_percent(self, limit: ast.Expr, limit_str: str) -> str:
         """Render the LIMIT value for a set-operation query when `LIMIT … PERCENT` was used.
 
@@ -185,8 +265,7 @@ class BasePrinter(Visitor[str]):
             if self.pretty:
                 query = query.strip()
             if expr.set_operator is not None:
-                if expr.set_operator in ("INTERSECT ALL", "EXCEPT ALL") and self.dialect != "postgres":
-                    raise ImpossibleASTError(f"{expr.set_operator} is not supported in the '{self.dialect}' dialect")
+                self._assert_set_operator_supported(expr.set_operator)
                 if self.pretty:
                     ret += f"\n{self.indent(1)}{expr.set_operator}\n{self.indent(1)}"
                 else:
@@ -270,8 +349,8 @@ class BasePrinter(Visitor[str]):
         ctes = [self.visit(cte) for cte in node.ctes.values()] if node.ctes else None
         has_recursive_cte = any(cte.recursive for cte in node.ctes.values()) if node.ctes else False
 
-        if has_recursive_cte and self.dialect != "postgres":
-            raise ImpossibleASTError("Recursive CTEs are only supported in PostgreSQL dialect")
+        if has_recursive_cte:
+            self._assert_recursive_cte_supported()
 
         window = (
             ", ".join(
@@ -289,8 +368,8 @@ class BasePrinter(Visitor[str]):
             else:
                 group_by = [self.visit(column) for column in node.group_by]
         having = self.visit(node.having) if node.having else None
-        if node.qualify is not None and self.dialect != "postgres":
-            raise QueryError("QUALIFY is not supported in the '{}' dialect".format(self.dialect))
+        if node.qualify is not None:
+            self._assert_qualify_supported()
         qualify = self.visit(node.qualify) if node.qualify else None
         order_by = [self.visit(column) for column in node.order_by] if node.order_by else None
 
@@ -364,8 +443,8 @@ class BasePrinter(Visitor[str]):
             )
 
         if limit is not None:
-            if node.limit_with_ties and self.dialect == "postgres":
-                raise QueryError("WITH TIES is not supported in postgres dialect")
+            if node.limit_with_ties:
+                self._assert_with_ties_supported()
             limit_str = self._render_select_query_limit_clause(limit, bool(node.limit_percent))
             clauses.append(limit_str)
             if node.limit_with_ties:
@@ -546,9 +625,8 @@ class BasePrinter(Visitor[str]):
         elif isinstance(node.type, ast.SelectQueryAliasType) and node.alias is not None:
             join_strings.append(self.visit(node.table))
             alias_str = f"AS {self._print_identifier(node.alias)}"
-            if node.column_aliases and self.dialect == "postgres":
-                col_names = ", ".join(self._print_identifier(c) for c in node.column_aliases)
-                alias_str += f" ({col_names})"
+            if node.column_aliases:
+                alias_str += self._render_column_aliases_inline_suffix(node.column_aliases)
             join_strings.append(alias_str)
 
         elif isinstance(node.type, ast.LazyTableType):
@@ -558,9 +636,9 @@ class BasePrinter(Visitor[str]):
             join_strings.extend(self._render_untyped_join_expr(node))
 
         if node.column_aliases and not isinstance(node.type, ast.SelectQueryAliasType):
-            if self.dialect == "postgres":
-                col_aliases = ", ".join(self._print_identifier(ca) for ca in node.column_aliases)
-                join_strings.append(f"({col_aliases})")
+            appended = self._render_column_aliases_appended(node.column_aliases)
+            if appended is not None:
+                join_strings.append(appended)
 
         if node.table_final:
             raise QueryError("The FINAL keyword is not supported in HogQL as it causes slow queries")
@@ -692,7 +770,7 @@ class BasePrinter(Visitor[str]):
         return f"[{', '.join([self.visit(expr) for expr in node.exprs])}]"
 
     def visit_dict(self, node: ast.Dict):
-        tuple_function = "ROW" if self.dialect == "postgres" else "tuple"
+        tuple_function = self._dict_tuple_function_name()
         str = f"{tuple_function}('__hx_tag', '__hx_obj'"
         for key, value in node.items:
             str += f", {self.visit(key)}, {self.visit(value)}"
@@ -1106,8 +1184,8 @@ class BasePrinter(Visitor[str]):
                 # For column-aliased tables in postgres, use the aliased name
                 # (the DB handles renaming via the (a,b,c) syntax). For other
                 # dialects, use the real DB column name.
-                if isinstance(type.table_type, ast.ColumnAliasedTableType) and self.dialect == "postgres":
-                    field_sql = self._print_identifier(type.name)
+                if isinstance(type.table_type, ast.ColumnAliasedTableType):
+                    field_sql = self._render_column_aliased_field_name(type, resolved_field)
                 else:
                     # resolved_field may be an ast.Alias; in both cases .name is the physical column name to emit
                     if not isinstance(resolved_field, DatabaseField):
@@ -1364,36 +1442,7 @@ class BasePrinter(Visitor[str]):
         exprs = [self.visit(expr) for expr in node.exprs or []]
         cloned_node = cast(ast.WindowFunction, clone_expr(node))
 
-        # For compatibility with ClickHouse syntax, convert lag/lead to lagInFrame/leadInFrame and add default window frame if needed
-        if identifier in ("lag", "lead") and self.dialect != "postgres":
-            identifier = f"{identifier}InFrame"
-            # Wrap the first expression (value) and third expression (default) in toNullable()
-            # The second expression (offset) must remain a non-nullable integer
-            if len(exprs) > 0:
-                exprs[0] = f"toNullable({exprs[0]})"  # value
-            # If there's no window frame specified, add the default one
-            if not cloned_node.over_expr and not cloned_node.over_identifier:
-                cloned_node.over_expr = self._create_default_window_frame(cloned_node)
-            # If there's an over_identifier, we need to extract the new window expr just for this function
-            elif cloned_node.over_identifier:
-                # Find the last select query to look up the window definition
-                last_select = self._last_select()
-                if last_select and last_select.window_exprs and cloned_node.over_identifier in last_select.window_exprs:
-                    base_window = last_select.window_exprs[cloned_node.over_identifier]
-                    # Create a new window expr based on the referenced one
-                    cloned_node.over_expr = ast.WindowExpr(
-                        partition_by=base_window.partition_by,
-                        order_by=base_window.order_by,
-                        frame_method="ROWS" if not base_window.frame_method else base_window.frame_method,
-                        frame_start=base_window.frame_start
-                        or ast.WindowFrameExpr(frame_type="PRECEDING", frame_value=None),
-                        frame_end=base_window.frame_end
-                        or ast.WindowFrameExpr(frame_type="FOLLOWING", frame_value=None),
-                    )
-                    cloned_node.over_identifier = None
-            # If there's an ORDER BY but no frame, add the default frame
-            elif cloned_node.over_expr and cloned_node.over_expr.order_by and not cloned_node.over_expr.frame_method:
-                cloned_node.over_expr = self._create_default_window_frame(cloned_node)
+        identifier = self._apply_window_function_rewrites(identifier, exprs, cloned_node)
 
         # Handle any additional function arguments
         args = f"({', '.join(self.visit(arg) for arg in cloned_node.args)})" if cloned_node.args else ""

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -105,6 +105,86 @@ class BasePrinter(Visitor[str]):
         """
         return True
 
+    def _assert_set_operator_supported(self, set_operator: str) -> None:
+        """Raise if this dialect does not support the given set operator. Postgres overrides to permit all."""
+        if set_operator in ("INTERSECT ALL", "EXCEPT ALL"):
+            raise ImpossibleASTError(f"{set_operator} is not supported in the '{self.dialect}' dialect")
+
+    def _assert_recursive_cte_supported(self) -> None:
+        """Raise if this dialect does not support recursive CTEs. Postgres overrides to permit."""
+        raise ImpossibleASTError("Recursive CTEs are only supported in PostgreSQL dialect")
+
+    def _assert_qualify_supported(self) -> None:
+        """Raise if this dialect does not support the QUALIFY clause. Postgres overrides to permit."""
+        raise QueryError("QUALIFY is not supported in the '{}' dialect".format(self.dialect))
+
+    def _assert_with_ties_supported(self) -> None:
+        """Raise if this dialect does not support WITH TIES. Postgres overrides to reject."""
+        return
+
+    def _render_column_aliases_inline_suffix(self, column_aliases: list[str]) -> str:
+        """Suffix appended to ``AS alias`` when ``column_aliases`` are present. Postgres emits ``(col_a, col_b)``."""
+        return ""
+
+    def _render_column_aliases_appended(self, column_aliases: list[str]) -> str | None:
+        """String appended to the join-expression list when column aliases apply outside a SELECT alias.
+
+        Default returns ``None`` (not emitted); Postgres returns ``(col_a, col_b)``.
+        """
+        return None
+
+    def _dict_tuple_function_name(self) -> str:
+        """Name of the tuple-constructor function used when lowering a HogQL dict literal. Postgres uses ``ROW``."""
+        return "tuple"
+
+    def _render_column_aliased_field_name(self, type: "ast.FieldType", resolved_field) -> str:
+        """Column name to emit when the enclosing table type is ``ColumnAliasedTableType``.
+
+        Default uses the resolved database column name. Postgres overrides to use the alias declared on
+        the table type (Postgres renames the projection via the ``(a, b, c)`` syntax).
+        """
+        return self._print_identifier(resolved_field.name)
+
+    def _apply_window_function_rewrites(
+        self, identifier: str, exprs: list[str], cloned_node: "ast.WindowFunction"
+    ) -> str:
+        """Rewrite ``lag``/``lead`` into the ClickHouse ``lagInFrame``/``leadInFrame`` form.
+
+        The rewrite renames the function, wraps the value argument in ``toNullable``, and injects a default
+        window frame when none is present. Postgres overrides to return the identifier unchanged because its
+        native ``lag``/``lead`` already provides the desired semantics.
+        """
+        if identifier not in ("lag", "lead"):
+            return identifier
+        identifier = f"{identifier}InFrame"
+        # Wrap the first expression (value) and third expression (default) in toNullable()
+        # The second expression (offset) must remain a non-nullable integer
+        if len(exprs) > 0:
+            exprs[0] = f"toNullable({exprs[0]})"  # value
+        # If there's no window frame specified, add the default one
+        if not cloned_node.over_expr and not cloned_node.over_identifier:
+            cloned_node.over_expr = self._create_default_window_frame(cloned_node)
+        # If there's an over_identifier, we need to extract the new window expr just for this function
+        elif cloned_node.over_identifier:
+            # Find the last select query to look up the window definition
+            last_select = self._last_select()
+            if last_select and last_select.window_exprs and cloned_node.over_identifier in last_select.window_exprs:
+                base_window = last_select.window_exprs[cloned_node.over_identifier]
+                # Create a new window expr based on the referenced one
+                cloned_node.over_expr = ast.WindowExpr(
+                    partition_by=base_window.partition_by,
+                    order_by=base_window.order_by,
+                    frame_method="ROWS" if not base_window.frame_method else base_window.frame_method,
+                    frame_start=base_window.frame_start
+                    or ast.WindowFrameExpr(frame_type="PRECEDING", frame_value=None),
+                    frame_end=base_window.frame_end or ast.WindowFrameExpr(frame_type="FOLLOWING", frame_value=None),
+                )
+                cloned_node.over_identifier = None
+        # If there's an ORDER BY but no frame, add the default frame
+        elif cloned_node.over_expr and cloned_node.over_expr.order_by and not cloned_node.over_expr.frame_method:
+            cloned_node.over_expr = self._create_default_window_frame(cloned_node)
+        return identifier
+
     def _render_set_query_limit_percent(self, limit: ast.Expr, limit_str: str) -> str:
         """Render the LIMIT value for a set-operation query when `LIMIT … PERCENT` was used.
 
@@ -185,8 +265,7 @@ class BasePrinter(Visitor[str]):
             if self.pretty:
                 query = query.strip()
             if expr.set_operator is not None:
-                if expr.set_operator in ("INTERSECT ALL", "EXCEPT ALL") and self.dialect != "postgres":
-                    raise ImpossibleASTError(f"{expr.set_operator} is not supported in the '{self.dialect}' dialect")
+                self._assert_set_operator_supported(expr.set_operator)
                 if self.pretty:
                     ret += f"\n{self.indent(1)}{expr.set_operator}\n{self.indent(1)}"
                 else:
@@ -270,8 +349,8 @@ class BasePrinter(Visitor[str]):
         ctes = [self.visit(cte) for cte in node.ctes.values()] if node.ctes else None
         has_recursive_cte = any(cte.recursive for cte in node.ctes.values()) if node.ctes else False
 
-        if has_recursive_cte and self.dialect != "postgres":
-            raise ImpossibleASTError("Recursive CTEs are only supported in PostgreSQL dialect")
+        if has_recursive_cte:
+            self._assert_recursive_cte_supported()
 
         window = (
             ", ".join(
@@ -289,8 +368,8 @@ class BasePrinter(Visitor[str]):
             else:
                 group_by = [self.visit(column) for column in node.group_by]
         having = self.visit(node.having) if node.having else None
-        if node.qualify is not None and self.dialect != "postgres":
-            raise QueryError("QUALIFY is not supported in the '{}' dialect".format(self.dialect))
+        if node.qualify is not None:
+            self._assert_qualify_supported()
         qualify = self.visit(node.qualify) if node.qualify else None
         order_by = [self.visit(column) for column in node.order_by] if node.order_by else None
 
@@ -359,8 +438,8 @@ class BasePrinter(Visitor[str]):
             )
 
         if limit is not None:
-            if node.limit_with_ties and self.dialect == "postgres":
-                raise QueryError("WITH TIES is not supported in postgres dialect")
+            if node.limit_with_ties:
+                self._assert_with_ties_supported()
             limit_str = self._render_select_query_limit_clause(limit, bool(node.limit_percent))
             clauses.append(limit_str)
             if node.limit_with_ties:
@@ -541,9 +620,8 @@ class BasePrinter(Visitor[str]):
         elif isinstance(node.type, ast.SelectQueryAliasType) and node.alias is not None:
             join_strings.append(self.visit(node.table))
             alias_str = f"AS {self._print_identifier(node.alias)}"
-            if node.column_aliases and self.dialect == "postgres":
-                col_names = ", ".join(self._print_identifier(c) for c in node.column_aliases)
-                alias_str += f" ({col_names})"
+            if node.column_aliases:
+                alias_str += self._render_column_aliases_inline_suffix(node.column_aliases)
             join_strings.append(alias_str)
 
         elif isinstance(node.type, ast.LazyTableType):
@@ -553,9 +631,9 @@ class BasePrinter(Visitor[str]):
             join_strings.extend(self._render_untyped_join_expr(node))
 
         if node.column_aliases and not isinstance(node.type, ast.SelectQueryAliasType):
-            if self.dialect == "postgres":
-                col_aliases = ", ".join(self._print_identifier(ca) for ca in node.column_aliases)
-                join_strings.append(f"({col_aliases})")
+            appended = self._render_column_aliases_appended(node.column_aliases)
+            if appended is not None:
+                join_strings.append(appended)
 
         if node.table_final:
             raise QueryError("The FINAL keyword is not supported in HogQL as it causes slow queries")
@@ -687,7 +765,7 @@ class BasePrinter(Visitor[str]):
         return f"[{', '.join([self.visit(expr) for expr in node.exprs])}]"
 
     def visit_dict(self, node: ast.Dict):
-        tuple_function = "ROW" if self.dialect == "postgres" else "tuple"
+        tuple_function = self._dict_tuple_function_name()
         str = f"{tuple_function}('__hx_tag', '__hx_obj'"
         for key, value in node.items:
             str += f", {self.visit(key)}, {self.visit(value)}"
@@ -1083,8 +1161,8 @@ class BasePrinter(Visitor[str]):
                 # For column-aliased tables in postgres, use the aliased name
                 # (the DB handles renaming via the (a,b,c) syntax). For other
                 # dialects, use the real DB column name.
-                if isinstance(type.table_type, ast.ColumnAliasedTableType) and self.dialect == "postgres":
-                    field_sql = self._print_identifier(type.name)
+                if isinstance(type.table_type, ast.ColumnAliasedTableType):
+                    field_sql = self._render_column_aliased_field_name(type, resolved_field)
                 else:
                     # resolved_field may be an ast.Alias; in both cases .name is the physical column name to emit
                     field_sql = self._print_identifier(resolved_field.name)
@@ -1337,36 +1415,7 @@ class BasePrinter(Visitor[str]):
         exprs = [self.visit(expr) for expr in node.exprs or []]
         cloned_node = cast(ast.WindowFunction, clone_expr(node))
 
-        # For compatibility with ClickHouse syntax, convert lag/lead to lagInFrame/leadInFrame and add default window frame if needed
-        if identifier in ("lag", "lead") and self.dialect != "postgres":
-            identifier = f"{identifier}InFrame"
-            # Wrap the first expression (value) and third expression (default) in toNullable()
-            # The second expression (offset) must remain a non-nullable integer
-            if len(exprs) > 0:
-                exprs[0] = f"toNullable({exprs[0]})"  # value
-            # If there's no window frame specified, add the default one
-            if not cloned_node.over_expr and not cloned_node.over_identifier:
-                cloned_node.over_expr = self._create_default_window_frame(cloned_node)
-            # If there's an over_identifier, we need to extract the new window expr just for this function
-            elif cloned_node.over_identifier:
-                # Find the last select query to look up the window definition
-                last_select = self._last_select()
-                if last_select and last_select.window_exprs and cloned_node.over_identifier in last_select.window_exprs:
-                    base_window = last_select.window_exprs[cloned_node.over_identifier]
-                    # Create a new window expr based on the referenced one
-                    cloned_node.over_expr = ast.WindowExpr(
-                        partition_by=base_window.partition_by,
-                        order_by=base_window.order_by,
-                        frame_method="ROWS" if not base_window.frame_method else base_window.frame_method,
-                        frame_start=base_window.frame_start
-                        or ast.WindowFrameExpr(frame_type="PRECEDING", frame_value=None),
-                        frame_end=base_window.frame_end
-                        or ast.WindowFrameExpr(frame_type="FOLLOWING", frame_value=None),
-                    )
-                    cloned_node.over_identifier = None
-            # If there's an ORDER BY but no frame, add the default frame
-            elif cloned_node.over_expr and cloned_node.over_expr.order_by and not cloned_node.over_expr.frame_method:
-                cloned_node.over_expr = self._create_default_window_frame(cloned_node)
+        identifier = self._apply_window_function_rewrites(identifier, exprs, cloned_node)
 
         # Handle any additional function arguments
         args = f"({', '.join(self.visit(arg) for arg in cloned_node.args)})" if cloned_node.args else ""

--- a/posthog/hogql/printer/postgres.py
+++ b/posthog/hogql/printer/postgres.py
@@ -39,6 +39,38 @@ class PostgresPrinter(BasePrinter):
     def _min_function_name(self) -> str:
         return "least"
 
+    def _assert_set_operator_supported(self, set_operator: str) -> None:
+        return
+
+    def _assert_recursive_cte_supported(self) -> None:
+        return
+
+    def _assert_qualify_supported(self) -> None:
+        return
+
+    def _assert_with_ties_supported(self) -> None:
+        raise QueryError("WITH TIES is not supported in postgres dialect")
+
+    def _render_column_aliases_inline_suffix(self, column_aliases: list[str]) -> str:
+        col_names = ", ".join(self._print_identifier(c) for c in column_aliases)
+        return f" ({col_names})"
+
+    def _render_column_aliases_appended(self, column_aliases: list[str]) -> str | None:
+        col_aliases = ", ".join(self._print_identifier(ca) for ca in column_aliases)
+        return f"({col_aliases})"
+
+    def _dict_tuple_function_name(self) -> str:
+        return "ROW"
+
+    def _render_column_aliased_field_name(self, type: ast.FieldType, resolved_field) -> str:
+        return self._print_identifier(type.name)
+
+    def _apply_window_function_rewrites(
+        self, identifier: str, exprs: list[str], cloned_node: ast.WindowFunction
+    ) -> str:
+        # Postgres's native lag/lead already has the semantics we want; skip the ClickHouse-style rewrite.
+        return identifier
+
     def _render_set_query_limit_percent(self, limit: ast.Expr, limit_str: str) -> str:
         return f"{limit_str} %"
 

--- a/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
+++ b/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
@@ -923,15 +923,7 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.person_id,
-               events.`mat_$browser`,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-13'), lessOrEquals(toDate(events.timestamp), '2024-01-17'))) AS events
+     FROM events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Asia/Tokyo')), max(toTimeZone(raw_sessions.max_timestamp, 'Asia/Tokyo'))), 10)))) AS `$is_bounce`,
@@ -948,7 +940,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Tokyo'))), lessOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Tokyo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Tokyo'))), lessOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Tokyo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`


### PR DESCRIPTION
## Problem

After PRs 1-3 (#54483, #54517, #54669) drained ClickHouse and HogQL branches from the shared base printer, `BasePrinter` still had 9 `self.dialect == "postgres"` / `!= "postgres"` branches across 6 methods. PR 4 drains them, completing the structural split.

After this PR, `BasePrinter` contains **zero** dialect-specific branches of any kind. The only remaining uses of `self.dialect` in `base.py` are the field assignment, error-message interpolation, and the argument passed to `resolve_types` in `_get_table_predicates` — all handled in PR 5.

## Changes

### Feature gates

Four "is this feature supported in this dialect" gates with side-effectful defaults (raises) and one-line PG overrides:

- `_assert_set_operator_supported(set_operator)` — base raises for `INTERSECT ALL` / `EXCEPT ALL`; PG permits all.
- `_assert_recursive_cte_supported()` — base raises; PG permits.
- `_assert_qualify_supported()` — base raises; PG permits.
- `_assert_with_ties_supported()` — base permits; PG raises (inverse direction — WITH TIES is CH-only).

Call sites replace inline `if ... and self.dialect ... : raise` with single method calls.

### `visit_join_expr` column-aliases

Two tiny PG-only branches that append `(col_a, col_b)` become hooks:

- `_render_column_aliases_inline_suffix(column_aliases) -> str` — default `""`; PG returns `" (col_a, col_b)"`.
- `_render_column_aliases_appended(column_aliases) -> str | None` — default `None`; PG returns `"(col_a, col_b)"`.

### `visit_dict` tuple constructor

`_dict_tuple_function_name()` hook — default `"tuple"`, PG returns `"ROW"`.

### `visit_field_type` ColumnAliasedTableType

PG uses the declared alias name; others use the resolved DB column name. Extracted to `_render_column_aliased_field_name(type, resolved_field)` hook.

### `visit_window_function` lag/lead rewrite

The substantial ~30-line block that renames `lag`/`lead` → `lagInFrame`/`leadInFrame`, wraps the value argument in `toNullable`, and injects default window frames (all CH-flavored) was extracted into `_apply_window_function_rewrites(identifier, exprs, cloned_node) -> str`. Base implements the rewrite; PG overrides to return the identifier unchanged.

### Result

```
$ grep -c 'self\.dialect == \|self\.dialect != ' posthog/hogql/printer/base.py
0
```

`PostgresPrinter` grew by ~32 lines (6 new hook overrides). `BasePrinter` retains the extracted method so CH/HogQL continue to use the CH-flavored rewrite; only the conditional was removed.

## How did you test this code?

- `ruff check posthog/hogql/printer/` — clean.
- `mypy posthog/hogql/printer/` — no new errors beyond the pre-existing `FieldOrTable` baseline.
- `hogli test posthog/hogql/printer/test/test_printer.py -k 'not with_recursive and not _save'` — **523 passed, 175 snapshots passed, 0 failed** across all three dialects. Excluded two tests that need the `aux` CH cluster (local env limitation); CI exercises them.

## Publish to changelog?

no

## 🤖 LLM context

Authored via Claude Code. Fourth in the planned 5-PR series splitting dialect-specific logic out of the shared HogQL printer. After this lands, PR 5 will remove the `self.dialect` field itself (error-message strings switch to `type(self).__name__` and `_get_table_predicates` passes a class-level dialect constant to the resolver), fully closing out the refactor.

Stacked on #54669. Base branch is `hogql/move-hogql-branches`, not `master`.
