### PR TITLE
chore: hide "Last used" badge with only one login method

### DIFF
--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -96,7 +96,8 @@ export function Login(): JSX.Element {
     const prevEmail = usePrevious(login.email)
 
     // Hide the "Last used" badge when there's only one login method (e.g. self-hosted with just password)
-    const hasMultipleLoginMethods = socialAuthAvailable || precheckResponse.saml_available
+    const hasMultipleLoginMethods =
+        socialAuthAvailable || precheckResponse.saml_available || lastLoginMethod === 'passkey'
     const effectiveLastLoginMethod: LoginMethod = hasMultipleLoginMethods ? lastLoginMethod : null
 
     useEffect(() => {

--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -83,7 +83,7 @@ export function Login(): JSX.Element {
         signupUrl,
         resendResponseLoading,
     } = useValues(loginLogic)
-    const { preflight } = useValues(preflightLogic)
+    const { preflight, socialAuthAvailable } = useValues(preflightLogic)
 
     const passwordInputRef = useRef<HTMLInputElement>(null)
     const preventPasswordError = useRef(false)
@@ -95,17 +95,9 @@ export function Login(): JSX.Element {
     const lastLoginMethod = getCookie(LAST_LOGIN_METHOD_COOKIE) as LoginMethod
     const prevEmail = usePrevious(login.email)
 
-    // Only surface the "Last used" badge when there's more than one login method configured for the
-    // instance — otherwise (common on self-hosted with just password) the hint is redundant noise.
-    // Passkey is intentionally not counted: the button is always rendered on this page and it's tied
-    // to the same account as password, rather than being an independently configurable login method.
-    const socialProvidersCount = preflight
-        ? Object.values(preflight.available_social_auth_providers).filter(Boolean).length
-        : 0
-    const configuredLoginMethodsCount = precheckResponse.sso_enforcement
-        ? 1
-        : 1 /* password */ + (precheckResponse.saml_available ? 1 : 0) + socialProvidersCount
-    const effectiveLastLoginMethod: LoginMethod = configuredLoginMethodsCount >= 2 ? lastLoginMethod : null
+    // Hide the "Last used" badge when there's only one login method (e.g. self-hosted with just password)
+    const hasMultipleLoginMethods = socialAuthAvailable || precheckResponse.saml_available
+    const effectiveLastLoginMethod: LoginMethod = hasMultipleLoginMethods ? lastLoginMethod : null
 
     useEffect(() => {
         const wasPasswordHidden = wasPasswordHiddenRef.current

--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -95,6 +95,18 @@ export function Login(): JSX.Element {
     const lastLoginMethod = getCookie(LAST_LOGIN_METHOD_COOKIE) as LoginMethod
     const prevEmail = usePrevious(login.email)
 
+    // Only surface the "Last used" badge when there's more than one login method configured for the
+    // instance — otherwise (common on self-hosted with just password) the hint is redundant noise.
+    // Passkey is intentionally not counted: the button is always rendered on this page and it's tied
+    // to the same account as password, rather than being an independently configurable login method.
+    const socialProvidersCount = preflight
+        ? Object.values(preflight.available_social_auth_providers).filter(Boolean).length
+        : 0
+    const configuredLoginMethodsCount = precheckResponse.sso_enforcement
+        ? 1
+        : 1 /* password */ + (precheckResponse.saml_available ? 1 : 0) + socialProvidersCount
+    const effectiveLastLoginMethod: LoginMethod = configuredLoginMethodsCount >= 2 ? lastLoginMethod : null
+
     useEffect(() => {
         const wasPasswordHidden = wasPasswordHiddenRef.current
         wasPasswordHiddenRef.current = isPasswordHidden
@@ -210,7 +222,7 @@ export function Login(): JSX.Element {
                                         passwordInputRef.current?.focus()
                                     }
                                 }}
-                                badgeText={lastLoginMethod === 'password' ? 'Last used' : undefined}
+                                badgeText={effectiveLastLoginMethod === 'password' ? 'Last used' : undefined}
                             />
                         </LemonField>
                         <div className={clsx('PasswordWrapper', isPasswordHidden && 'zero-height')}>
@@ -267,7 +279,7 @@ export function Login(): JSX.Element {
                             <SSOEnforcedLoginButton
                                 provider={precheckResponse.sso_enforcement}
                                 email={login.email}
-                                isLastUsed={lastLoginMethod === precheckResponse.sso_enforcement}
+                                isLastUsed={effectiveLastLoginMethod === precheckResponse.sso_enforcement}
                             />
                         )}
 
@@ -276,7 +288,7 @@ export function Login(): JSX.Element {
                             <SSOEnforcedLoginButton
                                 provider="saml"
                                 email={login.email}
-                                isLastUsed={lastLoginMethod === 'saml'}
+                                isLastUsed={effectiveLastLoginMethod === 'saml'}
                             />
                         )}
                     </Form>
@@ -293,7 +305,7 @@ export function Login(): JSX.Element {
                     <SocialLoginButtons
                         caption="Or log in with"
                         topDivider
-                        lastUsedProvider={lastLoginMethod}
+                        lastUsedProvider={effectiveLastLoginMethod}
                         showPasskey
                     />
                 )}


### PR DESCRIPTION
## Problem

On self-hosted instances with only password authentication enabled, the "Last used" badge appears on the password field even though there's only one login method available. This badge is only meaningful when users have multiple login methods. 

## How did you test this code?
Logged in and out locally with a single auth method

## Publish to changelog?

no