### PR TITLE
fix(debug): fix table overflow and flex growth on query performance page

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -189,7 +189,7 @@ export function QueryPerformance(): JSX.Element {
                 loading={slowestQueriesLoading}
                 emptyState="No experiment queries found in this time range"
                 pagination={{ pageSize: 20 }}
-                className="overflow-visible!"
+                className="overflow-visible! flex-none!"
                 expandable={{
                     expandedRowRender: function ExpandedQuery(item) {
                         return (
@@ -221,6 +221,8 @@ export function QueryPerformance(): JSX.Element {
                 dataSource={precomputationTeams}
                 loading={precomputationTeamsLoading}
                 emptyState={search ? 'No teams found' : 'No teams have precomputation enabled'}
+                pagination={{ pageSize: 20 }}
+                className="overflow-visible! flex-none!"
             />
         </SceneContent>
     )


### PR DESCRIPTION
## Problem

Tables on the query performance page are clipped by the parent layout's `overflow: hidden`. Empty tables bloat to ~1000px due to `flex: 1` in LemonTable's SCSS.

## Changes

Add `overflow-visible!` and `flex-none!` overrides to both tables on the query performance page. Also add pagination to the precomputation table.

## How did you test this code?

Tested locally with 50 fake rows — pagination works, table renders fully, empty state has minimal height.