### PR TITLE
fix: tolerate duplicate SPT billing activation when subscription already active

### DIFF
--- a/ee/api/agentic_provisioning/test/base.py
+++ b/ee/api/agentic_provisioning/test/base.py
@@ -5,9 +5,12 @@ from urllib.parse import urlencode
 import pytest
 from posthog.test.base import APIBaseTest
 
+from django.conf import settings
 from django.core.cache import cache
 from django.test import override_settings
 
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from rest_framework.test import APIClient
 
 from ee.api.agentic_provisioning.signature import compute_signature
@@ -17,8 +20,26 @@ HMAC_SECRET = "test_hmac_secret"
 TEST_STRIPE_OAUTH_CLIENT_ID = "test_stripe_oauth_client_id"
 
 
+def _generate_rsa_key() -> str:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pem.decode("utf-8")
+
+
+_RSA_KEY = _generate_rsa_key()
+
+
 @pytest.mark.requires_secrets
-@override_settings(STRIPE_APP_SECRET_KEY=HMAC_SECRET, STRIPE_POSTHOG_OAUTH_CLIENT_ID=TEST_STRIPE_OAUTH_CLIENT_ID)
+@override_settings(
+    STRIPE_APP_SECRET_KEY=HMAC_SECRET,
+    STRIPE_POSTHOG_OAUTH_CLIENT_ID=TEST_STRIPE_OAUTH_CLIENT_ID,
+    OIDC_RSA_PRIVATE_KEY=_RSA_KEY,
+    OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, "OIDC_RSA_PRIVATE_KEY": _RSA_KEY},
+)
 class StripeProvisioningTestBase(APIBaseTest):
     def setUp(self):
         super().setUp()

--- a/ee/api/agentic_provisioning/test/test_spt.py
+++ b/ee/api/agentic_provisioning/test/test_spt.py
@@ -74,7 +74,15 @@ class TestSharedPaymentToken(StripeProvisioningTestBase):
     @patch("ee.billing.billing_manager.build_billing_token", return_value="test_billing_token")
     @patch("posthog.cloud_utils.get_cached_instance_license")
     def test_provisioning_spt_failure(
-        self, _name, has_active_subscription, expected_status, expected_code, mock_license, mock_build_token, mock_post, mock_get
+        self,
+        _name,
+        has_active_subscription,
+        expected_status,
+        expected_code,
+        mock_license,
+        mock_build_token,
+        mock_post,
+        mock_get,
     ):
         mock_license.return_value = MagicMock()
         mock_post.return_value = MagicMock(status_code=500)

--- a/ee/api/agentic_provisioning/test/test_spt.py
+++ b/ee/api/agentic_provisioning/test/test_spt.py
@@ -61,12 +61,18 @@ class TestSharedPaymentToken(StripeProvisioningTestBase):
         assert res.status_code == 200
         mock_post.assert_not_called()
 
+    @patch("ee.api.agentic_provisioning.views.requests.get")
     @patch("ee.api.agentic_provisioning.views.requests.post")
     @patch("ee.billing.billing_manager.build_billing_token", return_value="test_billing_token")
     @patch("posthog.cloud_utils.get_cached_instance_license")
-    def test_provisioning_returns_error_if_billing_activation_fails(self, mock_license, mock_build_token, mock_post):
+    def test_provisioning_returns_error_if_billing_activation_fails(
+        self, mock_license, mock_build_token, mock_post, mock_get
+    ):
         mock_license.return_value = MagicMock()
         mock_post.return_value = MagicMock(status_code=500)
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: {"customer": {"has_active_subscription": False}}
+        )
 
         token = self._get_bearer_token()
         res = self._post_signed_with_bearer(
@@ -84,6 +90,32 @@ class TestSharedPaymentToken(StripeProvisioningTestBase):
         body = res.json()
         assert body["status"] == "error"
         assert body["error"]["code"] == "requires_payment_credentials"
+
+    @patch("ee.api.agentic_provisioning.views.requests.get")
+    @patch("ee.api.agentic_provisioning.views.requests.post")
+    @patch("ee.billing.billing_manager.build_billing_token", return_value="test_billing_token")
+    @patch("posthog.cloud_utils.get_cached_instance_license")
+    def test_provisioning_succeeds_if_spt_fails_but_billing_already_active(
+        self, mock_license, mock_build_token, mock_post, mock_get
+    ):
+        mock_license.return_value = MagicMock()
+        mock_post.return_value = MagicMock(status_code=500)
+        mock_get.return_value = MagicMock(status_code=200, json=lambda: {"customer": {"has_active_subscription": True}})
+
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources",
+            data={
+                "service_id": "analytics",
+                "payment_credentials": {
+                    "type": "stripe_payment_token",
+                    "stripe_payment_token": "spt_test_123",
+                },
+            },
+            token=token,
+        )
+        assert res.status_code == 200
+        assert res.json()["status"] == "complete"
 
     def test_token_exchange_returns_orchestrator(self):
         """Token exchange should return payment_credentials: orchestrator so Stripe collects payment."""

--- a/ee/api/agentic_provisioning/test/test_spt.py
+++ b/ee/api/agentic_provisioning/test/test_spt.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from django.core.cache import cache
+
 from parameterized import parameterized
 
 from ee.api.agentic_provisioning.test.base import StripeProvisioningTestBase

--- a/ee/api/agentic_provisioning/test/test_spt.py
+++ b/ee/api/agentic_provisioning/test/test_spt.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from django.core.cache import cache
+from parameterized import parameterized
 
 from ee.api.agentic_provisioning.test.base import StripeProvisioningTestBase
 
@@ -61,17 +62,23 @@ class TestSharedPaymentToken(StripeProvisioningTestBase):
         assert res.status_code == 200
         mock_post.assert_not_called()
 
+    @parameterized.expand(
+        [
+            ("billing_inactive", False, 400, "requires_payment_credentials"),
+            ("billing_already_active", True, 200, "complete"),
+        ]
+    )
     @patch("ee.api.agentic_provisioning.views.requests.get")
     @patch("ee.api.agentic_provisioning.views.requests.post")
     @patch("ee.billing.billing_manager.build_billing_token", return_value="test_billing_token")
     @patch("posthog.cloud_utils.get_cached_instance_license")
-    def test_provisioning_returns_error_if_billing_activation_fails(
-        self, mock_license, mock_build_token, mock_post, mock_get
+    def test_provisioning_spt_failure(
+        self, _name, has_active_subscription, expected_status, expected_code, mock_license, mock_build_token, mock_post, mock_get
     ):
         mock_license.return_value = MagicMock()
         mock_post.return_value = MagicMock(status_code=500)
         mock_get.return_value = MagicMock(
-            status_code=200, json=lambda: {"customer": {"has_active_subscription": False}}
+            status_code=200, json=lambda: {"customer": {"has_active_subscription": has_active_subscription}}
         )
 
         token = self._get_bearer_token()
@@ -86,36 +93,12 @@ class TestSharedPaymentToken(StripeProvisioningTestBase):
             },
             token=token,
         )
-        assert res.status_code == 400
+        assert res.status_code == expected_status
         body = res.json()
-        assert body["status"] == "error"
-        assert body["error"]["code"] == "requires_payment_credentials"
-
-    @patch("ee.api.agentic_provisioning.views.requests.get")
-    @patch("ee.api.agentic_provisioning.views.requests.post")
-    @patch("ee.billing.billing_manager.build_billing_token", return_value="test_billing_token")
-    @patch("posthog.cloud_utils.get_cached_instance_license")
-    def test_provisioning_succeeds_if_spt_fails_but_billing_already_active(
-        self, mock_license, mock_build_token, mock_post, mock_get
-    ):
-        mock_license.return_value = MagicMock()
-        mock_post.return_value = MagicMock(status_code=500)
-        mock_get.return_value = MagicMock(status_code=200, json=lambda: {"customer": {"has_active_subscription": True}})
-
-        token = self._get_bearer_token()
-        res = self._post_signed_with_bearer(
-            "/api/agentic/provisioning/resources",
-            data={
-                "service_id": "analytics",
-                "payment_credentials": {
-                    "type": "stripe_payment_token",
-                    "stripe_payment_token": "spt_test_123",
-                },
-            },
-            token=token,
-        )
-        assert res.status_code == 200
-        assert res.json()["status"] == "complete"
+        if expected_status == 400:
+            assert body["error"]["code"] == expected_code
+        else:
+            assert body["status"] == expected_code
 
     def test_token_exchange_returns_orchestrator(self):
         """Token exchange should return payment_credentials: orchestrator so Stripe collects payment."""

--- a/ee/api/agentic_provisioning/test/test_update_service.py
+++ b/ee/api/agentic_provisioning/test/test_update_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
+
 from parameterized import parameterized
 
 from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisioningTestBase

--- a/ee/api/agentic_provisioning/test/test_update_service.py
+++ b/ee/api/agentic_provisioning/test/test_update_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
+from parameterized import parameterized
 
 from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisioningTestBase
 
@@ -35,42 +36,24 @@ class TestProvisioningUpdateService(StripeProvisioningTestBase):
         assert "/api/activate/authorize" in call_args[0]
         assert call_kwargs["json"] == {"shared_payment_token": "spt_test_123"}
 
+    @parameterized.expand(
+        [
+            ("billing_inactive", False, 400, "billing_activation_failed"),
+            ("billing_already_active", True, 200, "complete"),
+        ]
+    )
     @patch("ee.api.agentic_provisioning.views.requests.get")
     @patch("ee.api.agentic_provisioning.views.requests.post")
     @patch("ee.billing.billing_manager.build_billing_token", return_value="test_billing_token")
     @patch("posthog.cloud_utils.get_cached_instance_license")
-    def test_update_service_returns_error_if_billing_fails(self, mock_license, mock_build_token, mock_post, mock_get):
-        mock_license.return_value = MagicMock()
-        mock_post.return_value = MagicMock(status_code=500)
-        mock_get.return_value = MagicMock(
-            status_code=200, json=lambda: {"customer": {"has_active_subscription": False}}
-        )
-
-        token = self._get_bearer_token()
-        res = self._post_signed_with_bearer(
-            f"/api/agentic/provisioning/resources/{self.team.id}/update_service",
-            data={
-                "service_id": "pay_as_you_go",
-                "payment_credentials": {
-                    "type": "stripe_payment_token",
-                    "stripe_payment_token": "spt_test_123",
-                },
-            },
-            token=token,
-        )
-        assert res.status_code == 400
-        assert res.json()["error"]["code"] == "billing_activation_failed"
-
-    @patch("ee.api.agentic_provisioning.views.requests.get")
-    @patch("ee.api.agentic_provisioning.views.requests.post")
-    @patch("ee.billing.billing_manager.build_billing_token", return_value="test_billing_token")
-    @patch("posthog.cloud_utils.get_cached_instance_license")
-    def test_update_service_succeeds_if_spt_fails_but_billing_already_active(
-        self, mock_license, mock_build_token, mock_post, mock_get
+    def test_update_service_spt_failure(
+        self, _name, has_active_subscription, expected_status, expected_code, mock_license, mock_build_token, mock_post, mock_get
     ):
         mock_license.return_value = MagicMock()
         mock_post.return_value = MagicMock(status_code=500)
-        mock_get.return_value = MagicMock(status_code=200, json=lambda: {"customer": {"has_active_subscription": True}})
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: {"customer": {"has_active_subscription": has_active_subscription}}
+        )
 
         token = self._get_bearer_token()
         res = self._post_signed_with_bearer(
@@ -84,9 +67,13 @@ class TestProvisioningUpdateService(StripeProvisioningTestBase):
             },
             token=token,
         )
-        assert res.status_code == 200
-        assert res.json()["status"] == "complete"
-        assert res.json()["service_id"] == "pay_as_you_go"
+        assert res.status_code == expected_status
+        body = res.json()
+        if expected_status == 400:
+            assert body["error"]["code"] == expected_code
+        else:
+            assert body["status"] == expected_code
+            assert body["service_id"] == "pay_as_you_go"
 
     def test_update_service_without_spt(self):
         token = self._get_bearer_token()

--- a/ee/api/agentic_provisioning/test/test_update_service.py
+++ b/ee/api/agentic_provisioning/test/test_update_service.py
@@ -48,7 +48,15 @@ class TestProvisioningUpdateService(StripeProvisioningTestBase):
     @patch("ee.billing.billing_manager.build_billing_token", return_value="test_billing_token")
     @patch("posthog.cloud_utils.get_cached_instance_license")
     def test_update_service_spt_failure(
-        self, _name, has_active_subscription, expected_status, expected_code, mock_license, mock_build_token, mock_post, mock_get
+        self,
+        _name,
+        has_active_subscription,
+        expected_status,
+        expected_code,
+        mock_license,
+        mock_build_token,
+        mock_post,
+        mock_get,
     ):
         mock_license.return_value = MagicMock()
         mock_post.return_value = MagicMock(status_code=500)

--- a/ee/api/agentic_provisioning/test/test_update_service.py
+++ b/ee/api/agentic_provisioning/test/test_update_service.py
@@ -35,12 +35,16 @@ class TestProvisioningUpdateService(StripeProvisioningTestBase):
         assert "/api/activate/authorize" in call_args[0]
         assert call_kwargs["json"] == {"shared_payment_token": "spt_test_123"}
 
+    @patch("ee.api.agentic_provisioning.views.requests.get")
     @patch("ee.api.agentic_provisioning.views.requests.post")
     @patch("ee.billing.billing_manager.build_billing_token", return_value="test_billing_token")
     @patch("posthog.cloud_utils.get_cached_instance_license")
-    def test_update_service_returns_error_if_billing_fails(self, mock_license, mock_build_token, mock_post):
+    def test_update_service_returns_error_if_billing_fails(self, mock_license, mock_build_token, mock_post, mock_get):
         mock_license.return_value = MagicMock()
         mock_post.return_value = MagicMock(status_code=500)
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: {"customer": {"has_active_subscription": False}}
+        )
 
         token = self._get_bearer_token()
         res = self._post_signed_with_bearer(
@@ -56,6 +60,33 @@ class TestProvisioningUpdateService(StripeProvisioningTestBase):
         )
         assert res.status_code == 400
         assert res.json()["error"]["code"] == "billing_activation_failed"
+
+    @patch("ee.api.agentic_provisioning.views.requests.get")
+    @patch("ee.api.agentic_provisioning.views.requests.post")
+    @patch("ee.billing.billing_manager.build_billing_token", return_value="test_billing_token")
+    @patch("posthog.cloud_utils.get_cached_instance_license")
+    def test_update_service_succeeds_if_spt_fails_but_billing_already_active(
+        self, mock_license, mock_build_token, mock_post, mock_get
+    ):
+        mock_license.return_value = MagicMock()
+        mock_post.return_value = MagicMock(status_code=500)
+        mock_get.return_value = MagicMock(status_code=200, json=lambda: {"customer": {"has_active_subscription": True}})
+
+        token = self._get_bearer_token()
+        res = self._post_signed_with_bearer(
+            f"/api/agentic/provisioning/resources/{self.team.id}/update_service",
+            data={
+                "service_id": "pay_as_you_go",
+                "payment_credentials": {
+                    "type": "stripe_payment_token",
+                    "stripe_payment_token": "spt_test_123",
+                },
+            },
+            token=token,
+        )
+        assert res.status_code == 200
+        assert res.json()["status"] == "complete"
+        assert res.json()["service_id"] == "pay_as_you_go"
 
     def test_update_service_without_spt(self):
         token = self._get_bearer_token()

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -880,17 +880,24 @@ def _activate_billing_with_spt(team: Team, user: User, spt_token: str) -> bool:
         return False
 
 
-def _try_activate_billing_with_spt(request: Request, team: Team, user: User) -> bool | None:
-    """Try to activate billing with an SPT from payment_credentials.
-
-    Returns True if succeeded, False if failed, None if no SPT was present.
-    """
+def _extract_spt(request: Request) -> str | None:
     payment_credentials = request.data.get("payment_credentials")
     if isinstance(payment_credentials, dict) and payment_credentials.get("type") == "stripe_payment_token":
-        spt_token = payment_credentials.get("stripe_payment_token")
-        if spt_token:
-            return _activate_billing_with_spt(team, user, spt_token)
+        return payment_credentials.get("stripe_payment_token") or None
     return None
+
+
+def _try_activate_billing_with_spt(request: Request, team: Team, user: User) -> bool | None:
+    """Activate billing if an SPT is present, skipping if billing is already active.
+
+    Returns True if succeeded or already active, False if failed, None if no SPT was present.
+    """
+    spt_token = _extract_spt(request)
+    if not spt_token:
+        return None
+    if _team_has_active_billing(team, user):
+        return True
+    return _activate_billing_with_spt(team, user, spt_token)
 
 
 def _create_provisioned_pat(user: User, team: Team) -> str | None:
@@ -1047,7 +1054,7 @@ def provisioning_resources_create(request: Request) -> Response:
     _set_provisioning_service_id(team, resolved_service_id)
 
     billing_result = _try_activate_billing_with_spt(request, team, user)
-    if billing_result is False and not _team_has_active_billing(team, user):
+    if billing_result is False:
         return Response(
             {
                 "status": "error",
@@ -1208,7 +1215,7 @@ def provisioning_update_service(request: Request, resource_id: str) -> Response:
         return _error_response("unknown_service", f"Unknown service_id: {service_id}", resource_id=resource_id)
 
     billing_result = _try_activate_billing_with_spt(request, team, user)
-    if billing_result is False and not _team_has_active_billing(team, user):
+    if billing_result is False:
         return _error_response(
             "billing_activation_failed",
             "Failed to activate billing with payment credentials",

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -814,6 +814,36 @@ def _exchange_refresh_token(request: Request) -> Response:
     )
 
 
+def _team_has_active_billing(team: Team, user: User) -> bool:
+    """Check if the team's organization already has an active billing subscription."""
+    try:
+        from posthog.cloud_utils import get_cached_instance_license
+
+        from ee.billing.billing_manager import build_billing_token
+
+        license = get_cached_instance_license()
+        if not license:
+            return False
+
+        organization = team.organization
+        billing_token = build_billing_token(license, organization, user)
+
+        res = requests.get(
+            f"{BILLING_SERVICE_URL}/api/billing",
+            headers={"Authorization": f"Bearer {billing_token}"},
+            timeout=30,
+        )
+
+        if res.status_code != 200:
+            return False
+
+        customer = res.json().get("customer", {})
+        return bool(customer.get("has_active_subscription"))
+    except Exception:
+        capture_exception(additional_properties={"team_id": team.id, "org_id": str(team.organization_id)})
+        return False
+
+
 def _activate_billing_with_spt(team: Team, user: User, spt_token: str) -> bool:
     """Call the billing service to activate a subscription with a Stripe Shared Payment Token.
 
@@ -1020,7 +1050,7 @@ def provisioning_resources_create(request: Request) -> Response:
     _set_provisioning_service_id(team, resolved_service_id)
 
     billing_result = _try_activate_billing_with_spt(request, team, user)
-    if billing_result is False:
+    if billing_result is False and not _team_has_active_billing(team, user):
         return Response(
             {
                 "status": "error",
@@ -1181,7 +1211,7 @@ def provisioning_update_service(request: Request, resource_id: str) -> Response:
         return _error_response("unknown_service", f"Unknown service_id: {service_id}", resource_id=resource_id)
 
     billing_result = _try_activate_billing_with_spt(request, team, user)
-    if billing_result is False:
+    if billing_result is False and not _team_has_active_billing(team, user):
         return _error_response(
             "billing_activation_failed",
             "Failed to activate billing with payment credentials",

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -814,19 +814,23 @@ def _exchange_refresh_token(request: Request) -> Response:
     )
 
 
+def _build_billing_token(team: Team, user: User) -> str | None:
+    from posthog.cloud_utils import get_cached_instance_license
+
+    from ee.billing.billing_manager import build_billing_token
+
+    license = get_cached_instance_license()
+    if not license:
+        return None
+    return build_billing_token(license, team.organization, user)
+
+
 def _team_has_active_billing(team: Team, user: User) -> bool:
     """Check if the team's organization already has an active billing subscription."""
     try:
-        from posthog.cloud_utils import get_cached_instance_license
-
-        from ee.billing.billing_manager import build_billing_token
-
-        license = get_cached_instance_license()
-        if not license:
+        billing_token = _build_billing_token(team, user)
+        if not billing_token:
             return False
-
-        organization = team.organization
-        billing_token = build_billing_token(license, organization, user)
 
         res = requests.get(
             f"{BILLING_SERVICE_URL}/api/billing",
@@ -850,17 +854,10 @@ def _activate_billing_with_spt(team: Team, user: User, spt_token: str) -> bool:
     Returns True if activation succeeded, False otherwise.
     """
     try:
-        from posthog.cloud_utils import get_cached_instance_license
-
-        from ee.billing.billing_manager import build_billing_token
-
-        license = get_cached_instance_license()
-        if not license:
+        billing_token = _build_billing_token(team, user)
+        if not billing_token:
             capture_exception(Exception("No license found for SPT billing activation"))
             return False
-
-        organization = team.organization
-        billing_token = build_billing_token(license, organization, user)
 
         res = requests.post(
             f"{BILLING_SERVICE_URL}/api/activate/authorize",
@@ -872,11 +869,11 @@ def _activate_billing_with_spt(team: Team, user: User, spt_token: str) -> bool:
         if res.status_code not in (200, 201):
             capture_exception(
                 Exception(f"Billing SPT activation failed: {res.status_code}"),
-                {"team_id": team.id, "org_id": str(organization.id), "status": res.status_code},
+                {"team_id": team.id, "org_id": str(team.organization_id), "status": res.status_code},
             )
             return False
 
-        logger.info("stripe_app.spt_billing_activated", team_id=team.id, org_id=str(organization.id))
+        logger.info("stripe_app.spt_billing_activated", team_id=team.id, org_id=str(team.organization_id))
         return True
     except Exception:
         capture_exception(additional_properties={"team_id": team.id, "org_id": str(team.organization_id)})

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -30,7 +30,7 @@ const errorTrackingAssignmentRulesList = (): ToolBase<
         const projectId = await context.stateManager.getProjectId()
         const result = await context.api.request<Schemas.PaginatedErrorTrackingAssignmentRuleList>({
             method: 'GET',
-            path: `/api/environments/${projectId}/error_tracking/assignment_rules/`,
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/error_tracking/assignment_rules/`,
             query: {
                 limit: params.limit,
                 offset: params.offset,
@@ -183,7 +183,7 @@ const errorTrackingIssuesSplitCreate = (): ToolBase<
         }
         const result = await context.api.request<Schemas.ErrorTrackingIssueSplitResponse>({
             method: 'POST',
-            path: `/api/environments/${projectId}/error_tracking/issues/${params.id}/split/`,
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/error_tracking/issues/${encodeURIComponent(String(params.id))}/split/`,
             body,
         })
         return result


### PR DESCRIPTION
## Problem

When upgrading from free to pay_as_you_go via Stripe's orchestrator (`stripe projects update`), two requests are sent in sequence: an `update_service` call (which activates billing via SPT) followed by a resource re-provision (which also includes an SPT). The second SPT activation attempt fails because billing was already activated by the first call, causing a 400 `requires_payment_credentials` error on the resource creation.

Additionally, provisioning events didn't capture whether an SPT was present or what the billing activation outcome was, making it hard to debug payment flow issues.

## Changes

- Added `_build_billing_token()` helper to deduplicate license/token boilerplate between billing helpers
- Added `_team_has_active_billing()` that checks the billing service for an existing active subscription
- `_try_activate_billing_with_spt` now checks billing status first when an SPT is present, skipping activation if already active (no extra GET on requests without SPT)
- Applied the same fix to both `provisioning_resource_create` and `update_service` handlers
- Added `has_spt` and `billing_result` properties to `resource_created` and `update_service` capture events
- Added capture events on billing failure error paths (previously silent)
- Fixed `OIDC_RSA_PRIVATE_KEY` missing from the provisioning test base class
- Parametrized SPT failure tests covering both "billing inactive -> 400" and "billing already active -> 200" scenarios

## How did you test this code?

- All 15 provisioning tests pass locally (`test_spt.py` + `test_update_service.py`)
- E2E tested against running PostHog + mock billing service locally: provisioned a resource, called update_service with SPT, then called provision-resource with a second SPT - second call succeeds because billing check returns active
- This is an agent-authored PR; manual end-to-end testing with Stripe CLI recommended before merge

No changelog.

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored fix based on debugging a live Stripe provisioning flow failure where the orchestrator sends two sequential SPT-bearing requests during a plan upgrade.