### PR TITLE
fix(replay): strip session IDs when creating/loading saved filter

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -60,7 +60,7 @@ import {
 import { sessionRecordingSavedFiltersLogic } from '../filters/sessionRecordingSavedFiltersLogic'
 import { TimestampFormat, playerSettingsLogic } from '../player/playerSettingsLogic'
 import { playlistFiltersLogic } from '../playlist/playlistFiltersLogic'
-import { createPlaylist, updatePlaylist } from '../playlist/playlistUtils'
+import { createPlaylist, stripSessionIds, updatePlaylist } from '../playlist/playlistUtils'
 import {
     defaultRecordingDurationFilter,
     sessionRecordingsPlaylistLogic,
@@ -361,7 +361,10 @@ const SaveFiltersModal = ({
     }
 
     const addSavedFilter = async (): Promise<void> => {
-        const f = await createPlaylist({ name: savedFilterName, filters, type: 'filters' }, false)
+        const f = await createPlaylist(
+            { name: savedFilterName, filters: stripSessionIds(filters), type: 'filters' },
+            false
+        )
         reportRecordingPlaylistCreated('new')
         loadSavedFilters()
         setIsOpen(false)
@@ -540,7 +543,7 @@ const ReplayFiltersTab = ({
         }
 
         if (pendingFilterApplication.filters) {
-            setFilters(pendingFilterApplication.filters as Partial<RecordingUniversalFilters>)
+            setFilters(stripSessionIds(pendingFilterApplication.filters as Partial<RecordingUniversalFilters>))
             setAppliedSavedFilter(pendingFilterApplication)
             setActiveFilterTab('filters')
         }
@@ -553,7 +556,11 @@ const ReplayFiltersTab = ({
             return
         }
 
-        const f = await updatePlaylist(appliedSavedFilter.short_id, { filters, type: 'filters' }, false)
+        const f = await updatePlaylist(
+            appliedSavedFilter.short_id,
+            { filters: stripSessionIds(filters), type: 'filters' },
+            false
+        )
         loadSavedFilters()
         setAppliedSavedFilter(f)
     }
@@ -592,7 +599,11 @@ const ReplayFiltersTab = ({
                                 size="small"
                                 icon={<IconTrash />}
                                 onClick={() =>
-                                    setFilters(appliedSavedFilter.filters as Partial<RecordingUniversalFilters>)
+                                    setFilters(
+                                        stripSessionIds(
+                                            appliedSavedFilter.filters as Partial<RecordingUniversalFilters>
+                                        )
+                                    )
                                 }
                             >
                                 Discard changes

--- a/frontend/src/scenes/session-recordings/filters/SavedFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/SavedFilters.tsx
@@ -30,6 +30,7 @@ import {
 
 import { sessionRecordingSavedFiltersLogic } from '../filters/sessionRecordingSavedFiltersLogic'
 import { playlistFiltersLogic } from '../playlist/playlistFiltersLogic'
+import { stripSessionIds } from '../playlist/playlistUtils'
 import { SavedFiltersEmptyState, SavedFiltersLoadingState } from './SavedFiltersStates'
 
 export function isPlaylistRecordingsCounts(x: unknown): x is PlaylistRecordingsCounts {
@@ -150,7 +151,7 @@ export function SavedFilters({
                         <div
                             onClick={() => {
                                 if (filter && filter.filters) {
-                                    setFilters(filter.filters)
+                                    setFilters(stripSessionIds(filter.filters))
                                     setActiveFilterTab('filters')
                                     setAppliedSavedFilter(filter)
                                 }

--- a/frontend/src/scenes/session-recordings/filters/sessionRecordingSavedFiltersLogic.ts
+++ b/frontend/src/scenes/session-recordings/filters/sessionRecordingSavedFiltersLogic.ts
@@ -15,7 +15,7 @@ import {
     SessionRecordingPlaylistType,
 } from '~/types'
 
-import { deletePlaylist } from '../playlist/playlistUtils'
+import { deletePlaylist, stripSessionIds } from '../playlist/playlistUtils'
 import type { sessionRecordingSavedFiltersLogicType } from './sessionRecordingSavedFiltersLogicType'
 
 export const PLAYLISTS_PER_PAGE = 30
@@ -136,7 +136,7 @@ export const sessionRecordingSavedFiltersLogic = kea<sessionRecordingSavedFilter
             if (savedFilterId) {
                 const savedFilter = await api.recordings.getPlaylist(savedFilterId)
                 if (savedFilter) {
-                    router.actions.push(urls.replay(ReplayTabs.Home, savedFilter.filters))
+                    router.actions.push(urls.replay(ReplayTabs.Home, stripSessionIds(savedFilter.filters)))
                     actions.setAppliedSavedFilter(savedFilter)
                 }
             }

--- a/frontend/src/scenes/session-recordings/playlist/playlistUtils.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/playlistUtils.test.ts
@@ -1,6 +1,12 @@
-import { summarizePlaylistFilters } from 'scenes/session-recordings/playlist/playlistUtils'
+import { stripSessionIds, summarizePlaylistFilters } from 'scenes/session-recordings/playlist/playlistUtils'
 
-import { CohortType, FilterLogicalOperator, PropertyFilterType, PropertyOperator } from '~/types'
+import {
+    CohortType,
+    FilterLogicalOperator,
+    PropertyFilterType,
+    PropertyOperator,
+    RecordingUniversalFilters,
+} from '~/types'
 
 describe('summarizePlaylistFilters()', () => {
     const cohortIdsMapped: Partial<Record<CohortType['id'], CohortType>> = {
@@ -167,5 +173,50 @@ describe('summarizePlaylistFilters()', () => {
         ).toEqual(
             'Pageview & Random action, on Initial browser = Chrome & custom_property ∋ blah & cohorts: New Yorkers'
         )
+    })
+})
+
+describe('stripSessionIds()', () => {
+    const baseFilters: Partial<RecordingUniversalFilters> = {
+        date_from: '-30d',
+        date_to: null,
+        filter_test_accounts: false,
+        filter_group: {
+            type: FilterLogicalOperator.And,
+            values: [
+                {
+                    type: FilterLogicalOperator.And,
+                    values: [
+                        {
+                            key: 'id',
+                            type: PropertyFilterType.Cohort,
+                            operator: PropertyOperator.In,
+                            value: 247048,
+                        },
+                    ],
+                },
+            ],
+        },
+    }
+
+    it('strips session ids, leaves other filter fields untouched', () => {
+        const result = stripSessionIds({
+            ...baseFilters,
+            session_ids: ['019d68e1-1165-7cf9-b87b-759fe1604d99'],
+        })
+        expect(result).toEqual(baseFilters)
+    })
+
+    it('returns the same reference when session_ids is absent', () => {
+        // no allocation, no mutation — cheap no-op path
+        const input = { ...baseFilters }
+        expect(stripSessionIds(input)).toBe(input)
+    })
+
+    it.each([
+        ['undefined', undefined],
+        ['null', null],
+    ])('passes %s through unchanged', (_name, input) => {
+        expect(stripSessionIds(input as any)).toBe(input)
     })
 })

--- a/frontend/src/scenes/session-recordings/playlist/playlistUtils.ts
+++ b/frontend/src/scenes/session-recordings/playlist/playlistUtils.ts
@@ -17,7 +17,24 @@ import { urls } from 'scenes/urls'
 import { deleteFromTree, refreshTreeItem } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import { cohortsModelType } from '~/models/cohortsModelType'
 import { getCoreFilterDefinition } from '~/taxonomy/helpers'
-import { PropertyOperator, SessionRecordingPlaylistType, UniversalFilterValue } from '~/types'
+import {
+    PropertyOperator,
+    RecordingUniversalFilters,
+    SessionRecordingPlaylistType,
+    UniversalFilterValue,
+} from '~/types'
+
+/**
+ * There's an edge case (ticket) where depending on entrypoint to Replay, pre-seeded
+ * session IDs can be accidentally saved explicilty as part of a saved filter (unintentionally)
+ */
+export function stripSessionIds<T extends Partial<RecordingUniversalFilters> | undefined | null>(filters: T): T {
+    if (!filters || !('session_ids' in filters)) {
+        return filters
+    }
+    const { session_ids: _session_ids, ...rest } = filters
+    return rest as T
+}
 
 function getOperatorSymbol(operator: PropertyOperator | null): string {
     if (!operator) {


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/55914 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/57583)  
Customer was seeing odd behavior where, for example:   
Replay Home -> Apply Filter A : results  
Load Saved Filter (which has Filter A and Filter B), remove filter B (so only Filter A) : ZERO results  
  
Turns out there was a weird edge case where if the URL has explicit Session IDs (entered replay from a Person, or other non-direct entrypoint) it will copy those params as part of the Saved Filter even when they're not represented in the UI  
  
So the saved filter wasnt ACTUALLY just "Filter A + Filter B," it was "Filter A + Filter B + [six session ids]" 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

strip the session IDs from filters when creating a Saved Filter

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->