### PR TITLE
feat(debug): show org and team names in slowest queries table

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -113,7 +113,9 @@ export function QueryPerformance(): JSX.Element {
         },
         {
             title: 'Organization',
-            dataIndex: 'organization_name',
+            render: function OrgCell(_, item) {
+                return <span>{item.organization_name || <span className="text-muted">Unknown</span>}</span>
+            },
         },
         {
             title: 'Team',

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -112,9 +112,18 @@ export function QueryPerformance(): JSX.Element {
             },
         },
         {
-            title: 'Team ID',
-            dataIndex: 'team_id',
-            width: 80,
+            title: 'Organization',
+            dataIndex: 'organization_name',
+        },
+        {
+            title: 'Team',
+            render: function TeamCell(_, item) {
+                return (
+                    <span>
+                        {item.team_name || 'Unknown'} <span className="text-muted">({item.team_id})</span>
+                    </span>
+                )
+            },
         },
         {
             title: 'Experiment',
@@ -152,7 +161,7 @@ export function QueryPerformance(): JSX.Element {
     ]
 
     return (
-        <SceneContent className="mt-4">
+        <SceneContent className="mt-4 pb-8">
             <SceneTitleSection
                 name="Query performance"
                 description="Internal tooling for monitoring and managing query performance across all projects."

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -118,14 +118,9 @@ export function QueryPerformance(): JSX.Element {
             },
         },
         {
-            title: 'Team',
-            render: function TeamCell(_, item) {
-                return (
-                    <span>
-                        {item.team_name || 'Unknown'} <span className="text-muted">({item.team_id})</span>
-                    </span>
-                )
-            },
+            title: 'Team ID',
+            dataIndex: 'team_id',
+            width: 80,
         },
         {
             title: 'Experiment',

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -22,6 +22,8 @@ export interface SlowestQuery {
     exception: string
     status: number
     team_id: number
+    team_name: string | null
+    organization_name: string | null
     query_type: string
     experiment_name: string
     experiment_metric_name: string

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -335,6 +335,16 @@ class DebugCHQueries(viewsets.ViewSet):
             },
         )
 
+        # Batch-fetch team and org names from Postgres
+        team_ids = {row[6] for row in response if row[6]}
+        teams_by_id = {}
+        if team_ids:
+            for team in Team.objects.filter(id__in=team_ids).select_related("organization"):
+                teams_by_id[team.id] = {
+                    "team_name": team.name,
+                    "organization_name": team.organization.name if team.organization else None,
+                }
+
         return Response(
             [
                 {
@@ -345,6 +355,8 @@ class DebugCHQueries(viewsets.ViewSet):
                     "exception": row[4],
                     "status": row[5],
                     "team_id": row[6],
+                    "team_name": teams_by_id.get(row[6], {}).get("team_name"),
+                    "organization_name": teams_by_id.get(row[6], {}).get("organization_name"),
                     "query_type": row[7],
                     "experiment_name": row[8],
                     "experiment_metric_name": row[9],


### PR DESCRIPTION
## Problem

Slowest queries table only shows team ID — can't tell which customer is affected.

## Changes

- Batch-fetch org names from Postgres after ClickHouse query
- Add Organization and Team ID columns to slowest queries table
- Add bottom padding to page

## How did you test this code?

Existing tests pass. Tested locally.