### PR TITLE
feat(flags): add version history reconstruction endpoint

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -2328,9 +2328,9 @@ class FeatureFlagViewSet(
     def versions(self, request: request.Request, version_number: str, **kwargs) -> Response:
         feature_flag: FeatureFlag = self.get_object()
 
-        if feature_flag.is_remote_configuration:
+        if feature_flag.is_remote_configuration or feature_flag.has_encrypted_payloads:
             return Response(
-                {"detail": "Version history is not available for remote configuration flags."},
+                {"detail": "Version history is not available for remote configuration or encrypted flags."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1915,6 +1915,49 @@ class DependentFlagSerializer(serializers.Serializer):
     name = serializers.CharField(help_text="Feature flag name")
 
 
+class FeatureFlagVersionResponseSerializer(serializers.ModelSerializer):
+    """Feature flag state at a given version plus reconstruction metadata."""
+
+    created_by = serializers.IntegerField(read_only=True, allow_null=True)
+    filters = serializers.DictField(read_only=True)
+    is_historical = serializers.BooleanField(
+        read_only=True,
+        help_text="False for the current version; true for reconstructed historical versions.",
+    )
+    version_timestamp = serializers.DateTimeField(read_only=True, allow_null=True)
+    modified_by = serializers.IntegerField(
+        read_only=True,
+        allow_null=True,
+        help_text="User from the activity log entry that produced this version.",
+    )
+
+    class Meta:
+        model = FeatureFlag
+        fields = [
+            "id",
+            "key",
+            "name",
+            "filters",
+            "active",
+            "deleted",
+            "version",
+            "rollback_conditions",
+            "performed_rollback",
+            "ensure_experience_continuity",
+            "has_enriched_analytics",
+            "is_remote_configuration",
+            "has_encrypted_payloads",
+            "evaluation_runtime",
+            "bucketing_identifier",
+            "last_called_at",
+            "created_at",
+            "created_by",
+            "is_historical",
+            "version_timestamp",
+            "modified_by",
+        ]
+
+
 class UserBlastRadiusRequestSerializer(serializers.Serializer):
     condition = serializers.DictField(required=True, help_text="The release condition to evaluate")
     group_type_index = serializers.IntegerField(
@@ -2313,7 +2356,7 @@ class FeatureFlagViewSet(
             ),
         ],
         responses={
-            200: OpenApiResponse(description="Reconstructed feature flag state at the given version."),
+            200: FeatureFlagVersionResponseSerializer,
             400: OpenApiResponse(description="Version history is not available for remote configuration flags."),
             404: OpenApiResponse(description="Version not found."),
             422: OpenApiResponse(description="Activity log incomplete; cannot reconstruct this version."),
@@ -2353,7 +2396,7 @@ class FeatureFlagViewSet(
                 status=status.HTTP_422_UNPROCESSABLE_ENTITY,
             )
 
-        return Response(result)
+        return Response(FeatureFlagVersionResponseSerializer(instance=result).data)
 
     @validated_request(
         query_serializer=MyFlagsQuerySerializer,

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -77,6 +77,11 @@ from posthog.models.feature_flag.local_evaluation import (
     get_flags_response_if_none_match,
 )
 from posthog.models.feature_flag.types import PropertyFilterType
+from posthog.models.feature_flag.version_history import (
+    VersionHistoryIncomplete,
+    VersionNotFound,
+    reconstruct_flag_at_version,
+)
 from posthog.models.group.group import Group
 from posthog.models.property import Property
 from posthog.models.signals import model_activity_signal, mutable_receiver
@@ -2321,12 +2326,6 @@ class FeatureFlagViewSet(
         required_scopes=["feature_flag:read"],
     )
     def versions(self, request: request.Request, version_number: str, **kwargs) -> Response:
-        from posthog.models.feature_flag.version_history import (
-            VersionHistoryIncomplete,
-            VersionNotFound,
-            reconstruct_flag_at_version,
-        )
-
         feature_flag: FeatureFlag = self.get_object()
 
         if feature_flag.is_remote_configuration:

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -2297,6 +2297,65 @@ class FeatureFlagViewSet(
             status=200,
         )
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                "version_number",
+                OpenApiTypes.INT,
+                location=OpenApiParameter.PATH,
+                required=True,
+                description="The version number to reconstruct.",
+            ),
+        ],
+        responses={
+            200: OpenApiResponse(description="Reconstructed feature flag state at the given version."),
+            400: OpenApiResponse(description="Version history is not available for remote configuration flags."),
+            404: OpenApiResponse(description="Version not found."),
+            422: OpenApiResponse(description="Activity log incomplete; cannot reconstruct this version."),
+        },
+    )
+    @action(
+        methods=["GET"],
+        detail=True,
+        url_path=r"versions/(?P<version_number>[0-9]+)",
+        required_scopes=["feature_flag:read"],
+    )
+    def versions(self, request: request.Request, version_number: str, **kwargs) -> Response:
+        from posthog.models.feature_flag.version_history import (
+            VersionHistoryIncomplete,
+            VersionNotFound,
+            reconstruct_flag_at_version,
+        )
+
+        feature_flag: FeatureFlag = self.get_object()
+
+        if feature_flag.is_remote_configuration:
+            return Response(
+                {"detail": "Version history is not available for remote configuration flags."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        target_version = int(version_number)
+
+        try:
+            result = reconstruct_flag_at_version(
+                flag=feature_flag,
+                target_version=target_version,
+                team_id=self.team_id,
+            )
+        except VersionNotFound as e:
+            return Response(
+                {"detail": str(e)},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except VersionHistoryIncomplete as e:
+            return Response(
+                {"detail": str(e)},
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            )
+
+        return Response(result)
+
     @validated_request(
         query_serializer=MyFlagsQuerySerializer,
         responses={

--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -2818,101 +2818,79 @@
 # ---
 # name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.71
   '''
-  SELECT "ee_featureflagroleaccess"."id",
-         "ee_featureflagroleaccess"."feature_flag_id",
-         "ee_featureflagroleaccess"."role_id",
-         "ee_featureflagroleaccess"."added_at",
-         "ee_featureflagroleaccess"."updated_at"
-  FROM "ee_featureflagroleaccess"
-  WHERE "ee_featureflagroleaccess"."feature_flag_id" = 99999
+  SELECT "posthog_experiment"."id",
+         "posthog_experiment"."name",
+         "posthog_experiment"."description",
+         "posthog_experiment"."team_id",
+         "posthog_experiment"."filters",
+         "posthog_experiment"."parameters",
+         "posthog_experiment"."secondary_metrics",
+         "posthog_experiment"."created_by_id",
+         "posthog_experiment"."feature_flag_id",
+         "posthog_experiment"."exposure_cohort_id",
+         "posthog_experiment"."holdout_id",
+         "posthog_experiment"."start_date",
+         "posthog_experiment"."end_date",
+         "posthog_experiment"."created_at",
+         "posthog_experiment"."updated_at",
+         "posthog_experiment"."archived",
+         "posthog_experiment"."deleted",
+         "posthog_experiment"."type",
+         "posthog_experiment"."variants",
+         "posthog_experiment"."exposure_criteria",
+         "posthog_experiment"."metrics",
+         "posthog_experiment"."metrics_secondary",
+         "posthog_experiment"."primary_metrics_ordered_uuids",
+         "posthog_experiment"."secondary_metrics_ordered_uuids",
+         "posthog_experiment"."stats_config",
+         "posthog_experiment"."scheduling_config",
+         "posthog_experiment"."only_count_matured_users",
+         "posthog_experiment"."status",
+         "posthog_experiment"."conclusion",
+         "posthog_experiment"."conclusion_comment"
+  FROM "posthog_experiment"
+  WHERE ("posthog_experiment"."feature_flag_id" = 99999
+         AND NOT "posthog_experiment"."deleted")
   '''
 # ---
 # name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.72
   '''
-  SELECT "ee_featureflagroleaccess"."id",
-         "ee_featureflagroleaccess"."feature_flag_id",
-         "ee_featureflagroleaccess"."role_id",
-         "ee_featureflagroleaccess"."added_at",
-         "ee_featureflagroleaccess"."updated_at"
-  FROM "ee_featureflagroleaccess"
-  WHERE "ee_featureflagroleaccess"."feature_flag_id" = 99999
+  SELECT "posthog_experiment"."id",
+         "posthog_experiment"."name",
+         "posthog_experiment"."description",
+         "posthog_experiment"."team_id",
+         "posthog_experiment"."filters",
+         "posthog_experiment"."parameters",
+         "posthog_experiment"."secondary_metrics",
+         "posthog_experiment"."created_by_id",
+         "posthog_experiment"."feature_flag_id",
+         "posthog_experiment"."exposure_cohort_id",
+         "posthog_experiment"."holdout_id",
+         "posthog_experiment"."start_date",
+         "posthog_experiment"."end_date",
+         "posthog_experiment"."created_at",
+         "posthog_experiment"."updated_at",
+         "posthog_experiment"."archived",
+         "posthog_experiment"."deleted",
+         "posthog_experiment"."type",
+         "posthog_experiment"."variants",
+         "posthog_experiment"."exposure_criteria",
+         "posthog_experiment"."metrics",
+         "posthog_experiment"."metrics_secondary",
+         "posthog_experiment"."primary_metrics_ordered_uuids",
+         "posthog_experiment"."secondary_metrics_ordered_uuids",
+         "posthog_experiment"."stats_config",
+         "posthog_experiment"."scheduling_config",
+         "posthog_experiment"."only_count_matured_users",
+         "posthog_experiment"."status",
+         "posthog_experiment"."conclusion",
+         "posthog_experiment"."conclusion_comment"
+  FROM "posthog_experiment"
+  WHERE ("posthog_experiment"."feature_flag_id" = 99999
+         AND NOT "posthog_experiment"."deleted")
   '''
 # ---
 # name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.73
-  '''
-  SELECT "posthog_experiment"."id",
-         "posthog_experiment"."name",
-         "posthog_experiment"."description",
-         "posthog_experiment"."team_id",
-         "posthog_experiment"."filters",
-         "posthog_experiment"."parameters",
-         "posthog_experiment"."secondary_metrics",
-         "posthog_experiment"."created_by_id",
-         "posthog_experiment"."feature_flag_id",
-         "posthog_experiment"."exposure_cohort_id",
-         "posthog_experiment"."holdout_id",
-         "posthog_experiment"."start_date",
-         "posthog_experiment"."end_date",
-         "posthog_experiment"."created_at",
-         "posthog_experiment"."updated_at",
-         "posthog_experiment"."archived",
-         "posthog_experiment"."deleted",
-         "posthog_experiment"."type",
-         "posthog_experiment"."variants",
-         "posthog_experiment"."exposure_criteria",
-         "posthog_experiment"."metrics",
-         "posthog_experiment"."metrics_secondary",
-         "posthog_experiment"."primary_metrics_ordered_uuids",
-         "posthog_experiment"."secondary_metrics_ordered_uuids",
-         "posthog_experiment"."stats_config",
-         "posthog_experiment"."scheduling_config",
-         "posthog_experiment"."only_count_matured_users",
-         "posthog_experiment"."status",
-         "posthog_experiment"."conclusion",
-         "posthog_experiment"."conclusion_comment"
-  FROM "posthog_experiment"
-  WHERE ("posthog_experiment"."feature_flag_id" = 99999
-         AND NOT "posthog_experiment"."deleted")
-  '''
-# ---
-# name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.74
-  '''
-  SELECT "posthog_experiment"."id",
-         "posthog_experiment"."name",
-         "posthog_experiment"."description",
-         "posthog_experiment"."team_id",
-         "posthog_experiment"."filters",
-         "posthog_experiment"."parameters",
-         "posthog_experiment"."secondary_metrics",
-         "posthog_experiment"."created_by_id",
-         "posthog_experiment"."feature_flag_id",
-         "posthog_experiment"."exposure_cohort_id",
-         "posthog_experiment"."holdout_id",
-         "posthog_experiment"."start_date",
-         "posthog_experiment"."end_date",
-         "posthog_experiment"."created_at",
-         "posthog_experiment"."updated_at",
-         "posthog_experiment"."archived",
-         "posthog_experiment"."deleted",
-         "posthog_experiment"."type",
-         "posthog_experiment"."variants",
-         "posthog_experiment"."exposure_criteria",
-         "posthog_experiment"."metrics",
-         "posthog_experiment"."metrics_secondary",
-         "posthog_experiment"."primary_metrics_ordered_uuids",
-         "posthog_experiment"."secondary_metrics_ordered_uuids",
-         "posthog_experiment"."stats_config",
-         "posthog_experiment"."scheduling_config",
-         "posthog_experiment"."only_count_matured_users",
-         "posthog_experiment"."status",
-         "posthog_experiment"."conclusion",
-         "posthog_experiment"."conclusion_comment"
-  FROM "posthog_experiment"
-  WHERE ("posthog_experiment"."feature_flag_id" = 99999
-         AND NOT "posthog_experiment"."deleted")
-  '''
-# ---
-# name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.75
   '''
   SELECT "posthog_survey"."id",
          "posthog_survey"."team_id",
@@ -2956,7 +2934,7 @@
   WHERE "posthog_survey"."linked_flag_id" = 99999
   '''
 # ---
-# name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.76
+# name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.74
   '''
   SELECT "posthog_earlyaccessfeature"."id",
          "posthog_earlyaccessfeature"."team_id",
@@ -2969,6 +2947,81 @@
          "posthog_earlyaccessfeature"."created_at"
   FROM "posthog_earlyaccessfeature"
   WHERE "posthog_earlyaccessfeature"."feature_flag_id" = 99999
+  '''
+# ---
+# name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.75
+  '''
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."logo_media_id",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."is_active",
+         "posthog_organization"."is_not_active_reason",
+         "posthog_organization"."session_cookie_age",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."is_ai_data_processing_approved",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."members_can_invite",
+         "posthog_organization"."members_can_use_personal_api_keys",
+         "posthog_organization"."allow_publicly_shared_resources",
+         "posthog_organization"."default_role_id",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."default_experiment_stats_method",
+         "posthog_organization"."default_anonymize_ips",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."is_pending_deletion",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."is_platform"
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
+  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         AND "posthog_organizationmembership"."user_id" = 99999)
+  LIMIT 21
+  '''
+# ---
+# name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.76
+  '''
+  SELECT "posthog_dashboard"."id",
+         "posthog_dashboard"."name",
+         "posthog_dashboard"."description",
+         "posthog_dashboard"."team_id",
+         "posthog_dashboard"."pinned",
+         "posthog_dashboard"."created_at",
+         "posthog_dashboard"."created_by_id",
+         "posthog_dashboard"."deleted",
+         "posthog_dashboard"."last_accessed_at",
+         "posthog_dashboard"."last_refresh",
+         "posthog_dashboard"."filters",
+         "posthog_dashboard"."variables",
+         "posthog_dashboard"."breakdown_colors",
+         "posthog_dashboard"."data_color_theme_id",
+         "posthog_dashboard"."creation_mode",
+         "posthog_dashboard"."restriction_level",
+         "posthog_dashboard"."quick_filter_ids",
+         "posthog_dashboard"."deprecated_tags",
+         "posthog_dashboard"."tags",
+         "posthog_dashboard"."share_token",
+         "posthog_dashboard"."is_shared"
+  FROM "posthog_dashboard"
+  INNER JOIN "posthog_featureflagdashboards" ON ("posthog_dashboard"."id" = "posthog_featureflagdashboards"."dashboard_id")
+  WHERE (NOT ("posthog_dashboard"."deleted")
+         AND "posthog_featureflagdashboards"."feature_flag_id" = 99999)
   '''
 # ---
 # name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.77
@@ -3019,77 +3072,26 @@
 # ---
 # name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.78
   '''
-  SELECT "posthog_dashboard"."id",
-         "posthog_dashboard"."name",
-         "posthog_dashboard"."description",
-         "posthog_dashboard"."team_id",
-         "posthog_dashboard"."pinned",
-         "posthog_dashboard"."created_at",
-         "posthog_dashboard"."created_by_id",
-         "posthog_dashboard"."deleted",
-         "posthog_dashboard"."last_accessed_at",
-         "posthog_dashboard"."last_refresh",
-         "posthog_dashboard"."filters",
-         "posthog_dashboard"."variables",
-         "posthog_dashboard"."breakdown_colors",
-         "posthog_dashboard"."data_color_theme_id",
-         "posthog_dashboard"."creation_mode",
-         "posthog_dashboard"."restriction_level",
-         "posthog_dashboard"."quick_filter_ids",
-         "posthog_dashboard"."deprecated_tags",
-         "posthog_dashboard"."tags",
-         "posthog_dashboard"."share_token",
-         "posthog_dashboard"."is_shared"
-  FROM "posthog_dashboard"
-  INNER JOIN "posthog_featureflagdashboards" ON ("posthog_dashboard"."id" = "posthog_featureflagdashboards"."dashboard_id")
-  WHERE (NOT ("posthog_dashboard"."deleted")
-         AND "posthog_featureflagdashboards"."feature_flag_id" = 99999)
+  SELECT 1 AS "a"
+  FROM "posthog_team"
+  WHERE ("posthog_team"."project_id" = 99999
+         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 99999}'::jsonb)
+  LIMIT 1
   '''
 # ---
 # name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.79
   '''
-  SELECT "posthog_organizationmembership"."id",
-         "posthog_organizationmembership"."organization_id",
-         "posthog_organizationmembership"."user_id",
-         "posthog_organizationmembership"."level",
-         "posthog_organizationmembership"."joined_at",
-         "posthog_organizationmembership"."updated_at",
-         "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."logo_media_id",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."is_active",
-         "posthog_organization"."is_not_active_reason",
-         "posthog_organization"."session_cookie_age",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."is_ai_data_processing_approved",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."members_can_invite",
-         "posthog_organization"."members_can_use_personal_api_keys",
-         "posthog_organization"."allow_publicly_shared_resources",
-         "posthog_organization"."default_role_id",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."default_experiment_stats_method",
-         "posthog_organization"."default_anonymize_ips",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."is_pending_deletion",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist",
-         "posthog_organization"."is_platform"
-  FROM "posthog_organizationmembership"
-  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 99999)
-  LIMIT 21
+  SELECT "posthog_featureflagevaluationcontext"."id",
+         "posthog_featureflagevaluationcontext"."feature_flag_id",
+         "posthog_featureflagevaluationcontext"."evaluation_context_id",
+         "posthog_featureflagevaluationcontext"."created_at",
+         "posthog_evaluationcontext"."id",
+         "posthog_evaluationcontext"."name",
+         "posthog_evaluationcontext"."team_id",
+         "posthog_evaluationcontext"."created_at"
+  FROM "posthog_featureflagevaluationcontext"
+  INNER JOIN "posthog_evaluationcontext" ON ("posthog_featureflagevaluationcontext"."evaluation_context_id" = "posthog_evaluationcontext"."id")
+  WHERE "posthog_featureflagevaluationcontext"."feature_flag_id" = 99999
   '''
 # ---
 # name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.8
@@ -3138,11 +3140,10 @@
 # ---
 # name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.80
   '''
-  SELECT 1 AS "a"
-  FROM "posthog_team"
-  WHERE ("posthog_team"."project_id" = 99999
-         AND "posthog_team"."session_recording_linked_flag" @> '{"id": 99999}'::jsonb)
-  LIMIT 1
+  SELECT "posthog_tag"."name"
+  FROM "posthog_taggeditem"
+  INNER JOIN "posthog_tag" ON ("posthog_taggeditem"."tag_id" = "posthog_tag"."id")
+  WHERE "posthog_taggeditem"."feature_flag_id" = 99999
   '''
 # ---
 # name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.81

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -12279,3 +12279,131 @@ class TestFeatureFlagLimits(APIBaseTest):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "Maximum of 2 feature flags allowed per team" in str(response.json())
+
+
+class TestFeatureFlagVersions(APIBaseTest):
+    def _create_flag_via_api(self, key="test-flag", **kwargs):
+        data = {
+            "name": "Test Flag",
+            "key": key,
+            "filters": {"groups": [{"rollout_percentage": 100}]},
+            **kwargs,
+        }
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags",
+            data,
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        return response.json()
+
+    def _update_flag_via_api(self, flag_id, **kwargs):
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/feature_flags/{flag_id}",
+            kwargs,
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        return response.json()
+
+    def test_get_version_1_after_update(self):
+        flag = self._create_flag_via_api(name="V1 Name")
+        flag_id = flag["id"]
+
+        self._update_flag_via_api(flag_id, name="V2 Name", version=flag["version"])
+
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{flag_id}/versions/1/")
+        assert response.status_code == status.HTTP_200_OK
+
+        data = response.json()
+        assert data["version"] == 1
+        assert data["name"] == "V1 Name"
+        assert data["is_historical"] is True
+        assert data["id"] == flag_id
+
+    def test_get_current_version(self):
+        flag = self._create_flag_via_api(name="V1 Name")
+        flag_id = flag["id"]
+
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{flag_id}/versions/1/")
+        assert response.status_code == status.HTTP_200_OK
+
+        data = response.json()
+        assert data["version"] == 1
+        assert data["is_historical"] is False
+
+    def test_version_not_found_returns_404(self):
+        flag = self._create_flag_via_api()
+        flag_id = flag["id"]
+
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{flag_id}/versions/999/")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_version_zero_returns_404(self):
+        flag = self._create_flag_via_api()
+        flag_id = flag["id"]
+
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{flag_id}/versions/0/")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_reconstruct_filters_change(self):
+        v1_filters = {"groups": [{"rollout_percentage": 50}]}
+        v2_filters = {
+            "groups": [
+                {
+                    "rollout_percentage": 100,
+                    "properties": [{"key": "email", "value": "test@example.com", "type": "person"}],
+                }
+            ]
+        }
+
+        flag = self._create_flag_via_api(filters=v1_filters)
+        flag_id = flag["id"]
+
+        self._update_flag_via_api(flag_id, filters=v2_filters, version=flag["version"])
+
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{flag_id}/versions/1/")
+        assert response.status_code == status.HTTP_200_OK
+
+        data = response.json()
+        assert data["filters"]["groups"][0]["rollout_percentage"] == 50
+
+    def test_multiple_versions(self):
+        flag = self._create_flag_via_api(name="V1")
+        flag_id = flag["id"]
+
+        updated = self._update_flag_via_api(flag_id, name="V2", version=flag["version"])
+        self._update_flag_via_api(flag_id, name="V3", version=updated["version"])
+
+        v1 = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{flag_id}/versions/1/").json()
+        v2 = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{flag_id}/versions/2/").json()
+        v3 = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{flag_id}/versions/3/").json()
+
+        assert v1["name"] == "V1"
+        assert v1["is_historical"] is True
+        assert v2["name"] == "V2"
+        assert v2["is_historical"] is True
+        assert v3["name"] == "V3"
+        assert v3["is_historical"] is False
+
+    def test_incomplete_history_returns_422(self):
+        flag = self._create_flag_via_api()
+        flag_id = flag["id"]
+        from posthog.models.feature_flag.feature_flag import FeatureFlag
+
+        FeatureFlag.objects.filter(id=flag_id).update(version=5)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{flag_id}/versions/2/")
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert "incomplete" in response.json()["detail"].lower()
+
+    def test_remote_config_flag_returns_400(self):
+        flag = self._create_flag_via_api()
+        flag_id = flag["id"]
+        from posthog.models.feature_flag.feature_flag import FeatureFlag
+
+        FeatureFlag.objects.filter(id=flag_id).update(is_remote_configuration=True)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{flag_id}/versions/1/")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "remote configuration" in response.json()["detail"].lower()

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -12389,7 +12389,6 @@ class TestFeatureFlagVersions(APIBaseTest):
     def test_incomplete_history_returns_422(self):
         flag = self._create_flag_via_api()
         flag_id = flag["id"]
-        from posthog.models.feature_flag.feature_flag import FeatureFlag
 
         FeatureFlag.objects.filter(id=flag_id).update(version=5)
 
@@ -12400,7 +12399,6 @@ class TestFeatureFlagVersions(APIBaseTest):
     def test_remote_config_flag_returns_400(self):
         flag = self._create_flag_via_api()
         flag_id = flag["id"]
-        from posthog.models.feature_flag.feature_flag import FeatureFlag
 
         FeatureFlag.objects.filter(id=flag_id).update(is_remote_configuration=True)
 

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -12396,12 +12396,18 @@ class TestFeatureFlagVersions(APIBaseTest):
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         assert "incomplete" in response.json()["detail"].lower()
 
-    def test_remote_config_flag_returns_400(self):
+    @parameterized.expand(
+        [
+            ("remote_configuration", {"is_remote_configuration": True}),
+            ("encrypted_payloads", {"has_encrypted_payloads": True}),
+        ]
+    )
+    def test_unsupported_flag_returns_400(self, _name, update_kwargs):
         flag = self._create_flag_via_api()
         flag_id = flag["id"]
 
-        FeatureFlag.objects.filter(id=flag_id).update(is_remote_configuration=True)
+        FeatureFlag.objects.filter(id=flag_id).update(**update_kwargs)
 
         response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{flag_id}/versions/1/")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "remote configuration" in response.json()["detail"].lower()
+        assert "not available" in response.json()["detail"].lower()

--- a/posthog/models/feature_flag/test/test_version_history.py
+++ b/posthog/models/feature_flag/test/test_version_history.py
@@ -1,5 +1,7 @@
 from posthog.test.base import BaseTest
 
+from parameterized import parameterized
+
 from posthog.models.activity_logging.activity_log import Change, ChangeAction, Detail, log_activity
 from posthog.models.feature_flag.feature_flag import FeatureFlag
 from posthog.models.feature_flag.version_history import (
@@ -95,14 +97,17 @@ class TestReconstructFlagAtVersion(BaseTest):
         assert result["key"] == "test-flag"
         assert result["id"] == flag.id
 
-    def test_version_out_of_range_raises(self):
+    @parameterized.expand(
+        [
+            ("below_range", 0),
+            ("above_range", 4),
+        ]
+    )
+    def test_version_out_of_range_raises(self, _name, target_version):
         flag = self._create_flag(version=3)
 
         with self.assertRaises(VersionNotFound):
-            reconstruct_flag_at_version(flag, target_version=0, team_id=self.team.id)
-
-        with self.assertRaises(VersionNotFound):
-            reconstruct_flag_at_version(flag, target_version=4, team_id=self.team.id)
+            reconstruct_flag_at_version(flag, target_version=target_version, team_id=self.team.id)
 
     def test_null_version_raises(self):
         flag = self._create_flag(version=None)
@@ -242,33 +247,21 @@ class TestReconstructFlagAtVersion(BaseTest):
         assert v4["version"] == 4
         assert v4["is_historical"] is False
 
-    def test_reconstruct_filters_without_groups_key_gets_normalized(self):
-        v1_filters: dict = {"some_legacy_key": "value"}
+    @parameterized.expand(
+        [
+            ("none", None, {"groups": []}),
+            ("empty_dict", {}, {"groups": []}),
+            ("missing_groups_key", {"some_legacy_key": "value"}, {"some_legacy_key": "value", "groups": []}),
+        ]
+    )
+    def test_reconstruct_filters_gets_normalized(self, _name, v1_filters, expected):
         v2_filters = {"groups": [{"rollout_percentage": 100}]}
 
         flag = self._create_flag(filters=v2_filters, version=1)
         self._simulate_update(flag, {"filters": (v1_filters, v2_filters)})
 
         result = reconstruct_flag_at_version(flag, target_version=1, team_id=self.team.id)
-        assert result["filters"] == {"some_legacy_key": "value", "groups": []}
-
-    def test_reconstruct_filters_none_gets_normalized(self):
-        v2_filters = {"groups": [{"rollout_percentage": 100}]}
-
-        flag = self._create_flag(filters=v2_filters, version=1)
-        self._simulate_update(flag, {"filters": (None, v2_filters)})
-
-        result = reconstruct_flag_at_version(flag, target_version=1, team_id=self.team.id)
-        assert result["filters"] == {"groups": []}
-
-    def test_reconstruct_filters_empty_dict_gets_normalized(self):
-        v2_filters = {"groups": [{"rollout_percentage": 100}]}
-
-        flag = self._create_flag(filters=v2_filters, version=1)
-        self._simulate_update(flag, {"filters": ({}, v2_filters)})
-
-        result = reconstruct_flag_at_version(flag, target_version=1, team_id=self.team.id)
-        assert result["filters"] == {"groups": []}
+        assert result["filters"] == expected
 
     def test_reconstruct_field_cleared_to_none(self):
         rollback = {"threshold": 5}

--- a/posthog/models/feature_flag/test/test_version_history.py
+++ b/posthog/models/feature_flag/test/test_version_history.py
@@ -242,6 +242,34 @@ class TestReconstructFlagAtVersion(BaseTest):
         assert v4["version"] == 4
         assert v4["is_historical"] is False
 
+    def test_reconstruct_filters_without_groups_key_gets_normalized(self):
+        v1_filters: dict = {"some_legacy_key": "value"}
+        v2_filters = {"groups": [{"rollout_percentage": 100}]}
+
+        flag = self._create_flag(filters=v2_filters, version=1)
+        self._simulate_update(flag, {"filters": (v1_filters, v2_filters)})
+
+        result = reconstruct_flag_at_version(flag, target_version=1, team_id=self.team.id)
+        assert result["filters"] == {"some_legacy_key": "value", "groups": []}
+
+    def test_reconstruct_filters_none_gets_normalized(self):
+        v2_filters = {"groups": [{"rollout_percentage": 100}]}
+
+        flag = self._create_flag(filters=v2_filters, version=1)
+        self._simulate_update(flag, {"filters": (None, v2_filters)})
+
+        result = reconstruct_flag_at_version(flag, target_version=1, team_id=self.team.id)
+        assert result["filters"] == {"groups": []}
+
+    def test_reconstruct_filters_empty_dict_gets_normalized(self):
+        v2_filters = {"groups": [{"rollout_percentage": 100}]}
+
+        flag = self._create_flag(filters=v2_filters, version=1)
+        self._simulate_update(flag, {"filters": ({}, v2_filters)})
+
+        result = reconstruct_flag_at_version(flag, target_version=1, team_id=self.team.id)
+        assert result["filters"] == {"groups": []}
+
     def test_reconstruct_field_cleared_to_none(self):
         rollback = {"threshold": 5}
         flag = self._create_flag(rollback_conditions=rollback, version=1)

--- a/posthog/models/feature_flag/test/test_version_history.py
+++ b/posthog/models/feature_flag/test/test_version_history.py
@@ -1,0 +1,241 @@
+from posthog.test.base import BaseTest
+
+from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
+from posthog.models.feature_flag.feature_flag import FeatureFlag
+from posthog.models.feature_flag.version_history import (
+    VersionHistoryIncomplete,
+    VersionNotFound,
+    reconstruct_flag_at_version,
+)
+
+
+def _log_flag_update(
+    team_id: int,
+    org_id,
+    user,
+    flag: FeatureFlag,
+    changes: list[Change],
+) -> None:
+    log_activity(
+        organization_id=org_id,
+        team_id=team_id,
+        user=user,
+        was_impersonated=False,
+        item_id=flag.id,
+        scope="FeatureFlag",
+        activity="updated",
+        detail=Detail(changes=changes, name=flag.key),
+    )
+
+
+class TestReconstructFlagAtVersion(BaseTest):
+    def _create_flag(self, **kwargs) -> FeatureFlag:
+        defaults = {
+            "team": self.team,
+            "created_by": self.user,
+            "key": "test-flag",
+            "name": "Test Flag",
+            "filters": {"groups": [{"rollout_percentage": 100}]},
+            "active": True,
+            "version": 1,
+        }
+        defaults.update(kwargs)
+        return FeatureFlag.objects.create(**defaults)
+
+    def _simulate_update(
+        self,
+        flag: FeatureFlag,
+        changes: dict,
+    ) -> None:
+        old_version = flag.version
+        new_version = old_version + 1
+
+        activity_changes = [
+            Change(type="FeatureFlag", action="changed", field="version", before=old_version, after=new_version)
+        ]
+        for field, (before, after) in changes.items():
+            if before is None and after is not None:
+                action = "created"
+            elif before is not None and after is None:
+                action = "deleted"
+            else:
+                action = "changed"
+            activity_changes.append(Change(type="FeatureFlag", action=action, field=field, before=before, after=after))
+
+        # Update the flag in the DB
+        flag.version = new_version
+        for field, (_, after) in changes.items():
+            setattr(flag, field, after)
+        flag.save()
+
+        _log_flag_update(
+            team_id=self.team.id,
+            org_id=self.organization.id,
+            user=self.user,
+            flag=flag,
+            changes=activity_changes,
+        )
+
+    def test_current_version_returns_current_state(self):
+        flag = self._create_flag(version=3)
+        result = reconstruct_flag_at_version(flag, target_version=3, team_id=self.team.id)
+
+        assert result["is_historical"] is False
+        assert result["version"] == 3
+        assert result["key"] == "test-flag"
+        assert result["id"] == flag.id
+
+    def test_version_out_of_range_raises(self):
+        flag = self._create_flag(version=3)
+
+        with self.assertRaises(VersionNotFound):
+            reconstruct_flag_at_version(flag, target_version=0, team_id=self.team.id)
+
+        with self.assertRaises(VersionNotFound):
+            reconstruct_flag_at_version(flag, target_version=4, team_id=self.team.id)
+
+    def test_null_version_raises(self):
+        flag = self._create_flag(version=None)
+
+        with self.assertRaises(VersionHistoryIncomplete):
+            reconstruct_flag_at_version(flag, target_version=1, team_id=self.team.id)
+
+    def test_reconstruct_version_1_from_version_2(self):
+        flag = self._create_flag(name="Original Name", version=1)
+        self._simulate_update(flag, {"name": ("Original Name", "Updated Name")})
+
+        result = reconstruct_flag_at_version(flag, target_version=1, team_id=self.team.id)
+
+        assert result["is_historical"] is True
+        assert result["version"] == 1
+        assert result["name"] == "Original Name"
+        assert result["created_by"] == self.user.id
+
+    def test_reconstruct_version_1_from_version_3(self):
+        flag = self._create_flag(name="V1 Name", active=True, version=1)
+        self._simulate_update(flag, {"name": ("V1 Name", "V2 Name")})
+        self._simulate_update(flag, {"name": ("V2 Name", "V3 Name"), "active": (True, False)})
+
+        result = reconstruct_flag_at_version(flag, target_version=1, team_id=self.team.id)
+        assert result["version"] == 1
+        assert result["name"] == "V1 Name"
+        assert result["active"] is True
+
+    def test_reconstruct_intermediate_version(self):
+        flag = self._create_flag(name="V1 Name", active=True, version=1)
+        self._simulate_update(flag, {"name": ("V1 Name", "V2 Name")})
+        self._simulate_update(flag, {"name": ("V2 Name", "V3 Name")})
+        self._simulate_update(flag, {"active": (True, False)})
+
+        result = reconstruct_flag_at_version(flag, target_version=2, team_id=self.team.id)
+        assert result["version"] == 2
+        assert result["name"] == "V2 Name"
+        assert result["active"] is True
+        assert result["is_historical"] is True
+
+    def test_reconstruct_complex_filters(self):
+        v1_filters = {"groups": [{"rollout_percentage": 50}]}
+        v2_filters = {"groups": [{"rollout_percentage": 100, "properties": [{"key": "email", "value": "test"}]}]}
+
+        flag = self._create_flag(filters=v1_filters, version=1)
+        self._simulate_update(flag, {"filters": (v1_filters, v2_filters)})
+
+        result = reconstruct_flag_at_version(flag, target_version=1, team_id=self.team.id)
+        assert result["filters"] == v1_filters
+
+    def test_reconstruct_boolean_field_flips(self):
+        flag = self._create_flag(active=True, version=1)
+        self._simulate_update(flag, {"active": (True, False)})
+        self._simulate_update(flag, {"active": (False, True)})
+
+        v1 = reconstruct_flag_at_version(flag, target_version=1, team_id=self.team.id)
+        assert v1["active"] is True
+
+        v2 = reconstruct_flag_at_version(flag, target_version=2, team_id=self.team.id)
+        assert v2["active"] is False
+
+    def test_reconstruct_field_set_from_none(self):
+        flag = self._create_flag(rollback_conditions=None, version=1)
+        rollback = {"threshold": 5}
+        self._simulate_update(flag, {"rollback_conditions": (None, rollback)})
+
+        result = reconstruct_flag_at_version(flag, target_version=1, team_id=self.team.id)
+        assert result["rollback_conditions"] is None
+
+    def test_reconstruct_multiple_fields_in_one_update(self):
+        flag = self._create_flag(name="V1", active=True, version=1)
+        v1_filters = flag.filters
+        v2_filters = {"groups": [{"rollout_percentage": 50}]}
+
+        self._simulate_update(
+            flag,
+            {
+                "name": ("V1", "V2"),
+                "active": (True, False),
+                "filters": (v1_filters, v2_filters),
+            },
+        )
+
+        result = reconstruct_flag_at_version(flag, target_version=1, team_id=self.team.id)
+        assert result["name"] == "V1"
+        assert result["active"] is True
+        assert result["filters"] == v1_filters
+
+    def test_missing_activity_log_raises(self):
+        flag = self._create_flag(version=5)
+        # No activity log entries exist — can't reconstruct anything before current
+
+        with self.assertRaises(VersionHistoryIncomplete):
+            reconstruct_flag_at_version(flag, target_version=2, team_id=self.team.id)
+
+    def test_version_timestamp_for_version_1(self):
+        flag = self._create_flag(version=1)
+        self._simulate_update(flag, {"name": ("V1", "V2")})
+
+        result = reconstruct_flag_at_version(flag, target_version=1, team_id=self.team.id)
+        assert result["version_timestamp"] == flag.created_at
+        assert result["modified_by"] == self.user.id
+
+    def test_version_timestamp_for_intermediate_version(self):
+        flag = self._create_flag(version=1)
+        self._simulate_update(flag, {"name": ("V1", "V2")})
+        self._simulate_update(flag, {"name": ("V2", "V3")})
+
+        result = reconstruct_flag_at_version(flag, target_version=2, team_id=self.team.id)
+        assert result["version_timestamp"] is not None
+        assert result["modified_by"] == self.user.id
+
+    def test_reconstruct_all_versions_sequentially(self):
+        flag = self._create_flag(name="V1", active=True, version=1)
+        self._simulate_update(flag, {"name": ("V1", "V2")})
+        self._simulate_update(flag, {"name": ("V2", "V3"), "active": (True, False)})
+        self._simulate_update(flag, {"name": ("V3", "V4"), "active": (False, True)})
+
+        v1 = reconstruct_flag_at_version(flag, target_version=1, team_id=self.team.id)
+        assert v1["name"] == "V1"
+        assert v1["active"] is True
+        assert v1["version"] == 1
+
+        v2 = reconstruct_flag_at_version(flag, target_version=2, team_id=self.team.id)
+        assert v2["name"] == "V2"
+        assert v2["active"] is True
+        assert v2["version"] == 2
+
+        v3 = reconstruct_flag_at_version(flag, target_version=3, team_id=self.team.id)
+        assert v3["name"] == "V3"
+        assert v3["active"] is False
+        assert v3["version"] == 3
+
+        v4 = reconstruct_flag_at_version(flag, target_version=4, team_id=self.team.id)
+        assert v4["name"] == "V4"
+        assert v4["active"] is True
+        assert v4["version"] == 4
+        assert v4["is_historical"] is False
+
+    def test_reconstruct_field_cleared_to_none(self):
+        rollback = {"threshold": 5}
+        flag = self._create_flag(rollback_conditions=rollback, version=1)
+        self._simulate_update(flag, {"rollback_conditions": (rollback, None)})
+
+        result = reconstruct_flag_at_version(flag, target_version=1, team_id=self.team.id)
+        assert result["rollback_conditions"] == {"threshold": 5}

--- a/posthog/models/feature_flag/test/test_version_history.py
+++ b/posthog/models/feature_flag/test/test_version_history.py
@@ -1,8 +1,9 @@
 from posthog.test.base import BaseTest
 
-from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
+from posthog.models.activity_logging.activity_log import Change, ChangeAction, Detail, log_activity
 from posthog.models.feature_flag.feature_flag import FeatureFlag
 from posthog.models.feature_flag.version_history import (
+    RECONSTRUCTABLE_FIELDS,
     VersionHistoryIncomplete,
     VersionNotFound,
     reconstruct_flag_at_version,
@@ -47,6 +48,7 @@ class TestReconstructFlagAtVersion(BaseTest):
         flag: FeatureFlag,
         changes: dict,
     ) -> None:
+        assert flag.version is not None
         old_version = flag.version
         new_version = old_version + 1
 
@@ -54,12 +56,13 @@ class TestReconstructFlagAtVersion(BaseTest):
             Change(type="FeatureFlag", action="changed", field="version", before=old_version, after=new_version)
         ]
         for field, (before, after) in changes.items():
-            if before is None and after is not None:
-                action = "created"
-            elif before is not None and after is None:
-                action = "deleted"
-            else:
-                action = "changed"
+            action: ChangeAction = (
+                "created"
+                if before is None and after is not None
+                else "deleted"
+                if before is not None and after is None
+                else "changed"
+            )
             activity_changes.append(Change(type="FeatureFlag", action=action, field=field, before=before, after=after))
 
         # Update the flag in the DB
@@ -75,6 +78,13 @@ class TestReconstructFlagAtVersion(BaseTest):
             flag=flag,
             changes=activity_changes,
         )
+
+    def test_reconstructable_fields_are_concrete_model_fields(self):
+        flag = self._create_flag()
+        for field in RECONSTRUCTABLE_FIELDS:
+            assert hasattr(flag, field), (
+                f"RECONSTRUCTABLE_FIELDS contains '{field}' which is not a concrete attribute on FeatureFlag"
+            )
 
     def test_current_version_returns_current_state(self):
         flag = self._create_flag(version=3)

--- a/posthog/models/feature_flag/version_history.py
+++ b/posthog/models/feature_flag/version_history.py
@@ -16,7 +16,7 @@ class VersionHistoryIncomplete(Exception):
 def _get_reconstructable_fields() -> frozenset[str]:
     """Derive tracked fields dynamically so new FeatureFlag fields are picked up automatically."""
     excluded = set(common_field_exclusions) | set(field_exclusions.get("FeatureFlag", []))
-    return frozenset(f.name for f in FeatureFlag._meta.get_fields() if f.name not in excluded)
+    return frozenset(f.name for f in FeatureFlag._meta.get_fields() if f.name not in excluded and hasattr(f, "column"))
 
 
 RECONSTRUCTABLE_FIELDS = _get_reconstructable_fields()

--- a/posthog/models/feature_flag/version_history.py
+++ b/posthog/models/feature_flag/version_history.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any
 
-from posthog.models.activity_logging.activity_log import ActivityLog
+from posthog.models.activity_logging.activity_log import ActivityLog, common_field_exclusions, field_exclusions
 from posthog.models.feature_flag.feature_flag import FeatureFlag
 
 
@@ -13,28 +13,13 @@ class VersionHistoryIncomplete(Exception):
     pass
 
 
-# Fields tracked in the activity log for feature flags.
-# Must stay in sync with the fields that changes_between() compares
-# (i.e. FeatureFlag model fields minus common_field_exclusions and
-# field_exclusions["FeatureFlag"] in activity_log.py).
-RECONSTRUCTABLE_FIELDS = frozenset(
-    [
-        "key",
-        "name",
-        "filters",
-        "active",
-        "deleted",
-        "version",
-        "rollback_conditions",
-        "performed_rollback",
-        "ensure_experience_continuity",
-        "is_remote_configuration",
-        "has_encrypted_payloads",
-        "evaluation_runtime",
-        "bucketing_identifier",
-        "has_enriched_analytics",
-    ]
-)
+def _get_reconstructable_fields() -> frozenset[str]:
+    """Derive tracked fields dynamically so new FeatureFlag fields are picked up automatically."""
+    excluded = set(common_field_exclusions) | set(field_exclusions.get("FeatureFlag", []))
+    return frozenset(f.name for f in FeatureFlag._meta.get_fields() if f.name not in excluded)
+
+
+RECONSTRUCTABLE_FIELDS = _get_reconstructable_fields()
 
 # Fields that need special accessor logic instead of plain getattr.
 _FIELD_ACCESSORS: dict[str, Any] = {

--- a/posthog/models/feature_flag/version_history.py
+++ b/posthog/models/feature_flag/version_history.py
@@ -144,6 +144,13 @@ def reconstruct_flag_at_version(
         else:
             raise VersionHistoryIncomplete(f"Activity log is incomplete. Cannot reconstruct version {target_version}.")
 
+    # Normalize filters to always include "groups", matching get_filters() behavior.
+    raw_filters = fields.get("filters")
+    if not raw_filters:
+        fields["filters"] = {"groups": []}
+    elif "groups" not in raw_filters:
+        fields["filters"] = {**raw_filters, "groups": []}
+
     return _build_response(
         flag,
         fields,

--- a/posthog/models/feature_flag/version_history.py
+++ b/posthog/models/feature_flag/version_history.py
@@ -1,0 +1,168 @@
+from datetime import datetime
+from typing import Any
+
+from posthog.models.activity_logging.activity_log import ActivityLog
+from posthog.models.feature_flag.feature_flag import FeatureFlag
+
+
+class VersionNotFound(Exception):
+    pass
+
+
+class VersionHistoryIncomplete(Exception):
+    pass
+
+
+# Fields tracked in the activity log for feature flags.
+# Must stay in sync with the fields that changes_between() compares
+# (i.e. FeatureFlag model fields minus common_field_exclusions and
+# field_exclusions["FeatureFlag"] in activity_log.py).
+RECONSTRUCTABLE_FIELDS = frozenset(
+    [
+        "key",
+        "name",
+        "filters",
+        "active",
+        "deleted",
+        "version",
+        "rollback_conditions",
+        "performed_rollback",
+        "ensure_experience_continuity",
+        "is_remote_configuration",
+        "has_encrypted_payloads",
+        "evaluation_runtime",
+        "bucketing_identifier",
+        "has_enriched_analytics",
+    ]
+)
+
+# Fields that need special accessor logic instead of plain getattr.
+_FIELD_ACCESSORS: dict[str, Any] = {
+    "filters": lambda flag: flag.get_filters(),
+}
+
+
+def _extract_tracked_fields(flag: FeatureFlag) -> dict[str, Any]:
+    return {
+        field: _FIELD_ACCESSORS[field](flag) if field in _FIELD_ACCESSORS else getattr(flag, field)
+        for field in RECONSTRUCTABLE_FIELDS
+    }
+
+
+def _build_response(
+    flag: FeatureFlag,
+    fields: dict[str, Any],
+    *,
+    is_historical: bool,
+    version_timestamp: datetime | None,
+    modified_by: int | None,
+) -> dict[str, Any]:
+    return {
+        **fields,
+        "id": flag.id,
+        "created_at": flag.created_at,
+        "created_by": flag.created_by_id,
+        "is_historical": is_historical,
+        "version_timestamp": version_timestamp,
+        "modified_by": modified_by,
+    }
+
+
+def _get_version_after(changes: list[dict[str, Any]]) -> int | None:
+    """Extract the 'after' value from the version change in an activity log entry."""
+    for change in changes:
+        if change.get("field") == "version":
+            return change.get("after")
+    return None
+
+
+def reconstruct_flag_at_version(
+    flag: FeatureFlag,
+    target_version: int,
+    team_id: int,
+) -> dict[str, Any]:
+    """
+    Reconstruct a feature flag's state at a given version by working
+    backward from the current state using the activity log.
+
+    Returns a dict of field values representing the flag at that version.
+
+    Raises VersionNotFound if the version is out of range.
+    Raises VersionHistoryIncomplete if activity log entries are missing.
+    """
+    current_version = flag.version
+    if current_version is None:
+        raise VersionHistoryIncomplete("Flag has no version set")
+
+    if target_version < 1 or target_version > current_version:
+        raise VersionNotFound(f"Version {target_version} not found (current version is {current_version})")
+
+    fields = _extract_tracked_fields(flag)
+
+    if target_version == current_version:
+        return _build_response(
+            flag,
+            fields,
+            is_historical=False,
+            version_timestamp=flag.updated_at or flag.created_at,
+            modified_by=flag.last_modified_by_id,
+        )
+
+    # Fetch activity log entries that bump the version, newest first, streaming
+    # with .iterator() so we stop reading from the DB once we reach the target.
+    # Soft-delete and restore also bump the version but are logged as "deleted"
+    # and "restored" rather than "updated".
+    entries = (
+        ActivityLog.objects.filter(
+            team_id=team_id,
+            scope="FeatureFlag",
+            item_id=str(flag.id),
+            activity__in=["updated", "deleted", "restored"],
+        )
+        .order_by("-created_at", "-id")
+        .values_list("detail", "created_at", "user_id")
+        .iterator()
+    )
+
+    # Walk backwards, undoing changes until we reach the target version.
+    # Each entry with version_after > target_version needs to be undone.
+    # The entry with version_after == target_version created our target — use its metadata.
+    version_timestamp = None
+    modified_by = None
+    reached_target = False
+
+    for detail, created_at, user_id in entries:
+        changes = (detail or {}).get("changes") or []
+        version_after = _get_version_after(changes)
+
+        if version_after is None:
+            continue
+
+        if version_after == target_version:
+            version_timestamp = created_at
+            modified_by = user_id
+            reached_target = True
+            break
+
+        if version_after > target_version:
+            for change in changes:
+                field = change.get("field")
+                if field and field in RECONSTRUCTABLE_FIELDS:
+                    fields[field] = change.get("before")
+
+    if not reached_target:
+        if target_version == 1:
+            # Version 1 is the creation — no activity log entry transitions "into" it.
+            # We've undone all entries, so fields now represent the creation state.
+            version_timestamp = flag.created_at
+            modified_by = flag.created_by_id
+        else:
+            raise VersionHistoryIncomplete(f"Activity log is incomplete. Cannot reconstruct version {target_version}.")
+
+    return _build_response(
+        flag,
+        fields,
+        is_historical=True,
+        version_timestamp=version_timestamp,
+        modified_by=modified_by,
+    )

--- a/posthog/models/feature_flag/version_history.py
+++ b/posthog/models/feature_flag/version_history.py
@@ -134,6 +134,9 @@ def reconstruct_flag_at_version(
                 field = change.get("field")
                 if field and field in RECONSTRUCTABLE_FIELDS:
                     fields[field] = change.get("before")
+        elif version_after < target_version:
+            # Entries are newest-first; falling below the target means its entry is missing.
+            break
 
     if not reached_target:
         if target_version == 1:

--- a/posthog/models/feature_flag/version_history.py
+++ b/posthog/models/feature_flag/version_history.py
@@ -21,6 +21,11 @@ def _get_reconstructable_fields() -> frozenset[str]:
 
 RECONSTRUCTABLE_FIELDS = _get_reconstructable_fields()
 
+# Safety cap on the number of activity log entries scanned when walking backwards.
+# In normal use we stop early once we reach the target version; this bound protects
+# against unbounded scans if the activity log is malformed or much larger than expected.
+MAX_HISTORY_ENTRIES = 10_000
+
 # Fields that need special accessor logic instead of plain getattr.
 _FIELD_ACCESSORS: dict[str, Any] = {
     "filters": lambda flag: flag.get_filters(),
@@ -105,7 +110,7 @@ def reconstruct_flag_at_version(
             activity__in=["updated", "deleted", "restored"],
         )
         .order_by("-created_at", "-id")
-        .values_list("detail", "created_at", "user_id")
+        .values_list("detail", "created_at", "user_id")[:MAX_HISTORY_ENTRIES]
         .iterator()
     )
 
@@ -147,7 +152,9 @@ def reconstruct_flag_at_version(
         else:
             raise VersionHistoryIncomplete(f"Activity log is incomplete. Cannot reconstruct version {target_version}.")
 
-    # Normalize filters to always include "groups", matching get_filters() behavior.
+    # Historical activity log entries may store filters in legacy shapes
+    # (None, {}, or missing "groups"). Normalize so the response shape is
+    # predictable for API consumers.
     raw_filters = fields.get("filters")
     if not raw_filters:
         fields["filters"] = {"groups": []}

--- a/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
+++ b/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
@@ -251,45 +251,6 @@
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.18
   '''
-  SELECT "ee_featureflagroleaccess"."id",
-         "ee_featureflagroleaccess"."feature_flag_id",
-         "ee_featureflagroleaccess"."role_id",
-         "ee_featureflagroleaccess"."added_at",
-         "ee_featureflagroleaccess"."updated_at"
-  FROM "ee_featureflagroleaccess"
-  WHERE "ee_featureflagroleaccess"."feature_flag_id" = 99999
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.19
-  '''
-  SELECT "ee_featureflagroleaccess"."id",
-         "ee_featureflagroleaccess"."feature_flag_id",
-         "ee_featureflagroleaccess"."role_id",
-         "ee_featureflagroleaccess"."added_at",
-         "ee_featureflagroleaccess"."updated_at"
-  FROM "ee_featureflagroleaccess"
-  WHERE "ee_featureflagroleaccess"."feature_flag_id" = 99999
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.2
-  '''
-  SELECT "posthog_organizationintegration"."id",
-         "posthog_organizationintegration"."organization_id",
-         "posthog_organizationintegration"."kind",
-         "posthog_organizationintegration"."integration_id",
-         "posthog_organizationintegration"."config",
-         "posthog_organizationintegration"."sensitive_config",
-         "posthog_organizationintegration"."created_by_id",
-         "posthog_organizationintegration"."created_at",
-         "posthog_organizationintegration"."updated_at"
-  FROM "posthog_organizationintegration"
-  WHERE ("posthog_organizationintegration"."kind" = 'vercel'
-         AND "posthog_organizationintegration"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)
-  LIMIT 21
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.20
-  '''
   SELECT "posthog_experiment"."id",
          "posthog_experiment"."name",
          "posthog_experiment"."description",
@@ -324,7 +285,7 @@
   WHERE "posthog_experiment"."feature_flag_id" = 99999
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.21
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.19
   '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -362,7 +323,24 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.22
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.2
+  '''
+  SELECT "posthog_organizationintegration"."id",
+         "posthog_organizationintegration"."organization_id",
+         "posthog_organizationintegration"."kind",
+         "posthog_organizationintegration"."integration_id",
+         "posthog_organizationintegration"."config",
+         "posthog_organizationintegration"."sensitive_config",
+         "posthog_organizationintegration"."created_by_id",
+         "posthog_organizationintegration"."created_at",
+         "posthog_organizationintegration"."updated_at"
+  FROM "posthog_organizationintegration"
+  WHERE ("posthog_organizationintegration"."kind" = 'vercel'
+         AND "posthog_organizationintegration"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)
+  LIMIT 21
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.20
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -466,7 +444,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.23
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.21
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -504,7 +482,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.24
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.22
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -542,7 +520,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.25
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.23
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -646,7 +624,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.26
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.24
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -677,7 +655,7 @@
   UPDATE
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.27
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.25
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -708,7 +686,7 @@
   LIMIT 1
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.28
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.26
   '''
   SELECT "posthog_filesystem"."team_id",
          "posthog_filesystem"."id",
@@ -730,7 +708,7 @@
                   AND "posthog_filesystem"."shortcut" IS NOT NULL))
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.29
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.27
   '''
   SELECT "posthog_filesystemshortcut"."id",
          "posthog_filesystemshortcut"."team_id",
@@ -749,35 +727,7 @@
                   AND "posthog_filesystemshortcut"."href" IS NOT NULL))
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.3
-  '''
-  SELECT "posthog_scheduledchange"."id",
-         "posthog_scheduledchange"."record_id",
-         "posthog_scheduledchange"."model_name",
-         "posthog_scheduledchange"."payload",
-         "posthog_scheduledchange"."scheduled_at",
-         "posthog_scheduledchange"."executed_at",
-         "posthog_scheduledchange"."failure_reason",
-         "posthog_scheduledchange"."failure_count",
-         "posthog_scheduledchange"."is_recurring",
-         "posthog_scheduledchange"."recurrence_interval",
-         "posthog_scheduledchange"."last_executed_at",
-         "posthog_scheduledchange"."cron_expression",
-         "posthog_scheduledchange"."end_date",
-         "posthog_scheduledchange"."team_id",
-         "posthog_scheduledchange"."created_at",
-         "posthog_scheduledchange"."created_by_id",
-         "posthog_scheduledchange"."updated_at"
-  FROM "posthog_scheduledchange"
-  WHERE ("posthog_scheduledchange"."executed_at" IS NULL
-         AND "posthog_scheduledchange"."scheduled_at" <= '2023-12-21 09:00:00+00:00'::timestamptz)
-  ORDER BY "posthog_scheduledchange"."scheduled_at" ASC
-  LIMIT 10000
-  FOR
-  UPDATE NOWAIT
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.30
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.28
   '''
   SELECT "posthog_integration"."id",
          "posthog_integration"."team_id",
@@ -794,7 +744,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.31
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.29
   '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -832,7 +782,35 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.32
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.3
+  '''
+  SELECT "posthog_scheduledchange"."id",
+         "posthog_scheduledchange"."record_id",
+         "posthog_scheduledchange"."model_name",
+         "posthog_scheduledchange"."payload",
+         "posthog_scheduledchange"."scheduled_at",
+         "posthog_scheduledchange"."executed_at",
+         "posthog_scheduledchange"."failure_reason",
+         "posthog_scheduledchange"."failure_count",
+         "posthog_scheduledchange"."is_recurring",
+         "posthog_scheduledchange"."recurrence_interval",
+         "posthog_scheduledchange"."last_executed_at",
+         "posthog_scheduledchange"."cron_expression",
+         "posthog_scheduledchange"."end_date",
+         "posthog_scheduledchange"."team_id",
+         "posthog_scheduledchange"."created_at",
+         "posthog_scheduledchange"."created_by_id",
+         "posthog_scheduledchange"."updated_at"
+  FROM "posthog_scheduledchange"
+  WHERE ("posthog_scheduledchange"."executed_at" IS NULL
+         AND "posthog_scheduledchange"."scheduled_at" <= '2023-12-21 09:00:00+00:00'::timestamptz)
+  ORDER BY "posthog_scheduledchange"."scheduled_at" ASC
+  LIMIT 10000
+  FOR
+  UPDATE NOWAIT
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.30
   '''
   SELECT "posthog_organizationintegration"."id",
          "posthog_organizationintegration"."organization_id",
@@ -849,7 +827,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.33
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.31
   '''
   SELECT "posthog_taggeditem"."id",
          "posthog_taggeditem"."tag_id",
@@ -863,135 +841,113 @@
          "posthog_taggeditem"."ticket_id"
   FROM "posthog_taggeditem"
   WHERE "posthog_taggeditem"."feature_flag_id" = 99999
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.32
+  '''
+  SELECT "posthog_taggeditem"."id",
+         "posthog_taggeditem"."tag_id",
+         "posthog_taggeditem"."dashboard_id",
+         "posthog_taggeditem"."insight_id",
+         "posthog_taggeditem"."event_definition_id",
+         "posthog_taggeditem"."property_definition_id",
+         "posthog_taggeditem"."action_id",
+         "posthog_taggeditem"."feature_flag_id",
+         "posthog_taggeditem"."experiment_saved_metric_id",
+         "posthog_taggeditem"."ticket_id"
+  FROM "posthog_taggeditem"
+  WHERE "posthog_taggeditem"."feature_flag_id" = 99999
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.33
+  '''
+  SELECT "posthog_survey"."id",
+         "posthog_survey"."team_id",
+         "posthog_survey"."name",
+         "posthog_survey"."description",
+         "posthog_survey"."linked_flag_id",
+         "posthog_survey"."targeting_flag_id",
+         "posthog_survey"."linked_insight_id",
+         "posthog_survey"."internal_targeting_flag_id",
+         "posthog_survey"."internal_response_sampling_flag_id",
+         "posthog_survey"."type",
+         "posthog_survey"."conditions",
+         "posthog_survey"."questions",
+         "posthog_survey"."appearance",
+         "posthog_survey"."created_at",
+         "posthog_survey"."created_by_id",
+         "posthog_survey"."start_date",
+         "posthog_survey"."end_date",
+         "posthog_survey"."updated_at",
+         "posthog_survey"."archived",
+         "posthog_survey"."responses_limit",
+         "posthog_survey"."response_sampling_start_date",
+         "posthog_survey"."response_sampling_interval_type",
+         "posthog_survey"."response_sampling_interval",
+         "posthog_survey"."response_sampling_limit",
+         "posthog_survey"."response_sampling_daily_limits",
+         "posthog_survey"."iteration_count",
+         "posthog_survey"."iteration_frequency_days",
+         "posthog_survey"."iteration_start_dates",
+         "posthog_survey"."current_iteration",
+         "posthog_survey"."current_iteration_start_date",
+         "posthog_survey"."schedule",
+         "posthog_survey"."enable_partial_responses",
+         "posthog_survey"."enable_iframe_embedding",
+         "posthog_survey"."headline_summary",
+         "posthog_survey"."headline_response_count",
+         "posthog_survey"."question_summaries",
+         "posthog_survey"."form_content",
+         "posthog_survey"."translations"
+  FROM "posthog_survey"
+  WHERE "posthog_survey"."internal_response_sampling_flag_id" = 99999
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.34
   '''
-  SELECT "posthog_taggeditem"."id",
-         "posthog_taggeditem"."tag_id",
-         "posthog_taggeditem"."dashboard_id",
-         "posthog_taggeditem"."insight_id",
-         "posthog_taggeditem"."event_definition_id",
-         "posthog_taggeditem"."property_definition_id",
-         "posthog_taggeditem"."action_id",
-         "posthog_taggeditem"."feature_flag_id",
-         "posthog_taggeditem"."experiment_saved_metric_id",
-         "posthog_taggeditem"."ticket_id"
-  FROM "posthog_taggeditem"
-  WHERE "posthog_taggeditem"."feature_flag_id" = 99999
+  SELECT "posthog_survey"."id",
+         "posthog_survey"."team_id",
+         "posthog_survey"."name",
+         "posthog_survey"."description",
+         "posthog_survey"."linked_flag_id",
+         "posthog_survey"."targeting_flag_id",
+         "posthog_survey"."linked_insight_id",
+         "posthog_survey"."internal_targeting_flag_id",
+         "posthog_survey"."internal_response_sampling_flag_id",
+         "posthog_survey"."type",
+         "posthog_survey"."conditions",
+         "posthog_survey"."questions",
+         "posthog_survey"."appearance",
+         "posthog_survey"."created_at",
+         "posthog_survey"."created_by_id",
+         "posthog_survey"."start_date",
+         "posthog_survey"."end_date",
+         "posthog_survey"."updated_at",
+         "posthog_survey"."archived",
+         "posthog_survey"."responses_limit",
+         "posthog_survey"."response_sampling_start_date",
+         "posthog_survey"."response_sampling_interval_type",
+         "posthog_survey"."response_sampling_interval",
+         "posthog_survey"."response_sampling_limit",
+         "posthog_survey"."response_sampling_daily_limits",
+         "posthog_survey"."iteration_count",
+         "posthog_survey"."iteration_frequency_days",
+         "posthog_survey"."iteration_start_dates",
+         "posthog_survey"."current_iteration",
+         "posthog_survey"."current_iteration_start_date",
+         "posthog_survey"."schedule",
+         "posthog_survey"."enable_partial_responses",
+         "posthog_survey"."enable_iframe_embedding",
+         "posthog_survey"."headline_summary",
+         "posthog_survey"."headline_response_count",
+         "posthog_survey"."question_summaries",
+         "posthog_survey"."form_content",
+         "posthog_survey"."translations"
+  FROM "posthog_survey"
+  WHERE "posthog_survey"."internal_response_sampling_flag_id" = 99999
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.35
-  '''
-  SELECT "posthog_survey"."id",
-         "posthog_survey"."team_id",
-         "posthog_survey"."name",
-         "posthog_survey"."description",
-         "posthog_survey"."linked_flag_id",
-         "posthog_survey"."targeting_flag_id",
-         "posthog_survey"."linked_insight_id",
-         "posthog_survey"."internal_targeting_flag_id",
-         "posthog_survey"."internal_response_sampling_flag_id",
-         "posthog_survey"."type",
-         "posthog_survey"."conditions",
-         "posthog_survey"."questions",
-         "posthog_survey"."appearance",
-         "posthog_survey"."created_at",
-         "posthog_survey"."created_by_id",
-         "posthog_survey"."start_date",
-         "posthog_survey"."end_date",
-         "posthog_survey"."updated_at",
-         "posthog_survey"."archived",
-         "posthog_survey"."responses_limit",
-         "posthog_survey"."response_sampling_start_date",
-         "posthog_survey"."response_sampling_interval_type",
-         "posthog_survey"."response_sampling_interval",
-         "posthog_survey"."response_sampling_limit",
-         "posthog_survey"."response_sampling_daily_limits",
-         "posthog_survey"."iteration_count",
-         "posthog_survey"."iteration_frequency_days",
-         "posthog_survey"."iteration_start_dates",
-         "posthog_survey"."current_iteration",
-         "posthog_survey"."current_iteration_start_date",
-         "posthog_survey"."schedule",
-         "posthog_survey"."enable_partial_responses",
-         "posthog_survey"."enable_iframe_embedding",
-         "posthog_survey"."headline_summary",
-         "posthog_survey"."headline_response_count",
-         "posthog_survey"."question_summaries",
-         "posthog_survey"."form_content",
-         "posthog_survey"."translations"
-  FROM "posthog_survey"
-  WHERE "posthog_survey"."internal_response_sampling_flag_id" = 99999
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.36
-  '''
-  SELECT "posthog_survey"."id",
-         "posthog_survey"."team_id",
-         "posthog_survey"."name",
-         "posthog_survey"."description",
-         "posthog_survey"."linked_flag_id",
-         "posthog_survey"."targeting_flag_id",
-         "posthog_survey"."linked_insight_id",
-         "posthog_survey"."internal_targeting_flag_id",
-         "posthog_survey"."internal_response_sampling_flag_id",
-         "posthog_survey"."type",
-         "posthog_survey"."conditions",
-         "posthog_survey"."questions",
-         "posthog_survey"."appearance",
-         "posthog_survey"."created_at",
-         "posthog_survey"."created_by_id",
-         "posthog_survey"."start_date",
-         "posthog_survey"."end_date",
-         "posthog_survey"."updated_at",
-         "posthog_survey"."archived",
-         "posthog_survey"."responses_limit",
-         "posthog_survey"."response_sampling_start_date",
-         "posthog_survey"."response_sampling_interval_type",
-         "posthog_survey"."response_sampling_interval",
-         "posthog_survey"."response_sampling_limit",
-         "posthog_survey"."response_sampling_daily_limits",
-         "posthog_survey"."iteration_count",
-         "posthog_survey"."iteration_frequency_days",
-         "posthog_survey"."iteration_start_dates",
-         "posthog_survey"."current_iteration",
-         "posthog_survey"."current_iteration_start_date",
-         "posthog_survey"."schedule",
-         "posthog_survey"."enable_partial_responses",
-         "posthog_survey"."enable_iframe_embedding",
-         "posthog_survey"."headline_summary",
-         "posthog_survey"."headline_response_count",
-         "posthog_survey"."question_summaries",
-         "posthog_survey"."form_content",
-         "posthog_survey"."translations"
-  FROM "posthog_survey"
-  WHERE "posthog_survey"."internal_response_sampling_flag_id" = 99999
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.37
-  '''
-  SELECT "ee_featureflagroleaccess"."id",
-         "ee_featureflagroleaccess"."feature_flag_id",
-         "ee_featureflagroleaccess"."role_id",
-         "ee_featureflagroleaccess"."added_at",
-         "ee_featureflagroleaccess"."updated_at"
-  FROM "ee_featureflagroleaccess"
-  WHERE "ee_featureflagroleaccess"."feature_flag_id" = 99999
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.38
-  '''
-  SELECT "ee_featureflagroleaccess"."id",
-         "ee_featureflagroleaccess"."feature_flag_id",
-         "ee_featureflagroleaccess"."role_id",
-         "ee_featureflagroleaccess"."added_at",
-         "ee_featureflagroleaccess"."updated_at"
-  FROM "ee_featureflagroleaccess"
-  WHERE "ee_featureflagroleaccess"."feature_flag_id" = 99999
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.39
   '''
   SELECT "posthog_experiment"."id",
          "posthog_experiment"."name",
@@ -1025,6 +981,196 @@
          "posthog_experiment"."conclusion_comment"
   FROM "posthog_experiment"
   WHERE "posthog_experiment"."feature_flag_id" = 99999
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.36
+  '''
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."logo_media_id",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."is_active",
+         "posthog_organization"."is_not_active_reason",
+         "posthog_organization"."session_cookie_age",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."is_ai_data_processing_approved",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."members_can_invite",
+         "posthog_organization"."members_can_use_personal_api_keys",
+         "posthog_organization"."allow_publicly_shared_resources",
+         "posthog_organization"."default_role_id",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."default_experiment_stats_method",
+         "posthog_organization"."default_anonymize_ips",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."is_pending_deletion",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."is_platform"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.37
+  '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."parent_team_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."onboarding_tasks",
+         "posthog_team"."ingested_event",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."secret_api_token",
+         "posthog_team"."secret_api_token_backup",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_masking_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_recording_trigger_match_type_config",
+         "posthog_team"."session_recording_trigger_groups",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."session_recording_retention_period",
+         "posthog_team"."conversations_enabled",
+         "posthog_team"."conversations_settings",
+         "posthog_team"."proactive_tasks_enabled",
+         "posthog_team"."survey_config",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."product_tours_opt_in",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."logs_settings",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."receive_org_level_activity_logs",
+         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
+         "posthog_team"."web_analytics_pre_aggregated_tables_version",
+         "posthog_team"."flags_persistence_default",
+         "posthog_team"."feature_flag_confirmation_enabled",
+         "posthog_team"."feature_flag_confirmation_message",
+         "posthog_team"."default_evaluation_environments_enabled",
+         "posthog_team"."require_evaluation_environment_tags",
+         "posthog_team"."default_evaluation_contexts_enabled",
+         "posthog_team"."require_evaluation_contexts",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."human_friendly_comparison_periods",
+         "posthog_team"."cookieless_server_hash_mode",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."default_data_theme",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at",
+         "posthog_team"."api_query_rate_limit",
+         "posthog_team"."revenue_tracking_config",
+         "posthog_team"."drop_events_older_than",
+         "posthog_team"."base_currency",
+         "posthog_team"."experiment_recalculation_time",
+         "posthog_team"."default_experiment_confidence_level",
+         "posthog_team"."default_experiment_stats_method",
+         "posthog_team"."business_model"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.38
+  '''
+  SELECT "posthog_scheduledchange"."id",
+         "posthog_scheduledchange"."record_id",
+         "posthog_scheduledchange"."model_name",
+         "posthog_scheduledchange"."payload",
+         "posthog_scheduledchange"."scheduled_at",
+         "posthog_scheduledchange"."executed_at",
+         "posthog_scheduledchange"."failure_reason",
+         "posthog_scheduledchange"."failure_count",
+         "posthog_scheduledchange"."is_recurring",
+         "posthog_scheduledchange"."recurrence_interval",
+         "posthog_scheduledchange"."last_executed_at",
+         "posthog_scheduledchange"."cron_expression",
+         "posthog_scheduledchange"."end_date",
+         "posthog_scheduledchange"."team_id",
+         "posthog_scheduledchange"."created_at",
+         "posthog_scheduledchange"."created_by_id",
+         "posthog_scheduledchange"."updated_at"
+  FROM "posthog_scheduledchange"
+  WHERE "posthog_scheduledchange"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.39
+  '''
+  SELECT "posthog_scheduledchange"."id",
+         "posthog_scheduledchange"."record_id",
+         "posthog_scheduledchange"."model_name",
+         "posthog_scheduledchange"."payload",
+         "posthog_scheduledchange"."scheduled_at",
+         "posthog_scheduledchange"."executed_at",
+         "posthog_scheduledchange"."failure_reason",
+         "posthog_scheduledchange"."failure_count",
+         "posthog_scheduledchange"."is_recurring",
+         "posthog_scheduledchange"."recurrence_interval",
+         "posthog_scheduledchange"."last_executed_at",
+         "posthog_scheduledchange"."cron_expression",
+         "posthog_scheduledchange"."end_date",
+         "posthog_scheduledchange"."team_id",
+         "posthog_scheduledchange"."created_at",
+         "posthog_scheduledchange"."created_by_id",
+         "posthog_scheduledchange"."updated_at"
+  FROM "posthog_scheduledchange"
+  WHERE "posthog_scheduledchange"."id" = 99999
+  LIMIT 21
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.4
@@ -1067,147 +1213,29 @@
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.40
   '''
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."logo_media_id",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."is_active",
-         "posthog_organization"."is_not_active_reason",
-         "posthog_organization"."session_cookie_age",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."is_ai_data_processing_approved",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."members_can_invite",
-         "posthog_organization"."members_can_use_personal_api_keys",
-         "posthog_organization"."allow_publicly_shared_resources",
-         "posthog_organization"."default_role_id",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."default_experiment_stats_method",
-         "posthog_organization"."default_anonymize_ips",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."is_pending_deletion",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist",
-         "posthog_organization"."is_platform"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  SELECT "posthog_scheduledchange"."id",
+         "posthog_scheduledchange"."record_id",
+         "posthog_scheduledchange"."model_name",
+         "posthog_scheduledchange"."payload",
+         "posthog_scheduledchange"."scheduled_at",
+         "posthog_scheduledchange"."executed_at",
+         "posthog_scheduledchange"."failure_reason",
+         "posthog_scheduledchange"."failure_count",
+         "posthog_scheduledchange"."is_recurring",
+         "posthog_scheduledchange"."recurrence_interval",
+         "posthog_scheduledchange"."last_executed_at",
+         "posthog_scheduledchange"."cron_expression",
+         "posthog_scheduledchange"."end_date",
+         "posthog_scheduledchange"."team_id",
+         "posthog_scheduledchange"."created_at",
+         "posthog_scheduledchange"."created_by_id",
+         "posthog_scheduledchange"."updated_at"
+  FROM "posthog_scheduledchange"
+  WHERE "posthog_scheduledchange"."id" = 99999
   LIMIT 21
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.41
-  '''
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."parent_team_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."onboarding_tasks",
-         "posthog_team"."ingested_event",
-         "posthog_team"."person_processing_opt_out",
-         "posthog_team"."secret_api_token",
-         "posthog_team"."secret_api_token_backup",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_recording_masking_config",
-         "posthog_team"."session_recording_url_trigger_config",
-         "posthog_team"."session_recording_url_blocklist_config",
-         "posthog_team"."session_recording_event_trigger_config",
-         "posthog_team"."session_recording_trigger_match_type_config",
-         "posthog_team"."session_recording_trigger_groups",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."session_recording_retention_period",
-         "posthog_team"."conversations_enabled",
-         "posthog_team"."conversations_settings",
-         "posthog_team"."proactive_tasks_enabled",
-         "posthog_team"."survey_config",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."product_tours_opt_in",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."capture_dead_clicks",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_web_vitals_opt_in",
-         "posthog_team"."autocapture_web_vitals_allowed_metrics",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."logs_settings",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."receive_org_level_activity_logs",
-         "posthog_team"."web_analytics_pre_aggregated_tables_enabled",
-         "posthog_team"."web_analytics_pre_aggregated_tables_version",
-         "posthog_team"."flags_persistence_default",
-         "posthog_team"."feature_flag_confirmation_enabled",
-         "posthog_team"."feature_flag_confirmation_message",
-         "posthog_team"."default_evaluation_environments_enabled",
-         "posthog_team"."require_evaluation_environment_tags",
-         "posthog_team"."default_evaluation_contexts_enabled",
-         "posthog_team"."require_evaluation_contexts",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."human_friendly_comparison_periods",
-         "posthog_team"."cookieless_server_hash_mode",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."default_data_theme",
-         "posthog_team"."extra_settings",
-         "posthog_team"."modifiers",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at",
-         "posthog_team"."api_query_rate_limit",
-         "posthog_team"."revenue_tracking_config",
-         "posthog_team"."drop_events_older_than",
-         "posthog_team"."base_currency",
-         "posthog_team"."experiment_recalculation_time",
-         "posthog_team"."default_experiment_confidence_level",
-         "posthog_team"."default_experiment_stats_method",
-         "posthog_team"."business_model"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.42
   '''
   SELECT "posthog_scheduledchange"."id",
          "posthog_scheduledchange"."record_id",
@@ -1228,6 +1256,36 @@
          "posthog_scheduledchange"."updated_at"
   FROM "posthog_scheduledchange"
   WHERE "posthog_scheduledchange"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.42
+  '''
+  SELECT "posthog_featureflag"."id",
+         "posthog_featureflag"."key",
+         "posthog_featureflag"."name",
+         "posthog_featureflag"."filters",
+         "posthog_featureflag"."team_id",
+         "posthog_featureflag"."created_by_id",
+         "posthog_featureflag"."created_at",
+         "posthog_featureflag"."updated_at",
+         "posthog_featureflag"."deleted",
+         "posthog_featureflag"."active",
+         "posthog_featureflag"."version",
+         "posthog_featureflag"."last_modified_by_id",
+         "posthog_featureflag"."rollback_conditions",
+         "posthog_featureflag"."performed_rollback",
+         "posthog_featureflag"."ensure_experience_continuity",
+         "posthog_featureflag"."usage_dashboard_id",
+         "posthog_featureflag"."has_enriched_analytics",
+         "posthog_featureflag"."is_remote_configuration",
+         "posthog_featureflag"."has_encrypted_payloads",
+         "posthog_featureflag"."evaluation_runtime",
+         "posthog_featureflag"."bucketing_identifier",
+         "posthog_featureflag"."last_called_at"
+  FROM "posthog_featureflag"
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND "posthog_featureflag"."key" = 'flag-1')
   LIMIT 21
   '''
 # ---

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -768,6 +768,66 @@ export interface FeatureFlagStatusResponseApi {
     reason: string
 }
 
+export type FeatureFlagVersionResponseApiFilters = { [key: string]: unknown }
+
+/**
+ * Feature flag state at a given version plus reconstruction metadata.
+ */
+export interface FeatureFlagVersionResponseApi {
+    readonly id: number
+    /** @maxLength 400 */
+    key: string
+    name?: string
+    readonly filters: FeatureFlagVersionResponseApiFilters
+    active?: boolean
+    deleted?: boolean
+    /**
+     * @minimum -2147483648
+     * @maximum 2147483647
+     * @nullable
+     */
+    version?: number | null
+    rollback_conditions?: unknown | null
+    /** @nullable */
+    performed_rollback?: boolean | null
+    /** @nullable */
+    ensure_experience_continuity?: boolean | null
+    /** @nullable */
+    has_enriched_analytics?: boolean | null
+    /** @nullable */
+    is_remote_configuration?: boolean | null
+    /** @nullable */
+    has_encrypted_payloads?: boolean | null
+    /** Specifies where this feature flag should be evaluated
+
+* `server` - Server
+* `client` - Client
+* `all` - All */
+    evaluation_runtime?: EvaluationRuntimeEnumApi | BlankEnumApi | NullEnumApi | null
+    /** Identifier used for bucketing users into rollout and variants
+
+* `distinct_id` - User ID (default)
+* `device_id` - Device ID */
+    bucketing_identifier?: BucketingIdentifierEnumApi | BlankEnumApi | NullEnumApi | null
+    /**
+     * Last time this feature flag was called (from $feature_flag_called events)
+     * @nullable
+     */
+    last_called_at?: string | null
+    created_at?: string
+    /** @nullable */
+    readonly created_by: number | null
+    /** False for the current version; true for reconstructed historical versions. */
+    readonly is_historical: boolean
+    /** @nullable */
+    readonly version_timestamp: string | null
+    /**
+     * User from the activity log entry that produced this version.
+     * @nullable
+     */
+    readonly modified_by: number | null
+}
+
 /**
  * * `add` - add
  * `remove` - remove

--- a/products/feature_flags/frontend/generated/api.ts
+++ b/products/feature_flags/frontend/generated/api.ts
@@ -18,6 +18,7 @@ import type {
     FeatureFlagApi,
     FeatureFlagCreateRequestSchemaApi,
     FeatureFlagStatusResponseApi,
+    FeatureFlagVersionResponseApi,
     FeatureFlagsActivityRetrieve2Params,
     FeatureFlagsActivityRetrieveParams,
     FeatureFlagsEvaluationReasonsRetrieveParams,
@@ -397,8 +398,8 @@ export const featureFlagsVersionsRetrieve = async (
     id: number,
     versionNumber: number,
     options?: RequestInit
-): Promise<void> => {
-    return apiMutator<void>(getFeatureFlagsVersionsRetrieveUrl(projectId, id, versionNumber), {
+): Promise<FeatureFlagVersionResponseApi> => {
+    return apiMutator<FeatureFlagVersionResponseApi>(getFeatureFlagsVersionsRetrieveUrl(projectId, id, versionNumber), {
         ...options,
         method: 'GET',
     })

--- a/products/feature_flags/frontend/generated/api.ts
+++ b/products/feature_flags/frontend/generated/api.ts
@@ -388,6 +388,27 @@ export const featureFlagsStatusRetrieve = async (
 
 If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
  */
+export const getFeatureFlagsVersionsRetrieveUrl = (projectId: string, id: number, versionNumber: number) => {
+    return `/api/projects/${projectId}/feature_flags/${id}/versions/${versionNumber}/`
+}
+
+export const featureFlagsVersionsRetrieve = async (
+    projectId: string,
+    id: number,
+    versionNumber: number,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getFeatureFlagsVersionsRetrieveUrl(projectId, id, versionNumber), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+/**
+ * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
+
+If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
+ */
 export const getFeatureFlagsActivityRetrieveUrl = (projectId: string, params?: FeatureFlagsActivityRetrieveParams) => {
     const normalizedParams = new URLSearchParams()
 

--- a/products/feature_flags/mcp/tools.yaml
+++ b/products/feature_flags/mcp/tools.yaml
@@ -306,3 +306,6 @@ tools:
     feature-flags-bulk-update-tags-create:
         operation: feature_flags_bulk_update_tags_create
         enabled: false
+    feature-flags-versions-retrieve:
+        operation: feature_flags_versions_retrieve
+        enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16298,6 +16298,66 @@ export namespace Schemas {
       reason: string;
     }
 
+    export type FeatureFlagVersionResponseFilters = {[key: string]: unknown};
+
+    /**
+     * Feature flag state at a given version plus reconstruction metadata.
+     */
+    export interface FeatureFlagVersionResponse {
+      readonly id: number;
+      /** @maxLength 400 */
+      key: string;
+      name?: string;
+      readonly filters: FeatureFlagVersionResponseFilters;
+      active?: boolean;
+      deleted?: boolean;
+      /**
+       * @minimum -2147483648
+       * @maximum 2147483647
+       * @nullable
+       */
+      version?: number | null;
+      rollback_conditions?: unknown | null;
+      /** @nullable */
+      performed_rollback?: boolean | null;
+      /** @nullable */
+      ensure_experience_continuity?: boolean | null;
+      /** @nullable */
+      has_enriched_analytics?: boolean | null;
+      /** @nullable */
+      is_remote_configuration?: boolean | null;
+      /** @nullable */
+      has_encrypted_payloads?: boolean | null;
+      /** Specifies where this feature flag should be evaluated
+
+    * `server` - Server
+    * `client` - Client
+    * `all` - All */
+      evaluation_runtime?: EvaluationRuntimeEnum | BlankEnum | NullEnum | null;
+      /** Identifier used for bucketing users into rollout and variants
+
+    * `distinct_id` - User ID (default)
+    * `device_id` - Device ID */
+      bucketing_identifier?: BucketingIdentifierEnum | BlankEnum | NullEnum | null;
+      /**
+       * Last time this feature flag was called (from $feature_flag_called events)
+       * @nullable
+       */
+      last_called_at?: string | null;
+      created_at?: string;
+      /** @nullable */
+      readonly created_by: number | null;
+      /** False for the current version; true for reconstructed historical versions. */
+      readonly is_historical: boolean;
+      /** @nullable */
+      readonly version_timestamp: string | null;
+      /**
+       * User from the activity log entry that produced this version.
+       * @nullable
+       */
+      readonly modified_by: number | null;
+    }
+
     export interface FileSystem {
       readonly id: string;
       path: string;


### PR DESCRIPTION
## Problem

Feature flags have a `version` field that increments on each update, but there's no way to view what a flag looked like at a previous version. Users need to review past configurations for debugging and auditing purposes.

This can come in handy in two situations:

1. When viewing `$feature_flag_called` events, we can show metadata reconstructed from the flag history (rather than sending all that data in every event).
2. For the flag debugger that @gustavohstrassburger is working on, this would allow us to see the flag version at that time. Of course this would require one extra step to get the flag version for that date (out of scope of this PR).

We may want a read-only view in the UI for flag versions later, but that can be done as a follow-up.

## Changes

- Add `GET /api/projects/{team_id}/feature_flags/{id}/versions/{version_number}` endpoint that reconstructs the flag state at any prior version by reverse-applying activity log changes
- Add `reconstruct_flag_at_version()` in `posthog/models/feature_flag/version_history.py` — walks the activity log backwards from the current state to rebuild the flag at the requested version
- Custom exceptions `VersionNotFound` and `VersionHistoryIncomplete` for clear error handling when the version doesn't exist or the activity log is incomplete
- Returns 400 for remote configuration flags (which don't use versioning)

## How did you test this code?

- Unit tests for `reconstruct_flag_at_version()` covering forward reconstruction, multi-field changes, missing activity log entries, and edge cases (`posthog/models/feature_flag/test/test_version_history.py`)
- API integration tests for the endpoint covering version retrieval, 404 for unknown versions, and 400 for remote config flags (`posthog/api/test/test_feature_flag.py::TestFeatureFlagVersions`)
- Manually tested endpoint with `curl`.

## Publish to changelog?

no