### PR TITLE
fix: flakey postgres-parity-test

### DIFF
--- a/nodejs/tests/helpers/kafka.ts
+++ b/nodejs/tests/helpers/kafka.ts
@@ -108,6 +108,49 @@ export async function createTopics(kafkaConfig: any, topics: string[]): Promise<
     client.disconnect()
 }
 
+/**
+ * Create Kafka topics if they don't already exist, without deleting existing topics.
+ * Unlike resetKafka, this preserves ClickHouse Kafka engine consumer connections,
+ * avoiding the slow reconnection cycle that causes flaky tests.
+ */
+export async function ensureKafkaTopics(
+    topics: string[],
+    extraServerConfig?: Partial<PluginsServerConfig>
+): Promise<void> {
+    const config = { ...overrideWithEnv(defaultConfig, process.env), ...extraServerConfig }
+
+    const kafkaConfig = {
+        'client.id': 'nodejs-test',
+        'metadata.broker.list': (config.KAFKA_HOSTS || '').split(',').join(','),
+    }
+
+    const client = AdminClient.create(kafkaConfig)
+    const timeout = 10000
+
+    for (const topic of topics) {
+        await new Promise<void>((resolve, reject) => {
+            client.createTopic(
+                { topic, num_partitions: 1, replication_factor: 1 },
+                timeout,
+                (error: LibrdKafkaError) => {
+                    if (error) {
+                        if (error.code === CODES.ERRORS.ERR_TOPIC_ALREADY_EXISTS) {
+                            resolve()
+                        } else {
+                            console.error(`Failed to create topic ${topic}:`, error)
+                            reject(error)
+                        }
+                    } else {
+                        resolve()
+                    }
+                }
+            )
+        })
+    }
+
+    client.disconnect()
+}
+
 export async function deleteAllTopics(kafkaConfig: any): Promise<void> {
     // Use a consumer to get metadata
     const consumer = new KafkaConsumer(

--- a/nodejs/tests/helpers/kafka.ts
+++ b/nodejs/tests/helpers/kafka.ts
@@ -35,14 +35,40 @@ import {
 } from '../../src/config/kafka-topics'
 import { PluginsServerConfig } from '../../src/types'
 
-export async function resetKafka(extraServerConfig?: Partial<PluginsServerConfig>): Promise<void> {
+function buildKafkaConfig(extraServerConfig?: Partial<PluginsServerConfig>) {
     const config = { ...overrideWithEnv(defaultConfig, process.env), ...extraServerConfig }
-
-    const kafkaConfig = {
+    return {
         'client.id': 'nodejs-test',
         'metadata.broker.list': (config.KAFKA_HOSTS || '').split(',').join(','),
     }
+}
 
+async function createTopicsWithClient(client: ReturnType<typeof AdminClient.create>, topics: string[]): Promise<void> {
+    const timeout = 10000
+    for (const topic of topics) {
+        await new Promise<void>((resolve, reject) => {
+            client.createTopic(
+                { topic, num_partitions: 1, replication_factor: 1 },
+                timeout,
+                (error: LibrdKafkaError) => {
+                    if (error) {
+                        if (error.code === CODES.ERRORS.ERR_TOPIC_ALREADY_EXISTS) {
+                            resolve()
+                        } else {
+                            console.error(`Failed to create topic ${topic}:`, error)
+                            reject(error)
+                        }
+                    } else {
+                        resolve()
+                    }
+                }
+            )
+        })
+    }
+}
+
+export async function resetKafka(extraServerConfig?: Partial<PluginsServerConfig>): Promise<void> {
+    const kafkaConfig = buildKafkaConfig(extraServerConfig)
     await createTopics(kafkaConfig, [
         KAFKA_CLICKHOUSE_AI_EVENTS_JSON,
         KAFKA_EVENTS_JSON,
@@ -80,31 +106,8 @@ export async function resetKafka(extraServerConfig?: Partial<PluginsServerConfig
 
 export async function createTopics(kafkaConfig: any, topics: string[]): Promise<void> {
     const client = AdminClient.create(kafkaConfig)
-    const timeout = 10000
-
     await deleteAllTopics(kafkaConfig)
-
-    for (const topic of topics) {
-        await new Promise<void>((resolve, reject) => {
-            client.createTopic(
-                { topic, num_partitions: 1, replication_factor: 1 },
-                timeout,
-                (error: LibrdKafkaError) => {
-                    if (error) {
-                        if (error.code === CODES.ERRORS.ERR_TOPIC_ALREADY_EXISTS) {
-                            resolve()
-                        } else {
-                            console.error(`Failed to create topic ${topic}:`, error)
-                            reject(error)
-                        }
-                    } else {
-                        resolve()
-                    }
-                }
-            )
-        })
-    }
-
+    await createTopicsWithClient(client, topics)
     client.disconnect()
 }
 
@@ -117,37 +120,9 @@ export async function ensureKafkaTopics(
     topics: string[],
     extraServerConfig?: Partial<PluginsServerConfig>
 ): Promise<void> {
-    const config = { ...overrideWithEnv(defaultConfig, process.env), ...extraServerConfig }
-
-    const kafkaConfig = {
-        'client.id': 'nodejs-test',
-        'metadata.broker.list': (config.KAFKA_HOSTS || '').split(',').join(','),
-    }
-
+    const kafkaConfig = buildKafkaConfig(extraServerConfig)
     const client = AdminClient.create(kafkaConfig)
-    const timeout = 10000
-
-    for (const topic of topics) {
-        await new Promise<void>((resolve, reject) => {
-            client.createTopic(
-                { topic, num_partitions: 1, replication_factor: 1 },
-                timeout,
-                (error: LibrdKafkaError) => {
-                    if (error) {
-                        if (error.code === CODES.ERRORS.ERR_TOPIC_ALREADY_EXISTS) {
-                            resolve()
-                        } else {
-                            console.error(`Failed to create topic ${topic}:`, error)
-                            reject(error)
-                        }
-                    } else {
-                        resolve()
-                    }
-                }
-            )
-        })
-    }
-
+    await createTopicsWithClient(client, topics)
     client.disconnect()
 }
 

--- a/nodejs/tests/worker/ingestion/postgres-parity.test.ts
+++ b/nodejs/tests/worker/ingestion/postgres-parity.test.ts
@@ -18,7 +18,8 @@ import {
     fetchPersons,
 } from '../../../src/worker/ingestion/persons/repositories/test-helpers'
 import { Clickhouse } from '../../helpers/clickhouse'
-import { resetKafka } from '../../helpers/kafka'
+import { waitForExpect } from '../../helpers/expectations'
+import { ensureKafkaTopics } from '../../helpers/kafka'
 import { createUserTeamAndOrganization, resetTestDatabase } from '../../helpers/sql'
 
 jest.mock('../../../src/utils/logger')
@@ -34,7 +35,47 @@ function createPersonOutputs(kafkaProducer: KafkaProducerWrapper) {
         ),
     })
 }
-jest.setTimeout(45000) // 45s > delayUntilEventIngested budget (300 × 100ms = 30s) to let the helper throw its actionable error before Jest fires
+/**
+ * After topic creation/recreation, ClickHouse Kafka engine consumers need to connect.
+ * With auto.offset.reset=latest, messages produced before connection are missed.
+ * We produce probe messages until ClickHouse consumes one, guaranteeing the
+ * consumer is active before tests begin.
+ */
+async function waitForClickHousePersonConsumer(clickhouse: Clickhouse): Promise<void> {
+    const producer = await KafkaProducerWrapper.create(undefined)
+    const probeTeamId = -1
+
+    try {
+        await waitForExpect(async () => {
+            await producer.queueMessages({
+                topic: KAFKA_PERSON,
+                messages: [
+                    {
+                        value: JSON.stringify({
+                            id: new UUIDT().toString(),
+                            created_at: DateTime.utc().toFormat('yyyy-MM-dd HH:mm:ss'),
+                            properties: '{}',
+                            team_id: probeTeamId,
+                            is_identified: 0,
+                            is_deleted: 0,
+                            version: 0,
+                        }),
+                    },
+                ],
+            })
+            await producer.flush()
+
+            const result = await clickhouse.query<{ count: number }>(
+                `SELECT count() as count FROM person WHERE team_id = ${probeTeamId}`
+            )
+            expect(Number(result[0]?.count ?? 0)).toBeGreaterThan(0)
+        }, 30_000)
+    } finally {
+        await producer.disconnect()
+    }
+}
+
+jest.setTimeout(60000) // 60s to accommodate warmup + delayUntilEventIngested budget
 
 const extraServerConfig: Partial<PluginsServerConfig> = {
     LOG_LEVEL: 'info',
@@ -51,20 +92,20 @@ describe('postgres parity', () => {
 
     beforeAll(async () => {
         clickhouse = Clickhouse.create()
-        // Reset Kafka topics once before all tests. Doing this in beforeEach
-        // causes ClickHouse StorageKafka consumers to lose their partition
-        // assignments every time topics are deleted/recreated, leading to
-        // "Can't get assignment" errors and 100s+ polling hangs.
-        await resetKafka(extraServerConfig)
+        // Ensure topics exist without deleting them. Deleting and recreating
+        // topics causes ClickHouse StorageKafka consumers to lose partition
+        // assignments, leading to missed messages and polling timeouts.
+        await ensureKafkaTopics([KAFKA_PERSON, KAFKA_PERSON_DISTINCT_ID], extraServerConfig)
+        await waitForClickHousePersonConsumer(clickhouse)
     })
 
     beforeEach(async () => {
         jest.spyOn(process, 'exit').mockImplementation()
 
-        // Generate unique teamId to avoid collisions across test files
+        // Generate unique teamId to avoid collisions across test files.
+        // This provides ClickHouse isolation without truncating tables,
+        // which would be redundant and risks disrupting Kafka consumers.
         teamId = Math.floor((Date.now() % 1000000000) + Math.random() * 1000000)
-
-        await clickhouse.resetTestDatabase()
 
         await resetTestDatabase()
 
@@ -121,11 +162,11 @@ describe('postgres parity', () => {
         )
         await kafkaProducer.flush()
 
-        await clickhouse.delayUntilEventIngested(() => clickhouse.fetchPersons())
+        await clickhouse.delayUntilEventIngested(() => clickhouse.fetchPersons(teamId))
         await clickhouse.delayUntilEventIngested(() => clickhouse.fetchDistinctIdValues(person), 2)
         await clickhouse.delayUntilEventIngested(() => clickhouse.fetchDistinctIds(person), 2)
 
-        const clickHousePersons = (await clickhouse.fetchPersons()).map((row) => ({
+        const clickHousePersons = (await clickhouse.fetchPersons(teamId)).map((row) => ({
             ...row,
             properties: parseJSON(row.properties), // avoids depending on key sort order
         }))
@@ -219,7 +260,7 @@ describe('postgres parity', () => {
             )
         )
 
-        await clickhouse.delayUntilEventIngested(() => clickhouse.fetchPersons())
+        await clickhouse.delayUntilEventIngested(() => clickhouse.fetchPersons(teamId))
         await clickhouse.delayUntilEventIngested(() => clickhouse.fetchDistinctIdValues(person), 2)
 
         // update properties and set is_identified to true
@@ -237,10 +278,10 @@ describe('postgres parity', () => {
         )
 
         await clickhouse.delayUntilEventIngested(async () =>
-            (await clickhouse.fetchPersons()).filter((p) => p.is_identified)
+            (await clickhouse.fetchPersons(teamId)).filter((p) => p.is_identified)
         )
 
-        const clickHousePersons = await clickhouse.fetchPersons()
+        const clickHousePersons = await clickhouse.fetchPersons(teamId)
         const postgresPersons = await fetchPersons(postgres)
 
         expect(clickHousePersons.filter((p) => p.team_id.toString() === teamId.toString()).length).toEqual(1)
@@ -274,10 +315,10 @@ describe('postgres parity', () => {
         expect(updatedPerson.version).toEqual(2)
 
         await clickhouse.delayUntilEventIngested(async () =>
-            (await clickhouse.fetchPersons()).filter((p) => !p.is_identified)
+            (await clickhouse.fetchPersons(teamId)).filter((p) => !p.is_identified)
         )
 
-        const clickHousePersons2 = await clickhouse.fetchPersons()
+        const clickHousePersons2 = await clickhouse.fetchPersons(teamId)
         const postgresPersons2 = await fetchPersons(postgres)
 
         expect(clickHousePersons2.length).toEqual(1)
@@ -343,7 +384,7 @@ describe('postgres parity', () => {
         )
         await kafkaProducer.flush()
 
-        await clickhouse.delayUntilEventIngested(() => clickhouse.fetchPersons())
+        await clickhouse.delayUntilEventIngested(() => clickhouse.fetchPersons(teamId))
         const [postgresPerson] = await fetchPersons(postgres)
 
         await clickhouse.delayUntilEventIngested(() => clickhouse.fetchDistinctIds(postgresPerson), 1)
@@ -451,7 +492,7 @@ describe('postgres parity', () => {
         )
         await kafkaProducer.flush()
 
-        await clickhouse.delayUntilEventIngested(() => clickhouse.fetchPersons())
+        await clickhouse.delayUntilEventIngested(() => clickhouse.fetchPersons(teamId))
         const [postgresPerson] = await fetchPersons(postgres)
 
         await clickhouse.delayUntilEventIngested(() => clickhouse.fetchDistinctIdValues(postgresPerson), 1)
@@ -518,9 +559,9 @@ describe('postgres parity', () => {
         })
 
         await clickhouse.delayUntilEventIngested(async () =>
-            (await clickhouse.fetchPersons()).length === 1 ? ['deleted!'] : []
+            (await clickhouse.fetchPersons(teamId)).length === 1 ? ['deleted!'] : []
         )
-        const clickHousePersons = await clickhouse.fetchPersons()
+        const clickHousePersons = await clickhouse.fetchPersons(teamId)
         const postgresPersons = await fetchPersons(postgres)
 
         expect(clickHousePersons.length).toEqual(1)


### PR DESCRIPTION
## Problem

The `postgres-parity.test.ts` test suite is flaky in CI, with all 4 tests timing out waiting for data to appear in ClickHouse (`Failed to get data in time, got []`). The root cause is `resetKafka()` deleting and recreating all Kafka topics in `beforeAll`, which causes ClickHouse's Kafka engine consumers to lose their partition assignments. With `auto.offset.reset=latest`, any messages produced before the consumers reconnect are permanently missed.

## Changes

- Added `ensureKafkaTopics()` helper that creates topics only if they don't exist, without deleting existing ones, preserving ClickHouse Kafka engine consumer connections
- Added a `waitForClickHousePersonConsumer()` warmup that produces probe messages until ClickHouse consumes one, guaranteeing the consumer is active before tests begin (same pattern used in `ingestion-e2e.test.ts`)
- Replaced `resetKafka()` with `ensureKafkaTopics()` in the test suite
- Removed `clickhouse.resetTestDatabase()` from `beforeEach` since each test already uses a unique random `teamId` for isolation
- Added `teamId` filtering to all `clickhouse.fetchPersons()` calls so tests only see their own data


## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
