### PR TITLE
chore(ci): fix npm publish workflow for cli releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,6 +309,7 @@ jobs:
                   merge-multiple: true
             - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
               with:
+                  node-version: 24
                   registry-url: 'https://registry.npmjs.org'
             - name: Ensure modern npm (OIDC support)
               run: npm install -g npm@11.6.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,7 +309,6 @@ jobs:
                   merge-multiple: true
             - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
               with:
-                  node-version-file: .nvmrc
                   registry-url: 'https://registry.npmjs.org'
             - name: Ensure modern npm (OIDC support)
               run: npm install -g npm@11.6.4


### PR DESCRIPTION
## Problem

The CLI release workflow's `publish-npm` job was forcing the Node.js version from `.nvmrc` but there was no checkout before which causes the job to fail.

https://github.com/PostHog/posthog/actions/runs/24446105535/job/71425311908?pr=54642
