### PR TITLE
fix(tasks): address initial_permission_mode review feedback

### DIFF
--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -910,7 +910,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         },
         summary="Send command to agent server",
         description="Forward a JSON-RPC command to the agent server running in the sandbox. "
-        "Supports user_message, cancel, and close commands.",
+        "Supports user_message, cancel, close, permission_response, and set_config_option commands.",
         strict_request_validation=True,
     )
     @action(

--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -1,3 +1,15 @@
+from typing import Literal, get_args
+
+ClaudePermissionMode = Literal["default", "acceptEdits", "plan", "bypassPermissions"]
+CodexPermissionMode = Literal["auto", "read-only", "full-access"]
+InitialPermissionMode = ClaudePermissionMode | CodexPermissionMode
+
+INITIAL_PERMISSION_MODE_CHOICES: list[str] = list(get_args(ClaudePermissionMode))
+CODEX_INITIAL_PERMISSION_MODE_CHOICES: list[str] = list(get_args(CodexPermissionMode))
+ALL_INITIAL_PERMISSION_MODE_CHOICES: list[str] = [
+    arg for member in get_args(InitialPermissionMode) for arg in get_args(member)
+]
+
 DEFAULT_TRUSTED_DOMAINS = [
     # PostHog Services
     "posthog.com",

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -731,6 +731,16 @@ class TaskRunCommandRequestSerializer(serializers.Serializer):
             content = params.get("content")
             if not content or not isinstance(content, str) or not content.strip():
                 raise serializers.ValidationError({"params": "content is required and must be a non-empty string"})
+        elif method == "permission_response":
+            if not params.get("requestId") or not isinstance(params.get("requestId"), str):
+                raise serializers.ValidationError({"params": "requestId is required and must be a non-empty string"})
+            if not params.get("optionId") or not isinstance(params.get("optionId"), str):
+                raise serializers.ValidationError({"params": "optionId is required and must be a non-empty string"})
+        elif method == "set_config_option":
+            if not params.get("configId") or not isinstance(params.get("configId"), str):
+                raise serializers.ValidationError({"params": "configId is required and must be a non-empty string"})
+            if not params.get("value") or not isinstance(params.get("value"), str):
+                raise serializers.ValidationError({"params": "value is required and must be a non-empty string"})
         return attrs
 
 

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -724,23 +724,23 @@ class TaskRunCommandRequestSerializer(serializers.Serializer):
             raise serializers.ValidationError("id must be a string or number")
         return value
 
+    @staticmethod
+    def _require_nonempty_string(params: dict, key: str) -> None:
+        value = params.get(key)
+        if not value or not isinstance(value, str) or not value.strip():
+            raise serializers.ValidationError({"params": f"{key} is required and must be a non-empty string"})
+
     def validate(self, attrs):
         method = attrs["method"]
         params = attrs.get("params", {})
         if method == "user_message":
-            content = params.get("content")
-            if not content or not isinstance(content, str) or not content.strip():
-                raise serializers.ValidationError({"params": "content is required and must be a non-empty string"})
+            self._require_nonempty_string(params, "content")
         elif method == "permission_response":
-            if not params.get("requestId") or not isinstance(params.get("requestId"), str):
-                raise serializers.ValidationError({"params": "requestId is required and must be a non-empty string"})
-            if not params.get("optionId") or not isinstance(params.get("optionId"), str):
-                raise serializers.ValidationError({"params": "optionId is required and must be a non-empty string"})
+            self._require_nonempty_string(params, "requestId")
+            self._require_nonempty_string(params, "optionId")
         elif method == "set_config_option":
-            if not params.get("configId") or not isinstance(params.get("configId"), str):
-                raise serializers.ValidationError({"params": "configId is required and must be a non-empty string"})
-            if not params.get("value") or not isinstance(params.get("value"), str):
-                raise serializers.ValidationError({"params": "value is required and must be a non-empty string"})
+            self._require_nonempty_string(params, "configId")
+            self._require_nonempty_string(params, "value")
         return attrs
 
 

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -8,6 +8,11 @@ from posthog.api.shared import UserBasicSerializer
 from posthog.models.integration import Integration
 from posthog.storage import object_storage
 
+from .constants import (
+    ALL_INITIAL_PERMISSION_MODE_CHOICES,
+    CODEX_INITIAL_PERMISSION_MODE_CHOICES,
+    INITIAL_PERMISSION_MODE_CHOICES,
+)
 from .models import SandboxEnvironment, Task, TaskRun
 from .services.title_generator import generate_task_title
 from .temporal.process_task.utils import (
@@ -22,13 +27,6 @@ from .temporal.process_task.utils import (
 )
 
 PRESIGNED_URL_CACHE_TTL = 55 * 60  # 55 minutes (less than 1 hour URL expiry)
-
-INITIAL_PERMISSION_MODE_CHOICES = ["default", "acceptEdits", "plan", "bypassPermissions"]
-CODEX_INITIAL_PERMISSION_MODE_CHOICES = ["auto", "read-only", "full-access"]
-ALL_INITIAL_PERMISSION_MODE_CHOICES = [
-    *INITIAL_PERMISSION_MODE_CHOICES,
-    *CODEX_INITIAL_PERMISSION_MODE_CHOICES,
-]
 
 
 class TaskSerializer(serializers.ModelSerializer):

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -14,6 +14,7 @@ from posthog.models.integration import GitHubIntegration, Integration
 from posthog.temporal.oauth import PosthogMcpScopes, has_write_scopes
 
 from products.mcp_store.backend.facade.api import get_active_installations
+from products.tasks.backend.constants import InitialPermissionMode
 
 if TYPE_CHECKING:
     from products.tasks.backend.models import Task
@@ -153,18 +154,7 @@ class RunState(BaseModel, extra="allow"):
     sandbox_environment_id: str | None = None
     pending_user_message: str | None = None
     pending_user_message_ts: str | None = None
-    initial_permission_mode: (
-        Literal[
-            "default",
-            "acceptEdits",
-            "plan",
-            "bypassPermissions",
-            "auto",
-            "read-only",
-            "full-access",
-        ]
-        | None
-    ) = None
+    initial_permission_mode: InitialPermissionMode | None = None
     slack_thread_url: str | None = None
     interaction_origin: str | None = None
     slack_sent_relay_ids: list[str] | None = None

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -153,6 +153,7 @@ class RunState(BaseModel, extra="allow"):
     sandbox_environment_id: str | None = None
     pending_user_message: str | None = None
     pending_user_message_ts: str | None = None
+    initial_permission_mode: str | None = None
     slack_thread_url: str | None = None
     interaction_origin: str | None = None
     slack_sent_relay_ids: list[str] | None = None

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -153,7 +153,18 @@ class RunState(BaseModel, extra="allow"):
     sandbox_environment_id: str | None = None
     pending_user_message: str | None = None
     pending_user_message_ts: str | None = None
-    initial_permission_mode: str | None = None
+    initial_permission_mode: (
+        Literal[
+            "default",
+            "acceptEdits",
+            "plan",
+            "bypassPermissions",
+            "auto",
+            "read-only",
+            "full-access",
+        ]
+        | None
+    ) = None
     slack_thread_url: str | None = None
     interaction_origin: str | None = None
     slack_sent_relay_ids: list[str] | None = None

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -349,6 +349,72 @@ class TestTaskAPI(BaseTaskAPITest):
         )
         mock_workflow.assert_called_once()
 
+    @parameterized.expand(
+        [
+            ("default",),
+            ("acceptEdits",),
+            ("plan",),
+            ("bypassPermissions",),
+        ]
+    )
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_persists_initial_permission_mode(self, mode, mock_workflow):
+        task = self.create_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"initial_permission_mode": mode},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        task_run = TaskRun.objects.get(id=response.json()["latest_run"]["id"])
+        assert task_run.state["initial_permission_mode"] == mode
+        mock_workflow.assert_called_once()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_omits_initial_permission_mode_when_not_set(self, mock_workflow):
+        task = self.create_task()
+
+        response = self.client.post(f"/api/projects/@current/tasks/{task.id}/run/")
+
+        assert response.status_code == status.HTTP_200_OK
+        task_run = TaskRun.objects.get(id=response.json()["latest_run"]["id"])
+        assert "initial_permission_mode" not in (task_run.state or {})
+        mock_workflow.assert_called_once()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_rejects_invalid_initial_permission_mode(self, mock_workflow):
+        task = self.create_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"initial_permission_mode": "invalid_mode"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        mock_workflow.assert_not_called()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_combines_pending_user_message_and_initial_permission_mode(self, mock_workflow):
+        task = self.create_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {
+                "pending_user_message": "Start with this",
+                "initial_permission_mode": "plan",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        task_run = TaskRun.objects.get(id=response.json()["latest_run"]["id"])
+        assert task_run.state["pending_user_message"] == "Start with this"
+        assert task_run.state["initial_permission_mode"] == "plan"
+        mock_workflow.assert_called_once()
+
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
     def test_run_endpoint_persists_pr_authorship_metadata(self, mock_workflow):
         task = self.create_task()
@@ -2363,6 +2429,64 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.json()["result"]["closed"])
 
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
+    @patch("products.tasks.backend.api.http_requests.post")
+    def test_command_proxies_permission_response(self, mock_post):
+        get_sandbox_jwt_public_key.cache_clear()
+        self._mock_agent_response(
+            mock_post,
+            {"jsonrpc": "2.0", "id": "req-4", "result": {"acknowledged": True}},
+        )
+
+        task = self.create_task()
+        run = self._create_run_with_sandbox(task)
+
+        response = self.client.post(
+            self._command_url(task, run),
+            {
+                "jsonrpc": "2.0",
+                "method": "permission_response",
+                "params": {"requestId": "perm-1", "optionId": "allow"},
+                "id": "req-4",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        call_kwargs = mock_post.call_args[1]
+        self.assertEqual(call_kwargs["json"]["method"], "permission_response")
+        self.assertEqual(call_kwargs["json"]["params"]["requestId"], "perm-1")
+        self.assertEqual(call_kwargs["json"]["params"]["optionId"], "allow")
+
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
+    @patch("products.tasks.backend.api.http_requests.post")
+    def test_command_proxies_set_config_option(self, mock_post):
+        get_sandbox_jwt_public_key.cache_clear()
+        self._mock_agent_response(
+            mock_post,
+            {"jsonrpc": "2.0", "id": "req-5", "result": {"updated": True}},
+        )
+
+        task = self.create_task()
+        run = self._create_run_with_sandbox(task)
+
+        response = self.client.post(
+            self._command_url(task, run),
+            {
+                "jsonrpc": "2.0",
+                "method": "set_config_option",
+                "params": {"configId": "mode", "value": "plan"},
+                "id": "req-5",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        call_kwargs = mock_post.call_args[1]
+        self.assertEqual(call_kwargs["json"]["method"], "set_config_option")
+        self.assertEqual(call_kwargs["json"]["params"]["configId"], "mode")
+        self.assertEqual(call_kwargs["json"]["params"]["value"], "plan")
+
     def test_command_fails_without_sandbox_url(self):
         task = self.create_task()
         run = TaskRun.objects.create(
@@ -2388,6 +2512,30 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
             ("unknown_method", {"jsonrpc": "2.0", "method": "unknown_method", "params": {}}),
             ("user_message_empty_content", {"jsonrpc": "2.0", "method": "user_message", "params": {"content": ""}}),
             ("user_message_missing_content", {"jsonrpc": "2.0", "method": "user_message", "params": {}}),
+            (
+                "permission_response_missing_requestId",
+                {"jsonrpc": "2.0", "method": "permission_response", "params": {"optionId": "allow"}},
+            ),
+            (
+                "permission_response_missing_optionId",
+                {"jsonrpc": "2.0", "method": "permission_response", "params": {"requestId": "req-1"}},
+            ),
+            (
+                "permission_response_empty_params",
+                {"jsonrpc": "2.0", "method": "permission_response", "params": {}},
+            ),
+            (
+                "set_config_option_missing_configId",
+                {"jsonrpc": "2.0", "method": "set_config_option", "params": {"value": "plan"}},
+            ),
+            (
+                "set_config_option_missing_value",
+                {"jsonrpc": "2.0", "method": "set_config_option", "params": {"configId": "mode"}},
+            ),
+            (
+                "set_config_option_empty_params",
+                {"jsonrpc": "2.0", "method": "set_config_option", "params": {}},
+            ),
         ]
     )
     def test_command_rejects_invalid_payloads(self, _name, payload):

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -363,7 +363,7 @@ class TestTaskAPI(BaseTaskAPITest):
 
         response = self.client.post(
             f"/api/projects/@current/tasks/{task.id}/run/",
-            {"initial_permission_mode": mode},
+            {"initial_permission_mode": mode, "runtime_adapter": "claude", "model": "claude-sonnet-4-6"},
             format="json",
         )
 
@@ -405,6 +405,8 @@ class TestTaskAPI(BaseTaskAPITest):
             {
                 "pending_user_message": "Start with this",
                 "initial_permission_mode": "plan",
+                "runtime_adapter": "claude",
+                "model": "claude-sonnet-4-6",
             },
             format="json",
         )

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -442,7 +442,7 @@ export const tasksRunsArtifactsPresignCreate = async (
 }
 
 /**
- * Forward a JSON-RPC command to the agent server running in the sandbox. Supports user_message, cancel, and close commands.
+ * Forward a JSON-RPC command to the agent server running in the sandbox. Supports user_message, cancel, close, permission_response, and set_config_option commands.
  * @summary Send command to agent server
  */
 export const getTasksRunsCommandCreateUrl = (projectId: string, taskId: string, id: string) => {

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -30,7 +30,7 @@ const errorTrackingAssignmentRulesList = (): ToolBase<
         const projectId = await context.stateManager.getProjectId()
         const result = await context.api.request<Schemas.PaginatedErrorTrackingAssignmentRuleList>({
             method: 'GET',
-            path: `/api/environments/${projectId}/error_tracking/assignment_rules/`,
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/error_tracking/assignment_rules/`,
             query: {
                 limit: params.limit,
                 offset: params.offset,
@@ -183,7 +183,7 @@ const errorTrackingIssuesSplitCreate = (): ToolBase<
         }
         const result = await context.api.request<Schemas.ErrorTrackingIssueSplitResponse>({
             method: 'POST',
-            path: `/api/environments/${projectId}/error_tracking/issues/${params.id}/split/`,
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/error_tracking/issues/${encodeURIComponent(String(params.id))}/split/`,
             body,
         })
         return result


### PR DESCRIPTION
## Problem

Review feedback on the `initial_permission_mode` feature identified missing param validation, a lack of type safety in `RunState`, a stale endpoint description, and zero test coverage for the new functionality.

## Changes

- Add `initial_permission_mode: str | None = None` as an explicit typed field on `RunState` instead of relying on `extra="allow"`
- Add defense-in-depth param validation for `permission_response` (`requestId`, `optionId`) and `set_config_option` (`configId`, `value`) commands, matching the Zod schemas in posthog/code
- Update stale command endpoint description to list all 5 supported methods
- Add 15 tests covering valid/invalid permission modes, extra_state assembly, command proxying, and param rejection

## How did you test this code?

All 199 tests in `products/tasks/backend/tests/test_api.py` pass, including 15 new tests.

## Publish to changelog?

No

## Docs update

N/A