### PR TITLE
chore(ws): use cooperative-sticky partition assignment in v3 load

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py
@@ -101,6 +101,7 @@ class KafkaConsumerService:
             "auto.offset.reset": "latest",
             "enable.auto.commit": False,
             "security.protocol": self._kafka_security_protocol or _KafkaSecurityProtocol.PLAINTEXT,
+            "partition.assignment.strategy": "cooperative-sticky",
         }
         consumer = ConfluentConsumer(config)
         consumer.subscribe(


### PR DESCRIPTION
## Problem

Without an explicit `partition.assignment.strategy`, librdkafka falls back to `range`, which rebalances eagerly: every member revokes every partition on each group change (pod restart, autoscale, deploy) and reassigns from scratch. On a group this size that means processing pauses on every rebalance, even for partitions that weren't going to move.

## Changes

Set `partition.assignment.strategy` to `cooperative-sticky` (KIP-429) on the `KafkaConsumerService`. Cooperative rebalancing runs incrementally: only partitions that actually change owner get revoked, the rest keep flowing through the rebalance.

## How did you test this code?

Test pass
No local tests possible


## Publish to changelog?

NO
