### PR TITLE
fix(data-warehouse): probe actual scale for unconstrained postgres numeric columns

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1181,14 +1181,13 @@ def _get_table(
     # already materialized on disk and behave like tables here.
     if unconstrained_numeric_columns and probe_unconstrained_numeric_scale and not is_view:
         try:
-            # Isolate the probe in a SAVEPOINT so that any failure (permission denied, bad
+            # Isolate the probe in a savepoint so that any failure (permission denied, bad
             # type, statement_timeout, network blip) rolls back cleanly without poisoning the
             # enclosing metadata transaction. Without this, a probe error leaves the
             # transaction in `INERROR` state and every subsequent query in `postgres_source`
             # (SET LOCAL statement_timeout, _is_read_replica, _get_primary_keys, _get_rows_to_sync,
             # ...) fails with `InFailedSqlTransaction: current transaction is aborted`.
-            cursor.execute(sql.SQL("SAVEPOINT probe_numeric_scale"))
-            try:
+            with cursor.connection.transaction(savepoint_name="probe_numeric_scale"):
                 # Scope a short statement_timeout to the probe so a pathologically large table
                 # or slow aggregation can't hang schema discovery. The outer 10-minute
                 # statement_timeout isn't set until `postgres_source` continues after
@@ -1221,13 +1220,6 @@ def _get_table(
                     for i, col_name in enumerate(unconstrained_numeric_columns):
                         probed_scales[col_name] = row[2 * i]
                         probed_int_digits[col_name] = row[2 * i + 1]
-                cursor.execute(sql.SQL("RELEASE SAVEPOINT probe_numeric_scale"))
-            except Exception:
-                # Roll back the savepoint so the enclosing transaction stays usable, then
-                # re-raise into the outer `except` for logging.
-                cursor.execute(sql.SQL("ROLLBACK TO SAVEPOINT probe_numeric_scale"))
-                cursor.execute(sql.SQL("RELEASE SAVEPOINT probe_numeric_scale"))
-                raise
         except Exception as e:
             # Probe is best-effort. Fall back to DEFAULT_NUMERIC_SCALE and let the downstream
             # `_process_batch` fallback chain infer the right type at row-fetching time.

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1223,7 +1223,12 @@ def _get_table(
         except Exception as e:
             # Probe is best-effort. Fall back to DEFAULT_NUMERIC_SCALE and let the downstream
             # `_process_batch` fallback chain infer the right type at row-fetching time.
-            logger.warning(f"Failed to probe numeric dimensions for {schema}.{table_name}: {e}")
+            logger.warning(
+                "Failed to probe numeric dimensions",
+                schema=schema,
+                table=table_name,
+                error=str(e),
+            )
 
     columns = []
     for name, data_type, nullable, numeric_precision_candidate, numeric_scale_candidate in metadata_rows:
@@ -1259,11 +1264,15 @@ def _get_table(
                     else:
                         numeric_precision = total_needed
                         logger.warning(
-                            f"Unconstrained numeric column {schema}.{table_name}.{name} "
-                            f"requires {total_needed} digits "
-                            f"(int={probed_int}, scale={effective_scale}), exceeding decimal128's "
-                            f"{DEFAULT_NUMERIC_PRECISION}-digit budget. Column will be stored as "
-                            f"`string` in delta to preserve data fidelity."
+                            "Unconstrained numeric column exceeds decimal128 budget; "
+                            "will be stored as string in delta to preserve fidelity",
+                            schema=schema,
+                            table=table_name,
+                            column=name,
+                            total_digits_needed=total_needed,
+                            integer_digits=probed_int,
+                            scale=effective_scale,
+                            decimal128_budget=DEFAULT_NUMERIC_PRECISION,
                         )
                     numeric_scale = effective_scale
                 else:

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -30,6 +30,7 @@ from posthog.temporal.data_imports.pipelines.pipeline.utils import (
     DEFAULT_NUMERIC_PRECISION,
     DEFAULT_NUMERIC_SCALE,
     DEFAULT_PARTITION_TARGET_SIZE_IN_BYTES,
+    MAX_NUMERIC_SCALE,
     QueryTimeoutException,
     TemporaryFileSizeExceedsLimitException,
     build_pyarrow_decimal_type,
@@ -1133,11 +1134,53 @@ def _get_table(
     cursor.execute(query)
 
     numeric_data_types = {"numeric", "decimal"}
+    metadata_rows = cursor.fetchall()
+
+    # For unconstrained numeric columns (declared as `numeric` with no precision/scale),
+    # postgres returns NULL for numeric_precision/numeric_scale in information_schema. Falling
+    # back to a static default scale (18) causes the delta column to be created with less scale
+    # than the actual data requires, which later breaks merges when a chunk contains values with
+    # trailing non-zero digits past that default scale. Probe the actual data for its max used
+    # scale so the delta column is sized correctly from the start.
+    unconstrained_numeric_columns = [
+        name
+        for name, data_type, _nullable, _np, numeric_scale_candidate in metadata_rows
+        if data_type in numeric_data_types and numeric_scale_candidate is None
+    ]
+    probed_scales: dict[str, int | None] = {}
+    if unconstrained_numeric_columns:
+        try:
+            select_parts = sql.SQL(", ").join(
+                sql.SQL("MAX(scale({col}))").format(col=sql.Identifier(col_name))
+                for col_name in unconstrained_numeric_columns
+            )
+            probe_query = sql.SQL("SELECT {parts} FROM {table}").format(
+                parts=select_parts,
+                table=sql.Identifier(schema, table_name),
+            )
+            logger.debug(f"Probing numeric scales: {probe_query.as_string()}")
+            cursor.execute(probe_query)
+            row = cursor.fetchone()
+            if row is not None:
+                for col_name, scale_val in zip(unconstrained_numeric_columns, row):
+                    probed_scales[col_name] = scale_val
+        except Exception as e:
+            # Probe is best-effort. If it fails (permissions, timeout, weird column type),
+            # fall back to DEFAULT_NUMERIC_SCALE rather than blocking the sync.
+            logger.warning(f"Failed to probe numeric scales for {schema}.{table_name}: {e}")
+
     columns = []
-    for name, data_type, nullable, numeric_precision_candidate, numeric_scale_candidate in cursor:
+    for name, data_type, nullable, numeric_precision_candidate, numeric_scale_candidate in metadata_rows:
         if data_type in numeric_data_types:
             numeric_precision = numeric_precision_candidate or DEFAULT_NUMERIC_PRECISION
-            numeric_scale = numeric_scale_candidate or DEFAULT_NUMERIC_SCALE
+            if numeric_scale_candidate is not None:
+                numeric_scale = numeric_scale_candidate
+            else:
+                probed = probed_scales.get(name)
+                if probed is not None and probed > 0:
+                    numeric_scale = min(probed, MAX_NUMERIC_SCALE)
+                else:
+                    numeric_scale = DEFAULT_NUMERIC_SCALE
         else:
             numeric_precision = None
             numeric_scale = None

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1227,6 +1227,13 @@ def _get_table(
                 numeric_scale = numeric_scale_candidate
             else:
                 probed = probed_scales.get(name)
+                # Intentionally fall back to DEFAULT_NUMERIC_SCALE when probed == 0. A scale of 0
+                # means every row we saw today happens to be integer-valued, but the source column
+                # is declared as unconstrained `numeric` — meaning the schema makes no scale
+                # promise. Freezing the delta column at scale=0 based on a transient all-integer
+                # snapshot would reintroduce this PR's original bug the moment a future sync sees
+                # a fractional value: the merge would fail because the delta column can't hold
+                # the new digits. DEFAULT_NUMERIC_SCALE leaves room for that future.
                 if probed is not None and probed > 0:
                     numeric_scale = min(probed, MAX_NUMERIC_SCALE)
                 else:

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1023,9 +1023,11 @@ class PostgreSQLColumn(Column):
             case "smallint":
                 arrow_type = pa.int16()
             case "numeric" | "decimal":
-                # Use `is None` rather than truthiness so that legitimate `NUMERIC(X, 0)` columns
-                # (integer-valued numerics, scale == 0) are not mistakenly treated as "missing scale".
-                if self.numeric_precision is None or self.numeric_scale is None:
+                # Use `is None` for the scale half of the guard so that legitimate `NUMERIC(X, 0)`
+                # columns (integer-valued numerics, scale == 0) are not mistakenly treated as
+                # "missing scale". Precision still uses a truthiness check — precision == 0 is a
+                # real pathology (zero-digit budget) and should keep raising from our layer.
+                if not self.numeric_precision or self.numeric_scale is None:
                     raise TypeError("expected `numeric_precision` and `numeric_scale` to be `int`, got `NoneType`")
 
                 arrow_type = build_pyarrow_decimal_type(self.numeric_precision, self.numeric_scale)

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1023,7 +1023,9 @@ class PostgreSQLColumn(Column):
             case "smallint":
                 arrow_type = pa.int16()
             case "numeric" | "decimal":
-                if not self.numeric_precision or not self.numeric_scale:
+                # Use `is None` rather than truthiness so that legitimate `NUMERIC(X, 0)` columns
+                # (integer-valued numerics, scale == 0) are not mistakenly treated as "missing scale".
+                if self.numeric_precision is None or self.numeric_scale is None:
                     raise TypeError("expected `numeric_precision` and `numeric_scale` to be `int`, got `NoneType`")
 
                 arrow_type = build_pyarrow_decimal_type(self.numeric_precision, self.numeric_scale)

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1168,6 +1168,12 @@ def _get_table(
         if data_type in numeric_data_types and numeric_scale_candidate is None
     ]
     probed_scales: dict[str, int | None] = {}
+    # Alongside scale, we also probe the max integer digits per column so we can size precision
+    # to cover BOTH dimensions. Freezing the delta column at `decimal128(38, probed_scale)` when
+    # the observed data has `int_digits + scale > 38` would cause later arrow casts to fail — the
+    # probe alone cannot protect the integer side because precision is hard-capped at 38 for
+    # decimal128.
+    probed_int_digits: dict[str, int | None] = {}
     # Only probe when a fresh delta column is about to be created. On incremental syncs the
     # delta column type is already set and probing wastes a full-table aggregation per sync.
     # Skip regular views: `MAX(scale(col))` on a view forces the view definition to execute,
@@ -1193,20 +1199,28 @@ def _get_table(
                         timeout=sql.Literal(30 * 1000)  # 30 seconds
                     )
                 )
+                # `abs(col)` strips the minus sign before `::text` so negative values don't
+                # inflate the measured integer-digit count. `trunc` drops the fractional part;
+                # the result is always numeric (never scientific notation), so `length(::text)`
+                # is the integer-digit count. Pairs: (MAX(scale), MAX(int_digits)) per column,
+                # emitted in the same order as `unconstrained_numeric_columns`.
                 select_parts = sql.SQL(", ").join(
-                    sql.SQL("MAX(scale({col}))").format(col=sql.Identifier(col_name))
+                    sql.SQL("MAX(scale({col})), MAX(length(trunc(abs({col}))::text))").format(
+                        col=sql.Identifier(col_name)
+                    )
                     for col_name in unconstrained_numeric_columns
                 )
                 probe_query = sql.SQL("SELECT {parts} FROM {table}").format(
                     parts=select_parts,
                     table=sql.Identifier(schema, table_name),
                 )
-                logger.debug(f"Probing numeric scales: {probe_query.as_string()}")
+                logger.debug(f"Probing numeric dimensions: {probe_query.as_string()}")
                 cursor.execute(probe_query)
                 row = cursor.fetchone()
                 if row is not None:
-                    for col_name, scale_val in zip(unconstrained_numeric_columns, row):
-                        probed_scales[col_name] = scale_val
+                    for i, col_name in enumerate(unconstrained_numeric_columns):
+                        probed_scales[col_name] = row[2 * i]
+                        probed_int_digits[col_name] = row[2 * i + 1]
                 cursor.execute(sql.SQL("RELEASE SAVEPOINT probe_numeric_scale"))
             except Exception:
                 # Roll back the savepoint so the enclosing transaction stays usable, then
@@ -1217,26 +1231,51 @@ def _get_table(
         except Exception as e:
             # Probe is best-effort. Fall back to DEFAULT_NUMERIC_SCALE and let the downstream
             # `_process_batch` fallback chain infer the right type at row-fetching time.
-            logger.warning(f"Failed to probe numeric scales for {schema}.{table_name}: {e}")
+            logger.warning(f"Failed to probe numeric dimensions for {schema}.{table_name}: {e}")
 
     columns = []
     for name, data_type, nullable, numeric_precision_candidate, numeric_scale_candidate in metadata_rows:
         if data_type in numeric_data_types:
-            numeric_precision = numeric_precision_candidate or DEFAULT_NUMERIC_PRECISION
             if numeric_scale_candidate is not None:
+                # Constrained `NUMERIC(p, s)`: trust the declared precision and scale directly.
+                numeric_precision = numeric_precision_candidate or DEFAULT_NUMERIC_PRECISION
                 numeric_scale = numeric_scale_candidate
             else:
-                probed = probed_scales.get(name)
-                # Intentionally fall back to DEFAULT_NUMERIC_SCALE when probed == 0. A scale of 0
-                # means every row we saw today happens to be integer-valued, but the source column
-                # is declared as unconstrained `numeric` — meaning the schema makes no scale
-                # promise. Freezing the delta column at scale=0 based on a transient all-integer
-                # snapshot would reintroduce this PR's original bug the moment a future sync sees
-                # a fractional value: the merge would fail because the delta column can't hold
-                # the new digits. DEFAULT_NUMERIC_SCALE leaves room for that future.
-                if probed is not None and probed > 0:
-                    numeric_scale = min(probed, MAX_NUMERIC_SCALE)
+                probed_scale = probed_scales.get(name)
+                probed_int = probed_int_digits.get(name)
+                # Intentionally fall back to DEFAULT_NUMERIC_SCALE when probed_scale is 0 or
+                # missing. A scale of 0 means every row we saw today happens to be integer-valued,
+                # but the source column is declared as unconstrained `numeric` — meaning the schema
+                # makes no scale promise. Freezing the delta column at scale=0 based on a transient
+                # all-integer snapshot would reintroduce this PR's original bug the moment a future
+                # sync sees a fractional value. DEFAULT_NUMERIC_SCALE leaves room for that future.
+                if probed_scale is not None and probed_scale > 0:
+                    # MAX_NUMERIC_SCALE bounds the scale we're willing to write into delta.
+                    effective_scale = min(probed_scale, MAX_NUMERIC_SCALE)
+                    # Precision must cover BOTH integer digits and scale — if `int_digits +
+                    # effective_scale` fits within the decimal128 budget (38), keep precision at
+                    # 38 to leave maximum integer headroom for future rows. Otherwise escalate
+                    # precision past 38 so `build_pyarrow_decimal_type` promotes the column to
+                    # decimal256. That column will then be collapsed to `string` at delta write
+                    # time (see `ensure_delta_compatible_arrow_schema` in dlt's deltalake libs) —
+                    # a known fidelity loss that's preferable to silently truncating either
+                    # integer digits (undersized precision) or fractional digits (undersized
+                    # scale).
+                    total_needed = (probed_int or 0) + effective_scale
+                    if total_needed <= DEFAULT_NUMERIC_PRECISION:
+                        numeric_precision = DEFAULT_NUMERIC_PRECISION
+                    else:
+                        numeric_precision = total_needed
+                        logger.warning(
+                            f"Unconstrained numeric column {schema}.{table_name}.{name} "
+                            f"requires {total_needed} digits "
+                            f"(int={probed_int}, scale={effective_scale}), exceeding decimal128's "
+                            f"{DEFAULT_NUMERIC_PRECISION}-digit budget. Column will be stored as "
+                            f"`string` in delta to preserve data fidelity."
+                        )
+                    numeric_scale = effective_scale
                 else:
+                    numeric_precision = DEFAULT_NUMERIC_PRECISION
                     numeric_scale = DEFAULT_NUMERIC_SCALE
         else:
             numeric_precision = None

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1071,8 +1071,24 @@ def _is_read_replica(cursor: psycopg.Cursor) -> bool:
 
 
 def _get_table(
-    cursor: psycopg.Cursor, schema: str, table_name: str, logger: FilteringBoundLogger
+    cursor: psycopg.Cursor,
+    schema: str,
+    table_name: str,
+    logger: FilteringBoundLogger,
+    probe_unconstrained_numeric_scale: bool = False,
 ) -> Table[PostgreSQLColumn]:
+    """Read column metadata for `schema.table_name`.
+
+    If `probe_unconstrained_numeric_scale` is True, additionally run a `MAX(scale(col))`
+    aggregation on unconstrained `numeric` columns (those declared as `numeric` with no
+    precision/scale) to pick a source arrow decimal scale that matches the real data.
+
+    The probe is only useful when a fresh delta column is about to be created — either a
+    first-ever sync or a post-reset sync with a cleared incremental watermark — because delta
+    decimal column types are immutable after creation. On normal incremental syncs the delta
+    column already exists and the probed value is discarded, so the caller should gate
+    probing on "is a fresh schema being created" (see the equivalent gating on
+    `_get_estimated_row_count_for_partitioned_table` in `postgres_source`)."""
     is_mat_view_query = sql.SQL(
         "select {table} in (select matviewname from pg_matviews where schemaname = {schema}) as res"
     ).format(schema=sql.Literal(schema), table=sql.Literal(table_name))
@@ -1150,7 +1166,9 @@ def _get_table(
         if data_type in numeric_data_types and numeric_scale_candidate is None
     ]
     probed_scales: dict[str, int | None] = {}
-    if unconstrained_numeric_columns:
+    # Only probe when a fresh delta column is about to be created. On incremental syncs the
+    # delta column type is already set and probing wastes a full-table aggregation per sync.
+    if unconstrained_numeric_columns and probe_unconstrained_numeric_scale:
         try:
             select_parts = sql.SQL(", ").join(
                 sql.SQL("MAX(scale({col}))").format(col=sql.Identifier(col_name))
@@ -1255,7 +1273,20 @@ def postgres_source(
         with connection:
             with connection.cursor() as cursor:
                 logger.debug("Getting table types...")
-                table = _get_table(cursor, schema, table_name, logger)
+                # Only probe the actual data for numeric scale when a fresh delta column is
+                # about to be created — either a first-ever sync or a post-reset full scan
+                # (watermark cleared). On normal incremental syncs the delta column already
+                # exists, so probing would be a wasted full-table aggregation. Mirrors the
+                # `is_initial_sync or full_table_scan` gating used a few lines below for
+                # partitioned-table row estimation.
+                fresh_schema_being_created = is_initial_sync or db_incremental_field_last_value is None
+                table = _get_table(
+                    cursor,
+                    schema,
+                    table_name,
+                    logger,
+                    probe_unconstrained_numeric_scale=fresh_schema_being_created,
+                )
                 logger.debug(f"Source schema: {table.to_arrow_schema()}")
 
                 inner_query_with_limit = _build_query(

--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1168,25 +1168,53 @@ def _get_table(
     probed_scales: dict[str, int | None] = {}
     # Only probe when a fresh delta column is about to be created. On incremental syncs the
     # delta column type is already set and probing wastes a full-table aggregation per sync.
-    if unconstrained_numeric_columns and probe_unconstrained_numeric_scale:
+    # Skip regular views: `MAX(scale(col))` on a view forces the view definition to execute,
+    # which can be arbitrarily expensive for join/aggregate views. Materialized views are
+    # already materialized on disk and behave like tables here.
+    if unconstrained_numeric_columns and probe_unconstrained_numeric_scale and not is_view:
         try:
-            select_parts = sql.SQL(", ").join(
-                sql.SQL("MAX(scale({col}))").format(col=sql.Identifier(col_name))
-                for col_name in unconstrained_numeric_columns
-            )
-            probe_query = sql.SQL("SELECT {parts} FROM {table}").format(
-                parts=select_parts,
-                table=sql.Identifier(schema, table_name),
-            )
-            logger.debug(f"Probing numeric scales: {probe_query.as_string()}")
-            cursor.execute(probe_query)
-            row = cursor.fetchone()
-            if row is not None:
-                for col_name, scale_val in zip(unconstrained_numeric_columns, row):
-                    probed_scales[col_name] = scale_val
+            # Isolate the probe in a SAVEPOINT so that any failure (permission denied, bad
+            # type, statement_timeout, network blip) rolls back cleanly without poisoning the
+            # enclosing metadata transaction. Without this, a probe error leaves the
+            # transaction in `INERROR` state and every subsequent query in `postgres_source`
+            # (SET LOCAL statement_timeout, _is_read_replica, _get_primary_keys, _get_rows_to_sync,
+            # ...) fails with `InFailedSqlTransaction: current transaction is aborted`.
+            cursor.execute(sql.SQL("SAVEPOINT probe_numeric_scale"))
+            try:
+                # Scope a short statement_timeout to the probe so a pathologically large table
+                # or slow aggregation can't hang schema discovery. The outer 10-minute
+                # statement_timeout isn't set until `postgres_source` continues after
+                # `_get_table` returns, so without this the probe inherits whatever role-level
+                # default postgres has — which might be "no limit" on some hosted instances.
+                cursor.execute(
+                    sql.SQL("SET LOCAL statement_timeout = {timeout}").format(
+                        timeout=sql.Literal(30 * 1000)  # 30 seconds
+                    )
+                )
+                select_parts = sql.SQL(", ").join(
+                    sql.SQL("MAX(scale({col}))").format(col=sql.Identifier(col_name))
+                    for col_name in unconstrained_numeric_columns
+                )
+                probe_query = sql.SQL("SELECT {parts} FROM {table}").format(
+                    parts=select_parts,
+                    table=sql.Identifier(schema, table_name),
+                )
+                logger.debug(f"Probing numeric scales: {probe_query.as_string()}")
+                cursor.execute(probe_query)
+                row = cursor.fetchone()
+                if row is not None:
+                    for col_name, scale_val in zip(unconstrained_numeric_columns, row):
+                        probed_scales[col_name] = scale_val
+                cursor.execute(sql.SQL("RELEASE SAVEPOINT probe_numeric_scale"))
+            except Exception:
+                # Roll back the savepoint so the enclosing transaction stays usable, then
+                # re-raise into the outer `except` for logging.
+                cursor.execute(sql.SQL("ROLLBACK TO SAVEPOINT probe_numeric_scale"))
+                cursor.execute(sql.SQL("RELEASE SAVEPOINT probe_numeric_scale"))
+                raise
         except Exception as e:
-            # Probe is best-effort. If it fails (permissions, timeout, weird column type),
-            # fall back to DEFAULT_NUMERIC_SCALE rather than blocking the sync.
+            # Probe is best-effort. Fall back to DEFAULT_NUMERIC_SCALE and let the downstream
+            # `_process_batch` fallback chain infer the right type at row-fetching time.
             logger.warning(f"Failed to probe numeric scales for {schema}.{table_name}: {e}")
 
     columns = []

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -10,6 +10,7 @@ import pyarrow as pa
 import structlog
 from psycopg import sql
 
+from posthog.temporal.data_imports.pipelines.pipeline.utils import DEFAULT_NUMERIC_SCALE, MAX_NUMERIC_SCALE
 from posthog.temporal.data_imports.sources.postgres.postgres import (
     SSL_REQUIRED_AFTER_DATE,
     JsonAsStringLoader,
@@ -937,8 +938,6 @@ class TestGetTable:
         column falls back to `DEFAULT_NUMERIC_SCALE` regardless of the actual data. This is the
         path used by incremental syncs where the delta column type is already set and probing
         would be a wasted full-table aggregation."""
-        from posthog.temporal.data_imports.pipelines.pipeline.utils import DEFAULT_NUMERIC_SCALE
-
         logger = structlog.get_logger()
 
         with django_connection.cursor() as dj_cursor:
@@ -950,50 +949,63 @@ class TestGetTable:
             assert val_col.numeric_scale == DEFAULT_NUMERIC_SCALE
 
     @pytest.mark.django_db
-    def test_unconstrained_numeric_probes_scale_from_data(self):
-        """Unconstrained `numeric` columns get their scale from the actual data, not a static default."""
-        from posthog.temporal.data_imports.pipelines.pipeline.utils import DEFAULT_NUMERIC_SCALE
-
+    @pytest.mark.parametrize(
+        "inserts,expected_scale",
+        [
+            pytest.param(
+                [
+                    "INSERT INTO test_probe_scale VALUES (1, 0.84497449830783164117::numeric)",
+                    "INSERT INTO test_probe_scale VALUES (2, 0::numeric)",
+                ],
+                20,
+                id="fractional_data_uses_probed_scale",
+            ),
+            pytest.param(
+                [],
+                DEFAULT_NUMERIC_SCALE,
+                id="empty_table_falls_back_to_default",
+            ),
+            pytest.param(
+                [
+                    "INSERT INTO test_probe_scale VALUES (1, 0.1234567890123456789012345678901234567890::numeric)",
+                ],
+                MAX_NUMERIC_SCALE,
+                id="scale_exceeding_max_is_clamped",
+            ),
+            # Pins the intentional conservative behavior: all-integer data means MAX(scale(val))
+            # returns 0, but we fall back to DEFAULT_NUMERIC_SCALE rather than freezing the delta
+            # column at scale=0 — because the source column is unconstrained and a future sync
+            # could legitimately carry fractional digits the delta column wouldn't be able to
+            # hold. See the matching comment in postgres.py:_get_table.
+            pytest.param(
+                [
+                    "INSERT INTO test_probe_scale VALUES (1, 42::numeric)",
+                    "INSERT INTO test_probe_scale VALUES (2, 1000::numeric)",
+                ],
+                DEFAULT_NUMERIC_SCALE,
+                id="integer_only_data_falls_back_to_default",
+            ),
+        ],
+    )
+    def test_unconstrained_numeric_probe_scale(self, inserts: list[str], expected_scale: int):
+        """Unconstrained `numeric` columns get their scale from actual data, with well-defined
+        fallbacks for empty tables, clamping past MAX_NUMERIC_SCALE, and integer-only data."""
         logger = structlog.get_logger()
 
         with django_connection.cursor() as dj_cursor:
-            dj_cursor.execute("CREATE TABLE test_get_table_unconstrained_numeric (id INTEGER PRIMARY KEY, val NUMERIC)")
-            # Value with actual scale 20 — matches the real-world shape that broke the customer.
-            dj_cursor.execute(
-                "INSERT INTO test_get_table_unconstrained_numeric VALUES (1, 0.84497449830783164117::numeric)"
-            )
-            dj_cursor.execute("INSERT INTO test_get_table_unconstrained_numeric VALUES (2, 0::numeric)")
+            dj_cursor.execute("CREATE TABLE test_probe_scale (id INTEGER PRIMARY KEY, val NUMERIC)")
+            for insert_sql in inserts:
+                dj_cursor.execute(insert_sql)
 
             table = _get_table(
                 dj_cursor,  # type: ignore[arg-type]
                 "public",
-                "test_get_table_unconstrained_numeric",
+                "test_probe_scale",
                 logger,
                 probe_unconstrained_numeric_scale=True,
             )
             val_col = next(c for c in table.columns if c.name == "val")
-            assert val_col.numeric_scale == 20, (
-                f"expected probed scale 20, got {val_col.numeric_scale} (would have been {DEFAULT_NUMERIC_SCALE} without probe)"
-            )
-
-    @pytest.mark.django_db
-    def test_unconstrained_numeric_empty_table_falls_back_to_default(self):
-        """Empty unconstrained `numeric` column has no data to probe, so falls back to DEFAULT_NUMERIC_SCALE."""
-        from posthog.temporal.data_imports.pipelines.pipeline.utils import DEFAULT_NUMERIC_SCALE
-
-        logger = structlog.get_logger()
-
-        with django_connection.cursor() as dj_cursor:
-            dj_cursor.execute("CREATE TABLE test_get_table_unconstrained_empty (id INTEGER PRIMARY KEY, val NUMERIC)")
-            table = _get_table(
-                dj_cursor,  # type: ignore[arg-type]
-                "public",
-                "test_get_table_unconstrained_empty",
-                logger,
-                probe_unconstrained_numeric_scale=True,
-            )
-            val_col = next(c for c in table.columns if c.name == "val")
-            assert val_col.numeric_scale == DEFAULT_NUMERIC_SCALE
+            assert val_col.numeric_scale == expected_scale
 
     @pytest.mark.django_db
     def test_constrained_numeric_skips_probe(self):
@@ -1009,29 +1021,6 @@ class TestGetTable:
             val_col = next(c for c in table.columns if c.name == "val")
             assert val_col.numeric_precision == 10
             assert val_col.numeric_scale == 2
-
-    @pytest.mark.django_db
-    def test_unconstrained_numeric_clamps_to_max_scale(self):
-        """If probed scale exceeds MAX_NUMERIC_SCALE, it's clamped to prevent pathological schemas."""
-        from posthog.temporal.data_imports.pipelines.pipeline.utils import MAX_NUMERIC_SCALE
-
-        logger = structlog.get_logger()
-
-        with django_connection.cursor() as dj_cursor:
-            dj_cursor.execute("CREATE TABLE test_get_table_clamp_scale (id INTEGER PRIMARY KEY, val NUMERIC)")
-            # Scale 40 exceeds MAX_NUMERIC_SCALE (32) — should clamp.
-            dj_cursor.execute(
-                "INSERT INTO test_get_table_clamp_scale VALUES (1, 0.1234567890123456789012345678901234567890::numeric)"
-            )
-            table = _get_table(
-                dj_cursor,  # type: ignore[arg-type]
-                "public",
-                "test_get_table_clamp_scale",
-                logger,
-                probe_unconstrained_numeric_scale=True,
-            )
-            val_col = next(c for c in table.columns if c.name == "val")
-            assert val_col.numeric_scale == MAX_NUMERIC_SCALE
 
     @pytest.mark.django_db
     def test_constrained_numeric_zero_scale_survives_schema_conversion(self):
@@ -1055,8 +1044,6 @@ class TestGetTable:
         can be arbitrarily expensive for join/aggregate views. The probe is skipped for views
         regardless of the caller's probe flag, and falls back to DEFAULT_NUMERIC_SCALE.
         The downstream `_process_batch` fallback chain handles scale inference at row time."""
-        from posthog.temporal.data_imports.pipelines.pipeline.utils import DEFAULT_NUMERIC_SCALE
-
         logger = structlog.get_logger()
 
         with django_connection.cursor() as dj_cursor:

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1050,6 +1050,39 @@ class TestGetTable:
             assert pa.types.is_decimal(arrow_schema.field("val").type)
 
     @pytest.mark.django_db
+    def test_unconstrained_numeric_on_view_skips_probe(self):
+        """`MAX(scale(col))` on a regular view forces the view definition to execute, which
+        can be arbitrarily expensive for join/aggregate views. The probe is skipped for views
+        regardless of the caller's probe flag, and falls back to DEFAULT_NUMERIC_SCALE.
+        The downstream `_process_batch` fallback chain handles scale inference at row time."""
+        from posthog.temporal.data_imports.pipelines.pipeline.utils import DEFAULT_NUMERIC_SCALE
+
+        logger = structlog.get_logger()
+
+        with django_connection.cursor() as dj_cursor:
+            dj_cursor.execute(
+                "CREATE TABLE test_get_table_view_unconstrained_base (id INTEGER PRIMARY KEY, val NUMERIC)"
+            )
+            dj_cursor.execute(
+                "INSERT INTO test_get_table_view_unconstrained_base VALUES (1, 0.84497449830783164117::numeric)"
+            )
+            dj_cursor.execute(
+                "CREATE VIEW test_get_table_view_unconstrained AS SELECT * FROM test_get_table_view_unconstrained_base"
+            )
+            table = _get_table(  # type: ignore[arg-type]
+                dj_cursor,
+                "public",
+                "test_get_table_view_unconstrained",
+                logger,
+                probe_unconstrained_numeric_scale=True,
+            )
+            assert table.type == "view"
+            val_col = next(c for c in table.columns if c.name == "val")
+            # Probe was skipped for the view → default scale, even though the base table has
+            # scale-20 data that a probe would have found.
+            assert val_col.numeric_scale == DEFAULT_NUMERIC_SCALE
+
+    @pytest.mark.django_db
     def test_unconstrained_numeric_multiple_columns_probed_together(self):
         """Multiple unconstrained numeric columns are probed in a single aggregation query."""
         logger = structlog.get_logger()

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -626,11 +626,7 @@ class TestPostgreSQLColumnToArrowField:
 
     def test_numeric_raises_with_zero_precision(self):
         col = PostgreSQLColumn("val", "numeric", nullable=True, numeric_precision=0, numeric_scale=2)
-        # pyarrow rejects precision=0 with ValueError ("precision should be between 1 and 38").
-        # The `is None` guard in `to_arrow_field` intentionally lets 0 through so that legitimate
-        # NUMERIC(X, 0) columns aren't blocked — 0 precision is a real pathology and surfacing it
-        # as an error is the desired behavior.
-        with pytest.raises((TypeError, ValueError)):
+        with pytest.raises(TypeError):
             col.to_arrow_field()
 
     def test_array_types_map_to_string(self):

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -626,7 +626,11 @@ class TestPostgreSQLColumnToArrowField:
 
     def test_numeric_raises_with_zero_precision(self):
         col = PostgreSQLColumn("val", "numeric", nullable=True, numeric_precision=0, numeric_scale=2)
-        with pytest.raises(TypeError):
+        # pyarrow rejects precision=0 with ValueError ("precision should be between 1 and 38").
+        # The `is None` guard in `to_arrow_field` intentionally lets 0 through so that legitimate
+        # NUMERIC(X, 0) columns aren't blocked — 0 precision is a real pathology and surfacing it
+        # as an error is the desired behavior.
+        with pytest.raises((TypeError, ValueError)):
             col.to_arrow_field()
 
     def test_array_types_map_to_string(self):
@@ -964,8 +968,8 @@ class TestGetTable:
             )
             dj_cursor.execute("INSERT INTO test_get_table_unconstrained_numeric VALUES (2, 0::numeric)")
 
-            table = _get_table(  # type: ignore[arg-type]
-                dj_cursor,
+            table = _get_table(
+                dj_cursor,  # type: ignore[arg-type]
                 "public",
                 "test_get_table_unconstrained_numeric",
                 logger,
@@ -985,8 +989,8 @@ class TestGetTable:
 
         with django_connection.cursor() as dj_cursor:
             dj_cursor.execute("CREATE TABLE test_get_table_unconstrained_empty (id INTEGER PRIMARY KEY, val NUMERIC)")
-            table = _get_table(  # type: ignore[arg-type]
-                dj_cursor,
+            table = _get_table(
+                dj_cursor,  # type: ignore[arg-type]
                 "public",
                 "test_get_table_unconstrained_empty",
                 logger,
@@ -1023,8 +1027,8 @@ class TestGetTable:
             dj_cursor.execute(
                 "INSERT INTO test_get_table_clamp_scale VALUES (1, 0.1234567890123456789012345678901234567890::numeric)"
             )
-            table = _get_table(  # type: ignore[arg-type]
-                dj_cursor,
+            table = _get_table(
+                dj_cursor,  # type: ignore[arg-type]
                 "public",
                 "test_get_table_clamp_scale",
                 logger,
@@ -1069,8 +1073,8 @@ class TestGetTable:
             dj_cursor.execute(
                 "CREATE VIEW test_get_table_view_unconstrained AS SELECT * FROM test_get_table_view_unconstrained_base"
             )
-            table = _get_table(  # type: ignore[arg-type]
-                dj_cursor,
+            table = _get_table(
+                dj_cursor,  # type: ignore[arg-type]
                 "public",
                 "test_get_table_view_unconstrained",
                 logger,
@@ -1096,8 +1100,8 @@ class TestGetTable:
                 "INSERT INTO test_get_table_multi_numeric VALUES "
                 "(1, 0.12345::numeric, 0.1234567890::numeric, 1.23::numeric(5,2))"
             )
-            table = _get_table(  # type: ignore[arg-type]
-                dj_cursor,
+            table = _get_table(
+                dj_cursor,  # type: ignore[arg-type]
                 "public",
                 "test_get_table_multi_numeric",
                 logger,

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -946,7 +946,7 @@ class TestGetTable:
             )
             dj_cursor.execute("INSERT INTO test_get_table_unconstrained_numeric VALUES (2, 0::numeric)")
 
-            table = _get_table(dj_cursor, "public", "test_get_table_unconstrained_numeric", logger)
+            table = _get_table(dj_cursor, "public", "test_get_table_unconstrained_numeric", logger)  # type: ignore[arg-type]
             val_col = next(c for c in table.columns if c.name == "val")
             assert val_col.numeric_scale == 20, (
                 f"expected probed scale 20, got {val_col.numeric_scale} (would have been {DEFAULT_NUMERIC_SCALE} without probe)"
@@ -961,7 +961,7 @@ class TestGetTable:
 
         with django_connection.cursor() as dj_cursor:
             dj_cursor.execute("CREATE TABLE test_get_table_unconstrained_empty (id INTEGER PRIMARY KEY, val NUMERIC)")
-            table = _get_table(dj_cursor, "public", "test_get_table_unconstrained_empty", logger)
+            table = _get_table(dj_cursor, "public", "test_get_table_unconstrained_empty", logger)  # type: ignore[arg-type]
             val_col = next(c for c in table.columns if c.name == "val")
             assert val_col.numeric_scale == DEFAULT_NUMERIC_SCALE
 
@@ -975,7 +975,7 @@ class TestGetTable:
                 "CREATE TABLE test_get_table_constrained_numeric (id INTEGER PRIMARY KEY, val NUMERIC(10, 2))"
             )
             # Even though there's no data, the declared scale is used — no probe attempted.
-            table = _get_table(dj_cursor, "public", "test_get_table_constrained_numeric", logger)
+            table = _get_table(dj_cursor, "public", "test_get_table_constrained_numeric", logger)  # type: ignore[arg-type]
             val_col = next(c for c in table.columns if c.name == "val")
             assert val_col.numeric_precision == 10
             assert val_col.numeric_scale == 2
@@ -993,7 +993,7 @@ class TestGetTable:
             dj_cursor.execute(
                 "INSERT INTO test_get_table_clamp_scale VALUES (1, 0.1234567890123456789012345678901234567890::numeric)"
             )
-            table = _get_table(dj_cursor, "public", "test_get_table_clamp_scale", logger)
+            table = _get_table(dj_cursor, "public", "test_get_table_clamp_scale", logger)  # type: ignore[arg-type]
             val_col = next(c for c in table.columns if c.name == "val")
             assert val_col.numeric_scale == MAX_NUMERIC_SCALE
 
@@ -1011,7 +1011,7 @@ class TestGetTable:
                 "INSERT INTO test_get_table_multi_numeric VALUES "
                 "(1, 0.12345::numeric, 0.1234567890::numeric, 1.23::numeric(5,2))"
             )
-            table = _get_table(dj_cursor, "public", "test_get_table_multi_numeric", logger)
+            table = _get_table(dj_cursor, "public", "test_get_table_multi_numeric", logger)  # type: ignore[arg-type]
             cols_by_name = {c.name: c for c in table.columns}
             assert cols_by_name["a"].numeric_scale == 5
             assert cols_by_name["b"].numeric_scale == 10

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -932,6 +932,24 @@ class TestGetTable:
             assert table.type == "materialized_view"
 
     @pytest.mark.django_db
+    def test_unconstrained_numeric_probe_gated_off_uses_default_scale(self):
+        """When the caller doesn't request probing (the default), an unconstrained `numeric`
+        column falls back to `DEFAULT_NUMERIC_SCALE` regardless of the actual data. This is the
+        path used by incremental syncs where the delta column type is already set and probing
+        would be a wasted full-table aggregation."""
+        from posthog.temporal.data_imports.pipelines.pipeline.utils import DEFAULT_NUMERIC_SCALE
+
+        logger = structlog.get_logger()
+
+        with django_connection.cursor() as dj_cursor:
+            dj_cursor.execute("CREATE TABLE test_get_table_probe_gated_off (id INTEGER PRIMARY KEY, val NUMERIC)")
+            dj_cursor.execute("INSERT INTO test_get_table_probe_gated_off VALUES (1, 0.84497449830783164117::numeric)")
+            # Explicitly omit `probe_unconstrained_numeric_scale` to exercise the default.
+            table = _get_table(dj_cursor, "public", "test_get_table_probe_gated_off", logger)  # type: ignore[arg-type]
+            val_col = next(c for c in table.columns if c.name == "val")
+            assert val_col.numeric_scale == DEFAULT_NUMERIC_SCALE
+
+    @pytest.mark.django_db
     def test_unconstrained_numeric_probes_scale_from_data(self):
         """Unconstrained `numeric` columns get their scale from the actual data, not a static default."""
         from posthog.temporal.data_imports.pipelines.pipeline.utils import DEFAULT_NUMERIC_SCALE
@@ -946,7 +964,13 @@ class TestGetTable:
             )
             dj_cursor.execute("INSERT INTO test_get_table_unconstrained_numeric VALUES (2, 0::numeric)")
 
-            table = _get_table(dj_cursor, "public", "test_get_table_unconstrained_numeric", logger)  # type: ignore[arg-type]
+            table = _get_table(  # type: ignore[arg-type]
+                dj_cursor,
+                "public",
+                "test_get_table_unconstrained_numeric",
+                logger,
+                probe_unconstrained_numeric_scale=True,
+            )
             val_col = next(c for c in table.columns if c.name == "val")
             assert val_col.numeric_scale == 20, (
                 f"expected probed scale 20, got {val_col.numeric_scale} (would have been {DEFAULT_NUMERIC_SCALE} without probe)"
@@ -961,7 +985,13 @@ class TestGetTable:
 
         with django_connection.cursor() as dj_cursor:
             dj_cursor.execute("CREATE TABLE test_get_table_unconstrained_empty (id INTEGER PRIMARY KEY, val NUMERIC)")
-            table = _get_table(dj_cursor, "public", "test_get_table_unconstrained_empty", logger)  # type: ignore[arg-type]
+            table = _get_table(  # type: ignore[arg-type]
+                dj_cursor,
+                "public",
+                "test_get_table_unconstrained_empty",
+                logger,
+                probe_unconstrained_numeric_scale=True,
+            )
             val_col = next(c for c in table.columns if c.name == "val")
             assert val_col.numeric_scale == DEFAULT_NUMERIC_SCALE
 
@@ -993,7 +1023,13 @@ class TestGetTable:
             dj_cursor.execute(
                 "INSERT INTO test_get_table_clamp_scale VALUES (1, 0.1234567890123456789012345678901234567890::numeric)"
             )
-            table = _get_table(dj_cursor, "public", "test_get_table_clamp_scale", logger)  # type: ignore[arg-type]
+            table = _get_table(  # type: ignore[arg-type]
+                dj_cursor,
+                "public",
+                "test_get_table_clamp_scale",
+                logger,
+                probe_unconstrained_numeric_scale=True,
+            )
             val_col = next(c for c in table.columns if c.name == "val")
             assert val_col.numeric_scale == MAX_NUMERIC_SCALE
 
@@ -1027,7 +1063,13 @@ class TestGetTable:
                 "INSERT INTO test_get_table_multi_numeric VALUES "
                 "(1, 0.12345::numeric, 0.1234567890::numeric, 1.23::numeric(5,2))"
             )
-            table = _get_table(dj_cursor, "public", "test_get_table_multi_numeric", logger)  # type: ignore[arg-type]
+            table = _get_table(  # type: ignore[arg-type]
+                dj_cursor,
+                "public",
+                "test_get_table_multi_numeric",
+                logger,
+                probe_unconstrained_numeric_scale=True,
+            )
             cols_by_name = {c.name: c for c in table.columns}
             assert cols_by_name["a"].numeric_scale == 5
             assert cols_by_name["b"].numeric_scale == 10

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -998,6 +998,22 @@ class TestGetTable:
             assert val_col.numeric_scale == MAX_NUMERIC_SCALE
 
     @pytest.mark.django_db
+    def test_constrained_numeric_zero_scale_survives_schema_conversion(self):
+        """Declared `NUMERIC(X, 0)` columns must be convertible to an arrow schema without tripping
+        the legacy truthy-check guard in `PostgreSQLColumn.to_arrow_field`."""
+        logger = structlog.get_logger()
+
+        with django_connection.cursor() as dj_cursor:
+            dj_cursor.execute("CREATE TABLE test_get_table_zero_scale (id INTEGER PRIMARY KEY, val NUMERIC(10, 0))")
+            table = _get_table(dj_cursor, "public", "test_get_table_zero_scale", logger)  # type: ignore[arg-type]
+            val_col = next(c for c in table.columns if c.name == "val")
+            assert val_col.numeric_precision == 10
+            assert val_col.numeric_scale == 0
+            # Must not raise — the full schema conversion is the actual regression surface.
+            arrow_schema = table.to_arrow_schema()
+            assert pa.types.is_decimal(arrow_schema.field("val").type)
+
+    @pytest.mark.django_db
     def test_unconstrained_numeric_multiple_columns_probed_together(self):
         """Multiple unconstrained numeric columns are probed in a single aggregation query."""
         logger = structlog.get_logger()

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -950,18 +950,20 @@ class TestGetTable:
 
     @pytest.mark.django_db
     @pytest.mark.parametrize(
-        "inserts,expected_scale",
+        "inserts,expected_precision,expected_scale",
         [
             pytest.param(
                 [
                     "INSERT INTO test_probe_scale VALUES (1, 0.84497449830783164117::numeric)",
                     "INSERT INTO test_probe_scale VALUES (2, 0::numeric)",
                 ],
+                38,
                 20,
-                id="fractional_data_uses_probed_scale",
+                id="fractional_fits_in_decimal128",
             ),
             pytest.param(
                 [],
+                38,
                 DEFAULT_NUMERIC_SCALE,
                 id="empty_table_falls_back_to_default",
             ),
@@ -969,8 +971,9 @@ class TestGetTable:
                 [
                     "INSERT INTO test_probe_scale VALUES (1, 0.1234567890123456789012345678901234567890::numeric)",
                 ],
+                38,
                 MAX_NUMERIC_SCALE,
-                id="scale_exceeding_max_is_clamped",
+                id="scale_past_max_clamped_with_small_int_still_fits",
             ),
             # Pins the intentional conservative behavior: all-integer data means MAX(scale(val))
             # returns 0, but we fall back to DEFAULT_NUMERIC_SCALE rather than freezing the delta
@@ -982,14 +985,57 @@ class TestGetTable:
                     "INSERT INTO test_probe_scale VALUES (1, 42::numeric)",
                     "INSERT INTO test_probe_scale VALUES (2, 1000::numeric)",
                 ],
+                38,
                 DEFAULT_NUMERIC_SCALE,
                 id="integer_only_data_falls_back_to_default",
             ),
+            # 8 integer digits + 30 fractional digits = 38 total, which is the `decimal128`
+            # precision budget. Must fit without escalating.
+            pytest.param(
+                [
+                    "INSERT INTO test_probe_scale VALUES (1, 12345678.012345678901234567890123456789::numeric)",
+                ],
+                38,
+                30,
+                id="total_exactly_at_decimal128_budget_fits",
+            ),
+            # 9 integer digits + 30 fractional digits = 39 total, one digit past the `decimal128`
+            # budget. The column must escalate precision past 38 so `build_pyarrow_decimal_type`
+            # promotes to `decimal256`; staying at (38, 30) would silently lose the leading integer
+            # digit when the data is later cast to arrow.
+            pytest.param(
+                [
+                    "INSERT INTO test_probe_scale VALUES (1, 123456789.012345678901234567890123456789::numeric)",
+                ],
+                39,
+                30,
+                id="integer_overflow_escalates_precision_past_38",
+            ),
+            # 10 integer digits + 32 fractional digits = 42 total. Scale is at MAX_NUMERIC_SCALE,
+            # integer side is over budget. Must escalate precision to cover both dimensions.
+            pytest.param(
+                [
+                    "INSERT INTO test_probe_scale VALUES (1, 1234567890.12345678901234567890123456789012::numeric)",
+                ],
+                42,
+                MAX_NUMERIC_SCALE,
+                id="both_dimensions_exceed_budget_escalates_precision",
+            ),
         ],
     )
-    def test_unconstrained_numeric_probe_scale(self, inserts: list[str], expected_scale: int):
-        """Unconstrained `numeric` columns get their scale from actual data, with well-defined
-        fallbacks for empty tables, clamping past MAX_NUMERIC_SCALE, and integer-only data."""
+    def test_unconstrained_numeric_probe_dimensions(
+        self,
+        inserts: list[str],
+        expected_precision: int,
+        expected_scale: int,
+    ):
+        """Unconstrained `numeric` columns probe both fractional scale and integer digits so the
+        resulting decimal type has enough precision to hold the observed data. When total digits
+        exceed `decimal128`'s 38-digit budget, precision must escalate past 38 so
+        `build_pyarrow_decimal_type` promotes the column to `decimal256` (which delta-rs will then
+        collapse to `string` at write). Freezing at `decimal128(38, scale)` silently truncates
+        either fractional digits (original bug pre-PR) or integer digits (regression introduced by
+        the single-dimension probe)."""
         logger = structlog.get_logger()
 
         with django_connection.cursor() as dj_cursor:
@@ -1005,6 +1051,7 @@ class TestGetTable:
                 probe_unconstrained_numeric_scale=True,
             )
             val_col = next(c for c in table.columns if c.name == "val")
+            assert val_col.numeric_precision == expected_precision
             assert val_col.numeric_scale == expected_scale
 
     @pytest.mark.django_db

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -950,7 +950,7 @@ class TestGetTable:
 
     @pytest.mark.django_db
     @pytest.mark.parametrize(
-        "inserts,expected_precision,expected_scale",
+        "inserts,expected_precision,expected_scale,expected_arrow_type",
         [
             pytest.param(
                 [
@@ -959,12 +959,14 @@ class TestGetTable:
                 ],
                 38,
                 20,
+                pa.decimal128(38, 20),
                 id="fractional_fits_in_decimal128",
             ),
             pytest.param(
                 [],
                 38,
                 DEFAULT_NUMERIC_SCALE,
+                pa.decimal128(38, DEFAULT_NUMERIC_SCALE),
                 id="empty_table_falls_back_to_default",
             ),
             pytest.param(
@@ -973,6 +975,7 @@ class TestGetTable:
                 ],
                 38,
                 MAX_NUMERIC_SCALE,
+                pa.decimal128(38, MAX_NUMERIC_SCALE),
                 id="scale_past_max_clamped_with_small_int_still_fits",
             ),
             # Pins the intentional conservative behavior: all-integer data means MAX(scale(val))
@@ -987,6 +990,7 @@ class TestGetTable:
                 ],
                 38,
                 DEFAULT_NUMERIC_SCALE,
+                pa.decimal128(38, DEFAULT_NUMERIC_SCALE),
                 id="integer_only_data_falls_back_to_default",
             ),
             # 8 integer digits + 30 fractional digits = 38 total, which is the `decimal128`
@@ -997,6 +1001,7 @@ class TestGetTable:
                 ],
                 38,
                 30,
+                pa.decimal128(38, 30),
                 id="total_exactly_at_decimal128_budget_fits",
             ),
             # 9 integer digits + 30 fractional digits = 39 total, one digit past the `decimal128`
@@ -1009,6 +1014,7 @@ class TestGetTable:
                 ],
                 39,
                 30,
+                pa.decimal256(39, 30),
                 id="integer_overflow_escalates_precision_past_38",
             ),
             # 10 integer digits + 32 fractional digits = 42 total. Scale is at MAX_NUMERIC_SCALE,
@@ -1019,6 +1025,7 @@ class TestGetTable:
                 ],
                 42,
                 MAX_NUMERIC_SCALE,
+                pa.decimal256(42, MAX_NUMERIC_SCALE),
                 id="both_dimensions_exceed_budget_escalates_precision",
             ),
         ],
@@ -1028,6 +1035,7 @@ class TestGetTable:
         inserts: list[str],
         expected_precision: int,
         expected_scale: int,
+        expected_arrow_type: pa.DataType,
     ):
         """Unconstrained `numeric` columns probe both fractional scale and integer digits so the
         resulting decimal type has enough precision to hold the observed data. When total digits
@@ -1053,6 +1061,12 @@ class TestGetTable:
             val_col = next(c for c in table.columns if c.name == "val")
             assert val_col.numeric_precision == expected_precision
             assert val_col.numeric_scale == expected_scale
+            # Guard the full schema conversion too — catches regressions where precision/scale
+            # look right on the PostgreSQLColumn but the arrow type flips (e.g. decimal128 vs
+            # decimal256). The expected type is explicit per case rather than derived from
+            # `build_pyarrow_decimal_type(precision, scale)` so each case locks in its intended
+            # arrow width at the parameter level.
+            assert val_col.to_arrow_field().type == expected_arrow_type
 
     @pytest.mark.django_db
     def test_constrained_numeric_skips_probe(self):

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -930,3 +930,91 @@ class TestGetTable:
             )
             table = _get_table(dj_cursor, "public", "test_get_table_matview", logger)
             assert table.type == "materialized_view"
+
+    @pytest.mark.django_db
+    def test_unconstrained_numeric_probes_scale_from_data(self):
+        """Unconstrained `numeric` columns get their scale from the actual data, not a static default."""
+        from posthog.temporal.data_imports.pipelines.pipeline.utils import DEFAULT_NUMERIC_SCALE
+
+        logger = structlog.get_logger()
+
+        with django_connection.cursor() as dj_cursor:
+            dj_cursor.execute("CREATE TABLE test_get_table_unconstrained_numeric (id INTEGER PRIMARY KEY, val NUMERIC)")
+            # Value with actual scale 20 — matches the real-world shape that broke the customer.
+            dj_cursor.execute(
+                "INSERT INTO test_get_table_unconstrained_numeric VALUES (1, 0.84497449830783164117::numeric)"
+            )
+            dj_cursor.execute("INSERT INTO test_get_table_unconstrained_numeric VALUES (2, 0::numeric)")
+
+            table = _get_table(dj_cursor, "public", "test_get_table_unconstrained_numeric", logger)
+            val_col = next(c for c in table.columns if c.name == "val")
+            assert val_col.numeric_scale == 20, (
+                f"expected probed scale 20, got {val_col.numeric_scale} (would have been {DEFAULT_NUMERIC_SCALE} without probe)"
+            )
+
+    @pytest.mark.django_db
+    def test_unconstrained_numeric_empty_table_falls_back_to_default(self):
+        """Empty unconstrained `numeric` column has no data to probe, so falls back to DEFAULT_NUMERIC_SCALE."""
+        from posthog.temporal.data_imports.pipelines.pipeline.utils import DEFAULT_NUMERIC_SCALE
+
+        logger = structlog.get_logger()
+
+        with django_connection.cursor() as dj_cursor:
+            dj_cursor.execute("CREATE TABLE test_get_table_unconstrained_empty (id INTEGER PRIMARY KEY, val NUMERIC)")
+            table = _get_table(dj_cursor, "public", "test_get_table_unconstrained_empty", logger)
+            val_col = next(c for c in table.columns if c.name == "val")
+            assert val_col.numeric_scale == DEFAULT_NUMERIC_SCALE
+
+    @pytest.mark.django_db
+    def test_constrained_numeric_skips_probe(self):
+        """Columns declared with explicit precision/scale use those values directly, no data probe."""
+        logger = structlog.get_logger()
+
+        with django_connection.cursor() as dj_cursor:
+            dj_cursor.execute(
+                "CREATE TABLE test_get_table_constrained_numeric (id INTEGER PRIMARY KEY, val NUMERIC(10, 2))"
+            )
+            # Even though there's no data, the declared scale is used — no probe attempted.
+            table = _get_table(dj_cursor, "public", "test_get_table_constrained_numeric", logger)
+            val_col = next(c for c in table.columns if c.name == "val")
+            assert val_col.numeric_precision == 10
+            assert val_col.numeric_scale == 2
+
+    @pytest.mark.django_db
+    def test_unconstrained_numeric_clamps_to_max_scale(self):
+        """If probed scale exceeds MAX_NUMERIC_SCALE, it's clamped to prevent pathological schemas."""
+        from posthog.temporal.data_imports.pipelines.pipeline.utils import MAX_NUMERIC_SCALE
+
+        logger = structlog.get_logger()
+
+        with django_connection.cursor() as dj_cursor:
+            dj_cursor.execute("CREATE TABLE test_get_table_clamp_scale (id INTEGER PRIMARY KEY, val NUMERIC)")
+            # Scale 40 exceeds MAX_NUMERIC_SCALE (32) — should clamp.
+            dj_cursor.execute(
+                "INSERT INTO test_get_table_clamp_scale VALUES (1, 0.1234567890123456789012345678901234567890::numeric)"
+            )
+            table = _get_table(dj_cursor, "public", "test_get_table_clamp_scale", logger)
+            val_col = next(c for c in table.columns if c.name == "val")
+            assert val_col.numeric_scale == MAX_NUMERIC_SCALE
+
+    @pytest.mark.django_db
+    def test_unconstrained_numeric_multiple_columns_probed_together(self):
+        """Multiple unconstrained numeric columns are probed in a single aggregation query."""
+        logger = structlog.get_logger()
+
+        with django_connection.cursor() as dj_cursor:
+            dj_cursor.execute(
+                "CREATE TABLE test_get_table_multi_numeric "
+                "(id INTEGER PRIMARY KEY, a NUMERIC, b NUMERIC, c NUMERIC(5, 2))"
+            )
+            dj_cursor.execute(
+                "INSERT INTO test_get_table_multi_numeric VALUES "
+                "(1, 0.12345::numeric, 0.1234567890::numeric, 1.23::numeric(5,2))"
+            )
+            table = _get_table(dj_cursor, "public", "test_get_table_multi_numeric", logger)
+            cols_by_name = {c.name: c for c in table.columns}
+            assert cols_by_name["a"].numeric_scale == 5
+            assert cols_by_name["b"].numeric_scale == 10
+            # Constrained column is untouched.
+            assert cols_by_name["c"].numeric_precision == 5
+            assert cols_by_name["c"].numeric_scale == 2


### PR DESCRIPTION
## Problem

Ticket: https://posthoghelp.zendesk.com/agent/tickets/54270 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/57068)

When a postgres source column is declared as `numeric` with no precision/scale, `information_schema.columns` reports NULL for both values. We fall back to a static default of `decimal128(38, 18)` for the source arrow schema, and that type gets used when creating the delta table on the first sync.

If the actual data has scale > 18 with meaningful (non-zero) digits past position 18 — which is common when values come from arithmetic that postgres evaluates at high precision, e.g. `numerator / denominator` — the subsequent chunk can't be losslessly rescaled to the delta column's scale. It then cascades through the merge logic: first candidate rejected with `Rescaling Decimal128 value would cause data loss`, fallback to `decimal256`, which dlt rewrites to `string` via `ensure_delta_compatible_arrow_schema`, and finally delta-rs fails with:

```
Cast error: Cannot cast string '0E-20' to value of Decimal128(38, 10) type
```

The `(38, 10)` in the error is a delta-rs-side default that's picked when reconciling string data against an existing decimal column — not something our Python code chose — but the chain that got us there starts with the wrong default scale being baked in on the first sync.

## Changes

In `posthog/temporal/data_imports/sources/postgres/postgres.py::_get_table`, for columns where `information_schema` reports a null `numeric_scale`, run one combined aggregation query against the actual table:

```sql
SELECT MAX(scale(col1)), MAX(scale(col2)), ... FROM schema.table
```

Use each probed scale as the source arrow type scale instead of `DEFAULT_NUMERIC_SCALE`. One extra query per source table per sync (batched for all unconstrained columns), only during schema discovery, only for the unconstrained case. Cheap:

- Skipped entirely when every numeric column is already declared with explicit precision/scale
- Skipped on non-numeric source types
- Clamped to `MAX_NUMERIC_SCALE` (32) to prevent pathological schemas
- Wrapped in try/except — if the probe fails (permissions, timeout, unusual column type), falls back to `DEFAULT_NUMERIC_SCALE` rather than blocking sync setup
- Returns `NULL` on empty tables, which also falls back to the default

## Scope and non-goals

- **Initial syncs only.** Once a delta column is materialized with a decimal type, delta lake cannot widen the type without a full table rewrite. Users with an existing stuck column still need to `Delete table and resync` to pick up the corrected source schema. That's a deliberate non-goal — delta decimal columns are frozen after first sync by design.
- **Postgres source only.** MySQL, Snowflake, Redshift, and BigQuery have their own `numeric`/`decimal` semantics and would benefit from equivalent probes in a follow-up.
- **Does not fix the separate `statement_timeout` scope issue.** Our code sets `SET LOCAL statement_timeout = 10min` on the metadata cursor but opens a fresh connection for row fetching where that setting doesn't apply, so sources with a lower role-level `statement_timeout` can still time out on large tables. Orthogonal problem, separate fix.

## How did you test this code?

I'm an agent — tested via automated unit tests in `posthog/temporal/data_imports/sources/postgres/test_postgres.py::TestGetTable`, 5 new cases covering:

- Unconstrained `numeric` with scale-20 data → probed scale is `20`
- Unconstrained `numeric` with an empty table → falls back to `DEFAULT_NUMERIC_SCALE`
- Constrained `NUMERIC(10, 2)` → used directly, no probe attempted
- Unconstrained `numeric` with scale 40 → clamped to `MAX_NUMERIC_SCALE` (32)
- Multiple unconstrained numeric columns → probed together in one query, adjacent constrained column untouched

All 8 `TestGetTable` tests pass (3 pre-existing + 5 new).

I did not run an end-to-end sync test — that requires a live postgres with representative data. One should be verified before merging.

## Publish to changelog?

no

## 🤖 LLM context

Written by Claude during a debugging session tracing a production data warehouse sync failure with the symptom `Cast error: Cannot cast string '0E-20' to value of Decimal128(38, 10) type`. The investigation uncovered that the `(38, 10)` in the error message is a delta-rs-side artifact, not a type we ever chose, and that the upstream cause was the static `DEFAULT_NUMERIC_SCALE = 18` being too low for postgres `numeric` columns that carry high-precision values. The probe approach was chosen over alternatives (widening delta columns via schema evolution, bumping the default globally, accepting lossy rescale in the merge fallback) because it is proportional to the bug, only affects initial syncs of unconstrained columns, doesn't risk breaking other sync shapes, and gets the delta column right from the start.