### PR TITLE
fix: Disable DNS cache for workflows-batch-export

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
@@ -322,7 +322,13 @@ async def insert_into_workflows_activity_from_stage(inputs: WorkflowsInsertInput
         async with aiohttp.ClientSession(
             trust_env=False,
             connector=aiohttp.TCPConnector(
-                limit=settings.BATCH_EXPORT_WORKFLOWS_MAX_CONCURRENT_REQUESTS, keepalive_timeout=5
+                limit=settings.BATCH_EXPORT_WORKFLOWS_MAX_CONCURRENT_REQUESTS,
+                keepalive_timeout=5,
+                # CDP API may scale up and down, so we must make new DNS requests rather
+                # than keep a cache. ttl_dns_cache is already low (10s) but if the
+                # connections are active, then the cache won't be refreshed, and must be
+                # disabled entirely.
+                use_dns_cache=False,
             ),
             headers={
                 "X-Internal-Api-Secret": settings.INTERNAL_API_SECRET,

--- a/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
@@ -195,6 +195,7 @@ class WorkflowsConsumer(Consumer):
                 ServiceUnavailable,
                 TooManyRequests,
                 aiohttp.ServerDisconnectedError,
+                aiohttp.ClientOSError,
             ),
             # Retry forever on retryable errors
             max_attempts=None,


### PR DESCRIPTION
## Problem

Due to auto-scaling, we cannot use aiohttp's DNS cache and must resolve IPs. 

Also, auto-scaling can cause connections to abruptly terminate with `ClientOSError`, which we should retry on. This may cause duplicates, but that has to be handled with graceful termination on the server's side.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Disable DNS cache.
Retry on `ClientOSError`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually.

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
