### PR TITLE
fix(insights): return boxplot data in results instead of separate field

### DIFF
--- a/ee/hogai/context/insight/format/__init__.py
+++ b/ee/hogai/context/insight/format/__init__.py
@@ -48,10 +48,8 @@ if TYPE_CHECKING:
 
 
 def is_boxplot_query(query: BaseModel) -> bool:
-    return (
-        getattr(query, "trendsFilter", None) is not None
-        and getattr(query.trendsFilter, "display", None) == ChartDisplayType.BOX_PLOT
-    )
+    trends_filter = getattr(query, "trendsFilter", None)
+    return trends_filter is not None and getattr(trends_filter, "display", None) == ChartDisplayType.BOX_PLOT
 
 
 def get_boxplot_results(response: dict[str, Any]) -> list[Any]:

--- a/ee/hogai/context/insight/format/__init__.py
+++ b/ee/hogai/context/insight/format/__init__.py
@@ -47,6 +47,19 @@ if TYPE_CHECKING:
     from posthog.models import Team
 
 
+def is_boxplot_query(query: BaseModel) -> bool:
+    return (
+        getattr(query, "trendsFilter", None) is not None
+        and getattr(query.trendsFilter, "display", None) == ChartDisplayType.BOX_PLOT
+    )
+
+
+def get_boxplot_results(response: dict[str, Any]) -> list[Any]:
+    # TODO: remove boxplot_data fallback once cached responses have rotated (added 2026-04-17)
+    results = response.get("results", [])
+    return results if results else response.get("boxplot_data", [])
+
+
 def format_query_results_for_llm(
     query: BaseModel,
     response: dict[str, Any],
@@ -69,11 +82,8 @@ def format_query_results_for_llm(
         query = query.source
 
     if isinstance(query, AssistantTrendsQuery | TrendsQuery):
-        if (
-            getattr(query, "trendsFilter", None)
-            and getattr(query.trendsFilter, "display", None) == ChartDisplayType.BOX_PLOT
-        ):
-            return BoxPlotResultsFormatter(response["results"]).format()
+        if is_boxplot_query(query):
+            return BoxPlotResultsFormatter(get_boxplot_results(response)).format()
         return TrendsResultsFormatter(query, response["results"]).format()
     elif isinstance(query, AssistantFunnelsQuery | FunnelsQuery):
         return FunnelResultsFormatter(query, response["results"], team, utc_now).format()

--- a/ee/hogai/context/insight/format/__init__.py
+++ b/ee/hogai/context/insight/format/__init__.py
@@ -11,6 +11,7 @@ from posthog.schema import (
     AssistantRetentionQuery,
     AssistantStickinessQuery,
     AssistantTrendsQuery,
+    ChartDisplayType,
     DataTableNode,
     DataVisualizationNode,
     FunnelsQuery,
@@ -68,9 +69,11 @@ def format_query_results_for_llm(
         query = query.source
 
     if isinstance(query, AssistantTrendsQuery | TrendsQuery):
-        boxplot_data = response.get("boxplot_data")
-        if boxplot_data is not None:
-            return BoxPlotResultsFormatter(boxplot_data).format()
+        if (
+            getattr(query, "trendsFilter", None)
+            and getattr(query.trendsFilter, "display", None) == ChartDisplayType.BOX_PLOT
+        ):
+            return BoxPlotResultsFormatter(response["results"]).format()
         return TrendsResultsFormatter(query, response["results"]).format()
     elif isinstance(query, AssistantFunnelsQuery | FunnelsQuery):
         return FunnelResultsFormatter(query, response["results"], team, utc_now).format()

--- a/ee/hogai/context/insight/format/test/test_format_query_results_for_llm.py
+++ b/ee/hogai/context/insight/format/test/test_format_query_results_for_llm.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 from parameterized import parameterized
 
 from posthog.schema import (
+    ChartDisplayType,
     DataTableNode,
     DataVisualizationNode,
     EventsNode,
@@ -13,6 +14,7 @@ from posthog.schema import (
     InsightVizNode,
     LifecycleQuery,
     StickinessQuery,
+    TrendsFilter,
     TrendsQuery,
 )
 
@@ -24,10 +26,9 @@ class TestFormatQueryResultsForLlm(TestCase):
         [
             (
                 "boxplot_data_uses_boxplot_formatter",
-                TrendsQuery(series=[]),
+                TrendsQuery(series=[], trendsFilter=TrendsFilter(display=ChartDisplayType.BOX_PLOT)),
                 {
-                    "results": [],
-                    "boxplot_data": [
+                    "results": [
                         {
                             "day": "2025-01-20",
                             "label": "Day 1",
@@ -102,8 +103,8 @@ class TestFormatQueryResultsForLlm(TestCase):
 
     def test_boxplot_empty_list_still_uses_boxplot_formatter(self):
         team = MagicMock()
-        query = TrendsQuery(series=[])
-        response: dict[str, Any] = {"results": [], "boxplot_data": []}
+        query = TrendsQuery(series=[], trendsFilter=TrendsFilter(display=ChartDisplayType.BOX_PLOT))
+        response: dict[str, Any] = {"results": []}
         result = format_query_results_for_llm(query, response, team)
         self.assertEqual(result, "No data recorded for this time period.")
 

--- a/ee/hogai/context/insight/query_executor.py
+++ b/ee/hogai/context/insight/query_executor.py
@@ -66,6 +66,8 @@ from ee.hogai.context.insight.format import (
     SQLResultsFormatter,
     StickinessResultsFormatter,
     TrendsResultsFormatter,
+    get_boxplot_results,
+    is_boxplot_query,
 )
 from ee.hogai.tool_errors import MaxToolRetryableError
 from ee.hogai.utils.prompt import format_prompt_string
@@ -461,12 +463,9 @@ class AssistantQueryExecutor:
         try:
             # Handle assistant-specific query types with direct formatting
             if isinstance(query, AssistantTrendsQuery | TrendsQuery):
-                if (
-                    getattr(query, "trendsFilter", None)
-                    and getattr(query.trendsFilter, "display", None) == ChartDisplayType.BOX_PLOT
-                ):
+                if is_boxplot_query(query):
                     formatter_name = "BoxPlotResultsFormatter"
-                    result = BoxPlotResultsFormatter(response["results"]).format()
+                    result = BoxPlotResultsFormatter(get_boxplot_results(response)).format()
                 else:
                     formatter_name = "TrendsResultsFormatter"
                     result = TrendsResultsFormatter(query, response["results"]).format()

--- a/ee/hogai/context/insight/query_executor.py
+++ b/ee/hogai/context/insight/query_executor.py
@@ -461,10 +461,12 @@ class AssistantQueryExecutor:
         try:
             # Handle assistant-specific query types with direct formatting
             if isinstance(query, AssistantTrendsQuery | TrendsQuery):
-                boxplot_data = response.get("boxplot_data")
-                if boxplot_data is not None:
+                if (
+                    getattr(query, "trendsFilter", None)
+                    and getattr(query.trendsFilter, "display", None) == ChartDisplayType.BOX_PLOT
+                ):
                     formatter_name = "BoxPlotResultsFormatter"
-                    result = BoxPlotResultsFormatter(boxplot_data).format()
+                    result = BoxPlotResultsFormatter(response["results"]).format()
                 else:
                     formatter_name = "TrendsResultsFormatter"
                     result = TrendsResultsFormatter(query, response["results"]).format()

--- a/ee/hogai/context/insight/test/test_query_executor.py
+++ b/ee/hogai/context/insight/test/test_query_executor.py
@@ -440,10 +440,12 @@ class TestAssistantQueryExecutor(NonAtomicBaseTest):
         self.assertIn("2025-01-20|46|120|15|-30", result)
 
     async def test_compress_results_boxplot_data(self):
-        query = TrendsQuery(series=[EventsNode(event="$pageview")])
+        query = TrendsQuery(
+            series=[EventsNode(event="$pageview")],
+            trendsFilter=TrendsFilter(display=ChartDisplayType.BOX_PLOT),
+        )
         response: dict[str, Any] = {
-            "results": [],
-            "boxplot_data": [
+            "results": [
                 {
                     "day": "2025-01-20",
                     "label": "Day 1",

--- a/frontend/src/mocks/fixtures/api/projects/team_id/insights/trendsBoxPlot.json
+++ b/frontend/src/mocks/fixtures/api/projects/team_id/insights/trendsBoxPlot.json
@@ -12,8 +12,7 @@
     "color": null,
     "last_refresh": null,
     "refreshing": false,
-    "result": [],
-    "boxplot_data": [
+    "result": [
         {
             "day": "2022-03-05",
             "label": "5-Mar-2022",

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -8723,7 +8723,7 @@
             "additionalProperties": false,
             "properties": {
                 "boxplot_data": {
-                    "description": "Box plot data when display type is BoxPlot",
+                    "deprecated": "Box plot data is now returned in results. This field is no longer populated.",
                     "items": {
                         "$ref": "#/definitions/BoxPlotDatum"
                     },
@@ -30273,7 +30273,7 @@
                     "additionalProperties": false,
                     "properties": {
                         "boxplot_data": {
-                            "description": "Box plot data when display type is BoxPlot",
+                            "deprecated": "Box plot data is now returned in results. This field is no longer populated.",
                             "items": {
                                 "$ref": "#/definitions/BoxPlotDatum"
                             },
@@ -37083,7 +37083,7 @@
             "additionalProperties": false,
             "properties": {
                 "boxplot_data": {
-                    "description": "Box plot data when display type is BoxPlot",
+                    "deprecated": "Box plot data is now returned in results. This field is no longer populated.",
                     "items": {
                         "$ref": "#/definitions/BoxPlotDatum"
                     },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1440,7 +1440,7 @@ export interface TrendsQueryResponse extends AnalyticsQueryResponseBase {
     results: Record<string, any>[]
     /** Wether more breakdown values are available. */
     hasMore?: boolean
-    /** Box plot data when display type is BoxPlot */
+    /** @deprecated Box plot data is now returned in results. This field is no longer populated. */
     boxplot_data?: BoxPlotDatum[]
 }
 

--- a/frontend/src/scenes/insights/__mocks__/createInsightScene.tsx
+++ b/frontend/src/scenes/insights/__mocks__/createInsightScene.tsx
@@ -86,8 +86,6 @@ export function createInsightStory(
                         // sql insights
                         columns: (insight as any).columns,
                         types: (insight as any).types,
-                        // trends box plot insight
-                        boxplot_data: (insight as any).boxplot_data,
                     }),
                 ],
             },

--- a/frontend/src/scenes/insights/views/BoxPlot/boxPlotChartLogic.tsx
+++ b/frontend/src/scenes/insights/views/BoxPlot/boxPlotChartLogic.tsx
@@ -41,6 +41,7 @@ export const boxPlotChartLogic = kea<boxPlotChartLogicType>([
             (s) => [s.insightData],
             (insightData): BoxPlotDatum[] => {
                 const result = insightData?.result ?? insightData?.results
+                // TODO: remove boxplot_data fallback once cached responses have rotated (added 2026-04-16)
                 const data = Array.isArray(result) && result.length > 0 ? result : insightData?.boxplot_data
                 if (!Array.isArray(data) || data.length === 0) {
                     return []

--- a/frontend/src/scenes/insights/views/BoxPlot/boxPlotChartLogic.tsx
+++ b/frontend/src/scenes/insights/views/BoxPlot/boxPlotChartLogic.tsx
@@ -40,10 +40,12 @@ export const boxPlotChartLogic = kea<boxPlotChartLogicType>([
         boxplotData: [
             (s) => [s.insightData],
             (insightData): BoxPlotDatum[] => {
-                if (!insightData?.boxplot_data) {
+                const result = insightData?.result ?? insightData?.results
+                const data = Array.isArray(result) && result.length > 0 ? result : insightData?.boxplot_data
+                if (!Array.isArray(data) || data.length === 0) {
                     return []
                 }
-                return insightData.boxplot_data
+                return data
             },
         ],
         seriesGroups: [

--- a/posthog/hogql_queries/insights/trends/boxplot_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/boxplot_trends_query_runner.py
@@ -27,7 +27,6 @@ class BoxPlotTrendsQueryRunner(TrendsQueryRunner):
         if any(not s.math_property for s in self.query.series):
             return TrendsQueryResponse(
                 results=[],
-                boxplot_data=[],
                 modifiers=self.modifiers,
                 error="A numeric property must be selected for box plot.",
                 resolved_date_range=resolved_date_range,
@@ -79,7 +78,6 @@ class BoxPlotTrendsQueryRunner(TrendsQueryRunner):
             elif getattr(series_node, "math_property_type", None) == "session_properties":
                 return TrendsQueryResponse(
                     results=[],
-                    boxplot_data=[],
                     modifiers=self.modifiers,
                     error=f"Unsupported session property: {series_node.math_property}",
                     resolved_date_range=resolved_date_range,
@@ -155,8 +153,7 @@ class BoxPlotTrendsQueryRunner(TrendsQueryRunner):
                     )
 
         return TrendsQueryResponse(
-            results=[],
-            boxplot_data=all_boxplot_data,
+            results=[d.model_dump() for d in all_boxplot_data],
             timings=all_timings or None,
             hogql=response_hogql,
             error=". ".join(debug_errors) if debug_errors else None,

--- a/posthog/hogql_queries/insights/trends/test/test_boxplot_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_boxplot_trends_query_runner.py
@@ -12,7 +12,7 @@ from posthog.test.base import (
 
 from parameterized import parameterized
 
-from posthog.schema import ChartDisplayType, DateRange, EventsNode, TrendsFilter, TrendsQuery
+from posthog.schema import BoxPlotDatum, ChartDisplayType, DateRange, EventsNode, TrendsFilter, TrendsQuery
 
 from posthog.hogql_queries.insights.trends.boxplot_trends_query_runner import BoxPlotTrendsQueryRunner
 from posthog.models.utils import uuid7
@@ -61,7 +61,9 @@ class TestBoxPlotTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             series=series or [EventsNode(kind="EventsNode", math="sum", math_property=math_property)],
         )
         runner = BoxPlotTrendsQueryRunner(team=self.team, query=query)
-        return runner.calculate()
+        response = runner.calculate()
+        response.boxplot_data = [BoxPlotDatum(**d) for d in response.results]
+        return response
 
     @snapshot_clickhouse_queries
     def test_no_data_fills_all_dates_with_zeros(self):
@@ -72,7 +74,6 @@ class TestBoxPlotTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             assert datum.min == 0.0
             assert datum.max == 0.0
             assert datum.mean == 0.0
-        assert response.results == []
 
     @parameterized.expand(
         [

--- a/posthog/hogql_queries/insights/trends/test/test_boxplot_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_boxplot_trends_query_runner.py
@@ -61,16 +61,19 @@ class TestBoxPlotTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             series=series or [EventsNode(kind="EventsNode", math="sum", math_property=math_property)],
         )
         runner = BoxPlotTrendsQueryRunner(team=self.team, query=query)
-        response = runner.calculate()
-        response.boxplot_data = [BoxPlotDatum(**d) for d in response.results]
-        return response
+        return runner.calculate()
+
+    @staticmethod
+    def _parse_boxplot_results(response) -> list[BoxPlotDatum]:
+        return [BoxPlotDatum(**d) for d in response.results]
 
     @snapshot_clickhouse_queries
     def test_no_data_fills_all_dates_with_zeros(self):
         response = self._run_boxplot_query("2023-12-08", "2023-12-10")
+        data = self._parse_boxplot_results(response)
 
-        assert len(response.boxplot_data) == 3
-        for datum in response.boxplot_data:
+        assert len(data) == 3
+        for datum in data:
             assert datum.min == 0.0
             assert datum.max == 0.0
             assert datum.mean == 0.0
@@ -140,9 +143,10 @@ class TestBoxPlotTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         response = self._run_boxplot_query("2023-12-02", "2023-12-02")
+        data = self._parse_boxplot_results(response)
 
-        assert len(response.boxplot_data) == 1
-        datum = response.boxplot_data[0]
+        assert len(data) == 1
+        datum = data[0]
 
         assert datum.min == expected_min
         assert datum.max == expected_max
@@ -166,17 +170,18 @@ class TestBoxPlotTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         response = self._run_boxplot_query("2023-12-02", "2023-12-03")
+        data = self._parse_boxplot_results(response)
 
-        assert len(response.boxplot_data) == 2
+        assert len(data) == 2
 
-        day1 = response.boxplot_data[0]
+        day1 = data[0]
         assert day1.day == "2023-12-02"
         assert day1.min == 100.0
         assert day1.max == 200.0
         assert day1.mean == 150.0
         assert day1.min <= day1.p25 <= day1.median <= day1.p75 <= day1.max
 
-        day2 = response.boxplot_data[1]
+        day2 = data[1]
         assert day2.day == "2023-12-03"
         assert day2.min == 500.0
         assert day2.max == 600.0
@@ -194,9 +199,10 @@ class TestBoxPlotTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         response = self._run_boxplot_query("2023-12-02", "2023-12-02")
+        data = self._parse_boxplot_results(response)
 
-        assert len(response.boxplot_data) == 1
-        datum = response.boxplot_data[0]
+        assert len(data) == 1
+        datum = data[0]
         assert datum.min == 10.0
         assert datum.max == 90.0
         assert datum.mean == 50.0
@@ -216,8 +222,9 @@ class TestBoxPlotTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         response = self._run_boxplot_query("2023-12-01", "2023-12-07")
+        data = self._parse_boxplot_results(response)
 
-        days = [d.day for d in response.boxplot_data]
+        days = [d.day for d in data]
         assert days == [
             "2023-12-01",
             "2023-12-02",
@@ -228,7 +235,7 @@ class TestBoxPlotTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             "2023-12-07",
         ]
 
-        days_with_data = {d.day: d for d in response.boxplot_data}
+        days_with_data = {d.day: d for d in data}
         assert days_with_data["2023-12-01"].min == 100.0
         assert days_with_data["2023-12-05"].min == 500.0
 
@@ -260,10 +267,11 @@ class TestBoxPlotTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         response = self._run_boxplot_query(date_from, date_to, interval=interval)
 
-        assert len(response.boxplot_data) >= 1
+        data = self._parse_boxplot_results(response)
+        assert len(data) >= 1
         from datetime import datetime
 
-        datetime.strptime(response.boxplot_data[0].day, expected_format)
+        datetime.strptime(data[0].day, expected_format)
 
     @parameterized.expand(
         [
@@ -290,8 +298,9 @@ class TestBoxPlotTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         response = self._run_boxplot_query("2023-12-02", "2023-12-02", filter_test_accounts=filter_test_accounts)
 
-        assert len(response.boxplot_data) == 1
-        assert response.boxplot_data[0].max == expected_max
+        data = self._parse_boxplot_results(response)
+        assert len(data) == 1
+        assert data[0].max == expected_max
 
     @parameterized.expand(
         [
@@ -331,9 +340,10 @@ class TestBoxPlotTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         response = self._run_boxplot_query("2023-12-02", "2023-12-02", properties=properties)
 
-        assert len(response.boxplot_data) == 1
-        assert response.boxplot_data[0].min == expected_min
-        assert response.boxplot_data[0].max == expected_max
+        data = self._parse_boxplot_results(response)
+        assert len(data) == 1
+        assert data[0].min == expected_min
+        assert data[0].max == expected_max
 
     @snapshot_clickhouse_queries
     def test_multiple_series_returns_data_for_each(self):
@@ -354,9 +364,10 @@ class TestBoxPlotTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-        assert len(response.boxplot_data) == 2
-        series_0 = [d for d in response.boxplot_data if d.series_index == 0]
-        series_1 = [d for d in response.boxplot_data if d.series_index == 1]
+        data = self._parse_boxplot_results(response)
+        assert len(data) == 2
+        series_0 = [d for d in data if d.series_index == 0]
+        series_1 = [d for d in data if d.series_index == 1]
         assert len(series_0) == 1
         assert len(series_1) == 1
         assert series_0[0].min == 100.0
@@ -384,9 +395,10 @@ class TestBoxPlotTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         response = self._run_boxplot_query("2023-12-02", "2023-12-02")
+        data = self._parse_boxplot_results(response)
 
-        assert len(response.boxplot_data) == 1
-        datum = response.boxplot_data[0]
+        assert len(data) == 1
+        datum = data[0]
         assert datum.min == 0.0
         assert datum.max == 0.0
         assert datum.mean == 0.0
@@ -410,12 +422,13 @@ class TestBoxPlotTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         response = self._run_boxplot_query("2023-12-01", "2023-12-05")
+        data = self._parse_boxplot_results(response)
 
-        days = [d.day for d in response.boxplot_data]
+        days = [d.day for d in data]
         assert days == ["2023-12-01", "2023-12-02", "2023-12-03", "2023-12-04", "2023-12-05"]
-        assert response.boxplot_data[0].min == 100.0
-        assert response.boxplot_data[2].min == 300.0
-        assert response.boxplot_data[4].min == 500.0
+        assert data[0].min == 100.0
+        assert data[2].min == 300.0
+        assert data[4].min == 500.0
 
     @snapshot_clickhouse_queries
     def test_custom_event_name(self):
@@ -430,8 +443,9 @@ class TestBoxPlotTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             series=[EventsNode(kind="EventsNode", event="purchase", math="sum", math_property="amount")],
         )
 
-        assert len(response.boxplot_data) == 1
-        assert response.boxplot_data[0].min == 42.0
+        data = self._parse_boxplot_results(response)
+        assert len(data) == 1
+        assert data[0].min == 42.0
 
     @snapshot_clickhouse_queries
     def test_each_datum_has_label_and_day(self):
@@ -449,7 +463,7 @@ class TestBoxPlotTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         response = self._run_boxplot_query("2023-12-02", "2023-12-03")
 
-        for datum in response.boxplot_data:
+        for datum in self._parse_boxplot_results(response):
             assert datum.day is not None
             assert datum.label is not None
             assert len(datum.label) > 0
@@ -494,8 +508,9 @@ class TestBoxPlotTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             ],
         )
 
-        assert len(response.boxplot_data) == 1
-        datum = response.boxplot_data[0]
+        data = self._parse_boxplot_results(response)
+        assert len(data) == 1
+        datum = data[0]
         assert datum.day == "2023-12-02"
         assert datum.min > 0
         assert datum.max > 0

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -8488,11 +8488,7 @@ class TrendsQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    boxplot_data: list[BoxPlotDatum] | None = Field(
-        default=None,
-        description="Deprecated: box plot data is now returned in results. This field is no longer populated.",
-        deprecated="Box plot data is now returned in results.",
-    )
+    boxplot_data: list[BoxPlotDatum] | None = None
     error: str | None = Field(
         default=None,
         description=(
@@ -11644,11 +11640,7 @@ class CachedTrendsQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    boxplot_data: list[BoxPlotDatum] | None = Field(
-        default=None,
-        description="Deprecated: box plot data is now returned in results. This field is no longer populated.",
-        deprecated="Box plot data is now returned in results.",
-    )
+    boxplot_data: list[BoxPlotDatum] | None = None
     cache_key: str
     cache_target_age: AwareDatetime | None = None
     calculation_trigger: str | None = Field(
@@ -16453,11 +16445,7 @@ class QueryResponseAlternative66(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    boxplot_data: list[BoxPlotDatum] | None = Field(
-        default=None,
-        description="Deprecated: box plot data is now returned in results. This field is no longer populated.",
-        deprecated="Box plot data is now returned in results.",
-    )
+    boxplot_data: list[BoxPlotDatum] | None = None
     error: str | None = Field(
         default=None,
         description=(

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -8489,7 +8489,9 @@ class TrendsQueryResponse(BaseModel):
         extra="forbid",
     )
     boxplot_data: list[BoxPlotDatum] | None = Field(
-        default=None, description="Box plot data when display type is BoxPlot"
+        default=None,
+        description="Deprecated: box plot data is now returned in results. This field is no longer populated.",
+        deprecated="Box plot data is now returned in results.",
     )
     error: str | None = Field(
         default=None,
@@ -11643,7 +11645,9 @@ class CachedTrendsQueryResponse(BaseModel):
         extra="forbid",
     )
     boxplot_data: list[BoxPlotDatum] | None = Field(
-        default=None, description="Box plot data when display type is BoxPlot"
+        default=None,
+        description="Deprecated: box plot data is now returned in results. This field is no longer populated.",
+        deprecated="Box plot data is now returned in results.",
     )
     cache_key: str
     cache_target_age: AwareDatetime | None = None
@@ -16450,7 +16454,9 @@ class QueryResponseAlternative66(BaseModel):
         extra="forbid",
     )
     boxplot_data: list[BoxPlotDatum] | None = Field(
-        default=None, description="Box plot data when display type is BoxPlot"
+        default=None,
+        description="Deprecated: box plot data is now returned in results. This field is no longer populated.",
+        deprecated="Box plot data is now returned in results.",
     )
     error: str | None = Field(
         default=None,

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -999,11 +999,7 @@ export interface QueryTimingApi {
 export type TrendsQueryResponseApiResultsItem = { [key: string]: unknown }
 
 export interface TrendsQueryResponseApi {
-    /**
-     * Deprecated: box plot data is now returned in results. This field is no longer populated.
-     * @deprecated
-     * @nullable
-     */
+    /** @nullable */
     boxplot_data?: BoxPlotDatumApi[] | null
     /**
      * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -1000,7 +1000,8 @@ export type TrendsQueryResponseApiResultsItem = { [key: string]: unknown }
 
 export interface TrendsQueryResponseApi {
     /**
-     * Box plot data when display type is BoxPlot
+     * Deprecated: box plot data is now returned in results. This field is no longer populated.
+     * @deprecated
      * @nullable
      */
     boxplot_data?: BoxPlotDatumApi[] | null

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2034,7 +2034,8 @@ export namespace Schemas {
 
     export interface TrendsQueryResponse {
       /**
-       * Box plot data when display type is BoxPlot
+       * Deprecated: box plot data is now returned in results. This field is no longer populated.
+       * @deprecated
        * @nullable
        */
       boxplot_data?: BoxPlotDatum[] | null;
@@ -30107,7 +30108,8 @@ export namespace Schemas {
 
     export interface QueryResponseAlternative66 {
       /**
-       * Box plot data when display type is BoxPlot
+       * Deprecated: box plot data is now returned in results. This field is no longer populated.
+       * @deprecated
        * @nullable
        */
       boxplot_data?: BoxPlotDatum[] | null;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -2033,11 +2033,7 @@ export namespace Schemas {
     export type TrendsQueryResponseResultsItem = { [key: string]: unknown };
 
     export interface TrendsQueryResponse {
-      /**
-       * Deprecated: box plot data is now returned in results. This field is no longer populated.
-       * @deprecated
-       * @nullable
-       */
+      /** @nullable */
       boxplot_data?: BoxPlotDatum[] | null;
       /**
        * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.
@@ -30107,11 +30103,7 @@ export namespace Schemas {
     export type QueryResponseAlternative66ResultsItem = { [key: string]: unknown };
 
     export interface QueryResponseAlternative66 {
-      /**
-       * Deprecated: box plot data is now returned in results. This field is no longer populated.
-       * @deprecated
-       * @nullable
-       */
+      /** @nullable */
       boxplot_data?: BoxPlotDatum[] | null;
       /**
        * Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.


### PR DESCRIPTION
## Problem

Boxplot insights show empty results in subscription emails and exports. This is because boxplot was the only insight type that returned its data in a separate `boxplot_data` field on `TrendsQueryResponse` instead of using `results` like every other insight type. The InsightSerializer pipeline only passes through `results`, so `boxplot_data` was silently dropped during export rendering.

## Changes

<img width="800" height="568" alt="CleanShot 2026-04-17 at 00 34 05" src="https://github.com/user-attachments/assets/270db533-a893-4e0e-8058-3e4afd461422" />

- **Backend**: `BoxPlotTrendsQueryRunner` now puts boxplot data into `results` (as dicts via `model_dump()`) instead of the separate `boxplot_data` field
- **Frontend**: `boxPlotChartLogic` reads from `result`/`results` first, with a fallback to `boxplot_data` for old cached responses
- **Schema**: `boxplot_data` field on `TrendsQueryResponse` marked as deprecated
- **AI context**: `format_query_results_for_llm` and `AssistantQueryExecutor` detect boxplot via query display type instead of checking for the presence of `boxplot_data`

## How did you test this code?

- Updated existing backend tests for `BoxPlotTrendsQueryRunner` to verify data flows through `results`
- Updated `format_query_results_for_llm` tests to use the new query-type-based detection
- Updated frontend mock fixture to match the new response shape
- This is an agent-authored PR — manual end-to-end testing of subscription delivery with a boxplot insight has not been performed

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 LLM context

Agent-authored PR. The root cause was that boxplot was special-cased with its own response field (`boxplot_data`) while all other insight types use `results`. This caused data loss in any pipeline that only passes through `results` (subscriptions, exports, cached insight rendering).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*