### PR TITLE
feat(ingestion): fix new CH col added in 0186 that missed a table to fix migration 0232

### DIFF
--- a/posthog/clickhouse/migrations/0232_warpstream_ingestion_kafka_engines.py
+++ b/posthog/clickhouse/migrations/0232_warpstream_ingestion_kafka_engines.py
@@ -56,7 +56,7 @@ ALTER TABLE writable_events
 
 operations = (
     []
-    if not settings.CLOUD_DEPLOYMENT
+    if settings.CLOUD_DEPLOYMENT not in ("US", "EU", "DEV")
     else [
         # events_json (INGESTION_EVENTS — WS tables go to events ingestion nodes)
         #

--- a/posthog/clickhouse/migrations/0232_warpstream_ingestion_kafka_engines.py
+++ b/posthog/clickhouse/migrations/0232_warpstream_ingestion_kafka_engines.py
@@ -8,7 +8,11 @@ from posthog.models.ai_events.sql import (
     DISTRIBUTED_AI_EVENTS_TABLE_SQL,
     KAFKA_AI_EVENTS_WS_TABLE_SQL,
 )
-from posthog.models.event.sql import EVENTS_TABLE_JSON_WS_MV_SQL, KAFKA_EVENTS_TABLE_JSON_WS_SQL
+from posthog.models.event.sql import (
+    ALTER_TABLE_ADD_DYNAMICALLY_MATERIALIZED_COLUMNS,
+    EVENTS_TABLE_JSON_WS_MV_SQL,
+    KAFKA_EVENTS_TABLE_JSON_WS_SQL,
+)
 from posthog.models.group.sql import GROUPS_WS_TABLE_MV_SQL, KAFKA_GROUPS_WS_TABLE_SQL
 from posthog.models.person.sql import (
     KAFKA_PERSON_DISTINCT_ID2_WS_TABLE_SQL,
@@ -35,9 +39,19 @@ from posthog.models.person.sql import (
 # - kafka_ai_events_json_ws + ai_events_json_ws_mv (AI_EVENTS)
 # - kafka_heatmaps_ws + heatmaps_ws_mv (INGESTION_MEDIUM)
 
-ADD_HISTORICAL_MIGRATION_COLUMN_TO_WRITABLE_EVENTS = """
+# The writable_events table on INGESTION_EVENTS nodes was created out-of-band and
+# is missing columns that later migrations only applied to DATA nodes:
+#
+# - historical_migration Bool       (migration 0186 — only altered sharded_events/events on DATA)
+# - consumer_breadcrumbs Array(String) (migration 0113 — only altered writable_events on DATA)
+# - 40 dmat_* columns               (migration 0179 — only altered sharded_events/events on DATA)
+#
+# The WS MV (EVENTS_TABLE_JSON_WS_MV_SQL) SELECTs all of these, so they must exist
+# on the target writable_events before the MV can be created.
+ADD_MISSING_WRITABLE_EVENTS_COLUMNS = """
 ALTER TABLE writable_events
-ADD COLUMN IF NOT EXISTS historical_migration Bool
+    ADD COLUMN IF NOT EXISTS historical_migration Bool,
+    ADD COLUMN IF NOT EXISTS consumer_breadcrumbs Array(String)
 """
 
 operations = (
@@ -46,11 +60,14 @@ operations = (
     else [
         # events_json (INGESTION_EVENTS — WS tables go to events ingestion nodes)
         #
-        # Migration 0186 added historical_migration to sharded_events and events
-        # (DATA nodes) but missed writable_events. The WS MV SELECTs that column
-        # and writes TO writable_events, so the column must exist there first.
+        # Backfill missing columns on writable_events for INGESTION_EVENTS nodes.
         run_sql_with_exceptions(
-            ADD_HISTORICAL_MIGRATION_COLUMN_TO_WRITABLE_EVENTS,
+            ADD_MISSING_WRITABLE_EVENTS_COLUMNS,
+            node_roles=[NodeRole.INGESTION_EVENTS],
+        ),
+        # dmat_* slots (40 columns) — migration 0179 only added these to DATA nodes.
+        run_sql_with_exceptions(
+            ALTER_TABLE_ADD_DYNAMICALLY_MATERIALIZED_COLUMNS(table="writable_events"),
             node_roles=[NodeRole.INGESTION_EVENTS],
         ),
         run_sql_with_exceptions(

--- a/posthog/clickhouse/migrations/0232_warpstream_ingestion_kafka_engines.py
+++ b/posthog/clickhouse/migrations/0232_warpstream_ingestion_kafka_engines.py
@@ -35,11 +35,24 @@ from posthog.models.person.sql import (
 # - kafka_ai_events_json_ws + ai_events_json_ws_mv (AI_EVENTS)
 # - kafka_heatmaps_ws + heatmaps_ws_mv (INGESTION_MEDIUM)
 
+ADD_HISTORICAL_MIGRATION_COLUMN_TO_WRITABLE_EVENTS = """
+ALTER TABLE writable_events
+ADD COLUMN IF NOT EXISTS historical_migration Bool
+"""
+
 operations = (
     []
     if not settings.CLOUD_DEPLOYMENT
     else [
         # events_json (INGESTION_EVENTS — WS tables go to events ingestion nodes)
+        #
+        # Migration 0186 added historical_migration to sharded_events and events
+        # (DATA nodes) but missed writable_events. The WS MV SELECTs that column
+        # and writes TO writable_events, so the column must exist there first.
+        run_sql_with_exceptions(
+            ADD_HISTORICAL_MIGRATION_COLUMN_TO_WRITABLE_EVENTS,
+            node_roles=[NodeRole.INGESTION_EVENTS],
+        ),
         run_sql_with_exceptions(
             KAFKA_EVENTS_TABLE_JSON_WS_SQL(),
             node_roles=[NodeRole.INGESTION_EVENTS],


### PR DESCRIPTION
## Problem
An earlier CH migration 0186 added the new `historical_migration` field to `NodeRole.DATA` backed tables but not to `writeable_events` scoped to `NodeRole.INGESTION_EVENTS`. We need to patch that into stuck migration 0232 so it can proceed in prod (it's already landed)
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Apply missing column in stuck CH migration 0232
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
