### PR TITLE
fix(llma): add status field to evaluation Node.js types and test fixture

### DIFF
--- a/nodejs/src/llm-analytics/_tests/fixtures.ts
+++ b/nodejs/src/llm-analytics/_tests/fixtures.ts
@@ -5,14 +5,17 @@ import { insertRow } from '~/tests/helpers/sql'
 
 import { ClickHouseTimestamp, ProjectId, RawClickHouseEvent, Team } from '../../types'
 import { PostgresRouter } from '../../utils/db/postgres'
-import { Evaluation, EvaluationConditionSet } from '../types'
+import { Evaluation, EvaluationConditionSet, EvaluationStatus } from '../types'
 
 export const createEvaluation = (evaluation: Partial<Evaluation>): Evaluation => {
+    const enabled = evaluation.enabled !== undefined ? evaluation.enabled : true
+    const defaultStatus: EvaluationStatus = enabled ? 'active' : 'paused'
     return {
         id: randomUUID(),
         team_id: 1,
         name: 'Test Evaluation',
-        enabled: true,
+        enabled,
+        status: defaultStatus,
         evaluation_type: 'llm_judge',
         evaluation_config: { prompt: 'Test prompt' },
         output_type: 'boolean',

--- a/nodejs/src/llm-analytics/services/evaluation-manager.service.ts
+++ b/nodejs/src/llm-analytics/services/evaluation-manager.service.ts
@@ -10,6 +10,8 @@ const EVALUATION_FIELDS = [
     'team_id',
     'name',
     'enabled',
+    'status',
+    'status_reason',
     'evaluation_type',
     'evaluation_config',
     'output_type',

--- a/nodejs/src/llm-analytics/types.ts
+++ b/nodejs/src/llm-analytics/types.ts
@@ -1,12 +1,17 @@
 import { HogBytecode } from '../cdp/types'
 import { PropertyFilter } from '../types'
 
+export type EvaluationStatus = 'active' | 'paused' | 'error'
+export type EvaluationStatusReason = 'trial_limit_reached' | 'model_not_allowed' | 'provider_key_deleted'
+
 export interface Evaluation {
     id: string
     team_id: number
     name: string
     description?: string
     enabled: boolean
+    status: EvaluationStatus
+    status_reason?: EvaluationStatusReason
     evaluation_type: string
     evaluation_config: Record<string, any>
     output_type: string


### PR DESCRIPTION
## Problem

Migration `0023_evaluation_status` added a `NOT NULL` `status` column to `llm_analytics_evaluation`, but the Node.js `Evaluation` type and `insertEvaluation` test fixture were not updated. Every test in `evaluation-manager.service.test.ts` was failing in CI with:

```
error: null value in column "status" of relation "llm_analytics_evaluation" violates not-null constraint
```

## Changes

- Add `EvaluationStatus` and `EvaluationStatusReason` types to `nodejs/src/llm-analytics/types.ts`
- Add `status` (required) and `status_reason` (optional) to the `Evaluation` interface
- Update `createEvaluation` fixture to derive `status` from `enabled` (`active`/`paused`), matching the backfill logic in the migration
- Add `status` and `status_reason` to `EVALUATION_FIELDS` in `evaluation-manager.service.ts` so the service selects these columns

## How did you test this code?

TypeScript check passes with no errors. Logic mirrors the migration backfill: `enabled=true → status='active'`, `enabled=false → status='paused'`.

do not publish to changelog