### PR TITLE
fix(replay): append 'd' suffix to bare integer date params in admin delete UI

### DIFF
--- a/posthog/admin/admins/team_admin.py
+++ b/posthog/admin/admins/team_admin.py
@@ -755,6 +755,14 @@ class TeamAdmin(admin.ModelAdmin):
 
                 date_from = request.POST.get("date_from", "").strip()
                 date_to = request.POST.get("date_to", "").strip()
+
+                # Relative dates need a "d" suffix (e.g. "-360d") — bare integers
+                # like "-360" get parsed as ints by query_as_params_to_dict and
+                # fail Pydantic validation downstream.
+                if date_from.lstrip("-").isdigit():
+                    date_from = f"{date_from}d"
+                if date_to.lstrip("-").isdigit():
+                    date_to = f"{date_to}d"
                 duration_min = request.POST.get("duration_min", "").strip()
                 duration_max = request.POST.get("duration_max", "").strip()
                 person_uuid = request.POST.get("person_uuid", "").strip()


### PR DESCRIPTION
## Problem

The admin UI for deleting recordings accepts bare integer date values like `-360` for `date_from` and `-1` for `date_to`. These get passed as a query string (`date_from=-360&date_to=-1`) to the Temporal workflow, where `query_as_params_to_dict` runs `json.loads` on each value. Since `json.loads("-360")` returns the integer `-360`, Pydantic validation on `RecordingsQuery.date_from` (which expects a string) fails with:

```
Input should be a valid string", "input": -360
```

The frontend avoids this because it always uses the `-360d` format — `json.loads("-360d")` raises `JSONDecodeError` and falls through to the string path.

## Changes

Normalize bare integer date inputs in the admin UI by appending a `d` suffix (e.g. `-360` → `-360d`). Absolute dates like `2026-01-01` are unaffected since they contain non-digit characters.

## How did you test this code?

Verified the logic: `"-360".lstrip("-").isdigit()` → `True` → appends `d`. `"2026-01-01".lstrip("-").isdigit()` → `False` → unchanged. `"-7d".lstrip("-").isdigit()` → `False` → unchanged.

no

## Docs update



## 🤖 LLM context

Root-caused from failed EU Temporal workflow `delete-recordings-57759-c43e24f5-492a-41d6-87dc-c26de880bb63`. The safer fix would be in `query_as_params_to_dict` to not convert scalar strings to ints, but that has broader blast radius so we're fixing at the admin UI input layer instead.