### PR TITLE
fix(billing): reduce SFDC lookup chunk size to avoid HTTP 431

### DIFF
--- a/posthog/temporal/salesforce_enrichment/stripe_workflow.py
+++ b/posthog/temporal/salesforce_enrichment/stripe_workflow.py
@@ -39,9 +39,10 @@ from ee.billing.salesforce_enrichment.stripe_signals import StripeSignals, fetch
 
 LOGGER = get_logger(__name__)
 
-# SOQL IN clauses are limited by query length, not cardinality. ~500 UUID
-# org ids the IN list ~ 20k characters —  under the 100k SOQL limit
-_SFDC_LOOKUP_CHUNK_SIZE = 500
+# simple_salesforce sends SOQL as a GET URL parameter, so the HTTP URL/header
+# size limit (~16k) applies rather than the 100k SOQL limit. Each UUID org id
+# is ~40 chars with quotes and commas, so 200 ids ~ 8k — safely under the cap.
+_SFDC_LOOKUP_CHUNK_SIZE = 200
 
 
 def _compose_billing_street(signals: StripeSignals) -> str | None:


### PR DESCRIPTION
simple_salesforce sends SOQL queries as GET URL parameters, so the HTTP header size limit (~16k) applies rather than the 100k SOQL limit. With 500 UUID org ids the IN clause exceeded this, causing Salesforce to return HTTP 431 Request Header Fields Too Large. Reducing to 200 keeps the URL at ~8k, safely under the cap.

Ran into trouble with: https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/salesforce-stripe-enrichment-schedule-2026-04-16T11%3A52%3A28Z/019d9622-ae3f-7140-917f-cac9bb972080/timeline

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Follow up to: https://github.com/PostHog/posthog/pull/54447
Reduce chunk size to fit in `GET` query param char length 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

Ran it locally on 1000 accounts:
```
[runner] result:
{
  "committed_watermark_org_id": "019907c3-47c5-0000-a363-990daae6054d",
  "committed_watermark_ts": "2026-03-11T22:09:45.752000+00:00",
  "error_count": 0,
  "errors": [],
  "total_rows_fetched": 1000,
  "total_skipped_no_account": 78,
  "total_updated": 922
}
```

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
no

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
