### PR TITLE
fix(actions): form resetting after tab switch

### DIFF
--- a/products/actions/frontend/components/ActionHogFunctions.tsx
+++ b/products/actions/frontend/components/ActionHogFunctions.tsx
@@ -10,13 +10,13 @@ import { actionEditLogic } from '../logics/actionEditLogic'
 import { actionLogic } from '../logics/actionLogic'
 
 export function ActionHogFunctions(): JSX.Element | null {
-    const { action } = useValues(actionLogic)
-    return !action ? null : <Functions action={action} />
+    const { action, tabId } = useValues(actionLogic)
+    return !action ? null : <Functions action={action} tabId={tabId} />
 }
 
-const Functions = ({ action }: { action: ActionType }): JSX.Element => {
+const Functions = ({ action, tabId }: { action: ActionType; tabId?: string }): JSX.Element => {
     const { hasCohortFilters, actionChanged, showCohortDisablesFunctionsWarning } = useValues(
-        actionEditLogic({ id: action?.id, action })
+        actionEditLogic({ id: action?.id, action, tabId })
     )
     return (
         <LemonCollapse

--- a/products/actions/frontend/logics/actionEditLogic.tsx
+++ b/products/actions/frontend/logics/actionEditLogic.tsx
@@ -312,21 +312,25 @@ export const actionEditLogic = kea<actionEditLogicType>([
                 return false
             }
 
-            // Skip the prompt when the user is merely switching to another tab — our tab still
-            // exists, the logic stays mounted via the scene-logic cache, and the form state is
-            // preserved. We only want to prompt when the user is actually leaving this tab
-            // (closing it, or navigating within it to a different URL).
+            // Skip the prompt for tab switches — our tab still exists, the logic stays mounted
+            // via the scene-logic cache, and the form state is preserved. A tab switch shows up
+            // in one of two ways at beforeUnload time:
+            //  - switching AWAY: sceneLogic.activateTab() has already moved active to another
+            //    tab before router.push fires, so activeTabId !== our tabId.
+            //  - switching BACK: active is now us again, and the push target is our own tab's
+            //    stored pathname.
+            // Anything else (in-tab navigation, closing our tab) should still prompt.
             const myTabId = logic.props.tabId
             const scene = sceneLogic.findMounted()
             if (myTabId && scene && newLocation) {
-                const tabs = scene.values.tabs
-                const myTab = tabs.find((t) => t.id === myTabId)
-                const stillExists = Boolean(myTab)
-                const destinationMatchesAnotherTab = tabs.some(
-                    (t) => t.id !== myTabId && t.pathname === newLocation.pathname
-                )
-                if (stillExists && destinationMatchesAnotherTab) {
-                    return false
+                const myTab = scene.values.tabs.find((t) => t.id === myTabId)
+                if (myTab) {
+                    if (scene.values.activeTabId !== myTabId) {
+                        return false
+                    }
+                    if (myTab.pathname === newLocation.pathname) {
+                        return false
+                    }
                 }
             }
 

--- a/products/actions/frontend/logics/actionEditLogic.tsx
+++ b/products/actions/frontend/logics/actionEditLogic.tsx
@@ -9,6 +9,7 @@ import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { Link } from 'lib/lemon-ui/Link'
 import { eventDefinitionsTableLogic } from 'scenes/data-management/events/eventDefinitionsTableLogic'
+import { sceneLogic } from 'scenes/sceneLogic'
 import { urls } from 'scenes/urls'
 
 import { deleteFromTree, getLastNewFolder, refreshTreeItem } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
@@ -35,6 +36,7 @@ export interface SetActionProps {
 export interface ActionEditLogicProps {
     id: number
     action?: ActionType | null
+    tabId?: string
 }
 
 export const DEFAULT_ACTION_STEP: ActionStepType = {
@@ -45,7 +47,9 @@ export const DEFAULT_ACTION_STEP: ActionStepType = {
 export const actionEditLogic = kea<actionEditLogicType>([
     path((key) => ['scenes', 'actions', 'actionEditLogic', key]),
     props({} as ActionEditLogicProps),
-    key((props) => props.id || 'new'),
+    // Key by tabId AND id so each tab preserves its own form state across tab switches.
+    // Fall back to 'notab' for non-scene mounts (e.g. tests, side panel) to stay backwards-compatible.
+    key((props) => `${props.tabId || 'notab'}:${props.id || 'new'}`),
     connect(() => ({
         actions: [
             actionsModel,
@@ -66,8 +70,9 @@ export const actionEditLogic = kea<actionEditLogicType>([
         deleteAction: true,
         migrateToHogFunction: true,
         setReferencesSearch: (search: string) => ({ search }),
+        setOriginalAction: (action: ActionType | null) => ({ action }),
     }),
-    reducers({
+    reducers(({ props }) => ({
         createNew: [
             false,
             {
@@ -80,7 +85,18 @@ export const actionEditLogic = kea<actionEditLogicType>([
                 setReferencesSearch: (_, { search }) => search,
             },
         ],
-    }),
+        // originalAction mirrors the action at the time it was first loaded, so edits can be
+        // compared against it (e.g. to detect cohort filter additions). It is stored as a
+        // reducer rather than derived from props because the logic may outlive the initial
+        // props.action (e.g. when the logic is mounted eagerly by the scene logic before the
+        // action has loaded).
+        originalAction: [
+            (props.action ?? null) as ActionType | null,
+            {
+                setOriginalAction: (_, { action }) => action,
+            },
+        ],
+    })),
     forms(({ actions, props }) => ({
         action: {
             defaults:
@@ -140,6 +156,7 @@ export const actionEditLogic = kea<actionEditLogicType>([
 
                 lemonToast.success(`Action saved`)
                 actions.resetAction(updatedAction)
+                actions.setOriginalAction(action)
                 refreshTreeItem('action', String(action.id))
                 if (!props.id) {
                     // Mark task complete when creating a new action
@@ -147,7 +164,7 @@ export const actionEditLogic = kea<actionEditLogicType>([
                     router.actions.push(urls.action(action.id))
                 } else {
                     const id = parseInt(props.id.toString()) // props.id can be a string
-                    const logic = actionLogic.findMounted(id)
+                    const logic = actionLogic.findMounted({ tabId: props.tabId, id })
                     logic?.actions.loadActionSuccess(action)
                 }
 
@@ -168,7 +185,7 @@ export const actionEditLogic = kea<actionEditLogicType>([
                 false,
         ],
         originalActionHasCohortFilters: [
-            () => [(_, p: ActionEditLogicProps) => p.action],
+            (s) => [s.originalAction],
             (action) =>
                 action?.steps?.some((step: ActionStepType) => step.properties?.find((p: any) => p.type === 'cohort')) ??
                 false,
@@ -251,6 +268,7 @@ export const actionEditLogic = kea<actionEditLogicType>([
             if (props.action) {
                 // Sync the prop action with the internal state when mounting with an existing action
                 actions.setAction(props.action, { merge: false })
+                actions.setOriginalAction(props.action)
             }
             actions.loadReferences()
         }
@@ -292,6 +310,24 @@ export const actionEditLogic = kea<actionEditLogicType>([
             // Ignore in-page URL updates such as opening the side panel
             if (newLocation && newLocation.pathname === router.values.location.pathname) {
                 return false
+            }
+
+            // Skip the prompt when the user is merely switching to another tab — our tab still
+            // exists, the logic stays mounted via the scene-logic cache, and the form state is
+            // preserved. We only want to prompt when the user is actually leaving this tab
+            // (closing it, or navigating within it to a different URL).
+            const myTabId = logic.props.tabId
+            const scene = sceneLogic.findMounted()
+            if (myTabId && scene && newLocation) {
+                const tabs = scene.values.tabs
+                const myTab = tabs.find((t) => t.id === myTabId)
+                const stillExists = Boolean(myTab)
+                const destinationMatchesAnotherTab = tabs.some(
+                    (t) => t.id !== myTabId && t.pathname === newLocation.pathname
+                )
+                if (stillExists && destinationMatchesAnotherTab) {
+                    return false
+                }
             }
 
             return true

--- a/products/actions/frontend/logics/actionLogic.ts
+++ b/products/actions/frontend/logics/actionLogic.ts
@@ -15,11 +15,15 @@ import type { actionLogicType } from './actionLogicType'
 
 export interface ActionLogicProps {
     id: ActionType['id']
+    tabId?: string
 }
 
 export const actionLogic = kea<actionLogicType>([
     props({} as ActionLogicProps),
-    key((props) => props.id || 'new'),
+    // Key by tabId AND id so each tab preserves its own mounted scene-logic instance across
+    // tab switches. The scene-logic cache keeps this instance alive while another tab is
+    // active, which in turn keeps the held actionEditLogic alive (and its form state intact).
+    key((props) => `${props.tabId || 'notab'}:${props.id || 'new'}`),
     connect(() => ({
         values: [featureFlagLogic, ['featureFlags']],
     })),
@@ -76,6 +80,7 @@ export const actionLogic = kea<actionLogicType>([
         ],
     })),
     selectors({
+        tabId: [() => [(_, p: ActionLogicProps) => p.tabId], (tabId): string | undefined => tabId],
         projectTreeRef: [(_, p) => [p.id], (id): ProjectTreeRef => ({ type: 'action', ref: String(id) })],
         hasCohortFilters: [
             (s) => [s.action],
@@ -88,7 +93,8 @@ export const actionLogic = kea<actionLogicType>([
             (s) => [
                 s.action,
                 (state, props) =>
-                    actionEditLogic.findMounted(String(props?.id || 'new'))?.selectors.action(state).name || null,
+                    actionEditLogic.findMounted({ tabId: props?.tabId, id: props?.id })?.selectors.action(state).name ||
+                    null,
             ],
             (action, inProgressName): Breadcrumb[] => [
                 {
@@ -134,12 +140,19 @@ export const actionLogic = kea<actionLogicType>([
             actions.checkIsFinished(action)
         },
     })),
-    events(({ values, actions, props }) => ({
+    events(({ values, actions, props, cache }) => ({
         afterMount: () => {
             props.id && actions.loadAction()
+            // Mount actionEditLogic eagerly so it stays alive via our scene-logic instance
+            // for the duration of this tab. Because sceneLogic keeps one actionLogic per
+            // tab mounted in `cache.mountedTabLogic`, the edit logic (and therefore the
+            // in-progress form state) survives tab switches even when the scene component
+            // unmounts.
+            cache.editLogicUnmount = actionEditLogic({ tabId: props.tabId, id: props.id }).mount()
         },
         beforeUnmount: () => {
             values.pollTimeout && clearTimeout(values.pollTimeout)
+            cache.editLogicUnmount?.()
         },
     })),
 ])

--- a/products/actions/frontend/logics/actionLogic.ts
+++ b/products/actions/frontend/logics/actionLogic.ts
@@ -140,19 +140,12 @@ export const actionLogic = kea<actionLogicType>([
             actions.checkIsFinished(action)
         },
     })),
-    events(({ values, actions, props, cache }) => ({
+    events(({ values, actions, props }) => ({
         afterMount: () => {
             props.id && actions.loadAction()
-            // Mount actionEditLogic eagerly so it stays alive via our scene-logic instance
-            // for the duration of this tab. Because sceneLogic keeps one actionLogic per
-            // tab mounted in `cache.mountedTabLogic`, the edit logic (and therefore the
-            // in-progress form state) survives tab switches even when the scene component
-            // unmounts.
-            cache.editLogicUnmount = actionEditLogic({ tabId: props.tabId, id: props.id }).mount()
         },
         beforeUnmount: () => {
             values.pollTimeout && clearTimeout(values.pollTimeout)
-            cache.editLogicUnmount?.()
         },
     })),
 ])

--- a/products/actions/frontend/pages/Action.tsx
+++ b/products/actions/frontend/pages/Action.tsx
@@ -12,8 +12,10 @@ export const scene: SceneExport<ActionLogicProps> = {
     paramsToProps: ({ params: { id } }) => ({ id: parseInt(id) }),
 }
 
-export function Action({ id }: ActionLogicProps): JSX.Element {
-    const { action, actionLoading } = useValues(actionLogic({ id }))
+export function Action({ id, tabId }: ActionLogicProps): JSX.Element {
+    // Use the scene-bound logic (BindLogic in App.tsx supplies tabId), so we don't need to
+    // duplicate the key props here.
+    const { action, actionLoading } = useValues(actionLogic)
 
-    return <ActionEdit id={id} action={action} actionLoading={actionLoading} />
+    return <ActionEdit id={id} tabId={tabId} action={action} actionLoading={actionLoading} />
 }

--- a/products/actions/frontend/pages/Action.tsx
+++ b/products/actions/frontend/pages/Action.tsx
@@ -17,5 +17,16 @@ export function Action({ id, tabId }: ActionLogicProps): JSX.Element {
     // duplicate the key props here.
     const { action, actionLoading } = useValues(actionLogic)
 
-    return <ActionEdit id={id} tabId={tabId} action={action} actionLoading={actionLoading} />
+    return (
+        <ActionEdit
+            id={id}
+            tabId={tabId}
+            action={action}
+            actionLoading={actionLoading}
+            // Attach actionEditLogic to the scene-kept actionLogic so the form state survives
+            // tab switches: sceneLogic keeps actionLogic mounted per tab, and useAttachedLogic
+            // keeps actionEditLogic alive for as long as actionLogic is mounted.
+            attachTo={actionLogic({ id, tabId })}
+        />
+    )
 }

--- a/products/actions/frontend/pages/ActionEdit.tsx
+++ b/products/actions/frontend/pages/ActionEdit.tsx
@@ -1,4 +1,4 @@
-import { useActions, useValues } from 'kea'
+import { BuiltLogic, Logic, LogicWrapper, useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { router } from 'kea-router'
 import { useEffect, useMemo } from 'react'
@@ -21,6 +21,7 @@ import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
+import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { getAccessControlDisabledReason, userHasAccess } from 'lib/utils/accessControlUtils'
 import { interProjectCopyLogic } from 'scenes/resource-transfer/interProjectCopyLogic'
@@ -57,9 +58,10 @@ const RESOURCE_TYPE = 'action'
 
 export interface ActionEditProps extends ActionEditLogicProps {
     actionLoading?: boolean
+    attachTo?: BuiltLogic<Logic> | LogicWrapper<Logic>
 }
 
-export function ActionEdit({ action: loadedAction, id, tabId, actionLoading }: ActionEditProps): JSX.Element {
+export function ActionEdit({ action: loadedAction, id, tabId, actionLoading, attachTo }: ActionEditProps): JSX.Element {
     const logicProps: ActionEditLogicProps = {
         id,
         action: loadedAction,
@@ -67,12 +69,16 @@ export function ActionEdit({ action: loadedAction, id, tabId, actionLoading }: A
     }
     const { isComplete } = useValues(actionLogic)
     const logic = actionEditLogic(logicProps)
+    // Attach to the scene-kept actionLogic so the form state persists across tab switches:
+    // sceneLogic keeps actionLogic mounted per tab, and useAttachedLogic keeps actionEditLogic
+    // alive for as long as actionLogic is mounted, even when this component unmounts.
+    useAttachedLogic(logic, attachTo)
     const { action, actionChanged } = useValues(logic)
     const { submitAction, deleteAction, setActionValue, setAction, setOriginalAction } = useActions(logic)
 
     // Sync the loaded action prop with the logic's internal state. This runs after load even
-    // when the logic was mounted eagerly by the scene logic (before the action was loaded),
-    // so the form and originalAction reducer both get populated once the data arrives.
+    // when the logic was mounted eagerly by useAttachedLogic (before the action has finished
+    // loading), so the form and originalAction reducer both get populated once the data arrives.
     useEffect(() => {
         if (loadedAction && (!action || action.id !== loadedAction.id)) {
             setAction(loadedAction, { merge: false })

--- a/products/actions/frontend/pages/ActionEdit.tsx
+++ b/products/actions/frontend/pages/ActionEdit.tsx
@@ -59,22 +59,26 @@ export interface ActionEditProps extends ActionEditLogicProps {
     actionLoading?: boolean
 }
 
-export function ActionEdit({ action: loadedAction, id, actionLoading }: ActionEditProps): JSX.Element {
+export function ActionEdit({ action: loadedAction, id, tabId, actionLoading }: ActionEditProps): JSX.Element {
     const logicProps: ActionEditLogicProps = {
-        id: id,
+        id,
         action: loadedAction,
+        tabId,
     }
-    const { isComplete } = useValues(actionLogic({ id }))
+    const { isComplete } = useValues(actionLogic)
     const logic = actionEditLogic(logicProps)
     const { action, actionChanged } = useValues(logic)
-    const { submitAction, deleteAction, setActionValue, setAction } = useActions(logic)
+    const { submitAction, deleteAction, setActionValue, setAction, setOriginalAction } = useActions(logic)
 
-    // Sync the loaded action prop with the logic's internal state
+    // Sync the loaded action prop with the logic's internal state. This runs after load even
+    // when the logic was mounted eagerly by the scene logic (before the action was loaded),
+    // so the form and originalAction reducer both get populated once the data arrives.
     useEffect(() => {
         if (loadedAction && (!action || action.id !== loadedAction.id)) {
             setAction(loadedAction, { merge: false })
+            setOriginalAction(loadedAction)
         }
-    }, [loadedAction, action, setAction])
+    }, [loadedAction, action, setAction, setOriginalAction])
     const { tags } = useValues(tagsModel)
     const { addProductIntentForCrossSell } = useActions(teamLogic)
     const { canCopyToProject } = useValues(interProjectCopyLogic)

--- a/products/actions/frontend/pages/ActionEdit.tsx
+++ b/products/actions/frontend/pages/ActionEdit.tsx
@@ -73,7 +73,7 @@ export function ActionEdit({ action: loadedAction, id, tabId, actionLoading, att
     // sceneLogic keeps actionLogic mounted per tab, and useAttachedLogic keeps actionEditLogic
     // alive for as long as actionLogic is mounted, even when this component unmounts.
     useAttachedLogic(logic, attachTo)
-    const { action, actionChanged } = useValues(logic)
+    const { action, actionChanged, isActionSubmitting } = useValues(logic)
     const { submitAction, deleteAction, setActionValue, setAction, setOriginalAction } = useActions(logic)
 
     // Sync the loaded action prop with the logic's internal state. This runs after load even
@@ -244,7 +244,7 @@ export function ActionEdit({ action: loadedAction, id, tabId, actionLoading, att
                                 data-attr="save-action-button"
                                 type="primary"
                                 htmlType="submit"
-                                loading={actionLoading}
+                                loading={isActionSubmitting}
                                 onClick={(e) => {
                                     e.preventDefault()
                                     if (id) {
@@ -255,7 +255,9 @@ export function ActionEdit({ action: loadedAction, id, tabId, actionLoading, att
                                     }
                                 }}
                                 size="small"
-                                disabledReason={!actionChanged ? 'No changes to save' : undefined}
+                                disabledReason={
+                                    isActionSubmitting ? 'Saving…' : !actionChanged ? 'No changes to save' : undefined
+                                }
                             >
                                 {actionChanged ? 'Save' : 'No changes'}
                             </LemonButton>


### PR DESCRIPTION
## Problem

When multiple scene tabs are open and you start filling in the New Action form, switching tabs triggered a "leave action?" prompt and — on confirm — wiped the form. After saving, the button had no loading state either, so double-clicks produced "action with this name already exists."

Also, saving in the New Action form has no loading state.

## Changes

- Make `actionLogic` and `actionEditLogic` tab-aware (keyed by `tabId:id`).
- Attach `actionEditLogic` to the scene-kept `actionLogic` via `useAttachedLogic` so the form survives tab switches (matches the `cohortEditLogic` pattern).
- Refine `beforeUnload.enabled` using `sceneLogic.activeTabId`: skip the prompt both when switching away (active tab has moved) and when switching back (destination matches our tab's own pathname). In-tab navigation and tab closures still prompt.
- Move `originalActionHasCohortFilters` off `props.action` onto an `originalAction` reducer, since props are frozen at mount time and the logic is now mounted eagerly.
- Wire the Save button's `loading`/`disabledReason` to kea-forms' `isActionSubmitting` instead of the unrelated `actionLoading` GET flag.

## How did you test this code?

Manually.

## Publish to changelog?

no