### PR TITLE
feat(ch-migrate): diff engine — diff_state, detect_orphans, Kafka cascade prevention

### DIFF
--- a/posthog/clickhouse/migration_tools/state_diff.py
+++ b/posthog/clickhouse/migration_tools/state_diff.py
@@ -204,6 +204,19 @@ def _normalize_interval_funcs(s: str) -> str:
     return _INTERVAL_RE.sub(_sub, s)
 
 
+def _find_close_paren(s: str, open_pos: int) -> int | None:
+    """Return the index of the ')' matching s[open_pos], or None if unbalanced."""
+    depth = 1
+    i = open_pos + 1
+    while i < len(s) and depth > 0:
+        if s[i] == "(":
+            depth += 1
+        elif s[i] == ")":
+            depth -= 1
+        i += 1
+    return (i - 1) if depth == 0 else None
+
+
 def _strip_outer_balanced_parens(s: str, start: int) -> tuple[str, bool]:
     """If s[start] is '(', find matching ')' and strip if the group is redundant.
 
@@ -213,22 +226,13 @@ def _strip_outer_balanced_parens(s: str, start: int) -> tuple[str, bool]:
     """
     if start >= len(s) or s[start] != "(":
         return s, False
-    depth = 1
-    i = start + 1
-    while i < len(s) and depth > 0:
-        if s[i] == "(":
-            depth += 1
-        elif s[i] == ")":
-            depth -= 1
-        i += 1
-    if depth != 0:
+    end = _find_close_paren(s, start)
+    if end is None:
         return s, False
-    end = i - 1  # index of closing ')'
-    inner = s[start + 1 : end]
-    # Don't strip if inner is empty or if stripping would remove function-call parens
-    # (function call = identifier immediately before the '(')
+    # Don't strip function-call parens (identifier immediately before '(')
     if start > 0 and re.match(r"\w", s[start - 1]):
         return s, False
+    inner = s[start + 1 : end]
     s = s[:start] + inner + s[end + 1 :]
     return s, True
 
@@ -249,33 +253,21 @@ def _strip_redundant_parens(s: str) -> str:
         # Strip outer parens wrapping the full lambda body: -> (...) → -> ...
         m = re.search(r"->\s*\(", s)
         if m:
-            paren_start = m.end() - 1
-            s, _ = _strip_outer_balanced_parens(s, paren_start)
+            s, _ = _strip_outer_balanced_parens(s, m.end() - 1)
 
         # Strip parens around AND/OR operands by scanning for paren groups
         # adjacent to boolean operators
         changed = True
         while changed:
             changed = False
-            # Find (expr) followed by AND/OR
             for m in re.finditer(r"\(", s):
                 pos = m.start()
                 # Skip function-call parens (preceded by word char)
                 if pos > 0 and re.match(r"\w", s[pos - 1]):
                     continue
-                # Find the matching close paren
-                depth = 1
-                j = pos + 1
-                while j < len(s) and depth > 0:
-                    if s[j] == "(":
-                        depth += 1
-                    elif s[j] == ")":
-                        depth -= 1
-                    j += 1
-                if depth != 0:
+                close = _find_close_paren(s, pos)
+                if close is None:
                     continue
-                close = j - 1
-                # Check if followed by AND/OR or preceded by AND/OR (or ->)
                 after = s[close + 1 :].lstrip()
                 before = s[:pos].rstrip()
                 is_bool_context = (
@@ -284,8 +276,7 @@ def _strip_redundant_parens(s: str) -> str:
                     or before.endswith("->")
                 )
                 if is_bool_context:
-                    inner = s[pos + 1 : close]
-                    s = s[:pos] + inner + s[close + 1 :]
+                    s = s[:pos] + s[pos + 1 : close] + s[close + 1 :]
                     changed = True
                     break  # restart scan after mutation
 

--- a/posthog/clickhouse/migration_tools/state_diff.py
+++ b/posthog/clickhouse/migration_tools/state_diff.py
@@ -79,7 +79,7 @@ def _resolve_setting(key: str) -> str:
 @dataclass
 class StateDiff:
     # "create", "alter_add_column", "alter_drop_column",
-    # "alter_modify_column", "drop", "recreate_mv", "recreate"
+    # "alter_modify_column", "drop", "recreate"
     action: str
     table: str
     detail: str
@@ -307,7 +307,7 @@ def _normalize_type(s: str) -> str:
     Handles:
     - Enum8/Enum16 → Enum (strip bit-width suffix and = N value assignments)
     - DateTime64 → DateTime64(3) (3 is the default precision)
-    - Decimal(18, 10) → Decimal64(10) (CH alias)
+    - Decimal(P, S) → Decimal32/64/128/256(S) (CH precision aliases)
     """
     # Fix 2: Enum8('a' = 1, 'b' = 2) → Enum('a', 'b')
     s = re.sub(r"Enum(?:8|16)\(", "Enum(", s)
@@ -315,8 +315,9 @@ def _normalize_type(s: str) -> str:
     # Fix 4: DateTime64 without precision → DateTime64(3)
     s = re.sub(r"\bDateTime64\b(?!\()", "DateTime64(3)", s)
 
-    # Fix 4: Decimal(18, 10) → Decimal64(10) etc.
-    # Decimal(P, S) where P ≤ 18 → Decimal64(S); P ≤ 9 → Decimal32(S); P ≤ 38 → Decimal128(S)
+    # Fix 4: Decimal(P, S) → Decimal32/64/128/256(S) etc.
+    # P ≤ 9 → Decimal32(S); P ≤ 18 → Decimal64(S);
+    # P ≤ 38 → Decimal128(S); P ≤ 76 → Decimal256(S)
     def _decimal_alias(m: re.Match) -> str:
         p, s = int(m.group(1)), m.group(2)
         if p <= 9:
@@ -325,6 +326,8 @@ def _normalize_type(s: str) -> str:
             return f"Decimal64({s})"
         elif p <= 38:
             return f"Decimal128({s})"
+        elif p <= 76:
+            return f"Decimal256({s})"
         return m.group(0)
 
     s = re.sub(r"\bDecimal\(\s*(\d+)\s*,\s*(\d+)\s*\)", _decimal_alias, s)
@@ -686,11 +689,20 @@ def diff_state(
     current: dict[str, TableSchema],
     database: str | None = None,
     cluster: str | None = None,
+    destructive: bool = False,
 ) -> list[StateDiff]:
     """Compare desired state against current schema and produce a list of diffs.
 
     Returns StateDiff objects sorted in dependency order (drops before creates,
     local before distributed, kafka before MV).
+
+    When destructive=False (the default), operations that require DROP (orphan
+    removal, engine-change recreates, structural recreates, MV SELECT changes)
+    are skipped and logged as warnings instead of being emitted as diffs. Set
+    destructive=True to include DROP-bearing operations in the output.
+
+    MV DROP operations always precede source-table ALTERs so that in-flight
+    inserts are not lost to a schema mismatch.
     """
     db = database or desired.database
     cl = cluster or desired.cluster
@@ -727,6 +739,13 @@ def diff_state(
 
     # Tables to drop (in current but not in desired)
     for table_name in sorted(current_names - desired_names):
+        if not destructive:
+            logger.warning(
+                "ch_migrate: table %s is an orphan (in ClickHouse but not in any YAML) — "
+                "run with destructive=True to emit the DROP",
+                table_name,
+            )
+            continue
         current_table = current[table_name]
         drops.append(
             StateDiff(
@@ -765,19 +784,35 @@ def diff_state(
         desired_table = desired.tables[table_name]
         current_table = current[table_name]
 
-        # Engine mismatch → recreate
+        # Engine mismatch → recreate (requires DROP — gated behind destructive)
         if desired_table.engine.lower() != current_table.engine.lower():
+            _engine_detail = f"engine changed: {current_table.engine} -> {desired_table.engine}"
+            if not destructive:
+                logger.warning(
+                    "ch_migrate: %s requires DROP+CREATE (%s) — run with destructive=True to emit",
+                    table_name,
+                    _engine_detail,
+                )
+                continue
             drop_sql = _drop_stmt(current_table.engine, db, table_name)
             if _is_mv(desired_table.engine) or _is_mv(current_table.engine):
-                recreates.append(
+                # Split into separate drop + create so the MV DROP lands before
+                # any source-table ALTERs in the final sorted output.
+                drops.append(
                     StateDiff(
-                        action="recreate_mv",
+                        action="drop",
                         table=table_name,
-                        detail=(
-                            f"Recreate MV {table_name} "
-                            f"(engine changed: {current_table.engine} -> {desired_table.engine})"
-                        ),
-                        sql=(f"{drop_sql};\n{_generate_create_sql(desired_table, db, cl)}"),
+                        detail=f"Drop MV {table_name} ({_engine_detail} — will recreate)",
+                        sql=drop_sql,
+                        node_roles=desired_table.on_nodes,
+                    )
+                )
+                creates.append(
+                    StateDiff(
+                        action="create",
+                        table=table_name,
+                        detail=f"Recreate MV {table_name} ({_engine_detail})",
+                        sql=_generate_create_sql(desired_table, db, cl),
                         node_roles=desired_table.on_nodes,
                         depends_on=[desired_table.target] if desired_table.target else [],
                     )
@@ -787,10 +822,8 @@ def diff_state(
                     StateDiff(
                         action="recreate",
                         table=table_name,
-                        detail=(
-                            f"Recreate {table_name} (engine changed: {current_table.engine} -> {desired_table.engine})"
-                        ),
-                        sql=(f"{drop_sql};\n{_generate_create_sql(desired_table, db, cl)}"),
+                        detail=f"Recreate {table_name} ({_engine_detail})",
+                        sql=f"{drop_sql};\n{_generate_create_sql(desired_table, db, cl)}",
                         node_roles=desired_table.on_nodes,
                         sharded=desired_table.sharded,
                     )
@@ -952,14 +985,32 @@ def diff_state(
 
         if structural_recreate:
             detail_str = "; ".join(structural_details)
+            if not destructive:
+                logger.warning(
+                    "ch_migrate: %s requires DROP+CREATE (%s) — run with destructive=True to emit",
+                    table_name,
+                    detail_str,
+                )
+                continue
             drop_sql = _drop_stmt(current_table.engine, db, table_name)
             if _is_mv(desired_table.engine):
-                recreates.append(
+                # Split into separate drop + create so the MV DROP lands before
+                # any source-table ALTERs in the final sorted output.
+                drops.append(
                     StateDiff(
-                        action="recreate_mv",
+                        action="drop",
+                        table=table_name,
+                        detail=f"Drop MV {table_name} ({detail_str} — will recreate)",
+                        sql=drop_sql,
+                        node_roles=desired_table.on_nodes,
+                    )
+                )
+                creates.append(
+                    StateDiff(
+                        action="create",
                         table=table_name,
                         detail=f"Recreate MV {table_name} ({detail_str})",
-                        sql=f"{drop_sql};\n{_generate_create_sql(desired_table, db, cl)}",
+                        sql=_generate_create_sql(desired_table, db, cl),
                         node_roles=desired_table.on_nodes,
                         depends_on=[desired_table.target] if desired_table.target else [],
                     )
@@ -991,24 +1042,30 @@ def diff_state(
                 and not is_select_star
                 and desired_norm != _normalize_mv_select(current_select, database=db)
             ):
-                drops.append(
-                    StateDiff(
-                        action="drop",
-                        table=table_name,
-                        detail=f"Drop MV {table_name} (SELECT changed — will recreate)",
-                        sql=_drop_stmt(current_table.engine, db, table_name),
-                        node_roles=desired_table.on_nodes,
+                if not destructive:
+                    logger.warning(
+                        "ch_migrate: MV %s SELECT changed — run with destructive=True to emit the DROP+recreate",
+                        table_name,
                     )
-                )
-                creates.append(
-                    StateDiff(
-                        action="create",
-                        table=table_name,
-                        detail=f"Recreate MV {table_name} with updated SELECT",
-                        sql=_generate_create_sql(desired_table, db, cl),
-                        node_roles=desired_table.on_nodes,
+                else:
+                    drops.append(
+                        StateDiff(
+                            action="drop",
+                            table=table_name,
+                            detail=f"Drop MV {table_name} (SELECT changed — will recreate)",
+                            sql=_drop_stmt(current_table.engine, db, table_name),
+                            node_roles=desired_table.on_nodes,
+                        )
                     )
-                )
+                    creates.append(
+                        StateDiff(
+                            action="create",
+                            table=table_name,
+                            detail=f"Recreate MV {table_name} with updated SELECT",
+                            sql=_generate_create_sql(desired_table, db, cl),
+                            node_roles=desired_table.on_nodes,
+                        )
+                    )
             elif not current_select:
                 logger.warning(
                     "MV %s: SELECT comparison not possible (as_select not available from host). "
@@ -1184,28 +1241,19 @@ def diff_state(
     # table if it was created inline. Re-add a CREATE step for any Kafka
     # table referenced by the MV's SELECT.
     #
-    # MV recreation takes two shapes in the diff:
-    #   1. A single `recreate_mv` entry (structural change: target/engine/etc.)
-    #   2. A paired DROP + CREATE on the same MV table name (SELECT changed,
-    #      see the MV SELECT comparison above that emits `drop` + `create`).
-    # Both cascade-drop the Kafka source, so both must trigger re-creation.
+    # MV recreation always produces a drop+create pair: the DROP goes into
+    # `drops` (sorted first as tier-3) and the CREATE goes into `creates`
+    # (sorted last as tier-3). Tables appearing in both lists are MV recreations.
     kafka_tables_in_desired = {name: t for name, t in desired_without_skipped.items() if _is_kafka(t.engine)}
     if kafka_tables_in_desired:
         # Collect table names already being created so we don't duplicate.
         tables_being_created = {d.table for d in creates}
 
-        # Build the set of MV names being recreated: explicit recreate_mv
-        # entries, plus tables that appear as BOTH a drop and a create (the
-        # drop+create pair path for SELECT changes).
+        # Tables that appear as both a drop and a create are being recreated.
         dropped_names = {d.table for d in drops}
         created_names = {d.table for d in creates}
-        drop_create_pairs = dropped_names & created_names
-
         recreated_mv_names: set[str] = set()
-        for rec in recreates:
-            if rec.action == "recreate_mv":
-                recreated_mv_names.add(rec.table)
-        for name in drop_create_pairs:
+        for name in dropped_names & created_names:
             maybe_desired: DesiredTable | None = desired_without_skipped.get(name)
             if maybe_desired and _is_mv(maybe_desired.engine):
                 recreated_mv_names.add(name)

--- a/posthog/clickhouse/migration_tools/state_diff.py
+++ b/posthog/clickhouse/migration_tools/state_diff.py
@@ -1094,6 +1094,12 @@ def diff_state(
             {(c.name, _normalize_type(c.type)) for c in desired_cols.values()}
             != {(c.name, _normalize_type(c.type)) for c in current_cols.values()}
         ):
+            if not destructive:
+                logger.warning(
+                    "ch_migrate: %s requires DROP+CREATE for column change — run with destructive=True",
+                    table_name,
+                )
+                continue
             drops.append(
                 StateDiff(
                     action="drop",
@@ -1278,6 +1284,9 @@ def diff_state(
                         )
                     )
                     tables_being_created.add(kafka_name)
+        # Re-sort creates so cascade-appended Kafka CREATEs (tier 0) land
+        # before MV CREATEs (tier 3) that depend on them.
+        creates.sort(key=_create_sort_key)
 
     return drops + alters + creates + recreates
 

--- a/posthog/clickhouse/migration_tools/state_diff.py
+++ b/posthog/clickhouse/migration_tools/state_diff.py
@@ -1,0 +1,1274 @@
+"""Diff engine: compare desired state against current live schema.
+
+Produces a list of StateDiff objects, each representing a single DDL operation
+(CREATE, ALTER, DROP, recreate) with the SQL to execute, target node roles,
+and dependency ordering.
+
+The diff respects ClickHouse ecosystem rules:
+- DROP MV before altering source tables
+- CREATE local tables before Distributed tables
+- CREATE Kafka tables before MVs
+- ALTER all ecosystem tables when adding a column (sharded + writable + readable)
+"""
+
+from __future__ import annotations
+
+import re
+import logging
+from dataclasses import dataclass, field
+
+from django.conf import settings as django_settings
+
+from posthog.clickhouse.migration_tools.desired_state import ColumnDef, DesiredState, DesiredTable
+from posthog.clickhouse.migration_tools.schema_introspect import TableSchema
+
+logger = logging.getLogger("migrations")
+
+# Sentinel value used in schema YAML to indicate the value should come from Django settings
+_FROM_SETTINGS_SENTINEL = "__from_settings__"
+
+# Map of YAML setting keys to Django settings attributes
+_SETTINGS_RESOLUTION: dict[str, str] = {
+    "kafka_broker_list": "KAFKA_HOSTS_FOR_CLICKHOUSE",
+    "password": "CLICKHOUSE_PASSWORD",
+    "user": "CLICKHOUSE_USER",
+}
+
+
+def _resolve_physical_cluster(logical_name: str) -> str:
+    """Resolve a YAML logical cluster name to the physical CH cluster name.
+
+    Uses _CLUSTER_REGISTRY from cluster.py to map logical names (e.g. 'main')
+    to Django settings attrs (e.g. 'CLICKHOUSE_CLUSTER'), then reads the
+    setting value. Unknown names pass through unchanged so the eventual CH
+    error (CLUSTER_DOESNT_EXIST) still surfaces as the signal to fix the YAML.
+
+    Needed because the dev stack's physical cluster is 'posthog_migrations'
+    while production uses 'main' — same YAML, different CH cluster name.
+    """
+    from posthog.clickhouse.cluster import _CLUSTER_REGISTRY
+
+    entry = _CLUSTER_REGISTRY.get(logical_name)
+    if entry is None:
+        return logical_name
+    _host_attr, cluster_attr = entry
+    return getattr(django_settings, cluster_attr, logical_name)
+
+
+def _resolve_setting(key: str) -> str:
+    """Resolve a __from_settings__ sentinel to its Django settings value.
+
+    Each key resolves independently. Only `kafka_broker_list` falls back to the
+    dev-stack broker host — credentials (`password`, `user`) return an empty
+    string when unset, which renders as an empty SOURCE/LAYOUT param. Prior
+    behavior returned `kafka:9092` for every unset key, corrupting non-Kafka
+    rendered DDL like `PASSWORD 'kafka:9092'` for Dictionary sources.
+    """
+    attr = _SETTINGS_RESOLUTION.get(key)
+    if attr:
+        val = getattr(django_settings, attr, None)
+        if val:
+            return ",".join(val) if isinstance(val, list) else str(val)
+    if key == "kafka_broker_list":
+        logger.warning("Setting %s (Django attr %s) is unset, falling back to kafka:9092", key, attr or key)
+        return "kafka:9092"
+    logger.warning("Setting %s (Django attr %s) is unset, returning empty string", key, attr or key)
+    return ""
+
+
+@dataclass
+class StateDiff:
+    # "create", "alter_add_column", "alter_drop_column",
+    # "alter_modify_column", "drop", "recreate_mv", "recreate"
+    action: str
+    table: str
+    detail: str
+    sql: str
+    node_roles: list[str]
+    sharded: bool = False
+    is_alter_on_replicated_table: bool = False
+    depends_on: list[str] = field(default_factory=list)
+    # Logical cluster this diff targets (e.g. "main", "logs", "sessions").
+    # Set by _compute_diffs so handle_apply can route each step to the right
+    # cluster instead of running everything against the migrations cluster.
+    cluster: str = ""
+
+
+# Engine tier determines creation order and helps classify table types
+_ENGINE_TIER: dict[str, int] = {
+    "kafka": 0,
+    "mergetree": 1,
+    "replacingmergetree": 1,
+    "replicatedmergetree": 1,
+    "replicatedreplacingmergetree": 1,
+    "collapsingmergetree": 1,
+    "replicatedcollapsingmergetree": 1,
+    "versionedcollapsingmergetree": 1,
+    "replicatedversionedcollapsingmergetree": 1,
+    "summingmergetree": 1,
+    "replicatedsummingmergetree": 1,
+    "aggregatingmergetree": 1,
+    "replicatedaggregatingmergetree": 1,
+    "distributed": 2,
+    "materializedview": 3,
+    "dictionary": 3,
+}
+
+
+def _engine_tier(engine: str) -> int:
+    return _ENGINE_TIER.get(engine.lower(), 1)
+
+
+def _is_mergetree(engine: str) -> bool:
+    return "mergetree" in engine.lower()
+
+
+def _is_distributed(engine: str) -> bool:
+    return engine.lower() == "distributed"
+
+
+def _is_mv(engine: str) -> bool:
+    return engine.lower() == "materializedview"
+
+
+def _is_kafka(engine: str) -> bool:
+    return engine.lower() == "kafka"
+
+
+def _is_dictionary(engine: str) -> bool:
+    return engine.lower() == "dictionary"
+
+
+def _drop_stmt(engine: str, database: str, table: str) -> str:
+    """Return the right DROP verb for an engine. Dictionaries require DROP DICTIONARY."""
+    if _is_dictionary(engine):
+        return f"DROP DICTIONARY IF EXISTS {database}.{table}"
+    return f"DROP TABLE IF EXISTS {database}.{table}"
+
+
+# Tracking tables are bookkeeping infrastructure managed by `bootstrap`,
+# never declared in any YAML. Both `diff_state` and the cluster-wide orphan
+# scan in `_compute_diffs` exclude them so we never emit a DROP for the
+# tool's own state tables.
+TRACKING_TABLES: frozenset[str] = frozenset(
+    {
+        "clickhouse_schema_migrations",
+        "infi_clickhouse_orm_migrations",
+        "infi_clickhouse_orm_migrations_distributed",
+    }
+)
+
+
+def has_placeholder_select(t: DesiredTable) -> bool:
+    """True if a desired MV's SELECT body contains a `...` placeholder.
+
+    The YAML baseline for several ecosystems was mechanically generated and
+    left the SELECT body as a sentinel for later hand-filling. These MVs
+    stay managed by legacy `migrate_clickhouse` until the YAML grows real
+    bodies. Two variants observed in the wild:
+      - `SELECT ... FROM source`             (full body stubbed)
+      - `SELECT col1, col2, ... FROM source` (trailing cols stubbed)
+    The trailing `...` in a valid SELECT list is not legal ClickHouse
+    syntax, so this check won't accidentally skip real MVs.
+    """
+    if not _is_mv(t.engine) or not t.select:
+        return False
+    select_body = t.select
+    return "SELECT ..." in select_body or ", ..." in select_body or ",..." in select_body
+
+
+# ClickHouse normalizes toIntervalX(N) → INTERVAL N X in system.columns,
+# but YAML may use either form. Map function names to interval units.
+_INTERVAL_FUNCS = {
+    "tointervalday": "DAY",
+    "tointervalhour": "HOUR",
+    "tointervalminute": "MINUTE",
+    "tointervalsecond": "SECOND",
+    "tointervalweek": "WEEK",
+    "tointervalmonth": "MONTH",
+    "tointervalyear": "YEAR",
+}
+
+_INTERVAL_RE = re.compile(r"(toInterval[A-Za-z]+)\s*\(\s*([^)]+?)\s*\)")
+
+
+def _normalize_interval_funcs(s: str) -> str:
+    """Convert toIntervalX(N) → INTERVAL N X for CH canonical form equivalence."""
+
+    def _sub(m: re.Match) -> str:
+        fn = m.group(1).lower()
+        arg = m.group(2).strip()
+        unit = _INTERVAL_FUNCS.get(fn)
+        return f"INTERVAL {arg} {unit}" if unit else m.group(0)
+
+    return _INTERVAL_RE.sub(_sub, s)
+
+
+def _strip_outer_balanced_parens(s: str, start: int) -> tuple[str, bool]:
+    """If s[start] is '(', find matching ')' and strip if the group is redundant.
+
+    A paren group is redundant when it wraps an AND/OR operand — i.e. the
+    character before '(' or after ')' is adjacent to AND/OR (or -> or start/end).
+    Returns (possibly-modified string, whether a strip happened).
+    """
+    if start >= len(s) or s[start] != "(":
+        return s, False
+    depth = 1
+    i = start + 1
+    while i < len(s) and depth > 0:
+        if s[i] == "(":
+            depth += 1
+        elif s[i] == ")":
+            depth -= 1
+        i += 1
+    if depth != 0:
+        return s, False
+    end = i - 1  # index of closing ')'
+    inner = s[start + 1 : end]
+    # Don't strip if inner is empty or if stripping would remove function-call parens
+    # (function call = identifier immediately before the '(')
+    if start > 0 and re.match(r"\w", s[start - 1]):
+        return s, False
+    s = s[:start] + inner + s[end + 1 :]
+    return s, True
+
+
+def _strip_redundant_parens(s: str) -> str:
+    """Iteratively strip semantically-redundant parentheses in lambda bodies.
+
+    CH wraps lambda conditions at two levels:
+    1. Outer: ``-> (expr)`` → ``-> expr``
+    2. Per-operand: ``(cond1) AND (cond2)`` → ``cond1 AND cond2``
+
+    Since we only need equality comparison (not execution), stripping these
+    redundant wrappers is safe.
+    """
+    prev = None
+    while prev != s:
+        prev = s
+        # Strip outer parens wrapping the full lambda body: -> (...) → -> ...
+        m = re.search(r"->\s*\(", s)
+        if m:
+            paren_start = m.end() - 1
+            s, _ = _strip_outer_balanced_parens(s, paren_start)
+
+        # Strip parens around AND/OR operands by scanning for paren groups
+        # adjacent to boolean operators
+        changed = True
+        while changed:
+            changed = False
+            # Find (expr) followed by AND/OR
+            for m in re.finditer(r"\(", s):
+                pos = m.start()
+                # Skip function-call parens (preceded by word char)
+                if pos > 0 and re.match(r"\w", s[pos - 1]):
+                    continue
+                # Find the matching close paren
+                depth = 1
+                j = pos + 1
+                while j < len(s) and depth > 0:
+                    if s[j] == "(":
+                        depth += 1
+                    elif s[j] == ")":
+                        depth -= 1
+                    j += 1
+                if depth != 0:
+                    continue
+                close = j - 1
+                # Check if followed by AND/OR or preceded by AND/OR (or ->)
+                after = s[close + 1 :].lstrip()
+                before = s[:pos].rstrip()
+                is_bool_context = (
+                    re.match(r"\b(?:and|or)\b", after, re.IGNORECASE)
+                    or re.search(r"\b(?:and|or)\s*$", before, re.IGNORECASE)
+                    or before.endswith("->")
+                )
+                if is_bool_context:
+                    inner = s[pos + 1 : close]
+                    s = s[:pos] + inner + s[close + 1 :]
+                    changed = True
+                    break  # restart scan after mutation
+
+        s = re.sub(r"  +", " ", s)
+    return s
+
+
+def _normalize_default(s: str) -> str:
+    """Normalize a default expression for semantic comparison.
+
+    Handles: backslash-escaped quotes, toIntervalX(N) → INTERVAL N X,
+    case folding, whitespace collapse, lambda-body paren stripping,
+    nested AND/OR operand paren stripping.
+    """
+    # Fix 3: Normalize backslash-escaped quotes (CH double-escapes in some contexts)
+    s = s.replace('\\\\"', '"').replace('\\"', '"')
+    s = _normalize_interval_funcs(s)
+    s = re.sub(r"\s+", " ", s.strip().lower())
+    # Fix 1+6: Strip semantically redundant parens in lambda bodies,
+    # including nested per-operand parens CH adds around AND/OR clauses.
+    s = _strip_redundant_parens(s)
+    return s
+
+
+def _normalize_type(s: str) -> str:
+    """Normalize a column type string for semantic comparison.
+
+    Handles:
+    - Enum8/Enum16 → Enum (strip bit-width suffix and = N value assignments)
+    - DateTime64 → DateTime64(3) (3 is the default precision)
+    - Decimal(18, 10) → Decimal64(10) (CH alias)
+    """
+    # Fix 2: Enum8('a' = 1, 'b' = 2) → Enum('a', 'b')
+    s = re.sub(r"Enum(?:8|16)\(", "Enum(", s)
+    s = re.sub(r"'([^']+)'\s*=\s*\d+", r"'\1'", s)
+    # Fix 4: DateTime64 without precision → DateTime64(3)
+    s = re.sub(r"\bDateTime64\b(?!\()", "DateTime64(3)", s)
+
+    # Fix 4: Decimal(18, 10) → Decimal64(10) etc.
+    # Decimal(P, S) where P ≤ 18 → Decimal64(S); P ≤ 9 → Decimal32(S); P ≤ 38 → Decimal128(S)
+    def _decimal_alias(m: re.Match) -> str:
+        p, s = int(m.group(1)), m.group(2)
+        if p <= 9:
+            return f"Decimal32({s})"
+        elif p <= 18:
+            return f"Decimal64({s})"
+        elif p <= 38:
+            return f"Decimal128({s})"
+        return m.group(0)
+
+    s = re.sub(r"\bDecimal\(\s*(\d+)\s*,\s*(\d+)\s*\)", _decimal_alias, s)
+    # Bool and Boolean are aliases in ClickHouse — normalize to Boolean
+    s = re.sub(r"\bBool\b", "Boolean", s)
+    return s
+
+
+# Kafka virtual columns injected by ClickHouse — not declared in YAML.
+_KAFKA_VIRTUAL_COLUMNS = frozenset(
+    {
+        "_topic",
+        "_key",
+        "_offset",
+        "_partition",
+        "_timestamp",
+        "_headers",
+    }
+)
+
+
+def _is_kafka_virtual_column(name: str) -> bool:
+    return name in _KAFKA_VIRTUAL_COLUMNS or name.startswith("_headers.")
+
+
+def _columns_sql(columns: list[ColumnDef]) -> str:
+    parts = []
+    for col in columns:
+        line = f"    {col.name} {col.type}"
+        if col.default_expression:
+            kind = col.default_kind or "DEFAULT"
+            line += f" {kind} {col.default_expression}"
+        if col.codec:
+            line += f" CODEC({col.codec})"
+        parts.append(line)
+    return ",\n".join(parts)
+
+
+# Dictionary metadata renderers. Keep these as small, pure functions so the
+# DROP+CREATE path below can re-use them without duplicating format strings.
+# Value types: YAML admits str/int/bool for source+layout params.
+
+
+def _normalize_layout_type(layout: str) -> str:
+    """Normalize a dictionary LAYOUT type name for semantic comparison.
+
+    CH auto-prepends COMPLEX_KEY_ when the primary key is non-integer or
+    composite. HASHED with String key → COMPLEX_KEY_HASHED. RANGE_HASHED with
+    String key → COMPLEX_KEY_RANGE_HASHED. These are semantically identical
+    — the YAML declares HASHED but CH stores COMPLEX_KEY_HASHED. Strip the
+    prefix to compare.
+
+    The two introspection sources (`layout_name` column vs `LAYOUT(...)` clause
+    parsed out of `create_table_query`) disagree on underscores — one stores
+    `COMPLEX_KEY_RANGE_HASHED`, the other `COMPLEXKEYRANGEHASHED`. Strip all
+    underscores after the prefix strip so both forms compare equal regardless
+    of which introspection path produced the string.
+    """
+    upper = layout.upper()
+    upper = re.sub(r"^COMPLEX_KEY_", "", upper)
+    upper = re.sub(r"^COMPLEXKEY", "", upper)
+    return upper.replace("_", "")
+
+
+def _render_dict_param(key: str, value: object) -> str:
+    """Render one `key value` pair inside a SOURCE(...) or LAYOUT(...) clause.
+
+    Handles the `__from_settings__` sentinel — when set, resolves via Django
+    settings using the YAML key (matching the Kafka settings convention).
+    Strings are single-quoted, ints/bools are bare.
+    """
+    if isinstance(value, str) and value == _FROM_SETTINGS_SENTINEL:
+        return f"{key} '{_resolve_setting(key)}'"
+    if isinstance(value, str):
+        return f"{key} '{value}'"
+    if isinstance(value, bool):
+        return f"{key} {1 if value else 0}"
+    return f"{key} {value}"
+
+
+def _render_dict_source(source: dict | None) -> str:
+    """Render SOURCE(...) clause from a YAML mapping.
+
+    `type` is the source kind (CLICKHOUSE, HTTP, MYSQL, etc). All other keys
+    become parameter names inside the parens. Example:
+        {"type": "HTTP", "url": "https://x", "format": "CSVWithNames"}
+      → SOURCE(HTTP(url 'https://x' format 'CSVWithNames'))
+    """
+    if not source or "type" not in source:
+        raise ValueError("Dictionary source requires a 'type' key (e.g. CLICKHOUSE, HTTP)")
+    kind = source["type"].upper()
+    parts = [_render_dict_param(k, v) for k, v in source.items() if k != "type"]
+    inner = " ".join(parts)
+    return f"SOURCE({kind}({inner}))"
+
+
+def _render_dict_layout(layout: dict | None) -> str:
+    """Render LAYOUT(TYPE(...)) clause. Optional `params` becomes key/value pairs."""
+    if not layout or "type" not in layout:
+        raise ValueError("Dictionary layout requires a 'type' key (e.g. HASHED, COMPLEX_KEY_HASHED)")
+    kind = layout["type"].upper()
+    params = layout.get("params") or {}
+    if params:
+        inner = " ".join(_render_dict_param(k, v) for k, v in params.items())
+        return f"LAYOUT({kind}({inner}))"
+    return f"LAYOUT({kind}())"
+
+
+def _render_dict_lifetime(lifetime: dict | None) -> str:
+    """Render LIFETIME(MIN x MAX y). Both min+max required for stable refresh windows."""
+    if not lifetime or "min" not in lifetime or "max" not in lifetime:
+        raise ValueError("Dictionary lifetime requires 'min' and 'max' keys")
+    return f"LIFETIME(MIN {int(lifetime['min'])} MAX {int(lifetime['max'])})"
+
+
+def _render_dict_range(dict_range: dict | None) -> str:
+    """Render RANGE(MIN x MAX y). Used by RANGE_HASHED layouts for per-range lookups.
+
+    `min`/`max` are column names (e.g. `start_date`/`end_date`), not integer
+    bounds — CH interprets them as column refs into the dictionary's own rows.
+    Returns an empty string when `dict_range` is None (non-RANGE_HASHED dicts).
+    """
+    if not dict_range:
+        return ""
+    if "min" not in dict_range or "max" not in dict_range:
+        raise ValueError("Dictionary range requires 'min' and 'max' keys (column names)")
+    return f"RANGE(MIN {dict_range['min']} MAX {dict_range['max']})"
+
+
+def _generate_create_sql(
+    table: DesiredTable,
+    database: str,
+    cluster: str,
+) -> str:
+    """Generate CREATE TABLE/VIEW SQL from a DesiredTable."""
+    cols = _columns_sql(table.columns)
+
+    if _is_dictionary(table.engine):
+        if not table.primary_key:
+            raise ValueError(f"Dictionary {table.name!r} missing required 'primary_key'")
+        pk = f"PRIMARY KEY {table.primary_key}"
+        source = _render_dict_source(table.dict_source)
+        layout = _render_dict_layout(table.dict_layout)
+        lifetime = _render_dict_lifetime(table.dict_lifetime)
+        rng = _render_dict_range(table.dict_range)
+        # RANGE clause appears after LIFETIME in the DDL grammar. Only RANGE_HASHED
+        # layouts use it — for other layouts, _render_dict_range returns "" and we
+        # omit the extra line entirely.
+        tail = f"\n{rng}" if rng else ""
+        return (
+            f"CREATE DICTIONARY IF NOT EXISTS {database}.{table.name}\n"
+            f"(\n{cols}\n)\n"
+            f"{pk}\n{source}\n{layout}\n{lifetime}{tail}"
+        )
+
+    if _is_mv(table.engine):
+        target = table.target or ""
+        select = (table.select or "SELECT * FROM ???").replace("{{ database }}", database)
+        return f"CREATE MATERIALIZED VIEW IF NOT EXISTS {database}.{table.name}\nTO {database}.{target}\nAS {select}"
+
+    if _is_distributed(table.engine):
+        source = table.source or ""
+        sharding = table.sharding_key or "rand()"
+        physical_cluster = _resolve_physical_cluster(cluster)
+
+        # Split `source` into database + table arguments for the Distributed
+        # engine. When the YAML says `source: system.processes`, passing the
+        # whole string as the table-name argument causes ClickHouse to resolve
+        # `system.processes` as a table in the local database, which fails.
+        # Splitting on the first `.` lets the engine find the source in a
+        # different database (e.g. `system.*` or a shared data DB).
+        if "." in source:
+            src_db, src_table = source.split(".", 1)
+        else:
+            src_db = database
+            src_table = source
+
+        # Distributed tables that wrap a system.* table (or any source table
+        # whose columns should be inherited rather than redeclared) are
+        # authored in the YAML with an empty `columns: []` list. Rendering an
+        # empty column list as `(\n\n)` produces a syntax error; ClickHouse
+        # requires either a non-empty column list or an `AS <source>` clause
+        # that tells it to copy columns from the referenced table.
+        #
+        # When the YAML has zero columns, emit the `AS <source>` form. Source
+        # resolution:
+        #   - If `source` contains a dot, use it verbatim (e.g. `system.processes`).
+        #   - Otherwise, qualify it with the current database.
+        # The Distributed cluster args use the split src_db/src_table.
+        if not table.columns:
+            source_ref = source if "." in source else f"{database}.{source}"
+            return (
+                f"CREATE TABLE IF NOT EXISTS {database}.{table.name} AS {source_ref}\n"
+                f"ENGINE = Distributed('{physical_cluster}', '{src_db}', '{src_table}', {sharding})"
+            )
+
+        return (
+            f"CREATE TABLE IF NOT EXISTS {database}.{table.name}\n"
+            f"(\n{cols}\n"
+            f") ENGINE = Distributed('{physical_cluster}', '{src_db}', '{src_table}', {sharding})"
+        )
+
+    if _is_kafka(table.engine):
+        # Kafka engine doesn't support MATERIALIZED or EPHEMERAL columns — they
+        # get silently dropped on CREATE, causing MVs above to fail when their
+        # SELECT references the missing columns. Strip them from the column list.
+        kafka_cols = [c for c in table.columns if not c.default_kind or c.default_kind.upper() in ("DEFAULT", "")]
+        kafka_cols_sql = _columns_sql(kafka_cols)
+        settings_lines = []
+        if table.settings:
+            for k, v in table.settings.items():
+                resolved = _resolve_setting(k) if str(v) == _FROM_SETTINGS_SENTINEL else v
+                settings_lines.append(f"    {k} = '{resolved}'")
+        settings_block = ",\n".join(settings_lines)
+        return (
+            f"CREATE TABLE IF NOT EXISTS {database}.{table.name}\n"
+            f"(\n{kafka_cols_sql}\n"
+            f") ENGINE = Kafka()\n"
+            f"SETTINGS\n{settings_block}"
+        )
+
+    # MergeTree family.
+    # Replicated* engines must be given explicit (zk_path, replica_name) args —
+    # otherwise ClickHouse falls back to a default path containing a `{uuid}` macro
+    # that can only be resolved inside an ON CLUSTER query or a Replicated database
+    # engine. The runner sends CREATE statements directly to each host via
+    # map_hosts_by_roles(), so there is no ON CLUSTER context and the macro fails:
+    #   Code: 36. DB::Exception: Macro 'uuid' in engine arguments is only supported
+    #   when the UUID is explicitly specified, used within an ON CLUSTER query,
+    #   or when using the Replicated database engine.
+    # This mirrors the pattern tracking.py uses for the tracking table itself and
+    # matches the legacy PostHog ZK path convention.
+    #
+    # Some MergeTree variants take additional engine arguments after the
+    # zk_path/replica pair:
+    #   - Collapsing:         ENGINE(zk, replica, sign_col)
+    #   - VersionedCollapsing: ENGINE(zk, replica, sign_col, version_col)
+    #   - Replacing:          ENGINE(zk, replica, [version_col])
+    #   - Summing:            ENGINE(zk, replica, [(summed_cols)])
+    # We auto-detect the canonical column names (`sign`, `version`) from the
+    # table's columns. The YAML always declares them explicitly (the legacy
+    # migrations that seeded the YAML use the same naming).
+    column_names = {c.name for c in table.columns}
+    engine_name = table.engine
+    engine_lower = engine_name.lower()
+
+    def _zk_args() -> str:
+        zk_path = f"/clickhouse/tables/{{shard}}/{database}/{table.name}"
+        return f"'{zk_path}', '{{replica}}'"
+
+    def _find_column(candidates: tuple[str, ...]) -> str | None:
+        """Return the first candidate column name that exists in the table.
+
+        Legacy PostHog migrations use both `sign`/`version` and `_sign`/`_version`
+        naming — the underscore-prefixed form is common for internal/system
+        columns. Auto-detect both so engine arg rendering works regardless of
+        which convention the YAML uses.
+        """
+        for c in candidates:
+            if c in column_names:
+                return c
+        return None
+
+    if engine_name.startswith("Replicated"):
+        extra_args: list[str] = []
+        if "versionedcollapsing" in engine_lower:
+            # sign + version required
+            sign = _find_column(("sign", "_sign"))
+            version = _find_column(("version", "_version"))
+            if sign:
+                extra_args.append(sign)
+            if version:
+                extra_args.append(version)
+        elif "collapsing" in engine_lower:
+            # sign required
+            sign = _find_column(("sign", "_sign"))
+            if sign:
+                extra_args.append(sign)
+        elif "replacing" in engine_lower:
+            # version optional — include if present
+            version = _find_column(("version", "_version"))
+            if version:
+                extra_args.append(version)
+        # Summing/Aggregating without explicit columns = OK with just zk args
+
+        if extra_args:
+            engine_call = f"{engine_name}({_zk_args()}, {', '.join(extra_args)})"
+        else:
+            engine_call = f"{engine_name}({_zk_args()})"
+    else:
+        engine_call = f"{engine_name}()"
+
+    partition = f"\nPARTITION BY {table.partition_by}" if table.partition_by else ""
+    order_by = f"\nORDER BY ({', '.join(table.order_by)})" if table.order_by else ""
+
+    return (
+        f"CREATE TABLE IF NOT EXISTS {database}.{table.name}\n(\n{cols}\n) ENGINE = {engine_call}{partition}{order_by}"
+    )
+
+
+def _strip_trailing_settings(s: str) -> str:
+    """Remove a top-level trailing ``SETTINGS ...`` clause.
+
+    Scans for ``SETTINGS`` tokens from right to left and strips the first one
+    that sits at paren-depth 0. Tokens inside subqueries (positive depth)
+    are left alone — those aren't the MV's engine settings, they're part of
+    the SELECT's semantics.
+    """
+    positions = [m.start() for m in re.finditer(r"\bSETTINGS\b", s, re.IGNORECASE)]
+    for pos in reversed(positions):
+        depth = 0
+        for ch in s[:pos]:
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+        if depth == 0:
+            return s[:pos].rstrip()
+    return s
+
+
+def _normalize_mv_select(sql: str, database: str | None = None) -> str:
+    """Normalize MV SELECT SQL for semantic comparison.
+
+    Handles the common false-positive cases that cause spurious MV recreates:
+    - Indentation/whitespace changes
+    - Keyword casing (CH uppercases keywords in stored SELECT)
+    - Database prefix on table names (CH adds ``posthog_test.`` or ``<db>.``)
+    - Trailing ``SETTINGS`` clause (CH may append engine settings)
+
+    ``database`` scopes the database-prefix strip: only ``<database>.`` is
+    removed, so table aliases in JOINs (e.g. ``a.x, b.y``) survive. When
+    ``None``, the legacy Jinja ``{{ database }}.`` template is still stripped.
+    """
+    # Remove comments
+    s = re.sub(r"--[^\n]*\n", " ", sql)
+    s = re.sub(r"/\*.*?\*/", " ", s, flags=re.DOTALL)
+    # Strip top-level trailing SETTINGS clause (subquery SETTINGS survive)
+    s = _strip_trailing_settings(s)
+    # Resolve Jinja-style {{ database }} template before lowercasing
+    s = re.sub(r"\{\{\s*database\s*\}\}\.", "", s)
+    # Lowercase everything — simpler and more robust than keyword-by-keyword
+    s = s.lower()
+    # Strip the configured database prefix only (not JOIN aliases). If the
+    # caller didn't supply one, leave all ``word.`` prefixes intact.
+    if database:
+        s = re.sub(rf"\b{re.escape(database.lower())}\.", "", s)
+    # Normalize == to = with surrounding spaces (CH stores `x = 0`, YAML may have `x==0`)
+    s = re.sub(r"==", " = ", s)
+    # Strip redundant parens that CH adds to lambda bodies and expressions
+    s = _strip_redundant_parens(s)
+    # Collapse whitespace
+    s = re.sub(r"\s+", " ", s)
+    return s.strip()
+
+
+def diff_state(
+    desired: DesiredState,
+    current: dict[str, TableSchema],
+    database: str | None = None,
+    cluster: str | None = None,
+) -> list[StateDiff]:
+    """Compare desired state against current schema and produce a list of diffs.
+
+    Returns StateDiff objects sorted in dependency order (drops before creates,
+    local before distributed, kafka before MV).
+    """
+    db = database or desired.database
+    cl = cluster or desired.cluster
+
+    drops: list[StateDiff] = []
+    creates: list[StateDiff] = []
+    alters: list[StateDiff] = []
+    recreates: list[StateDiff] = []
+
+    # See `has_placeholder_select` (module level) for why these are skipped.
+    skipped_placeholder_mvs = [name for name, t in desired.tables.items() if has_placeholder_select(t)]
+    if skipped_placeholder_mvs:
+        logger.warning(
+            "ch_migrate: skipping %d MV(s) with placeholder SELECT body — "
+            "fill in the YAML select: field to manage these via ch_migrate: %s",
+            len(skipped_placeholder_mvs),
+            ", ".join(skipped_placeholder_mvs),
+        )
+
+    desired_without_skipped = {name: t for name, t in desired.tables.items() if not has_placeholder_select(t)}
+
+    desired_names = set(desired_without_skipped.keys())
+    current_names = set(current.keys())
+
+    # Placeholder MVs are managed by legacy `migrate_clickhouse`, not ch_migrate.
+    # They're stripped from desired_names above — also strip from current_names
+    # so current - desired doesn't emit a spurious DROP for them.
+    current_names -= set(skipped_placeholder_mvs)
+
+    # Tracking tables are bookkeeping infrastructure managed by bootstrap,
+    # not declared in any YAML. If they're in current they belong there —
+    # never emit DROP for them (would delete the tool's own state).
+    current_names -= TRACKING_TABLES
+
+    # Tables to drop (in current but not in desired)
+    for table_name in sorted(current_names - desired_names):
+        current_table = current[table_name]
+        drops.append(
+            StateDiff(
+                action="drop",
+                table=table_name,
+                detail=f"Table {table_name} exists but is not in desired state",
+                sql=_drop_stmt(current_table.engine, db, table_name),
+                node_roles=["ALL"],
+            )
+        )
+
+    # Tables to create (in desired but not in current)
+    for table_name in sorted(desired_names - current_names):
+        desired_table = desired.tables[table_name]
+        deps = []
+        if _is_distributed(desired_table.engine) and desired_table.source:
+            deps.append(desired_table.source)
+        if _is_mv(desired_table.engine):
+            if desired_table.target:
+                deps.append(desired_table.target)
+
+        creates.append(
+            StateDiff(
+                action="create",
+                table=table_name,
+                detail=f"Create {desired_table.engine} table {table_name}",
+                sql=_generate_create_sql(desired_table, db, cl),
+                node_roles=desired_table.on_nodes,
+                sharded=desired_table.sharded,
+                depends_on=deps,
+            )
+        )
+
+    # Tables that exist in both — check for changes
+    for table_name in sorted(desired_names & current_names):
+        desired_table = desired.tables[table_name]
+        current_table = current[table_name]
+
+        # Engine mismatch → recreate
+        if desired_table.engine.lower() != current_table.engine.lower():
+            drop_sql = _drop_stmt(current_table.engine, db, table_name)
+            if _is_mv(desired_table.engine) or _is_mv(current_table.engine):
+                recreates.append(
+                    StateDiff(
+                        action="recreate_mv",
+                        table=table_name,
+                        detail=(
+                            f"Recreate MV {table_name} "
+                            f"(engine changed: {current_table.engine} -> {desired_table.engine})"
+                        ),
+                        sql=(f"{drop_sql};\n{_generate_create_sql(desired_table, db, cl)}"),
+                        node_roles=desired_table.on_nodes,
+                        depends_on=[desired_table.target] if desired_table.target else [],
+                    )
+                )
+            else:
+                recreates.append(
+                    StateDiff(
+                        action="recreate",
+                        table=table_name,
+                        detail=(
+                            f"Recreate {table_name} (engine changed: {current_table.engine} -> {desired_table.engine})"
+                        ),
+                        sql=(f"{drop_sql};\n{_generate_create_sql(desired_table, db, cl)}"),
+                        node_roles=desired_table.on_nodes,
+                        sharded=desired_table.sharded,
+                    )
+                )
+            continue
+
+        # Structural field comparisons (order_by, partition_by, sharding_key, source, target, settings)
+        structural_recreate = False
+        structural_details: list[str] = []
+
+        if _is_mergetree(desired_table.engine):
+            # ORDER BY
+            if desired_table.order_by:
+                current_sorting = current_table.sorting_key
+                desired_sorting = ", ".join(desired_table.order_by)
+                if current_sorting and current_sorting != desired_sorting:
+                    structural_details.append(f"ORDER BY changed: {current_sorting} -> {desired_sorting}")
+                    structural_recreate = True
+            # PARTITION BY
+            if desired_table.partition_by:
+                if current_table.partition_key and current_table.partition_key != desired_table.partition_by:
+                    structural_details.append(
+                        f"PARTITION BY changed: {current_table.partition_key} -> {desired_table.partition_by}"
+                    )
+                    structural_recreate = True
+
+        if _is_distributed(desired_table.engine):
+            # sharding_key — requires recreate
+            if desired_table.sharding_key and current_table.engine_full:
+                if desired_table.sharding_key not in current_table.engine_full:
+                    structural_details.append(f"sharding_key changed (desired: {desired_table.sharding_key})")
+                    structural_recreate = True
+            # source — the local table backing the Distributed table
+            # Handle both forms: unqualified "foo" and qualified "db.foo" (split into
+            # separate db/table args in engine_full as `'db', 'foo'`).
+            if desired_table.source and current_table.engine_full:
+                src = desired_table.source
+                if "." in src:
+                    src_db, src_table = src.split(".", 1)
+                    # Match the split form CH stores: `'db', 'table'`
+                    matches = (f"'{src_db}', '{src_table}'" in current_table.engine_full) or (
+                        src in current_table.engine_full
+                    )
+                else:
+                    matches = src in current_table.engine_full
+                if not matches:
+                    structural_details.append(f"source table changed (desired: {src})")
+                    structural_recreate = True
+
+        if _is_mv(desired_table.engine):
+            # target — the destination table for the MV
+            if desired_table.target and current_table.engine_full:
+                if desired_table.target not in current_table.engine_full:
+                    structural_details.append(f"MV target changed (desired: {desired_table.target})")
+                    structural_recreate = True
+
+        if _is_kafka(desired_table.engine):
+            # Kafka settings (broker_list, topic_list, group_name, format) — requires recreate
+            if desired_table.settings and current_table.engine_full:
+                for setting_key, setting_val in desired_table.settings.items():
+                    resolved = (
+                        _resolve_setting(setting_key)
+                        if str(setting_val) == _FROM_SETTINGS_SENTINEL
+                        else str(setting_val)
+                    )
+                    if resolved not in current_table.engine_full:
+                        structural_details.append(f"Kafka setting '{setting_key}' changed (desired: {resolved})")
+                        structural_recreate = True
+
+        if _is_dictionary(desired_table.engine):
+            # Dictionaries don't support ALTER — structural metadata changes
+            # force DROP + CREATE. Keep this check conservative: only trigger
+            # on changes we can verify unambiguously. CH normalizes stored DDL
+            # in ways that would false-positive any substring param check
+            # (password is masked as [HIDDEN], layout types auto-upgrade from
+            # RANGE_HASHED → COMPLEX_KEY_RANGE_HASHED when the key is complex,
+            # param casing flips between YAML form and CH uppercasing, URL
+            # query string ordering is not stable). We rely on engine_full
+            # (sourced from create_table_query in schema_introspect) for
+            # primary key + range comparisons only.
+            haystack = current_table.engine_full or ""
+            if desired_table.primary_key and haystack:
+                if f"PRIMARY KEY {desired_table.primary_key}" not in haystack:
+                    structural_details.append(f"PRIMARY KEY changed (desired: {desired_table.primary_key})")
+                    structural_recreate = True
+            # Layout type — normalize COMPLEX_KEY_ prefix both sides because
+            # CH auto-prepends it when the primary key has multiple columns or
+            # is a non-integer type. HASHED with String key stores as
+            # COMPLEX_KEY_HASHED; RANGE_HASHED with String key stores as
+            # COMPLEX_KEY_RANGE_HASHED. Semantically identical.
+            desired_layout_type = (
+                desired_table.dict_layout.get("type", "") if desired_table.dict_layout else ""
+            ).upper()
+            if desired_layout_type:
+                current_layout_type = (current_table.dict_layout_type or "").upper()
+                # Dicts report empty layout_type when NOT_LOADED; fall back to
+                # scanning engine_full for the layout DDL clause.
+                if not current_layout_type and haystack:
+                    layout_match = re.search(r"LAYOUT\(\s*(\w+)", haystack, re.IGNORECASE)
+                    if layout_match:
+                        current_layout_type = layout_match.group(1).upper()
+                if current_layout_type:
+                    norm_desired = _normalize_layout_type(desired_layout_type)
+                    norm_current = _normalize_layout_type(current_layout_type)
+                    if norm_desired != norm_current:
+                        structural_details.append(
+                            f"LAYOUT type changed: {current_layout_type} -> {desired_layout_type}"
+                        )
+                        structural_recreate = True
+            # Source type — compare kinds only (CLICKHOUSE vs HTTP vs MYSQL).
+            # Param-level diffs are NOT checked: passwords are masked in the
+            # stored DDL, users vary across environments, query text
+            # ordering/whitespace is reformatted by CH. Structural source
+            # kind changes are rare and safe to catch here.
+            if desired_table.dict_source and desired_table.dict_source.get("type"):
+                desired_source_type = desired_table.dict_source["type"].upper()
+                current_source_type = (current_table.dict_source_type or "").upper()
+                if not current_source_type and haystack:
+                    source_match = re.search(r"SOURCE\(\s*(\w+)", haystack, re.IGNORECASE)
+                    if source_match:
+                        current_source_type = source_match.group(1).upper()
+                if current_source_type and current_source_type != desired_source_type:
+                    structural_details.append(f"SOURCE type changed: {current_source_type} -> {desired_source_type}")
+                    structural_recreate = True
+            # Lifetime — prefer structured comparison (ints), fall back to
+            # substring scan of engine_full when the dict is NOT_LOADED.
+            if desired_table.dict_lifetime:
+                lt = desired_table.dict_lifetime
+                desired_min = int(lt.get("min", 0))
+                desired_max = int(lt.get("max", 0))
+                current_min = current_table.dict_lifetime_min
+                current_max = current_table.dict_lifetime_max
+                if not (current_min or current_max) and haystack:
+                    lifetime_match = re.search(r"LIFETIME\(\s*MIN\s+(\d+)\s+MAX\s+(\d+)", haystack, re.IGNORECASE)
+                    if lifetime_match:
+                        current_min = int(lifetime_match.group(1))
+                        current_max = int(lifetime_match.group(2))
+                if (current_min or current_max) and (current_min != desired_min or current_max != desired_max):
+                    structural_details.append(
+                        f"LIFETIME changed: {current_min}/{current_max} -> {desired_min}/{desired_max}"
+                    )
+                    structural_recreate = True
+            # RANGE clause — compare presence + column names only, not formatting.
+            if desired_table.dict_range and haystack:
+                desired_min_col = desired_table.dict_range.get("min", "")
+                desired_max_col = desired_table.dict_range.get("max", "")
+                range_match = re.search(r"RANGE\(\s*MIN\s+(\w+)\s+MAX\s+(\w+)", haystack, re.IGNORECASE)
+                if range_match:
+                    current_min_col, current_max_col = range_match.group(1), range_match.group(2)
+                    if (current_min_col, current_max_col) != (desired_min_col, desired_max_col):
+                        structural_details.append(
+                            f"RANGE changed: ({current_min_col}, {current_max_col}) -> "
+                            f"({desired_min_col}, {desired_max_col})"
+                        )
+                        structural_recreate = True
+                elif "RANGE(" not in haystack.upper():
+                    structural_details.append(f"RANGE missing (desired: MIN {desired_min_col} MAX {desired_max_col})")
+                    structural_recreate = True
+
+        if structural_recreate:
+            detail_str = "; ".join(structural_details)
+            drop_sql = _drop_stmt(current_table.engine, db, table_name)
+            if _is_mv(desired_table.engine):
+                recreates.append(
+                    StateDiff(
+                        action="recreate_mv",
+                        table=table_name,
+                        detail=f"Recreate MV {table_name} ({detail_str})",
+                        sql=f"{drop_sql};\n{_generate_create_sql(desired_table, db, cl)}",
+                        node_roles=desired_table.on_nodes,
+                        depends_on=[desired_table.target] if desired_table.target else [],
+                    )
+                )
+            else:
+                recreates.append(
+                    StateDiff(
+                        action="recreate",
+                        table=table_name,
+                        detail=f"Recreate {table_name} ({detail_str})",
+                        sql=f"{drop_sql};\n{_generate_create_sql(desired_table, db, cl)}",
+                        node_roles=desired_table.on_nodes,
+                        sharded=desired_table.sharded,
+                    )
+                )
+            continue
+
+        # Column default/codec changes — ALTER MODIFY COLUMN (checked during column comparison below)
+
+        # For MVs, compare SELECT if both sides have it
+        if _is_mv(desired_table.engine) and desired_table.select:
+            current_select = current_table.as_select if hasattr(current_table, "as_select") else ""
+            # SELECT * expands to explicit columns at creation time — skip comparison
+            # since CH will always store the expanded form, never matching the YAML literally.
+            desired_norm = _normalize_mv_select(desired_table.select, database=db)
+            is_select_star = re.match(r"^select \* from\b", desired_norm)
+            if (
+                current_select
+                and not is_select_star
+                and desired_norm != _normalize_mv_select(current_select, database=db)
+            ):
+                drops.append(
+                    StateDiff(
+                        action="drop",
+                        table=table_name,
+                        detail=f"Drop MV {table_name} (SELECT changed — will recreate)",
+                        sql=_drop_stmt(current_table.engine, db, table_name),
+                        node_roles=desired_table.on_nodes,
+                    )
+                )
+                creates.append(
+                    StateDiff(
+                        action="create",
+                        table=table_name,
+                        detail=f"Recreate MV {table_name} with updated SELECT",
+                        sql=_generate_create_sql(desired_table, db, cl),
+                        node_roles=desired_table.on_nodes,
+                    )
+                )
+            elif not current_select:
+                logger.warning(
+                    "MV %s: SELECT comparison not possible (as_select not available from host). "
+                    "Verify manually with 'ch_migrate schema'.",
+                    table_name,
+                )
+
+        # Column comparison
+        desired_cols = {c.name: c for c in desired_table.columns}
+        current_cols = {c.name: c for c in current_table.columns}
+
+        # Distributed tables with empty columns inherit from their source table —
+        # skip column diff entirely to avoid spurious DROP COLUMN diffs.
+        if _is_distributed(desired_table.engine) and not desired_table.columns:
+            continue
+
+        # Filter Kafka virtual columns from live schema — CH injects these
+        # automatically (_topic, _key, _offset, etc.) and they aren't in YAML.
+        if _is_kafka(desired_table.engine):
+            current_cols = {k: v for k, v in current_cols.items() if not _is_kafka_virtual_column(k)}
+
+        # Kafka/Dictionary engines don't support ALTER — recreate instead.
+        # Compare by (name, type) tuples because desired_cols has ColumnDef values
+        # while current_cols has ColumnSchema values (different dataclass types).
+        if desired_table.engine.lower() in ("kafka", "dictionary") and (
+            {(c.name, _normalize_type(c.type)) for c in desired_cols.values()}
+            != {(c.name, _normalize_type(c.type)) for c in current_cols.values()}
+        ):
+            drops.append(
+                StateDiff(
+                    action="drop",
+                    table=table_name,
+                    detail=f"Drop {desired_table.engine} table {table_name} (recreate for column change)",
+                    sql=_drop_stmt(current_table.engine, db, table_name),
+                    node_roles=desired_table.on_nodes,
+                )
+            )
+            creates.append(
+                StateDiff(
+                    action="create",
+                    table=table_name,
+                    detail=f"Recreate {desired_table.engine} table {table_name} with updated columns",
+                    sql=_generate_create_sql(desired_table, db, cl),
+                    node_roles=desired_table.on_nodes,
+                )
+            )
+            continue
+
+        # Skip column diffing for MVs (columns are derived from SELECT)
+        if _is_mv(desired_table.engine):
+            continue
+
+        is_replicated = _is_mergetree(desired_table.engine) and "replicated" in desired_table.engine.lower()
+
+        # Missing columns (in desired but not in current) → ADD COLUMN
+        for col_name in sorted(set(desired_cols.keys()) - set(current_cols.keys())):
+            col = desired_cols[col_name]
+            default_clause = ""
+            if col.default_expression:
+                kind = col.default_kind or "DEFAULT"
+                default_clause = f" {kind} {col.default_expression}"
+            alters.append(
+                StateDiff(
+                    action="alter_add_column",
+                    table=table_name,
+                    detail=f"Add column {col_name} {col.type} to {table_name}",
+                    sql=f"ALTER TABLE {db}.{table_name} ADD COLUMN IF NOT EXISTS {col_name} {col.type}{default_clause}",
+                    node_roles=desired_table.on_nodes,
+                    sharded=desired_table.sharded,
+                    is_alter_on_replicated_table=is_replicated,
+                )
+            )
+
+        # Extra columns (in current but not in desired) → DROP COLUMN
+        for col_name in sorted(set(current_cols.keys()) - set(desired_cols.keys())):
+            alters.append(
+                StateDiff(
+                    action="alter_drop_column",
+                    table=table_name,
+                    detail=f"Drop column {col_name} from {table_name}",
+                    sql=f"ALTER TABLE {db}.{table_name} DROP COLUMN IF EXISTS {col_name}",
+                    node_roles=desired_table.on_nodes,
+                    sharded=desired_table.sharded,
+                    is_alter_on_replicated_table=is_replicated,
+                )
+            )
+
+        # Type mismatches → MODIFY COLUMN
+        for col_name in sorted(set(desired_cols.keys()) & set(current_cols.keys())):
+            desired_col = desired_cols[col_name]
+            current_col = current_cols[col_name]
+            if _normalize_type(desired_col.type) != _normalize_type(current_col.type):
+                alters.append(
+                    StateDiff(
+                        action="alter_modify_column",
+                        table=table_name,
+                        detail=(
+                            f"Modify column {col_name} from {current_col.type} to {desired_col.type} on {table_name}"
+                        ),
+                        sql=f"ALTER TABLE {db}.{table_name} MODIFY COLUMN {col_name} {desired_col.type}",
+                        node_roles=desired_table.on_nodes,
+                        sharded=desired_table.sharded,
+                        is_alter_on_replicated_table=is_replicated,
+                    )
+                )
+                continue
+
+            # Default kind/expression changes → MODIFY COLUMN.
+            # Normalize semantically: CH lowercases function names in system.columns
+            # and converts toIntervalX(N) to INTERVAL N X. See _normalize_default().
+            # When the YAML drops `default:` but the live column still has one,
+            # emit `MODIFY COLUMN <name> <type> REMOVE DEFAULT` so reconcile
+            # actually removes it. Earlier the short-circuit on `desired_default`
+            # being empty made removals silently ignored.
+            desired_default = f"{desired_col.default_kind} {desired_col.default_expression}".strip()
+            current_default = f"{current_col.default_kind} {current_col.default_expression}".strip()
+
+            normalized_desired = _normalize_default(desired_default) if desired_default else ""
+            normalized_current = _normalize_default(current_default) if current_default else ""
+
+            if normalized_desired != normalized_current:
+                if desired_default:
+                    kind = desired_col.default_kind or "DEFAULT"
+                    modify_clause = f"{col_name} {desired_col.type} {kind} {desired_col.default_expression}"
+                    detail = (
+                        f"Modify column {col_name} default on {table_name}: {current_default!r} -> {desired_default!r}"
+                    )
+                else:
+                    modify_clause = f"{col_name} {desired_col.type} REMOVE DEFAULT"
+                    detail = f"Remove default from column {col_name} on {table_name}: {current_default!r} -> (none)"
+                alters.append(
+                    StateDiff(
+                        action="alter_modify_column",
+                        table=table_name,
+                        detail=detail,
+                        sql=f"ALTER TABLE {db}.{table_name} MODIFY COLUMN {modify_clause}",
+                        node_roles=desired_table.on_nodes,
+                        sharded=desired_table.sharded,
+                        is_alter_on_replicated_table=is_replicated,
+                    )
+                )
+
+    # Sort by dependency order:
+    # 1. Drop MVs first (tier 3 drops first)
+    # 2. Drop distributed (tier 2)
+    # 3. Drop local/kafka (tier 1/0)
+    # 4. Alters on local tables
+    # 5. Alters on distributed tables
+    # 6. Creates in tier order (kafka=0, local=1, distributed=2, MV=3)
+    # 7. Recreates (MV recreates last)
+
+    def _drop_sort_key(d: StateDiff) -> tuple[int, str]:
+        # Higher tier drops first (MVs before distributed before local)
+        tier = 3 - _engine_tier(current.get(d.table, TableSchema(name=d.table, engine="")).engine)
+        return (tier, d.table)
+
+    def _alter_sort_key(d: StateDiff) -> tuple[int, str]:
+        table = desired.tables.get(d.table)
+        tier = _engine_tier(table.engine) if table else 1
+        return (tier, d.table)
+
+    def _create_sort_key(d: StateDiff) -> tuple[int, str]:
+        table = desired.tables.get(d.table)
+        tier = _engine_tier(table.engine) if table else 1
+        return (tier, d.table)
+
+    drops.sort(key=_drop_sort_key)
+    alters.sort(key=_alter_sort_key)
+    creates.sort(key=_create_sort_key)
+
+    # Fix 5: Kafka/MV recreate cascade prevention.
+    # When an MV is recreated, ClickHouse can cascade-drop the source Kafka
+    # table if it was created inline. Re-add a CREATE step for any Kafka
+    # table referenced by the MV's SELECT.
+    #
+    # MV recreation takes two shapes in the diff:
+    #   1. A single `recreate_mv` entry (structural change: target/engine/etc.)
+    #   2. A paired DROP + CREATE on the same MV table name (SELECT changed,
+    #      see the MV SELECT comparison above that emits `drop` + `create`).
+    # Both cascade-drop the Kafka source, so both must trigger re-creation.
+    kafka_tables_in_desired = {name: t for name, t in desired_without_skipped.items() if _is_kafka(t.engine)}
+    if kafka_tables_in_desired:
+        # Collect table names already being created so we don't duplicate.
+        tables_being_created = {d.table for d in creates}
+
+        # Build the set of MV names being recreated: explicit recreate_mv
+        # entries, plus tables that appear as BOTH a drop and a create (the
+        # drop+create pair path for SELECT changes).
+        dropped_names = {d.table for d in drops}
+        created_names = {d.table for d in creates}
+        drop_create_pairs = dropped_names & created_names
+
+        recreated_mv_names: set[str] = set()
+        for rec in recreates:
+            if rec.action == "recreate_mv":
+                recreated_mv_names.add(rec.table)
+        for name in drop_create_pairs:
+            maybe_desired: DesiredTable | None = desired_without_skipped.get(name)
+            if maybe_desired and _is_mv(maybe_desired.engine):
+                recreated_mv_names.add(name)
+
+        for mv_name in recreated_mv_names:
+            mv_table = desired_without_skipped.get(mv_name)
+            if not mv_table or not mv_table.select:
+                continue
+            # Find which Kafka tables are referenced in the MV SELECT
+            for kafka_name, kafka_def in kafka_tables_in_desired.items():
+                # Check if the Kafka table name appears in the MV's SELECT
+                # (qualified as db.name or unqualified)
+                if kafka_name in mv_table.select and kafka_name not in tables_being_created:
+                    creates.append(
+                        StateDiff(
+                            action="create",
+                            table=kafka_name,
+                            detail=f"Re-create Kafka table {kafka_name} (cascade-dropped by MV {mv_name} recreate)",
+                            sql=_generate_create_sql(kafka_def, db, cl),
+                            node_roles=kafka_def.on_nodes,
+                            depends_on=[],
+                        )
+                    )
+                    tables_being_created.add(kafka_name)
+
+    return drops + alters + creates + recreates
+
+
+def detect_orphans(
+    desired_states: list[DesiredState],
+    current: dict[str, TableSchema],
+    exclude_patterns: list[str] | None = None,
+) -> list[str]:
+    """Find tables in current schema that are not declared in any YAML.
+
+    Returns a sorted list of orphan table names. This is read-only — it
+    only reports, it does not drop anything.
+    """
+    declared: set[str] = set()
+    for ds in desired_states:
+        declared.update(ds.tables.keys())
+
+    default_exclude = {"infi_clickhouse_orm_migrations", "clickhouse_schema_migrations"}
+    exclude = default_exclude | set(exclude_patterns or [])
+
+    orphans = []
+    for name in current:
+        if name in declared or name in exclude:
+            continue
+        engine = current[name].engine.lower()
+        if engine in ("view", "join"):
+            continue
+        if name.startswith("_tmp") or name.startswith("pending_deletes"):
+            continue
+        orphans.append(name)
+
+    return sorted(orphans)

--- a/posthog/clickhouse/test/test_state_diff_engine.py
+++ b/posthog/clickhouse/test/test_state_diff_engine.py
@@ -433,3 +433,107 @@ class TestKafkaCascadeOnSelectChange:
         diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
         kafka_creates = [d for d in diffs if d.action == "create" and d.table == "kafka_events"]
         assert len(kafka_creates) == 0, f"Unexpected Kafka recreate: {[d.detail for d in diffs]}"
+
+
+class TestKafkaColumnChangeDestructiveGate:
+    """Kafka column change requires destructive=True — safe mode must suppress it."""
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_no_drop_in_safe_mode(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "kafka_events": DesiredTable(
+                    name="kafka_events",
+                    engine="Kafka",
+                    columns=[_col("event", "String"), _col("new_col", "UInt64")],
+                    on_nodes=["all"],
+                    settings={"kafka_broker_list": "localhost:9092", "kafka_topic_list": "events"},
+                ),
+            }
+        )
+        current = {
+            "kafka_events": TableSchema(
+                name="kafka_events",
+                engine="Kafka",
+                columns=[_live_col("event", "String")],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster", destructive=False)
+        drops = [d for d in diffs if d.action == "drop" and d.table == "kafka_events"]
+        assert len(drops) == 0, f"Expected no drops in safe mode but got: {[d.detail for d in drops]}"
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_drop_emitted_in_destructive_mode(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "kafka_events": DesiredTable(
+                    name="kafka_events",
+                    engine="Kafka",
+                    columns=[_col("event", "String"), _col("new_col", "UInt64")],
+                    on_nodes=["all"],
+                    settings={"kafka_broker_list": "localhost:9092", "kafka_topic_list": "events"},
+                ),
+            }
+        )
+        current = {
+            "kafka_events": TableSchema(
+                name="kafka_events",
+                engine="Kafka",
+                columns=[_live_col("event", "String")],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster", destructive=True)
+        drops = [d for d in diffs if d.action == "drop" and d.table == "kafka_events"]
+        creates = [d for d in diffs if d.action == "create" and d.table == "kafka_events"]
+        assert len(drops) == 1, f"Expected 1 drop in destructive mode but got: {[d.detail for d in diffs]}"
+        assert len(creates) == 1, f"Expected 1 create in destructive mode but got: {[d.detail for d in diffs]}"
+
+
+class TestKafkaCascadeOrdering:
+    """Kafka CASCADE CREATE must appear before the MV CREATE that depends on it."""
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_kafka_create_before_mv_create(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "kafka_events": DesiredTable(
+                    name="kafka_events",
+                    engine="Kafka",
+                    columns=[_col("event", "String")],
+                    on_nodes=["all"],
+                    settings={"kafka_broker_list": "localhost:9092", "kafka_topic_list": "events"},
+                ),
+                "kafka_events_mv": DesiredTable(
+                    name="kafka_events_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["all"],
+                    target="sharded_events",
+                    select="SELECT event FROM posthog.kafka_events",
+                ),
+            }
+        )
+        current = {
+            "kafka_events": TableSchema(
+                name="kafka_events",
+                engine="Kafka",
+                columns=[_live_col("event", "String")],
+            ),
+            "kafka_events_mv": TableSchema(
+                name="kafka_events_mv",
+                engine="MaterializedView",
+                engine_full="MaterializedView TO posthog.old_target",
+                as_select="SELECT event FROM posthog.kafka_events",
+                columns=[_live_col("event", "String")],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster", destructive=True)
+        create_tables = [d.table for d in diffs if d.action == "create"]
+        assert "kafka_events" in create_tables, f"Expected kafka_events CREATE: {[d.detail for d in diffs]}"
+        assert "kafka_events_mv" in create_tables, f"Expected kafka_events_mv CREATE: {[d.detail for d in diffs]}"
+        kafka_idx = create_tables.index("kafka_events")
+        mv_idx = create_tables.index("kafka_events_mv")
+        assert kafka_idx < mv_idx, f"Kafka CREATE must come before MV CREATE, got order: {create_tables}"

--- a/posthog/clickhouse/test/test_state_diff_engine.py
+++ b/posthog/clickhouse/test/test_state_diff_engine.py
@@ -293,9 +293,11 @@ class TestKafkaMVCascadePrevention:
                 columns=[_live_col("event", "String")],
             ),
         }
-        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
-        mv_recreates = [d for d in diffs if d.action == "recreate_mv"]
-        assert len(mv_recreates) == 1, f"Expected 1 MV recreate but got: {[d.detail for d in mv_recreates]}"
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster", destructive=True)
+        mv_drops = [d for d in diffs if d.action == "drop" and d.table == "kafka_events_mv"]
+        mv_creates = [d for d in diffs if d.action == "create" and d.table == "kafka_events_mv"]
+        assert len(mv_drops) == 1, f"Expected 1 MV drop but got: {[d.detail for d in diffs]}"
+        assert len(mv_creates) == 1, f"Expected 1 MV create but got: {[d.detail for d in diffs]}"
         kafka_creates = [d for d in diffs if d.action == "create" and d.table == "kafka_events"]
         assert len(kafka_creates) == 1, f"Expected Kafka re-create but got: {[d.detail for d in kafka_creates]}"
         assert "cascade" in kafka_creates[0].detail.lower()
@@ -376,7 +378,7 @@ class TestKafkaCascadeOnSelectChange:
                 columns=[_live_col("event", "String")],
             ),
         }
-        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster", destructive=True)
 
         mv_drops = [d for d in diffs if d.action == "drop" and d.table == "kafka_events_mv"]
         mv_creates = [d for d in diffs if d.action == "create" and d.table == "kafka_events_mv"]

--- a/posthog/clickhouse/test/test_state_diff_engine.py
+++ b/posthog/clickhouse/test/test_state_diff_engine.py
@@ -1,0 +1,433 @@
+"""Tests for diff_state convergence — verifying idempotent apply (second run = 0 diffs)."""
+
+from unittest.mock import patch
+
+from posthog.clickhouse.migration_tools.desired_state import ColumnDef, DesiredState, DesiredTable
+from posthog.clickhouse.migration_tools.schema_introspect import ColumnSchema, TableSchema
+from posthog.clickhouse.migration_tools.state_diff import _generate_create_sql, diff_state
+
+
+def _make_desired(tables: dict[str, DesiredTable]) -> DesiredState:
+    return DesiredState(ecosystem="test", cluster="test_cluster", tables=tables)
+
+
+def _col(name: str, type: str, default_kind: str = "", default_expression: str = "") -> ColumnDef:
+    return ColumnDef(name=name, type=type, default_kind=default_kind, default_expression=default_expression)
+
+
+def _live_col(name: str, type: str, default_kind: str = "", default_expression: str = "") -> ColumnSchema:
+    return ColumnSchema(name=name, type=type, default_kind=default_kind, default_expression=default_expression)
+
+
+_PATCH_RESOLVE = patch(
+    "posthog.clickhouse.migration_tools.state_diff._resolve_physical_cluster",
+    return_value="test_cluster",
+)
+_PATCH_SETTING = patch(
+    "posthog.clickhouse.migration_tools.state_diff._resolve_setting",
+    side_effect=lambda k: k,
+)
+
+
+class TestDiffConvergenceIntervalDefault:
+    """Fix 1: toIntervalDay(7) in YAML should match INTERVAL 7 DAY from system.columns."""
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_no_spurious_alter_for_interval_default(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "test_table": DesiredTable(
+                    name="test_table",
+                    engine="ReplacingMergeTree",
+                    columns=[
+                        _col("id", "UInt64"),
+                        _col(
+                            "expires", "Date", default_kind="DEFAULT", default_expression="today() + toIntervalDay(7)"
+                        ),
+                    ],
+                    on_nodes=["all"],
+                    order_by=["id"],
+                ),
+            }
+        )
+        current = {
+            "test_table": TableSchema(
+                name="test_table",
+                engine="ReplacingMergeTree",
+                columns=[
+                    _live_col("id", "UInt64"),
+                    _live_col("expires", "Date", default_kind="DEFAULT", default_expression="today() + INTERVAL 7 DAY"),
+                ],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        assert len(diffs) == 0, f"Expected 0 diffs but got: {[d.detail for d in diffs]}"
+
+
+class TestDiffConvergenceKafkaVirtualColumns:
+    """Fix 2: Kafka virtual columns should not trigger recreate."""
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_no_recreate_when_only_virtual_columns_differ(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "kafka_events": DesiredTable(
+                    name="kafka_events",
+                    engine="Kafka",
+                    columns=[
+                        _col("event", "String"),
+                        _col("timestamp", "DateTime"),
+                    ],
+                    on_nodes=["all"],
+                    settings={"kafka_broker_list": "localhost:9092", "kafka_topic_list": "events"},
+                ),
+            }
+        )
+        current = {
+            "kafka_events": TableSchema(
+                name="kafka_events",
+                engine="Kafka",
+                columns=[
+                    _live_col("event", "String"),
+                    _live_col("timestamp", "DateTime"),
+                    _live_col("_topic", "LowCardinality(String)"),
+                    _live_col("_key", "String"),
+                    _live_col("_offset", "UInt64"),
+                    _live_col("_partition", "UInt64"),
+                    _live_col("_timestamp", "Nullable(DateTime)"),
+                    _live_col("_headers", "Map(String, String)"),
+                ],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        assert len(diffs) == 0, f"Expected 0 diffs but got: {[d.detail for d in diffs]}"
+
+
+class TestDiffConvergenceDistributedEmptyColumns:
+    """Fix 4: Distributed tables with columns: [] should not generate column diffs."""
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_no_drop_columns_for_empty_desired(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "events_dist": DesiredTable(
+                    name="events_dist",
+                    engine="Distributed",
+                    columns=[],
+                    on_nodes=["all"],
+                    source="sharded_events",
+                ),
+            }
+        )
+        current = {
+            "events_dist": TableSchema(
+                name="events_dist",
+                engine="Distributed",
+                columns=[
+                    _live_col("uuid", "UUID"),
+                    _live_col("event", "String"),
+                    _live_col("timestamp", "DateTime"),
+                ],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        drop_diffs = [d for d in diffs if "drop_column" in d.action.lower() or "Drop column" in d.detail]
+        assert len(drop_diffs) == 0, f"Expected no column drops but got: {[d.detail for d in drop_diffs]}"
+
+
+class TestDiffConvergenceKafkaMVStability:
+    """Fix 3: Kafka table not recreated means its MV stays stable too."""
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_kafka_and_mv_stable_on_second_apply(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "kafka_events": DesiredTable(
+                    name="kafka_events",
+                    engine="Kafka",
+                    columns=[_col("event", "String")],
+                    on_nodes=["all"],
+                    settings={"kafka_broker_list": "localhost:9092", "kafka_topic_list": "events"},
+                ),
+                "kafka_events_mv": DesiredTable(
+                    name="kafka_events_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["all"],
+                    target="sharded_events",
+                    select="SELECT event FROM posthog.kafka_events",
+                ),
+            }
+        )
+        current = {
+            "kafka_events": TableSchema(
+                name="kafka_events",
+                engine="Kafka",
+                columns=[
+                    _live_col("event", "String"),
+                    _live_col("_topic", "LowCardinality(String)"),
+                    _live_col("_offset", "UInt64"),
+                ],
+            ),
+            "kafka_events_mv": TableSchema(
+                name="kafka_events_mv",
+                engine="MaterializedView",
+                as_select="SELECT event FROM posthog.kafka_events",
+                columns=[_live_col("event", "String")],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        assert len(diffs) == 0, f"Expected 0 diffs but got: {[d.detail for d in diffs]}"
+
+
+class TestDiffConvergenceEnum8:
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_no_alter_for_enum8_vs_enum(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "test_table": DesiredTable(
+                    name="test_table",
+                    engine="ReplacingMergeTree",
+                    columns=[
+                        _col("id", "UInt64"),
+                        _col("status", "Enum('active', 'deleted')"),
+                    ],
+                    on_nodes=["all"],
+                    order_by=["id"],
+                ),
+            }
+        )
+        current = {
+            "test_table": TableSchema(
+                name="test_table",
+                engine="ReplacingMergeTree",
+                columns=[
+                    _live_col("id", "UInt64"),
+                    _live_col("status", "Enum8('active' = 1, 'deleted' = 2)"),
+                ],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        assert len(diffs) == 0, f"Expected 0 diffs but got: {[d.detail for d in diffs]}"
+
+
+class TestDiffConvergenceMvSelect:
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_no_recreate_when_only_db_prefix_differs(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "events_mv": DesiredTable(
+                    name="events_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["all"],
+                    target="sharded_events",
+                    select="SELECT event FROM kafka_events",
+                ),
+            }
+        )
+        current = {
+            "events_mv": TableSchema(
+                name="events_mv",
+                engine="MaterializedView",
+                as_select="SELECT event FROM posthog_test.kafka_events",
+                columns=[_live_col("event", "String")],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog_test", cluster="test_cluster")
+        assert len(diffs) == 0, f"Expected 0 diffs but got: {[d.detail for d in diffs]}"
+
+
+class TestKafkaMVCascadePrevention:
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_kafka_recreated_after_mv_recreate(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "kafka_events": DesiredTable(
+                    name="kafka_events",
+                    engine="Kafka",
+                    columns=[_col("event", "String")],
+                    on_nodes=["all"],
+                    settings={"kafka_broker_list": "localhost:9092", "kafka_topic_list": "events"},
+                ),
+                "sharded_events": DesiredTable(
+                    name="sharded_events",
+                    engine="ReplacingMergeTree",
+                    columns=[_col("event", "String")],
+                    on_nodes=["all"],
+                    order_by=["event"],
+                ),
+                "kafka_events_mv": DesiredTable(
+                    name="kafka_events_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["all"],
+                    target="sharded_events",
+                    select="SELECT event FROM posthog.kafka_events",
+                ),
+            }
+        )
+        current = {
+            "kafka_events": TableSchema(
+                name="kafka_events",
+                engine="Kafka",
+                columns=[_live_col("event", "String")],
+            ),
+            "sharded_events": TableSchema(
+                name="sharded_events",
+                engine="ReplacingMergeTree",
+                columns=[_live_col("event", "String")],
+            ),
+            "kafka_events_mv": TableSchema(
+                name="kafka_events_mv",
+                engine="MaterializedView",
+                engine_full="MaterializedView TO posthog.old_target",
+                as_select="SELECT event FROM posthog.kafka_events",
+                columns=[_live_col("event", "String")],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        mv_recreates = [d for d in diffs if d.action == "recreate_mv"]
+        assert len(mv_recreates) == 1, f"Expected 1 MV recreate but got: {[d.detail for d in mv_recreates]}"
+        kafka_creates = [d for d in diffs if d.action == "create" and d.table == "kafka_events"]
+        assert len(kafka_creates) == 1, f"Expected Kafka re-create but got: {[d.detail for d in kafka_creates]}"
+        assert "cascade" in kafka_creates[0].detail.lower()
+
+
+class TestDistributedSourceWithDbPrefix:
+    """P1-C: Distributed(..., '<db>', '<table>', ...) must split source on '.'."""
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_system_processes_split_into_db_and_table(self, _mock_setting, _mock_cluster):
+        table = DesiredTable(
+            name="distributed_system_processes",
+            engine="Distributed",
+            columns=[],
+            on_nodes=["all"],
+            source="system.processes",
+        )
+        sql = _generate_create_sql(table, "posthog_test", "test_cluster")
+
+        assert "'system', 'processes'" in sql, f"Expected 'system', 'processes' in: {sql}"
+        assert "'posthog_test', 'system.processes'" not in sql
+        assert "AS system.processes" in sql
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_undotted_source_uses_current_database(self, _mock_setting, _mock_cluster):
+        table = DesiredTable(
+            name="events_dist",
+            engine="Distributed",
+            columns=[_col("uuid", "UUID")],
+            on_nodes=["all"],
+            source="sharded_events",
+        )
+        sql = _generate_create_sql(table, "posthog", "test_cluster")
+
+        assert "'posthog', 'sharded_events'" in sql
+
+
+class TestKafkaCascadeOnSelectChange:
+    """P1-B: When an MV's SELECT changes, cascade fix re-creates the Kafka source."""
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_kafka_recreated_on_mv_select_change(self, _mock_setting, _mock_cluster):
+        desired = _make_desired(
+            {
+                "kafka_events": DesiredTable(
+                    name="kafka_events",
+                    engine="Kafka",
+                    columns=[_col("event", "String")],
+                    on_nodes=["all"],
+                    settings={"kafka_broker_list": "localhost:9092", "kafka_topic_list": "events"},
+                ),
+                "kafka_events_mv": DesiredTable(
+                    name="kafka_events_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["all"],
+                    target="sharded_events",
+                    select="SELECT event, toUnixTimestamp(timestamp) AS ts FROM posthog.kafka_events",
+                ),
+            }
+        )
+        current = {
+            "kafka_events": TableSchema(
+                name="kafka_events",
+                engine="Kafka",
+                columns=[
+                    _live_col("event", "String"),
+                    _live_col("_topic", "LowCardinality(String)"),
+                ],
+            ),
+            "kafka_events_mv": TableSchema(
+                name="kafka_events_mv",
+                engine="MaterializedView",
+                as_select="SELECT event FROM posthog.kafka_events",
+                columns=[_live_col("event", "String")],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+
+        mv_drops = [d for d in diffs if d.action == "drop" and d.table == "kafka_events_mv"]
+        mv_creates = [d for d in diffs if d.action == "create" and d.table == "kafka_events_mv"]
+        assert len(mv_drops) == 1, f"Expected MV drop; got {[d.detail for d in diffs]}"
+        assert len(mv_creates) == 1, f"Expected MV create; got {[d.detail for d in diffs]}"
+
+        kafka_creates = [d for d in diffs if d.action == "create" and d.table == "kafka_events"]
+        assert len(kafka_creates) == 1, (
+            f"Expected Kafka source to be re-added after MV recreate; got {[d.detail for d in diffs]}"
+        )
+        assert "cascade-dropped" in kafka_creates[0].detail.lower()
+
+    @_PATCH_RESOLVE
+    @_PATCH_SETTING
+    def test_no_cascade_when_mv_stable(self, _mock_setting, _mock_cluster):
+        """Regression: Kafka is not re-added when the MV isn't being recreated."""
+        desired = _make_desired(
+            {
+                "kafka_events": DesiredTable(
+                    name="kafka_events",
+                    engine="Kafka",
+                    columns=[_col("event", "String")],
+                    on_nodes=["all"],
+                    settings={"kafka_broker_list": "localhost:9092", "kafka_topic_list": "events"},
+                ),
+                "kafka_events_mv": DesiredTable(
+                    name="kafka_events_mv",
+                    engine="MaterializedView",
+                    columns=[],
+                    on_nodes=["all"],
+                    target="sharded_events",
+                    select="SELECT event FROM posthog.kafka_events",
+                ),
+            }
+        )
+        current = {
+            "kafka_events": TableSchema(
+                name="kafka_events",
+                engine="Kafka",
+                columns=[
+                    _live_col("event", "String"),
+                    _live_col("_topic", "LowCardinality(String)"),
+                ],
+            ),
+            "kafka_events_mv": TableSchema(
+                name="kafka_events_mv",
+                engine="MaterializedView",
+                as_select="SELECT event FROM posthog.kafka_events",
+                columns=[_live_col("event", "String")],
+            ),
+        }
+        diffs = diff_state(desired, current, database="posthog", cluster="test_cluster")
+        kafka_creates = [d for d in diffs if d.action == "create" and d.table == "kafka_events"]
+        assert len(kafka_creates) == 0, f"Unexpected Kafka recreate: {[d.detail for d in diffs]}"


### PR DESCRIPTION
## Problem

With normalization in place (PR8), the diff engine itself can compare desired state against live schema. This PR ships `diff_state` — the core function that takes a `DesiredState` and a map of live `TableSchema`s and produces an ordered list of `StateDiff` steps ready for execution. Ordering matters: MVs must be dropped before their source tables are altered, Kafka tables must be created before MVs, and Distributed tables after their local shards.

## Changes

- `posthog/clickhouse/migration_tools/state_diff.py` — complete module: normalization layer (from PR8) plus `_generate_create_sql`, `diff_state`, and `detect_orphans`; handles CREATE, ALTER ADD/DROP/MODIFY COLUMN, recreate_mv, drop, and Kafka cascade prevention
- `posthog/clickhouse/test/test_state_diff_engine.py` — convergence tests verifying that a second `diff_state` call on an already-applied schema produces 0 diffs; covers interval defaults, Kafka virtual columns, Distributed empty columns, Enum8 normalization, MV SELECT normalization, cascade prevention

Note: `state_diff.py` is 1274 lines because the diff engine is inherently stateful — splitting further would break the dependency ordering logic. PR8 ships the normalization-only half as a review checkpoint.

Depends on PR8 (normalization layer, #54825), PR7 (schema introspection, #54821), PR6 (YAML parser, #54815).

## How did you test this code?

Draft — tests require `schema_introspect` from PR7 and `desired_state` from PR6. The convergence test file runs clean once the dependency chain is merged. Normalization unit tests (41 passing) are in PR8.

## Publish to changelog?

No

## 🤖 LLM context

Agent-authored draft PR. Part of the ch_migrate tiny-PR stack (Batch 2 of 3, PR9/12).