### PR TITLE
fix(replay): handle undefined props in sessionRecordingsPlaylistLogic KEA key

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -546,7 +546,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
     props({} as SessionRecordingPlaylistLogicProps),
     key(
         (props: SessionRecordingPlaylistLogicProps) =>
-            `${props.logicKey}-${props.personUUID}-${props.updateSearchParams ? '-with-search' : ''}`
+            `${props.logicKey ?? ''}-${props.personUUID ?? ''}-${props.updateSearchParams ? '-with-search' : ''}`
     ),
     connect(() => ({
         actions: [


### PR DESCRIPTION
## Problem

The `sessionRecordingsPlaylistLogic` KEA key builder unconditionally interpolates optional props (`logicKey`, `personUUID`) into the Redux store path, producing keys like `webAnalytics-undefined-` when callers don't provide `personUUID`. This causes the error:

```
[KEA] Can not find path "scenes.session-recordings.playlist.sessionRecordingsPlaylistLogic.webAnalytics-undefined-" in the store.
```

Affects web analytics recordings tile, replay categories, and several other callers that don't have a person context.

## Changes

Added nullish coalescing (`?? ''`) to the key template so undefined optional props become empty strings instead of the literal `"undefined"`.

## How did you test this code?

I'm an agent and haven't tested this manually. The change is a one-line fix adding `?? ''` to two optional prop interpolations in a template string. Existing tests should continue to pass — keys change from `*-undefined-*` to `*--*` but KEA keys only need to be unique, not stable across deploys.

## Publish to changelog?

no

## Docs update



## 🤖 LLM context

Agent-authored fix for error tracking issue [019d95fe-68da-7db2-892c-bcce5504e810](https://us.posthog.com/project/2/error_tracking/019d95fe-68da-7db2-892c-bcce5504e810). Single-line change to coalesce undefined optional props in a KEA key builder.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*