### PR TITLE
refactor(dashboard): remove dashboard-template-chooser-experiment flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -395,6 +395,7 @@ export const FEATURE_FLAGS = {
     PIPELINE_STATUS_PAGE: 'pipeline-status-page', // owner: @clr182 #team-support
     POST_ONBOARDING_MODAL_EXPERIMENT: 'post-onboarding-modal-experiment', // owner: @fercgomes #team-growth multivariate=control,test
     POSTHOG_AI_ALERTS: 'posthog-ai-alerts', // owner: #team-posthog-ai
+    PRODUCT_ANALYTICS_DASHBOARD_MODAL_SMART_DEFAULTS: 'product-analytics-dashboard-modal-smart-defaults', // owner: @sam #team-product-analytics
     POSTHOG_AI_BILLING_DISPLAY: 'posthog-ai-billing-display', // owner: #team-posthog-ai
     POSTHOG_AI_CHANGELOG: 'posthog-ai-changelog', // owner: #team-posthog-ai
     POSTHOG_AI_CONVERSATION_FEEDBACK_CONFIG: 'posthog-ai-conversation-feedback-config', // owner: #team-posthog-ai
@@ -404,7 +405,6 @@ export const FEATURE_FLAGS = {
     PRODUCT_ANALYTICS_AI_INSIGHT_ANALYSIS: 'product-analytics-ai-insight-analysis', // owner: #team-analytics-platform, used to show AI analysis section in insights
     PRODUCT_ANALYTICS_DASHBOARD_AI_ANALYSIS: 'product-analytics-dashboard-ai-analysis', // owner: @anirudhpillai #team-product-analytics
     PRODUCT_ANALYTICS_DASHBOARD_COLORS: 'dashboard-colors', // owner: @thmsobrmlr #team-product-analytics
-    PRODUCT_ANALYTICS_DASHBOARD_MODAL_SMART_DEFAULTS: 'product-analytics-dashboard-modal-smart-defaults', // owner: @sam #team-product-analytics
     PRODUCT_ANALYTICS_HIDE_WEEKENDS: 'product-analytics-hide-weekends', // owner: @kliment-slice #team-irl-events
     PRODUCT_ANALYTICS_HOG_CHARTS: 'product-analytics-hog-charts', // owner: @sampennington #team-product-analytics
     PRODUCT_ANALYTICS_HOME_TAB: 'product-analytics-home-tab', // owner: @anirudhpillai #team-product-analytics

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -402,7 +402,6 @@ export const FEATURE_FLAGS = {
     PASSWORD_PROTECTED_SHARES: 'password-protected-shares', // owner: @aspicer
     DASHBOARD_AUTO_PREVIEW_LIMIT: 'dashboard-auto-preview-limit', // owner: @pauldambra #team-product-analytics
     DASHBOARD_QUICK_FILTERS_EXPERIMENT: 'dashboard-quick-filters-experiment', // owner: @vdekrijger #team-product-analytics multivariate=control,test
-    DASHBOARD_TEMPLATE_CHOOSER_EXPERIMENT: 'dashboard-template-chooser-experiment', // owner: @mattp #team-analytics-platform multivariate=control,simple,new
     CUSTOMER_DASHBOARD_TEMPLATE_AUTHORING: 'customer-dashboard-template-authoring', // owner: @mattp #team-analytics-platform org-scoped; project templates for non-staff
     DASHBOARDS_AI_METADATA_GENERATION: 'dashboards-ai-metadata-generation', // owner: @mattp, #team-analytics-platform
     PRODUCT_ANALYTICS_DASHBOARD_MODAL_SMART_DEFAULTS: 'product-analytics-dashboard-modal-smart-defaults', // owner: @sam #team-product-analytics

--- a/frontend/src/scenes/dashboard/NewDashboardModal.tsx
+++ b/frontend/src/scenes/dashboard/NewDashboardModal.tsx
@@ -4,15 +4,10 @@ import { useMemo } from 'react'
 import { IconPlus } from '@posthog/icons'
 import { LemonButton, LemonInput } from '@posthog/lemon-ui'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { DialogClose, DialogPrimitive, DialogPrimitiveTitle } from 'lib/ui/DialogPrimitive/DialogPrimitive'
 import { pluralize } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
-import {
-    dashboardTemplateChooserLogic,
-    resolveDashboardTemplateChooserExperimentVariant,
-} from 'scenes/dashboard/dashboards/templates/dashboardTemplateChooserLogic'
+import { dashboardTemplateChooserLogic } from 'scenes/dashboard/dashboards/templates/dashboardTemplateChooserLogic'
 import { dashboardTemplatesLogic } from 'scenes/dashboard/dashboards/templates/dashboardTemplatesLogic'
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
 
@@ -34,18 +29,13 @@ export function NewDashboardModal(): JSX.Element {
     const { templateFilter } = useValues(templatesLogic)
     const { setTemplateFilter } = useActions(templatesLogic)
 
-    const { featureFlags } = useValues(featureFlagLogic)
-    const experimentVariant = resolveDashboardTemplateChooserExperimentVariant(
-        featureFlags[FEATURE_FLAGS.DASHBOARD_TEMPLATE_CHOOSER_EXPERIMENT]
-    )
     const createChooserLogic = useMemo(
         () =>
             dashboardTemplateChooserLogic({
                 scope: templateScope,
-                experimentVariant,
                 availabilityContexts: undefined,
             }),
-        [templateScope, experimentVariant]
+        [templateScope]
     )
     const { isLoading: blankDashboardLoading } = useValues(createChooserLogic)
     const { blankTileClicked } = useActions(createChooserLogic)
@@ -113,7 +103,7 @@ export function NewDashboardModal(): JSX.Element {
                     {activeDashboardTemplate ? (
                         <DashboardTemplateVariables />
                     ) : (
-                        <DashboardTemplateChooser scope={templateScope} experimentVariant={experimentVariant} />
+                        <DashboardTemplateChooser scope={templateScope} />
                     )}
                 </div>
             </div>

--- a/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplateChooser.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/DashboardTemplateChooser.tsx
@@ -2,25 +2,13 @@ import { useActions, useValues } from 'kea'
 
 import { IconPlus } from '@posthog/icons'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { cn } from 'lib/utils/css-classes'
 
-import {
-    dashboardTemplateChooserLogic,
-    DashboardTemplateChooserExperimentVariant,
-    DashboardTemplateChooserLogicProps,
-    resolveDashboardTemplateChooserExperimentVariant,
-} from './dashboardTemplateChooserLogic'
+import { dashboardTemplateChooserLogic, DashboardTemplateChooserLogicProps } from './dashboardTemplateChooserLogic'
 import { TemplateItem } from './DashboardTemplateItem'
 import { DashboardTemplateItemSkeleton } from './DashboardTemplateItemSkeleton'
 import { DashboardTemplateProps } from './dashboardTemplatesLogic'
-
-export type DashboardTemplateChooserRootProps = DashboardTemplateProps & {
-    /** When set (e.g. from `NewDashboardModal`), avoids a second feature-flag read so Kea keys stay in sync with parent `dashboardTemplateChooserLogic`. */
-    experimentVariant?: DashboardTemplateChooserExperimentVariant
-}
 
 const gridClass = 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4'
 
@@ -30,112 +18,9 @@ const teamTemplateGridClass = 'grid grid-cols-1 md:grid-cols-2 gap-3'
 /** Single column on small viewports; two columns from `lg` up (modal/tablet often still feels “small” at `md`) */
 const featuredGridClass = 'grid grid-cols-1 lg:grid-cols-2 gap-4'
 
-function SimpleVariant(
-    props: DashboardTemplateProps & { experimentVariant: DashboardTemplateChooserExperimentVariant }
-): JSX.Element {
-    const { experimentVariant, className, availabilityContexts, ...chooserProps } = props
-    const logicProps: DashboardTemplateChooserLogicProps = { ...chooserProps, experimentVariant, availabilityContexts }
-    const chooser = dashboardTemplateChooserLogic(logicProps)
-    const {
-        allTemplatesLoading,
-        teamTemplates,
-        officialTemplates,
-        hasActiveFilter,
-        showDashedEmptyState,
-        showOfficialGrid,
-        showBlankTile,
-    } = useValues(chooser)
-    const { templateTileClicked, blankTileClicked, setTemplateFilter } = useActions(chooser)
-
-    return (
-        <div className={cn('flex flex-col gap-6', className)}>
-            {teamTemplates.length > 0 ? (
-                <section>
-                    <div className="mb-3">
-                        <h3 className="text-base font-semibold m-0">Team templates</h3>
-                        <p className="text-secondary text-sm m-0 mt-1">Templates saved for this project.</p>
-                    </div>
-                    <div className={teamTemplateGridClass}>
-                        {teamTemplates.map((template, index) => (
-                            <TemplateItem
-                                key={template.id}
-                                template={template}
-                                onClick={() => templateTileClicked(template, 'team_section')}
-                                index={index}
-                                data-attr="create-dashboard-from-template-team"
-                                showCover={false}
-                            />
-                        ))}
-                    </div>
-                </section>
-            ) : null}
-            {showDashedEmptyState ? (
-                <div className="flex flex-col items-center justify-center rounded-md border border-dashed border-border bg-fill-secondary px-6 py-14 text-center">
-                    <h4 className="m-0 text-base font-semibold">
-                        {hasActiveFilter ? 'No templates match your search' : 'No templates to show here'}
-                    </h4>
-                    <p className="mt-2 mb-0 max-w-md text-secondary text-sm">
-                        {hasActiveFilter
-                            ? 'Try different keywords, clear the filter to see every template again, or start with a blank dashboard.'
-                            : showBlankTile
-                              ? 'Start with a blank dashboard, or check back later for new templates.'
-                              : 'No templates are available in this context.'}
-                    </p>
-                    <div className="mt-5 flex flex-wrap items-center justify-center gap-2">
-                        {showBlankTile ? (
-                            <LemonButton
-                                type="primary"
-                                icon={<IconPlus />}
-                                onClick={() => blankTileClicked('main_grid')}
-                                data-attr="create-dashboard-blank-inline-empty"
-                            >
-                                Blank dashboard
-                            </LemonButton>
-                        ) : null}
-                        {hasActiveFilter ? (
-                            <LemonButton
-                                type="secondary"
-                                onClick={() => setTemplateFilter('')}
-                                data-attr="clear-dashboard-template-filter"
-                            >
-                                Clear filter
-                            </LemonButton>
-                        ) : null}
-                    </div>
-                </div>
-            ) : showOfficialGrid ? (
-                <section>
-                    <div className="mb-3">
-                        <h3 className="text-base font-semibold m-0">PostHog templates</h3>
-                        <p className="text-secondary text-sm m-0 mt-1">
-                            Curated templates from PostHog to help you get started.
-                        </p>
-                    </div>
-                    <div className={gridClass}>
-                        {allTemplatesLoading
-                            ? Array.from({ length: 3 }).map((_, i) => <DashboardTemplateItemSkeleton key={i} />)
-                            : officialTemplates.map((template, index) => (
-                                  <TemplateItem
-                                      key={template.id}
-                                      template={template}
-                                      onClick={() => templateTileClicked(template, 'main_grid')}
-                                      index={index}
-                                      data-attr="create-dashboard-from-template"
-                                      showFavourite={experimentVariant === 'simple' && template.is_featured}
-                                  />
-                              ))}
-                    </div>
-                </section>
-            ) : null}
-        </div>
-    )
-}
-
-function NewLayoutVariant(
-    props: DashboardTemplateProps & { experimentVariant: DashboardTemplateChooserExperimentVariant }
-): JSX.Element {
-    const { experimentVariant, className, availabilityContexts, ...chooserProps } = props
-    const logicProps: DashboardTemplateChooserLogicProps = { ...chooserProps, experimentVariant, availabilityContexts }
+export function DashboardTemplateChooser(props: DashboardTemplateProps): JSX.Element {
+    const { className, availabilityContexts, ...chooserProps } = props
+    const logicProps: DashboardTemplateChooserLogicProps = { ...chooserProps, availabilityContexts }
     const chooser = dashboardTemplateChooserLogic(logicProps)
     const {
         allTemplatesLoading,
@@ -264,25 +149,4 @@ function NewLayoutVariant(
             ) : null}
         </div>
     )
-}
-
-export function DashboardTemplateChooser({
-    experimentVariant: experimentVariantProp,
-    ...props
-}: DashboardTemplateChooserRootProps): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
-    const variant: DashboardTemplateChooserExperimentVariant =
-        experimentVariantProp ??
-        resolveDashboardTemplateChooserExperimentVariant(
-            featureFlags[FEATURE_FLAGS.DASHBOARD_TEMPLATE_CHOOSER_EXPERIMENT]
-        )
-
-    switch (variant) {
-        case 'simple':
-            return <SimpleVariant {...props} experimentVariant={variant} />
-        case 'new':
-            return <NewLayoutVariant {...props} experimentVariant={variant} />
-        default:
-            return <SimpleVariant {...props} experimentVariant="control" />
-    }
 }

--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateChooserLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateChooserLogic.ts
@@ -1,7 +1,6 @@
 import { actions, connect, kea, key, listeners, path, props, selectors } from 'kea'
 import posthog from 'posthog-js'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
 
 import { DashboardTemplateType, TemplateAvailabilityContext } from '~/types'
@@ -10,18 +9,7 @@ import type { dashboardTemplateChooserLogicType } from './dashboardTemplateChoos
 import { runBlankDashboardFlow, runDashboardTemplateClickFlow } from './dashboardTemplateCreationFlows'
 import { DashboardTemplateProps, dashboardTemplatesLogic } from './dashboardTemplatesLogic'
 
-export type DashboardTemplateChooserExperimentVariant = 'control' | 'simple' | 'new'
-
-/** Single place for flag → chooser experiment variant (modal toolbar + grid must agree on chooser logic key). */
-export function resolveDashboardTemplateChooserExperimentVariant(
-    raw: unknown
-): DashboardTemplateChooserExperimentVariant {
-    return raw === 'simple' || raw === 'new' || raw === 'control' ? raw : 'new'
-}
-
-export type DashboardTemplateChooserLogicProps = DashboardTemplateProps & {
-    experimentVariant: DashboardTemplateChooserExperimentVariant
-}
+export type DashboardTemplateChooserLogicProps = DashboardTemplateProps
 
 function availabilityContextsKey(contexts: DashboardTemplateProps['availabilityContexts']): string {
     if (!contexts?.length) {
@@ -61,7 +49,7 @@ export const dashboardTemplateChooserLogic = kea<dashboardTemplateChooserLogicTy
     props({} as DashboardTemplateChooserLogicProps),
     key(
         (p: DashboardTemplateChooserLogicProps) =>
-            `${p.scope ?? 'default'}|${p.experimentVariant}|${availabilityContextsKey(p.availabilityContexts)}`
+            `${p.scope ?? 'default'}|${availabilityContextsKey(p.availabilityContexts)}`
     ),
     connect((props: DashboardTemplateChooserLogicProps) => ({
         values: [
@@ -186,15 +174,12 @@ export const dashboardTemplateChooserLogic = kea<dashboardTemplateChooserLogicTy
                 return
             }
             posthog.capture('dashboard template chooser template clicked', {
-                experiment_variant: props.experimentVariant,
                 selection_type: 'template',
                 tile_location: tileLocation,
                 template_id: template.id,
                 template_name: template.template_name.toLowerCase(),
                 is_featured: template.is_featured === true,
                 template_scope: template.scope ?? null,
-                $feature_flag: FEATURE_FLAGS.DASHBOARD_TEMPLATE_CHOOSER_EXPERIMENT,
-                $feature_flag_response: props.experimentVariant,
             })
             runDashboardTemplateClickFlow(template, {
                 isLoading: values.isLoading,
@@ -212,11 +197,8 @@ export const dashboardTemplateChooserLogic = kea<dashboardTemplateChooserLogicTy
                 return
             }
             posthog.capture('dashboard template chooser template clicked', {
-                experiment_variant: props.experimentVariant,
                 selection_type: 'blank',
                 tile_location: tileLocation,
-                $feature_flag: FEATURE_FLAGS.DASHBOARD_TEMPLATE_CHOOSER_EXPERIMENT,
-                $feature_flag_response: props.experimentVariant,
             })
             runBlankDashboardFlow({
                 isLoading: values.isLoading,

--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateChooserLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateChooserLogic.ts
@@ -84,11 +84,6 @@ export const dashboardTemplateChooserLogic = kea<dashboardTemplateChooserLogicTy
     // Optional props in selector deps: use `(_, props) => props.field` like dataTableLogic `queryWithDefaults`
     // (LogicPropSelectors wraps optional props as callables; cohort's `p.query` is required so it works there).
     selectors({
-        filteredTemplates: [
-            (s) => [s.allTemplates, (_, props) => props.availabilityContexts],
-            (raw: DashboardTemplateType[], availabilityContexts: DashboardTemplateProps['availabilityContexts']) =>
-                filterTemplatesByAvailability(raw, availabilityContexts),
-        ],
         showBlankTile: [
             () => [(_, props) => props.availabilityContexts],
             (availabilityContexts: DashboardTemplateProps['availabilityContexts']) =>
@@ -98,11 +93,6 @@ export const dashboardTemplateChooserLogic = kea<dashboardTemplateChooserLogicTy
             (s) => [s.allTemplates, (_, props) => props.availabilityContexts],
             (raw: DashboardTemplateType[], availabilityContexts: DashboardTemplateProps['availabilityContexts']) =>
                 filterTemplatesByAvailability(raw, availabilityContexts).filter(isTeamTemplate),
-        ],
-        officialTemplates: [
-            (s) => [s.allTemplates, (_, props) => props.availabilityContexts],
-            (raw: DashboardTemplateType[], availabilityContexts: DashboardTemplateProps['availabilityContexts']) =>
-                filterTemplatesByAvailability(raw, availabilityContexts).filter((t) => !isTeamTemplate(t)),
         ],
         featuredTemplates: [
             (s) => [s.allTemplates, (_, props) => props.availabilityContexts],
@@ -126,16 +116,6 @@ export const dashboardTemplateChooserLogic = kea<dashboardTemplateChooserLogicTy
                 raw: DashboardTemplateType[],
                 availabilityContexts: DashboardTemplateProps['availabilityContexts']
             ) => !loading && filterTemplatesByAvailability(raw, availabilityContexts).length === 0,
-        ],
-        showOfficialGrid: [
-            (s) => [s.allTemplatesLoading, s.allTemplates, (_, props) => props.availabilityContexts],
-            (
-                loading: boolean,
-                raw: DashboardTemplateType[],
-                availabilityContexts: DashboardTemplateProps['availabilityContexts']
-            ) =>
-                loading ||
-                filterTemplatesByAvailability(raw, availabilityContexts).filter((t) => !isTeamTemplate(t)).length > 0,
         ],
         allMatchesInFeaturedSection: [
             (s) => [s.allTemplates, (_, props) => props.availabilityContexts],


### PR DESCRIPTION
## Problem

The `dashboard-template-chooser-experiment` multivariate feature flag (variants: `control`, `simple`, `new`) has been rolled out at 100%. The winning variant is `new`, so we can drop the flag plumbing, the two losing variants, and the experiment-specific event properties.

## Changes

- `lib/constants.tsx` — remove the `DASHBOARD_TEMPLATE_CHOOSER_EXPERIMENT` entry.
- `dashboardTemplateChooserLogic.ts` — drop the `DashboardTemplateChooserExperimentVariant` type, `resolveDashboardTemplateChooserExperimentVariant()`, the `experimentVariant` prop (and its segment in `key()`), the `FEATURE_FLAGS` import, and `experiment_variant` / `\$feature_flag` / `\$feature_flag_response` from both `posthog.capture` calls.
- `DashboardTemplateChooser.tsx` — delete `SimpleVariant` entirely; inline the old `NewLayoutVariant` as the top-level `DashboardTemplateChooser`. Remove the flag-routing switch and the `featureFlagLogic` / `FEATURE_FLAGS` imports. `DashboardTemplateChooserRootProps` collapses to `DashboardTemplateProps`.
- `NewDashboardModal.tsx` — drop the flag read, the `experimentVariant` local, and its thread-through to `dashboardTemplateChooserLogic(...)` and `<DashboardTemplateChooser>`.

`NewDashboardModal.test.tsx` didn't need changes — it already mocks both `DashboardTemplateChooser` and `dashboardTemplateChooserLogic`, so it's indifferent to the removed prop.

Heads-up for the reviewer: kea typegen (`dashboardTemplateChooserLogicType.ts`) will regenerate since the logic props shape changed.

## How did you test this code?

- Verified no remaining references to \`DASHBOARD_TEMPLATE_CHOOSER_EXPERIMENT\`, \`resolveDashboardTemplateChooserExperimentVariant\`, \`DashboardTemplateChooserExperimentVariant\`, \`SimpleVariant\`, or \`NewLayoutVariant\` anywhere in the repo.
- Linter is clean on all four touched files.

I'm an agent (Cursor) — no manual browser verification was run.

## Publish to changelog?

no

## 🤖 LLM context

Authored via Cursor. Winning variant confirmed as \`new\` (matched the resolver's fallback). All experiment-specific event properties were dropped; if historical analyses need to persist a \`template_chooser_variant: 'new'\` marker on the \`dashboard template chooser template clicked\` event, ping me and I'll add it back as a static property.

Made with [Cursor](https://cursor.com)