### PR TITLE
fix: Add log_entries to session replay outputs

### DIFF
--- a/nodejs/src/session-recording/config.ts
+++ b/nodejs/src/session-recording/config.ts
@@ -154,6 +154,8 @@ export type SessionReplayOutputsConfig = {
 
     SESSION_REPLAY_OUTPUT_TOPHOG_TOPIC: string
     SESSION_REPLAY_OUTPUT_TOPHOG_PRODUCER: ProducerName
+
+    SESSION_REPLAY_OUTPUT_LOG_ENTRIES_PRODUCER: ProducerName
 }
 
 export function getDefaultSessionReplayOutputsConfig(): SessionReplayOutputsConfig {
@@ -164,5 +166,6 @@ export function getDefaultSessionReplayOutputsConfig(): SessionReplayOutputsConf
         SESSION_REPLAY_OUTPUT_OVERFLOW_PRODUCER: DEFAULT_PRODUCER,
         SESSION_REPLAY_OUTPUT_TOPHOG_TOPIC: KAFKA_CLICKHOUSE_TOPHOG,
         SESSION_REPLAY_OUTPUT_TOPHOG_PRODUCER: DEFAULT_PRODUCER,
+        SESSION_REPLAY_OUTPUT_LOG_ENTRIES_PRODUCER: DEFAULT_PRODUCER,
     }
 }

--- a/nodejs/src/session-recording/consumer.e2e.test.ts
+++ b/nodejs/src/session-recording/consumer.e2e.test.ts
@@ -19,7 +19,13 @@ import {
     KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS,
     KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS,
 } from '../config/kafka-topics'
-import { DLQ_OUTPUT, INGESTION_WARNINGS_OUTPUT, OVERFLOW_OUTPUT, TOPHOG_OUTPUT } from '../ingestion/common/outputs'
+import {
+    DLQ_OUTPUT,
+    INGESTION_WARNINGS_OUTPUT,
+    LOG_ENTRIES_OUTPUT,
+    OVERFLOW_OUTPUT,
+    TOPHOG_OUTPUT,
+} from '../ingestion/common/outputs'
 import { IngestionOutputs } from '../ingestion/outputs/ingestion-outputs'
 import { SingleIngestionOutput } from '../ingestion/outputs/single-ingestion-output'
 import { KafkaProducerWrapper } from '../kafka/producer'
@@ -868,6 +874,12 @@ describe('Session Recording Consumer Integration', () => {
                 TOPHOG_OUTPUT,
                 'clickhouse_tophog_test',
                 kafkaMessageProducer,
+                'test'
+            ),
+            [LOG_ENTRIES_OUTPUT]: new SingleIngestionOutput(
+                LOG_ENTRIES_OUTPUT,
+                'log_entries_test',
+                kafkaMetadataProducer,
                 'test'
             ),
         })

--- a/nodejs/src/session-recording/consumer.ts
+++ b/nodejs/src/session-recording/consumer.ts
@@ -4,7 +4,13 @@ import { CODES, Message, TopicPartition, TopicPartitionOffset, features, librdka
 import { instrumentFn } from '~/common/tracing/tracing-utils'
 
 import { buildIntegerMatcher } from '../config/config'
-import { DlqOutput, IngestionWarningsOutput, OverflowOutput, TophogOutput } from '../ingestion/common/outputs'
+import {
+    DlqOutput,
+    IngestionWarningsOutput,
+    LogEntriesOutput,
+    OverflowOutput,
+    TophogOutput,
+} from '../ingestion/common/outputs'
 import { IngestionConsumerConfig } from '../ingestion/config'
 import { IngestionOutputs } from '../ingestion/outputs/ingestion-outputs'
 import { BatchPipelineUnwrapper } from '../ingestion/pipelines/batch-pipeline-unwrapper'
@@ -82,7 +88,9 @@ export class SessionRecordingIngester {
     constructor(
         private config: SessionRecordingIngesterConfig,
         postgres: PostgresRouter,
-        outputs: IngestionOutputs<IngestionWarningsOutput | DlqOutput | OverflowOutput | TophogOutput>,
+        outputs: IngestionOutputs<
+            IngestionWarningsOutput | DlqOutput | OverflowOutput | TophogOutput | LogEntriesOutput
+        >,
         kafkaMetadataProducer: KafkaProducerWrapper,
         redisPool: RedisPool,
         restrictionRedisPool: RedisPool
@@ -147,11 +155,9 @@ export class SessionRecordingIngester {
             this.kafkaMetadataProducer,
             this.config.SESSION_RECORDING_V2_REPLAY_EVENTS_KAFKA_TOPIC
         )
-        const consoleLogStore = new SessionConsoleLogStore(
-            this.kafkaMetadataProducer,
-            this.config.SESSION_RECORDING_V2_CONSOLE_LOG_ENTRIES_KAFKA_TOPIC,
-            { messageLimit: this.config.SESSION_RECORDING_V2_CONSOLE_LOG_STORE_SYNC_BATCH_LIMIT }
-        )
+        const consoleLogStore = new SessionConsoleLogStore(outputs, {
+            messageLimit: this.config.SESSION_RECORDING_V2_CONSOLE_LOG_STORE_SYNC_BATCH_LIMIT,
+        })
         this.fileStorage = s3Client
             ? new RetentionAwareStorage(
                   s3Client,

--- a/nodejs/src/session-recording/outputs/registry.ts
+++ b/nodejs/src/session-recording/outputs/registry.ts
@@ -1,4 +1,10 @@
-import { DLQ_OUTPUT, INGESTION_WARNINGS_OUTPUT, OVERFLOW_OUTPUT, TOPHOG_OUTPUT } from '../../ingestion/common/outputs'
+import {
+    DLQ_OUTPUT,
+    INGESTION_WARNINGS_OUTPUT,
+    LOG_ENTRIES_OUTPUT,
+    OVERFLOW_OUTPUT,
+    TOPHOG_OUTPUT,
+} from '../../ingestion/common/outputs'
 import { IngestionOutputsBuilder } from '../../ingestion/outputs/ingestion-outputs-builder'
 
 /** Register all session replay outputs on the builder. Call `.build(registry, config)` to resolve. */
@@ -19,5 +25,9 @@ export function createOutputsRegistry() {
         .register(TOPHOG_OUTPUT, {
             topicKey: 'SESSION_REPLAY_OUTPUT_TOPHOG_TOPIC',
             producerKey: 'SESSION_REPLAY_OUTPUT_TOPHOG_PRODUCER',
+        })
+        .register(LOG_ENTRIES_OUTPUT, {
+            topicKey: 'SESSION_RECORDING_V2_CONSOLE_LOG_ENTRIES_KAFKA_TOPIC',
+            producerKey: 'SESSION_REPLAY_OUTPUT_LOG_ENTRIES_PRODUCER',
         })
 }

--- a/nodejs/src/session-recording/sessions/session-console-log-store.test.ts
+++ b/nodejs/src/session-recording/sessions/session-console-log-store.test.ts
@@ -1,4 +1,6 @@
-import { KafkaProducerWrapper, TopicMessage } from '../../kafka/producer'
+import { LOG_ENTRIES_OUTPUT, LogEntriesOutput } from '../../ingestion/common/outputs'
+import { IngestionOutputs } from '../../ingestion/outputs/ingestion-outputs'
+import { IngestionOutputMessage } from '../../ingestion/outputs/types'
 import { ClickHouseTimestamp } from '../../types'
 import { parseJSON } from '../../utils/json-parse'
 import { ConsoleLogLevel } from '../rrweb-types'
@@ -16,18 +18,28 @@ jest.mock('./metrics', () => ({
     },
 }))
 
+type QueueMessagesCall = [LogEntriesOutput, IngestionOutputMessage[]]
+
+const getQueuedMessages = (outputs: jest.Mocked<IngestionOutputs<LogEntriesOutput>>, callIndex: number) => {
+    const call = outputs.queueMessages.mock.calls[callIndex] as QueueMessagesCall
+    expect(call[0]).toBe(LOG_ENTRIES_OUTPUT)
+    return call[1]
+}
+
+const parseMessageValue = (msg: IngestionOutputMessage) =>
+    parseJSON((msg.value as Buffer).toString()) as ConsoleLogEntry
+
 describe('SessionConsoleLogStore', () => {
     let store: SessionConsoleLogStore
-    let mockProducer: jest.Mocked<KafkaProducerWrapper>
+    let mockOutputs: jest.Mocked<IngestionOutputs<LogEntriesOutput>>
 
     beforeEach(() => {
         jest.clearAllMocks()
-        mockProducer = {
+        mockOutputs = {
             queueMessages: jest.fn().mockResolvedValue(undefined),
-            flush: jest.fn().mockResolvedValue(undefined),
-        } as unknown as jest.Mocked<KafkaProducerWrapper>
+        } as unknown as jest.Mocked<IngestionOutputs<LogEntriesOutput>>
 
-        store = new SessionConsoleLogStore(mockProducer, 'log_entries_v2', { messageLimit: 1000 })
+        store = new SessionConsoleLogStore(mockOutputs, { messageLimit: 1000 })
     })
 
     it('should queue logs to kafka with correct data', async () => {
@@ -67,11 +79,9 @@ describe('SessionConsoleLogStore', () => {
         await store.storeSessionConsoleLogs(logs)
         await store.flush()
 
-        expect(mockProducer.queueMessages).toHaveBeenCalledTimes(1)
-        const queuedMessage = mockProducer.queueMessages.mock.calls[0][0] as TopicMessage
-        expect(queuedMessage.topic).toBe('log_entries_v2')
-        const queuedMessages = queuedMessage.messages
-        const parsedLogs = queuedMessages.map((msg) => parseJSON(msg.value as string))
+        expect(mockOutputs.queueMessages).toHaveBeenCalledTimes(1)
+        const queuedMessages = getQueuedMessages(mockOutputs, 0)
+        const parsedLogs = queuedMessages.map(parseMessageValue)
 
         expect(parsedLogs).toMatchObject([
             {
@@ -115,12 +125,12 @@ describe('SessionConsoleLogStore', () => {
     it('should handle empty logs array', async () => {
         await store.storeSessionConsoleLogs([])
         await store.flush()
-        expect(mockProducer.queueMessages).not.toHaveBeenCalled()
+        expect(mockOutputs.queueMessages).not.toHaveBeenCalled()
     })
 
     it('should handle producer errors', async () => {
         const error = new Error('Kafka producer error')
-        mockProducer.queueMessages.mockRejectedValueOnce(error)
+        mockOutputs.queueMessages.mockRejectedValueOnce(error)
 
         const logs: ConsoleLogEntry[] = [
             {
@@ -166,69 +176,11 @@ describe('SessionConsoleLogStore', () => {
         await store.storeSessionConsoleLogs(logs)
         await store.flush()
 
-        const queuedMessage = mockProducer.queueMessages.mock.calls[0][0] as TopicMessage
-        const parsedLogs = queuedMessage.messages.map((msg) => parseJSON(msg.value as string))
+        const queuedMessages = getQueuedMessages(mockOutputs, 0)
+        const parsedLogs = queuedMessages.map(parseMessageValue)
 
         expect(parsedLogs[0].batch_id).toBe('batch1')
         expect(parsedLogs[1].batch_id).toBe('batch2')
-    })
-
-    it('should not produce if topic is empty', async () => {
-        store = new SessionConsoleLogStore(mockProducer, '', { messageLimit: 1000 })
-
-        const logs: ConsoleLogEntry[] = [
-            {
-                team_id: 1,
-                message: 'Test log message',
-                level: ConsoleLogLevel.Info,
-                log_source: 'session_replay',
-                log_source_id: 'session123',
-                instance_id: null,
-                timestamp: makeTimestamp('2025-01-01 10:00:00.000'),
-                batch_id: 'batch123',
-            },
-        ]
-
-        await store.storeSessionConsoleLogs(logs)
-        await store.flush()
-        expect(mockProducer.queueMessages).not.toHaveBeenCalled()
-    })
-
-    it('should use custom topic when provided', async () => {
-        const customTopic = 'custom_log_entries_topic'
-        store = new SessionConsoleLogStore(mockProducer, customTopic, { messageLimit: 1000 })
-
-        const logs: ConsoleLogEntry[] = [
-            {
-                team_id: 1,
-                message: 'Test log message',
-                level: ConsoleLogLevel.Info,
-                log_source: 'session_replay',
-                log_source_id: 'session123',
-                instance_id: null,
-                timestamp: makeTimestamp('2025-01-01 10:00:00.000'),
-                batch_id: 'batch123',
-            },
-        ]
-
-        await store.storeSessionConsoleLogs(logs)
-        await store.flush()
-
-        const queuedMessage = mockProducer.queueMessages.mock.calls[0][0] as TopicMessage
-        expect(queuedMessage.topic).toBe(customTopic)
-    })
-
-    describe('flush behavior', () => {
-        it('should call producer flush', async () => {
-            await store.flush()
-            expect(mockProducer.flush).toHaveBeenCalledTimes(1)
-        })
-
-        it('should handle producer flush errors', async () => {
-            const error = new Error('Flush error')
-            mockProducer.flush.mockRejectedValueOnce(error)
-            await expect(store.flush()).rejects.toThrow(error)
-        })
     })
 
     describe('metrics', () => {
@@ -266,40 +218,12 @@ describe('SessionConsoleLogStore', () => {
             await store.flush()
             expect(SessionBatchMetrics.incrementConsoleLogsStored).not.toHaveBeenCalled()
         })
-
-        it('should not increment metric when topic is empty', async () => {
-            store = new SessionConsoleLogStore(mockProducer, '', { messageLimit: 1000 })
-            const logs: ConsoleLogEntry[] = [
-                {
-                    team_id: 1,
-                    message: 'Test log message',
-                    level: ConsoleLogLevel.Info,
-                    log_source: 'session_replay',
-                    log_source_id: 'session123',
-                    instance_id: null,
-                    timestamp: makeTimestamp('2025-01-01 10:00:00.000'),
-                    batch_id: 'batch123',
-                },
-            ]
-
-            await store.storeSessionConsoleLogs(logs)
-            await store.flush()
-            expect(SessionBatchMetrics.incrementConsoleLogsStored).not.toHaveBeenCalled()
-        })
     })
 
     describe('message limit and sync behavior', () => {
-        let mockProducer: jest.Mocked<KafkaProducerWrapper>
-        let store: SessionConsoleLogStore
-
         beforeEach(() => {
-            mockProducer = {
-                queueMessages: jest.fn().mockResolvedValue(undefined),
-                flush: jest.fn().mockResolvedValue(undefined),
-            } as unknown as jest.Mocked<KafkaProducerWrapper>
-
             // Set message limit to 2 to make testing easier
-            store = new SessionConsoleLogStore(mockProducer, 'log_entries_v2', { messageLimit: 2 })
+            store = new SessionConsoleLogStore(mockOutputs, { messageLimit: 2 })
         })
 
         const createTestLog = (id: string): ConsoleLogEntry => ({
@@ -319,18 +243,16 @@ describe('SessionConsoleLogStore', () => {
 
             // First store call should not trigger sync
             await store.storeSessionConsoleLogs([log1])
-            expect(mockProducer.queueMessages).not.toHaveBeenCalled()
+            expect(mockOutputs.queueMessages).not.toHaveBeenCalled()
 
             // Second store call should trigger sync because limit is 2
             await store.storeSessionConsoleLogs([log2])
-            expect(mockProducer.queueMessages).toHaveBeenCalledTimes(1)
-            expect(mockProducer.queueMessages).toHaveBeenCalledWith({
-                topic: 'log_entries_v2',
-                messages: [
-                    { key: 'session1', value: expect.any(String) },
-                    { key: 'session2', value: expect.any(String) },
-                ],
-            })
+            expect(mockOutputs.queueMessages).toHaveBeenCalledTimes(1)
+            const queuedMessages = getQueuedMessages(mockOutputs, 0)
+            expect(queuedMessages).toEqual([
+                { key: 'session1', value: expect.any(Buffer) },
+                { key: 'session2', value: expect.any(Buffer) },
+            ])
         })
 
         it('should handle batches larger than the limit', async () => {
@@ -342,15 +264,13 @@ describe('SessionConsoleLogStore', () => {
             await store.storeSessionConsoleLogs([log1, log2, log3])
 
             // Should trigger immediate sync due to exceeding limit
-            expect(mockProducer.queueMessages).toHaveBeenCalledTimes(1)
-            expect(mockProducer.queueMessages).toHaveBeenCalledWith({
-                topic: 'log_entries_v2',
-                messages: [
-                    { key: 'session1', value: expect.any(String) },
-                    { key: 'session2', value: expect.any(String) },
-                    { key: 'session3', value: expect.any(String) },
-                ],
-            })
+            expect(mockOutputs.queueMessages).toHaveBeenCalledTimes(1)
+            const queuedMessages = getQueuedMessages(mockOutputs, 0)
+            expect(queuedMessages).toEqual([
+                { key: 'session1', value: expect.any(Buffer) },
+                { key: 'session2', value: expect.any(Buffer) },
+                { key: 'session3', value: expect.any(Buffer) },
+            ])
         })
 
         it('should sync remaining messages on flush', async () => {
@@ -358,16 +278,13 @@ describe('SessionConsoleLogStore', () => {
 
             // Store one log (under limit)
             await store.storeSessionConsoleLogs([log1])
-            expect(mockProducer.queueMessages).not.toHaveBeenCalled()
+            expect(mockOutputs.queueMessages).not.toHaveBeenCalled()
 
             // Flush should sync remaining messages
             await store.flush()
-            expect(mockProducer.queueMessages).toHaveBeenCalledTimes(1)
-            expect(mockProducer.queueMessages).toHaveBeenCalledWith({
-                topic: 'log_entries_v2',
-                messages: [{ key: 'session1', value: expect.any(String) }],
-            })
-            expect(mockProducer.flush).toHaveBeenCalled()
+            expect(mockOutputs.queueMessages).toHaveBeenCalledTimes(1)
+            const queuedMessages = getQueuedMessages(mockOutputs, 0)
+            expect(queuedMessages).toEqual([{ key: 'session1', value: expect.any(Buffer) }])
         })
     })
 })

--- a/nodejs/src/session-recording/sessions/session-console-log-store.ts
+++ b/nodejs/src/session-recording/sessions/session-console-log-store.ts
@@ -1,4 +1,5 @@
-import { KafkaProducerWrapper } from '../../kafka/producer'
+import { LOG_ENTRIES_OUTPUT, LogEntriesOutput } from '../../ingestion/common/outputs'
+import { IngestionOutputs } from '../../ingestion/outputs/ingestion-outputs'
 import { ClickHouseTimestamp } from '../../types'
 import { logger } from '../../utils/logger'
 import { ConsoleLogLevel } from '../rrweb-types'
@@ -21,19 +22,15 @@ export class SessionConsoleLogStore {
     private readonly messageLimit: number
 
     constructor(
-        private readonly producer: KafkaProducerWrapper,
-        private readonly topic: string,
+        private readonly outputs: IngestionOutputs<LogEntriesOutput>,
         options: { messageLimit: number }
     ) {
         this.messageLimit = options.messageLimit
         logger.debug('session_console_log_store_created')
-        if (!this.topic) {
-            logger.warn('session_console_log_store_no_topic_configured')
-        }
     }
 
     public async storeSessionConsoleLogs(logs: ConsoleLogEntry[]): Promise<void> {
-        if (logs.length === 0 || !this.topic) {
+        if (logs.length === 0) {
             return
         }
 
@@ -52,7 +49,6 @@ export class SessionConsoleLogStore {
     public async flush(): Promise<void> {
         logger.info(`flushing ${this.consoleLogsCount} console logs`)
         await this.sync()
-        await this.producer.flush()
         this.consoleLogsCount = 0
     }
 
@@ -64,14 +60,13 @@ export class SessionConsoleLogStore {
         logger.debug(`syncing ${this.pendingMessages.length} console log messages`)
 
         const messages = this.pendingMessages.map((log) => ({
-            value: JSON.stringify(log),
+            value: Buffer.from(JSON.stringify(log)),
             key: log.log_source_id,
         }))
         this.pendingMessages = []
 
-        await this.producer.queueMessages({
-            topic: this.topic,
-            messages,
-        })
+        // queueMessages awaits delivery acks for every message, so no separate flush is needed
+        // to guarantee messages are on Kafka before the batch offset is committed.
+        await this.outputs.queueMessages(LOG_ENTRIES_OUTPUT, messages)
     }
 }


### PR DESCRIPTION
## Problem

Session replay as missing the output for `log_entries`, this PR addresses this and moves the producing to that topic to the same IngestionOutputs standard

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
