### PR TITLE
fix(ci): remove python installation step from clickhouse docker

### DIFF
--- a/docker/clickhouse/docker-entrypoint-initdb.d/init-db.sh
+++ b/docker/clickhouse/docker-entrypoint-initdb.d/init-db.sh
@@ -1,14 +1,6 @@
 #!/bin/bash
 set -e
 
-apt-get update
-apt-get -y install python3.9
-
-# Check if /usr/bin/python3 already exists and if it points to python3.9
-if [[ $(readlink /usr/bin/python3) != "/usr/bin/python3.9" ]]; then
-    ln -sf /usr/bin/python3.9 /usr/bin/python3
-fi
-
 cp -r /idl/* /var/lib/clickhouse/format_schemas/
 
 # Wait for ClickHouse to be ready to accept queries, then flush log tables to ensure


### PR DESCRIPTION
## Problem

The docker entrypoint for the ClickHouse images sporadically fails downloading python 3.9. Python is not required any more, as it was only used for Funnel UDFs, which are now written in Rust.

## Changes

Removes the python installation step.

## How did you test this code?

CI is green on this PR