### PR TITLE
chore(ci): add concurrency groups to 4 workflows

### DIFF
--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -6,6 +6,10 @@ on:
             - master
     pull_request:
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
     contents: read
     pull-requests: read

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -6,6 +6,10 @@ on:
     pull_request:
     merge_group:
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
     CARGO_TERM_COLOR: always
     UV_HTTP_TIMEOUT: 120

--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -5,6 +5,10 @@ on:
     pull_request:
     merge_group:
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 name: Security
 
 permissions:

--- a/.github/workflows/ci-turbo.yml
+++ b/.github/workflows/ci-turbo.yml
@@ -2,6 +2,10 @@ name: Turbo CI
 on:
     pull_request:
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
     turbo-affected-4:
         timeout-minutes: 30


### PR DESCRIPTION
## Problem

3 of 8 required deployment workflows (Dagster CI, Rust CI, Security) and `ci-turbo.yml` lack concurrency groups. The other 16 CI workflows already use the standard pattern. Without concurrency groups, rapid pushes to a PR (common during review cycles) produce redundant parallel runs on paid depot runners instead of cancelling stale ones.

## Changes

Adds the standard concurrency group to 4 workflows:
- `ci-dagster.yml` (required, depot runner)
- `ci-rust.yml` (required, depot 4-CPU runner)
- `ci-security.yaml` (required, ubuntu runner)
- `ci-turbo.yml` (not required, depot 4-CPU runner)

The pattern cancels in-progress runs on PR pushes. Master runs are never cancelled (each gets a unique `run_id` group).

```yaml
concurrency:
    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

## How did you test this code?

YAML syntax validated locally. The concurrency block is identical to the pattern already used across 16 CI workflows (e.g., `ci-backend.yml:18-20`). No behavioral change to master builds.

## Docs update

no

## LLM context

Agent-authored. Identified missing concurrency groups by surveying all CI workflow configurations against the established pattern.