### PR TITLE
fix(surveys): handle missing optional survey booleans

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -92,6 +92,7 @@ import {
     buildAggregateQuery,
     buildOpenEndedQuery,
     buildPartialResponsesFilter,
+    buildSurveyOptionalBooleanPropertyFilter,
     buildSurveyTimestampFilter,
     calculateSurveyRates,
     createAnswerFilterHogQLExpression,
@@ -747,7 +748,10 @@ export const surveyLogic = kea<surveyLogicType>([
                         AND (
                             event != '${SurveyEventName.DISMISSED}'
                             OR
-                            JSONExtractString(properties, '${SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED}') != 'true'
+                            ${buildSurveyOptionalBooleanPropertyFilter(
+                                SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED,
+                                'true'
+                            )}
                         )
                         AND (
                             -- Include non-'sent' events directly
@@ -800,7 +804,10 @@ export const surveyLogic = kea<surveyLogicType>([
                             AND (
                             event != '${SurveyEventName.DISMISSED}'
                             OR
-                            JSONExtractString(properties, '${SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED}') != 'true'
+                            ${buildSurveyOptionalBooleanPropertyFilter(
+                                SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED,
+                                'true'
+                            )}
                             )
                             AND {filters} -- Apply property filters here to reduce initial events
                         GROUP BY person_id
@@ -1576,7 +1583,10 @@ export const surveyLogic = kea<surveyLogicType>([
                  * So we return all responses that don't have it.
                  * For posthog-js > 1.240, we use the $survey_completed property.
                  */
-                return `AND JSONExtractString(properties, '${SurveyEventProperties.SURVEY_COMPLETED}') != 'false'`
+                return `AND ${buildSurveyOptionalBooleanPropertyFilter(
+                    SurveyEventProperties.SURVEY_COMPLETED,
+                    'false'
+                )}`
             },
         ],
         archivedResponsesFilter: [

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -20,6 +20,7 @@ import {
 import {
     buildSurveyExampleInvocationGlobals,
     buildPartialResponsesFilter,
+    buildSurveyOptionalBooleanPropertyFilter,
     buildSurveyTimestampFilter,
     calculateNpsBreakdown,
     createAnswerFilterHogQLExpression,
@@ -918,6 +919,19 @@ describe('survey utils', () => {
     })
 
     describe('buildPartialResponsesFilter', () => {
+        it('keeps missing survey_completed values eligible for complete-response queries', () => {
+            const survey = {
+                id: 'test-survey-id',
+                created_at: '2024-11-19T00:00:00Z',
+                end_date: null,
+                enable_partial_responses: false,
+            } as Survey
+
+            expect(buildPartialResponsesFilter(survey)).toBe(
+                `AND ${buildSurveyOptionalBooleanPropertyFilter(SurveyEventProperties.SURVEY_COMPLETED, 'false')}`
+            )
+        })
+
         it('uses same date bounds as buildSurveyTimestampFilter', () => {
             const survey = {
                 id: 'test-survey-id',
@@ -950,6 +964,14 @@ describe('survey utils', () => {
             expect(partialFilter).toContain('properties.`$survey_id`')
             expect(partialFilter).toContain('properties.`$survey_submission_id`')
             expect(partialFilter).not.toContain('JSONExtractString')
+        })
+    })
+
+    describe('buildSurveyOptionalBooleanPropertyFilter', () => {
+        it('builds a null-safe comparison for optional survey booleans', () => {
+            expect(
+                buildSurveyOptionalBooleanPropertyFilter(SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED, 'true')
+            ).toBe(`coalesce(JSONExtractString(properties, '$survey_partially_completed'), '') != 'true'`)
         })
     })
 })

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -576,9 +576,16 @@ export function doesSurveyHaveDisplayConditions(survey: Survey | NewSurvey): boo
     return false
 }
 
+export function buildSurveyOptionalBooleanPropertyFilter(
+    propertyName: SurveyEventProperties,
+    excludedValue: 'true' | 'false'
+): string {
+    return `coalesce(JSONExtractString(properties, '${propertyName}'), '') != '${excludedValue}'`
+}
+
 export function buildPartialResponsesFilter(survey: Survey, dateRange?: SurveyDateRange | null): string {
     if (!survey.enable_partial_responses) {
-        return `AND JSONExtractString(properties, '${SurveyEventProperties.SURVEY_COMPLETED}') != 'false'`
+        return `AND ${buildSurveyOptionalBooleanPropertyFilter(SurveyEventProperties.SURVEY_COMPLETED, 'false')}`
     }
 
     const { fromDate, toDate } = getResolvedSurveyDateRange(survey, dateRange)


### PR DESCRIPTION
## Problem

Survey queries in the frontend were comparing optional survey boolean properties with plain string inequality checks.

When `$survey_completed` or `$survey_partially_completed` was missing, those checks could evaluate to `NULL` and exclude rows that should have remained eligible. That caused consolidated survey results to miss responses even though the underlying response counts still looked correct.

## Changes

- added a shared helper for optional survey boolean filters that uses a null-safe `coalesce(JSONExtractString(...), '')` comparison
- updated the frontend survey stats and aggregate query builders to use the shared helper for `$survey_completed` and `$survey_partially_completed`
- added focused tests covering the missing-property behavior and the generated HogQL fragment

## How did you test this code?

- `hogli test frontend/src/scenes/surveys/utils.test.ts`
- `pnpm --filter=@posthog/frontend typescript:check` crashed locally with a Node out-of-memory error before reporting TypeScript results

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

no docs update needed

## 🤖 LLM context

Agent-authored PR.

Context:
- traced the regression chain from `5d2a765345` and the follow-up `2cdf8c8838a`
- confirmed the remaining live issue was frontend-only for optional survey boolean fields
- kept the optimized property-access path for non-boolean identifier fields like `$survey_id` and `$survey_submission_id`
