### PR TITLE
refactor(logs): one HogFunction per alert destination event

### DIFF
--- a/products/alerts/mcp/tools.yaml
+++ b/products/alerts/mcp/tools.yaml
@@ -143,3 +143,9 @@ tools:
     logs-alerts-simulate-create:
         operation: logs_alerts_simulate_create
         enabled: false
+    logs-alerts-destinations-create:
+        operation: logs_alerts_destinations_create
+        enabled: false
+    logs-alerts-destinations-delete-create:
+        operation: logs_alerts_destinations_delete_create
+        enabled: false

--- a/products/logs/backend/alert_destinations.py
+++ b/products/logs/backend/alert_destinations.py
@@ -1,0 +1,156 @@
+"""Build HogFunction configurations for logs alert notifications."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from products.logs.backend.models import LogsAlertConfiguration
+
+EventKind = Literal["firing", "resolved"]
+
+
+@dataclass(frozen=True)
+class EventKindSpec:
+    event_id: str
+    header: str
+    body: str
+
+
+EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
+    "firing": EventKindSpec(
+        event_id="$logs_alert_firing",
+        header="Log alert '{event.properties.alert_name}' is firing",
+        body=(
+            "*Threshold breached:* {event.properties.result_count} logs in "
+            "{event.properties.window_minutes}m "
+            "(threshold: {event.properties.threshold_operator} {event.properties.threshold_count})"
+        ),
+    ),
+    "resolved": EventKindSpec(
+        event_id="$logs_alert_resolved",
+        header="Log alert '{event.properties.alert_name}' has resolved",
+        body=(
+            "*Current count:* {event.properties.result_count} logs in "
+            "{event.properties.window_minutes}m "
+            "(threshold: {event.properties.threshold_operator} {event.properties.threshold_count})"
+        ),
+    ),
+}
+
+EVENT_KINDS: tuple[EventKind, ...] = tuple(EVENT_KIND_CONFIG.keys())
+
+
+_SEVERITY_SERVICE_CONTEXT = (
+    "{if(length(event.properties.severity_levels) > 0 or length(event.properties.service_names) > 0,"
+    " concat("
+    "  if(length(event.properties.severity_levels) > 0,"
+    "    concat('Severity: ', arrayStringConcat(event.properties.severity_levels, ', ')),"
+    "    ''),"
+    "  if(length(event.properties.severity_levels) > 0 and length(event.properties.service_names) > 0,"
+    "    ' | ', ''),"
+    "  if(length(event.properties.service_names) > 0,"
+    "    concat('Services: ', arrayStringConcat(event.properties.service_names, ', ')),"
+    "    '')"
+    " ),"
+    " 'All log levels and services')}"
+)
+
+
+def _slack_blocks(spec: EventKindSpec) -> list[dict]:
+    return [
+        {"type": "header", "text": {"type": "plain_text", "text": spec.header}},
+        {"type": "section", "text": {"type": "mrkdwn", "text": spec.body}},
+        {
+            "type": "context",
+            "elements": [
+                {"type": "mrkdwn", "text": _SEVERITY_SERVICE_CONTEXT},
+                {"type": "mrkdwn", "text": "Project: <{project.url}|{project.name}>"},
+            ],
+        },
+        {"type": "divider"},
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "url": "{project.url}/logs?{event.properties.logs_url_params}",
+                    "text": {"text": "View logs", "type": "plain_text"},
+                    "type": "button",
+                }
+            ],
+        },
+    ]
+
+
+def _webhook_body(kind: EventKind) -> dict[str, str]:
+    return {
+        "event": kind,
+        "alert_id": "{event.properties.alert_id}",
+        "alert_name": "{event.properties.alert_name}",
+        "result_count": "{event.properties.result_count}",
+        "threshold_count": "{event.properties.threshold_count}",
+        "threshold_operator": "{event.properties.threshold_operator}",
+        "window_minutes": "{event.properties.window_minutes}",
+        "service_names": "{event.properties.service_names}",
+        "severity_levels": "{event.properties.severity_levels}",
+        "logs_url": "{project.url}/logs?{event.properties.logs_url_params}",
+        "triggered_at": "{event.properties.triggered_at}",
+    }
+
+
+def _filter_for(alert: LogsAlertConfiguration, kind: EventKind) -> dict[str, Any]:
+    return {
+        "events": [{"id": EVENT_KIND_CONFIG[kind].event_id, "type": "events"}],
+        "properties": [
+            {
+                "key": "alert_id",
+                "value": str(alert.id),
+                "operator": "exact",
+                "type": "event",
+            }
+        ],
+    }
+
+
+def build_slack_config(
+    alert: LogsAlertConfiguration,
+    kind: EventKind,
+    slack_workspace_id: int,
+    slack_channel_id: str,
+    slack_channel_name: str | None,
+) -> dict[str, Any]:
+    spec = EVENT_KIND_CONFIG[kind]
+    channel_display = slack_channel_name or "channel"
+    return {
+        "team": alert.team,
+        "type": "internal_destination",
+        "enabled": True,
+        "filters": _filter_for(alert, kind),
+        "name": f"{alert.name}: {kind} → Slack #{channel_display}",
+        "template_id": "template-slack",
+        "inputs": {
+            "blocks": {"value": _slack_blocks(spec)},
+            "text": {"value": spec.header},
+            "slack_workspace": {"value": slack_workspace_id},
+            "channel": {"value": slack_channel_id},
+        },
+    }
+
+
+def build_webhook_config(
+    alert: LogsAlertConfiguration,
+    kind: EventKind,
+    webhook_url: str,
+) -> dict[str, Any]:
+    return {
+        "team": alert.team,
+        "type": "internal_destination",
+        "enabled": True,
+        "filters": _filter_for(alert, kind),
+        "name": f"{alert.name}: {kind} → Webhook {webhook_url}",
+        "template_id": "template-webhook",
+        "inputs": {
+            "body": {"value": _webhook_body(kind)},
+            "url": {"value": webhook_url},
+        },
+    }

--- a/products/logs/backend/alerts_api.py
+++ b/products/logs/backend/alerts_api.py
@@ -13,16 +13,19 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from posthog.api.hog_function import HogFunctionSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.event_usage import report_user_action
 from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
+from posthog.models.hog_functions.hog_function import HogFunction
 from posthog.models.signals import model_activity_signal, mutable_receiver
 from posthog.models.team.team import Team
 from posthog.permissions import PostHogFeatureFlagPermission
 from posthog.utils import relative_date_parse
 
 from products.logs.backend.alert_check_query import AlertCheckQuery, BucketedCount
+from products.logs.backend.alert_destinations import EVENT_KINDS, EventKind, build_slack_config, build_webhook_config
 from products.logs.backend.alert_state_machine import (
     AlertCheckOutcome,
     AlertSnapshot,
@@ -270,6 +273,42 @@ class LogsAlertSimulateResponseSerializer(serializers.Serializer):
     threshold_operator = serializers.CharField(help_text="Threshold operator used for evaluation.")
 
 
+class LogsAlertCreateDestinationSerializer(serializers.Serializer):
+    type = serializers.ChoiceField(choices=["slack", "webhook"], help_text="Destination type — slack or webhook.")
+    slack_workspace_id = serializers.IntegerField(
+        required=False, help_text="Integration ID for the Slack workspace. Required when type=slack."
+    )
+    slack_channel_id = serializers.CharField(required=False, help_text="Slack channel ID. Required when type=slack.")
+    slack_channel_name = serializers.CharField(
+        required=False, allow_blank=True, help_text="Human-readable channel name for display."
+    )
+    webhook_url = serializers.URLField(
+        required=False, help_text="HTTPS endpoint to POST to. Required when type=webhook."
+    )
+
+    def validate(self, attrs: dict) -> dict:
+        destination_type = attrs["type"]
+        if destination_type == "slack":
+            if not attrs.get("slack_workspace_id") or not attrs.get("slack_channel_id"):
+                raise ValidationError("slack_workspace_id and slack_channel_id are required for slack destinations.")
+        elif destination_type == "webhook":
+            if not attrs.get("webhook_url"):
+                raise ValidationError("webhook_url is required for webhook destinations.")
+        return attrs
+
+
+class LogsAlertDeleteDestinationSerializer(serializers.Serializer):
+    hog_function_ids = serializers.ListField(
+        child=serializers.UUIDField(),
+        min_length=1,
+        help_text="HogFunction IDs to delete as one atomic destination group.",
+    )
+
+
+class LogsAlertDestinationResponseSerializer(serializers.Serializer):
+    hog_function_ids = serializers.ListField(child=serializers.UUIDField())
+
+
 def _build_reason(
     prev_state: AlertState,
     outcome: AlertCheckOutcome,
@@ -374,6 +413,85 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
         return queryset.filter(team_id=self.team_id)
+
+    @extend_schema(
+        request=LogsAlertCreateDestinationSerializer,
+        responses={201: LogsAlertDestinationResponseSerializer},
+        description="Create a notification destination for this alert. One HogFunction is created per alert event kind (firing, resolved, ...) atomically.",
+    )
+    @action(detail=True, methods=["POST"], url_path="destinations")
+    def create_destination(self, request: Request, *args: object, **kwargs: object) -> Response:
+        alert = self.get_object()
+        serializer = LogsAlertCreateDestinationSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        with transaction.atomic():
+            hog_functions = [self._build_and_create_hog_function(alert, data, kind) for kind in EVENT_KINDS]
+
+        report_user_action(
+            request.user,
+            "logs alert destination created",
+            {"alert_id": str(alert.id), "type": data["type"], "event_kinds": list(EVENT_KINDS)},
+        )
+        response = LogsAlertDestinationResponseSerializer({"hog_function_ids": [hf.id for hf in hog_functions]})
+        return Response(response.data, status=201)
+
+    @extend_schema(
+        request=LogsAlertDeleteDestinationSerializer,
+        responses={204: None},
+        description="Delete a notification destination by deleting its HogFunction group atomically.",
+    )
+    @action(detail=True, methods=["POST"], url_path="destinations/delete")
+    def delete_destination(self, request: Request, *args: object, **kwargs: object) -> Response:
+        alert = self.get_object()
+        serializer = LogsAlertDeleteDestinationSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        hog_function_ids = serializer.validated_data["hog_function_ids"]
+
+        with transaction.atomic():
+            updated = HogFunction.objects.filter(
+                team_id=self.team_id,
+                id__in=hog_function_ids,
+                filters__properties__contains=[{"key": "alert_id", "value": str(alert.id)}],
+            ).update(deleted=True)
+            if updated != len(hog_function_ids):
+                # Ownership check: if the filtered UPDATE touched fewer rows than we were asked
+                # to delete, something in the list doesn't belong to this alert. Roll back.
+                raise ValidationError("One or more HogFunctions do not belong to this alert.")
+
+        report_user_action(
+            request.user,
+            "logs alert destination deleted",
+            {"alert_id": str(alert.id), "count": len(hog_function_ids)},
+        )
+        return Response(status=204)
+
+    def _build_and_create_hog_function(
+        self,
+        alert: LogsAlertConfiguration,
+        data: dict,
+        kind: EventKind,
+    ) -> HogFunction:
+        if data["type"] == "slack":
+            config = build_slack_config(
+                alert,
+                kind,
+                slack_workspace_id=data["slack_workspace_id"],
+                slack_channel_id=data["slack_channel_id"],
+                slack_channel_name=data.get("slack_channel_name"),
+            )
+        else:
+            config = build_webhook_config(alert, kind, webhook_url=data["webhook_url"])
+
+        # Route through HogFunctionSerializer so template lookup and bytecode compilation run.
+        team = config.pop("team")
+        serializer = HogFunctionSerializer(
+            data=config,
+            context={"request": self.request, "get_team": lambda: team, "is_create": True},
+        )
+        serializer.is_valid(raise_exception=True)
+        return serializer.save(team=team)
 
     @extend_schema(
         request=LogsAlertSimulateRequestSerializer,

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -484,6 +484,170 @@ class TestLogsAlertAPI(APIBaseTest):
         assert data["snooze_until"] is not None
         assert data["threshold_count"] == 200
 
+    # --- Destinations ---
+
+    def _destinations_url(self, alert_id: str) -> str:
+        return f"{self.base_url}{alert_id}/destinations/"
+
+    def _destinations_delete_url(self, alert_id: str) -> str:
+        return f"{self.base_url}{alert_id}/destinations/delete/"
+
+    def _sync_destination_templates(self) -> None:
+        # Destination creation goes through the full HogFunctionSerializer pipeline,
+        # which looks up a HogFunctionTemplate by template_id. Seed Slack + webhook.
+        from posthog.cdp.templates.hog_function_template import sync_template_to_db
+        from posthog.cdp.templates.slack.template_slack import template as template_slack
+        from posthog.models.hog_function_template import HogFunctionTemplate
+
+        sync_template_to_db(template_slack)
+        HogFunctionTemplate.objects.get_or_create(
+            template_id="template-webhook",
+            defaults={
+                "sha": "1.0.0",
+                "name": "Webhook",
+                "description": "Generic webhook template",
+                "code": "return event",
+                "code_language": "hog",
+                "inputs_schema": [{"key": "url", "type": "string"}, {"key": "body", "type": "json"}],
+                "type": "destination",
+                "status": "stable",
+                "category": ["Integrations"],
+                "free": True,
+            },
+        )
+
+    @patch("products.logs.backend.alerts_api.report_user_action")
+    def test_create_slack_destination_creates_one_hog_function_per_event_kind(self, mock_report):
+        self._sync_destination_templates()
+        from posthog.models.hog_functions.hog_function import HogFunction
+
+        created = self._create_via_api()
+        response = self.client.post(
+            self._destinations_url(created["id"]),
+            {
+                "type": "slack",
+                "slack_workspace_id": 42,
+                "slack_channel_id": "C123",
+                "slack_channel_name": "alerts",
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        ids = response.json()["hog_function_ids"]
+        assert len(ids) == 2  # firing + resolved
+
+        hog_functions = HogFunction.objects.filter(id__in=ids).order_by("name")
+        event_ids = sorted([(hf.filters or {})["events"][0]["id"] for hf in hog_functions])
+        assert event_ids == ["$logs_alert_firing", "$logs_alert_resolved"]
+        for hf in hog_functions:
+            assert hf.template_id == "template-slack"
+            inputs = hf.inputs or {}
+            assert inputs["channel"]["value"] == "C123"
+            assert inputs["slack_workspace"]["value"] == 42
+            text_value = inputs["text"]["value"]
+            assert "{if(" not in text_value
+            alert_id_filter = (hf.filters or {})["properties"][0]
+            assert alert_id_filter == {
+                "key": "alert_id",
+                "value": created["id"],
+                "operator": "exact",
+                "type": "event",
+            }
+
+        reset_calls = [c for c in mock_report.call_args_list if c.args[1] == "logs alert destination created"]
+        assert len(reset_calls) == 1
+
+    def test_create_webhook_destination_creates_one_hog_function_per_event_kind(self):
+        from posthog.models.hog_functions.hog_function import HogFunction
+
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        response = self.client.post(
+            self._destinations_url(created["id"]),
+            {"type": "webhook", "webhook_url": "https://example.com/hook"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        ids = response.json()["hog_function_ids"]
+        assert len(ids) == 2
+
+        hog_functions = HogFunction.objects.filter(id__in=ids)
+        for hf in hog_functions:
+            assert hf.template_id == "template-webhook"
+            inputs = hf.inputs or {}
+            assert inputs["url"]["value"] == "https://example.com/hook"
+            body = inputs["body"]["value"]
+            assert body["event"] in ("firing", "resolved")
+
+    @parameterized.expand(
+        [
+            ("slack_missing_workspace", {"type": "slack", "slack_channel_id": "C1"}),
+            ("slack_missing_channel", {"type": "slack", "slack_workspace_id": 1}),
+            ("webhook_missing_url", {"type": "webhook"}),
+            ("webhook_invalid_url", {"type": "webhook", "webhook_url": "not-a-url"}),
+        ]
+    )
+    def test_create_destination_rejects_invalid_payloads(self, _name: str, payload: dict) -> None:
+        created = self._create_via_api()
+        response = self.client.post(self._destinations_url(created["id"]), payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_create_destination_on_other_teams_alert_returns_404(self):
+        other_team = Team.objects.create(organization=self.organization, name="Other")
+        other_alert = LogsAlertConfiguration.objects.create(
+            team=other_team, name="Other", threshold_count=10, filters={"severityLevels": ["error"]}
+        )
+        response = self.client.post(
+            self._destinations_url(str(other_alert.id)),
+            {"type": "webhook", "webhook_url": "https://example.com/hook"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_delete_destination_removes_hog_functions(self):
+        from posthog.models.hog_functions.hog_function import HogFunction
+
+        self._sync_destination_templates()
+        created = self._create_via_api()
+        create_response = self.client.post(
+            self._destinations_url(created["id"]),
+            {"type": "webhook", "webhook_url": "https://example.com/hook"},
+            format="json",
+        )
+        ids = create_response.json()["hog_function_ids"]
+
+        delete_response = self.client.post(
+            self._destinations_delete_url(created["id"]),
+            {"hog_function_ids": ids},
+            format="json",
+        )
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+        assert HogFunction.objects.filter(id__in=ids, deleted=False).count() == 0
+
+    def test_delete_destination_rejects_foreign_hog_function_ids(self):
+        self._sync_destination_templates()
+        created_a = self._create_via_api()
+        created_b = self._create_via_api(name="Another alert")
+
+        a_ids = self.client.post(
+            self._destinations_url(created_a["id"]),
+            {"type": "webhook", "webhook_url": "https://example.com/a"},
+            format="json",
+        ).json()["hog_function_ids"]
+        b_ids = self.client.post(
+            self._destinations_url(created_b["id"]),
+            {"type": "webhook", "webhook_url": "https://example.com/b"},
+            format="json",
+        ).json()["hog_function_ids"]
+
+        # Trying to delete alert A's HogFunctions via alert B's endpoint should fail.
+        response = self.client.post(
+            self._destinations_delete_url(created_b["id"]),
+            {"hog_function_ids": a_ids + b_ids},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
     # --- Simulate ---
 
     def _simulate_url(self) -> str:

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertNotifications.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertNotifications.tsx
@@ -8,43 +8,37 @@ import { SlackChannelPicker, SlackNotConfiguredBanner } from 'lib/integrations/S
 import { slackIntegrationLogic } from 'lib/integrations/slackIntegrationLogic'
 import { urls } from 'scenes/urls'
 
-import { HogFunctionType, SlackChannelType } from '~/types'
+import { SlackChannelType } from '~/types'
 
 import { LOGS_ALERT_NOTIFICATION_TYPE_OPTIONS, logsAlertNotificationLogic } from './logsAlertNotificationLogic'
 import {
+    LogsAlertDestinationGroup,
     LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
     LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK,
     PendingLogsAlertNotification,
 } from './logsAlertUtils'
 
-function resolveSlackChannelName(channelValue: string, slackChannels: SlackChannelType[]): string | null {
+function slackChannelLabel(channelValue: string, slackChannels: SlackChannelType[]): string {
     const channelId = channelValue.split('|')[0]
-    return slackChannels.find((c) => c.id === channelId)?.name ?? null
+    const name = slackChannels.find((c) => c.id === channelId)?.name
+    return name ? `Slack #${name}` : 'Slack'
 }
 
-function getHogFunctionDestination(
-    hf: HogFunctionType,
-    slackChannels: SlackChannelType[]
-): { type: string; detail: string | null } {
-    const channelValue = hf.inputs?.channel?.value
-    if (channelValue && typeof channelValue === 'string') {
-        const channelName = resolveSlackChannelName(channelValue, slackChannels)
-        return { type: 'Slack', detail: channelName ? `#${channelName}` : null }
+function resolveGroupLabel(group: LogsAlertDestinationGroup, slackChannels: SlackChannelType[]): string {
+    if (group.type === LOGS_ALERT_NOTIFICATION_TYPE_SLACK) {
+        const hf = group.hogFunctions[0]
+        const channelValue = hf.inputs?.channel?.value
+        if (typeof channelValue === 'string') {
+            return slackChannelLabel(channelValue, slackChannels)
+        }
     }
-    if (channelValue) {
-        return { type: 'Slack', detail: null }
-    }
-    const urlValue = hf.inputs?.url?.value
-    if (urlValue && typeof urlValue === 'string') {
-        return { type: 'Webhook', detail: urlValue }
-    }
-    return { type: hf.name, detail: null }
+    return group.label
 }
 
 export function LogsAlertNotifications(): JSX.Element {
     const {
-        existingHogFunctions,
         existingHogFunctionsLoading,
+        destinationGroups,
         pendingNotifications,
         firstSlackIntegration,
         selectedType,
@@ -54,7 +48,7 @@ export function LogsAlertNotifications(): JSX.Element {
     const {
         addPendingNotification,
         removePendingNotification,
-        deleteExistingHogFunction,
+        deleteExistingDestination,
         setSelectedType,
         setSlackChannelValue,
         setWebhookUrl,
@@ -104,51 +98,52 @@ export function LogsAlertNotifications(): JSX.Element {
     }
 
     return (
-        <div className="space-y-4">
-            {(existingHogFunctionsLoading || existingHogFunctions.length > 0) && (
+        <div className="flex flex-col gap-2">
+            <p className="text-xs text-muted-alt m-0">
+                Each destination delivers notifications for all alert events — firing and resolved.
+            </p>
+            {(existingHogFunctionsLoading || destinationGroups.length > 0) && (
                 <div>
                     {existingHogFunctionsLoading ? (
                         <LemonSkeleton className="h-8" repeat={2} />
-                    ) : existingHogFunctions.length > 0 ? (
+                    ) : destinationGroups.length > 0 ? (
                         <div className="space-y-2">
-                            {existingHogFunctions.map((hf) => {
-                                const { type: destType, detail } = getHogFunctionDestination(hf, slackChannels)
-                                return (
-                                    <div
-                                        key={hf.id}
-                                        className="flex items-center justify-between border rounded p-2 gap-2"
-                                    >
-                                        <div className="flex-1 min-w-0">
-                                            <div className="flex items-center gap-2">
-                                                <span className="text-sm font-medium">{destType}</span>
-                                                <LemonTag type={hf.enabled ? 'success' : 'default'} size="small">
-                                                    {hf.enabled ? 'Active' : 'Paused'}
-                                                </LemonTag>
-                                            </div>
-                                            {detail && (
-                                                <span className="text-xs text-muted-alt truncate block">{detail}</span>
-                                            )}
+                            {destinationGroups.map((group) => (
+                                <div
+                                    key={group.key}
+                                    className="flex items-center justify-between border rounded p-2 gap-2"
+                                >
+                                    <div className="flex-1 min-w-0">
+                                        <div className="flex items-center gap-2 flex-wrap">
+                                            <span className="text-sm font-medium truncate">
+                                                {resolveGroupLabel(group, slackChannels)}
+                                            </span>
+                                            <LemonTag type={group.enabled ? 'success' : 'default'} size="small">
+                                                {group.enabled ? 'Active' : 'Paused'}
+                                            </LemonTag>
                                         </div>
-                                        <div className="flex items-center gap-1 shrink-0">
+                                    </div>
+                                    <div className="flex items-center gap-1 shrink-0">
+                                        {group.hogFunctions.length === 1 && (
                                             <LemonButton
                                                 icon={<IconExternal />}
                                                 size="xsmall"
-                                                to={urls.hogFunction(hf.id)}
+                                                to={urls.hogFunction(group.hogFunctions[0].id)}
                                                 targetBlank
                                                 hideExternalLinkIcon
                                                 tooltip="Open destination"
                                             />
-                                            <LemonButton
-                                                icon={<IconTrash />}
-                                                size="xsmall"
-                                                status="danger"
-                                                onClick={() => deleteExistingHogFunction(hf)}
-                                                tooltip="Delete notification"
-                                            />
-                                        </div>
+                                        )}
+                                        <LemonButton
+                                            icon={<IconTrash />}
+                                            size="xsmall"
+                                            status="danger"
+                                            onClick={() => deleteExistingDestination(group)}
+                                            tooltip="Delete notification"
+                                        />
                                     </div>
-                                )
-                            })}
+                                </div>
+                            ))}
                         </div>
                     ) : null}
                 </div>

--- a/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertNotificationLogic.test.ts
+++ b/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertNotificationLogic.test.ts
@@ -2,26 +2,28 @@ import { expectLogic } from 'kea-test-utils'
 
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
-import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 
 import { initKeaTests } from '~/test/init'
 import { HogFunctionType } from '~/types'
 
+import { logsAlertsDestinationsCreate, logsAlertsDestinationsDeleteCreate } from 'products/logs/frontend/generated/api'
+
 import { logsAlertNotificationLogic } from '../logsAlertNotificationLogic'
-import { buildLogsAlertFilterConfig } from '../logsAlertUtils'
+import { buildLogsAlertFilterConfig, LogsAlertDestinationGroup } from '../logsAlertUtils'
 
 jest.mock('lib/api', () => ({
     __esModule: true,
     default: {
         hogFunctions: {
             list: jest.fn(),
-            create: jest.fn(),
         },
     },
 }))
 
-jest.mock('lib/utils/deleteWithUndo', () => ({
-    deleteWithUndo: jest.fn(),
+jest.mock('products/logs/frontend/generated/api', () => ({
+    __esModule: true,
+    logsAlertsDestinationsCreate: jest.fn(),
+    logsAlertsDestinationsDeleteCreate: jest.fn(),
 }))
 
 jest.mock('lib/lemon-ui/LemonToast/LemonToast', () => ({
@@ -32,13 +34,15 @@ jest.mock('lib/lemon-ui/LemonToast/LemonToast', () => ({
 }))
 
 const mockApi = api as jest.Mocked<typeof api>
-const mockDeleteWithUndo = deleteWithUndo as jest.MockedFunction<typeof deleteWithUndo>
+const mockCreate = logsAlertsDestinationsCreate as jest.MockedFunction<typeof logsAlertsDestinationsCreate>
+const mockDelete = logsAlertsDestinationsDeleteCreate as jest.MockedFunction<typeof logsAlertsDestinationsDeleteCreate>
 
 const MOCK_HOG_FUNCTION = {
     id: 'hf-1',
     name: 'Test Notification',
     enabled: true,
     inputs: { channel: { value: 'C123' } },
+    filters: {},
 } as unknown as HogFunctionType
 
 describe('logsAlertNotificationLogic', () => {
@@ -49,7 +53,7 @@ describe('logsAlertNotificationLogic', () => {
     })
 
     describe('pending notifications', () => {
-        it('adds a pending notification', async () => {
+        it('adds a pending notification', () => {
             const logic = logsAlertNotificationLogic({ alertId: undefined })
             logic.mount()
 
@@ -73,21 +77,13 @@ describe('logsAlertNotificationLogic', () => {
             const logic = logsAlertNotificationLogic({ alertId: undefined })
             logic.mount()
 
-            logic.actions.addPendingNotification({
-                type: 'webhook',
-                webhookUrl: 'https://a.com',
-            })
-            logic.actions.addPendingNotification({
-                type: 'webhook',
-                webhookUrl: 'https://b.com',
-            })
+            logic.actions.addPendingNotification({ type: 'webhook', webhookUrl: 'https://a.com' })
+            logic.actions.addPendingNotification({ type: 'webhook', webhookUrl: 'https://b.com' })
 
             logic.actions.removePendingNotification(0)
 
             expect(logic.values.pendingNotifications).toHaveLength(1)
-            expect(logic.values.pendingNotifications[0]).toMatchObject({
-                webhookUrl: 'https://b.com',
-            })
+            expect(logic.values.pendingNotifications[0]).toMatchObject({ webhookUrl: 'https://b.com' })
 
             logic.unmount()
         })
@@ -122,7 +118,7 @@ describe('logsAlertNotificationLogic', () => {
             logic.unmount()
         })
 
-        it('loads hog functions filtered by alert id', async () => {
+        it('loads hog functions filtered by alert id only (not by event)', async () => {
             ;(mockApi.hogFunctions.list as jest.Mock).mockResolvedValue({
                 results: [MOCK_HOG_FUNCTION],
             })
@@ -137,6 +133,13 @@ describe('logsAlertNotificationLogic', () => {
                 filter_groups: [buildLogsAlertFilterConfig('alert-1')],
                 full: true,
             })
+            // The filter must not include events — otherwise per-event HogFunctions
+            // created by the backend fan-out won't match the JSONB @> query.
+            expect(mockApi.hogFunctions.list).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    filter_groups: [expect.not.objectContaining({ events: expect.anything() })],
+                })
+            )
             expect(logic.values.existingHogFunctions).toEqual([MOCK_HOG_FUNCTION])
 
             logic.unmount()
@@ -149,37 +152,52 @@ describe('logsAlertNotificationLogic', () => {
             logic.mount()
 
             await expectLogic(logic, () => {
-                logic.actions.createPendingHogFunctions('alert-1', 'My Alert')
+                logic.actions.createPendingHogFunctions('alert-1')
             }).toFinishAllListeners()
 
-            expect(mockApi.hogFunctions.create).not.toHaveBeenCalled()
+            expect(mockCreate).not.toHaveBeenCalled()
 
             logic.unmount()
         })
 
-        it('creates hog functions for each pending notification', async () => {
-            ;(mockApi.hogFunctions.create as jest.Mock).mockResolvedValue(MOCK_HOG_FUNCTION)
+        it('sends one bundle-create call per pending notification (backend fans out per event)', async () => {
+            mockCreate.mockResolvedValue({ hog_function_ids: ['hf-1', 'hf-2'] } as any)
 
             const logic = logsAlertNotificationLogic({ alertId: undefined })
             logic.mount()
 
             logic.actions.addPendingNotification({ type: 'webhook', webhookUrl: 'https://a.com' })
-            logic.actions.addPendingNotification({ type: 'webhook', webhookUrl: 'https://b.com' })
+            logic.actions.addPendingNotification({
+                type: 'slack',
+                slackWorkspaceId: 42,
+                slackChannelId: 'C456',
+                slackChannelName: 'alerts',
+            })
 
             await expectLogic(logic, () => {
-                logic.actions.createPendingHogFunctions('alert-1', 'My Alert')
+                logic.actions.createPendingHogFunctions('alert-1')
             }).toFinishAllListeners()
 
-            expect(mockApi.hogFunctions.create).toHaveBeenCalledTimes(2)
+            expect(mockCreate).toHaveBeenCalledTimes(2)
+            expect(mockCreate).toHaveBeenCalledWith(expect.any(String), 'alert-1', {
+                type: 'webhook',
+                webhook_url: 'https://a.com',
+            })
+            expect(mockCreate).toHaveBeenCalledWith(expect.any(String), 'alert-1', {
+                type: 'slack',
+                slack_workspace_id: 42,
+                slack_channel_id: 'C456',
+                slack_channel_name: 'alerts',
+            })
             expect(lemonToast.success).toHaveBeenCalledWith('2 notification destination(s) created.')
             expect(logic.values.pendingNotifications).toHaveLength(0)
 
             logic.unmount()
         })
 
-        it('retains failed notifications on partial failure', async () => {
-            ;(mockApi.hogFunctions.create as jest.Mock)
-                .mockResolvedValueOnce(MOCK_HOG_FUNCTION)
+        it('retains only the failed notifications so the user can retry them', async () => {
+            mockCreate
+                .mockResolvedValueOnce({ hog_function_ids: ['hf-ok'] } as any)
                 .mockRejectedValueOnce(new Error('API error'))
 
             const logic = logsAlertNotificationLogic({ alertId: undefined })
@@ -189,25 +207,23 @@ describe('logsAlertNotificationLogic', () => {
             logic.actions.addPendingNotification({ type: 'webhook', webhookUrl: 'https://fail.com' })
 
             await expectLogic(logic, () => {
-                logic.actions.createPendingHogFunctions('alert-1', 'My Alert')
+                logic.actions.createPendingHogFunctions('alert-1')
             }).toFinishAllListeners()
 
             expect(lemonToast.error).toHaveBeenCalledWith(expect.stringContaining('1 notification(s) failed to create'))
             expect(logic.values.pendingNotifications).toHaveLength(1)
-            expect(logic.values.pendingNotifications[0]).toMatchObject({
-                webhookUrl: 'https://fail.com',
-            })
+            expect(logic.values.pendingNotifications[0]).toMatchObject({ webhookUrl: 'https://fail.com' })
 
             logic.unmount()
         })
     })
 
-    describe('deleteExistingHogFunction', () => {
-        it('optimistically removes from state and calls deleteWithUndo', async () => {
+    describe('deleteExistingDestination', () => {
+        it('sends the whole group of HogFunction ids in a single atomic delete call', async () => {
             ;(mockApi.hogFunctions.list as jest.Mock).mockResolvedValue({
                 results: [MOCK_HOG_FUNCTION],
             })
-            ;(mockDeleteWithUndo as jest.Mock).mockResolvedValue(undefined)
+            mockDelete.mockResolvedValue(undefined as any)
 
             const logic = logsAlertNotificationLogic({ alertId: 'alert-1' })
             logic.mount()
@@ -215,17 +231,51 @@ describe('logsAlertNotificationLogic', () => {
             await expectLogic(logic).toFinishAllListeners()
             expect(logic.values.existingHogFunctions).toHaveLength(1)
 
-            logic.actions.deleteExistingHogFunction(MOCK_HOG_FUNCTION)
+            const group: LogsAlertDestinationGroup = {
+                key: 'slack:C123',
+                type: 'slack',
+                label: 'Slack #alerts',
+                hogFunctions: [MOCK_HOG_FUNCTION, { ...MOCK_HOG_FUNCTION, id: 'hf-2' }],
+                enabled: true,
+            }
 
-            // Optimistic removal happens immediately via reducer
-            expect(logic.values.existingHogFunctions).toHaveLength(0)
+            logic.actions.deleteExistingDestination(group)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(mockDelete).toHaveBeenCalledWith(expect.any(String), 'alert-1', {
+                hog_function_ids: ['hf-1', 'hf-2'],
+            })
+            expect(lemonToast.success).toHaveBeenCalledWith('Removed Slack #alerts')
+            expect(mockApi.hogFunctions.list).toHaveBeenCalledTimes(2)
+
+            logic.unmount()
+        })
+
+        it('reloads from the server on delete failure so the list reflects actual state', async () => {
+            ;(mockApi.hogFunctions.list as jest.Mock).mockResolvedValue({
+                results: [MOCK_HOG_FUNCTION],
+            })
+            mockDelete.mockRejectedValue(new Error('network'))
+
+            const logic = logsAlertNotificationLogic({ alertId: 'alert-1' })
+            logic.mount()
 
             await expectLogic(logic).toFinishAllListeners()
-            expect(mockDeleteWithUndo).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    object: { id: MOCK_HOG_FUNCTION.id, name: MOCK_HOG_FUNCTION.name },
-                })
-            )
+
+            const group: LogsAlertDestinationGroup = {
+                key: 'slack:C123',
+                type: 'slack',
+                label: 'Slack #alerts',
+                hogFunctions: [MOCK_HOG_FUNCTION],
+                enabled: true,
+            }
+
+            logic.actions.deleteExistingDestination(group)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(lemonToast.error).toHaveBeenCalledWith(expect.stringContaining('Failed to remove Slack #alerts'))
+            // List loader fired twice: once on mount, once after the error
+            expect(mockApi.hogFunctions.list).toHaveBeenCalledTimes(2)
 
             logic.unmount()
         })

--- a/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertUtils.test.ts
+++ b/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertUtils.test.ts
@@ -1,18 +1,10 @@
-import { LOGS_ALERT_FIRING_EVENT_ID, LOGS_ALERT_RESOLVED_EVENT_ID } from 'lib/constants'
+import { HogFunctionType, PropertyFilterType, PropertyOperator } from '~/types'
 
-import { PropertyFilterType, PropertyOperator } from '~/types'
-
-import {
-    buildLogsAlertFilterConfig,
-    buildLogsAlertHogFunctionPayload,
-    LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
-    LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK,
-    PendingLogsAlertNotification,
-} from '../logsAlertUtils'
+import { buildLogsAlertFilterConfig, groupLogsAlertDestinations } from '../logsAlertUtils'
 
 describe('logsAlertUtils', () => {
     describe('buildLogsAlertFilterConfig', () => {
-        it('includes alert_id property filter with exact operator', () => {
+        it('filters by alert_id property only so it matches every per-event HogFunction', () => {
             const config = buildLogsAlertFilterConfig('alert-123')
 
             expect(config.properties).toEqual([
@@ -23,129 +15,114 @@ describe('logsAlertUtils', () => {
                     type: PropertyFilterType.Event,
                 },
             ])
-        })
-
-        it('includes both firing and resolved event filters', () => {
-            const config = buildLogsAlertFilterConfig('alert-123')
-
-            expect(config.events).toEqual([
-                {
-                    id: LOGS_ALERT_FIRING_EVENT_ID,
-                    type: 'events',
-                },
-                {
-                    id: LOGS_ALERT_RESOLVED_EVENT_ID,
-                    type: 'events',
-                },
-            ])
+            // Deliberately no events array — see comment on buildLogsAlertFilterConfig.
+            expect(config.events).toBeUndefined()
         })
     })
 
-    describe('buildLogsAlertHogFunctionPayload', () => {
-        it('builds slack payload with conditional blocks and both-event filter', () => {
-            const notification: PendingLogsAlertNotification = {
-                type: LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
-                slackWorkspaceId: 42,
-                slackChannelId: 'C123',
-                slackChannelName: 'alerts',
-            }
+    describe('groupLogsAlertDestinations', () => {
+        const slackHf = (id: string, channel: string, enabled = true): HogFunctionType =>
+            ({
+                id,
+                name: `slack-${id}`,
+                enabled,
+                inputs: { channel: { value: channel } },
+                filters: {},
+            }) as unknown as HogFunctionType
 
-            const payload = buildLogsAlertHogFunctionPayload('alert-1', 'API errors', notification)
+        const webhookHf = (id: string, url: string, enabled = true): HogFunctionType =>
+            ({
+                id,
+                name: `webhook-${id}`,
+                enabled,
+                inputs: { url: { value: url } },
+                filters: {},
+            }) as unknown as HogFunctionType
 
-            expect(payload).toMatchObject({
-                type: 'internal_destination',
+        const resolveSlack = (channelValue: string): string | null => `channel-for-${channelValue}`
+
+        it('collapses multiple HogFunctions for the same slack channel into one group', () => {
+            const firing = slackHf('hf-1', 'C123')
+            const resolved = slackHf('hf-2', 'C123')
+
+            const groups = groupLogsAlertDestinations([firing, resolved], resolveSlack)
+
+            expect(groups).toHaveLength(1)
+            expect(groups[0]).toMatchObject({
+                key: 'slack:C123',
+                type: 'slack',
+                label: 'Slack #channel-for-C123',
                 enabled: true,
-                masking: null,
-                name: 'API errors: Slack #alerts',
-                template_id: 'template-slack',
             })
-            expect(payload.inputs?.slack_workspace).toEqual({ value: 42 })
-            expect(payload.inputs?.channel).toEqual({ value: 'C123' })
-            expect(payload.filters?.events).toHaveLength(2)
-            expect(payload.filters?.events?.[0].id).toBe(LOGS_ALERT_FIRING_EVENT_ID)
-            expect(payload.filters?.events?.[1].id).toBe(LOGS_ALERT_RESOLVED_EVENT_ID)
-
-            // Slack blocks use if() conditionals for firing vs resolved copy
-            const headerText = payload.inputs?.blocks?.value?.[0]?.text?.text
-            expect(headerText).toContain("if(event.event == '$logs_alert_resolved'")
-            expect(headerText).toContain('has resolved')
-            expect(headerText).toContain('is firing')
-
-            // Context block includes services/severities element
-            const contextBlock = payload.inputs?.blocks?.value?.[2]
-            expect(contextBlock?.type).toBe('context')
-            expect(contextBlock?.elements).toHaveLength(2)
-            const filterContext = contextBlock?.elements?.[0]?.text
-            expect(filterContext).toContain('severity_levels')
-            expect(filterContext).toContain('service_names')
+            expect(groups[0].hogFunctions).toHaveLength(2)
         })
 
-        it('uses fallback name when alertName is undefined for slack', () => {
-            const notification: PendingLogsAlertNotification = {
-                type: LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
-                slackWorkspaceId: 1,
-                slackChannelId: 'C456',
-                slackChannelName: 'general',
-            }
+        it('collapses multiple HogFunctions for the same webhook url into one group', () => {
+            const a = webhookHf('hf-1', 'https://example.com/hook')
+            const b = webhookHf('hf-2', 'https://example.com/hook')
 
-            const payload = buildLogsAlertHogFunctionPayload('alert-2', undefined, notification)
+            const groups = groupLogsAlertDestinations([a, b], resolveSlack)
 
-            expect(payload.name).toBe('Alert: Slack #general')
+            expect(groups).toHaveLength(1)
+            expect(groups[0]).toMatchObject({
+                key: 'webhook:https://example.com/hook',
+                type: 'webhook',
+                label: 'Webhook https://example.com/hook',
+            })
+            expect(groups[0].hogFunctions).toHaveLength(2)
         })
 
-        it('uses fallback channel name when slackChannelName is undefined', () => {
-            const notification: PendingLogsAlertNotification = {
-                type: LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
-                slackWorkspaceId: 1,
-                slackChannelId: 'C789',
-            }
+        it('keeps distinct slack channels and webhook urls as separate groups', () => {
+            const groups = groupLogsAlertDestinations(
+                [
+                    slackHf('a', 'C123'),
+                    slackHf('b', 'C456'),
+                    webhookHf('c', 'https://one.example'),
+                    webhookHf('d', 'https://two.example'),
+                ],
+                resolveSlack
+            )
 
-            const payload = buildLogsAlertHogFunctionPayload('alert-3', 'My Alert', notification)
-
-            expect(payload.name).toBe('My Alert: Slack #channel')
+            expect(groups.map((g) => g.key).sort()).toEqual([
+                'slack:C123',
+                'slack:C456',
+                'webhook:https://one.example',
+                'webhook:https://two.example',
+            ])
         })
 
-        it('builds webhook payload with conditional event discriminator', () => {
-            const notification: PendingLogsAlertNotification = {
-                type: LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK,
-                webhookUrl: 'https://example.com/hook',
-            }
+        it('marks a group as disabled when any HogFunction in it is disabled (AND semantics)', () => {
+            const firing = slackHf('hf-1', 'C123', true)
+            const resolved = slackHf('hf-2', 'C123', false)
 
-            const payload = buildLogsAlertHogFunctionPayload('alert-4', 'DB errors', notification)
+            const groups = groupLogsAlertDestinations([firing, resolved], resolveSlack)
 
-            expect(payload).toMatchObject({
-                type: 'internal_destination',
+            expect(groups).toHaveLength(1)
+            expect(groups[0].enabled).toBe(false)
+        })
+
+        it('falls back to a bare Slack label when the channel name cannot be resolved', () => {
+            const hf = slackHf('hf-1', 'C_UNKNOWN')
+
+            const groups = groupLogsAlertDestinations([hf], () => null)
+
+            expect(groups[0].label).toBe('Slack')
+        })
+
+        it('produces an isolated per-HogFunction group for unrecognised inputs', () => {
+            const unknown = {
+                id: 'hf-x',
+                name: 'Weird destination',
                 enabled: true,
-                masking: null,
-                name: 'DB errors: Webhook https://example.com/hook',
-                template_id: 'template-webhook',
-            })
-            expect(payload.inputs?.url).toEqual({ value: 'https://example.com/hook' })
-            expect(payload.inputs?.body?.value).toMatchObject({
-                event: "{if(event.event == '$logs_alert_resolved', 'resolved', 'firing')}",
-                alert_id: '{event.properties.alert_id}',
-                alert_name: '{event.properties.alert_name}',
-                result_count: '{event.properties.result_count}',
-                threshold_count: '{event.properties.threshold_count}',
-                threshold_operator: '{event.properties.threshold_operator}',
-                window_minutes: '{event.properties.window_minutes}',
-                service_names: '{event.properties.service_names}',
-                severity_levels: '{event.properties.severity_levels}',
-                logs_url: '{project.url}/logs?{event.properties.logs_url_params}',
-                triggered_at: '{event.properties.triggered_at}',
-            })
-            expect(payload.filters?.events).toHaveLength(2)
-        })
+                inputs: {},
+                filters: {},
+            } as unknown as HogFunctionType
 
-        it('uses fallback name when alertName is undefined for webhook', () => {
-            const notification: PendingLogsAlertNotification = {
-                type: LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK,
-                webhookUrl: 'https://example.com/hook',
-            }
+            const groups = groupLogsAlertDestinations([unknown], resolveSlack)
 
-            const payload = buildLogsAlertHogFunctionPayload('alert-5', undefined, notification)
-
-            expect(payload.name).toBe('Alert: Webhook https://example.com/hook')
+            expect(groups).toHaveLength(1)
+            expect(groups[0].key).toBe('unknown:hf-x')
+            expect(groups[0].label).toBe('Weird destination')
         })
     })
 })

--- a/products/logs/frontend/components/LogsAlerting/logsAlertFormLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertFormLogic.ts
@@ -229,7 +229,7 @@ export const logsAlertFormLogic = kea<logsAlertFormLogicType>([
 
                     if (values.pendingNotifications.length > 0) {
                         const notifLogic = logsAlertNotificationLogic({ alertId: props.alert?.id })
-                        await notifLogic.asyncActions.createPendingHogFunctions(savedAlertId, form.name)
+                        await notifLogic.asyncActions.createPendingHogFunctions(savedAlertId)
                     }
 
                     actions.setEditingAlert(null)

--- a/products/logs/frontend/components/LogsAlerting/logsAlertNotificationLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertNotificationLogic.ts
@@ -4,17 +4,19 @@ import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
-import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { projectLogic } from 'scenes/projectLogic'
 
 import { HogFunctionType, IntegrationType } from '~/types'
 
+import { logsAlertsDestinationsCreate, logsAlertsDestinationsDeleteCreate } from 'products/logs/frontend/generated/api'
+
 import type { logsAlertNotificationLogicType } from './logsAlertNotificationLogicType'
 import {
     buildLogsAlertFilterConfig,
-    buildLogsAlertHogFunctionPayload,
+    groupLogsAlertDestinations,
     LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
     LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK,
+    LogsAlertDestinationGroup,
     LogsAlertNotificationType,
     PendingLogsAlertNotification,
 } from './logsAlertUtils'
@@ -43,8 +45,8 @@ export const logsAlertNotificationLogic = kea<logsAlertNotificationLogicType>([
         removePendingNotification: (index: number) => ({ index }),
         clearPendingNotifications: true,
         setPendingNotifications: (notifications: PendingLogsAlertNotification[]) => ({ notifications }),
-        deleteExistingHogFunction: (hogFunction: HogFunctionType) => ({ hogFunction }),
-        createPendingHogFunctions: (alertId: string, alertName?: string) => ({ alertId, alertName }),
+        deleteExistingDestination: (group: LogsAlertDestinationGroup) => ({ group }),
+        createPendingHogFunctions: (alertId: string) => ({ alertId }),
         setSelectedType: (selectedType: LogsAlertNotificationType) => ({ selectedType }),
         setSlackChannelValue: (slackChannelValue: string | null) => ({ slackChannelValue }),
         setWebhookUrl: (webhookUrl: string) => ({ webhookUrl }),
@@ -78,19 +80,6 @@ export const logsAlertNotificationLogic = kea<logsAlertNotificationLogicType>([
                 setSelectedType: (_, { selectedType }) => selectedType,
             },
         ],
-        existingHogFunctions: [
-            [] as HogFunctionType[],
-            {
-                deleteExistingHogFunction: (state, { hogFunction }) => state.filter((hf) => hf.id !== hogFunction.id),
-            },
-        ],
-    }),
-
-    selectors({
-        firstSlackIntegration: [
-            (s) => [s.slackIntegrations],
-            (slackIntegrations: IntegrationType[] | undefined): IntegrationType | undefined => slackIntegrations?.[0],
-        ],
     }),
 
     loaders(({ props }) => ({
@@ -113,37 +102,63 @@ export const logsAlertNotificationLogic = kea<logsAlertNotificationLogicType>([
         ],
     })),
 
-    listeners(({ actions, values }) => ({
+    selectors({
+        firstSlackIntegration: [
+            (s) => [s.slackIntegrations],
+            (slackIntegrations: IntegrationType[] | undefined): IntegrationType | undefined => slackIntegrations?.[0],
+        ],
+        // Channel-name resolution happens in the view — slackChannels lives in a dynamically-keyed logic.
+        destinationGroups: [
+            (s) => [s.existingHogFunctions],
+            (hogFunctions: HogFunctionType[]): LogsAlertDestinationGroup[] =>
+                groupLogsAlertDestinations(hogFunctions, () => null),
+        ],
+    }),
+
+    listeners(({ actions, values, props }) => ({
         loadIntegrationsSuccess: () => {
             if (!values.firstSlackIntegration) {
                 actions.setSelectedType(LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK)
             }
         },
-        deleteExistingHogFunction: async ({ hogFunction }) => {
-            await deleteWithUndo({
-                endpoint: `projects/${values.currentProjectId}/hog_functions`,
-                object: {
-                    id: hogFunction.id,
-                    name: hogFunction.name,
-                },
-                callback: (undo) => {
-                    if (undo) {
-                        actions.loadExistingHogFunctions()
-                    }
-                },
-            })
+        deleteExistingDestination: async ({ group }) => {
+            if (!props.alertId) {
+                return
+            }
+            try {
+                await logsAlertsDestinationsDeleteCreate(String(values.currentProjectId), props.alertId, {
+                    hog_function_ids: group.hogFunctions.map((hf) => hf.id),
+                })
+                lemonToast.success(`Removed ${group.label}`)
+                actions.loadExistingHogFunctions()
+            } catch {
+                lemonToast.error(`Failed to remove ${group.label}`)
+                actions.loadExistingHogFunctions()
+            }
         },
 
-        createPendingHogFunctions: async ({ alertId, alertName }) => {
+        createPendingHogFunctions: async ({ alertId }) => {
             const pending = values.pendingNotifications
             if (pending.length === 0) {
                 return
             }
 
+            const projectId = String(values.currentProjectId)
             const results = await Promise.allSettled(
                 pending.map((notification) => {
-                    const payload = buildLogsAlertHogFunctionPayload(alertId, alertName, notification)
-                    return api.hogFunctions.create(payload)
+                    const payload =
+                        notification.type === LOGS_ALERT_NOTIFICATION_TYPE_SLACK
+                            ? {
+                                  type: LOGS_ALERT_NOTIFICATION_TYPE_SLACK,
+                                  slack_workspace_id: notification.slackWorkspaceId,
+                                  slack_channel_id: notification.slackChannelId,
+                                  slack_channel_name: notification.slackChannelName,
+                              }
+                            : {
+                                  type: LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK,
+                                  webhook_url: notification.webhookUrl,
+                              }
+                    return logsAlertsDestinationsCreate(projectId, alertId, payload)
                 })
             )
 
@@ -155,8 +170,8 @@ export const logsAlertNotificationLogic = kea<logsAlertNotificationLogicType>([
                 )
                 actions.setPendingNotifications(failedNotifications)
             } else {
-                if (results.length > 0) {
-                    lemonToast.success(`${results.length} notification destination(s) created.`)
+                if (pending.length > 0) {
+                    lemonToast.success(`${pending.length} notification destination(s) created.`)
                 }
                 actions.clearPendingNotifications()
             }

--- a/products/logs/frontend/components/LogsAlerting/logsAlertUtils.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertUtils.ts
@@ -1,13 +1,3 @@
-import {
-    LOGS_ALERT_FIRING_EVENT_ID,
-    LOGS_ALERT_FIRING_SUB_TEMPLATE_ID,
-    LOGS_ALERT_RESOLVED_EVENT_ID,
-} from 'lib/constants'
-import {
-    HOG_FUNCTION_SUB_TEMPLATES,
-    HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES,
-} from 'scenes/hog-functions/sub-templates/sub-templates'
-
 import { CyclotronJobFiltersType, HogFunctionType, PropertyFilterType, PropertyOperator } from '~/types'
 
 export const LOGS_ALERT_NOTIFICATION_TYPE_SLACK = 'slack' as const
@@ -28,130 +18,67 @@ export type PendingLogsAlertNotification =
           webhookUrl: string
       }
 
-export const buildLogsAlertFilterConfig = (alertId: string): CyclotronJobFiltersType => ({
-    properties: [
-        {
-            key: 'alert_id',
-            value: alertId,
-            operator: PropertyOperator.Exact,
-            type: PropertyFilterType.Event,
-        },
-    ],
-    events: [
-        {
-            id: LOGS_ALERT_FIRING_EVENT_ID,
-            type: 'events',
-        },
-        {
-            id: LOGS_ALERT_RESOLVED_EVENT_ID,
-            type: 'events',
-        },
-    ],
-})
-
-const LOGS_ALERT_SLACK_BLOCKS = [
-    {
-        type: 'header',
-        text: {
-            type: 'plain_text',
-            text: "Log alert '{event.properties.alert_name}' {if(event.event == '$logs_alert_resolved', 'has resolved', 'is firing')}",
-        },
-    },
-    {
-        type: 'section',
-        text: {
-            type: 'mrkdwn',
-            text: "*{if(event.event == '$logs_alert_resolved', 'Current count', 'Threshold breached')}:* {event.properties.result_count} logs in {event.properties.window_minutes}m (threshold: {event.properties.threshold_operator} {event.properties.threshold_count})",
-        },
-    },
-    {
-        type: 'context',
-        elements: [
+// Filter used to list every HogFunction tied to a given alert, regardless of which
+// event kind it handles. Deliberately omits the `events` array: the backend
+// create endpoint fans out into one HogFunction per event kind, and JSONB `@>`
+// matching would require a HogFunction's `filters.events` to contain every event
+// we list — which no single HogFunction does post-fan-out. The `alert_id`
+// property alone uniquely identifies all HogFunctions belonging to the alert.
+export function buildLogsAlertFilterConfig(alertId: string): CyclotronJobFiltersType {
+    return {
+        properties: [
             {
-                type: 'mrkdwn',
-                text: [
-                    '{if(length(event.properties.severity_levels) > 0 or length(event.properties.service_names) > 0, concat(',
-                    "if(length(event.properties.severity_levels) > 0, concat('Severity: ', arrayStringConcat(event.properties.severity_levels, ', ')), ''),",
-                    "if(length(event.properties.severity_levels) > 0 and length(event.properties.service_names) > 0, ' | ', ''),",
-                    "if(length(event.properties.service_names) > 0, concat('Services: ', arrayStringConcat(event.properties.service_names, ', ')), '')",
-                    "), 'All log levels and services')}",
-                ].join(''),
-            },
-            { type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' },
-        ],
-    },
-    { type: 'divider' },
-    {
-        type: 'actions',
-        elements: [
-            {
-                url: '{project.url}/logs?{event.properties.logs_url_params}',
-                text: { text: 'View logs', type: 'plain_text' },
-                type: 'button',
+                key: 'alert_id',
+                value: alertId,
+                operator: PropertyOperator.Exact,
+                type: PropertyFilterType.Event,
             },
         ],
-    },
-]
-
-const BASE_SLACK_INPUTS =
-    HOG_FUNCTION_SUB_TEMPLATES[LOGS_ALERT_FIRING_SUB_TEMPLATE_ID].find((t) => t.template_id === 'template-slack')
-        ?.inputs ?? {}
-
-const LOGS_ALERT_SLACK_INPUTS = {
-    ...BASE_SLACK_INPUTS,
-    blocks: { value: LOGS_ALERT_SLACK_BLOCKS },
-    text: {
-        value: "Log alert '{event.properties.alert_name}' {if(event.event == '$logs_alert_resolved', 'has resolved', 'is firing')}",
-    },
-}
-
-const LOGS_ALERT_WEBHOOK_BODY: Record<string, string> = {
-    event: "{if(event.event == '$logs_alert_resolved', 'resolved', 'firing')}",
-    alert_id: '{event.properties.alert_id}',
-    alert_name: '{event.properties.alert_name}',
-    result_count: '{event.properties.result_count}',
-    threshold_count: '{event.properties.threshold_count}',
-    threshold_operator: '{event.properties.threshold_operator}',
-    window_minutes: '{event.properties.window_minutes}',
-    service_names: '{event.properties.service_names}',
-    severity_levels: '{event.properties.severity_levels}',
-    logs_url: '{project.url}/logs?{event.properties.logs_url_params}',
-    triggered_at: '{event.properties.triggered_at}',
-}
-
-export function buildLogsAlertHogFunctionPayload(
-    alertId: string,
-    alertName: string | undefined,
-    notification: PendingLogsAlertNotification
-): Partial<HogFunctionType> {
-    const commonProps = HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES[LOGS_ALERT_FIRING_SUB_TEMPLATE_ID]
-    const base = {
-        type: commonProps.type,
-        enabled: true,
-        masking: null,
-        filters: buildLogsAlertFilterConfig(alertId),
     }
+}
 
-    if (notification.type === 'slack') {
-        return {
-            ...base,
-            name: `${alertName ?? 'Alert'}: Slack #${notification.slackChannelName ?? 'channel'}`,
-            template_id: 'template-slack',
-            inputs: {
-                ...LOGS_ALERT_SLACK_INPUTS,
-                slack_workspace: { value: notification.slackWorkspaceId },
-                channel: { value: notification.slackChannelId },
-            },
+export type LogsAlertDestinationGroup = {
+    key: string
+    type: LogsAlertNotificationType
+    label: string
+    hogFunctions: HogFunctionType[]
+    enabled: boolean
+}
+
+export function groupLogsAlertDestinations(
+    hogFunctions: HogFunctionType[],
+    resolveSlackLabel: (channelValue: string) => string | null
+): LogsAlertDestinationGroup[] {
+    const groups = new Map<string, LogsAlertDestinationGroup>()
+    for (const hf of hogFunctions) {
+        const slackChannelValue = hf.inputs?.channel?.value
+        const webhookUrl = hf.inputs?.url?.value
+        let key: string
+        let type: LogsAlertNotificationType
+        let label: string
+
+        if (typeof slackChannelValue === 'string') {
+            type = LOGS_ALERT_NOTIFICATION_TYPE_SLACK
+            key = `slack:${slackChannelValue}`
+            const channelName = resolveSlackLabel(slackChannelValue)
+            label = channelName ? `Slack #${channelName}` : 'Slack'
+        } else if (typeof webhookUrl === 'string') {
+            type = LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK
+            key = `webhook:${webhookUrl}`
+            label = `Webhook ${webhookUrl}`
+        } else {
+            type = LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK
+            key = `unknown:${hf.id}`
+            label = hf.name
+        }
+
+        const existing = groups.get(key)
+        if (existing) {
+            existing.hogFunctions.push(hf)
+            existing.enabled = existing.enabled && hf.enabled
+        } else {
+            groups.set(key, { key, type, label, hogFunctions: [hf], enabled: hf.enabled })
         }
     }
-
-    return {
-        ...base,
-        name: `${alertName ?? 'Alert'}: Webhook ${notification.webhookUrl}`,
-        template_id: 'template-webhook',
-        inputs: {
-            url: { value: notification.webhookUrl },
-            body: { value: LOGS_ALERT_WEBHOOK_BODY },
-        },
-    }
+    return Array.from(groups.values())
 }

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -272,6 +272,46 @@ export interface PatchedLogsAlertConfigurationApi {
     readonly updated_at?: string | null
 }
 
+/**
+ * * `slack` - slack
+ * `webhook` - webhook
+ */
+export type LogsAlertCreateDestinationTypeEnumApi =
+    (typeof LogsAlertCreateDestinationTypeEnumApi)[keyof typeof LogsAlertCreateDestinationTypeEnumApi]
+
+export const LogsAlertCreateDestinationTypeEnumApi = {
+    Slack: 'slack',
+    Webhook: 'webhook',
+} as const
+
+export interface LogsAlertCreateDestinationApi {
+    /** Destination type — slack or webhook.
+
+* `slack` - slack
+* `webhook` - webhook */
+    type: LogsAlertCreateDestinationTypeEnumApi
+    /** Integration ID for the Slack workspace. Required when type=slack. */
+    slack_workspace_id?: number
+    /** Slack channel ID. Required when type=slack. */
+    slack_channel_id?: string
+    /** Human-readable channel name for display. */
+    slack_channel_name?: string
+    /** HTTPS endpoint to POST to. Required when type=webhook. */
+    webhook_url?: string
+}
+
+export interface LogsAlertDestinationResponseApi {
+    hog_function_ids: string[]
+}
+
+export interface LogsAlertDeleteDestinationApi {
+    /**
+     * HogFunction IDs to delete as one atomic destination group.
+     * @minItems 1
+     */
+    hog_function_ids: string[]
+}
+
 export interface LogsAlertSimulateRequestApi {
     /** Filter criteria — same format as LogsAlertConfiguration.filters. */
     filters: unknown

--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -11,6 +11,9 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
 import type {
     ExplainRequestApi,
     LogsAlertConfigurationApi,
+    LogsAlertCreateDestinationApi,
+    LogsAlertDeleteDestinationApi,
+    LogsAlertDestinationResponseApi,
     LogsAlertSimulateRequestApi,
     LogsAlertSimulateResponseApi,
     LogsAlertsListParams,
@@ -290,6 +293,48 @@ export const logsAlertsDestroy = async (projectId: string, id: string, options?:
     return apiMutator<void>(getLogsAlertsDestroyUrl(projectId, id), {
         ...options,
         method: 'DELETE',
+    })
+}
+
+/**
+ * Create a notification destination for this alert. One HogFunction is created per alert event kind (firing, resolved, ...) atomically.
+ */
+export const getLogsAlertsDestinationsCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/logs/alerts/${id}/destinations/`
+}
+
+export const logsAlertsDestinationsCreate = async (
+    projectId: string,
+    id: string,
+    logsAlertCreateDestinationApi: LogsAlertCreateDestinationApi,
+    options?: RequestInit
+): Promise<LogsAlertDestinationResponseApi> => {
+    return apiMutator<LogsAlertDestinationResponseApi>(getLogsAlertsDestinationsCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(logsAlertCreateDestinationApi),
+    })
+}
+
+/**
+ * Delete a notification destination by deleting its HogFunction group atomically.
+ */
+export const getLogsAlertsDestinationsDeleteCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/logs/alerts/${id}/destinations/delete/`
+}
+
+export const logsAlertsDestinationsDeleteCreate = async (
+    projectId: string,
+    id: string,
+    logsAlertDeleteDestinationApi: LogsAlertDeleteDestinationApi,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getLogsAlertsDestinationsDeleteCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(logsAlertDeleteDestinationApi),
     })
 }
 

--- a/products/logs/mcp/tools.yaml
+++ b/products/logs/mcp/tools.yaml
@@ -134,3 +134,9 @@ tools:
     logs-sparkline-create:
         operation: logs_sparkline_create
         enabled: false
+    logs-alerts-destinations-create:
+        operation: logs_alerts_destinations_create
+        enabled: false
+    logs-alerts-destinations-delete-create:
+        operation: logs_alerts_destinations_delete_create
+        enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -19134,6 +19134,46 @@ export namespace Schemas {
       readonly updated_at: string | null;
     }
 
+    /**
+     * * `slack` - slack
+    * `webhook` - webhook
+     */
+    export type LogsAlertCreateDestinationTypeEnum = typeof LogsAlertCreateDestinationTypeEnum[keyof typeof LogsAlertCreateDestinationTypeEnum];
+
+
+    export const LogsAlertCreateDestinationTypeEnum = {
+      Slack: 'slack',
+      Webhook: 'webhook',
+    } as const;
+
+    export interface LogsAlertCreateDestination {
+      /** Destination type — slack or webhook.
+
+    * `slack` - slack
+    * `webhook` - webhook */
+      type: LogsAlertCreateDestinationTypeEnum;
+      /** Integration ID for the Slack workspace. Required when type=slack. */
+      slack_workspace_id?: number;
+      /** Slack channel ID. Required when type=slack. */
+      slack_channel_id?: string;
+      /** Human-readable channel name for display. */
+      slack_channel_name?: string;
+      /** HTTPS endpoint to POST to. Required when type=webhook. */
+      webhook_url?: string;
+    }
+
+    export interface LogsAlertDeleteDestination {
+      /**
+       * HogFunction IDs to delete as one atomic destination group.
+       * @minItems 1
+       */
+      hog_function_ids: string[];
+    }
+
+    export interface LogsAlertDestinationResponse {
+      hog_function_ids: string[];
+    }
+
     export interface LogsAlertSimulateBucket {
       /** Bucket start timestamp. */
       timestamp: string;


### PR DESCRIPTION
## Problem

Logs alert destinations shipped with a single HogFunction per channel that handled both `$logs_alert_firing` and `$logs_alert_resolved` via Hog `if()` conditionals inside the Slack/webhook template:

```
text: "Log alert '{event.properties.alert_name}' {if(event.event == '$logs_alert_resolved', 'has resolved', 'is firing')}"
event: "{if(event.event == '$logs_alert_resolved', 'resolved', 'firing')}"
```

Three problems with that shape:

1. **Unique-to-logs smell.** Insight alerts only emit one event; error tracking splits each event into its own sub-template with one HogFunction per trigger. The `if()`\-in-template pattern existed nowhere else in the codebase.
2. **Didn't scale.** Adding a third event (`$logs_alert_auto_disabled` for the BROKEN-state work) would have required three-way nested `if()`s in every Slack block, every webhook body field, and every button URL — and the broken-alert deep-link URL is structurally different from the firing/resolved logs-viewer URL, so the branches wouldn't share shape.
3. **Frontend fan-out would have been worse.** The alternative — one HogFunction per destination but N creates fanned out from the frontend — would have re-introduced partial-failure retry queues and atomicity-on-save problems that have nothing to do with notification content.

## Changes

Moves fan-out to the backend. One user action (adding a Slack channel or webhook URL to an alert) now creates N HogFunctions in a single `transaction.atomic()`, one per event kind, each with its own static template.

**Backend**

- New `products/logs/backend/alert_destinations.py`. Owns per-event templates via `EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec]` (currently `firing`, `resolved`). Provides `build_slack_config` / `build_webhook_config` helpers. No conditional Hog expressions anywhere.
- New DRF actions on `LogsAlertConfigurationViewSet`:
    - `POST /api/projects/{pid}/logs/alerts/{id}/destinations/` — flat payload (`{type, slack_*/webhook_url}`). Loops `EVENT_KINDS` inside `transaction.atomic()`, creates one HogFunction per kind via the full `HogFunctionSerializer` pipeline (template lookup → inputs_schema → bytecode — identical to direct `POST /api/hog_functions/`). Returns the created HogFunction IDs.
    - `POST /api/projects/{pid}/logs/alerts/{id}/destinations/delete/` — atomic soft-delete of a group, validated to all belong to this alert via the `alert_id` property filter. Single-query: `UPDATE ... WHERE alert_id=X AND id IN (...)` returns affected count; mismatch rolls back.

**Frontend**

- `logsAlertUtils.ts` shrank from ~165 to ~110 lines. Deleted: `buildLogsAlertHogFunctionPayload`, `LOGS_ALERT_SLACK_BLOCKS`, `LOGS_ALERT_SLACK_INPUTS`, `LOGS_ALERT_WEBHOOK_BODY`, `BASE_SLACK_INPUTS`. Added: `groupLogsAlertDestinations` for display aggregation.
- `logsAlertNotificationLogic.ts` calls the new bundle endpoints; no client-side fan-out, no retry queue complexity.
- `LogsAlertNotifications.tsx` renders one row per destination (backend still creates N HogFunctions per row). Added a note: _"Each destination delivers notifications for all alert events — firing and resolved."_

**Net effect**

- Zero conditional Hog expressions in the codebase.
- Adding a new event kind is a one-line change to `EVENT_KIND_CONFIG` on the backend. No frontend changes required.
- Atomic create + delete on the destination level — a user action either fully succeeds or rolls back.

## How did you test this code?

- Backend: 9 new destination tests in `test_alerts_api.py` — happy path (Slack + webhook), validation rejection (4 invalid payloads, parameterized), cross-team 404, foreign-id delete rejection, round-trip delete. All 66 tests in the file pass.
- Frontend: 47 tests across `logsAlertUtils.test.ts`, `logsAlertNotificationLogic.test.ts`, `logsAlertFormLogic.test.ts`. Covers the new `groupLogsAlertDestinations`, bundle endpoint payload shape, optimistic delete + reload-on-failure, and an explicit regression test that the list filter never includes `events` (JSONB `@>` query gotcha).
- Manual: created an alert with a webhook destination via the UI in local dev, verified two HogFunctions were created (one per event, each with a static per-event template and no `if()` expressions). Edited the alert and confirmed the destination still appeared. Deleted the destination and confirmed both HogFunctions were soft-deleted atomically.

## Publish to changelog?

no

## Docs update

No user-facing behavioral change — skipping docs.