### PR TITLE
feat(batch-exports): add `snowflake_ingested_timestamp` metadata column to Snowflake exports

### DIFF
--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.tsx
@@ -275,8 +275,8 @@ function getEventTable(service: BatchExportService['type']): DatabaseSchemaBatch
                 },
             }),
             ...(service == 'Snowflake' && {
-                snowflake_ingested_at: {
-                    name: 'snowflake_ingested_at',
+                snowflake_ingested_timestamp: {
+                    name: 'snowflake_ingested_timestamp',
                     hogql_value: 'NOW64()',
                     type: 'datetime',
                     schema_valid: true,

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.tsx
@@ -274,6 +274,14 @@ function getEventTable(service: BatchExportService['type']): DatabaseSchemaBatch
                     schema_valid: true,
                 },
             }),
+            ...(service == 'Snowflake' && {
+                snowflake_ingested_at: {
+                    name: 'snowflake_ingested_at',
+                    hogql_value: 'NOW64()',
+                    type: 'datetime',
+                    schema_valid: true,
+                },
+            }),
         },
     }
 

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -1157,7 +1157,7 @@ def snowflake_default_fields() -> list[BatchExportField]:
     # Fields kept for backwards compatibility with legacy apps schema.
     batch_export_fields.append({"expression": "elements_chain", "alias": "elements"})
     batch_export_fields.append({"expression": "''", "alias": "site_url"})
-    batch_export_fields.append({"expression": "NOW64()", "alias": "snowflake_ingested_at"})
+    batch_export_fields.append({"expression": "NOW64()", "alias": "snowflake_ingested_timestamp"})
     batch_export_fields.pop(batch_export_fields.index({"expression": "created_at", "alias": "created_at"}))
 
     # For historical reasons, 'set' and 'set_once' are prefixed with 'people_'.

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -1157,6 +1157,7 @@ def snowflake_default_fields() -> list[BatchExportField]:
     # Fields kept for backwards compatibility with legacy apps schema.
     batch_export_fields.append({"expression": "elements_chain", "alias": "elements"})
     batch_export_fields.append({"expression": "''", "alias": "site_url"})
+    batch_export_fields.append({"expression": "NOW64()", "alias": "snowflake_ingested_at"})
     batch_export_fields.pop(batch_export_fields.index({"expression": "created_at", "alias": "created_at"}))
 
     # For historical reasons, 'set' and 'set_once' are prefixed with 'people_'.

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
@@ -65,6 +65,7 @@ async def _run_activity(
     timestamp_columns: collections.abc.Sequence[str] = (),
     uppercase_columns: list[str] | None = None,
     extra_fields: dict[str, t.Any] | None = None,
+    min_ingested_timestamp: dt.datetime | None = None,
 ):
     """Helper function to run insert_into_snowflake_activity_from_stage and assert records in Snowflake"""
     insert_inputs = SnowflakeInsertInputs(
@@ -117,6 +118,7 @@ async def _run_activity(
             timestamp_columns=timestamp_columns,
             uppercase_columns=uppercase_columns,
             extra_fields=extra_fields,
+            min_ingested_timestamp=min_ingested_timestamp,
         )
     return result
 
@@ -168,6 +170,8 @@ async def test_insert_into_snowflake_activity_inserts_data_into_snowflake_table(
         elif batch_export_model.name == "sessions":
             sort_key = "session_id"
 
+    min_ingested_timestamp = dt.datetime.now(dt.UTC).replace(tzinfo=None)
+
     await _run_activity(
         activity_environment=activity_environment,
         snowflake_cursor=snowflake_cursor,
@@ -181,6 +185,7 @@ async def test_insert_into_snowflake_activity_inserts_data_into_snowflake_table(
         batch_export_schema=batch_export_schema,
         exclude_events=exclude_events,
         sort_key=sort_key,
+        min_ingested_timestamp=min_ingested_timestamp,
     )
 
 

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
@@ -463,6 +463,7 @@ async def test_insert_into_snowflake_activity_heartbeats(
     activity_environment.on_heartbeat = capture_heartbeat_details
 
     table_name = f"test_insert_activity_table_{ateam.pk}"
+    min_ingested_timestamp = dt.datetime.now(dt.UTC).replace(tzinfo=None)
     insert_inputs = SnowflakeInsertInputs(
         team_id=ateam.pk,
         table_name=table_name,
@@ -504,6 +505,7 @@ async def test_insert_into_snowflake_activity_heartbeats(
         data_interval_start=data_interval_start,
         data_interval_end=data_interval_end,
         sort_key="event",
+        min_ingested_timestamp=min_ingested_timestamp,
     )
 
 

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow_e2e.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow_e2e.py
@@ -60,6 +60,7 @@ async def _run_workflow(
     expected_status: str = "Completed",
     sort_key: str = "event",
     expect_data_interval_start_none: bool = False,
+    min_ingested_timestamp: dt.datetime | None = None,
 ):
     """Helper function to run SnowflakeBatchExportWorkflow and assert records in Snowflake"""
     workflow_id = str(uuid4())
@@ -127,6 +128,7 @@ async def _run_workflow(
         exclude_events=exclude_events,
         batch_export_model=batch_export_model or batch_export_schema,
         sort_key=sort_key,
+        min_ingested_timestamp=min_ingested_timestamp,
     )
 
     return run
@@ -161,6 +163,8 @@ async def test_snowflake_export_workflow(
     elif model is not None:
         batch_export_schema = model
 
+    min_ingested_timestamp = dt.datetime.now(dt.UTC).replace(tzinfo=None)
+
     await _run_workflow(
         clickhouse_client=clickhouse_client,
         snowflake_cursor=snowflake_cursor,
@@ -172,6 +176,7 @@ async def test_snowflake_export_workflow(
         batch_export_model=batch_export_model,
         batch_export_schema=batch_export_schema,
         exclude_events=exclude_events,
+        min_ingested_timestamp=min_ingested_timestamp,
     )
 
 
@@ -206,6 +211,8 @@ async def test_snowflake_export_workflow_with_many_files(
     elif model is not None:
         batch_export_schema = model
 
+    min_ingested_timestamp = dt.datetime.now(dt.UTC).replace(tzinfo=None)
+
     await _run_workflow(
         clickhouse_client=clickhouse_client,
         snowflake_cursor=snowflake_cursor,
@@ -218,6 +225,7 @@ async def test_snowflake_export_workflow_with_many_files(
         batch_export_schema=batch_export_schema,
         exclude_events=exclude_events,
         settings_overrides={"BATCH_EXPORT_SNOWFLAKE_UPLOAD_CHUNK_SIZE_BYTES": 1},
+        min_ingested_timestamp=min_ingested_timestamp,
     )
 
 
@@ -260,6 +268,8 @@ async def test_snowflake_export_workflow_backfill_earliest_persons(
         end_at=data_interval_end.isoformat(),
     )
 
+    min_ingested_timestamp = dt.datetime.now(dt.UTC).replace(tzinfo=None)
+
     await _run_workflow(
         clickhouse_client=clickhouse_client,
         snowflake_cursor=snowflake_cursor,
@@ -273,6 +283,7 @@ async def test_snowflake_export_workflow_backfill_earliest_persons(
         settings_overrides={"BATCH_EXPORT_SNOWFLAKE_UPLOAD_CHUNK_SIZE_BYTES": 1},
         execution_timeout=dt.timedelta(minutes=10),
         expect_data_interval_start_none=True,
+        min_ingested_timestamp=min_ingested_timestamp,
     )
 
 

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
@@ -399,7 +399,7 @@ async def assert_clickhouse_records_in_snowflake(
         expected_fields: List of fields expected to be in the destination table.
         expect_duplicates: Whether duplicates are expected (e.g. when testing retrying logic).
         extra_fields: Additional fields present in the Snowflake table (that are not present in the ClickHouse table).
-        min_ingested_timestamp: If set, assert all `snowflake_ingested_at` values are >= this.
+        min_ingested_timestamp: If set, assert all `snowflake_ingested_timestamp` values are >= this.
     """
     snowflake_cursor.execute(f'SELECT * FROM "{table_name}"')
 
@@ -412,13 +412,13 @@ async def assert_clickhouse_records_in_snowflake(
     # We rely on the order of the columns in each row matching the order set in cursor.description.
     # This seems to be the case, at least for now.
     inserted_records = []
-    inserted_snowflake_ingested_at = []
+    inserted_snowflake_ingested_timestamps = []
     for row in rows:
         record = {}
 
         for index in columns.keys():
-            if columns[index] == "snowflake_ingested_at":
-                inserted_snowflake_ingested_at.append(row[index])
+            if columns[index] == "snowflake_ingested_timestamp":
+                inserted_snowflake_ingested_timestamps.append(row[index])
                 continue
 
             if columns[index] in json_columns and row[index] is not None:
@@ -484,9 +484,9 @@ async def assert_clickhouse_records_in_snowflake(
             expected_record = {}
 
             for k, v in record.items():
-                if k == "_inserted_at" or k == "snowflake_ingested_at":
+                if k == "_inserted_at" or k == "snowflake_ingested_timestamp":
                     # _inserted_at is not exported, only used for tracking progress.
-                    # snowflake_ingested_at cannot be compared as it comes from an unstable function.
+                    # snowflake_ingested_timestamp cannot be compared as it comes from an unstable function.
                     continue
 
                 if k in json_columns and isinstance(v, str):
@@ -529,7 +529,9 @@ async def assert_clickhouse_records_in_snowflake(
     assert inserted_records == expected_records
     assert len(inserted_column_names) > 0
 
-    if len(inserted_snowflake_ingested_at) > 0:
-        assert all(ts is not None for ts in inserted_snowflake_ingested_at)
-        if min_ingested_timestamp is not None:
-            assert all(ts >= min_ingested_timestamp for ts in inserted_snowflake_ingested_at)
+    if len(inserted_snowflake_ingested_timestamps) > 0:
+        assert min_ingested_timestamp is not None, (
+            "Must set `min_ingested_timestamp` for comparison with exported value"
+        )
+        assert all(ts is not None for ts in inserted_snowflake_ingested_timestamps)
+        assert all(ts >= min_ingested_timestamp for ts in inserted_snowflake_ingested_timestamps)

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
@@ -382,6 +382,7 @@ async def assert_clickhouse_records_in_snowflake(
     timestamp_columns: collections.abc.Sequence[str] = (),
     uppercase_columns: list[str] | None = None,
     extra_fields: dict[str, t.Any] | None = None,
+    min_ingested_timestamp: dt.datetime | None = None,
 ):
     """Assert ClickHouse records are written to Snowflake table.
 
@@ -398,6 +399,7 @@ async def assert_clickhouse_records_in_snowflake(
         expected_fields: List of fields expected to be in the destination table.
         expect_duplicates: Whether duplicates are expected (e.g. when testing retrying logic).
         extra_fields: Additional fields present in the Snowflake table (that are not present in the ClickHouse table).
+        min_ingested_timestamp: If set, assert all `snowflake_ingested_at` values are >= this.
     """
     snowflake_cursor.execute(f'SELECT * FROM "{table_name}"')
 
@@ -410,10 +412,15 @@ async def assert_clickhouse_records_in_snowflake(
     # We rely on the order of the columns in each row matching the order set in cursor.description.
     # This seems to be the case, at least for now.
     inserted_records = []
+    inserted_snowflake_ingested_at = []
     for row in rows:
         record = {}
 
         for index in columns.keys():
+            if columns[index] == "snowflake_ingested_at":
+                inserted_snowflake_ingested_at.append(row[index])
+                continue
+
             if columns[index] in json_columns and row[index] is not None:
                 record[columns[index]] = json.loads(row[index])
             elif isinstance(row[index], int) and columns[index] in timestamp_columns:
@@ -477,8 +484,9 @@ async def assert_clickhouse_records_in_snowflake(
             expected_record = {}
 
             for k, v in record.items():
-                if k == "_inserted_at":
+                if k == "_inserted_at" or k == "snowflake_ingested_at":
                     # _inserted_at is not exported, only used for tracking progress.
+                    # snowflake_ingested_at cannot be compared as it comes from an unstable function.
                     continue
 
                 if k in json_columns and isinstance(v, str):
@@ -520,3 +528,8 @@ async def assert_clickhouse_records_in_snowflake(
     assert inserted_records[0] == expected_records[0]
     assert inserted_records == expected_records
     assert len(inserted_column_names) > 0
+
+    if len(inserted_snowflake_ingested_at) > 0:
+        assert all(ts is not None for ts in inserted_snowflake_ingested_at)
+        if min_ingested_timestamp is not None:
+            assert all(ts >= min_ingested_timestamp for ts in inserted_snowflake_ingested_at)


### PR DESCRIPTION
## Problem

Snowflake batch exports lack an ingestion timestamp column, making it harder to distinguish when data was loaded into the destination versus when the event originally occurred. 

## Changes

- Use similar approach to BigQuery and Databricks, which have `bq_ingested_timestamp` and `databricks_ingested_timestamp` respectively:
    - Add `snowflake_ingested_timestamp` column (via `NOW64()`) to `snowflake_default_fields()` in the Snowflake batch export destination
    - Add the field to the frontend batch export config form so it appears in the documented schema
- Update tests: 
    - Update `assert_clickhouse_records_in_snowflake` test helper to handle the non-deterministic timestamp (skip from record comparison, verify non-null, optionally assert a minimum bound)
    - Thread `min_ingested_timestamp` assertion through the main parametrized e2e test

Note that this change is backwards-compatible: existing tables without the column are unaffected — the pipeline silently drops fields missing from the destination table.

## How did you test this code?

- Ran existing automated tests (and added new assertions)
    - We have an existing test which checks that we handle the addition of new columns in a backwards-compatible fashion
- Ran a Snowflake batch export using the local stack and verified the new column was present (and doesn't get added to an existing export)

## Publish to changelog?

Yes, add a brief entry.

## Docs update

We should update the schema for Snowflake batch exports: `/docs/cdp/batch-exports/snowflake`

## 🤖 LLM context

Agent-authored PR. The backward-compatibility safety was verified by tracing through the full pipeline code (`get_table` field filtering → `SchemaTransformer.cast_record_batch` KeyError skip → `COPY INTO` field selection) and confirmed with a temporary e2e integration test against real Snowflake.