### PR TITLE
fix(tests): repair cross-sell test and close backend CI filter gap

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -117,6 +117,8 @@ jobs:
                         - pytest.ini
                         - .test_durations # Used for pytest-split sharding
                         - frontend/src/queries/schema.json # Used for generating schema.py
+                        - frontend/src/products.json # Loaded at runtime by posthog/products.py
+                        - 'products/*/manifest.tsx' # Generates products.json
                         - rust/feature-flags/src/properties/property_models.rs # Operator parity check
                         # Make sure we run if someone is explicitly changing the workflow
                         - .github/workflows/ci-backend.yml
@@ -160,6 +162,8 @@ jobs:
                         - pytest.ini
                         - .test_durations
                         - frontend/src/queries/schema.json
+                        - frontend/src/products.json
+                        - 'products/*/manifest.tsx'
                         - rust/feature-flags/src/properties/property_models.rs
                         - .github/workflows/ci-backend.yml
                         - .github/clickhouse-versions.json

--- a/bin/find_affected_tests.py
+++ b/bin/find_affected_tests.py
@@ -78,6 +78,7 @@ FULL_RUN_PATTERNS = (
     "bin/ci-wait-for-docker",
     # Non-Python files that affect generated Python code or test behavior
     "frontend/src/queries/schema.json",
+    "frontend/src/products.json",  # Loaded at runtime by posthog/products.py
     "frontend/public/email/",
     "rust/feature-flags/src/properties/property_models.rs",
     "common/plugin_transpiler/src",

--- a/posthog/models/file_system/test/test_user_product_list.py
+++ b/posthog/models/file_system/test/test_user_product_list.py
@@ -350,8 +350,8 @@ class TestUserProductList(BaseTest):
         unreleased_products = products_by_category.get(ProductItemCategory.UNRELEASED, [])
 
         # Add a product from the Tools category
-        assert "Data pipelines" in products_by_category.get(ProductItemCategory.TOOLS, [])
-        UserProductList.objects.create(user=user, team=self.team, product_path="Data pipelines", enabled=True)
+        assert "Web scripts" in products_by_category.get(ProductItemCategory.TOOLS, [])
+        UserProductList.objects.create(user=user, team=self.team, product_path="Web scripts", enabled=True)
 
         # Add a product from the Unreleased category
         assert "Links" in products_by_category.get(ProductItemCategory.UNRELEASED, [])


### PR DESCRIPTION
## Problem

A follow-up to #54484, which removed \"Data pipelines\" from `frontend/src/products.json` but left a stale reference in `posthog/models/file_system/test/test_user_product_list.py`. The test now fails on master:

```
AssertionError: assert 'Data pipelines' in ['Web scripts', 'Endpoints', 'Notebooks', 'Toolbar', 'Workflows']
```

Backend CI never ran on #54484 because its path filter only triggers on `posthog/**/*` and `products/**/backend/**/*`. But `posthog/products.py` loads `frontend/src/products.json` at runtime — a cross-stack dependency the filter didn't know about.

## Changes

- Swap `\"Data pipelines\"` → `\"Web scripts\"` in the TOOLS-category test (still a valid TOOLS product).
- Add `frontend/src/products.json` and `products/*/manifest.tsx` to both the `backend:` and `legacy:` path filters in `.github/workflows/ci-backend.yml` so future changes to either file trigger backend tests.

## How did you test this code?

- Ran the previously failing test locally; it passes.
- No manual UI testing — this is a test + CI config change.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Opus 4.6 in a Claude Code session. Diagnosed the test failure, traced it to #54484, pushed the test fix, then identified and patched the path-filter gap that let the breakage through CI.