### PR TITLE
feat(ch-migrate): canonical test table YAML for parser smoke test

### DIFF
--- a/posthog/clickhouse/schema/test_table.yaml
+++ b/posthog/clickhouse/schema/test_table.yaml
@@ -1,0 +1,20 @@
+ecosystem: test
+cluster: main
+tables:
+    ch_migrate_test:
+        engine: MergeTree
+        on_nodes: all
+        order_by:
+            - team_id
+            - id
+        columns:
+            - name: id
+              type: UInt64
+            - name: team_id
+              type: UInt32
+            - name: name
+              type: String
+            - name: created_at
+              type: DateTime
+              default_kind: DEFAULT
+              default_expression: now()

--- a/posthog/clickhouse/test/test_test_table_yaml.py
+++ b/posthog/clickhouse/test/test_test_table_yaml.py
@@ -1,0 +1,33 @@
+"""Smoke test: verify test_table.yaml parses correctly via parse_desired_state."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_test_table_yaml_parses():
+    from posthog.clickhouse.migration_tools.desired_state import parse_desired_state
+
+    yaml_path = Path(__file__).parent.parent.parent / "clickhouse" / "schema" / "test_table.yaml"
+    assert yaml_path.exists(), f"test_table.yaml not found at {yaml_path}"
+
+    state = parse_desired_state(yaml_path)
+
+    assert state.ecosystem == "test"
+    assert state.cluster == "main"
+    assert "ch_migrate_test" in state.tables
+
+    t = state.tables["ch_migrate_test"]
+    assert t.engine == "MergeTree"
+    assert t.order_by == ["team_id", "id"]
+
+    col_names = [c.name for c in t.columns]
+    assert "id" in col_names
+    assert "team_id" in col_names
+    assert "name" in col_names
+    assert "created_at" in col_names
+
+    created_at = next(c for c in t.columns if c.name == "created_at")
+    assert created_at.type == "DateTime"
+    assert created_at.default_kind == "DEFAULT"
+    assert created_at.default_expression == "now()"


### PR DESCRIPTION
## Problem

Rory asked for one small testing table rather than 46 production YAMLs. The YAML parser (PR6) needs at least one fixture file to verify the full parse path end-to-end — column types, defaults, order_by, engine, cluster. This PR is that fixture.

## Changes

- `posthog/clickhouse/schema/test_table.yaml` — a minimal MergeTree table (`ch_migrate_test`) with 4 columns covering the common field types: bare UInt64/UInt32/String and a DateTime with a DEFAULT expression
- `posthog/clickhouse/test/test_test_table_yaml.py` — smoke test that calls `parse_desired_state()` on the file and asserts the parsed structure is correct

## How did you test this code?

Draft — smoke test runs once PR6 (desired_state/parse_desired_state, #54815) is merged. The test itself is 33 lines of pure assertions.

Depends on PR6 (YAML parser, #54815).

## Publish to changelog?

No

## 🤖 LLM context

Agent-authored draft PR. Part of the ch_migrate tiny-PR stack (Batch 2 of 3, PR11/12).