### PR TITLE
feat: send welcome email for provisioned accounts

### DIFF
--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -472,8 +472,8 @@ def _handle_new_user(
     try:
         reset_token = password_reset_token_generator.make_token(user)
         send_provisioning_welcome.delay(user.id, reset_token, partner_label)
-    except Exception as e:
-        capture_exception(e, {"user_id": user.id, "step": "provisioning_welcome_email"})
+    except Exception:
+        capture_exception(additional_properties={"user_id": user.id, "step": "provisioning_welcome_email"})
 
     code = secrets.token_urlsafe(32)
     cache_key = f"{AUTH_CODE_CACHE_PREFIX}{code}"

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -472,8 +472,8 @@ def _handle_new_user(
     try:
         reset_token = password_reset_token_generator.make_token(user)
         send_provisioning_welcome.delay(user.id, reset_token, partner_label)
-    except Exception:
-        capture_exception(Exception("Failed to send provisioning welcome email"), {"user_id": user.id})
+    except Exception as e:
+        capture_exception(e, {"user_id": user.id, "step": "provisioning_welcome_email"})
 
     code = secrets.token_urlsafe(32)
     cache_key = f"{AUTH_CODE_CACHE_PREFIX}{code}"

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -28,6 +28,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from posthog.api.authentication import password_reset_token_generator
 from posthog.exceptions_capture import capture_exception
 from posthog.models.integration import StripeIntegration
 from posthog.models.oauth import (
@@ -46,6 +47,7 @@ from posthog.models.utils import (
     generate_random_token_personal,
     mask_key_value,
 )
+from posthog.tasks.email import send_provisioning_welcome
 from posthog.utils import get_instance_region
 
 from ee.settings import BILLING_SERVICE_URL
@@ -466,6 +468,12 @@ def _handle_new_user(
         )
 
     _capture_provisioning_event("account_request", "new_user", region=region)
+
+    try:
+        reset_token = password_reset_token_generator.make_token(user)
+        send_provisioning_welcome.delay(user.id, reset_token, partner_label)
+    except Exception:
+        capture_exception(Exception("Failed to send provisioning welcome email"), {"user_id": user.id})
 
     code = secrets.token_urlsafe(32)
     cache_key = f"{AUTH_CODE_CACHE_PREFIX}{code}"

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -271,6 +271,26 @@ def send_member_join(invitee_uuid: str, organization_id: str) -> None:
 
 
 @shared_task(**EMAIL_TASK_KWARGS)
+def send_provisioning_welcome(user_id: int, token: str, partner_name: str = "") -> None:
+    user = User.objects.get(pk=user_id)
+    message = EmailMessage(
+        use_http=True,
+        campaign_key=f"provisioning-welcome-{user.uuid}-{timezone.now().timestamp()}",
+        subject="Welcome to PostHog - set your password",
+        template_name="provisioning_welcome",
+        template_context={
+            "preheader": "Your PostHog account is ready. Set your password to log in.",
+            "link": f"/reset/{user.uuid}/{token}",
+            "cloud": is_cloud(),
+            "site_url": settings.SITE_URL,
+            "partner_name": partner_name,
+        },
+    )
+    message.add_user_recipient(user)
+    message.send(send_async=False)
+
+
+@shared_task(**EMAIL_TASK_KWARGS)
 def send_password_reset(user_id: int, token: str) -> None:
     user = User.objects.get(pk=user_id)
     message = EmailMessage(

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -53,6 +53,7 @@
     'posthog.tasks.email.send_personal_api_key_exposed',
     'posthog.tasks.email.send_project_deleted_email',
     'posthog.tasks.email.send_project_secret_api_key_exposed',
+    'posthog.tasks.email.send_provisioning_welcome',
     'posthog.tasks.email.send_team_hog_functions_digest',
     'posthog.tasks.email.send_two_factor_auth_backup_code_used_email',
     'posthog.tasks.email.send_two_factor_auth_disabled_email',

--- a/posthog/tasks/test/test_email.py
+++ b/posthog/tasks/test/test_email.py
@@ -34,6 +34,7 @@ from posthog.tasks.email import (
     send_member_join,
     send_new_ticket_notification,
     send_password_reset,
+    send_provisioning_welcome,
     send_saved_query_materialization_failure,
     should_send_notification,
     should_send_pipeline_error_notification,
@@ -131,6 +132,32 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
         assert len(mocked_email_messages) == 1
         assert mocked_email_messages[0].send.call_count == 1
         assert mocked_email_messages[0].html_body
+
+    def test_send_provisioning_welcome(self, MockEmailMessage: MagicMock) -> None:
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+        org, user = create_org_team_and_user("2022-01-02 00:00:00", "admin@posthog.com")
+        token = password_reset_token_generator.make_token(self.user)
+
+        send_provisioning_welcome(user.id, token, "Wizard")
+
+        assert len(mocked_email_messages) == 1
+        assert mocked_email_messages[0].send.call_count == 1
+        assert mocked_email_messages[0].html_body
+        assert "Set your password" in mocked_email_messages[0].html_body
+        assert "Wizard" in mocked_email_messages[0].html_body
+
+    def test_send_provisioning_welcome_without_partner(self, MockEmailMessage: MagicMock) -> None:
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+        org, user = create_org_team_and_user("2022-01-02 00:00:00", "admin@posthog.com")
+        token = password_reset_token_generator.make_token(self.user)
+
+        send_provisioning_welcome(user.id, token)
+
+        assert len(mocked_email_messages) == 1
+        assert mocked_email_messages[0].send.call_count == 1
+        assert mocked_email_messages[0].html_body
+        assert "Set your password" in mocked_email_messages[0].html_body
+        assert "via" not in mocked_email_messages[0].html_body
 
     @patch("posthoganalytics.capture")
     def test_send_email_verification(self, mock_capture: MagicMock, MockEmailMessage: MagicMock) -> None:

--- a/posthog/templates/email/provisioning_welcome.html
+++ b/posthog/templates/email/provisioning_welcome.html
@@ -1,0 +1,18 @@
+{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}{% block section %}
+<p>
+    Welcome to PostHog! Your account was created{% if partner_name %} via {{ partner_name }}{% endif %}.
+</p>
+<p>
+    Set a password to log in to PostHog directly.
+</p>
+<div class="mb mt text-center">
+    <a class="button" href="{% absolute_uri link %}">Set your password</a>
+</div>
+
+<div class="mt muted">
+    <p>
+        If the button above doesn't work, paste this link into your browser:<br />
+        <a href="{% absolute_uri link %}">{% absolute_uri link %}</a>
+    </p>
+</div>
+{% endblock %} {% block preheader %}{{preheader}}{% endblock %}{% block heading %}Welcome to PostHog{% endblock %}


### PR DESCRIPTION
## Problem

When a new account is created via the agentic provisioning API (wizard, Stripe, or future TPAs), the user has no password and receives no email. They can't log into the PostHog web UI unless they manually navigate to /reset.

## Changes

- New email template `provisioning_welcome.html` - "Welcome to PostHog" with a "Set your password" button. Partner-aware: shows "Your account was created via [Partner Name]" when applicable.
- New Celery task `send_provisioning_welcome` in `posthog/tasks/email.py` that generates a password reset token and sends the welcome email.
- `_handle_new_user` in provisioning views sends the welcome email after account creation via `.delay()`. Email failure is caught and reported to error tracking without blocking account creation.
- Uses the existing `/reset/{uuid}/{token}` endpoint - same mechanism as password reset, just with welcome-appropriate copy.

## How did you test this code?

- 2 new unit tests: `test_send_provisioning_welcome` (with partner name) and `test_send_provisioning_welcome_without_partner`
- All 24 provisioning auth/token tests pass
- All 43 email task tests pass
- Full provisioning flow tested against US prod (account creation, token exchange, resource provisioning)
- Agent-authored: manual email delivery testing was not performed

## Publish to changelog?

No

## 🤖 LLM context

Co-authored with Claude Code. The email reuses Django's password reset token infrastructure but with a welcome-appropriate template. The `partner_name` context lets the same template work for wizard, Stripe, and future TPAs.