### PR TITLE
chore(ch_migrate): sync typing baselines for split stack

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -347,6 +347,7 @@ posthog/caching/insight_cache.py:0: error: Argument 2 to "process_query_dict" ha
 posthog/caching/insight_caching_state.py:0: error: Argument "params" to "execute" of "CursorWrapper" has incompatible type "list[object]"; expected "Sequence[bool | int | float | Decimal | str | <6 more items> | None] | Mapping[str, bool | int | float | Decimal | str | <6 more items> | None] | None | None"  [arg-type]
 posthog/caching/warming.py:0: error: Argument 2 to "process_query_dict" has incompatible type "Any | None"; expected "dict[Any, Any]"  [arg-type]
 posthog/clickhouse/client/tracing.py:0: error: Argument 2 to "set_attribute" of "Span" has incompatible type "Any | None"; expected "str | bool | int | float | Sequence[str] | Sequence[bool] | Sequence[int] | Sequence[float]"  [arg-type]
+posthog/clickhouse/test/_stubs.py:0: error: NamedTuple type as an attribute is not supported  [misc]
 posthog/dags/backfill_materialized_column.py:0: error: "str" has no attribute "strftime"  [attr-defined]
 posthog/dags/backfill_materialized_column.py:0: error: Argument 1 to "map_all_hosts_in_shards" of "ClickhouseCluster" has incompatible type "Mapping[int, Any]"; expected "dict[int, Callable[[Any], Never]]"  [arg-type]
 posthog/dags/backfill_materialized_column.py:0: error: Argument 1 to "map_any_host_in_shards" of "ClickhouseCluster" has incompatible type "Mapping[int, AlterTableMutationRunner]"; expected "dict[int, Callable[[Any], Never]]"  [arg-type]

--- a/ty-baseline.txt
+++ b/ty-baseline.txt
@@ -729,6 +729,8 @@ posthog/cdp/validation.py:0: error: Invalid override of method `validate`: Defin
 posthog/celery.py:0: error: Cannot subscript object of type `None` with no `__getitem__` method  [non-subscriptable]
 posthog/celery.py:0: warning: Attribute `connect` may be missing on object of type `Unknown | None | Signal`  [possibly-missing-attribute]
 posthog/clickhouse/client/connection.py:0: error: Cannot assign to a subscript on an object of type `None`  [invalid-assignment]
+posthog/clickhouse/migration_tools/state_diff.py:0: error: Non-overlapping equality check (left operand type: "dict[str, ColumnDef]", right operand type: "dict[str, ColumnSchema]")  [comparison-overlap]
+posthog/clickhouse/test/_stubs.py:0: error: NamedTuple type as an attribute is not supported  [misc]
 posthog/dags/common/resources.py:0: warning: Submodule `extensions` may not be available as an attribute on module `psycopg2`  [possibly-missing-attribute]
 posthog/dags/common/resources.py:0: warning: Submodule `extensions` may not be available as an attribute on module `psycopg2`  [possibly-missing-attribute]
 posthog/dags/delete_persons_from_trigger_log.py:0: warning: Submodule `extensions` may not be available as an attribute on module `psycopg2`  [possibly-missing-attribute]


### PR DESCRIPTION
## Summary
- keep baseline-only updates in a dedicated cleanup slice at the end of the split stack
- remove baseline churn from the routing PR so routing behavior review stays focused
- preserve mypy/ty expectations after the split PR series refactors

## Test plan
- [x] `git diff matt/ch-migrate-2d-routing...matt/ch-migrate-2e-cleanup -- mypy-baseline.txt ty-baseline.txt`
- [x] `git diff matt/ch-migrate-2c-locking...matt/ch-migrate-2d-routing` excludes baseline-only edits