### PR TITLE
chore: capture saml/sso/jit domain setting events

### DIFF
--- a/frontend/src/lib/posthog-typed.ts
+++ b/frontend/src/lib/posthog-typed.ts
@@ -2761,9 +2761,6 @@ interface EventSchemas {
     'organization deleted': Record<string, any>
     'organization domain created': Record<string, any>
     'organization domain deleted': Record<string, any>
-    'organization domain jit provisioning enabled': Record<string, any>
-    'organization domain saml configured': Record<string, any>
-    'organization domain sso enforcement updated': Record<string, any>
     'organization environments rollback completed': Record<string, any>
     'organization environments rollback project id conflict': Record<string, any>
     'organization environments rollback started': Record<string, any>

--- a/frontend/src/lib/posthog-typed.ts
+++ b/frontend/src/lib/posthog-typed.ts
@@ -2761,6 +2761,9 @@ interface EventSchemas {
     'organization deleted': Record<string, any>
     'organization domain created': Record<string, any>
     'organization domain deleted': Record<string, any>
+    'organization domain jit provisioning enabled': Record<string, any>
+    'organization domain saml configured': Record<string, any>
+    'organization domain sso enforcement updated': Record<string, any>
     'organization environments rollback completed': Record<string, any>
     'organization environments rollback project id conflict': Record<string, any>
     'organization environments rollback started': Record<string, any>

--- a/posthog/api/organization_domain.py
+++ b/posthog/api/organization_domain.py
@@ -267,7 +267,7 @@ class OrganizationDomainViewset(TeamAndOrgViewSetMixin, ModelViewSet):
 
     def _capture_domain_setting_event(self, request: Request) -> None:
         data = request.data
-        if any(f in data for f in ("saml_entity_id", "saml_acs_url", "saml_x509_cert")):
+        if any(f.startswith("saml_") for f in data):
             event_type = "saml configured"
         elif "sso_enforcement" in data:
             event_type = "sso enforcement updated"

--- a/posthog/api/organization_domain.py
+++ b/posthog/api/organization_domain.py
@@ -265,6 +265,23 @@ class OrganizationDomainViewset(TeamAndOrgViewSetMixin, ModelViewSet):
 
         return response.Response(serializer.data, status=201)
 
+    def _capture_domain_setting_event(self, request: Request) -> None:
+        data = request.data
+        if any(f in data for f in ("saml_entity_id", "saml_acs_url", "saml_x509_cert")):
+            event_type = "saml configured"
+        elif "sso_enforcement" in data:
+            event_type = "sso enforcement updated"
+        elif data.get("jit_provisioning_enabled") is True:
+            event_type = "jit provisioning enabled"
+        else:
+            return
+
+        _capture_domain_event(request, self.get_object(), event_type)
+
+    def update(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
+        self._capture_domain_setting_event(request)
+        return super().update(request, *args, **kwargs)
+
     def destroy(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
         instance = self.get_object()
 


### PR DESCRIPTION
## Problem

We don't track when admins configure SAML, change SSO enforcement, or toggle JIT provisioning. These are the signals we need for the enterprise upsell flow (e.g. nudging SCIM/RBAC after SAML setup). 

## Changes

Added _capture_domain_setting_event() on OrganizationDomainViewset with 3 new events: 
`organization domain saml configured`
`organization domain sso enforcement updated`
`organization domain jit provisioning enabled`
based on which fields are in the PATCH request. Frontend sends only changed fields. 

## Publish to changelog?

no