### PR TITLE
feat(logs): notify users when an alert auto-breaks

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -609,6 +609,7 @@ export const INSIGHT_ALERT_FIRING_EVENT_ID = '$insight_alert_firing'
 export const LOGS_ALERT_FIRING_SUB_TEMPLATE_ID = 'logs-alert-firing'
 export const LOGS_ALERT_FIRING_EVENT_ID = '$logs_alert_firing'
 export const LOGS_ALERT_RESOLVED_EVENT_ID = '$logs_alert_resolved'
+export const LOGS_ALERT_AUTO_DISABLED_EVENT_ID = '$logs_alert_auto_disabled'
 
 export const COHORT_PERSONS_QUERY_LIMIT = 10000
 

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
@@ -49,6 +49,10 @@ export const getProductEventFilterOptions = (contextId: HogFunctionConfiguration
                     label: 'Log alert resolved',
                     value: '$logs_alert_resolved',
                 },
+                {
+                    label: 'Log alert auto-disabled',
+                    value: '$logs_alert_auto_disabled',
+                },
             ]
         case 'discussion-mention':
             return [

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -111,6 +111,13 @@ export const HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES: Record<
         filters: { events: [{ id: '$logs_alert_resolved', type: 'events' }] },
         flag: FEATURE_FLAGS.LOGS_ALERTING,
     },
+    'logs-alert-auto-disabled': {
+        sub_template_id: 'logs-alert-auto-disabled',
+        type: 'internal_destination',
+        context_id: 'logs-alerting',
+        filters: { events: [{ id: '$logs_alert_auto_disabled', type: 'events' }] },
+        flag: FEATURE_FLAGS.LOGS_ALERTING,
+    },
 }
 
 export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, HogFunctionSubTemplateType[]> = {
@@ -914,6 +921,58 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             },
         },
     ],
+    'logs-alert-auto-disabled': [
+        {
+            ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['logs-alert-auto-disabled'],
+            template_id: 'template-webhook',
+            name: 'HTTP Webhook on log alert auto-disabled',
+            description: 'Send a webhook when a log alert is auto-disabled due to repeated failures',
+        },
+        {
+            ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['logs-alert-auto-disabled'],
+            template_id: 'template-slack',
+            name: 'Post to Slack on log alert auto-disabled',
+            description: 'Post to Slack when a log alert is auto-disabled due to repeated failures',
+            inputs: {
+                blocks: {
+                    value: [
+                        {
+                            type: 'header',
+                            text: {
+                                type: 'plain_text',
+                                text: "Log alert '{event.properties.alert_name}' was auto-disabled",
+                            },
+                        },
+                        {
+                            type: 'section',
+                            text: {
+                                type: 'mrkdwn',
+                                text: '*Reason:* {event.properties.consecutive_failures} consecutive check failures.\n*Last error:* {event.properties.last_error_message}',
+                            },
+                        },
+                        {
+                            type: 'context',
+                            elements: [{ type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' }],
+                        },
+                        { type: 'divider' },
+                        {
+                            type: 'actions',
+                            elements: [
+                                {
+                                    url: '{project.url}/logs?alertId={event.properties.alert_id}',
+                                    text: { text: 'View alert', type: 'plain_text' },
+                                    type: 'button',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                text: {
+                    value: "Log alert '{event.properties.alert_name}' was auto-disabled after {event.properties.consecutive_failures} consecutive failures",
+                },
+            },
+        },
+    ],
 }
 
 export const getSubTemplate = (
@@ -939,6 +998,7 @@ export const eventToHogFunctionContextId = (event: string | undefined): HogFunct
             return 'discussion-mention'
         case '$logs_alert_firing':
         case '$logs_alert_resolved':
+        case '$logs_alert_auto_disabled':
             return 'logs-alerting'
         default:
             return 'standard'

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6510,6 +6510,7 @@ export type HogFunctionSubTemplateIdType =
     | 'experiment-significant'
     | 'logs-alert-firing'
     | 'logs-alert-resolved'
+    | 'logs-alert-auto-disabled'
 
 export type HogFunctionConfigurationType = Omit<
     HogFunctionType,

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -16,6 +16,7 @@ from posthog.exceptions_capture import capture_exception
 
 from products.logs.backend.alert_check_query import AlertCheckQuery
 from products.logs.backend.alert_state_machine import (
+    AlertCheckOutcome,
     AlertSnapshot,
     AlertState,
     CheckResult,
@@ -225,6 +226,17 @@ def _evaluate_single_alert(
 
         alert.save(update_fields=update_fields)
 
+    transitioned_to_broken = committed_state == AlertState.BROKEN and state_before != AlertState.BROKEN.value
+    if transitioned_to_broken:
+        logger.warning(
+            "Alert broken after consecutive failures",
+            alert_id=str(alert.id),
+            alert_name=alert.name,
+            team_id=alert.team_id,
+            consecutive_failures=outcome.consecutive_failures,
+        )
+        _emit_auto_disabled_event(alert, outcome, now)
+
     stats["checked"] += 1
 
     if outcome.error_message:
@@ -252,31 +264,12 @@ def _evaluate_single_alert(
         logger.exception("Failed to record alert check metrics", alert_id=str(alert.id))
 
 
-def _emit_alert_event(
+def _produce_alert_internal_event(
     alert: LogsAlertConfiguration,
     event_name: str,
-    check_result: CheckResult,
+    properties: dict,
     now: datetime,
-    *,
-    date_from: datetime,
-    date_to: datetime,
 ) -> bool:
-    """Produce an internal event to Kafka for CDP processing. Returns True on success."""
-    properties: dict = {
-        "alert_id": str(alert.id),
-        "alert_name": alert.name,
-        "team_id": alert.team_id,
-        "threshold_count": alert.threshold_count,
-        "threshold_operator": alert.threshold_operator,
-        "window_minutes": alert.window_minutes,
-        "result_count": check_result.result_count,
-        "filters": alert.filters,
-        "service_names": alert.filters.get("serviceNames", []),
-        "severity_levels": alert.filters.get("severityLevels", []),
-        "logs_url_params": build_logs_url_params(alert.filters, date_from=date_from, date_to=date_to),
-        "triggered_at": now.isoformat(),
-    }
-
     try:
         produce_internal_event(
             team_id=alert.team_id,
@@ -291,3 +284,47 @@ def _emit_alert_event(
     except Exception as e:
         capture_exception(e, {"alert_id": str(alert.id), "event": event_name})
         return False
+
+
+def _emit_alert_event(
+    alert: LogsAlertConfiguration,
+    event_name: str,
+    check_result: CheckResult,
+    now: datetime,
+    *,
+    date_from: datetime,
+    date_to: datetime,
+) -> bool:
+    properties: dict = {
+        "alert_id": str(alert.id),
+        "alert_name": alert.name,
+        "team_id": alert.team_id,
+        "threshold_count": alert.threshold_count,
+        "threshold_operator": alert.threshold_operator,
+        "window_minutes": alert.window_minutes,
+        "result_count": check_result.result_count,
+        "filters": alert.filters,
+        "service_names": alert.filters.get("serviceNames", []),
+        "severity_levels": alert.filters.get("severityLevels", []),
+        "logs_url_params": build_logs_url_params(alert.filters, date_from=date_from, date_to=date_to),
+        "triggered_at": now.isoformat(),
+    }
+    return _produce_alert_internal_event(alert, event_name, properties, now)
+
+
+def _emit_auto_disabled_event(
+    alert: LogsAlertConfiguration,
+    outcome: AlertCheckOutcome,
+    now: datetime,
+) -> None:
+    properties: dict = {
+        "alert_id": str(alert.id),
+        "alert_name": alert.name,
+        "team_id": alert.team_id,
+        "consecutive_failures": outcome.consecutive_failures,
+        "last_error_message": outcome.error_message or "",
+        "service_names": alert.filters.get("serviceNames", []),
+        "severity_levels": alert.filters.get("severityLevels", []),
+        "triggered_at": now.isoformat(),
+    }
+    _produce_alert_internal_event(alert, "$logs_alert_auto_disabled", properties, now)

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -409,3 +409,68 @@ class TestEvaluateSingleAlert(APIBaseTest):
         assert alert.state == LogsAlertConfiguration.State.NOT_FIRING
         # But notification is suppressed by cooldown
         mock_produce.assert_not_called()
+
+    @parameterized.expand(
+        [
+            (
+                "hits_threshold",
+                4,
+                LogsAlertConfiguration.State.NOT_FIRING,
+                LogsAlertConfiguration.State.BROKEN,
+                5,
+                1,
+            ),
+            (
+                "below_threshold",
+                3,
+                LogsAlertConfiguration.State.NOT_FIRING,
+                LogsAlertConfiguration.State.ERRORED,
+                4,
+                0,
+            ),
+            (
+                "already_broken",
+                5,
+                LogsAlertConfiguration.State.BROKEN,
+                LogsAlertConfiguration.State.BROKEN,
+                5,
+                0,
+            ),
+        ]
+    )
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_break_on_consecutive_failures(
+        self,
+        _name,
+        initial_failures,
+        initial_state,
+        expected_state,
+        expected_failures,
+        expected_events,
+        mock_produce,
+        mock_query_cls,
+    ):
+        alert = self._make_alert(
+            threshold_count=5,
+            consecutive_failures=initial_failures,
+            state=initial_state,
+        )
+        mock_query_cls.return_value.execute.side_effect = Exception("ClickHouse timeout")
+
+        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
+
+        alert.refresh_from_db()
+        assert alert.state == expected_state
+        assert alert.consecutive_failures == expected_failures
+        auto_disabled_calls = [
+            c
+            for c in mock_produce.call_args_list
+            if c.kwargs.get("event") and c.kwargs["event"].event == "$logs_alert_auto_disabled"
+        ]
+        assert len(auto_disabled_calls) == expected_events
+        if expected_events:
+            props = auto_disabled_calls[0].kwargs["event"].properties
+            assert props["consecutive_failures"] == expected_failures
+            assert "ClickHouse timeout" in props["last_error_message"]


### PR DESCRIPTION
## Problem

Log alerts can fail repeatedly due to infrastructure issues or query problems, but users currently have no visibility into when alerts are automatically disabled due to consecutive failures. This creates a blind spot where users may think their alerts are active when they've actually been disabled.

## Changes

- Added support for `$logs_alert_auto_disabled` events that are emitted when a log alert is automatically disabled after reaching the consecutive failure threshold
- Added new constant `LOGS_ALERT_AUTO_DISABLED_EVENT_ID` for the auto-disabled event
- Created webhook and Slack notification templates for auto-disabled alerts with relevant context including failure count and error messages
- Updated the alert evaluation logic to emit auto-disabled events when alerts transition to the BROKEN state
- Added the auto-disabled event to logs alert filter configurations so users can set up notifications
- Included comprehensive test coverage for the auto-disable functionality

The Slack notification includes:

- Alert name and reason for auto-disable
- Number of consecutive failures and last error message
- Direct link to view the alert in the logs interface

## How did you test this code?

Added unit tests covering:

- Alerts transitioning to BROKEN state after hitting the failure threshold
- Alerts that don't reach the threshold remaining in ERRORED state
- Already broken alerts not triggering duplicate events
- Proper event emission with correct properties including failure count and error messages

The tests verify that auto-disabled events are only emitted when an alert transitions from a non-broken state to BROKEN state, preventing duplicate notifications.

## Publish to changelog?

No - alerting not released yet

## Docs update

no