### PR TITLE
feat(dashboards): show subscription count on subscribe button

### DIFF
--- a/frontend/src/lib/components/Scenes/SceneSubscribeButton.tsx
+++ b/frontend/src/lib/components/Scenes/SceneSubscribeButton.tsx
@@ -1,12 +1,14 @@
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
 import { IconBell } from '@posthog/icons'
 
+import { IconWithCount } from 'lib/lemon-ui/icons/icons'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 
 import { QueryBasedInsightModel } from '~/types'
 
+import { subscriptionsLogic } from '../Subscriptions/subscriptionsLogic'
 import { SubscriptionBaseProps, urlForSubscriptions } from '../Subscriptions/utils'
 import { SceneDataAttrKeyProps } from './utils'
 
@@ -22,6 +24,7 @@ export function SceneSubscribeButton({
     disabledReasons,
 }: SceneSubscribeButtonProps): JSX.Element {
     const { push } = useActions(router)
+    const { subscriptions } = useValues(subscriptionsLogic({ insightShortId: insight?.short_id, dashboardId }))
 
     return (
         <ButtonPrimitive
@@ -30,7 +33,9 @@ export function SceneSubscribeButton({
             data-attr={`${dataAttrKey}-subscribe-dropdown-menu-item`}
             disabledReasons={disabledReasons}
         >
-            <IconBell />
+            <IconWithCount count={subscriptions?.length} showZero={false}>
+                <IconBell />
+            </IconWithCount>
             Subscribe
         </ButtonPrimitive>
     )


### PR DESCRIPTION
## Problem

Dashboards (and insights) don't surface how many subscriptions are already configured until you open the subscriptions modal. Alerts on insights already show a small count badge on the bell icon in the scene panel — subscriptions should do the same.

## Changes

<img width="1400" height="794" alt="CleanShot 2026-04-16 at 17 53 37@2x" src="https://github.com/user-attachments/assets/df6d2c6e-8599-42b7-8a49-9059dcd2c5d6" />

## How did you test this code?

Locally

## Publish to changelog?

no

## 🤖 LLM context

Authored by a Cursor agent in one short session. Reference: `SceneAlertsButton` + `insightAlertsLogic` were used as the pattern; `subscriptionsLogic` already supports both keying modes so no backend / logic changes were needed.

Made with [Cursor](https://cursor.com)