### PR TITLE
feat(ch-migrate): plan command — ch_migrate plan, ManifestStep, plan_generator

### DIFF
--- a/posthog/clickhouse/migration_tools/manifest.py
+++ b/posthog/clickhouse/migration_tools/manifest.py
@@ -1,0 +1,34 @@
+"""Shared data types for ClickHouse migration steps."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+ROLE_MAP: dict[str, str] = {
+    "DATA": "data",
+    "COORDINATOR": "coordinator",
+    "INGESTION_EVENTS": "events",
+    "INGESTION_SMALL": "small",
+    "INGESTION_MEDIUM": "medium",
+    "SHUFFLEHOG": "shufflehog",
+    "ENDPOINTS": "endpoints",
+    "LOGS": "logs",
+    "ALL": "all",
+    "OPS": "ops",
+    "AI_EVENTS": "ai_events",
+    "AUX": "aux",
+    "SESSIONS": "sessions",
+}
+
+
+@dataclass
+class ManifestStep:
+    sql: str
+    node_roles: list[str]
+    comment: str = ""
+    sharded: bool = False
+    is_alter_on_replicated_table: bool = False
+    # Logical cluster name this step targets. Empty string means the caller
+    # should use the default migrations cluster. Propagated from StateDiff
+    # so the runner can resolve the correct physical cluster per step.
+    cluster: str = ""

--- a/posthog/clickhouse/migration_tools/plan_generator.py
+++ b/posthog/clickhouse/migration_tools/plan_generator.py
@@ -1,0 +1,147 @@
+"""Generate human-readable plans and executable ManifestStep lists from StateDiffs.
+
+Takes a list[StateDiff] from state_diff.diff_state() and produces:
+1. A human-readable plan (like terraform plan) with +/-/~ symbols
+2. A list of ManifestStep objects that the existing runner can execute
+3. Rollback steps (reverse of the plan)
+"""
+
+from __future__ import annotations
+
+from posthog.clickhouse.migration_tools.manifest import ManifestStep
+from posthog.clickhouse.migration_tools.state_diff import StateDiff
+
+# Map action to plan symbol
+_ACTION_SYMBOL: dict[str, str] = {
+    "create": "+",
+    "drop": "-",
+    "alter_add_column": "~",
+    "alter_drop_column": "~",
+    "alter_modify_column": "~",
+    "recreate_mv": "-/+",
+    "recreate": "-/+",
+}
+
+
+def generate_plan_text(diffs: list[StateDiff]) -> str:
+    """Generate a human-readable plan string (like terraform plan output)."""
+    if not diffs:
+        return "No changes. Infrastructure is up to date."
+
+    lines: list[str] = []
+
+    # Kafka table recreate warning — ingestion pauses between DROP and CREATE
+    kafka_recreates = [d for d in diffs if d.action in ("drop", "recreate") and "kafka" in d.table.lower()]
+    if kafka_recreates:
+        lines.append("\u26a0\ufe0f  KAFKA TABLE RECREATE WARNING")
+        lines.append("=" * 60)
+        for k in kafka_recreates:
+            lines.append(f"  - {k.table}: ingestion will pause between DROP and CREATE.")
+            lines.append("    Messages accumulating in Kafka during this window may be")
+            lines.append("    lost if the topic retention expires. Consumer group offsets")
+            lines.append("    reset. Dependent MaterializedViews will also need recreating.")
+        lines.append("")
+        lines.append("  Recommended: pause upstream producers or extend retention before applying.")
+        lines.append("=" * 60)
+        lines.append("")
+
+    lines.append("ch_migrate plan:\n")
+
+    creates = 0
+    destroys = 0
+    modifies = 0
+
+    for diff in diffs:
+        symbol = _ACTION_SYMBOL.get(diff.action, "?")
+        if diff.action == "alter_modify_column":
+            lines.append(
+                f"  \u26a0 {diff.table:40s} ({diff.detail} \u2014 rewrites data, may take hours on large tables)"
+            )
+        else:
+            lines.append(f"  {symbol} {diff.table:40s} ({diff.detail})")
+
+        if diff.action == "create":
+            creates += 1
+        elif diff.action == "drop":
+            destroys += 1
+        elif diff.action in ("recreate", "recreate_mv"):
+            destroys += 1
+            creates += 1
+        else:
+            modifies += 1
+
+    parts = []
+    if modifies:
+        parts.append(f"{modifies} to modify")
+    if destroys:
+        parts.append(f"{destroys} to destroy")
+    if creates:
+        parts.append(f"{creates} to create")
+
+    lines.append(f"\nPlan: {', '.join(parts)}.")
+    return "\n".join(lines)
+
+
+def generate_manifest_steps(diffs: list[StateDiff]) -> list[tuple[ManifestStep, str]]:
+    """Convert StateDiffs into ManifestStep + SQL pairs for the existing runner."""
+    steps: list[tuple[ManifestStep, str]] = []
+
+    for diff in diffs:
+        if diff.action in ("recreate", "recreate_mv"):
+            # Split into DROP + CREATE
+            sql_parts = diff.sql.split(";\n", 1)
+            if len(sql_parts) == 2:
+                drop_sql, create_sql = sql_parts
+                steps.append(
+                    (
+                        ManifestStep(
+                            sql=f"_reconcile:drop_{diff.table}",
+                            node_roles=diff.node_roles,
+                            comment=f"Drop {diff.table} for recreation",
+                            sharded=diff.sharded,
+                            cluster=diff.cluster,
+                        ),
+                        drop_sql,
+                    )
+                )
+                steps.append(
+                    (
+                        ManifestStep(
+                            sql=f"_reconcile:create_{diff.table}",
+                            node_roles=diff.node_roles,
+                            comment=f"Recreate {diff.table}",
+                            sharded=diff.sharded,
+                            cluster=diff.cluster,
+                        ),
+                        create_sql,
+                    )
+                )
+            else:
+                steps.append(
+                    (
+                        ManifestStep(
+                            sql=f"_reconcile:{diff.action}_{diff.table}",
+                            node_roles=diff.node_roles,
+                            comment=diff.detail,
+                            sharded=diff.sharded,
+                            cluster=diff.cluster,
+                        ),
+                        diff.sql,
+                    )
+                )
+        else:
+            steps.append(
+                (
+                    ManifestStep(
+                        sql=f"_reconcile:{diff.action}_{diff.table}",
+                        node_roles=diff.node_roles,
+                        comment=diff.detail,
+                        sharded=diff.sharded,
+                        is_alter_on_replicated_table=diff.is_alter_on_replicated_table,
+                        cluster=diff.cluster,
+                    ),
+                    diff.sql,
+                )
+            )
+
+    return steps

--- a/posthog/clickhouse/test/test_plan_generator.py
+++ b/posthog/clickhouse/test/test_plan_generator.py
@@ -1,0 +1,113 @@
+"""Unit tests for plan_generator — generate_plan_text and generate_manifest_steps."""
+
+from __future__ import annotations
+
+import unittest
+
+from posthog.clickhouse.migration_tools.plan_generator import generate_manifest_steps, generate_plan_text
+from posthog.clickhouse.migration_tools.state_diff import StateDiff
+
+
+class TestPlanGeneratorHumanReadable(unittest.TestCase):
+    def test_plan_includes_symbols(self) -> None:
+        diffs = [
+            StateDiff(
+                action="alter_add_column",
+                table="sharded_events",
+                detail="Add column foo String to sharded_events",
+                sql="ALTER TABLE ...",
+                node_roles=["DATA"],
+            ),
+            StateDiff(
+                action="drop",
+                table="old_mv",
+                detail="Table old_mv exists but is not in desired state",
+                sql="DROP TABLE ...",
+                node_roles=["ALL"],
+            ),
+            StateDiff(
+                action="create",
+                table="new_table",
+                detail="Create MergeTree table new_table",
+                sql="CREATE TABLE ...",
+                node_roles=["DATA"],
+            ),
+        ]
+        plan = generate_plan_text(diffs)
+        self.assertIn("~", plan)
+        self.assertIn("-", plan)
+        self.assertIn("+", plan)
+        self.assertIn("sharded_events", plan)
+        self.assertIn("old_mv", plan)
+        self.assertIn("new_table", plan)
+        self.assertIn("Plan:", plan)
+        self.assertIn("ch_migrate plan:", plan)
+
+    def test_no_changes_plan(self) -> None:
+        plan = generate_plan_text([])
+        self.assertIn("No changes", plan)
+
+    def test_kafka_recreate_warning(self) -> None:
+        diffs = [
+            StateDiff(
+                action="recreate",
+                table="kafka_events",
+                detail="Recreate kafka_events",
+                sql="DROP TABLE IF EXISTS posthog.kafka_events;\nCREATE TABLE posthog.kafka_events ...",
+                node_roles=["ALL"],
+            ),
+        ]
+        plan = generate_plan_text(diffs)
+        self.assertIn("KAFKA TABLE RECREATE WARNING", plan)
+        self.assertIn("ingestion will pause", plan)
+
+
+class TestManifestStepGeneration(unittest.TestCase):
+    def test_generates_manifest_steps(self) -> None:
+        diffs = [
+            StateDiff(
+                action="alter_add_column",
+                table="t",
+                detail="Add col",
+                sql="ALTER TABLE posthog.t ADD COLUMN IF NOT EXISTS foo String",
+                node_roles=["DATA"],
+                sharded=True,
+                is_alter_on_replicated_table=True,
+            ),
+        ]
+        steps = generate_manifest_steps(diffs)
+        self.assertEqual(len(steps), 1)
+        step, sql = steps[0]
+        self.assertEqual(step.node_roles, ["DATA"])
+        self.assertTrue(step.sharded)
+        self.assertTrue(step.is_alter_on_replicated_table)
+        self.assertIn("ALTER TABLE", sql)
+
+    def test_recreate_splits_into_drop_create(self) -> None:
+        diffs = [
+            StateDiff(
+                action="recreate_mv",
+                table="my_mv",
+                detail="Recreate MV",
+                sql="DROP TABLE IF EXISTS posthog.my_mv;\nCREATE MATERIALIZED VIEW ...",
+                node_roles=["ALL"],
+            ),
+        ]
+        steps = generate_manifest_steps(diffs)
+        self.assertEqual(len(steps), 2)
+        self.assertIn("drop", steps[0][0].sql)
+        self.assertIn("create", steps[1][0].sql)
+
+    def test_cluster_propagated_to_steps(self) -> None:
+        diffs = [
+            StateDiff(
+                action="create",
+                table="t",
+                detail="Create t",
+                sql="CREATE TABLE ...",
+                node_roles=["ALL"],
+                cluster="logs",
+            ),
+        ]
+        steps = generate_manifest_steps(diffs)
+        self.assertEqual(steps[0][0].cluster, "logs")

--- a/posthog/management/commands/ch_migrate.py
+++ b/posthog/management/commands/ch_migrate.py
@@ -1,0 +1,221 @@
+# ruff: noqa: T201 allow print statements
+"""
+ClickHouse schema management -- declarative, Terraform-style.
+
+Subcommand (this slice):
+  plan  -- diff schema/*.yaml vs live ClickHouse, show plan
+
+Modules: desired_state, state_diff, plan_generator, schema_introspect.
+"""
+
+from typing import Any
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from posthog.clickhouse.cluster import get_all_logical_clusters, get_cluster_by_name, is_known_cluster
+
+DEFAULT_SCHEMA_DIR = "posthog/clickhouse/schema"
+
+
+def _any_client(cluster: Any) -> Any:
+    return cluster.any_host(lambda c: c).result()
+
+
+class Command(BaseCommand):
+    help = "ClickHouse schema management -- plan"
+
+    def add_arguments(self, parser: Any) -> None:
+        subparsers = parser.add_subparsers(dest="subcommand")
+
+        plan_parser = subparsers.add_parser("plan", help="Diff desired-state YAML vs live ClickHouse")
+        plan_parser.add_argument(
+            "--schema-dir",
+            type=str,
+            default=DEFAULT_SCHEMA_DIR,
+            help="Directory with desired-state YAML files",
+        )
+        plan_parser.add_argument(
+            "--cluster",
+            type=str,
+            default=None,
+            help="Filter to a specific cluster (e.g. main, logs). Default: all clusters.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        subcommand = options.get("subcommand")
+        handlers: dict[str, Any] = {
+            "plan": self.handle_plan,
+        }
+        handler = handlers.get(subcommand or "")
+        if handler:
+            handler(options)
+        else:
+            self.print_help("manage.py", "ch_migrate")
+
+    def _compute_diffs(
+        self, database: str, schema_dir: Any, cluster_filter: str | None = None
+    ) -> tuple[list, str | None]:
+        """Compute desired-vs-current diffs. Returns (diffs, error_message).
+
+        Connects to the correct ClickHouse host for each logical cluster
+        declared in the YAML files. When *cluster_filter* is set, only YAML
+        files matching that cluster are diffed.
+        """
+        from collections import defaultdict
+
+        from posthog.clickhouse.migration_tools.desired_state import parse_desired_state_dir
+        from posthog.clickhouse.migration_tools.state_diff import (
+            TRACKING_TABLES,
+            StateDiff,
+            _drop_stmt,
+            diff_state,
+            has_placeholder_select,
+        )
+
+        desired_states = parse_desired_state_dir(schema_dir)
+        if not desired_states:
+            return [], f"No YAML files found in {schema_dir}"
+
+        if cluster_filter:
+            desired_states = [ds for ds in desired_states if ds.cluster == cluster_filter]
+            if not desired_states:
+                return [], f"No YAML files for cluster '{cluster_filter}' in {schema_dir}"
+
+        for ds in desired_states:
+            if not is_known_cluster(ds.cluster):
+                known = ", ".join(get_all_logical_clusters())
+                return [], (
+                    f"Schema file for ecosystem '{ds.ecosystem}' references cluster "
+                    f"'{ds.cluster}' which is not in the cluster registry. "
+                    f"Known clusters: {known}. "
+                    f"Add '{ds.cluster}' to _REGISTRY in posthog/clickhouse/cluster.py with the "
+                    f"appropriate CLICKHOUSE_*_HOST and CLICKHOUSE_*_CLUSTER settings."
+                )
+
+        by_cluster: dict[str, list] = defaultdict(list)
+        for ds in desired_states:
+            by_cluster[ds.cluster].append(ds)
+
+        all_desired_names: set[str] = set()
+        all_placeholder_names: set[str] = set()
+        for ds in desired_states:
+            for name, t in ds.tables.items():
+                all_desired_names.add(name)
+                if has_placeholder_select(t):
+                    all_placeholder_names.add(name)
+
+        from posthog.clickhouse.client.migration_tools import get_migrations_cluster
+        from posthog.clickhouse.migration_tools.schema_introspect import dump_schema_all_hosts
+
+        def _union_from_cluster(cluster_obj: Any) -> dict[str, Any]:
+            per_host = dump_schema_all_hosts(cluster_obj, database)
+            union: dict[str, Any] = {}
+            for _host_info, host_schema in per_host.items():
+                for tbl_name, tbl_schema in host_schema.items():
+                    if tbl_name not in union:
+                        union[tbl_name] = tbl_schema
+            return union
+
+        _migrations_union: dict[str, Any] | None = None
+
+        def _fallback_union() -> dict[str, Any]:
+            nonlocal _migrations_union
+            if _migrations_union is None:
+                _migrations_union = _union_from_cluster(get_migrations_cluster())
+            return _migrations_union
+
+        all_diffs = []
+        for cluster_name, states in by_cluster.items():
+            used_fallback = False
+            try:
+                cluster_obj = get_cluster_by_name(cluster_name)
+                current = _union_from_cluster(cluster_obj)
+            except Exception as exc:
+                exc_str = str(exc)
+                is_unreachable = (
+                    "CLUSTER_DOESNT_EXIST" in exc_str
+                    or "Code: 701" in exc_str
+                    or "Code: 210" in exc_str
+                    or "Connection refused" in exc_str
+                    or "Name or service not known" in exc_str
+                    or "not found" in exc_str.lower()
+                )
+                if is_unreachable:
+                    ecosystem_names = ", ".join(s.ecosystem for s in states)
+                    print(
+                        f"Warning: cluster '{cluster_name}' "
+                        f"(ecosystems: {ecosystem_names}) unreachable; "
+                        f"falling back to migrations-cluster schema. Details: {exc_str[:200]}"
+                    )
+                    try:
+                        current = _fallback_union()
+                        used_fallback = True
+                    except Exception as fallback_exc:
+                        print(
+                            f"Warning: fallback to migrations cluster also failed for "
+                            f"'{cluster_name}': {fallback_exc!s:.200}. Skipping."
+                        )
+                        continue
+                else:
+                    raise
+
+            for desired in states:
+                if used_fallback:
+                    ecosystem_current = {}
+                else:
+                    ecosystem_current = {name: table for name, table in current.items() if name in desired.tables}
+                diffs = diff_state(desired, ecosystem_current, database=database)
+                for d in diffs:
+                    d.cluster = cluster_name
+                    all_diffs.append(d)
+
+            if used_fallback:
+                continue
+
+            for table_name in sorted(current.keys()):
+                if table_name in all_desired_names:
+                    continue
+                if table_name in TRACKING_TABLES:
+                    continue
+                if table_name in all_placeholder_names:
+                    continue
+                current_table = current[table_name]
+                all_diffs.append(
+                    StateDiff(
+                        action="drop",
+                        table=table_name,
+                        detail=(
+                            f"Orphan: table {table_name} exists but is not declared in any "
+                            f"YAML on cluster {cluster_name}"
+                        ),
+                        sql=_drop_stmt(current_table.engine, database, table_name),
+                        node_roles=["ALL"],
+                        cluster=cluster_name,
+                    )
+                )
+
+        return all_diffs, None
+
+    def handle_plan(self, options: dict[str, Any]) -> None:
+        from pathlib import Path
+
+        from posthog.clickhouse.migration_tools.plan_generator import generate_plan_text
+
+        database: str = settings.CLICKHOUSE_DATABASE
+        schema_dir = Path(options.get("schema_dir", DEFAULT_SCHEMA_DIR))
+
+        if not schema_dir.exists():
+            print(f"Schema directory not found: {schema_dir}")
+            print("Run 'ch_migrate generate' to create schema YAML files.")
+            return
+
+        cluster_filter = options.get("cluster")
+        all_diffs, err = self._compute_diffs(database, schema_dir, cluster_filter=cluster_filter)
+        if err:
+            print(err)
+            return
+
+        if cluster_filter:
+            print(f"Filtering to cluster: {cluster_filter}\n")
+        print(generate_plan_text(all_diffs))


### PR DESCRIPTION
## Problem

With the diff engine in place (PR9), we need a user-facing command and the pipeline that converts raw `StateDiff` objects into both a human-readable plan and executable `ManifestStep` objects. This PR ships `python manage.py ch_migrate plan` — the read-only half of the reconciliation loop.

## Changes

- `posthog/clickhouse/migration_tools/manifest.py` — `ManifestStep` dataclass and `ROLE_MAP` (shared data contract between plan_generator and runner)
- `posthog/clickhouse/migration_tools/plan_generator.py` — `generate_plan_text` (terraform-style +/-/~ output with Kafka recreate warnings) and `generate_manifest_steps` (converts `StateDiff` list to `ManifestStep + SQL` pairs for the runner)
- `posthog/management/commands/ch_migrate.py` — plan-only slice: `add_arguments` (plan subparser), `handle`, `_compute_diffs` (per-cluster introspection with satellite fallback), `handle_plan`
- `posthog/clickhouse/test/test_plan_generator.py` — unit tests for `generate_plan_text` and `generate_manifest_steps`; no CH connection required

## How did you test this code?

Draft — unit tests for plan_generator run once the dependency chain (PR6–PR9) is merged. `generate_plan_text` and `generate_manifest_steps` tests are pure Python (no Django, no CH).

Depends on PR9 (diff engine, #54826), PR8 (normalization, #54825), PR7 (#54821), PR6 (#54815).

## Publish to changelog?

No

## 🤖 LLM context

Agent-authored draft PR. Part of the ch_migrate tiny-PR stack (Batch 2 of 3, PR10/12).