### PR TITLE
fix(data-warehouse): keep Learn more button next to banner text

### DIFF
--- a/products/data_warehouse/frontend/shared/components/FreeHistoricalSyncsBanner.tsx
+++ b/products/data_warehouse/frontend/shared/components/FreeHistoricalSyncsBanner.tsx
@@ -14,24 +14,22 @@ export function FreeHistoricalSyncsBanner({ hideGetStarted }: { hideGetStarted?:
     return (
         <>
             <LemonBanner type="info" className="min-h-[auto] my-2">
-                <div className="flex flex-col gap-1.5">
-                    <div className="flex items-center gap-2">
-                        <span className="text-sm">
-                            Sync all your historical data from any new source for free during the first 7 days (100M
-                            rows limit for the free plan)
-                        </span>
+                <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                    <span className="text-sm">
+                        Sync all your historical data from any new source for free during the first 7 days (100M rows
+                        limit for the free plan)
+                    </span>
 
-                        <LemonButton
-                            type="primary"
-                            size="xsmall"
-                            onClick={() => {
-                                posthog.capture('historical_sync_banner_learn_more_clicked')
-                                setShowModal(true)
-                            }}
-                        >
-                            Learn more
-                        </LemonButton>
-                    </div>
+                    <LemonButton
+                        type="primary"
+                        size="xsmall"
+                        onClick={() => {
+                            posthog.capture('historical_sync_banner_learn_more_clicked')
+                            setShowModal(true)
+                        }}
+                    >
+                        Learn more
+                    </LemonButton>
                 </div>
             </LemonBanner>
 


### PR DESCRIPTION
## Problem

On the new data warehouse source page, the free-historical-syncs banner renders the `Learn more` button at the far right edge, disconnected from the info text (see screenshot in the session).

Root cause: `LemonBanner` wraps children in a `grow overflow-hidden` div, so the content row stretches to the full banner width. The banner's inner row used `flex items-center gap-2`, which lets the text span expand to the wrapped line width and pushes the button to the right edge.

## Changes

`products/data_warehouse/frontend/shared/components/FreeHistoricalSyncsBanner.tsx`:

- Dropped the redundant outer `flex-col gap-1.5` wrapper (only one child).
- Switched the row to `flex flex-wrap items-center gap-x-2 gap-y-1` so flex items use their natural widths. The button hugs the text end when the row fits and wraps to the next line on narrow viewports.

## How did you test this code?

Agent-authored change — I did not manually verify in a running browser. The fix is a Tailwind layout swap with no logic changes; reviewers should confirm visually that the `Learn more` button sits next to the text on wide viewports and wraps cleanly below on narrow ones.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Code (Opus 4.6) in response to a screenshot of the banner with the button floating far right. Investigation traced the layout stretch to `LemonBanner`'s `grow` children wrapper in [LemonBanner.tsx](frontend/src/lib/lemon-ui/LemonBanner/LemonBanner.tsx); fix applied to the consuming banner rather than the shared primitive.