### PR TITLE
fix(llma): remove session recording button if doesn't exist

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -36,6 +36,7 @@ import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { HighlightedJSONViewer } from 'lib/components/HighlightedJSONViewer'
 import { JSONViewer } from 'lib/components/JSONViewer'
 import { NotFound } from 'lib/components/NotFound'
+import { sessionRecordingExistsLogic } from 'lib/components/ViewRecordingButton/sessionRecordingExistsLogic'
 import ViewRecordingButton, { RecordingPlayerType } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
@@ -1464,7 +1465,18 @@ const EventContent = React.memo(
 
         const childEventsForSessionId: LLMTraceEvent[] | undefined = node?.children?.map((child) => child.event)
         const sessionId = event ? getSessionID(event, childEventsForSessionId) : null
-        const hasSessionRecording = !!sessionId
+
+        const { checkRecordingExists: registerRecordingCheck } = useActions(sessionRecordingExistsLogic)
+        const { getRecordingExists } = useValues(sessionRecordingExistsLogic)
+
+        useEffect(() => {
+            if (sessionId) {
+                registerRecordingCheck(sessionId)
+            }
+        }, [sessionId, registerRecordingCheck])
+
+        const recordingExists = sessionId ? getRecordingExists(sessionId) : false
+        const hasSessionRecording = !!sessionId && recordingExists !== false
 
         const isGenerationEvent = event && isLLMEvent(event) && event.event === '$ai_generation'
 

--- a/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTraceScene.tsx
@@ -36,7 +36,6 @@ import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { HighlightedJSONViewer } from 'lib/components/HighlightedJSONViewer'
 import { JSONViewer } from 'lib/components/JSONViewer'
 import { NotFound } from 'lib/components/NotFound'
-import { sessionRecordingExistsLogic } from 'lib/components/ViewRecordingButton/sessionRecordingExistsLogic'
 import ViewRecordingButton, { RecordingPlayerType } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
@@ -102,7 +101,6 @@ import {
     formatLLMLatency,
     formatLLMUsage,
     getEventType,
-    getSessionID,
     getSessionStartTimestamp,
     getTraceTimestamp,
     hasCostBreakdown,
@@ -1424,21 +1422,6 @@ function EventContentDisplay({
     )
 }
 
-function findNodeForEvent(tree: EnrichedTraceTreeNode[], eventId: string): EnrichedTraceTreeNode | null {
-    for (const node of tree) {
-        if (node.event.id === eventId) {
-            return node
-        }
-        if (node.children) {
-            const result = findNodeForEvent(node.children, eventId)
-            if (result) {
-                return result
-            }
-        }
-    }
-    return null
-}
-
 const EventContent = React.memo(
     ({
         trace,
@@ -1456,27 +1439,15 @@ const EventContent = React.memo(
         showBillingInfo?: boolean
     }): JSX.Element => {
         const traceLogic = useMountedLogic(llmAnalyticsTraceLogic)
+        const traceDataLogic = useMountedLogic(llmAnalyticsTraceDataLogic)
         const { featureFlags } = useValues(featureFlagLogic)
         const { displayOption, lineNumber, initialTab, viewMode, highlightMessageIndex } = useValues(traceLogic)
         const { handleTextViewFallback, copyLinePermalink, setViewMode } = useActions(traceLogic)
+        const { sessionId, selectedNode } = useValues(traceDataLogic)
 
-        const node = event && isLLMEvent(event) ? findNodeForEvent(tree, event.id) : null
-        const aggregation = node?.aggregation || null
+        const aggregation = selectedNode?.aggregation || null
 
-        const childEventsForSessionId: LLMTraceEvent[] | undefined = node?.children?.map((child) => child.event)
-        const sessionId = event ? getSessionID(event, childEventsForSessionId) : null
-
-        const { checkRecordingExists: registerRecordingCheck } = useActions(sessionRecordingExistsLogic)
-        const { getRecordingExists } = useValues(sessionRecordingExistsLogic)
-
-        useEffect(() => {
-            if (sessionId) {
-                registerRecordingCheck(sessionId)
-            }
-        }, [sessionId, registerRecordingCheck])
-
-        const recordingExists = sessionId ? getRecordingExists(sessionId) : false
-        const hasSessionRecording = !!sessionId && recordingExists !== false
+        const hasSessionRecording = !!sessionId
 
         const isGenerationEvent = event && isLLMEvent(event) && event.event === '$ai_generation'
 
@@ -1646,6 +1617,7 @@ const EventContent = React.memo(
                                             data-attr="llm-analytics"
                                             sessionId={sessionId || undefined}
                                             timestamp={removeMilliseconds(event.createdAt)}
+                                            checkRecordingExists
                                         />
                                     )}
                                 </div>

--- a/products/llm_analytics/frontend/llmAnalyticsTraceDataLogic.ts
+++ b/products/llm_analytics/frontend/llmAnalyticsTraceDataLogic.ts
@@ -32,7 +32,7 @@ import {
     findTraceOccurrences,
 } from './searchUtils'
 import { SENTIMENT_DATE_WINDOW_DAYS } from './sentimentUtils'
-import { formatLLMUsage, getEventType, isLLMEvent, normalizeMessages } from './utils'
+import { formatLLMUsage, getEventType, getSessionID, isLLMEvent, normalizeMessages } from './utils'
 
 export interface TraceDataLogicProps {
     traceId: string
@@ -385,6 +385,28 @@ export const llmAnalyticsTraceDataLogic = kea<llmAnalyticsTraceDataLogicType>([
                 return undefined
             },
         ],
+        selectedNode: [
+            (s) => [s.event, s.enrichedTree],
+            (
+                event: LLMTrace | LLMTraceEvent | null,
+                enrichedTree: EnrichedTraceTreeNode[]
+            ): EnrichedTraceTreeNode | null => {
+                if (!event || !isLLMEvent(event)) {
+                    return null
+                }
+                return findNodeForEvent(enrichedTree, event.id)
+            },
+        ],
+        sessionId: [
+            (s) => [s.selectedNode, s.event],
+            (node: EnrichedTraceTreeNode | null, event: LLMTrace | LLMTraceEvent | null): string | null => {
+                if (!event) {
+                    return null
+                }
+                const childEvents = node?.children?.map((child) => child.event)
+                return getSessionID(event, childEvents)
+            },
+        ],
         availableEventTypes: [
             (s) => [s.enrichedTree],
             (enrichedTree: EnrichedTraceTreeNode[]): string[] => {
@@ -584,6 +606,21 @@ function aggregateSpanMetrics(node: TraceTreeNode): SpanAggregation {
 
 // Export functions for testing
 export { findEventWithParents }
+
+export function findNodeForEvent(tree: EnrichedTraceTreeNode[], eventId: string): EnrichedTraceTreeNode | null {
+    for (const node of tree) {
+        if (node.event.id === eventId) {
+            return node
+        }
+        if (node.children) {
+            const result = findNodeForEvent(node.children, eventId)
+            if (result) {
+                return result
+            }
+        }
+    }
+    return null
+}
 
 export function getInitialFocusEventId(
     showableEvents: LLMTraceEvent[],


### PR DESCRIPTION
## Problem

If the session_id is passed to a trace but there is no recording, it'll still display a button.

## Changes

Added a check for rendering the button.

## How did you test this code?

Reproduced locally and validated fix.

Before
<img width="1266" height="703" alt="Screenshot 2026-04-16 at 5 27 22 PM" src="https://github.com/user-attachments/assets/18f6f392-f65f-4c3c-bb84-4e73c4e51732" />
After
<img width="1240" height="594" alt="Screenshot 2026-04-16 at 6 21 48 PM" src="https://github.com/user-attachments/assets/8d25f64e-798c-41c9-95e4-4c2678e198f6" />

## Publish to changelog?

No

<!-- ## 🤖 LLM context -->
🤖