### PR TITLE
feat(llm-gateway): Remove plan_aware_throttling feature flag and make plan resolution always-on

### DIFF
--- a/products/tasks/backend/seat_api.py
+++ b/products/tasks/backend/seat_api.py
@@ -134,10 +134,13 @@ class SeatViewSet(viewsets.ViewSet):
 
     def _require_org_member(self, distinct_id: str, request: Request) -> None:
         org = cast(User, request.user).organization
-        if not org or not OrganizationMembership.objects.filter(
-            user__distinct_id=distinct_id,
-            organization=org,
-        ).exists():
+        if (
+            not org
+            or not OrganizationMembership.objects.filter(
+                user__distinct_id=distinct_id,
+                organization=org,
+            ).exists()
+        ):
             raise PermissionDenied("Target user is not a member of this organization.")
 
     @staticmethod

--- a/products/tasks/backend/seat_api.py
+++ b/products/tasks/backend/seat_api.py
@@ -132,6 +132,14 @@ class SeatViewSet(viewsets.ViewSet):
         if not _is_org_admin(request.user):
             raise PermissionDenied("Only organization admins can perform this action.")
 
+    def _require_org_member(self, distinct_id: str, request: Request) -> None:
+        org = cast(User, request.user).organization
+        if not org or not OrganizationMembership.objects.filter(
+            user__distinct_id=distinct_id,
+            organization=org,
+        ).exists():
+            raise PermissionDenied("Target user is not a member of this organization.")
+
     @staticmethod
     def _filtered_query_params(request: Request) -> dict[str, str]:
         product_key = request.query_params.get("product_key", "")
@@ -168,6 +176,7 @@ class SeatViewSet(viewsets.ViewSet):
             return Response({"detail": "Invalid user_distinct_id format"}, status=status.HTTP_400_BAD_REQUEST)
         if str(body_distinct_id) != str(cast(User, request.user).distinct_id):
             self._require_admin(request)
+            self._require_org_member(str(body_distinct_id), request)
 
         headers = self._get_billing_headers(request)
         if not headers:
@@ -186,6 +195,8 @@ class SeatViewSet(viewsets.ViewSet):
             return Response({"detail": "No organization or license found"}, status=status.HTTP_400_BAD_REQUEST)
 
         distinct_id = self._resolve_distinct_id(pk, request)
+        if pk != "me":
+            self._require_org_member(distinct_id, request)
         resp = self._billing_request(
             "GET",
             f"/api/v2/seats/{distinct_id}/",
@@ -204,6 +215,8 @@ class SeatViewSet(viewsets.ViewSet):
             return Response({"detail": "No organization or license found"}, status=status.HTTP_400_BAD_REQUEST)
 
         distinct_id = self._resolve_distinct_id(pk, request)
+        if pk != "me":
+            self._require_org_member(distinct_id, request)
         resp = self._billing_request(
             "PATCH",
             f"/api/v2/seats/{distinct_id}/",
@@ -222,6 +235,8 @@ class SeatViewSet(viewsets.ViewSet):
             return Response({"detail": "No organization or license found"}, status=status.HTTP_400_BAD_REQUEST)
 
         distinct_id = self._resolve_distinct_id(pk, request)
+        if pk != "me":
+            self._require_org_member(distinct_id, request)
         resp = self._billing_request(
             "DELETE",
             f"/api/v2/seats/{distinct_id}/",
@@ -241,6 +256,8 @@ class SeatViewSet(viewsets.ViewSet):
             return Response({"detail": "No organization or license found"}, status=status.HTTP_400_BAD_REQUEST)
 
         distinct_id = self._resolve_distinct_id(pk, request)
+        if pk != "me":
+            self._require_org_member(distinct_id, request)
         resp = self._billing_request(
             "POST",
             f"/api/v2/seats/{distinct_id}/reactivate/",

--- a/products/tasks/backend/seat_api.py
+++ b/products/tasks/backend/seat_api.py
@@ -15,7 +15,6 @@ from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentic
 from posthog.cloud_utils import get_cached_instance_license
 from posthog.models.organization import OrganizationMembership
 from posthog.models.user import User
-from posthog.permissions import APIScopePermission
 
 # TODO: Centralize billing proxy through BillingManager (ee/billing/) to avoid
 # duplicating auth header construction and keep all billing communication in one place
@@ -51,8 +50,7 @@ class SeatViewSet(viewsets.ViewSet):
     """
 
     authentication_classes = [SessionAuthentication, PersonalAPIKeyAuthentication, OAuthAccessTokenAuthentication]
-    permission_classes = [IsAuthenticated, APIScopePermission]
-    scope_object = "INTERNAL"
+    permission_classes = [IsAuthenticated]
     http_method_names = ["get", "post", "patch", "delete", "head", "options"]
 
     # ------------------------------------------------------------------

--- a/products/tasks/backend/seat_api.py
+++ b/products/tasks/backend/seat_api.py
@@ -132,7 +132,7 @@ class SeatViewSet(viewsets.ViewSet):
         if not _is_org_admin(request.user):
             raise PermissionDenied("Only organization admins can perform this action.")
 
-    def _require_org_member(self, distinct_id: str, request: Request) -> None:
+    def _require_org_member(self, request: Request, distinct_id: str) -> None:
         org = cast(User, request.user).organization
         if (
             not org
@@ -142,6 +142,12 @@ class SeatViewSet(viewsets.ViewSet):
             ).exists()
         ):
             raise PermissionDenied("Target user is not a member of this organization.")
+
+    def _resolve_and_check_membership(self, request: Request, pk: str | None) -> str:
+        distinct_id = self._resolve_distinct_id(pk, request)
+        if pk != "me":
+            self._require_org_member(request, distinct_id)
+        return distinct_id
 
     @staticmethod
     def _filtered_query_params(request: Request) -> dict[str, str]:
@@ -179,7 +185,7 @@ class SeatViewSet(viewsets.ViewSet):
             return Response({"detail": "Invalid user_distinct_id format"}, status=status.HTTP_400_BAD_REQUEST)
         if str(body_distinct_id) != str(cast(User, request.user).distinct_id):
             self._require_admin(request)
-            self._require_org_member(str(body_distinct_id), request)
+        self._require_org_member(request, str(body_distinct_id))
 
         headers = self._get_billing_headers(request)
         if not headers:
@@ -197,9 +203,7 @@ class SeatViewSet(viewsets.ViewSet):
         if not headers:
             return Response({"detail": "No organization or license found"}, status=status.HTTP_400_BAD_REQUEST)
 
-        distinct_id = self._resolve_distinct_id(pk, request)
-        if pk != "me":
-            self._require_org_member(distinct_id, request)
+        distinct_id = self._resolve_and_check_membership(request, pk)
         resp = self._billing_request(
             "GET",
             f"/api/v2/seats/{distinct_id}/",
@@ -217,9 +221,7 @@ class SeatViewSet(viewsets.ViewSet):
         if not headers:
             return Response({"detail": "No organization or license found"}, status=status.HTTP_400_BAD_REQUEST)
 
-        distinct_id = self._resolve_distinct_id(pk, request)
-        if pk != "me":
-            self._require_org_member(distinct_id, request)
+        distinct_id = self._resolve_and_check_membership(request, pk)
         resp = self._billing_request(
             "PATCH",
             f"/api/v2/seats/{distinct_id}/",
@@ -237,9 +239,7 @@ class SeatViewSet(viewsets.ViewSet):
         if not headers:
             return Response({"detail": "No organization or license found"}, status=status.HTTP_400_BAD_REQUEST)
 
-        distinct_id = self._resolve_distinct_id(pk, request)
-        if pk != "me":
-            self._require_org_member(distinct_id, request)
+        distinct_id = self._resolve_and_check_membership(request, pk)
         resp = self._billing_request(
             "DELETE",
             f"/api/v2/seats/{distinct_id}/",
@@ -258,9 +258,7 @@ class SeatViewSet(viewsets.ViewSet):
         if not headers:
             return Response({"detail": "No organization or license found"}, status=status.HTTP_400_BAD_REQUEST)
 
-        distinct_id = self._resolve_distinct_id(pk, request)
-        if pk != "me":
-            self._require_org_member(distinct_id, request)
+        distinct_id = self._resolve_and_check_membership(request, pk)
         resp = self._billing_request(
             "POST",
             f"/api/v2/seats/{distinct_id}/reactivate/",

--- a/products/tasks/backend/tests/test_seat_api.py
+++ b/products/tasks/backend/tests/test_seat_api.py
@@ -54,6 +54,10 @@ class BaseSeatAPITest(TestCase):
         cls.user = User.objects.create_user(email="member@example.com", first_name="Member", password="password")
         cls.organization.members.add(cls.user)
 
+        cls.external_user = User.objects.create_user(
+            email="external@example.com", first_name="External", password="password"
+        )
+
     def setUp(self):
         self.client = APIClient()
 
@@ -151,6 +155,48 @@ class TestSeatAPIAdminPermissions(BaseSeatAPITest):
     def test_reactivate_other_user_requires_admin(self, mock_request, _mock_license, _mock_token):
         self._auth_as_member()
         response = self.client.post(f"/api/seats/{self.admin_user.distinct_id}/reactivate/", format="json")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @patch("products.tasks.backend.seat_api.requests.request")
+    def test_retrieve_non_org_member_rejected(self, mock_request, _mock_license, _mock_token):
+        self._auth_as_admin()
+        response = self.client.get(f"/api/seats/{self.external_user.distinct_id}/?product_key=posthog_code")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @patch("products.tasks.backend.seat_api.requests.request")
+    def test_patch_non_org_member_rejected(self, mock_request, _mock_license, _mock_token):
+        self._auth_as_admin()
+        response = self.client.patch(
+            f"/api/seats/{self.external_user.distinct_id}/",
+            {"product_key": "posthog_code", "plan_key": "posthog-code-200-20260301"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @patch("products.tasks.backend.seat_api.requests.request")
+    def test_delete_non_org_member_rejected(self, mock_request, _mock_license, _mock_token):
+        self._auth_as_admin()
+        response = self.client.delete(f"/api/seats/{self.external_user.distinct_id}/?product_key=posthog_code")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @patch("products.tasks.backend.seat_api.requests.request")
+    def test_create_for_non_org_member_rejected(self, mock_request, _mock_license, _mock_token):
+        self._auth_as_admin()
+        response = self.client.post(
+            "/api/seats/",
+            {
+                "product_key": "posthog_code",
+                "plan_key": "posthog-code-free-20260301",
+                "user_distinct_id": str(self.external_user.distinct_id),
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @patch("products.tasks.backend.seat_api.requests.request")
+    def test_reactivate_non_org_member_rejected(self, mock_request, _mock_license, _mock_token):
+        self._auth_as_admin()
+        response = self.client.post(f"/api/seats/{self.external_user.distinct_id}/reactivate/", format="json")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
 

--- a/products/tasks/backend/tests/test_seat_api.py
+++ b/products/tasks/backend/tests/test_seat_api.py
@@ -39,6 +39,7 @@ class BaseSeatAPITest(TestCase):
     team: ClassVar[Team]
     user: ClassVar[User]
     admin_user: ClassVar[User]
+    external_user: ClassVar[User]
 
     @classmethod
     def setUpTestData(cls):

--- a/products/tasks/backend/tests/test_seat_api.py
+++ b/products/tasks/backend/tests/test_seat_api.py
@@ -284,11 +284,12 @@ class TestSeatAPIResponseUnwrapping(BaseSeatAPITest):
 
 @patch("products.tasks.backend.seat_api.build_billing_token", return_value=MOCK_BILLING_TOKEN)
 @patch("products.tasks.backend.seat_api.get_cached_instance_license", return_value=MagicMock())
-class TestSeatAPIKeyScope(BaseSeatAPITest):
-    """Personal API keys should be rejected (scope_object = INTERNAL)."""
+class TestSeatAPIKeyAccess(BaseSeatAPITest):
+    """Personal API keys are allowed so the LLM gateway can resolve seats."""
 
     @patch("products.tasks.backend.seat_api.requests.request")
-    def test_personal_api_key_rejected(self, mock_request, _mock_license, _mock_token):
+    def test_personal_api_key_allowed(self, mock_request, _mock_license, _mock_token):
+        mock_request.return_value = _billing_response({"seat": MOCK_SEAT})
         token = generate_random_token_personal()
         PersonalAPIKey.objects.create(
             label="test",
@@ -301,4 +302,4 @@ class TestSeatAPIKeyScope(BaseSeatAPITest):
             "/api/seats/me/?product_key=posthog_code",
             headers={"authorization": f"Bearer {token}"},
         )
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_200_OK

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -620,31 +620,3 @@ export const tasksRepositoryReadinessRetrieve = async (
         method: 'GET',
     })
 }
-
-/**
- * GET /api/seats/?product_key= -> GET /api/v2/seats/
- */
-export const getSeatsRetrieveUrl = () => {
-    return `/api/seats/`
-}
-
-export const seatsRetrieve = async (options?: RequestInit): Promise<void> => {
-    return apiMutator<void>(getSeatsRetrieveUrl(), {
-        ...options,
-        method: 'GET',
-    })
-}
-
-/**
- * POST /api/seats/ -> POST /api/v2/seats/
- */
-export const getSeatsCreateUrl = () => {
-    return `/api/seats/`
-}
-
-export const seatsCreate = async (options?: RequestInit): Promise<void> => {
-    return apiMutator<void>(getSeatsCreateUrl(), {
-        ...options,
-        method: 'POST',
-    })
-}

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -149,9 +149,9 @@ class Settings(BaseSettings):
 
     default_fallback_cost_usd: float = 0.01
 
-    posthog_api_url: str = ""
+    posthog_api_base_url: str = ""
     plan_cache_ttl: int = 300  # 5 minutes
-    plan_aware_throttling_enabled: bool = False
+    plan_aware_throttling_enabled: bool = True
     free_plan_trial_period_days: int = 30
 
     @field_validator("product_cost_limits", mode="before")

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -149,9 +149,8 @@ class Settings(BaseSettings):
 
     default_fallback_cost_usd: float = 0.01
 
-    posthog_api_base_url: str = ""
+    posthog_api_base_url: str = "https://us.posthog.com"
     plan_cache_ttl: int = 300  # 5 minutes
-    plan_aware_throttling_enabled: bool = True
     free_plan_trial_period_days: int = 30
 
     @field_validator("product_cost_limits", mode="before")

--- a/services/llm-gateway/src/llm_gateway/main.py
+++ b/services/llm-gateway/src/llm_gateway/main.py
@@ -151,7 +151,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         redis=app.state.redis,
         http_client=app.state.http_client,
     )
-    logger.info("Plan resolver initialized", posthog_api_url=settings.posthog_api_url or "(not configured)")
+    logger.info("Plan resolver initialized", posthog_api_base_url=settings.posthog_api_base_url or "(not configured)")
 
     logger.info(
         "rate_limits_configured",

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -38,6 +38,7 @@ def _is_free_plan_throttled(context: ThrottleContext) -> bool:
         context.product == POSTHOG_CODE_PRODUCT
         and settings.plan_aware_throttling_enabled
         and not is_pro_plan(context.plan_key)
+        and context.seat_created_at is not None
     )
 
 

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -33,10 +33,8 @@ class CostStatus:
 
 
 def _is_free_plan_throttled(context: ThrottleContext) -> bool:
-    settings = get_settings()
     return (
         context.product == POSTHOG_CODE_PRODUCT
-        and settings.plan_aware_throttling_enabled
         and not is_pro_plan(context.plan_key)
         and context.seat_created_at is not None
     )
@@ -260,9 +258,8 @@ class UserCostSustainedThrottle(_UserCostThrottleBase):
         base_key = super()._get_cache_key(context)
         if not base_key:
             return base_key
-        settings = get_settings()
-        if context.product == POSTHOG_CODE_PRODUCT and settings.plan_aware_throttling_enabled:
-            period = get_billing_period_number(context.seat_created_at, settings.free_plan_trial_period_days)
+        if context.product == POSTHOG_CODE_PRODUCT:
+            period = get_billing_period_number(context.seat_created_at, get_settings().free_plan_trial_period_days)
             return f"{base_key}:period:{period}"
         return base_key
 

--- a/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
+++ b/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
@@ -78,9 +78,8 @@ async def resolve_plan_info(
     user_id: int,
     product: str,
 ) -> PlanInfo:
-    """Resolve plan info, returning safe defaults if disabled or on failure."""
-    settings = get_settings()
-    if product != POSTHOG_CODE_PRODUCT or not settings.plan_aware_throttling_enabled:
+    """Resolve plan info, returning safe defaults on failure."""
+    if product != POSTHOG_CODE_PRODUCT:
         return PlanInfo(plan_key=None, in_trial_period=True, seat_created_at=None)
 
     plan_resolver: PlanResolver = request.app.state.plan_resolver

--- a/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
+++ b/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
@@ -169,10 +169,10 @@ class PlanResolver:
         Returns (None, None) for legitimate "no plan" states (404, no API URL).
         """
         settings = get_settings()
-        if not settings.posthog_api_url:
+        if not settings.posthog_api_base_url:
             return None, None
 
-        url = f"{settings.posthog_api_url.rstrip('/')}/api/seats/me/"
+        url = f"{settings.posthog_api_base_url.rstrip('/')}/api/seats/me/"
         resp = await self._http.get(
             url,
             params={"product_key": POSTHOG_CODE_PRODUCT},

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -1,5 +1,3 @@
-from collections.abc import Iterator
-
 import pytest
 
 from llm_gateway.auth.models import AuthenticatedUser
@@ -304,24 +302,19 @@ class TestUserCostSustainedThrottle:
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
-    async def test_cache_key_includes_product_and_scope(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "false")
-        get_settings.cache_clear()
+    async def test_cache_key_includes_product_and_scope(self) -> None:
         from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
 
         throttle = UserCostSustainedThrottle(redis=None)
         context = make_context(product="posthog_code", end_user_id="42")
 
         key = throttle._get_cache_key(context)
-        assert key == "cost:user:user_cost_sustained:posthog_code:42"
-        get_settings.cache_clear()
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:0"
 
     @pytest.mark.asyncio
-    async def test_cache_key_includes_period_for_free_plan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_cache_key_includes_period_for_free_plan(self) -> None:
         from datetime import UTC, datetime, timedelta
 
-        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "true")
-        get_settings.cache_clear()
         from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
 
         throttle = UserCostSustainedThrottle(redis=None)
@@ -336,14 +329,11 @@ class TestUserCostSustainedThrottle:
 
         key = throttle._get_cache_key(context)
         assert key == "cost:user:user_cost_sustained:posthog_code:42:period:0"
-        get_settings.cache_clear()
 
     @pytest.mark.asyncio
-    async def test_cache_key_period_increments_after_period_days(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_cache_key_period_increments_after_period_days(self) -> None:
         from datetime import UTC, datetime, timedelta
 
-        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "true")
-        get_settings.cache_clear()
         from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
 
         throttle = UserCostSustainedThrottle(redis=None)
@@ -358,14 +348,11 @@ class TestUserCostSustainedThrottle:
 
         key = throttle._get_cache_key(context)
         assert key == "cost:user:user_cost_sustained:posthog_code:42:period:1"
-        get_settings.cache_clear()
 
     @pytest.mark.asyncio
-    async def test_cache_key_includes_period_for_pro_plan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_cache_key_includes_period_for_pro_plan(self) -> None:
         from datetime import UTC, datetime, timedelta
 
-        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "true")
-        get_settings.cache_clear()
         from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
 
         throttle = UserCostSustainedThrottle(redis=None)
@@ -379,7 +366,6 @@ class TestUserCostSustainedThrottle:
 
         key = throttle._get_cache_key(context)
         assert key == "cost:user:user_cost_sustained:posthog_code:42:period:0"
-        get_settings.cache_clear()
 
 
 class TestBurstSustainedInteraction:
@@ -1038,13 +1024,6 @@ class TestRateLimitPoisoningPrevention:
 
 
 class TestPlanAwareThrottling:
-    @pytest.fixture(autouse=True)
-    def enable_plan_throttling(self, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "true")
-        get_settings.cache_clear()
-        yield
-        get_settings.cache_clear()
-
     @pytest.mark.asyncio
     async def test_trial_user_gets_burst_limit_of_5(self) -> None:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
@@ -1144,18 +1123,6 @@ class TestPlanAwareThrottling:
         result = await throttle.allow_request(context)
         assert result.allowed is True
 
-    @pytest.mark.asyncio
-    async def test_flag_off_skips_plan_limits(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "false")
-        get_settings.cache_clear()
-        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
-
-        throttle = UserCostBurstThrottle(redis=None)
-        context = make_context(product="posthog_code", plan_key=None)
-
-        await throttle.record_cost(context, 50.0)
-        result = await throttle.allow_request(context)
-        assert result.allowed is True
 
 
 class TestCostAccumulatorTTL:

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -1124,7 +1124,6 @@ class TestPlanAwareThrottling:
         assert result.allowed is True
 
 
-
 class TestCostAccumulatorTTL:
     def test_cost_expires_after_window(self) -> None:
         from unittest.mock import patch

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -302,7 +302,7 @@ class TestUserCostSustainedThrottle:
         get_settings.cache_clear()
 
     @pytest.mark.asyncio
-    async def test_cache_key_includes_product_and_scope(self) -> None:
+    async def test_cache_key_includes_product_scope_and_period(self) -> None:
         from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
 
         throttle = UserCostSustainedThrottle(redis=None)

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -1050,7 +1050,9 @@ class TestPlanAwareThrottling:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         throttle = UserCostBurstThrottle(redis=None)
-        context = make_context(product="posthog_code", plan_key=None, in_trial_period=True)
+        context = make_context(
+            product="posthog_code", plan_key=None, in_trial_period=True, seat_created_at="2026-01-01T00:00:00+00:00"
+        )
 
         await throttle.record_cost(context, 5.0)
         result = await throttle.allow_request(context)
@@ -1061,7 +1063,9 @@ class TestPlanAwareThrottling:
         from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
 
         throttle = UserCostSustainedThrottle(redis=None)
-        context = make_context(product="posthog_code", plan_key=None, in_trial_period=True)
+        context = make_context(
+            product="posthog_code", plan_key=None, in_trial_period=True, seat_created_at="2026-01-01T00:00:00+00:00"
+        )
 
         await throttle.record_cost(context, 50.0)
         result = await throttle.allow_request(context)
@@ -1072,7 +1076,9 @@ class TestPlanAwareThrottling:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         throttle = UserCostBurstThrottle(redis=None)
-        context = make_context(product="posthog_code", plan_key=None, in_trial_period=False)
+        context = make_context(
+            product="posthog_code", plan_key=None, in_trial_period=False, seat_created_at="2025-01-01T00:00:00+00:00"
+        )
 
         result = await throttle.allow_request(context)
         assert result.allowed is False
@@ -1082,10 +1088,23 @@ class TestPlanAwareThrottling:
         from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
 
         throttle = UserCostSustainedThrottle(redis=None)
-        context = make_context(product="posthog_code", plan_key=None, in_trial_period=False)
+        context = make_context(
+            product="posthog_code", plan_key=None, in_trial_period=False, seat_created_at="2025-01-01T00:00:00+00:00"
+        )
 
         result = await throttle.allow_request(context)
         assert result.allowed is False
+
+    @pytest.mark.asyncio
+    async def test_no_seat_gets_pro_limits(self) -> None:
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        context = make_context(product="posthog_code", plan_key=None, in_trial_period=True, seat_created_at=None)
+
+        await throttle.record_cost(context, 50.0)
+        result = await throttle.allow_request(context)
+        assert result.allowed is True
 
     @pytest.mark.asyncio
     async def test_pro_plan_allows_higher_usage(self) -> None:
@@ -1103,7 +1122,12 @@ class TestPlanAwareThrottling:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         throttle = UserCostBurstThrottle(redis=None)
-        context = make_context(product="posthog_code", plan_key="posthog-code-free-20260301", in_trial_period=True)
+        context = make_context(
+            product="posthog_code",
+            plan_key="posthog-code-free-20260301",
+            in_trial_period=True,
+            seat_created_at="2026-01-01T00:00:00+00:00",
+        )
 
         await throttle.record_cost(context, 4.0)
         result = await throttle.allow_request(context)

--- a/services/llm-gateway/tests/test_plan_resolver.py
+++ b/services/llm-gateway/tests/test_plan_resolver.py
@@ -98,7 +98,7 @@ class TestPlanResolver:
 
     async def test_returns_none_plan_when_no_api_url(self, resolver: PlanResolver) -> None:
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
-            mock_settings.return_value.posthog_api_url = ""
+            mock_settings.return_value.posthog_api_base_url = ""
             mock_settings.return_value.plan_cache_ttl = 300
             mock_settings.return_value.free_plan_trial_period_days = 30
             result = await resolver.get_plan(user_id=1, auth_header="Bearer phx_test")
@@ -150,7 +150,7 @@ class TestPlanResolver:
         resolver_with_redis._http.get = AsyncMock(return_value=mock_resp)  # type: ignore[method-assign]
 
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
-            mock_settings.return_value.posthog_api_url = "https://app.posthog.com"
+            mock_settings.return_value.posthog_api_base_url = "https://app.posthog.com"
             mock_settings.return_value.plan_cache_ttl = 300
             mock_settings.return_value.free_plan_trial_period_days = 30
             result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
@@ -175,7 +175,7 @@ class TestPlanResolver:
         resolver._http.get = AsyncMock(return_value=mock_resp)  # type: ignore[method-assign]
 
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
-            mock_settings.return_value.posthog_api_url = "https://app.posthog.com"
+            mock_settings.return_value.posthog_api_base_url = "https://app.posthog.com"
             mock_settings.return_value.plan_cache_ttl = 300
             mock_settings.return_value.free_plan_trial_period_days = 30
             await resolver.get_plan(user_id=1, auth_header="Bearer phx_mysecretkey")
@@ -190,7 +190,7 @@ class TestPlanResolver:
         resolver._http.get = AsyncMock(return_value=mock_resp)  # type: ignore[method-assign]
 
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
-            mock_settings.return_value.posthog_api_url = "https://app.posthog.com"
+            mock_settings.return_value.posthog_api_base_url = "https://app.posthog.com"
             mock_settings.return_value.plan_cache_ttl = 300
             mock_settings.return_value.free_plan_trial_period_days = 30
             result = await resolver.get_plan(user_id=1, auth_header="Bearer phx_test")
@@ -202,7 +202,7 @@ class TestPlanResolver:
         resolver._http.get = AsyncMock(side_effect=Exception("connection refused"))  # type: ignore[method-assign]
 
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
-            mock_settings.return_value.posthog_api_url = "https://app.posthog.com"
+            mock_settings.return_value.posthog_api_base_url = "https://app.posthog.com"
             mock_settings.return_value.plan_cache_ttl = 300
             mock_settings.return_value.free_plan_trial_period_days = 30
             result = await resolver.get_plan(user_id=1, auth_header="Bearer phx_test")
@@ -220,7 +220,7 @@ class TestPlanResolver:
         resolver_with_redis._http.get = AsyncMock(side_effect=Exception("connection refused"))  # type: ignore[method-assign]
 
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
-            mock_settings.return_value.posthog_api_url = "https://app.posthog.com"
+            mock_settings.return_value.posthog_api_base_url = "https://app.posthog.com"
             mock_settings.return_value.plan_cache_ttl = 300
             mock_settings.return_value.free_plan_trial_period_days = 30
             result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -4,7 +4,6 @@ import pytest
 from fastapi.testclient import TestClient
 
 from llm_gateway.api.usage import _to_cost_limit_status
-from llm_gateway.config import get_settings
 from llm_gateway.rate_limiting.cost_throttles import (
     CostStatus,
     UserCostBurstThrottle,
@@ -130,7 +129,6 @@ class TestUsageEndpoint:
         assert data["burst"]["used_percent"] == 0
         assert data["sustained"]["used_percent"] == 0
         assert data["is_rate_limited"] is False
-        get_settings.cache_clear()
 
     def test_returns_401_without_auth(self, client: TestClient) -> None:
         response = client.get("/v1/usage/posthog_code")

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -75,15 +75,14 @@ class TestUsageEndpoint:
         assert data["sustained"]["used_percent"] == 0
         assert data["is_rate_limited"] is False
 
-    def test_returns_trial_limits_when_flag_on(
-        self, authenticated_usage_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    def test_returns_trial_limits_for_free_plan_with_seat(
+        self, authenticated_usage_client: TestClient
     ) -> None:
-        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "true")
-        get_settings.cache_clear()
-
         app = authenticated_usage_client.app
         app.state.plan_resolver.get_plan = AsyncMock(
-            return_value=PlanInfo(plan_key=None, in_trial_period=True, seat_created_at=None)
+            return_value=PlanInfo(
+                plan_key=None, in_trial_period=True, seat_created_at="2026-01-01T00:00:00+00:00"
+            )
         )
 
         response = authenticated_usage_client.get(
@@ -95,17 +94,17 @@ class TestUsageEndpoint:
 
         assert data["burst"]["used_percent"] == 0
         assert data["sustained"]["used_percent"] == 0
-        get_settings.cache_clear()
 
     def test_returns_zero_limits_when_trial_expired(
-        self, authenticated_usage_client: TestClient, monkeypatch: pytest.MonkeyPatch
+        self, authenticated_usage_client: TestClient
     ) -> None:
-        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "true")
-        get_settings.cache_clear()
-
         app = authenticated_usage_client.app
         app.state.plan_resolver.get_plan = AsyncMock(
-            return_value=PlanInfo(plan_key="posthog-code-free-20260301", in_trial_period=False, seat_created_at=None)
+            return_value=PlanInfo(
+                plan_key="posthog-code-free-20260301",
+                in_trial_period=False,
+                seat_created_at="2025-01-01T00:00:00+00:00",
+            )
         )
 
         response = authenticated_usage_client.get(
@@ -120,14 +119,10 @@ class TestUsageEndpoint:
         assert data["sustained"]["used_percent"] == 100.0
         assert data["sustained"]["exceeded"] is True
         assert data["is_rate_limited"] is True
-        get_settings.cache_clear()
 
     def test_returns_pro_limits_with_pro_plan(
-        self, authenticated_usage_client: TestClient, monkeypatch: pytest.MonkeyPatch
+        self, authenticated_usage_client: TestClient
     ) -> None:
-        monkeypatch.setenv("LLM_GATEWAY_PLAN_AWARE_THROTTLING_ENABLED", "true")
-        get_settings.cache_clear()
-
         app = authenticated_usage_client.app
         app.state.plan_resolver.get_plan = AsyncMock(
             return_value=PlanInfo(plan_key="posthog-code-200-20260301", in_trial_period=False, seat_created_at=None)

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -75,14 +75,10 @@ class TestUsageEndpoint:
         assert data["sustained"]["used_percent"] == 0
         assert data["is_rate_limited"] is False
 
-    def test_returns_trial_limits_for_free_plan_with_seat(
-        self, authenticated_usage_client: TestClient
-    ) -> None:
+    def test_returns_trial_limits_for_free_plan_with_seat(self, authenticated_usage_client: TestClient) -> None:
         app = authenticated_usage_client.app
         app.state.plan_resolver.get_plan = AsyncMock(
-            return_value=PlanInfo(
-                plan_key=None, in_trial_period=True, seat_created_at="2026-01-01T00:00:00+00:00"
-            )
+            return_value=PlanInfo(plan_key=None, in_trial_period=True, seat_created_at="2026-01-01T00:00:00+00:00")
         )
 
         response = authenticated_usage_client.get(
@@ -95,9 +91,7 @@ class TestUsageEndpoint:
         assert data["burst"]["used_percent"] == 0
         assert data["sustained"]["used_percent"] == 0
 
-    def test_returns_zero_limits_when_trial_expired(
-        self, authenticated_usage_client: TestClient
-    ) -> None:
+    def test_returns_zero_limits_when_trial_expired(self, authenticated_usage_client: TestClient) -> None:
         app = authenticated_usage_client.app
         app.state.plan_resolver.get_plan = AsyncMock(
             return_value=PlanInfo(
@@ -120,9 +114,7 @@ class TestUsageEndpoint:
         assert data["sustained"]["exceeded"] is True
         assert data["is_rate_limited"] is True
 
-    def test_returns_pro_limits_with_pro_plan(
-        self, authenticated_usage_client: TestClient
-    ) -> None:
+    def test_returns_pro_limits_with_pro_plan(self, authenticated_usage_client: TestClient) -> None:
         app = authenticated_usage_client.app
         app.state.plan_resolver.get_plan = AsyncMock(
             return_value=PlanInfo(plan_key="posthog-code-200-20260301", in_trial_period=False, seat_created_at=None)

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -61,7 +61,7 @@ class TestUsageEndpoint:
         with TestClient(app) as c:
             yield c
 
-    def test_returns_pro_limits_when_flag_off(self, authenticated_usage_client: TestClient) -> None:
+    def test_returns_pro_limits_by_default(self, authenticated_usage_client: TestClient) -> None:
         response = authenticated_usage_client.get(
             "/v1/usage/posthog_code",
             headers={"Authorization": "Bearer phx_test"},

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -30,7 +30,7 @@ const errorTrackingAssignmentRulesList = (): ToolBase<
         const projectId = await context.stateManager.getProjectId()
         const result = await context.api.request<Schemas.PaginatedErrorTrackingAssignmentRuleList>({
             method: 'GET',
-            path: `/api/environments/${projectId}/error_tracking/assignment_rules/`,
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/error_tracking/assignment_rules/`,
             query: {
                 limit: params.limit,
                 offset: params.offset,
@@ -183,7 +183,7 @@ const errorTrackingIssuesSplitCreate = (): ToolBase<
         }
         const result = await context.api.request<Schemas.ErrorTrackingIssueSplitResponse>({
             method: 'POST',
-            path: `/api/environments/${projectId}/error_tracking/issues/${params.id}/split/`,
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/error_tracking/issues/${encodeURIComponent(String(params.id))}/split/`,
             body,
         })
         return result


### PR DESCRIPTION
## Problem

The plan resolver is now always active, there's no feature flag to flip. The gateway resolves the plan via `/api/seats/me/?product_key=posthog_code`, cached in Redis for 5 minutes. (only for requests attributed to the `posthog_code` product)

Current behavior:
- No seat (no plan at all): $100/day burst, $1,000/30d sustained = same as pro. Alpha users are here today so nothing changes for them.
- Free plan with a seat, in trial (< 30 days from seat_created_at): $5/day, $50/30d
- Free plan with a seat, trial expired (> 30 days from seat_created_at): $0/$0 = hard block
- Pro plan: $100/day, $1,000/30d

So alpha users currently have no seats and get full pro limits. When beta launches and seats are created, the free plan limits kick in automatically with no code change needed.

## Changes

  1. Remove plan_aware_throttling_enabled feature flag — throttling is always active for posthog_code
  2. Default posthog_api_base_url to https://us.posthog.com (renamed from posthog_api_url)
  3. Treat seatless users (seat_created_at=None) as pro-tier instead of free-tier
  4. Always include billing period in sustained throttle cache keys
  5. Clean up tests: remove flag toggling and add explicit seat_created_at in test contexts

## How did you test this code?

Manually