### PR TITLE
fix(experiments): stabilize precomputation query hash for running experiments

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
@@ -123,6 +123,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
             ttl_seconds=DEFAULT_EXPOSURE_TTL_SECONDS,
             table=LazyComputationTable.EXPERIMENT_EXPOSURES_PREAGGREGATED,
             placeholders=placeholders,
+            sentinel_placeholders={"experiment_date_to"},
         )
 
     def _get_exposure_query(self) -> ast.SelectQuery:

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -188,6 +188,7 @@ class ExperimentQueryRunner(QueryRunner):
             ttl_seconds=DEFAULT_EXPOSURE_TTL_SECONDS,
             table=LazyComputationTable.EXPERIMENT_EXPOSURES_PREAGGREGATED,
             placeholders=placeholders,
+            sentinel_placeholders={"experiment_date_to"},
         )
 
     def _ensure_metric_events_precomputed(self, builder: ExperimentQueryBuilder) -> LazyComputationResult:

--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -964,14 +964,25 @@ def ensure_precomputed(
     base_placeholders = placeholders or {}
     _validate_no_reserved_placeholders(base_placeholders)
 
+    if sentinel_placeholders:
+        missing = sentinel_placeholders - set(base_placeholders)
+        if missing:
+            raise ValueError(
+                f"sentinel_placeholders {missing} must also be present in placeholders "
+                "so real values are available at INSERT time."
+            )
+
     # Parse the query template with sentinel placeholders for stable hashing.
     # time_window_min/max are always sentinelized (managed by the executor).
     # Callers can opt additional placeholders into sentinelization via sentinel_placeholders.
-    hash_placeholders = {
+    caller_sentinels: dict[str, ast.Expr] = {
+        name: ast.Constant(value=f"__{name.upper()}__") for name in (sentinel_placeholders or set())
+    }
+    hash_placeholders: dict[str, ast.Expr] = {
         **base_placeholders,
         "time_window_min": ast.Constant(value="__TIME_WINDOW_MIN__"),
         "time_window_max": ast.Constant(value="__TIME_WINDOW_MAX__"),
-        **{name: ast.Constant(value=f"__{name.upper()}__") for name in (sentinel_placeholders or set())},
+        **caller_sentinels,
     }
     parsed_for_hash = parse_select(insert_query, placeholders=hash_placeholders)
     assert isinstance(parsed_for_hash, ast.SelectQuery)

--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -894,6 +894,7 @@ def ensure_precomputed(
     ttl_seconds: int | dict[str, int] = DEFAULT_TTL_SECONDS,
     table: LazyComputationTable = LazyComputationTable.PREAGGREGATION_RESULTS,
     placeholders: dict[str, ast.Expr] | None = None,
+    sentinel_placeholders: set[str] | None = None,
 ) -> LazyComputationResult:
     """
     Ensure lazy-computed data exists for the given query and time range.
@@ -927,6 +928,10 @@ def ensure_precomputed(
         table: The target computation table (default "preaggregation_results")
         placeholders: Additional placeholder values to substitute into the query.
                       time_window_min and time_window_max are added automatically.
+        sentinel_placeholders: Placeholder names to replace with fixed sentinel values
+                      for hashing. Use this for placeholders whose values change between
+                      requests (e.g. datetime.now()) but shouldn't invalidate the cache.
+                      The real values are still used at INSERT time.
 
     Returns:
         ComputationResult with job_ids that can be used to query the data
@@ -959,11 +964,14 @@ def ensure_precomputed(
     base_placeholders = placeholders or {}
     _validate_no_reserved_placeholders(base_placeholders)
 
-    # Parse the query template with sentinel time placeholders for stable hashing
+    # Parse the query template with sentinel placeholders for stable hashing.
+    # time_window_min/max are always sentinelized (managed by the executor).
+    # Callers can opt additional placeholders into sentinelization via sentinel_placeholders.
     hash_placeholders = {
         **base_placeholders,
         "time_window_min": ast.Constant(value="__TIME_WINDOW_MIN__"),
         "time_window_max": ast.Constant(value="__TIME_WINDOW_MAX__"),
+        **{name: ast.Constant(value=f"__{name.upper()}__") for name in (sentinel_placeholders or set())},
     }
     parsed_for_hash = parse_select(insert_query, placeholders=hash_placeholders)
     assert isinstance(parsed_for_hash, ast.SelectQuery)

--- a/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
@@ -1086,21 +1086,21 @@ class TestEnsurePrecomputed(ClickhouseTestMixin, BaseTest):
             GROUP BY time_window_start
         """
 
-        kwargs = {
-            "team": self.team,
-            "insert_query": query,
-            "time_range_start": datetime(2024, 1, 1, tzinfo=UTC),
-            "time_range_end": datetime(2024, 1, 2, tzinfo=UTC),
-            "sentinel_placeholders": {"my_date"},
-        }
-
         first = ensure_precomputed(
-            **kwargs,
+            team=self.team,
+            insert_query=query,
+            time_range_start=datetime(2024, 1, 1, tzinfo=UTC),
+            time_range_end=datetime(2024, 1, 2, tzinfo=UTC),
             placeholders={"my_date": ast.Constant(value=datetime(2024, 1, 5, 12, 0, 0, tzinfo=UTC))},
+            sentinel_placeholders={"my_date"},
         )
         second = ensure_precomputed(
-            **kwargs,
+            team=self.team,
+            insert_query=query,
+            time_range_start=datetime(2024, 1, 1, tzinfo=UTC),
+            time_range_end=datetime(2024, 1, 2, tzinfo=UTC),
             placeholders={"my_date": ast.Constant(value=datetime(2024, 1, 5, 12, 0, 30, tzinfo=UTC))},
+            sentinel_placeholders={"my_date"},
         )
 
         assert first.ready is True
@@ -1121,27 +1121,27 @@ class TestEnsurePrecomputed(ClickhouseTestMixin, BaseTest):
             GROUP BY time_window_start
         """
 
-        kwargs = {
-            "team": self.team,
-            "insert_query": query,
-            "time_range_start": datetime(2024, 1, 1, tzinfo=UTC),
-            "time_range_end": datetime(2024, 1, 2, tzinfo=UTC),
-            "sentinel_placeholders": {"my_date"},
-        }
-
         first = ensure_precomputed(
-            **kwargs,
+            team=self.team,
+            insert_query=query,
+            time_range_start=datetime(2024, 1, 1, tzinfo=UTC),
+            time_range_end=datetime(2024, 1, 2, tzinfo=UTC),
             placeholders={
                 "event_name": ast.Constant(value="$pageview"),
                 "my_date": ast.Constant(value=datetime(2024, 1, 5, tzinfo=UTC)),
             },
+            sentinel_placeholders={"my_date"},
         )
         second = ensure_precomputed(
-            **kwargs,
+            team=self.team,
+            insert_query=query,
+            time_range_start=datetime(2024, 1, 1, tzinfo=UTC),
+            time_range_end=datetime(2024, 1, 2, tzinfo=UTC),
             placeholders={
                 "event_name": ast.Constant(value="$pageleave"),
                 "my_date": ast.Constant(value=datetime(2024, 1, 5, tzinfo=UTC)),
             },
+            sentinel_placeholders={"my_date"},
         )
 
         assert first.job_ids[0] != second.job_ids[0]

--- a/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
@@ -1072,6 +1072,91 @@ class TestEnsurePrecomputed(ClickhouseTestMixin, BaseTest):
                 f"Job {job.time_range_start}: expected TTL ~{expected_ttl}, got {actual_ttl}"
             )
 
+    def test_sentinel_placeholders_produce_stable_hash(self):
+        query = """
+            SELECT
+                toStartOfDay(timestamp) as time_window_start,
+                [] as breakdown_value,
+                uniqExactState(person_id) as uniq_exact_state
+            FROM events
+            WHERE event = '$pageview'
+                AND timestamp >= {time_window_min}
+                AND timestamp < {time_window_max}
+                AND timestamp <= {my_date}
+            GROUP BY time_window_start
+        """
+
+        kwargs = {
+            "team": self.team,
+            "insert_query": query,
+            "time_range_start": datetime(2024, 1, 1, tzinfo=UTC),
+            "time_range_end": datetime(2024, 1, 2, tzinfo=UTC),
+            "sentinel_placeholders": {"my_date"},
+        }
+
+        first = ensure_precomputed(
+            **kwargs,
+            placeholders={"my_date": ast.Constant(value=datetime(2024, 1, 5, 12, 0, 0, tzinfo=UTC))},
+        )
+        second = ensure_precomputed(
+            **kwargs,
+            placeholders={"my_date": ast.Constant(value=datetime(2024, 1, 5, 12, 0, 30, tzinfo=UTC))},
+        )
+
+        assert first.ready is True
+        assert second.ready is True
+        assert second.job_ids[0] == first.job_ids[0]
+
+    def test_non_sentinel_placeholder_change_produces_different_hash(self):
+        query = """
+            SELECT
+                toStartOfDay(timestamp) as time_window_start,
+                [] as breakdown_value,
+                uniqExactState(person_id) as uniq_exact_state
+            FROM events
+            WHERE event = {event_name}
+                AND timestamp >= {time_window_min}
+                AND timestamp < {time_window_max}
+                AND timestamp <= {my_date}
+            GROUP BY time_window_start
+        """
+
+        kwargs = {
+            "team": self.team,
+            "insert_query": query,
+            "time_range_start": datetime(2024, 1, 1, tzinfo=UTC),
+            "time_range_end": datetime(2024, 1, 2, tzinfo=UTC),
+            "sentinel_placeholders": {"my_date"},
+        }
+
+        first = ensure_precomputed(
+            **kwargs,
+            placeholders={
+                "event_name": ast.Constant(value="$pageview"),
+                "my_date": ast.Constant(value=datetime(2024, 1, 5, tzinfo=UTC)),
+            },
+        )
+        second = ensure_precomputed(
+            **kwargs,
+            placeholders={
+                "event_name": ast.Constant(value="$pageleave"),
+                "my_date": ast.Constant(value=datetime(2024, 1, 5, tzinfo=UTC)),
+            },
+        )
+
+        assert first.job_ids[0] != second.job_ids[0]
+
+    def test_sentinel_placeholders_must_exist_in_placeholders(self):
+        with pytest.raises(ValueError, match="must also be present in placeholders"):
+            ensure_precomputed(
+                team=self.team,
+                insert_query=self.MANUAL_INSERT_QUERY,
+                time_range_start=datetime(2024, 1, 1, tzinfo=UTC),
+                time_range_end=datetime(2024, 1, 2, tzinfo=UTC),
+                placeholders={},
+                sentinel_placeholders={"nonexistent"},
+            )
+
 
 class TestParseTtlSchedule(BaseTest):
     def test_int_returns_schedule_with_no_rules(self):


### PR DESCRIPTION
## Problem

Experiment exposure precomputation produces wildly inconsistent results on every page load for running experiments. We observed exposure counts fluctuating randomly across consecutive reloads, e.g. 50,337 → 15,469 → 40,272 → 50,361.

### Root cause

The `experiment_date_to` placeholder in the precomputation query resolves to `datetime.now()` (formatted to the second) for running experiments. This value is baked into the query hash, so the hash changes on every request. Each request:

1. Computes a new hash (because `datetime.now()` changed)
2. Finds zero cached jobs for that hash
3. Recomputes everything from scratch, INSERTs all exposure data into ClickHouse
4. Immediately SELECTs from the just-inserted jobs

Step 4 races against ClickHouse replication. The INSERT distributes data across multiple shards, and some shards haven't committed by the time the SELECT runs. Which shards are ready is effectively random, so each request sees a random fraction of the total data.

This also means every request does a full events table scan and INSERT, adding unnecessary load.

### Why quorum doesn't help

The system already sets `insert_quorum='auto'` to ensure writes are replicated before the INSERT returns. But that's irrelevant here because each request writes data under new job IDs and reads those new job IDs. The replicated data from the previous request (different hash, different job IDs) is never read.

## Changes

Add a `sentinel_placeholders` parameter to `ensure_precomputed()` that lets callers declare placeholders whose values change between requests but shouldn't invalidate the cache. These get replaced with fixed sentinels for hashing (same mechanism already used for `time_window_min/max`), while real values are still used at INSERT time.

Experiment exposure precomputation passes `sentinel_placeholders={"experiment_date_to"}`.

With a stable hash, the first request creates jobs and INSERTs data. Every subsequent request finds those same jobs already READY, so there's no INSERT, no replication race, no fluctuation. The race condition goes from "every request" to "only the first computation."

`experiment_date_from` (the experiment start date) is deliberately kept in the hash. If the experiment start date is changed (i.e. resetting the experiment), we do want to invalidate all data.

Follow-ups:
- Address the read-after-write consistency gap so even the first computation is correct (analysis in `products/analytics_platform/backend/lazy_computation/CONSISTENCY.md`)

## How did you test this code?

Existing tests pass.