### PR TITLE
perf(marketing-analytics): compose adapter UNION as AST to skip parse_select

### DIFF
--- a/products/marketing_analytics/backend/api.py
+++ b/products/marketing_analytics/backend/api.py
@@ -157,9 +157,7 @@ class MarketingAnalyticsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
 
             query.limit = ast.Constant(value=10)
 
-            hogql_str = query.to_hogql()
-
-            result = execute_hogql_query(hogql_str, self.team)
+            result = execute_hogql_query(query, self.team)
 
             return Response(
                 {
@@ -167,7 +165,7 @@ class MarketingAnalyticsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
                     "row_count": len(result.results) if result.results else 0,
                     "columns": result.columns or [],
                     "sample_data": (result.results or [])[:10],
-                    "hogql": hogql_str,
+                    "hogql": query.to_hogql(),
                 }
             )
 

--- a/products/marketing_analytics/backend/hogql_queries/adapters/base.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/base.py
@@ -417,10 +417,3 @@ class MarketingSourceAdapter(ABC, Generic[ConfigType]):
             self.logger.error("Query generation failed", error=error_msg, exc_info=True)
             self._log_query_generation(False, error_msg)
             return None
-
-    def build_query_string(self) -> Optional[str]:
-        """
-        Build SQL query string (backwards compatibility).
-        """
-        query = self.build_query()
-        return query.to_hogql() if query else None

--- a/products/marketing_analytics/backend/hogql_queries/adapters/factory.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/factory.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 
 from posthog.schema import NativeMarketingSource, SourceMap
 
+from posthog.hogql import ast
 from posthog.hogql.database.database import Database
 
 from products.data_warehouse.backend.models import DataWarehouseTable, ExternalDataSource
@@ -21,10 +22,10 @@ from products.marketing_analytics.backend.hogql_queries.adapters.snapchat_ads im
 from products.marketing_analytics.backend.hogql_queries.adapters.tiktok_ads import TikTokAdsAdapter
 
 from ..constants import (
-    FALLBACK_EMPTY_QUERY,
     TABLE_PATTERNS,
     VALID_NATIVE_MARKETING_SOURCES,
     VALID_NON_NATIVE_MARKETING_SOURCES,
+    build_fallback_empty_query_ast,
 )
 from ..utils import map_url_to_provider
 from .base import (
@@ -585,24 +586,32 @@ class MarketingSourceFactory:
                 self.logger.exception("Error validating adapter", source_type=adapter.get_source_type(), error=str(e))
         return valid_adapters
 
-    def build_union_query(self, adapters: list[MarketingSourceAdapter]) -> str:
-        """Build union query from all valid adapters"""
+    def build_union_query_ast(self, adapters: list[MarketingSourceAdapter]) -> ast.SelectQuery | ast.SelectSetQuery:
+        """Build union query AST from all valid adapters.
+
+        Returning an AST avoids the expensive parse_select roundtrip (~700 ms
+        for ~10 KB HogQL in cpp-json, ~9 s in the Python parser) that we used
+        to pay on every dashboard render.
+        """
         # Sort adapters by source_id to ensure deterministic UNION ALL ordering
         # This prevents flaky tests where query optimizer reorders UNION ALL clauses
         sorted_adapters = sorted(adapters, key=lambda adapter: adapter.config.source_id)
 
-        queries = []
+        queries: list[ast.SelectQuery | ast.SelectSetQuery] = []
         for adapter in sorted_adapters:
             try:
-                query = adapter.build_query_string()
-                if query:
+                query = adapter.build_query()
+                if query is not None:
                     queries.append(query)
             except Exception as e:
                 self.logger.exception(
                     "Error building query for adapter", source_type=adapter.get_source_type(), error=str(e)
                 )
 
-        return "\nUNION ALL\n".join(queries) if queries else FALLBACK_EMPTY_QUERY
+        if not queries:
+            return build_fallback_empty_query_ast()
+
+        return ast.SelectSetQuery.create_from_queries(queries, set_operator="UNION ALL")
 
     def _get_schema_id_for_table(self, table: DataWarehouseTable) -> str | None:
         """Get schema ID for a warehouse table"""

--- a/products/marketing_analytics/backend/hogql_queries/constants.py
+++ b/products/marketing_analytics/backend/hogql_queries/constants.py
@@ -85,20 +85,31 @@ TOTAL_REPORTED_CONVERSION_VALUE_FIELD = "total_reported_conversion_value"
 # Field used for joining with conversion goals
 MATCH_KEY_FIELD = "match_key"
 
+
 # Fallback query when no valid adapters are found (includes all 9 columns in correct order)
 # Order: match_key, campaign, id, source, impressions, clicks, cost, reported_conversion, reported_conversion_value
-FALLBACK_EMPTY_QUERY = (
-    f"SELECT '' as {MATCH_KEY_FIELD}, "
-    f"'No Campaign' as {MarketingAnalyticsColumnsSchemaNames.CAMPAIGN}, "
-    f"'No ID' as {MarketingAnalyticsColumnsSchemaNames.ID}, "
-    f"'No Source' as {MarketingAnalyticsColumnsSchemaNames.SOURCE}, "
-    f"0.0 as {MarketingAnalyticsColumnsSchemaNames.IMPRESSIONS}, "
-    f"0.0 as {MarketingAnalyticsColumnsSchemaNames.CLICKS}, "
-    f"0.0 as {MarketingAnalyticsColumnsSchemaNames.COST}, "
-    f"0.0 as {MarketingAnalyticsColumnsSchemaNames.REPORTED_CONVERSION}, "
-    f"0.0 as {MarketingAnalyticsColumnsSchemaNames.REPORTED_CONVERSION_VALUE} "
-    "WHERE 1=0"
-)
+def build_fallback_empty_query_ast() -> ast.SelectQuery:
+    return ast.SelectQuery(
+        select=[
+            ast.Alias(alias=MATCH_KEY_FIELD, expr=ast.Constant(value="")),
+            ast.Alias(alias=MarketingAnalyticsColumnsSchemaNames.CAMPAIGN, expr=ast.Constant(value="No Campaign")),
+            ast.Alias(alias=MarketingAnalyticsColumnsSchemaNames.ID, expr=ast.Constant(value="No ID")),
+            ast.Alias(alias=MarketingAnalyticsColumnsSchemaNames.SOURCE, expr=ast.Constant(value="No Source")),
+            ast.Alias(alias=MarketingAnalyticsColumnsSchemaNames.IMPRESSIONS, expr=ast.Constant(value=0.0)),
+            ast.Alias(alias=MarketingAnalyticsColumnsSchemaNames.CLICKS, expr=ast.Constant(value=0.0)),
+            ast.Alias(alias=MarketingAnalyticsColumnsSchemaNames.COST, expr=ast.Constant(value=0.0)),
+            ast.Alias(alias=MarketingAnalyticsColumnsSchemaNames.REPORTED_CONVERSION, expr=ast.Constant(value=0.0)),
+            ast.Alias(
+                alias=MarketingAnalyticsColumnsSchemaNames.REPORTED_CONVERSION_VALUE, expr=ast.Constant(value=0.0)
+            ),
+        ],
+        where=ast.CompareOperation(
+            left=ast.Constant(value=1),
+            op=ast.CompareOperationOp.Eq,
+            right=ast.Constant(value=0),
+        ),
+    )
+
 
 # AST Expression mappings for MarketingAnalyticsBaseColumns
 BASE_COLUMN_MAPPING = {

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -42,18 +42,12 @@ logger = structlog.get_logger(__name__)
 ResponseType = TypeVar("ResponseType", bound=AnalyticsQueryResponseProtocol)
 
 
-# parse_select on the adapter UNION string (~10 KB) takes ~2 s in HogQL's
-# Python parser. Cache the parsed AST and clone on each hit (~1 ms).
-# 32 covers all ~30 real adapter combinations observed in prod.
+# parse_select on this ~10 KB UNION takes ~2 s in HogQL's Python parser.
+# Replacing the date literals with placeholders makes the template stable
+# across date ranges and compare-mode periods, so all hit the same cache entry.
+# 32 covers the ~30 adapter combinations observed in prod.
 @lru_cache(maxsize=32)
 def _cached_parse_union_template(union_template: str) -> ast.SelectQuery | ast.SelectSetQuery:
-    """Parse a date-range-agnostic template of the adapter UNION query.
-
-    The template contains ``{date_from}`` and ``{date_to}`` placeholders where
-    concrete datetimes used to be. Parsing happens once per unique template
-    (team config × drill-down combination); callers substitute the actual
-    dates on each request via ``replace_placeholders``.
-    """
     parsed = parse_select(union_template)
     assert isinstance(parsed, ast.SelectQuery | ast.SelectSetQuery)
     return parsed
@@ -64,21 +58,6 @@ def _parse_adapter_union_query(
     date_from_str: str,
     date_to_str: str,
 ) -> ast.SelectQuery | ast.SelectSetQuery:
-    """Parse the adapter UNION string with an LRU cache on the date-agnostic template.
-
-    Strategy:
-
-    1. Normalise the string by replacing the concrete ``'date_from_str'`` and
-       ``'date_to_str'`` literals with ``{date_from}`` / ``{date_to}``
-       placeholders. The resulting template is stable across different date
-       ranges for the same team config.
-    2. Parse the template — cached across requests.
-    3. Clone the cached AST and substitute the placeholders with the actual
-       datetimes for this request.
-
-    With compare mode, current and previous periods generate different dates
-    but the SAME template, so both hit the same cache entry.
-    """
     template = union_query_string.replace(f"'{date_from_str}'", "{date_from}").replace(f"'{date_to_str}'", "{date_to}")
 
     cached = _cached_parse_union_template(template)
@@ -299,10 +278,6 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             ]
         )
 
-        # Parse the union query as a subquery and wrap it in a JoinExpr.
-        # The parse is cached on a date-agnostic template (dates become
-        # {date_from}/{date_to} placeholders before caching), so different
-        # date ranges and compare-mode periods all hit the same cache entry.
         union_subquery = _parse_adapter_union_query(
             union_query_string,
             date_from_str=self.query_date_range.date_from_str,

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -19,7 +19,6 @@ from posthog.hogql.database.schema.channel_type import ChannelTypeExprs, create_
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_select
 from posthog.hogql.placeholders import replace_placeholders
-from posthog.hogql.visitor import clone_expr
 
 from posthog.hogql_queries.query_runner import AnalyticsQueryResponseProtocol, AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_compare_to_date_range import QueryCompareToDateRange
@@ -61,11 +60,8 @@ def _parse_adapter_union_query(
     template = union_query_string.replace(f"'{date_from_str}'", "{date_from}").replace(f"'{date_to_str}'", "{date_to}")
 
     cached = _cached_parse_union_template(template)
-    cloned = clone_expr(cached)
-    assert isinstance(cloned, ast.SelectQuery | ast.SelectSetQuery)
-
     substituted = replace_placeholders(
-        cloned,
+        cached,
         {
             "date_from": ast.Constant(value=date_from_str),
             "date_to": ast.Constant(value=date_to_str),

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from functools import cached_property, lru_cache
+from functools import cached_property
 from typing import Generic, Optional, TypeVar
 
 import structlog
@@ -17,8 +17,6 @@ from posthog.schema import (
 from posthog.hogql import ast
 from posthog.hogql.database.schema.channel_type import ChannelTypeExprs, create_channel_type_expr
 from posthog.hogql.modifiers import create_default_modifiers_for_team
-from posthog.hogql.parser import parse_select
-from posthog.hogql.placeholders import replace_placeholders
 
 from posthog.hogql_queries.query_runner import AnalyticsQueryResponseProtocol, AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_compare_to_date_range import QueryCompareToDateRange
@@ -39,36 +37,6 @@ from .utils import convert_team_conversion_goals_to_objects
 logger = structlog.get_logger(__name__)
 
 ResponseType = TypeVar("ResponseType", bound=AnalyticsQueryResponseProtocol)
-
-
-# parse_select on this ~10 KB UNION takes ~2 s in HogQL's Python parser.
-# Replacing the date literals with placeholders makes the template stable
-# across date ranges and compare-mode periods, so all hit the same cache entry.
-# 32 covers the ~30 adapter combinations observed in prod.
-@lru_cache(maxsize=32)
-def _cached_parse_union_template(union_template: str) -> ast.SelectQuery | ast.SelectSetQuery:
-    parsed = parse_select(union_template)
-    assert isinstance(parsed, ast.SelectQuery | ast.SelectSetQuery)
-    return parsed
-
-
-def _parse_adapter_union_query(
-    union_query_string: str,
-    date_from_str: str,
-    date_to_str: str,
-) -> ast.SelectQuery | ast.SelectSetQuery:
-    template = union_query_string.replace(f"'{date_from_str}'", "{date_from}").replace(f"'{date_to_str}'", "{date_to}")
-
-    cached = _cached_parse_union_template(template)
-    substituted = replace_placeholders(
-        cached,
-        {
-            "date_from": ast.Constant(value=date_from_str),
-            "date_to": ast.Constant(value=date_to_str),
-        },
-    )
-    assert isinstance(substituted, ast.SelectQuery | ast.SelectSetQuery)
-    return substituted
 
 
 class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC, Generic[ResponseType]):
@@ -115,7 +83,7 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             logger.exception("Error getting marketing source adapters", error=str(e))
             return []
 
-    def _build_campaign_cost_select(self, union_query_string: str) -> ast.SelectQuery:
+    def _build_campaign_cost_select(self, union_subquery: ast.SelectQuery | ast.SelectSetQuery) -> ast.SelectQuery:
         """Build the campaign_costs CTE SELECT query"""
         # Build GROUP BY using configuration - this will be overridden in aggregated queries
         group_by_exprs: list[ast.Expr] = self._get_group_by_expressions()
@@ -274,11 +242,6 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             ]
         )
 
-        union_subquery = _parse_adapter_union_query(
-            union_query_string,
-            date_from_str=self.query_date_range.date_from_str,
-            date_to_str=self.query_date_range.date_to_str,
-        )
         union_join_expr = ast.JoinExpr(table=union_subquery)
 
         # Build the CTE SELECT query
@@ -460,7 +423,10 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
         )
 
     def _build_complete_query_ast(
-        self, union_query_string: str, processors: list, date_range: QueryDateRange
+        self,
+        union_subquery: ast.SelectQuery | ast.SelectSetQuery,
+        processors: list,
+        date_range: QueryDateRange,
     ) -> ast.SelectQuery:
         """Build the complete query with CTEs using AST expressions"""
 
@@ -474,7 +440,7 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
         ctes: dict[str, ast.CTE] = {}
 
         # Add campaign_costs CTE
-        campaign_cost_select = self._build_campaign_cost_select(union_query_string)
+        campaign_cost_select = self._build_campaign_cost_select(union_subquery)
         campaign_cost_cte = ast.CTE(
             name=self.config.campaign_costs_cte_name, expr=campaign_cost_select, cte_type="subquery"
         )
@@ -533,8 +499,8 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             # Get marketing source adapters
             adapters = self._get_marketing_source_adapters(date_range=self.query_date_range)
 
-            # Build the union query using the factory
-            union_query_string = self._factory(date_range=self.query_date_range).build_union_query(adapters)
+            # Build the union query using the factory (AST form to skip parse_select).
+            union_subquery = self._factory(date_range=self.query_date_range).build_union_query_ast(adapters)
 
             # Get conversion goals and filter out invalid ones
             conversion_goals = self._get_team_conversion_goals()
@@ -548,7 +514,7 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             )
 
             # Build the complete query with CTEs using AST
-            return self._build_complete_query_ast(union_query_string, processors, self.query_date_range)
+            return self._build_complete_query_ast(union_subquery, processors, self.query_date_range)
 
     def _generate_aggregated_conversion_goals_cte(self, conversion_aggregator, date_range) -> Optional[ast.CTE]:
         """Generate aggregated conversion goals CTE without GROUP BY for aggregated queries"""

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from functools import cached_property
+from functools import cached_property, lru_cache
 from typing import Generic, Optional, TypeVar
 
 import structlog
@@ -18,6 +18,8 @@ from posthog.hogql import ast
 from posthog.hogql.database.schema.channel_type import ChannelTypeExprs, create_channel_type_expr
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_select
+from posthog.hogql.placeholders import replace_placeholders
+from posthog.hogql.visitor import clone_expr
 
 from posthog.hogql_queries.query_runner import AnalyticsQueryResponseProtocol, AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_compare_to_date_range import QueryCompareToDateRange
@@ -38,6 +40,73 @@ from .utils import convert_team_conversion_goals_to_objects
 logger = structlog.get_logger(__name__)
 
 ResponseType = TypeVar("ResponseType", bound=AnalyticsQueryResponseProtocol)
+
+
+# HogQL's parse_select is surprisingly slow — a 10KB UNION ALL of adapter
+# subqueries takes ~2s on Python to lex + parse + build the custom AST.
+# The same string is reparsed on every dashboard render (and twice when
+# ``compareFilter.compare`` is set — once per period). Cache the parsed AST
+# and hand out clones on each hit. The clone is a fast in-memory walk
+# (~1ms for these shapes) and protects the cached tree from downstream
+# mutations by the printer/resolver.
+#
+# Size chosen to hold a reasonable multi-tenant working set per worker:
+# a handful of teams × a handful of (date_range, drill_down) combinations.
+# Each cached AST is ~100-500KB, so 64 * 500KB ≈ 32MB upper bound per
+# worker. Lowering this starves multi-tenant workers; raising it wastes
+# memory when the long tail of unique strings rarely hits again.
+_MAX_CACHED_UNION_PARSE = 64
+
+
+@lru_cache(maxsize=_MAX_CACHED_UNION_PARSE)
+def _cached_parse_union_template(union_template: str) -> ast.SelectQuery | ast.SelectSetQuery:
+    """Parse a date-range-agnostic template of the adapter UNION query.
+
+    The template contains ``{date_from}`` and ``{date_to}`` placeholders where
+    concrete datetimes used to be. Parsing happens once per unique template
+    (team config × drill-down combination); callers substitute the actual
+    dates on each request via ``replace_placeholders``.
+    """
+    parsed = parse_select(union_template)
+    assert isinstance(parsed, ast.SelectQuery | ast.SelectSetQuery)
+    return parsed
+
+
+def _parse_adapter_union_query(
+    union_query_string: str,
+    date_from_str: str,
+    date_to_str: str,
+) -> ast.SelectQuery | ast.SelectSetQuery:
+    """Parse the adapter UNION string with an LRU cache on the date-agnostic template.
+
+    Strategy:
+
+    1. Normalise the string by replacing the concrete ``'date_from_str'`` and
+       ``'date_to_str'`` literals with ``{date_from}`` / ``{date_to}``
+       placeholders. The resulting template is stable across different date
+       ranges for the same team config.
+    2. Parse the template — cached across requests.
+    3. Clone the cached AST and substitute the placeholders with the actual
+       datetimes for this request.
+
+    With compare mode, current and previous periods generate different dates
+    but the SAME template, so both hit the same cache entry.
+    """
+    template = union_query_string.replace(f"'{date_from_str}'", "{date_from}").replace(f"'{date_to_str}'", "{date_to}")
+
+    cached = _cached_parse_union_template(template)
+    cloned = clone_expr(cached)
+    assert isinstance(cloned, ast.SelectQuery | ast.SelectSetQuery)
+
+    substituted = replace_placeholders(
+        cloned,
+        {
+            "date_from": ast.Constant(value=date_from_str),
+            "date_to": ast.Constant(value=date_to_str),
+        },
+    )
+    assert isinstance(substituted, ast.SelectQuery | ast.SelectSetQuery)
+    return substituted
 
 
 class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC, Generic[ResponseType]):
@@ -243,8 +312,15 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             ]
         )
 
-        # Parse the union query as a subquery and wrap it in a JoinExpr
-        union_subquery = parse_select(union_query_string)
+        # Parse the union query as a subquery and wrap it in a JoinExpr.
+        # The parse is cached on a date-agnostic template (dates become
+        # {date_from}/{date_to} placeholders before caching), so different
+        # date ranges and compare-mode periods all hit the same cache entry.
+        union_subquery = _parse_adapter_union_query(
+            union_query_string,
+            date_from_str=self.query_date_range.date_from_str,
+            date_to_str=self.query_date_range.date_to_str,
+        )
         union_join_expr = ast.JoinExpr(table=union_subquery)
 
         # Build the CTE SELECT query

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -42,23 +42,10 @@ logger = structlog.get_logger(__name__)
 ResponseType = TypeVar("ResponseType", bound=AnalyticsQueryResponseProtocol)
 
 
-# HogQL's parse_select is surprisingly slow — a 10KB UNION ALL of adapter
-# subqueries takes ~2s on Python to lex + parse + build the custom AST.
-# The same string is reparsed on every dashboard render (and twice when
-# ``compareFilter.compare`` is set — once per period). Cache the parsed AST
-# and hand out clones on each hit. The clone is a fast in-memory walk
-# (~1ms for these shapes) and protects the cached tree from downstream
-# mutations by the printer/resolver.
-#
-# Size chosen to hold a reasonable multi-tenant working set per worker:
-# a handful of teams × a handful of (date_range, drill_down) combinations.
-# Each cached AST is ~100-500KB, so 64 * 500KB ≈ 32MB upper bound per
-# worker. Lowering this starves multi-tenant workers; raising it wastes
-# memory when the long tail of unique strings rarely hits again.
-_MAX_CACHED_UNION_PARSE = 64
-
-
-@lru_cache(maxsize=_MAX_CACHED_UNION_PARSE)
+# parse_select on the adapter UNION string (~10 KB) takes ~2 s in HogQL's
+# Python parser. Cache the parsed AST and clone on each hit (~1 ms).
+# 32 covers all ~30 real adapter combinations observed in prod.
+@lru_cache(maxsize=32)
 def _cached_parse_union_template(union_template: str) -> ast.SelectQuery | ast.SelectSetQuery:
     """Parse a date-range-agnostic template of the adapter UNION query.
 

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_aggregated_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_aggregated_query_runner.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 from posthog.schema import BaseMathType, DateRange, MarketingAnalyticsAggregatedQuery, NodeKind
 
+from posthog.hogql.parser import parse_select
 from posthog.hogql.test.utils import pretty_print_in_tests
 
 from products.marketing_analytics.backend.hogql_queries.marketing_analytics_aggregated_query_runner import (
@@ -54,7 +55,7 @@ class TestMarketingAnalyticsAggregatedQueryRunner(ClickhouseTestMixin, BaseTest)
         # Mock the adapters to return a simple query
         mock_adapter = Mock()
         mock_adapter.get_source_id.return_value = "test_source"
-        mock_adapter.build_query_string.return_value = (
+        mock_adapter.build_query.return_value = parse_select(
             "SELECT 'Campaign' as campaign, 'id1' as id, 'google' as source, "
             "100 as impressions, 10 as clicks, 50.0 as cost, 5 as reported_conversion, "
             "'Campaign' as match_key"

--- a/products/marketing_analytics/backend/services/utm_audit.py
+++ b/products/marketing_analytics/backend/services/utm_audit.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from posthog.schema import DateRange, NativeMarketingSource
 
+from posthog.hogql import ast
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
@@ -142,29 +143,52 @@ def _get_campaigns_with_spend(team: Team, date_range: QueryDateRange) -> list[Ca
     if not valid_adapters:
         return []
 
-    union_query = factory.build_union_query(valid_adapters)
-    if not union_query:
-        return []
+    union_subquery = factory.build_union_query_ast(valid_adapters)
 
-    # The union query is built from trusted internal adapters (no user input),
-    # so f-string composition is safe here. The subquery produces columns:
-    # match_key, campaign, id, source, impressions, clicks, cost, reported_conversion, reported_conversion_value
-    hogql = f"""
-        SELECT
-            campaign,
-            id,
-            source,
-            sum(toFloat(ifNull(cost, 0))) as total_cost,
-            sum(toFloat(ifNull(clicks, 0))) as total_clicks,
-            sum(toFloat(ifNull(impressions, 0))) as total_impressions
-        FROM ({union_query})
-        GROUP BY campaign, id, source
-        HAVING total_cost > 0
-        ORDER BY total_cost DESC
-        LIMIT 500
-    """
+    def _sum_to_float(column: str) -> ast.Call:
+        return ast.Call(
+            name="sum",
+            args=[
+                ast.Call(
+                    name="toFloat",
+                    args=[
+                        ast.Call(
+                            name="ifNull",
+                            args=[ast.Field(chain=[column]), ast.Constant(value=0)],
+                        )
+                    ],
+                )
+            ],
+        )
 
-    result = execute_hogql_query(hogql, team)
+    campaign_field = ast.Field(chain=["campaign"])
+    id_field = ast.Field(chain=["id"])
+    source_field = ast.Field(chain=["source"])
+    total_cost_field = ast.Field(chain=["total_cost"])
+
+    # The subquery produces columns: match_key, campaign, id, source, impressions, clicks,
+    # cost, reported_conversion, reported_conversion_value.
+    query = ast.SelectQuery(
+        select=[
+            campaign_field,
+            id_field,
+            source_field,
+            ast.Alias(alias="total_cost", expr=_sum_to_float("cost")),
+            ast.Alias(alias="total_clicks", expr=_sum_to_float("clicks")),
+            ast.Alias(alias="total_impressions", expr=_sum_to_float("impressions")),
+        ],
+        select_from=ast.JoinExpr(table=union_subquery),
+        group_by=[campaign_field, id_field, source_field],
+        having=ast.CompareOperation(
+            left=total_cost_field,
+            op=ast.CompareOperationOp.Gt,
+            right=ast.Constant(value=0),
+        ),
+        order_by=[ast.OrderExpr(expr=total_cost_field, order="DESC")],
+        limit=ast.Constant(value=500),
+    )
+
+    result = execute_hogql_query(query, team)
     campaigns = []
     for row in result.results or []:
         campaigns.append(


### PR DESCRIPTION
## Problem

The marketing analytics dashboard builds a `campaign_costs` CTE by UNION ALL-ing a subquery per ad platform adapter. On every render, the runner serialised each adapter to HogQL, concatenated the strings with `UNION ALL`, and called `parse_select()` on the resulting ~10 KB string to turn it back into an AST.

Benchmarking that parse on a realistic union:

| Backend | Time per call |
|---|---|
| Python parser | ~9 s |
| cpp-json (default in prod) | ~700 ms |

The PR originally added a template cache around the parse step. Digging into it made the real issue obvious: adapters already return `ast.SelectQuery` from `build_query()` — the migration to AST happened in commit `a9342e1a9` (Jun 2025) but the factory never followed. A `build_query_string()` wrapper was left "for backwards compatibility", but its only caller was the factory itself. So each render paid `AST → to_hogql() → join → parse_select → AST` for no reason.

## Changes

Replace the roundtrip with direct AST composition, no cache needed:

1. **`adapters/factory.py`** — `build_union_query` (string) → `build_union_query_ast` using `ast.SelectSetQuery.create_from_queries(queries, set_operator="UNION ALL")`.
2. **`adapters/base.py`** — remove `build_query_string()` (dead now that the factory consumes AST).
3. **`constants.py`** — `FALLBACK_EMPTY_QUERY` (string) → `build_fallback_empty_query_ast()`.
4. **`marketing_analytics_base_query_runner.py`** — remove the parse cache and its helpers; `_build_campaign_cost_select` and `_build_complete_query_ast` consume the AST directly.
5. **`services/utm_audit.py`** — the outer `SELECT ... FROM ({union}) ...` was another `str → parse_select` site. Rebuilt as AST and passed straight to `execute_hogql_query`.
6. **`backend/api.py`** — the mapping-test endpoint was doing `query.to_hogql()` and then letting `execute_hogql_query` reparse it. Pass the AST directly.

## Benchmark

Same ~10 KB union, same machine:

| Approach | Time per render |
|---|---|
| Master (string roundtrip, cpp-json) | ~715 ms |
| Original cache approach (hit) | ~2 ms |
| This PR (`SelectSetQuery.create_from_queries`) | ~0.004 ms |

Compare-mode renders pay this twice, so the wall-clock saving is ~1.4 s.

## How did you test this code?

- Full marketing analytics backend suite passes: `test_marketing_analytics_table_query_runner` (+ `_business`, `_compare`), `test_marketing_analytics_aggregated_query_runner`, `test_conversion_goal_processor`, `test_conversion_goals_aggregator`, `test_adapters`, `test_factory`, `test_utm_audit`, `test_custom_source_mappings_integration`, `test_campaign_field_preferences`, `test_marketing_analytics_config`, `test_constants` — 452 tests, 51 snapshots.
- Snapshots unchanged, which is the intended outcome: the emitted HogQL is identical, we just skip the string roundtrip that produced it.
- Ruff clean.

## Publish to changelog?

No publish to changelog.