### PR TITLE
feat(alerts): add alert error classification for user-facing messages

### DIFF
--- a/products/logs/backend/alert_error_classifier.py
+++ b/products/logs/backend/alert_error_classifier.py
@@ -1,0 +1,64 @@
+"""Surface safe user-facing messages for alert check failures.
+
+Thin adapter over `posthog.errors.classify_query_error` — maps the existing
+category enum to alert-specific messages. Raw exception text still goes to
+Sentry via `capture_exception`; this module only produces UI/Slack-safe strings.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from posthog.hogql.errors import ExposedHogQLError
+
+from posthog.errors import ExposedCHQueryError, QueryErrorCategory, classify_query_error
+
+AlertErrorCode = Literal["server_busy", "query_performance", "invalid_query", "cancelled", "unknown"]
+
+
+@dataclass(frozen=True)
+class ClassifiedAlertError:
+    code: AlertErrorCode
+    user_message: str
+
+
+_UNKNOWN = ClassifiedAlertError(
+    code="unknown",
+    user_message="Alert check failed unexpectedly. PostHog has been notified.",
+)
+
+
+def classify(exc: Exception) -> ClassifiedAlertError:
+    category = classify_query_error(exc)
+
+    if category == QueryErrorCategory.RATE_LIMITED:
+        return ClassifiedAlertError(
+            code="server_busy",
+            user_message="PostHog is temporarily busy. The alert check will retry automatically.",
+        )
+
+    if category == QueryErrorCategory.QUERY_PERFORMANCE_ERROR:
+        return ClassifiedAlertError(
+            code="query_performance",
+            user_message="Query is too expensive. Try narrower filters or a shorter window.",
+        )
+
+    if category == QueryErrorCategory.USER_ERROR:
+        # Only expose the message text when the exception type guarantees sanitization —
+        # ExposedCHQueryError.__str__ strips DB::Exception / Stack trace framing, and
+        # ExposedHogQLError carries an explicit user-safe message. Many ClickHouse error
+        # codes carry USER_ERROR category but ship as raw InternalCHQueryError (via
+        # wrap_clickhouse_query_error) with the full DB::Exception text intact — fall
+        # those through to the generic unknown message rather than leaking internals.
+        if isinstance(exc, ExposedCHQueryError | ExposedHogQLError):
+            return ClassifiedAlertError(code="invalid_query", user_message=str(exc)[:500])
+        return _UNKNOWN
+
+    if category == QueryErrorCategory.CANCELLED:
+        return ClassifiedAlertError(
+            code="cancelled",
+            user_message="Alert check was cancelled. It will retry automatically.",
+        )
+
+    return _UNKNOWN

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -15,6 +15,7 @@ from posthog.cdp.internal_events import InternalEventEvent, produce_internal_eve
 from posthog.exceptions_capture import capture_exception
 
 from products.logs.backend.alert_check_query import AlertCheckQuery
+from products.logs.backend.alert_error_classifier import classify as classify_alert_error
 from products.logs.backend.alert_state_machine import (
     AlertCheckOutcome,
     AlertSnapshot,
@@ -126,17 +127,20 @@ def _evaluate_single_alert(
             query_duration_ms=query_result.query_duration_ms,
         )
     except Exception as e:
+        classified = classify_alert_error(e)
+        capture_exception(e, {"alert_id": str(alert.id), "classification": classified.code})
         logger.warning(
             "Alert check query failed",
             alert_id=str(alert.id),
             alert_name=alert.name,
             team_id=alert.team_id,
             error=str(e),
+            classification=classified.code,
         )
         check_result = CheckResult(
             result_count=None,
             threshold_breached=False,
-            error_message=str(e),
+            error_message=classified.user_message,
         )
 
     snapshot = AlertSnapshot(

--- a/products/logs/backend/test/test_alert_error_classifier.py
+++ b/products/logs/backend/test/test_alert_error_classifier.py
@@ -1,0 +1,80 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from parameterized import parameterized
+
+from posthog.hogql.errors import ExposedHogQLError
+
+from posthog.errors import ExposedCHQueryError, InternalCHQueryError, QueryErrorCategory
+
+from products.logs.backend.alert_error_classifier import classify
+
+
+def _with_category(category: QueryErrorCategory):
+    return patch("products.logs.backend.alert_error_classifier.classify_query_error", return_value=category)
+
+
+class TestClassifyAlertError(TestCase):
+    @parameterized.expand(
+        [
+            (QueryErrorCategory.RATE_LIMITED, "server_busy"),
+            (QueryErrorCategory.QUERY_PERFORMANCE_ERROR, "query_performance"),
+            (QueryErrorCategory.CANCELLED, "cancelled"),
+            (QueryErrorCategory.ERROR, "unknown"),
+        ]
+    )
+    def test_category_maps_to_expected_code(self, category: QueryErrorCategory, expected_code: str) -> None:
+        with _with_category(category):
+            result = classify(Exception("whatever"))
+
+        assert result.code == expected_code
+        assert result.user_message, "user_message must never be empty"
+
+    def test_user_error_from_exposed_ch_error_surfaces_sanitized_text(self) -> None:
+        # ExposedCHQueryError.__str__ strips the DB::Exception / Stack trace framing,
+        # so the remaining text is safe to surface verbatim.
+        exc = ExposedCHQueryError("DB::Exception: Unknown identifier 'foo'\nStack trace: internal", code=47)
+        with _with_category(QueryErrorCategory.USER_ERROR):
+            result = classify(exc)
+
+        assert result.code == "invalid_query"
+        assert "DB::Exception" not in result.user_message
+        assert "Stack trace" not in result.user_message
+        assert "Unknown identifier 'foo'" in result.user_message
+
+    def test_user_error_from_exposed_hogql_error_surfaces_its_message(self) -> None:
+        exc = ExposedHogQLError("Alert filter has an invalid property")
+        with _with_category(QueryErrorCategory.USER_ERROR):
+            result = classify(exc)
+
+        assert result.code == "invalid_query"
+        assert result.user_message == "Alert filter has an invalid property"
+
+    def test_user_error_from_internal_ch_error_falls_back_to_unknown(self) -> None:
+        # USER_ERROR-category codes that aren't marked user_safe get wrapped as raw
+        # InternalCHQueryError — the message still contains DB::Exception framing,
+        # so we must not surface it.
+        exc = InternalCHQueryError(
+            "Code: 62. DB::Exception: Syntax error near token 'from' at position 412 (Stack trace: ...)",
+            code=62,
+        )
+        with _with_category(QueryErrorCategory.USER_ERROR):
+            result = classify(exc)
+
+        assert result.code == "unknown"
+        assert "DB::Exception" not in result.user_message
+        assert "Syntax error" not in result.user_message
+        assert "PostHog" in result.user_message
+
+    def test_user_error_message_is_truncated(self) -> None:
+        exc = ExposedCHQueryError("x" * 5000, code=47)
+        with _with_category(QueryErrorCategory.USER_ERROR):
+            result = classify(exc)
+
+        assert len(result.user_message) == 500
+
+    def test_unknown_message_mentions_posthog(self) -> None:
+        with _with_category(QueryErrorCategory.ERROR):
+            result = classify(RuntimeError("something unexpected"))
+
+        assert "PostHog" in result.user_message

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -8,6 +8,8 @@ from django.db.models import F
 
 from parameterized import parameterized
 
+from posthog.errors import QueryErrorCategory
+
 from products.logs.backend.alert_check_query import AlertCheckCountResult
 from products.logs.backend.models import MAX_EVALUATION_PERIODS, LogsAlertCheck, LogsAlertConfiguration
 from products.logs.backend.temporal.activities import CheckAlertsOutput, _check_alerts_sync, _evaluate_single_alert
@@ -222,8 +224,17 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
-    def test_clickhouse_failure_creates_error_audit_row(self, mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute.side_effect = Exception("ClickHouse timeout")
+    @patch(
+        "products.logs.backend.alert_error_classifier.classify_query_error",
+        return_value=QueryErrorCategory.QUERY_PERFORMANCE_ERROR,
+    )
+    def test_clickhouse_failure_creates_error_audit_row(self, _mock_classify, mock_produce, mock_query_cls):
+        # Force the classifier to treat this as a performance error so the assertion
+        # doesn't depend on whether the raw message hits one of the shared classifier's
+        # recognized shapes.
+        mock_query_cls.return_value.execute.side_effect = Exception(
+            "Code: 160. DB::Exception: Estimated query execution time is too long"
+        )
         alert = self._make_alert()
         stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
         now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
@@ -233,7 +244,8 @@ class TestEvaluateSingleAlert(APIBaseTest):
         check = LogsAlertCheck.objects.get(alert=alert)
         assert check.result_count is None
         assert check.threshold_breached is False
-        assert check.error_message == "ClickHouse timeout"
+        assert check.error_message == "Query is too expensive. Try narrower filters or a shorter window."
+        assert "DB::Exception" not in (check.error_message or "")
         assert stats["errored"] == 1
 
     @freeze_time("2025-01-01T00:01:00Z")
@@ -490,9 +502,15 @@ class TestEvaluateSingleAlert(APIBaseTest):
             consecutive_failures=initial_failures,
             state=initial_state,
         )
-        mock_query_cls.return_value.execute.side_effect = Exception("ClickHouse timeout")
+        mock_query_cls.return_value.execute.side_effect = Exception(
+            "Code: 160. DB::Exception: Estimated query execution time is too long"
+        )
 
-        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
+        with patch(
+            "products.logs.backend.alert_error_classifier.classify_query_error",
+            return_value=QueryErrorCategory.QUERY_PERFORMANCE_ERROR,
+        ):
+            _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
 
         alert.refresh_from_db()
         assert alert.state == expected_state
@@ -506,4 +524,6 @@ class TestEvaluateSingleAlert(APIBaseTest):
         if expected_events:
             props = auto_disabled_calls[0].kwargs["event"].properties
             assert props["consecutive_failures"] == expected_failures
-            assert "ClickHouse timeout" in props["last_error_message"]
+            # Auto-disabled event surfaces the classified user message, never the raw CH exception.
+            assert props["last_error_message"] == "Query is too expensive. Try narrower filters or a shorter window."
+            assert "DB::Exception" not in props["last_error_message"]


### PR DESCRIPTION
## Problem

Alert check failures were exposing raw database exceptions and technical error messages to users in the UI and Slack notifications, making it difficult for users to understand what went wrong and how to fix issues with their alerts.

## Changes

- Added `alert_error_classifier.py` module that maps query error categories to user-friendly alert-specific messages
- Integrated the classifier into the alert evaluation workflow to surface appropriate error messages
- Raw exceptions are still captured in Sentry for debugging, but users now see helpful messages like "Query is too expensive. Try narrower filters or a shorter window." instead of raw ClickHouse errors
- Error messages for user-facing queries are truncated to 500 characters to prevent overly long error displays
- Added error classification codes (`server_busy`, `query_performance`, `invalid_query`, `cancelled`, `unknown`) for better error categorization

## How did you test this code?

unit tests covering:

- Mapping of different query error categories to appropriate alert error codes
- User error message surfacing and truncation
- Integration with the existing alert evaluation workflow
- Updated existing integration tests to verify classified error messages appear in audit logs and auto-disable events instead of raw database exceptions

## Publish to changelog?

No

## Docs update

No