### PR TITLE
fix(rbac): make dashboard_template inherit access from dashboard

### DIFF
--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -55,7 +55,6 @@ ACCESS_CONTROL_RESOURCES: tuple[APIScopeObject, ...] = (
     "action",
     "customer_analytics",
     "dashboard",
-    "dashboard_template",
     "experiment",
     "external_data_source",
     "feature_flag",
@@ -82,6 +81,7 @@ RESOURCE_INHERITANCE_MAP: dict[APIScopeObject, APIScopeObject] = {
     "llm_prompt": "llm_analytics",
     "customer_journey": "customer_analytics",
     "experiment_saved_metric": "experiment",
+    "dashboard_template": "dashboard",
 }
 
 

--- a/products/dashboards/backend/api/test/test_dashboard_templates.py
+++ b/products/dashboards/backend/api/test/test_dashboard_templates.py
@@ -954,9 +954,11 @@ class TestCustomerDashboardTemplateAuthoring(APIBaseTest):
         self.organization.save()
 
     def _grant_template_viewer(self) -> None:
+        # `dashboard_template` inherits access from `dashboard`, so viewer on the parent resource
+        # is what limits a non-staff user to read-only template access.
         AccessControl.objects.create(
             team=self.team,
-            resource="dashboard_template",
+            resource="dashboard",
             resource_id=None,
             organization_member=self.organization_membership,
             role=None,


### PR DESCRIPTION
## Problem

`dashboard_template` was added as a top-level entry in `ACCESS_CONTROL_RESOURCES`, making it appear as an independent resource in the RBAC picker UI. Dashboard templates are a means of producing dashboards, not a separately-managed resource, so permissions should inherit from `dashboard`.

<img width="991" height="419" alt="image" src="https://github.com/user-attachments/assets/b9b87227-b4a0-44bc-bcdc-04cb7a84aea4" />


## Changes

- Remove `dashboard_template` from `ACCESS_CONTROL_RESOURCES`
- Add `dashboard_template -> dashboard` to `RESOURCE_INHERITANCE_MAP`

## How did you test this code?

- No automated tests added — change is a one-line move between existing registries
- Manually verified the viewset's `scope_object = "dashboard_template"` + `AccessControlPermission` still resolves required levels through the inheritance map, so enforcement is unchanged

## Publish to changelog?

no