### PR TITLE
fix(replay): disable autoplay next when filters open

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -186,10 +186,10 @@ function PlayerWrapper({
     const { isFiltersExpanded } = useValues(playlistFiltersLogic)
 
     const onPlayNextRecording = useCallback(() => {
-        if (nextSessionRecording?.id) {
+        if (nextSessionRecording?.id && !isFiltersExpanded) {
             setSelectedRecordingId(nextSessionRecording.id)
         }
-    }, [nextSessionRecording, setSelectedRecordingId])
+    }, [nextSessionRecording, setSelectedRecordingId, isFiltersExpanded])
 
     return (
         <div


### PR DESCRIPTION
## Problem

this annoyed me and paul

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

disable auto advance to next recording when filters open

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

played a recording, scrolled to nearly-the-end, and then opened filter -- no advanicng

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->