### PR TITLE
fix(dagster): fix dagster backups not working for logs

### DIFF
--- a/posthog/dags/backups.py
+++ b/posthog/dags/backups.py
@@ -773,7 +773,9 @@ def incremental_non_sharded_backup_schedule(context: dagster.ScheduleEvaluationC
 )
 def full_logs_backup_schedule(context: dagster.ScheduleEvaluationContext):
     """Launch a full backup for logs tables"""
-    cluster_resource = BackupsClickhouseClusterResource(cluster=settings.CLICKHOUSE_MIGRATIONS_CLUSTER)
+    cluster_resource = BackupsClickhouseClusterResource(
+        host=settings.CLICKHOUSE_LOGS_HOST, cluster=settings.CLICKHOUSE_LOGS_CLUSTER
+    )
     for table in LOGS_TABLES:
         request = run_backup_request(
             table,
@@ -795,7 +797,9 @@ def full_logs_backup_schedule(context: dagster.ScheduleEvaluationContext):
 )
 def incremental_logs_backup_schedule(context: dagster.ScheduleEvaluationContext):
     """Launch an incremental backup for logs tables"""
-    cluster_resource = BackupsClickhouseClusterResource(cluster=settings.CLICKHOUSE_MIGRATIONS_CLUSTER)
+    cluster_resource = BackupsClickhouseClusterResource(
+        host=settings.CLICKHOUSE_LOGS_HOST, cluster=settings.CLICKHOUSE_LOGS_CLUSTER
+    )
     for table in LOGS_TABLES:
         request = run_backup_request(
             table,

--- a/posthog/dags/backups.py
+++ b/posthog/dags/backups.py
@@ -19,7 +19,7 @@ from posthog.dags.common import JobOwners, check_for_concurrent_runs
 from posthog.dags.common.resources import BackupsClickhouseClusterResource
 
 BACKUP_RESOURCE_DEFS = {
-    "cluster": BackupsClickhouseClusterResource.configure_at_launch(),
+    "cluster": BackupsClickhouseClusterResource(),
     "s3": S3Resource.configure_at_launch(),
 }
 

--- a/posthog/dags/backups.py
+++ b/posthog/dags/backups.py
@@ -19,7 +19,7 @@ from posthog.dags.common import JobOwners, check_for_concurrent_runs
 from posthog.dags.common.resources import BackupsClickhouseClusterResource
 
 BACKUP_RESOURCE_DEFS = {
-    "cluster": BackupsClickhouseClusterResource(),
+    "cluster": BackupsClickhouseClusterResource.configure_at_launch(),
     "s3": S3Resource.configure_at_launch(),
 }
 
@@ -275,12 +275,14 @@ def check_running_backup_for_table(
     Check if a backup for the requested table is in progress (it shouldn't, so fail if that's the case).
     """
     table = Table(name=config.table)
-    is_running_backup = (
-        cluster.map_hosts_by_role(table.is_backup_in_progress, node_role=config.node_role, workload=config.workload)
-        .result()
-        .values()
-    )
-    if any(is_running_backup):
+    results = cluster.map_hosts_by_role(
+        table.is_backup_in_progress, node_role=config.node_role, workload=config.workload
+    ).result()
+    if not results:
+        raise dagster.Failure(
+            description=f"No hosts found for node_role={config.node_role}, workload={config.workload}. Check cluster configuration."
+        )
+    if any(results.values()):
         raise dagster.Failure(
             description=f"A backup for table {table.name} is still in progress, this run shouldn't have been triggered. Review concurrency limits / schedule triggering logic. If there is not Dagster job running and there is a backup going on, it's worth checking what happened."
         )
@@ -643,7 +645,10 @@ def non_sharded_backup():
     cleanup_old_backups(backup=completed_backup, all_backups=all_backups)
 
 
-def prepare_run_config(config: BackupConfig) -> dagster.RunConfig:
+def prepare_run_config(
+    config: BackupConfig,
+    cluster_resource: BackupsClickhouseClusterResource | None = None,
+) -> dagster.RunConfig:
     # Dagster's config system expects enum names (e.g. "DATA"), not values (e.g. "data").
     # model_dump(mode="json") serializes StrEnum as the value string, so we override
     # enum fields to use their name instead.
@@ -652,7 +657,7 @@ def prepare_run_config(config: BackupConfig) -> dagster.RunConfig:
     config_dict["node_role"] = config.node_role.name
 
     return dagster.RunConfig(
-        {
+        ops={
             op.name: {"config": config_dict}
             for op in [
                 check_running_backup_for_table,
@@ -662,7 +667,8 @@ def prepare_run_config(config: BackupConfig) -> dagster.RunConfig:
                 wait_for_backup,
                 cleanup_old_backups,
             ]
-        }
+        },
+        resources={"cluster": cluster_resource} if cluster_resource else {},
     )
 
 
@@ -673,6 +679,7 @@ def run_backup_request(
     owner: JobOwners = JobOwners.TEAM_CLICKHOUSE,
     workload: Workload = Workload.OFFLINE,
     node_role: NodeRole = NodeRole.DATA,
+    cluster_resource: BackupsClickhouseClusterResource | None = None,
 ) -> Optional[dagster.RunRequest]:
     skip_reason = check_for_concurrent_runs(
         context,
@@ -695,7 +702,7 @@ def run_backup_request(
 
     return dagster.RunRequest(
         run_key=f"{timestamp.strftime('%Y%m%d')}-{table}",
-        run_config=prepare_run_config(config),
+        run_config=prepare_run_config(config, cluster_resource=cluster_resource),
         tags={
             "backup_type": "incremental" if incremental else "full",
             "table": table,
@@ -766,6 +773,7 @@ def incremental_non_sharded_backup_schedule(context: dagster.ScheduleEvaluationC
 )
 def full_logs_backup_schedule(context: dagster.ScheduleEvaluationContext):
     """Launch a full backup for logs tables"""
+    cluster_resource = BackupsClickhouseClusterResource(cluster=settings.CLICKHOUSE_MIGRATIONS_CLUSTER)
     for table in LOGS_TABLES:
         request = run_backup_request(
             table,
@@ -774,6 +782,7 @@ def full_logs_backup_schedule(context: dagster.ScheduleEvaluationContext):
             owner=JobOwners.TEAM_LOGS,
             workload=Workload.LOGS,
             node_role=NodeRole.LOGS,
+            cluster_resource=cluster_resource,
         )
         if request:
             yield request
@@ -786,6 +795,7 @@ def full_logs_backup_schedule(context: dagster.ScheduleEvaluationContext):
 )
 def incremental_logs_backup_schedule(context: dagster.ScheduleEvaluationContext):
     """Launch an incremental backup for logs tables"""
+    cluster_resource = BackupsClickhouseClusterResource(cluster=settings.CLICKHOUSE_MIGRATIONS_CLUSTER)
     for table in LOGS_TABLES:
         request = run_backup_request(
             table,
@@ -794,6 +804,7 @@ def incremental_logs_backup_schedule(context: dagster.ScheduleEvaluationContext)
             owner=JobOwners.TEAM_LOGS,
             workload=Workload.LOGS,
             node_role=NodeRole.LOGS,
+            cluster_resource=cluster_resource,
         )
         if request:
             yield request

--- a/posthog/dags/common/resources.py
+++ b/posthog/dags/common/resources.py
@@ -90,6 +90,9 @@ class BackupsClickhouseClusterResource(dagster.ConfigurableResource):
     async BACKUP threads don't inherit session-level settings.
     """
 
+    host: str = settings.CLICKHOUSE_HOST
+    cluster: str = settings.CLICKHOUSE_CLUSTER
+
     client_settings: dict[str, str] = {
         "max_execution_time": "0",
         "max_memory_usage": "0",
@@ -109,6 +112,8 @@ class BackupsClickhouseClusterResource(dagster.ConfigurableResource):
             )
         return get_cluster(
             context.log,
+            host=self.host,
+            cluster=self.cluster,
             client_settings=self.client_settings,
             retry_policy=RetryPolicy(
                 max_attempts=8,

--- a/posthog/dags/locations/logs.py
+++ b/posthog/dags/locations/logs.py
@@ -1,9 +1,6 @@
-from django.conf import settings
-
 import dagster
 
 from posthog.dags import backups
-from posthog.dags.common.resources import ClickhouseClusterResource
 
 from . import resources
 
@@ -15,10 +12,5 @@ defs = dagster.Definitions(
         backups.full_logs_backup_schedule,
         backups.incremental_logs_backup_schedule,
     ],
-    resources={
-        **resources,
-        "cluster": ClickhouseClusterResource(
-            host=settings.CLICKHOUSE_LOGS_HOST, cluster=settings.CLICKHOUSE_LOGS_CLUSTER
-        ),
-    },
+    resources=resources,
 )


### PR DESCRIPTION
## Problem

dagster backups were always running on the "posthog" cluster. The location override for logs was not working as job config overrides locations config


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

update things so we can override the cluster per job and set the logs backup jobs to use the logs cluster+host
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

existing tests
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
