### PR TITLE
fix: gclid is stored as `person.properties.$gclid`

### DIFF
--- a/frontend/src/mocks/fixtures/_hogFunctionTemplatesDestinations.json
+++ b/frontend/src/mocks/fixtures/_hogFunctionTemplatesDestinations.json
@@ -13601,7 +13601,7 @@
                             "type": "string",
                             "label": "Google Click ID (gclid)",
                             "secret": false,
-                            "default": "{person.properties.gclid ?? person.properties.$initial_gclid}",
+                            "default": "{person.properties.$gclid ?? person.properties.$initial_gclid}",
                             "required": true,
                             "description": "The Google click ID (gclid) associated with this conversion."
                         },

--- a/nodejs/src/cdp/templates/_destinations/google_ads/google.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/google_ads/google.template.ts
@@ -21,7 +21,7 @@ const build_inputs = (): HogFunctionInputSchemaType[] => {
             type: 'string',
             label: 'Google Click ID (gclid)',
             description: 'The Google click ID (gclid) associated with this conversion.',
-            default: '{person.properties.gclid ?? person.properties.$initial_gclid}',
+            default: '{person.properties.$gclid ?? person.properties.$initial_gclid}',
             secret: false,
             required: true,
         },


### PR DESCRIPTION
## Problem

The default config for getting the `inputs.gclid` is currently set to `{person.properties.gclid ?? person.properties.$initial_gclid}`, but we store the google click ID as `person.properties.$gclid`

<img width="971" height="296" alt="image" src="https://github.com/user-attachments/assets/c51c56da-f143-4dee-a6da-06ad0379b648" />

## Changes

Updates the default Hog stmt

## How did you test this code?

Updated test fixture

## Publish to changelog?

No