### PR TITLE
feat(ducklake): add team_id label to DuckLake copy workflow metrics

### DIFF
--- a/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
@@ -813,7 +813,7 @@ class DuckLakeCopyDataImportsWorkflow(PostHogWorkflow):
                 if verification_results:
                     for result in verification_results:
                         status = "passed" if result.passed else "failed"
-                        get_ducklake_copy_data_imports_verification_metric(result.name, status).add(1)
+                        get_ducklake_copy_data_imports_verification_metric(inputs.team_id, result.name, status).add(1)
 
                 failed_checks = [result for result in verification_results if not result.passed]
                 if failed_checks:
@@ -841,7 +841,7 @@ class DuckLakeCopyDataImportsWorkflow(PostHogWorkflow):
                     pending_staging_cleanup.remove(model.staging_uri)
         except Exception:
             failed = True
-            get_ducklake_copy_data_imports_finished_metric(status="failed").add(1)
+            get_ducklake_copy_data_imports_finished_metric(status="failed", team_id=inputs.team_id).add(1)
             raise
         finally:
             for staging_uri in pending_staging_cleanup:
@@ -862,4 +862,4 @@ class DuckLakeCopyDataImportsWorkflow(PostHogWorkflow):
                     )
 
         if not failed:
-            get_ducklake_copy_data_imports_finished_metric(status="completed").add(1)
+            get_ducklake_copy_data_imports_finished_metric(status="completed", team_id=inputs.team_id).add(1)

--- a/posthog/temporal/ducklake/ducklake_copy_data_modeling_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_copy_data_modeling_workflow.py
@@ -443,7 +443,7 @@ class DuckLakeCopyDataModelingWorkflow(PostHogWorkflow):
                 if verification_results:
                     for result in verification_results:
                         status = "passed" if result.passed else "failed"
-                        get_ducklake_copy_data_modeling_verification_metric(result.name, status).add(1)
+                        get_ducklake_copy_data_modeling_verification_metric(inputs.team_id, result.name, status).add(1)
 
                 failed_checks = [result for result in verification_results if not result.passed]
                 if failed_checks:
@@ -471,7 +471,7 @@ class DuckLakeCopyDataModelingWorkflow(PostHogWorkflow):
                     pending_staging_cleanup.remove(model.staging_uri)
         except Exception:
             failed = True
-            get_ducklake_copy_data_modeling_finished_metric(status="failed").add(1)
+            get_ducklake_copy_data_modeling_finished_metric(status="failed", team_id=inputs.team_id).add(1)
             raise
         finally:
             for staging_uri in pending_staging_cleanup:
@@ -492,7 +492,7 @@ class DuckLakeCopyDataModelingWorkflow(PostHogWorkflow):
                     )
 
         if not failed:
-            get_ducklake_copy_data_modeling_finished_metric(status="completed").add(1)
+            get_ducklake_copy_data_modeling_finished_metric(status="completed", team_id=inputs.team_id).add(1)
 
 
 def _copy_data_modeling_via_duckgres(inputs: DuckLakeCopyActivityInputs, logger) -> None:

--- a/posthog/temporal/ducklake/metrics.py
+++ b/posthog/temporal/ducklake/metrics.py
@@ -2,10 +2,10 @@ from temporalio import workflow
 from temporalio.common import MetricCounter
 
 
-def get_ducklake_copy_data_modeling_finished_metric(status: str) -> MetricCounter:
+def get_ducklake_copy_data_modeling_finished_metric(team_id: int, status: str) -> MetricCounter:
     return (
         workflow.metric_meter()
-        .with_additional_attributes({"status": status})
+        .with_additional_attributes({"status": status, "team_id": str(team_id)})
         .create_counter(
             "ducklake_copy_data_modeling_finished",
             "Number of DuckLake data modeling copy workflows finished, including failures.",
@@ -13,10 +13,10 @@ def get_ducklake_copy_data_modeling_finished_metric(status: str) -> MetricCounte
     )
 
 
-def get_ducklake_copy_data_modeling_verification_metric(check: str, status: str) -> MetricCounter:
+def get_ducklake_copy_data_modeling_verification_metric(team_id: int, check: str, status: str) -> MetricCounter:
     return (
         workflow.metric_meter()
-        .with_additional_attributes({"check": check, "status": status})
+        .with_additional_attributes({"check": check, "status": status, "team_id": str(team_id)})
         .create_counter(
             "ducklake_copy_data_modeling_verification",
             "Number of DuckLake data modeling verification checks executed grouped by status.",
@@ -24,10 +24,10 @@ def get_ducklake_copy_data_modeling_verification_metric(check: str, status: str)
     )
 
 
-def get_ducklake_copy_data_imports_finished_metric(status: str) -> MetricCounter:
+def get_ducklake_copy_data_imports_finished_metric(team_id: int, status: str) -> MetricCounter:
     return (
         workflow.metric_meter()
-        .with_additional_attributes({"status": status})
+        .with_additional_attributes({"status": status, "team_id": str(team_id)})
         .create_counter(
             "ducklake_copy_data_imports_finished",
             "Number of DuckLake data imports copy workflows finished, including failures.",
@@ -35,10 +35,10 @@ def get_ducklake_copy_data_imports_finished_metric(status: str) -> MetricCounter
     )
 
 
-def get_ducklake_copy_data_imports_verification_metric(check_name: str, status: str) -> MetricCounter:
+def get_ducklake_copy_data_imports_verification_metric(team_id: int, check_name: str, status: str) -> MetricCounter:
     return (
         workflow.metric_meter()
-        .with_additional_attributes({"check": check_name, "status": status})
+        .with_additional_attributes({"check": check_name, "status": status, "team_id": str(team_id)})
         .create_counter(
             "ducklake_copy_data_imports_verification",
             "Number of DuckLake data imports verification checks completed.",


### PR DESCRIPTION
## Problem

The DuckLake copy workflow metrics (`ducklake_copy_data_imports_finished`, `ducklake_copy_data_imports_verification`, and their data modeling counterparts) lack a `team_id` label, making it impossible to filter by team in Grafana/VictoriaMetrics dashboards.

## Changes

Adds `team_id` as a metric attribute to all four DuckLake copy metric counters in both the data imports and data modeling workflows. Follows the existing convention from `posthog/temporal/data_imports/pipelines/pipeline_v3/metrics.py` where `team_id` is passed as a string and placed as the first parameter.

## How did you test this code?

No existing tests for this metrics code. The change is mechanical — adding a parameter to 4 metric factory functions and passing `inputs.team_id` at all 6 call sites. Cardinality is bounded by the `ducklake-data-imports-copy-workflow` feature flag rollout.

## Publish to changelog?

No

## Docs update

N/A