### PR TITLE
fix: debounce concurrent logout calls causing flaky e2e test

### DIFF
--- a/frontend/src/scenes/userLogic.ts
+++ b/frontend/src/scenes/userLogic.ts
@@ -228,8 +228,12 @@ export const userLogic = kea<userLogicType>([
             },
         ],
     }),
-    listeners(({ actions, values }) => ({
+    listeners(({ actions, values, cache }) => ({
         logout: ({ preserveLocation }) => {
+            if (cache.loggingOut) {
+                return
+            }
+            cache.loggingOut = true
             posthog.reset()
             if (preserveLocation) {
                 // Forward the current path so that after re-login the user lands back where they were


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

After #54729, clicking logout while in-flight API requests resolved with 401 could land users on `/login?next=...` instead of plain `/login`.

`userLogic.logout()` sets `window.location.href = '/logout'`, but the browser doesn't navigate instantly. In that gap, a 401 triggers `apiStatusLogic` → `logout(true)`, which overwrites `window.location.href` with `/logout?next=<path>`. Backend then redirects to `/login?next=...`.

Fixes flaky e2e tests:

- `playwright/e2e/auth-password-reset.spec.ts:16` - Can request password reset
- `playwright/e2e/auth-password-reset.spec.ts:28` - Cannot reset with invalid token
- playwright/e2e/auth.spec.ts:13,18,32,46 - multiple logout-then-/login assertions

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Changes

`cache.loggingOut` guard so the first `logout()` wins

## How did you test this code?

Tests

## Publish to changelog?

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->