### PR TITLE
chore(replay): move all rasterizer ffmpeg format options into buildCaptureConfig

### DIFF
--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/capture.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/capture.test.ts
@@ -19,7 +19,6 @@ jest.mock(
         }
         return {
             __mockRecorder: recorder,
-            PuppeteerCaptureFormat: { MP4: jest.fn().mockReturnValue('mp4-format') },
             capture: jest.fn().mockResolvedValue(recorder),
         }
     },

--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/config.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/config.test.ts
@@ -114,6 +114,9 @@ describe('config', () => {
             it('includes MP4 baseline output opts by default', () => {
                 const config = buildCaptureConfig(baseInput())
                 expect(config.outputFormat).toBe('mp4')
+                expect(config.ffmpegOutputOpts).toContain('-f mp4')
+                expect(config.ffmpegOutputOpts).toContain('-c:v libx264')
+                expect(config.ffmpegOutputOpts).toContain('-preset veryfast')
                 expect(config.ffmpegOutputOpts).toContain('-crf 23')
                 expect(config.ffmpegOutputOpts).toContain('-pix_fmt yuv420p')
                 expect(config.ffmpegOutputOpts).toContain('-movflags +faststart')

--- a/nodejs/src/session-replay/recording-rasterizer/capture/capture.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/capture/capture.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs/promises'
-import { PuppeteerCaptureFormat, capture as captureVideo } from 'puppeteer-capture'
+import { capture as captureVideo } from 'puppeteer-capture'
 
 import { RasterizationError } from '../errors'
 import { type Logger, createLogger } from '../logger'
@@ -28,9 +28,11 @@ export async function capturePlayback(
     const page = player.page
 
     // Start capture — installs virtual time shims before playback.
+    // All format/codec options live in captureConfig.ffmpegOutputOpts so every
+    // output format is configured in one place (buildCaptureConfig).
     const recorder = await captureVideo(page, {
         fps: captureConfig.captureFps,
-        format: PuppeteerCaptureFormat.MP4('veryfast', 'libx264'),
+        format: async () => {}, // no-op — ffmpegOutputOpts carries all format settings
         // eslint-disable-next-line @typescript-eslint/require-await
         customFfmpegConfig: async (ffmpeg: any) => {
             ffmpeg.outputOptions(captureConfig.ffmpegOutputOpts)

--- a/nodejs/src/session-replay/recording-rasterizer/capture/config.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/capture/config.ts
@@ -58,7 +58,7 @@ export function buildCaptureConfig(input: RasterizeRecordingInput): CaptureConfi
             ? ['-f webm', '-c:v libvpx-vp9', '-crf 30', '-b:v 0']
             : outputFormat === 'gif'
               ? ['-f gif', '-c:v gif', '-loop', '0']
-              : ['-crf 23', '-pix_fmt yuv420p', '-movflags +faststart']
+              : ['-f mp4', '-c:v libx264', '-preset veryfast', '-crf 23', '-pix_fmt yuv420p', '-movflags +faststart']
     if (input.trim) {
         ffmpegOutputOpts.push(`-t ${input.trim}`)
     }


### PR DESCRIPTION
## Problem

`PuppeteerCaptureFormat.MP4()` was hardcoded as the base ffmpeg format for all output types, so WebM/GIF exports get stale MP4 flags (`-preset veryfast`, `-movflags`) appended before the actual format options. ffmpeg silently ignores them but the command line is misleading and fragile.

## Changes

Move all format/codec options into `buildCaptureConfig`'s `ffmpegOutputOpts`. The capture layer passes a no-op format to puppeteer-capture.

## How did you test this code?

All 193 rasterizer unit tests pass. Not manually tested end-to-end.

## Publish to changelog?

no