### PR TITLE
perf(cymbal): cache cl100k_base tokenizer to fix CPU starvation

### DIFF
--- a/rust/cymbal/src/lib.rs
+++ b/rust/cymbal/src/lib.rs
@@ -27,6 +27,7 @@ pub mod symbol_store;
 pub mod teams;
 #[cfg(test)]
 pub mod test_utils;
+pub mod tokenizer;
 pub mod types;
 
 pub fn recursively_sanitize_properties(

--- a/rust/cymbal/src/signals.rs
+++ b/rust/cymbal/src/signals.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
 use serde::Serialize;
-use tiktoken_rs::cl100k_base;
 use tracing::warn;
 
 use crate::config::Config;
 use crate::issue_resolution::Issue;
 use crate::metric_consts::{SIGNAL_EMITTED, SIGNAL_EMIT_FAILED, SIGNAL_EMIT_RESPONSE};
+use crate::tokenizer::CL100K_BPE;
 use crate::types::OutputErrProps;
 
 /// Signal payload matching the Django internal API contract.
@@ -39,9 +39,7 @@ impl<'a> From<IssueSignalContext<'a>> for EmitSignalRequest {
             ctx.issue.name.as_deref().unwrap_or("Unknown"),
             ctx.issue.description.as_deref().unwrap_or(""),
         );
-        let header_tokens = cl100k_base()
-            .map(|bpe| bpe.encode_with_special_tokens(&header).len())
-            .unwrap_or(0);
+        let header_tokens = CL100K_BPE.encode_with_special_tokens(&header).len();
         let stacktrace = ctx.props.print_stacktrace(Some(8000 - header_tokens));
         let description = format!("{header}\n```\n{stacktrace}\n```");
 

--- a/rust/cymbal/src/tokenizer.rs
+++ b/rust/cymbal/src/tokenizer.rs
@@ -1,0 +1,33 @@
+//! Cached tiktoken cl100k_base encoder.
+//!
+//! `tiktoken_rs::cl100k_base()` rebuilds the entire BPE encoder on every call
+//! (decoding ~100k vocabulary entries and constructing several HashMaps), which
+//! costs ~50-200ms of CPU per invocation. We call it on hot paths — every signal
+//! emission and every stacktrace truncation check — so we cache it once for the
+//! lifetime of the process.
+
+use once_cell::sync::Lazy;
+use tiktoken_rs::{cl100k_base, CoreBPE};
+
+pub static CL100K_BPE: Lazy<CoreBPE> =
+    Lazy::new(|| cl100k_base().expect("cl100k_base encoder must be constructible"));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cl100k_bpe_is_reused_across_calls() {
+        // Two derefs should yield the same underlying instance (same address),
+        // proving the encoder is initialized once and reused.
+        let first: *const CoreBPE = &*CL100K_BPE;
+        let second: *const CoreBPE = &*CL100K_BPE;
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn cl100k_bpe_encodes_text() {
+        let tokens = CL100K_BPE.encode_with_special_tokens("hello world");
+        assert!(!tokens.is_empty());
+    }
+}

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -6,7 +6,6 @@ use sha2::{Digest, Sha512};
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::ops::{Deref, DerefMut};
-use tiktoken_rs::cl100k_base;
 use uuid::Uuid;
 
 use crate::fingerprinting::{
@@ -17,6 +16,7 @@ use crate::frames::{Frame, RawFrame};
 use crate::issue_resolution::Issue;
 use crate::langs::apple::AppleDebugImage;
 use crate::metric_consts::POSTHOG_SDK_EXCEPTION_RESOLVED;
+use crate::tokenizer::CL100K_BPE;
 
 mod exception;
 mod stacktrace;
@@ -385,7 +385,7 @@ impl OutputErrProps {
             return full;
         };
 
-        let bpe = cl100k_base().unwrap();
+        let bpe = &*CL100K_BPE;
         let tokens = bpe.encode_with_special_tokens(&full);
 
         if tokens.len() <= limit {


### PR DESCRIPTION
## Problem

Cymbal was burning huge amounts of CPU on `tiktoken_rs::cl100k_base()` and emitting `sqlx::pool::acquire` slow-acquire warnings (`acquired_after_secs > 5`). A CPU diff flame graph showed `MaybeSignalClient::emit_issue_created` jumping from ~19% baseline to ~65% of total CPU (+232%, ~16 minutes of CPU time), with the bulk of that time spent inside `tiktoken_rs` constructing the BPE encoder (deep `hashbrown` / sort towers).

`tiktoken_rs::cl100k_base()` rebuilds the entire encoder on every call:

- decodes ~100k base64-encoded vocabulary entries
- constructs several `HashMap`s
- builds the BPE merge ranks
- compiles the GPT-4 splitter regex

That's roughly 50–200 ms of pure CPU per call. We were calling it on hot paths:

- `EmitSignalRequest::from` (every emitted signal — issue created / reopened / spiking)
- `ExceptionProperties::print_stacktrace` (called by every signal emission for token-budgeted truncation)

So every new issue triggered two full encoder rebuilds, run on the shared tokio runtime via `tokio::spawn`. Under load this starved runtime workers, which in turn starved the sqlx pool's internal wakeups — manifesting as the slow-acquire warnings and downstream `/process` lag, even though the pool itself wasn't actually exhausted.

## Changes

- New `cymbal::tokenizer` module exposing a single `Lazy<CoreBPE>` (`CL100K_BPE`) — built once for the lifetime of the process.
- `signals.rs` and `types/mod.rs` now use the cached encoder instead of calling `cl100k_base()` directly.
- Two unit tests asserting the encoder is reused across calls and that encoding still works.

`CoreBPE` is plain data (no interior mutability) so a shared `&'static` reference is safe for concurrent use.

## How did you test this code?

- `cargo build -p cymbal` clean, no new warnings.
- `cargo test -p cymbal --lib tokenizer::` — both new tests pass.
- Existing cymbal tests still pass.
- I'm an agent; I have not deployed or run a production load test. The expected behavioral effect is purely a perf/CPU reduction — the cached encoder produces identical token counts to the previously-rebuilt one.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 LLM context

Authored by Claude (Opus 4.7, 1M context). Investigation started from a `sqlx::pool::acquire` slow-acquire warning and a CPU diff flame graph; root cause turned out to be repeated tokenizer construction starving the tokio runtime, not actual pool exhaustion. Several follow-ups were identified but intentionally left out of this PR to keep it minimal and easy to revert:

- bound concurrency on spawned signal emissions (currently unbounded `tokio::spawn`)
- drop PG connections / commit transactions in `linking/issue.rs` before invoking `signal_client.emit_*`
- raise `max_pg_connections` (currently 4) and add `acquire_timeout` on the pool
- apply the same `Lazy<CoreBPE>` pattern in `embedding-worker` (same anti-pattern there, less hot)
