### PR TITLE
feat: add raw SQL query runner to ClickHouse query debugger

### DIFF
--- a/frontend/src/lib/components/AppShortcuts/utils/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/AppShortcuts/utils/DebugCHQueries.tsx
@@ -14,6 +14,7 @@ import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
+import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
 import { humanizeBytes } from 'lib/utils'
@@ -26,10 +27,11 @@ import { FilterLogicalOperator, PropertyFilterType, PropertyOperator, Realm, Reg
 import { CodeSnippet, Language } from '../../CodeSnippet'
 import type { debugCHQueriesLogicType } from './DebugCHQueriesType'
 import { FlamegraphViewer } from './FlamegraphViewer'
+import { RawSqlDebug } from './RawSqlDebug'
 
 export function openCHQueriesDebugModal(): void {
     LemonDialog.open({
-        title: 'ClickHouse queries recently executed for this user',
+        title: 'ClickHouse query debugger',
         content: <DebugCHQueries />,
         primaryButton: null,
         width: 1600,
@@ -285,6 +287,7 @@ export function DebugCHQueries({ insightId, experimentId }: DebugCHQueriesProps)
         profilingResultLoading,
     } = useValues(logic)
     const { setPathFilter, loadDebugResponse, runProfile } = useActions(logic)
+    const [tab, setTab] = useState<string>('recent')
 
     const errorTrackingLink = (key: string, value: string | number): string => {
         return urls.errorTracking({
@@ -307,6 +310,70 @@ export function DebugCHQueries({ insightId, experimentId }: DebugCHQueriesProps)
         })
     }
 
+    return (
+        <LemonTabs
+            activeKey={tab}
+            onChange={setTab}
+            tabs={[
+                {
+                    key: 'recent',
+                    label: 'Recent queries',
+                    content: (
+                        <RecentQueries
+                            debugResponseLoading={debugResponseLoading}
+                            debugResponse={debugResponse}
+                            filteredQueries={filteredQueries}
+                            pathFilter={pathFilter}
+                            paths={paths}
+                            profilingQuerySql={profilingQuerySql}
+                            profilingResult={profilingResult}
+                            profilingResultLoading={profilingResultLoading}
+                            setPathFilter={setPathFilter}
+                            loadDebugResponse={loadDebugResponse}
+                            runProfile={runProfile}
+                            errorTrackingLink={errorTrackingLink}
+                        />
+                    ),
+                },
+                {
+                    key: 'run_query',
+                    label: 'Run query',
+                    content: <RawSqlDebug />,
+                },
+            ]}
+        />
+    )
+}
+
+interface RecentQueriesProps {
+    debugResponseLoading: boolean
+    debugResponse: DebugResponse
+    filteredQueries: Query[] | undefined
+    pathFilter: string | null
+    paths: [string, number][] | null
+    profilingQuerySql: string | null
+    profilingResult: ProfilingResult | null
+    profilingResultLoading: boolean
+    setPathFilter: (path: string | null) => void
+    loadDebugResponse: () => void
+    runProfile: (query: string) => void
+    errorTrackingLink: (key: string, value: string | number) => string
+}
+
+function RecentQueries({
+    debugResponseLoading,
+    debugResponse,
+    filteredQueries,
+    pathFilter,
+    paths,
+    profilingQuerySql,
+    profilingResult,
+    profilingResultLoading,
+    setPathFilter,
+    loadDebugResponse,
+    runProfile,
+    errorTrackingLink,
+}: RecentQueriesProps): JSX.Element {
     return (
         <>
             {!debugResponseLoading && !!debugResponse.hourly_stats ? (
@@ -569,7 +636,7 @@ export function DebugCHQueries({ insightId, experimentId }: DebugCHQueriesProps)
                         },
                     },
                 ]}
-                dataSource={filteredQueries}
+                dataSource={filteredQueries ?? []}
                 loading={debugResponseLoading}
                 loadingSkeletonRows={5}
                 pagination={undefined}

--- a/frontend/src/lib/components/AppShortcuts/utils/RawSqlDebug.scss
+++ b/frontend/src/lib/components/AppShortcuts/utils/RawSqlDebug.scss
@@ -1,0 +1,38 @@
+.RawSqlDebug__table {
+    width: 100%;
+    font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+    font-size: 0.75rem;
+    border-spacing: 0;
+    border-collapse: separate;
+
+    thead th {
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        padding: 0.375rem 0.5rem;
+        font-weight: 600;
+        text-align: left;
+        white-space: nowrap;
+        background: var(--color-bg-surface-primary);
+        border-bottom: 1px solid var(--border);
+    }
+
+    tbody td {
+        max-width: 400px;
+        padding: 0.25rem 0.5rem;
+        word-break: break-all;
+        white-space: pre-wrap;
+        cursor: pointer;
+        border-bottom: 1px solid var(--border-light);
+
+        &.RawSqlDebug__cell--collapsed {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+    }
+
+    tbody tr:hover td {
+        background: var(--primary-highlight);
+    }
+}

--- a/frontend/src/lib/components/AppShortcuts/utils/RawSqlDebug.tsx
+++ b/frontend/src/lib/components/AppShortcuts/utils/RawSqlDebug.tsx
@@ -1,0 +1,229 @@
+import './RawSqlDebug.scss'
+
+import { useActions, useValues } from 'kea'
+import { useState } from 'react'
+
+import { IconCollapse, IconExpand } from '@posthog/icons'
+
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonTable } from 'lib/lemon-ui/LemonTable'
+import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { CodeEditorResizeable } from 'lib/monaco/CodeEditorResizable'
+
+import { rawSqlLogic } from './rawSqlLogic'
+import type { QueryLogEntry, RawSqlColumn } from './rawSqlLogic'
+
+export function RawSqlDebug(): JSX.Element {
+    const { query, rawSqlResult, rawSqlResultLoading, rawSqlError, queryLogEntry, queryLogEntryLoading } =
+        useValues(rawSqlLogic)
+    const { setQuery, runQuery, cancelQuery } = useActions(rawSqlLogic)
+    const [tab, setTab] = useState<string>('results')
+    const [editorCollapsed, setEditorCollapsed] = useState(false)
+
+    return (
+        <div className="flex flex-col h-[70vh]">
+            {/* Editor pane */}
+            <div className="flex-shrink-0">
+                <div className="flex items-center justify-between mb-1">
+                    <div className="flex gap-2 items-center">
+                        <LemonButton
+                            type="primary"
+                            size="small"
+                            onClick={() => runQuery()}
+                            loading={rawSqlResultLoading}
+                            disabledReason={rawSqlResultLoading ? 'Running...' : !query.trim() ? 'Enter a query' : null}
+                        >
+                            Run
+                        </LemonButton>
+                        {rawSqlResultLoading && (
+                            <LemonButton size="small" type="secondary" status="danger" onClick={() => cancelQuery()}>
+                                Cancel
+                            </LemonButton>
+                        )}
+                        {rawSqlResult && (
+                            <span className="text-xs text-muted">
+                                {rawSqlResult.execution_time_ms}ms · {rawSqlResult.rows.length} rows
+                                {rawSqlResult.truncated ? ' (truncated)' : ''}
+                            </span>
+                        )}
+                    </div>
+                    <LemonButton
+                        size="small"
+                        icon={editorCollapsed ? <IconExpand /> : <IconCollapse />}
+                        onClick={() => setEditorCollapsed(!editorCollapsed)}
+                    />
+                </div>
+                {!editorCollapsed && (
+                    <CodeEditorResizeable
+                        language="sql"
+                        value={query}
+                        onChange={(v) => setQuery(v ?? '')}
+                        height={150}
+                        minHeight="3rem"
+                        maxHeight="40vh"
+                        onPressCmdEnter={() => runQuery()}
+                    />
+                )}
+            </div>
+
+            {/* Results pane — fills remaining space */}
+            <div className="flex-1 min-h-0 mt-2 flex flex-col">
+                {rawSqlError && (
+                    <LemonBanner type="error" className="text-xs font-mono">
+                        {rawSqlError}
+                    </LemonBanner>
+                )}
+
+                {rawSqlResult ? (
+                    <>
+                        {/* Tab bar stays fixed */}
+                        <LemonTabs
+                            activeKey={tab}
+                            onChange={setTab}
+                            tabs={[
+                                { key: 'results', label: 'Results' },
+                                {
+                                    key: 'query_log',
+                                    label: (
+                                        <>
+                                            Query log
+                                            {queryLogEntryLoading && (
+                                                <LemonTag size="small" className="ml-1">
+                                                    Loading...
+                                                </LemonTag>
+                                            )}
+                                        </>
+                                    ),
+                                },
+                            ]}
+                        />
+                        {/* Tab content scrolls */}
+                        <div className="flex-1 min-h-0 overflow-auto border rounded">
+                            {tab === 'results' ? (
+                                <ResultsTable columns={rawSqlResult.columns} rows={rawSqlResult.rows} />
+                            ) : (
+                                <QueryLogPanel entry={queryLogEntry} loading={queryLogEntryLoading} />
+                            )}
+                        </div>
+                    </>
+                ) : !rawSqlResultLoading ? (
+                    <div className="text-muted text-sm p-4">Press Cmd+Enter or click Run to execute.</div>
+                ) : null}
+            </div>
+        </div>
+    )
+}
+
+const PAGE_SIZE = 50
+
+function ResultsTable({ columns, rows }: { columns: RawSqlColumn[]; rows: any[][] }): JSX.Element {
+    const [page, setPage] = useState(0)
+    const totalPages = Math.ceil(rows.length / PAGE_SIZE)
+    const pageRows = rows.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
+
+    return (
+        <div>
+            <table className="RawSqlDebug__table">
+                <thead>
+                    <tr>
+                        {columns.map((col, i) => (
+                            <th key={i}>
+                                <div>{col.name}</div>
+                                <div className="text-xs text-muted font-normal">{col.type}</div>
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {pageRows.map((row, i) => (
+                        <tr key={page * PAGE_SIZE + i}>
+                            {row.map((val, j) => (
+                                <Cell key={j} value={val} />
+                            ))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+            {totalPages > 1 && (
+                <div className="flex items-center justify-between p-2 border-t text-xs">
+                    <span className="text-muted">
+                        {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, rows.length)} of {rows.length}
+                    </span>
+                    <div className="flex gap-1">
+                        <LemonButton size="xsmall" disabled={page === 0} onClick={() => setPage(page - 1)}>
+                            Previous
+                        </LemonButton>
+                        <LemonButton size="xsmall" disabled={page >= totalPages - 1} onClick={() => setPage(page + 1)}>
+                            Next
+                        </LemonButton>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}
+
+function Cell({ value }: { value: any }): JSX.Element {
+    const [expanded, setExpanded] = useState(false)
+    const isNull = value === null || value === undefined
+
+    const formatted = isNull ? '' : typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value)
+
+    return (
+        <td className={expanded ? '' : 'RawSqlDebug__cell--collapsed'} onClick={() => setExpanded(!expanded)}>
+            {isNull ? <span className="text-muted italic">NULL</span> : formatted}
+        </td>
+    )
+}
+
+function QueryLogPanel({ entry, loading }: { entry: QueryLogEntry | null; loading: boolean }): JSX.Element {
+    if (loading) {
+        return <div className="text-muted p-4">Fetching query log from ClickHouse...</div>
+    }
+
+    if (!entry) {
+        return (
+            <LemonBanner type="info">
+                Query log entry not yet available. ClickHouse may take a moment to flush the query_log.
+            </LemonBanner>
+        )
+    }
+
+    const data = entry.entry
+    const dataSource = Object.entries(data).map(([key, value]) => ({ key, value }))
+
+    return (
+        <LemonTable
+            dataSource={dataSource}
+            columns={[
+                {
+                    title: 'Column',
+                    dataIndex: 'key',
+                    width: 250,
+                    render: (_, row) => <span className="font-mono text-xs">{row.key}</span>,
+                },
+                {
+                    title: 'Value',
+                    dataIndex: 'value',
+                    render: (_, row) => {
+                        const val = row.value
+                        if (val === null || val === undefined || val === '') {
+                            return <span className="text-muted italic">—</span>
+                        }
+                        if (typeof val === 'object') {
+                            return (
+                                <span className="font-mono text-xs whitespace-pre-wrap break-all">
+                                    {JSON.stringify(val, null, 2)}
+                                </span>
+                            )
+                        }
+                        return <span className="font-mono text-xs break-all">{String(val)}</span>
+                    },
+                },
+            ]}
+            size="small"
+        />
+    )
+}

--- a/frontend/src/lib/components/AppShortcuts/utils/rawSqlLogic.ts
+++ b/frontend/src/lib/components/AppShortcuts/utils/rawSqlLogic.ts
@@ -1,0 +1,149 @@
+import { actions, afterMount, kea, listeners, path, reducers } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api, { getCookie } from 'lib/api'
+
+import type { rawSqlLogicType } from './rawSqlLogicType'
+
+let activeAbortController: AbortController | null = null
+
+function killQuery(queryId: string): void {
+    // Use raw fetch so it doesn't depend on a free Django worker
+    void fetch('/api/debug_ch_queries/cancel_query/', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': getCookie('csrftoken') || getCookie('posthog_csrftoken') || '',
+        },
+        body: JSON.stringify({ query_id: queryId }),
+        keepalive: true,
+    })
+}
+
+export interface RawSqlColumn {
+    name: string
+    type: string
+}
+
+export interface RawSqlResult {
+    columns: RawSqlColumn[]
+    rows: any[][]
+    query_id: string
+    execution_time_ms: number
+    truncated: boolean
+}
+
+export interface QueryLogEntry {
+    status: 'complete' | 'pending'
+    entry: Record<string, any>
+}
+
+const DEFAULT_QUERY = 'SELECT 1'
+
+export const rawSqlLogic = kea<rawSqlLogicType>([
+    path(['lib', 'components', 'CommandPalette', 'rawSqlLogic']),
+    actions({
+        setQuery: (query: string) => ({ query }),
+        runQuery: true,
+        cancelQuery: true,
+        setRunningQueryId: (queryId: string | null) => ({ queryId }),
+        loadQueryLog: (queryId: string) => ({ queryId }),
+    }),
+    reducers({
+        query: [DEFAULT_QUERY, { setQuery: (_, { query }) => query }],
+        runningQueryId: [
+            null as string | null,
+            {
+                setRunningQueryId: (_, { queryId }) => queryId,
+                runQuerySuccess: () => null,
+                runQueryFailure: () => null,
+                cancelQuery: () => null,
+            },
+        ],
+        rawSqlError: [
+            null as string | null,
+            {
+                runQuery: () => null,
+                runQueryFailure: (_, { errorObject, error }) => {
+                    // errorObject is the full ApiError; error is just error.message
+                    const detail = errorObject?.detail || errorObject?.data?.detail
+                    if (detail) {
+                        // DRF ValidationError wraps in an array
+                        return Array.isArray(detail) ? detail.join(', ') : String(detail)
+                    }
+                    return String(error)
+                },
+            },
+        ],
+    }),
+    loaders(({ values, actions }) => ({
+        rawSqlResult: [
+            null as RawSqlResult | null,
+            {
+                runQuery: async () => {
+                    activeAbortController?.abort()
+                    activeAbortController = new AbortController()
+                    const queryId = `rawsql_${Math.random().toString(36).slice(2, 10)}`
+                    actions.setRunningQueryId(queryId)
+                    try {
+                        return await api.create(
+                            'api/debug_ch_queries/raw_sql/',
+                            { query: values.query, query_id: queryId },
+                            { signal: activeAbortController.signal }
+                        )
+                    } finally {
+                        activeAbortController = null
+                    }
+                },
+            },
+        ],
+        queryLogEntry: [
+            null as QueryLogEntry | null,
+            {
+                loadQueryLog: async ({ queryId }: { queryId: string }) => {
+                    const maxAttempts = 5
+                    const intervalMs = 1000
+                    for (let i = 0; i < maxAttempts; i++) {
+                        if (i > 0) {
+                            await new Promise((resolve) => setTimeout(resolve, intervalMs))
+                        }
+                        const result = await api.get(`api/debug_ch_queries/query_log_entry/?query_id=${queryId}`)
+                        if (result.status === 'complete') {
+                            return result as QueryLogEntry
+                        }
+                    }
+                    return null
+                },
+            },
+        ],
+    })),
+    listeners(({ actions, values }) => ({
+        runQuerySuccess: ({ rawSqlResult }) => {
+            if (rawSqlResult?.query_id) {
+                actions.loadQueryLog(rawSqlResult.query_id)
+            }
+        },
+        cancelQuery: () => {
+            // Abort the HTTP request to free the Django worker thread
+            activeAbortController?.abort()
+            activeAbortController = null
+            // Then kill the ClickHouse query via raw fetch
+            const queryId = values.runningQueryId
+            if (queryId) {
+                killQuery(queryId)
+            }
+        },
+    })),
+    afterMount(({ actions }) => {
+        // Load query from URL hash if present
+        const hash = window.location.hash
+        if (hash.startsWith('#q=')) {
+            try {
+                const query = decodeURIComponent(hash.slice(3))
+                actions.setQuery(query)
+            } catch {
+                // ignore malformed hash
+            }
+        }
+    }),
+])

--- a/frontend/src/lib/components/AppShortcuts/utils/rawSqlLogic.ts
+++ b/frontend/src/lib/components/AppShortcuts/utils/rawSqlLogic.ts
@@ -57,7 +57,6 @@ export const rawSqlLogic = kea<rawSqlLogicType>([
                 setRunningQueryId: (_, { queryId }) => queryId,
                 runQuerySuccess: () => null,
                 runQueryFailure: () => null,
-                cancelQuery: () => null,
             },
         ],
         rawSqlError: [
@@ -124,11 +123,11 @@ export const rawSqlLogic = kea<rawSqlLogicType>([
             }
         },
         cancelQuery: () => {
-            // Abort the HTTP request to free the Django worker thread
             activeAbortController?.abort()
             activeAbortController = null
-            // Then kill the ClickHouse query via raw fetch
+            // Read before clearing — reducers run before listeners in kea
             const queryId = values.runningQueryId
+            actions.setRunningQueryId(null)
             if (queryId) {
                 killQuery(queryId)
             }

--- a/frontend/src/lib/components/SessionTimeline/timeline/items/eventDetails.tsx
+++ b/frontend/src/lib/components/SessionTimeline/timeline/items/eventDetails.tsx
@@ -182,7 +182,7 @@ export const LazyEventDetailsRenderer: React.FC<RendererProps<TimelineItem>> = (
         return () => {
             mounted = false
         }
-    }, [item.id, item.category, item.timestamp, sessionId])
+    }, [item.id, item.category, item.timestamp, sessionId, item])
 
     if (loading) {
         return (

--- a/frontend/src/queries/nodes/DataVisualization/Components/Heatmap/TwoDimensionalHeatmap.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Heatmap/TwoDimensionalHeatmap.tsx
@@ -161,7 +161,7 @@ export function TwoDimensionalHeatmap({ allowSorting = true }: { allowSorting?: 
     const { xAxisColumn, yAxisColumn, valueColumn, nullLabel, nullValue } = heatmapSettings
     const sorting = useMemo(
         () => getSortingFromHeatmapSettings(heatmapSettings),
-        [heatmapSettings.sortColumn, heatmapSettings.sortOrder]
+        [heatmapSettings.sortColumn, heatmapSettings.sortOrder, heatmapSettings]
     )
     const selectedColumns = [xAxisColumn, yAxisColumn, valueColumn]
     const rows =

--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -45,7 +45,11 @@ export function DistributionModal(): JSX.Element {
             setVariants(experiment.feature_flag?.filters?.multivariate?.variants || [])
             setRolloutPercentage(experiment.feature_flag?.filters?.groups?.[0]?.rollout_percentage ?? 100)
         }
-    }, [isDistributionModalOpen, experiment.feature_flag?.filters?.multivariate?.variants])
+    }, [
+        isDistributionModalOpen,
+        experiment.feature_flag?.filters?.multivariate?.variants,
+        experiment.feature_flag.filters.groups,
+    ])
 
     const handleClose = (): void => {
         closeDistributionModal()

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveAnimatedTable.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveAnimatedTable.tsx
@@ -110,7 +110,7 @@ export function LiveAnimatedTable<T>({
 
     useLayoutEffect(() => {
         prevPositionsRef.current = new Map(items.map((item, index) => [keyExtractor(item), index]))
-    }, [items])
+    }, [items, keyExtractor])
 
     return (
         <div className={clsx('bg-bg-light rounded-lg border p-4', className)}>

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -444,7 +444,7 @@ class DebugCHQueries(viewsets.ViewSet):
         if value is None or isinstance(value, (str, float, bool)):
             return value
         if isinstance(value, int):
-            if -(2**63) <= value <= 2**63 - 1:
+            if -(2**53 - 1) <= value <= 2**53 - 1:
                 return value
             return str(value)
         return str(value)
@@ -474,9 +474,9 @@ class DebugCHQueries(viewsets.ViewSet):
                     },
                     query_id=query_id,
                 )
-        except Exception as e:
+        except Exception:
             logger.exception("Raw SQL execution failed for query_id %s", query_id)
-            raise exceptions.ValidationError(f"Query execution failed: {e}")
+            raise exceptions.ValidationError("Query execution failed. Check the server logs for details.")
         execution_time_ms = round((time.monotonic() - start_time) * 1000)
 
         rows, column_types = result
@@ -501,6 +501,8 @@ class DebugCHQueries(viewsets.ViewSet):
         query_id = request.data.get("query_id", "").strip()
         if not query_id:
             raise exceptions.ValidationError("No query_id provided.")
+        if not query_id.startswith("rawsql_"):
+            raise exceptions.ValidationError("query_id must start with 'rawsql_'.")
 
         try:
             sync_execute(
@@ -526,16 +528,17 @@ class DebugCHQueries(viewsets.ViewSet):
                 result = client.execute(
                     """
                     SELECT *
-                    FROM system.query_log
+                    FROM clusterAllReplicas(%(cluster)s, system, query_log)
                     WHERE query_id = %(query_id)s
                         AND type != 'QueryStart'
                         AND is_initial_query
                     ORDER BY event_time DESC
                     LIMIT 1
+                    SETTINGS skip_unavailable_shards=1
                     """,
                     with_column_types=True,
                     settings={"readonly": 2, "max_execution_time": 5},
-                    params={"query_id": query_id},
+                    params={"query_id": query_id, "cluster": CLICKHOUSE_CLUSTER},
                 )
         except Exception:
             logger.exception("Failed to fetch query log for %s", query_id)

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -438,3 +438,117 @@ class DebugCHQueries(viewsets.ViewSet):
         sample_count = sum(row[1] for row in trace_results)
 
         return Response({"status": "complete", "folded_stacks": folded_stacks, "sample_count": sample_count})
+
+    @staticmethod
+    def _serialize_cell(value: object) -> object:
+        if value is None or isinstance(value, (str, float, bool)):
+            return value
+        if isinstance(value, int):
+            if -(2**63) <= value <= 2**63 - 1:
+                return value
+            return str(value)
+        return str(value)
+
+    @action(detail=False, methods=["POST"], url_path="raw_sql")
+    def raw_sql(self, request):
+        if not (request.user.is_staff or DEBUG):
+            raise exceptions.PermissionDenied("Only staff users can run raw SQL.")
+
+        query = request.data.get("query", "").strip()
+        if not query:
+            raise exceptions.ValidationError("No query provided.")
+
+        query_id = request.data.get("query_id", "").strip()
+        if not query_id or not query_id.startswith("rawsql_"):
+            query_id = f"rawsql_{generate_short_id()}"
+
+        start_time = time.monotonic()
+        try:
+            with get_client_from_pool(workload=Workload.OFFLINE, readonly=False) as client:
+                result = client.execute(
+                    query,
+                    with_column_types=True,
+                    settings={
+                        "readonly": 2,
+                        "max_execution_time": 30,
+                    },
+                    query_id=query_id,
+                )
+        except Exception as e:
+            logger.exception("Raw SQL execution failed for query_id %s", query_id)
+            raise exceptions.ValidationError(f"Query execution failed: {e}")
+        execution_time_ms = round((time.monotonic() - start_time) * 1000)
+
+        rows, column_types = result
+        columns = [{"name": name, "type": type_str} for name, type_str in column_types]
+        capped_rows = [[self._serialize_cell(cell) for cell in row] for row in rows[:1000]]
+
+        return Response(
+            {
+                "columns": columns,
+                "rows": capped_rows,
+                "query_id": query_id,
+                "execution_time_ms": execution_time_ms,
+                "truncated": len(rows) > 1000,
+            }
+        )
+
+    @action(detail=False, methods=["POST"], url_path="cancel_query")
+    def cancel_query(self, request):
+        if not (request.user.is_staff or DEBUG):
+            raise exceptions.PermissionDenied("Only staff users can cancel queries.")
+
+        query_id = request.data.get("query_id", "").strip()
+        if not query_id:
+            raise exceptions.ValidationError("No query_id provided.")
+
+        try:
+            sync_execute(
+                "KILL QUERY WHERE query_id = %(query_id)s",
+                {"query_id": query_id},
+            )
+        except Exception:
+            logger.exception("Failed to cancel query %s", query_id)
+
+        return Response({"status": "ok"})
+
+    @action(detail=False, methods=["GET"], url_path="query_log_entry")
+    def query_log_entry(self, request):
+        if not (request.user.is_staff or DEBUG):
+            raise exceptions.PermissionDenied("Only staff users can view query log entries.")
+
+        query_id = request.query_params.get("query_id", "").strip()
+        if not query_id:
+            raise exceptions.ValidationError("No query_id provided.")
+
+        try:
+            with get_client_from_pool(workload=Workload.OFFLINE, readonly=False) as client:
+                result = client.execute(
+                    """
+                    SELECT *
+                    FROM system.query_log
+                    WHERE query_id = %(query_id)s
+                        AND type != 'QueryStart'
+                        AND is_initial_query
+                    ORDER BY event_time DESC
+                    LIMIT 1
+                    """,
+                    with_column_types=True,
+                    settings={"readonly": 2, "max_execution_time": 5},
+                    params={"query_id": query_id},
+                )
+        except Exception:
+            logger.exception("Failed to fetch query log for %s", query_id)
+            return Response({"status": "error"}, status=500)
+
+        rows, column_types = result
+
+        if not rows:
+            return Response({"status": "pending"}, status=202)
+
+        row = rows[0]
+        entry = {}
+        for i, (name, _) in enumerate(column_types):
+            entry[name] = self._serialize_cell(row[i])
+
+        return Response({"status": "complete", "entry": entry})

--- a/posthog/api/test/test_debug_ch_queries.py
+++ b/posthog/api/test/test_debug_ch_queries.py
@@ -97,3 +97,110 @@ class TestDebugCHQueryProfileResults(APIBaseTest):
         self.assertEqual(data["status"], "complete")
         self.assertEqual(data["folded_stacks"], ["main;foo;bar 10", "main;baz 5"])
         self.assertEqual(data["sample_count"], 15)
+
+
+class TestDebugCHQueryRawSQL(APIBaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def test_non_staff_gets_403(self):
+        self.user.is_staff = False
+        self.user.save()
+        with patch("posthog.api.debug_ch_queries.DEBUG", False):
+            resp = self.client.post("/api/debug_ch_queries/raw_sql/", {"query": "SELECT 1"}, format="json")
+            self.assertEqual(resp.status_code, HTTP_403_FORBIDDEN)
+
+    def test_rejects_empty_query(self):
+        self.user.is_staff = True
+        self.user.save()
+        resp = self.client.post("/api/debug_ch_queries/raw_sql/", {"query": ""}, format="json")
+        self.assertEqual(resp.status_code, HTTP_400_BAD_REQUEST)
+
+    @patch("posthog.api.debug_ch_queries.get_client_from_pool")
+    def test_returns_results_and_query_id(self, mock_get_client):
+        self.user.is_staff = True
+        self.user.save()
+
+        mock_client = MagicMock()
+        mock_client.execute.return_value = (
+            [(1, "hello")],
+            [("number", "UInt64"), ("text", "String")],
+        )
+        mock_get_client.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_get_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        resp = self.client.post(
+            "/api/debug_ch_queries/raw_sql/", {"query": "SELECT 1 AS number, 'hello' AS text"}, format="json"
+        )
+        self.assertEqual(resp.status_code, HTTP_200_OK)
+        data = resp.json()
+        self.assertTrue(data["query_id"].startswith("rawsql_"))
+        self.assertEqual(data["columns"], [{"name": "number", "type": "UInt64"}, {"name": "text", "type": "String"}])
+        self.assertEqual(data["rows"], [[1, "hello"]])
+        self.assertIn("execution_time_ms", data)
+        self.assertFalse(data["truncated"])
+
+    @patch("posthog.api.debug_ch_queries.DEBUG", True)
+    @patch("posthog.api.debug_ch_queries.get_client_from_pool")
+    def test_allowed_in_debug_mode(self, mock_get_client):
+        self.user.is_staff = False
+        self.user.save()
+
+        mock_client = MagicMock()
+        mock_client.execute.return_value = ([(1,)], [("n", "UInt64")])
+        mock_get_client.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_get_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        resp = self.client.post("/api/debug_ch_queries/raw_sql/", {"query": "SELECT 1"}, format="json")
+        self.assertEqual(resp.status_code, HTTP_200_OK)
+
+
+class TestDebugCHQueryLogEntry(APIBaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def test_non_staff_gets_403(self):
+        self.user.is_staff = False
+        self.user.save()
+        with patch("posthog.api.debug_ch_queries.DEBUG", False):
+            resp = self.client.get("/api/debug_ch_queries/query_log_entry/?query_id=test")
+            self.assertEqual(resp.status_code, HTTP_403_FORBIDDEN)
+
+    def test_missing_query_id_gets_400(self):
+        self.user.is_staff = True
+        self.user.save()
+        resp = self.client.get("/api/debug_ch_queries/query_log_entry/")
+        self.assertEqual(resp.status_code, HTTP_400_BAD_REQUEST)
+
+    @patch("posthog.api.debug_ch_queries.get_client_from_pool")
+    def test_returns_202_when_pending(self, mock_get_client):
+        self.user.is_staff = True
+        self.user.save()
+
+        mock_client = MagicMock()
+        mock_client.execute.return_value = ([], [])
+        mock_get_client.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_get_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        resp = self.client.get("/api/debug_ch_queries/query_log_entry/?query_id=rawsql_abc")
+        self.assertEqual(resp.status_code, HTTP_202_ACCEPTED)
+        self.assertEqual(resp.json()["status"], "pending")
+
+    @patch("posthog.api.debug_ch_queries.get_client_from_pool")
+    def test_returns_query_log_entry(self, mock_get_client):
+        self.user.is_staff = True
+        self.user.save()
+
+        mock_client = MagicMock()
+        mock_client.execute.return_value = (
+            [(150, 10000, 50000)],
+            [("query_duration_ms", "UInt64"), ("read_rows", "UInt64"), ("read_bytes", "UInt64")],
+        )
+        mock_get_client.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_get_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        resp = self.client.get("/api/debug_ch_queries/query_log_entry/?query_id=rawsql_abc")
+        self.assertEqual(resp.status_code, HTTP_200_OK)
+        data = resp.json()
+        self.assertEqual(data["status"], "complete")
+        self.assertEqual(data["entry"]["query_duration_ms"], 150)
+        self.assertEqual(data["entry"]["read_rows"], 10000)
+        self.assertEqual(data["entry"]["read_bytes"], 50000)

--- a/posthog/api/test/test_debug_ch_queries.py
+++ b/posthog/api/test/test_debug_ch_queries.py
@@ -154,6 +154,43 @@ class TestDebugCHQueryRawSQL(APIBaseTest):
         self.assertEqual(resp.status_code, HTTP_200_OK)
 
 
+class TestDebugCHQueryCancelQuery(APIBaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def test_non_staff_gets_403(self):
+        self.user.is_staff = False
+        self.user.save()
+        with patch("posthog.api.debug_ch_queries.DEBUG", False):
+            resp = self.client.post("/api/debug_ch_queries/cancel_query/", {"query_id": "rawsql_abc"}, format="json")
+            self.assertEqual(resp.status_code, HTTP_403_FORBIDDEN)
+
+    def test_missing_query_id_gets_400(self):
+        self.user.is_staff = True
+        self.user.save()
+        resp = self.client.post("/api/debug_ch_queries/cancel_query/", {}, format="json")
+        self.assertEqual(resp.status_code, HTTP_400_BAD_REQUEST)
+
+    def test_rejects_non_rawsql_prefix(self):
+        self.user.is_staff = True
+        self.user.save()
+        resp = self.client.post("/api/debug_ch_queries/cancel_query/", {"query_id": "some_other_query"}, format="json")
+        self.assertEqual(resp.status_code, HTTP_400_BAD_REQUEST)
+
+    @patch("posthog.api.debug_ch_queries.sync_execute")
+    def test_kills_query(self, mock_sync_execute):
+        self.user.is_staff = True
+        self.user.save()
+
+        resp = self.client.post("/api/debug_ch_queries/cancel_query/", {"query_id": "rawsql_abc123"}, format="json")
+        self.assertEqual(resp.status_code, HTTP_200_OK)
+        mock_sync_execute.assert_called_once()
+        call_args = mock_sync_execute.call_args
+        self.assertIn("KILL QUERY", call_args[0][0])
+        self.assertEqual(
+            call_args[1]["query_id"] if "query_id" in call_args[1] else call_args[0][1]["query_id"], "rawsql_abc123"
+        )
+
+
 class TestDebugCHQueryLogEntry(APIBaseTest):
     CLASS_DATA_LEVEL_SETUP = False
 

--- a/products/workflows/frontend/OptOuts/CustomerIOImportModal.stories.tsx
+++ b/products/workflows/frontend/OptOuts/CustomerIOImportModal.stories.tsx
@@ -85,7 +85,7 @@ const Template: StoryFn<StoryProps> = ({ syncConfig }) => {
 
     useEffect(() => {
         openImportModal()
-    }, [])
+    }, [openImportModal])
 
     return <CustomerIOImportModal />
 }


### PR DESCRIPTION
## Problem

When debugging ClickHouse query performance, developers currently need to use Metabase or connect directly to ClickHouse to run raw SQL and inspect query logs. The existing ClickHouse query debugger modal only shows recent queries — there's no way to run ad-hoc queries and see the `system.query_log` entry for each execution in one place.

## Changes

Adds a **"Run query"** tab to the ClickHouse query debugger modal (accessible via the debug shortcuts menu, help menu, or account menu).

**Backend** (`posthog/api/debug_ch_queries.py`):
- `POST /api/debug_ch_queries/raw_sql/` — execute raw ClickHouse SQL, returns columns + rows + query_id. Uses `readonly:2` and `max_execution_time:30` for safety.
- `GET /api/debug_ch_queries/query_log_entry/` — fetch full `system.query_log` entry (all columns) for a given query_id
- `POST /api/debug_ch_queries/cancel_query/` — sends `KILL QUERY` to ClickHouse by query_id
- Large integers (UInt128 UUIDs) are serialized as strings to avoid JSON overflow

**Frontend** (`frontend/src/lib/components/AppShortcuts/utils/`):
- `RawSqlDebug.tsx` — Monaco SQL editor (collapsible, resizable) + results table + query log panel
- `rawSqlLogic.ts` — Kea logic for query execution, cancellation via AbortController + KILL QUERY, and query log auto-fetch
- Results table with sticky column headers, click-to-expand cells, pagination (50 rows/page)
- Cancel button that aborts the HTTP request and kills the ClickHouse query
- Modal title updated to "ClickHouse query debugger"

## How did you test this code?

- verified running and canceling queries locally
- unit test

## Publish to changelog?

No

## Docs update

No
## 🤖 LLM context

This PR was authored by PostHog Code. The feature was built iteratively through conversation, addressing issues as they came up (UInt128 overflow, cancel not working due to blocked workers, sticky headers, cell expansion performance).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*