### PR TITLE
feat(error_tracking): add issue facade kickoff

### DIFF
--- a/products/error_tracking/backend/api/external_references.py
+++ b/products/error_tracking/backend/api/external_references.py
@@ -17,6 +17,7 @@ from posthog.models.integration import (
     LinearIntegration,
 )
 
+from products.error_tracking.backend import logic
 from products.error_tracking.backend.models import ErrorTrackingExternalReference, ErrorTrackingIssue
 
 logger = structlog.get_logger(__name__)
@@ -44,19 +45,9 @@ class ErrorTrackingExternalReferenceSerializer(serializers.ModelSerializer):
         read_only_fields = ["external_url"]
 
     def get_external_url(self, reference: ErrorTrackingExternalReference) -> str:
-        external_context: dict[str, str] = reference.external_context or {}
-        if reference.integration.kind == Integration.IntegrationKind.LINEAR:
-            url_key = LinearIntegration(reference.integration).url_key()
-            return f"https://linear.app/{url_key}/issue/{external_context['id']}"
-        elif reference.integration.kind == Integration.IntegrationKind.GITHUB:
-            org = GitHubIntegration(reference.integration).organization()
-            return f"https://github.com/{org}/{external_context['repository']}/issues/{external_context['number']}"
-        elif reference.integration.kind == Integration.IntegrationKind.GITLAB:
-            gitlab = GitLabIntegration(reference.integration)
-            return f"{gitlab.hostname}/{gitlab.project_path}/issues/{external_context['issue_id']}"
-        elif reference.integration.kind == Integration.IntegrationKind.JIRA:
-            jira = JiraIntegration(reference.integration)
-            return f"{jira.site_url()}/browse/{external_context['key']}"
+        external_url = logic.build_external_issue_url(reference)
+        if external_url:
+            return external_url
         raise ValidationError("Provider not supported")
 
     def validate(self, data):

--- a/products/error_tracking/backend/api/external_references.py
+++ b/products/error_tracking/backend/api/external_references.py
@@ -48,6 +48,10 @@ class ErrorTrackingExternalReferenceSerializer(serializers.ModelSerializer):
         external_url = logic.build_external_issue_url(reference)
         if external_url:
             return external_url
+
+        if logic.is_supported_external_issue_provider(reference.integration.kind):
+            raise ValidationError("Missing required external context fields")
+
         raise ValidationError("Provider not supported")
 
     def validate(self, data):

--- a/products/error_tracking/backend/facade/__init__.py
+++ b/products/error_tracking/backend/facade/__init__.py
@@ -1,0 +1,19 @@
+from . import types
+from .api import (
+    IssueNotFoundError,
+    get_issue,
+    get_issue_id_for_fingerprint,
+    get_issue_values,
+    issue_exists,
+    list_issues,
+)
+
+__all__ = [
+    "IssueNotFoundError",
+    "types",
+    "get_issue",
+    "get_issue_id_for_fingerprint",
+    "get_issue_values",
+    "issue_exists",
+    "list_issues",
+]

--- a/products/error_tracking/backend/facade/api.py
+++ b/products/error_tracking/backend/facade/api.py
@@ -1,0 +1,88 @@
+"""Facade API for error tracking.
+
+This is the ONLY module other apps are allowed to import.
+"""
+
+from uuid import UUID
+
+from .. import logic
+from . import types as contracts
+
+IssueNotFoundError = logic.ErrorTrackingIssueNotFoundError
+
+
+def _to_issue_assignee(assignment) -> contracts.ErrorTrackingIssueAssignee | None:
+    if assignment is None:
+        return None
+
+    assignee_id = assignment.user_id if assignment.user_id else str(assignment.role_id) if assignment.role_id else None
+    assignee_type = "role" if assignment.role_id else "user"
+
+    return contracts.ErrorTrackingIssueAssignee(id=assignee_id, type=assignee_type)
+
+
+def _to_external_reference(reference) -> contracts.ErrorTrackingExternalReference:
+    integration = reference.integration
+    return contracts.ErrorTrackingExternalReference(
+        id=reference.id,
+        integration=contracts.ErrorTrackingExternalReferenceIntegration(
+            id=integration.id,
+            kind=integration.kind,
+            display_name=integration.display_name,
+        ),
+        external_url=logic.build_external_issue_url(reference),
+    )
+
+
+def _to_issue_cohort(issue) -> contracts.ErrorTrackingIssueCohort | None:
+    for issue_cohort in issue.cohorts.all():
+        cohort = issue_cohort.cohort
+        if not cohort.deleted:
+            return contracts.ErrorTrackingIssueCohort(id=issue_cohort.cohort_id, name=cohort.name)
+    return None
+
+
+def _to_issue_preview(issue) -> contracts.ErrorTrackingIssuePreview:
+    return contracts.ErrorTrackingIssuePreview(
+        id=issue.id,
+        status=issue.status,
+        name=issue.name,
+        description=issue.description,
+        first_seen=getattr(issue, "first_seen", None),
+        assignee=_to_issue_assignee(getattr(issue, "assignment", None)),
+    )
+
+
+def _to_issue(issue) -> contracts.ErrorTrackingIssue:
+    return contracts.ErrorTrackingIssue(
+        id=issue.id,
+        status=issue.status,
+        name=issue.name,
+        description=issue.description,
+        first_seen=getattr(issue, "first_seen", None),
+        assignee=_to_issue_assignee(getattr(issue, "assignment", None)),
+        external_issues=[_to_external_reference(reference) for reference in issue.external_issues.all()],
+        cohort=_to_issue_cohort(issue),
+    )
+
+
+def list_issues(team_id: int) -> list[contracts.ErrorTrackingIssuePreview]:
+    issues = logic.list_issues(team_id)
+    return [_to_issue_preview(issue) for issue in issues]
+
+
+def get_issue(issue_id: UUID, team_id: int) -> contracts.ErrorTrackingIssue:
+    issue = logic.get_issue(issue_id=issue_id, team_id=team_id)
+    return _to_issue(issue)
+
+
+def issue_exists(team_id: int) -> bool:
+    return logic.issue_exists(team_id=team_id)
+
+
+def get_issue_id_for_fingerprint(team_id: int, fingerprint: str) -> UUID | None:
+    return logic.get_issue_id_for_fingerprint(team_id=team_id, fingerprint=fingerprint)
+
+
+def get_issue_values(team_id: int, key: str | None, value: str | None) -> list[str]:
+    return logic.get_issue_values(team_id=team_id, key=key, value=value)

--- a/products/error_tracking/backend/facade/import_map.md
+++ b/products/error_tracking/backend/facade/import_map.md
@@ -1,0 +1,50 @@
+# Error tracking internal import map (phase 0)
+
+Generated during facade isolation kickoff.
+This tracks cross-product imports that currently bypass the facade.
+
+## Current public-ish surfaces consumed externally
+
+| Internal module                                                 | External consumers                                                                                                                                                                                                                                                                                      | Capability class                       |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `backend.models`                                                | `ee/hogai/context/error_tracking/context.py`, `products/tasks/backend/repository_readiness.py`, `posthog/tasks/usage_report.py`, `posthog/tasks/email.py`, `posthog/models/remote_config.py`, `posthog/models/product_intent/product_intent.py`, `posthog/management/commands/*`, plus tests/admin/demo | read/list/detail, counters, async/task |
+| `backend.weekly_digest`                                         | `posthog/tasks/email.py`                                                                                                                                                                                                                                                                                | async/task (weekly digest fan-out)     |
+| `backend.hogql_queries.*`                                       | `posthog/hogql_queries/query_runner.py`, `products/signals/backend/temporal/backfill_error_tracking.py`, `products/posthog_ai/scripts/hogql_example/__init__.py`                                                                                                                                        | read/list analytics query execution    |
+| `backend.api` package                                           | `posthog/api/__init__.py`                                                                                                                                                                                                                                                                               | HTTP routing entrypoint                |
+| `backend.api.issues` serializer                                 | `backend/hogql_queries/error_tracking_query_runner_v1.py`, `backend/hogql_queries/error_tracking_issue_correlation_query_runner.py`                                                                                                                                                                     | read/list serialization coupling       |
+| `backend.remote_config` and `backend.api.suppression_rules`     | `posthog/models/remote_config.py`                                                                                                                                                                                                                                                                       | config read                            |
+| `backend.embedding`, `backend.indexed_embedding`, `backend.sql` | `posthog/clickhouse/schema.py`, `posthog/clickhouse/migrations/*`, `posthog/api/embedding_worker.py`, `products/signals/backend/management/commands/cleanup_signals.py`, `posthog/conftest.py`                                                                                                          | schema/constants (infra)               |
+| `backend.tools.search_issues`                                   | `ee/hogai/core/agent_modes/presets/error_tracking.py`                                                                                                                                                                                                                                                   | tool invocation                        |
+
+## Initial migration focus (stack order)
+
+1. **Read-only issue access** (lowest risk): move model reads to `backend/facade/api.py` (`list_issues`, `get_issue`, `issue_exists`, fingerprint lookup, values lookup).
+2. **Cross-product issue readers**: migrate `ee/hogai/context/error_tracking/context.py`, `products/tasks/backend/repository_readiness.py`, `posthog/tasks/usage_report.py`.
+3. **Task and digest callers**: migrate `posthog/tasks/email.py` and `backend/weekly_digest.py` consumers.
+4. **Presentation migration**: move `backend/api/*.py` viewsets into `backend/presentation/views.py`/`serializers.py` and route through facade.
+5. **Boundary enforcement + cleanup**: add `backend/facade/contracts.py`, `backend:contract-check`, and `tach` interface block once legacy paths are removed.
+
+## Graphite stack template
+
+```bash
+# Base branch
+
+gt checkout master
+
+gt create -m "chore(error-tracking): add facade kickoff and import map"
+# PR 1
+
+gt create -m "refactor(error-tracking): migrate issue readers to facade"
+# PR 2
+
+gt create -m "refactor(error-tracking): migrate digest and task callers"
+# PR 3
+
+gt create -m "refactor(error-tracking): move api viewsets to presentation layer"
+# PR 4
+
+gt create -m "chore(error-tracking): enforce facade interfaces and contracts"
+# PR 5
+```
+
+Use `gt modify -a` to amend each branch and `gt submit --stack` to open/update the full stacked PR chain.

--- a/products/error_tracking/backend/facade/types.py
+++ b/products/error_tracking/backend/facade/types.py
@@ -1,0 +1,57 @@
+"""Transitional contract types for error tracking facade.
+
+These dataclasses are framework-free and represent the facade boundary.
+They will move to contracts.py when the product structure migration is complete.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class ErrorTrackingIssueAssignee:
+    id: int | str | None
+    type: str
+
+
+@dataclass(frozen=True)
+class ErrorTrackingIssueCohort:
+    id: int
+    name: str
+
+
+@dataclass(frozen=True)
+class ErrorTrackingExternalReferenceIntegration:
+    id: int
+    kind: str
+    display_name: str
+
+
+@dataclass(frozen=True)
+class ErrorTrackingExternalReference:
+    id: UUID
+    integration: ErrorTrackingExternalReferenceIntegration
+    external_url: str
+
+
+@dataclass(frozen=True)
+class ErrorTrackingIssuePreview:
+    id: UUID
+    status: str
+    name: str | None
+    description: str | None
+    first_seen: datetime | None
+    assignee: ErrorTrackingIssueAssignee | None
+
+
+@dataclass(frozen=True)
+class ErrorTrackingIssue:
+    id: UUID
+    status: str
+    name: str | None
+    description: str | None
+    first_seen: datetime | None
+    assignee: ErrorTrackingIssueAssignee | None
+    external_issues: list[ErrorTrackingExternalReference] = field(default_factory=list)
+    cohort: ErrorTrackingIssueCohort | None = None

--- a/products/error_tracking/backend/logic.py
+++ b/products/error_tracking/backend/logic.py
@@ -1,0 +1,105 @@
+from uuid import UUID
+
+from django.db.models import QuerySet
+
+from posthog.models.integration import (
+    GitHubIntegration,
+    GitLabIntegration,
+    Integration,
+    JiraIntegration,
+    LinearIntegration,
+)
+
+from products.error_tracking.backend.models import (
+    ErrorTrackingExternalReference,
+    ErrorTrackingIssue,
+    ErrorTrackingIssueFingerprintV2,
+)
+
+
+class ErrorTrackingIssueNotFoundError(Exception):
+    pass
+
+
+def get_issues_queryset(team_id: int) -> QuerySet[ErrorTrackingIssue]:
+    return (
+        ErrorTrackingIssue.objects.with_first_seen()
+        .select_related("assignment")
+        .prefetch_related("external_issues__integration")
+        .prefetch_related("cohorts__cohort")
+        .filter(team_id=team_id)
+    )
+
+
+def list_issues(team_id: int) -> QuerySet[ErrorTrackingIssue]:
+    return get_issues_queryset(team_id)
+
+
+def get_issue(issue_id: UUID, team_id: int) -> ErrorTrackingIssue:
+    issue = get_issues_queryset(team_id).filter(id=issue_id).first()
+    if issue is None:
+        raise ErrorTrackingIssueNotFoundError
+    return issue
+
+
+def issue_exists(team_id: int) -> bool:
+    return ErrorTrackingIssue.objects.filter(team_id=team_id).exists()
+
+
+def get_issue_id_for_fingerprint(team_id: int, fingerprint: str) -> UUID | None:
+    return (
+        ErrorTrackingIssueFingerprintV2.objects.filter(team_id=team_id, fingerprint=fingerprint)
+        .values_list("issue_id", flat=True)
+        .first()
+    )
+
+
+def get_issue_values(team_id: int, key: str | None, value: str | None) -> list[str]:
+    if not key or not value:
+        return []
+
+    queryset = ErrorTrackingIssue.objects.filter(team_id=team_id)
+
+    if key == "name":
+        return list(queryset.filter(name__icontains=value).values_list("name", flat=True))
+
+    if key == "issue_description":
+        return list(queryset.filter(description__icontains=value).values_list("description", flat=True))
+
+    return []
+
+
+def build_external_issue_url(reference: ErrorTrackingExternalReference) -> str:
+    external_context: dict[str, str] = reference.external_context or {}
+    integration = reference.integration
+
+    if integration.kind == Integration.IntegrationKind.LINEAR:
+        issue_id = external_context.get("id")
+        if not issue_id:
+            return ""
+        url_key = LinearIntegration(integration).url_key()
+        return f"https://linear.app/{url_key}/issue/{issue_id}"
+
+    if integration.kind == Integration.IntegrationKind.GITHUB:
+        repository = external_context.get("repository")
+        number = external_context.get("number")
+        if not repository or not number:
+            return ""
+        org = GitHubIntegration(integration).organization()
+        return f"https://github.com/{org}/{repository}/issues/{number}"
+
+    if integration.kind == Integration.IntegrationKind.GITLAB:
+        issue_id = external_context.get("issue_id")
+        if not issue_id:
+            return ""
+        gitlab = GitLabIntegration(integration)
+        return f"{gitlab.hostname}/{gitlab.project_path}/issues/{issue_id}"
+
+    if integration.kind == Integration.IntegrationKind.JIRA:
+        issue_key = external_context.get("key")
+        if not issue_key:
+            return ""
+        jira = JiraIntegration(integration)
+        return f"{jira.site_url()}/browse/{issue_key}"
+
+    return ""

--- a/products/error_tracking/backend/logic.py
+++ b/products/error_tracking/backend/logic.py
@@ -21,7 +21,11 @@ class ErrorTrackingIssueNotFoundError(Exception):
     pass
 
 
-def get_issues_queryset(team_id: int) -> QuerySet[ErrorTrackingIssue]:
+def get_issue_list_queryset(team_id: int) -> QuerySet[ErrorTrackingIssue]:
+    return ErrorTrackingIssue.objects.with_first_seen().select_related("assignment").filter(team_id=team_id)
+
+
+def get_issue_detail_queryset(team_id: int) -> QuerySet[ErrorTrackingIssue]:
     return (
         ErrorTrackingIssue.objects.with_first_seen()
         .select_related("assignment")
@@ -32,11 +36,11 @@ def get_issues_queryset(team_id: int) -> QuerySet[ErrorTrackingIssue]:
 
 
 def list_issues(team_id: int) -> QuerySet[ErrorTrackingIssue]:
-    return get_issues_queryset(team_id)
+    return get_issue_list_queryset(team_id)
 
 
 def get_issue(issue_id: UUID, team_id: int) -> ErrorTrackingIssue:
-    issue = get_issues_queryset(team_id).filter(id=issue_id).first()
+    issue = get_issue_detail_queryset(team_id).filter(id=issue_id).first()
     if issue is None:
         raise ErrorTrackingIssueNotFoundError
     return issue
@@ -61,10 +65,18 @@ def get_issue_values(team_id: int, key: str | None, value: str | None) -> list[s
     queryset = ErrorTrackingIssue.objects.filter(team_id=team_id)
 
     if key == "name":
-        return list(queryset.filter(name__icontains=value).values_list("name", flat=True))
+        return [
+            issue_name
+            for issue_name in queryset.filter(name__icontains=value).values_list("name", flat=True)
+            if issue_name is not None
+        ]
 
     if key == "issue_description":
-        return list(queryset.filter(description__icontains=value).values_list("description", flat=True))
+        return [
+            issue_description
+            for issue_description in queryset.filter(description__icontains=value).values_list("description", flat=True)
+            if issue_description is not None
+        ]
 
     return []
 

--- a/products/error_tracking/backend/logic.py
+++ b/products/error_tracking/backend/logic.py
@@ -21,6 +21,20 @@ class ErrorTrackingIssueNotFoundError(Exception):
     pass
 
 
+SUPPORTED_EXTERNAL_ISSUE_PROVIDERS = frozenset(
+    {
+        Integration.IntegrationKind.LINEAR,
+        Integration.IntegrationKind.GITHUB,
+        Integration.IntegrationKind.GITLAB,
+        Integration.IntegrationKind.JIRA,
+    }
+)
+
+
+def is_supported_external_issue_provider(kind: str) -> bool:
+    return kind in SUPPORTED_EXTERNAL_ISSUE_PROVIDERS
+
+
 def get_issue_list_queryset(team_id: int) -> QuerySet[ErrorTrackingIssue]:
     return ErrorTrackingIssue.objects.with_first_seen().select_related("assignment").filter(team_id=team_id)
 

--- a/products/error_tracking/backend/test/test_facade_api.py
+++ b/products/error_tracking/backend/test/test_facade_api.py
@@ -1,5 +1,7 @@
 from posthog.test.base import BaseTest
 
+from parameterized import parameterized
+
 from posthog.models import Team
 
 from products.error_tracking.backend.facade import (
@@ -69,12 +71,19 @@ class TestErrorTrackingFacadeAPI(BaseTest):
 
         assert result == issue.id
 
-    def test_get_issue_values(self):
+    @parameterized.expand(
+        [
+            ["name", "name", "checkout", ["Checkout timeout", "Checkout type error"]],
+            ["issue_description", "issue_description", "timeout", ["A timeout during payment"]],
+            ["missing_key", None, "timeout", []],
+            ["missing_value", "name", None, []],
+            ["unknown_key", "unknown", "checkout", []],
+        ]
+    )
+    def test_get_issue_values(self, _name: str, key: str | None, value: str | None, expected: list[str]):
         self._create_issue(team=self.team, name="Checkout timeout", description="A timeout during payment")
         self._create_issue(team=self.team, name="Checkout type error", description="Type mismatch in checkout")
 
-        values_by_name = api.get_issue_values(team_id=self.team.id, key="name", value="checkout")
-        values_by_description = api.get_issue_values(team_id=self.team.id, key="issue_description", value="timeout")
+        values = api.get_issue_values(team_id=self.team.id, key=key, value=value)
 
-        assert sorted(values_by_name) == ["Checkout timeout", "Checkout type error"]
-        assert values_by_description == ["A timeout during payment"]
+        assert sorted(values) == sorted(expected)

--- a/products/error_tracking/backend/test/test_facade_api.py
+++ b/products/error_tracking/backend/test/test_facade_api.py
@@ -1,0 +1,80 @@
+from posthog.test.base import BaseTest
+
+from posthog.models import Team
+
+from products.error_tracking.backend.facade import (
+    api,
+    types as contracts,
+)
+from products.error_tracking.backend.models import (
+    ErrorTrackingIssue,
+    ErrorTrackingIssueAssignment,
+    ErrorTrackingIssueFingerprintV2,
+)
+
+
+class TestErrorTrackingFacadeAPI(BaseTest):
+    def _create_issue(self, *, team, name: str, description: str | None = None) -> ErrorTrackingIssue:
+        issue = ErrorTrackingIssue.objects.create(team=team, name=name, description=description)
+        ErrorTrackingIssueFingerprintV2.objects.create(team=team, issue=issue, fingerprint=f"fp-{issue.id}")
+        return issue
+
+    def test_list_issues_returns_contracts_scoped_by_team(self):
+        issue = self._create_issue(team=self.team, name="Checkout failed", description="Payment intent error")
+        ErrorTrackingIssueAssignment.objects.create(issue=issue, team=self.team, user=self.user)
+
+        other_team = Team.objects.create(organization=self.organization, name="Other team")
+        self._create_issue(team=other_team, name="Other team issue")
+
+        issues = api.list_issues(team_id=self.team.id)
+
+        assert len(issues) == 1
+        assert isinstance(issues[0], contracts.ErrorTrackingIssuePreview)
+        assert issues[0].id == issue.id
+        assert issues[0].assignee is not None
+        assert issues[0].assignee.id == self.user.id
+        assert issues[0].assignee.type == "user"
+
+    def test_get_issue_returns_contract(self):
+        issue = self._create_issue(team=self.team, name="Unhandled TypeError")
+
+        result = api.get_issue(issue_id=issue.id, team_id=self.team.id)
+
+        assert isinstance(result, contracts.ErrorTrackingIssue)
+        assert result.id == issue.id
+        assert result.name == "Unhandled TypeError"
+        assert result.external_issues == []
+        assert result.cohort is None
+
+    def test_get_issue_raises_for_other_team(self):
+        issue = self._create_issue(team=self.team, name="Scoped issue")
+        other_team = Team.objects.create(organization=self.organization, name="Other team")
+
+        with self.assertRaises(api.IssueNotFoundError):
+            api.get_issue(issue_id=issue.id, team_id=other_team.id)
+
+    def test_issue_exists(self):
+        assert api.issue_exists(team_id=self.team.id) is False
+
+        self._create_issue(team=self.team, name="Any issue")
+
+        assert api.issue_exists(team_id=self.team.id) is True
+
+    def test_get_issue_id_for_fingerprint(self):
+        issue = ErrorTrackingIssue.objects.create(team=self.team, name="Fingerprint lookup")
+        fingerprint = "fingerprint-lookup"
+        ErrorTrackingIssueFingerprintV2.objects.create(team=self.team, issue=issue, fingerprint=fingerprint)
+
+        result = api.get_issue_id_for_fingerprint(team_id=self.team.id, fingerprint=fingerprint)
+
+        assert result == issue.id
+
+    def test_get_issue_values(self):
+        self._create_issue(team=self.team, name="Checkout timeout", description="A timeout during payment")
+        self._create_issue(team=self.team, name="Checkout type error", description="Type mismatch in checkout")
+
+        values_by_name = api.get_issue_values(team_id=self.team.id, key="name", value="checkout")
+        values_by_description = api.get_issue_values(team_id=self.team.id, key="issue_description", value="timeout")
+
+        assert sorted(values_by_name) == ["Checkout timeout", "Checkout type error"]
+        assert values_by_description == ["A timeout during payment"]

--- a/services/mcp/src/generated/conversations/api.ts
+++ b/services/mcp/src/generated/conversations/api.ts
@@ -136,6 +136,7 @@ export const ConversationsTicketsPartialUpdateBody = /* @__PURE__ */ zod
                 'Ticket priority: low, medium, or high. Null if unset.\n\n* `low` - Low\n* `medium` - Medium\n* `high` - High'
             ),
         sla_due_at: zod.iso.datetime({}).nullish().describe('SLA deadline set via workflows. Null means no SLA.'),
+        snoozed_until: zod.iso.datetime({}).nullish(),
         tags: zod.array(zod.unknown()).optional(),
     })
     .describe('Serializer mixin that handles tags for objects.')

--- a/services/mcp/src/tools/generated/conversations.ts
+++ b/services/mcp/src/tools/generated/conversations.ts
@@ -127,6 +127,9 @@ const conversationsTicketsUpdate = (): ToolBase<
         if (params.sla_due_at !== undefined) {
             body['sla_due_at'] = params.sla_due_at
         }
+        if (params.snoozed_until !== undefined) {
+            body['snoozed_until'] = params.snoozed_until
+        }
         if (params.tags !== undefined) {
             body['tags'] = params.tags
         }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/conversations-tickets-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/conversations-tickets-update.json
@@ -43,6 +43,18 @@
             ],
             "description": "SLA deadline set via workflows. Null means no SLA."
         },
+        "snoozed_until": {
+            "anyOf": [
+                {
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
         "status": {
             "description": "Ticket status: new, open, pending, on_hold, or resolved\n\n* `new` - New\n* `open` - Open\n* `pending` - Pending\n* `on_hold` - On hold\n* `resolved` - Resolved",
             "enum": ["new", "open", "pending", "on_hold", "resolved"],


### PR DESCRIPTION
## Problem

Error tracking is still in legacy isolation mode.
Cross-product callers and the current API layer directly depend on product internals,
which blocks moving the product to the facade/contracts architecture.
This PR starts that migration with a narrow, read-focused kickoff slice.

## Changes

- Added `products/error_tracking/backend/logic.py` with team-scoped read helpers for issues and fingerprint lookups.
- Added an initial facade surface in `products/error_tracking/backend/facade/api.py`.
- Added framework-free facade dataclasses in `products/error_tracking/backend/facade/types.py`.
- Added a migration import map in `products/error_tracking/backend/facade/import_map.md` with external usage classification and a proposed Graphite stack plan.
- Added facade tests in `products/error_tracking/backend/test/test_facade_api.py` covering scoping, not-found behavior, lookups, and value filtering.

## How did you test this code?

- `ruff check products/error_tracking/backend/logic.py products/error_tracking/backend/facade/types.py products/error_tracking/backend/facade/api.py products/error_tracking/backend/facade/__init__.py products/error_tracking/backend/test/test_facade_api.py`
- `hogli test products/error_tracking/backend/test/test_facade_api.py`
- `bin/hogli product:lint error_tracking`

No manual UI testing was performed in this PR.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

no docs update needed (internal backend architecture kickoff)

## 🤖 LLM context

- Session used pi worker mode with repository skills for product isolation planning and implementation.
- Graphite CLI was used to create the branch and submit this PR.
