### PR TITLE
refactor(hogql): remove self.dialect from BasePrinter

### DIFF
--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -2,7 +2,7 @@ import re
 from collections.abc import Iterable
 from datetime import date, datetime
 from difflib import get_close_matches
-from typing import Any, Literal, Optional, Union, cast
+from typing import Any, ClassVar, Literal, Optional, Union, cast
 from uuid import UUID
 
 from django.conf import settings as django_settings
@@ -67,19 +67,19 @@ def resolve_field_type(expr: ast.Expr) -> ast.Type | None:
 class BasePrinter(Visitor[str]):
     # NOTE: Call "print_ast()", not this class directly.
     # Shared AST walker for all dialect printers (HogQL, ClickHouse, Postgres).
-    # Dialect-specific behavior currently lives behind `self.dialect` checks
-    # and is being progressively moved into subclass overrides.
+    # Each subclass sets ``DIALECT_NAME`` to identify itself for error messages and
+    # resolver wiring; dialect-specific rendering lives in subclass-overridden hooks.
+
+    DIALECT_NAME: ClassVar[HogQLDialect]
 
     def __init__(
         self,
         context: HogQLContext,
-        dialect: HogQLDialect,
         stack: list[AST] | None = None,
         settings: HogQLGlobalSettings | None = None,
         pretty: bool = False,
     ):
         self.context = context
-        self.dialect = dialect
         self.stack: list[AST] = stack or []  # Keep track of all traversed nodes.
         self.settings = settings
         self.pretty = pretty
@@ -108,7 +108,7 @@ class BasePrinter(Visitor[str]):
     def _assert_set_operator_supported(self, set_operator: str) -> None:
         """Raise if this dialect does not support the given set operator. Postgres overrides to permit all."""
         if set_operator in ("INTERSECT ALL", "EXCEPT ALL"):
-            raise ImpossibleASTError(f"{set_operator} is not supported in the '{self.dialect}' dialect")
+            raise ImpossibleASTError(f"{set_operator} is not supported in the '{self.DIALECT_NAME}' dialect")
 
     def _assert_recursive_cte_supported(self) -> None:
         """Raise if this dialect does not support recursive CTEs. Postgres overrides to permit."""
@@ -116,7 +116,7 @@ class BasePrinter(Visitor[str]):
 
     def _assert_qualify_supported(self) -> None:
         """Raise if this dialect does not support the QUALIFY clause. Postgres overrides to permit."""
-        raise QueryError("QUALIFY is not supported in the '{}' dialect".format(self.dialect))
+        raise QueryError("QUALIFY is not supported in the '{}' dialect".format(self.DIALECT_NAME))
 
     def _assert_with_ties_supported(self) -> None:
         """Raise if this dialect does not support WITH TIES. Postgres overrides to reject."""
@@ -191,7 +191,7 @@ class BasePrinter(Visitor[str]):
         `limit_str` is the already-visited limit expression. The default raises because
         most dialects don't support LIMIT percent; CH and PG override.
         """
-        raise QueryError(f"LIMIT percent is not allowed in {self.dialect} dialect")
+        raise QueryError(f"LIMIT percent is not allowed in {self.DIALECT_NAME} dialect")
 
     def _render_select_query_limit_clause(self, limit: ast.Expr, is_percent: bool) -> str:
         """Render the full LIMIT clause (including the keyword) for a single SELECT.
@@ -199,7 +199,7 @@ class BasePrinter(Visitor[str]):
         Default handles the non-percent case and raises for percent; CH and PG override.
         """
         if is_percent:
-            raise QueryError(f"LIMIT percent is not allowed in {self.dialect} dialect")
+            raise QueryError(f"LIMIT percent is not allowed in {self.DIALECT_NAME} dialect")
         return f"LIMIT {self.visit(limit)}"
 
     def _validate_within_group_for_aggregation(self, node: "ast.Call", func_meta) -> None:
@@ -241,9 +241,11 @@ class BasePrinter(Visitor[str]):
 
     def visit_cte(self, node: ast.CTE):
         if node.materialized is not None:
-            raise ImpossibleASTError(f"CTE materialization hints are not supported in the '{self.dialect}' dialect")
+            raise ImpossibleASTError(
+                f"CTE materialization hints are not supported in the '{self.DIALECT_NAME}' dialect"
+            )
         if node.using_key is not None:
-            raise ImpossibleASTError(f"CTE USING KEY is not supported in the '{self.dialect}' dialect")
+            raise ImpossibleASTError(f"CTE USING KEY is not supported in the '{self.DIALECT_NAME}' dialect")
 
         if node.cte_type == "subquery":
             if node.columns is not None:
@@ -507,7 +509,7 @@ class BasePrinter(Visitor[str]):
             return []
 
         scope = ast.SelectQueryType(tables={"t": node_type})
-        return [resolve_types(clone_expr(pred), self.context, self.dialect, [scope]) for pred in predicates]
+        return [resolve_types(clone_expr(pred), self.context, self.DIALECT_NAME, [scope]) for pred in predicates]
 
     def _print_table_ref(self, table_type: ast.TableType | ast.LazyTableType, node: ast.JoinExpr) -> str:
         """Print a table reference. Fail-fast by default: each dialect must override.
@@ -764,7 +766,7 @@ class BasePrinter(Visitor[str]):
         return ""
 
     def visit_array_slice(self, node: ast.ArraySlice):
-        raise QueryError(f"Array slices are not allowed in {self.dialect} dialect")
+        raise QueryError(f"Array slices are not allowed in {self.DIALECT_NAME} dialect")
 
     def visit_array(self, node: ast.Array):
         return f"[{', '.join([self.visit(expr) for expr in node.exprs])}]"
@@ -777,7 +779,7 @@ class BasePrinter(Visitor[str]):
         return str + ")"
 
     def visit_try_cast(self, node: ast.TryCast):
-        raise QueryError(f"TRY_CAST is not allowed in {self.dialect} dialect")
+        raise QueryError(f"TRY_CAST is not allowed in {self.DIALECT_NAME} dialect")
 
     def visit_lambda(self, node: ast.Lambda):
         identifiers = [self._print_identifier(arg) for arg in node.args]

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -72,6 +72,11 @@ class BasePrinter(Visitor[str]):
 
     DIALECT_NAME: ClassVar[HogQLDialect]
 
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if not hasattr(cls, "DIALECT_NAME"):
+            raise TypeError(f"{cls.__name__} must define DIALECT_NAME")
+
     def __init__(
         self,
         context: HogQLContext,

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -2,7 +2,7 @@ import re
 from collections.abc import Iterable
 from datetime import date, datetime
 from difflib import get_close_matches
-from typing import Any, Literal, Optional, Union, cast
+from typing import Any, ClassVar, Literal, Optional, Union, cast
 from uuid import UUID
 
 from django.conf import settings as django_settings
@@ -67,19 +67,19 @@ def resolve_field_type(expr: ast.Expr) -> ast.Type | None:
 class BasePrinter(Visitor[str]):
     # NOTE: Call "print_ast()", not this class directly.
     # Shared AST walker for all dialect printers (HogQL, ClickHouse, Postgres).
-    # Dialect-specific behavior currently lives behind `self.dialect` checks
-    # and is being progressively moved into subclass overrides.
+    # Each subclass sets ``DIALECT_NAME`` to identify itself for error messages and
+    # resolver wiring; dialect-specific rendering lives in subclass-overridden hooks.
+
+    DIALECT_NAME: ClassVar[HogQLDialect]
 
     def __init__(
         self,
         context: HogQLContext,
-        dialect: HogQLDialect,
         stack: list[AST] | None = None,
         settings: HogQLGlobalSettings | None = None,
         pretty: bool = False,
     ):
         self.context = context
-        self.dialect = dialect
         self.stack: list[AST] = stack or []  # Keep track of all traversed nodes.
         self.settings = settings
         self.pretty = pretty
@@ -108,7 +108,7 @@ class BasePrinter(Visitor[str]):
     def _assert_set_operator_supported(self, set_operator: str) -> None:
         """Raise if this dialect does not support the given set operator. Postgres overrides to permit all."""
         if set_operator in ("INTERSECT ALL", "EXCEPT ALL"):
-            raise ImpossibleASTError(f"{set_operator} is not supported in the '{self.dialect}' dialect")
+            raise ImpossibleASTError(f"{set_operator} is not supported in the '{self.DIALECT_NAME}' dialect")
 
     def _assert_recursive_cte_supported(self) -> None:
         """Raise if this dialect does not support recursive CTEs. Postgres overrides to permit."""
@@ -116,7 +116,7 @@ class BasePrinter(Visitor[str]):
 
     def _assert_qualify_supported(self) -> None:
         """Raise if this dialect does not support the QUALIFY clause. Postgres overrides to permit."""
-        raise QueryError("QUALIFY is not supported in the '{}' dialect".format(self.dialect))
+        raise QueryError("QUALIFY is not supported in the '{}' dialect".format(self.DIALECT_NAME))
 
     def _assert_with_ties_supported(self) -> None:
         """Raise if this dialect does not support WITH TIES. Postgres overrides to reject."""
@@ -191,7 +191,7 @@ class BasePrinter(Visitor[str]):
         `limit_str` is the already-visited limit expression. The default raises because
         most dialects don't support LIMIT percent; CH and PG override.
         """
-        raise QueryError(f"LIMIT percent is not allowed in {self.dialect} dialect")
+        raise QueryError(f"LIMIT percent is not allowed in {self.DIALECT_NAME} dialect")
 
     def _render_select_query_limit_clause(self, limit: ast.Expr, is_percent: bool) -> str:
         """Render the full LIMIT clause (including the keyword) for a single SELECT.
@@ -199,7 +199,7 @@ class BasePrinter(Visitor[str]):
         Default handles the non-percent case and raises for percent; CH and PG override.
         """
         if is_percent:
-            raise QueryError(f"LIMIT percent is not allowed in {self.dialect} dialect")
+            raise QueryError(f"LIMIT percent is not allowed in {self.DIALECT_NAME} dialect")
         return f"LIMIT {self.visit(limit)}"
 
     def _validate_within_group_for_aggregation(self, node: "ast.Call", func_meta) -> None:
@@ -241,9 +241,11 @@ class BasePrinter(Visitor[str]):
 
     def visit_cte(self, node: ast.CTE):
         if node.materialized is not None:
-            raise ImpossibleASTError(f"CTE materialization hints are not supported in the '{self.dialect}' dialect")
+            raise ImpossibleASTError(
+                f"CTE materialization hints are not supported in the '{self.DIALECT_NAME}' dialect"
+            )
         if node.using_key is not None:
-            raise ImpossibleASTError(f"CTE USING KEY is not supported in the '{self.dialect}' dialect")
+            raise ImpossibleASTError(f"CTE USING KEY is not supported in the '{self.DIALECT_NAME}' dialect")
 
         if node.cte_type == "subquery":
             if node.columns is not None:
@@ -502,7 +504,7 @@ class BasePrinter(Visitor[str]):
             return []
 
         scope = ast.SelectQueryType(tables={"t": node_type})
-        return [resolve_types(clone_expr(pred), self.context, self.dialect, [scope]) for pred in predicates]
+        return [resolve_types(clone_expr(pred), self.context, self.DIALECT_NAME, [scope]) for pred in predicates]
 
     def _print_table_ref(self, table_type: ast.TableType | ast.LazyTableType, node: ast.JoinExpr) -> str:
         """Print a table reference. Fail-fast by default: each dialect must override.
@@ -759,7 +761,7 @@ class BasePrinter(Visitor[str]):
         return ""
 
     def visit_array_slice(self, node: ast.ArraySlice):
-        raise QueryError(f"Array slices are not allowed in {self.dialect} dialect")
+        raise QueryError(f"Array slices are not allowed in {self.DIALECT_NAME} dialect")
 
     def visit_array(self, node: ast.Array):
         return f"[{', '.join([self.visit(expr) for expr in node.exprs])}]"
@@ -772,7 +774,7 @@ class BasePrinter(Visitor[str]):
         return str + ")"
 
     def visit_try_cast(self, node: ast.TryCast):
-        raise QueryError(f"TRY_CAST is not allowed in {self.dialect} dialect")
+        raise QueryError(f"TRY_CAST is not allowed in {self.DIALECT_NAME} dialect")
 
     def visit_lambda(self, node: ast.Lambda):
         identifiers = [self._print_identifier(arg) for arg in node.args]

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -1,6 +1,6 @@
 import re
 from datetime import date, datetime
-from typing import Literal, Union, cast
+from typing import ClassVar, Literal, Union, cast
 from uuid import UUID
 
 from django.conf import settings as django_settings
@@ -9,7 +9,7 @@ from posthog.schema import PropertyGroupsMode
 
 from posthog.hogql import ast
 from posthog.hogql.ast import AST, Constant, StringType
-from posthog.hogql.constants import HogQLGlobalSettings
+from posthog.hogql.constants import HogQLDialect, HogQLGlobalSettings
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import DANGEROUS_NoTeamIdCheckTable, DatabaseField, SavedQuery
 from posthog.hogql.database.s3_table import DataWarehouseTable, S3Table
@@ -86,15 +86,7 @@ COLUMNS_WITH_HACKY_OPTIMIZED_NULL_HANDLING = {
 
 
 class ClickHousePrinter(BasePrinter):
-    def __init__(
-        self,
-        context: HogQLContext,
-        dialect: Literal["clickhouse"],
-        stack: list[AST] | None = None,
-        settings: HogQLGlobalSettings | None = None,
-        pretty: bool = False,
-    ):
-        super().__init__(context=context, dialect=dialect, stack=stack, settings=settings, pretty=pretty)
+    DIALECT_NAME: ClassVar[HogQLDialect] = "clickhouse"
 
     def _render_set_query_limit_percent(self, limit: ast.Expr, limit_str: str) -> str:
         return str(self._limit_percent_constant_value(limit))
@@ -1268,12 +1260,7 @@ class ClickHousePrinter(BasePrinter):
 
             if isinstance(column, ast.Call) and not dropped_hidden_alias:
                 with self.context.timings.measure("printer"):
-                    column_alias = safe_identifier(
-                        HogQLPrinter(
-                            context=self.context,
-                            dialect="hogql",
-                        ).visit(column)
-                    )
+                    column_alias = safe_identifier(HogQLPrinter(context=self.context).visit(column))
                 # ClickHouse rejects duplicate aliases for different expressions in the
                 # same SELECT. This can happen after "*" expansion if a subquery already
                 # exposes a generated expression name like `toDate(period_end)`.

--- a/posthog/hogql/printer/clickhouse.py
+++ b/posthog/hogql/printer/clickhouse.py
@@ -1,6 +1,6 @@
 import re
 from datetime import date, datetime
-from typing import Literal, Union, cast
+from typing import ClassVar, Literal, Union, cast
 from uuid import UUID
 
 from django.conf import settings as django_settings
@@ -9,7 +9,7 @@ from posthog.schema import PropertyGroupsMode
 
 from posthog.hogql import ast
 from posthog.hogql.ast import AST, Constant, StringType
-from posthog.hogql.constants import HogQLGlobalSettings
+from posthog.hogql.constants import HogQLDialect, HogQLGlobalSettings
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import DANGEROUS_NoTeamIdCheckTable, DatabaseField, SavedQuery
 from posthog.hogql.database.s3_table import DataWarehouseTable, S3Table
@@ -86,15 +86,7 @@ COLUMNS_WITH_HACKY_OPTIMIZED_NULL_HANDLING = {
 
 
 class ClickHousePrinter(BasePrinter):
-    def __init__(
-        self,
-        context: HogQLContext,
-        dialect: Literal["clickhouse"],
-        stack: list[AST] | None = None,
-        settings: HogQLGlobalSettings | None = None,
-        pretty: bool = False,
-    ):
-        super().__init__(context=context, dialect=dialect, stack=stack, settings=settings, pretty=pretty)
+    DIALECT_NAME: ClassVar[HogQLDialect] = "clickhouse"
 
     def _render_set_query_limit_percent(self, limit: ast.Expr, limit_str: str) -> str:
         return str(self._limit_percent_constant_value(limit))
@@ -1260,12 +1252,7 @@ class ClickHousePrinter(BasePrinter):
 
             if isinstance(column, ast.Call) and not dropped_hidden_alias:
                 with self.context.timings.measure("printer"):
-                    column_alias = safe_identifier(
-                        HogQLPrinter(
-                            context=self.context,
-                            dialect="hogql",
-                        ).visit(column)
-                    )
+                    column_alias = safe_identifier(HogQLPrinter(context=self.context).visit(column))
                 # ClickHouse rejects duplicate aliases for different expressions in the
                 # same SELECT. This can happen after "*" expansion if a subquery already
                 # exposes a generated expression name like `toDate(period_end)`.

--- a/posthog/hogql/printer/hogql.py
+++ b/posthog/hogql/printer/hogql.py
@@ -1,6 +1,7 @@
-from typing import cast
+from typing import ClassVar, cast
 
 from posthog.hogql import ast
+from posthog.hogql.constants import HogQLDialect
 from posthog.hogql.printer.base import BasePrinter
 
 
@@ -11,6 +12,8 @@ class HogQLPrinter(BasePrinter):
     syntax (nullish access, cohort ops, placeholder arguments) rather than
     lowering the tree to a target SQL dialect.
     """
+
+    DIALECT_NAME: ClassVar[HogQLDialect] = "hogql"
 
     def _render_aggregation_name(self, node: ast.Call, func_meta) -> str:
         return node.name

--- a/posthog/hogql/printer/postgres.py
+++ b/posthog/hogql/printer/postgres.py
@@ -1,10 +1,10 @@
 import re
 import hashlib
-from typing import Literal
+from typing import ClassVar
 
 from posthog.hogql import ast
 from posthog.hogql.ast import AST
-from posthog.hogql.constants import HogQLGlobalSettings
+from posthog.hogql.constants import HogQLDialect, HogQLGlobalSettings
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.direct_postgres_table import DirectPostgresTable
 from posthog.hogql.database.models import StructDatabaseField
@@ -23,15 +23,16 @@ _SAFE_FUNCTION_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 class PostgresPrinter(BasePrinter):
+    DIALECT_NAME: ClassVar[HogQLDialect] = "postgres"
+
     def __init__(
         self,
         context: HogQLContext,
-        dialect: Literal["postgres"],
         stack: list[AST] | None = None,
         settings: HogQLGlobalSettings | None = None,
         pretty: bool = False,
     ):
-        super().__init__(context=context, dialect=dialect, stack=stack, settings=settings, pretty=pretty)
+        super().__init__(context=context, stack=stack, settings=settings, pretty=pretty)
         self._truncated_identifiers: dict[str, str] = {}
         self._used_truncated_identifiers: set[str] = set()
         self._connection_supported_functions = self._get_connection_supported_functions()

--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -176,7 +176,6 @@ def print_prepared_ast(
             case "clickhouse":
                 printer = ClickHousePrinter(
                     context=context,
-                    dialect=dialect,
                     stack=printer_stack,
                     settings=settings,
                     pretty=pretty,
@@ -184,7 +183,6 @@ def print_prepared_ast(
             case "postgres":
                 printer = PostgresPrinter(
                     context=context,
-                    dialect=dialect,
                     stack=printer_stack,
                     settings=settings,
                     pretty=pretty,
@@ -192,7 +190,6 @@ def print_prepared_ast(
             case "hogql":
                 printer = HogQLPrinter(
                     context=context,
-                    dialect=dialect,
                     stack=printer_stack,
                     settings=settings,
                     pretty=pretty,

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -1754,7 +1754,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
 
             ctx = HogQLContext(enable_select_queries=True, limit_top_select=False)
             query = query.copy()
-            query["query"] = _PlaceholderPreservingPrinter(context=ctx, dialect="hogql").visit(parsed)
+            query["query"] = _PlaceholderPreservingPrinter(context=ctx).visit(parsed)
             return query, pagination
 
         raise ValidationError({"limit": f"Limit/offset parameters are only supported for HogQLQuery, not {query_kind}"})


### PR DESCRIPTION
## Problem

After PRs 1-4, `BasePrinter` has zero dialect-specific branches — but still carries a `self.dialect: HogQLDialect` field, used only for error-message interpolation and to pass as an argument to `resolve_types` in `_get_table_predicates`. PR 5 removes that last coupling.

After this PR, adding a new dialect (e.g. DuckDB) is **a new file with `DIALECT_NAME = "duckdb"` and a dispatch arm in `utils.py`** — zero edits to `base.py`.

## Changes

### Class-level `DIALECT_NAME` constants

Each subclass now carries `DIALECT_NAME: ClassVar[HogQLDialect]`:

- `ClickHousePrinter.DIALECT_NAME = "clickhouse"`
- `PostgresPrinter.DIALECT_NAME = "postgres"`
- `HogQLPrinter.DIALECT_NAME = "hogql"`

`BasePrinter` declares the annotation without a default so subclasses must provide one.

### `self.dialect` → `self.DIALECT_NAME`

7 error-message interpolation sites in `base.py` (LIMIT percent × 2, set operator, QUALIFY, CTE materialization, CTE USING KEY, array slices, TRY_CAST) now read `self.DIALECT_NAME`. The interpolated string is byte-identical — no test assertions on error text need to change.

The `resolve_types(..., self.dialect, ...)` call in `_get_table_predicates` becomes `resolve_types(..., self.DIALECT_NAME, ...)`.

### Constructor cleanup

- `BasePrinter.__init__` loses the `dialect: HogQLDialect` parameter and the `self.dialect = dialect` assignment.
- `ClickHousePrinter.__init__` is **deleted** — it was a pure `super().__init__(...)` forward.
- `PostgresPrinter.__init__` keeps its truncation-state setup but drops the `dialect` parameter and the `dialect=dialect` forwarding kwarg.
- `HogQLPrinter` has no `__init__` to change.

### Callers

- `print_prepared_ast` in `utils.py` drops the `dialect=dialect` kwarg from each of the three printer constructor calls.
- The internal `HogQLPrinter(..., dialect="hogql")` instantiation at `clickhouse.py:1255` drops the kwarg.
- The `_PlaceholderPreservingPrinter(..., dialect="hogql")` instantiation at `products/endpoints/backend/api.py:1757` drops the kwarg.

The public entry point `prepare_and_print_ast(..., dialect: HogQLDialect)` is unchanged — `dialect` is still how callers select which subclass to instantiate.

### Result

```
$ grep -c "self\.dialect" posthog/hogql/printer/*.py
posthog/hogql/printer/base.py:0
posthog/hogql/printer/clickhouse.py:0
posthog/hogql/printer/hogql.py:0
posthog/hogql/printer/postgres.py:0
posthog/hogql/printer/utils.py:0
```

## How did you test this code?

- `ruff check` — clean.
- `mypy posthog/hogql/printer/ products/endpoints/backend/api.py` — no new errors beyond the pre-existing `FieldOrTable` baseline.
- `hogli test posthog/hogql/printer/test/test_printer.py -k 'not with_recursive and not _save'` — **523 passed, 175 snapshots passed, 0 failed** across all three dialects. Two tests excluded locally because they need the `aux` ClickHouse cluster; CI exercises them.

## Publish to changelog?

no

## 🤖 LLM context

Authored via Claude Code. Fifth and final PR in the series splitting dialect-specific logic out of the shared HogQL printer. Follows #54483 (shell split), #54517 (ClickHouse branches), #54669 (HogQL branches), #54681 (Postgres branches).

With this landed, the printer module is structurally complete for adding DuckDB (or any other dialect) as a fully additive change — new subclass file + one match arm in `utils.py`. No edits to `base.py` required.

Stacked on #54681. Base branch is `hogql/move-postgres-branches`, not `master`.
