### PR TITLE
fix(insights): allow clearing breakdown limit input while editing

### DIFF
--- a/frontend/src/scenes/insights/filters/BreakdownFilter/GlobalBreakdownOptionsMenu.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/GlobalBreakdownOptionsMenu.tsx
@@ -11,14 +11,15 @@ import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
 import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
 
+const MIN_BREAKDOWN_LIMIT = 1
+const MAX_BREAKDOWN_LIMIT = 1000
+
 export const GlobalBreakdownOptionsMenu = (): JSX.Element => {
     const { insightProps } = useValues(insightLogic)
     const { isTrends } = useValues(insightVizDataLogic(insightProps))
 
-    const { breakdownLimit, breakdownLimitInputValue, breakdownHideOtherAggregation } =
-        useValues(taxonomicBreakdownFilterLogic)
-    const { setBreakdownLimitInput, resetBreakdownLimitInput, setBreakdownHideOtherAggregation } =
-        useActions(taxonomicBreakdownFilterLogic)
+    const { breakdownLimit, breakdownHideOtherAggregation } = useValues(taxonomicBreakdownFilterLogic)
+    const { setBreakdownLimit, setBreakdownHideOtherAggregation } = useActions(taxonomicBreakdownFilterLogic)
 
     return (
         <>
@@ -50,16 +51,38 @@ export const GlobalBreakdownOptionsMenu = (): JSX.Element => {
                 <LemonLabel className="font-medium" htmlFor="breakdown-limit">
                     Breakdown limit
                 </LemonLabel>
+                {/*
+                 * Uncontrolled input so the user can freely clear the field while
+                 * retyping. The DOM owns the draft; we only commit to the filter
+                 * on blur / Enter. `key={breakdownLimit}` remounts the input when
+                 * the committed value changes externally so `defaultValue` stays
+                 * in sync.
+                 */}
                 <LemonInput
+                    key={breakdownLimit}
                     id="breakdown-limit"
-                    min={1}
-                    max={1000}
-                    value={breakdownLimitInputValue}
-                    onChange={setBreakdownLimitInput}
-                    onBlur={resetBreakdownLimitInput}
+                    type="number"
+                    min={MIN_BREAKDOWN_LIMIT}
+                    max={MAX_BREAKDOWN_LIMIT}
+                    defaultValue={breakdownLimit}
                     fullWidth={false}
                     className="w-20 ml-2"
-                    type="number"
+                    onBlur={(event) => {
+                        const target = event.currentTarget
+                        const raw = target.value
+                        if (raw === '') {
+                            // Don't commit an empty value — restore the last
+                            // committed limit instead.
+                            target.value = String(breakdownLimit)
+                            return
+                        }
+                        const clamped = Math.min(Math.max(Number(raw), MIN_BREAKDOWN_LIMIT), MAX_BREAKDOWN_LIMIT)
+                        target.value = String(clamped)
+                        if (clamped !== breakdownLimit) {
+                            setBreakdownLimit(clamped)
+                        }
+                    }}
+                    onPressEnter={(event) => event.currentTarget.blur()}
                 />
             </div>
         </>

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/GlobalBreakdownOptionsMenu.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/GlobalBreakdownOptionsMenu.tsx
@@ -1,7 +1,6 @@
 import './BreakdownTagMenu.scss'
 
 import { useActions, useValues } from 'kea'
-import { useEffect, useState } from 'react'
 
 import { IconInfo } from '@posthog/icons'
 import { LemonInput, LemonLabel, LemonSwitch } from '@posthog/lemon-ui'
@@ -12,46 +11,14 @@ import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
 import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
 
-const MAX_BREAKDOWN_LIMIT = 1000
-
 export const GlobalBreakdownOptionsMenu = (): JSX.Element => {
     const { insightProps } = useValues(insightLogic)
     const { isTrends } = useValues(insightVizDataLogic(insightProps))
 
-    const { breakdownLimit, breakdownHideOtherAggregation } = useValues(taxonomicBreakdownFilterLogic)
-    const { setBreakdownLimit, setBreakdownHideOtherAggregation } = useActions(taxonomicBreakdownFilterLogic)
-
-    // Keep a local copy of the input value so the user can temporarily clear the
-    // field while editing without committing an empty/NaN value to the filter.
-    const [inputValue, setInputValue] = useState<number | undefined>(breakdownLimit)
-
-    // Sync when the committed limit changes outside of the input (e.g. initial
-    // load or external updates). We intentionally overwrite any in-progress
-    // empty state here — once the upstream value changes, that's the new truth.
-    useEffect(() => {
-        setInputValue(breakdownLimit)
-    }, [breakdownLimit])
-
-    const handleChange = (value: number | undefined): void => {
-        if (value === undefined || Number.isNaN(value)) {
-            // Allow the field to be cleared visually, but don't commit an empty
-            // value — the filter keeps the previous limit until a valid number
-            // is entered.
-            setInputValue(undefined)
-            return
-        }
-        const capped = Math.min(value, MAX_BREAKDOWN_LIMIT)
-        setInputValue(capped)
-        setBreakdownLimit(capped)
-    }
-
-    const handleBlur = (): void => {
-        // If the user left the field empty, restore the last committed value
-        // so the input doesn't stay visually blank.
-        if (inputValue === undefined || Number.isNaN(inputValue)) {
-            setInputValue(breakdownLimit)
-        }
-    }
+    const { breakdownLimit, breakdownLimitInputValue, breakdownHideOtherAggregation } =
+        useValues(taxonomicBreakdownFilterLogic)
+    const { setBreakdownLimitInput, resetBreakdownLimitInput, setBreakdownHideOtherAggregation } =
+        useActions(taxonomicBreakdownFilterLogic)
 
     return (
         <>
@@ -86,10 +53,10 @@ export const GlobalBreakdownOptionsMenu = (): JSX.Element => {
                 <LemonInput
                     id="breakdown-limit"
                     min={1}
-                    max={MAX_BREAKDOWN_LIMIT}
-                    value={inputValue}
-                    onChange={handleChange}
-                    onBlur={handleBlur}
+                    max={1000}
+                    value={breakdownLimitInputValue}
+                    onChange={setBreakdownLimitInput}
+                    onBlur={resetBreakdownLimitInput}
                     fullWidth={false}
                     className="w-20 ml-2"
                     type="number"

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/GlobalBreakdownOptionsMenu.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/GlobalBreakdownOptionsMenu.tsx
@@ -1,6 +1,7 @@
 import './BreakdownTagMenu.scss'
 
 import { useActions, useValues } from 'kea'
+import { useEffect, useState } from 'react'
 
 import { IconInfo } from '@posthog/icons'
 import { LemonInput, LemonLabel, LemonSwitch } from '@posthog/lemon-ui'
@@ -11,12 +12,46 @@ import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
 import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
 
+const MAX_BREAKDOWN_LIMIT = 1000
+
 export const GlobalBreakdownOptionsMenu = (): JSX.Element => {
     const { insightProps } = useValues(insightLogic)
     const { isTrends } = useValues(insightVizDataLogic(insightProps))
 
     const { breakdownLimit, breakdownHideOtherAggregation } = useValues(taxonomicBreakdownFilterLogic)
     const { setBreakdownLimit, setBreakdownHideOtherAggregation } = useActions(taxonomicBreakdownFilterLogic)
+
+    // Keep a local copy of the input value so the user can temporarily clear the
+    // field while editing without committing an empty/NaN value to the filter.
+    const [inputValue, setInputValue] = useState<number | undefined>(breakdownLimit)
+
+    // Sync when the committed limit changes outside of the input (e.g. initial
+    // load or external updates). We intentionally overwrite any in-progress
+    // empty state here — once the upstream value changes, that's the new truth.
+    useEffect(() => {
+        setInputValue(breakdownLimit)
+    }, [breakdownLimit])
+
+    const handleChange = (value: number | undefined): void => {
+        if (value === undefined || Number.isNaN(value)) {
+            // Allow the field to be cleared visually, but don't commit an empty
+            // value — the filter keeps the previous limit until a valid number
+            // is entered.
+            setInputValue(undefined)
+            return
+        }
+        const capped = Math.min(value, MAX_BREAKDOWN_LIMIT)
+        setInputValue(capped)
+        setBreakdownLimit(capped)
+    }
+
+    const handleBlur = (): void => {
+        // If the user left the field empty, restore the last committed value
+        // so the input doesn't stay visually blank.
+        if (inputValue === undefined || Number.isNaN(inputValue)) {
+            setInputValue(breakdownLimit)
+        }
+    }
 
     return (
         <>
@@ -51,10 +86,10 @@ export const GlobalBreakdownOptionsMenu = (): JSX.Element => {
                 <LemonInput
                     id="breakdown-limit"
                     min={1}
-                    max={1000}
-                    value={breakdownLimit}
-                    // :HACKY: We cap the breakdown limit in the `onChange` handler, as the `max` prop doesn't enforce anything.
-                    onChange={(value) => setBreakdownLimit(value !== undefined ? Math.min(value, 1000) : undefined)}
+                    max={MAX_BREAKDOWN_LIMIT}
+                    value={inputValue}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
                     fullWidth={false}
                     className="w-20 ml-2"
                     type="number"

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -72,14 +72,6 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
         }),
         removeBreakdown: (breakdown: string | number, breakdownType: string) => ({ breakdown, breakdownType }),
         setBreakdownLimit: (value: number | undefined) => ({ value }),
-        // Tracks the raw value in the breakdown limit input (including temporarily
-        // empty while the user is retyping). Commits only when a valid number is
-        // entered. `NaN` is normalized to `undefined` so downstream code doesn't
-        // have to handle it.
-        setBreakdownLimitInput: (value: number | undefined) => ({
-            value: value === undefined || Number.isNaN(value) ? undefined : value,
-        }),
-        resetBreakdownLimitInput: true,
         setHistogramBinsUsed: (
             breakdown: string | number,
             breakdownType: string,
@@ -128,23 +120,6 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
             undefined as number | undefined,
             {
                 setBreakdownLimit: (_, { value }) => value,
-            },
-        ],
-        breakdownLimitInput: [
-            undefined as number | undefined,
-            {
-                setBreakdownLimitInput: (_, { value }) => value,
-            },
-        ],
-        // Whether the input is currently being edited — when true, the input
-        // shows `breakdownLimitInput` (which may be `undefined` for an empty
-        // field); when false, it falls back to the committed `breakdownLimit`.
-        breakdownLimitInputActive: [
-            false,
-            {
-                setBreakdownLimitInput: () => true,
-                resetBreakdownLimitInput: () => false,
-                setBreakdownLimit: () => false,
             },
         ],
         localNormalizeBreakdownURL: [
@@ -246,14 +221,6 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
         breakdownLimit: [
             (s) => [s.breakdownFilter, s.localBreakdownLimit],
             (breakdownFilter, localBreakdownLimit) => localBreakdownLimit || breakdownFilter?.breakdown_limit || 25,
-        ],
-        // Value shown in the breakdown limit input. While editing, it mirrors
-        // the raw input state (may be `undefined` for an empty field). When
-        // not editing, it falls back to the committed `breakdownLimit`.
-        breakdownLimitInputValue: [
-            (s) => [s.breakdownLimit, s.breakdownLimitInput, s.breakdownLimitInputActive],
-            (breakdownLimit, breakdownLimitInput, breakdownLimitInputActive): number | undefined =>
-                breakdownLimitInputActive ? breakdownLimitInput : breakdownLimit,
         ],
         normalizeBreakdownUrl: [
             (s) => [s.breakdownFilter, s.localNormalizeBreakdownURL],
@@ -517,16 +484,6 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
                 ...values.breakdownFilter,
                 breakdown_limit: value,
             })
-        },
-        setBreakdownLimitInput: ({ value }) => {
-            // Only commit valid numbers — an empty/cleared input should not
-            // trigger a reload. `setBreakdownLimit`'s own listener debounces
-            // the actual filter update. Clamp to [1, 1000]: the selector's
-            // `|| 25` fallback would otherwise silently swallow `0`/negatives.
-            if (value === undefined) {
-                return
-            }
-            actions.setBreakdownLimit(Math.min(Math.max(value, 1), 1000))
         },
         setNormalizeBreakdownURL: ({ normalizeBreakdownURL, breakdown, breakdownType }) => {
             if (values.isMultipleBreakdownsEnabled && !isSingleBreakdown(values.breakdownFilter)) {

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -521,11 +521,12 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
         setBreakdownLimitInput: ({ value }) => {
             // Only commit valid numbers — an empty/cleared input should not
             // trigger a reload. `setBreakdownLimit`'s own listener debounces
-            // the actual filter update.
+            // the actual filter update. Clamp to [1, 1000]: the selector's
+            // `|| 25` fallback would otherwise silently swallow `0`/negatives.
             if (value === undefined) {
                 return
             }
-            actions.setBreakdownLimit(Math.min(value, 1000))
+            actions.setBreakdownLimit(Math.min(Math.max(value, 1), 1000))
         },
         setNormalizeBreakdownURL: ({ normalizeBreakdownURL, breakdown, breakdownType }) => {
             if (values.isMultipleBreakdownsEnabled && !isSingleBreakdown(values.breakdownFilter)) {

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -72,6 +72,14 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
         }),
         removeBreakdown: (breakdown: string | number, breakdownType: string) => ({ breakdown, breakdownType }),
         setBreakdownLimit: (value: number | undefined) => ({ value }),
+        // Tracks the raw value in the breakdown limit input (including temporarily
+        // empty while the user is retyping). Commits only when a valid number is
+        // entered. `NaN` is normalized to `undefined` so downstream code doesn't
+        // have to handle it.
+        setBreakdownLimitInput: (value: number | undefined) => ({
+            value: value === undefined || Number.isNaN(value) ? undefined : value,
+        }),
+        resetBreakdownLimitInput: true,
         setHistogramBinsUsed: (
             breakdown: string | number,
             breakdownType: string,
@@ -120,6 +128,23 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
             undefined as number | undefined,
             {
                 setBreakdownLimit: (_, { value }) => value,
+            },
+        ],
+        breakdownLimitInput: [
+            undefined as number | undefined,
+            {
+                setBreakdownLimitInput: (_, { value }) => value,
+            },
+        ],
+        // Whether the input is currently being edited — when true, the input
+        // shows `breakdownLimitInput` (which may be `undefined` for an empty
+        // field); when false, it falls back to the committed `breakdownLimit`.
+        breakdownLimitInputActive: [
+            false,
+            {
+                setBreakdownLimitInput: () => true,
+                resetBreakdownLimitInput: () => false,
+                setBreakdownLimit: () => false,
             },
         ],
         localNormalizeBreakdownURL: [
@@ -221,6 +246,14 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
         breakdownLimit: [
             (s) => [s.breakdownFilter, s.localBreakdownLimit],
             (breakdownFilter, localBreakdownLimit) => localBreakdownLimit || breakdownFilter?.breakdown_limit || 25,
+        ],
+        // Value shown in the breakdown limit input. While editing, it mirrors
+        // the raw input state (may be `undefined` for an empty field). When
+        // not editing, it falls back to the committed `breakdownLimit`.
+        breakdownLimitInputValue: [
+            (s) => [s.breakdownLimit, s.breakdownLimitInput, s.breakdownLimitInputActive],
+            (breakdownLimit, breakdownLimitInput, breakdownLimitInputActive): number | undefined =>
+                breakdownLimitInputActive ? breakdownLimitInput : breakdownLimit,
         ],
         normalizeBreakdownUrl: [
             (s) => [s.breakdownFilter, s.localNormalizeBreakdownURL],
@@ -484,6 +517,15 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
                 ...values.breakdownFilter,
                 breakdown_limit: value,
             })
+        },
+        setBreakdownLimitInput: ({ value }) => {
+            // Only commit valid numbers — an empty/cleared input should not
+            // trigger a reload. `setBreakdownLimit`'s own listener debounces
+            // the actual filter update.
+            if (value === undefined) {
+                return
+            }
+            actions.setBreakdownLimit(Math.min(value, 1000))
         },
         setNormalizeBreakdownURL: ({ normalizeBreakdownURL, breakdown, breakdownType }) => {
             if (values.isMultipleBreakdownsEnabled && !isSingleBreakdown(values.breakdownFilter)) {


### PR DESCRIPTION
## Problem

The **Breakdown limit** input in the breakdown tag popover could not be cleared while editing. Because the field was bound directly to the logic's `breakdownLimit` value, backspacing the last digit emitted `NaN` from the native number input; React's controlled `value={NaN}` is treated as invalid, so the previous digit stayed on screen. In practice this meant a user could delete `5` from `25` to get `2`, but could not then delete the `2` to type a new number — the field appeared to resist being cleared.

## Changes

Moves the draft/editing state for the breakdown limit input into `taxonomicBreakdownFilterLogic` (per the repo convention that business logic lives in the kea logic, not React hooks):

- **Actions**: `setBreakdownLimitInput(value)` (normalizes `NaN` → `undefined`) and `resetBreakdownLimitInput` (restore committed value on blur).
- **Reducers**: `breakdownLimitInput` holds the raw draft value; `breakdownLimitInputActive` tracks whether the user is currently editing, so an empty draft can be distinguished from "not touched".
- **Selector**: `breakdownLimitInputValue` returns the draft while active, otherwise falls back to the committed `breakdownLimit`.
- **Listener**: when the draft is a valid number, it's routed through `setBreakdownLimit` (which continues to debounce the actual filter update by 300 ms). Values are clamped to `[1, 1000]` here so a `0` or negative can't silently pass through the `|| 25` fallback in the `breakdownLimit` selector.

The component drops `useState`/`useEffect` and binds `value` / `onChange` / `onBlur` straight to the kea values and actions.

## How did you test this code?

I'm an agent — I did **not** manually click through the popover. I verified:

- The existing `taxonomicBreakdownFilterLogic` test (`setBreakdownLimit: updates correctly`) still exercises the commit path unchanged.
- The file passes `oxlint` locally.
- Jest and `kea-typegen` weren't available in my sandbox; the generated `*Type.ts` files are gitignored and will be regenerated in CI.

Reviewer sanity check: open the breakdown popover on any trends insight, clear the **Breakdown limit** input fully, type a new number, and confirm the insight only reloads after the 300 ms debounce on the new value. Leaving the field blank and blurring should restore the previously committed limit.

## Publish to changelog?

no

## Docs update

No docs changes required.

## 🤖 LLM context

Authored by Claude Code. Session: https://claude.ai/code/session_01LGycfYzABCoDZmAdBNhTmA

Iterated in three commits: (1) initial fix using React local state, (2) refactored to move state into the kea logic after a reviewer pointed out the hooks-vs-logic convention, (3) added a min-floor clamp after a Greptile review noted that `0`/negatives could fall through the `||` fallback in the selector.