### PR TITLE
feat: Recycle connections in workflows batch export

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
@@ -1,4 +1,6 @@
 import json
+import time
+import typing
 import asyncio
 import datetime as dt
 import dataclasses
@@ -33,6 +35,11 @@ from products.batch_exports.backend.temporal.utils import (
     handle_non_retryable_errors,
     make_retryable_with_exponential_backoff,
 )
+
+if typing.TYPE_CHECKING:
+    from aiohttp.client_proto import ResponseHandler
+    from aiohttp.client_reqrep import ConnectionKey
+
 
 LOGGER = get_write_only_logger(__name__)
 EXTERNAL_LOGGER = get_logger("EXTERNAL")
@@ -263,6 +270,115 @@ class WorkflowsConsumer(Consumer):
         pass
 
 
+class Tracking:
+    """A basic tracking class."""
+
+    __slots__ = ("count", "first_added")
+
+    def __init__(self):
+        self.count: int = 0
+        self.first_added: float = time.monotonic()
+
+    def increment(self) -> None:
+        self.count += 1
+
+
+class TrackingAddSet(set):
+    """Track how many times objects are added and when they are first added.
+
+    This adds a `Tracking` to each object added to the set to keep track of how many
+    times the it is added to the set, and when was the first time it was added.
+
+    This is a relatively cheap way to track objects: We don't need to keep any
+    references, but rather just piggyback on the object itself.
+
+    There is a risk that the object implements the attribute we use for tracking, i.e.
+    `__tracking__`, so we check the objects class and do nothing if that is the case.
+    Also, we cannot add attributes to objects that do not have `__dict__`, so we ignore
+    those.
+    """
+
+    def add(self, element, /) -> None:
+        cls = type(element)
+        if hasattr(cls, "__tracking__") or not hasattr(element, "__dict__"):
+            return super().add(element)
+
+        if not hasattr(element, "__tracking__"):
+            element.__tracking__ = Tracking()
+
+        element.__tracking__.increment()
+        super().add(element)
+
+
+class RecyclingTCPConnector(aiohttp.TCPConnector):
+    """Subclass of `aiohttp.TCPConnector` with connection recycling.
+
+    In addition to `keepalive_timeout` checks, connections are closed after
+    `recycle_requests` uses or after `recycle_timeout` seconds since created.
+
+    aiohttp's connection lifecycle works roughly as follows:
+    * When issuing a request, `aiohttp.ClientSession` calls `connect` on the connector
+        (`aiohttp.TCPConnector` on our case).
+    * `connect` attempts to get a connection from the pool (which is just a dictionary
+        and a deque) and if none are present creates a new connection.
+    * The created connection is added to `self._acquired`.
+    * After a response is received, the underlying connection is released back to the
+        pool.
+    * When this happens, `self._release` is called, the connection removed from
+        `self._acquired` and added back to the pool.
+
+    This means we can track when connections are added to `self._acquired` to determine
+    how many times they are used and when they are first created (the first time they are
+    added to `self._acquired`.
+
+    Finally, we override `self._release` to use the tracking info and close the
+    connection if necessary.
+    """
+
+    def __init__(
+        self,
+        *args,
+        recycle_requests: int | None = None,
+        recycle_timeout: int | float | None = None,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self._acquired = TrackingAddSet()
+        self._recycle_requests = recycle_requests or -1
+        self._recycle_timeout = recycle_timeout or -1
+
+    def _release(
+        self,
+        key: "ConnectionKey",
+        protocol: "ResponseHandler",
+        *,
+        should_close: bool = False,
+    ) -> None:
+        """Override connection release to determine if it must be recycled.
+
+        This is called when connections are returned to the pool. We can inspect the
+        connection's tracking and set it to `force_close` if any of the following:
+
+        * The number of times it has been acquired exceeds `self._recycle_requests`.
+        * The time since the connection was first acquired happened more than
+            `self._recycle_timeout` seconds ago.
+
+        Once set to `force_close`, `super()._release(...)` takes care of closing the
+        connection and it will force a reconnect on the next `connect`.
+        """
+        tracking = getattr(protocol, "__tracking__", None)
+
+        if tracking is None or not isinstance(tracking, Tracking):
+            return super()._release(key, protocol, should_close=should_close)
+
+        now = time.monotonic()
+
+        should_recycle = tracking.count > self._recycle_requests or now - tracking.first_added > self._recycle_timeout
+        if should_recycle:
+            protocol.force_close()
+        super()._release(key, protocol, should_close=should_close)
+
+
 @dataclasses.dataclass
 class WorkflowsInsertInputs:
     """Inputs for Workflows."""
@@ -321,8 +437,9 @@ async def insert_into_workflows_activity_from_stage(inputs: WorkflowsInsertInput
         # nosemgrep: aiohttp-missing-trust-env
         async with aiohttp.ClientSession(
             trust_env=False,
-            connector=aiohttp.TCPConnector(
-                limit=settings.BATCH_EXPORT_WORKFLOWS_MAX_CONCURRENT_REQUESTS, keepalive_timeout=5
+            connector=RecyclingTCPConnector(
+                limit=settings.BATCH_EXPORT_WORKFLOWS_MAX_CONCURRENT_REQUESTS,
+                keepalive_timeout=5,
             ),
             headers={
                 "X-Internal-Api-Secret": settings.INTERNAL_API_SECRET,

--- a/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
@@ -201,7 +201,11 @@ class WorkflowsConsumer(Consumer):
                 InternalServerError,
                 ServiceUnavailable,
                 TooManyRequests,
+                # These two represent the server going away, first gracefully then
+                # ungracefully. Since we are talking to our own server, we know it
+                # should be there, so let's keep trying.
                 aiohttp.ServerDisconnectedError,
+                aiohttp.ClientOSError,
             ),
             # Retry forever on retryable errors
             max_attempts=None,

--- a/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
@@ -348,8 +348,8 @@ class RecyclingTCPConnector(aiohttp.TCPConnector):
     ):
         super().__init__(*args, **kwargs)
         self._acquired = TrackingAddSet()
-        self._recycle_requests = recycle_requests or -1
-        self._recycle_timeout = recycle_timeout or -1
+        self._recycle_requests = recycle_requests
+        self._recycle_timeout = recycle_timeout
 
     def _release(
         self,
@@ -377,7 +377,9 @@ class RecyclingTCPConnector(aiohttp.TCPConnector):
 
         now = time.monotonic()
 
-        should_recycle = tracking.count > self._recycle_requests or now - tracking.first_added > self._recycle_timeout
+        should_recycle = (self._recycle_requests is not None and tracking.count > self._recycle_requests) or (
+            self._recycle_timeout is not None and now - tracking.first_added > self._recycle_timeout
+        )
         if should_recycle:
             protocol.force_close()
         super()._release(key, protocol, should_close=should_close)
@@ -444,6 +446,8 @@ async def insert_into_workflows_activity_from_stage(inputs: WorkflowsInsertInput
             connector=RecyclingTCPConnector(
                 limit=settings.BATCH_EXPORT_WORKFLOWS_MAX_CONCURRENT_REQUESTS,
                 keepalive_timeout=5,
+                recycle_requests=50_000,
+                recycle_timeout=60,
             ),
             headers={
                 "X-Internal-Api-Secret": settings.INTERNAL_API_SECRET,

--- a/products/batch_exports/backend/tests/temporal/destinations/workflows/test_utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/workflows/test_utils.py
@@ -1,5 +1,9 @@
+import asyncio
+
 import pytest
 from unittest.mock import MagicMock, patch
+
+from aiohttp.client_proto import ResponseHandler
 
 from products.batch_exports.backend.temporal.destinations.workflows_batch_export import (
     RecyclingTCPConnector,
@@ -102,3 +106,9 @@ def test_recycling_connector_skips_protocol_without_tracking():
 
     super_release.assert_called_once()
     assert not hasattr(protocol, "force_close") or not protocol.force_close.called
+
+
+async def test_response_handler_can_be_tracked():
+    handler = ResponseHandler(asyncio.get_running_loop())
+    assert hasattr(handler, "__dict__"), "no longer can be monkeypatched"
+    assert not hasattr(handler, "__tracking__"), "must update tracking attribute"

--- a/products/batch_exports/backend/tests/temporal/destinations/workflows/test_utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/workflows/test_utils.py
@@ -1,0 +1,27 @@
+from products.batch_exports.backend.temporal.destinations.workflows_batch_export import Tracking, TrackingAddSet
+
+
+def test_tracking_increase_increments_count():
+    t = Tracking()
+
+    assert t.count == 0
+    t.increment()
+    assert t.count == 1
+
+
+def test_tracking_add_set_tracks_times_added():
+    s = TrackingAddSet()
+
+    class Element:
+        pass
+
+    element = Element()
+
+    s.add(element)
+    assert element.__tracking__.count == 1  # type: ignore
+
+    s.remove(element)
+    assert element.__tracking__.count == 1  # type: ignore
+
+    s.add(element)
+    assert element.__tracking__.count == 2  # type: ignore

--- a/products/batch_exports/backend/tests/temporal/destinations/workflows/test_utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/workflows/test_utils.py
@@ -1,4 +1,11 @@
-from products.batch_exports.backend.temporal.destinations.workflows_batch_export import Tracking, TrackingAddSet
+import pytest
+from unittest.mock import MagicMock, patch
+
+from products.batch_exports.backend.temporal.destinations.workflows_batch_export import (
+    RecyclingTCPConnector,
+    Tracking,
+    TrackingAddSet,
+)
 
 
 def test_tracking_increase_increments_count():
@@ -25,3 +32,73 @@ def test_tracking_add_set_tracks_times_added():
 
     s.add(element)
     assert element.__tracking__.count == 2  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "count,recycle_requests,expect_force_close",
+    [
+        (2, 1, True),
+        (1, 1, False),
+        (1, 0, True),
+    ],
+)
+@patch.object(RecyclingTCPConnector, "__init__", lambda self, *a, **kw: None)
+def test_recycling_connector_force_closes_when_request_threshold_exceeded(count, recycle_requests, expect_force_close):
+    connector = RecyclingTCPConnector.__new__(RecyclingTCPConnector)
+    connector._recycle_requests = recycle_requests
+    connector._recycle_timeout = None
+
+    protocol = MagicMock()
+    protocol.__tracking__ = Tracking()
+    protocol.__tracking__.count = count
+
+    with patch("aiohttp.TCPConnector._release"):
+        connector._release(MagicMock(), protocol)
+
+    assert protocol.force_close.called is expect_force_close
+
+
+@pytest.mark.parametrize(
+    "elapsed,recycle_timeout,expect_force_close",
+    [
+        (11, 10, True),
+        (10, 10, False),
+        (5, 10, False),
+    ],
+)
+@patch.object(RecyclingTCPConnector, "__init__", lambda self, *a, **kw: None)
+def test_recycling_connector_force_closes_when_timeout_exceeded(elapsed, recycle_timeout, expect_force_close):
+    connector = RecyclingTCPConnector.__new__(RecyclingTCPConnector)
+    connector._recycle_requests = None
+    connector._recycle_timeout = recycle_timeout
+
+    protocol = MagicMock()
+    tracking = Tracking()
+    tracking.first_added = 100.0
+    protocol.__tracking__ = tracking
+
+    with (
+        patch(
+            "products.batch_exports.backend.temporal.destinations.workflows_batch_export.time.monotonic",
+            return_value=100.0 + elapsed,
+        ),
+        patch("aiohttp.TCPConnector._release"),
+    ):
+        connector._release(MagicMock(), protocol)
+
+    assert protocol.force_close.called is expect_force_close
+
+
+@patch.object(RecyclingTCPConnector, "__init__", lambda self, *a, **kw: None)
+def test_recycling_connector_skips_protocol_without_tracking():
+    connector = RecyclingTCPConnector.__new__(RecyclingTCPConnector)
+    connector._recycle_requests = 1
+    connector._recycle_timeout = None
+
+    protocol = MagicMock(spec=[])  # no __tracking__ attribute
+
+    with patch("aiohttp.TCPConnector._release") as super_release:
+        connector._release(MagicMock(), protocol)
+
+    super_release.assert_called_once()
+    assert not hasattr(protocol, "force_close") or not protocol.force_close.called


### PR DESCRIPTION
## Problem

### Problem 1

When our Workflows API scales _up_, the Workflows batch export continues to re-use the same connections, as they are still active. This means we do not ever send traffic to new Workflows API instances, and continue to push all the load on the original instances. 

### Problem 2

Secondly, when our Workflows API scales _down_ we have a similar problem and attempt to re-use a connection to a server that now went away. This can raise a `ClientOSError` if the server was scaled down forcibly. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

### Problem 1

Introduce a new connector class `RecyclingTCPConnector`. This connector class allows recycling connections after a timeout and/or after the connection has been acquired a certain amount of times.

It works by injecting a tracking object into the connection objects aiohttp uses, and then checking this tracking when connections are released (After a response is produced). If any of the parameters are exceeded, then the connection is closed.

I originally explored ideas that didn't involve this monkeypatching, thinking this could live close to where `keepalive_timeout` is checked or where `force_close` is checked, since this is a similar operation.

Unfortunately, I didn't think this would work nicely without subclassing every single object aiohttp passes around: The tracking would have to live somewhere, and the `TCPConnector` class does not hold references to connections: They get passed from the pool (`self._conns`) to the `Connection` wrapper returned to the caller and to `self_acquired`. Where would tracking go? It didn't really fit anywhere but in the connection itself. Or the tracking would have to be added to the pool and other dictionaries everywhere. Or I would need to hold copies of the references to connections to track stuff. All this seemed very heavy and exhausting.

Monkeypatching is a bit more hacky, but besides getting a solution directly in aiohttp (which seems to be requested, https://github.com/aio-libs/aiohttp/issues/10722, maybe we could contribute upstream), I couldn't come up with a better solution.

### Problem 2

Introduce retries on `ClientOSError`. **These retries can cause duplicates**: This exception represents the server shutting down ungracefully, so we don't know whether a request was processed or not. So, if the server was killed after a request was processed, but before a response was sent back to the batch export, retrying the request would produce a duplicate after it is processed a second time.

All in all, this means that retrying is not enough, and we should also review the server configuration to make sure it is gracefully shut down. But if it isn't, then I think we also don't want to fail here. 
 
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran existing tests, added new ones, will run this in development environment too.

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 LLM context

I pinged the robot to solve the most important problem: naming. It suggested the `RecyclingTCPConnector` name and I thought it was fine, so I used that. If any other suggestions come up, happy to consider them.

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
