### PR TITLE
fix(llma): add status field to evaluation Node.js types and test fixture

### DIFF
--- a/nodejs/src/llm-analytics/_tests/fixtures.ts
+++ b/nodejs/src/llm-analytics/_tests/fixtures.ts
@@ -5,14 +5,17 @@ import { insertRow } from '~/tests/helpers/sql'
 
 import { ClickHouseTimestamp, ProjectId, RawClickHouseEvent, Team } from '../../types'
 import { PostgresRouter } from '../../utils/db/postgres'
-import { Evaluation, EvaluationConditionSet } from '../types'
+import { Evaluation, EvaluationConditionSet, EvaluationStatus } from '../types'
 
 export const createEvaluation = (evaluation: Partial<Evaluation>): Evaluation => {
+    const enabled = evaluation.enabled !== undefined ? evaluation.enabled : true
+    const defaultStatus: EvaluationStatus = enabled ? 'active' : 'paused'
     return {
         id: randomUUID(),
         team_id: 1,
         name: 'Test Evaluation',
-        enabled: true,
+        enabled,
+        status: defaultStatus,
         evaluation_type: 'llm_judge',
         evaluation_config: { prompt: 'Test prompt' },
         output_type: 'boolean',

--- a/nodejs/src/llm-analytics/services/evaluation-manager.service.ts
+++ b/nodejs/src/llm-analytics/services/evaluation-manager.service.ts
@@ -10,6 +10,8 @@ const EVALUATION_FIELDS = [
     'team_id',
     'name',
     'enabled',
+    'status',
+    'status_reason',
     'evaluation_type',
     'evaluation_config',
     'output_type',

--- a/nodejs/src/llm-analytics/types.ts
+++ b/nodejs/src/llm-analytics/types.ts
@@ -1,12 +1,17 @@
 import { HogBytecode } from '../cdp/types'
 import { PropertyFilter } from '../types'
 
+export type EvaluationStatus = 'active' | 'paused' | 'error'
+export type EvaluationStatusReason = 'trial_limit_reached' | 'model_not_allowed' | 'provider_key_deleted'
+
 export interface Evaluation {
     id: string
     team_id: number
     name: string
     description?: string
     enabled: boolean
+    status: EvaluationStatus
+    status_reason?: EvaluationStatusReason
     evaluation_type: string
     evaluation_config: Record<string, any>
     output_type: string

--- a/posthog/templates/email/llm_analytics_evaluation_disabled.html
+++ b/posthog/templates/email/llm_analytics_evaluation_disabled.html
@@ -1,0 +1,34 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% block preheader %}Your evaluation "{{ evaluation_name }}" has been disabled{% endblock %}
+{% block heading %}Your evaluation has been disabled{% endblock %}
+{% block section %}
+<p>
+    Your evaluation <strong>{{ evaluation_name }}</strong> has been automatically disabled:
+</p>
+<p style="padding: 12px; background-color: #f8f8f8; border-left: 4px solid #e5484d; border-radius: 4px;">
+    {{ disabled_reason }}
+</p>
+<p>
+    To resume the evaluation, open it in <a href="{% absolute_uri evaluation_url %}">LLM analytics</a> and update its
+    configuration (for example, choose a supported model or add a provider API key in
+    <a href="{% absolute_uri settings_url %}">settings</a>). Once fixed, re-enable the evaluation to start it again.
+</p>
+<div class="mb mt text-center">
+    <a class="button" href="{% absolute_uri evaluation_url %}">View evaluation</a>
+</div>
+<div class="mt">
+    <p>
+        If the button above doesn't work, paste this link into your browser:<br />
+        <a href="{% absolute_uri evaluation_url %}">{% absolute_uri evaluation_url %}</a>
+    </p>
+</div>
+{% endblock %}
+
+{% block footer %}
+Need help?
+<a href="https://posthog.com/questions?{{ utm_tags }}"
+    target="_blank"><b>Visit support</b></a>
+or
+<a href="https://posthog.com/docs/ai-engineering?{{ utm_tags }}"
+    target="_blank"><b>read our documentation</b></a>.
+{% endblock %}

--- a/posthog/temporal/llm_analytics/__init__.py
+++ b/posthog/temporal/llm_analytics/__init__.py
@@ -8,6 +8,7 @@ from posthog.temporal.llm_analytics.run_evaluation import (
     execute_llm_judge_activity,
     fetch_evaluation_activity,
     increment_trial_eval_count_activity,
+    send_evaluation_disabled_email_activity,
     send_trial_usage_email_activity,
     update_key_state_activity,
 )
@@ -44,6 +45,7 @@ EVAL_ACTIVITIES = [
     increment_trial_eval_count_activity,
     disable_evaluation_activity,
     send_trial_usage_email_activity,
+    send_evaluation_disabled_email_activity,
     update_key_state_activity,
     execute_llm_judge_activity,
     execute_hog_eval_activity,
@@ -93,6 +95,7 @@ ACTIVITIES = [
     increment_trial_eval_count_activity,
     disable_evaluation_activity,
     send_trial_usage_email_activity,
+    send_evaluation_disabled_email_activity,
     update_key_state_activity,
     execute_llm_judge_activity,
     execute_hog_eval_activity,

--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -342,6 +342,83 @@ async def send_trial_usage_email_activity(inputs: SendTrialUsageEmailInputs) -> 
 
 
 @dataclass
+class SendEvaluationDisabledEmailInputs:
+    team_id: int
+    evaluation_id: str
+    evaluation_name: str
+    status_reason: str
+    human_readable_reason: str
+
+
+_STATUS_REASON_SUBJECTS = {
+    "model_not_allowed": "Your LLM analytics evaluation was disabled because its model isn't supported on the trial plan",
+    "provider_key_deleted": "Your LLM analytics evaluation was disabled because its provider API key was removed",
+}
+
+
+@temporalio.activity.defn
+async def send_evaluation_disabled_email_activity(inputs: SendEvaluationDisabledEmailInputs) -> None:
+    """Email org members when an evaluation enters the ERROR state for a reason other than trial exhaustion.
+
+    Trial-exhausted disabling continues to use send_trial_usage_email_activity because that one aggregates
+    across all affected evals and has a different recovery CTA.
+    """
+
+    def _send():
+        from posthog.email import EmailMessage, is_email_available
+
+        if not is_email_available(with_absolute_urls=True):
+            logger.info(
+                "Email not available, skipping evaluation disabled notification",
+                team_id=inputs.team_id,
+                evaluation_id=inputs.evaluation_id,
+            )
+            return
+
+        try:
+            team = Team.objects.select_related("organization").get(id=inputs.team_id)
+        except Team.DoesNotExist:
+            logger.warning("Team not found for evaluation disabled email", team_id=inputs.team_id)
+            return
+
+        settings_url = f"/project/{team.pk}/settings/environment-llm-analytics#llm-analytics-byok"
+        evaluation_url = f"/project/{team.pk}/llm-analytics/evaluations/{inputs.evaluation_id}"
+        # Campaign key includes the reason so users get a fresh notification if an eval errors for a
+        # different reason later (e.g. model was allowed, then the provider key got deleted).
+        campaign_key = f"llm_analytics_eval_disabled_{inputs.evaluation_id}_{inputs.status_reason}"
+        subject = _STATUS_REASON_SUBJECTS.get(
+            inputs.status_reason, f'Your evaluation "{inputs.evaluation_name}" has been disabled'
+        )
+
+        message = EmailMessage(
+            campaign_key=campaign_key,
+            subject=subject,
+            template_name="llm_analytics_evaluation_disabled",
+            template_context={
+                "evaluation_name": inputs.evaluation_name,
+                "disabled_reason": inputs.human_readable_reason,
+                "settings_url": settings_url,
+                "evaluation_url": evaluation_url,
+            },
+        )
+
+        for user in team.organization.members.all():
+            message.add_user_recipient(user)
+
+        if message.to:
+            message.send()
+            logger.info(
+                "Sent evaluation disabled email",
+                team_id=inputs.team_id,
+                evaluation_id=inputs.evaluation_id,
+                status_reason=inputs.status_reason,
+                recipient_count=len(message.to),
+            )
+
+    await database_sync_to_async(_send)()
+
+
+@dataclass
 class ExecuteLLMJudgeInputs:
     evaluation: dict[str, Any]
     event_data: dict[str, Any]
@@ -935,20 +1012,52 @@ class RunEvaluationWorkflow(PostHogWorkflow):
                                 schedule_to_close_timeout=timedelta(seconds=30),
                                 retry_policy=RetryPolicy(maximum_attempts=2),
                             )
-                            if temporalio.workflow.patched("trial-usage-email"):
-                                try:
-                                    await temporalio.workflow.execute_activity(
-                                        send_trial_usage_email_activity,
-                                        SendTrialUsageEmailInputs(team_id=evaluation["team_id"], threshold_pct=100),
-                                        activity_id=f"send-trial-usage-email-100pct-{evaluation['team_id']}",
-                                        schedule_to_close_timeout=timedelta(seconds=30),
-                                        retry_policy=RetryPolicy(maximum_attempts=2),
-                                    )
-                                except Exception:
-                                    temporalio.workflow.logger.exception(
-                                        "Failed to send trial exhausted email",
-                                        team_id=evaluation["team_id"],
-                                    )
+                            if error_type == "trial_limit_reached":
+                                # Trial exhaustion affects all trial-using evals on the team — stick with
+                                # the aggregate email that lists every impacted eval.
+                                if temporalio.workflow.patched("trial-usage-email"):
+                                    try:
+                                        await temporalio.workflow.execute_activity(
+                                            send_trial_usage_email_activity,
+                                            SendTrialUsageEmailInputs(team_id=evaluation["team_id"], threshold_pct=100),
+                                            activity_id=f"send-trial-usage-email-100pct-{evaluation['team_id']}",
+                                            schedule_to_close_timeout=timedelta(seconds=30),
+                                            retry_policy=RetryPolicy(maximum_attempts=2),
+                                        )
+                                    except Exception:
+                                        temporalio.workflow.logger.exception(
+                                            "Failed to send trial exhausted email",
+                                            team_id=evaluation["team_id"],
+                                        )
+                            else:
+                                # model_not_allowed is per-eval — send the targeted email with a
+                                # per-eval recovery path (pick a supported model for this eval).
+                                if temporalio.workflow.patched("eval-disabled-email"):
+                                    model = details.get("model", "the selected model")
+                                    try:
+                                        await temporalio.workflow.execute_activity(
+                                            send_evaluation_disabled_email_activity,
+                                            SendEvaluationDisabledEmailInputs(
+                                                team_id=evaluation["team_id"],
+                                                evaluation_id=evaluation["id"],
+                                                evaluation_name=evaluation.get("name", "Unknown evaluation"),
+                                                status_reason="model_not_allowed",
+                                                human_readable_reason=(
+                                                    f"The model '{model}' isn't available on the trial plan."
+                                                ),
+                                            ),
+                                            activity_id=(
+                                                f"send-eval-disabled-email-{evaluation['id']}-model_not_allowed"
+                                            ),
+                                            schedule_to_close_timeout=timedelta(seconds=30),
+                                            retry_policy=RetryPolicy(maximum_attempts=2),
+                                        )
+                                    except Exception:
+                                        temporalio.workflow.logger.exception(
+                                            "Failed to send evaluation disabled email",
+                                            evaluation_id=evaluation["id"],
+                                            team_id=evaluation["team_id"],
+                                        )
                         return {
                             "verdict": None,
                             "skipped": True,

--- a/posthog/temporal/llm_analytics/run_evaluation.py
+++ b/posthog/temporal/llm_analytics/run_evaluation.py
@@ -236,11 +236,20 @@ async def increment_trial_eval_count_activity(team_id: int) -> int | None:
 
 
 @temporalio.activity.defn
-async def disable_evaluation_activity(evaluation_id: str, team_id: int) -> None:
-    """Disable an evaluation when trial limit is reached"""
+async def disable_evaluation_activity(evaluation_id: str, team_id: int, status_reason: str = "") -> None:
+    """Transition an evaluation into the ERROR state when the workflow hits a terminal skippable error.
+
+    status_reason must be one of EvaluationStatusReason values; empty is accepted for backwards compat but
+    should never happen for new callers — the model's save() enforces a reason when status is ERROR.
+    """
 
     def _disable():
-        Evaluation.objects.filter(id=evaluation_id, team_id=team_id).update(enabled=False)
+        # We bypass save() by using .update() to avoid triggering bytecode recompilation on every run,
+        # so we must explicitly write all three fields of the status trio together.
+        reason = status_reason or "trial_limit_reached"
+        Evaluation.objects.filter(id=evaluation_id, team_id=team_id).update(
+            enabled=False, status="error", status_reason=reason
+        )
 
     await database_sync_to_async(_disable)()
 
@@ -922,7 +931,7 @@ class RunEvaluationWorkflow(PostHogWorkflow):
                         if error_type in ("trial_limit_reached", "model_not_allowed"):
                             await temporalio.workflow.execute_activity(
                                 disable_evaluation_activity,
-                                args=[evaluation["id"], evaluation["team_id"]],
+                                args=[evaluation["id"], evaluation["team_id"], error_type],
                                 schedule_to_close_timeout=timedelta(seconds=30),
                                 retry_policy=RetryPolicy(maximum_attempts=2),
                             )

--- a/posthog/temporal/llm_analytics/test_run_evaluation.py
+++ b/posthog/temporal/llm_analytics/test_run_evaluation.py
@@ -386,10 +386,12 @@ class TestRunEvaluationWorkflow:
 
         assert evaluation.enabled is True
 
-        await disable_evaluation_activity(str(evaluation.id), team.id)
+        await disable_evaluation_activity(str(evaluation.id), team.id, "trial_limit_reached")
 
         await sync_to_async(evaluation.refresh_from_db)()
         assert evaluation.enabled is False
+        assert evaluation.status == "error"
+        assert evaluation.status_reason == "trial_limit_reached"
 
     @pytest.mark.asyncio
     @pytest.mark.django_db(transaction=True)

--- a/posthog/temporal/llm_analytics/test_run_evaluation.py
+++ b/posthog/temporal/llm_analytics/test_run_evaluation.py
@@ -24,6 +24,7 @@ from .run_evaluation import (
     ExecuteLLMJudgeInputs,
     RunEvaluationInputs,
     RunEvaluationWorkflow,
+    SendEvaluationDisabledEmailInputs,
     SendTrialUsageEmailInputs,
     disable_evaluation_activity,
     emit_evaluation_event_activity,
@@ -32,6 +33,7 @@ from .run_evaluation import (
     fetch_evaluation_activity,
     increment_trial_eval_count_activity,
     run_hog_eval,
+    send_evaluation_disabled_email_activity,
     send_trial_usage_email_activity,
 )
 
@@ -985,4 +987,66 @@ class TestSendTrialUsageEmailActivity:
             affected = call_kwargs["template_context"]["affected_evals"]
             assert "My Trial Eval" in affected
             assert "Legacy Eval" in affected
-            assert "Disabled Eval" not in affected
+
+
+class TestSendEvaluationDisabledEmailActivity:
+    @pytest.fixture
+    def setup_data(self, db):
+        from posthog.models import Organization, Team, User
+
+        organization = Organization.objects.create(name="Test Org")
+        User.objects.create_and_join(organization=organization, email="test@example.com", password="password")
+        team = Team.objects.create(organization=organization, name="Test Team")
+        return {"team": team, "organization": organization}
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db(transaction=True)
+    async def test_sends_email_with_evaluation_disabled_template(self, setup_data):
+        team = setup_data["team"]
+
+        with (
+            patch("posthog.email.is_email_available", return_value=True),
+            patch("posthog.email.EmailMessage") as mock_email_class,
+        ):
+            mock_message = MagicMock()
+            mock_email_class.return_value = mock_message
+
+            await send_evaluation_disabled_email_activity(
+                SendEvaluationDisabledEmailInputs(
+                    team_id=team.id,
+                    evaluation_id="eval-123",
+                    evaluation_name="My Eval",
+                    status_reason="model_not_allowed",
+                    human_readable_reason="The model 'gpt-9' isn't available on the trial plan.",
+                )
+            )
+
+            mock_email_class.assert_called_once()
+            call_kwargs = mock_email_class.call_args[1]
+            assert call_kwargs["template_name"] == "llm_analytics_evaluation_disabled"
+            assert call_kwargs["template_context"]["evaluation_name"] == "My Eval"
+            assert "isn't available on the trial plan" in call_kwargs["template_context"]["disabled_reason"]
+            # Campaign key must include the reason so a later different-reason error triggers a fresh email.
+            assert "model_not_allowed" in call_kwargs["campaign_key"]
+            mock_message.send.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.django_db(transaction=True)
+    async def test_skips_when_email_not_available(self, setup_data):
+        team = setup_data["team"]
+
+        with (
+            patch("posthog.email.is_email_available", return_value=False),
+            patch("posthog.email.EmailMessage") as mock_email_class,
+        ):
+            await send_evaluation_disabled_email_activity(
+                SendEvaluationDisabledEmailInputs(
+                    team_id=team.id,
+                    evaluation_id="eval-123",
+                    evaluation_name="My Eval",
+                    status_reason="model_not_allowed",
+                    human_readable_reason="reason",
+                )
+            )
+
+            mock_email_class.assert_not_called()

--- a/posthog/temporal/llm_analytics/test_run_evaluation.py
+++ b/posthog/temporal/llm_analytics/test_run_evaluation.py
@@ -386,12 +386,12 @@ class TestRunEvaluationWorkflow:
         evaluation = setup_data["evaluation"]
         team = setup_data["team"]
 
-        assert evaluation.enabled is True
+        assert evaluation.enabled
 
         await disable_evaluation_activity(str(evaluation.id), team.id, "trial_limit_reached")
 
         await sync_to_async(evaluation.refresh_from_db)()
-        assert evaluation.enabled is False
+        assert not evaluation.enabled
         assert evaluation.status == "error"
         assert evaluation.status_reason == "trial_limit_reached"
 

--- a/products/llm_analytics/backend/api/evaluations.py
+++ b/products/llm_analytics/backend/api/evaluations.py
@@ -65,6 +65,8 @@ class EvaluationSerializer(serializers.ModelSerializer):
             "name",
             "description",
             "enabled",
+            "status",
+            "status_reason",
             "evaluation_type",
             "evaluation_config",
             "output_type",
@@ -76,7 +78,9 @@ class EvaluationSerializer(serializers.ModelSerializer):
             "created_by",
             "deleted",
         ]
-        read_only_fields = ["id", "created_at", "updated_at", "created_by"]
+        # status / status_reason are server-managed (coerced from enabled on user writes, set directly by
+        # system transitions). Clients toggle `enabled`; the model's save() keeps the trio consistent.
+        read_only_fields = ["id", "status", "status_reason", "created_at", "updated_at", "created_by"]
 
     def validate(self, data):
         if "evaluation_config" in data and "output_config" in data:

--- a/products/llm_analytics/backend/api/provider_keys.py
+++ b/products/llm_analytics/backend/api/provider_keys.py
@@ -341,12 +341,13 @@ class LLMProviderKeyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, v
 
             evals_enabled = 0
             if enable:
+                # Re-enabling via key assignment: clear any prior error state and transition back to ACTIVE.
                 evals_enabled = Evaluation.objects.filter(
                     id__in=evaluation_ids,
                     team_id=self.team_id,
                     deleted=False,
                     enabled=False,
-                ).update(enabled=True)
+                ).update(enabled=True, status="active", status_reason=None)
 
         report_user_action(
             request.user,
@@ -393,9 +394,10 @@ class LLMProviderKeyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, v
                 )
             )
             with transaction.atomic():
+                # Deleting the key leaves dependent evals unrunnable — mark them as errored, not paused.
                 Evaluation.objects.filter(
                     model_configuration_id__in=model_config_ids, team_id=self.team_id, deleted=False
-                ).update(enabled=False)
+                ).update(enabled=False, status="error", status_reason="provider_key_deleted")
                 return super().destroy(request, *args, **kwargs)
 
 

--- a/products/llm_analytics/backend/migrations/0023_evaluation_status.py
+++ b/products/llm_analytics/backend/migrations/0023_evaluation_status.py
@@ -1,0 +1,50 @@
+from django.db import migrations, models
+
+
+def backfill_status(apps, schema_editor):
+    Evaluation = apps.get_model("llm_analytics", "Evaluation")
+    # We can't retroactively tell which disabled evals were system-disabled vs user-paused,
+    # so everything inactive starts as PAUSED. Future system transitions will set ERROR correctly.
+    Evaluation.objects.filter(enabled=True).update(status="active")
+    Evaluation.objects.filter(enabled=False).update(status="paused")
+
+
+def reverse_noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("llm_analytics", "0022_reviewqueue_reviewqueueitem_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="evaluation",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("active", "Active"),
+                    ("paused", "Paused"),
+                    ("error", "Error"),
+                ],
+                default="paused",
+                max_length=20,
+            ),
+        ),
+        migrations.AddField(
+            model_name="evaluation",
+            name="status_reason",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("trial_limit_reached", "Trial evaluation limit reached"),
+                    ("model_not_allowed", "Model not available on the trial plan"),
+                    ("provider_key_deleted", "Provider API key was deleted"),
+                ],
+                max_length=50,
+                null=True,
+            ),
+        ),
+        migrations.RunPython(backfill_status, reverse_noop),
+    ]

--- a/products/llm_analytics/backend/migrations/max_migration.txt
+++ b/products/llm_analytics/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0022_reviewqueue_reviewqueueitem_and_more
+0023_evaluation_status

--- a/products/llm_analytics/backend/models/evaluations.py
+++ b/products/llm_analytics/backend/models/evaluations.py
@@ -81,6 +81,14 @@ class Evaluation(UUIDTModel):
         instance._initial_status = instance.status
         return instance
 
+    def refresh_from_db(self, *args, **kwargs) -> None:
+        # Refreshing replaces the in-memory state with DB state — the change-tracking baseline must
+        # follow, otherwise a subsequent caller-side edit would be compared against stale initials and
+        # the coerce step could misinterpret which field moved.
+        super().refresh_from_db(*args, **kwargs)
+        self._initial_enabled = self.enabled
+        self._initial_status = self.status
+
     def __str__(self):
         return self.name
 

--- a/products/llm_analytics/backend/models/evaluations.py
+++ b/products/llm_analytics/backend/models/evaluations.py
@@ -12,6 +12,18 @@ from .evaluation_configs import EvaluationType, OutputType, validate_evaluation_
 logger = structlog.get_logger(__name__)
 
 
+class EvaluationStatus(models.TextChoices):
+    ACTIVE = "active", "Active"
+    PAUSED = "paused", "Paused"
+    ERROR = "error", "Error"
+
+
+class EvaluationStatusReason(models.TextChoices):
+    TRIAL_LIMIT_REACHED = "trial_limit_reached", "Trial evaluation limit reached"
+    MODEL_NOT_ALLOWED = "model_not_allowed", "Model not available on the trial plan"
+    PROVIDER_KEY_DELETED = "provider_key_deleted", "Provider API key was deleted"
+
+
 class Evaluation(UUIDTModel):
     class Meta:
         ordering = ["-created_at", "id"]
@@ -25,7 +37,12 @@ class Evaluation(UUIDTModel):
     team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE)
     name = models.CharField(max_length=400)
     description = models.TextField(blank=True, default="")
+
+    # Lifecycle state. `status` is authoritative; `enabled` is a boolean projection kept in sync by save() for
+    # backwards compatibility with existing API / DB callers. When status is ERROR, status_reason must be set.
     enabled = models.BooleanField(default=False)
+    status = models.CharField(max_length=20, choices=EvaluationStatus.choices, default=EvaluationStatus.PAUSED)
+    status_reason = models.CharField(max_length=50, choices=EvaluationStatusReason.choices, null=True, blank=True)
 
     evaluation_type = models.CharField(max_length=50, choices=EvaluationType.choices)
     evaluation_config = models.JSONField(default=dict)
@@ -50,12 +67,80 @@ class Evaluation(UUIDTModel):
     created_by = models.ForeignKey("posthog.User", on_delete=models.SET_NULL, null=True, blank=True)
     deleted = models.BooleanField(default=False)
 
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        # Snapshot of the fields as last loaded / saved — used by _coerce_status_and_enabled to know which
+        # field the caller actually moved when enabled and status disagree.
+        self._initial_enabled = self.enabled
+        self._initial_status = self.status
+
+    @classmethod
+    def from_db(cls, db, field_names, values):
+        instance = super().from_db(db, field_names, values)
+        instance._initial_enabled = instance.enabled
+        instance._initial_status = instance.status
+        return instance
+
     def __str__(self):
         return self.name
+
+    def _coerce_status_and_enabled(self) -> None:
+        """Reconcile status with enabled at save time.
+
+        New records: derive status from enabled unless the caller explicitly set status (e.g. ERROR + reason).
+        Existing records: whichever field actually changed since load drives the other. This lets existing
+        callers keep PATCHing `enabled` without knowing about status, while system transitions that write
+        `status` directly take effect even when `enabled` is stale in memory.
+
+        Post-reconciliation invariants are always enforced:
+            - ACTIVE  → enabled=True,  status_reason=None
+            - PAUSED  → enabled=False, status_reason=None
+            - ERROR   → enabled=False, status_reason required (raises otherwise)
+        """
+        # UUIDTModel assigns pk in __init__, so we can't use `self.pk is None` to detect new rows.
+        is_new = self._state.adding
+        if is_new:
+            if self.status == EvaluationStatus.PAUSED and self.enabled:
+                self.status = EvaluationStatus.ACTIVE
+            elif self.status == EvaluationStatus.ACTIVE and not self.enabled:
+                self.status = EvaluationStatus.PAUSED
+        else:
+            enabled_changed = self.enabled != self._initial_enabled
+            status_changed = self.status != self._initial_status
+            if status_changed and not enabled_changed:
+                self.enabled = self.status == EvaluationStatus.ACTIVE
+            elif enabled_changed and not status_changed:
+                self.status = EvaluationStatus.ACTIVE if self.enabled else EvaluationStatus.PAUSED
+
+        if self.status == EvaluationStatus.ACTIVE:
+            self.enabled = True
+            self.status_reason = None
+        elif self.status == EvaluationStatus.PAUSED:
+            self.enabled = False
+            self.status_reason = None
+        elif self.status == EvaluationStatus.ERROR:
+            self.enabled = False
+            if not self.status_reason:
+                raise ValidationError({"status_reason": "status_reason is required when status is ERROR"})
+
+    def set_status(
+        self, status: "EvaluationStatus | str", reason: "EvaluationStatusReason | str | None" = None
+    ) -> None:
+        """Transition helper. Prefer this (or .save()) over .update() so invariants stay enforced.
+
+        Callers using QuerySet.update() bypass save() — they must write all three fields together.
+        """
+        self.status = EvaluationStatus(status)
+        self.status_reason = EvaluationStatusReason(reason) if reason else None
+        self.save(update_fields=["status", "status_reason", "enabled", "updated_at"])
 
     def save(self, *args, **kwargs):
         from posthog.cdp.filters import compile_filters_bytecode
         from posthog.cdp.validation import compile_hog
+
+        # Coerce status and enabled into a consistent pair. status is authoritative, but we accept writes to
+        # either field — typically `enabled` from user PATCHes, `status` from system transitions.
+        self._coerce_status_and_enabled()
 
         # Validate evaluation and output configs
         if self.evaluation_config or self.output_config:
@@ -85,7 +170,11 @@ class Evaluation(UUIDTModel):
             compiled_conditions.append(compiled_condition)
 
         self.conditions = compiled_conditions
-        return super().save(*args, **kwargs)
+        result = super().save(*args, **kwargs)
+        # Refresh the baseline so the next save cycle compares against the post-save state.
+        self._initial_enabled = self.enabled
+        self._initial_status = self.status
+        return result
 
 
 @receiver(post_save, sender=Evaluation)

--- a/products/llm_analytics/backend/models/test/test_evaluations.py
+++ b/products/llm_analytics/backend/models/test/test_evaluations.py
@@ -3,6 +3,8 @@ from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
 
+from parameterized import parameterized
+
 from products.llm_analytics.backend.models.evaluations import Evaluation, EvaluationStatus, EvaluationStatusReason
 
 
@@ -272,6 +274,7 @@ class TestEvaluationModel(BaseTest):
         evaluation.refresh_from_db()
 
         self.assertEqual(evaluation.conditions[0]["id"], "my-custom-id")
+        self.assertEqual(evaluation.conditions[0]["rollout_percentage"], 75)
 
 
 class TestEvaluationStatusCoercion(BaseTest):
@@ -289,14 +292,15 @@ class TestEvaluationStatusCoercion(BaseTest):
         defaults.update(overrides)
         return Evaluation.objects.create(**defaults)
 
-    def test_new_enabled_row_has_active_status(self):
-        evaluation = self._create(enabled=True)
-        self.assertEqual(evaluation.status, EvaluationStatus.ACTIVE)
-        self.assertIsNone(evaluation.status_reason)
-
-    def test_new_disabled_row_has_paused_status(self):
-        evaluation = self._create(enabled=False)
-        self.assertEqual(evaluation.status, EvaluationStatus.PAUSED)
+    @parameterized.expand(
+        [
+            (True, EvaluationStatus.ACTIVE),
+            (False, EvaluationStatus.PAUSED),
+        ]
+    )
+    def test_new_row_status_derived_from_enabled(self, enabled, expected_status):
+        evaluation = self._create(enabled=enabled)
+        self.assertEqual(evaluation.status, expected_status)
         self.assertIsNone(evaluation.status_reason)
 
     def test_flipping_enabled_false_on_active_row_transitions_to_paused(self):
@@ -351,3 +355,21 @@ class TestEvaluationStatusCoercion(BaseTest):
         self.assertEqual(evaluation.status, EvaluationStatus.ERROR)
         self.assertEqual(evaluation.status_reason, EvaluationStatusReason.PROVIDER_KEY_DELETED)
         self.assertFalse(evaluation.enabled)
+
+    def test_refresh_from_db_resets_change_tracking_baseline(self):
+        """After refresh_from_db, a subsequent edit must be compared against DB state — not the
+        pre-refresh in-memory snapshot. Without this, a user toggling enabled=True after refresh on
+        an errored instance would be silently coerced back to enabled=False."""
+        evaluation = self._create(enabled=True)
+        # Simulate a system transition happening elsewhere (another worker, another request, etc.).
+        Evaluation.objects.filter(id=evaluation.id).update(
+            enabled=False, status=EvaluationStatus.ERROR, status_reason=EvaluationStatusReason.TRIAL_LIMIT_REACHED
+        )
+
+        evaluation.refresh_from_db()
+        # User re-enables from the now-refreshed state.
+        evaluation.enabled = True
+        evaluation.save()
+        self.assertEqual(evaluation.status, EvaluationStatus.ACTIVE)
+        self.assertTrue(evaluation.enabled)
+        self.assertIsNone(evaluation.status_reason)

--- a/products/llm_analytics/backend/models/test/test_evaluations.py
+++ b/products/llm_analytics/backend/models/test/test_evaluations.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
 
-from products.llm_analytics.backend.models.evaluations import Evaluation
+from products.llm_analytics.backend.models.evaluations import Evaluation, EvaluationStatus, EvaluationStatusReason
 
 
 class TestEvaluationModel(BaseTest):
@@ -272,4 +272,82 @@ class TestEvaluationModel(BaseTest):
         evaluation.refresh_from_db()
 
         self.assertEqual(evaluation.conditions[0]["id"], "my-custom-id")
-        self.assertEqual(evaluation.conditions[0]["rollout_percentage"], 75)
+
+
+class TestEvaluationStatusCoercion(BaseTest):
+    def _create(self, **overrides) -> Evaluation:
+        defaults: dict = {
+            "team": self.team,
+            "name": "Test",
+            "evaluation_type": "llm_judge",
+            "evaluation_config": {"prompt": "p"},
+            "output_type": "boolean",
+            "output_config": {},
+            "created_by": self.user,
+            "conditions": [],
+        }
+        defaults.update(overrides)
+        return Evaluation.objects.create(**defaults)
+
+    def test_new_enabled_row_has_active_status(self):
+        evaluation = self._create(enabled=True)
+        self.assertEqual(evaluation.status, EvaluationStatus.ACTIVE)
+        self.assertIsNone(evaluation.status_reason)
+
+    def test_new_disabled_row_has_paused_status(self):
+        evaluation = self._create(enabled=False)
+        self.assertEqual(evaluation.status, EvaluationStatus.PAUSED)
+        self.assertIsNone(evaluation.status_reason)
+
+    def test_flipping_enabled_false_on_active_row_transitions_to_paused(self):
+        evaluation = self._create(enabled=True)
+        evaluation.enabled = False
+        evaluation.save()
+        self.assertEqual(evaluation.status, EvaluationStatus.PAUSED)
+        self.assertFalse(evaluation.enabled)
+
+    def test_flipping_enabled_true_on_errored_row_transitions_to_active_and_clears_reason(self):
+        evaluation = self._create(enabled=False)
+        evaluation.status = EvaluationStatus.ERROR
+        evaluation.status_reason = EvaluationStatusReason.TRIAL_LIMIT_REACHED
+        evaluation.save()
+        self.assertEqual(evaluation.status, EvaluationStatus.ERROR)
+
+        evaluation.enabled = True
+        evaluation.save()
+        self.assertEqual(evaluation.status, EvaluationStatus.ACTIVE)
+        self.assertTrue(evaluation.enabled)
+        self.assertIsNone(evaluation.status_reason)
+
+    def test_setting_status_error_requires_reason(self):
+        evaluation = self._create(enabled=True)
+        evaluation.status = EvaluationStatus.ERROR
+        with self.assertRaises(ValidationError):
+            evaluation.save()
+
+    def test_setting_status_error_with_reason_forces_enabled_false(self):
+        evaluation = self._create(enabled=True)
+        evaluation.status = EvaluationStatus.ERROR
+        evaluation.status_reason = EvaluationStatusReason.MODEL_NOT_ALLOWED
+        evaluation.save()
+        self.assertEqual(evaluation.status, EvaluationStatus.ERROR)
+        self.assertFalse(evaluation.enabled)
+        self.assertEqual(evaluation.status_reason, EvaluationStatusReason.MODEL_NOT_ALLOWED)
+
+    def test_paused_status_clears_any_stale_status_reason(self):
+        evaluation = self._create(enabled=True)
+        evaluation.status = EvaluationStatus.ERROR
+        evaluation.status_reason = EvaluationStatusReason.TRIAL_LIMIT_REACHED
+        evaluation.save()
+
+        evaluation.status = EvaluationStatus.PAUSED
+        evaluation.save()
+        self.assertIsNone(evaluation.status_reason)
+
+    def test_set_status_helper_transitions_all_three_fields(self):
+        evaluation = self._create(enabled=True)
+        evaluation.set_status(EvaluationStatus.ERROR, EvaluationStatusReason.PROVIDER_KEY_DELETED)
+        evaluation.refresh_from_db()
+        self.assertEqual(evaluation.status, EvaluationStatus.ERROR)
+        self.assertEqual(evaluation.status_reason, EvaluationStatusReason.PROVIDER_KEY_DELETED)
+        self.assertFalse(evaluation.enabled)

--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
@@ -3,7 +3,7 @@ import { Field, Form } from 'kea-forms'
 import { combineUrl, router } from 'kea-router'
 import { useRef } from 'react'
 
-import { IconArrowLeft, IconInfo, IconPlay, IconTrends } from '@posthog/icons'
+import { IconArrowLeft, IconInfo, IconPlay, IconTrends, IconWarning } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
@@ -38,6 +38,7 @@ import { EvaluationPromptEditor } from './components/EvaluationPromptEditor'
 import { EvaluationRunsTable } from './components/EvaluationRunsTable'
 import { EvaluationTriggers } from './components/EvaluationTriggers'
 import { LLMEvaluationLogicProps, llmEvaluationLogic } from './llmEvaluationLogic'
+import { statusReasonLabel } from './statusDisplay'
 import { EvaluationType } from './types'
 
 export function LLMAnalyticsEvaluation(): JSX.Element {
@@ -183,9 +184,15 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
                             <LemonTag type="primary">New</LemonTag>
                         ) : (
                             <>
-                                <LemonTag type={evaluation.enabled ? 'success' : 'default'}>
-                                    {evaluation.enabled ? 'Enabled' : 'Disabled'}
-                                </LemonTag>
+                                {evaluation.status === 'error' ? (
+                                    <LemonTag type="danger" icon={<IconWarning />}>
+                                        Error
+                                    </LemonTag>
+                                ) : (
+                                    <LemonTag type={evaluation.enabled ? 'success' : 'default'}>
+                                        {evaluation.enabled ? 'Enabled' : 'Disabled'}
+                                    </LemonTag>
+                                )}
                                 {hasUnsavedChanges && <LemonTag type="warning">Unsaved changes</LemonTag>}
                             </>
                         )}
@@ -233,6 +240,19 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
                     )}
                 </div>
             </div>
+
+            {evaluation.status === 'error' && (
+                <LemonBanner type="error">
+                    <div className="space-y-1">
+                        <p className="font-semibold">This evaluation was automatically disabled</p>
+                        <p>
+                            {statusReasonLabel(evaluation.status_reason)}. Update the configuration below (e.g. choose a
+                            supported model or add a provider API key in settings), then re-enable the evaluation to
+                            resume running.
+                        </p>
+                    </div>
+                </LemonBanner>
+            )}
 
             {evaluationProviderKeyIssue && (
                 <LemonBanner type="warning">

--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluationsScene.tsx
@@ -1,7 +1,7 @@
 import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 
-import { IconCopy, IconPencil, IconPlus, IconSearch, IconTrash } from '@posthog/icons'
+import { IconCopy, IconPencil, IconPlus, IconSearch, IconTrash, IconWarning } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
@@ -43,6 +43,7 @@ import { OfflineEvaluationsTab } from './components/OfflineEvaluationsTab'
 import { EvaluationStats, evaluationMetricsLogic } from './evaluationMetricsLogic'
 import { EvaluationTemplatesEmptyState } from './EvaluationTemplates'
 import { llmEvaluationsLogic } from './llmEvaluationsLogic'
+import { statusReasonLabel } from './statusDisplay'
 import { EvaluationConfig } from './types'
 
 export const scene: SceneExport = {
@@ -115,8 +116,20 @@ function LLMAnalyticsEvaluationsContent({ tabId }: { tabId?: string }): JSX.Elem
         },
         {
             title: 'Status',
-            key: 'enabled',
+            key: 'status',
             render: (_, evaluation) => {
+                // When the system has marked an eval as errored, the toggle is misleading — flipping it
+                // would just fail. Show an error pill instead so the row is visibly different and users
+                // click through to the detail page to see what's wrong and how to fix it.
+                if (evaluation.status === 'error') {
+                    return (
+                        <Tooltip title={`${statusReasonLabel(evaluation.status_reason)}. Open to fix.`}>
+                            <LemonTag type="danger" icon={<IconWarning />} data-attr="evaluation-status-error">
+                                Error
+                            </LemonTag>
+                        </Tooltip>
+                    )
+                }
                 const canEnable = canEnableEvaluation(evaluation)
                 const isBlocked = !canEnable && !evaluation.enabled
                 return (
@@ -149,7 +162,11 @@ function LLMAnalyticsEvaluationsContent({ tabId }: { tabId?: string }): JSX.Elem
                     </div>
                 )
             },
-            sorter: (a, b) => Number(b.enabled) - Number(a.enabled),
+            // Sort: errors first (most attention-demanding), then enabled, then paused.
+            sorter: (a, b) => {
+                const rank = (e: EvaluationConfig): number => (e.status === 'error' ? 0 : e.enabled ? 1 : 2)
+                return rank(a) - rank(b)
+            },
         },
         {
             title: 'Method',

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.test.ts
@@ -60,6 +60,8 @@ const mockEvaluation: EvaluationConfig = {
     name: 'Test Evaluation',
     description: 'A test evaluation',
     enabled: true,
+    status: 'active',
+    status_reason: null,
     evaluation_type: 'llm_judge',
     evaluation_config: { prompt: 'Is this response helpful?' },
     output_type: 'boolean',

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -386,6 +386,8 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                     name: template?.name || '',
                     description: template?.description || '',
                     enabled: true,
+                    status: 'active' as const,
+                    status_reason: null,
                     output_type: 'boolean' as const,
                     output_config: {},
                     conditions: [
@@ -458,6 +460,8 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                     name: '',
                     description: '',
                     enabled: true,
+                    status: 'active',
+                    status_reason: null,
                     evaluation_type: 'llm_judge',
                     evaluation_config: {
                         prompt: '',

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.test.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.test.ts
@@ -48,6 +48,8 @@ const evaluationWithKey = (id: string, providerKeyId: string | null): Evaluation
     name: `Evaluation ${id}`,
     description: '',
     enabled: true,
+    status: 'active',
+    status_reason: null,
     evaluation_type: 'llm_judge',
     evaluation_config: { prompt: 'Prompt' },
     output_type: 'boolean',

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.test.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.test.ts
@@ -120,6 +120,20 @@ describe('llmEvaluationsLogic', () => {
             ])
         })
 
+        it('optimistic toggle keeps status in sync with enabled', async () => {
+            const errored = evaluationWithKey('eval-errored', 'key-ok')
+            errored.enabled = false
+            errored.status = 'error'
+            errored.status_reason = 'trial_limit_reached'
+            logic.actions.loadEvaluationsSuccess([errored])
+
+            logic.actions.toggleEvaluationEnabledSuccess('eval-errored')
+
+            await expectLogic(logic).toMatchValues({
+                evaluations: [expect.objectContaining({ enabled: true, status: 'active', status_reason: null })],
+            })
+        })
+
         it('dispatches toggleEvaluationEnabledFailure when the API rejects the toggle', async () => {
             useMocks({
                 patch: {

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationsLogic.ts
@@ -88,7 +88,17 @@ export const llmEvaluationsLogic = kea<llmEvaluationsLogicType>([
                 deleteEvaluationSuccess: (state, { id }) => state.filter((e: EvaluationConfig) => e.id !== id),
                 duplicateEvaluationSuccess: (state, { evaluation }) => [...state, evaluation],
                 toggleEvaluationEnabledSuccess: (state, { id }) =>
-                    state.map((e: EvaluationConfig) => (e.id === id ? { ...e, enabled: !e.enabled } : e)),
+                    state.map((e: EvaluationConfig) =>
+                        e.id === id
+                            ? {
+                                  ...e,
+                                  enabled: !e.enabled,
+                                  // Keep status in sync so the list-column pill updates optimistically.
+                                  status: !e.enabled ? 'active' : 'paused',
+                                  status_reason: null,
+                              }
+                            : e
+                    ),
             },
         ],
         evaluationsLoading: [

--- a/products/llm_analytics/frontend/evaluations/statusDisplay.test.ts
+++ b/products/llm_analytics/frontend/evaluations/statusDisplay.test.ts
@@ -1,0 +1,16 @@
+import { statusReasonLabel } from './statusDisplay'
+
+describe('statusReasonLabel', () => {
+    it.each([
+        ['trial_limit_reached' as const, 'Trial evaluation limit reached'],
+        ['model_not_allowed' as const, 'Model not available on the trial plan'],
+        ['provider_key_deleted' as const, 'Provider API key was deleted'],
+    ])('maps %s to user-facing copy', (reason, expected) => {
+        expect(statusReasonLabel(reason)).toBe(expected)
+    })
+
+    it('returns a generic fallback when reason is null or undefined', () => {
+        expect(statusReasonLabel(null)).toBe('Disabled by the system')
+        expect(statusReasonLabel(undefined)).toBe('Disabled by the system')
+    })
+})

--- a/products/llm_analytics/frontend/evaluations/statusDisplay.ts
+++ b/products/llm_analytics/frontend/evaluations/statusDisplay.ts
@@ -1,0 +1,14 @@
+import { EvaluationStatusReason } from './types'
+
+const REASON_LABELS: Record<EvaluationStatusReason, string> = {
+    trial_limit_reached: 'Trial evaluation limit reached',
+    model_not_allowed: 'Model not available on the trial plan',
+    provider_key_deleted: 'Provider API key was deleted',
+}
+
+export function statusReasonLabel(reason: EvaluationStatusReason | null | undefined): string {
+    if (!reason) {
+        return 'Disabled by the system'
+    }
+    return REASON_LABELS[reason] ?? 'Disabled by the system'
+}

--- a/products/llm_analytics/frontend/evaluations/types.ts
+++ b/products/llm_analytics/frontend/evaluations/types.ts
@@ -4,6 +4,8 @@ import { LLMProvider } from '../settings/llmProviderKeysLogic'
 
 export type EvaluationType = 'llm_judge' | 'hog'
 export type EvaluationOutputType = 'boolean'
+export type EvaluationStatus = 'active' | 'paused' | 'error'
+export type EvaluationStatusReason = 'trial_limit_reached' | 'model_not_allowed' | 'provider_key_deleted'
 
 export interface ModelConfiguration {
     provider: LLMProvider
@@ -30,6 +32,8 @@ export interface BaseEvaluationConfig {
     name: string
     description?: string
     enabled: boolean
+    status: EvaluationStatus
+    status_reason: EvaluationStatusReason | null
     output_type: EvaluationOutputType
     output_config: EvaluationOutputConfig
     conditions: EvaluationConditionSet[]

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -8,6 +8,36 @@
  * OpenAPI spec version: 1.0.0
  */
 /**
+ * * `active` - Active
+ * `paused` - Paused
+ * `error` - Error
+ */
+export type EvaluationStatusEnumApi = (typeof EvaluationStatusEnumApi)[keyof typeof EvaluationStatusEnumApi]
+
+export const EvaluationStatusEnumApi = {
+    Active: 'active',
+    Paused: 'paused',
+    Error: 'error',
+} as const
+
+/**
+ * * `trial_limit_reached` - Trial evaluation limit reached
+ * `model_not_allowed` - Model not available on the trial plan
+ * `provider_key_deleted` - Provider API key was deleted
+ */
+export type StatusReasonEnumApi = (typeof StatusReasonEnumApi)[keyof typeof StatusReasonEnumApi]
+
+export const StatusReasonEnumApi = {
+    TrialLimitReached: 'trial_limit_reached',
+    ModelNotAllowed: 'model_not_allowed',
+    ProviderKeyDeleted: 'provider_key_deleted',
+} as const
+
+export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
+
+export const NullEnumApi = {} as const
+
+/**
  * * `llm_judge` - LLM as a judge
  * `hog` - Hog
  */
@@ -86,10 +116,6 @@ export const BlankEnumApi = {
     '': '',
 } as const
 
-export type NullEnumApi = (typeof NullEnumApi)[keyof typeof NullEnumApi]
-
-export const NullEnumApi = {} as const
-
 /**
  * @nullable
  */
@@ -122,6 +148,8 @@ export interface EvaluationApi {
     name: string
     description?: string
     enabled?: boolean
+    readonly status: EvaluationStatusEnumApi
+    readonly status_reason: StatusReasonEnumApi | NullEnumApi | null
     evaluation_type: EvaluationTypeEnumApi
     evaluation_config?: unknown
     output_type: OutputTypeEnumApi

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14418,6 +14418,34 @@ export namespace Schemas {
     }
 
     /**
+     * * `active` - Active
+    * `paused` - Paused
+    * `error` - Error
+     */
+    export type EvaluationStatusEnum = typeof EvaluationStatusEnum[keyof typeof EvaluationStatusEnum];
+
+
+    export const EvaluationStatusEnum = {
+      Active: 'active',
+      Paused: 'paused',
+      Error: 'error',
+    } as const;
+
+    /**
+     * * `trial_limit_reached` - Trial evaluation limit reached
+    * `model_not_allowed` - Model not available on the trial plan
+    * `provider_key_deleted` - Provider API key was deleted
+     */
+    export type StatusReasonEnum = typeof StatusReasonEnum[keyof typeof StatusReasonEnum];
+
+
+    export const StatusReasonEnum = {
+      TrialLimitReached: 'trial_limit_reached',
+      ModelNotAllowed: 'model_not_allowed',
+      ProviderKeyDeleted: 'provider_key_deleted',
+    } as const;
+
+    /**
      * * `llm_judge` - LLM as a judge
     * `hog` - Hog
      */
@@ -14476,6 +14504,8 @@ export namespace Schemas {
       name: string;
       description?: string;
       enabled?: boolean;
+      readonly status: EvaluationStatusEnum;
+      readonly status_reason: StatusReasonEnum | NullEnum | null;
       evaluation_type: EvaluationTypeEnum;
       evaluation_config?: unknown;
       output_type: OutputTypeEnum;
@@ -24001,6 +24031,8 @@ export namespace Schemas {
       name?: string;
       description?: string;
       enabled?: boolean;
+      readonly status?: EvaluationStatusEnum;
+      readonly status_reason?: StatusReasonEnum | NullEnum | null;
       evaluation_type?: EvaluationTypeEnum;
       evaluation_config?: unknown;
       output_type?: OutputTypeEnum;


### PR DESCRIPTION
## Problem

Migration `0023_evaluation_status` added a `NOT NULL` `status` column to `llm_analytics_evaluation`, but the Node.js `Evaluation` type and `insertEvaluation` test fixture were not updated. Every test that inserts an evaluation was failing in CI with:

```
error: null value in column "status" of relation "llm_analytics_evaluation" violates not-null constraint
```

## Changes

- Add `EvaluationStatus` and `EvaluationStatusReason` types to `nodejs/src/llm-analytics/types.ts`
- Add `status` (required) and `status_reason` (optional) to the `Evaluation` interface
- Update `createEvaluation` fixture to derive `status` from `enabled` (`active`/`paused`), matching the backfill logic in the migration
- Add `status` and `status_reason` to `EVALUATION_FIELDS` in `evaluation-manager.service.ts` so the service actually selects these columns

## How did you test this code?

TypeScript check passes with no errors (`pnpm exec tsc --noEmit`).

The logic mirrors the migration backfill: `enabled=true → status='active'`, `enabled=false → status='paused'`.

do not publish to changelog