### PR TITLE
fix(surveys): restore safe survey response queries

### DIFF
--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -11,6 +11,7 @@ import {
     SurveyDisplayConditions,
     SurveyEventName,
     SurveyEventProperties,
+    SurveyQuestion,
     SurveyQuestionType,
     SurveyType,
     SurveyWidgetType,
@@ -252,6 +253,33 @@ describe('survey utils', () => {
                 $survey_response_q3: ['Funnels', 'Session replay'],
                 $survey_response_q4: '9',
             })
+        })
+    })
+
+    describe('getSurveyResponse', () => {
+        it('uses the backend HogQL helper for single-value questions', () => {
+            const question = {
+                id: 'question-123',
+                type: SurveyQuestionType.Rating,
+                question: 'How satisfied are you?',
+                scale: 10,
+                display: 'number',
+                lowerBoundLabel: 'Low',
+                upperBoundLabel: 'High',
+            } as SurveyQuestion
+
+            expect(getSurveyResponse(question, 0)).toBe("getSurveyResponse(0, 'question-123')")
+        })
+
+        it('uses the backend HogQL helper for multiple choice questions', () => {
+            const question = {
+                id: 'question-456',
+                type: SurveyQuestionType.MultipleChoice,
+                question: 'Which features do you use?',
+                choices: ['Insights', 'Session replay'],
+            } as SurveyQuestion
+
+            expect(getSurveyResponse(question, 1)).toBe("getSurveyResponse(1, 'question-456', true)")
         })
     })
 

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -370,20 +370,15 @@ function escapeSqlString(value: string): string {
 }
 
 export function getSurveyResponse(question: SurveyQuestion, index: number): string {
-    const { indexBasedKey, idBasedKey } = getResponseFieldWithId(index, question.id)
-
+    // Delegate to the backend HogQL helper so survey response typing stays
+    // consistent with PropertyDefinition metadata and materialized column rules.
     if (question.type === SurveyQuestionType.MultipleChoice) {
-        return `if(
-        JSONHas(events.properties, '${idBasedKey}') AND length(JSONExtractArrayRaw(events.properties, '${idBasedKey}')) > 0,
-        JSONExtractArrayRaw(events.properties, '${idBasedKey}'),
-        JSONExtractArrayRaw(events.properties, '${indexBasedKey}')
-    )`
+        return question.id
+            ? `getSurveyResponse(${index}, '${question.id}', true)`
+            : `getSurveyResponse(${index}, '', true)`
     }
 
-    return `COALESCE(
-        NULLIF(events.properties['${idBasedKey}'], ''),
-        NULLIF(events.properties['${indexBasedKey}'], '')
-    )`
+    return question.id ? `getSurveyResponse(${index}, '${question.id}')` : `getSurveyResponse(${index})`
 }
 
 /**


### PR DESCRIPTION
## Problem

A recent surveys query change switched consolidated survey result queries to direct property access for survey responses. For surveys where one response key is treated as numeric and the legacy fallback key is treated as string, ClickHouse rejects the generated `coalesce(...)` with `NO_COMMON_TYPE`.

## Changes

Restore the frontend survey query helper to emit the backend `getSurveyResponse(...)` HogQL helper instead of duplicating the response extraction inline.

Add a focused frontend regression test so the helper continues to route through the backend implementation for both single-value and multiple-choice questions.

## How did you test this code?

- `hogli test frontend/src/scenes/surveys/utils.test.ts`
- Attempted `hogli test posthog/hogql/printer/test/test_printer.py -k get_survey_response`, but local Postgres is not available in this environment

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 LLM context

Authored in Codex. The key point from debugging was that the broken compiled query mixed a numeric survey response branch with a string fallback branch inside `coalesce(...)`. This fix routes the frontend back through the existing backend HogQL helper, which already guards against that type mismatch.
