### PR TITLE
feat(logs): reset endpoint + broken alert notifications

### DIFF
--- a/products/alerts/mcp/tools.yaml
+++ b/products/alerts/mcp/tools.yaml
@@ -149,3 +149,6 @@ tools:
     logs-alerts-destinations-delete-create:
         operation: logs_alerts_destinations_delete_create
         enabled: false
+    logs-alerts-reset-create:
+        operation: logs_alerts_reset_create
+        enabled: false

--- a/products/logs/backend/alert_destinations.py
+++ b/products/logs/backend/alert_destinations.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 
 from products.logs.backend.models import LogsAlertConfiguration
 
-EventKind = Literal["firing", "resolved"]
+EventKind = Literal["firing", "resolved", "broken"]
 
 
 @dataclass(frozen=True)
@@ -15,6 +15,23 @@ class EventKindSpec:
     event_id: str
     header: str
     body: str
+    button_url: str
+    button_label: str
+    webhook_body: dict[str, str]
+
+
+_FIRE_RESOLVE_WEBHOOK_BODY: dict[str, str] = {
+    "alert_id": "{event.properties.alert_id}",
+    "alert_name": "{event.properties.alert_name}",
+    "result_count": "{event.properties.result_count}",
+    "threshold_count": "{event.properties.threshold_count}",
+    "threshold_operator": "{event.properties.threshold_operator}",
+    "window_minutes": "{event.properties.window_minutes}",
+    "service_names": "{event.properties.service_names}",
+    "severity_levels": "{event.properties.severity_levels}",
+    "logs_url": "{project.url}/logs?{event.properties.logs_url_params}",
+    "triggered_at": "{event.properties.triggered_at}",
+}
 
 
 EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
@@ -26,6 +43,9 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
             "{event.properties.window_minutes}m "
             "(threshold: {event.properties.threshold_operator} {event.properties.threshold_count})"
         ),
+        button_url="{project.url}/logs?{event.properties.logs_url_params}",
+        button_label="View logs",
+        webhook_body={"event": "firing", **_FIRE_RESOLVE_WEBHOOK_BODY},
     ),
     "resolved": EventKindSpec(
         event_id="$logs_alert_resolved",
@@ -35,6 +55,32 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
             "{event.properties.window_minutes}m "
             "(threshold: {event.properties.threshold_operator} {event.properties.threshold_count})"
         ),
+        button_url="{project.url}/logs?{event.properties.logs_url_params}",
+        button_label="View logs",
+        webhook_body={"event": "resolved", **_FIRE_RESOLVE_WEBHOOK_BODY},
+    ),
+    "broken": EventKindSpec(
+        event_id="$logs_alert_auto_disabled",
+        header="Log alert '{event.properties.alert_name}' was auto-disabled",
+        body=(
+            "*Reason:* {event.properties.consecutive_failures} consecutive check failures.\n"
+            "*Last error:* {event.properties.last_error_message}"
+        ),
+        # Deep-link to the alert modal (via the ?alertId= param handled in logsSceneLogic) —
+        # a broken alert's viewer URL would show zero logs because the alert is no longer checking.
+        button_url="{project.url}/logs?alertId={event.properties.alert_id}",
+        button_label="View alert",
+        webhook_body={
+            "event": "broken",
+            "alert_id": "{event.properties.alert_id}",
+            "alert_name": "{event.properties.alert_name}",
+            "consecutive_failures": "{event.properties.consecutive_failures}",
+            "last_error_message": "{event.properties.last_error_message}",
+            "service_names": "{event.properties.service_names}",
+            "severity_levels": "{event.properties.severity_levels}",
+            "alert_url": "{project.url}/logs?alertId={event.properties.alert_id}",
+            "triggered_at": "{event.properties.triggered_at}",
+        },
     ),
 }
 
@@ -73,29 +119,13 @@ def _slack_blocks(spec: EventKindSpec) -> list[dict]:
             "type": "actions",
             "elements": [
                 {
-                    "url": "{project.url}/logs?{event.properties.logs_url_params}",
-                    "text": {"text": "View logs", "type": "plain_text"},
+                    "url": spec.button_url,
+                    "text": {"text": spec.button_label, "type": "plain_text"},
                     "type": "button",
                 }
             ],
         },
     ]
-
-
-def _webhook_body(kind: EventKind) -> dict[str, str]:
-    return {
-        "event": kind,
-        "alert_id": "{event.properties.alert_id}",
-        "alert_name": "{event.properties.alert_name}",
-        "result_count": "{event.properties.result_count}",
-        "threshold_count": "{event.properties.threshold_count}",
-        "threshold_operator": "{event.properties.threshold_operator}",
-        "window_minutes": "{event.properties.window_minutes}",
-        "service_names": "{event.properties.service_names}",
-        "severity_levels": "{event.properties.severity_levels}",
-        "logs_url": "{project.url}/logs?{event.properties.logs_url_params}",
-        "triggered_at": "{event.properties.triggered_at}",
-    }
 
 
 def _filter_for(alert: LogsAlertConfiguration, kind: EventKind) -> dict[str, Any]:
@@ -142,6 +172,7 @@ def build_webhook_config(
     kind: EventKind,
     webhook_url: str,
 ) -> dict[str, Any]:
+    spec = EVENT_KIND_CONFIG[kind]
     return {
         "team": alert.team,
         "type": "internal_destination",
@@ -150,7 +181,7 @@ def build_webhook_config(
         "name": f"{alert.name}: {kind} → Webhook {webhook_url}",
         "template_id": "template-webhook",
         "inputs": {
-            "body": {"value": _webhook_body(kind)},
+            "body": {"value": spec.webhook_body},
             "url": {"value": webhook_url},
         },
     }

--- a/products/logs/backend/alerts_api.py
+++ b/products/logs/backend/alerts_api.py
@@ -7,6 +7,7 @@ from django.db import transaction
 from django.db.models import OuterRef, QuerySet, Subquery
 
 from drf_spectacular.utils import extend_schema, extend_schema_field
+from loginas.utils import is_impersonated_session
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
@@ -21,6 +22,7 @@ from posthog.models.activity_logging.activity_log import Change, Detail, changes
 from posthog.models.hog_functions.hog_function import HogFunction
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.team.team import Team
+from posthog.models.user import User
 from posthog.permissions import PostHogFeatureFlagPermission
 from posthog.utils import relative_date_parse
 
@@ -545,8 +547,8 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             log_activity(
                 organization_id=self.team.organization_id,
                 team_id=self.team_id,
-                user=request.user,
-                was_impersonated=False,
+                user=cast(User, request.user),
+                was_impersonated=is_impersonated_session(request),
                 item_id=alert.id,
                 scope="LogsAlertConfiguration",
                 activity="reset",

--- a/products/logs/backend/alerts_api.py
+++ b/products/logs/backend/alerts_api.py
@@ -17,7 +17,7 @@ from posthog.api.hog_function import HogFunctionSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.event_usage import report_user_action
-from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
+from posthog.models.activity_logging.activity_log import Change, Detail, changes_between, log_activity
 from posthog.models.hog_functions.hog_function import HogFunction
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.team.team import Team
@@ -525,6 +525,53 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         )
         serializer.is_valid(raise_exception=True)
         return serializer.save(team=team)
+
+    @extend_schema(
+        request=None,
+        responses={200: LogsAlertConfigurationSerializer},
+        description="Reset a broken alert. Clears the consecutive-failure counter and schedules an immediate recheck.",
+    )
+    @action(detail=True, methods=["POST"], url_path="reset")
+    def reset(self, request: Request, *args: object, **kwargs: object) -> Response:
+        alert = self.get_object()
+        if alert.state != LogsAlertConfiguration.State.BROKEN:
+            raise ValidationError({"state": "Only broken alerts can be reset."})
+        previous_failures = alert.consecutive_failures
+        with transaction.atomic():
+            updated = alert.mark_for_recheck(reset_state=True)
+            alert.save(update_fields=updated)
+            # The model's auto-signal skips these fields (signal_exclusions silences
+            # engine-driven churn) so we log the user-initiated reset explicitly.
+            log_activity(
+                organization_id=self.team.organization_id,
+                team_id=self.team_id,
+                user=request.user,
+                was_impersonated=False,
+                item_id=alert.id,
+                scope="LogsAlertConfiguration",
+                activity="reset",
+                detail=Detail(
+                    name=alert.name,
+                    changes=[
+                        Change(
+                            type="LogsAlertConfiguration",
+                            action="changed",
+                            field="state",
+                            before="broken",
+                            after="not_firing",
+                        ),
+                        Change(
+                            type="LogsAlertConfiguration",
+                            action="changed",
+                            field="consecutive_failures",
+                            before=previous_failures,
+                            after=0,
+                        ),
+                    ],
+                ),
+            )
+        report_user_action(request.user, "logs alert reset", {"alert_id": str(alert.id)})
+        return Response(self.get_serializer(alert).data)
 
     @extend_schema(
         request=LogsAlertSimulateRequestSerializer,

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -572,11 +572,11 @@ class TestLogsAlertAPI(APIBaseTest):
         )
         assert response.status_code == status.HTTP_201_CREATED, response.json()
         ids = response.json()["hog_function_ids"]
-        assert len(ids) == 2  # firing + resolved
+        assert len(ids) == 3  # firing + resolved + broken
 
         hog_functions = HogFunction.objects.filter(id__in=ids).order_by("name")
         event_ids = sorted([(hf.filters or {})["events"][0]["id"] for hf in hog_functions])
-        assert event_ids == ["$logs_alert_firing", "$logs_alert_resolved"]
+        assert event_ids == ["$logs_alert_auto_disabled", "$logs_alert_firing", "$logs_alert_resolved"]
         for hf in hog_functions:
             assert hf.template_id == "template-slack"
             inputs = hf.inputs or {}
@@ -607,7 +607,7 @@ class TestLogsAlertAPI(APIBaseTest):
         )
         assert response.status_code == status.HTTP_201_CREATED, response.json()
         ids = response.json()["hog_function_ids"]
-        assert len(ids) == 2
+        assert len(ids) == 3
 
         hog_functions = HogFunction.objects.filter(id__in=ids)
         for hf in hog_functions:
@@ -615,7 +615,7 @@ class TestLogsAlertAPI(APIBaseTest):
             inputs = hf.inputs or {}
             assert inputs["url"]["value"] == "https://example.com/hook"
             body = inputs["body"]["value"]
-            assert body["event"] in ("firing", "resolved")
+            assert body["event"] in ("firing", "resolved", "broken")
 
     @parameterized.expand(
         [
@@ -685,6 +685,82 @@ class TestLogsAlertAPI(APIBaseTest):
             format="json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    # --- Reset ---
+
+    def _reset_url(self, alert_id: str) -> str:
+        return f"{self.base_url}{alert_id}/reset/"
+
+    @patch("products.logs.backend.alerts_api.report_user_action")
+    def test_reset_broken_alert(self, mock_report):
+        created = self._create_via_api()
+        LogsAlertConfiguration.objects.filter(pk=created["id"]).update(
+            state=LogsAlertConfiguration.State.BROKEN,
+            consecutive_failures=5,
+            next_check_at=datetime.now(UTC) + timedelta(minutes=10),
+        )
+
+        response = self.client.post(self._reset_url(created["id"]))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        data = response.json()
+        assert data["state"] == "not_firing"
+        assert data["consecutive_failures"] == 0
+        assert data["next_check_at"] is None
+        reset_calls = [c for c in mock_report.call_args_list if c.args[1] == "logs alert reset"]
+        assert len(reset_calls) == 1
+
+    @parameterized.expand(
+        [
+            ("not_firing", LogsAlertConfiguration.State.NOT_FIRING),
+            ("firing", LogsAlertConfiguration.State.FIRING),
+            ("errored", LogsAlertConfiguration.State.ERRORED),
+            ("snoozed", LogsAlertConfiguration.State.SNOOZED),
+            ("pending_resolve", LogsAlertConfiguration.State.PENDING_RESOLVE),
+        ]
+    )
+    def test_reset_rejects_non_broken_alert(self, _name: str, state: str) -> None:
+        created = self._create_via_api()
+        LogsAlertConfiguration.objects.filter(pk=created["id"]).update(state=state)
+
+        response = self.client.post(self._reset_url(created["id"]))
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Only broken alerts can be reset." in str(response.json())
+
+    def test_reset_other_teams_alert_returns_404(self):
+        other_team = Team.objects.create(organization=self.organization, name="Other")
+        other_alert = LogsAlertConfiguration.objects.create(
+            team=other_team,
+            name="Other team alert",
+            threshold_count=10,
+            filters={"severityLevels": ["error"]},
+            state=LogsAlertConfiguration.State.BROKEN,
+            consecutive_failures=5,
+        )
+
+        response = self.client.post(self._reset_url(str(other_alert.id)))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_reset_writes_activity_log(self):
+        from posthog.models.activity_logging.activity_log import ActivityLog
+
+        created = self._create_via_api()
+        LogsAlertConfiguration.objects.filter(pk=created["id"]).update(
+            state=LogsAlertConfiguration.State.BROKEN,
+            consecutive_failures=5,
+        )
+        ActivityLog.objects.filter(item_id=str(created["id"])).delete()
+
+        response = self.client.post(self._reset_url(created["id"]))
+        assert response.status_code == status.HTTP_200_OK
+
+        entries = list(ActivityLog.objects.filter(item_id=str(created["id"])))
+        assert len(entries) >= 1, [e.activity for e in ActivityLog.objects.all()]
+        changed_fields = {c["field"] for entry in entries for c in (entry.detail or {}).get("changes", [])}
+        assert "state" in changed_fields
+        assert "consecutive_failures" in changed_fields
 
     # --- Simulate ---
 

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertNotifications.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertNotifications.tsx
@@ -100,7 +100,7 @@ export function LogsAlertNotifications(): JSX.Element {
     return (
         <div className="flex flex-col gap-2">
             <p className="text-xs text-muted-alt m-0">
-                Each destination delivers notifications for all alert events — firing and resolved.
+                Each destination delivers notifications for all alert events — firing, resolved, and broken.
             </p>
             {(existingHogFunctionsLoading || destinationGroups.length > 0) && (
                 <div>

--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -340,6 +340,24 @@ export const logsAlertsDestinationsDeleteCreate = async (
 }
 
 /**
+ * Reset a broken alert. Clears the consecutive-failure counter and schedules an immediate recheck.
+ */
+export const getLogsAlertsResetCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/logs/alerts/${id}/reset/`
+}
+
+export const logsAlertsResetCreate = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<LogsAlertConfigurationApi> => {
+    return apiMutator<LogsAlertConfigurationApi>(getLogsAlertsResetCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+    })
+}
+
+/**
  * Simulate a logs alert on historical data using the full state machine. Read-only — no alert check records are created.
  */
 export const getLogsAlertsSimulateCreateUrl = (projectId: string) => {

--- a/products/logs/mcp/tools.yaml
+++ b/products/logs/mcp/tools.yaml
@@ -155,3 +155,6 @@ tools:
     logs-alerts-destinations-delete-create:
         operation: logs_alerts_destinations_delete_create
         enabled: false
+    logs-alerts-reset-create:
+        operation: logs_alerts_reset_create
+        enabled: false


### PR DESCRIPTION
## Problem

Log alerts need better handling when they become broken due to consecutive failures. Currently, there's no way to reset a broken alert or receive notifications when an alert becomes auto-disabled.

## Changes

- Added a new "broken" event type for log alerts that triggers when an alert is auto-disabled due to consecutive failures
- Implemented a reset endpoint (`POST /api/projects/{id}/logs/alerts/{id}/reset/`) that allows resetting broken alerts by clearing the consecutive failure counter and scheduling an immediate recheck
- Enhanced alert destinations to support the new "broken" event type with appropriate messaging and deep-linking to the alert configuration
- Updated notification text to mention all three event types: firing, resolved, and broken
- Added comprehensive test coverage for the reset functionality including activity logging

The broken alert notifications include:
- Reason for auto-disable (consecutive failure count)
- Last error message
- Deep-link to alert configuration instead of logs view
- Webhook payload with relevant broken alert properties

## How did you test this code?

Added unit tests covering:
- Reset endpoint functionality for broken alerts
- Validation that only broken alerts can be reset
- Activity logging for reset actions
- Authorization checks (404 for other team's alerts)
- Error handling for non-broken alert states
- Webhook and Slack destination creation with the new broken event type

The tests verify that resetting a broken alert properly clears the consecutive failure counter, updates the state to "not_firing", and logs the activity appropriately.

## Publish to changelog?

Yes - this adds new functionality for managing broken log alerts.

## Docs update

This adds a new API endpoint that should be documented.