### PR TITLE
fix(sessions): set prefer_global_in_and_join on sessions queries

### DIFF
--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -147,6 +147,10 @@ class HogQLGlobalSettings(HogQLQuerySettings):
     # experimental support for nonequal joins
     allow_experimental_join_condition: Optional[bool] = True
     preferred_block_size_bytes: Optional[int] = None
+    # Rewrites IN/JOIN to GLOBAL IN/GLOBAL JOIN on Distributed tables. Needed when
+    # a subquery references a table that isn't present on every shard of the outer
+    # Distributed table (e.g. events subquery inside a sessions-cluster query).
+    prefer_global_in_and_join: Optional[bool] = None
     use_hive_partitioning: Optional[int] = 0
 
 

--- a/posthog/hogql_queries/sessions_query_runner.py
+++ b/posthog/hogql_queries/sessions_query_runner.py
@@ -7,6 +7,7 @@ from django.utils.timezone import now
 from posthog.schema import CachedSessionsQueryResponse, DashboardFilter, SessionsQuery, SessionsQueryResponse
 
 from posthog.hogql import ast
+from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.parser import parse_expr, parse_order_expr
 from posthog.hogql.property import action_to_expr, has_aggregation, map_virtual_properties, property_to_expr
 
@@ -498,6 +499,11 @@ class SessionsQueryRunner(AnalyticsQueryRunner[SessionsQueryResponse]):
                 return stmt
 
     def _calculate(self) -> SessionsQueryResponse:
+        # Sessions tables are Distributed across a ClickHouse cluster that doesn't
+        # host events/persons. prefer_global_in_and_join=1 tells ClickHouse to
+        # evaluate any IN/JOIN subqueries on the initiator and broadcast the set,
+        # avoiding UNKNOWN_TABLE on sessions shards when the subquery references
+        # a table that only lives on the main cluster.
         query_result = self.paginator.execute_hogql_query(
             query=self.to_query(),
             team=self.team,
@@ -505,6 +511,7 @@ class SessionsQueryRunner(AnalyticsQueryRunner[SessionsQueryResponse]):
             timings=self.timings,
             modifiers=self.modifiers,
             limit_context=self.limit_context,
+            settings=HogQLGlobalSettings(prefer_global_in_and_join=True),
         )
 
         # Convert star field from tuple to dict in each result

--- a/posthog/hogql_queries/test/__snapshots__/test_sessions_query_runner.ambr
+++ b/posthog/hogql_queries/test/__snapshots__/test_sessions_query_runner.ambr
@@ -44,6 +44,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -91,6 +92,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -136,6 +138,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -181,6 +184,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -226,6 +230,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -261,6 +266,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -296,6 +302,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -331,6 +338,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -360,6 +368,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -405,6 +414,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -450,6 +460,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -496,6 +507,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -524,6 +536,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -571,6 +584,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -620,6 +634,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -665,6 +680,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -712,6 +728,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -759,6 +776,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -804,6 +822,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -849,6 +868,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -904,6 +924,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -933,6 +954,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -981,6 +1003,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -1009,6 +1032,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -1056,6 +1080,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -1091,6 +1116,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -1126,6 +1152,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -1161,6 +1188,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -1196,6 +1224,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -1224,6 +1253,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -1251,6 +1281,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -1282,6 +1313,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---
@@ -1310,6 +1342,7 @@
                     transform_null_in=1,
                     optimize_min_equality_disjunction_chain_length=4294967295,
                     allow_experimental_join_condition=1,
+                    prefer_global_in_and_join=1,
                     use_hive_partitioning=0
   '''
 # ---

--- a/posthog/hogql_queries/test/test_sessions_query_runner.py
+++ b/posthog/hogql_queries/test/test_sessions_query_runner.py
@@ -1123,3 +1123,13 @@ class TestSessionsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
             assert isinstance(response, CachedSessionsQueryResponse)
             assert len(response.results) == 3
+
+    def test_query_uses_prefer_global_in_and_join(self):
+        # Sessions tables are Distributed across a cluster that doesn't have
+        # events/persons. prefer_global_in_and_join avoids UNKNOWN_TABLE when
+        # the user filters sessions by an events subquery.
+        query = SessionsQuery(after="2024-01-01", kind="SessionsQuery", select=["*"])
+        runner = SessionsQueryRunner(query=query, team=self.team)
+        runner.run()
+        assert runner.paginator.response.clickhouse is not None
+        assert "prefer_global_in_and_join=1" in runner.paginator.response.clickhouse


### PR DESCRIPTION
Sessions tables are Distributed to a ClickHouse cluster that doesn't host events/persons. When a sessions query includes an IN-subquery against those tables (e.g. Activity → Sessions filtered by an event property), ClickHouse ships the subquery to each sessions shard and fails with UNKNOWN_TABLE.

Setting prefer_global_in_and_join=1 on SessionsQueryRunner queries tells ClickHouse to evaluate the subquery once on the initiator and broadcast the result to shards. No HogQL changes — ClickHouse handles the promotion based on actual cluster topology.

Scope is limited to SessionsQueryRunner so other query paths (persons LazyJoin, cohort filters, insights) are unaffected.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
