### PR TITLE
fix(billing): use empty-page check for stripe enrichment pagination

### DIFF
--- a/posthog/temporal/salesforce_enrichment/stripe_workflow.py
+++ b/posthog/temporal/salesforce_enrichment/stripe_workflow.py
@@ -337,7 +337,7 @@ class SalesforceStripeEnrichmentWorkflow(PostHogWorkflow):
             state.pending_watermark_org_id = page_result.next_cursor_org_id
 
         reached_max = inputs.max_rows is not None and state.total_rows_fetched >= inputs.max_rows
-        is_last_page = page_result.rows_fetched < page_size
+        is_last_page = page_result.rows_fetched == 0
         done = is_last_page or reached_max
 
         if done:

--- a/posthog/temporal/tests/salesforce_enrichment/test_stripe_workflow.py
+++ b/posthog/temporal/tests/salesforce_enrichment/test_stripe_workflow.py
@@ -343,7 +343,7 @@ class TestWorkflowRun(SimpleTestCase):
         mock_workflow.continue_as_new = MagicMock()
 
         wf = SalesforceStripeEnrichmentWorkflow()
-        inputs = StripeEnrichmentInputs(page_size=500)
+        inputs = StripeEnrichmentInputs(page_size=500, max_rows=100)
         result = await wf.run(inputs)
 
         assert mock_workflow.execute_activity.await_count == 3
@@ -408,7 +408,7 @@ class TestWorkflowRun(SimpleTestCase):
         mock_workflow.continue_as_new = MagicMock()
 
         wf = SalesforceStripeEnrichmentWorkflow()
-        inputs = StripeEnrichmentInputs(page_size=500, force_full_refresh=True)
+        inputs = StripeEnrichmentInputs(page_size=500, force_full_refresh=True, max_rows=10)
         result = await wf.run(inputs)
 
         # Force-full-refresh skips the *read* of the prior watermark, but
@@ -449,7 +449,7 @@ class TestWorkflowRun(SimpleTestCase):
             cursor_org_id="org-499",
         )
         wf = SalesforceStripeEnrichmentWorkflow()
-        inputs = StripeEnrichmentInputs(page_size=500, state=state)
+        inputs = StripeEnrichmentInputs(page_size=500, state=state, max_rows=510)
         result = await wf.run(inputs)
 
         # The continuation must pass the stored cursor to the activity and
@@ -460,7 +460,6 @@ class TestWorkflowRun(SimpleTestCase):
         assert page_inputs.cursor_last_changed_at == "2026-04-12T00:00:00+00:00"
         assert page_inputs.cursor_org_id == "org-499"
 
-        # Page size 10 < inputs.page_size 500 — this is the final iteration.
         assert result["total_rows_fetched"] == 510
         assert result["committed_watermark_ts"] == "2026-04-13T00:00:00+00:00"
         assert result["committed_watermark_org_id"] == "org-509"
@@ -485,7 +484,7 @@ class TestWorkflowRun(SimpleTestCase):
         mock_workflow.continue_as_new = MagicMock()
 
         wf = SalesforceStripeEnrichmentWorkflow()
-        inputs = StripeEnrichmentInputs(page_size=500)
+        inputs = StripeEnrichmentInputs(page_size=500, max_rows=10)
         result = await wf.run(inputs)
 
         assert result["error_count"] == 15
@@ -513,7 +512,7 @@ class TestWorkflowRun(SimpleTestCase):
         mock_workflow.continue_as_new = MagicMock()
 
         wf = SalesforceStripeEnrichmentWorkflow()
-        inputs = StripeEnrichmentInputs(page_size=500)
+        inputs = StripeEnrichmentInputs(page_size=500, max_rows=3)
         result = await wf.run(inputs)
 
         # commit_stripe_watermark_activity must NOT run — only the watermark
@@ -556,7 +555,7 @@ class TestWorkflowRun(SimpleTestCase):
             cursor_org_id="org-prev",
         )
         wf = SalesforceStripeEnrichmentWorkflow()
-        inputs = StripeEnrichmentInputs(page_size=500, state=state)
+        inputs = StripeEnrichmentInputs(page_size=500, state=state, max_rows=1002)
         result = await wf.run(inputs)
 
         # Two awaits: the page activity, then commit_stripe_watermark_activity.


### PR DESCRIPTION
The previous `rows_fetched < page_size` check caused the workflow to stop early when DuckGres returned slightly fewer rows than the LIMIT, leaving most accounts unprocessed. Switching to `rows_fetched == 0` ensures pagination continues until the data source is truly exhausted.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Ran a backfill: https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/salesforce-stripe-enrichment-manual-backfill/019d96ac-81e2-7864-8713-1152cd0d2a45/history

Didn't complete because duckgres returned 4998 rows even though over 95k are remaining

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
Only terminate pagination when `rows_fetched == 0`

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

Ran it locally:
<img width="1622" height="626" alt="image" src="https://github.com/user-attachments/assets/6bbce37d-0892-47e1-912f-fb0ee5c89b22" />

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->
no

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
