### PR TITLE
fix(replay): skip detached element events when count is zero or unchanged

### DIFF
--- a/frontend/src/detachedElementTracker.test.ts
+++ b/frontend/src/detachedElementTracker.test.ts
@@ -1,4 +1,4 @@
-import { mapToTopN } from './detachedElementTracker'
+import { mapToTopN, shouldCaptureDetachedElements } from './detachedElementTracker'
 
 describe('mapToTopN', () => {
     it.each([
@@ -55,5 +55,60 @@ describe('mapToTopN', () => {
         },
     ])('$label', ({ map, limit, expected }) => {
         expect(mapToTopN(map, limit)).toEqual(expected)
+    })
+})
+
+describe('shouldCaptureDetachedElements', () => {
+    it.each([
+        {
+            label: 'skips when zero even on first scan',
+            currentCount: 0,
+            previousCount: null,
+            expected: false,
+        },
+        {
+            label: 'first scan with nonzero count always captures',
+            currentCount: 5,
+            previousCount: null,
+            expected: true,
+        },
+        {
+            label: 'skips when count is unchanged',
+            currentCount: 3,
+            previousCount: 3,
+            expected: false,
+        },
+        {
+            label: 'captures when count increases',
+            currentCount: 5,
+            previousCount: 3,
+            expected: true,
+        },
+        {
+            label: 'captures when count decreases',
+            currentCount: 2,
+            previousCount: 5,
+            expected: true,
+        },
+        {
+            label: 'skips when count stays at zero',
+            currentCount: 0,
+            previousCount: 0,
+            expected: false,
+        },
+        {
+            label: 'captures when count goes from zero to nonzero',
+            currentCount: 1,
+            previousCount: 0,
+            expected: true,
+        },
+        {
+            label: 'skips when count goes from nonzero to zero',
+            currentCount: 0,
+            previousCount: 7,
+            expected: false,
+        },
+    ])('$label', ({ currentCount, previousCount, expected }) => {
+        expect(shouldCaptureDetachedElements(currentCount, previousCount)).toBe(expected)
     })
 })

--- a/frontend/src/detachedElementTracker.ts
+++ b/frontend/src/detachedElementTracker.ts
@@ -22,6 +22,16 @@ interface MemLensScanner {
     dispose: () => void
 }
 
+export function shouldCaptureDetachedElements(currentCount: number, previousCount: number | null): boolean {
+    if (currentCount === 0) {
+        return false
+    }
+    if (previousCount === null) {
+        return true
+    }
+    return currentCount !== previousCount
+}
+
 export function mapToTopN(map: Map<string, number>, limit: number): Record<string, number> {
     const entries = Array.from(map.entries())
     entries.sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
@@ -65,7 +75,14 @@ export function startDetachedElementTracking(posthog: Capturable): void {
                 trackEventListenerLeaks: false,
             })
 
+            let previousDetachedCount: number | null = null
+
             scan.subscribe((result) => {
+                if (!shouldCaptureDetachedElements(result.totalDetachedElements, previousDetachedCount)) {
+                    return
+                }
+                previousDetachedCount = result.totalDetachedElements
+
                 posthog.capture('detached_elements', {
                     total_elements: result.totalElements,
                     detached_elements: result.totalDetachedElements,
@@ -80,6 +97,7 @@ export function startDetachedElementTracking(posthog: Capturable): void {
                 if (document.hidden) {
                     scan.stop()
                 } else {
+                    previousDetachedCount = null
                     scan.start()
                 }
             }

--- a/frontend/src/detachedElementTracker.ts
+++ b/frontend/src/detachedElementTracker.ts
@@ -79,6 +79,7 @@ export function startDetachedElementTracking(posthog: Capturable): void {
 
             scan.subscribe((result) => {
                 if (!shouldCaptureDetachedElements(result.totalDetachedElements, previousDetachedCount)) {
+                    previousDetachedCount = result.totalDetachedElements
                     return
                 }
                 previousDetachedCount = result.totalDetachedElements


### PR DESCRIPTION
## Problem

The detached element tracker sends a `detached_elements` event every 30 seconds regardless of whether anything changed. When there are no detached elements (common case), or the count is stable, this creates noisy, low-value events.

## Changes

- Added `shouldCaptureDetachedElements` guard that skips capture when `totalDetachedElements` is 0 or unchanged from the previous scan
- First scan after visibility resume always captures (previous count resets to `null`) to establish a fresh baseline
- Added 8 parameterized tests covering all transitions (null previous, same count, increase, decrease, zero edge cases)

## How did you test this code?

This PR was authored by an agent. Unit tests cover the decision logic exhaustively via parameterized cases. No manual testing was performed.

```
pnpm --filter=@posthog/frontend exec jest frontend/src/detachedElementTracker.test.ts --verbose
# 14 passed (6 existing + 8 new)
```

## Publish to changelog?

No

## Docs update

N/A

## 🤖 LLM context

Agent-authored PR. The `shouldCaptureDetachedElements` pure function was extracted to keep the logic testable without needing to mock MemLens.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*