### PR TITLE
feat(clickhouse): migration tracking table with cluster-wide advisory locking

### DIFF
--- a/posthog/clickhouse/migration_tools/tracking.py
+++ b/posthog/clickhouse/migration_tools/tracking.py
@@ -1,0 +1,270 @@
+"""Advisory locking for concurrent apply prevention.
+
+The tracking table is ReplicatedMergeTree ON CLUSTER so that every node
+in the cluster sees the same lock/history rows. This prevents two
+concurrent ``ch_migrate apply`` calls on different hosts from both
+acquiring the advisory lock.
+"""
+
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+TRACKING_TABLE_NAME = "clickhouse_schema_migrations"
+
+TRACKING_TABLE_DDL = """
+CREATE TABLE IF NOT EXISTS {database}.clickhouse_schema_migrations ON CLUSTER {cluster} (
+    migration_number UInt32,
+    migration_name String,
+    step_index Int32,
+    host String,
+    node_role String,
+    direction Enum8('up' = 1, 'down' = 2),
+    checksum String,
+    applied_at DateTime64(3),
+    success Bool
+) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{{shard}}/{database}/clickhouse_schema_migrations', '{{replica}}')
+ORDER BY (migration_number, step_index, host, direction, applied_at)
+"""
+
+# Advisory lock constants.
+LOCK_MIGRATION_NUMBER = 0
+LOCK_STEP_INDEX = -999
+LOCK_TIMEOUT_MINUTES = 30
+
+
+@dataclass
+class StepRecord:
+    migration_number: int
+    migration_name: str
+    step_index: int
+    host: str
+    node_role: str
+    direction: str
+    checksum: str
+    success: bool
+
+
+def _ensure_tracking_table(client: Any, database: str, cluster: str = "posthog_migrations") -> None:
+    """Create the tracking table on every node via ON CLUSTER (idempotent)."""
+    client.execute(TRACKING_TABLE_DDL.format(database=database, cluster=cluster))
+
+
+def _record_step(
+    client: Any,
+    record: StepRecord,
+    database: str = "",
+) -> None:
+    table_ref = f"{database}.{TRACKING_TABLE_NAME}" if database else TRACKING_TABLE_NAME
+    sql = f"""
+        INSERT INTO {table_ref}
+        (migration_number, migration_name, step_index, host, node_role, direction, checksum, applied_at, success)
+        VALUES
+    """
+    now = datetime.now(tz=UTC)
+    params = [
+        (
+            record.migration_number,
+            record.migration_name,
+            record.step_index,
+            record.host,
+            record.node_role,
+            record.direction,
+            record.checksum,
+            now,
+            record.success,
+        )
+    ]
+    client.execute(sql, params)
+
+
+def acquire_apply_lock(
+    client: Any,
+    database: str,
+    hostname: str,
+    *,
+    force: bool = False,
+    cluster: str = "posthog_migrations",
+) -> tuple[bool, str]:
+    """Cluster-wide advisory lock via ReplicatedMergeTree INSERT.
+
+    The tracking table is replicated across all nodes, so a lock row
+    inserted on any host is visible to every other host after replication
+    converges. We INSERT a lock row, wait briefly for replication, then
+    verify no other host also acquired — if so, we back off.
+    """
+    _ensure_tracking_table(client, database, cluster)
+    table_ref = f"{database}.{TRACKING_TABLE_NAME}"
+
+    if force:
+        _record_step(
+            client=client,
+            record=StepRecord(
+                migration_number=LOCK_MIGRATION_NUMBER,
+                migration_name="__lock__",
+                step_index=LOCK_STEP_INDEX,
+                host=hostname,
+                node_role="*",
+                direction="up",
+                checksum="lock",
+                success=True,
+            ),
+            database=database,
+        )
+        return (True, "")
+
+    # Check for an existing active lock before attempting to insert.
+    # A lock is "active" when there is an 'up' row with no subsequent 'down' row.
+    check_sql = f"""
+        SELECT host, applied_at
+        FROM {table_ref}
+        WHERE migration_number = {LOCK_MIGRATION_NUMBER}
+          AND step_index = {LOCK_STEP_INDEX}
+          AND direction = 'up'
+          AND success = 1
+          AND applied_at > now() - INTERVAL {LOCK_TIMEOUT_MINUTES} MINUTE
+          AND host != %(hostname)s
+          AND applied_at > (
+              SELECT coalesce(max(applied_at), toDateTime64('1970-01-01', 3))
+              FROM {table_ref}
+              WHERE migration_number = {LOCK_MIGRATION_NUMBER}
+                AND step_index = {LOCK_STEP_INDEX}
+                AND direction = 'down'
+          )
+        ORDER BY applied_at DESC
+        LIMIT 1
+    """
+    existing = client.execute(check_sql, {"hostname": hostname})
+    if existing:
+        return (
+            False,
+            f"Another ch_migrate apply is running on {existing[0][0]} (started {existing[0][1]}). Use --force to override.",
+        )
+
+    # Insert the acquire record
+    _record_step(
+        client=client,
+        record=StepRecord(
+            migration_number=LOCK_MIGRATION_NUMBER,
+            migration_name="__lock__",
+            step_index=LOCK_STEP_INDEX,
+            host=hostname,
+            node_role="*",
+            direction="up",
+            checksum="lock",
+            success=True,
+        ),
+        database=database,
+    )
+
+    # Force replication convergence before the double-lock check. A fixed
+    # sleep (0.5s, 5s, ...) is not a correctness barrier — under replication
+    # lag each host can still see only its own insert. SYSTEM SYNC REPLICA
+    # STRICT blocks until the local replica has drained its ZooKeeper
+    # replication queue, so when we then SELECT we observe all peer inserts
+    # that beat ours to the leader. Hosts that INSERT simultaneously will
+    # disagree on the tie-break (applied_at, host) but both observe the same
+    # sorted set and agree on the winner.
+    try:
+        client.execute(f"SYSTEM SYNC REPLICA {table_ref} STRICT")
+    except Exception:
+        # SYNC REPLICA is only valid on Replicated engines; fall back to a
+        # short sleep for local-only dev stacks where the tracking table is
+        # plain MergeTree. This path is not safe under real concurrency but
+        # matches the single-host dev environment.
+        time.sleep(1)
+    # Deterministic tie-break: earliest-applied wins, then lexicographic
+    # hostname. Both callers sort the same rows identically regardless of
+    # which one landed in the driver result first, so they agree on the
+    # winner. Prior `ORDER BY applied_at DESC` let the winner flip when two
+    # inserts landed in the same millisecond.
+    verify_sql = f"""
+        SELECT host, applied_at
+        FROM {table_ref}
+        WHERE migration_number = {LOCK_MIGRATION_NUMBER}
+          AND step_index = {LOCK_STEP_INDEX}
+          AND direction = 'up'
+          AND success = 1
+          AND applied_at > now() - INTERVAL {LOCK_TIMEOUT_MINUTES} MINUTE
+          AND applied_at > (
+              SELECT coalesce(max(applied_at), toDateTime64('1970-01-01', 3))
+              FROM {table_ref}
+              WHERE migration_number = {LOCK_MIGRATION_NUMBER}
+                AND step_index = {LOCK_STEP_INDEX}
+                AND direction = 'down'
+          )
+        ORDER BY applied_at ASC, host ASC
+    """
+    active = client.execute(verify_sql)
+    if len(active) > 1 and active[0][0] != hostname:
+        # Race: another host won. Release and back off.
+        release_apply_lock(client, database, hostname)
+        return (
+            False,
+            f"Race detected — lock held by {active[0][0]}. Use --force to override.",
+        )
+
+    return (True, "")
+
+
+# Schema version sentinel: records which git commit was last applied.
+VERSION_STEP_INDEX = -2
+
+
+def record_schema_version(client: Any, database: str, commit_hash: str, hostname: str) -> None:
+    """Record the git commit hash of the schema YAML that was just applied."""
+    _record_step(
+        client=client,
+        record=StepRecord(
+            migration_number=LOCK_MIGRATION_NUMBER,
+            migration_name=commit_hash,
+            step_index=VERSION_STEP_INDEX,
+            host=hostname,
+            node_role="*",
+            direction="up",
+            checksum="version",
+            success=True,
+        ),
+        database=database,
+    )
+
+
+def get_latest_schema_version(client: Any, database: str) -> tuple[str, str, str] | None:
+    """Return (commit_hash, host, applied_at) of the last applied schema version, or None."""
+    table_ref = f"{database}.{TRACKING_TABLE_NAME}"
+    sql = f"""
+        SELECT migration_name, host, applied_at
+        FROM {table_ref}
+        WHERE migration_number = {LOCK_MIGRATION_NUMBER}
+          AND step_index = {VERSION_STEP_INDEX}
+          AND success = 1
+        ORDER BY applied_at DESC
+        LIMIT 1
+    """
+    rows = client.execute(sql)
+    if rows:
+        return (rows[0][0], rows[0][1], str(rows[0][2]))
+    return None
+
+
+def release_apply_lock(client: Any, database: str, hostname: str) -> None:
+    """Release the advisory lock by inserting a direction='down' row.
+
+    The acquire logic checks for 'up' rows whose applied_at exceeds the
+    latest 'down' row — this release row makes the lock invisible.
+    """
+    _record_step(
+        client=client,
+        record=StepRecord(
+            migration_number=LOCK_MIGRATION_NUMBER,
+            migration_name="__lock__",
+            step_index=LOCK_STEP_INDEX,
+            host=hostname,
+            node_role="*",
+            direction="down",
+            checksum="unlock",
+            success=True,
+        ),
+        database=database,
+    )

--- a/posthog/clickhouse/migration_tools/tracking.py
+++ b/posthog/clickhouse/migration_tools/tracking.py
@@ -7,6 +7,7 @@ acquiring the advisory lock.
 """
 
 import time
+import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal
@@ -99,24 +100,29 @@ def acquire_apply_lock(
 
     if not force:
         # Check for an existing active lock before attempting to insert.
-        # A lock is "active" when there is an 'up' row with no subsequent 'down' row.
+        # A lock is "active" when a host's 'up' row is newer than that host's
+        # own latest 'down' row (per-host scope). The JOIN is host-scoped so
+        # that a loser releasing its own lock does not make the winner's lock
+        # invisible via an unscoped max(applied_at) on the 'down' table.
         check_sql = f"""
-            SELECT host, applied_at
-            FROM {table_ref}
-            WHERE migration_number = {LOCK_MIGRATION_NUMBER}
-              AND step_index = {LOCK_STEP_INDEX}
-              AND direction = 'up'
-              AND success = 1
-              AND applied_at > now() - INTERVAL {LOCK_TIMEOUT_MINUTES} MINUTE
-              AND host != %(hostname)s
-              AND applied_at > (
-                  SELECT coalesce(max(applied_at), toDateTime64('1970-01-01', 3))
-                  FROM {table_ref}
-                  WHERE migration_number = {LOCK_MIGRATION_NUMBER}
-                    AND step_index = {LOCK_STEP_INDEX}
-                    AND direction = 'down'
-              )
-            ORDER BY applied_at DESC
+            SELECT t.host, t.applied_at
+            FROM {table_ref} AS t
+            LEFT JOIN (
+                SELECT host, max(applied_at) AS last_released
+                FROM {table_ref}
+                WHERE migration_number = {LOCK_MIGRATION_NUMBER}
+                  AND step_index = {LOCK_STEP_INDEX}
+                  AND direction = 'down'
+                GROUP BY host
+            ) AS d ON t.host = d.host
+            WHERE t.migration_number = {LOCK_MIGRATION_NUMBER}
+              AND t.step_index = {LOCK_STEP_INDEX}
+              AND t.direction = 'up'
+              AND t.success = 1
+              AND t.applied_at > now() - INTERVAL {LOCK_TIMEOUT_MINUTES} MINUTE
+              AND t.host != %(hostname)s
+              AND t.applied_at > coalesce(d.last_released, toDateTime64('1970-01-01', 3))
+            ORDER BY t.applied_at DESC
             LIMIT 1
         """
         existing = client.execute(check_sql, {"hostname": hostname})
@@ -169,30 +175,44 @@ def acquire_apply_lock(
     # which one landed in the driver result first, so they agree on the
     # winner. Prior `ORDER BY applied_at DESC` let the winner flip when two
     # inserts landed in the same millisecond.
+    # The 'down' subquery is host-scoped (LEFT JOIN GROUP BY host) so that a
+    # race loser releasing its own lock cannot make the winner's 'up' row
+    # invisible via an unscoped max(applied_at) across all hosts.
     verify_sql = f"""
-        SELECT host, applied_at
-        FROM {table_ref}
-        WHERE migration_number = {LOCK_MIGRATION_NUMBER}
-          AND step_index = {LOCK_STEP_INDEX}
-          AND direction = 'up'
-          AND success = 1
-          AND applied_at > now() - INTERVAL {LOCK_TIMEOUT_MINUTES} MINUTE
-          AND applied_at > (
-              SELECT coalesce(max(applied_at), toDateTime64('1970-01-01', 3))
-              FROM {table_ref}
-              WHERE migration_number = {LOCK_MIGRATION_NUMBER}
-                AND step_index = {LOCK_STEP_INDEX}
-                AND direction = 'down'
-          )
-        ORDER BY applied_at ASC, host ASC
+        SELECT t.host, t.applied_at
+        FROM {table_ref} AS t
+        LEFT JOIN (
+            SELECT host, max(applied_at) AS last_released
+            FROM {table_ref}
+            WHERE migration_number = {LOCK_MIGRATION_NUMBER}
+              AND step_index = {LOCK_STEP_INDEX}
+              AND direction = 'down'
+            GROUP BY host
+        ) AS d ON t.host = d.host
+        WHERE t.migration_number = {LOCK_MIGRATION_NUMBER}
+          AND t.step_index = {LOCK_STEP_INDEX}
+          AND t.direction = 'up'
+          AND t.success = 1
+          AND t.applied_at > now() - INTERVAL {LOCK_TIMEOUT_MINUTES} MINUTE
+          AND t.applied_at > coalesce(d.last_released, toDateTime64('1970-01-01', 3))
+        ORDER BY t.applied_at ASC, t.host ASC
     """
     active = client.execute(verify_sql)
+    if not active:
+        # Unexpected: our own INSERT should be visible after SYNC REPLICA.
+        # Most likely cause is extreme clock skew pushing the row outside the
+        # LOCK_TIMEOUT_MINUTES window. Log and proceed cautiously — the caller
+        # holds the lock as far as it can tell; a subsequent acquire on another
+        # host will see no competition and also proceed (correctness degraded).
+        logging.getLogger(__name__).warning(
+            "ch_migrate: verify returned no active lock rows after INSERT — possible clock skew on %s",
+            hostname,
+        )
+        return (True, "")
     if len(active) > 1 and active[0][0] != hostname:
         if force:
             # --force skips the pre-check but still runs SYNC+verify so we can
             # detect competing apply runs. Log the override; don't back off.
-            import logging
-
             logging.getLogger(__name__).warning("ch_migrate --force: overriding lock held by %s", active[0][0])
             return (True, "")
         # Race: another host won. Release and back off.
@@ -210,7 +230,14 @@ VERSION_STEP_INDEX = -2
 
 
 def record_schema_version(client: Any, database: str, commit_hash: str, hostname: str) -> None:
-    """Record the git commit hash of the schema YAML that was just applied."""
+    """Record the git commit hash of the schema YAML that was just applied.
+
+    Precondition: the tracking table must already exist. In the normal
+    acquire → apply → record_schema_version → release flow this is
+    guaranteed because acquire_apply_lock calls _ensure_tracking_table.
+    If called in isolation (e.g. a future CLI subcommand), call
+    _ensure_tracking_table first.
+    """
     _record_step(
         client=client,
         record=StepRecord(
@@ -228,7 +255,10 @@ def record_schema_version(client: Any, database: str, commit_hash: str, hostname
 
 
 def get_latest_schema_version(client: Any, database: str) -> tuple[str, str, str] | None:
-    """Return (commit_hash, host, applied_at) of the last applied schema version, or None."""
+    """Return (commit_hash, host, applied_at) of the last applied schema version, or None.
+
+    Precondition: the tracking table must already exist (see record_schema_version).
+    """
     table_ref = f"{database}.{TRACKING_TABLE_NAME}"
     sql = f"""
         SELECT migration_name, host, applied_at

--- a/posthog/clickhouse/migration_tools/tracking.py
+++ b/posthog/clickhouse/migration_tools/tracking.py
@@ -9,7 +9,7 @@ acquiring the advisory lock.
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 
 TRACKING_TABLE_NAME = "clickhouse_schema_migrations"
 
@@ -41,7 +41,7 @@ class StepRecord:
     step_index: int
     host: str
     node_role: str
-    direction: str
+    direction: Literal["up", "down"]
     checksum: str
     success: bool
 
@@ -97,52 +97,36 @@ def acquire_apply_lock(
     _ensure_tracking_table(client, database, cluster)
     table_ref = f"{database}.{TRACKING_TABLE_NAME}"
 
-    if force:
-        _record_step(
-            client=client,
-            record=StepRecord(
-                migration_number=LOCK_MIGRATION_NUMBER,
-                migration_name="__lock__",
-                step_index=LOCK_STEP_INDEX,
-                host=hostname,
-                node_role="*",
-                direction="up",
-                checksum="lock",
-                success=True,
-            ),
-            database=database,
-        )
-        return (True, "")
+    if not force:
+        # Check for an existing active lock before attempting to insert.
+        # A lock is "active" when there is an 'up' row with no subsequent 'down' row.
+        check_sql = f"""
+            SELECT host, applied_at
+            FROM {table_ref}
+            WHERE migration_number = {LOCK_MIGRATION_NUMBER}
+              AND step_index = {LOCK_STEP_INDEX}
+              AND direction = 'up'
+              AND success = 1
+              AND applied_at > now() - INTERVAL {LOCK_TIMEOUT_MINUTES} MINUTE
+              AND host != %(hostname)s
+              AND applied_at > (
+                  SELECT coalesce(max(applied_at), toDateTime64('1970-01-01', 3))
+                  FROM {table_ref}
+                  WHERE migration_number = {LOCK_MIGRATION_NUMBER}
+                    AND step_index = {LOCK_STEP_INDEX}
+                    AND direction = 'down'
+              )
+            ORDER BY applied_at DESC
+            LIMIT 1
+        """
+        existing = client.execute(check_sql, {"hostname": hostname})
+        if existing:
+            return (
+                False,
+                f"Another ch_migrate apply is running on {existing[0][0]} (started {existing[0][1]}). Use --force to override.",
+            )
 
-    # Check for an existing active lock before attempting to insert.
-    # A lock is "active" when there is an 'up' row with no subsequent 'down' row.
-    check_sql = f"""
-        SELECT host, applied_at
-        FROM {table_ref}
-        WHERE migration_number = {LOCK_MIGRATION_NUMBER}
-          AND step_index = {LOCK_STEP_INDEX}
-          AND direction = 'up'
-          AND success = 1
-          AND applied_at > now() - INTERVAL {LOCK_TIMEOUT_MINUTES} MINUTE
-          AND host != %(hostname)s
-          AND applied_at > (
-              SELECT coalesce(max(applied_at), toDateTime64('1970-01-01', 3))
-              FROM {table_ref}
-              WHERE migration_number = {LOCK_MIGRATION_NUMBER}
-                AND step_index = {LOCK_STEP_INDEX}
-                AND direction = 'down'
-          )
-        ORDER BY applied_at DESC
-        LIMIT 1
-    """
-    existing = client.execute(check_sql, {"hostname": hostname})
-    if existing:
-        return (
-            False,
-            f"Another ch_migrate apply is running on {existing[0][0]} (started {existing[0][1]}). Use --force to override.",
-        )
-
-    # Insert the acquire record
+    # Insert the acquire record (always, whether forced or not)
     _record_step(
         client=client,
         record=StepRecord(
@@ -168,12 +152,18 @@ def acquire_apply_lock(
     # sorted set and agree on the winner.
     try:
         client.execute(f"SYSTEM SYNC REPLICA {table_ref} STRICT")
-    except Exception:
-        # SYNC REPLICA is only valid on Replicated engines; fall back to a
-        # short sleep for local-only dev stacks where the tracking table is
-        # plain MergeTree. This path is not safe under real concurrency but
-        # matches the single-host dev environment.
+    except Exception as e:
+        # ClickHouse raises "Table ... is not replicated" (or similar) when
+        # SYSTEM SYNC REPLICA runs against a plain MergeTree table (dev stack).
+        # Silently fall through only for that case; re-raise everything else
+        # (ZooKeeper unreachable, timeout, network partition) so the caller
+        # aborts the acquire instead of proceeding without a replication barrier.
+        if "is not replicated" not in str(e) and "NOT_IMPLEMENTED" not in str(e):
+            raise
+        # Non-replicated engine (dev only) — best-effort sleep. Safe because the
+        # dev stack is single-host and cannot have competing apply processes.
         time.sleep(1)
+
     # Deterministic tie-break: earliest-applied wins, then lexicographic
     # hostname. Both callers sort the same rows identically regardless of
     # which one landed in the driver result first, so they agree on the
@@ -198,6 +188,13 @@ def acquire_apply_lock(
     """
     active = client.execute(verify_sql)
     if len(active) > 1 and active[0][0] != hostname:
+        if force:
+            # --force skips the pre-check but still runs SYNC+verify so we can
+            # detect competing apply runs. Log the override; don't back off.
+            import logging
+
+            logging.getLogger(__name__).warning("ch_migrate --force: overriding lock held by %s", active[0][0])
+            return (True, "")
         # Race: another host won. Release and back off.
         release_apply_lock(client, database, hostname)
         return (

--- a/posthog/clickhouse/test/_stubs.py
+++ b/posthog/clickhouse/test/_stubs.py
@@ -1,0 +1,244 @@
+"""Shared Django/ClickHouse stubs for standalone migration tool tests.
+
+WHY STUBS INSTEAD OF DJANGO TEST RUNNER:
+PostHog's Django startup (posthog/__init__.py, settings, celery) triggers
+ClickHouse client connections, Kafka configuration, and celery app setup.
+Running these tests via `DJANGO_SETTINGS_MODULE=posthog.settings.test pytest`
+requires a full Django environment with live ClickHouse — impractical for
+unit tests that only exercise YAML parsing, diff logic, and plan generation.
+These stubs isolate the migration_tools package from Django/CH/celery so
+tests run fast with zero infrastructure.
+
+Usage at the top of each test file (BEFORE any posthog imports):
+
+    import posthog.clickhouse.test._stubs as _stubs  # noqa: F401
+
+    # _stubs installs itself on import — now posthog.* is safe to import.
+
+Or for standalone execution:
+
+    _BASE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+    sys.path.insert(0, _BASE)
+    import posthog.clickhouse.test._stubs  # noqa: F401
+
+This module installs all stubs on import — no need to call install_stubs() explicitly.
+The stubs are idempotent and safe to import multiple times.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+from unittest.mock import MagicMock
+
+_BASE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if _BASE not in sys.path:
+    sys.path.insert(0, _BASE)
+
+
+def _django_is_configured() -> bool:
+    try:
+        from django.conf import settings
+
+        val = getattr(settings, "USE_I18N", None)
+        return isinstance(val, bool)
+    except Exception:
+        return False
+
+
+class _NodeRole:
+    DATA = "DATA"
+    COORDINATOR = "COORDINATOR"
+    ALL = "ALL"
+
+    def __init__(self, value: str = "data") -> None:
+        self.value = value
+
+
+class _FakeQuery:
+    def __init__(self, sql: str) -> None:
+        self.sql = sql
+
+
+class _FakeRunPython:
+    def __init__(self, fn: object) -> None:
+        self.fn = fn
+
+
+def _fake_get_cluster(*args: object, **kwargs: object) -> MagicMock:
+    mock = MagicMock()
+    mock.any_host.return_value.result.return_value = {}
+    return mock
+
+
+def _install() -> None:
+    if _django_is_configured():
+        return
+
+    # posthog package — prevent __init__.py from running
+    if "posthog" not in sys.modules:
+        pkg = types.ModuleType("posthog")
+        pkg.__path__ = [os.path.join(_BASE, "posthog")]
+        pkg.__package__ = "posthog"
+        pkg.celery_app = None  # type: ignore[attr-defined]
+        sys.modules["posthog"] = pkg
+
+    # posthog.celery
+    _celery = types.ModuleType("posthog.celery")
+    _celery.app = types.SimpleNamespace()  # type: ignore[attr-defined]
+    sys.modules.setdefault("posthog.celery", _celery)
+
+    # posthog.clickhouse (package)
+    ch_pkg = types.ModuleType("posthog.clickhouse")
+    ch_pkg.__path__ = [os.path.join(_BASE, "posthog/clickhouse")]
+    ch_pkg.__package__ = "posthog.clickhouse"
+    sys.modules.setdefault("posthog.clickhouse", ch_pkg)
+
+    # posthog.clickhouse.client
+    fake_client = types.ModuleType("posthog.clickhouse.client")
+    fake_client.__path__ = [os.path.join(_BASE, "posthog/clickhouse/client")]
+    fake_client.__package__ = "posthog.clickhouse.client"
+    sys.modules.setdefault("posthog.clickhouse.client", fake_client)
+
+    # posthog.clickhouse.client.connection
+    fake_conn = types.ModuleType("posthog.clickhouse.client.connection")
+    fake_conn.NodeRole = _NodeRole  # type: ignore[attr-defined]
+    sys.modules.setdefault("posthog.clickhouse.client.connection", fake_conn)
+
+    # posthog.clickhouse.cluster
+    fake_cluster = types.ModuleType("posthog.clickhouse.cluster")
+    fake_cluster.Query = _FakeQuery  # type: ignore[attr-defined]
+    fake_cluster.get_cluster = _fake_get_cluster  # type: ignore[attr-defined]
+    fake_cluster.ClickhouseCluster = MagicMock  # type: ignore[attr-defined]
+
+    # HostInfo is a NamedTuple used by schema_introspect — provide a lightweight stand-in
+    from collections import namedtuple as _nt
+
+    fake_cluster.HostInfo = _nt(  # type: ignore[attr-defined]
+        "HostInfo",
+        ["connection_info", "shard_num", "replica_num", "host_cluster_type", "host_cluster_role"],
+    )
+    # _CLUSTER_REGISTRY is needed by state_diff._resolve_physical_cluster.
+    # Mirrors the real registry in posthog/clickhouse/cluster.py — maps YAML
+    # logical names to (host_attr, cluster_attr) tuples.
+    fake_cluster._CLUSTER_REGISTRY = {  # type: ignore[attr-defined]
+        "main": ("CLICKHOUSE_HOST", "CLICKHOUSE_CLUSTER"),
+        "logs": ("CLICKHOUSE_LOGS_CLUSTER_HOST", "CLICKHOUSE_LOGS_CLUSTER"),
+        "migrations": ("CLICKHOUSE_MIGRATIONS_HOST", "CLICKHOUSE_MIGRATIONS_CLUSTER"),
+        "sessions": ("CLICKHOUSE_HOST", "CLICKHOUSE_SESSIONS_CLUSTER"),
+        "ops": ("CLICKHOUSE_HOST", "CLICKHOUSE_OPS_CLUSTER"),
+        "ai_events": ("CLICKHOUSE_HOST", "CLICKHOUSE_AI_EVENTS_CLUSTER"),
+        "aux": ("CLICKHOUSE_HOST", "CLICKHOUSE_AUX_CLUSTER"),
+    }
+    sys.modules.setdefault("posthog.clickhouse.cluster", fake_cluster)
+
+    # infi.clickhouse_orm
+    for mod_name in ("infi", "infi.clickhouse_orm"):
+        m = types.ModuleType(mod_name)
+        m.__path__ = ["/fake"]
+        sys.modules.setdefault(mod_name, m)
+
+    infi_migrations = types.ModuleType("infi.clickhouse_orm.migrations")
+    infi_migrations.__path__ = ["/fake"]
+    infi_migrations.RunPython = _FakeRunPython  # type: ignore[attr-defined]
+    sys.modules.setdefault("infi.clickhouse_orm.migrations", infi_migrations)
+
+    # posthog.settings
+    fake_settings = types.ModuleType("posthog.settings")
+    fake_settings.E2E_TESTING = False  # type: ignore[attr-defined]
+    fake_settings.DEBUG = True  # type: ignore[attr-defined]
+    fake_settings.CLOUD_DEPLOYMENT = False  # type: ignore[attr-defined]
+    sys.modules.setdefault("posthog.settings", fake_settings)
+
+    fake_ds = types.ModuleType("posthog.settings.data_stores")
+    fake_ds.CLICKHOUSE_MIGRATIONS_CLUSTER = "default"  # type: ignore[attr-defined]
+    fake_ds.CLICKHOUSE_MIGRATIONS_HOST = "localhost"  # type: ignore[attr-defined]
+    sys.modules.setdefault("posthog.settings.data_stores", fake_ds)
+
+    # posthog.clickhouse.client.migration_tools
+    fake_mt = types.ModuleType("posthog.clickhouse.client.migration_tools")
+    fake_mt.get_migrations_cluster = _fake_get_cluster  # type: ignore[attr-defined]
+    sys.modules.setdefault("posthog.clickhouse.client.migration_tools", fake_mt)
+
+    # posthog.clickhouse.migration_tools.cluster_registry — let real module load
+    # (its only dependency is posthog.clickhouse.cluster which is already stubbed above)
+
+    # yaml (for manifest.py)
+
+    _yaml_stub = types.ModuleType("yaml")
+    try:
+        import yaml as _real_yaml
+
+        _yaml_stub.safe_load = _real_yaml.safe_load  # type: ignore[attr-defined]
+        _yaml_stub.dump = _real_yaml.dump  # type: ignore[attr-defined]
+    except ImportError:
+        _yaml_stub.safe_load = lambda f: None  # type: ignore[attr-defined]
+        _yaml_stub.dump = lambda *a, **kw: None  # type: ignore[attr-defined]
+    sys.modules.setdefault("yaml", _yaml_stub)
+
+    # posthog.clickhouse.test (package)
+    test_pkg = types.ModuleType("posthog.clickhouse.test")
+    test_pkg.__path__ = [os.path.join(_BASE, "posthog/clickhouse/test")]
+    test_pkg.__package__ = "posthog.clickhouse.test"
+    sys.modules.setdefault("posthog.clickhouse.test", test_pkg)
+
+    # django stubs (for ch_migrate command tests)
+    for mod_name in ("django", "django.conf", "django.core", "django.core.management", "django.core.management.base"):
+        m = types.ModuleType(mod_name)
+        m.__path__ = ["/fake"]
+        sys.modules.setdefault(mod_name, m)
+
+    if not hasattr(sys.modules.get("django.conf"), "settings"):
+        settings_ns = types.SimpleNamespace(
+            CLICKHOUSE_DATABASE="default",
+            CLICKHOUSE_HOST="localhost",
+            CLICKHOUSE_CLUSTER="posthog",
+            CLICKHOUSE_LOGS_CLUSTER_HOST="localhost",
+            CLICKHOUSE_LOGS_CLUSTER="posthog_single_shard",
+            CLICKHOUSE_MIGRATIONS_HOST="localhost",
+            CLICKHOUSE_MIGRATIONS_CLUSTER="posthog_migrations",
+            # Satellite cluster names resolved by _CLUSTER_REGISTRY via state_diff
+            CLICKHOUSE_SESSIONS_CLUSTER="posthog_sessions",
+            CLICKHOUSE_OPS_CLUSTER="posthog_ops",
+            CLICKHOUSE_AI_EVENTS_CLUSTER="posthog_ai_events",
+            CLICKHOUSE_AUX_CLUSTER="posthog_aux",
+        )
+        sys.modules["django.conf"].settings = settings_ns  # type: ignore[attr-defined]
+
+    class _FakeBaseCommand:
+        def __init__(self) -> None:
+            self.stdout = __import__("io").StringIO()
+            self.stderr = __import__("io").StringIO()
+
+        def print_help(self, *args: object) -> None:
+            pass
+
+    class _FakeCommandError(Exception):
+        """Stand-in for django.core.management.base.CommandError.
+
+        Used by ch_migrate.handle_apply to signal non-zero exit on step failure.
+        Real Django raises this and Django's management runner catches it to
+        print a clean error and exit with code 1.
+        """
+
+    if not hasattr(sys.modules.get("django.core.management.base"), "BaseCommand"):
+        sys.modules["django.core.management.base"].BaseCommand = _FakeBaseCommand  # type: ignore[attr-defined]
+    if not hasattr(sys.modules.get("django.core.management.base"), "CommandError"):
+        sys.modules["django.core.management.base"].CommandError = _FakeCommandError  # type: ignore[attr-defined]
+
+    # Wire submodule attributes so `from posthog import settings` works
+    sys.modules["posthog"].settings = sys.modules["posthog.settings"]  # type: ignore[attr-defined]
+    sys.modules["posthog.settings"].data_stores = sys.modules["posthog.settings.data_stores"]  # type: ignore[attr-defined]
+
+    # posthog.management.commands — make it a resolvable package
+    for mod_name in ("posthog.management", "posthog.management.commands"):
+        if mod_name not in sys.modules:
+            m = types.ModuleType(mod_name)
+            m.__path__ = [os.path.join(_BASE, mod_name.replace(".", "/"))]
+            m.__package__ = mod_name
+            sys.modules[mod_name] = m
+
+
+_install()

--- a/posthog/clickhouse/test/conftest.py
+++ b/posthog/clickhouse/test/conftest.py
@@ -1,0 +1,24 @@
+"""Pytest conftest — loads Django/ClickHouse stubs before test modules are imported.
+
+This replaces the importlib.util bootstrap that was duplicated across every
+test file in this directory.  Stubs install themselves on load and are
+idempotent, so re-importing _stubs in a test file is safe but unnecessary.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import importlib.util
+
+_BASE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if _BASE not in sys.path:
+    sys.path.insert(0, _BASE)
+
+_spec = importlib.util.spec_from_file_location(
+    "posthog.clickhouse.test._stubs",
+    os.path.join(_BASE, "posthog", "clickhouse", "test", "_stubs.py"),
+)
+assert _spec and _spec.loader
+_stubs_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_stubs_mod)

--- a/posthog/clickhouse/test/test_advisory_lock.py
+++ b/posthog/clickhouse/test/test_advisory_lock.py
@@ -80,20 +80,43 @@ class TestAdvisoryLock(unittest.TestCase):
         self.assertTrue(acquired)
         self.assertEqual(reason, "")
 
-    def test_advisory_lock_force_overrides_other_host(self) -> None:
-        """force=True acquires even when another host holds the lock."""
+    @patch("posthog.clickhouse.migration_tools.tracking.time.sleep")
+    def test_advisory_lock_force_skips_precheck_but_still_verifies(self, mock_sleep: MagicMock) -> None:
+        """force=True skips the pre-check SELECT but still runs INSERT + SYNC + verify."""
         client = MagicMock()
+        now = datetime.now(tz=UTC)
         client.execute.side_effect = [
-            None,  # CREATE TABLE ON CLUSTER (ensure tracking table)
-            None,  # INSERT lock row directly (no check with force=True)
+            None,  # CREATE TABLE ON CLUSTER
+            None,  # INSERT lock row (no pre-check SELECT)
+            None,  # SYSTEM SYNC REPLICA
+            [("my-pod", now)],  # Verify -- only our lock
         ]
 
         acquired, reason = acquire_apply_lock(client, "default", "my-pod", force=True)
 
         self.assertTrue(acquired)
         self.assertEqual(reason, "")
-        # Two calls: CREATE ON CLUSTER + INSERT (via _record_step). No verify needed.
-        self.assertEqual(client.execute.call_count, 2)
+        # Four calls: CREATE + INSERT + SYNC + verify (no pre-check SELECT)
+        self.assertEqual(client.execute.call_count, 4)
+
+    @patch("posthog.clickhouse.migration_tools.tracking.time.sleep")
+    def test_advisory_lock_force_logs_warning_when_other_host_wins(self, mock_sleep: MagicMock) -> None:
+        """force=True returns acquired when verify shows another host, logging a warning."""
+        client = MagicMock()
+        now = datetime.now(tz=UTC)
+        client.execute.side_effect = [
+            None,  # CREATE TABLE ON CLUSTER
+            None,  # INSERT lock row
+            None,  # SYSTEM SYNC REPLICA
+            [("other-pod", now), ("my-pod", now)],  # Verify -- other-pod won the tie-break
+        ]
+
+        with self.assertLogs("posthog.clickhouse.migration_tools.tracking", level="WARNING") as cm:
+            acquired, reason = acquire_apply_lock(client, "default", "my-pod", force=True)
+
+        self.assertTrue(acquired)
+        self.assertEqual(reason, "")
+        self.assertTrue(any("other-pod" in line for line in cm.output))
 
     @patch("posthog.clickhouse.migration_tools.tracking.time.sleep")
     def test_advisory_lock_race_detected(self, mock_sleep: MagicMock) -> None:
@@ -141,6 +164,116 @@ class TestAdvisoryLock(unittest.TestCase):
         self.assertIn("{cluster}", TRACKING_TABLE_DDL)
         self.assertIn("{{shard}}", TRACKING_TABLE_DDL)
         self.assertIn("{{replica}}", TRACKING_TABLE_DDL)
+
+
+class TestSyncReplicaFallback(unittest.TestCase):
+    """SYNC REPLICA exception routing in acquire_apply_lock."""
+
+    @patch("posthog.clickhouse.migration_tools.tracking.time.sleep")
+    def test_not_replicated_error_swallowed(self, mock_sleep: MagicMock) -> None:
+        """'is not replicated' exception is caught and replaced by a brief sleep."""
+        client = MagicMock()
+        now = datetime.now(tz=UTC)
+        client.execute.side_effect = [
+            None,  # CREATE TABLE
+            [],  # Pre-check SELECT — no existing lock
+            None,  # INSERT lock row
+            Exception("Table default.clickhouse_schema_migrations is not replicated"),
+            [("my-pod", now)],  # Verify
+        ]
+
+        acquired, _ = acquire_apply_lock(client, "default", "my-pod")
+
+        self.assertTrue(acquired)
+        mock_sleep.assert_called_once_with(1)
+
+    @patch("posthog.clickhouse.migration_tools.tracking.time.sleep")
+    def test_not_implemented_error_swallowed(self, mock_sleep: MagicMock) -> None:
+        """'NOT_IMPLEMENTED' exception (alt ClickHouse error code) is also swallowed."""
+        client = MagicMock()
+        now = datetime.now(tz=UTC)
+        client.execute.side_effect = [
+            None,
+            [],
+            None,
+            Exception("Code: 48. DB::Exception: NOT_IMPLEMENTED"),
+            [("my-pod", now)],
+        ]
+
+        acquired, _ = acquire_apply_lock(client, "default", "my-pod")
+
+        self.assertTrue(acquired)
+        mock_sleep.assert_called_once_with(1)
+
+    @patch("posthog.clickhouse.migration_tools.tracking.time.sleep")
+    def test_zookeeper_error_reraises(self, mock_sleep: MagicMock) -> None:
+        """Replication failures that are NOT 'is not replicated' re-raise so caller aborts."""
+        client = MagicMock()
+        client.execute.side_effect = [
+            None,
+            [],
+            None,
+            Exception("ZooKeeper session expired"),
+        ]
+
+        with self.assertRaises(Exception, msg="ZooKeeper session expired"):
+            acquire_apply_lock(client, "default", "my-pod")
+
+        mock_sleep.assert_not_called()
+
+
+class TestSchemaVersion(unittest.TestCase):
+    """Tests for record_schema_version and get_latest_schema_version."""
+
+    def test_record_schema_version_inserts_correct_sentinel(self) -> None:
+        """record_schema_version inserts a row with VERSION_STEP_INDEX and commit_hash."""
+        from posthog.clickhouse.migration_tools.tracking import VERSION_STEP_INDEX, record_schema_version
+
+        client = MagicMock()
+        client.execute.return_value = None
+
+        record_schema_version(client, "default", "abc123", "my-pod")
+
+        client.execute.assert_called_once()
+        call_args = client.execute.call_args
+        params = call_args[0][1][0]  # (sql, params_list)[0]
+        # migration_name at index 1
+        self.assertEqual(params[1], "abc123")
+        # step_index at index 2
+        self.assertEqual(params[2], VERSION_STEP_INDEX)
+        self.assertEqual(VERSION_STEP_INDEX, -2)
+        # direction at index 5
+        self.assertEqual(params[5], "up")
+        # checksum at index 6
+        self.assertEqual(params[6], "version")
+
+    def test_get_latest_schema_version_returns_tuple(self) -> None:
+        """get_latest_schema_version returns (commit_hash, host, applied_at_str) when a row exists."""
+        from posthog.clickhouse.migration_tools.tracking import get_latest_schema_version
+
+        client = MagicMock()
+        now = datetime.now(tz=UTC)
+        client.execute.return_value = [("abc123", "my-pod", now)]
+
+        result = get_latest_schema_version(client, "default")
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        commit_hash, host, applied_at_str = result
+        self.assertEqual(commit_hash, "abc123")
+        self.assertEqual(host, "my-pod")
+        self.assertEqual(applied_at_str, str(now))
+
+    def test_get_latest_schema_version_returns_none_when_empty(self) -> None:
+        """get_latest_schema_version returns None when the table has no version rows."""
+        from posthog.clickhouse.migration_tools.tracking import get_latest_schema_version
+
+        client = MagicMock()
+        client.execute.return_value = []
+
+        result = get_latest_schema_version(client, "default")
+
+        self.assertIsNone(result)
 
 
 if __name__ == "__main__":

--- a/posthog/clickhouse/test/test_advisory_lock.py
+++ b/posthog/clickhouse/test/test_advisory_lock.py
@@ -1,0 +1,147 @@
+"""Unit tests for advisory locking in tracking.py.
+
+Tests acquire_apply_lock and release_apply_lock with mocked ClickHouse
+client — no Django or ClickHouse connection required.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import posthog.clickhouse.test._stubs  # noqa: F401
+from posthog.clickhouse.migration_tools.tracking import acquire_apply_lock, release_apply_lock
+
+
+class TestAdvisoryLock(unittest.TestCase):
+    """Tests for the advisory lock mechanism."""
+
+    @patch("posthog.clickhouse.migration_tools.tracking.time.sleep")
+    def test_advisory_lock_prevents_concurrent_apply(self, mock_sleep: MagicMock) -> None:
+        """An active lock from another host prevents acquisition."""
+        client = MagicMock()
+        now = datetime.now(tz=UTC)
+        # Flow: ensure table, check for existing lock (found -> reject)
+        client.execute.side_effect = [
+            None,  # CREATE TABLE ON CLUSTER (ensure tracking table)
+            [("other-pod", now)],  # Check SELECT -- another host holds the lock
+        ]
+
+        acquired, reason = acquire_apply_lock(client, "default", "my-pod")
+
+        self.assertFalse(acquired)
+        self.assertIn("other-pod", reason)
+        self.assertIn("--force", reason)
+
+    @patch("posthog.clickhouse.migration_tools.tracking.time.sleep")
+    def test_advisory_lock_expired_allows_apply(self, mock_sleep: MagicMock) -> None:
+        """No active lock (expired or absent) allows acquisition."""
+        client = MagicMock()
+        now = datetime.now(tz=UTC)
+        client.execute.side_effect = [
+            None,  # CREATE TABLE ON CLUSTER (ensure tracking table)
+            [],  # Check SELECT -- no active lock
+            None,  # INSERT lock row (via _record_step)
+            None,  # SYSTEM SYNC REPLICA (replication barrier)
+            [("my-pod", now)],  # Post-replication verify -- only our lock
+        ]
+
+        acquired, reason = acquire_apply_lock(client, "default", "my-pod")
+
+        self.assertTrue(acquired)
+        self.assertEqual(reason, "")
+        # Five calls: CREATE ON CLUSTER + check SELECT + INSERT + SYNC REPLICA + verify SELECT
+        self.assertEqual(client.execute.call_count, 5)
+        # SYNC REPLICA succeeded, so no sleep fallback
+        mock_sleep.assert_not_called()
+        sync_sql = client.execute.call_args_list[3].args[0]
+        self.assertIn("SYSTEM SYNC REPLICA", sync_sql)
+        self.assertIn("STRICT", sync_sql)
+        verify_sql = client.execute.call_args_list[4].args[0]
+        self.assertIn("ORDER BY applied_at ASC, host ASC", verify_sql)
+
+    @patch("posthog.clickhouse.migration_tools.tracking.time.sleep")
+    def test_advisory_lock_same_host_allows_reacquire(self, mock_sleep: MagicMock) -> None:
+        """A lock from the same host allows re-acquisition (idempotent)."""
+        client = MagicMock()
+        now = datetime.now(tz=UTC)
+        client.execute.side_effect = [
+            None,  # CREATE TABLE ON CLUSTER
+            [],  # Check SELECT -- no lock from OTHER hosts
+            None,  # INSERT lock row
+            None,  # SYSTEM SYNC REPLICA
+            [("my-pod", now)],  # Verify -- our own host holds the lock
+        ]
+
+        acquired, reason = acquire_apply_lock(client, "default", "my-pod")
+
+        self.assertTrue(acquired)
+        self.assertEqual(reason, "")
+
+    def test_advisory_lock_force_overrides_other_host(self) -> None:
+        """force=True acquires even when another host holds the lock."""
+        client = MagicMock()
+        client.execute.side_effect = [
+            None,  # CREATE TABLE ON CLUSTER (ensure tracking table)
+            None,  # INSERT lock row directly (no check with force=True)
+        ]
+
+        acquired, reason = acquire_apply_lock(client, "default", "my-pod", force=True)
+
+        self.assertTrue(acquired)
+        self.assertEqual(reason, "")
+        # Two calls: CREATE ON CLUSTER + INSERT (via _record_step). No verify needed.
+        self.assertEqual(client.execute.call_count, 2)
+
+    @patch("posthog.clickhouse.migration_tools.tracking.time.sleep")
+    def test_advisory_lock_race_detected(self, mock_sleep: MagicMock) -> None:
+        """When two hosts both insert before replication, the loser backs off."""
+        client = MagicMock()
+        now = datetime.now(tz=UTC)
+        client.execute.side_effect = [
+            None,  # CREATE TABLE ON CLUSTER
+            [],  # Check SELECT -- no lock (race window)
+            None,  # INSERT lock row
+            None,  # SYSTEM SYNC REPLICA
+            [("other-pod", now), ("my-pod", now)],  # Verify -- two locks! other-pod won
+            None,  # release_apply_lock INSERT (direction=down)
+        ]
+
+        acquired, reason = acquire_apply_lock(client, "default", "my-pod")
+
+        self.assertFalse(acquired)
+        self.assertIn("Race detected", reason)
+        self.assertIn("other-pod", reason)
+
+    def test_release_apply_lock_inserts_down_row(self) -> None:
+        """Release inserts a direction='down', success=True row."""
+        client = MagicMock()
+        client.execute.return_value = None
+
+        release_apply_lock(client, "default", "my-pod")
+
+        # Should have inserted a row (via _record_step which calls client.execute)
+        client.execute.assert_called_once()
+        # Verify the INSERT contains direction='down'
+        call_args = client.execute.call_args
+        params = call_args[0][1][0]  # positional: (sql, params_list)
+        # direction is at index 5 in the tuple
+        self.assertEqual(params[5], "down")
+        # success is at index 8
+        self.assertTrue(params[8])
+
+    def test_tracking_table_ddl_uses_replicated_engine(self) -> None:
+        """The tracking table DDL must use ReplicatedMergeTree and ON CLUSTER."""
+        from posthog.clickhouse.migration_tools.tracking import TRACKING_TABLE_DDL
+
+        self.assertIn("ReplicatedMergeTree", TRACKING_TABLE_DDL)
+        self.assertIn("ON CLUSTER", TRACKING_TABLE_DDL)
+        self.assertIn("{cluster}", TRACKING_TABLE_DDL)
+        self.assertIn("{{shard}}", TRACKING_TABLE_DDL)
+        self.assertIn("{{replica}}", TRACKING_TABLE_DDL)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/posthog/clickhouse/test/test_advisory_lock.py
+++ b/posthog/clickhouse/test/test_advisory_lock.py
@@ -60,7 +60,8 @@ class TestAdvisoryLock(unittest.TestCase):
         self.assertIn("SYSTEM SYNC REPLICA", sync_sql)
         self.assertIn("STRICT", sync_sql)
         verify_sql = client.execute.call_args_list[4].args[0]
-        self.assertIn("ORDER BY applied_at ASC, host ASC", verify_sql)
+        self.assertIn("ORDER BY t.applied_at ASC, t.host ASC", verify_sql)
+        self.assertIn("LEFT JOIN", verify_sql)
 
     @patch("posthog.clickhouse.migration_tools.tracking.time.sleep")
     def test_advisory_lock_same_host_allows_reacquire(self, mock_sleep: MagicMock) -> None:
@@ -154,6 +155,24 @@ class TestAdvisoryLock(unittest.TestCase):
         self.assertEqual(params[5], "down")
         # success is at index 8
         self.assertTrue(params[8])
+
+    @patch("posthog.clickhouse.migration_tools.tracking.time.sleep")
+    def test_verify_empty_logs_warning_and_returns_acquired(self, mock_sleep: MagicMock) -> None:
+        """Empty verify (extreme clock skew) logs a warning and returns acquired=True."""
+        client = MagicMock()
+        client.execute.side_effect = [
+            None,  # CREATE TABLE
+            [],  # Pre-check — no existing lock
+            None,  # INSERT
+            None,  # SYNC REPLICA
+            [],  # Verify — empty (clock skew / extreme lag)
+        ]
+
+        with self.assertLogs("posthog.clickhouse.migration_tools.tracking", level="WARNING") as cm:
+            acquired, _ = acquire_apply_lock(client, "default", "my-pod")
+
+        self.assertTrue(acquired)
+        self.assertTrue(any("clock skew" in line for line in cm.output))
 
     def test_tracking_table_ddl_uses_replicated_engine(self) -> None:
         """The tracking table DDL must use ReplicatedMergeTree and ON CLUSTER."""


### PR DESCRIPTION
## Problem

ch_migrate apply has no audit trail and no protection against two concurrent applies running on different cluster nodes simultaneously. Without a history table, there is no way to verify what was applied, when, and from which host. Without a lock, two concurrent applies can race and produce conflicting DDL.

## Changes

- `posthog/clickhouse/migration_tools/tracking.py` — persists each plan/apply run to `clickhouse_schema_migrations` (ReplicatedMergeTree ON CLUSTER). Records migration number, step index, host, node role, direction, checksum, timestamp, and success. Implements a cluster-wide advisory lock using insert semantics and `SYSTEM SYNC REPLICA STRICT` for replication convergence before the double-lock verification.
- `posthog/clickhouse/test/test_advisory_lock.py` — inline unit tests for lock acquisition, expiry, race detection, force-override, and release; no live ClickHouse required
- `posthog/clickhouse/test/_stubs.py` — shared Django/ClickHouse stubs for standalone test execution
- `posthog/clickhouse/test/conftest.py` — pytest conftest loading stubs before collection

## How did you test this code?

Unit tests in `test_advisory_lock.py` cover all lock state transitions using a mocked ClickHouse client. Tests verify SQL call counts and parameter values directly.

Draft — unit tests pass locally with dependency files from co-pending PRs present. Full end-to-end requires PR12 (runner) to be merged first.

## Publish to changelog?

No

## 🤖 LLM context

Agent-authored draft PR. Part of the ch_migrate tiny-PR stack (Batch 3 of 3). Depends on PR12 (runner). No separate ClickHouse migration file — the tracking table DDL lives in `tracking.py` as `TRACKING_TABLE_DDL` and is created idempotently by `_ensure_tracking_table()` on first apply.