### PR TITLE
fix(insights): allow empty properties for dwh series

### DIFF
--- a/posthog/hogql_queries/insights/utils/properties.py
+++ b/posthog/hogql_queries/insights/utils/properties.py
@@ -1,4 +1,4 @@
-from posthog.schema import PropertyGroupFilter
+from posthog.schema import PropertyGroupFilter, PropertyGroupFilterValue
 
 from posthog.hogql import ast
 from posthog.hogql.property import property_to_expr
@@ -7,6 +7,29 @@ from posthog.hogql_queries.insights.query_context import QueryContext
 from posthog.types import AnyPropertyFilter
 
 type PropertiesType = list[AnyPropertyFilter] | PropertyGroupFilter | None
+
+
+def has_any_property_filters(properties: object) -> bool:
+    """Check if properties contain any actual filter values, not just empty group structure."""
+    if isinstance(properties, PropertyGroupFilter):
+        return any(has_any_property_filters_in_group(value) for value in properties.values)
+    if isinstance(properties, list):
+        return len(properties) > 0
+    return bool(properties)
+
+
+def has_any_property_filters_in_group(group: PropertyGroupFilterValue) -> bool:
+    if not group.values:
+        return False
+
+    for value in group.values:
+        if isinstance(value, PropertyGroupFilterValue):
+            if has_any_property_filters_in_group(value):
+                return True
+        else:
+            return True
+
+    return False
 
 
 class Properties:
@@ -33,7 +56,7 @@ class Properties:
                 exprs.append(property_to_expr(property, team))
 
         # Properties
-        if query.properties is not None and query.properties != []:
+        if has_any_property_filters(query.properties):
             exprs.append(property_to_expr(query.properties, team))
 
         return exprs

--- a/posthog/hogql_queries/insights/utils/properties.py
+++ b/posthog/hogql_queries/insights/utils/properties.py
@@ -1,3 +1,5 @@
+from typing import TypeGuard
+
 from posthog.schema import PropertyGroupFilter, PropertyGroupFilterValue
 
 from posthog.hogql import ast
@@ -9,7 +11,7 @@ from posthog.types import AnyPropertyFilter
 type PropertiesType = list[AnyPropertyFilter] | PropertyGroupFilter | None
 
 
-def has_any_property_filters(properties: object) -> bool:
+def has_any_property_filters(properties: object) -> TypeGuard[list[AnyPropertyFilter] | PropertyGroupFilter]:
     """Check if properties contain any actual filter values, not just empty group structure."""
     if isinstance(properties, PropertyGroupFilter):
         return any(has_any_property_filters_in_group(value) for value in properties.values)

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -93,6 +93,7 @@ from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries
 from posthog.errors import classify_query_error, clickhouse_error_type
 from posthog.event_usage import AnalyticsProps, groups, report_user_or_team_action
 from posthog.exceptions_capture import capture_exception
+from posthog.hogql_queries.insights.utils.properties import has_any_property_filters
 from posthog.hogql_queries.query_cache import count_query_cache_hit
 from posthog.hogql_queries.query_cache_base import QueryCacheManagerBase
 from posthog.hogql_queries.query_cache_factory import get_query_cache_manager
@@ -1832,7 +1833,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         # The default logic below applies to all insights and a lot of other queries
         # Notable exception: `HogQLQuery`, which has `properties` and `dateRange` within `HogQLFilters`
         if dashboard_filter.properties:
-            if self.query.properties and _has_any_property_filters(self.query.properties):
+            if self.query.properties and has_any_property_filters(self.query.properties):
                 # Check if query expects only a list (e.g. WebOverviewQuery) vs union with PropertyGroupFilter
                 properties_field = self.query.__class__.model_fields.get("properties")
                 expects_only_list = properties_field and get_origin(properties_field.annotation) is list
@@ -1876,32 +1877,6 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                     )
                 )
         self.__post_init__()
-
-
-def _has_any_property_filters(
-    properties: object,
-) -> bool:
-    """Check if properties contain any actual filter values, not just empty group structure."""
-    if isinstance(properties, PropertyGroupFilter):
-        return any(_has_any_property_filters_in_group(v) for v in properties.values)
-    if isinstance(properties, list):
-        return len(properties) > 0
-    return bool(properties)
-
-
-def _has_any_property_filters_in_group(
-    group: PropertyGroupFilterValue,
-) -> bool:
-    if not group.values:
-        return False
-    for v in group.values:
-        if isinstance(v, PropertyGroupFilterValue):
-            if _has_any_property_filters_in_group(v):
-                return True
-        else:
-            # It's an actual property filter
-            return True
-    return False
 
 
 # Type constraint for analytics query responses

--- a/posthog/hogql_queries/validation/rules.py
+++ b/posthog/hogql_queries/validation/rules.py
@@ -3,6 +3,7 @@ from rest_framework.exceptions import ValidationError
 from posthog.schema import FunnelsQuery, LifecycleQuery, StickinessQuery, TrendsQuery
 
 from posthog.hogql_queries.insights.utils.entities import has_data_warehouse_node
+from posthog.hogql_queries.insights.utils.properties import has_any_property_filters
 from posthog.hogql_queries.validation.utils import get_query_insight_name
 from posthog.hogql_queries.validation.validation import QueryValidationContext
 
@@ -21,7 +22,7 @@ class DisallowUnsupportedDataWarehouseSettings:
             return
 
         unsupported_settings: list[str] = []
-        if context.query.properties not in (None, []):
+        if has_any_property_filters(context.query.properties):
             unsupported_settings.append("filters")
         if context.query.filterTestAccounts:
             unsupported_settings.append("test account filters")

--- a/posthog/hogql_queries/validation/test_rules.py
+++ b/posthog/hogql_queries/validation/test_rules.py
@@ -4,7 +4,14 @@ from unittest.mock import MagicMock
 from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
-from posthog.schema import EventsNode, LifecycleDataWarehouseNode, LifecycleQuery
+from posthog.schema import (
+    EventsNode,
+    FilterLogicalOperator,
+    LifecycleDataWarehouseNode,
+    LifecycleQuery,
+    PropertyGroupFilter,
+    PropertyGroupFilterValue,
+)
 
 from posthog.hogql_queries.validation.rules import DisallowUnsupportedDataWarehouseSettings, RequireAtLeastOneSeries
 from posthog.hogql_queries.validation.validation import QueryValidationContext
@@ -82,6 +89,25 @@ class TestDisallowUnsupportedDataWarehouseSettings(BaseTest):
             filterTestAccounts=True,
             samplingFactor=0.1,
             series=[EventsNode(event="$pageview")],
+        )
+
+        DisallowUnsupportedDataWarehouseSettings().validate(self._context(query))
+
+    def test_allows_empty_property_groups_for_data_warehouse_series(self):
+        query = LifecycleQuery(
+            series=self._data_warehouse_series(),
+            properties=PropertyGroupFilter(
+                type=FilterLogicalOperator.AND_,
+                values=[PropertyGroupFilterValue(type=FilterLogicalOperator.AND_, values=[])],
+            ),
+        )
+
+        DisallowUnsupportedDataWarehouseSettings().validate(self._context(query))
+
+    def test_allows_empty_property_list_for_data_warehouse_series(self):
+        query = LifecycleQuery(
+            series=self._data_warehouse_series(),
+            properties=[],
         )
 
         DisallowUnsupportedDataWarehouseSettings().validate(self._context(query))


### PR DESCRIPTION
## Problem

Empty property filters trigger the `DisallowUnsupportedDataWarehouseSettings` validation rule.

## Changes

Allows empty property filters.

## How did you test this code?

Added tests