### PR TITLE
chore(insights): collapse EditorFilters to single-column panel layout

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -232,7 +232,6 @@ export const FEATURE_FLAGS = {
     AA_TEST_BAYESIAN_NEW: 'aa-test-bayesian-new', // owner: #team-experiments
     ADVANCE_MARKETING_ANALYTICS_SETTINGS: 'advance-marketing-analytics-settings', // owner: @jabahamondes  #team-web-analytics
     MARKETING_ANALYTICS_DRILL_DOWN: 'marketing-analytics-drill-down', // owner: @jabahamondes  #team-web-analytics
-    MARKETING_ANALYTICS_EXTENDED_DRILL_DOWN: 'marketing-analytics-extended-drill-down', // owner: @jabahamondes  #team-web-analytics
     MARKETING_ANALYTICS_UTM_AUDIT: 'marketing-analytics-utm-audit', // owner: @jabahamondes  #team-web-analytics
     APPROVALS: 'approvals', // owner: @yasen-posthog #team-platform-features
     AI_ONLY_MODE: 'ai-only-mode', // owner: #team-posthog-ai
@@ -294,7 +293,6 @@ export const FEATURE_FLAGS = {
     EXPERIMENT_SESSION_REPLAYS_SKILL: 'experiment-session-replays-skill', // owner: @rodrigoi #team-experiments
     EXPERIMENT_SIGNIFICANCE_ALERTS: 'experiment-significance-alerts', // owner: @jurajmajerik #team-experiments
     EXPERIMENT_QUERY_PREAGGREGATION: 'experiment-query-preaggregation', // owner: @jurajmajerik #team-experiments
-    EXPERIMENTS_METRIC_EVENTS_PRECOMPUTATION: 'experiments-metric-events-precomputation', // owner: @jurajmajerik #team-experiments
     EXPERIMENT_FUNNEL_ACTORS_QUERY: 'experiment-funnel-actors-query', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_DW_AA_TEST: 'experiments-dw-aa-test', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments
@@ -306,11 +304,13 @@ export const FEATURE_FLAGS = {
     FEATURE_FLAG_MIXED_TARGETING: 'feature-flag-mixed-targeting', // owner: @dmarticus #team-feature-flags
     FEATURE_FLAG_NOTIFICATIONS: 'feature-flag-notifications', // owner: @reecejones #team-platform-features
     FEATURE_FLAG_USAGE_DASHBOARD_CHECKBOX: 'feature-flag-usage-dashboard-checkbox', // owner: #team-feature-flags, globally disabled, enables opt-out of auto dashboard creation
+    FLAG_BUCKETING_IDENTIFIER: 'flag-bucketing-identifier', // owner: @andehen #team-experiments
     REALTIME_COHORT_FLAG_TARGETING: 'realtime-cohort-flag-targeting', // owner: @dmarticus #team-feature-flags
     FLAG_EVALUATION_RUNTIMES: 'flag-evaluation-runtimes', // owner: @dmarticus #team-feature-flags
     FLAG_EVALUATION_TAGS: 'flag-evaluation-tags', // owner: @dmarticus #team-feature-flags
     FLAGGED_FEATURE_INDICATOR: 'flagged-feature-indicator', // owner: @benjackwhite
     GROUP_PROFILE_EXPERIMENT: 'group-profile-experiment', // owner: @arthurdedeus #team-customer-analytics
+    INSIGHT_OPTIONS_PAGE: 'insight-options-page', // owner: @rafaeelaudibert #team-growth multivariate=control,test,dropdown
     PRODUCT_ANALYTICS_HOME_TAB: 'product-analytics-home-tab', // owner: @anirudhpillai #team-product-analytics
     INTER_PROJECT_TRANSFERS: 'inter-project-transfers', // owner: @reecejones #team-platform-features
     LINKS: 'links', // owner: @marconlp #team-link (team doesn't exist for now, maybe will come back in the future)
@@ -359,7 +359,6 @@ export const FEATURE_FLAGS = {
     MAX_SESSION_SUMMARIZATION_VIDEO_AS_BASE: 'max-session-summarization-video-as-base', // owner: #team-signals
     PRODUCT_AUTONOMY: 'product-autonomy', // owner: #team-signals
     MESSAGING_SES: 'messaging-ses', // owner #team-workflows
-    NOTEBOOKS_COLLABORATION: 'notebooks-collaboration', // owner: #team-platform-features
     NOTEBOOKS_COLLAPSIBLE_SECTIONS: 'notebooks-collapsible-sections', // owner: @benjackwhite
     NOTEBOOK_PYTHON: 'notebook-python', // owner: #team-data-tools
     PAGE_REPORTS_AVERAGE_PAGE_VIEW: 'page-reports-average-page-view', // owner: @jordanm-posthog #team-web-analytics
@@ -371,7 +370,6 @@ export const FEATURE_FLAGS = {
     PRODUCT_ANALYTICS_DASHBOARD_COLORS: 'dashboard-colors', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_ANALYTICS_HIDE_WEEKENDS: 'product-analytics-hide-weekends', // owner: @kliment-slice #team-irl-events
     PRODUCT_ANALYTICS_HOG_CHARTS: 'product-analytics-hog-charts', // owner: @sampennington #team-product-analytics
-    PRODUCT_ANALYTICS_SIMPLE_EDITOR: 'product-analytics-simple-editor', // owner: @sampennington #team-product-analytics
     PRODUCT_ANALYTICS_INSIGHT_HORIZONTAL_CONTROLS: 'insight-horizontal-controls', // owner: #team-product-analytics
     PRODUCT_ANALYTICS_PATHS_V2: 'paths-v2', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_ANALYTICS_RETENTION_AGGREGATION: 'retention-aggregation', // owner: @anirudhpillai #team-product-analytics
@@ -381,7 +379,6 @@ export const FEATURE_FLAGS = {
     PRODUCT_SUPPORT: 'product-support-release', // owner: @veryayskiy #team-conversations
     PRODUCT_SUPPORT_SIDE_PANEL: 'product-support-side-panel', // owner: @veryayskiy #team-conversations
     PRODUCT_SUPPORT_AI_SUGGESTION: 'product-support-ai-suggestion', // owner: @veryayskiy #team-conversations
-    PRODUCT_SUPPORT_TICKET_VIEWS: 'product-support-ticket-views', // owner: @veryayskiy #team-conversations
     ONBOARDING_PRODUCT_SELECTION_HEADING: 'onboarding-product-selection-heading', // owner: #team-growth, payload overrides the heading copy on the first onboarding page
     ONBOARDING_NAVBAR: 'onboarding-navbar', // owner: #team-growth, hides the navbar during onboarding to reduce distractions multivariate=true
     ONBOARDING_SESSION_REPLAY_MEDIA: 'onboarding-session-replay-media', // owner: @fercgomes #team-growth multivariate=control,screenshot,demo
@@ -393,10 +390,8 @@ export const FEATURE_FLAGS = {
     ONBOARDING_WIZARD_PROMINENCE: 'onboarding-wizard-prominence', // owner: #team-growth multivariate=control,wizard-hero,wizard-tab,wizard-only
     ONBOARDING_WIZARD_INSTALLATION_IMPROVED_COPY: 'onboarding-wizard-installation-improved-copy', // owner: @fercgomes #team-growth multivariate=control,test
     ONBOARDING_MOBILE_INSTALL_HELPER: 'onboarding-mobile-install-helper', // owner: @fercgomes #team-growth multivariate=control,test — target $device_type=Mobile at the flag level
-    ONBOARDING_DATA_WAREHOUSE_VALUE_PROP: 'onboarding-data-warehouse-value-prop', // owner: @fercgomes #team-growth multivariate=control,table,query
     OWNER_ONLY_BILLING: 'owner-only-billing', // owner: @pawelcebula #team-billing
     POST_ONBOARDING_MODAL_EXPERIMENT: 'post-onboarding-modal-experiment', // owner: @fercgomes #team-growth multivariate=control,test
-    QUICK_START_PULSE_INDICATOR: 'quick-start-pulse-indicator', // owner: @fercgomes #team-growth multivariate=control,test
     PASSKEY_SIGNUP_ENABLED: 'passkey-signup-enabled', // owner: @reecejones #team-platform-features
     PASSWORD_PROTECTED_SHARES: 'password-protected-shares', // owner: @aspicer
     DASHBOARD_AUTO_PREVIEW_LIMIT: 'dashboard-auto-preview-limit', // owner: @pauldambra #team-product-analytics
@@ -433,6 +428,7 @@ export const FEATURE_FLAGS = {
     SEMVER_TARGETING: 'semver-targeting', // owner: #team-feature-flags
     SHOPIFY_DWH: 'shopify-dwh', // owner: #team-warehouse-sources
     SLACK_DWH: 'slack-dwh', // owner: @MarconLP #team-warehouse-sources
+    SHOW_DATA_PIPELINES_NAV_ITEM: 'show-data-pipelines-nav-item', // owner: @raquelmsmith
     SHOW_REFERRER_FAVICON: 'show-referrer-favicon', // owner: @jordanm-posthog #team-web-analytics
     SHOW_REPLAY_FILTERS_FEEDBACK_BUTTON: 'show-replay-filters-feedback-button', // owner: @ksvat #team-replay
     SHOW_SESSION_SUMMARY_FEEDBACK_SURVEY: 'show-session-summary-feedback-survey', // owner: @hayne #team-replay
@@ -446,7 +442,6 @@ export const FEATURE_FLAGS = {
     SURVEYS_FORM_BUILDER: 'surveys-form-builder', // owner: @adboio #team-surveys
     SURVEY_HEADLINE_SUMMARY: 'survey-headline-summary', // owner: @adboio #team-surveys
     SURVEYS_INSIGHT_BUTTON_EXPERIMENT: 'ask-users-why-ai-vs-quickcreate', // owner: @adboio #team-surveys multivariate=true
-    SURVEYS_TOOLBAR: 'surveys-toolbar', // owner: @fcgomes
     SURVEYS_WEB_ANALYTICS_CROSS_SELL: 'surveys-in-web-analytics', // owner: @adboio #team-surveys
     TASK_SUMMARIES: 'task-summaries', // owner: #team-llm-analytics
     TASK_TOOL: 'phai-task-tool', // owner: @kappa90 #team-posthog-ai
@@ -463,9 +458,9 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_EMPTY_ONBOARDING: 'web-analytics-empty-onboarding', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_HEALTH_TAB: 'web_analytics_health_tab', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_INCLUDE_HOST: 'web-analytics-include-host', // owner: @lricoy #team-web-analytics
-    WEB_ANALYTICS_LIVE_EDIT_LAYOUT: 'web-analytics-live-edit-layout', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_LIVE_MAP: 'web-analytics-live-map', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_LIVE_METRICS: 'web-analytics-live-metrics', // owner: @jordanm-posthog #team-web-analytics
+    WEB_ANALYTICS_LIVE_REFERRERS: 'web-analytics-live-referrers', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_MARKETING: 'marketing-analytics', // owner: @jabahamondes #team-web-analytics
     MARKETING_ANALYTICS_MULTI_TOUCH_ATTRIBUTION: 'marketing-analytics-multi-touch-attribution', // owner: @jabahamondes #team-web-analytics
     WEB_ANALYTICS_OPEN_URL: 'web-analytics-open-url', // owner: @lricoy #team-web-analytics
@@ -476,6 +471,7 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_REGIONS_MAP: 'web-analytics-regions-map', // owner: @jordanm-posthog #team-web-analytics
     WEB_ANALYTICS_TOOLTIP_COMPARISON_LABELS: 'web-analytics-tooltip-comparison-labels', // owner: @lricoy #team-web-analytics
     WORKFLOWS_BATCH_TRIGGERS: 'workflows-batch-triggers', // owner: #team-workflows
+    WORKFLOWS_RECURRING_SCHEDULES: 'workflows-recurring-schedules', // owner: #team-workflows
     WORKFLOWS_INTERNAL_EVENT_FILTERS: 'workflows-internal-event-filters', // owner: @haven #team-workflows
     WORKFLOWS_PERSON_TIMEZONE: 'workflows-person-timezone', // owner: #team-workflows
     WORKFLOWS_PUSH_NOTIFICATIONS: 'workflows-push-notifications', // owner: @Odin #team-workflows

--- a/frontend/src/queries/nodes/InsightViz/EditorFilterGroup.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilterGroup.tsx
@@ -1,73 +1,21 @@
-import clsx from 'clsx'
-
-import { IconCollapse, IconExpand } from '@posthog/icons'
-
-import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { slugify } from 'lib/utils'
-
 import { InsightQueryNode } from '~/queries/schema/schema-general'
 import type { InsightEditorFilterGroup, InsightLogicProps } from '~/types'
 
 import { EditorFilterGroupTile } from './EditorFilterGroupTile'
-import { EditorFilterItems } from './EditorFilterItems'
-import { useEditorGroupExpansion } from './useEditorGroupExpansion'
 
 export interface EditorFilterGroupProps {
     editorFilterGroup: InsightEditorFilterGroup
     insightProps: InsightLogicProps
     query: InsightQueryNode
-    asTile?: boolean
     queryKind?: string
 }
 
-export function EditorFilterGroup({
-    insightProps,
-    editorFilterGroup,
-    asTile,
-    queryKind,
-}: EditorFilterGroupProps): JSX.Element {
-    const { title, defaultExpanded, editorFilters, collapsedSummary } = editorFilterGroup
-    const hasContent = !!collapsedSummary
-    const [isRowExpanded, setIsRowExpanded, isExpandable] = useEditorGroupExpansion(defaultExpanded, hasContent)
-
-    if (asTile) {
-        return (
-            <EditorFilterGroupTile
-                insightProps={insightProps}
-                editorFilterGroup={editorFilterGroup}
-                queryKind={queryKind}
-            />
-        )
-    }
-
+export function EditorFilterGroup({ insightProps, editorFilterGroup, queryKind }: EditorFilterGroupProps): JSX.Element {
     return (
-        <div>
-            {isExpandable && (
-                <LemonButton
-                    fullWidth
-                    onClick={() => setIsRowExpanded(!isRowExpanded)}
-                    sideIcon={isRowExpanded ? <IconCollapse /> : <IconExpand />}
-                    title={isRowExpanded ? 'Show less' : 'Show more'}
-                    data-attr={'editor-filter-group-collapse-' + slugify(title)}
-                >
-                    <div className="flex items-center gap-2 font-semibold">
-                        <span>{title}</span>
-                        {!isRowExpanded && collapsedSummary && (
-                            <span className="text-xs font-normal text-secondary">{collapsedSummary}</span>
-                        )}
-                    </div>
-                </LemonButton>
-            )}
-
-            {isRowExpanded && (
-                <div
-                    className={clsx('flex flex-col gap-2', {
-                        'border rounded p-2 mt-1': isExpandable && isRowExpanded,
-                    })}
-                >
-                    <EditorFilterItems editorFilters={editorFilters} insightProps={insightProps} />
-                </div>
-            )}
-        </div>
+        <EditorFilterGroupTile
+            insightProps={insightProps}
+            editorFilterGroup={editorFilterGroup}
+            queryKind={queryKind}
+        />
     )
 }

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.test.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.test.tsx
@@ -1,11 +1,9 @@
 import '@testing-library/jest-dom'
 
-import { act, cleanup, render, screen, within } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BindLogic, Provider } from 'kea'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -39,23 +37,6 @@ function makeTrendsQuery(): TrendsQuery {
     return {
         kind: NodeKind.TrendsQuery,
         series: [{ kind: NodeKind.EventsNode, name: '$pageview', event: '$pageview', math: BaseMathType.TotalCount }],
-    }
-}
-
-function makeDataWarehouseTrendsQuery(): TrendsQuery {
-    return {
-        kind: NodeKind.TrendsQuery,
-        series: [
-            {
-                kind: NodeKind.DataWarehouseNode,
-                id: 'warehouse_orders',
-                table_name: 'warehouse_orders',
-                name: 'Orders',
-                timestamp_field: 'created_at',
-                id_field: 'order_id',
-                distinct_id_field: 'customer_id',
-            },
-        ],
     }
 }
 
@@ -121,145 +102,72 @@ describe('EditorFilters', () => {
             },
         })
         initKeaTests()
-        featureFlagLogic().mount()
     })
 
     afterEach(() => {
         cleanup()
     })
 
-    describe.each([
-        { flagEnabled: 'control', label: 'flag off' },
-        { flagEnabled: 'test', label: 'flag on' },
-    ])('PRODUCT_ANALYTICS_SIMPLE_EDITOR $label', ({ flagEnabled }) => {
-        beforeEach(() => {
-            featureFlagLogic.actions.setFeatureFlags([], {
-                [FEATURE_FLAGS.PRODUCT_ANALYTICS_SIMPLE_EDITOR]: flagEnabled,
-            })
-        })
-
-        it.each([
-            {
-                name: 'trends',
-                query: makeTrendsQuery(),
-                expectedPresent: ['Filters'],
-                expectedAbsent: ['Lifecycle Toggles', 'Retention condition', 'Event Types', 'Starts at'],
-            },
-            {
-                name: 'lifecycle',
-                query: makeLifecycleQuery(),
-                expectedPresent: ['Lifecycle Toggles', 'Filters'],
-                expectedAbsent: ['Retention condition', 'Event Types', 'Stickiness Criteria'],
-            },
-            {
-                name: 'stickiness',
-                query: makeStickinessQuery(),
-                expectedPresent: ['Stickiness Criteria', 'Filters'],
-                expectedAbsent: ['Lifecycle Toggles', 'Retention condition', 'Event Types'],
-            },
-            {
-                name: 'retention',
-                query: makeRetentionQuery(),
-                expectedPresent: ['Retention condition', 'Calculation options', 'Filters'],
-                expectedAbsent: ['Lifecycle Toggles', 'Stickiness Criteria', 'Event Types'],
-            },
-            {
-                name: 'funnels',
-                query: makeFunnelsQuery(),
-                expectedPresent: ['Filters', 'Advanced options'],
-                expectedAbsent: ['Lifecycle Toggles', 'Retention condition', 'Event Types'],
-            },
-            {
-                name: 'paths',
-                query: makePathsQuery(),
-                expectedPresent: ['Event Types', 'Starts at', 'Filters'],
-                expectedAbsent: ['Lifecycle Toggles', 'Retention condition', 'Stickiness Criteria'],
-            },
-        ])('$name shows correct filter labels', ({ query, expectedPresent, expectedAbsent }) => {
-            setupAndRender(query)
-            for (const text of expectedPresent) {
-                expect(screen.getByText(text)).toBeInTheDocument()
-            }
-            for (const text of expectedAbsent) {
-                expect(screen.queryByText(text)).not.toBeInTheDocument()
-            }
-        })
+    it.each([
+        {
+            name: 'trends',
+            query: makeTrendsQuery(),
+            expectedPresent: ['Filters'],
+            expectedAbsent: ['Lifecycle Toggles', 'Retention condition', 'Event Types', 'Starts at'],
+        },
+        {
+            name: 'lifecycle',
+            query: makeLifecycleQuery(),
+            expectedPresent: ['Lifecycle Toggles', 'Filters'],
+            expectedAbsent: ['Retention condition', 'Event Types', 'Stickiness Criteria'],
+        },
+        {
+            name: 'stickiness',
+            query: makeStickinessQuery(),
+            expectedPresent: ['Stickiness Criteria', 'Filters'],
+            expectedAbsent: ['Lifecycle Toggles', 'Retention condition', 'Event Types'],
+        },
+        {
+            name: 'retention',
+            query: makeRetentionQuery(),
+            expectedPresent: ['Retention condition', 'Calculation options', 'Filters'],
+            expectedAbsent: ['Lifecycle Toggles', 'Stickiness Criteria', 'Event Types'],
+        },
+        {
+            name: 'funnels',
+            query: makeFunnelsQuery(),
+            expectedPresent: ['Filters', 'Advanced options'],
+            expectedAbsent: ['Lifecycle Toggles', 'Retention condition', 'Event Types'],
+        },
+        {
+            name: 'paths',
+            query: makePathsQuery(),
+            expectedPresent: ['Event Types', 'Starts at', 'Filters'],
+            expectedAbsent: ['Lifecycle Toggles', 'Retention condition', 'Stickiness Criteria'],
+        },
+    ])('$name shows correct filter labels', ({ query, expectedPresent, expectedAbsent }) => {
+        setupAndRender(query)
+        for (const text of expectedPresent) {
+            expect(screen.getByText(text)).toBeInTheDocument()
+        }
+        for (const text of expectedAbsent) {
+            expect(screen.queryByText(text)).not.toBeInTheDocument()
+        }
     })
 
-    describe('classic layout (flag off)', () => {
-        beforeEach(() => {
-            featureFlagLogic.actions.setFeatureFlags([], {
-                [FEATURE_FLAGS.PRODUCT_ANALYTICS_SIMPLE_EDITOR]: 'control',
-            })
-        })
-
-        it('shows formula mode toggle for trends', () => {
-            setupAndRender(makeTrendsQuery())
-            expect(screen.getByText('Enable formula mode')).toBeInTheDocument()
-        })
-
-        it('toggles to "Disable formula mode" after clicking', async () => {
-            const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
-            jest.useFakeTimers()
-            setupAndRender(makeTrendsQuery())
-
-            await user.click(screen.getByText('Enable formula mode'))
-            await act(async () => {
-                jest.advanceTimersByTime(500)
-            })
-
-            expect(screen.getByText('Disable formula mode')).toBeInTheDocument()
-            jest.useRealTimers()
-        })
-
-        it('expands advanced options section on click', async () => {
-            setupAndRender(makeFunnelsQuery())
-
-            expect(screen.queryByText('Use person properties from query time')).not.toBeInTheDocument()
-
-            await userEvent.click(screen.getByRole('button', { name: /Advanced options/ }))
-
-            expect(screen.getByText('Use person properties from query time')).toBeInTheDocument()
-        })
-
-        it('disables query-time person properties for data warehouse insights', async () => {
-            setupAndRender(makeDataWarehouseTrendsQuery())
-
-            await userEvent.click(screen.getByRole('button', { name: /Advanced options/ }))
-
-            const disabledArea = screen.getByText('Use person properties from query time').closest('.LemonDisabledArea')
-            expect(disabledArea).toHaveAttribute('aria-disabled', 'true')
-
-            await userEvent.hover(disabledArea as HTMLElement)
-
-            expect(
-                await screen.findByText('Data warehouse insights always use the latest table properties.')
-            ).toBeInTheDocument()
-            expect(within(disabledArea as HTMLElement).getByRole('switch')).toBeDisabled()
-        })
+    it('hides formula mode toggle for trends', () => {
+        setupAndRender(makeTrendsQuery())
+        expect(screen.queryByText('Enable formula mode')).not.toBeInTheDocument()
     })
 
-    describe('panels layout (flag on)', () => {
-        beforeEach(() => {
-            featureFlagLogic.actions.setFeatureFlags([], {
-                [FEATURE_FLAGS.PRODUCT_ANALYTICS_SIMPLE_EDITOR]: 'test',
-            })
-        })
+    it('shows funnel settings collapsed by default and expandable', async () => {
+        setupAndRender(makeFunnelsQuery())
 
-        it('hides formula mode toggle for trends', () => {
-            setupAndRender(makeTrendsQuery())
-            expect(screen.queryByText('Enable formula mode')).not.toBeInTheDocument()
-        })
+        const settingsButton = screen.getByRole('button', { name: /Funnel settings/ })
+        expect(settingsButton).toBeInTheDocument()
+        expect(settingsButton).toHaveAttribute('title', 'Show more')
 
-        it('shows funnel settings collapsed by default and expandable', async () => {
-            setupAndRender(makeFunnelsQuery())
-
-            const settingsButton = screen.getByRole('button', { name: /Funnel settings/ })
-            expect(settingsButton).toBeInTheDocument()
-            expect(settingsButton).toHaveAttribute('title', 'Show more')
-
-            await userEvent.click(settingsButton)
-            expect(settingsButton).toHaveAttribute('title', 'Show less')
-        })
+        await userEvent.click(settingsButton)
+        expect(settingsButton).toHaveAttribute('title', 'Show less')
     })
 })

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -4,7 +4,6 @@ import { IconInfo } from '@posthog/icons'
 import { Link, Tooltip } from '@posthog/lemon-ui'
 
 import { NON_BREAKDOWN_DISPLAY_TYPES } from 'lib/constants'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { pluralize } from 'lib/utils'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { Attribution } from 'scenes/insights/EditorFilters/AttributionFilter'
@@ -47,9 +46,7 @@ import { EditorFiltersShell } from './EditorFiltersShell'
 import { getBreakdownSummary, getFiltersSummary, getSeriesSummary, visibleFilters } from './editorFilterUtils'
 import { GlobalAndOrFilters } from './GlobalAndOrFilters'
 import { LifecycleToggles } from './LifecycleToggles'
-import { TrendsFormula } from './TrendsFormula'
 import { TrendsSeries } from './TrendsSeries'
-import { TrendsSeriesLabel } from './TrendsSeriesLabel'
 
 export interface EditorFiltersProps {
     query: InsightQueryNode
@@ -59,7 +56,6 @@ export interface EditorFiltersProps {
 
 export function EditorFilters({ query, showing, embedded }: EditorFiltersProps): JSX.Element | null {
     const { hasAvailableFeature } = useValues(userLogic)
-    const editorPanelsEnabled = useFeatureFlag('PRODUCT_ANALYTICS_SIMPLE_EDITOR', 'test')
 
     const { insightProps } = useValues(insightLogic)
     const {
@@ -73,7 +69,6 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
         display,
         pathsFilter,
         querySource,
-        hasFormula,
         series,
         breakdownFilter,
         properties,
@@ -115,51 +110,36 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
                 display || ChartDisplayType.ActionsLineGraph
             ))
 
-    // Compute summaries for collapsible sections (used when editorPanelsEnabled)
-    const seriesSummary = editorPanelsEnabled ? getSeriesSummary(series) : null
-    const filtersSummary = editorPanelsEnabled ? getFiltersSummary(properties) : null
-    const breakdownSummary = editorPanelsEnabled ? getBreakdownSummary(breakdownFilter) : null
-    const exclusionCount = editorPanelsEnabled && isPaths ? (pathsFilter?.excludeEvents?.length ?? 0) : 0
+    const seriesSummary = getSeriesSummary(series)
+    const filtersSummary = getFiltersSummary(properties)
+    const breakdownSummary = getBreakdownSummary(breakdownFilter)
+    const exclusionCount = isPaths ? (pathsFilter?.excludeEvents?.length ?? 0) : 0
     const exclusionsSummary = exclusionCount > 0 ? pluralize(exclusionCount, 'exclusion') : null
 
     const leftEditorFilterGroups: InsightEditorFilterGroup[] = [
         {
             title: 'Retention condition',
             defaultExpanded: true,
-            show: editorPanelsEnabled && isRetention,
+            show: isRetention,
             editorFilters: [{ key: 'retention-condition', component: RetentionCondition }],
         },
         {
             title: 'Calculation options',
             defaultExpanded: false,
-            show: editorPanelsEnabled && isRetention,
+            show: isRetention,
             editorFilters: [{ key: 'retention-options', component: RetentionOptions }],
         },
         {
-            title: editorPanelsEnabled && isFunnels ? 'Steps' : 'General',
-            show: !(editorPanelsEnabled && isRetention),
-            defaultExpanded: editorPanelsEnabled ? true : undefined,
+            title: isFunnels ? 'Steps' : 'General',
+            show: !isRetention,
+            defaultExpanded: true,
             headerExtra:
-                editorPanelsEnabled &&
-                isFunnels &&
-                (querySource as FunnelsQuery)?.funnelsFilter?.funnelVizType !== FunnelVizTypeEnum.Flow ? (
+                isFunnels && (querySource as FunnelsQuery)?.funnelsFilter?.funnelVizType !== FunnelVizTypeEnum.Flow ? (
                     <Tooltip docLink="https://posthog.com/docs/product-analytics/funnels#graph-type">
                         <FunnelVizType insightProps={insightProps} />
                     </Tooltip>
                 ) : null,
             editorFilters: visibleFilters([
-                {
-                    key: 'retention-condition',
-                    label: 'Retention condition',
-                    component: RetentionCondition,
-                    show: isRetention,
-                },
-                {
-                    key: 'retention-options',
-                    label: 'Calculation options',
-                    component: RetentionOptions,
-                    show: isRetention,
-                },
                 { key: 'query-steps', component: FunnelsQuerySteps, show: isFunnels },
                 { key: 'event-types', label: 'Event Types', component: PathsEventsTypes, show: isPaths },
                 {
@@ -194,43 +174,25 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
         },
         {
             title: 'Series',
-            defaultExpanded: editorPanelsEnabled ? true : undefined,
-            collapsedSummary: editorPanelsEnabled ? seriesSummary : undefined,
+            defaultExpanded: true,
+            collapsedSummary: seriesSummary,
             editorFilters: visibleFilters([
                 {
                     key: 'series',
-                    label:
-                        !editorPanelsEnabled &&
-                        isTrends &&
-                        display !== ChartDisplayType.CalendarHeatmap &&
-                        display !== ChartDisplayType.BoxPlot
-                            ? TrendsSeriesLabel
-                            : undefined,
                     component: TrendsSeries,
                     show: isTrendsLike,
-                },
-                {
-                    key: 'formula',
-                    label: 'Formula',
-                    component: TrendsFormula,
-                    show: !editorPanelsEnabled && isTrends && hasFormula && display !== ChartDisplayType.BoxPlot,
                 },
             ]),
         },
         {
-            title:
-                editorPanelsEnabled && isFunnels
-                    ? 'Funnel settings'
-                    : editorPanelsEnabled && isPaths
-                      ? 'Path settings'
-                      : 'Advanced options',
-            defaultExpanded: editorPanelsEnabled ? false : undefined,
+            title: isFunnels ? 'Funnel settings' : isPaths ? 'Path settings' : 'Advanced options',
+            defaultExpanded: false,
             editorFilters: visibleFilters([
                 { key: 'paths-advanced', component: PathsAdvanced, show: isPaths },
                 {
                     key: 'funnel-step-configuration',
                     component: FunnelStepConfiguration,
-                    show: isFunnels && editorPanelsEnabled,
+                    show: isFunnels,
                 },
                 { key: 'funnels-advanced', component: FunnelsAdvanced, show: isFunnels },
             ]),
@@ -240,8 +202,8 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
     const rightEditorFilterGroups: InsightEditorFilterGroup[] = [
         {
             title: 'Filters',
-            defaultExpanded: editorPanelsEnabled ? false : undefined,
-            collapsedSummary: editorPanelsEnabled ? filtersSummary : undefined,
+            defaultExpanded: false,
+            collapsedSummary: filtersSummary,
             editorFilters: visibleFilters([
                 {
                     key: 'toggles',
@@ -298,15 +260,15 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
                 },
                 {
                     key: 'properties',
-                    label: editorPanelsEnabled ? undefined : 'Filters',
+                    label: undefined,
                     component: GlobalAndOrFilters as (props: EditorFilterProps) => JSX.Element | null,
                 },
             ]),
         },
         {
             title: 'Breakdown',
-            defaultExpanded: editorPanelsEnabled ? false : undefined,
-            collapsedSummary: editorPanelsEnabled ? breakdownSummary : undefined,
+            defaultExpanded: false,
+            collapsedSummary: breakdownSummary,
             editorFilters: visibleFilters([
                 { key: 'breakdown', component: Breakdown, show: hasBreakdown },
                 {
@@ -366,8 +328,8 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
         },
         {
             title: 'Exclusions',
-            defaultExpanded: editorPanelsEnabled ? false : undefined,
-            collapsedSummary: editorPanelsEnabled ? exclusionsSummary : undefined,
+            defaultExpanded: false,
+            collapsedSummary: exclusionsSummary,
             editorFilters: visibleFilters([
                 {
                     key: 'paths-exclusions',
@@ -407,50 +369,17 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
     const visibleGroups = (groups: InsightEditorFilterGroup[]): InsightEditorFilterGroup[] =>
         groups.filter((g) => g.show !== false && g.editorFilters.length > 0)
 
-    const filterGroupsGroups = editorPanelsEnabled
-        ? [
-              {
-                  title: 'single',
-                  editorFilterGroups: [
-                      ...visibleGroups(leftEditorFilterGroups),
-                      ...visibleGroups(rightEditorFilterGroups),
-                  ],
-              },
-          ]
-        : [
-              { title: 'left', editorFilterGroups: visibleGroups(leftEditorFilterGroups) },
-              { title: 'right', editorFilterGroups: visibleGroups(rightEditorFilterGroups) },
-          ]
-
-    if (!editorPanelsEnabled) {
-        return (
-            <EditorFiltersShell query={query} showing={showing} embedded={embedded}>
-                {filterGroupsGroups.map(({ title, editorFilterGroups }) => (
-                    <div key={title} className="grow shrink basis-[28rem] flex flex-col gap-4 max-w-full">
-                        {editorFilterGroups.map((editorFilterGroup) => (
-                            <EditorFilterGroup
-                                key={editorFilterGroup.title}
-                                editorFilterGroup={editorFilterGroup}
-                                insightProps={insightProps}
-                                query={query}
-                            />
-                        ))}
-                    </div>
-                ))}
-            </EditorFiltersShell>
-        )
-    }
+    const allFilterGroups = [...visibleGroups(leftEditorFilterGroups), ...visibleGroups(rightEditorFilterGroups)]
 
     return (
-        <EditorFiltersShell query={query} showing={showing} embedded={embedded} asPanels>
+        <EditorFiltersShell query={query} showing={showing} embedded={embedded}>
             <div className="flex flex-col gap-3">
-                {filterGroupsGroups[0].editorFilterGroups.map((editorFilterGroup) => (
+                {allFilterGroups.map((editorFilterGroup) => (
                     <EditorFilterGroup
                         key={editorFilterGroup.title}
                         editorFilterGroup={editorFilterGroup}
                         insightProps={insightProps}
                         query={query}
-                        asTile
                         queryKind={querySource?.kind}
                     />
                 ))}


### PR DESCRIPTION
## Problem

The `PRODUCT_ANALYTICS_SIMPLE_EDITOR` experiment is shipping the test variant. This PR cleans up the `EditorFilters` internals and deletes the flag constant. Stacked under #54791 (`EditorFiltersShell` cleanup).

## Changes

- Remove `useFeatureFlag('PRODUCT_ANALYTICS_SIMPLE_EDITOR', 'test')` from `EditorFilters.tsx` and collapse the dual-layout (left/right columns vs single panel) to a single tile column.
- Drop `EditorFilterGroup`'s non-tile expand/collapse body — it now always delegates to `EditorFilterGroupTile`.
- Update `EditorFilters.test.tsx` — remove the parametrized flag block, keep the panels-layout assertions.
- Delete the `PRODUCT_ANALYTICS_SIMPLE_EDITOR` constant from `lib/constants.tsx`.

## How did you test this code?

I'm an agent — no manual testing. This branch is a file-level subset of #54188, which had all 8 `EditorFilters.test.tsx` tests passing.

**Important:** this PR must land together with #54791 — merging alone would leave the shell rendering its legacy layout.

## Publish to changelog?

## 🤖 LLM context

Split out from #54188. Stacked under #54791.