### PR TITLE
fix: Generalized admin email updates to happen on any OrgMembership save

### DIFF
--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -78,15 +78,11 @@ class OrganizationMemberSerializer(serializers.ModelSerializer):
             organization=updated_membership.organization,
             user=self.context["request"].user,
         )
-        level_changed = False
         for attr, value in validated_data.items():
             if attr == "level":
-                requesting_membership.validate_update(updated_membership, cast(Any, value))
-                level_changed = True
+                requesting_membership.validate_update(updated_membership, value)
             setattr(updated_membership, attr, value)
         updated_membership.save()
-        if level_changed:
-            self.context["request"].user.update_billing_organization_users(updated_membership.organization)
         return updated_membership
 
 

--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import cast
 
 from django.db.models import F, Model, Prefetch, QuerySet
 from django.shortcuts import get_object_or_404

--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -80,7 +80,9 @@ class OrganizationMemberSerializer(serializers.ModelSerializer):
         )
         for attr, value in validated_data.items():
             if attr == "level":
-                requesting_membership.validate_update(updated_membership, value)
+                requesting_membership.validate_update(
+                    updated_membership, cast(OrganizationMembership.Level | None, value)
+                )
             setattr(updated_membership, attr, value)
         updated_membership.save()
         return updated_membership

--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -78,15 +78,11 @@ class OrganizationMemberSerializer(serializers.ModelSerializer):
             organization=updated_membership.organization,
             user=self.context["request"].user,
         )
-        level_changed = False
         for attr, value in validated_data.items():
             if attr == "level":
                 requesting_membership.validate_update(updated_membership, value)
-                level_changed = True
             setattr(updated_membership, attr, value)
         updated_membership.save()
-        if level_changed:
-            self.context["request"].user.update_billing_organization_users(updated_membership.organization)
         return updated_membership
 
 

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -1,7 +1,9 @@
 from datetime import timedelta
 
 from posthog.test.base import APIBaseTest, QueryMatchingTest
-from unittest.mock import ANY, call, patch
+from unittest.mock import ANY, patch
+
+from django.test import override_settings
 
 from rest_framework import status
 
@@ -52,9 +54,10 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.json(), self.permission_denied_response())
 
+    @override_settings(CLOUD_DEPLOYMENT="US")
     @patch("posthoganalytics.capture")
-    @patch("posthog.models.user.User.update_billing_organization_users")
-    def test_delete_organization_member(self, mock_update_billing_organization_users, mock_capture):
+    @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
+    def test_delete_organization_member(self, mock_sync_delay, mock_capture):
         user = User.objects.create_and_join(self.organization, "test@x.com", None, "X")
         membership_queryset = OrganizationMembership.objects.filter(user=user, organization=self.organization)
         self.assertTrue(membership_queryset.exists())
@@ -65,7 +68,9 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
         self.assertTrue(membership_queryset.exists())
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
-        response = self.client.delete(f"/api/organizations/@current/members/{user.uuid}/")
+        mock_sync_delay.reset_mock()
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.delete(f"/api/organizations/@current/members/{user.uuid}/")
         self.assertEqual(response.status_code, 204)
         self.assertFalse(membership_queryset.exists(), False)
 
@@ -83,11 +88,7 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
             },
             groups={"instance": "http://localhost:8010", "organization": str(self.organization.id)},
         )
-        assert mock_update_billing_organization_users.call_count == 2
-        assert mock_update_billing_organization_users.call_args_list == [
-            call(self.organization),
-            call(self.organization),
-        ]
+        mock_sync_delay.assert_called_once_with(str(self.organization.id))
 
     def test_scoped_api_keys_endpoint(self):
         # Create a user who is a member of the organization
@@ -224,12 +225,15 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
         self.assertEqual(response_data["has_keys_active_last_week"], False)
         self.assertEqual(response_data["keys"], [])
 
+    @override_settings(CLOUD_DEPLOYMENT="US")
     @patch("posthoganalytics.capture")
-    @patch("posthog.models.user.User.update_billing_organization_users")
-    def test_leave_organization(self, mock_update_billing_organization_users, mock_capture):
+    @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
+    def test_leave_organization(self, mock_sync_delay, mock_capture):
         membership_queryset = OrganizationMembership.objects.filter(user=self.user, organization=self.organization)
         self.assertEqual(membership_queryset.count(), 1)
-        response = self.client.delete(f"/api/organizations/@current/members/{self.user.uuid}/")
+        mock_sync_delay.reset_mock()
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.delete(f"/api/organizations/@current/members/{self.user.uuid}/")
         self.assertEqual(response.status_code, 204)
         self.assertEqual(membership_queryset.count(), 0)
 
@@ -248,22 +252,22 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
             groups={"instance": ANY, "organization": str(self.organization.id)},
         )
 
-        assert mock_update_billing_organization_users.call_count == 1
-        assert mock_update_billing_organization_users.call_args_list == [
-            call(self.organization),
-        ]
+        mock_sync_delay.assert_called_once_with(str(self.organization.id))
 
-    @patch("posthog.models.user.User.update_billing_organization_users")
-    def test_change_organization_member_level(self, mock_update_billing_organization_users):
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
+    def test_change_organization_member_level(self, mock_sync_delay):
         self.organization_membership.level = OrganizationMembership.Level.OWNER
         self.organization_membership.save()
         user = User.objects.create_user("test@x.com", None, "X")
         membership = OrganizationMembership.objects.create(user=user, organization=self.organization)
         self.assertEqual(membership.level, OrganizationMembership.Level.MEMBER)
-        response = self.client.patch(
-            f"/api/organizations/@current/members/{user.uuid}",
-            {"level": OrganizationMembership.Level.ADMIN},
-        )
+        mock_sync_delay.reset_mock()
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.patch(
+                f"/api/organizations/@current/members/{user.uuid}",
+                {"level": OrganizationMembership.Level.ADMIN},
+            )
         self.assertEqual(response.status_code, 200)
         updated_membership = OrganizationMembership.objects.get(user=user, organization=self.organization)
         self.assertEqual(updated_membership.level, OrganizationMembership.Level.ADMIN)
@@ -291,40 +295,40 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
                 "level": OrganizationMembership.Level.ADMIN.value,
             },
         )
-        assert mock_update_billing_organization_users.call_count == 1
-        assert mock_update_billing_organization_users.call_args_list == [
-            call(self.organization),
-        ]
+        mock_sync_delay.assert_called_once_with(str(self.organization.id))
 
-    @patch("posthog.models.user.User.update_billing_organization_users")
-    def test_admin_can_promote_to_admin(self, mock_update_billing_organization_users):
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
+    def test_admin_can_promote_to_admin(self, mock_sync_delay):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
         user = User.objects.create_user("test@x.com", None, "X")
         membership = OrganizationMembership.objects.create(user=user, organization=self.organization)
         self.assertEqual(membership.level, OrganizationMembership.Level.MEMBER)
-        response = self.client.patch(
-            f"/api/organizations/@current/members/{user.uuid}",
-            {"level": OrganizationMembership.Level.ADMIN},
-        )
+        mock_sync_delay.reset_mock()
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.patch(
+                f"/api/organizations/@current/members/{user.uuid}",
+                {"level": OrganizationMembership.Level.ADMIN},
+            )
         self.assertEqual(response.status_code, 200)
         updated_membership = OrganizationMembership.objects.get(user=user, organization=self.organization)
         self.assertEqual(updated_membership.level, OrganizationMembership.Level.ADMIN)
 
-        assert mock_update_billing_organization_users.call_count == 1
-        assert mock_update_billing_organization_users.call_args_list == [
-            call(self.organization),
-        ]
+        mock_sync_delay.assert_called_once_with(str(self.organization.id))
 
-    @patch("posthog.models.user.User.update_billing_organization_users")
-    def test_change_organization_member_level_requires_admin(self, mock_update_billing_organization_users):
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
+    def test_change_organization_member_level_requires_admin(self, mock_sync_delay):
         user = User.objects.create_user("test@x.com", None, "X")
         membership = OrganizationMembership.objects.create(user=user, organization=self.organization)
         self.assertEqual(membership.level, OrganizationMembership.Level.MEMBER)
-        response = self.client.patch(
-            f"/api/organizations/@current/members/{user.uuid}/",
-            {"level": OrganizationMembership.Level.ADMIN},
-        )
+        mock_sync_delay.reset_mock()
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.patch(
+                f"/api/organizations/@current/members/{user.uuid}/",
+                {"level": OrganizationMembership.Level.ADMIN},
+            )
 
         updated_membership = OrganizationMembership.objects.get(user=user, organization=self.organization)
         self.assertEqual(updated_membership.level, OrganizationMembership.Level.MEMBER)
@@ -339,7 +343,7 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
         )
         self.assertEqual(response.status_code, 403)
 
-        assert mock_update_billing_organization_users.call_count == 0
+        mock_sync_delay.assert_not_called()
 
     def test_cannot_change_own_organization_member_level(self):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -2178,10 +2178,8 @@ class TestInviteSignupAPI(APIBaseTest):
         self.assertEqual(len(member_join_emails), 0)
 
     @patch("posthoganalytics.capture")
-    @patch("ee.billing.billing_manager.BillingManager.update_billing_organization_users")
-    def test_existing_user_can_sign_up_to_a_new_organization(
-        self, mock_update_billing_organization_users, mock_capture
-    ):
+    @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
+    def test_existing_user_can_sign_up_to_a_new_organization(self, mock_sync_delay, mock_capture):
         user = self._create_user("test+159@posthog.com", VALID_TEST_PASSWORD, role_at_organization="product")
         new_org = Organization.objects.create(name="TestCo")
         new_team = Team.objects.create(organization=new_org)
@@ -2204,7 +2202,8 @@ class TestInviteSignupAPI(APIBaseTest):
                 valid_until=datetime(2038, 1, 19, 3, 14, 7),
             )
 
-        with self.is_cloud(True):
+        mock_sync_delay.reset_mock()
+        with self.is_cloud(True), self.captureOnCommitCallbacks(execute=True):
             response = self.client.post(f"/api/signup/{invite.id}/")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(
@@ -2260,8 +2259,8 @@ class TestInviteSignupAPI(APIBaseTest):
         response = self.client.get("/api/users/@me/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        # Assert that the org's distinct IDs are sent to billing
-        mock_update_billing_organization_users.assert_called_once_with(new_org)
+        # Assert that the billing sync was enqueued for the newly joined organization
+        mock_sync_delay.assert_called_once_with(str(new_org.id))
 
     @patch("posthoganalytics.capture")
     def test_cannot_use_claim_invite_endpoint_to_update_user(self, mock_capture):

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -510,6 +510,9 @@ class OrganizationMembership(ModelActivityMixin, UUIDTModel):
     joined_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
+    # Transient flag set by the pre_save signal to communicate level changes to post_save.
+    _level_changed: bool = False
+
     class Meta:
         constraints = [
             models.UniqueConstraint(
@@ -661,16 +664,39 @@ def sync_billing_on_membership_removal(sender, instance: OrganizationMembership,
 def organization_membership_saved(sender: Any, instance: OrganizationMembership, **kwargs: Any) -> None:
     from posthog.event_usage import report_user_organization_membership_level_changed
 
+    instance._level_changed = False
     try:
         old_instance = OrganizationMembership.objects.get(id=instance.id)
         if old_instance.level != instance.level:
-            # the level has been changed
+            instance._level_changed = True
             report_user_organization_membership_level_changed(
                 instance.user, instance.organization, instance.level, old_instance.level
             )
     except OrganizationMembership.DoesNotExist:
         # The instance is new, or we are setting up test data
         pass
+
+
+@receiver(post_save, sender=OrganizationMembership)
+def sync_billing_on_membership_save(sender, instance: OrganizationMembership, created: bool, **kwargs):
+    # Covers any path that creates a membership or changes its level, including
+    # Organization.bootstrap, the Vercel integration, and direct ORM saves that
+    # bypass OrganizationMemberSerializer. Mirrors sync_billing_on_membership_removal.
+    from posthog.tasks.sync_billing import sync_members_to_billing
+
+    if not is_cloud():
+        return
+
+    if not created and not getattr(instance, "_level_changed", False):
+        return
+
+    organization_id = str(instance.organization_id)
+
+    def _sync_if_org_exists():
+        if Organization.objects.filter(id=organization_id).exists():
+            sync_members_to_billing.delay(organization_id)
+
+    transaction.on_commit(_sync_if_org_exists)
 
 
 @receiver(post_save, sender=Organization)

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -501,6 +501,9 @@ class OrganizationMembership(ModelActivityMixin, UUIDTModel):
     joined_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
+    # Transient flag set by the pre_save signal to communicate level changes to post_save.
+    _level_changed: bool = False
+
     class Meta:
         constraints = [
             models.UniqueConstraint(
@@ -652,16 +655,39 @@ def sync_billing_on_membership_removal(sender, instance: OrganizationMembership,
 def organization_membership_saved(sender: Any, instance: OrganizationMembership, **kwargs: Any) -> None:
     from posthog.event_usage import report_user_organization_membership_level_changed
 
+    instance._level_changed = False
     try:
         old_instance = OrganizationMembership.objects.get(id=instance.id)
         if old_instance.level != instance.level:
-            # the level has been changed
+            instance._level_changed = True
             report_user_organization_membership_level_changed(
                 instance.user, instance.organization, instance.level, old_instance.level
             )
     except OrganizationMembership.DoesNotExist:
         # The instance is new, or we are setting up test data
         pass
+
+
+@receiver(post_save, sender=OrganizationMembership)
+def sync_billing_on_membership_save(sender, instance: OrganizationMembership, created: bool, **kwargs):
+    # Covers any path that creates a membership or changes its level, including
+    # Organization.bootstrap, the Vercel integration, and direct ORM saves that
+    # bypass OrganizationMemberSerializer. Mirrors sync_billing_on_membership_removal.
+    from posthog.tasks.sync_billing import sync_members_to_billing
+
+    if not is_cloud():
+        return
+
+    if not created and not getattr(instance, "_level_changed", False):
+        return
+
+    organization_id = str(instance.organization_id)
+
+    def _sync_if_org_exists():
+        if Organization.objects.filter(id=organization_id).exists():
+            sync_members_to_billing.delay(organization_id)
+
+    transaction.on_commit(_sync_if_org_exists)
 
 
 @receiver(post_save, sender=Organization)

--- a/posthog/models/test/test_organization_membership_signals.py
+++ b/posthog/models/test/test_organization_membership_signals.py
@@ -1,63 +1,172 @@
-from posthog.test.base import BaseTest
+from posthog.test.base import APIBaseTest, BaseTest
 from unittest.mock import patch
 
 from django.test import override_settings
 
-from posthog.models import Organization
+from rest_framework import status
+
+from posthog.models import Organization, User
 from posthog.models.organization import OrganizationMembership
 
 
 @override_settings(CLOUD_DEPLOYMENT="US")
 class TestSyncBillingOnMembershipRemoval(BaseTest):
     @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
-    @patch("django.db.transaction.on_commit", side_effect=lambda f: f())
-    def test_membership_deletion_triggers_billing_sync(self, _mock_on_commit, mock_delay):
+    def test_membership_deletion_triggers_billing_sync(self, mock_delay):
         membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
         org_id = str(self.organization.id)
 
-        membership.delete()
+        with self.captureOnCommitCallbacks(execute=True):
+            membership.delete()
 
         mock_delay.assert_called_with(org_id)
 
     @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
-    @patch("django.db.transaction.on_commit", side_effect=lambda f: f())
-    def test_queryset_deletion_triggers_billing_sync(self, _mock_on_commit, mock_delay):
+    def test_queryset_deletion_triggers_billing_sync(self, mock_delay):
         org_id = str(self.organization.id)
 
-        OrganizationMembership.objects.filter(user=self.user, organization=self.organization).delete()
+        with self.captureOnCommitCallbacks(execute=True):
+            OrganizationMembership.objects.filter(user=self.user, organization=self.organization).delete()
 
         mock_delay.assert_called_with(org_id)
 
     @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
-    @patch("django.db.transaction.on_commit", side_effect=lambda f: f())
     @override_settings(CLOUD_DEPLOYMENT=None)
-    def test_no_billing_sync_when_not_cloud(self, _mock_on_commit, mock_delay):
+    def test_no_billing_sync_when_not_cloud(self, mock_delay):
         membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
-        membership.delete()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            membership.delete()
 
         mock_delay.assert_not_called()
 
     @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
-    @patch("django.db.transaction.on_commit", side_effect=lambda f: f())
-    def test_user_deletion_triggers_billing_sync_for_each_org(self, _mock_on_commit, mock_delay):
+    def test_user_deletion_triggers_billing_sync_for_each_org(self, mock_delay):
         other_org = Organization.objects.create(name="Other Org")
         OrganizationMembership.objects.create(user=self.user, organization=other_org, level=1)
 
         org_ids = {str(self.organization.id), str(other_org.id)}
 
-        self.user.delete()
+        with self.captureOnCommitCallbacks(execute=True):
+            self.user.delete()
 
         synced_org_ids = {c.args[0] for c in mock_delay.call_args_list}
         assert org_ids.issubset(synced_org_ids)
 
     @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
     def test_org_deletion_does_not_sync(self, mock_delay):
-        callbacks: list = []
-        with patch("django.db.transaction.on_commit", side_effect=lambda f: callbacks.append(f)):
+        with self.captureOnCommitCallbacks(execute=True):
             self.organization.delete()
 
-        # Run callbacks after deletion completes (simulates post-commit)
-        for cb in callbacks:
-            cb()
+        mock_delay.assert_not_called()
+
+
+@override_settings(CLOUD_DEPLOYMENT="US")
+class TestSyncBillingOnMembershipSave(BaseTest):
+    @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
+    def test_membership_creation_triggers_billing_sync(self, mock_delay):
+        # Covers Organization.bootstrap, Vercel integration, and any other path
+        # that creates OrganizationMembership directly (bypassing User.join).
+        other_org = Organization.objects.create(name="Bootstrap Org")
+        mock_delay.reset_mock()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            OrganizationMembership.objects.create(
+                user=self.user, organization=other_org, level=OrganizationMembership.Level.OWNER
+            )
+
+        mock_delay.assert_called_once_with(str(other_org.id))
+
+    @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
+    def test_membership_level_change_triggers_billing_sync(self, mock_delay):
+        # Covers direct ORM level changes that bypass OrganizationMemberSerializer,
+        # e.g. the Vercel integration's _add_user_to_organization level bump.
+        membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        mock_delay.reset_mock()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            membership.level = OrganizationMembership.Level.ADMIN
+            membership.save(update_fields=["level"])
+
+        mock_delay.assert_called_once_with(str(self.organization.id))
+
+    @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
+    def test_membership_save_without_level_change_does_not_sync(self, mock_delay):
+        membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        mock_delay.reset_mock()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            membership.save()
 
         mock_delay.assert_not_called()
+
+    @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
+    @override_settings(CLOUD_DEPLOYMENT=None)
+    def test_no_billing_sync_when_not_cloud_on_save(self, mock_delay):
+        other_org = Organization.objects.create(name="Non-cloud Org")
+        mock_delay.reset_mock()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            OrganizationMembership.objects.create(
+                user=self.user, organization=other_org, level=OrganizationMembership.Level.OWNER
+            )
+
+        mock_delay.assert_not_called()
+
+
+@override_settings(CLOUD_DEPLOYMENT="US")
+class TestSyncBillingFlows(APIBaseTest):
+    """End-to-end flow coverage: each user-level operation must trigger the signal-driven sync."""
+
+    @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
+    def test_user_join_triggers_billing_sync(self, mock_delay):
+        other_org = Organization.objects.create(name="Joinable Org")
+        mock_delay.reset_mock()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self.user.join(organization=other_org, level=OrganizationMembership.Level.MEMBER)
+
+        mock_delay.assert_called_once_with(str(other_org.id))
+
+    @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
+    def test_user_leave_triggers_billing_sync(self, mock_delay):
+        other_org = Organization.objects.create(name="Leavable Org")
+        OrganizationMembership.objects.create(
+            user=self.user, organization=other_org, level=OrganizationMembership.Level.OWNER
+        )
+        member = User.objects.create_and_join(other_org, "leaver@x.com", None, "X")
+        mock_delay.reset_mock()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            member.leave(organization=other_org)
+
+        mock_delay.assert_called_once_with(str(other_org.id))
+
+    @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
+    def test_api_member_level_change_triggers_billing_sync(self, mock_delay):
+        member = User.objects.create_and_join(self.organization, "promotable@x.com", None, "X")
+        self.organization_membership.level = OrganizationMembership.Level.OWNER
+        self.organization_membership.save()
+        mock_delay.reset_mock()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.patch(
+                f"/api/organizations/@current/members/{member.uuid}/",
+                {"level": OrganizationMembership.Level.ADMIN.value},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_delay.assert_called_once_with(str(self.organization.id))
+
+    @patch("posthog.tasks.sync_billing.sync_members_to_billing.delay")
+    def test_api_member_delete_triggers_billing_sync(self, mock_delay):
+        member = User.objects.create_and_join(self.organization, "removable@x.com", None, "X")
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+        mock_delay.reset_mock()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.delete(f"/api/organizations/@current/members/{member.uuid}/")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        mock_delay.assert_called_once_with(str(self.organization.id))

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -436,7 +436,6 @@ class User(AbstractUser, UUIDTClassicModel, ModelActivityMixin):
                     },
                 )
 
-        self.update_billing_organization_users(organization)
         return membership
 
     @property
@@ -464,7 +463,6 @@ class User(AbstractUser, UUIDTClassicModel, ModelActivityMixin):
                 )
                 self.team = self.current_team  # Update cached property
                 self.save()
-        self.update_billing_organization_users(organization)
 
     def update_billing_organization_users(self, organization: Organization) -> None:
         from ee.billing.billing_manager import BillingManager  # avoid circular import

--- a/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
+++ b/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
@@ -923,7 +923,15 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events
+     FROM
+       (SELECT events.`$session_id_uuid`,
+               events.distinct_id,
+               events.event,
+               events.person_id,
+               events.`mat_$browser`,
+               events.timestamp
+        FROM events
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-13'), lessOrEquals(toDate(events.timestamp), '2024-01-17'))) AS events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Asia/Tokyo')), max(toTimeZone(raw_sessions.max_timestamp, 'Asia/Tokyo'))), 10)))) AS `$is_bounce`,
@@ -940,7 +948,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Tokyo'))), lessOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Tokyo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
+     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Tokyo'))), lessOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Tokyo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
@@ -1071,15 +1079,7 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.person_id,
-               events.`mat_$browser`,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-13'), lessOrEquals(toDate(events.timestamp), '2024-01-17'))) AS events
+     FROM events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Pacific/Auckland')), max(toTimeZone(raw_sessions.max_timestamp, 'Pacific/Auckland'))), 10)))) AS `$is_bounce`,
@@ -1096,7 +1096,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Pacific/Auckland'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Pacific/Auckland'))), lessOrEquals(toTimeZone(events.timestamp, 'Pacific/Auckland'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Pacific/Auckland')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Pacific/Auckland'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Pacific/Auckland'))), lessOrEquals(toTimeZone(events.timestamp, 'Pacific/Auckland'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Pacific/Auckland')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`


### PR DESCRIPTION
This removes ad-hoc calls that updated sometimes.

## Problem

Admin emails weren't properly synced to billing under some circumstances

## Changes

Add a signal to OrgMembership to schedule an update on a change instead of sprinkling hardcoded calls here and there.

## How did you test this code?

Added tests, ran old tests