### PR TITLE
feat(ch-migrate): add exchange_rate production schema YAML

### DIFF
--- a/posthog/clickhouse/schema/exchange_rate.yaml
+++ b/posthog/clickhouse/schema/exchange_rate.yaml
@@ -1,0 +1,20 @@
+ecosystem: exchange_rate
+cluster: main
+tables:
+    exchange_rate:
+        engine: ReplicatedReplacingMergeTree
+        on_nodes: all
+        order_by:
+            - date
+            - currency
+        columns:
+            - name: currency
+              type: String
+            - name: date
+              type: Date
+            - name: rate
+              type: Decimal64(10)
+            - name: version
+              type: UInt32
+              default_kind: DEFAULT
+              default_expression: toUnixTimestamp(now())


### PR DESCRIPTION
## Problem

The ch_migrate tool has no production schema YAMLs — only a test table. `ch_migrate plan` runs but manages nothing.

## Changes

- `posthog/clickhouse/schema/exchange_rate.yaml` — declarative desired-state spec for the `exchange_rate` table (ReplicatedReplacingMergeTree, 4 columns). First production table in the ch_migrate schema registry.

The dictionary (`exchange_rate_dict`) is omitted from this PR — dictionary YAML support is in PR15 and will be added in a follow-up.

## Dependencies

Requires PR6 (YAML parser), PR10 (plan command) to be useful. PR15 (templates) required for `apply` to generate correct DDL.

## How did you test this code?

Draft — `ch_migrate plan` parses the YAML and diffs against live ClickHouse once the tool chain is merged.

## Publish to changelog?

No

## 🤖 LLM context

Agent-authored draft PR. Part of the ch_migrate schema adoption track (PR17, first production YAML).