### PR TITLE
chore(insights): simplify EditorFiltersShell to panel layout only

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/EditorFiltersShell.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFiltersShell.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { useMemo, useRef } from 'react'
-import { CSSTransition } from 'react-transition-group'
 
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { resizerLogic } from 'lib/components/Resizer/resizerLogic'
@@ -14,9 +13,7 @@ import { QUERY_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
 import {
     AssistantFunnelsQuery,
     AssistantHogQLQuery,
-    AssistantPathsQuery,
     AssistantRetentionQuery,
-    AssistantStickinessQuery,
     AssistantTrendsQuery,
 } from '~/queries/schema/schema-assistant-queries'
 import {
@@ -35,17 +32,10 @@ export interface EditorFiltersShellProps {
     query: InsightQueryNode
     showing: boolean
     embedded: boolean
-    asPanels?: boolean
     children: React.ReactNode
 }
 
-export function EditorFiltersShell({
-    query,
-    showing,
-    embedded,
-    asPanels,
-    children,
-}: EditorFiltersShellProps): JSX.Element {
+export function EditorFiltersShell({ query, showing, embedded, children }: EditorFiltersShellProps): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { querySource, shouldShowSessionAnalysisWarning } = useValues(insightVizDataLogic(insightProps))
     const { setQuery } = useActions(insightVizDataLogic(insightProps))
@@ -68,143 +58,72 @@ export function EditorFiltersShell({
 
     const QueryTypeIcon = QUERY_TYPES_METADATA[query.kind].icon
 
-    if (asPanels) {
-        return (
-            <div
-                ref={panelRef}
-                className={clsx(
-                    'EditorFiltersWrapper EditorFiltersWrapper--panels relative self-stretch @container/editor-panel',
-                    isResizing ? '' : 'transition-all duration-300 ease-out',
-                    showing
-                        ? 'opacity-100 p-px overflow-visible'
-                        : '!w-0 !min-w-0 !max-w-0 opacity-0 overflow-hidden border-0 !p-0'
-                )}
-                style={
-                    showing
-                        ? ({
-                              '--editor-panel-width': panelWidth ? `${panelWidth}px` : 'max(min(30%, 600px), 420px)',
-                          } as React.CSSProperties)
-                        : undefined
-                }
-            >
-                {showing ? (
-                    <MaxTool
-                        identifier="create_insight"
-                        context={{ current_query: querySource }}
-                        contextDescription={{ text: 'Current query', icon: <QueryTypeIcon /> }}
-                        callback={(
-                            toolOutput:
-                                | AssistantTrendsQuery
-                                | AssistantFunnelsQuery
-                                | AssistantRetentionQuery
-                                | AssistantHogQLQuery
-                        ) => {
-                            const source = castAssistantQuery(toolOutput)
-                            if (!source) {
-                                return
-                            }
-                            let node: QuerySchema
-                            if (isHogQLQuery(source)) {
-                                node = {
-                                    kind: NodeKind.DataVisualizationNode,
-                                    source,
-                                } satisfies DataVisualizationNode
-                            } else if (isInsightQueryNode(source)) {
-                                node = { kind: NodeKind.InsightVizNode, source } satisfies InsightVizNode
-                            } else {
-                                node = source
-                            }
-                            handleInsightSuggested(node)
-                            setQuery(node)
-                        }}
-                        initialMaxPrompt="Show me users who "
-                        className="h-full @min-[900px]/insight-viz:mr-3 [&_button.absolute]:!-top-2.5 [&_button.absolute]:!-right-2.5"
-                        active={maxToolActive}
-                    >
-                        <div className="@min-[1100px]/insight-viz:h-full @min-[1100px]/insight-viz:overflow-y-auto pb-0.5">
-                            {shouldShowSessionAnalysisWarning ? <SessionAnalysisWarning /> : null}
-                            {children}
-                            {previousQuery && (
-                                <SuggestionBanner
-                                    previousQuery={previousQuery}
-                                    suggestedQuery={suggestedQuery}
-                                    onReject={onRejectSuggestedInsight}
-                                />
-                            )}
-                        </div>
-                    </MaxTool>
-                ) : null}
-                {showing && <Resizer {...resizerProps} className="hidden @min-[900px]/insight-viz:block" />}
-            </div>
-        )
-    }
-
     return (
-        <CSSTransition in={showing} timeout={250} classNames="anim-" mountOnEnter unmountOnExit>
-            <div className="EditorFiltersWrapper">
-                {shouldShowSessionAnalysisWarning ? <SessionAnalysisWarning /> : null}
-
-                <div>
-                    <MaxTool
-                        identifier="create_insight"
-                        context={{
-                            current_query: querySource,
-                        }}
-                        contextDescription={{
-                            text: 'Current query',
-                            icon: <QueryTypeIcon />,
-                        }}
-                        callback={(
-                            toolOutput:
-                                | AssistantTrendsQuery
-                                | AssistantFunnelsQuery
-                                | AssistantRetentionQuery
-                                | AssistantStickinessQuery
-                                | AssistantPathsQuery
-                                | AssistantHogQLQuery
-                        ) => {
-                            const source = castAssistantQuery(toolOutput)
-                            if (!source) {
-                                return
-                            }
-
-                            let node: QuerySchema
-                            if (isHogQLQuery(source)) {
-                                node = {
-                                    kind: NodeKind.DataVisualizationNode,
-                                    source,
-                                } satisfies DataVisualizationNode
-                            } else if (isInsightQueryNode(source)) {
-                                node = { kind: NodeKind.InsightVizNode, source } satisfies InsightVizNode
-                            } else {
-                                node = source
-                            }
-
-                            handleInsightSuggested(node)
-                            setQuery(node)
-                        }}
-                        initialMaxPrompt="Show me users who "
-                        className="EditorFiltersWrapper__max-tool"
-                        active={maxToolActive}
-                    >
-                        <div
-                            className={clsx('@container/editor flex flex-row flex-wrap gap-8 bg-surface-primary', {
-                                'p-4 rounded border': !embedded,
-                            })}
-                        >
-                            {children}
-                        </div>
-                    </MaxTool>
-
-                    {previousQuery && (
-                        <SuggestionBanner
-                            previousQuery={previousQuery}
-                            suggestedQuery={suggestedQuery}
-                            onReject={onRejectSuggestedInsight}
-                        />
-                    )}
-                </div>
-            </div>
-        </CSSTransition>
+        <div
+            ref={panelRef}
+            className={clsx(
+                'EditorFiltersWrapper EditorFiltersWrapper--panels relative self-stretch @container/editor-panel',
+                isResizing ? '' : 'transition-all duration-300 ease-out',
+                showing
+                    ? 'opacity-100 p-px overflow-visible'
+                    : '!w-0 !min-w-0 !max-w-0 opacity-0 overflow-hidden border-0 !p-0'
+            )}
+            style={
+                showing
+                    ? ({
+                          '--editor-panel-width': panelWidth ? `${panelWidth}px` : 'max(min(30%, 600px), 420px)',
+                      } as React.CSSProperties)
+                    : undefined
+            }
+        >
+            {showing ? (
+                <MaxTool
+                    identifier="create_insight"
+                    context={{ current_query: querySource }}
+                    contextDescription={{ text: 'Current query', icon: <QueryTypeIcon /> }}
+                    callback={(
+                        toolOutput:
+                            | AssistantTrendsQuery
+                            | AssistantFunnelsQuery
+                            | AssistantRetentionQuery
+                            | AssistantHogQLQuery
+                    ) => {
+                        const source = castAssistantQuery(toolOutput)
+                        if (!source) {
+                            return
+                        }
+                        let node: QuerySchema
+                        if (isHogQLQuery(source)) {
+                            node = {
+                                kind: NodeKind.DataVisualizationNode,
+                                source,
+                            } satisfies DataVisualizationNode
+                        } else if (isInsightQueryNode(source)) {
+                            node = { kind: NodeKind.InsightVizNode, source } satisfies InsightVizNode
+                        } else {
+                            node = source
+                        }
+                        handleInsightSuggested(node)
+                        setQuery(node)
+                    }}
+                    initialMaxPrompt="Show me users who "
+                    className="h-full @min-[900px]/insight-viz:mr-3 [&_button.absolute]:!-top-2.5 [&_button.absolute]:!-right-2.5"
+                    active={maxToolActive}
+                >
+                    <div className="@min-[1100px]/insight-viz:h-full @min-[1100px]/insight-viz:overflow-y-auto pb-0.5">
+                        {shouldShowSessionAnalysisWarning ? <SessionAnalysisWarning /> : null}
+                        {children}
+                        {previousQuery && (
+                            <SuggestionBanner
+                                previousQuery={previousQuery}
+                                suggestedQuery={suggestedQuery}
+                                onReject={onRejectSuggestedInsight}
+                            />
+                        )}
+                    </div>
+                </MaxTool>
+            ) : null}
+            {showing && <Resizer {...resizerProps} className="hidden @min-[900px]/insight-viz:block" />}
+        </div>
     )
 }


### PR DESCRIPTION
## Problem

Final cleanup in the `PRODUCT_ANALYTICS_SIMPLE_EDITOR` flag removal. Stacked on top of the `EditorFilters` cleanup that stopped passing the `asPanels` prop.

## Changes

- Delete the legacy `CSSTransition`-wrapped render path in `EditorFiltersShell`.
- Remove the `asPanels` prop from the component's signature.

## How did you test this code?

I'm an agent — no manual testing. This branch is a file-level subset of #54188.

## Publish to changelog?

## 🤖 LLM context

Split out from #54188. Base is the `EditorFilters` cleanup PR since this drops the `asPanels` prop and callers must stop passing it first.