### PR TITLE
feat(oauth): add CIMD metadata endpoint for PostHog Wizard

### DIFF
--- a/ee/api/agentic_provisioning/authentication.py
+++ b/ee/api/agentic_provisioning/authentication.py
@@ -13,6 +13,7 @@ from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
 
+from posthog.api.oauth.cimd import get_application_by_client_id
 from posthog.models.oauth import OAuthApplication, find_oauth_access_token
 
 from .signature import _compute_hmac, _get_raw_body, _parse_signature_header
@@ -130,7 +131,7 @@ class ProvisioningAuthentication(BaseAuthentication):
 
     def _identify_pkce_partner(self, client_id: str) -> OAuthApplication | None:
         try:
-            app = OAuthApplication.objects.get(client_id=client_id)
+            app = get_application_by_client_id(client_id)
             if not app.is_provisioning_partner or not app.provisioning_active:
                 return None
             return app

--- a/ee/api/agentic_provisioning/test/test_provisioning_auth.py
+++ b/ee/api/agentic_provisioning/test/test_provisioning_auth.py
@@ -525,6 +525,78 @@ class TestProvisioningAuthentication(APIBaseTest):
         self.wizard_app.provisioning_can_provision_resources = True
         self.wizard_app.save(update_fields=["provisioning_can_provision_resources"])
 
+    # --- CIMD URL-based PKCE identification ---
+
+    def test_pkce_partner_identified_by_cimd_url(self):
+        cimd_url = "https://example.com/api/oauth/wizard/client-metadata"
+        cimd_app = OAuthApplication.objects.create(
+            name="CIMD Wizard",
+            client_secret="",
+            client_type=OAuthApplication.CLIENT_PUBLIC,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="http://localhost:8239/callback",
+            algorithm="RS256",
+            is_cimd_client=True,
+            cimd_metadata_url=cimd_url,
+            provisioning_auth_method="pkce",
+            provisioning_partner_type="wizard",
+            provisioning_active=True,
+            provisioning_can_create_accounts=True,
+            provisioning_can_provision_resources=True,
+        )
+
+        verifier, challenge = _pkce_pair()
+        res = self.client.post(
+            "/api/agentic/provisioning/account_requests",
+            data={
+                "id": "req_cimd_pkce",
+                "email": "cimd-wizard@example.com",
+                "client_id": cimd_url,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+            content_type="application/json",
+            HTTP_API_VERSION="0.1d",
+        )
+        assert res.status_code == 200
+        assert res.json()["type"] == "oauth"
+
+        cimd_app.delete()
+
+    def test_cimd_url_inactive_partner_rejected(self):
+        cimd_url = "https://example.com/api/oauth/wizard/client-metadata-inactive"
+        cimd_app = OAuthApplication.objects.create(
+            name="Inactive CIMD Wizard",
+            client_secret="",
+            client_type=OAuthApplication.CLIENT_PUBLIC,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="http://localhost:8239/callback",
+            algorithm="RS256",
+            is_cimd_client=True,
+            cimd_metadata_url=cimd_url,
+            provisioning_auth_method="pkce",
+            provisioning_partner_type="wizard",
+            provisioning_active=False,
+            provisioning_can_create_accounts=True,
+        )
+
+        _, challenge = _pkce_pair()
+        res = self.client.post(
+            "/api/agentic/provisioning/account_requests",
+            data={
+                "id": "req_cimd_inactive",
+                "email": "cimd-inactive@example.com",
+                "client_id": cimd_url,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+            content_type="application/json",
+            HTTP_API_VERSION="0.1d",
+        )
+        assert res.status_code == 401
+
+        cimd_app.delete()
+
     # --- PKCE code_challenge_method validation ---
 
     def test_plain_code_challenge_method_rejected(self):

--- a/posthog/api/oauth/test_wizard_metadata.py
+++ b/posthog/api/oauth/test_wizard_metadata.py
@@ -1,0 +1,39 @@
+from django.test import SimpleTestCase, override_settings
+
+
+@override_settings(SITE_URL="https://us.posthog.com")
+class TestWizardClientMetadataView(SimpleTestCase):
+    def test_returns_valid_cimd_metadata(self):
+        res = self.client.get("/api/oauth/wizard/client-metadata")
+        assert res.status_code == 200
+        data = res.json()
+
+        assert data["client_id"] == "https://us.posthog.com/api/oauth/wizard/client-metadata"
+        assert data["client_name"] == "PostHog Wizard"
+        assert data["redirect_uris"] == ["http://localhost:8239/callback"]
+        assert data["grant_types"] == ["authorization_code"]
+        assert data["response_types"] == ["code"]
+        assert data["token_endpoint_auth_method"] == "none"
+
+    def test_client_id_matches_hosted_path(self):
+        res = self.client.get("/api/oauth/wizard/client-metadata")
+        data = res.json()
+        assert data["client_id"].endswith("/api/oauth/wizard/client-metadata")
+
+    @override_settings(SITE_URL="https://eu.posthog.com")
+    def test_client_id_uses_site_url_for_eu(self):
+        res = self.client.get("/api/oauth/wizard/client-metadata")
+        data = res.json()
+        assert data["client_id"] == "https://eu.posthog.com/api/oauth/wizard/client-metadata"
+
+    def test_cache_control_header_set(self):
+        res = self.client.get("/api/oauth/wizard/client-metadata")
+        assert res["Cache-Control"] == "public, max-age=3600"
+
+    def test_content_type_is_json(self):
+        res = self.client.get("/api/oauth/wizard/client-metadata")
+        assert "application/json" in res["Content-Type"]
+
+    def test_post_not_allowed(self):
+        res = self.client.post("/api/oauth/wizard/client-metadata")
+        assert res.status_code == 405

--- a/posthog/api/oauth/wizard_metadata.py
+++ b/posthog/api/oauth/wizard_metadata.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.http import JsonResponse
 from django.views import View
 
-
 WIZARD_METADATA_PATH = "api/oauth/wizard/client-metadata"
 
 

--- a/posthog/api/oauth/wizard_metadata.py
+++ b/posthog/api/oauth/wizard_metadata.py
@@ -1,0 +1,34 @@
+from django.conf import settings
+from django.http import JsonResponse
+from django.views import View
+
+
+WIZARD_METADATA_PATH = "api/oauth/wizard/client-metadata"
+
+
+class WizardClientMetadataView(View):
+    """
+    Serves a static CIMD (Client ID Metadata Document) for the PostHog Wizard CLI.
+
+    The client_id in the response is the canonical URL where this document is hosted,
+    constructed from SITE_URL so it's correct on each region (US, EU, self-hosted).
+    """
+
+    http_method_names = ["get"]
+
+    def get(self, request):
+        client_id = f"{settings.SITE_URL}/{WIZARD_METADATA_PATH}"
+
+        metadata = {
+            "client_id": client_id,
+            "client_name": "PostHog Wizard",
+            "redirect_uris": ["http://localhost:8239/callback"],
+            "grant_types": ["authorization_code"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+        }
+
+        response = JsonResponse(metadata)
+        response["Cache-Control"] = "public, max-age=3600"
+        response["Content-Type"] = "application/json"
+        return response

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -33,7 +33,7 @@ from posthog.api import (
     user,
 )
 from posthog.api.oauth.connected_apps import ConnectedAppsViewSet
-from posthog.api.oauth.wizard_metadata import WizardClientMetadataView
+from posthog.api.oauth.wizard_metadata import WIZARD_METADATA_PATH, WizardClientMetadataView
 from posthog.api.query import progress
 from posthog.api.sdk_doctor import sdk_doctor
 from posthog.api.slack import slack_interactivity_callback
@@ -283,7 +283,7 @@ urlpatterns = [
         ConnectedAppsViewSet.as_view({"post": "revoke"}),
     ),
     path(
-        "api/oauth/wizard/client-metadata",
+        WIZARD_METADATA_PATH,
         WizardClientMetadataView.as_view(),
         name="wizard-client-metadata",
     ),

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -33,6 +33,7 @@ from posthog.api import (
     user,
 )
 from posthog.api.oauth.connected_apps import ConnectedAppsViewSet
+from posthog.api.oauth.wizard_metadata import WizardClientMetadataView
 from posthog.api.query import progress
 from posthog.api.sdk_doctor import sdk_doctor
 from posthog.api.slack import slack_interactivity_callback
@@ -280,6 +281,11 @@ urlpatterns = [
     path(
         "api/oauth/connected-apps/<uuid:pk>/revoke/",
         ConnectedAppsViewSet.as_view({"post": "revoke"}),
+    ),
+    path(
+        "api/oauth/wizard/client-metadata",
+        WizardClientMetadataView.as_view(),
+        name="wizard-client-metadata",
     ),
     re_path(r"^api.+", api_not_found),
     path("authorize_and_redirect/", login_required(authorize_and_redirect)),


### PR DESCRIPTION
## Problem

The PostHog Wizard CLI needs to auto-register as an OAuth application on any PostHog region (US, EU, self-hosted) without manual Django admin setup. CIMD (Client ID Metadata Document, draft-ietf-oauth-client-id-metadata-document-00) infrastructure already exists but there's no hosted metadata document for the wizard, and the agentic provisioning auth doesn't support CIMD URL-form client_ids.

## Changes

1. **New endpoint**: `GET /api/oauth/wizard/client-metadata` - serves a static CIMD JSON document with `client_id` set to the canonical URL (derived from `SITE_URL` so it's correct per-region)
2. **Provisioning auth CIMD support**: Updated `_identify_pkce_partner` in `ee/api/agentic_provisioning/authentication.py` to use `get_application_by_client_id()` instead of direct `OAuthApplication.objects.get(client_id=...)`, enabling lookup by both CIMD URLs and opaque UUIDs
3. **Provisioning fields**: Kept manual (option C from the spec) - CIMD auto-creates the app, admin enables provisioning separately. This is safest since provisioning grants account creation powers.

## How did you test this?

- Unit tests for metadata endpoint (6 tests): valid response, per-region client_id, cache headers, content type, POST rejection
- Integration tests for CIMD PKCE identification (2 tests): active CIMD partner identified and used for provisioning, inactive CIMD partner rejected
- All existing provisioning auth tests still pass (backward compatible - opaque client_ids work unchanged)

## Changelog

Adds CIMD metadata endpoint for PostHog Wizard CLI auto-registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)