### PR TITLE
fix(onboarding): add missing info type to CalloutBox component

### DIFF
--- a/frontend/src/scenes/onboarding/OnboardingDocsContentWrapper.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingDocsContentWrapper.tsx
@@ -24,7 +24,7 @@ export interface OnboardingComponentsContext {
         file?: string
     }>
     CalloutBox: React.ComponentType<{
-        type: 'action' | 'fyi' | 'caution'
+        type: 'action' | 'fyi' | 'caution' | 'info'
         icon?: string
         title?: string
         children: ReactNode
@@ -214,12 +214,12 @@ function CalloutBox({
     title,
     children,
 }: {
-    type: 'action' | 'fyi' | 'caution'
+    type: 'action' | 'fyi' | 'caution' | 'info'
     icon?: string
     title?: string
     children: ReactNode
 }): JSX.Element {
-    const bannerType = type === 'caution' ? 'warning' : type === 'action' ? 'info' : 'info'
+    const bannerType = type === 'caution' ? 'warning' : 'info'
 
     return (
         <LemonBanner type={bannerType} className="my-4 [&>*]:font-normal">


### PR DESCRIPTION
## Problem

PR #53668 introduced `<CalloutBox type="info">` across 28 LLM analytics onboarding docs files, but the `CalloutBox` component type only accepts `'action' | 'fyi' | 'caution'`. This breaks `typescript:check` CI for every PR rebased on master.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## ![Screenshot 2026-04-15 at 15.15.09.png](https://app.graphite.com/user-attachments/assets/2a54849b-1ac4-4f0b-bb94-bbf8179fefab.png)

## 

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

Tests

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->