### PR TITLE
fix(llma): surface save/toggle errors on evaluations

### DIFF
--- a/products/llm_analytics/frontend/evaluations/apiErrors.test.ts
+++ b/products/llm_analytics/frontend/evaluations/apiErrors.test.ts
@@ -1,0 +1,35 @@
+import { ApiError } from 'lib/api'
+
+import { evaluationErrorMessage } from './apiErrors'
+
+describe('evaluationErrorMessage', () => {
+    it('extracts a DRF field-level validation error', () => {
+        const error = new ApiError('Non-OK response', 400, undefined, {
+            enabled: ['Trial evaluation limit reached. Add a provider API key to re-enable.'],
+        })
+        expect(evaluationErrorMessage(error, 'fallback')).toBe(
+            'Trial evaluation limit reached. Add a provider API key to re-enable.'
+        )
+    })
+
+    it('extracts a nested field error from a model_configuration-style payload', () => {
+        const error = new ApiError('Non-OK response', 400, undefined, {
+            model_configuration: { provider_key_id: 'Provider key not found' },
+        })
+        expect(evaluationErrorMessage(error, 'fallback')).toBe('Provider key not found')
+    })
+
+    it('falls back to detail when no field errors are present', () => {
+        const error = new ApiError('Something', 403, undefined, { detail: 'You do not have access' })
+        expect(evaluationErrorMessage(error, 'fallback')).toBe('You do not have access')
+    })
+
+    it('falls back to the supplied default when nothing useful is available', () => {
+        const error = new ApiError('Non-OK response [PATCH /api/...]', 500, undefined, null)
+        expect(evaluationErrorMessage(error, 'fallback copy')).toBe('fallback copy')
+    })
+
+    it('unwraps a plain Error', () => {
+        expect(evaluationErrorMessage(new Error('Network down'), 'fallback')).toBe('Network down')
+    })
+})

--- a/products/llm_analytics/frontend/evaluations/apiErrors.test.ts
+++ b/products/llm_analytics/frontend/evaluations/apiErrors.test.ts
@@ -3,33 +3,42 @@ import { ApiError } from 'lib/api'
 import { evaluationErrorMessage } from './apiErrors'
 
 describe('evaluationErrorMessage', () => {
-    it('extracts a DRF field-level validation error', () => {
-        const error = new ApiError('Non-OK response', 400, undefined, {
-            enabled: ['Trial evaluation limit reached. Add a provider API key to re-enable.'],
-        })
-        expect(evaluationErrorMessage(error, 'fallback')).toBe(
-            'Trial evaluation limit reached. Add a provider API key to re-enable.'
-        )
-    })
-
-    it('extracts a nested field error from a model_configuration-style payload', () => {
-        const error = new ApiError('Non-OK response', 400, undefined, {
-            model_configuration: { provider_key_id: 'Provider key not found' },
-        })
-        expect(evaluationErrorMessage(error, 'fallback')).toBe('Provider key not found')
-    })
-
-    it('falls back to detail when no field errors are present', () => {
-        const error = new ApiError('Something', 403, undefined, { detail: 'You do not have access' })
-        expect(evaluationErrorMessage(error, 'fallback')).toBe('You do not have access')
-    })
-
-    it('falls back to the supplied default when nothing useful is available', () => {
-        const error = new ApiError('Non-OK response [PATCH /api/...]', 500, undefined, null)
-        expect(evaluationErrorMessage(error, 'fallback copy')).toBe('fallback copy')
-    })
-
-    it('unwraps a plain Error', () => {
-        expect(evaluationErrorMessage(new Error('Network down'), 'fallback')).toBe('Network down')
+    it.each<[string, unknown, string]>([
+        [
+            'extracts a DRF field-level validation error',
+            new ApiError('Non-OK response', 400, undefined, {
+                enabled: ['Trial evaluation limit reached. Add a provider API key to re-enable.'],
+            }),
+            'Trial evaluation limit reached. Add a provider API key to re-enable.',
+        ],
+        [
+            'extracts a nested field error from a model_configuration-style payload',
+            new ApiError('Non-OK response', 400, undefined, {
+                model_configuration: { provider_key_id: 'Provider key not found' },
+            }),
+            'Provider key not found',
+        ],
+        [
+            'prefers detail over other keys on APIException payloads',
+            new ApiError('Non-OK response', 400, undefined, {
+                type: 'validation_error',
+                code: 'invalid',
+                detail: 'The request body is malformed.',
+            }),
+            'The request body is malformed.',
+        ],
+        [
+            'returns detail when that is all the response carries',
+            new ApiError('Something', 403, undefined, { detail: 'You do not have access' }),
+            'You do not have access',
+        ],
+        [
+            'falls back to the supplied default when nothing useful is available',
+            new ApiError('Non-OK response [PATCH /api/...]', 500, undefined, null),
+            'fallback copy',
+        ],
+        ['unwraps a plain Error', new Error('Network down'), 'Network down'],
+    ])('%s', (_, error, expected) => {
+        expect(evaluationErrorMessage(error, 'fallback copy')).toBe(expected)
     })
 })

--- a/products/llm_analytics/frontend/evaluations/apiErrors.ts
+++ b/products/llm_analytics/frontend/evaluations/apiErrors.ts
@@ -1,0 +1,44 @@
+import { ApiError } from 'lib/api'
+
+function firstStringIn(value: unknown): string | null {
+    if (typeof value === 'string' && value.trim().length > 0) {
+        return value
+    }
+    if (Array.isArray(value)) {
+        for (const item of value) {
+            const nested = firstStringIn(item)
+            if (nested) {
+                return nested
+            }
+        }
+    }
+    if (value && typeof value === 'object') {
+        for (const nested of Object.values(value as Record<string, unknown>)) {
+            const found = firstStringIn(nested)
+            if (found) {
+                return found
+            }
+        }
+    }
+    return null
+}
+
+export function evaluationErrorMessage(error: unknown, fallback: string): string {
+    if (error instanceof ApiError) {
+        if (error.data && typeof error.data === 'object') {
+            const fieldMessage = firstStringIn(error.data)
+            if (fieldMessage) {
+                return fieldMessage
+            }
+        }
+        if (error.detail) {
+            return error.detail
+        }
+        if (error.message && !error.message.startsWith('Non-OK response')) {
+            return error.message
+        }
+    } else if (error instanceof Error && error.message) {
+        return error.message
+    }
+    return fallback
+}

--- a/products/llm_analytics/frontend/evaluations/apiErrors.ts
+++ b/products/llm_analytics/frontend/evaluations/apiErrors.ts
@@ -25,14 +25,17 @@ function firstStringIn(value: unknown): string | null {
 
 export function evaluationErrorMessage(error: unknown, fallback: string): string {
     if (error instanceof ApiError) {
+        // Prefer DRF's top-level detail so that APIException payloads like
+        // {type: "validation_error", code: "invalid", detail: "..."} don't show "validation_error".
+        if (error.detail) {
+            return error.detail
+        }
+        // Fall back to walking serializer field errors like {"enabled": ["..."]}.
         if (error.data && typeof error.data === 'object') {
             const fieldMessage = firstStringIn(error.data)
             if (fieldMessage) {
                 return fieldMessage
             }
-        }
-        if (error.detail) {
-            return error.detail
         }
         if (error.message && !error.message.startsWith('Non-OK response')) {
             return error.message

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts
@@ -796,4 +796,45 @@ describe('llmEvaluationLogic', () => {
             })
         })
     })
+
+    describe('saveEvaluation failure handling', () => {
+        beforeEach(() => {
+            useMocks({
+                get: {
+                    '/api/environments/:teamId/llm_analytics/provider_keys/': { results: mockProviderKeys },
+                    '/api/environments/:teamId/llm_analytics/evaluation_config/': {
+                        trial_eval_limit: 100,
+                        trial_evals_used: 100,
+                        trial_evals_remaining: 0,
+                        active_provider_key: null,
+                        created_at: '2024-01-01T00:00:00Z',
+                        updated_at: '2024-01-01T00:00:00Z',
+                    },
+                    '/api/environments/:teamId/evaluations/:id/': mockEvaluation,
+                },
+                patch: {
+                    '/api/environments/:teamId/evaluations/:id/': (_, __, ctx) => [
+                        ctx.status(400),
+                        ctx.json({
+                            enabled: ['Trial evaluation limit reached. Add a provider API key to re-enable.'],
+                        }),
+                    ],
+                },
+            })
+
+            logic = llmEvaluationLogic({ evaluationId: 'eval-123' })
+            logic.mount()
+        })
+
+        it('dispatches saveEvaluationFailure and resets submitting state on 400', async () => {
+            await expectLogic(logic).toDispatchActions(['loadEvaluationSuccess'])
+            logic.actions.setEvaluationName('Renamed')
+
+            logic.actions.saveEvaluation()
+
+            await expectLogic(logic)
+                .toDispatchActions(['saveEvaluation', 'saveEvaluationFailure'])
+                .toMatchValues({ evaluationFormSubmitting: false })
+        })
+    })
 })

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -4,6 +4,7 @@ import { combineUrl, router } from 'kea-router'
 import posthog from 'posthog-js'
 
 import api from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
 import { signalSourcesLogic } from 'scenes/inbox/signalSourcesLogic'
 import { SignalSourceConfig, SignalSourceProduct, SignalSourceType } from 'scenes/inbox/types'
@@ -17,6 +18,7 @@ import { parseTrialProviderKeyId } from '../ModelPicker'
 import { LLMProviderKey, llmProviderKeysLogic } from '../settings/llmProviderKeysLogic'
 import { isUnhealthyProviderKeyState } from '../settings/providerKeyStateUtils'
 import { queryEvaluationRuns } from '../utils'
+import { evaluationErrorMessage } from './apiErrors'
 import { EVALUATION_SUMMARY_MAX_RUNS } from './constants'
 import type { llmEvaluationLogicType } from './llmEvaluationLogicType'
 import { EvaluationTemplateKey, defaultEvaluationTemplates } from './templates'
@@ -94,6 +96,7 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
         // Evaluation management actions
         saveEvaluation: true,
         saveEvaluationSuccess: (evaluation: EvaluationConfig) => ({ evaluation }),
+        saveEvaluationFailure: (error: string) => ({ error }),
         loadEvaluation: true,
         loadEvaluationSuccess: (evaluation: EvaluationConfig | null) => ({ evaluation }),
         resetEvaluation: true,
@@ -292,6 +295,7 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
             {
                 saveEvaluation: () => true,
                 saveEvaluationSuccess: () => false,
+                saveEvaluationFailure: () => false,
             },
         ],
         signalEmissionOptimistic: [
@@ -518,7 +522,9 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                 }
                 router.actions.push(urls.llmAnalyticsEvaluations(), router.values.searchParams)
             } catch (error) {
-                console.error('Failed to save evaluation:', error)
+                const message = evaluationErrorMessage(error, 'Failed to save evaluation')
+                lemonToast.error(message)
+                actions.saveEvaluationFailure(message)
             }
         },
 

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.test.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.test.ts
@@ -118,6 +118,25 @@ describe('llmEvaluationsLogic', () => {
             ])
         })
 
+        it('dispatches toggleEvaluationEnabledFailure when the API rejects the toggle', async () => {
+            useMocks({
+                patch: {
+                    '/api/environments/:teamId/evaluations/:id/': (_, __, ctx) => [
+                        ctx.status(400),
+                        ctx.json({
+                            enabled: ['Trial evaluation limit reached. Add a provider API key to re-enable.'],
+                        }),
+                    ],
+                },
+            })
+
+            logic.actions.loadEvaluationsSuccess([evaluationWithKey('eval-default', null)])
+
+            logic.actions.toggleEvaluationEnabled('eval-default')
+
+            await expectLogic(logic).toDispatchActions(['toggleEvaluationEnabled', 'toggleEvaluationEnabledFailure'])
+        })
+
         it('returns an empty array when all used keys are healthy', async () => {
             logic.actions.loadEvaluationsSuccess([
                 evaluationWithKey('eval-ok-1', 'key-ok'),

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.ts
@@ -4,6 +4,7 @@ import { combineUrl, router } from 'kea-router'
 import api from 'lib/api'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { tabAwareActionToUrl } from 'lib/logic/scenes/tabAwareActionToUrl'
 import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
@@ -14,6 +15,7 @@ import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-genera
 
 import { LLMProviderKey, llmProviderKeysLogic } from '../settings/llmProviderKeysLogic'
 import { isUnhealthyProviderKeyState } from '../settings/providerKeyStateUtils'
+import { evaluationErrorMessage } from './apiErrors'
 import type { llmEvaluationsLogicType } from './llmEvaluationsLogicType'
 import { EvaluationConfig } from './types'
 
@@ -59,6 +61,7 @@ export const llmEvaluationsLogic = kea<llmEvaluationsLogicType>([
         duplicateEvaluationSuccess: (evaluation: EvaluationConfig) => ({ evaluation }),
         toggleEvaluationEnabled: (id: string) => ({ id }),
         toggleEvaluationEnabledSuccess: (id: string) => ({ id }),
+        toggleEvaluationEnabledFailure: (id: string, error: string) => ({ id, error }),
         setEvaluationsFilter: (filter: string) => ({ filter }),
     }),
 
@@ -198,23 +201,26 @@ export const llmEvaluationsLogic = kea<llmEvaluationsLogicType>([
         },
 
         toggleEvaluationEnabled: async ({ id }) => {
+            const evaluation = values.evaluations.find((e: EvaluationConfig) => e.id === id)
+            if (!evaluation) {
+                return
+            }
+
+            const teamId = teamLogic.values.currentTeamId
+            if (!teamId) {
+                return
+            }
+
             try {
-                const evaluation = values.evaluations.find((e: EvaluationConfig) => e.id === id)
-                if (!evaluation) {
-                    return
-                }
-
-                const teamId = teamLogic.values.currentTeamId
-                if (!teamId) {
-                    return
-                }
-
                 await api.update(`/api/environments/${teamId}/evaluations/${id}/`, {
                     enabled: !evaluation.enabled,
                 })
                 actions.toggleEvaluationEnabledSuccess(id)
             } catch (error) {
-                console.error('Failed to toggle evaluation enabled:', error)
+                const action = evaluation.enabled ? 'disable' : 'enable'
+                const message = evaluationErrorMessage(error, `Failed to ${action} evaluation`)
+                lemonToast.error(message)
+                actions.toggleEvaluationEnabledFailure(id, message)
             }
         },
     })),


### PR DESCRIPTION
## Problem

Users reported an infinite loading spinner when clicking **Save changes** on an evaluation (see [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1776237532844509)). Root cause: the `saveEvaluation` listener in `llmEvaluationLogic.ts` caught errors with `console.error` only, and the `evaluationFormSubmitting` reducer had no failure case — so when the backend returned 400 (e.g. `{"enabled": "Trial evaluation limit reached..."}`), the submit button stayed in its loading state forever with no feedback.

The same silent-fail pattern existed on the list-page enable toggle in `llmEvaluationsLogic.ts` — the API rejection was swallowed and the user saw the toggle pop back with no explanation.

The backend already returns a perfectly descriptive error message. We were just throwing it away.

## Changes

- Add a `saveEvaluationFailure` action to the detail-page logic, wired into the submitting reducer so the button unsticks on failure
- Add a `toggleEvaluationEnabledFailure` action to the list-page logic
- Both paths now pull the DRF field error (or `detail`, or a nested message) off the response and show it via `lemonToast.error`
- Extract the DRF error-unwrapping into a small shared helper (`apiErrors.ts`) with unit tests — DRF field-level errors aren't picked up by `ApiError.detail` so we walk the payload
- Add logic tests covering both failure paths

No UI copy changes — the backend message is already informative (e.g. *"Trial evaluation limit reached. Add a provider API key to re-enable this evaluation."*).

## How did you test this code?

- `apiErrors.test.ts` covers the shape-unwrapping (field array, nested object, `detail`, plain Error, fallback)
- Added failure-path tests to `llmEvaluationLogic.test.ts` and `llmEvaluationsLogic.test.ts` that mock a 400 and assert the failure action dispatches and the submitting reducer resets
- All 59 tests in the evaluations logic suite pass
- Did **not** run this manually in the browser yet — that's next on the list and will be covered by the follow-up UX PR that consumes the same error paths

## Publish to changelog?

No

## Docs update

No docs changes needed.

## 🤖 LLM context

Authored with Claude Code. Surrounding investigation found two existing in-flight PRs (#54629, #54635) that add a `disabled_reason` field and UX indicators, but neither touches the Save/toggle silent-failure bug that was the user's actual reported symptom — so we split this out as a standalone hotfix. The `disabled_reason` + recovery-CTA work will be a follow-up PR tracked under a separate issue.