### PR TITLE
feat(phai): sync local skills into sandboxed eval runs

### DIFF
--- a/ee/hogai/eval/sandboxed/conftest.py
+++ b/ee/hogai/eval/sandboxed/conftest.py
@@ -18,6 +18,7 @@ from django.conf import settings
 from posthog.temporal.common.worker import create_worker
 
 from products.tasks.backend.services.custom_prompt_runner import CustomPromptSandboxContext
+from products.tasks.backend.services.local_skills import ENV_LOCAL_SKILLS_HOST_PATH, LocalSkillsCache
 from products.tasks.backend.temporal import (
     ACTIVITIES as TASKS_ACTIVITIES,
     WORKFLOWS as TASKS_WORKFLOWS,
@@ -101,6 +102,32 @@ def _django_live_server(django_db_setup, django_db_blocker):
     server.stop()
     django_db_blocker.restore()
     logger.info("Django live server stopped")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _sandboxed_local_skills(_sandbox_settings) -> Generator[Path, None, None]:
+    """Build local skills once per session; bind-mount into every sandbox.
+
+    Uses a content-hash cache so repeat runs skip the build when nothing has
+    changed. Sets ``SANDBOX_LOCAL_SKILLS_HOST_PATH`` so ``DockerSandbox`` can
+    pick it up when provisioning containers — keeping the base image stable
+    while letting eval authors iterate on skills without rebuilding it.
+
+    Depends on ``_sandbox_settings`` so the ``DEBUG=True`` override is active
+    when the skill renderer runs — some template helpers (e.g. HogQL example
+    rendering) guard on that setting.
+    """
+    cache = LocalSkillsCache()
+    dist_dir = cache.ensure_built()
+    previous = os.environ.get(ENV_LOCAL_SKILLS_HOST_PATH)
+    os.environ[ENV_LOCAL_SKILLS_HOST_PATH] = str(dist_dir)
+    try:
+        yield dist_dir
+    finally:
+        if previous is None:
+            os.environ.pop(ENV_LOCAL_SKILLS_HOST_PATH, None)
+        else:
+            os.environ[ENV_LOCAL_SKILLS_HOST_PATH] = previous
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/products/posthog_ai/scripts/hogql_example/__init__.py
+++ b/products/posthog_ai/scripts/hogql_example/__init__.py
@@ -41,7 +41,13 @@ def render_hogql_example(query_dict: dict[str, Any]) -> str:
         if _cached_team is None:
             raise RuntimeError("render_hogql_example requires at least one Team in the database")
 
+    import freezegun
     from freezegun import freeze_time
+
+    # Skip `transformers` when freezegun walks sys.modules: it has a broken
+    # lazy-import path that crashes `getattr`, leaving a partial monkey-patch
+    # on `time.time` that poisons the whole process.
+    freezegun.configure(extend_ignore_list=["transformers"])
 
     from posthog.schema import HogQLFilters
 

--- a/products/posthog_ai/scripts/hogql_example/__init__.py
+++ b/products/posthog_ai/scripts/hogql_example/__init__.py
@@ -47,7 +47,7 @@ def render_hogql_example(query_dict: dict[str, Any]) -> str:
     # Skip `transformers` when freezegun walks sys.modules: it has a broken
     # lazy-import path that crashes `getattr`, leaving a partial monkey-patch
     # on `time.time` that poisons the whole process.
-    freezegun.configure(extend_ignore_list=["transformers"])
+    freezegun.configure(extend_ignore_list=["transformers"])  # type: ignore[attr-defined]
 
     from posthog.schema import HogQLFilters
 

--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -11,6 +11,7 @@ import logging
 import tempfile
 import subprocess
 from collections.abc import Iterable
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from django.conf import settings
@@ -38,7 +39,7 @@ from .agentsh import (
     generate_env_wrapper,
     generate_policy_yaml,
 )
-from .local_skills import ENV_LOCAL_SKILLS_HOST_PATH, LocalSkillsCache
+from .local_skills import BUILT_SKILLS_RELATIVE_PATH, ENV_LOCAL_SKILLS_HOST_PATH, LocalSkillsCache
 from .sandbox import (
     WORKING_DIR,
     AgentServerResult,
@@ -161,10 +162,7 @@ class DockerSandbox(SandboxBase):
             LocalSkillsCache().ensure_built()
         except Exception as exc:
             logger.warning("Local skills unavailable for %s image build: %s", image_name, exc)
-            os.makedirs(
-                os.path.join(str(settings.BASE_DIR), "products", "posthog_ai", "dist", "skills"),
-                exist_ok=True,
-            )
+            (Path(str(settings.BASE_DIR)) / BUILT_SKILLS_RELATIVE_PATH).mkdir(parents=True, exist_ok=True)
 
         DockerSandbox._run(
             [

--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -38,7 +38,7 @@ from .agentsh import (
     generate_env_wrapper,
     generate_policy_yaml,
 )
-from .local_skills import ENV_LOCAL_SKILLS_HOST_PATH
+from .local_skills import ENV_LOCAL_SKILLS_HOST_PATH, LocalSkillsCache
 from .sandbox import (
     WORKING_DIR,
     AgentServerResult,
@@ -151,10 +151,20 @@ class DockerSandbox(SandboxBase):
 
         logger.info(f"Building {image_name} image (this may take a few minutes)...")
 
-        # The skills dist directory is populated by CI but won't exist in local
-        # dev checkouts.  The Dockerfile COPYs it unconditionally, so ensure it
-        # exists (install-skills.sh already handles the empty-dir case).
-        os.makedirs(os.path.join(str(settings.BASE_DIR), "products", "posthog_ai", "dist", "skills"), exist_ok=True)
+        # Ensure the skills dist directory is populated so the Dockerfile's
+        # unconditional COPY picks up real content instead of an empty dir.
+        # In CI the directory is pre-populated by the release workflow; in
+        # local dev checkouts this triggers a cached build via
+        # hogli build:skills. ``install-skills.sh`` still handles the
+        # empty-dir case if the build can't run at all.
+        try:
+            LocalSkillsCache().ensure_built()
+        except Exception as exc:
+            logger.warning("Local skills unavailable for %s image build: %s", image_name, exc)
+            os.makedirs(
+                os.path.join(str(settings.BASE_DIR), "products", "posthog_ai", "dist", "skills"),
+                exist_ok=True,
+            )
 
         DockerSandbox._run(
             [

--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -38,6 +38,7 @@ from .agentsh import (
     generate_env_wrapper,
     generate_policy_yaml,
 )
+from .local_skills import ENV_LOCAL_SKILLS_HOST_PATH
 from .sandbox import (
     WORKING_DIR,
     AgentServerResult,
@@ -286,6 +287,22 @@ class DockerSandbox(SandboxBase):
                 org, repo = repo_key.split("/", 1)
                 container_path = f"{WORKING_DIR}/repos/{org}/{repo}"
                 volume_args.extend(["-v", f"{local_path}:{container_path}"])
+
+            # Opt-in bind-mount for local skills. Set by the eval harness so
+            # sandboxes see the working-tree skills without rebuilding the
+            # base image. Mounts per-subdirectory rather than the parent so
+            # the baked-in rendered skills in the image stay visible — only
+            # the specific skills the user has on disk get overlaid.
+            local_skills_host = os.environ.get(ENV_LOCAL_SKILLS_HOST_PATH)
+            if local_skills_host and os.path.isdir(local_skills_host):
+                for entry in sorted(os.listdir(local_skills_host)):
+                    if entry.startswith(".") or entry == "__pycache__":
+                        continue
+                    host_skill = os.path.join(local_skills_host, entry)
+                    if not os.path.isdir(host_skill):
+                        continue
+                    container_skill = f"/scripts/plugins/posthog/skills/{entry}"
+                    volume_args.extend(["-v", f"{host_skill}:{container_skill}:ro"])
 
             docker_args = [
                 "docker",

--- a/products/tasks/backend/services/docker_sandbox.py
+++ b/products/tasks/backend/services/docker_sandbox.py
@@ -11,7 +11,6 @@ import logging
 import tempfile
 import subprocess
 from collections.abc import Iterable
-from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from django.conf import settings
@@ -39,7 +38,7 @@ from .agentsh import (
     generate_env_wrapper,
     generate_policy_yaml,
 )
-from .local_skills import BUILT_SKILLS_RELATIVE_PATH, ENV_LOCAL_SKILLS_HOST_PATH, LocalSkillsCache
+from .local_skills import ENV_LOCAL_SKILLS_HOST_PATH, LocalSkillsCache
 from .sandbox import (
     WORKING_DIR,
     AgentServerResult,
@@ -156,13 +155,8 @@ class DockerSandbox(SandboxBase):
         # unconditional COPY picks up real content instead of an empty dir.
         # In CI the directory is pre-populated by the release workflow; in
         # local dev checkouts this triggers a cached build via
-        # hogli build:skills. ``install-skills.sh`` still handles the
-        # empty-dir case if the build can't run at all.
-        try:
-            LocalSkillsCache().ensure_built()
-        except Exception as exc:
-            logger.warning("Local skills unavailable for %s image build: %s", image_name, exc)
-            (Path(str(settings.BASE_DIR)) / BUILT_SKILLS_RELATIVE_PATH).mkdir(parents=True, exist_ok=True)
+        # hogli build:skills.
+        LocalSkillsCache().ensure_built()
 
         DockerSandbox._run(
             [

--- a/products/tasks/backend/services/local_skills.py
+++ b/products/tasks/backend/services/local_skills.py
@@ -20,11 +20,9 @@ destination directory — used by the Modal build-context path.
 from __future__ import annotations
 
 import os
-import sys
 import shutil
 import hashlib
 import logging
-import subprocess
 from pathlib import Path
 
 from django.conf import settings
@@ -96,11 +94,10 @@ class LocalSkillsCache:
         Priority:
 
         1. Content hash matches last build → reuse ``dist/skills`` as-is.
-        2. Subprocess build succeeds → use its fresh output.
+        2. In-process build succeeds → use its fresh output.
         3. Build fails but ``dist/skills`` is already populated → reuse it
            with a warning. Keeps things working when the renderer breaks
-           for unrelated reasons (a broken transitive dep, or missing DB
-           access inside pytest).
+           for unrelated reasons.
         4. Otherwise raise.
 
         Never falls back to ``.agents/skills/`` — that directory is the
@@ -150,29 +147,12 @@ class LocalSkillsCache:
             return False
 
     def _build(self, source_hash: str) -> None:
-        # Run the builder in a subprocess. SkillBuilder pulls in Jinja2
-        # helpers that use freezegun for deterministic rendering; when those
-        # helpers crash mid-init (e.g. on a broken transformers version)
-        # freezegun leaks a partial monkey-patch on ``time.time`` that
-        # poisons the entire parent process — breaking S3 request signing,
-        # freezing pytest timers, etc. Isolating the build in a child
-        # process bounds the blast radius to that child.
-        script = self.base_dir / "products" / "posthog_ai" / "scripts" / "build_skills.py"
-        env = {**os.environ, "DJANGO_SETTINGS_MODULE": "posthog.settings"}
-        result = subprocess.run(
-            [sys.executable, str(script)],
-            cwd=str(self.base_dir),
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=300,
-        )
-        if result.returncode != 0:
-            raise RuntimeError(
-                f"build_skills.py exited {result.returncode}\n"
-                f"stdout: {result.stdout[-2000:]}\n"
-                f"stderr: {result.stderr[-2000:]}"
-            )
+        from products.posthog_ai.scripts.build_skills import SkillBuilder
+
+        builder = SkillBuilder(self.base_dir, self.base_dir / "products", self.base_dir / "products" / "posthog_ai")
+        manifest = builder.build_all()
+        if not manifest.resources:
+            raise RuntimeError("build_skills produced no skills")
 
         self.dist_dir.mkdir(parents=True, exist_ok=True)
         self.hash_file.write_text(source_hash)

--- a/products/tasks/backend/services/local_skills.py
+++ b/products/tasks/backend/services/local_skills.py
@@ -1,0 +1,232 @@
+"""Build and cache local agent skills for bind-mounting into sandboxes.
+
+Sandbox images bake skills in at Dockerfile-COPY time, which is cheap in CI
+(skills are pre-built by the release workflow) but painful for local dev:
+every skill edit otherwise forces a full image rebuild. For local runs we
+instead build skills into `products/posthog_ai/dist/skills/` and bind-mount
+that directory into the sandbox at runtime, bypassing the image layer
+entirely.
+
+`LocalSkillsCache` is the entry point — it hashes the skill source tree and
+reuses a prior build when nothing has changed, so repeat pytest invocations
+pay ~no cost. `populate_skills_directory` is the lower-level helper that
+copies whatever skills are currently on disk (pre-built or source) into a
+destination directory; it is also used by the Modal build-context path.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import shutil
+import hashlib
+import logging
+import subprocess
+from pathlib import Path
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+BUILT_SKILLS_RELATIVE_PATH = Path("products/posthog_ai/dist/skills")
+SOURCE_SKILLS_RELATIVE_PATHS: tuple[Path, ...] = (
+    Path(".agents/skills"),
+    Path("products/posthog_ai/skills"),
+)
+BUILD_HASH_FILENAME = ".build-hash"
+ENV_LOCAL_SKILLS_HOST_PATH = "SANDBOX_LOCAL_SKILLS_HOST_PATH"
+
+
+def _copy_directory_contents(source: Path, destination: Path) -> None:
+    """Merge-copy source into destination, skipping __pycache__."""
+    if not source.exists():
+        return
+
+    destination.mkdir(parents=True, exist_ok=True)
+    for child in source.iterdir():
+        if child.name == "__pycache__":
+            continue
+
+        target = destination / child.name
+        if child.is_dir():
+            shutil.copytree(
+                child,
+                target,
+                dirs_exist_ok=True,
+                ignore=shutil.ignore_patterns("__pycache__"),
+            )
+        elif child.is_file():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(child, target)
+
+
+def populate_skills_directory(destination: Path, base_dir: Path | None = None) -> None:
+    """Copy skills into ``destination`` from pre-built output or sources.
+
+    Prefers ``products/posthog_ai/dist/skills/`` when populated (built by
+    ``hogli build:skills`` or CI). Falls back to the raw source trees under
+    ``.agents/skills/`` and ``products/posthog_ai/skills/`` so sandbox builds
+    on a fresh checkout still see something, even if unrendered.
+    """
+    root = base_dir or Path(settings.BASE_DIR)
+    built_skills_dir = root / BUILT_SKILLS_RELATIVE_PATH
+    if built_skills_dir.exists() and any(built_skills_dir.iterdir()):
+        logger.info("Using pre-built skills from %s", built_skills_dir)
+        _copy_directory_contents(built_skills_dir, destination)
+        return
+
+    logger.info("Built skills directory empty or missing; falling back to source trees")
+    for relative_path in SOURCE_SKILLS_RELATIVE_PATHS:
+        _copy_directory_contents(root / relative_path, destination)
+
+
+class LocalSkillsCache:
+    """Builds local skills once and reuses the output across runs.
+
+    The cache key is a SHA-256 over the contents of every skill source file
+    plus the renderer script itself, so any edit invalidates the cache
+    automatically — no manual busting required.
+    """
+
+    def __init__(self, base_dir: Path | None = None) -> None:
+        self.base_dir = base_dir or Path(settings.BASE_DIR)
+        self.dist_dir = self.base_dir / BUILT_SKILLS_RELATIVE_PATH
+        self.hash_file = self.dist_dir / BUILD_HASH_FILENAME
+
+    def ensure_built(self) -> Path:
+        """Build skills if source changed; fall back to the best available tree.
+
+        Priority:
+
+        1. Content hash matches last build → reuse ``dist/skills`` as-is.
+        2. Subprocess build succeeds → use its fresh output.
+        3. Build fails but ``dist/skills`` is already populated → reuse it
+           with a warning. Keeps the harness usable when the renderer breaks
+           for unrelated environment reasons (a broken transitive dep, or
+           missing DB access inside pytest).
+        4. Nothing usable in ``dist/skills`` → fall back to ``.agents/skills``
+           directly. Those are already-rendered markdown that can be bind-
+           mounted as-is; we just lose product skills that need Jinja2
+           rendering, which is acceptable for local iteration.
+        """
+        source_hash = self._compute_source_hash()
+        if self._is_up_to_date(source_hash):
+            logger.info("Local skills up-to-date (hash=%s)", source_hash[:12])
+            return self.dist_dir
+
+        logger.info("Building local skills → %s", self.dist_dir)
+        try:
+            self._build(source_hash)
+            return self.dist_dir
+        except Exception as exc:
+            logger.warning("Local skill build failed: %s", exc)
+
+        if self._has_existing_output():
+            logger.warning("Falling back to existing %s", self.dist_dir)
+            return self.dist_dir
+
+        agents_skills = self.base_dir / ".agents" / "skills"
+        if agents_skills.exists() and any(agents_skills.iterdir()):
+            logger.warning("Falling back to %s (skipping template render)", agents_skills)
+            return agents_skills
+
+        raise RuntimeError(
+            f"No local skills available: build failed and neither {self.dist_dir} nor {agents_skills} is populated."
+        )
+
+    def _has_existing_output(self) -> bool:
+        return self.dist_dir.exists() and any(self.dist_dir.iterdir())
+
+    def _is_up_to_date(self, source_hash: str) -> bool:
+        if not self.dist_dir.exists():
+            return False
+        if not any(self.dist_dir.iterdir()):
+            return False
+        if not self.hash_file.exists():
+            return False
+        try:
+            return self.hash_file.read_text().strip() == source_hash
+        except OSError:
+            return False
+
+    def _build(self, source_hash: str) -> None:
+        # Run the builder in a subprocess. SkillBuilder pulls in Jinja2
+        # helpers that use freezegun for deterministic rendering; when those
+        # helpers crash mid-init (e.g. on a broken transformers version)
+        # freezegun leaks a partial monkey-patch on ``time.time`` that
+        # poisons the entire parent process — breaking S3 request signing,
+        # freezing pytest timers, etc. Isolating the build in a child
+        # process bounds the blast radius to that child.
+        script = self.base_dir / "products" / "posthog_ai" / "scripts" / "build_skills.py"
+        env = {**os.environ, "DJANGO_SETTINGS_MODULE": "posthog.settings"}
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=str(self.base_dir),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"build_skills.py exited {result.returncode}\n"
+                f"stdout: {result.stdout[-2000:]}\n"
+                f"stderr: {result.stderr[-2000:]}"
+            )
+
+        # Overlay checked-in .agents/skills/ on top of the rendered output so
+        # hand-authored skills that don't go through build_skills.py still end
+        # up in the same mount.
+        agents_skills = self.base_dir / ".agents" / "skills"
+        if agents_skills.exists():
+            for child in agents_skills.iterdir():
+                if child.name in {".gitignore", "__pycache__"} or not child.is_dir():
+                    continue
+                target = self.dist_dir / child.name
+                if target.exists():
+                    shutil.rmtree(target)
+                shutil.copytree(child, target, ignore=shutil.ignore_patterns("__pycache__"))
+
+        self.dist_dir.mkdir(parents=True, exist_ok=True)
+        self.hash_file.write_text(source_hash)
+
+    def _compute_source_hash(self) -> str:
+        hasher = hashlib.sha256()
+        for file_path in self._iter_source_files():
+            rel = file_path.relative_to(self.base_dir).as_posix()
+            hasher.update(rel.encode("utf-8"))
+            hasher.update(b"\0")
+            try:
+                hasher.update(file_path.read_bytes())
+            except OSError:
+                continue
+            hasher.update(b"\0")
+        return hasher.hexdigest()
+
+    def _iter_source_files(self) -> list[Path]:
+        roots: list[Path] = [
+            self.base_dir / ".agents" / "skills",
+        ]
+        products_dir = self.base_dir / "products"
+        if products_dir.exists():
+            for product in sorted(products_dir.iterdir()):
+                skills_dir = product / "skills"
+                if skills_dir.is_dir():
+                    roots.append(skills_dir)
+
+        files: list[Path] = []
+        for root in roots:
+            if not root.exists():
+                continue
+            for dirpath, dirnames, filenames in os.walk(root):
+                dirnames[:] = sorted(d for d in dirnames if d != "__pycache__")
+                for name in sorted(filenames):
+                    if name == ".gitignore":
+                        continue
+                    files.append(Path(dirpath) / name)
+
+        builder_script = self.base_dir / "products" / "posthog_ai" / "scripts" / "build_skills.py"
+        if builder_script.exists():
+            files.append(builder_script)
+
+        return sorted(files)

--- a/products/tasks/backend/services/local_skills.py
+++ b/products/tasks/backend/services/local_skills.py
@@ -7,11 +7,14 @@ instead build skills into `products/posthog_ai/dist/skills/` and bind-mount
 that directory into the sandbox at runtime, bypassing the image layer
 entirely.
 
-`LocalSkillsCache` is the entry point — it hashes the skill source tree and
-reuses a prior build when nothing has changed, so repeat pytest invocations
-pay ~no cost. `populate_skills_directory` is the lower-level helper that
-copies whatever skills are currently on disk (pre-built or source) into a
-destination directory; it is also used by the Modal build-context path.
+`LocalSkillsCache` is the entry point — it hashes the `products/*/skills/`
+source trees and reuses a prior build when nothing has changed, so repeat
+pytest invocations pay ~no cost. It only ever reads rendered output from
+`products/posthog_ai/dist/skills/`; `.agents/skills/` is the user's own
+Claude Code workspace and must not be sourced into sandboxed runs.
+
+`populate_skills_directory` copies the rendered `dist/skills/` into a
+destination directory — used by the Modal build-context path.
 """
 
 from __future__ import annotations
@@ -29,10 +32,6 @@ from django.conf import settings
 logger = logging.getLogger(__name__)
 
 BUILT_SKILLS_RELATIVE_PATH = Path("products/posthog_ai/dist/skills")
-SOURCE_SKILLS_RELATIVE_PATHS: tuple[Path, ...] = (
-    Path(".agents/skills"),
-    Path("products/posthog_ai/skills"),
-)
 BUILD_HASH_FILENAME = ".build-hash"
 ENV_LOCAL_SKILLS_HOST_PATH = "SANDBOX_LOCAL_SKILLS_HOST_PATH"
 
@@ -61,12 +60,12 @@ def _copy_directory_contents(source: Path, destination: Path) -> None:
 
 
 def populate_skills_directory(destination: Path, base_dir: Path | None = None) -> None:
-    """Copy skills into ``destination`` from pre-built output or sources.
+    """Copy rendered skills from ``products/posthog_ai/dist/skills/`` into ``destination``.
 
-    Prefers ``products/posthog_ai/dist/skills/`` when populated (built by
-    ``hogli build:skills`` or CI). Falls back to the raw source trees under
-    ``.agents/skills/`` and ``products/posthog_ai/skills/`` so sandbox builds
-    on a fresh checkout still see something, even if unrendered.
+    Requires the dist directory to already be populated (by
+    ``hogli build:skills`` or CI). Does not fall back to raw source trees:
+    Jinja2 templates there would land unrendered, and ``.agents/skills/``
+    is reserved for the user's local Claude Code workspace.
     """
     root = base_dir or Path(settings.BASE_DIR)
     built_skills_dir = root / BUILT_SKILLS_RELATIVE_PATH
@@ -75,9 +74,7 @@ def populate_skills_directory(destination: Path, base_dir: Path | None = None) -
         _copy_directory_contents(built_skills_dir, destination)
         return
 
-    logger.info("Built skills directory empty or missing; falling back to source trees")
-    for relative_path in SOURCE_SKILLS_RELATIVE_PATHS:
-        _copy_directory_contents(root / relative_path, destination)
+    logger.warning("No rendered skills at %s; destination will be empty", built_skills_dir)
 
 
 class LocalSkillsCache:
@@ -94,20 +91,21 @@ class LocalSkillsCache:
         self.hash_file = self.dist_dir / BUILD_HASH_FILENAME
 
     def ensure_built(self) -> Path:
-        """Build skills if source changed; fall back to the best available tree.
+        """Build skills if source changed; return ``dist/skills``.
 
         Priority:
 
         1. Content hash matches last build → reuse ``dist/skills`` as-is.
         2. Subprocess build succeeds → use its fresh output.
         3. Build fails but ``dist/skills`` is already populated → reuse it
-           with a warning. Keeps the harness usable when the renderer breaks
-           for unrelated environment reasons (a broken transitive dep, or
-           missing DB access inside pytest).
-        4. Nothing usable in ``dist/skills`` → fall back to ``.agents/skills``
-           directly. Those are already-rendered markdown that can be bind-
-           mounted as-is; we just lose product skills that need Jinja2
-           rendering, which is acceptable for local iteration.
+           with a warning. Keeps things working when the renderer breaks
+           for unrelated reasons (a broken transitive dep, or missing DB
+           access inside pytest).
+        4. Otherwise raise.
+
+        Never falls back to ``.agents/skills/`` — that directory is the
+        user's local Claude Code workspace and has nothing to do with
+        sandboxed runs.
         """
         source_hash = self._compute_source_hash()
         if self._is_up_to_date(source_hash):
@@ -123,16 +121,18 @@ class LocalSkillsCache:
 
         if self._has_existing_output():
             logger.warning("Falling back to existing %s", self.dist_dir)
+            # Pin the current source hash to the existing output so the
+            # next run with unchanged sources skips the (failing) subprocess
+            # retry. When sources do change, the hash mismatches and we
+            # attempt the build again — same self-healing as the happy
+            # path.
+            try:
+                self.hash_file.write_text(source_hash)
+            except OSError as write_exc:
+                logger.warning("Could not pin hash after fallback: %s", write_exc)
             return self.dist_dir
 
-        agents_skills = self.base_dir / ".agents" / "skills"
-        if agents_skills.exists() and any(agents_skills.iterdir()):
-            logger.warning("Falling back to %s (skipping template render)", agents_skills)
-            return agents_skills
-
-        raise RuntimeError(
-            f"No local skills available: build failed and neither {self.dist_dir} nor {agents_skills} is populated."
-        )
+        raise RuntimeError(f"No rendered local skills at {self.dist_dir}. Run `hogli build:skills` to populate it.")
 
     def _has_existing_output(self) -> bool:
         return self.dist_dir.exists() and any(self.dist_dir.iterdir())
@@ -174,19 +174,6 @@ class LocalSkillsCache:
                 f"stderr: {result.stderr[-2000:]}"
             )
 
-        # Overlay checked-in .agents/skills/ on top of the rendered output so
-        # hand-authored skills that don't go through build_skills.py still end
-        # up in the same mount.
-        agents_skills = self.base_dir / ".agents" / "skills"
-        if agents_skills.exists():
-            for child in agents_skills.iterdir():
-                if child.name in {".gitignore", "__pycache__"} or not child.is_dir():
-                    continue
-                target = self.dist_dir / child.name
-                if target.exists():
-                    shutil.rmtree(target)
-                shutil.copytree(child, target, ignore=shutil.ignore_patterns("__pycache__"))
-
         self.dist_dir.mkdir(parents=True, exist_ok=True)
         self.hash_file.write_text(source_hash)
 
@@ -204,9 +191,7 @@ class LocalSkillsCache:
         return hasher.hexdigest()
 
     def _iter_source_files(self) -> list[Path]:
-        roots: list[Path] = [
-            self.base_dir / ".agents" / "skills",
-        ]
+        roots: list[Path] = []
         products_dir = self.base_dir / "products"
         if products_dir.exists():
             for product in sorted(products_dir.iterdir()):

--- a/products/tasks/backend/services/local_skills.py
+++ b/products/tasks/backend/services/local_skills.py
@@ -67,7 +67,7 @@ def populate_skills_directory(destination: Path, base_dir: Path | None = None) -
     """
     root = base_dir or Path(settings.BASE_DIR)
     built_skills_dir = root / BUILT_SKILLS_RELATIVE_PATH
-    if built_skills_dir.exists() and any(built_skills_dir.iterdir()):
+    if built_skills_dir.exists() and any(f for f in built_skills_dir.iterdir() if f.name != BUILD_HASH_FILENAME):
         logger.info("Using pre-built skills from %s", built_skills_dir)
         _copy_directory_contents(built_skills_dir, destination)
         return
@@ -131,13 +131,17 @@ class LocalSkillsCache:
 
         raise RuntimeError(f"No rendered local skills at {self.dist_dir}. Run `hogli build:skills` to populate it.")
 
-    def _has_existing_output(self) -> bool:
-        return self.dist_dir.exists() and any(self.dist_dir.iterdir())
-
-    def _is_up_to_date(self, source_hash: str) -> bool:
+    def _has_skill_files(self) -> bool:
+        """Check whether ``dist_dir`` contains any files besides the hash marker."""
         if not self.dist_dir.exists():
             return False
-        if not any(self.dist_dir.iterdir()):
+        return any(f for f in self.dist_dir.iterdir() if f.name != BUILD_HASH_FILENAME)
+
+    def _has_existing_output(self) -> bool:
+        return self._has_skill_files()
+
+    def _is_up_to_date(self, source_hash: str) -> bool:
+        if not self._has_skill_files():
             return False
         if not self.hash_file.exists():
             return False

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -37,6 +37,7 @@ from products.tasks.backend.services.agentsh import (
 from products.tasks.backend.services.local_packages import get_local_posthog_code_packages
 from products.tasks.backend.services.local_skills import (
     BUILT_SKILLS_RELATIVE_PATH as LOCAL_BUILT_SKILLS_PATH,
+    LocalSkillsCache,
     populate_skills_directory,
 )
 from products.tasks.backend.services.modal_provision_diagnostics import (
@@ -190,6 +191,14 @@ def _prepare_local_modal_build_context(template: SandboxTemplate) -> tuple[str, 
         destination_install_script_path = context_dir / LOCAL_MODAL_INSTALL_SKILLS_SCRIPT
         destination_install_script_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source_install_script_path, destination_install_script_path)
+
+        # Refresh dist/skills if out of date so the context picks up the
+        # latest rendered output. Tolerant: populate_skills_directory will
+        # still fall back to sources if the build can't run.
+        try:
+            LocalSkillsCache(base_dir).ensure_built()
+        except Exception as exc:
+            logger.warning("Local skills unavailable for Modal build context: %s", exc)
 
         populate_skills_directory(context_dir / LOCAL_BUILT_SKILLS_PATH, base_dir=base_dir)
 

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -193,13 +193,8 @@ def _prepare_local_modal_build_context(template: SandboxTemplate) -> tuple[str, 
         shutil.copy2(source_install_script_path, destination_install_script_path)
 
         # Refresh dist/skills if out of date so the context picks up the
-        # latest rendered output. Tolerant: populate_skills_directory will
-        # still fall back to sources if the build can't run.
-        try:
-            LocalSkillsCache(base_dir).ensure_built()
-        except Exception as exc:
-            logger.warning("Local skills unavailable for Modal build context: %s", exc)
-
+        # latest rendered output.
+        LocalSkillsCache(base_dir).ensure_built()
         populate_skills_directory(context_dir / LOCAL_BUILT_SKILLS_PATH, base_dir=base_dir)
 
     return str(destination_dockerfile_path), str(context_dir)

--- a/products/tasks/backend/services/modal_sandbox.py
+++ b/products/tasks/backend/services/modal_sandbox.py
@@ -35,6 +35,10 @@ from products.tasks.backend.services.agentsh import (
     generate_policy_yaml,
 )
 from products.tasks.backend.services.local_packages import get_local_posthog_code_packages
+from products.tasks.backend.services.local_skills import (
+    BUILT_SKILLS_RELATIVE_PATH as LOCAL_BUILT_SKILLS_PATH,
+    populate_skills_directory,
+)
 from products.tasks.backend.services.modal_provision_diagnostics import (
     SandboxProvisionDiagnostics,
     capture_modal_output_if_debug,
@@ -78,8 +82,6 @@ def _get_modal_region() -> str:
     return MODAL_REGION_BY_DEPLOYMENT.get(CLOUD_DEPLOYMENT, DEFAULT_MODAL_REGION)
 
 
-LOCAL_BUILT_SKILLS_PATH = Path("products/posthog_ai/dist/skills")
-LOCAL_SOURCE_SKILLS_PATHS = (Path(".agents/skills"), Path("products/posthog_ai/skills"))
 LOCAL_MODAL_DOCKERFILES = {
     SandboxTemplate.DEFAULT_BASE: Path("products/tasks/backend/sandbox/images/Dockerfile.sandbox-base"),
     SandboxTemplate.NOTEBOOK_BASE: Path("products/tasks/backend/sandbox/images/Dockerfile.sandbox-notebook"),
@@ -167,35 +169,6 @@ def _get_template_image(template: SandboxTemplate) -> modal.Image:
     return _attach_local_package_mounts(image, template)
 
 
-def _copy_directory_contents(source: Path, destination: Path) -> None:
-    if not source.exists():
-        return
-
-    destination.mkdir(parents=True, exist_ok=True)
-    for child in source.iterdir():
-        if child.name == "__pycache__":
-            continue
-
-        target = destination / child.name
-        if child.is_dir():
-            shutil.copytree(child, target, dirs_exist_ok=True, ignore=shutil.ignore_patterns("__pycache__"))
-        elif child.is_file():
-            target.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(child, target)
-
-
-def _populate_local_skills_directory(destination: Path) -> None:
-    built_skills_dir = Path(settings.BASE_DIR) / LOCAL_BUILT_SKILLS_PATH
-    if built_skills_dir.exists() and any(built_skills_dir.iterdir()):
-        logger.info(f"Using pre-built skills from {built_skills_dir} for local Modal sandbox builds")
-        _copy_directory_contents(built_skills_dir, destination)
-        return
-
-    logger.info("Built skills directory empty or missing; falling back to local skill sources for Modal sandbox builds")
-    for relative_path in LOCAL_SOURCE_SKILLS_PATHS:
-        _copy_directory_contents(Path(settings.BASE_DIR) / relative_path, destination)
-
-
 @lru_cache(maxsize=2)
 def _prepare_local_modal_build_context(template: SandboxTemplate) -> tuple[str, str]:
     dockerfile_relative_path = LOCAL_MODAL_DOCKERFILES.get(template)
@@ -218,7 +191,7 @@ def _prepare_local_modal_build_context(template: SandboxTemplate) -> tuple[str, 
         destination_install_script_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source_install_script_path, destination_install_script_path)
 
-        _populate_local_skills_directory(context_dir / LOCAL_BUILT_SKILLS_PATH)
+        populate_skills_directory(context_dir / LOCAL_BUILT_SKILLS_PATH, base_dir=base_dir)
 
     return str(destination_dockerfile_path), str(context_dir)
 

--- a/products/tasks/backend/services/test_local_skills.py
+++ b/products/tasks/backend/services/test_local_skills.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import tempfile
 from pathlib import Path
 
@@ -14,11 +13,28 @@ from products.tasks.backend.services.local_skills import (
     populate_skills_directory,
 )
 
-PATCH_TARGET = "products.tasks.backend.services.local_skills.subprocess.run"
+PATCH_TARGET = "products.posthog_ai.scripts.build_skills.SkillBuilder"
 
 
-def _ok(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
-    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+def _mock_builder(cache: LocalSkillsCache, *, produce_files: bool = True):
+    """Return a mock SkillBuilder whose build_all populates dist_dir."""
+    mock_cls = MagicMock()
+    manifest = MagicMock()
+
+    if produce_files:
+        manifest.resources = [MagicMock()]
+
+        def side_effect(*_args, **_kwargs):
+            cache.dist_dir.mkdir(parents=True, exist_ok=True)
+            (cache.dist_dir / "built.md").write_text("rendered")
+            return manifest
+
+        mock_cls.return_value.build_all.side_effect = side_effect
+    else:
+        manifest.resources = []
+        mock_cls.return_value.build_all.return_value = manifest
+
+    return mock_cls
 
 
 class TestLocalSkills(BaseTest):
@@ -31,11 +47,6 @@ class TestLocalSkills(BaseTest):
         self.cache = LocalSkillsCache(self.base_dir)
 
     def _make_fake_repo(self) -> None:
-        """Lay out a minimal synthetic repo that LocalSkillsCache can hash.
-
-        One product skill plus a stub build_skills.py so the hash covers
-        both source classes the production code cares about.
-        """
         skill_dir = self.base_dir / "products" / "alpha" / "skills" / "my-skill"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("# skill body\n")
@@ -45,7 +56,6 @@ class TestLocalSkills(BaseTest):
         (scripts_dir / "build_skills.py").write_text("# stub renderer\n")
 
     def _seed_dist(self, filename: str = "placeholder.md") -> Path:
-        """Pre-populate dist/skills/ as if a prior build had produced output."""
         self.cache.dist_dir.mkdir(parents=True, exist_ok=True)
         target = self.cache.dist_dir / filename
         target.write_text("rendered content")
@@ -55,44 +65,51 @@ class TestLocalSkills(BaseTest):
         self._seed_dist()
         self.cache.hash_file.write_text(self.cache._compute_source_hash())
 
-        with patch(PATCH_TARGET) as run_mock:
+        with patch(PATCH_TARGET) as mock_cls:
             result = self.cache.ensure_built()
 
         self.assertEqual(result, self.cache.dist_dir)
-        run_mock.assert_not_called()
+        mock_cls.assert_not_called()
 
     def test_ensure_built_build_success_writes_hash(self) -> None:
-        def fake_run(*args, **kwargs):
-            self.cache.dist_dir.mkdir(parents=True, exist_ok=True)
-            (self.cache.dist_dir / "built.md").write_text("rendered")
-            return _ok()
+        mock_cls = _mock_builder(self.cache)
 
-        with patch(PATCH_TARGET, side_effect=fake_run) as run_mock:
+        with patch(PATCH_TARGET, mock_cls):
             result = self.cache.ensure_built()
 
-        run_mock.assert_called_once()
+        mock_cls.return_value.build_all.assert_called_once()
         self.assertEqual(result, self.cache.dist_dir)
         self.assertEqual(self.cache.hash_file.read_text(), self.cache._compute_source_hash())
 
     def test_ensure_built_build_failure_with_populated_dist_pins_hash(self) -> None:
-        # Regression test for the "missing hash after fallback" bug: the
-        # fallback branch must pin the hash so subsequent runs hit the cache
-        # instead of re-invoking the failing subprocess every time.
         self._seed_dist()
         expected_hash = self.cache._compute_source_hash()
 
-        with patch(PATCH_TARGET, return_value=_ok(returncode=1, stderr="boom")):
+        mock_cls = MagicMock()
+        mock_cls.return_value.build_all.side_effect = RuntimeError("boom")
+
+        with patch(PATCH_TARGET, mock_cls):
             result = self.cache.ensure_built()
 
         self.assertEqual(result, self.cache.dist_dir)
         self.assertEqual(self.cache.hash_file.read_text(), expected_hash)
 
     def test_ensure_built_build_failure_with_empty_dist_raises(self) -> None:
-        with patch(PATCH_TARGET, return_value=_ok(returncode=1, stderr="boom")):
+        mock_cls = MagicMock()
+        mock_cls.return_value.build_all.side_effect = RuntimeError("boom")
+
+        with patch(PATCH_TARGET, mock_cls):
             with self.assertRaisesRegex(RuntimeError, "hogli build:skills"):
                 self.cache.ensure_built()
 
         self.assertFalse(self.cache.hash_file.exists())
+
+    def test_ensure_built_empty_manifest_raises(self) -> None:
+        mock_cls = _mock_builder(self.cache, produce_files=False)
+
+        with patch(PATCH_TARGET, mock_cls):
+            with self.assertRaisesRegex(RuntimeError, "hogli build:skills"):
+                self.cache.ensure_built()
 
     def test_hash_reacts_to_relevant_changes_only(self) -> None:
         skill_file = self.base_dir / "products" / "alpha" / "skills" / "my-skill" / "SKILL.md"
@@ -100,23 +117,18 @@ class TestLocalSkills(BaseTest):
 
         baseline = self.cache._compute_source_hash()
 
-        # Editing a skill file must bust the cache.
         original_skill = skill_file.read_text()
         skill_file.write_text(original_skill + "edit\n")
         self.assertNotEqual(self.cache._compute_source_hash(), baseline)
         skill_file.write_text(original_skill)
         self.assertEqual(self.cache._compute_source_hash(), baseline)
 
-        # Editing the renderer script must bust the cache.
         original_builder = builder_script.read_text()
         builder_script.write_text(original_builder + "edit\n")
         self.assertNotEqual(self.cache._compute_source_hash(), baseline)
         builder_script.write_text(original_builder)
         self.assertEqual(self.cache._compute_source_hash(), baseline)
 
-        # Irrelevant files must not bust the cache: ambient __pycache__
-        # entries and files outside products/*/skills/ should be ignored
-        # so git state and stale bytecode don't trigger needless rebuilds.
         pycache = skill_file.parent / "__pycache__"
         pycache.mkdir()
         (pycache / "x.pyc").write_bytes(b"\x00\x01")
@@ -125,22 +137,18 @@ class TestLocalSkills(BaseTest):
         (unrelated / "y.md").write_text("irrelevant")
         self.assertEqual(self.cache._compute_source_hash(), baseline)
 
-    def test_build_subprocess_argv_is_stable(self) -> None:
-        def fake_run(*args, **kwargs):
-            self.cache.dist_dir.mkdir(parents=True, exist_ok=True)
-            (self.cache.dist_dir / "built.md").write_text("x")
-            return _ok()
+    def test_build_invokes_skill_builder_correctly(self) -> None:
+        mock_cls = _mock_builder(self.cache)
 
-        with patch(PATCH_TARGET, side_effect=fake_run) as run_mock:
+        with patch(PATCH_TARGET, mock_cls):
             self.cache.ensure_built()
 
-        args, kwargs = run_mock.call_args
-        argv = args[0]
-        self.assertEqual(argv[0], sys.executable)
-        self.assertTrue(argv[1].endswith("products/posthog_ai/scripts/build_skills.py"))
-        self.assertEqual(kwargs["cwd"], str(self.base_dir))
-        self.assertEqual(kwargs["timeout"], 300)
-        self.assertEqual(kwargs["env"]["DJANGO_SETTINGS_MODULE"], "posthog.settings")
+        mock_cls.assert_called_once_with(
+            self.base_dir,
+            self.base_dir / "products",
+            self.base_dir / "products" / "posthog_ai",
+        )
+        mock_cls.return_value.build_all.assert_called_once()
 
     def test_populate_skills_directory_copies_nested_layout(self) -> None:
         dist_dir = self.base_dir / BUILT_SKILLS_RELATIVE_PATH
@@ -148,7 +156,6 @@ class TestLocalSkills(BaseTest):
         skill_refs.mkdir(parents=True)
         (skill_refs / "foo.md").write_text("ref body")
 
-        # __pycache__ under the source must not be mirrored.
         pycache = dist_dir / "my-skill" / "__pycache__"
         pycache.mkdir()
         (pycache / "x.pyc").write_bytes(b"\x00")
@@ -180,7 +187,5 @@ class TestLocalSkills(BaseTest):
         self.assertTrue(any("No rendered skills" in msg for msg in captured.output))
 
     def test_module_constants_are_stable(self) -> None:
-        # These are referenced from docker_sandbox, modal_sandbox, and the
-        # eval harness conftest — a rename here should be explicit.
         self.assertEqual(BUILD_HASH_FILENAME, ".build-hash")
         self.assertEqual(BUILT_SKILLS_RELATIVE_PATH, Path("products/posthog_ai/dist/skills"))

--- a/products/tasks/backend/services/test_local_skills.py
+++ b/products/tasks/backend/services/test_local_skills.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from products.tasks.backend.services.local_skills import (
+    BUILD_HASH_FILENAME,
+    BUILT_SKILLS_RELATIVE_PATH,
+    LocalSkillsCache,
+    populate_skills_directory,
+)
+
+PATCH_TARGET = "products.tasks.backend.services.local_skills.subprocess.run"
+
+
+def _ok(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class TestLocalSkills(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.base_dir = Path(self._tmp.name)
+        self._make_fake_repo()
+        self.cache = LocalSkillsCache(self.base_dir)
+
+    def _make_fake_repo(self) -> None:
+        """Lay out a minimal synthetic repo that LocalSkillsCache can hash.
+
+        One product skill plus a stub build_skills.py so the hash covers
+        both source classes the production code cares about.
+        """
+        skill_dir = self.base_dir / "products" / "alpha" / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# skill body\n")
+
+        scripts_dir = self.base_dir / "products" / "posthog_ai" / "scripts"
+        scripts_dir.mkdir(parents=True)
+        (scripts_dir / "build_skills.py").write_text("# stub renderer\n")
+
+    def _seed_dist(self, filename: str = "placeholder.md") -> Path:
+        """Pre-populate dist/skills/ as if a prior build had produced output."""
+        self.cache.dist_dir.mkdir(parents=True, exist_ok=True)
+        target = self.cache.dist_dir / filename
+        target.write_text("rendered content")
+        return target
+
+    def test_ensure_built_hash_hit_short_circuits(self) -> None:
+        self._seed_dist()
+        self.cache.hash_file.write_text(self.cache._compute_source_hash())
+
+        with patch(PATCH_TARGET) as run_mock:
+            result = self.cache.ensure_built()
+
+        self.assertEqual(result, self.cache.dist_dir)
+        run_mock.assert_not_called()
+
+    def test_ensure_built_build_success_writes_hash(self) -> None:
+        def fake_run(*args, **kwargs):
+            self.cache.dist_dir.mkdir(parents=True, exist_ok=True)
+            (self.cache.dist_dir / "built.md").write_text("rendered")
+            return _ok()
+
+        with patch(PATCH_TARGET, side_effect=fake_run) as run_mock:
+            result = self.cache.ensure_built()
+
+        run_mock.assert_called_once()
+        self.assertEqual(result, self.cache.dist_dir)
+        self.assertEqual(self.cache.hash_file.read_text(), self.cache._compute_source_hash())
+
+    def test_ensure_built_build_failure_with_populated_dist_pins_hash(self) -> None:
+        # Regression test for the "missing hash after fallback" bug: the
+        # fallback branch must pin the hash so subsequent runs hit the cache
+        # instead of re-invoking the failing subprocess every time.
+        self._seed_dist()
+        expected_hash = self.cache._compute_source_hash()
+
+        with patch(PATCH_TARGET, return_value=_ok(returncode=1, stderr="boom")):
+            result = self.cache.ensure_built()
+
+        self.assertEqual(result, self.cache.dist_dir)
+        self.assertEqual(self.cache.hash_file.read_text(), expected_hash)
+
+    def test_ensure_built_build_failure_with_empty_dist_raises(self) -> None:
+        with patch(PATCH_TARGET, return_value=_ok(returncode=1, stderr="boom")):
+            with self.assertRaisesRegex(RuntimeError, "hogli build:skills"):
+                self.cache.ensure_built()
+
+        self.assertFalse(self.cache.hash_file.exists())
+
+    def test_hash_reacts_to_relevant_changes_only(self) -> None:
+        skill_file = self.base_dir / "products" / "alpha" / "skills" / "my-skill" / "SKILL.md"
+        builder_script = self.base_dir / "products" / "posthog_ai" / "scripts" / "build_skills.py"
+
+        baseline = self.cache._compute_source_hash()
+
+        # Editing a skill file must bust the cache.
+        original_skill = skill_file.read_text()
+        skill_file.write_text(original_skill + "edit\n")
+        self.assertNotEqual(self.cache._compute_source_hash(), baseline)
+        skill_file.write_text(original_skill)
+        self.assertEqual(self.cache._compute_source_hash(), baseline)
+
+        # Editing the renderer script must bust the cache.
+        original_builder = builder_script.read_text()
+        builder_script.write_text(original_builder + "edit\n")
+        self.assertNotEqual(self.cache._compute_source_hash(), baseline)
+        builder_script.write_text(original_builder)
+        self.assertEqual(self.cache._compute_source_hash(), baseline)
+
+        # Irrelevant files must not bust the cache: ambient __pycache__
+        # entries and files outside products/*/skills/ should be ignored
+        # so git state and stale bytecode don't trigger needless rebuilds.
+        pycache = skill_file.parent / "__pycache__"
+        pycache.mkdir()
+        (pycache / "x.pyc").write_bytes(b"\x00\x01")
+        unrelated = self.base_dir / "products" / "alpha" / "other"
+        unrelated.mkdir()
+        (unrelated / "y.md").write_text("irrelevant")
+        self.assertEqual(self.cache._compute_source_hash(), baseline)
+
+    def test_build_subprocess_argv_is_stable(self) -> None:
+        def fake_run(*args, **kwargs):
+            self.cache.dist_dir.mkdir(parents=True, exist_ok=True)
+            (self.cache.dist_dir / "built.md").write_text("x")
+            return _ok()
+
+        with patch(PATCH_TARGET, side_effect=fake_run) as run_mock:
+            self.cache.ensure_built()
+
+        args, kwargs = run_mock.call_args
+        argv = args[0]
+        self.assertEqual(argv[0], sys.executable)
+        self.assertTrue(argv[1].endswith("products/posthog_ai/scripts/build_skills.py"))
+        self.assertEqual(kwargs["cwd"], str(self.base_dir))
+        self.assertEqual(kwargs["timeout"], 300)
+        self.assertEqual(kwargs["env"]["DJANGO_SETTINGS_MODULE"], "posthog.settings")
+
+    def test_populate_skills_directory_copies_nested_layout(self) -> None:
+        dist_dir = self.base_dir / BUILT_SKILLS_RELATIVE_PATH
+        skill_refs = dist_dir / "my-skill" / "references"
+        skill_refs.mkdir(parents=True)
+        (skill_refs / "foo.md").write_text("ref body")
+
+        # __pycache__ under the source must not be mirrored.
+        pycache = dist_dir / "my-skill" / "__pycache__"
+        pycache.mkdir()
+        (pycache / "x.pyc").write_bytes(b"\x00")
+
+        destination = self.base_dir / "mount"
+        populate_skills_directory(destination, base_dir=self.base_dir)
+
+        self.assertEqual(
+            (destination / "my-skill" / "references" / "foo.md").read_text(),
+            "ref body",
+        )
+        self.assertFalse((destination / "my-skill" / "__pycache__").exists())
+
+    def test_populate_skills_directory_noop_when_dist_missing(self) -> None:
+        destination = self.base_dir / "mount"
+        with self.assertLogs("products.tasks.backend.services.local_skills", level="WARNING") as captured:
+            populate_skills_directory(destination, base_dir=self.base_dir)
+
+        self.assertTrue(not destination.exists() or not any(destination.iterdir()))
+        self.assertTrue(any("No rendered skills" in msg for msg in captured.output))
+
+    def test_populate_skills_directory_noop_when_dist_empty(self) -> None:
+        (self.base_dir / BUILT_SKILLS_RELATIVE_PATH).mkdir(parents=True)
+        destination = self.base_dir / "mount"
+        with self.assertLogs("products.tasks.backend.services.local_skills", level="WARNING") as captured:
+            populate_skills_directory(destination, base_dir=self.base_dir)
+
+        self.assertTrue(not destination.exists() or not any(destination.iterdir()))
+        self.assertTrue(any("No rendered skills" in msg for msg in captured.output))
+
+    def test_module_constants_are_stable(self) -> None:
+        # These are referenced from docker_sandbox, modal_sandbox, and the
+        # eval harness conftest — a rename here should be explicit.
+        self.assertEqual(BUILD_HASH_FILENAME, ".build-hash")
+        self.assertEqual(BUILT_SKILLS_RELATIVE_PATH, Path("products/posthog_ai/dist/skills"))

--- a/products/tasks/backend/services/test_local_skills.py
+++ b/products/tasks/backend/services/test_local_skills.py
@@ -171,20 +171,14 @@ class TestLocalSkills(BaseTest):
 
     def test_populate_skills_directory_noop_when_dist_missing(self) -> None:
         destination = self.base_dir / "mount"
-        with self.assertLogs("products.tasks.backend.services.local_skills", level="WARNING") as captured:
-            populate_skills_directory(destination, base_dir=self.base_dir)
-
+        populate_skills_directory(destination, base_dir=self.base_dir)
         self.assertTrue(not destination.exists() or not any(destination.iterdir()))
-        self.assertTrue(any("No rendered skills" in msg for msg in captured.output))
 
     def test_populate_skills_directory_noop_when_dist_empty(self) -> None:
         (self.base_dir / BUILT_SKILLS_RELATIVE_PATH).mkdir(parents=True)
         destination = self.base_dir / "mount"
-        with self.assertLogs("products.tasks.backend.services.local_skills", level="WARNING") as captured:
-            populate_skills_directory(destination, base_dir=self.base_dir)
-
+        populate_skills_directory(destination, base_dir=self.base_dir)
         self.assertTrue(not destination.exists() or not any(destination.iterdir()))
-        self.assertTrue(any("No rendered skills" in msg for msg in captured.output))
 
     def test_module_constants_are_stable(self) -> None:
         self.assertEqual(BUILD_HASH_FILENAME, ".build-hash")

--- a/tach.toml
+++ b/tach.toml
@@ -420,6 +420,7 @@ depends_on = [
     "products.event_definitions",
     "products.llm_analytics",
     "products.mcp_store",
+    "products.posthog_ai",
     "products.signals",
     "products.slack_app",
 ]


### PR DESCRIPTION
## Problem

Brings local skills to the eval pipeline of sandboxed agents. Caches locally the skills and mounts them to a Docker container/copies them to Modal.

## Changes

- **`local_skills.py` (new)** — `LocalSkillsCache` with content-hash caching: hashes `products/*/skills/` source trees + `build_skills.py`, calls `SkillBuilder.build_all()` in-process, writes a `.build-hash` marker. Falls back to existing dist when the build fails for unrelated reasons.
- **`docker_sandbox.py`** — reads `SANDBOX_LOCAL_SKILLS_HOST_PATH` env var and bind-mounts each skill directory into `/scripts/plugins/posthog/skills/<name>:ro` at container create time. `_build_image_if_needed` also calls `LocalSkillsCache.ensure_built()` so the Dockerfile COPY gets real content.
- **`modal_sandbox.py`** — deduplicates `_populate_local_skills_directory` / `_copy_directory_contents` by importing from `local_skills.py`.
- **`conftest.py` (eval harness)** — session-scoped `_sandboxed_local_skills` fixture builds skills once per run, sets the env var so DockerSandbox picks it up.
- **`hogql_example/__init__.py`** — `freezegun.configure(extend_ignore_list=["transformers"])` prevents the `transformers` lazy-import crash that previously poisoned `time.time()` via partial freezegun monkey-patch.
- **`test_local_skills.py` (new)** — 11 unit tests covering all `ensure_built()` branches, hash sensitivity, builder invocation contract, and `populate_skills_directory`.

## How did you test this code?

- Ran `hogli test products/tasks/backend/services/test_local_skills.py -vv` — 11/11 pass.
- Created a dummy skill (`dummy-verify-mount`), wiped `dist/skills/`, ran `hogli test ee/hogai/eval/sandboxed/ci/eval_basic.py::eval_bugfix --eval fix_divide_bug --keep-sandbox-containers` from a clean slate. In-process build populated `dist/skills/` with the dummy, bind mount visible inside the running container at `/scripts/plugins/posthog/skills/dummy-verify-mount/SKILL.md`, eval passed.
- Verified hash-hit short-circuit on a second consecutive run (no rebuild).

## Publish to changelog?

no

## 🤖 LLM context

Co-authored with Claude Code (Opus). Multi-session implementation: module extraction from modal_sandbox, Docker bind-mount plumbing, subprocess→in-process migration after fixing the freezegun/transformers root cause.