### PR TITLE
feat(ch-migrate): runner and ch_migrate apply command

### DIFF
--- a/posthog/clickhouse/migration_tools/runner.py
+++ b/posthog/clickhouse/migration_tools/runner.py
@@ -1,0 +1,151 @@
+"""Step execution engine -- routes SQL to correct ClickHouse nodes by role.
+
+Also provides legacy migration support: discover_migrations, get_pending_migrations,
+run_migration_down.
+"""
+
+from __future__ import annotations
+
+import os
+import importlib
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from posthog.clickhouse.migration_tools.manifest import ROLE_MAP, ManifestStep
+
+if TYPE_CHECKING:
+    from posthog.clickhouse.cluster import ClickhouseCluster
+
+# Legacy migrations live here
+MIGRATIONS_DIR = Path(__file__).resolve().parent.parent / "migrations"
+
+
+def _map_node_roles(manifest_roles: list[str]) -> list:
+    from posthog.clickhouse.client.connection import NodeRole
+
+    result = []
+    for role in manifest_roles:
+        role_value = ROLE_MAP.get(role)
+        if role_value is None:
+            raise ValueError(f"Unknown node role '{role}'. Valid roles: {sorted(ROLE_MAP.keys())}")
+        result.append(NodeRole(role_value))
+    return result
+
+
+def execute_migration_step(
+    cluster: ClickhouseCluster,
+    step: ManifestStep,
+    rendered_sql: str,
+) -> dict[Any, Any]:
+    """Routing: sharded+alter_replicated -> one_host_per_shard, alter_replicated -> any_host, else -> all hosts."""
+    from posthog.clickhouse.cluster import Query
+
+    query = Query(rendered_sql)
+    node_roles = _map_node_roles(step.node_roles)
+
+    if step.sharded and step.is_alter_on_replicated_table:
+        futures_map = cluster.map_one_host_per_shard(query)
+        return futures_map.result()
+    elif step.is_alter_on_replicated_table:
+        future = cluster.any_host_by_roles(query, node_roles=node_roles)
+        result = future.result()
+        return {"single_host": result}
+    else:
+        futures_map = cluster.map_hosts_by_roles(query, node_roles=node_roles)
+        return futures_map.result()
+
+
+# ------------------------------------------------------------------
+# Legacy migration support
+# ------------------------------------------------------------------
+
+
+def discover_migrations() -> list[str]:
+    """Find all legacy .py migration modules in the migrations directory.
+
+    Returns sorted module names like ['0001_initial', '0002_add_events', ...].
+    """
+    if not MIGRATIONS_DIR.exists():
+        return []
+
+    migrations = []
+    for entry in sorted(os.listdir(MIGRATIONS_DIR)):
+        # Match NNNN_name.py or NNNN_name/ (directory migrations)
+        if entry.startswith("0") and not entry.startswith("__"):
+            name = entry.removesuffix(".py")
+            # Accept .py files, legacy dir migrations with __init__.py, and
+            # new-style manifest directories with a manifest.yaml. Earlier
+            # this only matched __init__.py, so manifest-only migrations
+            # silently disappeared from legacy discovery.
+            entry_path = MIGRATIONS_DIR / entry
+            if entry_path.is_file() and entry.endswith(".py"):
+                migrations.append(name)
+            elif entry_path.is_dir() and (
+                (entry_path / "__init__.py").exists() or (entry_path / "manifest.yaml").exists()
+            ):
+                migrations.append(name)
+
+    return migrations
+
+
+def get_pending_migrations() -> list[str]:
+    """Return legacy migrations that haven't been applied yet.
+
+    Checks the infi clickhouse_orm migration tracking.
+    """
+    all_migrations = discover_migrations()
+    if not all_migrations:
+        return []
+
+    try:
+        from posthog.clickhouse.client.migration_tools import get_migrations_cluster
+
+        cluster = get_migrations_cluster()
+        client = cluster.any_host(lambda c: c).result()
+
+        # Check what's been recorded in the infi tracking system
+        rows = client.execute(
+            "SELECT name FROM system.tables WHERE database = 'default' AND name = 'infi_clickhouse_orm_migrations'"
+        )
+        if not rows:
+            return all_migrations  # no tracking table = everything is pending
+
+        applied_rows = client.execute("SELECT package_name FROM default.infi_clickhouse_orm_migrations")
+        applied = {row[0] for row in applied_rows}
+
+        return [m for m in all_migrations if m not in applied]
+    except Exception:
+        return all_migrations
+
+
+def run_migration_down(migration_number: int) -> None:
+    """Roll back a legacy migration by number."""
+    migrations = discover_migrations()
+    target = None
+    for m in migrations:
+        if m.startswith(f"{migration_number:04d}_"):
+            target = m
+            break
+
+    if target is None:
+        raise ValueError(f"Migration {migration_number} not found")
+
+    module_path = f"posthog.clickhouse.migrations.{target}"
+    module = importlib.import_module(module_path)
+    rollback_ops = getattr(module, "rollback_operations", [])
+
+    if not rollback_ops:
+        raise ValueError(f"Migration {target} has no rollback_operations")
+
+    from posthog.clickhouse.client.migration_tools import get_migrations_cluster
+
+    cluster = get_migrations_cluster()
+
+    for op in rollback_ops:
+        if hasattr(op, "sql"):
+            from posthog.clickhouse.cluster import Query
+
+            cluster.map_all_hosts(Query(op.sql)).result()
+        elif hasattr(op, "fn"):
+            client = cluster.any_host(lambda c: c).result()
+            op.fn(client)

--- a/posthog/clickhouse/test/test_runner.py
+++ b/posthog/clickhouse/test/test_runner.py
@@ -1,0 +1,66 @@
+"""Unit tests for runner.execute_migration_step routing logic."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from posthog.clickhouse.migration_tools.manifest import ManifestStep
+
+
+class TestExecuteMigrationStepRouting(unittest.TestCase):
+    """Verify that execute_migration_step calls the right cluster method."""
+
+    def _make_step(self, *, sharded: bool = False, is_alter_on_replicated: bool = False) -> ManifestStep:
+        return ManifestStep(
+            sql="_reconcile:create_t",
+            node_roles=["ALL"],
+            comment="test step",
+            sharded=sharded,
+            is_alter_on_replicated_table=is_alter_on_replicated,
+        )
+
+    def _run(self, step: ManifestStep) -> MagicMock:
+        cluster = MagicMock()
+        future = MagicMock()
+        future.result.return_value = {}
+        cluster.map_one_host_per_shard.return_value = future
+        cluster.any_host_by_roles.return_value = future
+        cluster.map_hosts_by_roles.return_value = future
+
+        with patch("posthog.clickhouse.migration_tools.runner._map_node_roles", return_value=[]):
+            from posthog.clickhouse.migration_tools.runner import execute_migration_step
+
+            execute_migration_step(cluster, step, "CREATE TABLE t ...")
+
+        return cluster
+
+    def test_sharded_alter_replicated_uses_one_host_per_shard(self):
+        step = self._make_step(sharded=True, is_alter_on_replicated=True)
+        cluster = self._run(step)
+        cluster.map_one_host_per_shard.assert_called_once()
+        cluster.any_host_by_roles.assert_not_called()
+        cluster.map_hosts_by_roles.assert_not_called()
+
+    def test_alter_replicated_only_uses_any_host(self):
+        step = self._make_step(sharded=False, is_alter_on_replicated=True)
+        cluster = self._run(step)
+        cluster.any_host_by_roles.assert_called_once()
+        cluster.map_one_host_per_shard.assert_not_called()
+        cluster.map_hosts_by_roles.assert_not_called()
+
+    def test_regular_step_uses_map_hosts_by_roles(self):
+        step = self._make_step(sharded=False, is_alter_on_replicated=False)
+        cluster = self._run(step)
+        cluster.map_hosts_by_roles.assert_called_once()
+        cluster.map_one_host_per_shard.assert_not_called()
+        cluster.any_host_by_roles.assert_not_called()
+
+
+class TestMapNodeRoles(unittest.TestCase):
+    def test_unknown_role_raises(self):
+        from posthog.clickhouse.migration_tools.runner import _map_node_roles
+
+        with self.assertRaises(ValueError) as ctx:
+            _map_node_roles(["UNKNOWN_ROLE"])
+        self.assertIn("UNKNOWN_ROLE", str(ctx.exception))

--- a/posthog/management/commands/ch_migrate.py
+++ b/posthog/management/commands/ch_migrate.py
@@ -1,0 +1,358 @@
+# ruff: noqa: T201 allow print statements
+"""
+ClickHouse schema management -- declarative, Terraform-style.
+
+Subcommands (this slice):
+  plan   -- diff schema/*.yaml vs live ClickHouse, show plan
+  apply  -- execute the reconciliation plan
+
+Modules: desired_state, state_diff, plan_generator, runner, tracking,
+schema_introspect.
+"""
+
+from typing import Any
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from posthog.clickhouse.cluster import get_all_logical_clusters, get_cluster_by_name, is_known_cluster
+
+DEFAULT_SCHEMA_DIR = "posthog/clickhouse/schema"
+
+
+def _any_client(cluster: Any) -> Any:
+    return cluster.any_host(lambda c: c).result()
+
+
+class Command(BaseCommand):
+    help = "ClickHouse schema management -- plan, apply"
+
+    def add_arguments(self, parser: Any) -> None:
+        subparsers = parser.add_subparsers(dest="subcommand")
+
+        plan_parser = subparsers.add_parser("plan", help="Diff desired-state YAML vs live ClickHouse")
+        plan_parser.add_argument("--schema-dir", type=str, default=DEFAULT_SCHEMA_DIR)
+        plan_parser.add_argument("--cluster", type=str, default=None)
+
+        apply_parser = subparsers.add_parser("apply", help="Execute the reconciliation plan")
+        apply_parser.add_argument("--schema-dir", type=str, default=DEFAULT_SCHEMA_DIR)
+        apply_parser.add_argument("--force", action="store_true", default=False)
+        apply_parser.add_argument("--yes", "-y", action="store_true", default=False, help="Skip confirmation prompt")
+        apply_parser.add_argument("--cluster", type=str, default=None)
+        apply_parser.add_argument(
+            "--continue-on-error",
+            action="store_true",
+            default=False,
+            help="Continue applying remaining steps after a failure instead of halting.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        subcommand = options.get("subcommand")
+        handlers: dict[str, Any] = {
+            "plan": self.handle_plan,
+            "apply": self.handle_apply,
+        }
+        handler = handlers.get(subcommand or "")
+        if handler:
+            handler(options)
+        else:
+            self.print_help("manage.py", "ch_migrate")
+
+    def _compute_diffs(
+        self, database: str, schema_dir: Any, cluster_filter: str | None = None
+    ) -> tuple[list, str | None]:
+        """Compute desired-vs-current diffs. Returns (diffs, error_message)."""
+        from collections import defaultdict
+
+        from posthog.clickhouse.migration_tools.desired_state import parse_desired_state_dir
+        from posthog.clickhouse.migration_tools.state_diff import (
+            TRACKING_TABLES,
+            StateDiff,
+            _drop_stmt,
+            diff_state,
+            has_placeholder_select,
+        )
+
+        desired_states = parse_desired_state_dir(schema_dir)
+        if not desired_states:
+            return [], f"No YAML files found in {schema_dir}"
+
+        if cluster_filter:
+            desired_states = [ds for ds in desired_states if ds.cluster == cluster_filter]
+            if not desired_states:
+                return [], f"No YAML files for cluster '{cluster_filter}' in {schema_dir}"
+
+        for ds in desired_states:
+            if not is_known_cluster(ds.cluster):
+                known = ", ".join(get_all_logical_clusters())
+                return [], (
+                    f"Schema file for ecosystem '{ds.ecosystem}' references cluster "
+                    f"'{ds.cluster}' which is not in the cluster registry. "
+                    f"Known clusters: {known}."
+                )
+
+        by_cluster: dict[str, list] = defaultdict(list)
+        for ds in desired_states:
+            by_cluster[ds.cluster].append(ds)
+
+        all_desired_names: set[str] = set()
+        all_placeholder_names: set[str] = set()
+        for ds in desired_states:
+            for name, t in ds.tables.items():
+                all_desired_names.add(name)
+                if has_placeholder_select(t):
+                    all_placeholder_names.add(name)
+
+        from posthog.clickhouse.client.migration_tools import get_migrations_cluster
+        from posthog.clickhouse.migration_tools.schema_introspect import dump_schema_all_hosts
+
+        def _union_from_cluster(cluster_obj: Any) -> dict[str, Any]:
+            per_host = dump_schema_all_hosts(cluster_obj, database)
+            union: dict[str, Any] = {}
+            for _host_info, host_schema in per_host.items():
+                for tbl_name, tbl_schema in host_schema.items():
+                    if tbl_name not in union:
+                        union[tbl_name] = tbl_schema
+            return union
+
+        _migrations_union: dict[str, Any] | None = None
+
+        def _fallback_union() -> dict[str, Any]:
+            nonlocal _migrations_union
+            if _migrations_union is None:
+                _migrations_union = _union_from_cluster(get_migrations_cluster())
+            return _migrations_union
+
+        all_diffs = []
+        for cluster_name, states in by_cluster.items():
+            used_fallback = False
+            try:
+                cluster_obj = get_cluster_by_name(cluster_name)
+                current = _union_from_cluster(cluster_obj)
+            except Exception as exc:
+                exc_str = str(exc)
+                is_unreachable = (
+                    "CLUSTER_DOESNT_EXIST" in exc_str
+                    or "Code: 701" in exc_str
+                    or "Code: 210" in exc_str
+                    or "Connection refused" in exc_str
+                    or "Name or service not known" in exc_str
+                    or "not found" in exc_str.lower()
+                )
+                if is_unreachable:
+                    ecosystem_names = ", ".join(s.ecosystem for s in states)
+                    print(
+                        f"Warning: cluster '{cluster_name}' "
+                        f"(ecosystems: {ecosystem_names}) unreachable; "
+                        f"falling back to migrations-cluster schema. Details: {exc_str[:200]}"
+                    )
+                    try:
+                        current = _fallback_union()
+                        used_fallback = True
+                    except Exception as fallback_exc:
+                        print(f"Warning: fallback also failed for '{cluster_name}': {fallback_exc!s:.200}. Skipping.")
+                        continue
+                else:
+                    raise
+
+            for desired in states:
+                ecosystem_current = {} if used_fallback else {n: t for n, t in current.items() if n in desired.tables}
+                diffs = diff_state(desired, ecosystem_current, database=database)
+                for d in diffs:
+                    d.cluster = cluster_name
+                    all_diffs.append(d)
+
+            if used_fallback:
+                continue
+
+            for table_name in sorted(current.keys()):
+                if table_name in all_desired_names or table_name in TRACKING_TABLES:
+                    continue
+                if table_name in all_placeholder_names:
+                    continue
+                current_table = current[table_name]
+                all_diffs.append(
+                    StateDiff(
+                        action="drop",
+                        table=table_name,
+                        detail=f"Orphan: {table_name} exists but is not declared in any YAML on cluster {cluster_name}",
+                        sql=_drop_stmt(current_table.engine, database, table_name),
+                        node_roles=["ALL"],
+                        cluster=cluster_name,
+                    )
+                )
+
+        return all_diffs, None
+
+    def handle_plan(self, options: dict[str, Any]) -> None:
+        from pathlib import Path
+
+        from posthog.clickhouse.migration_tools.plan_generator import generate_plan_text
+
+        database: str = settings.CLICKHOUSE_DATABASE
+        schema_dir = Path(options.get("schema_dir", DEFAULT_SCHEMA_DIR))
+        if not schema_dir.exists():
+            print(f"Schema directory not found: {schema_dir}")
+            return
+
+        cluster_filter = options.get("cluster")
+        all_diffs, err = self._compute_diffs(database, schema_dir, cluster_filter=cluster_filter)
+        if err:
+            print(err)
+            return
+
+        if cluster_filter:
+            print(f"Filtering to cluster: {cluster_filter}\n")
+        print(generate_plan_text(all_diffs))
+
+    def handle_apply(self, options: dict[str, Any]) -> None:
+        import time
+        import socket
+        import hashlib
+        import subprocess
+        from pathlib import Path
+
+        from posthog.clickhouse.client.migration_tools import get_migrations_cluster
+        from posthog.clickhouse.migration_tools.plan_generator import generate_manifest_steps, generate_plan_text
+        from posthog.clickhouse.migration_tools.runner import execute_migration_step
+        from posthog.clickhouse.migration_tools.tracking import (
+            StepRecord,
+            _record_step,
+            acquire_apply_lock,
+            record_schema_version,
+            release_apply_lock,
+        )
+
+        database: str = settings.CLICKHOUSE_DATABASE
+        force: bool = options.get("force", False)
+        schema_dir = Path(options.get("schema_dir", DEFAULT_SCHEMA_DIR))
+        if not schema_dir.exists():
+            print(f"Schema directory not found: {schema_dir}")
+            return
+
+        cluster_obj = get_migrations_cluster()
+        client = _any_client(cluster_obj)
+        hostname = socket.gethostname()
+
+        cluster_filter = options.get("cluster")
+        all_diffs, err = self._compute_diffs(database, schema_dir, cluster_filter=cluster_filter)
+        if err:
+            print(err)
+            return
+
+        if not all_diffs:
+            print("No changes. Infrastructure is up to date.")
+            return
+
+        print(generate_plan_text(all_diffs))
+        print()
+
+        auto_approve: bool = options.get("yes", False)
+        if not auto_approve:
+            answer = input(f"Apply {len(all_diffs)} change(s)? [y/N] ")
+            if answer.lower() not in ("y", "yes"):
+                print("Aborted.")
+                return
+
+        cluster_name = getattr(settings, "CLICKHOUSE_MIGRATIONS_CLUSTER", "posthog_migrations")
+        acquired, reason = acquire_apply_lock(client, database, hostname, force=force, cluster=cluster_name)
+        if not acquired:
+            print(reason)
+            return
+
+        continue_on_error: bool = options.get("continue_on_error", False)
+        failures: list[tuple[int, str, str]] = []
+
+        cluster_cache: dict[str, Any] = {"": cluster_obj}
+
+        def _resolve_step_cluster(step_cluster_name: str) -> Any:
+            key = step_cluster_name or ""
+            if key in cluster_cache:
+                return cluster_cache[key]
+            try:
+                resolved = get_cluster_by_name(step_cluster_name)
+            except Exception:
+                resolved = cluster_obj
+            cluster_cache[key] = resolved
+            return resolved
+
+        try:
+            steps = generate_manifest_steps(all_diffs)
+            print(f"Applying {len(steps)} step(s)...\n")
+
+            max_retries = 3
+            for i, (step, rendered_sql) in enumerate(steps):
+                print(f"  Step {i}: {step.comment}...", end=" ", flush=True)
+                checksum = hashlib.sha256(rendered_sql.encode()).hexdigest()
+                step_cluster = _resolve_step_cluster(step.cluster)
+                success = False
+                last_exc: Exception | None = None
+                for attempt in range(max_retries):
+                    try:
+                        execute_migration_step(step_cluster, step, rendered_sql)
+                        success = True
+                        break
+                    except Exception as exc:
+                        last_exc = exc
+                        if attempt < max_retries - 1:
+                            wait = 2**attempt
+                            print(f"\n    Retry {attempt + 1}/{max_retries} in {wait}s: {exc}", flush=True)
+                            time.sleep(wait)
+
+                if not success:
+                    assert last_exc is not None
+                    print(f"FAILED after {max_retries} attempts: {last_exc}")
+                    _record_step(
+                        client=client,
+                        record=StepRecord(
+                            migration_number=0,
+                            migration_name=step.comment or "reconcile",
+                            step_index=i,
+                            host=hostname,
+                            node_role="*",
+                            direction="up",
+                            checksum=checksum,
+                            success=False,
+                        ),
+                        database=database,
+                    )
+                    failures.append((i, step.comment or "reconcile", str(last_exc)))
+                    if not continue_on_error:
+                        print("\nApply halted. Pass --continue-on-error to surface all failures.")
+                        raise CommandError(f"Apply failed on step {i} ({step.comment or 'reconcile'}): {last_exc}")
+                    continue
+
+                print("OK")
+                _record_step(
+                    client=client,
+                    record=StepRecord(
+                        migration_number=0,
+                        migration_name=step.comment or "reconcile",
+                        step_index=i,
+                        host=hostname,
+                        node_role="*",
+                        direction="up",
+                        checksum=checksum,
+                        success=True,
+                    ),
+                    database=database,
+                )
+        finally:
+            release_apply_lock(client, database, hostname)
+
+        if failures:
+            print(f"\n=== APPLY SUMMARY: {len(steps) - len(failures)} OK, {len(failures)} FAILED ===")
+            for idx, name, err in failures:
+                first_line = err.split("\n", 1)[0][:300]
+                print(f"  step {idx} {name}: {first_line}")
+            raise CommandError(f"Apply finished with {len(failures)} failure(s) out of {len(steps)} step(s)")
+
+        try:
+            result = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True, timeout=5)
+            if result.returncode == 0 and result.stdout.strip():
+                record_schema_version(client, database, result.stdout.strip(), hostname)
+                print(f"Schema version recorded: {result.stdout.strip()[:12]}")
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+
+        print("\nApply completed successfully.")


### PR DESCRIPTION
## Problem

With the plan command (PR10) showing what changes will happen, the apply command executes those changes. This PR ships the step execution engine (`runner.py`) and the `ch_migrate apply` subcommand that ties everything together: compute diffs, show plan, confirm, acquire advisory lock, execute steps with retry, record progress, release lock.

## Changes

- `posthog/clickhouse/migration_tools/runner.py` — `execute_migration_step` routes SQL to the right ClickHouse nodes based on `ManifestStep` flags: sharded+replicated → `map_one_host_per_shard`, replicated-only → `any_host_by_roles`, everything else → `map_hosts_by_roles`; also includes legacy migration discovery helpers
- `posthog/management/commands/ch_migrate.py` — complete plan+apply command: `handle_plan` from PR10 plus `handle_apply` with advisory locking, per-step retry (3 attempts, exponential backoff), `--continue-on-error` mode, and git-hash schema version recording after successful apply
- `posthog/clickhouse/test/test_runner.py` — unit tests for step routing logic (mocked cluster, no CH required)

## How did you test this code?

Draft — unit tests for runner routing pass once `manifest.py` (PR10) is on master. The three routing branches (sharded+replicated, replicated-only, plain) are covered with mock cluster assertions.

Depends on PR10 (plan command + ManifestStep, #54828), PR9 (#54826), PR8 (#54825), PR7 (#54821), PR6 (#54815).

## Publish to changelog?

No

## 🤖 LLM context

Agent-authored draft PR. Part of the ch_migrate tiny-PR stack (Batch 2 of 3, PR12/12).