### PR TITLE
fix(logs): fix service view query not using projection

### DIFF
--- a/products/logs/backend/services_query_runner.py
+++ b/products/logs/backend/services_query_runner.py
@@ -74,13 +74,21 @@ class ServicesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunn
             """
             SELECT
                 service_name,
-                count() AS log_count,
-                countIf(lower(severity_text) IN ('error', 'fatal')) AS error_count
-            FROM logs
-            WHERE {where}
+                sum(_log_count) AS log_count,
+                sumIf(_log_count, in(severity_text, tuple('error', 'fatal'))) AS error_count
+            FROM (
+                SELECT
+                    service_name,
+                    count() AS _log_count,
+                    severity_text,
+                FROM logs
+                WHERE {where}
+                GROUP BY service_name, severity_text
+                ORDER BY _log_count DESC
+            )
             GROUP BY service_name
             ORDER BY log_count DESC
-            LIMIT 1000
+            LIMIT 25
             """,
             placeholders={
                 "where": self.where(),

--- a/products/logs/backend/services_query_runner.py
+++ b/products/logs/backend/services_query_runner.py
@@ -84,7 +84,6 @@ class ServicesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunn
                 FROM logs
                 WHERE {where}
                 GROUP BY service_name, severity_text
-                ORDER BY _log_count DESC
             )
             GROUP BY service_name
             ORDER BY log_count DESC


### PR DESCRIPTION
## Problem

we have an aggregating projection to optimise queries like this, but it wasn't being used making the service view very slow

## Changes

rejangle the fidgem so the projection is used
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
locally, EXPLAIN
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
