### PR TITLE
feat(clickhouse): DDL template generation and multi-cluster routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "pnpm": {
         "// Fix React version to a fixed known good version across the monorepo": "",
         "overrides": {
+            "axios": "^1.15.0",
             "@modelcontextprotocol/sdk": "^1.26.0",
             "@types/react": "18.3.27",
             "@types/react-dom": "18.3.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,7 @@ catalogs:
       version: 9.0.3
 
 overrides:
+  axios: ^1.15.0
   '@modelcontextprotocol/sdk': ^1.26.0
   '@types/react': 18.3.27
   '@types/react-dom': 18.3.7
@@ -12943,8 +12944,8 @@ packages:
     resolution: {integrity: sha512-1exVbW0X1O/HSr/WMwnaweyqcWOgZgLiVxdLG34pvSQk4NlYQr9OUy0JLwuhFfuVNQzzqgH57eYzkFBCb3bIsQ==}
     engines: {node: '>=4'}
 
-  axios@1.9.0:
-    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -15373,8 +15374,8 @@ packages:
     engines: {node: '>=18'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -19891,6 +19892,10 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
 
@@ -22454,8 +22459,8 @@ packages:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.399.0:
-    resolution: {integrity: sha512-VbqOnzfc2iOlgW9kmZsK93/f9IqH8jq5UgTemvSbAFrrxVSQgnqH87cThEHxO1GeMoAv5PyH4VIrh2ULlK5o7Q==}
+  unlayer-types@1.400.0:
+    resolution: {integrity: sha512-3x/DFE0UYvwNZ/S+8OZYjPKjEHscSFOwnnRNZNTRkLTRCugOkSS9owg1+7uinBdhwB+xYbAKIfxU9vS2dLLyFg==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -36962,11 +36967,11 @@ snapshots:
 
   axe-core@4.5.1: {}
 
-  axios@1.9.0:
+  axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.9
+      follow-redirects: 1.15.11
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -40123,7 +40128,7 @@ snapshots:
       async: 0.2.10
       which: 1.3.1
 
-  follow-redirects@1.15.9: {}
+  follow-redirects@1.15.11: {}
 
   for-each@0.3.5:
     dependencies:
@@ -46224,6 +46229,8 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  proxy-from-env@2.1.0: {}
+
   prr@1.0.1:
     optional: true
 
@@ -46849,7 +46856,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.3.1):
     dependencies:
       react: 18.3.1
-      unlayer-types: 1.399.0
+      unlayer-types: 1.400.0
 
   react-error-overlay@6.0.9: {}
 
@@ -49307,7 +49314,7 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unlayer-types@1.399.0: {}
+  unlayer-types@1.400.0: {}
 
   unpipe@1.0.0: {}
 
@@ -49724,7 +49731,7 @@ snapshots:
 
   wait-on@7.2.0:
     dependencies:
-      axios: 1.9.0
+      axios: 1.15.0
       joi: 17.11.0
       lodash: 4.18.1
       minimist: 1.2.8

--- a/posthog/clickhouse/migration_tools/templates.py
+++ b/posthog/clickhouse/migration_tools/templates.py
@@ -1,0 +1,180 @@
+# ruff: noqa: T201 allow print statements
+"""Generate desired-state YAML dicts from templates.
+
+Each template produces a dict matching the DesiredState YAML format:
+  ecosystem, cluster, tables: {name: {engine, columns, on_nodes, ...}}
+
+The ch_migrate generate command writes this dict as YAML.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def generate_schema_yaml(template_name: str, table: str, cluster: str) -> dict[str, Any] | None:
+    """Dispatch to the named template generator. Returns a dict or None on error."""
+    generators: dict[str, Any] = {
+        "ingestion_pipeline": _ingestion_pipeline,
+        "sharded_table": _sharded_table,
+        "add_column": _add_column,
+        "cross_cluster_readable": _cross_cluster_readable,
+        "materialized_view": _materialized_view,
+        "drop_table": _drop_table,
+    }
+
+    generator = generators.get(template_name)
+    if generator is None:
+        print(f"Unknown template: {template_name}")
+        print(f"Available templates: {', '.join(sorted(generators.keys()))}")
+        return None
+
+    return generator(table, cluster)
+
+
+_PLACEHOLDER_COLUMNS: list[dict[str, str]] = [
+    {"name": "id", "type": "UUID"},
+    {"name": "team_id", "type": "Int64"},
+    {"name": "timestamp", "type": "DateTime64(6, 'UTC')"},
+]
+
+
+def _ingestion_pipeline(table: str, cluster: str) -> dict[str, Any]:
+    """Full Kafka-to-ClickHouse pipeline: kafka + sharded + writable + readable + MV."""
+    return {
+        "ecosystem": table,
+        "cluster": cluster,
+        "tables": {
+            f"kafka_{table}": {
+                "engine": "Kafka",
+                "on_nodes": "INGESTION_EVENTS",
+                "settings": {
+                    "kafka_broker_list": "kafka:9092",
+                    "kafka_topic_list": table,
+                    "kafka_group_name": f"{table}_consumer",
+                    "kafka_format": "JSONEachRow",
+                },
+                "columns": list(_PLACEHOLDER_COLUMNS),
+            },
+            f"sharded_{table}": {
+                "engine": "ReplicatedMergeTree",
+                "sharded": True,
+                "on_nodes": "DATA",
+                "order_by": ["team_id", "id"],
+                "partition_by": "toYYYYMM(timestamp)",
+                "columns": list(_PLACEHOLDER_COLUMNS),
+            },
+            f"writable_{table}": {
+                "engine": "Distributed",
+                "source": f"sharded_{table}",
+                "sharding_key": "cityHash64(id)",
+                "on_nodes": "COORDINATOR",
+                "columns": f"inherit sharded_{table}",
+            },
+            table: {
+                "engine": "Distributed",
+                "source": f"sharded_{table}",
+                "sharding_key": "cityHash64(id)",
+                "on_nodes": "ALL",
+                "columns": f"inherit sharded_{table}",
+            },
+            f"{table}_mv": {
+                "engine": "MaterializedView",
+                "source": f"kafka_{table}",
+                "target": f"writable_{table}",
+                "select": f"SELECT * FROM {{{{ database }}}}.kafka_{table}",
+                "on_nodes": "INGESTION_EVENTS",
+                "columns": [],
+            },
+        },
+    }
+
+
+def _sharded_table(table: str, cluster: str) -> dict[str, Any]:
+    """Sharded table with distributed read/write layers (no Kafka or MV)."""
+    return {
+        "ecosystem": table,
+        "cluster": cluster,
+        "tables": {
+            f"sharded_{table}": {
+                "engine": "ReplicatedMergeTree",
+                "sharded": True,
+                "on_nodes": "DATA",
+                "order_by": ["team_id", "id"],
+                "partition_by": "toYYYYMM(timestamp)",
+                "columns": list(_PLACEHOLDER_COLUMNS),
+            },
+            f"writable_{table}": {
+                "engine": "Distributed",
+                "source": f"sharded_{table}",
+                "sharding_key": "cityHash64(id)",
+                "on_nodes": "COORDINATOR",
+                "columns": f"inherit sharded_{table}",
+            },
+            table: {
+                "engine": "Distributed",
+                "source": f"sharded_{table}",
+                "sharding_key": "cityHash64(id)",
+                "on_nodes": "ALL",
+                "columns": f"inherit sharded_{table}",
+            },
+        },
+    }
+
+
+def _add_column(table: str, cluster: str) -> dict[str, Any]:
+    """Placeholder for add-column -- user should edit an existing YAML file instead."""
+    print(f"To add a column, edit the existing schema file: posthog/clickhouse/schema/{table}.yaml")
+    print("Add the column to the sharded table's columns list.")
+    print("Inherited columns will propagate automatically.")
+    print("Then run: ch_migrate plan")
+    return {
+        "ecosystem": table,
+        "cluster": cluster,
+        "tables": {},
+    }
+
+
+def _cross_cluster_readable(table: str, cluster: str) -> dict[str, Any]:
+    """Distributed table on one cluster reading from another."""
+    return {
+        "ecosystem": table,
+        "cluster": cluster,
+        "tables": {
+            table: {
+                "engine": "Distributed",
+                "source": f"sharded_{table}",
+                "on_nodes": "ALL",
+                "columns": list(_PLACEHOLDER_COLUMNS),
+            },
+        },
+    }
+
+
+def _materialized_view(table: str, cluster: str) -> dict[str, Any]:
+    """Single materialized view."""
+    return {
+        "ecosystem": table,
+        "cluster": cluster,
+        "tables": {
+            f"{table}_mv": {
+                "engine": "MaterializedView",
+                "source": f"kafka_{table}",
+                "target": f"writable_{table}",
+                "select": f"SELECT * FROM {{{{ database }}}}.kafka_{table}",
+                "on_nodes": "ALL",
+                "columns": [],
+            },
+        },
+    }
+
+
+def _drop_table(table: str, cluster: str) -> dict[str, Any]:
+    """Empty ecosystem -- plan will show drops for existing tables not in desired state."""
+    print(f"To drop tables, remove them from posthog/clickhouse/schema/{table}.yaml")
+    print("or delete the file entirely. Then run: ch_migrate plan")
+    return {
+        "ecosystem": table,
+        "cluster": cluster,
+        "tables": {},
+    }

--- a/posthog/clickhouse/test/_stubs.py
+++ b/posthog/clickhouse/test/_stubs.py
@@ -1,0 +1,244 @@
+"""Shared Django/ClickHouse stubs for standalone migration tool tests.
+
+WHY STUBS INSTEAD OF DJANGO TEST RUNNER:
+PostHog's Django startup (posthog/__init__.py, settings, celery) triggers
+ClickHouse client connections, Kafka configuration, and celery app setup.
+Running these tests via `DJANGO_SETTINGS_MODULE=posthog.settings.test pytest`
+requires a full Django environment with live ClickHouse — impractical for
+unit tests that only exercise YAML parsing, diff logic, and plan generation.
+These stubs isolate the migration_tools package from Django/CH/celery so
+tests run fast with zero infrastructure.
+
+Usage at the top of each test file (BEFORE any posthog imports):
+
+    import posthog.clickhouse.test._stubs as _stubs  # noqa: F401
+
+    # _stubs installs itself on import — now posthog.* is safe to import.
+
+Or for standalone execution:
+
+    _BASE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+    sys.path.insert(0, _BASE)
+    import posthog.clickhouse.test._stubs  # noqa: F401
+
+This module installs all stubs on import — no need to call install_stubs() explicitly.
+The stubs are idempotent and safe to import multiple times.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+from unittest.mock import MagicMock
+
+_BASE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if _BASE not in sys.path:
+    sys.path.insert(0, _BASE)
+
+
+def _django_is_configured() -> bool:
+    try:
+        from django.conf import settings
+
+        val = getattr(settings, "USE_I18N", None)
+        return isinstance(val, bool)
+    except Exception:
+        return False
+
+
+class _NodeRole:
+    DATA = "DATA"
+    COORDINATOR = "COORDINATOR"
+    ALL = "ALL"
+
+    def __init__(self, value: str = "data") -> None:
+        self.value = value
+
+
+class _FakeQuery:
+    def __init__(self, sql: str) -> None:
+        self.sql = sql
+
+
+class _FakeRunPython:
+    def __init__(self, fn: object) -> None:
+        self.fn = fn
+
+
+def _fake_get_cluster(*args: object, **kwargs: object) -> MagicMock:
+    mock = MagicMock()
+    mock.any_host.return_value.result.return_value = {}
+    return mock
+
+
+def _install() -> None:
+    if _django_is_configured():
+        return
+
+    # posthog package — prevent __init__.py from running
+    if "posthog" not in sys.modules:
+        pkg = types.ModuleType("posthog")
+        pkg.__path__ = [os.path.join(_BASE, "posthog")]
+        pkg.__package__ = "posthog"
+        pkg.celery_app = None  # type: ignore[attr-defined]
+        sys.modules["posthog"] = pkg
+
+    # posthog.celery
+    _celery = types.ModuleType("posthog.celery")
+    _celery.app = types.SimpleNamespace()  # type: ignore[attr-defined]
+    sys.modules.setdefault("posthog.celery", _celery)
+
+    # posthog.clickhouse (package)
+    ch_pkg = types.ModuleType("posthog.clickhouse")
+    ch_pkg.__path__ = [os.path.join(_BASE, "posthog/clickhouse")]
+    ch_pkg.__package__ = "posthog.clickhouse"
+    sys.modules.setdefault("posthog.clickhouse", ch_pkg)
+
+    # posthog.clickhouse.client
+    fake_client = types.ModuleType("posthog.clickhouse.client")
+    fake_client.__path__ = [os.path.join(_BASE, "posthog/clickhouse/client")]
+    fake_client.__package__ = "posthog.clickhouse.client"
+    sys.modules.setdefault("posthog.clickhouse.client", fake_client)
+
+    # posthog.clickhouse.client.connection
+    fake_conn = types.ModuleType("posthog.clickhouse.client.connection")
+    fake_conn.NodeRole = _NodeRole  # type: ignore[attr-defined]
+    sys.modules.setdefault("posthog.clickhouse.client.connection", fake_conn)
+
+    # posthog.clickhouse.cluster
+    fake_cluster = types.ModuleType("posthog.clickhouse.cluster")
+    fake_cluster.Query = _FakeQuery  # type: ignore[attr-defined]
+    fake_cluster.get_cluster = _fake_get_cluster  # type: ignore[attr-defined]
+    fake_cluster.ClickhouseCluster = MagicMock  # type: ignore[attr-defined]
+
+    # HostInfo is a NamedTuple used by schema_introspect — provide a lightweight stand-in
+    from collections import namedtuple as _nt
+
+    fake_cluster.HostInfo = _nt(  # type: ignore[attr-defined]
+        "HostInfo",
+        ["connection_info", "shard_num", "replica_num", "host_cluster_type", "host_cluster_role"],
+    )
+    # _CLUSTER_REGISTRY is needed by state_diff._resolve_physical_cluster.
+    # Mirrors the real registry in posthog/clickhouse/cluster.py — maps YAML
+    # logical names to (host_attr, cluster_attr) tuples.
+    fake_cluster._CLUSTER_REGISTRY = {  # type: ignore[attr-defined]
+        "main": ("CLICKHOUSE_HOST", "CLICKHOUSE_CLUSTER"),
+        "logs": ("CLICKHOUSE_LOGS_CLUSTER_HOST", "CLICKHOUSE_LOGS_CLUSTER"),
+        "migrations": ("CLICKHOUSE_MIGRATIONS_HOST", "CLICKHOUSE_MIGRATIONS_CLUSTER"),
+        "sessions": ("CLICKHOUSE_HOST", "CLICKHOUSE_SESSIONS_CLUSTER"),
+        "ops": ("CLICKHOUSE_HOST", "CLICKHOUSE_OPS_CLUSTER"),
+        "ai_events": ("CLICKHOUSE_HOST", "CLICKHOUSE_AI_EVENTS_CLUSTER"),
+        "aux": ("CLICKHOUSE_HOST", "CLICKHOUSE_AUX_CLUSTER"),
+    }
+    sys.modules.setdefault("posthog.clickhouse.cluster", fake_cluster)
+
+    # infi.clickhouse_orm
+    for mod_name in ("infi", "infi.clickhouse_orm"):
+        m = types.ModuleType(mod_name)
+        m.__path__ = ["/fake"]
+        sys.modules.setdefault(mod_name, m)
+
+    infi_migrations = types.ModuleType("infi.clickhouse_orm.migrations")
+    infi_migrations.__path__ = ["/fake"]
+    infi_migrations.RunPython = _FakeRunPython  # type: ignore[attr-defined]
+    sys.modules.setdefault("infi.clickhouse_orm.migrations", infi_migrations)
+
+    # posthog.settings
+    fake_settings = types.ModuleType("posthog.settings")
+    fake_settings.E2E_TESTING = False  # type: ignore[attr-defined]
+    fake_settings.DEBUG = True  # type: ignore[attr-defined]
+    fake_settings.CLOUD_DEPLOYMENT = False  # type: ignore[attr-defined]
+    sys.modules.setdefault("posthog.settings", fake_settings)
+
+    fake_ds = types.ModuleType("posthog.settings.data_stores")
+    fake_ds.CLICKHOUSE_MIGRATIONS_CLUSTER = "default"  # type: ignore[attr-defined]
+    fake_ds.CLICKHOUSE_MIGRATIONS_HOST = "localhost"  # type: ignore[attr-defined]
+    sys.modules.setdefault("posthog.settings.data_stores", fake_ds)
+
+    # posthog.clickhouse.client.migration_tools
+    fake_mt = types.ModuleType("posthog.clickhouse.client.migration_tools")
+    fake_mt.get_migrations_cluster = _fake_get_cluster  # type: ignore[attr-defined]
+    sys.modules.setdefault("posthog.clickhouse.client.migration_tools", fake_mt)
+
+    # posthog.clickhouse.migration_tools.cluster_registry — let real module load
+    # (its only dependency is posthog.clickhouse.cluster which is already stubbed above)
+
+    # yaml (for manifest.py)
+
+    _yaml_stub = types.ModuleType("yaml")
+    try:
+        import yaml as _real_yaml
+
+        _yaml_stub.safe_load = _real_yaml.safe_load  # type: ignore[attr-defined]
+        _yaml_stub.dump = _real_yaml.dump  # type: ignore[attr-defined]
+    except ImportError:
+        _yaml_stub.safe_load = lambda f: None  # type: ignore[attr-defined]
+        _yaml_stub.dump = lambda *a, **kw: None  # type: ignore[attr-defined]
+    sys.modules.setdefault("yaml", _yaml_stub)
+
+    # posthog.clickhouse.test (package)
+    test_pkg = types.ModuleType("posthog.clickhouse.test")
+    test_pkg.__path__ = [os.path.join(_BASE, "posthog/clickhouse/test")]
+    test_pkg.__package__ = "posthog.clickhouse.test"
+    sys.modules.setdefault("posthog.clickhouse.test", test_pkg)
+
+    # django stubs (for ch_migrate command tests)
+    for mod_name in ("django", "django.conf", "django.core", "django.core.management", "django.core.management.base"):
+        m = types.ModuleType(mod_name)
+        m.__path__ = ["/fake"]
+        sys.modules.setdefault(mod_name, m)
+
+    if not hasattr(sys.modules.get("django.conf"), "settings"):
+        settings_ns = types.SimpleNamespace(
+            CLICKHOUSE_DATABASE="default",
+            CLICKHOUSE_HOST="localhost",
+            CLICKHOUSE_CLUSTER="posthog",
+            CLICKHOUSE_LOGS_CLUSTER_HOST="localhost",
+            CLICKHOUSE_LOGS_CLUSTER="posthog_single_shard",
+            CLICKHOUSE_MIGRATIONS_HOST="localhost",
+            CLICKHOUSE_MIGRATIONS_CLUSTER="posthog_migrations",
+            # Satellite cluster names resolved by _CLUSTER_REGISTRY via state_diff
+            CLICKHOUSE_SESSIONS_CLUSTER="posthog_sessions",
+            CLICKHOUSE_OPS_CLUSTER="posthog_ops",
+            CLICKHOUSE_AI_EVENTS_CLUSTER="posthog_ai_events",
+            CLICKHOUSE_AUX_CLUSTER="posthog_aux",
+        )
+        sys.modules["django.conf"].settings = settings_ns  # type: ignore[attr-defined]
+
+    class _FakeBaseCommand:
+        def __init__(self) -> None:
+            self.stdout = __import__("io").StringIO()
+            self.stderr = __import__("io").StringIO()
+
+        def print_help(self, *args: object) -> None:
+            pass
+
+    class _FakeCommandError(Exception):
+        """Stand-in for django.core.management.base.CommandError.
+
+        Used by ch_migrate.handle_apply to signal non-zero exit on step failure.
+        Real Django raises this and Django's management runner catches it to
+        print a clean error and exit with code 1.
+        """
+
+    if not hasattr(sys.modules.get("django.core.management.base"), "BaseCommand"):
+        sys.modules["django.core.management.base"].BaseCommand = _FakeBaseCommand  # type: ignore[attr-defined]
+    if not hasattr(sys.modules.get("django.core.management.base"), "CommandError"):
+        sys.modules["django.core.management.base"].CommandError = _FakeCommandError  # type: ignore[attr-defined]
+
+    # Wire submodule attributes so `from posthog import settings` works
+    sys.modules["posthog"].settings = sys.modules["posthog.settings"]  # type: ignore[attr-defined]
+    sys.modules["posthog.settings"].data_stores = sys.modules["posthog.settings.data_stores"]  # type: ignore[attr-defined]
+
+    # posthog.management.commands — make it a resolvable package
+    for mod_name in ("posthog.management", "posthog.management.commands"):
+        if mod_name not in sys.modules:
+            m = types.ModuleType(mod_name)
+            m.__path__ = [os.path.join(_BASE, mod_name.replace(".", "/"))]
+            m.__package__ = mod_name
+            sys.modules[mod_name] = m
+
+
+_install()

--- a/posthog/clickhouse/test/conftest.py
+++ b/posthog/clickhouse/test/conftest.py
@@ -1,0 +1,24 @@
+"""Pytest conftest — loads Django/ClickHouse stubs before test modules are imported.
+
+This replaces the importlib.util bootstrap that was duplicated across every
+test file in this directory.  Stubs install themselves on load and are
+idempotent, so re-importing _stubs in a test file is safe but unnecessary.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import importlib.util
+
+_BASE = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if _BASE not in sys.path:
+    sys.path.insert(0, _BASE)
+
+_spec = importlib.util.spec_from_file_location(
+    "posthog.clickhouse.test._stubs",
+    os.path.join(_BASE, "posthog", "clickhouse", "test", "_stubs.py"),
+)
+assert _spec and _spec.loader
+_stubs_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_stubs_mod)

--- a/posthog/clickhouse/test/test_routing_templates.py
+++ b/posthog/clickhouse/test/test_routing_templates.py
@@ -1,0 +1,383 @@
+"""Unit tests for ch_migrate multi-cluster routing and template generation.
+
+No Django or ClickHouse connection required.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import posthog.clickhouse.test._stubs  # noqa: F401
+from posthog.clickhouse.migration_tools.desired_state import ColumnDef, DesiredState, DesiredTable
+from posthog.clickhouse.migration_tools.schema_introspect import ColumnSchema, TableSchema
+
+
+def _make_desired_table(
+    name: str,
+    engine: str = "ReplicatedMergeTree",
+    columns: list[ColumnDef] | None = None,
+    on_nodes: list[str] | None = None,
+    **kwargs: object,
+) -> DesiredTable:
+    return DesiredTable(
+        name=name,
+        engine=engine,
+        columns=columns or [],
+        on_nodes=on_nodes or ["DATA"],
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def _make_table_schema(
+    name: str,
+    engine: str = "ReplicatedMergeTree",
+    columns: list[ColumnSchema] | None = None,
+) -> TableSchema:
+    return TableSchema(name=name, engine=engine, columns=columns or [])
+
+
+class TestTemplates(unittest.TestCase):
+    def test_ingestion_pipeline_uses_database_placeholder(self) -> None:
+        from posthog.clickhouse.migration_tools.templates import generate_schema_yaml
+
+        result = generate_schema_yaml("ingestion_pipeline", "my_events", "main")
+        assert result is not None
+        mv_table = result["tables"]["my_events_mv"]
+        assert "posthog.kafka_" not in mv_table["select"]
+        assert "{{ database }}" in mv_table["select"]
+
+    def test_materialized_view_uses_database_placeholder(self) -> None:
+        from posthog.clickhouse.migration_tools.templates import generate_schema_yaml
+
+        result = generate_schema_yaml("materialized_view", "my_events", "main")
+        assert result is not None
+        mv_table = result["tables"]["my_events_mv"]
+        assert "posthog.kafka_" not in mv_table["select"]
+        assert "{{ database }}" in mv_table["select"]
+
+    def test_unknown_template_returns_none(self) -> None:
+        from posthog.clickhouse.migration_tools.templates import generate_schema_yaml
+
+        result = generate_schema_yaml("nonexistent_template", "my_table", "main")
+        assert result is None
+
+    def test_sharded_table_produces_distributed_layers(self) -> None:
+        from posthog.clickhouse.migration_tools.templates import generate_schema_yaml
+
+        result = generate_schema_yaml("sharded_table", "widgets", "main")
+        assert result is not None
+        tables = result["tables"]
+        assert "sharded_widgets" in tables
+        assert "writable_widgets" in tables
+        assert "widgets" in tables
+        assert tables["sharded_widgets"]["engine"] == "ReplicatedMergeTree"
+        assert tables["writable_widgets"]["engine"] == "Distributed"
+
+
+class TestComputeDiffsPerCluster(unittest.TestCase):
+    """_compute_diffs must introspect each declared cluster separately.
+    Earlier it used the migrations-cluster union for every target, which
+    produced spurious diffs on satellite ecosystems.
+    """
+
+    def test_dump_schema_called_per_cluster(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from posthog.management.commands.ch_migrate import Command
+
+        logs_state = DesiredState(
+            ecosystem="logs",
+            cluster="logs",
+            tables={
+                "logs_table": _make_desired_table(
+                    "logs_table",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+        main_state = DesiredState(
+            ecosystem="events",
+            cluster="main",
+            tables={
+                "sharded_events": _make_desired_table(
+                    "sharded_events",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+
+        main_cluster = MagicMock(name="main-cluster")
+        logs_cluster = MagicMock(name="logs-cluster")
+
+        def fake_get_cluster_by_name(name: str, **_kw):
+            if name == "logs":
+                return logs_cluster
+            return main_cluster
+
+        dump_calls: list[object] = []
+
+        def fake_dump(cluster_obj, _database):
+            dump_calls.append(cluster_obj)
+            return {}
+
+        with (
+            patch(
+                "posthog.clickhouse.migration_tools.desired_state.parse_desired_state_dir",
+                return_value=[main_state, logs_state],
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.get_cluster_by_name",
+                side_effect=fake_get_cluster_by_name,
+            ),
+            patch("posthog.management.commands.ch_migrate.is_known_cluster", return_value=True),
+            patch(
+                "posthog.clickhouse.migration_tools.schema_introspect.dump_schema_all_hosts",
+                side_effect=fake_dump,
+            ),
+        ):
+            cmd = Command()
+            diffs, err = cmd._compute_diffs("posthog", "/tmp/fake_schema_dir")
+
+        self.assertIsNone(err, f"Expected no error; got: {err}")
+        self.assertIn(main_cluster, dump_calls, "main cluster not introspected")
+        self.assertIn(logs_cluster, dump_calls, "logs cluster not introspected")
+        migration_scans = [c for c in dump_calls if c is not main_cluster and c is not logs_cluster]
+        self.assertEqual(migration_scans, [], f"Unexpected fallback scans: {migration_scans}")
+
+    def test_unreachable_cluster_falls_back_to_migrations(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from posthog.management.commands.ch_migrate import Command
+
+        logs_state = DesiredState(
+            ecosystem="logs",
+            cluster="logs",
+            tables={
+                "logs_table": _make_desired_table(
+                    "logs_table",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+
+        migrations_cluster = MagicMock(name="migrations-cluster")
+        calls: list[object] = []
+
+        def fake_dump(cluster_obj, _database):
+            calls.append(cluster_obj)
+            return {}
+
+        with (
+            patch(
+                "posthog.clickhouse.migration_tools.desired_state.parse_desired_state_dir",
+                return_value=[logs_state],
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.get_cluster_by_name",
+                side_effect=Exception("Code: 701 CLUSTER_DOESNT_EXIST: Cluster 'logs' not found"),
+            ),
+            patch("posthog.management.commands.ch_migrate.is_known_cluster", return_value=True),
+            patch(
+                "posthog.clickhouse.client.migration_tools.get_migrations_cluster",
+                return_value=migrations_cluster,
+            ),
+            patch(
+                "posthog.clickhouse.migration_tools.schema_introspect.dump_schema_all_hosts",
+                side_effect=fake_dump,
+            ),
+        ):
+            cmd = Command()
+            diffs, err = cmd._compute_diffs("posthog", "/tmp/fake_schema_dir")
+
+        self.assertIsNone(err)
+        self.assertIn(migrations_cluster, calls, f"Migrations-cluster fallback not used: {calls}")
+
+
+class TestComputeDiffsSkipsOrphanScanOnFallback(unittest.TestCase):
+    """Pass 2 (orphan scan) must be skipped when the satellite cluster was
+    unreachable and `current` came from the migrations-cluster fallback.
+    Otherwise every main-cluster table becomes a spurious DROP orphan
+    against the unreachable satellite.
+    """
+
+    def test_no_orphan_drops_when_satellite_falls_back_to_migrations(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from posthog.management.commands.ch_migrate import Command
+
+        logs_state = DesiredState(
+            ecosystem="logs",
+            cluster="logs",
+            tables={
+                "logs_table": _make_desired_table(
+                    "logs_table",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+
+        def fake_get_cluster_by_name(name: str, **_kw):
+            if name == "logs":
+                raise Exception("Code: 701 CLUSTER_DOESNT_EXIST: Cluster 'logs' not found")
+            return MagicMock(name=f"{name}-cluster")
+
+        def fake_dump(_cluster_obj, _database):
+            return {
+                "host1": {
+                    "sharded_events": _make_table_schema("sharded_events", engine="ReplicatedMergeTree"),
+                    "sharded_heatmaps": _make_table_schema("sharded_heatmaps", engine="ReplicatedMergeTree"),
+                }
+            }
+
+        with (
+            patch(
+                "posthog.clickhouse.migration_tools.desired_state.parse_desired_state_dir",
+                return_value=[logs_state],
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.get_cluster_by_name",
+                side_effect=fake_get_cluster_by_name,
+            ),
+            patch("posthog.management.commands.ch_migrate.is_known_cluster", return_value=True),
+            patch(
+                "posthog.clickhouse.client.migration_tools.get_migrations_cluster",
+                return_value=MagicMock(name="migrations-cluster"),
+            ),
+            patch(
+                "posthog.clickhouse.migration_tools.schema_introspect.dump_schema_all_hosts",
+                side_effect=fake_dump,
+            ),
+        ):
+            cmd = Command()
+            diffs, err = cmd._compute_diffs("posthog", "/tmp/fake_schema_dir")
+
+        self.assertIsNone(err)
+        drops = [d for d in diffs if d.action == "drop"]
+        self.assertEqual(drops, [], f"Fallback must not emit orphan drops: {[d.table for d in drops]}")
+
+
+class TestComputeDiffsSharedPhysicalHost(unittest.TestCase):
+    """On dev stacks several logical clusters share the same physical host —
+    the orphan scan must NOT emit drops for tables owned by a sibling logical
+    cluster even though that cluster's ecosystems don't claim them.
+    """
+
+    def test_aux_does_not_drop_main_owned_tables(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from posthog.management.commands.ch_migrate import Command
+
+        main_state = DesiredState(
+            ecosystem="events",
+            cluster="main",
+            tables={
+                "sharded_events": _make_desired_table(
+                    "sharded_events",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+        aux_state = DesiredState(
+            ecosystem="error_tracking",
+            cluster="aux",
+            tables={
+                "error_tracking_fingerprint": _make_desired_table(
+                    "error_tracking_fingerprint",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+
+        def fake_dump(_cluster_obj, _database):
+            return {
+                "host1": {
+                    "sharded_events": _make_table_schema("sharded_events"),
+                    "error_tracking_fingerprint": _make_table_schema("error_tracking_fingerprint"),
+                }
+            }
+
+        with (
+            patch(
+                "posthog.clickhouse.migration_tools.desired_state.parse_desired_state_dir",
+                return_value=[main_state, aux_state],
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.get_cluster_by_name",
+                side_effect=lambda name, **_kw: MagicMock(name=f"{name}-cluster"),
+            ),
+            patch("posthog.management.commands.ch_migrate.is_known_cluster", return_value=True),
+            patch(
+                "posthog.clickhouse.migration_tools.schema_introspect.dump_schema_all_hosts",
+                side_effect=fake_dump,
+            ),
+        ):
+            cmd = Command()
+            diffs, err = cmd._compute_diffs("posthog", "/tmp/fake_schema_dir")
+
+        self.assertIsNone(err)
+        drops = [d for d in diffs if d.action == "drop"]
+        self.assertEqual(drops, [], f"No drops expected — every table is claimed: {[d.table for d in drops]}")
+
+    def test_shared_host_still_drops_tables_claimed_nowhere(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from posthog.management.commands.ch_migrate import Command
+
+        main_state = DesiredState(
+            ecosystem="events",
+            cluster="main",
+            tables={
+                "sharded_events": _make_desired_table(
+                    "sharded_events",
+                    engine="ReplicatedMergeTree",
+                    columns=[ColumnDef(name="id", type="UUID")],
+                    order_by=["id"],
+                ),
+            },
+        )
+
+        def fake_dump(_cluster_obj, _database):
+            return {
+                "host1": {
+                    "sharded_events": _make_table_schema("sharded_events"),
+                    "truly_orphan": _make_table_schema("truly_orphan", engine="MergeTree"),
+                }
+            }
+
+        with (
+            patch(
+                "posthog.clickhouse.migration_tools.desired_state.parse_desired_state_dir",
+                return_value=[main_state],
+            ),
+            patch(
+                "posthog.management.commands.ch_migrate.get_cluster_by_name",
+                side_effect=lambda name, **_kw: MagicMock(name=f"{name}-cluster"),
+            ),
+            patch("posthog.management.commands.ch_migrate.is_known_cluster", return_value=True),
+            patch(
+                "posthog.clickhouse.migration_tools.schema_introspect.dump_schema_all_hosts",
+                side_effect=fake_dump,
+            ),
+        ):
+            cmd = Command()
+            diffs, err = cmd._compute_diffs("posthog", "/tmp/fake_schema_dir")
+
+        self.assertIsNone(err)
+        drops = [d for d in diffs if d.action == "drop"]
+        self.assertEqual([d.table for d in drops], ["truly_orphan"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Two related gaps in the ch_migrate management command: (1) no way to scaffold new schema YAML files from common patterns without writing DDL from scratch, and (2) the plan/apply commands were not correctly routing DDL to the right ClickHouse cluster — all steps used the migrations cluster regardless of which logical cluster the YAML declared.

## Changes

- `posthog/clickhouse/migration_tools/templates.py` — template generators for six common DDL patterns: `ingestion_pipeline` (Kafka + sharded + distributed + MV), `sharded_table`, `materialized_view`, `cross_cluster_readable`, `add_column` (advisory), `drop_table` (advisory). Used by the `generate` subcommand to scaffold new schema YAML files.
- `posthog/management/commands/ch_migrate.py` — plan/apply/generate subcommands with multi-cluster routing. `_compute_diffs` groups YAML files by declared cluster and connects to each via `get_cluster_by_name()` independently. Unreachable satellite clusters fall back to the migrations cluster schema with a warning. `handle_apply` resolves the per-step cluster through `_resolve_step_cluster` so DDL runs against the correct target.
- `posthog/clickhouse/test/test_routing_templates.py` — inline unit tests for template generation and cluster routing; no live ClickHouse required
- `posthog/clickhouse/test/_stubs.py` and `conftest.py` — shared test infrastructure for standalone execution

## How did you test this code?

Unit tests in `test_routing_templates.py` cover template output correctness (database placeholder, table structure) and routing behavior (_compute_diffs per-cluster introspection, fallback on unreachable satellite, orphan scan skip on fallback, shared-physical-host guard). All tests use mocked cluster objects and patched parse/dump functions.

Draft — unit tests pass locally with dependency files from co-pending PRs present. Full end-to-end requires PR10 (plan generator) and PR13 (validator) to be merged first.

## Publish to changelog?

No

## 🤖 LLM context

Agent-authored draft PR. Part of the ch_migrate tiny-PR stack (Batch 3 of 3). Depends on PR10 (plan generator) and PR13 (validator). The management command file is trimmed to the plan/apply/generate subcommands — the full command with all subcommands ships in a later PR once the dependency chain is merged.