### PR TITLE
fix(ci): use .nvmrc in publish-npm job via sparse checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,6 +301,10 @@ jobs:
         permissions:
             id-token: write
         steps:
+            - uses: actions/checkout@v6
+              with:
+                  sparse-checkout: .nvmrc
+                  sparse-checkout-cone-mode: false
             - name: Fetch npm packages
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
               with:
@@ -309,7 +313,7 @@ jobs:
                   merge-multiple: true
             - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
               with:
-                  node-version: 24
+                  node-version-file: .nvmrc
                   registry-url: 'https://registry.npmjs.org'
             - name: Ensure modern npm (OIDC support)
               run: npm install -g npm@11.6.4


### PR DESCRIPTION
## Problem

#54686 fixed the `publish-npm` job by hardcoding `node-version: 24` since the job had no checkout step to read `.nvmrc` from. This undid the consistency we had across all CI workflows where `.nvmrc` is the single source of truth for the Node.js version.

## Changes

Add a [sparse checkout](https://github.com/actions/checkout#fetch-only-a-single-file) of just `.nvmrc` before `setup-node`, restoring `node-version-file: .nvmrc` in the `publish-npm` job.

## How did you test this code?

Audited all 19 workflow files that use `actions/setup-node` — this was the only job with a hardcoded version. The sparse checkout is a well-documented pattern for fetching a single file without cloning the full repo.

## Publish to changelog?

No

## Docs update

No

## 🤖 LLM context

Co-authored with Claude Code. Audited all CI workflows for Node.js version consistency before making the change.