### PR TITLE
chore(deps): bump axios to 1.15.0 to fix CVE-2026-40175

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "pnpm": {
         "// Fix React version to a fixed known good version across the monorepo": "",
         "overrides": {
+            "axios": "^1.15.0",
             "@modelcontextprotocol/sdk": "^1.26.0",
             "@types/react": "18.3.27",
             "@types/react-dom": "18.3.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,7 @@ catalogs:
       version: 9.0.3
 
 overrides:
+  axios: ^1.15.0
   '@modelcontextprotocol/sdk': ^1.26.0
   '@types/react': 18.3.27
   '@types/react-dom': 18.3.7
@@ -12943,8 +12944,8 @@ packages:
     resolution: {integrity: sha512-1exVbW0X1O/HSr/WMwnaweyqcWOgZgLiVxdLG34pvSQk4NlYQr9OUy0JLwuhFfuVNQzzqgH57eYzkFBCb3bIsQ==}
     engines: {node: '>=4'}
 
-  axios@1.9.0:
-    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -15373,8 +15374,8 @@ packages:
     engines: {node: '>=18'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -19891,6 +19892,10 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
 
@@ -22454,8 +22459,8 @@ packages:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.399.0:
-    resolution: {integrity: sha512-VbqOnzfc2iOlgW9kmZsK93/f9IqH8jq5UgTemvSbAFrrxVSQgnqH87cThEHxO1GeMoAv5PyH4VIrh2ULlK5o7Q==}
+  unlayer-types@1.400.0:
+    resolution: {integrity: sha512-3x/DFE0UYvwNZ/S+8OZYjPKjEHscSFOwnnRNZNTRkLTRCugOkSS9owg1+7uinBdhwB+xYbAKIfxU9vS2dLLyFg==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -36962,11 +36967,11 @@ snapshots:
 
   axe-core@4.5.1: {}
 
-  axios@1.9.0:
+  axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.9
+      follow-redirects: 1.15.11
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -40123,7 +40128,7 @@ snapshots:
       async: 0.2.10
       which: 1.3.1
 
-  follow-redirects@1.15.9: {}
+  follow-redirects@1.15.11: {}
 
   for-each@0.3.5:
     dependencies:
@@ -46224,6 +46229,8 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  proxy-from-env@2.1.0: {}
+
   prr@1.0.1:
     optional: true
 
@@ -46849,7 +46856,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.3.1):
     dependencies:
       react: 18.3.1
-      unlayer-types: 1.399.0
+      unlayer-types: 1.400.0
 
   react-error-overlay@6.0.9: {}
 
@@ -49307,7 +49314,7 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unlayer-types@1.399.0: {}
+  unlayer-types@1.400.0: {}
 
   unpipe@1.0.0: {}
 
@@ -49724,7 +49731,7 @@ snapshots:
 
   wait-on@7.2.0:
     dependencies:
-      axios: 1.9.0
+      axios: 1.15.0
       joi: 17.11.0
       lodash: 4.18.1
       minimist: 1.2.8


### PR DESCRIPTION
## Problem

The `axios` version we're using has a critical vulnerability opened. 

## Changes

- Added `"axios": "^1.15.0"` to `pnpm.overrides` in root `package.json` to pin the transitive dependency
- Updated `pnpm-lock.yaml` accordingly (axios 1.9.0 -> 1.15.0, follow-redirects 1.15.9 -> 1.15.11, proxy-from-env 1.1.0 -> 2.1.0)

## How did you test this code?

- `pnpm install` succeeds without errors
- Verified lockfile resolves axios to 1.15.0

## Publish to changelog?

no

## Docs update

no