### PR TITLE
feat(clickhouse): Bump CH local and CI to 26.3.9.8

### DIFF
--- a/.github/clickhouse-versions.json
+++ b/.github/clickhouse-versions.json
@@ -1,6 +1,6 @@
 {
     "production_eu": "clickhouse/clickhouse-server:25.12.8",
     "production_us": "clickhouse/clickhouse-server:25.8.12",
-    "local": "clickhouse/clickhouse-server:26.3.8",
+    "local": "clickhouse/clickhouse-server:26.3.9",
     "oldest_supported": "clickhouse/clickhouse-server:25.8.12"
 }

--- a/.github/clickhouse-versions.json
+++ b/.github/clickhouse-versions.json
@@ -1,6 +1,6 @@
 {
     "production_eu": "clickhouse/clickhouse-server:25.12.8",
     "production_us": "clickhouse/clickhouse-server:25.8.12",
-    "local": "clickhouse/clickhouse-server:26.3.9",
+    "local": "clickhouse/clickhouse-server:26.3.9.8",
     "oldest_supported": "clickhouse/clickhouse-server:25.8.12"
 }

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -318,7 +318,7 @@ jobs:
               env:
                   COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
                   COMPOSE_PROFILES: temporal,azure
-                  CLICKHOUSE_SERVER_IMAGE: clickhouse/clickhouse-server:26.3.8.4
+                  CLICKHOUSE_SERVER_IMAGE: clickhouse/clickhouse-server:26.3.9.8
               run: |
                   cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
                   bin/ci-wait-for-docker launch --background --down \
@@ -391,7 +391,7 @@ jobs:
               env:
                   COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
                   COMPOSE_PROFILES: temporal,azure
-                  CLICKHOUSE_SERVER_IMAGE: clickhouse/clickhouse-server:26.3.8.4
+                  CLICKHOUSE_SERVER_IMAGE: clickhouse/clickhouse-server:26.3.9.8
               run: bin/ci-wait-for-docker wait
 
             - name: Register Temporal search attributes

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -62,7 +62,7 @@ RUN corepack enable
 
 # --- Rarely changes: prebuilt binaries ---
 COPY --from=ghcr.io/astral-sh/uv:0.10.2 /uv /uvx /usr/local/bin/
-COPY --from=clickhouse/clickhouse-server:26.3.8.4 /usr/bin/clickhouse /usr/local/bin/clickhouse
+COPY --from=clickhouse/clickhouse-server:26.3.9.8 /usr/bin/clickhouse /usr/local/bin/clickhouse
 RUN ln -s clickhouse /usr/local/bin/clickhouse-client
 
 RUN ARCH=$(dpkg --print-architecture) && \

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -153,7 +153,7 @@ services:
         # Note: please keep the default version in sync across
         #       `posthog` and the `charts-clickhouse` repos
         #
-        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:26.3.8.4}
+        image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:26.3.9.8}
         restart: on-failure
         environment:
             CLICKHOUSE_SKIP_USER_SETUP: 1


### PR DESCRIPTION
Due to issues we saw with the previous upgrade we want to bump the minor version of CH to the newest LTS version to hopefully have the bugs fixed

## Problem

Current clickhouse seems unstable due to crashes, want to bump the minor version to see if it helps.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
