### PR TITLE
feat(cohorts): debounce person property backfill by 5 minutes

### DIFF
--- a/posthog/models/cohort/dependencies.py
+++ b/posthog/models/cohort/dependencies.py
@@ -10,9 +10,12 @@ from structlog import get_logger
 
 from posthog.models.cohort.cohort import Cohort, CohortType, is_cohort_recalculation_only_save
 from posthog.models.team.team import Team
+from posthog.redis import get_client as get_redis_client
 
 logger = get_logger(__name__)
 DEPENDENCY_CACHE_TIMEOUT = 7 * 24 * 60 * 60  # 1 week
+COHORT_BACKFILL_DEBOUNCE_SECONDS = 300  # 5 minutes
+COHORT_BACKFILL_REDIS_TTL_SECONDS = 360  # 6 minutes (countdown + safety margin)
 
 
 # Prometheus metrics for cache hit/miss tracking
@@ -248,20 +251,34 @@ def _extract_person_property_filters(cohort: Cohort) -> str:
 def _trigger_cohort_backfill(cohort: Cohort) -> None:
     """
     Trigger backfill for a realtime cohort with person properties.
-    Uses Celery to avoid blocking the caller.
+    Debounces with a 5-minute delay so rapid re-saves only trigger one backfill.
     """
     try:
         from posthog.tasks.calculate_cohort import trigger_cohort_backfill_task
 
-        logger.info(
-            "triggering_cohort_backfill_on_conditions_change",
-            cohort_id=cohort.pk,
-            team_id=cohort.team_id,
-            cohort_type=cohort.cohort_type,
-        )
+        redis_client = get_redis_client()
+        lock_key = f"cohort_backfill_pending:{cohort.pk}"
 
-        # Use Celery task to avoid blocking network I/O
-        trigger_cohort_backfill_task.delay(cohort.team_id, cohort.pk)
+        # Atomic set-if-not-exists with TTL. Returns True only for the first
+        # caller within the window; subsequent saves are debounced.
+        if redis_client.set(lock_key, 1, nx=True, ex=COHORT_BACKFILL_REDIS_TTL_SECONDS):
+            logger.info(
+                "triggering_cohort_backfill_on_conditions_change",
+                cohort_id=cohort.pk,
+                team_id=cohort.team_id,
+                cohort_type=cohort.cohort_type,
+                debounce_seconds=COHORT_BACKFILL_DEBOUNCE_SECONDS,
+            )
+            trigger_cohort_backfill_task.apply_async(
+                args=[cohort.team_id, cohort.pk],
+                countdown=COHORT_BACKFILL_DEBOUNCE_SECONDS,
+            )
+        else:
+            logger.info(
+                "cohort_backfill_already_pending",
+                cohort_id=cohort.pk,
+                team_id=cohort.team_id,
+            )
 
     except Exception as e:
         logger.exception(
@@ -270,7 +287,6 @@ def _trigger_cohort_backfill(cohort: Cohort) -> None:
             team_id=cohort.team_id,
             error=str(e),
         )
-        # Don't re-raise the exception to avoid breaking the main save operation
 
 
 @receiver(pre_save, sender=Cohort)

--- a/posthog/models/cohort/dependencies.py
+++ b/posthog/models/cohort/dependencies.py
@@ -15,7 +15,7 @@ from posthog.redis import get_client as get_redis_client
 logger = get_logger(__name__)
 DEPENDENCY_CACHE_TIMEOUT = 7 * 24 * 60 * 60  # 1 week
 COHORT_BACKFILL_DEBOUNCE_SECONDS = 300  # 5 minutes
-COHORT_BACKFILL_REDIS_TTL_SECONDS = 360  # 6 minutes (countdown + safety margin)
+COHORT_BACKFILL_REDIS_TTL_SECONDS = 300  # matches countdown; task reads fresh state at execution time
 
 
 # Prometheus metrics for cache hit/miss tracking
@@ -269,10 +269,15 @@ def _trigger_cohort_backfill(cohort: Cohort) -> None:
                 cohort_type=cohort.cohort_type,
                 debounce_seconds=COHORT_BACKFILL_DEBOUNCE_SECONDS,
             )
-            trigger_cohort_backfill_task.apply_async(
-                args=[cohort.team_id, cohort.pk],
-                countdown=COHORT_BACKFILL_DEBOUNCE_SECONDS,
-            )
+            try:
+                trigger_cohort_backfill_task.apply_async(
+                    args=[cohort.team_id, cohort.pk],
+                    countdown=COHORT_BACKFILL_DEBOUNCE_SECONDS,
+                )
+            except Exception:
+                # Release the lock so the next save can retry scheduling
+                redis_client.delete(lock_key)
+                raise
         else:
             logger.info(
                 "cohort_backfill_already_pending",

--- a/posthog/models/cohort/test/test_dependencies.py
+++ b/posthog/models/cohort/test/test_dependencies.py
@@ -11,7 +11,6 @@ from posthog.models import Cohort
 from posthog.models.cohort.cohort import CohortType
 from posthog.models.cohort.dependencies import (
     COHORT_BACKFILL_DEBOUNCE_SECONDS,
-    COHORT_BACKFILL_REDIS_TTL_SECONDS,
     COHORT_DEPENDENCY_CACHE_COUNTER,
     DEPENDENCY_CACHE_TIMEOUT,
     _extract_person_property_filters,
@@ -533,34 +532,30 @@ class TestCohortBackfillOnConditionsChanged(BaseTest):
         cohort = self._create_cohort(name="Test Cohort")
         self.assertFalse(_has_person_property_filters(cohort))
 
+    @parameterized.expand(
+        [
+            ("schedules_task_when_key_absent", True, True),
+            ("debounces_when_key_present", False, False),
+        ]
+    )
     @mock.patch("posthog.tasks.calculate_cohort.trigger_cohort_backfill_task")
     @mock.patch("posthog.models.cohort.dependencies.get_redis_client")
-    def test_trigger_cohort_backfill_calls_celery_task(self, mock_get_redis, mock_task):
+    def test_trigger_cohort_backfill_redis_set(
+        self, _name, redis_set_result, should_schedule, mock_get_redis, mock_task
+    ):
         mock_redis = mock.MagicMock()
-        mock_redis.set.return_value = True
+        mock_redis.set.return_value = redis_set_result
         mock_get_redis.return_value = mock_redis
         cohort = self._create_cohort(name="Test Cohort", cohort_type=CohortType.REALTIME)
 
         _trigger_cohort_backfill(cohort)
 
-        mock_redis.set.assert_called_once_with(
-            f"cohort_backfill_pending:{cohort.pk}", 1, nx=True, ex=COHORT_BACKFILL_REDIS_TTL_SECONDS
-        )
-        mock_task.apply_async.assert_called_once_with(
-            args=[cohort.team_id, cohort.pk], countdown=COHORT_BACKFILL_DEBOUNCE_SECONDS
-        )
-
-    @mock.patch("posthog.tasks.calculate_cohort.trigger_cohort_backfill_task")
-    @mock.patch("posthog.models.cohort.dependencies.get_redis_client")
-    def test_trigger_cohort_backfill_debounces_when_pending(self, mock_get_redis, mock_task):
-        mock_redis = mock.MagicMock()
-        mock_redis.set.return_value = False  # Key already exists
-        mock_get_redis.return_value = mock_redis
-        cohort = self._create_cohort(name="Test Cohort", cohort_type=CohortType.REALTIME)
-
-        _trigger_cohort_backfill(cohort)
-
-        mock_task.apply_async.assert_not_called()
+        if should_schedule:
+            mock_task.apply_async.assert_called_once_with(
+                args=[cohort.team_id, cohort.pk], countdown=COHORT_BACKFILL_DEBOUNCE_SECONDS
+            )
+        else:
+            mock_task.apply_async.assert_not_called()
 
     @mock.patch("posthog.tasks.calculate_cohort.trigger_cohort_backfill_task")
     @mock.patch("posthog.models.cohort.dependencies.get_redis_client")
@@ -573,6 +568,9 @@ class TestCohortBackfillOnConditionsChanged(BaseTest):
 
         # Should not raise
         _trigger_cohort_backfill(cohort)
+
+        # Redis key should be cleaned up so the next save can retry
+        mock_redis.delete.assert_called_once_with(f"cohort_backfill_pending:{cohort.pk}")
 
     @mock.patch("posthog.tasks.calculate_cohort.trigger_cohort_backfill_task")
     @mock.patch("posthog.models.cohort.dependencies.get_redis_client")

--- a/posthog/models/cohort/test/test_dependencies.py
+++ b/posthog/models/cohort/test/test_dependencies.py
@@ -10,6 +10,8 @@ from rest_framework.exceptions import ValidationError
 from posthog.models import Cohort
 from posthog.models.cohort.cohort import CohortType
 from posthog.models.cohort.dependencies import (
+    COHORT_BACKFILL_DEBOUNCE_SECONDS,
+    COHORT_BACKFILL_REDIS_TTL_SECONDS,
     COHORT_DEPENDENCY_CACHE_COUNTER,
     DEPENDENCY_CACHE_TIMEOUT,
     _extract_person_property_filters,
@@ -532,22 +534,55 @@ class TestCohortBackfillOnConditionsChanged(BaseTest):
         self.assertFalse(_has_person_property_filters(cohort))
 
     @mock.patch("posthog.tasks.calculate_cohort.trigger_cohort_backfill_task")
-    def test_trigger_cohort_backfill_calls_celery_task(self, mock_task):
-        """Test that _trigger_cohort_backfill calls the correct Celery task"""
+    @mock.patch("posthog.models.cohort.dependencies.get_redis_client")
+    def test_trigger_cohort_backfill_calls_celery_task(self, mock_get_redis, mock_task):
+        mock_redis = mock.MagicMock()
+        mock_redis.set.return_value = True
+        mock_get_redis.return_value = mock_redis
         cohort = self._create_cohort(name="Test Cohort", cohort_type=CohortType.REALTIME)
 
         _trigger_cohort_backfill(cohort)
 
-        mock_task.delay.assert_called_once_with(cohort.team_id, cohort.pk)
+        mock_redis.set.assert_called_once_with(
+            f"cohort_backfill_pending:{cohort.pk}", 1, nx=True, ex=COHORT_BACKFILL_REDIS_TTL_SECONDS
+        )
+        mock_task.apply_async.assert_called_once_with(
+            args=[cohort.team_id, cohort.pk], countdown=COHORT_BACKFILL_DEBOUNCE_SECONDS
+        )
 
     @mock.patch("posthog.tasks.calculate_cohort.trigger_cohort_backfill_task")
-    def test_trigger_cohort_backfill_handles_exceptions(self, mock_task):
-        """Test that _trigger_cohort_backfill handles exceptions gracefully"""
-        mock_task.delay.side_effect = Exception("Task failed")
+    @mock.patch("posthog.models.cohort.dependencies.get_redis_client")
+    def test_trigger_cohort_backfill_debounces_when_pending(self, mock_get_redis, mock_task):
+        mock_redis = mock.MagicMock()
+        mock_redis.set.return_value = False  # Key already exists
+        mock_get_redis.return_value = mock_redis
         cohort = self._create_cohort(name="Test Cohort", cohort_type=CohortType.REALTIME)
 
-        # Should not raise an exception
         _trigger_cohort_backfill(cohort)
+
+        mock_task.apply_async.assert_not_called()
+
+    @mock.patch("posthog.tasks.calculate_cohort.trigger_cohort_backfill_task")
+    @mock.patch("posthog.models.cohort.dependencies.get_redis_client")
+    def test_trigger_cohort_backfill_handles_task_exception(self, mock_get_redis, mock_task):
+        mock_redis = mock.MagicMock()
+        mock_redis.set.return_value = True
+        mock_get_redis.return_value = mock_redis
+        mock_task.apply_async.side_effect = Exception("Task failed")
+        cohort = self._create_cohort(name="Test Cohort", cohort_type=CohortType.REALTIME)
+
+        # Should not raise
+        _trigger_cohort_backfill(cohort)
+
+    @mock.patch("posthog.tasks.calculate_cohort.trigger_cohort_backfill_task")
+    @mock.patch("posthog.models.cohort.dependencies.get_redis_client")
+    def test_trigger_cohort_backfill_handles_redis_failure(self, mock_get_redis, mock_task):
+        mock_get_redis.side_effect = Exception("Redis unavailable")
+        cohort = self._create_cohort(name="Test Cohort", cohort_type=CohortType.REALTIME)
+
+        # Should not raise
+        _trigger_cohort_backfill(cohort)
+        mock_task.apply_async.assert_not_called()
 
     @mock.patch("posthog.models.cohort.dependencies._trigger_cohort_backfill")
     @mock.patch("posthoganalytics.feature_enabled", return_value=True)


### PR DESCRIPTION
## Problem

When a cohort is saved, person property backfilling starts immediately. If a user iterates on a cohort definition (saving multiple times in quick succession), this triggers many redundant backfill runs.

## Changes

Add a 5-minute debounce to `_trigger_cohort_backfill` using Redis `SET NX EX` + Celery `apply_async(countdown=300)`. The first save within a 5-minute window schedules the backfill; subsequent saves are no-ops. The task reads cohort state from DB at execution time, so it always uses the latest configuration.

## How did you test this code?

Unit tests covering: task scheduling with debounce, debounce when key already exists, graceful handling of task and Redis failures. All 47 existing tests pass.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No

## 🤖 LLM context

Agent-authored PR. Changes are scoped to `posthog/models/cohort/dependencies.py` and its test file.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*