### PR TITLE
fix(llma): run TracesQuery asynchronously to avoid 408 timeouts

### DIFF
--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -438,7 +438,7 @@ export function shouldQueryBeAsync(query: Node): boolean {
         isHogQLQuery(query) ||
         isTracesQuery(query) ||
         (isDataTableNode(query) && (isInsightQueryNode(query.source) || isTracesQuery(query.source))) ||
-        (isDataVisualizationNode(query) && isInsightQueryNode(query.source))
+        (isDataVisualizationNode(query) && (isInsightQueryNode(query.source) || isTracesQuery(query.source)))
     )
 }
 

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -436,7 +436,8 @@ export function shouldQueryBeAsync(query: Node): boolean {
     return (
         isInsightQueryNode(query) ||
         isHogQLQuery(query) ||
-        (isDataTableNode(query) && isInsightQueryNode(query.source)) ||
+        isTracesQuery(query) ||
+        (isDataTableNode(query) && (isInsightQueryNode(query.source) || isTracesQuery(query.source))) ||
         (isDataVisualizationNode(query) && isInsightQueryNode(query.source))
     )
 }

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -36,7 +36,7 @@ from posthog.api.monitoring import Feature, monitor
 from posthog.api.query_coalescer import QueryCoalescingMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.services.query import process_query_model
-from posthog.api.utils import action, is_insight_actors_options_query, is_insight_actors_query, is_insight_query
+from posthog.api.utils import action, is_async_query, is_insight_actors_options_query, is_insight_actors_query
 from posthog.clickhouse.client.execute_async import cancel_query, get_query_status
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.clickhouse.query_tagging import get_query_tag_value, get_query_tags, tag_queries
@@ -178,7 +178,7 @@ class QueryViewSet(QueryCoalescingMixin, TeamAndOrgViewSetMixin, PydanticModelMi
             if data.limit_context == SchemaLimitContext.POSTHOG_AI:
                 limit_context: LimitContext | None = LimitContext.POSTHOG_AI
             elif (
-                is_insight_query(query_dict)
+                is_async_query(query_dict)
                 or is_insight_actors_query(query_dict)
                 or is_insight_actors_options_query(query_dict)
             ) and get_query_tag_value("access_method") != "personal_api_key":

--- a/posthog/api/test/test_utils.py
+++ b/posthog/api/test/test_utils.py
@@ -13,6 +13,8 @@ from posthog.api.utils import (
     format_paginated_url,
     get_data,
     get_target_entity,
+    is_async_query,
+    is_insight_query,
     raise_if_user_provided_url_unsafe,
     safe_clickhouse_string,
     PublicIPOnlyHttpAdapter,
@@ -235,6 +237,44 @@ class TestUtils(BaseTest):
             "Internal IP",
             lambda: session.get(address),
         )
+
+    @parameterized.expand(
+        [
+            ("TrendsQuery is insight", {"kind": "TrendsQuery"}, True, True),
+            ("FunnelsQuery is insight", {"kind": "FunnelsQuery"}, True, True),
+            ("HogQLQuery is insight", {"kind": "HogQLQuery"}, True, True),
+            ("TracesQuery is async only", {"kind": "TracesQuery"}, False, True),
+            (
+                "DataTableNode wrapping TrendsQuery",
+                {"kind": "DataTableNode", "source": {"kind": "TrendsQuery"}},
+                True,
+                True,
+            ),
+            (
+                "DataTableNode wrapping TracesQuery",
+                {"kind": "DataTableNode", "source": {"kind": "TracesQuery"}},
+                False,
+                True,
+            ),
+            (
+                "DataVisualizationNode wrapping TracesQuery",
+                {"kind": "DataVisualizationNode", "source": {"kind": "TracesQuery"}},
+                False,
+                True,
+            ),
+            ("EventsQuery is neither", {"kind": "EventsQuery"}, False, False),
+            ("SessionsQuery is neither", {"kind": "SessionsQuery"}, False, False),
+            (
+                "DataTableNode wrapping EventsQuery",
+                {"kind": "DataTableNode", "source": {"kind": "EventsQuery"}},
+                False,
+                False,
+            ),
+        ]
+    )
+    def test_is_async_query(self, _name: str, query: dict, expected_insight: bool, expected_async: bool) -> None:
+        assert is_insight_query(query) == expected_insight
+        assert is_async_query(query) == expected_async
 
     @parameterized.expand(
         [

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -310,6 +310,7 @@ INSIGHT_KINDS = {
 ASYNC_QUERY_KINDS = INSIGHT_KINDS | {
     "TracesQuery",
 }
+_EXTRA_ASYNC_KINDS = ASYNC_QUERY_KINDS - INSIGHT_KINDS
 
 INSIGHT_ACTORS_KINDS = {
     "InsightActorsQuery",
@@ -347,13 +348,12 @@ def is_async_query(query: dict) -> bool:
 
     kind = query.get("kind")
     source = query.get("source")
-    extra_kinds = ASYNC_QUERY_KINDS - INSIGHT_KINDS
 
-    if kind in extra_kinds:
+    if kind in _EXTRA_ASYNC_KINDS:
         return True
     if kind in ("DataTableNode", "DataVisualizationNode"):
         source_kind = source.get("kind") if source and isinstance(source, dict) else getattr(source, "kind", None)
-        if source_kind in extra_kinds:
+        if source_kind in _EXTRA_ASYNC_KINDS:
             return True
 
     return False

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -342,18 +342,18 @@ def is_async_query(query: dict) -> bool:
 
     Superset of is_insight_query — also covers expensive non-insight queries.
     """
+    if is_insight_query(query):
+        return True
+
     kind = query.get("kind")
     source = query.get("source")
+    extra_kinds = ASYNC_QUERY_KINDS - INSIGHT_KINDS
 
-    if kind in ASYNC_QUERY_KINDS:
+    if kind in extra_kinds:
         return True
-    if kind == "HogQLQuery":
-        return True
-    if kind == "DataTableNode":
-        if source and (source.get("kind") or getattr(source, "kind", None)) in ASYNC_QUERY_KINDS:
-            return True
-    if kind == "DataVisualizationNode":
-        if source and (source.get("kind") or getattr(source, "kind", None)) in ASYNC_QUERY_KINDS:
+    if kind in ("DataTableNode", "DataVisualizationNode"):
+        source_kind = source.get("kind") if source and isinstance(source, dict) else getattr(source, "kind", None)
+        if source_kind in extra_kinds:
             return True
 
     return False

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -304,6 +304,13 @@ INSIGHT_KINDS = {
     "LifecycleQuery",
 }
 
+# Queries that should run asynchronously with an extended ClickHouse timeout.
+# Superset of INSIGHT_KINDS — includes expensive non-insight queries like TracesQuery
+# whose two-phase GROUP BY over the events table can exceed the default 60s limit.
+ASYNC_QUERY_KINDS = INSIGHT_KINDS | {
+    "TracesQuery",
+}
+
 INSIGHT_ACTORS_KINDS = {
     "InsightActorsQuery",
     "FunnelsActorsQuery",
@@ -325,6 +332,28 @@ def is_insight_query(query: dict) -> bool:
             return True
     if kind == "DataVisualizationNode":
         if source and (source.get("kind") or getattr(source, "kind", None)) in INSIGHT_KINDS:
+            return True
+
+    return False
+
+
+def is_async_query(query: dict) -> bool:
+    """Check if a query should run asynchronously with an extended timeout.
+
+    Superset of is_insight_query — also covers expensive non-insight queries.
+    """
+    kind = query.get("kind")
+    source = query.get("source")
+
+    if kind in ASYNC_QUERY_KINDS:
+        return True
+    if kind == "HogQLQuery":
+        return True
+    if kind == "DataTableNode":
+        if source and (source.get("kind") or getattr(source, "kind", None)) in ASYNC_QUERY_KINDS:
+            return True
+    if kind == "DataVisualizationNode":
+        if source and (source.get("kind") or getattr(source, "kind", None)) in ASYNC_QUERY_KINDS:
             return True
 
     return False


### PR DESCRIPTION
## Problem

The LLM analytics traces page (`/llm-analytics/traces`) throws 408 Request Timeout errors when TracesQuery takes longer than the default 60s ClickHouse timeout. This happens because TracesQuery is not classified as an async-eligible query, so it runs synchronously with the default timeout. Its two-phase GROUP BY over the events table regularly exceeds that limit when property filters (e.g., `chatId`) are applied.

## Changes

Introduce `ASYNC_QUERY_KINDS` (a superset of `INSIGHT_KINDS`) and wire TracesQuery into the async execution path on both frontend and backend:

- **Backend** (`posthog/api/utils.py`): Add `ASYNC_QUERY_KINDS` set and `is_async_query()` function. Use it in `posthog/api/query.py` instead of `is_insight_query()` for the `limit_context` decision, giving TracesQuery the extended 600s ClickHouse timeout.
- **Frontend** (`frontend/src/queries/utils.ts`): Add `isTracesQuery` to `shouldQueryBeAsync()` so the frontend sends `refresh='async'` and polls for results instead of waiting on a single blocking HTTP request.

## How did you test this code?

- Backend query API tests pass (`posthog/api/test/test_query.py` — 50 passed)
- Python linting passes (`ruff check`)
- TypeScript check shows no new errors (pre-existing errors in `products/workflows/` only)
- This was authored by an agent and has not been manually tested in the browser

## LLM context

Agent-authored PR fixing a 408 timeout error reported in PostHog error tracking.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*