### PR TITLE
fix: Use materialized columns for lib and lib version in SDK Outdated job

### DIFF
--- a/products/growth/backend/temporal/health_checks/sdk_outdated.py
+++ b/products/growth/backend/temporal/health_checks/sdk_outdated.py
@@ -24,16 +24,18 @@ logger = structlog.get_logger(__name__)
 SDK_VERSIONS_SQL = """
 SELECT
     team_id,
-    replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$lib'), ''), 'null'), '^"|"$', '') AS lib,
-    replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$lib_version'), ''), 'null'), '^"|"$', '') AS lib_version,
+    `mat_$lib` AS lib,
+    `mat_$lib_version` AS lib_version,
     max(timestamp) AS max_timestamp,
     count(*) AS event_count
 FROM events
 WHERE
     team_id IN %(team_ids)s
     AND timestamp >= now() - INTERVAL %(lookback_days)s DAY
-    AND lib != ''
-    AND lib_version != ''
+    AND `mat_$lib` IS NOT NULL
+    AND `mat_$lib` != ''
+    AND `mat_$lib_version` IS NOT NULL
+    AND `mat_$lib_version` != ''
 GROUP BY team_id, lib, lib_version
 ORDER BY
     team_id,


### PR DESCRIPTION
## Problem
SDK Outdated queries are timing out since we were using JSONExtract 🤦‍♂️
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Use the materialized columns 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
