### PR TITLE
fix: Update Slack language to include private channel info

### DIFF
--- a/frontend/src/mocks/fixtures/_hogFunctionTemplatesDestinations.json
+++ b/frontend/src/mocks/fixtures/_hogFunctionTemplatesDestinations.json
@@ -2380,7 +2380,7 @@
                     "hidden": false,
                     "secret": false,
                     "required": true,
-                    "description": "Select the channel to post to (e.g. #general). The PostHog app must be installed in the workspace. For private channels, the PostHog app must be member of the channel.",
+                    "description": "Select the channel to post to (e.g. #general). The PostHog app must be installed in the workspace. For private channels, the PostHog app must be a member of the channel.",
                     "integration_key": "slack_workspace",
                     "integration_field": "slack_channel"
                 },

--- a/frontend/src/mocks/fixtures/_hogFunctionTemplatesDestinations.json
+++ b/frontend/src/mocks/fixtures/_hogFunctionTemplatesDestinations.json
@@ -2380,7 +2380,7 @@
                     "hidden": false,
                     "secret": false,
                     "required": true,
-                    "description": "Select the channel to post to (e.g. #general). The PostHog app must be installed in the workspace.",
+                    "description": "Select the channel to post to (e.g. #general). The PostHog app must be installed in the workspace. For private channels, the PostHog app must be member of the channel.",
                     "integration_key": "slack_workspace",
                     "integration_field": "slack_channel"
                 },

--- a/frontend/src/scenes/data-pipelines/__mocks__/hogFunctionDestinations.json
+++ b/frontend/src/scenes/data-pipelines/__mocks__/hogFunctionDestinations.json
@@ -169,7 +169,7 @@
                     "required": true,
                     "secret": false,
                     "hidden": false,
-                    "description": "Select the channel to post to (e.g. #general). The PostHog app must be installed in the workspace.",
+                    "description": "Select the channel to post to (e.g. #general). The PostHog app must be installed in the workspace. For private channels, the PostHog app must be a member of the channel.",
                     "integration_key": "slack_workspace",
                     "integration_field": "slack_channel"
                 },
@@ -464,7 +464,7 @@
                         "integration_key": "slack_workspace",
                         "integration_field": "slack_channel",
                         "label": "Channel to post to",
-                        "description": "Select the channel to post to (e.g. #general). The PostHog app must be installed in the workspace.",
+                        "description": "Select the channel to post to (e.g. #general). The PostHog app must be installed in the workspace. For private channels, the PostHog app must be a member of the channel.",
                         "secret": false,
                         "hidden": false,
                         "required": true

--- a/posthog/cdp/templates/slack/template_slack.py
+++ b/posthog/cdp/templates/slack/template_slack.py
@@ -47,7 +47,7 @@ if (res.status != 200 or res.body.ok == false) {
             "integration_key": "slack_workspace",
             "integration_field": "slack_channel",
             "label": "Channel to post to",
-            "description": "Select the channel to post to (e.g. #general). The PostHog app must be installed in the workspace.",
+            "description": "Select the channel to post to (e.g. #general). The PostHog app must be installed in the workspace. For private channels, the PostHog app must be member of the channel.",
             "secret": False,
             "hidden": False,
             "required": True,

--- a/posthog/cdp/templates/slack/template_slack.py
+++ b/posthog/cdp/templates/slack/template_slack.py
@@ -47,7 +47,7 @@ if (res.status != 200 or res.body.ok == false) {
             "integration_key": "slack_workspace",
             "integration_field": "slack_channel",
             "label": "Channel to post to",
-            "description": "Select the channel to post to (e.g. #general). The PostHog app must be installed in the workspace. For private channels, the PostHog app must be member of the channel.",
+            "description": "Select the channel to post to (e.g. #general). The PostHog app must be installed in the workspace. For private channels, the PostHog app must be a member of the channel.",
             "secret": False,
             "hidden": False,
             "required": True,


### PR DESCRIPTION
## Problem

Customer wrote in with this language request as their channel wasn't showing up in the list until PostHog was added to it.

## Changes

Nothing more than text updates

## How did you test this code?

It's just language changes.

## Publish to changelog?

no

## Docs update


