### PR TITLE
fix: add exception handling to Heartbeater to prevent silent heartbeat loop death

### DIFF
--- a/posthog/temporal/common/heartbeat.py
+++ b/posthog/temporal/common/heartbeat.py
@@ -103,7 +103,7 @@ class Heartbeater:
         try:
             activity.heartbeat(*self.details)
         except Exception:
-            self.logger.warning("Final heartbeat on exit failed")
+            self.logger.exception("Final heartbeat on exit failed")
 
         self.heartbeat_task = None
         self.heartbeat_on_shutdown_task = None
@@ -114,9 +114,10 @@ class Heartbeater:
             await asyncio.sleep(delay)
             try:
                 activity.heartbeat(*self.details)
-                self.logger.debug("Heartbeat")
             except Exception:
                 self.logger.exception("Heartbeat failed")
+            else:
+                self.logger.debug("Heartbeat")
 
 
 class LivenessHeartbeater(Heartbeater):

--- a/posthog/temporal/common/heartbeat.py
+++ b/posthog/temporal/common/heartbeat.py
@@ -69,7 +69,12 @@ class Heartbeater:
             if not self.details:
                 return
 
-            activity.heartbeat(*self.details)
+            try:
+                activity.heartbeat(*self.details)
+            except Exception:
+                await self.logger.adebug("Shutdown heartbeat failed")
+                return
+
             if heartbeat_timeout:
                 heartbeat_timeout_seconds = heartbeat_timeout.total_seconds()
                 await self.logger.adebug(
@@ -95,7 +100,10 @@ class Heartbeater:
         if tasks_to_wait:
             await asyncio.wait(tasks_to_wait)
 
-        activity.heartbeat(*self.details)
+        try:
+            activity.heartbeat(*self.details)
+        except Exception:
+            self.logger.warning("Final heartbeat on exit failed")
 
         self.heartbeat_task = None
         self.heartbeat_on_shutdown_task = None
@@ -104,8 +112,11 @@ class Heartbeater:
         """Heartbeat forever every delay seconds."""
         while True:
             await asyncio.sleep(delay)
-            activity.heartbeat(*self.details)
-            self.logger.debug("Heartbeat")
+            try:
+                activity.heartbeat(*self.details)
+                self.logger.debug("Heartbeat")
+            except Exception:
+                self.logger.exception("Heartbeat failed")
 
 
 class LivenessHeartbeater(Heartbeater):

--- a/posthog/temporal/tests/common/test_heartbeat.py
+++ b/posthog/temporal/tests/common/test_heartbeat.py
@@ -14,6 +14,20 @@ def mock_activity_info():
     return info
 
 
+async def _block_forever():
+    """Awaitable that blocks until cancelled, standing in for activity.wait_for_worker_shutdown()."""
+    await asyncio.get_event_loop().create_future()
+
+
+@pytest.fixture(autouse=True)
+def _patch_wait_for_worker_shutdown():
+    with patch(
+        "posthog.temporal.common.heartbeat.activity.wait_for_worker_shutdown",
+        side_effect=_block_forever,
+    ):
+        yield
+
+
 class TestHeartbeater:
     @pytest.mark.asyncio
     async def test_heartbeat_loop_survives_exceptions(self, mock_activity_info):
@@ -54,7 +68,7 @@ class TestHeartbeater:
             async with heartbeater:
                 await asyncio.sleep(0.02)
 
-        heartbeater.logger.exception.assert_called_with("Heartbeat failed")
+        heartbeater.logger.exception.assert_any_call("Heartbeat failed")
 
     @pytest.mark.asyncio
     async def test_exit_heartbeat_survives_exception(self, mock_activity_info):
@@ -73,4 +87,4 @@ class TestHeartbeater:
             async with heartbeater:
                 pass
 
-            heartbeater.logger.warning.assert_called_with("Final heartbeat on exit failed")
+            heartbeater.logger.exception.assert_called_with("Final heartbeat on exit failed")

--- a/posthog/temporal/tests/common/test_heartbeat.py
+++ b/posthog/temporal/tests/common/test_heartbeat.py
@@ -1,0 +1,76 @@
+import asyncio
+import datetime as dt
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from posthog.temporal.common.heartbeat import Heartbeater
+
+
+@pytest.fixture
+def mock_activity_info():
+    info = MagicMock()
+    info.heartbeat_timeout = dt.timedelta(seconds=10)
+    return info
+
+
+class TestHeartbeater:
+    @pytest.mark.asyncio
+    async def test_heartbeat_loop_survives_exceptions(self, mock_activity_info):
+        """The heartbeat loop must continue after a transient exception from activity.heartbeat()."""
+        heartbeat_call_count = 0
+
+        def mock_heartbeat(*args):
+            nonlocal heartbeat_call_count
+            heartbeat_call_count += 1
+            if heartbeat_call_count == 1:
+                raise RuntimeError("Transient network error")
+
+        with (
+            patch("posthog.temporal.common.heartbeat.activity.info", return_value=mock_activity_info),
+            patch("posthog.temporal.common.heartbeat.activity.heartbeat", side_effect=mock_heartbeat),
+        ):
+            heartbeater = Heartbeater(details=("test",), factor=1000)
+            async with heartbeater:
+                # Wait enough for multiple heartbeat cycles (delay = 10s / 1000 = 0.01s)
+                await asyncio.sleep(0.05)
+
+        # First call raised, but loop continued and heartbeat was called again
+        assert heartbeat_call_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_loop_logs_exception(self, mock_activity_info):
+        """The heartbeat loop must log exceptions from activity.heartbeat()."""
+        with (
+            patch("posthog.temporal.common.heartbeat.activity.info", return_value=mock_activity_info),
+            patch(
+                "posthog.temporal.common.heartbeat.activity.heartbeat",
+                side_effect=RuntimeError("Transient error"),
+            ),
+        ):
+            heartbeater = Heartbeater(details=("test",), factor=1000)
+            heartbeater.logger = MagicMock()
+
+            async with heartbeater:
+                await asyncio.sleep(0.02)
+
+        heartbeater.logger.exception.assert_called_with("Heartbeat failed")
+
+    @pytest.mark.asyncio
+    async def test_exit_heartbeat_survives_exception(self, mock_activity_info):
+        """__aexit__ must not raise if the final heartbeat call fails."""
+        with (
+            patch("posthog.temporal.common.heartbeat.activity.info", return_value=mock_activity_info),
+            patch(
+                "posthog.temporal.common.heartbeat.activity.heartbeat",
+                side_effect=RuntimeError("Server unavailable"),
+            ),
+        ):
+            heartbeater = Heartbeater(details=("test",), factor=1000)
+            heartbeater.logger = MagicMock()
+
+            # Should not raise despite heartbeat failure on exit
+            async with heartbeater:
+                pass
+
+            heartbeater.logger.warning.assert_called_with("Final heartbeat on exit failed")


### PR DESCRIPTION
## Problem

Realtime cohort calculations are failing for p95-p99 with `TIMEOUT_TYPE_HEARTBEAT` after exhausting all 3 retry attempts. The Temporal activity stops sending heartbeats and gets killed.

The base `Heartbeater._heartbeat_forever` has no exception handling — if `activity.heartbeat()` throws (transient network error, temporary Temporal server issue), the heartbeat loop dies silently. No more heartbeats are sent, and after 5 minutes Temporal declares heartbeat timeout. The `LivenessHeartbeater` subclass already had the correct pattern with `try/except`, but the realtime cohort workflow uses the unprotected base class.

## Changes

Add `try/except` to all three unprotected `activity.heartbeat()` call sites in `Heartbeater`:
- `_heartbeat_forever` loop — the critical fix, prevents permanent heartbeat death from transient errors
- `__aexit__` final heartbeat — prevents masking the activity result on exit
- `heartbeat_on_shutdown` — prevents crash during worker shutdown

Uses `except Exception` which does not catch `CancelledError` (`BaseException`), so task cancellation still works correctly. All ~30 callsites using the base `Heartbeater` benefit from this fix.

## How did you test this code?

Added unit tests in `posthog/temporal/tests/common/test_heartbeat.py` covering:
- Heartbeat loop survives exceptions and continues running
- Exceptions are logged via `logger.exception`
- `__aexit__` does not raise when final heartbeat fails

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

N/A

## 🤖 LLM context

Agent-authored PR. Identified missing exception handling in `Heartbeater._heartbeat_forever` as root cause for p95-p99 cohort calculation heartbeat timeouts. The fix mirrors the existing pattern in `LivenessHeartbeater`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*