### PR TITLE
chore: regenerate MCP schema for snoozed_until field

### DIFF
--- a/services/mcp/src/generated/conversations/api.ts
+++ b/services/mcp/src/generated/conversations/api.ts
@@ -136,6 +136,7 @@ export const ConversationsTicketsPartialUpdateBody = /* @__PURE__ */ zod
                 'Ticket priority: low, medium, or high. Null if unset.\n\n* `low` - Low\n* `medium` - Medium\n* `high` - High'
             ),
         sla_due_at: zod.iso.datetime({}).nullish().describe('SLA deadline set via workflows. Null means no SLA.'),
+        snoozed_until: zod.iso.datetime({}).nullish(),
         tags: zod.array(zod.unknown()).optional(),
     })
     .describe('Serializer mixin that handles tags for objects.')

--- a/services/mcp/src/tools/generated/conversations.ts
+++ b/services/mcp/src/tools/generated/conversations.ts
@@ -127,6 +127,9 @@ const conversationsTicketsUpdate = (): ToolBase<
         if (params.sla_due_at !== undefined) {
             body['sla_due_at'] = params.sla_due_at
         }
+        if (params.snoozed_until !== undefined) {
+            body['snoozed_until'] = params.snoozed_until
+        }
         if (params.tags !== undefined) {
             body['tags'] = params.tags
         }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/conversations-tickets-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/conversations-tickets-update.json
@@ -43,6 +43,18 @@
             ],
             "description": "SLA deadline set via workflows. Null means no SLA."
         },
+        "snoozed_until": {
+            "anyOf": [
+                {
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
         "status": {
             "description": "Ticket status: new, open, pending, on_hold, or resolved\n\n* `new` - New\n* `open` - Open\n* `pending` - Pending\n* `on_hold` - On hold\n* `resolved` - Resolved",
             "enum": ["new", "open", "pending", "on_hold", "resolved"],


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

The `snoozed_until` field was added to the tickets serializer but the MCP generated types and tool schema snapshot weren't regenerated, breaking the MCP unit test CI check on master.

## Changes

Regenerate MCP schema, generated API types, and tool handler for the `snoozed_until` field.

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

Tests

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->