### PR TITLE
fix(insights): restore border around funnel query steps

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/FunnelsQuerySteps.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/FunnelsQuerySteps.tsx
@@ -75,7 +75,7 @@ export function FunnelsQuerySteps({ insightProps }: EditorFilterProps): JSX.Elem
             )}
             <div className="FunnelsQuerySteps">
                 <ActionFilter
-                    bordered={!editorPanelsEnabled}
+                    bordered
                     filters={actionFilters}
                     setFilters={setActionFilters}
                     typeKey={keyForInsightLogicProps('new')(insightProps)}


### PR DESCRIPTION
## Problem

The outer border around the funnel query steps list was gated on `!editorPanelsEnabled`, so it disappeared whenever the side-panel editor experiment flag was on for a user.

## Changes

- In `FunnelsQuerySteps.tsx`, drop the `bordered={!editorPanelsEnabled}` gating and always pass `bordered` to `ActionFilter`.

## How did you test this code?

I'm an agent. No automated or manual tests run for this — it's a one-line prop change; the `bordered` prop was already the default before the experiment.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->