### PR TITLE
perf(marketing-analytics): parallelise per-goal and compare-mode query builds

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/conversion_goals_aggregator.py
+++ b/products/marketing_analytics/backend/hogql_queries/conversion_goals_aggregator.py
@@ -1,8 +1,11 @@
+from concurrent.futures import ThreadPoolExecutor
+
 from posthog.schema import MarketingAnalyticsBaseColumns, MarketingAnalyticsDrillDownLevel
 
 from posthog.hogql import ast
 
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from posthog.settings import TEST
 
 from products.marketing_analytics.backend.hogql_queries.constants import UNIFIED_CONVERSION_GOALS_CTE_ALIAS
 
@@ -26,11 +29,11 @@ class ConversionGoalsAggregator:
         if not self.processors:
             raise ValueError("Cannot create unified CTE without conversion goal processors")
 
-        # Step 1: Generate individual conversion goal queries
-        conversion_subqueries = []
-
-        for processor in self.processors:
-            # Build additional conditions for this processor
+        # Step 1: Generate individual conversion goal queries.
+        # Each goal's build is independent, so we run them in a thread pool
+        # to collapse serial overhead (especially ensure_precomputed calls).
+        # Skipped in tests: Django test transactions aren't visible across threads.
+        def _build_base_query(processor: ConversionGoalProcessor) -> ast.SelectQuery:
             date_field = processor.get_date_field()
             additional_conditions = additional_conditions_getter(
                 date_range=date_range,
@@ -38,10 +41,16 @@ class ConversionGoalsAggregator:
                 date_field=date_field,
                 use_date_not_datetime=True,
             )
+            return processor.generate_cte_query(additional_conditions)
 
-            # Generate the base conversion goal query
-            base_query = processor.generate_cte_query(additional_conditions)
+        if not TEST and len(self.processors) > 1:
+            with ThreadPoolExecutor(max_workers=min(len(self.processors), 8), thread_name_prefix="ma_cte") as pool:
+                base_queries = list(pool.map(_build_base_query, self.processors))
+        else:
+            base_queries = [_build_base_query(p) for p in self.processors]
 
+        conversion_subqueries = []
+        for processor, base_query in zip(self.processors, base_queries):
             # Transform the query to include a column for this specific conversion goal
             # and zero columns for all other conversion goals
             # Note: base_query schema is: [0]=match_key, [1]=campaign, [2]=id, [3]=source, [4]=conversion

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
@@ -234,11 +234,12 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
             date_to=previous_date_range.date_to().isoformat(),
         )
 
-        # Create a new runner for the previous period
+        # Create a new runner for the previous period.
+        # Clone timings so the parallel to_query() calls don't race on the shared HogQLTimings instance.
         previous_runner = MarketingAnalyticsTableQueryRunner(
             query=previous_query,
             team=self.team,
-            timings=self.timings,
+            timings=self.timings.clone_for_subquery(0),
             modifiers=self.modifiers,
             limit_context=self.limit_context,
         )

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from typing import Optional
 
@@ -17,6 +18,7 @@ from posthog.hogql import ast
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
+from posthog.settings import TEST
 
 from products.marketing_analytics.backend.hogql_queries.marketing_analytics_config import MarketingAnalyticsConfig
 
@@ -241,8 +243,17 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
             limit_context=self.limit_context,
         )
 
-        previous_period_query = previous_runner.to_query()
-        current_period_query = self.to_query()
+        # Current and previous periods are independent — parallelise them.
+        # Skipped in tests: Django test transactions aren't visible across threads.
+        if TEST:
+            previous_period_query = previous_runner.to_query()
+            current_period_query = self.to_query()
+        else:
+            with ThreadPoolExecutor(max_workers=2, thread_name_prefix="ma_compare") as pool:
+                previous_future = pool.submit(previous_runner.to_query)
+                current_future = pool.submit(self.to_query)
+                previous_period_query = previous_future.result()
+                current_period_query = current_future.result()
 
         # Create the join manually with proper AST structure
         join_expr = self._build_compare_join(current_period_query, previous_period_query)


### PR DESCRIPTION
depends on https://github.com/PostHog/posthog/pull/54989

## Problem

Marketing analytics dashboards with multiple conversion goals build each goal's CTE query serially. With N goals, the dashboard pays N × build_time. Similarly, compare mode builds the current and previous period queries one after the other, doubling the wall clock time.

In production, each goal's `generate_cte_query` can trigger `ensure_precomputed` calls that block on PG + Redis + ClickHouse round-trips (~1-2s each). With 3 goals + compare, that's up to 6 × 1.5s = 9s of serialised overhead.

## Changes

**Per-goal parallelisation** (`conversion_goals_aggregator.py`):
- Wrap the per-processor `generate_cte_query` loop in a `ThreadPoolExecutor` with `max_workers=min(N_goals, 8)`.
- Total overhead becomes `max(goal_times)` instead of `sum(goal_times)`.

**Compare-mode parallelisation** (`marketing_analytics_table_query_runner.py`):
- Run `previous_runner.to_query()` and `self.to_query()` in a 2-thread pool instead of serially.

**TEST guard on both**:
- Django wraps each test in a transaction visible only to a single DB connection. `ThreadPoolExecutor` gives each worker its own connection, so worker threads can't see objects created in the test setup (e.g. Action fixtures). Both pools fall back to serial execution when `TEST=True`.
- This follows the same pattern as `posthog/sync.py` (`DatabaseSyncToAsync.thread_handler`), which also skips connection management in tests.

## How did you test this code?

- Ran `test_conversion_goals_aggregator` (25 tests), `test_marketing_analytics_table_query_runner_compare` (9 tests) — all pass.
- Benchmarked with 2 eligible goals, compare ON: serial ~4.2s → parallel ~3.1s for the build phase (local, GIL-bound). In production with remote PG/Redis/CH the improvement is larger since threads release GIL during I/O waits.

No publish to changelog