### PR TITLE
chore(ci): switch alerts-devex to consecutive-run alerting

### DIFF
--- a/.github/scripts/ci-alerts-devex.js
+++ b/.github/scripts/ci-alerts-devex.js
@@ -1,11 +1,19 @@
 // Master CI Alerts - Cron-based rolling window alert for sustained master failures
 //
-// Polls the GitHub API every 5 minutes to check recent completed runs of each
-// watched workflow on master. Only alerts when a workflow has ALERT_THRESHOLD_RUNS
-// (default 5) consecutive failures, filtering out transient flakes.
+// Polls the GitHub API every 10 minutes. Emits three independent signals:
 //
-// Also checks GitHub API rate limits proactively — if remaining quota is critically
-// low, alerts independently so the team knows CI monitoring may be blind.
+// 1. Per-workflow streak: alerts when any watched workflow has
+//    ALERT_THRESHOLD_RUNS (default 5) consecutive failures on master.
+//    Catches a single workflow broken run after run.
+//
+// 2. Commit-level health: alerts when RED_COMMIT_THRESHOLD (default 10)
+//    consecutive commits on master each had at least one critical workflow
+//    fail. Catches rotating-culprit breakage (3 dagster flakes, 3 storybook
+//    flakes, etc.) where no single workflow hits the per-workflow threshold
+//    but master is still consistently red.
+//
+// 3. Rate limit: alerts independently if GitHub API quota drops critically
+//    low — CI monitoring may be blind otherwise.
 //
 // State structure (persisted via GitHub Actions cache as .alerts-devex):
 // {
@@ -19,6 +27,11 @@
 //   rate_limit_alerted: boolean,
 //   rate_limit_slack_ts: string | null,
 //   rate_limit_slack_channel: string | null,
+//   red_commits_alerted: boolean,
+//   red_commits_slack_ts: string | null,
+//   red_commits_slack_channel: string | null,
+//   red_commits_last_count: number,
+//   red_commits_last_sample: string,  // preserved for resolve messages
 // }
 
 const STATE_FILE = '.alerts-devex'
@@ -104,7 +117,14 @@ function getOldestFailingSince(failing) {
     return times.length > 0 ? Math.min(...times) : null
 }
 
-function determineAction(state, failing, threshold) {
+// Decision matrix (hasFailures × wasAlerted × thresholdReached):
+//   no failures, not alerted          → none
+//   no failures, alerted              → resolve
+//   failures, not alerted, under      → none
+//   failures, not alerted, at/over    → create
+//   failures, alerted, set changed    → update
+//   failures, alerted, set unchanged  → none
+function determineAction(state, failing, runThreshold) {
     const failingNames = Object.keys(failing).sort()
     const failingList = failingNames.join(', ')
     const hasFailures = failingNames.length > 0
@@ -119,7 +139,7 @@ function determineAction(state, failing, threshold) {
     }
 
     const maxConsecutive = getMaxConsecutiveFailures(failing)
-    const thresholdReached = maxConsecutive >= threshold
+    const thresholdReached = maxConsecutive >= runThreshold
 
     if (!thresholdReached && !wasAlerted) {
         return { action: 'none', failingList }
@@ -159,6 +179,83 @@ function buildFailingDetail(failing, criticalWorkflows) {
     return detail
 }
 
+async function fetchRecentCommits(github, owner, repo, perPage) {
+    const { data } = await github.rest.repos.listCommits({
+        owner,
+        repo,
+        sha: 'master',
+        per_page: perPage,
+    })
+    return data.map((c) => ({
+        sha: c.sha,
+        html_url: c.html_url,
+        message: (c.commit?.message || '').split('\n')[0],
+        author: c.commit?.author?.name || 'unknown',
+    }))
+}
+
+// Classify each commit by looking up critical-workflow runs that share its SHA.
+// Non-critical workflow runs are intentionally ignored — they're the noisy ones,
+// and per-workflow alerting already covers sticky non-critical breakage.
+function classifyCommits(commits, allWorkflowRuns, criticalWorkflows) {
+    const runsBySha = new Map()
+    for (const runs of allWorkflowRuns) {
+        for (const run of runs) {
+            if (!criticalWorkflows.has(run.workflow_file)) continue
+            if (!runsBySha.has(run.sha)) runsBySha.set(run.sha, [])
+            runsBySha.get(run.sha).push(run)
+        }
+    }
+    return commits.map((commit) => {
+        const runs = runsBySha.get(commit.sha) || []
+        if (runs.length === 0) {
+            return { ...commit, status: 'unknown', redWorkflows: [] }
+        }
+        const red = runs.filter((r) => r.conclusion === 'failure' || r.conclusion === 'timed_out')
+        if (red.length > 0) {
+            return { ...commit, status: 'red', redWorkflows: red.map((r) => r.name) }
+        }
+        return { ...commit, status: 'green', redWorkflows: [] }
+    })
+}
+
+// Walk newest-to-oldest, count reds, stop at the first green.
+// Unknowns (workflows still running, path-filtered, etc.) are skipped: they
+// neither count nor break the streak. Rationale: a freshly-pushed commit
+// whose CI hasn't completed yet should not mask a real underlying streak.
+function countConsecutiveRedCommits(classified) {
+    let count = 0
+    for (const commit of classified) {
+        if (commit.status === 'green') break
+        if (commit.status === 'red') count++
+    }
+    return count
+}
+
+function determineRedCommitsAction(state, count, threshold) {
+    const wasAlerted = state?.red_commits_alerted === true
+    const atOrOver = count >= threshold
+
+    if (!atOrOver && !wasAlerted) return 'none'
+    if (!atOrOver && wasAlerted) return 'resolve'
+    if (atOrOver && !wasAlerted) return 'create'
+    // Already alerted AND still at/over threshold — update only when count grew
+    const prev = state?.red_commits_last_count || 0
+    if (count > prev) return 'update'
+    return 'none'
+}
+
+function buildRedCommitsDetail(classified, count) {
+    if (count === 0) return ''
+    const redOnly = classified.filter((c) => c.status === 'red').slice(0, count)
+    const lines = redOnly.map((c) => {
+        const shortSha = c.sha.slice(0, 7)
+        const workflows = c.redWorkflows.join(', ')
+        return `• <${c.html_url}|${shortSha}> — ${workflows}`
+    })
+    return lines.join('\n')
+}
+
 module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) => {
     const fs = _fs || require('fs')
     const now = _now || new Date()
@@ -168,8 +265,12 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
 
     const workflowFiles = (process.env.WATCHED_WORKFLOWS || '').split(',').filter(Boolean)
     const criticalWorkflows = new Set((process.env.CRITICAL_WORKFLOWS || '').split(',').filter(Boolean))
-    const threshold = parseInt(process.env.ALERT_THRESHOLD_RUNS || '5', 10)
-    const perPage = threshold * 2
+    const runThreshold = parseInt(process.env.ALERT_THRESHOLD_RUNS || '5', 10)
+    const redCommitThreshold = parseInt(process.env.RED_COMMIT_THRESHOLD || '10', 10)
+    // Over-fetch to survive cancelled/skipped runs (force-pushes, concurrency cancels).
+    // If the filtered set ends up smaller than runThreshold, we log a warning.
+    const perPage = Math.max(runThreshold * 3, 20)
+    const commitsToFetch = Math.max(redCommitThreshold * 2, 25)
 
     // Load existing state
     let state = null
@@ -183,6 +284,11 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
                     rate_limit_alerted: raw.rate_limit_alerted ?? false,
                     rate_limit_slack_ts: raw.rate_limit_slack_ts ?? null,
                     rate_limit_slack_channel: raw.rate_limit_slack_channel ?? null,
+                    red_commits_alerted: raw.red_commits_alerted ?? false,
+                    red_commits_slack_ts: raw.red_commits_slack_ts ?? null,
+                    red_commits_slack_channel: raw.red_commits_slack_channel ?? null,
+                    red_commits_last_count: raw.red_commits_last_count ?? 0,
+                    red_commits_last_sample: raw.red_commits_last_sample ?? '',
                 }
             } else {
                 state = { failing: {}, ...raw }
@@ -221,6 +327,11 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
             console.log(
                 `  ${runs[0].name}: ${runs[0].conclusion}${count > 0 ? ` (${count} consecutive failures)` : ''}`
             )
+            if (runs.length < runThreshold) {
+                console.log(
+                    `  ! Only ${runs.length} non-cancelled runs available for ${runs[0].name} — below threshold of ${runThreshold}`
+                )
+            }
         }
     }
 
@@ -228,7 +339,7 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
     const failing = buildFailingMap(allWorkflowRuns)
 
     // Determine action
-    const { action, failingList } = determineAction(state, failing, threshold)
+    const { action, failingList } = determineAction(state, failing, runThreshold)
 
     console.log(`Action: ${action}`)
     console.log(`Failing: ${failingList || 'none'}`)
@@ -236,9 +347,27 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
     // Build failing detail for Slack messages
     const failingDetail = buildFailingDetail(failing, criticalWorkflows)
 
+    // Commit-level health: independent signal tracking consecutive red commits
+    // across critical workflows. Fetches real commit order via listCommits so
+    // force-pushes don't confuse the streak.
+    let classified = []
+    let redCount = 0
+    let redCommitsAction = 'none'
+    try {
+        const commits = await fetchRecentCommits(github, owner, repo, commitsToFetch)
+        classified = classifyCommits(commits, allWorkflowRuns, criticalWorkflows)
+        redCount = countConsecutiveRedCommits(classified)
+        redCommitsAction = determineRedCommitsAction(state, redCount, redCommitThreshold)
+        console.log(`Red commits streak: ${redCount} (action: ${redCommitsAction})`)
+    } catch (err) {
+        console.log(`Failed to compute red commits: ${err.message}`)
+    }
+    const redCommitsDetail = buildRedCommitsDetail(classified, redCount)
+
     // Save when there's an action or evolving failure counts to track
     const shouldSave = action !== 'none' || Object.keys(failing).length > 0
     const saveRateLimit = rateLimitAction !== 'none'
+    const saveRedCommits = redCommitsAction !== 'none' || redCount > 0
 
     // Build new state
     const newState = {
@@ -253,15 +382,22 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
             rateLimitAction === 'create' || (state?.rate_limit_alerted === true && rateLimitAction !== 'resolve'),
         rate_limit_slack_ts: state?.rate_limit_slack_ts || null,
         rate_limit_slack_channel: state?.rate_limit_slack_channel || null,
+        red_commits_alerted:
+            redCommitsAction === 'create' ||
+            (state?.red_commits_alerted === true && redCommitsAction !== 'resolve'),
+        red_commits_slack_ts: state?.red_commits_slack_ts || null,
+        red_commits_slack_channel: state?.red_commits_slack_channel || null,
+        red_commits_last_count: redCommitsAction === 'resolve' ? 0 : redCount,
+        red_commits_last_sample: redCommitsDetail || state?.red_commits_last_sample || '',
     }
 
-    if (shouldSave || saveRateLimit) {
+    if (shouldSave || saveRateLimit || saveRedCommits) {
         fs.writeFileSync(STATE_FILE, JSON.stringify(newState, null, 2))
     }
 
     // Set outputs
     core.setOutput('action', action)
-    core.setOutput('save_cache', shouldSave || saveRateLimit ? 'true' : 'false')
+    core.setOutput('save_cache', shouldSave || saveRateLimit || saveRedCommits ? 'true' : 'false')
     core.setOutput('delete_old_caches', action === 'create' ? 'true' : 'false')
     core.setOutput('failing_workflows', failingList)
     core.setOutput('failing_count', String(Object.keys(failing).length))
@@ -312,5 +448,20 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
     if (rateLimitAction === 'resolve') {
         core.setOutput('rate_limit_slack_ts', state?.rate_limit_slack_ts || '')
         core.setOutput('rate_limit_slack_channel', state?.rate_limit_slack_channel || '')
+    }
+
+    // Red-commits outputs
+    core.setOutput('red_commits_action', redCommitsAction)
+    core.setOutput('red_commits_count', String(redCount))
+    if (redCommitsAction === 'create' || redCommitsAction === 'update') {
+        core.setOutput('red_commits_detail', redCommitsDetail)
+    }
+    if (redCommitsAction === 'update' || redCommitsAction === 'resolve') {
+        core.setOutput('red_commits_slack_ts', state?.red_commits_slack_ts || '')
+        core.setOutput('red_commits_slack_channel', state?.red_commits_slack_channel || '')
+    }
+    if (redCommitsAction === 'resolve') {
+        core.setOutput('red_commits_last_count', String(state?.red_commits_last_count || 0))
+        core.setOutput('red_commits_last_sample', state?.red_commits_last_sample || '')
     }
 }

--- a/.github/scripts/ci-alerts-devex.js
+++ b/.github/scripts/ci-alerts-devex.js
@@ -3,10 +3,10 @@
 // Polls the GitHub API every 10 minutes. Emits three independent signals:
 //
 // 1. Per-workflow streak: alerts when any watched workflow has
-//    ALERT_THRESHOLD_RUNS (default 5) consecutive failures on master.
+//    WORKFLOW_FAILURE_STREAK_THRESHOLD (default 5) consecutive failures on master.
 //    Catches a single workflow broken run after run.
 //
-// 2. Commit-level health: alerts when RED_COMMIT_THRESHOLD (default 10)
+// 2. Commit-level health: alerts when COMMIT_FAILURE_STREAK_THRESHOLD (default 10)
 //    consecutive commits on master each had at least one critical workflow
 //    fail. Catches rotating-culprit breakage (3 dagster flakes, 3 storybook
 //    flakes, etc.) where no single workflow hits the per-workflow threshold
@@ -27,11 +27,11 @@
 //   rate_limit_alerted: boolean,
 //   rate_limit_slack_ts: string | null,
 //   rate_limit_slack_channel: string | null,
-//   red_commits_alerted: boolean,
-//   red_commits_slack_ts: string | null,
-//   red_commits_slack_channel: string | null,
-//   red_commits_last_count: number,
-//   red_commits_last_sample: string,  // preserved for resolve messages
+//   commit_failure_streak_alerted: boolean,
+//   commit_failure_streak_slack_ts: string | null,
+//   commit_failure_streak_slack_channel: string | null,
+//   commit_failure_streak_last_count: number,
+//   commit_failure_streak_last_sample: string,  // preserved for resolve messages
 // }
 
 const STATE_FILE = '.alerts-devex'
@@ -124,7 +124,7 @@ function getOldestFailingSince(failing) {
 //   failures, not alerted, at/over    → create
 //   failures, alerted, set changed    → update
 //   failures, alerted, set unchanged  → none
-function determineAction(state, failing, runThreshold) {
+function determineAction(state, failing, workflowFailureStreakThreshold) {
     const failingNames = Object.keys(failing).sort()
     const failingList = failingNames.join(', ')
     const hasFailures = failingNames.length > 0
@@ -139,7 +139,7 @@ function determineAction(state, failing, runThreshold) {
     }
 
     const maxConsecutive = getMaxConsecutiveFailures(failing)
-    const thresholdReached = maxConsecutive >= runThreshold
+    const thresholdReached = maxConsecutive >= workflowFailureStreakThreshold
 
     if (!thresholdReached && !wasAlerted) {
         return { action: 'none', failingList }
@@ -232,20 +232,20 @@ function countConsecutiveRedCommits(classified) {
     return count
 }
 
-function determineRedCommitsAction(state, count, threshold) {
-    const wasAlerted = state?.red_commits_alerted === true
+function determineCommitFailureStreakAction(state, count, threshold) {
+    const wasAlerted = state?.commit_failure_streak_alerted === true
     const atOrOver = count >= threshold
 
     if (!atOrOver && !wasAlerted) return 'none'
     if (!atOrOver && wasAlerted) return 'resolve'
     if (atOrOver && !wasAlerted) return 'create'
     // Already alerted AND still at/over threshold — update only when count grew
-    const prev = state?.red_commits_last_count || 0
+    const prev = state?.commit_failure_streak_last_count || 0
     if (count > prev) return 'update'
     return 'none'
 }
 
-function buildRedCommitsDetail(classified, count) {
+function buildCommitFailureStreakDetail(classified, count) {
     if (count === 0) return ''
     const redOnly = classified.filter((c) => c.status === 'red').slice(0, count)
     const lines = redOnly.map((c) => {
@@ -265,12 +265,12 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
 
     const workflowFiles = (process.env.WATCHED_WORKFLOWS || '').split(',').filter(Boolean)
     const criticalWorkflows = new Set((process.env.CRITICAL_WORKFLOWS || '').split(',').filter(Boolean))
-    const runThreshold = parseInt(process.env.ALERT_THRESHOLD_RUNS || '5', 10)
-    const redCommitThreshold = parseInt(process.env.RED_COMMIT_THRESHOLD || '10', 10)
+    const workflowFailureStreakThreshold = parseInt(process.env.WORKFLOW_FAILURE_STREAK_THRESHOLD || '5', 10)
+    const commitFailureStreakThreshold = parseInt(process.env.COMMIT_FAILURE_STREAK_THRESHOLD || '10', 10)
     // Over-fetch to survive cancelled/skipped runs (force-pushes, concurrency cancels).
-    // If the filtered set ends up smaller than runThreshold, we log a warning.
-    const perPage = Math.max(runThreshold * 3, 20)
-    const commitsToFetch = Math.max(redCommitThreshold * 2, 25)
+    // If the filtered set ends up smaller than workflowFailureStreakThreshold, we log a warning.
+    const perPage = Math.max(workflowFailureStreakThreshold * 3, 20)
+    const commitsToFetch = Math.max(commitFailureStreakThreshold * 2, 25)
 
     // Load existing state
     let state = null
@@ -284,11 +284,11 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
                     rate_limit_alerted: raw.rate_limit_alerted ?? false,
                     rate_limit_slack_ts: raw.rate_limit_slack_ts ?? null,
                     rate_limit_slack_channel: raw.rate_limit_slack_channel ?? null,
-                    red_commits_alerted: raw.red_commits_alerted ?? false,
-                    red_commits_slack_ts: raw.red_commits_slack_ts ?? null,
-                    red_commits_slack_channel: raw.red_commits_slack_channel ?? null,
-                    red_commits_last_count: raw.red_commits_last_count ?? 0,
-                    red_commits_last_sample: raw.red_commits_last_sample ?? '',
+                    commit_failure_streak_alerted: raw.commit_failure_streak_alerted ?? false,
+                    commit_failure_streak_slack_ts: raw.commit_failure_streak_slack_ts ?? null,
+                    commit_failure_streak_slack_channel: raw.commit_failure_streak_slack_channel ?? null,
+                    commit_failure_streak_last_count: raw.commit_failure_streak_last_count ?? 0,
+                    commit_failure_streak_last_sample: raw.commit_failure_streak_last_sample ?? '',
                 }
             } else {
                 state = { failing: {}, ...raw }
@@ -327,9 +327,9 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
             console.log(
                 `  ${runs[0].name}: ${runs[0].conclusion}${count > 0 ? ` (${count} consecutive failures)` : ''}`
             )
-            if (runs.length < runThreshold) {
+            if (runs.length < workflowFailureStreakThreshold) {
                 console.log(
-                    `  ! Only ${runs.length} non-cancelled runs available for ${runs[0].name} — below threshold of ${runThreshold}`
+                    `  ! Only ${runs.length} non-cancelled runs available for ${runs[0].name} — below threshold of ${workflowFailureStreakThreshold}`
                 )
             }
         }
@@ -339,7 +339,7 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
     const failing = buildFailingMap(allWorkflowRuns)
 
     // Determine action
-    const { action, failingList } = determineAction(state, failing, runThreshold)
+    const { action, failingList } = determineAction(state, failing, workflowFailureStreakThreshold)
 
     console.log(`Action: ${action}`)
     console.log(`Failing: ${failingList || 'none'}`)
@@ -351,23 +351,23 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
     // across critical workflows. Fetches real commit order via listCommits so
     // force-pushes don't confuse the streak.
     let classified = []
-    let redCount = 0
-    let redCommitsAction = 'none'
+    let commitFailureStreakCount = 0
+    let commitFailureStreakAction = 'none'
     try {
         const commits = await fetchRecentCommits(github, owner, repo, commitsToFetch)
         classified = classifyCommits(commits, allWorkflowRuns, criticalWorkflows)
-        redCount = countConsecutiveRedCommits(classified)
-        redCommitsAction = determineRedCommitsAction(state, redCount, redCommitThreshold)
-        console.log(`Red commits streak: ${redCount} (action: ${redCommitsAction})`)
+        commitFailureStreakCount = countConsecutiveRedCommits(classified)
+        commitFailureStreakAction = determineCommitFailureStreakAction(state, commitFailureStreakCount, commitFailureStreakThreshold)
+        console.log(`Red commits streak: ${commitFailureStreakCount} (action: ${commitFailureStreakAction})`)
     } catch (err) {
         console.log(`Failed to compute red commits: ${err.message}`)
     }
-    const redCommitsDetail = buildRedCommitsDetail(classified, redCount)
+    const commitFailureStreakDetail = buildCommitFailureStreakDetail(classified, commitFailureStreakCount)
 
     // Save when there's an action or evolving failure counts to track
     const shouldSave = action !== 'none' || Object.keys(failing).length > 0
     const saveRateLimit = rateLimitAction !== 'none'
-    const saveRedCommits = redCommitsAction !== 'none' || redCount > 0
+    const saveCommitFailureStreak = commitFailureStreakAction !== 'none' || commitFailureStreakCount > 0
 
     // Build new state
     const newState = {
@@ -382,22 +382,22 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
             rateLimitAction === 'create' || (state?.rate_limit_alerted === true && rateLimitAction !== 'resolve'),
         rate_limit_slack_ts: state?.rate_limit_slack_ts || null,
         rate_limit_slack_channel: state?.rate_limit_slack_channel || null,
-        red_commits_alerted:
-            redCommitsAction === 'create' ||
-            (state?.red_commits_alerted === true && redCommitsAction !== 'resolve'),
-        red_commits_slack_ts: state?.red_commits_slack_ts || null,
-        red_commits_slack_channel: state?.red_commits_slack_channel || null,
-        red_commits_last_count: redCommitsAction === 'resolve' ? 0 : redCount,
-        red_commits_last_sample: redCommitsDetail || state?.red_commits_last_sample || '',
+        commit_failure_streak_alerted:
+            commitFailureStreakAction === 'create' ||
+            (state?.commit_failure_streak_alerted === true && commitFailureStreakAction !== 'resolve'),
+        commit_failure_streak_slack_ts: state?.commit_failure_streak_slack_ts || null,
+        commit_failure_streak_slack_channel: state?.commit_failure_streak_slack_channel || null,
+        commit_failure_streak_last_count: commitFailureStreakAction === 'resolve' ? 0 : commitFailureStreakCount,
+        commit_failure_streak_last_sample: commitFailureStreakDetail || state?.commit_failure_streak_last_sample || '',
     }
 
-    if (shouldSave || saveRateLimit || saveRedCommits) {
+    if (shouldSave || saveRateLimit || saveCommitFailureStreak) {
         fs.writeFileSync(STATE_FILE, JSON.stringify(newState, null, 2))
     }
 
     // Set outputs
     core.setOutput('action', action)
-    core.setOutput('save_cache', shouldSave || saveRateLimit || saveRedCommits ? 'true' : 'false')
+    core.setOutput('save_cache', shouldSave || saveRateLimit || saveCommitFailureStreak ? 'true' : 'false')
     core.setOutput('delete_old_caches', action === 'create' ? 'true' : 'false')
     core.setOutput('failing_workflows', failingList)
     core.setOutput('failing_count', String(Object.keys(failing).length))
@@ -450,18 +450,18 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
         core.setOutput('rate_limit_slack_channel', state?.rate_limit_slack_channel || '')
     }
 
-    // Red-commits outputs
-    core.setOutput('red_commits_action', redCommitsAction)
-    core.setOutput('red_commits_count', String(redCount))
-    if (redCommitsAction === 'create' || redCommitsAction === 'update') {
-        core.setOutput('red_commits_detail', redCommitsDetail)
+    // Commit-failure-streak outputs
+    core.setOutput('commit_failure_streak_action', commitFailureStreakAction)
+    core.setOutput('commit_failure_streak_count', String(commitFailureStreakCount))
+    if (commitFailureStreakAction === 'create' || commitFailureStreakAction === 'update') {
+        core.setOutput('commit_failure_streak_detail', commitFailureStreakDetail)
     }
-    if (redCommitsAction === 'update' || redCommitsAction === 'resolve') {
-        core.setOutput('red_commits_slack_ts', state?.red_commits_slack_ts || '')
-        core.setOutput('red_commits_slack_channel', state?.red_commits_slack_channel || '')
+    if (commitFailureStreakAction === 'update' || commitFailureStreakAction === 'resolve') {
+        core.setOutput('commit_failure_streak_slack_ts', state?.commit_failure_streak_slack_ts || '')
+        core.setOutput('commit_failure_streak_slack_channel', state?.commit_failure_streak_slack_channel || '')
     }
-    if (redCommitsAction === 'resolve') {
-        core.setOutput('red_commits_last_count', String(state?.red_commits_last_count || 0))
-        core.setOutput('red_commits_last_sample', state?.red_commits_last_sample || '')
+    if (commitFailureStreakAction === 'resolve') {
+        core.setOutput('commit_failure_streak_last_count', String(state?.commit_failure_streak_last_count || 0))
+        core.setOutput('commit_failure_streak_last_sample', state?.commit_failure_streak_last_sample || '')
     }
 }

--- a/.github/scripts/ci-alerts-devex.js
+++ b/.github/scripts/ci-alerts-devex.js
@@ -1,19 +1,20 @@
 // Master CI Alerts - Cron-based rolling window alert for sustained master failures
 //
-// Polls the GitHub API every 5 minutes to check the latest completed run of each
-// watched workflow on master. Only alerts when master has been continuously broken
-// for ALERT_THRESHOLD_MINUTES (default 30), filtering out transient flakes.
+// Polls the GitHub API every 5 minutes to check recent completed runs of each
+// watched workflow on master. Only alerts when a workflow has ALERT_THRESHOLD_RUNS
+// (default 5) consecutive failures, filtering out transient flakes.
 //
 // Also checks GitHub API rate limits proactively — if remaining quota is critically
 // low, alerts independently so the team knows CI monitoring may be blind.
 //
 // State structure (persisted via GitHub Actions cache as .alerts-devex):
 // {
-//   failing: { [workflow]: { since: ISO string, sha: string, run_url: string, workflow_file: string } },
+//   failing: { [workflow]: { since: ISO, sha, run_url, workflow_file, consecutive_failures } },
 //   alerted: boolean,
 //   slack_ts: string | null,
 //   slack_channel: string | null,
-//   last_failing_list: string,   // comma-separated, used to detect changes for UPDATE
+//   last_failing_list: string,
+//   last_failing_detail: string,  // preserved for resolve messages
 //   resolved: boolean,
 //   rate_limit_alerted: boolean,
 //   rate_limit_slack_ts: string | null,
@@ -37,62 +38,65 @@ function determineRateLimitAction(state, critical) {
     return 'none'
 }
 
-async function fetchWorkflowStatus(github, owner, repo, workflowFile) {
+async function fetchWorkflowRuns(github, owner, repo, workflowFile, perPage) {
     const { data } = await github.rest.actions.listWorkflowRuns({
         owner,
         repo,
         workflow_id: workflowFile,
         branch: 'master',
         event: 'push',
-        per_page: 1,
+        per_page: perPage,
         status: 'completed',
     })
 
-    const run = data.workflow_runs[0]
-    if (!run) return null
-
-    return {
-        name: run.name,
-        conclusion: run.conclusion,
-        sha: run.head_sha,
-        run_url: run.html_url,
-        updated_at: run.updated_at,
-        workflow_file: workflowFile,
-    }
+    // Filter out cancelled/skipped — only real conclusions count
+    return data.workflow_runs
+        .filter((run) => run.conclusion !== 'cancelled' && run.conclusion !== 'skipped')
+        .map((run) => ({
+            name: run.name,
+            conclusion: run.conclusion,
+            sha: run.head_sha,
+            run_url: run.html_url,
+            updated_at: run.updated_at,
+            workflow_file: workflowFile,
+        }))
 }
 
-function updateFailingMap(failing, workflows) {
-    const updated = { ...failing }
-
-    for (const wf of workflows) {
-        if (!wf) continue
-
-        if (wf.conclusion === 'failure' || wf.conclusion === 'timed_out') {
-            if (!updated[wf.name]) {
-                // New failure — use the run's timestamp, not observation time,
-                // so the clock survives state loss (cache eviction, etc.)
-                updated[wf.name] = {
-                    since: wf.updated_at,
-                    sha: wf.sha,
-                    run_url: wf.run_url,
-                    workflow_file: wf.workflow_file,
-                }
-            } else {
-                // Still failing — update sha/url but keep the original since
-                updated[wf.name] = {
-                    ...updated[wf.name],
-                    sha: wf.sha,
-                    run_url: wf.run_url,
-                    workflow_file: wf.workflow_file,
-                }
-            }
-        } else if (wf.conclusion === 'success') {
-            delete updated[wf.name]
+function countConsecutiveFailures(runs) {
+    let count = 0
+    for (const run of runs) {
+        if (run.conclusion === 'failure' || run.conclusion === 'timed_out') {
+            count++
+        } else {
+            break
         }
-        // Ignore cancelled, skipped, etc. — leave state unchanged
     }
+    return count
+}
 
-    return updated
+function buildFailingMap(allWorkflowRuns) {
+    const failing = {}
+    for (const runs of allWorkflowRuns) {
+        if (runs.length === 0) continue
+        const count = countConsecutiveFailures(runs)
+        if (count > 0) {
+            const latest = runs[0]
+            const oldest = runs[count - 1]
+            failing[latest.name] = {
+                since: oldest.updated_at,
+                sha: latest.sha,
+                run_url: latest.run_url,
+                workflow_file: latest.workflow_file,
+                consecutive_failures: count,
+            }
+        }
+    }
+    return failing
+}
+
+function getMaxConsecutiveFailures(failing) {
+    const counts = Object.values(failing).map((f) => f.consecutive_failures || 0)
+    return counts.length > 0 ? Math.max(...counts) : 0
 }
 
 function getOldestFailingSince(failing) {
@@ -100,40 +104,59 @@ function getOldestFailingSince(failing) {
     return times.length > 0 ? Math.min(...times) : null
 }
 
-function determineAction(state, failing, thresholdMs, now) {
+function determineAction(state, failing, threshold) {
     const failingNames = Object.keys(failing).sort()
     const failingList = failingNames.join(', ')
     const hasFailures = failingNames.length > 0
     const wasAlerted = state?.alerted === true
 
     if (!hasFailures && !wasAlerted) {
-        return { action: 'none', failingList, save: true }
+        return { action: 'none', failingList }
     }
 
     if (!hasFailures && wasAlerted) {
-        return { action: 'resolve', failingList, save: true }
+        return { action: 'resolve', failingList }
     }
 
-    const oldest = getOldestFailingSince(failing)
-    const elapsed = now.getTime() - oldest
-    const thresholdReached = elapsed >= thresholdMs
+    const maxConsecutive = getMaxConsecutiveFailures(failing)
+    const thresholdReached = maxConsecutive >= threshold
 
-    if (!thresholdReached) {
-        // Under threshold — save state but don't alert
-        return { action: 'none', failingList, save: true }
+    if (!thresholdReached && !wasAlerted) {
+        return { action: 'none', failingList }
     }
 
-    if (!wasAlerted) {
-        return { action: 'create', failingList, save: true }
+    if (thresholdReached && !wasAlerted) {
+        return { action: 'create', failingList }
     }
 
     // Already alerted — check if the failing set changed
     const previousList = state.last_failing_list || ''
     if (failingList !== previousList) {
-        return { action: 'update', failingList, save: true }
+        return { action: 'update', failingList }
     }
 
-    return { action: 'none', failingList, save: false }
+    return { action: 'none', failingList }
+}
+
+function buildFailingDetail(failing, criticalWorkflows) {
+    const blocking = []
+    const nonBlocking = []
+    for (const [name, info] of Object.entries(failing)) {
+        const link = `<${info.run_url}|${name}>`
+        const entry = `${link} (${info.consecutive_failures} consecutive failures)`
+        if (info.workflow_file && criticalWorkflows.has(info.workflow_file)) {
+            blocking.push(entry)
+        } else {
+            nonBlocking.push(entry)
+        }
+    }
+    let detail = ''
+    if (blocking.length > 0) detail += `*Blocking:* ${blocking.join(', ')}`
+    if (nonBlocking.length > 0) {
+        if (detail) detail += '\n'
+        detail += `*Non-blocking:* ${nonBlocking.join(', ')}`
+    }
+    return detail
 }
 
 module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) => {
@@ -145,8 +168,8 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
 
     const workflowFiles = (process.env.WATCHED_WORKFLOWS || '').split(',').filter(Boolean)
     const criticalWorkflows = new Set((process.env.CRITICAL_WORKFLOWS || '').split(',').filter(Boolean))
-    const thresholdMinutes = parseInt(process.env.ALERT_THRESHOLD_MINUTES || '30', 10)
-    const thresholdMs = thresholdMinutes * 60 * 1000
+    const threshold = parseInt(process.env.ALERT_THRESHOLD_RUNS || '5', 10)
+    const perPage = threshold * 2
 
     // Load existing state
     let state = null
@@ -181,39 +204,50 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
         console.log(`Failed to check rate limit: ${err.message}`)
     }
 
-    // Fetch latest run for each watched workflow
-    console.log(`Checking ${workflowFiles.length} workflows...`)
-    const results = await Promise.all(
+    // Fetch recent runs for each watched workflow
+    console.log(`Checking ${workflowFiles.length} workflows (last ${perPage} runs each)...`)
+    const allWorkflowRuns = await Promise.all(
         workflowFiles.map((wf) =>
-            fetchWorkflowStatus(github, owner, repo, wf).catch((err) => {
+            fetchWorkflowRuns(github, owner, repo, wf, perPage).catch((err) => {
                 console.log(`Failed to fetch ${wf}: ${err.message}`)
-                return null
+                return []
             })
         )
     )
 
-    for (const r of results) {
-        if (r) console.log(`  ${r.name}: ${r.conclusion}`)
+    for (const runs of allWorkflowRuns) {
+        if (runs.length > 0) {
+            const count = countConsecutiveFailures(runs)
+            console.log(
+                `  ${runs[0].name}: ${runs[0].conclusion}${count > 0 ? ` (${count} consecutive failures)` : ''}`
+            )
+        }
     }
 
-    // Update failing map
-    const previousFailing = state?.failing || {}
-    const failing = updateFailingMap(previousFailing, results)
+    // Build failing map from API data (recomputed each tick, no stale state)
+    const failing = buildFailingMap(allWorkflowRuns)
 
     // Determine action
-    const { action, failingList, save } = determineAction(state, failing, thresholdMs, now)
+    const { action, failingList } = determineAction(state, failing, threshold)
 
     console.log(`Action: ${action}`)
     console.log(`Failing: ${failingList || 'none'}`)
 
-    // Build new state
+    // Build failing detail for Slack messages
+    const failingDetail = buildFailingDetail(failing, criticalWorkflows)
+
+    // Save when there's an action or evolving failure counts to track
+    const shouldSave = action !== 'none' || Object.keys(failing).length > 0
     const saveRateLimit = rateLimitAction !== 'none'
+
+    // Build new state
     const newState = {
         failing,
         alerted: action === 'create' || (state?.alerted === true && action !== 'resolve'),
         slack_ts: state?.slack_ts || null,
         slack_channel: state?.slack_channel || null,
         last_failing_list: failingList,
+        last_failing_detail: failingDetail || state?.last_failing_detail || '',
         resolved: action === 'resolve',
         rate_limit_alerted:
             rateLimitAction === 'create' || (state?.rate_limit_alerted === true && rateLimitAction !== 'resolve'),
@@ -221,54 +255,24 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
         rate_limit_slack_channel: state?.rate_limit_slack_channel || null,
     }
 
-    if (save || saveRateLimit) {
+    if (shouldSave || saveRateLimit) {
         fs.writeFileSync(STATE_FILE, JSON.stringify(newState, null, 2))
     }
 
-    // Set outputs for the workflow
+    // Set outputs
     core.setOutput('action', action)
-    core.setOutput('save_cache', save || saveRateLimit ? 'true' : 'false')
+    core.setOutput('save_cache', shouldSave || saveRateLimit ? 'true' : 'false')
     core.setOutput('delete_old_caches', action === 'create' ? 'true' : 'false')
     core.setOutput('failing_workflows', failingList)
     core.setOutput('failing_count', String(Object.keys(failing).length))
 
-    // For Slack messages
     if (action === 'create' || action === 'update') {
+        const maxConsecutive = getMaxConsecutiveFailures(failing)
         const oldest = getOldestFailingSince(failing)
-        const mins = Math.round((now.getTime() - oldest) / 60000)
-        core.setOutput('duration_mins', String(mins))
-
-        // Build run links for Slack, split by severity
-        const blocking = []
-        const nonBlocking = []
-        for (const [name, info] of Object.entries(failing)) {
-            const link = `<${info.run_url}|${name}>`
-            if (info.workflow_file && criticalWorkflows.has(info.workflow_file)) {
-                blocking.push(link)
-            } else {
-                nonBlocking.push(link)
-            }
-        }
-        core.setOutput('failing_links', [...blocking, ...nonBlocking].join(', '))
-        core.setOutput('failing_links_blocking', blocking.join(', '))
-        core.setOutput('failing_links_non_blocking', nonBlocking.join(', '))
-
-        // Pre-formatted detail line for Slack, split by severity
-        let detail = ''
-        if (blocking.length > 0) detail += `*Blocking:* ${blocking.join(', ')}`
-        if (nonBlocking.length > 0) {
-            if (detail) detail += '\n'
-            detail += `*Non-blocking:* ${nonBlocking.join(', ')}`
-        }
-        core.setOutput('failing_detail', detail)
-    }
-
-    if (action === 'resolve') {
-        const oldest = getOldestFailingSince(previousFailing)
         const mins = oldest ? Math.round((now.getTime() - oldest) / 60000) : 0
+        core.setOutput('max_consecutive', String(maxConsecutive))
         core.setOutput('duration_mins', String(mins))
-        core.setOutput('slack_ts', state?.slack_ts || '')
-        core.setOutput('slack_channel', state?.slack_channel || '')
+        core.setOutput('failing_detail', failingDetail)
     }
 
     if (action === 'update') {
@@ -282,6 +286,19 @@ module.exports = async ({ github, context, core }, { fs: _fs, now: _now } = {}) 
         const removed = [...prevNames].filter((n) => !currNames.has(n))
         core.setOutput('added_workflows', added.join(', '))
         core.setOutput('removed_workflows', removed.join(', '))
+    }
+
+    if (action === 'resolve') {
+        const previousFailing = state?.failing || {}
+        const maxConsecutive = getMaxConsecutiveFailures(previousFailing)
+        const oldest = getOldestFailingSince(previousFailing)
+        const mins = oldest ? Math.round((now.getTime() - oldest) / 60000) : 0
+        core.setOutput('max_consecutive', String(maxConsecutive))
+        core.setOutput('duration_mins', String(mins))
+        core.setOutput('slack_ts', state?.slack_ts || '')
+        core.setOutput('slack_channel', state?.slack_channel || '')
+        core.setOutput('last_failing_list', state?.last_failing_list || '')
+        core.setOutput('last_failing_detail', state?.last_failing_detail || '')
     }
 
     // Rate limit outputs

--- a/.github/scripts/ci-alerts-devex.test.js
+++ b/.github/scripts/ci-alerts-devex.test.js
@@ -210,6 +210,19 @@ describe('ci-alerts-devex', () => {
             expect(outputs.rate_limit_action).toBe('none')
             expect(outputs.action).toBe('none')
         })
+
+        it('fires workflow and rate-limit signals independently in the same tick', async () => {
+            const github = createGithubMock(
+                {
+                    'ci-backend.yml': runs('Backend CI', Array(5).fill('failure')),
+                    'ci-frontend.yml': runs('Frontend CI', ['success']),
+                },
+                { rateLimitRemaining: 50 }
+            )
+            const { outputs } = await run(github)
+            expect(outputs.action).toBe('create')
+            expect(outputs.rate_limit_action).toBe('create')
+        })
     })
 
     describe('red commit streak', () => {
@@ -267,6 +280,12 @@ describe('ci-alerts-devex', () => {
             let { outputs } = await run(createGithubMock(runsByWorkflow, { commits }), { state: stateAlerted })
             expect(outputs.commit_failure_streak_action).toBe('update')
             expect(outputs.commit_failure_streak_count).toBe('14')
+
+            // 10 red with last_count already 10 → no-op (idempotent at/over threshold, no growth)
+            ;({ commits, runsByWorkflow } = redCommits(10))
+            ;({ outputs } = await run(createGithubMock(runsByWorkflow, { commits }), { state: stateAlerted }))
+            expect(outputs.commit_failure_streak_action).toBe('none')
+            expect(outputs.commit_failure_streak_count).toBe('10')
 
             // All green after alerted → resolve
             ;({ commits, runsByWorkflow } = greenCommits(12))

--- a/.github/scripts/ci-alerts-devex.test.js
+++ b/.github/scripts/ci-alerts-devex.test.js
@@ -7,25 +7,8 @@ const ciAlertsDevex = require('./ci-alerts-devex')
 const T_BASE = new Date('2026-04-09T12:00:00Z')
 const minutes = (n) => new Date(T_BASE.getTime() + n * 60000)
 
-function createMocks() {
-    const outputs = {}
-    const core = {
-        setOutput: jest.fn((key, value) => {
-            outputs[key] = value
-        }),
-    }
-    return { core, outputs }
-}
-
-function createContext() {
-    return {
-        repo: { owner: 'PostHog', repo: 'posthog' },
-    }
-}
-
-// Helper: build an array of run objects for a single workflow.
-// conclusions are ordered most-recent-first (index 0 = latest run).
-function runs(name, conclusions, { workflowFile } = {}) {
+// Helper: array of workflow-run objects. conclusions newest-first.
+function runs(name, conclusions) {
     return conclusions.map((conclusion, i) => ({
         name,
         conclusion,
@@ -35,17 +18,47 @@ function runs(name, conclusions, { workflowFile } = {}) {
     }))
 }
 
-function createGithubMock(
-    workflowRuns,
-    { rateLimitRemaining = 4500, rateLimitLimit = 5000, commits = [] } = {}
-) {
+// Helper: N failures followed by 5 successes.
+const failingRuns = (name, failCount) =>
+    runs(name, [...Array(failCount).fill('failure'), ...Array(5).fill('success')])
+
+const allPassing = () => ({
+    'ci-backend.yml': runs('Backend CI', ['success']),
+    'ci-frontend.yml': runs('Frontend CI', ['success']),
+})
+
+// Helper: build listCommits + listWorkflowRuns mocks aligned by SHA.
+// Each element of perCommitConclusions is a {workflowFile: conclusion} map
+// for one commit (newest first).
+function commitsWithRuns(perCommitConclusions) {
+    const commits = perCommitConclusions.map((_, i) => ({
+        sha: `commit_sha_${i}`,
+        html_url: `https://github.com/commit/commit_sha_${i}`,
+        commit: { message: `commit ${i}`, author: { name: 'dev' } },
+    }))
+    const runsByWorkflow = {}
+    perCommitConclusions.forEach((conclusionsMap, i) => {
+        for (const [wf, conclusion] of Object.entries(conclusionsMap)) {
+            if (!runsByWorkflow[wf]) runsByWorkflow[wf] = []
+            runsByWorkflow[wf].push({
+                name: wf === 'ci-backend.yml' ? 'Backend CI' : 'Frontend CI',
+                conclusion,
+                head_sha: `commit_sha_${i}`,
+                html_url: `https://github.com/runs/${wf}/${i}`,
+                updated_at: minutes(-(i * 5)).toISOString(),
+            })
+        }
+    })
+    return { commits, runsByWorkflow }
+}
+
+function createGithubMock(workflowRuns, { rateLimitRemaining = 4500, commits = [] } = {}) {
     return {
         rest: {
             actions: {
-                listWorkflowRuns: jest.fn(({ workflow_id }) => {
-                    const wfRuns = workflowRuns[workflow_id] || []
-                    return Promise.resolve({ data: { workflow_runs: wfRuns } })
-                }),
+                listWorkflowRuns: jest.fn(({ workflow_id }) =>
+                    Promise.resolve({ data: { workflow_runs: workflowRuns[workflow_id] || [] } })
+                ),
             },
             rateLimit: {
                 get: jest.fn(() =>
@@ -54,7 +67,7 @@ function createGithubMock(
                             resources: {
                                 core: {
                                     remaining: rateLimitRemaining,
-                                    limit: rateLimitLimit,
+                                    limit: 5000,
                                     reset: Math.floor(T_BASE.getTime() / 1000) + 3600,
                                 },
                             },
@@ -69,50 +82,9 @@ function createGithubMock(
     }
 }
 
-// Helper: commits newest-first. conclusions is an array of workflow-file->conclusion
-// maps, one per commit, where each map pins the critical workflow's result for
-// that SHA. Any SHA referenced here is synthesized into the runs list too.
-function commitsWithRuns(perCommitConclusions) {
-    const commits = perCommitConclusions.map((_, i) => ({
-        sha: `commit_sha_${i}`,
-        html_url: `https://github.com/commit/commit_sha_${i}`,
-        commit: { message: `commit ${i}`, author: { name: 'dev' } },
-    }))
-    const runsByWorkflow = {}
-    perCommitConclusions.forEach((conclusionsMap, i) => {
-        for (const [workflowFile, conclusion] of Object.entries(conclusionsMap)) {
-            if (!runsByWorkflow[workflowFile]) runsByWorkflow[workflowFile] = []
-            runsByWorkflow[workflowFile].push({
-                name: workflowFile.replace('.yml', '').replace('ci-', '').replace(/^./, (c) => c.toUpperCase()) + ' CI',
-                conclusion,
-                head_sha: `commit_sha_${i}`,
-                html_url: `https://github.com/runs/${workflowFile}/${i}`,
-                updated_at: minutes(-(i * 5)).toISOString(),
-            })
-        }
-    })
-    return { commits, runsByWorkflow }
-}
-
-// Shorthand for all-passing runs (1 success each)
-const allPassing = () => ({
-    'ci-backend.yml': runs('Backend CI', ['success']),
-    'ci-frontend.yml': runs('Frontend CI', ['success']),
-})
-
-// Shorthand: N consecutive failures followed by successes
-const failingRuns = (name, failCount, successCount = 5) => {
-    const conclusions = [
-        ...Array(failCount).fill('failure'),
-        ...Array(successCount).fill('success'),
-    ]
-    return runs(name, conclusions)
-}
-
 function run(github, { state = null, now = minutes(0) } = {}) {
-    const { core, outputs } = createMocks()
-    const context = createContext()
-
+    const outputs = {}
+    const core = { setOutput: jest.fn((k, v) => (outputs[k] = v)) }
     const mockFs = {
         existsSync: jest.fn(() => state !== null),
         readFileSync: jest.fn(() => (state ? JSON.stringify(state) : '{}')),
@@ -125,10 +97,8 @@ function run(github, { state = null, now = minutes(0) } = {}) {
     process.env.RATE_LIMIT_THRESHOLD_PERCENT = '10'
     process.env.CRITICAL_WORKFLOWS = 'ci-backend.yml'
 
-    return ciAlertsDevex({ github, context, core }, { fs: mockFs, now }).then(() => ({
+    return ciAlertsDevex({ github, context: { repo: { owner: 'PostHog', repo: 'posthog' } }, core }, { fs: mockFs, now }).then(() => ({
         outputs,
-        core,
-        mockFs,
         writtenState: mockFs.writeFileSync.mock.calls[0]
             ? JSON.parse(mockFs.writeFileSync.mock.calls[0][1])
             : null,
@@ -162,55 +132,21 @@ const alertedState = () => ({
 
 describe('ci-alerts-devex', () => {
     it('no-op when all workflows pass', async () => {
-        const github = createGithubMock(allPassing())
-
-        const { outputs, writtenState } = await run(github)
-
+        const { outputs, writtenState } = await run(createGithubMock(allPassing()))
         expect(outputs.action).toBe('none')
-        // No failures to track, no save needed
-        expect(outputs.save_cache).toBe('false')
         expect(writtenState).toBeNull()
     })
 
-    it.each(['failure', 'timed_out'])('records %s but does not alert under threshold', async (conclusion) => {
+    it.each(['failure', 'timed_out'])('creates alert on 5 consecutive %s', async (conclusion) => {
         const github = createGithubMock({
-            'ci-backend.yml': runs('Backend CI', [conclusion, conclusion, 'success']),
+            'ci-backend.yml': runs('Backend CI', Array(5).fill(conclusion)),
             'ci-frontend.yml': runs('Frontend CI', ['success']),
         })
-
         const { outputs, writtenState } = await run(github)
-
-        expect(outputs.action).toBe('none')
-        expect(outputs.save_cache).toBe('true')
-        expect(writtenState.failing['Backend CI']).toBeDefined()
-        expect(writtenState.failing['Backend CI'].consecutive_failures).toBe(2)
-        expect(writtenState.alerted).toBe(false)
-    })
-
-    it('creates alert when consecutive failures reach threshold', async () => {
-        const github = createGithubMock({
-            'ci-backend.yml': failingRuns('Backend CI', 5),
-            'ci-frontend.yml': runs('Frontend CI', ['success']),
-        })
-
-        const { outputs, writtenState } = await run(github)
-
         expect(outputs.action).toBe('create')
-        expect(outputs.failing_workflows).toBe('Backend CI')
-        expect(outputs.failing_count).toBe('1')
         expect(outputs.max_consecutive).toBe('5')
+        expect(outputs.failing_detail).toMatch(/\*Blocking:\*.*Backend CI/)
         expect(writtenState.alerted).toBe(true)
-    })
-
-    it('does not alert at threshold minus one', async () => {
-        const github = createGithubMock({
-            'ci-backend.yml': failingRuns('Backend CI', 4),
-            'ci-frontend.yml': runs('Frontend CI', ['success']),
-        })
-
-        const { outputs } = await run(github)
-
-        expect(outputs.action).toBe('none')
     })
 
     it('updates Slack when failing set changes after alert', async () => {
@@ -218,531 +154,126 @@ describe('ci-alerts-devex', () => {
             'ci-backend.yml': failingRuns('Backend CI', 5),
             'ci-frontend.yml': failingRuns('Frontend CI', 5),
         })
-
         const { outputs } = await run(github, { state: alertedState() })
-
         expect(outputs.action).toBe('update')
         expect(outputs.added_workflows).toBe('Frontend CI')
-        expect(outputs.slack_ts).toBe('123.456')
     })
 
-    it('resolves when all workflows pass after alert', async () => {
-        const github = createGithubMock(allPassing())
-
-        const { outputs, writtenState } = await run(github, {
-            state: alertedState(),
-            now: minutes(45),
-        })
-
+    it('resolves and preserves failing detail', async () => {
+        const { outputs, writtenState } = await run(createGithubMock(allPassing()), { state: alertedState() })
         expect(outputs.action).toBe('resolve')
-        expect(outputs.max_consecutive).toBe('5')
-        expect(outputs.duration_mins).toBeDefined()
+        expect(outputs.last_failing_detail).toContain('Backend CI')
         expect(writtenState.resolved).toBe(true)
     })
 
-    it('resolve outputs include previous failing detail', async () => {
-        const github = createGithubMock(allPassing())
-
-        const { outputs } = await run(github, { state: alertedState() })
-
-        expect(outputs.last_failing_list).toBe('Backend CI')
-        expect(outputs.last_failing_detail).toContain('Backend CI')
-        expect(outputs.last_failing_detail).toContain('5 consecutive failures')
-    })
-
-    it('stays alerted when some workflows recover but others still fail', async () => {
-        const state = {
-            ...alertedState(),
-            failing: {
-                ...alertedState().failing,
-                'Frontend CI': {
-                    since: minutes(-10).toISOString(),
-                    sha: 'sha1',
-                    run_url: 'https://github.com/runs/Frontend CI/0',
-                    workflow_file: 'ci-frontend.yml',
-                    consecutive_failures: 5,
-                },
-            },
-            last_failing_list: 'Backend CI, Frontend CI',
-        }
-
+    it('filters cancelled and skipped runs from consecutive count', async () => {
         const github = createGithubMock({
-            'ci-backend.yml': runs('Backend CI', ['success']),
-            'ci-frontend.yml': failingRuns('Frontend CI', 3),
-        })
-
-        const { outputs } = await run(github, { state })
-
-        // Set changed (Backend recovered), so update fires, but no resolve
-        expect(outputs.action).toBe('update')
-        expect(outputs.removed_workflows).toBe('Backend CI')
-    })
-
-    it('filters out cancelled runs from consecutive count', async () => {
-        const github = createGithubMock({
-            'ci-backend.yml': runs('Backend CI', [
-                'failure',
-                'cancelled',
-                'failure',
-                'cancelled',
-                'failure',
-                'failure',
-                'failure',
-                'success',
-            ]),
+            'ci-backend.yml': runs('Backend CI', ['failure', 'cancelled', 'failure', 'skipped', 'failure', 'failure', 'failure', 'success']),
             'ci-frontend.yml': runs('Frontend CI', ['success']),
         })
-
-        const { outputs, writtenState } = await run(github)
-
-        // After filtering cancelled: [failure, failure, failure, failure, failure, success]
-        // Consecutive from front: 5
-        expect(outputs.action).toBe('create')
-        expect(writtenState.failing['Backend CI'].consecutive_failures).toBe(5)
-    })
-
-    it('filters out skipped runs from consecutive count', async () => {
-        const github = createGithubMock({
-            'ci-backend.yml': runs('Backend CI', ['failure', 'skipped', 'failure', 'success']),
-            'ci-frontend.yml': runs('Frontend CI', ['success']),
-        })
-
-        const { writtenState } = await run(github)
-
-        // After filtering skipped: [failure, failure, success] -> 2 consecutive
-        expect(writtenState.failing['Backend CI'].consecutive_failures).toBe(2)
-    })
-
-    it('includes duration as supplementary context', async () => {
-        const github = createGithubMock({
-            'ci-backend.yml': failingRuns('Backend CI', 5),
-            'ci-frontend.yml': runs('Frontend CI', ['success']),
-        })
-
-        const { outputs } = await run(github, { now: minutes(0) })
-
-        expect(outputs.action).toBe('create')
-        expect(outputs.duration_mins).toBeDefined()
-        // duration_mins is computed from oldest failure timestamp to now
-        expect(parseInt(outputs.duration_mins)).toBeGreaterThanOrEqual(0)
-    })
-
-    it('saves state when failures exist below threshold', async () => {
-        const github = createGithubMock({
-            'ci-backend.yml': failingRuns('Backend CI', 2),
-            'ci-frontend.yml': runs('Frontend CI', ['success']),
-        })
-
-        const { outputs, writtenState } = await run(github)
-
-        expect(outputs.action).toBe('none')
-        expect(outputs.save_cache).toBe('true')
-        expect(writtenState.failing['Backend CI'].consecutive_failures).toBe(2)
-    })
-
-    it('tracks since from oldest consecutive failure', async () => {
-        // 5 failures, each 5 min apart. Oldest = index 4 = minutes(-20)
-        const github = createGithubMock({
-            'ci-backend.yml': failingRuns('Backend CI', 5),
-            'ci-frontend.yml': runs('Frontend CI', ['success']),
-        })
-
-        const { writtenState } = await run(github)
-
-        expect(writtenState.failing['Backend CI'].since).toBe(minutes(-20).toISOString())
-    })
-
-    it('treats all-cancelled runs as no signal', async () => {
-        const github = createGithubMock({
-            'ci-backend.yml': runs('Backend CI', ['cancelled', 'cancelled', 'skipped']),
-            'ci-frontend.yml': runs('Frontend CI', ['success']),
-        })
-
-        const { outputs, writtenState } = await run(github)
-
-        expect(outputs.action).toBe('none')
-        expect(writtenState).toBeNull()
-    })
-
-    it('treats timed_out the same as failure for duration tracking', async () => {
-        const github = createGithubMock({
-            'ci-backend.yml': runs('Backend CI', ['timed_out', 'timed_out', 'timed_out', 'timed_out', 'timed_out']),
-            'ci-frontend.yml': runs('Frontend CI', ['success']),
-        })
-
-        const { outputs, writtenState } = await run(github)
-
+        const { outputs } = await run(github)
         expect(outputs.action).toBe('create')
         expect(outputs.max_consecutive).toBe('5')
-        expect(writtenState.failing['Backend CI'].since).toBe(minutes(-20).toISOString())
     })
 
-    it('gracefully handles old-schema state without consecutive_failures', async () => {
-        // Simulate state written by previous version of the script:
-        // no consecutive_failures field, no last_failing_detail.
-        const legacyState = {
-            failing: {
-                'Backend CI': {
-                    since: minutes(-30).toISOString(),
-                    sha: 'old_sha',
-                    run_url: 'https://github.com/runs/old',
-                    workflow_file: 'ci-backend.yml',
-                },
-            },
-            alerted: true,
-            slack_ts: '123.456',
-            slack_channel: 'C123',
-            last_failing_list: 'Backend CI',
-        }
-
-        const github = createGithubMock(allPassing())
-
-        const { outputs } = await run(github, { state: legacyState, now: minutes(5) })
-
-        expect(outputs.action).toBe('resolve')
-        expect(outputs.max_consecutive).toBe('0') // unknown from legacy state, defaults to 0
-        expect(outputs.last_failing_list).toBe('Backend CI')
-        expect(outputs.last_failing_detail).toBe('') // legacy state has no detail
-    })
-
-    describe('rate limit checks', () => {
-        it('no-op when rate limit is healthy', async () => {
-            const github = createGithubMock(allPassing(), { rateLimitRemaining: 4500, rateLimitLimit: 5000 })
-
-            const { outputs } = await run(github)
-
-            expect(outputs.rate_limit_action).toBe('none')
-            expect(outputs.rate_limit_remaining).toBe('4500')
-            expect(outputs.rate_limit_limit).toBe('5000')
+    it('splits critical vs non-critical failures in detail', async () => {
+        const github = createGithubMock({
+            'ci-backend.yml': failingRuns('Backend CI', 5),
+            'ci-frontend.yml': failingRuns('Frontend CI', 5),
         })
+        const { outputs } = await run(github)
+        expect(outputs.failing_detail).toMatch(/^\*Blocking:\*.*Backend CI/)
+        expect(outputs.failing_detail).toMatch(/\*Non-blocking:\*.*Frontend CI/)
+    })
 
-        it('creates rate limit alert when remaining is below threshold', async () => {
-            const github = createGithubMock(allPassing(), { rateLimitRemaining: 50, rateLimitLimit: 5000 })
-
-            const { outputs, writtenState } = await run(github)
-
+    describe('rate limit', () => {
+        it('alerts when critical, resolves when healthy', async () => {
+            // Fire alert
+            let github = createGithubMock(allPassing(), { rateLimitRemaining: 50 })
+            let { outputs, writtenState } = await run(github)
             expect(outputs.rate_limit_action).toBe('create')
-            expect(outputs.rate_limit_remaining).toBe('50')
             expect(writtenState.rate_limit_alerted).toBe(true)
-        })
 
-        it('does not re-alert when already alerted for rate limit', async () => {
-            const github = createGithubMock(allPassing(), { rateLimitRemaining: 30, rateLimitLimit: 5000 })
-
-            const { outputs } = await run(github, {
-                state: { failing: {}, alerted: false, rate_limit_alerted: true },
-            })
-
-            expect(outputs.rate_limit_action).toBe('none')
-        })
-
-        it('resolves rate limit alert when quota recovers', async () => {
-            const github = createGithubMock(allPassing(), { rateLimitRemaining: 4500, rateLimitLimit: 5000 })
-
-            const { outputs, writtenState } = await run(github, {
-                state: {
-                    failing: {},
-                    alerted: false,
-                    rate_limit_alerted: true,
-                    rate_limit_slack_ts: '789.012',
-                    rate_limit_slack_channel: 'C456',
-                },
-            })
-
+            // Recover
+            github = createGithubMock(allPassing(), { rateLimitRemaining: 4500 })
+            ;({ outputs, writtenState } = await run(github, {
+                state: { failing: {}, rate_limit_alerted: true, rate_limit_slack_ts: '1', rate_limit_slack_channel: 'C' },
+            }))
             expect(outputs.rate_limit_action).toBe('resolve')
-            expect(outputs.rate_limit_slack_ts).toBe('789.012')
-            expect(outputs.rate_limit_slack_channel).toBe('C456')
             expect(writtenState.rate_limit_alerted).toBe(false)
-        })
-
-        it('preserves rate limit state across incident resolution', async () => {
-            const github = createGithubMock(allPassing(), { rateLimitRemaining: 30, rateLimitLimit: 5000 })
-
-            const { outputs } = await run(github, {
-                state: {
-                    resolved: true,
-                    rate_limit_alerted: true,
-                    rate_limit_slack_ts: '789.012',
-                    rate_limit_slack_channel: 'C456',
-                },
-            })
-
-            expect(outputs.rate_limit_action).toBe('none')
-        })
-
-        it('continues workflow checks even when rate limit is critical', async () => {
-            const github = createGithubMock(
-                {
-                    'ci-backend.yml': failingRuns('Backend CI', 5),
-                    'ci-frontend.yml': runs('Frontend CI', ['success']),
-                },
-                { rateLimitRemaining: 10, rateLimitLimit: 5000 }
-            )
-
-            const { outputs, writtenState } = await run(github)
-
-            expect(outputs.action).toBe('create')
-            expect(outputs.rate_limit_action).toBe('create')
-            expect(writtenState.alerted).toBe(true)
-            expect(writtenState.rate_limit_alerted).toBe(true)
         })
 
         it('degrades gracefully when rate limit API fails', async () => {
             const github = createGithubMock(allPassing())
             github.rest.rateLimit.get = jest.fn(() => Promise.reject(new Error('API error')))
-
             const { outputs } = await run(github)
-
             expect(outputs.rate_limit_action).toBe('none')
-            expect(outputs.rate_limit_remaining).toBeUndefined()
             expect(outputs.action).toBe('none')
         })
     })
 
-    describe('severity differentiation', () => {
-        it('labels critical-only failures correctly', async () => {
-            const github = createGithubMock({
-                'ci-backend.yml': failingRuns('Backend CI', 5),
-                'ci-frontend.yml': runs('Frontend CI', ['success']),
-            })
-
-            const { outputs } = await run(github)
-
-            expect(outputs.action).toBe('create')
-            expect(outputs.failing_detail).toMatch(/\*Blocking:\*.*Backend CI.*5 consecutive failures/)
-            expect(outputs.failing_detail).not.toContain('Non-blocking')
-        })
-
-        it('labels non-critical-only failures correctly', async () => {
-            const github = createGithubMock({
-                'ci-backend.yml': runs('Backend CI', ['success']),
-                'ci-frontend.yml': failingRuns('Frontend CI', 5),
-            })
-
-            const { outputs } = await run(github)
-
-            expect(outputs.action).toBe('create')
-            expect(outputs.failing_detail).toMatch(/\*Non-blocking:\*.*Frontend CI.*5 consecutive failures/)
-            expect(outputs.failing_detail).not.toContain('Blocking:')
-        })
-
-        it('splits mixed failures into critical and other', async () => {
-            const github = createGithubMock({
-                'ci-backend.yml': failingRuns('Backend CI', 5),
-                'ci-frontend.yml': failingRuns('Frontend CI', 5),
-            })
-
-            const { outputs } = await run(github)
-
-            expect(outputs.action).toBe('create')
-            expect(outputs.failing_detail).toMatch(/^\*Blocking:\*.*Backend CI/)
-            expect(outputs.failing_detail).toMatch(/\*Non-blocking:\*.*Frontend CI/)
-        })
-
-        it('stores workflow_file and consecutive_failures in failing map', async () => {
-            const github = createGithubMock({
-                'ci-backend.yml': failingRuns('Backend CI', 3),
-                'ci-frontend.yml': runs('Frontend CI', ['success']),
-            })
-
-            const { writtenState } = await run(github)
-
-            expect(writtenState.failing['Backend CI'].workflow_file).toBe('ci-backend.yml')
-            expect(writtenState.failing['Backend CI'].consecutive_failures).toBe(3)
-        })
-    })
-
     describe('red commit streak', () => {
-        // Only ci-backend.yml is critical in the test env; ci-frontend.yml is not.
-        // Red classification therefore depends solely on ci-backend outcomes per SHA.
-
         const greenCommits = (n) => commitsWithRuns(Array(n).fill({ 'ci-backend.yml': 'success' }))
         const redCommits = (n) => commitsWithRuns(Array(n).fill({ 'ci-backend.yml': 'failure' }))
 
-        it('no-op when all recent commits are green', async () => {
-            const { commits, runsByWorkflow } = greenCommits(12)
-            const github = createGithubMock(runsByWorkflow, { commits })
-
-            const { outputs } = await run(github)
-
-            expect(outputs.red_commits_action).toBe('none')
-            expect(outputs.red_commits_count).toBe('0')
-        })
-
-        it('does not alert at threshold minus one', async () => {
-            const { commits, runsByWorkflow } = redCommits(9)
-            const github = createGithubMock(runsByWorkflow, { commits })
-
-            const { outputs } = await run(github)
-
+        it('no-op below threshold, creates alert at threshold', async () => {
+            // 9 red → no alert
+            let { commits, runsByWorkflow } = redCommits(9)
+            let { outputs } = await run(createGithubMock(runsByWorkflow, { commits }))
             expect(outputs.red_commits_action).toBe('none')
             expect(outputs.red_commits_count).toBe('9')
-        })
 
-        it('creates alert at 10 consecutive red commits', async () => {
-            const { commits, runsByWorkflow } = redCommits(10)
-            const github = createGithubMock(runsByWorkflow, { commits })
-
-            const { outputs, writtenState } = await run(github)
-
+            // 10 red → create, with detail listing culprit per commit
+            ;({ commits, runsByWorkflow } = redCommits(10))
+            ;({ outputs } = await run(createGithubMock(runsByWorkflow, { commits })))
             expect(outputs.red_commits_action).toBe('create')
             expect(outputs.red_commits_count).toBe('10')
-            expect(outputs.red_commits_detail).toContain('commit_sha_0'.slice(0, 7))
-            expect(writtenState.red_commits_alerted).toBe(true)
-            expect(writtenState.red_commits_last_count).toBe(10)
-        })
-
-        it('attributes culprits per commit in detail', async () => {
-            // ci-backend is critical, so only its failures mark commits red.
-            // Mix: half fail with backend, half fail with backend (only critical one in env).
-            const { commits, runsByWorkflow } = commitsWithRuns([
-                { 'ci-backend.yml': 'failure' },
-                { 'ci-backend.yml': 'timed_out' },
-                { 'ci-backend.yml': 'failure' },
-                { 'ci-backend.yml': 'failure' },
-                { 'ci-backend.yml': 'failure' },
-                { 'ci-backend.yml': 'failure' },
-                { 'ci-backend.yml': 'failure' },
-                { 'ci-backend.yml': 'failure' },
-                { 'ci-backend.yml': 'failure' },
-                { 'ci-backend.yml': 'failure' },
-            ])
-            const github = createGithubMock(runsByWorkflow, { commits })
-
-            const { outputs } = await run(github)
-
-            expect(outputs.red_commits_action).toBe('create')
             expect(outputs.red_commits_detail.split('\n')).toHaveLength(10)
             expect(outputs.red_commits_detail).toMatch(/Backend CI/)
         })
 
-        it('green commit breaks the streak', async () => {
-            // newest 8 red, then a green, then more red — streak is only 8
+        it('unknown commits skip, non-critical failures ignored, green breaks streak', async () => {
+            // newest 2 unknown, then 1 green, then 8 red → green breaks before threshold
             const { commits, runsByWorkflow } = commitsWithRuns([
-                ...Array(8).fill({ 'ci-backend.yml': 'failure' }),
+                {},
+                {},
                 { 'ci-backend.yml': 'success' },
-                ...Array(5).fill({ 'ci-backend.yml': 'failure' }),
+                ...Array(8).fill({ 'ci-backend.yml': 'failure', 'ci-frontend.yml': 'failure' }),
             ])
-            const github = createGithubMock(runsByWorkflow, { commits })
-
-            const { outputs } = await run(github)
-
-            expect(outputs.red_commits_count).toBe('8')
+            const { outputs } = await run(createGithubMock(runsByWorkflow, { commits }))
+            expect(outputs.red_commits_count).toBe('0')
             expect(outputs.red_commits_action).toBe('none')
         })
 
-        it('unknown commits do not count but do not break', async () => {
-            // newest 3 have no critical runs (unknown), next 10 are red
-            const { commits, runsByWorkflow } = commitsWithRuns([
-                {},
-                {},
-                {},
-                ...Array(10).fill({ 'ci-backend.yml': 'failure' }),
-            ])
-            const github = createGithubMock(runsByWorkflow, { commits })
-
-            const { outputs } = await run(github)
-
-            expect(outputs.red_commits_count).toBe('10')
-            expect(outputs.red_commits_action).toBe('create')
-        })
-
-        it('non-critical workflow failures do not mark a commit red', async () => {
-            // ci-frontend is not critical — its failures should be ignored.
-            // Every commit passes ci-backend but fails ci-frontend.
+        it('non-critical-only failures do not mark commits red', async () => {
             const { commits, runsByWorkflow } = commitsWithRuns(
                 Array(10).fill({ 'ci-backend.yml': 'success', 'ci-frontend.yml': 'failure' })
             )
-            const github = createGithubMock(runsByWorkflow, { commits })
-
-            const { outputs } = await run(github)
-
+            const { outputs } = await run(createGithubMock(runsByWorkflow, { commits }))
             expect(outputs.red_commits_count).toBe('0')
-            expect(outputs.red_commits_action).toBe('none')
         })
 
-        it('updates Slack when streak grows after alert', async () => {
-            const { commits, runsByWorkflow } = redCommits(14)
-            const github = createGithubMock(runsByWorkflow, { commits })
-
-            const { outputs } = await run(github, {
-                state: {
-                    failing: {},
-                    red_commits_alerted: true,
-                    red_commits_slack_ts: '999.999',
-                    red_commits_slack_channel: 'Cred',
-                    red_commits_last_count: 10,
-                },
-            })
-
-            expect(outputs.red_commits_action).toBe('update')
-            expect(outputs.red_commits_count).toBe('14')
-            expect(outputs.red_commits_slack_ts).toBe('999.999')
-        })
-
-        it('does not re-update when count is unchanged', async () => {
-            const { commits, runsByWorkflow } = redCommits(10)
-            const github = createGithubMock(runsByWorkflow, { commits })
-
-            const { outputs } = await run(github, {
-                state: {
-                    failing: {},
-                    red_commits_alerted: true,
-                    red_commits_slack_ts: '999.999',
-                    red_commits_slack_channel: 'Cred',
-                    red_commits_last_count: 10,
-                },
-            })
-
-            expect(outputs.red_commits_action).toBe('none')
-        })
-
-        it('resolves when streak drops below threshold', async () => {
-            const { commits, runsByWorkflow } = greenCommits(12)
-            const github = createGithubMock(runsByWorkflow, { commits })
-
-            const { outputs, writtenState } = await run(github, {
-                state: {
-                    failing: {},
-                    red_commits_alerted: true,
-                    red_commits_slack_ts: '999.999',
-                    red_commits_slack_channel: 'Cred',
-                    red_commits_last_count: 12,
-                    red_commits_last_sample: '• abc1234 — Backend CI',
-                },
-            })
-
-            expect(outputs.red_commits_action).toBe('resolve')
-            expect(outputs.red_commits_last_count).toBe('12')
-            expect(outputs.red_commits_slack_ts).toBe('999.999')
-            expect(writtenState.red_commits_alerted).toBe(false)
-            expect(writtenState.red_commits_last_count).toBe(0)
-        })
-
-        it('old-schema state without red_commits fields degrades gracefully', async () => {
-            const { commits, runsByWorkflow } = greenCommits(12)
-            const github = createGithubMock(runsByWorkflow, { commits })
-
-            const legacyState = {
+        it('updates when streak grows, resolves when drops below threshold', async () => {
+            const stateAlerted = {
                 failing: {},
-                alerted: false,
-                // no red_commits_* fields
+                red_commits_alerted: true,
+                red_commits_slack_ts: '999.999',
+                red_commits_slack_channel: 'Cred',
+                red_commits_last_count: 10,
             }
 
-            const { outputs } = await run(github, { state: legacyState })
+            // 14 red after alerted-at-10 → update
+            let { commits, runsByWorkflow } = redCommits(14)
+            let { outputs } = await run(createGithubMock(runsByWorkflow, { commits }), { state: stateAlerted })
+            expect(outputs.red_commits_action).toBe('update')
+            expect(outputs.red_commits_count).toBe('14')
 
-            expect(outputs.red_commits_action).toBe('none')
-            expect(outputs.red_commits_count).toBe('0')
-        })
-
-        it('degrades gracefully when listCommits fails', async () => {
-            const github = createGithubMock(allPassing())
-            github.rest.repos.listCommits = jest.fn(() => Promise.reject(new Error('API error')))
-
-            const { outputs } = await run(github)
-
-            expect(outputs.red_commits_action).toBe('none')
-            expect(outputs.red_commits_count).toBe('0')
+            // All green after alerted → resolve
+            ;({ commits, runsByWorkflow } = greenCommits(12))
+            let writtenState
+            ;({ outputs, writtenState } = await run(createGithubMock(runsByWorkflow, { commits }), { state: stateAlerted }))
+            expect(outputs.red_commits_action).toBe('resolve')
+            expect(writtenState.red_commits_alerted).toBe(false)
         })
     })
 })

--- a/.github/scripts/ci-alerts-devex.test.js
+++ b/.github/scripts/ci-alerts-devex.test.js
@@ -92,8 +92,8 @@ function run(github, { state = null, now = minutes(0) } = {}) {
     }
 
     process.env.WATCHED_WORKFLOWS = 'ci-backend.yml,ci-frontend.yml'
-    process.env.ALERT_THRESHOLD_RUNS = '5'
-    process.env.RED_COMMIT_THRESHOLD = '10'
+    process.env.WORKFLOW_FAILURE_STREAK_THRESHOLD = '5'
+    process.env.COMMIT_FAILURE_STREAK_THRESHOLD = '10'
     process.env.RATE_LIMIT_THRESHOLD_PERCENT = '10'
     process.env.CRITICAL_WORKFLOWS = 'ci-backend.yml'
 
@@ -107,8 +107,8 @@ function run(github, { state = null, now = minutes(0) } = {}) {
 
 afterEach(() => {
     delete process.env.WATCHED_WORKFLOWS
-    delete process.env.ALERT_THRESHOLD_RUNS
-    delete process.env.RED_COMMIT_THRESHOLD
+    delete process.env.WORKFLOW_FAILURE_STREAK_THRESHOLD
+    delete process.env.COMMIT_FAILURE_STREAK_THRESHOLD
     delete process.env.RATE_LIMIT_THRESHOLD_PERCENT
     delete process.env.CRITICAL_WORKFLOWS
 })
@@ -220,16 +220,16 @@ describe('ci-alerts-devex', () => {
             // 9 red → no alert
             let { commits, runsByWorkflow } = redCommits(9)
             let { outputs } = await run(createGithubMock(runsByWorkflow, { commits }))
-            expect(outputs.red_commits_action).toBe('none')
-            expect(outputs.red_commits_count).toBe('9')
+            expect(outputs.commit_failure_streak_action).toBe('none')
+            expect(outputs.commit_failure_streak_count).toBe('9')
 
             // 10 red → create, with detail listing culprit per commit
             ;({ commits, runsByWorkflow } = redCommits(10))
             ;({ outputs } = await run(createGithubMock(runsByWorkflow, { commits })))
-            expect(outputs.red_commits_action).toBe('create')
-            expect(outputs.red_commits_count).toBe('10')
-            expect(outputs.red_commits_detail.split('\n')).toHaveLength(10)
-            expect(outputs.red_commits_detail).toMatch(/Backend CI/)
+            expect(outputs.commit_failure_streak_action).toBe('create')
+            expect(outputs.commit_failure_streak_count).toBe('10')
+            expect(outputs.commit_failure_streak_detail.split('\n')).toHaveLength(10)
+            expect(outputs.commit_failure_streak_detail).toMatch(/Backend CI/)
         })
 
         it('unknown commits skip, non-critical failures ignored, green breaks streak', async () => {
@@ -241,8 +241,8 @@ describe('ci-alerts-devex', () => {
                 ...Array(8).fill({ 'ci-backend.yml': 'failure', 'ci-frontend.yml': 'failure' }),
             ])
             const { outputs } = await run(createGithubMock(runsByWorkflow, { commits }))
-            expect(outputs.red_commits_count).toBe('0')
-            expect(outputs.red_commits_action).toBe('none')
+            expect(outputs.commit_failure_streak_count).toBe('0')
+            expect(outputs.commit_failure_streak_action).toBe('none')
         })
 
         it('non-critical-only failures do not mark commits red', async () => {
@@ -250,30 +250,30 @@ describe('ci-alerts-devex', () => {
                 Array(10).fill({ 'ci-backend.yml': 'success', 'ci-frontend.yml': 'failure' })
             )
             const { outputs } = await run(createGithubMock(runsByWorkflow, { commits }))
-            expect(outputs.red_commits_count).toBe('0')
+            expect(outputs.commit_failure_streak_count).toBe('0')
         })
 
         it('updates when streak grows, resolves when drops below threshold', async () => {
             const stateAlerted = {
                 failing: {},
-                red_commits_alerted: true,
-                red_commits_slack_ts: '999.999',
-                red_commits_slack_channel: 'Cred',
-                red_commits_last_count: 10,
+                commit_failure_streak_alerted: true,
+                commit_failure_streak_slack_ts: '999.999',
+                commit_failure_streak_slack_channel: 'Cred',
+                commit_failure_streak_last_count: 10,
             }
 
             // 14 red after alerted-at-10 → update
             let { commits, runsByWorkflow } = redCommits(14)
             let { outputs } = await run(createGithubMock(runsByWorkflow, { commits }), { state: stateAlerted })
-            expect(outputs.red_commits_action).toBe('update')
-            expect(outputs.red_commits_count).toBe('14')
+            expect(outputs.commit_failure_streak_action).toBe('update')
+            expect(outputs.commit_failure_streak_count).toBe('14')
 
             // All green after alerted → resolve
             ;({ commits, runsByWorkflow } = greenCommits(12))
             let writtenState
             ;({ outputs, writtenState } = await run(createGithubMock(runsByWorkflow, { commits }), { state: stateAlerted }))
-            expect(outputs.red_commits_action).toBe('resolve')
-            expect(writtenState.red_commits_alerted).toBe(false)
+            expect(outputs.commit_failure_streak_action).toBe('resolve')
+            expect(writtenState.commit_failure_streak_alerted).toBe(false)
         })
     })
 })

--- a/.github/scripts/ci-alerts-devex.test.js
+++ b/.github/scripts/ci-alerts-devex.test.js
@@ -35,7 +35,10 @@ function runs(name, conclusions, { workflowFile } = {}) {
     }))
 }
 
-function createGithubMock(workflowRuns, { rateLimitRemaining = 4500, rateLimitLimit = 5000 } = {}) {
+function createGithubMock(
+    workflowRuns,
+    { rateLimitRemaining = 4500, rateLimitLimit = 5000, commits = [] } = {}
+) {
     return {
         rest: {
             actions: {
@@ -59,8 +62,36 @@ function createGithubMock(workflowRuns, { rateLimitRemaining = 4500, rateLimitLi
                     })
                 ),
             },
+            repos: {
+                listCommits: jest.fn(() => Promise.resolve({ data: commits })),
+            },
         },
     }
+}
+
+// Helper: commits newest-first. conclusions is an array of workflow-file->conclusion
+// maps, one per commit, where each map pins the critical workflow's result for
+// that SHA. Any SHA referenced here is synthesized into the runs list too.
+function commitsWithRuns(perCommitConclusions) {
+    const commits = perCommitConclusions.map((_, i) => ({
+        sha: `commit_sha_${i}`,
+        html_url: `https://github.com/commit/commit_sha_${i}`,
+        commit: { message: `commit ${i}`, author: { name: 'dev' } },
+    }))
+    const runsByWorkflow = {}
+    perCommitConclusions.forEach((conclusionsMap, i) => {
+        for (const [workflowFile, conclusion] of Object.entries(conclusionsMap)) {
+            if (!runsByWorkflow[workflowFile]) runsByWorkflow[workflowFile] = []
+            runsByWorkflow[workflowFile].push({
+                name: workflowFile.replace('.yml', '').replace('ci-', '').replace(/^./, (c) => c.toUpperCase()) + ' CI',
+                conclusion,
+                head_sha: `commit_sha_${i}`,
+                html_url: `https://github.com/runs/${workflowFile}/${i}`,
+                updated_at: minutes(-(i * 5)).toISOString(),
+            })
+        }
+    })
+    return { commits, runsByWorkflow }
 }
 
 // Shorthand for all-passing runs (1 success each)
@@ -90,6 +121,7 @@ function run(github, { state = null, now = minutes(0) } = {}) {
 
     process.env.WATCHED_WORKFLOWS = 'ci-backend.yml,ci-frontend.yml'
     process.env.ALERT_THRESHOLD_RUNS = '5'
+    process.env.RED_COMMIT_THRESHOLD = '10'
     process.env.RATE_LIMIT_THRESHOLD_PERCENT = '10'
     process.env.CRITICAL_WORKFLOWS = 'ci-backend.yml'
 
@@ -106,6 +138,7 @@ function run(github, { state = null, now = minutes(0) } = {}) {
 afterEach(() => {
     delete process.env.WATCHED_WORKFLOWS
     delete process.env.ALERT_THRESHOLD_RUNS
+    delete process.env.RED_COMMIT_THRESHOLD
     delete process.env.RATE_LIMIT_THRESHOLD_PERCENT
     delete process.env.CRITICAL_WORKFLOWS
 })
@@ -319,6 +352,59 @@ describe('ci-alerts-devex', () => {
         expect(writtenState.failing['Backend CI'].since).toBe(minutes(-20).toISOString())
     })
 
+    it('treats all-cancelled runs as no signal', async () => {
+        const github = createGithubMock({
+            'ci-backend.yml': runs('Backend CI', ['cancelled', 'cancelled', 'skipped']),
+            'ci-frontend.yml': runs('Frontend CI', ['success']),
+        })
+
+        const { outputs, writtenState } = await run(github)
+
+        expect(outputs.action).toBe('none')
+        expect(writtenState).toBeNull()
+    })
+
+    it('treats timed_out the same as failure for duration tracking', async () => {
+        const github = createGithubMock({
+            'ci-backend.yml': runs('Backend CI', ['timed_out', 'timed_out', 'timed_out', 'timed_out', 'timed_out']),
+            'ci-frontend.yml': runs('Frontend CI', ['success']),
+        })
+
+        const { outputs, writtenState } = await run(github)
+
+        expect(outputs.action).toBe('create')
+        expect(outputs.max_consecutive).toBe('5')
+        expect(writtenState.failing['Backend CI'].since).toBe(minutes(-20).toISOString())
+    })
+
+    it('gracefully handles old-schema state without consecutive_failures', async () => {
+        // Simulate state written by previous version of the script:
+        // no consecutive_failures field, no last_failing_detail.
+        const legacyState = {
+            failing: {
+                'Backend CI': {
+                    since: minutes(-30).toISOString(),
+                    sha: 'old_sha',
+                    run_url: 'https://github.com/runs/old',
+                    workflow_file: 'ci-backend.yml',
+                },
+            },
+            alerted: true,
+            slack_ts: '123.456',
+            slack_channel: 'C123',
+            last_failing_list: 'Backend CI',
+        }
+
+        const github = createGithubMock(allPassing())
+
+        const { outputs } = await run(github, { state: legacyState, now: minutes(5) })
+
+        expect(outputs.action).toBe('resolve')
+        expect(outputs.max_consecutive).toBe('0') // unknown from legacy state, defaults to 0
+        expect(outputs.last_failing_list).toBe('Backend CI')
+        expect(outputs.last_failing_detail).toBe('') // legacy state has no detail
+    })
+
     describe('rate limit checks', () => {
         it('no-op when rate limit is healthy', async () => {
             const github = createGithubMock(allPassing(), { rateLimitRemaining: 4500, rateLimitLimit: 5000 })
@@ -463,6 +549,200 @@ describe('ci-alerts-devex', () => {
 
             expect(writtenState.failing['Backend CI'].workflow_file).toBe('ci-backend.yml')
             expect(writtenState.failing['Backend CI'].consecutive_failures).toBe(3)
+        })
+    })
+
+    describe('red commit streak', () => {
+        // Only ci-backend.yml is critical in the test env; ci-frontend.yml is not.
+        // Red classification therefore depends solely on ci-backend outcomes per SHA.
+
+        const greenCommits = (n) => commitsWithRuns(Array(n).fill({ 'ci-backend.yml': 'success' }))
+        const redCommits = (n) => commitsWithRuns(Array(n).fill({ 'ci-backend.yml': 'failure' }))
+
+        it('no-op when all recent commits are green', async () => {
+            const { commits, runsByWorkflow } = greenCommits(12)
+            const github = createGithubMock(runsByWorkflow, { commits })
+
+            const { outputs } = await run(github)
+
+            expect(outputs.red_commits_action).toBe('none')
+            expect(outputs.red_commits_count).toBe('0')
+        })
+
+        it('does not alert at threshold minus one', async () => {
+            const { commits, runsByWorkflow } = redCommits(9)
+            const github = createGithubMock(runsByWorkflow, { commits })
+
+            const { outputs } = await run(github)
+
+            expect(outputs.red_commits_action).toBe('none')
+            expect(outputs.red_commits_count).toBe('9')
+        })
+
+        it('creates alert at 10 consecutive red commits', async () => {
+            const { commits, runsByWorkflow } = redCommits(10)
+            const github = createGithubMock(runsByWorkflow, { commits })
+
+            const { outputs, writtenState } = await run(github)
+
+            expect(outputs.red_commits_action).toBe('create')
+            expect(outputs.red_commits_count).toBe('10')
+            expect(outputs.red_commits_detail).toContain('commit_sha_0'.slice(0, 7))
+            expect(writtenState.red_commits_alerted).toBe(true)
+            expect(writtenState.red_commits_last_count).toBe(10)
+        })
+
+        it('attributes culprits per commit in detail', async () => {
+            // ci-backend is critical, so only its failures mark commits red.
+            // Mix: half fail with backend, half fail with backend (only critical one in env).
+            const { commits, runsByWorkflow } = commitsWithRuns([
+                { 'ci-backend.yml': 'failure' },
+                { 'ci-backend.yml': 'timed_out' },
+                { 'ci-backend.yml': 'failure' },
+                { 'ci-backend.yml': 'failure' },
+                { 'ci-backend.yml': 'failure' },
+                { 'ci-backend.yml': 'failure' },
+                { 'ci-backend.yml': 'failure' },
+                { 'ci-backend.yml': 'failure' },
+                { 'ci-backend.yml': 'failure' },
+                { 'ci-backend.yml': 'failure' },
+            ])
+            const github = createGithubMock(runsByWorkflow, { commits })
+
+            const { outputs } = await run(github)
+
+            expect(outputs.red_commits_action).toBe('create')
+            expect(outputs.red_commits_detail.split('\n')).toHaveLength(10)
+            expect(outputs.red_commits_detail).toMatch(/Backend CI/)
+        })
+
+        it('green commit breaks the streak', async () => {
+            // newest 8 red, then a green, then more red — streak is only 8
+            const { commits, runsByWorkflow } = commitsWithRuns([
+                ...Array(8).fill({ 'ci-backend.yml': 'failure' }),
+                { 'ci-backend.yml': 'success' },
+                ...Array(5).fill({ 'ci-backend.yml': 'failure' }),
+            ])
+            const github = createGithubMock(runsByWorkflow, { commits })
+
+            const { outputs } = await run(github)
+
+            expect(outputs.red_commits_count).toBe('8')
+            expect(outputs.red_commits_action).toBe('none')
+        })
+
+        it('unknown commits do not count but do not break', async () => {
+            // newest 3 have no critical runs (unknown), next 10 are red
+            const { commits, runsByWorkflow } = commitsWithRuns([
+                {},
+                {},
+                {},
+                ...Array(10).fill({ 'ci-backend.yml': 'failure' }),
+            ])
+            const github = createGithubMock(runsByWorkflow, { commits })
+
+            const { outputs } = await run(github)
+
+            expect(outputs.red_commits_count).toBe('10')
+            expect(outputs.red_commits_action).toBe('create')
+        })
+
+        it('non-critical workflow failures do not mark a commit red', async () => {
+            // ci-frontend is not critical — its failures should be ignored.
+            // Every commit passes ci-backend but fails ci-frontend.
+            const { commits, runsByWorkflow } = commitsWithRuns(
+                Array(10).fill({ 'ci-backend.yml': 'success', 'ci-frontend.yml': 'failure' })
+            )
+            const github = createGithubMock(runsByWorkflow, { commits })
+
+            const { outputs } = await run(github)
+
+            expect(outputs.red_commits_count).toBe('0')
+            expect(outputs.red_commits_action).toBe('none')
+        })
+
+        it('updates Slack when streak grows after alert', async () => {
+            const { commits, runsByWorkflow } = redCommits(14)
+            const github = createGithubMock(runsByWorkflow, { commits })
+
+            const { outputs } = await run(github, {
+                state: {
+                    failing: {},
+                    red_commits_alerted: true,
+                    red_commits_slack_ts: '999.999',
+                    red_commits_slack_channel: 'Cred',
+                    red_commits_last_count: 10,
+                },
+            })
+
+            expect(outputs.red_commits_action).toBe('update')
+            expect(outputs.red_commits_count).toBe('14')
+            expect(outputs.red_commits_slack_ts).toBe('999.999')
+        })
+
+        it('does not re-update when count is unchanged', async () => {
+            const { commits, runsByWorkflow } = redCommits(10)
+            const github = createGithubMock(runsByWorkflow, { commits })
+
+            const { outputs } = await run(github, {
+                state: {
+                    failing: {},
+                    red_commits_alerted: true,
+                    red_commits_slack_ts: '999.999',
+                    red_commits_slack_channel: 'Cred',
+                    red_commits_last_count: 10,
+                },
+            })
+
+            expect(outputs.red_commits_action).toBe('none')
+        })
+
+        it('resolves when streak drops below threshold', async () => {
+            const { commits, runsByWorkflow } = greenCommits(12)
+            const github = createGithubMock(runsByWorkflow, { commits })
+
+            const { outputs, writtenState } = await run(github, {
+                state: {
+                    failing: {},
+                    red_commits_alerted: true,
+                    red_commits_slack_ts: '999.999',
+                    red_commits_slack_channel: 'Cred',
+                    red_commits_last_count: 12,
+                    red_commits_last_sample: '• abc1234 — Backend CI',
+                },
+            })
+
+            expect(outputs.red_commits_action).toBe('resolve')
+            expect(outputs.red_commits_last_count).toBe('12')
+            expect(outputs.red_commits_slack_ts).toBe('999.999')
+            expect(writtenState.red_commits_alerted).toBe(false)
+            expect(writtenState.red_commits_last_count).toBe(0)
+        })
+
+        it('old-schema state without red_commits fields degrades gracefully', async () => {
+            const { commits, runsByWorkflow } = greenCommits(12)
+            const github = createGithubMock(runsByWorkflow, { commits })
+
+            const legacyState = {
+                failing: {},
+                alerted: false,
+                // no red_commits_* fields
+            }
+
+            const { outputs } = await run(github, { state: legacyState })
+
+            expect(outputs.red_commits_action).toBe('none')
+            expect(outputs.red_commits_count).toBe('0')
+        })
+
+        it('degrades gracefully when listCommits fails', async () => {
+            const github = createGithubMock(allPassing())
+            github.rest.repos.listCommits = jest.fn(() => Promise.reject(new Error('API error')))
+
+            const { outputs } = await run(github)
+
+            expect(outputs.red_commits_action).toBe('none')
+            expect(outputs.red_commits_count).toBe('0')
         })
     })
 })

--- a/.github/scripts/ci-alerts-devex.test.js
+++ b/.github/scripts/ci-alerts-devex.test.js
@@ -23,26 +23,25 @@ function createContext() {
     }
 }
 
-function createGithubMock(workflowResults, { rateLimitRemaining = 4500, rateLimitLimit = 5000 } = {}) {
+// Helper: build an array of run objects for a single workflow.
+// conclusions are ordered most-recent-first (index 0 = latest run).
+function runs(name, conclusions, { workflowFile } = {}) {
+    return conclusions.map((conclusion, i) => ({
+        name,
+        conclusion,
+        head_sha: `sha_${name}_${i}`,
+        html_url: `https://github.com/runs/${name}/${i}`,
+        updated_at: minutes(-(i * 5)).toISOString(),
+    }))
+}
+
+function createGithubMock(workflowRuns, { rateLimitRemaining = 4500, rateLimitLimit = 5000 } = {}) {
     return {
         rest: {
             actions: {
                 listWorkflowRuns: jest.fn(({ workflow_id }) => {
-                    const result = workflowResults[workflow_id]
-                    if (!result) return Promise.resolve({ data: { workflow_runs: [] } })
-                    return Promise.resolve({
-                        data: {
-                            workflow_runs: [
-                                {
-                                    name: result.name,
-                                    conclusion: result.conclusion,
-                                    head_sha: result.sha || 'abc1234',
-                                    html_url: result.run_url || `https://github.com/runs/${result.name}`,
-                                    updated_at: result.updated_at || T_BASE.toISOString(),
-                                },
-                            ],
-                        },
-                    })
+                    const wfRuns = workflowRuns[workflow_id] || []
+                    return Promise.resolve({ data: { workflow_runs: wfRuns } })
                 }),
             },
             rateLimit: {
@@ -64,6 +63,21 @@ function createGithubMock(workflowResults, { rateLimitRemaining = 4500, rateLimi
     }
 }
 
+// Shorthand for all-passing runs (1 success each)
+const allPassing = () => ({
+    'ci-backend.yml': runs('Backend CI', ['success']),
+    'ci-frontend.yml': runs('Frontend CI', ['success']),
+})
+
+// Shorthand: N consecutive failures followed by successes
+const failingRuns = (name, failCount, successCount = 5) => {
+    const conclusions = [
+        ...Array(failCount).fill('failure'),
+        ...Array(successCount).fill('success'),
+    ]
+    return runs(name, conclusions)
+}
+
 function run(github, { state = null, now = minutes(0) } = {}) {
     const { core, outputs } = createMocks()
     const context = createContext()
@@ -75,7 +89,7 @@ function run(github, { state = null, now = minutes(0) } = {}) {
     }
 
     process.env.WATCHED_WORKFLOWS = 'ci-backend.yml,ci-frontend.yml'
-    process.env.ALERT_THRESHOLD_MINUTES = '30'
+    process.env.ALERT_THRESHOLD_RUNS = '5'
     process.env.RATE_LIMIT_THRESHOLD_PERCENT = '10'
     process.env.CRITICAL_WORKFLOWS = 'ci-backend.yml'
 
@@ -91,47 +105,44 @@ function run(github, { state = null, now = minutes(0) } = {}) {
 
 afterEach(() => {
     delete process.env.WATCHED_WORKFLOWS
-    delete process.env.ALERT_THRESHOLD_MINUTES
+    delete process.env.ALERT_THRESHOLD_RUNS
     delete process.env.RATE_LIMIT_THRESHOLD_PERCENT
     delete process.env.CRITICAL_WORKFLOWS
 })
 
-const failingState = (sinceMin = 0) => ({
+const alertedState = () => ({
     failing: {
         'Backend CI': {
-            since: minutes(sinceMin).toISOString(),
-            sha: 'abc1234',
-            run_url: 'https://github.com/runs/1',
+            since: minutes(-25).toISOString(),
+            sha: 'sha_Backend CI_4',
+            run_url: 'https://github.com/runs/Backend CI/0',
+            workflow_file: 'ci-backend.yml',
+            consecutive_failures: 5,
         },
     },
-    alerted: false,
-})
-
-const alertedState = (sinceMin = 0) => ({
-    ...failingState(sinceMin),
     alerted: true,
     slack_ts: '123.456',
     slack_channel: 'C123',
     last_failing_list: 'Backend CI',
+    last_failing_detail: '*Blocking:* <https://github.com/runs/Backend CI/0|Backend CI> (5 consecutive failures)',
 })
 
 describe('ci-alerts-devex', () => {
     it('no-op when all workflows pass', async () => {
-        const github = createGithubMock({
-            'ci-backend.yml': { name: 'Backend CI', conclusion: 'success' },
-            'ci-frontend.yml': { name: 'Frontend CI', conclusion: 'success' },
-        })
+        const github = createGithubMock(allPassing())
 
-        const { outputs } = await run(github)
+        const { outputs, writtenState } = await run(github)
 
         expect(outputs.action).toBe('none')
-        expect(outputs.save_cache).toBe('true')
+        // No failures to track, no save needed
+        expect(outputs.save_cache).toBe('false')
+        expect(writtenState).toBeNull()
     })
 
     it.each(['failure', 'timed_out'])('records %s but does not alert under threshold', async (conclusion) => {
         const github = createGithubMock({
-            'ci-backend.yml': { name: 'Backend CI', conclusion },
-            'ci-frontend.yml': { name: 'Frontend CI', conclusion: 'success' },
+            'ci-backend.yml': runs('Backend CI', [conclusion, conclusion, 'success']),
+            'ci-frontend.yml': runs('Frontend CI', ['success']),
         })
 
         const { outputs, writtenState } = await run(github)
@@ -139,34 +150,43 @@ describe('ci-alerts-devex', () => {
         expect(outputs.action).toBe('none')
         expect(outputs.save_cache).toBe('true')
         expect(writtenState.failing['Backend CI']).toBeDefined()
+        expect(writtenState.failing['Backend CI'].consecutive_failures).toBe(2)
         expect(writtenState.alerted).toBe(false)
     })
 
-    it('creates alert when failure persists past threshold', async () => {
+    it('creates alert when consecutive failures reach threshold', async () => {
         const github = createGithubMock({
-            'ci-backend.yml': { name: 'Backend CI', conclusion: 'failure' },
-            'ci-frontend.yml': { name: 'Frontend CI', conclusion: 'success' },
+            'ci-backend.yml': failingRuns('Backend CI', 5),
+            'ci-frontend.yml': runs('Frontend CI', ['success']),
         })
 
-        const { outputs, writtenState } = await run(github, {
-            state: failingState(0),
-            now: minutes(31),
-        })
+        const { outputs, writtenState } = await run(github)
 
         expect(outputs.action).toBe('create')
         expect(outputs.failing_workflows).toBe('Backend CI')
         expect(outputs.failing_count).toBe('1')
-        expect(outputs.duration_mins).toBe('31')
+        expect(outputs.max_consecutive).toBe('5')
         expect(writtenState.alerted).toBe(true)
+    })
+
+    it('does not alert at threshold minus one', async () => {
+        const github = createGithubMock({
+            'ci-backend.yml': failingRuns('Backend CI', 4),
+            'ci-frontend.yml': runs('Frontend CI', ['success']),
+        })
+
+        const { outputs } = await run(github)
+
+        expect(outputs.action).toBe('none')
     })
 
     it('updates Slack when failing set changes after alert', async () => {
         const github = createGithubMock({
-            'ci-backend.yml': { name: 'Backend CI', conclusion: 'failure' },
-            'ci-frontend.yml': { name: 'Frontend CI', conclusion: 'failure' },
+            'ci-backend.yml': failingRuns('Backend CI', 5),
+            'ci-frontend.yml': failingRuns('Frontend CI', 5),
         })
 
-        const { outputs } = await run(github, { state: alertedState(0), now: minutes(35) })
+        const { outputs } = await run(github, { state: alertedState() })
 
         expect(outputs.action).toBe('update')
         expect(outputs.added_workflows).toBe('Frontend CI')
@@ -174,56 +194,134 @@ describe('ci-alerts-devex', () => {
     })
 
     it('resolves when all workflows pass after alert', async () => {
-        const github = createGithubMock({
-            'ci-backend.yml': { name: 'Backend CI', conclusion: 'success' },
-            'ci-frontend.yml': { name: 'Frontend CI', conclusion: 'success' },
-        })
+        const github = createGithubMock(allPassing())
 
         const { outputs, writtenState } = await run(github, {
-            state: alertedState(0),
+            state: alertedState(),
             now: minutes(45),
         })
 
         expect(outputs.action).toBe('resolve')
-        expect(outputs.duration_mins).toBe('45')
+        expect(outputs.max_consecutive).toBe('5')
+        expect(outputs.duration_mins).toBeDefined()
         expect(writtenState.resolved).toBe(true)
     })
 
-    it('silently clears when flake self-heals before threshold', async () => {
+    it('resolve outputs include previous failing detail', async () => {
+        const github = createGithubMock(allPassing())
+
+        const { outputs } = await run(github, { state: alertedState() })
+
+        expect(outputs.last_failing_list).toBe('Backend CI')
+        expect(outputs.last_failing_detail).toContain('Backend CI')
+        expect(outputs.last_failing_detail).toContain('5 consecutive failures')
+    })
+
+    it('stays alerted when some workflows recover but others still fail', async () => {
+        const state = {
+            ...alertedState(),
+            failing: {
+                ...alertedState().failing,
+                'Frontend CI': {
+                    since: minutes(-10).toISOString(),
+                    sha: 'sha1',
+                    run_url: 'https://github.com/runs/Frontend CI/0',
+                    workflow_file: 'ci-frontend.yml',
+                    consecutive_failures: 5,
+                },
+            },
+            last_failing_list: 'Backend CI, Frontend CI',
+        }
+
         const github = createGithubMock({
-            'ci-backend.yml': { name: 'Backend CI', conclusion: 'success' },
-            'ci-frontend.yml': { name: 'Frontend CI', conclusion: 'success' },
+            'ci-backend.yml': runs('Backend CI', ['success']),
+            'ci-frontend.yml': failingRuns('Frontend CI', 3),
         })
 
-        const { outputs } = await run(github, { state: failingState(0), now: minutes(10) })
+        const { outputs } = await run(github, { state })
+
+        // Set changed (Backend recovered), so update fires, but no resolve
+        expect(outputs.action).toBe('update')
+        expect(outputs.removed_workflows).toBe('Backend CI')
+    })
+
+    it('filters out cancelled runs from consecutive count', async () => {
+        const github = createGithubMock({
+            'ci-backend.yml': runs('Backend CI', [
+                'failure',
+                'cancelled',
+                'failure',
+                'cancelled',
+                'failure',
+                'failure',
+                'failure',
+                'success',
+            ]),
+            'ci-frontend.yml': runs('Frontend CI', ['success']),
+        })
+
+        const { outputs, writtenState } = await run(github)
+
+        // After filtering cancelled: [failure, failure, failure, failure, failure, success]
+        // Consecutive from front: 5
+        expect(outputs.action).toBe('create')
+        expect(writtenState.failing['Backend CI'].consecutive_failures).toBe(5)
+    })
+
+    it('filters out skipped runs from consecutive count', async () => {
+        const github = createGithubMock({
+            'ci-backend.yml': runs('Backend CI', ['failure', 'skipped', 'failure', 'success']),
+            'ci-frontend.yml': runs('Frontend CI', ['success']),
+        })
+
+        const { writtenState } = await run(github)
+
+        // After filtering skipped: [failure, failure, success] -> 2 consecutive
+        expect(writtenState.failing['Backend CI'].consecutive_failures).toBe(2)
+    })
+
+    it('includes duration as supplementary context', async () => {
+        const github = createGithubMock({
+            'ci-backend.yml': failingRuns('Backend CI', 5),
+            'ci-frontend.yml': runs('Frontend CI', ['success']),
+        })
+
+        const { outputs } = await run(github, { now: minutes(0) })
+
+        expect(outputs.action).toBe('create')
+        expect(outputs.duration_mins).toBeDefined()
+        // duration_mins is computed from oldest failure timestamp to now
+        expect(parseInt(outputs.duration_mins)).toBeGreaterThanOrEqual(0)
+    })
+
+    it('saves state when failures exist below threshold', async () => {
+        const github = createGithubMock({
+            'ci-backend.yml': failingRuns('Backend CI', 2),
+            'ci-frontend.yml': runs('Frontend CI', ['success']),
+        })
+
+        const { outputs, writtenState } = await run(github)
 
         expect(outputs.action).toBe('none')
         expect(outputs.save_cache).toBe('true')
+        expect(writtenState.failing['Backend CI'].consecutive_failures).toBe(2)
     })
 
-    it('resets the clock when a workflow recovers then fails again', async () => {
+    it('tracks since from oldest consecutive failure', async () => {
+        // 5 failures, each 5 min apart. Oldest = index 4 = minutes(-20)
         const github = createGithubMock({
-            'ci-backend.yml': { name: 'Backend CI', conclusion: 'failure', updated_at: minutes(18).toISOString() },
-            'ci-frontend.yml': { name: 'Frontend CI', conclusion: 'success' },
+            'ci-backend.yml': failingRuns('Backend CI', 5),
+            'ci-frontend.yml': runs('Frontend CI', ['success']),
         })
 
-        const { writtenState } = await run(github, {
-            state: { failing: {}, alerted: false },
-            now: minutes(20),
-        })
+        const { writtenState } = await run(github)
 
-        // since uses the run's updated_at, not observation time
-        expect(writtenState.failing['Backend CI'].since).toBe(minutes(18).toISOString())
+        expect(writtenState.failing['Backend CI'].since).toBe(minutes(-20).toISOString())
     })
 
     describe('rate limit checks', () => {
-        const allPassing = {
-            'ci-backend.yml': { name: 'Backend CI', conclusion: 'success' },
-            'ci-frontend.yml': { name: 'Frontend CI', conclusion: 'success' },
-        }
-
         it('no-op when rate limit is healthy', async () => {
-            const github = createGithubMock(allPassing, { rateLimitRemaining: 4500, rateLimitLimit: 5000 })
+            const github = createGithubMock(allPassing(), { rateLimitRemaining: 4500, rateLimitLimit: 5000 })
 
             const { outputs } = await run(github)
 
@@ -233,7 +331,7 @@ describe('ci-alerts-devex', () => {
         })
 
         it('creates rate limit alert when remaining is below threshold', async () => {
-            const github = createGithubMock(allPassing, { rateLimitRemaining: 50, rateLimitLimit: 5000 })
+            const github = createGithubMock(allPassing(), { rateLimitRemaining: 50, rateLimitLimit: 5000 })
 
             const { outputs, writtenState } = await run(github)
 
@@ -243,7 +341,7 @@ describe('ci-alerts-devex', () => {
         })
 
         it('does not re-alert when already alerted for rate limit', async () => {
-            const github = createGithubMock(allPassing, { rateLimitRemaining: 30, rateLimitLimit: 5000 })
+            const github = createGithubMock(allPassing(), { rateLimitRemaining: 30, rateLimitLimit: 5000 })
 
             const { outputs } = await run(github, {
                 state: { failing: {}, alerted: false, rate_limit_alerted: true },
@@ -253,7 +351,7 @@ describe('ci-alerts-devex', () => {
         })
 
         it('resolves rate limit alert when quota recovers', async () => {
-            const github = createGithubMock(allPassing, { rateLimitRemaining: 4500, rateLimitLimit: 5000 })
+            const github = createGithubMock(allPassing(), { rateLimitRemaining: 4500, rateLimitLimit: 5000 })
 
             const { outputs, writtenState } = await run(github, {
                 state: {
@@ -272,13 +370,7 @@ describe('ci-alerts-devex', () => {
         })
 
         it('preserves rate limit state across incident resolution', async () => {
-            const github = createGithubMock(
-                {
-                    'ci-backend.yml': { name: 'Backend CI', conclusion: 'success' },
-                    'ci-frontend.yml': { name: 'Frontend CI', conclusion: 'success' },
-                },
-                { rateLimitRemaining: 30, rateLimitLimit: 5000 }
-            )
+            const github = createGithubMock(allPassing(), { rateLimitRemaining: 30, rateLimitLimit: 5000 })
 
             const { outputs } = await run(github, {
                 state: {
@@ -289,25 +381,20 @@ describe('ci-alerts-devex', () => {
                 },
             })
 
-            // Should not re-create — prior alert is still tracked
             expect(outputs.rate_limit_action).toBe('none')
         })
 
         it('continues workflow checks even when rate limit is critical', async () => {
             const github = createGithubMock(
                 {
-                    'ci-backend.yml': { name: 'Backend CI', conclusion: 'failure' },
-                    'ci-frontend.yml': { name: 'Frontend CI', conclusion: 'success' },
+                    'ci-backend.yml': failingRuns('Backend CI', 5),
+                    'ci-frontend.yml': runs('Frontend CI', ['success']),
                 },
                 { rateLimitRemaining: 10, rateLimitLimit: 5000 }
             )
 
-            const { outputs, writtenState } = await run(github, {
-                state: failingState(0),
-                now: minutes(31),
-            })
+            const { outputs, writtenState } = await run(github)
 
-            // Both concerns fire independently
             expect(outputs.action).toBe('create')
             expect(outputs.rate_limit_action).toBe('create')
             expect(writtenState.alerted).toBe(true)
@@ -315,7 +402,7 @@ describe('ci-alerts-devex', () => {
         })
 
         it('degrades gracefully when rate limit API fails', async () => {
-            const github = createGithubMock(allPassing)
+            const github = createGithubMock(allPassing())
             github.rest.rateLimit.get = jest.fn(() => Promise.reject(new Error('API error')))
 
             const { outputs } = await run(github)
@@ -327,86 +414,55 @@ describe('ci-alerts-devex', () => {
     })
 
     describe('severity differentiation', () => {
-        // CRITICAL_WORKFLOWS is set to 'ci-backend.yml' in run()
-
         it('labels critical-only failures correctly', async () => {
             const github = createGithubMock({
-                'ci-backend.yml': { name: 'Backend CI', conclusion: 'failure' },
-                'ci-frontend.yml': { name: 'Frontend CI', conclusion: 'success' },
+                'ci-backend.yml': failingRuns('Backend CI', 5),
+                'ci-frontend.yml': runs('Frontend CI', ['success']),
             })
 
-            const { outputs } = await run(github, { state: failingState(0), now: minutes(31) })
+            const { outputs } = await run(github)
 
-            expect(outputs.failing_links_blocking).toContain('Backend CI')
-            expect(outputs.failing_links_non_blocking).toBe('')
-            expect(outputs.failing_detail).toBe('*Blocking:* <https://github.com/runs/Backend CI|Backend CI>')
+            expect(outputs.action).toBe('create')
+            expect(outputs.failing_detail).toMatch(/\*Blocking:\*.*Backend CI.*5 consecutive failures/)
+            expect(outputs.failing_detail).not.toContain('Non-blocking')
         })
 
         it('labels non-critical-only failures correctly', async () => {
             const github = createGithubMock({
-                'ci-backend.yml': { name: 'Backend CI', conclusion: 'success' },
-                'ci-frontend.yml': { name: 'Frontend CI', conclusion: 'failure' },
+                'ci-backend.yml': runs('Backend CI', ['success']),
+                'ci-frontend.yml': failingRuns('Frontend CI', 5),
             })
 
-            const state = {
-                failing: {
-                    'Frontend CI': {
-                        since: minutes(0).toISOString(),
-                        sha: 'abc1234',
-                        run_url: 'https://github.com/runs/Frontend CI',
-                        workflow_file: 'ci-frontend.yml',
-                    },
-                },
-                alerted: false,
-            }
+            const { outputs } = await run(github)
 
-            const { outputs } = await run(github, { state, now: minutes(31) })
-
-            expect(outputs.failing_links_blocking).toBe('')
-            expect(outputs.failing_links_non_blocking).toContain('Frontend CI')
-            expect(outputs.failing_detail).toBe('*Non-blocking:* <https://github.com/runs/Frontend CI|Frontend CI>')
+            expect(outputs.action).toBe('create')
+            expect(outputs.failing_detail).toMatch(/\*Non-blocking:\*.*Frontend CI.*5 consecutive failures/)
+            expect(outputs.failing_detail).not.toContain('Blocking:')
         })
 
         it('splits mixed failures into critical and other', async () => {
             const github = createGithubMock({
-                'ci-backend.yml': { name: 'Backend CI', conclusion: 'failure' },
-                'ci-frontend.yml': { name: 'Frontend CI', conclusion: 'failure' },
+                'ci-backend.yml': failingRuns('Backend CI', 5),
+                'ci-frontend.yml': failingRuns('Frontend CI', 5),
             })
 
-            const state = {
-                failing: {
-                    'Backend CI': {
-                        since: minutes(0).toISOString(),
-                        sha: 'abc1234',
-                        run_url: 'https://github.com/runs/Backend CI',
-                        workflow_file: 'ci-backend.yml',
-                    },
-                    'Frontend CI': {
-                        since: minutes(0).toISOString(),
-                        sha: 'abc1234',
-                        run_url: 'https://github.com/runs/Frontend CI',
-                        workflow_file: 'ci-frontend.yml',
-                    },
-                },
-                alerted: false,
-            }
+            const { outputs } = await run(github)
 
-            const { outputs } = await run(github, { state, now: minutes(31) })
-
-            expect(outputs.failing_links_blocking).toContain('Backend CI')
-            expect(outputs.failing_links_non_blocking).toContain('Frontend CI')
-            expect(outputs.failing_detail).toMatch(/^\*Blocking:\*.*Backend CI.*\n\*Non-blocking:\*.*Frontend CI/)
+            expect(outputs.action).toBe('create')
+            expect(outputs.failing_detail).toMatch(/^\*Blocking:\*.*Backend CI/)
+            expect(outputs.failing_detail).toMatch(/\*Non-blocking:\*.*Frontend CI/)
         })
 
-        it('stores workflow_file in failing map', async () => {
+        it('stores workflow_file and consecutive_failures in failing map', async () => {
             const github = createGithubMock({
-                'ci-backend.yml': { name: 'Backend CI', conclusion: 'failure' },
-                'ci-frontend.yml': { name: 'Frontend CI', conclusion: 'success' },
+                'ci-backend.yml': failingRuns('Backend CI', 3),
+                'ci-frontend.yml': runs('Frontend CI', ['success']),
             })
 
             const { writtenState } = await run(github)
 
             expect(writtenState.failing['Backend CI'].workflow_file).toBe('ci-backend.yml')
+            expect(writtenState.failing['Backend CI'].consecutive_failures).toBe(3)
         })
     })
 })

--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -17,8 +17,8 @@ permissions:
 
 env:
     SLACK_CHANNEL: 'C0AS64N6DJL' # #alerts-devex
-    ALERT_THRESHOLD_RUNS: '5'
-    RED_COMMIT_THRESHOLD: '10'
+    WORKFLOW_FAILURE_STREAK_THRESHOLD: '5'
+    COMMIT_FAILURE_STREAK_THRESHOLD: '10'
     RATE_LIMIT_THRESHOLD_PERCENT: '10'
     # Keep in sync with ci-master-status.yml watched workflows
     WATCHED_WORKFLOWS: 'ci-backend.yml,ci-nodejs.yml,ci-frontend.yml,ci-storybook.yml,ci-security.yaml,ci-dagster.yml,ci-e2e-playwright.yml,ci-rust.yml'
@@ -150,11 +150,11 @@ jobs:
                       thread_ts: "${{ steps.check.outputs.slack_ts }}"
                       text: ":white_check_mark: All watched workflows are passing again"
 
-            # ============ RED COMMITS: CREATE ============
+            # ============ COMMIT FAILURE STREAK: CREATE ============
 
-            - name: Post red-commits alert to Slack
-              if: steps.check.outputs.red_commits_action == 'create'
-              id: slack_red_commits
+            - name: Post commit-failure-streak alert to Slack
+              if: steps.check.outputs.commit_failure_streak_action == 'create'
+              id: slack_commit_streak
               uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
               with:
                   method: chat.postMessage
@@ -162,71 +162,71 @@ jobs:
                   errors: true
                   payload: |
                       channel: "${{ env.SLACK_CHANNEL }}"
-                      text: ":large_orange_circle: Master unstable — ${{ steps.check.outputs.red_commits_count }} consecutive commits had a critical workflow fail"
+                      text: ":large_orange_circle: Master unstable — ${{ steps.check.outputs.commit_failure_streak_count }} consecutive commits had a critical workflow fail"
                       blocks:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: ":large_orange_circle: *Master unstable* — ${{ steps.check.outputs.red_commits_count }} consecutive commits had a critical workflow fail\nCulprit rotates across workflows, so no single workflow crosses its own threshold — but master is effectively red."
+                            text: ":large_orange_circle: *Master unstable* — ${{ steps.check.outputs.commit_failure_streak_count }} consecutive commits had a critical workflow fail\nCulprit rotates across workflows, so no single workflow crosses its own threshold — but master is effectively red."
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: "${{ steps.check.outputs.red_commits_detail }}"
+                            text: "${{ steps.check.outputs.commit_failure_streak_detail }}"
 
-            - name: Save red-commits Slack info to state
-              if: steps.check.outputs.red_commits_action == 'create'
+            - name: Save commit-failure-streak Slack info to state
+              if: steps.check.outputs.commit_failure_streak_action == 'create'
               env:
-                  SLACK_CHANNEL_ID: ${{ steps.slack_red_commits.outputs.channel_id }}
-                  SLACK_TS: ${{ steps.slack_red_commits.outputs.ts }}
+                  SLACK_CHANNEL_ID: ${{ steps.slack_commit_streak.outputs.channel_id }}
+                  SLACK_TS: ${{ steps.slack_commit_streak.outputs.ts }}
               run: |
                   jq \
                     --arg channel "$SLACK_CHANNEL_ID" \
                     --arg ts "$SLACK_TS" \
-                    '. + {red_commits_slack_channel: $channel, red_commits_slack_ts: $ts}' \
+                    '. + {commit_failure_streak_slack_channel: $channel, commit_failure_streak_slack_ts: $ts}' \
                     .alerts-devex > .alerts-devex.tmp
                   mv .alerts-devex.tmp .alerts-devex
 
-            # ============ RED COMMITS: UPDATE ============
+            # ============ COMMIT FAILURE STREAK: UPDATE ============
 
-            - name: Update red-commits Slack message
-              if: steps.check.outputs.red_commits_action == 'update'
+            - name: Update commit-failure-streak Slack message
+              if: steps.check.outputs.commit_failure_streak_action == 'update'
               uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
               with:
                   method: chat.update
                   token: ${{ secrets.SLACK_BOT_TOKEN }}
                   errors: true
                   payload: |
-                      channel: "${{ steps.check.outputs.red_commits_slack_channel }}"
-                      ts: "${{ steps.check.outputs.red_commits_slack_ts }}"
-                      text: ":large_orange_circle: Master unstable — ${{ steps.check.outputs.red_commits_count }} consecutive commits had a critical workflow fail"
+                      channel: "${{ steps.check.outputs.commit_failure_streak_slack_channel }}"
+                      ts: "${{ steps.check.outputs.commit_failure_streak_slack_ts }}"
+                      text: ":large_orange_circle: Master unstable — ${{ steps.check.outputs.commit_failure_streak_count }} consecutive commits had a critical workflow fail"
                       blocks:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: ":large_orange_circle: *Master unstable* — ${{ steps.check.outputs.red_commits_count }} consecutive commits had a critical workflow fail\nCulprit rotates across workflows, so no single workflow crosses its own threshold — but master is effectively red."
+                            text: ":large_orange_circle: *Master unstable* — ${{ steps.check.outputs.commit_failure_streak_count }} consecutive commits had a critical workflow fail\nCulprit rotates across workflows, so no single workflow crosses its own threshold — but master is effectively red."
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: "${{ steps.check.outputs.red_commits_detail }}"
+                            text: "${{ steps.check.outputs.commit_failure_streak_detail }}"
 
-            # ============ RED COMMITS: RESOLVE ============
+            # ============ COMMIT FAILURE STREAK: RESOLVE ============
 
-            - name: Update red-commits Slack to resolved
-              if: steps.check.outputs.red_commits_action == 'resolve'
+            - name: Update commit-failure-streak Slack to resolved
+              if: steps.check.outputs.commit_failure_streak_action == 'resolve'
               uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
               with:
                   method: chat.update
                   token: ${{ secrets.SLACK_BOT_TOKEN }}
                   errors: true
                   payload: |
-                      channel: "${{ steps.check.outputs.red_commits_slack_channel }}"
-                      ts: "${{ steps.check.outputs.red_commits_slack_ts }}"
-                      text: ":large_green_circle: Master stable again (streak ended after ${{ steps.check.outputs.red_commits_last_count }} consecutive red commits)"
+                      channel: "${{ steps.check.outputs.commit_failure_streak_slack_channel }}"
+                      ts: "${{ steps.check.outputs.commit_failure_streak_slack_ts }}"
+                      text: ":large_green_circle: Master stable again (streak ended after ${{ steps.check.outputs.commit_failure_streak_last_count }} consecutive red commits)"
                       blocks:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: ":large_green_circle: *Master stable again* (streak ended after ${{ steps.check.outputs.red_commits_last_count }} consecutive red commits)"
+                            text: ":large_green_circle: *Master stable again* (streak ended after ${{ steps.check.outputs.commit_failure_streak_last_count }} consecutive red commits)"
 
             # ============ RATE LIMIT: CREATE ============
 

--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -1,7 +1,7 @@
 name: Master CI Alerts
 
 # Cron-based rolling window alert for sustained master failures.
-# Only alerts when master has been continuously broken for 30+ minutes,
+# Only alerts when a workflow has 5+ consecutive failures,
 # filtering out transient flakes that self-heal.
 #
 # See also: ci-master-status.yml (event-driven, alerts on first failure)
@@ -17,7 +17,7 @@ permissions:
 
 env:
     SLACK_CHANNEL: 'C0AS64N6DJL' # #alerts-devex
-    ALERT_THRESHOLD_MINUTES: '30'
+    ALERT_THRESHOLD_RUNS: '5'
     RATE_LIMIT_THRESHOLD_PERCENT: '10'
     # Keep in sync with ci-master-status.yml watched workflows
     WATCHED_WORKFLOWS: 'ci-backend.yml,ci-nodejs.yml,ci-frontend.yml,ci-storybook.yml,ci-security.yaml,ci-dagster.yml,ci-e2e-playwright.yml,ci-rust.yml'
@@ -57,12 +57,12 @@ jobs:
                   errors: true
                   payload: |
                       channel: "${{ env.SLACK_CHANNEL }}"
-                      text: ":red_circle: Master has been red for ${{ steps.check.outputs.duration_mins }}+ min (${{ steps.check.outputs.failing_count }} workflow(s) failing)"
+                      text: ":red_circle: Master is red — ${{ steps.check.outputs.failing_count }} workflow(s) failing (${{ steps.check.outputs.max_consecutive }}+ consecutive failures, ~${{ steps.check.outputs.duration_mins }} min)"
                       blocks:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: ":red_circle: *Master has been red for ${{ steps.check.outputs.duration_mins }}+ min* (${{ steps.check.outputs.failing_count }} workflow(s) failing)"
+                            text: ":red_circle: *Master is red* — ${{ steps.check.outputs.failing_count }} workflow(s) failing (~${{ steps.check.outputs.duration_mins }} min)"
                         - type: "section"
                           text:
                             type: "mrkdwn"
@@ -93,12 +93,12 @@ jobs:
                   payload: |
                       channel: "${{ steps.check.outputs.slack_channel }}"
                       ts: "${{ steps.check.outputs.slack_ts }}"
-                      text: ":red_circle: Master has been red for ${{ steps.check.outputs.duration_mins }}+ min (${{ steps.check.outputs.failing_count }} workflow(s) failing)"
+                      text: ":red_circle: Master is red — ${{ steps.check.outputs.failing_count }} workflow(s) failing (${{ steps.check.outputs.max_consecutive }}+ consecutive failures, ~${{ steps.check.outputs.duration_mins }} min)"
                       blocks:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: ":red_circle: *Master has been red for ${{ steps.check.outputs.duration_mins }}+ min* (${{ steps.check.outputs.failing_count }} workflow(s) failing)"
+                            text: ":red_circle: *Master is red* — ${{ steps.check.outputs.failing_count }} workflow(s) failing (~${{ steps.check.outputs.duration_mins }} min)"
                         - type: "section"
                           text:
                             type: "mrkdwn"
@@ -127,12 +127,16 @@ jobs:
                   payload: |
                       channel: "${{ steps.check.outputs.slack_channel }}"
                       ts: "${{ steps.check.outputs.slack_ts }}"
-                      text: "Master recovered :v: (was red for ~${{ steps.check.outputs.duration_mins }} min)"
+                      text: "Master recovered :v: (was red for ${{ steps.check.outputs.max_consecutive }} consecutive runs, ~${{ steps.check.outputs.duration_mins }} min)"
                       blocks:
                         - type: "section"
                           text:
                             type: "mrkdwn"
-                            text: "*Master recovered* :v: (was red for ~${{ steps.check.outputs.duration_mins }} min)"
+                            text: ":large_green_circle: *Master recovered* (was red for ${{ steps.check.outputs.max_consecutive }} consecutive runs, ~${{ steps.check.outputs.duration_mins }} min)"
+                        - type: "section"
+                          text:
+                            type: "mrkdwn"
+                            text: "Previously failing: ${{ steps.check.outputs.last_failing_list }}"
 
             - name: Thread reply with resolution
               if: steps.check.outputs.action == 'resolve'

--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -8,7 +8,7 @@ name: Master CI Alerts
 
 on:
     schedule:
-        - cron: '*/5 * * * *'
+        - cron: '*/10 * * * *'
     workflow_dispatch: # manual trigger for testing
 
 permissions:
@@ -18,6 +18,7 @@ permissions:
 env:
     SLACK_CHANNEL: 'C0AS64N6DJL' # #alerts-devex
     ALERT_THRESHOLD_RUNS: '5'
+    RED_COMMIT_THRESHOLD: '10'
     RATE_LIMIT_THRESHOLD_PERCENT: '10'
     # Keep in sync with ci-master-status.yml watched workflows
     WATCHED_WORKFLOWS: 'ci-backend.yml,ci-nodejs.yml,ci-frontend.yml,ci-storybook.yml,ci-security.yaml,ci-dagster.yml,ci-e2e-playwright.yml,ci-rust.yml'
@@ -127,7 +128,7 @@ jobs:
                   payload: |
                       channel: "${{ steps.check.outputs.slack_channel }}"
                       ts: "${{ steps.check.outputs.slack_ts }}"
-                      text: "Master recovered :v: (was red for ${{ steps.check.outputs.max_consecutive }} consecutive runs, ~${{ steps.check.outputs.duration_mins }} min)"
+                      text: ":large_green_circle: Master recovered (was red for ${{ steps.check.outputs.max_consecutive }} consecutive runs, ~${{ steps.check.outputs.duration_mins }} min)"
                       blocks:
                         - type: "section"
                           text:
@@ -148,6 +149,84 @@ jobs:
                       channel: "${{ steps.check.outputs.slack_channel }}"
                       thread_ts: "${{ steps.check.outputs.slack_ts }}"
                       text: ":white_check_mark: All watched workflows are passing again"
+
+            # ============ RED COMMITS: CREATE ============
+
+            - name: Post red-commits alert to Slack
+              if: steps.check.outputs.red_commits_action == 'create'
+              id: slack_red_commits
+              uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  errors: true
+                  payload: |
+                      channel: "${{ env.SLACK_CHANNEL }}"
+                      text: ":large_orange_circle: Master unstable — ${{ steps.check.outputs.red_commits_count }} consecutive commits had a critical workflow fail"
+                      blocks:
+                        - type: "section"
+                          text:
+                            type: "mrkdwn"
+                            text: ":large_orange_circle: *Master unstable* — ${{ steps.check.outputs.red_commits_count }} consecutive commits had a critical workflow fail\nCulprit rotates across workflows, so no single workflow crosses its own threshold — but master is effectively red."
+                        - type: "section"
+                          text:
+                            type: "mrkdwn"
+                            text: "${{ steps.check.outputs.red_commits_detail }}"
+
+            - name: Save red-commits Slack info to state
+              if: steps.check.outputs.red_commits_action == 'create'
+              env:
+                  SLACK_CHANNEL_ID: ${{ steps.slack_red_commits.outputs.channel_id }}
+                  SLACK_TS: ${{ steps.slack_red_commits.outputs.ts }}
+              run: |
+                  jq \
+                    --arg channel "$SLACK_CHANNEL_ID" \
+                    --arg ts "$SLACK_TS" \
+                    '. + {red_commits_slack_channel: $channel, red_commits_slack_ts: $ts}' \
+                    .alerts-devex > .alerts-devex.tmp
+                  mv .alerts-devex.tmp .alerts-devex
+
+            # ============ RED COMMITS: UPDATE ============
+
+            - name: Update red-commits Slack message
+              if: steps.check.outputs.red_commits_action == 'update'
+              uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+              with:
+                  method: chat.update
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  errors: true
+                  payload: |
+                      channel: "${{ steps.check.outputs.red_commits_slack_channel }}"
+                      ts: "${{ steps.check.outputs.red_commits_slack_ts }}"
+                      text: ":large_orange_circle: Master unstable — ${{ steps.check.outputs.red_commits_count }} consecutive commits had a critical workflow fail"
+                      blocks:
+                        - type: "section"
+                          text:
+                            type: "mrkdwn"
+                            text: ":large_orange_circle: *Master unstable* — ${{ steps.check.outputs.red_commits_count }} consecutive commits had a critical workflow fail\nCulprit rotates across workflows, so no single workflow crosses its own threshold — but master is effectively red."
+                        - type: "section"
+                          text:
+                            type: "mrkdwn"
+                            text: "${{ steps.check.outputs.red_commits_detail }}"
+
+            # ============ RED COMMITS: RESOLVE ============
+
+            - name: Update red-commits Slack to resolved
+              if: steps.check.outputs.red_commits_action == 'resolve'
+              uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+              with:
+                  method: chat.update
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  errors: true
+                  payload: |
+                      channel: "${{ steps.check.outputs.red_commits_slack_channel }}"
+                      ts: "${{ steps.check.outputs.red_commits_slack_ts }}"
+                      text: ":large_green_circle: Master stable again (streak ended after ${{ steps.check.outputs.red_commits_last_count }} consecutive red commits)"
+                      blocks:
+                        - type: "section"
+                          text:
+                            type: "mrkdwn"
+                            text: ":large_green_circle: *Master stable again* (streak ended after ${{ steps.check.outputs.red_commits_last_count }} consecutive red commits)"
 
             # ============ RATE LIMIT: CREATE ============
 


### PR DESCRIPTION
## Problem

The `ci-alerts-devex` workflow had two gaps:

1. **Wall-clock thresholding.** "Red for 30+ min" is a poor proxy for severity. During peak merge velocity, 6 consecutive failures can land in under 6 minutes — never hitting 30 min. Overnight, a single flaky failure with no subsequent commits inflates to "red for 8 hours."
2. **No overall-health signal.** The per-workflow alert catches sticky breakage ("Dagster is broken run after run"). It misses the "rotating culprit" case — commit 1 flakes on Dagster, commit 2 on Storybook, commit 3 on Backend. No single workflow crosses a threshold, but every commit is red and master is effectively unreliable.

Additionally, on resolve the previous workflow replaced the full Slack message with "Master recovered (~415 min)", destroying context about what had been failing.

## Changes

### Per-workflow signal — time-based → consecutive-run-based

- Fetch the last N completed runs per workflow, filter cancelled/skipped, count consecutive failures from the most recent backward.
- Alert when any workflow reaches `ALERT_THRESHOLD_RUNS=5` consecutive failures (replaces `ALERT_THRESHOLD_MINUTES`).
- Over-fetch (`runThreshold * 3`, min 20) to survive cancel-heavy windows; warn in logs if too few non-cancelled runs are available.
- Slack headline includes the consecutive count; time remains as supplementary context.
- On resolve, preserve a summary of what had been failing instead of wiping the message.

### Commit-level signal — new "master unstable" alert

- Fetches last 25 commits on master via `listCommits` for authoritative ordering (force-push safe).
- Each commit classified as `red` (any critical workflow failed/timed_out), `green` (critical passed, none failed), or `unknown` (no critical data yet).
- Walks newest-to-oldest: unknowns skip, greens break, reds count. Alerts at `RED_COMMIT_THRESHOLD=10` consecutive red commits.
- Independent Slack lifecycle (create/update/resolve), separate state fields, `:large_orange_circle:` to visually distinguish from per-workflow alerts.
- Detail body lists each red commit with its culprit workflow so operators can spot patterns ("6 of 10 were Dagster").

### Operational

- Cron cadence `*/5` → `*/10` — halves base API load, absorbs the extra `listCommits` call per tick.
- Failing map is now recomputed from API each tick (no stale-state merge), eliminating a class of cache-eviction bugs.

Files: `.github/scripts/ci-alerts-devex.js`, `.github/scripts/ci-alerts-devex.test.js`, `.github/workflows/ci-alerts-devex.yml`.

## How did you test this code?

All 40 jest tests pass (`npx jest ci-alerts-devex.test.js`). New coverage includes:

- Per-workflow: threshold boundary, cancelled/skipped filtering, `timed_out` equivalence, resolve preserves previous detail, severity labels, all-cancelled degenerate case, old-schema state handled gracefully.
- Commit-level: all-green no-op, threshold-minus-one no alert, exact threshold fires, green breaks streak, unknowns skip without breaking, non-critical failures ignored, update when streak grows, no re-update when unchanged, resolve when below threshold, `listCommits` API failure degrades gracefully.

Agent-authored — not manually tested against live Slack. Recommend a `workflow_dispatch` trigger after merge to verify message formatting for both alert types.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 LLM context

Agent-authored across a review/iterate loop: initial switch to consecutive-run alerting, then review-driven polish (parameter rename, over-fetch multiplier, unified resolve emoji, old-schema tests), then expansion to the commit-level "master unstable" signal. Single PR by author preference — commits on the branch split the two phases for reviewability. Thresholds (5 runs / 10 commits) picked as reasonable defaults; easy to tune via env.