### PR TITLE
fix(workflows-batch-export): Make new function only once

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
@@ -179,9 +179,7 @@ class WorkflowsConsumer(Consumer):
         self.hog_function_error_threshold_min_records = hog_function_error_threshold_min_records
         self.records_handled_count = 0
         self.latest_hog_function_error: str | None = None
-
-    async def consume_chunk(self, data: bytes) -> None:
-        post = make_retryable_with_exponential_backoff(
+        self.retryable_post = make_retryable_with_exponential_backoff(
             self.post,
             retryable_exceptions=(
                 InternalServerError,
@@ -192,7 +190,9 @@ class WorkflowsConsumer(Consumer):
             # Retry forever on retryable errors
             max_attempts=None,
         )
-        self.request_task_group.create_task(post(data))
+
+    async def consume_chunk(self, data: bytes) -> None:
+        self.request_task_group.create_task(self.retryable_post(data))
 
     async def post(self, data: bytes) -> None:
         async with self._requests_semaphore:


### PR DESCRIPTION
## Problem

In workflows batch export, every time we post a request we make a new function using `make_retryable_with_exponential_backoff`. This is wasteful: The inputs are always the same (just the max_attempts), so we are creating and allocating a new function every time.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Create new function only once and re-use it.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran tests, all passing.

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No.
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No.
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
