### PR TITLE
fix(experiments): fix slowest_queries endpoint on production ClickHouse

### DIFF
--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -322,12 +322,11 @@ class DebugCHQueries(viewsets.ViewSet):
                     AND JSONExtractString(log_comment, 'product') = 'experiments'
                     AND is_initial_query
                     AND query NOT LIKE %(not_query)s
-                ORDER BY query_start_time DESC
-                LIMIT 100
                 SETTINGS skip_unavailable_shards=1
             )
             GROUP BY query_id
             ORDER BY query_duration_ms DESC
+            LIMIT 100
             """,
             {
                 "cluster": CLICKHOUSE_CLUSTER,

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -312,16 +312,22 @@ class DebugCHQueries(viewsets.ViewSet):
                 argMax(JSONExtractString(log_comment, 'experiment_name'), type) AS experiment_name,
                 argMax(JSONExtractString(log_comment, 'experiment_metric_name'), type) AS experiment_metric_name,
                 argMax(JSONExtractString(log_comment, 'experiment_execution_path'), type) AS experiment_execution_path
-            FROM clusterAllReplicas(%(cluster)s, system, query_log)
-            WHERE
-                event_time > now() - INTERVAL %(hours)s HOUR
-                AND JSONExtractString(log_comment, 'product') = 'experiments'
-                AND is_initial_query
-                AND query NOT LIKE %(not_query)s
+            FROM (
+                SELECT
+                    query_id, query, query_start_time, query_duration_ms, exception,
+                    toInt8(type) AS type, log_comment
+                FROM clusterAllReplicas(%(cluster)s, system, query_log)
+                WHERE
+                    event_time > now() - INTERVAL %(hours)s HOUR
+                    AND JSONExtractString(log_comment, 'product') = 'experiments'
+                    AND is_initial_query
+                    AND query NOT LIKE %(not_query)s
+                ORDER BY query_start_time DESC
+                LIMIT 100
+                SETTINGS skip_unavailable_shards=1
+            )
             GROUP BY query_id
             ORDER BY query_duration_ms DESC
-            LIMIT 100
-            SETTINGS skip_unavailable_shards=1
             """,
             {
                 "cluster": CLICKHOUSE_CLUSTER,

--- a/services/mcp/src/generated/conversations/api.ts
+++ b/services/mcp/src/generated/conversations/api.ts
@@ -136,6 +136,7 @@ export const ConversationsTicketsPartialUpdateBody = /* @__PURE__ */ zod
                 'Ticket priority: low, medium, or high. Null if unset.\n\n* `low` - Low\n* `medium` - Medium\n* `high` - High'
             ),
         sla_due_at: zod.iso.datetime({}).nullish().describe('SLA deadline set via workflows. Null means no SLA.'),
+        snoozed_until: zod.iso.datetime({}).nullish(),
         tags: zod.array(zod.unknown()).optional(),
     })
     .describe('Serializer mixin that handles tags for objects.')

--- a/services/mcp/src/tools/generated/conversations.ts
+++ b/services/mcp/src/tools/generated/conversations.ts
@@ -127,6 +127,9 @@ const conversationsTicketsUpdate = (): ToolBase<
         if (params.sla_due_at !== undefined) {
             body['sla_due_at'] = params.sla_due_at
         }
+        if (params.snoozed_until !== undefined) {
+            body['snoozed_until'] = params.snoozed_until
+        }
         if (params.tags !== undefined) {
             body['tags'] = params.tags
         }


### PR DESCRIPTION
## Problem

The `slowest_queries` endpoint returns a 500 on production ClickHouse. The column name `query` collides with the `argMax(query, type) AS query` alias, and production CH rejects the aggregate reference in WHERE.

## Changes

Wrap the raw table scan in a subquery so `query` in WHERE unambiguously refers to the column, not the alias.

## How did you test this code?

Ran the generated query directly on production ClickHouse via Metabase — returns results without error.

Do not publish to changelog.

## 🤖 LLM context

Agent-authored fix. Root cause identified from Grafana logs showing `CHQueryErrorIllegalAggregation`.