### PR TITLE
feat(data-warehouse): Added appmetrics publishing from external data jobs

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -165,15 +165,12 @@ async def update_external_data_job_model(inputs: UpdateExternalDataJobStatusInpu
                 logger.exception(friendly_errors[0])
                 inputs.latest_error = friendly_errors[0]
 
-    job = await database_sync_to_async_pool(update_external_job_status)(
+    await database_sync_to_async_pool(update_external_job_status)(
         job_id=job_id,
         status=ExternalDataJob.Status(inputs.status),
         latest_error=inputs.latest_error,
         team_id=inputs.team_id,
     )
-
-    job.finished_at = dt.datetime.now(dt.UTC)
-    await database_sync_to_async_pool(job.save)()
 
     logger.info(
         f"Updated external data job with for external data source {job_id} to status {inputs.status}",

--- a/posthog/temporal/data_imports/metrics.py
+++ b/posthog/temporal/data_imports/metrics.py
@@ -24,6 +24,11 @@ _TERMINAL_STATUS_TO_METRIC: dict[str, tuple[str, str]] = {
     "BillingLimitTooLow": ("failure", "billing_limited"),
 }
 
+# Shared source of truth for which ExternalDataJob statuses are terminal — also
+# imported by update_external_job_status to gate finished_at stamping and metric
+# emission on the first terminal transition.
+TERMINAL_JOB_STATUSES: frozenset[str] = frozenset(_TERMINAL_STATUS_TO_METRIC)
+
 
 def get_data_import_finished_metric(source_type: str | None, status: str) -> MetricCounter:
     source_type = source_type or "unknown"
@@ -81,8 +86,4 @@ def emit_data_import_app_metrics(job: "ExternalDataJob") -> None:
         for payload in payloads:
             producer.produce(topic=KAFKA_APP_METRICS2, data=payload)
     except Exception:
-        logger.exception(
-            "Failed to emit data import app_metrics2 rows for job %s (status=%s)",
-            job.id,
-            job.status,
-        )
+        logger.exception("Failed to emit data import app_metrics2 rows")

--- a/posthog/temporal/data_imports/metrics.py
+++ b/posthog/temporal/data_imports/metrics.py
@@ -1,5 +1,28 @@
+import logging
+import datetime as dt
+from typing import TYPE_CHECKING
+
 from temporalio import workflow
 from temporalio.common import MetricCounter
+
+from posthog.kafka_client.client import KafkaProducer
+from posthog.kafka_client.topics import KAFKA_APP_METRICS2
+from posthog.models.event.util import format_clickhouse_timestamp
+
+if TYPE_CHECKING:
+    from products.data_warehouse.backend.models.external_data_job import ExternalDataJob
+
+logger = logging.getLogger(__name__)
+
+
+DATA_IMPORT_APP_SOURCE = "warehouse_source_sync"
+
+_TERMINAL_STATUS_TO_METRIC: dict[str, tuple[str, str]] = {
+    "Completed": ("success", "succeeded"),
+    "Failed": ("failure", "failed"),
+    "BillingLimitReached": ("failure", "billing_limited"),
+    "BillingLimitTooLow": ("failure", "billing_limited"),
+}
 
 
 def get_data_import_finished_metric(source_type: str | None, status: str) -> MetricCounter:
@@ -9,3 +32,57 @@ def get_data_import_finished_metric(source_type: str | None, status: str) -> Met
         .with_additional_attributes({"source_type": source_type, "status": status})
         .create_counter("data_import_finished", "Number of data imports finished, for any reason (including failure).")
     )
+
+
+def emit_data_import_app_metrics(job: "ExternalDataJob") -> None:
+    """Emit app_metrics2 rows for a data import job that just reached terminal state.
+
+    Writes best-effort messages to the app_metrics2 Kafka topic — failures are
+    logged but never raised, so a broken metrics path cannot surface as a
+    pipeline failure. Runs that are not in a terminal status are a no-op.
+    """
+    kind_name = _TERMINAL_STATUS_TO_METRIC.get(job.status)
+    if kind_name is None:
+        return
+
+    metric_kind, metric_name = kind_name
+    finished_at = job.finished_at or dt.datetime.now(dt.UTC)
+    timestamp = format_clickhouse_timestamp(finished_at)
+
+    common_fields = {
+        "team_id": job.team_id,
+        "app_source": DATA_IMPORT_APP_SOURCE,
+        "app_source_id": str(job.pipeline_id),
+        "instance_id": str(job.schema_id) if job.schema_id else "",
+        "timestamp": timestamp,
+    }
+
+    payloads: list[dict] = [
+        {
+            **common_fields,
+            "metric_kind": metric_kind,
+            "metric_name": metric_name,
+            "count": 1,
+        }
+    ]
+
+    if job.rows_synced and job.rows_synced > 0:
+        payloads.append(
+            {
+                **common_fields,
+                "metric_kind": "rows",
+                "metric_name": "rows_synced",
+                "count": job.rows_synced,
+            }
+        )
+
+    try:
+        producer = KafkaProducer()
+        for payload in payloads:
+            producer.produce(topic=KAFKA_APP_METRICS2, data=payload)
+    except Exception:
+        logger.exception(
+            "Failed to emit data import app_metrics2 rows for job %s (status=%s)",
+            job.id,
+            job.status,
+        )

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -1,4 +1,3 @@
-import datetime as dt
 from collections.abc import Callable
 from typing import Any, Literal
 
@@ -215,14 +214,12 @@ def _run_post_load_for_already_processed_batch(export_signal: ExportSignalMessag
 
 
 def _mark_job_completed(export_signal: ExportSignalMessage) -> None:
-    job = update_external_job_status(
+    update_external_job_status(
         job_id=export_signal.job_id,
         team_id=export_signal.team_id,
         status=ExternalDataJob.Status.COMPLETED,
         latest_error=None,
     )
-    job.finished_at = dt.datetime.now(dt.UTC)
-    job.save()
 
     async_to_sync(finish_row_tracking)(export_signal.team_id, export_signal.schema_id)
 
@@ -250,14 +247,12 @@ def _mark_job_failed(export_signal: ExportSignalMessage, error: Exception) -> No
         )
         return
 
-    job = update_external_job_status(
+    update_external_job_status(
         job_id=export_signal.job_id,
         team_id=export_signal.team_id,
         status=ExternalDataJob.Status.FAILED,
         latest_error=str(error),
     )
-    job.finished_at = dt.datetime.now(dt.UTC)
-    job.save()
 
     logger.info(
         "job_marked_failed",

--- a/posthog/temporal/data_imports/tests/test_metrics_app_metrics2.py
+++ b/posthog/temporal/data_imports/tests/test_metrics_app_metrics2.py
@@ -1,0 +1,140 @@
+import datetime as dt
+from uuid import uuid4
+
+from freezegun import freeze_time
+from unittest import TestCase, mock
+
+from parameterized import parameterized
+
+from posthog.kafka_client.topics import KAFKA_APP_METRICS2
+from posthog.models.event.util import format_clickhouse_timestamp
+from posthog.temporal.data_imports.metrics import DATA_IMPORT_APP_SOURCE, emit_data_import_app_metrics
+
+from products.data_warehouse.backend.models.external_data_job import ExternalDataJob
+
+
+def _make_job(
+    *,
+    status: str,
+    rows_synced: int | None = 1234,
+    finished_at: dt.datetime | None = None,
+    team_id: int = 42,
+) -> mock.Mock:
+    job = mock.Mock(spec_set=("id", "team_id", "status", "rows_synced", "finished_at", "pipeline_id", "schema_id"))
+    job.id = uuid4()
+    job.team_id = team_id
+    job.status = status
+    job.rows_synced = rows_synced
+    job.finished_at = finished_at or dt.datetime(2026, 4, 15, 12, 30, 45, tzinfo=dt.UTC)
+    job.pipeline_id = uuid4()
+    job.schema_id = uuid4()
+    return job
+
+
+class TestEmitDataImportAppMetrics(TestCase):
+    @parameterized.expand(
+        [
+            (ExternalDataJob.Status.COMPLETED, "success", "succeeded"),
+            (ExternalDataJob.Status.FAILED, "failure", "failed"),
+            (ExternalDataJob.Status.BILLING_LIMIT_REACHED, "failure", "billing_limited"),
+            (ExternalDataJob.Status.BILLING_LIMIT_TOO_LOW, "failure", "billing_limited"),
+        ]
+    )
+    def test_terminal_status_emits_expected_metric(self, status, expected_kind, expected_name):
+        job = _make_job(status=status, rows_synced=1234)
+
+        with mock.patch("posthog.temporal.data_imports.metrics.KafkaProducer") as mock_producer_cls:
+            mock_producer = mock_producer_cls.return_value
+            emit_data_import_app_metrics(job)
+
+        produce_calls = mock_producer.produce.call_args_list
+        assert len(produce_calls) == 2
+
+        status_payload = produce_calls[0].kwargs["data"]
+        assert produce_calls[0].kwargs["topic"] == KAFKA_APP_METRICS2
+        assert status_payload["team_id"] == job.team_id
+        assert status_payload["app_source"] == DATA_IMPORT_APP_SOURCE
+        assert status_payload["app_source_id"] == str(job.pipeline_id)
+        assert status_payload["instance_id"] == str(job.schema_id)
+        assert status_payload["metric_kind"] == expected_kind
+        assert status_payload["metric_name"] == expected_name
+        assert status_payload["count"] == 1
+        assert status_payload["timestamp"] == format_clickhouse_timestamp(job.finished_at)
+
+        rows_payload = produce_calls[1].kwargs["data"]
+        assert rows_payload["metric_kind"] == "rows"
+        assert rows_payload["metric_name"] == "rows_synced"
+        assert rows_payload["count"] == 1234
+        assert rows_payload["timestamp"] == status_payload["timestamp"]
+
+    def test_billing_statuses_collapse_to_same_metric_name(self):
+        with mock.patch("posthog.temporal.data_imports.metrics.KafkaProducer") as mock_producer_cls:
+            mock_producer = mock_producer_cls.return_value
+            emit_data_import_app_metrics(_make_job(status=ExternalDataJob.Status.BILLING_LIMIT_REACHED))
+            emit_data_import_app_metrics(_make_job(status=ExternalDataJob.Status.BILLING_LIMIT_TOO_LOW))
+
+        status_calls = [
+            call for call in mock_producer.produce.call_args_list if call.kwargs["data"]["metric_kind"] == "failure"
+        ]
+        assert len(status_calls) == 2
+        assert all(call.kwargs["data"]["metric_name"] == "billing_limited" for call in status_calls)
+
+    @parameterized.expand(
+        [
+            ("zero", 0),
+            ("null", None),
+        ]
+    )
+    def test_rows_synced_suppressed_when_not_positive(self, _name, rows_synced):
+        job = _make_job(status=ExternalDataJob.Status.COMPLETED, rows_synced=rows_synced)
+
+        with mock.patch("posthog.temporal.data_imports.metrics.KafkaProducer") as mock_producer_cls:
+            mock_producer = mock_producer_cls.return_value
+            emit_data_import_app_metrics(job)
+
+        produce_calls = mock_producer.produce.call_args_list
+        assert len(produce_calls) == 1
+        assert produce_calls[0].kwargs["data"]["metric_kind"] == "success"
+
+    def test_non_terminal_status_emits_nothing(self):
+        job = _make_job(status=ExternalDataJob.Status.RUNNING)
+
+        with mock.patch("posthog.temporal.data_imports.metrics.KafkaProducer") as mock_producer_cls:
+            mock_producer = mock_producer_cls.return_value
+            emit_data_import_app_metrics(job)
+
+        mock_producer_cls.assert_not_called()
+        mock_producer.produce.assert_not_called()
+
+    def test_kafka_producer_error_is_swallowed(self):
+        job = _make_job(status=ExternalDataJob.Status.COMPLETED)
+
+        with mock.patch("posthog.temporal.data_imports.metrics.KafkaProducer") as mock_producer_cls:
+            mock_producer_cls.return_value.produce.side_effect = RuntimeError("kafka down")
+            emit_data_import_app_metrics(job)
+
+    def test_falls_back_to_now_when_finished_at_is_none(self):
+        job = _make_job(status=ExternalDataJob.Status.COMPLETED)
+        job.finished_at = None
+        frozen_now = dt.datetime(2026, 4, 15, 9, 0, 0, tzinfo=dt.UTC)
+
+        with (
+            freeze_time(frozen_now),
+            mock.patch("posthog.temporal.data_imports.metrics.KafkaProducer") as mock_producer_cls,
+        ):
+            mock_producer = mock_producer_cls.return_value
+            emit_data_import_app_metrics(job)
+
+        payload = mock_producer.produce.call_args_list[0].kwargs["data"]
+        assert payload["timestamp"] == format_clickhouse_timestamp(frozen_now)
+
+    def test_null_schema_id_becomes_empty_instance_id(self):
+        job = _make_job(status=ExternalDataJob.Status.COMPLETED)
+        job.schema_id = None
+
+        with mock.patch("posthog.temporal.data_imports.metrics.KafkaProducer") as mock_producer_cls:
+            mock_producer = mock_producer_cls.return_value
+            emit_data_import_app_metrics(job)
+
+        payload = mock_producer.produce.call_args_list[0].kwargs["data"]
+        assert payload["instance_id"] == ""

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -240,6 +240,7 @@ async def _run(
         mock.patch(
             "posthog.temporal.data_imports.external_data_job.get_data_import_finished_metric"
         ) as mock_get_data_import_finished_metric,
+        mock.patch("posthog.temporal.data_imports.metrics.KafkaProducer") as mock_app_metrics_producer_cls,
     ):
         await _execute_run(workflow_id, inputs, mock_data_response)
 
@@ -267,6 +268,26 @@ async def _run(
         mock_get_data_import_finished_metric.assert_called_with(
             source_type=source_type, status=ExternalDataJob.Status.COMPLETED.lower()
         )
+
+        # Assert that app_metrics2 rows were emitted for the successful job — both
+        # the success row and the rows_synced row (since a successful e2e run writes
+        # at least one row).
+        produce_calls = mock_app_metrics_producer_cls.return_value.produce.call_args_list
+        emitted_payloads = [call.kwargs["data"] for call in produce_calls]
+        status_rows = [
+            p for p in emitted_payloads if p["app_source_id"] == str(source.pk) and p["metric_kind"] == "success"
+        ]
+        rows_rows = [p for p in emitted_payloads if p["app_source_id"] == str(source.pk) and p["metric_kind"] == "rows"]
+        assert len(status_rows) == 1, f"expected one success row, got {emitted_payloads}"
+        assert status_rows[0]["app_source"] == "warehouse_source_sync"
+        assert status_rows[0]["metric_name"] == "succeeded"
+        assert status_rows[0]["count"] == 1
+        assert status_rows[0]["instance_id"] == str(schema.id)
+        assert status_rows[0]["team_id"] == team.pk
+        assert len(rows_rows) == 1, f"expected one rows_synced row, got {emitted_payloads}"
+        assert rows_rows[0]["metric_name"] == "rows_synced"
+        assert rows_rows[0]["count"] == run.rows_synced
+        assert rows_rows[0]["instance_id"] == str(schema.id)
 
         await sync_to_async(schema.refresh_from_db)()
 

--- a/products/data_warehouse/backend/external_data_source/jobs.py
+++ b/products/data_warehouse/backend/external_data_source/jobs.py
@@ -20,11 +20,6 @@ def update_external_job_status(
     model.status = status
     model.latest_error = latest_error
 
-    # Stamp finished_at once, here, when the job reaches a terminal state. This
-    # used to happen at three different call sites with a follow-up save() —
-    # consolidating lets the metric emitter below read a consistent value and
-    # avoids bumping the timestamp forward if a redelivered message transitions
-    # an already-terminal job.
     if status in _TERMINAL_JOB_STATUSES and model.finished_at is None:
         model.finished_at = dt.datetime.now(dt.UTC)
 

--- a/products/data_warehouse/backend/external_data_source/jobs.py
+++ b/products/data_warehouse/backend/external_data_source/jobs.py
@@ -1,16 +1,9 @@
 import datetime as dt
 
-from posthog.temporal.data_imports.metrics import emit_data_import_app_metrics
+from posthog.temporal.data_imports.metrics import TERMINAL_JOB_STATUSES, emit_data_import_app_metrics
 
 from products.data_warehouse.backend.models.external_data_job import ExternalDataJob
 from products.data_warehouse.backend.models.external_data_schema import ExternalDataSchema
-
-_TERMINAL_JOB_STATUSES = {
-    ExternalDataJob.Status.COMPLETED,
-    ExternalDataJob.Status.FAILED,
-    ExternalDataJob.Status.BILLING_LIMIT_REACHED,
-    ExternalDataJob.Status.BILLING_LIMIT_TOO_LOW,
-}
 
 
 def update_external_job_status(
@@ -20,7 +13,12 @@ def update_external_job_status(
     model.status = status
     model.latest_error = latest_error
 
-    if status in _TERMINAL_JOB_STATUSES and model.finished_at is None:
+    # Both the finished_at stamp and the metric emission must only fire on the
+    # first terminal transition — a retried Temporal activity or redelivered
+    # Kafka message can land here with the job already in a terminal state, and
+    # re-emitting would inflate the counters.
+    is_first_terminal_transition = status in TERMINAL_JOB_STATUSES and model.finished_at is None
+    if is_first_terminal_transition:
         model.finished_at = dt.datetime.now(dt.UTC)
 
     model.save()
@@ -37,6 +35,7 @@ def update_external_job_status(
 
     model.refresh_from_db()
 
-    emit_data_import_app_metrics(model)
+    if is_first_terminal_transition:
+        emit_data_import_app_metrics(model)
 
     return model

--- a/products/data_warehouse/backend/external_data_source/jobs.py
+++ b/products/data_warehouse/backend/external_data_source/jobs.py
@@ -1,5 +1,16 @@
+import datetime as dt
+
+from posthog.temporal.data_imports.metrics import emit_data_import_app_metrics
+
 from products.data_warehouse.backend.models.external_data_job import ExternalDataJob
 from products.data_warehouse.backend.models.external_data_schema import ExternalDataSchema
+
+_TERMINAL_JOB_STATUSES = {
+    ExternalDataJob.Status.COMPLETED,
+    ExternalDataJob.Status.FAILED,
+    ExternalDataJob.Status.BILLING_LIMIT_REACHED,
+    ExternalDataJob.Status.BILLING_LIMIT_TOO_LOW,
+}
 
 
 def update_external_job_status(
@@ -8,6 +19,15 @@ def update_external_job_status(
     model = ExternalDataJob.objects.get(id=job_id, team_id=team_id)
     model.status = status
     model.latest_error = latest_error
+
+    # Stamp finished_at once, here, when the job reaches a terminal state. This
+    # used to happen at three different call sites with a follow-up save() —
+    # consolidating lets the metric emitter below read a consistent value and
+    # avoids bumping the timestamp forward if a redelivered message transitions
+    # an already-terminal job.
+    if status in _TERMINAL_JOB_STATUSES and model.finished_at is None:
+        model.finished_at = dt.datetime.now(dt.UTC)
+
     model.save()
 
     if status == ExternalDataJob.Status.FAILED:
@@ -21,5 +41,7 @@ def update_external_job_status(
     schema.save()
 
     model.refresh_from_db()
+
+    emit_data_import_app_metrics(model)
 
     return model

--- a/products/data_warehouse/backend/external_data_source/test/test_jobs.py
+++ b/products/data_warehouse/backend/external_data_source/test/test_jobs.py
@@ -1,0 +1,120 @@
+import uuid
+
+import pytest
+from unittest.mock import patch
+
+from posthog.models import Organization, Team
+
+from products.data_warehouse.backend.external_data_source.jobs import update_external_job_status
+from products.data_warehouse.backend.models.external_data_job import ExternalDataJob
+from products.data_warehouse.backend.models.external_data_schema import ExternalDataSchema
+from products.data_warehouse.backend.models.external_data_source import ExternalDataSource
+
+pytestmark = [
+    pytest.mark.django_db,
+]
+
+
+def _create_org_team_source_schema_job() -> tuple[Team, ExternalDataSource, ExternalDataSchema, ExternalDataJob]:
+    org = Organization.objects.create(name="Test Org")
+    team = Team.objects.create(organization=org, name="Test Team")
+    source = ExternalDataSource.objects.create(
+        team=team,
+        source_id=str(uuid.uuid4()),
+        connection_id=str(uuid.uuid4()),
+        destination_id=str(uuid.uuid4()),
+        status="running",
+        source_type="Stripe",
+    )
+    schema = ExternalDataSchema.objects.create(name="Charge", team=team, source=source)
+    job = ExternalDataJob.objects.create(
+        team=team,
+        pipeline=source,
+        schema=schema,
+        status=ExternalDataJob.Status.RUNNING,
+        rows_synced=100,
+    )
+    return team, source, schema, job
+
+
+class TestUpdateExternalJobStatus:
+    def test_first_terminal_transition_stamps_finished_at_and_emits(self):
+        team, _source, _schema, job = _create_org_team_source_schema_job()
+
+        with patch(
+            "products.data_warehouse.backend.external_data_source.jobs.emit_data_import_app_metrics"
+        ) as mock_emit:
+            updated = update_external_job_status(
+                job_id=str(job.id),
+                team_id=team.pk,
+                status=ExternalDataJob.Status.COMPLETED,
+                latest_error=None,
+            )
+
+        assert updated.status == ExternalDataJob.Status.COMPLETED
+        assert updated.finished_at is not None
+        mock_emit.assert_called_once()
+        emitted_job = mock_emit.call_args.args[0]
+        assert emitted_job.id == job.id
+        assert emitted_job.status == ExternalDataJob.Status.COMPLETED
+
+    def test_retried_terminal_transition_is_idempotent(self):
+        """A redelivered Kafka message or retried Temporal activity must not
+        re-emit app_metrics2 rows for a job that already reached terminal state."""
+        team, _source, _schema, job = _create_org_team_source_schema_job()
+
+        with patch(
+            "products.data_warehouse.backend.external_data_source.jobs.emit_data_import_app_metrics"
+        ) as mock_emit:
+            update_external_job_status(
+                job_id=str(job.id),
+                team_id=team.pk,
+                status=ExternalDataJob.Status.COMPLETED,
+                latest_error=None,
+            )
+            first_finished_at = ExternalDataJob.objects.get(id=job.id).finished_at
+
+            update_external_job_status(
+                job_id=str(job.id),
+                team_id=team.pk,
+                status=ExternalDataJob.Status.COMPLETED,
+                latest_error=None,
+            )
+
+        assert mock_emit.call_count == 1
+        second_finished_at = ExternalDataJob.objects.get(id=job.id).finished_at
+        assert second_finished_at == first_finished_at
+
+    def test_non_terminal_status_does_not_emit_or_stamp(self):
+        team, _source, _schema, job = _create_org_team_source_schema_job()
+
+        with patch(
+            "products.data_warehouse.backend.external_data_source.jobs.emit_data_import_app_metrics"
+        ) as mock_emit:
+            updated = update_external_job_status(
+                job_id=str(job.id),
+                team_id=team.pk,
+                status=ExternalDataJob.Status.RUNNING,
+                latest_error=None,
+            )
+
+        assert updated.finished_at is None
+        mock_emit.assert_not_called()
+
+    def test_failed_status_emits_and_stamps(self):
+        team, _source, _schema, job = _create_org_team_source_schema_job()
+
+        with patch(
+            "products.data_warehouse.backend.external_data_source.jobs.emit_data_import_app_metrics"
+        ) as mock_emit:
+            updated = update_external_job_status(
+                job_id=str(job.id),
+                team_id=team.pk,
+                status=ExternalDataJob.Status.FAILED,
+                latest_error="boom",
+            )
+
+        assert updated.status == ExternalDataJob.Status.FAILED
+        assert updated.finished_at is not None
+        assert updated.latest_error == "boom"
+        mock_emit.assert_called_once()

--- a/services/mcp/src/generated/conversations/api.ts
+++ b/services/mcp/src/generated/conversations/api.ts
@@ -136,6 +136,7 @@ export const ConversationsTicketsPartialUpdateBody = /* @__PURE__ */ zod
                 'Ticket priority: low, medium, or high. Null if unset.\n\n* `low` - Low\n* `medium` - Medium\n* `high` - High'
             ),
         sla_due_at: zod.iso.datetime({}).nullish().describe('SLA deadline set via workflows. Null means no SLA.'),
+        snoozed_until: zod.iso.datetime({}).nullish(),
         tags: zod.array(zod.unknown()).optional(),
     })
     .describe('Serializer mixin that handles tags for objects.')

--- a/services/mcp/src/tools/generated/conversations.ts
+++ b/services/mcp/src/tools/generated/conversations.ts
@@ -127,6 +127,9 @@ const conversationsTicketsUpdate = (): ToolBase<
         if (params.sla_due_at !== undefined) {
             body['sla_due_at'] = params.sla_due_at
         }
+        if (params.snoozed_until !== undefined) {
+            body['snoozed_until'] = params.snoozed_until
+        }
         if (params.tags !== undefined) {
             body['tags'] = params.tags
         }


### PR DESCRIPTION
## Problem
- I wanna show more metrics and info to users on their sources and how much data is being synced

## Changes
- Publish sync data to `app_metrics2` kafka topic / clickhouse table
  - This is an aggregating table for storing internal metrics - we have a bunch of app logic / components built around showing UI for this data in the web app 
- Store metrics for rows synced and how many jobs succeeded/failed 

## How did you test this code?
- Updated e2e tests and specific tests for this new code 
- Gonna give it a few days to collect data and then add in UI to show these metrics

## Publish to changelog?
No

## Docs update
No