### PR TITLE
feat(skills): community skills contribution path and discoverable registry

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -164,6 +164,8 @@ AGENTS.md @PostHog/team-devex
 .claude/agents/ingestion/ @PostHog/team-ingestion
 .agents/skills/ingestion-*/ @PostHog/team-ingestion
 .claude/skills/ingestion-*/ @PostHog/team-ingestion
+products/community/skills/ @PostHog/team-devex
+products/posthog_ai/scripts/build_skills.py @PostHog/team-devex
 tools/pr-approval-agent/ @PostHog/team-devex
 tools/phrocs/ @PostHog/team-devex
 greptile.json @PostHog/team-devex

--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -219,7 +219,7 @@ jobs:
               run: |
                   DIST=products/posthog_ai/dist
                   # Monolithic archive (unchanged, preserved for existing consumers)
-                  # plus per-skill archives and the registry index (new in v2.0.0).
+                  # plus per-skill archives and the registry index.
                   ASSETS="$DIST/skills.zip $DIST/skills-index.json"
                   for zip in "$DIST"/*.zip; do
                       if [ "$(basename "$zip")" != "skills.zip" ]; then

--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -214,13 +214,28 @@ jobs:
                   MINOR=$(echo "${LATEST_TAG#agent-skills-v}" | cut -d. -f2)
                   echo "tag=agent-skills-v0.$((MINOR + 1)).0" >> "$GITHUB_OUTPUT"
 
+            - name: Collect release assets
+              id: assets
+              run: |
+                  DIST=products/posthog_ai/dist
+                  # Monolithic archive (unchanged, preserved for existing consumers)
+                  # plus per-skill archives and the registry index (new in v2.0.0).
+                  ASSETS="$DIST/skills.zip $DIST/skills-index.json"
+                  for zip in "$DIST"/*.zip; do
+                      if [ "$(basename "$zip")" != "skills.zip" ]; then
+                          ASSETS="$ASSETS $zip"
+                      fi
+                  done
+                  echo "assets=$ASSETS" >> "$GITHUB_OUTPUT"
+
             - name: Create versioned release
               env:
                   GH_TOKEN: ${{ github.token }}
                   RELEASE_TAG: ${{ steps.version.outputs.tag }}
               run: |
+                  # shellcheck disable=SC2086 # we want word-splitting here
                   gh release create "$RELEASE_TAG" \
-                      products/posthog_ai/dist/skills.zip \
+                      ${{ steps.assets.outputs.assets }} \
                       --title "Agent skills $RELEASE_TAG" \
                       --notes "Build from ${{ github.sha }}" \
                       --target "${{ github.sha }}" \
@@ -232,13 +247,15 @@ jobs:
                   RELEASE_TAG: ${{ steps.version.outputs.tag }}
               run: |
                   if gh release view agent-skills-latest &>/dev/null; then
+                      # shellcheck disable=SC2086
                       gh release upload agent-skills-latest \
-                          products/posthog_ai/dist/skills.zip --clobber
+                          ${{ steps.assets.outputs.assets }} --clobber
                       gh release edit agent-skills-latest \
                           --notes "Latest build — same as $RELEASE_TAG"
                   else
+                      # shellcheck disable=SC2086
                       gh release create agent-skills-latest \
-                          products/posthog_ai/dist/skills.zip \
+                          ${{ steps.assets.outputs.assets }} \
                           --title "Agent skills (Latest)" \
                           --notes "Latest build — same as $RELEASE_TAG" \
                           --target "${{ github.sha }}" \

--- a/docs/published/handbook/engineering/ai/contributing-skills.md
+++ b/docs/published/handbook/engineering/ai/contributing-skills.md
@@ -1,0 +1,112 @@
+---
+title: Contributing community skills
+sidebar: Docs
+showTitle: true
+---
+
+PostHog ships _community skills_ — markdown-only job-to-be-done templates that anyone outside PostHog can contribute. A community skill lives in the PostHog repo, is validated by the same CI that validates official skills, and is distributed through the public skills registry (`skills-index.json`). Any agent that consumes the registry — Claude Code, Cursor, the PostHog MCP server, custom frameworks — picks up community skills automatically once they ship.
+
+This page is the contributor-facing overview. For implementation-level details on the build pipeline and Jinja2 template helpers, see [Writing skills](/handbook/engineering/ai/writing-skills).
+
+## When to contribute a community skill
+
+A community skill is the right fit when you have a PostHog workflow that:
+
+- Takes multiple tool calls and benefits from a canonical walkthrough
+- Applies broadly (not hyper-specific to your project)
+- Fits in markdown — no code execution, no Pydantic schema introspection, no dynamic content
+
+If you need dynamic rendering (for example, regenerating HogQL examples whenever a Pydantic model changes), the skill belongs in `products/<product>/skills/` and must be owned by a PostHog product team. Open an issue with the proposal instead.
+
+## Where community skills live
+
+```text
+products/community/skills/
+├── README.md          # Overview
+├── CONTRIBUTING.md    # Detailed contribution guide + safety checklist
+├── .template/         # Starter scaffold (skipped by the build)
+└── <your-skill>/
+    ├── SKILL.md       # Required entry point
+    └── references/    # Optional markdown-only detail pages
+```
+
+Community skills are subject to stricter build rules than official skills:
+
+| Content                 | Official skills | Community skills           |
+| ----------------------- | --------------- | -------------------------- |
+| `SKILL.md`              | Required        | Required                   |
+| `references/*.md`       | Allowed         | Allowed                    |
+| `references/*.md.j2`    | Allowed         | **Rejected at build time** |
+| `scripts/*`             | Allowed         | **Rejected at build time** |
+| `SKILL.md.j2`           | Allowed         | **Rejected at build time** |
+| `source` in frontmatter | `official`      | Must be `community`        |
+
+Enforcement happens in `products/posthog_ai/scripts/build_skills.py`; `hogli lint:skills` catches violations without needing a Django environment, so contributors get fast feedback in CI.
+
+## Frontmatter schema
+
+Every skill (official or community) has Pydantic-validated frontmatter:
+
+```yaml
+---
+name: your-skill-name # required, lowercase-kebab-case, 3-64 chars, unique across the repo
+description: >- # required, 20-1024 chars — agents use this to decide whether to run the skill
+  Audit inactive surveys across a PostHog project and recommend ones
+  safe to archive.
+version: 0.1.0 # semver, bumped on meaningful changes
+category: surveys # one of: analytics, flags, experiments, replay, errors, llm, surveys, workflows, data-warehouse, other
+source: community # "community" for community-contributed; "official" for PostHog team
+tags: [audit, cleanup] # up to 8 free-form tags, used for registry filtering
+products: [surveys] # PostHog products the skill touches
+author: your-github-handle # optional, how you want to be credited
+requires_scopes: [survey:read] # MCP scopes an agent needs to run this skill
+---
+```
+
+All new fields beyond `name` and `description` are optional with sensible defaults for backwards compatibility with existing skills.
+
+## Distribution
+
+On every merge to master, `.github/workflows/ci-agent-skills.yml` publishes:
+
+1. **`skills.zip`** — the monolithic archive (existing consumers keep working unchanged)
+2. **`<skill-name>.zip`** — one zip per skill, so agents can install one skill at a time
+3. **`skills-index.json`** — the registry: a small JSON document listing every skill's metadata, archive URL, and SHA-256 checksum
+
+Assets land on two GitHub releases:
+
+- `agent-skills-v0.N.0` — versioned, bumped automatically
+- `agent-skills-latest` — the rolling release, always pointing at the most recent master build
+
+The canonical registry URL is:
+
+```text
+https://github.com/PostHog/posthog/releases/download/agent-skills-latest/skills-index.json
+```
+
+Agents should hit that URL to discover the full skill catalog.
+
+## Using the registry from the MCP server
+
+The PostHog MCP server exposes the registry through two tools:
+
+- `skills-list` — returns metadata for every published skill, with optional filters (`category`, `products`, `tags`, `source`, `search`)
+- `skills-get` — returns the full markdown of a named skill, including any `references/*.md` files
+
+Max and any other MCP-aware agent can call `skills-list` at the start of a complex PostHog workflow to check whether a canonical skill exists, then `skills-get` to pull the guidance.
+
+## Review process
+
+Community-skill PRs:
+
+1. Run the `Agent Skills` CI check (`hogli lint:skills` + `hogli build:skills`).
+2. Auto-request review from `@PostHog/team-devex` via `CODEOWNERS-soft`.
+3. Should include the safety checklist from [`products/community/skills/CONTRIBUTING.md`](https://github.com/PostHog/posthog/blob/master/products/community/skills/CONTRIBUTING.md#safety-checklist) in the PR description.
+
+Reviewers specifically check for: secrets in content, prompt-injection attempts, URLs pointing outside PostHog-owned domains, destructive instructions that skip user confirmation, and misleading descriptions.
+
+## Related
+
+- [Writing skills](/handbook/engineering/ai/writing-skills) — how the build pipeline works and how to write effective skill content
+- [Implementing MCP tools](/handbook/engineering/ai/implementing-mcp-tools) — how the tools referenced by skills are exposed to agents
+- [Sandboxed agents](/handbook/engineering/ai/sandboxed-agents) — running agents autonomously with scoped OAuth tokens

--- a/docs/published/handbook/engineering/ai/contributing-skills.md
+++ b/docs/published/handbook/engineering/ai/contributing-skills.md
@@ -44,12 +44,12 @@ Community vs official is determined by location (`products/community/skills/` vs
 
 ## Frontmatter schema
 
-Every skill (official or community) has Pydantic-validated frontmatter with just two fields:
+Every skill (official or community) has frontmatter with just two fields:
 
 ```yaml
 ---
-name: your-skill-name # required, lowercase-kebab-case, 3-64 chars, unique across the repo
-description: >- # required, 20-1024 chars — agents use this to decide whether to run the skill
+name: your-skill-name # required, lowercase-kebab-case, unique across the repo
+description: >- # required — agents use this to decide whether to run the skill
   Audit inactive surveys across a PostHog project and recommend ones
   safe to archive.
 ---

--- a/docs/published/handbook/engineering/ai/contributing-skills.md
+++ b/docs/published/handbook/engineering/ai/contributing-skills.md
@@ -32,20 +32,19 @@ products/community/skills/
 
 Community skills are subject to stricter build rules than official skills:
 
-| Content                 | Official skills | Community skills           |
-| ----------------------- | --------------- | -------------------------- |
-| `SKILL.md`              | Required        | Required                   |
-| `references/*.md`       | Allowed         | Allowed                    |
-| `references/*.md.j2`    | Allowed         | **Rejected at build time** |
-| `scripts/*`             | Allowed         | **Rejected at build time** |
-| `SKILL.md.j2`           | Allowed         | **Rejected at build time** |
-| `source` in frontmatter | `official`      | Must be `community`        |
+| Content              | Official skills | Community skills           |
+| -------------------- | --------------- | -------------------------- |
+| `SKILL.md`           | Required        | Required                   |
+| `references/*.md`    | Allowed         | Allowed                    |
+| `references/*.md.j2` | Allowed         | **Rejected at build time** |
+| `scripts/*`          | Allowed         | **Rejected at build time** |
+| `SKILL.md.j2`        | Allowed         | **Rejected at build time** |
 
-Enforcement happens in `products/posthog_ai/scripts/build_skills.py`; `hogli lint:skills` catches violations without needing a Django environment, so contributors get fast feedback in CI.
+Community vs official is determined by location (`products/community/skills/` vs `products/<product>/skills/`) — not by a frontmatter field. Enforcement happens in `products/posthog_ai/scripts/build_skills.py`; `hogli lint:skills` catches violations without needing a Django environment, so contributors get fast feedback in CI.
 
 ## Frontmatter schema
 
-Every skill (official or community) has Pydantic-validated frontmatter:
+Every skill (official or community) has Pydantic-validated frontmatter with just two fields:
 
 ```yaml
 ---
@@ -53,17 +52,10 @@ name: your-skill-name # required, lowercase-kebab-case, 3-64 chars, unique acros
 description: >- # required, 20-1024 chars — agents use this to decide whether to run the skill
   Audit inactive surveys across a PostHog project and recommend ones
   safe to archive.
-version: 0.1.0 # semver, bumped on meaningful changes
-category: surveys # one of: analytics, flags, experiments, replay, errors, llm, surveys, workflows, data-warehouse, other
-source: community # "community" for community-contributed; "official" for PostHog team
-tags: [audit, cleanup] # up to 8 free-form tags, used for registry filtering
-products: [surveys] # PostHog products the skill touches
-author: your-github-handle # optional, how you want to be credited
-requires_scopes: [survey:read] # MCP scopes an agent needs to run this skill
 ---
 ```
 
-All new fields beyond `name` and `description` are optional with sensible defaults for backwards compatibility with existing skills.
+This matches the [Anthropic agent skills convention](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview): `description` is the primary trigger signal, so invest in making it specific.
 
 ## Distribution
 
@@ -90,7 +82,7 @@ Agents should hit that URL to discover the full skill catalog.
 
 The PostHog MCP server exposes the registry through two tools:
 
-- `skills-list` — returns metadata for every published skill, with optional filters (`category`, `products`, `tags`, `source`, `search`)
+- `skills-list` — returns metadata for every published skill, with an optional `search` substring filter on name/description
 - `skills-get` — returns the full markdown of a named skill, including any `references/*.md` files
 
 Max and any other MCP-aware agent can call `skills-list` at the start of a complex PostHog workflow to check whether a canonical skill exists, then `skills-get` to pull the guidance.

--- a/products/community/skills/.template/SKILL.md
+++ b/products/community/skills/.template/SKILL.md
@@ -3,13 +3,6 @@ name: example-community-skill
 description: >-
   One- to two-sentence description of what this skill helps the agent do and
   when it should be used. Must be at least 20 characters.
-version: 0.1.0
-category: other
-source: community
-tags: []
-products: []
-author: your-github-handle
-requires_scopes: []
 ---
 
 # Example community skill

--- a/products/community/skills/.template/SKILL.md
+++ b/products/community/skills/.template/SKILL.md
@@ -2,7 +2,7 @@
 name: example-community-skill
 description: >-
   One- to two-sentence description of what this skill helps the agent do and
-  when it should be used. Must be at least 20 characters.
+  when it should be used.
 ---
 
 # Example community skill

--- a/products/community/skills/.template/SKILL.md
+++ b/products/community/skills/.template/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: example-community-skill
+description: >-
+  One- to two-sentence description of what this skill helps the agent do and
+  when it should be used. Must be at least 20 characters.
+version: 0.1.0
+category: other
+source: community
+tags: []
+products: []
+author: your-github-handle
+requires_scopes: []
+---
+
+# Example community skill
+
+Replace this template with a short introduction to what the skill accomplishes.
+
+## When to use this skill
+
+- The user asks about ...
+- The user wants to ...
+
+## What you'll need
+
+- Scopes: `example:read`
+- PostHog tools: `tool-a`, `tool-b`
+
+## Workflow
+
+1. **Step one** — describe what to do
+2. **Step two** — and what to do next
+3. **Step three** — and how to verify the outcome
+
+## Example
+
+Concrete example of the skill in action.

--- a/products/community/skills/CONTRIBUTING.md
+++ b/products/community/skills/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This guide walks through creating, validating, and submitting a skill.
 
 ## 1. What makes a good skill
 
-A skill is a **job-to-be-done template** — it answers "how do I accomplish X with PostHog?", not "what does tool Y do?". If you find yourself listing every argument a PostHog API accepts, you're probably documenting a tool. A skill should describe an outcome, the relevant tools, and the workflow that ties them together.
+A skill is a **job-to-be-done template**. It answers "how do I accomplish X with PostHog?", not "what does tool Y do?". If you find yourself listing every argument a PostHog API accepts, you're probably documenting a tool. A skill should describe an outcome, the relevant tools, and the workflow that ties them together.
 
 Good skill candidates:
 
@@ -40,17 +40,10 @@ name: your-skill-name # lowercase-kebab-case, 3-64 chars, must match directory
 description: >- # 20-1024 chars — when to use, what it does
   Audit inactive surveys across a PostHog project and recommend ones
   safe to archive. Use when the user wants to clean up survey clutter.
-version: 0.1.0 # semver, bump on meaningful content changes
-category: surveys # one of the registry categories (see schema below)
-source: community # must be "community" for skills in this directory
-tags: [audit, cleanup] # up to 8 free-form tags for discovery
-products: [surveys] # which PostHog products this skill touches
-author: your-github-handle # optional, how you'd like to be credited
-requires_scopes: [survey:read] # MCP scopes the agent needs
 ---
 ```
 
-Valid categories: `analytics`, `flags`, `experiments`, `replay`, `errors`, `llm`, `surveys`, `workflows`, `data-warehouse`, `other`.
+`name` and `description` are the only fields we validate — the description is what agents match against when deciding whether to run your skill, so make it specific.
 
 ## 3. Allowed content
 
@@ -102,7 +95,7 @@ This renders the skill and copies it to `.agents/skills/your-skill-name/`, where
   - A versioned release: `agent-skills-v0.N.0` (bumped automatically)
   - The rolling `agent-skills-latest` release
 - Your skill appears in `skills-index.json` on the next release and is immediately available to every agent that consumes the registry.
-- Renaming a skill after release is a breaking change for consumers — bump the `version` field and open a new PR explaining the rename.
+- Renaming a skill after release is a breaking change for consumers — open a new PR explaining the rename.
 
 ## Safety checklist
 
@@ -112,6 +105,6 @@ By contributing a skill, you agree that:
 - [ ] It does not include prompt-injection payloads designed to subvert agent behavior
 - [ ] All URLs point to `posthog.com`, `github.com/PostHog`, or other well-known public sources
 - [ ] Any instructions to write or delete PostHog data clearly call out the destructive nature and require user confirmation
-- [ ] The `description` accurately reflects what the skill does — it's the primary signal agents use to decide when to run it
+- [ ] The `description` accurately reflects what the skill does, as it's the primary signal agents use to decide when to run it
 
 Reviewers will reject contributions that fail these checks. Repeat or malicious violations may result in the contributor being blocked from future submissions.

--- a/products/community/skills/CONTRIBUTING.md
+++ b/products/community/skills/CONTRIBUTING.md
@@ -1,0 +1,117 @@
+# Contributing a community skill
+
+Community skills are markdown guides that teach AI agents how to accomplish a specific job in PostHog (for example: "audit inactive cohorts", "set up a funnel from recent pageviews", "triage error tracking alerts"). They're distributed through PostHog's skills registry and consumed by the MCP server, coding agents, and third-party tooling.
+
+This guide walks through creating, validating, and submitting a skill.
+
+## 1. What makes a good skill
+
+A skill is a **job-to-be-done template** — it answers "how do I accomplish X with PostHog?", not "what does tool Y do?". If you find yourself listing every argument a PostHog API accepts, you're probably documenting a tool. A skill should describe an outcome, the relevant tools, and the workflow that ties them together.
+
+Good skill candidates:
+
+- Repetitive PostHog workflows that take multiple tool calls
+- Analysis patterns that need context (which events? which filters?)
+- Maintenance tasks (cleanup, auditing, migration)
+
+Less good:
+
+- Single-tool wrappers (the tool description already covers that)
+- Opinionated tutorials that don't generalize
+- Anything that hardcodes credentials, URLs, or project IDs
+
+## 2. Create the skill
+
+```bash
+bin/hogli init:skill --product community --name <your-skill-name>
+```
+
+This scaffolds `products/community/skills/<your-skill-name>/SKILL.md` with the required frontmatter and a template body.
+
+Alternatively, copy `.template/SKILL.md` manually — then rename the directory to your skill name (`lowercase-kebab-case`, 3-64 characters).
+
+### Frontmatter requirements
+
+The generated frontmatter looks like:
+
+```yaml
+---
+name: your-skill-name # lowercase-kebab-case, 3-64 chars, must match directory
+description: >- # 20-1024 chars — when to use, what it does
+  Audit inactive surveys across a PostHog project and recommend ones
+  safe to archive. Use when the user wants to clean up survey clutter.
+version: 0.1.0 # semver, bump on meaningful content changes
+category: surveys # one of the registry categories (see schema below)
+source: community # must be "community" for skills in this directory
+tags: [audit, cleanup] # up to 8 free-form tags for discovery
+products: [surveys] # which PostHog products this skill touches
+author: your-github-handle # optional, how you'd like to be credited
+requires_scopes: [survey:read] # MCP scopes the agent needs
+---
+```
+
+Valid categories: `analytics`, `flags`, `experiments`, `replay`, `errors`, `llm`, `surveys`, `workflows`, `data-warehouse`, `other`.
+
+## 3. Allowed content
+
+Community skills are markdown-only. At build time, the following are rejected:
+
+- A `scripts/` directory
+- Any `.j2` Jinja2 template (including `SKILL.md.j2`)
+- Binary files
+
+You can include markdown reference pages under `references/` if your skill is long enough to benefit from progressive disclosure:
+
+```text
+products/community/skills/your-skill-name/
+├── SKILL.md            # Entry point (required)
+└── references/         # Optional
+    ├── details.md
+    └── examples.md
+```
+
+If you need capabilities beyond markdown (live Pydantic schema rendering, dynamic examples), the skill probably belongs in `products/<product>/skills/` — reach out in the PR and we'll help you find the right home.
+
+## 4. Validate locally
+
+Fast syntax check (no Django or database needed):
+
+```bash
+bin/hogli lint:skills
+```
+
+This catches: missing frontmatter, name/description schema violations, use of disallowed `.j2`/`scripts/` in a community skill, duplicate skill names across the whole repo.
+
+Full build + local install for testing with Claude Code or another MCP-aware agent:
+
+```bash
+bin/hogli sync:skill -- --name your-skill-name
+```
+
+This renders the skill and copies it to `.agents/skills/your-skill-name/`, where Claude Code and compatible agents pick it up automatically.
+
+## 5. Open a PR
+
+- Keep the PR focused: one skill per PR, no unrelated changes.
+- Paste the [safety checklist](#safety-checklist) below into your PR description so reviewers can walk through it with you.
+- The `Agent Skills` CI job (`.github/workflows/ci-agent-skills.yml`) runs `hogli lint:skills` + `hogli build:skills` on every PR. Reviewers from `@PostHog/team-devex` will be auto-assigned via `CODEOWNERS-soft`.
+
+## 6. What happens after merge
+
+- On merge to `master`, CI rebuilds the skill archive and publishes:
+  - A versioned release: `agent-skills-v0.N.0` (bumped automatically)
+  - The rolling `agent-skills-latest` release
+- Your skill appears in `skills-index.json` on the next release and is immediately available to every agent that consumes the registry.
+- Renaming a skill after release is a breaking change for consumers — bump the `version` field and open a new PR explaining the rename.
+
+## Safety checklist
+
+By contributing a skill, you agree that:
+
+- [ ] It contains no secrets, API keys, or other credentials
+- [ ] It does not include prompt-injection payloads designed to subvert agent behavior
+- [ ] All URLs point to `posthog.com`, `github.com/PostHog`, or other well-known public sources
+- [ ] Any instructions to write or delete PostHog data clearly call out the destructive nature and require user confirmation
+- [ ] The `description` accurately reflects what the skill does — it's the primary signal agents use to decide when to run it
+
+Reviewers will reject contributions that fail these checks. Repeat or malicious violations may result in the contributor being blocked from future submissions.

--- a/products/community/skills/CONTRIBUTING.md
+++ b/products/community/skills/CONTRIBUTING.md
@@ -36,14 +36,14 @@ The generated frontmatter looks like:
 
 ```yaml
 ---
-name: your-skill-name # lowercase-kebab-case, 3-64 chars, must match directory
-description: >- # 20-1024 chars — when to use, what it does
+name: your-skill-name # lowercase-kebab-case, must match directory
+description: >- # when to use, what it does
   Audit inactive surveys across a PostHog project and recommend ones
   safe to archive. Use when the user wants to clean up survey clutter.
 ---
 ```
 
-`name` and `description` are the only fields we validate — the description is what agents match against when deciding whether to run your skill, so make it specific.
+`name` and `description` are the only fields. The description is what agents match against when deciding whether to run your skill, so make it specific.
 
 ## 3. Allowed content
 

--- a/products/community/skills/README.md
+++ b/products/community/skills/README.md
@@ -1,0 +1,22 @@
+# Community skills
+
+This directory holds community-contributed PostHog skills — job-to-be-done templates that teach AI agents how to accomplish specific tasks in PostHog.
+
+Skills placed here are distributed alongside official PostHog skills through the agent-skills release pipeline, and surfaced in the skills registry (`skills-index.json`) consumed by the PostHog MCP server, third-party agent frameworks, and IDE extensions.
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the step-by-step contribution workflow, the contract for what a community skill is allowed to contain, and the review checklist.
+
+## Template
+
+A starter skill scaffold lives in [`.template/SKILL.md`](./.template/SKILL.md). The hidden directory prefix keeps it out of the build; copy it to a new directory (named in `lowercase-kebab-case`) when you start a new skill.
+
+## What lives here vs. in `products/<product>/skills/`
+
+| Location                     | Who maintains         | Allowed content                                                                                            |
+| ---------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `products/<product>/skills/` | PostHog product teams | Full access: markdown, `references/`, `scripts/`, Jinja2 templates (`.j2`) with access to Pydantic schemas |
+| `products/community/skills/` | The community         | Markdown only: `SKILL.md` plus optional `references/*.md`. No `scripts/`, no `.j2` templates               |
+
+The stricter rules for community skills keep the trust boundary clear — community contributions can't execute code, can't introspect Django models, and can't pull in arbitrary runtime context.

--- a/products/community/skills/README.md
+++ b/products/community/skills/README.md
@@ -1,6 +1,6 @@
 # Community skills
 
-This directory holds community-contributed PostHog skills — job-to-be-done templates that teach AI agents how to accomplish specific tasks in PostHog.
+This directory holds community-contributed PostHog skills; job-to-be-done templates that teach AI agents how to accomplish specific tasks in PostHog.
 
 Skills placed here are distributed alongside official PostHog skills through the agent-skills release pipeline, and surfaced in the skills registry (`skills-index.json`) consumed by the PostHog MCP server, third-party agent frameworks, and IDE extensions.
 
@@ -19,4 +19,4 @@ A starter skill scaffold lives in [`.template/SKILL.md`](./.template/SKILL.md). 
 | `products/<product>/skills/` | PostHog product teams | Full access: markdown, `references/`, `scripts/`, Jinja2 templates (`.j2`) with access to Pydantic schemas |
 | `products/community/skills/` | The community         | Markdown only: `SKILL.md` plus optional `references/*.md`. No `scripts/`, no `.j2` templates               |
 
-The stricter rules for community skills keep the trust boundary clear — community contributions can't execute code, can't introspect Django models, and can't pull in arbitrary runtime context.
+The stricter rules for community skills keep the trust boundary clear. Community contributions can't execute code, can't introspect Django models, and can't pull in arbitrary runtime context.

--- a/products/posthog_ai/scripts/build_skills.py
+++ b/products/posthog_ai/scripts/build_skills.py
@@ -63,23 +63,11 @@ _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 _BINARY_CHECK_SIZE = 8192
 _ALLOWED_SUBDIRS = {"references", "scripts"}
 
-# Community skills have stricter rules: markdown only, no templates, no scripts.
+# Community skills live at products/community/skills/ and have stricter rules:
+# markdown only, no Jinja2 templates, no scripts/.
 # See products/community/skills/CONTRIBUTING.md.
 _COMMUNITY_PRODUCT = "community"
-_COMMUNITY_DISALLOWED_SUBDIRS = {"scripts"}
-
-_SKILL_CATEGORIES = (
-    "analytics",
-    "flags",
-    "experiments",
-    "replay",
-    "errors",
-    "llm",
-    "surveys",
-    "workflows",
-    "data-warehouse",
-    "other",
-)
+_COMMUNITY_ALLOWED_SUBDIRS = {"references"}
 
 
 def _create_jinja_env(**extra_globals: object) -> Environment:
@@ -331,7 +319,13 @@ class SkillBuilder:
         entry_content = renderer.render(entry_path)
         entry_point = SkillFile(path="SKILL.md", content=entry_content)
 
-        allowed_subdirs = _ALLOWED_SUBDIRS - _COMMUNITY_DISALLOWED_SUBDIRS if is_community else _ALLOWED_SUBDIRS
+        allowed_subdirs = _COMMUNITY_ALLOWED_SUBDIRS if is_community else _ALLOWED_SUBDIRS
+
+        if is_community and (skill_dir / "scripts").is_dir():
+            raise ValueError(
+                f"Community skill {skill_dir.name} may not contain a scripts/ directory. "
+                "Community skills are markdown-only."
+            )
 
         files: list[SkillFile] = []
         for subdir_name in sorted(allowed_subdirs):
@@ -349,19 +343,8 @@ class SkillBuilder:
                             f"(found {file_path.relative_to(skill_dir)}). Use plain markdown instead."
                         )
                     content = renderer.render(file_path)
-                    rel_path = str(file_path.relative_to(skill_dir))
-                    if rel_path.endswith(".j2"):
-                        rel_path = rel_path.removesuffix(".j2")
+                    rel_path = str(file_path.relative_to(skill_dir)).removesuffix(".j2")
                     files.append(SkillFile(path=rel_path, content=content))
-
-        # Explicitly reject any subdirectory that community contributions tried to use.
-        if is_community:
-            for disallowed in _COMMUNITY_DISALLOWED_SUBDIRS:
-                if (skill_dir / disallowed).is_dir():
-                    raise ValueError(
-                        f"Community skill {skill_dir.name} may not contain a {disallowed}/ directory. "
-                        "Community skills are markdown-only."
-                    )
 
         return [entry_point, *files]
 
@@ -385,9 +368,7 @@ class SkillBuilder:
                 )
             rendered = renderer.render(skill.source_file)
             entry_content = rendered
-            out_name = skill.source_file.name
-            if out_name.endswith(".j2"):
-                out_name = out_name.removesuffix(".j2")
+            out_name = skill.source_file.name.removesuffix(".j2")
             skill_files = [SkillFile(path=out_name, content=rendered.strip())]
             source = str(skill.source_file.relative_to(self.repo_root))
             source_label = source
@@ -626,11 +607,8 @@ class SkillBuilder:
 
         source_label = str(skill.source_file.relative_to(self.repo_root))
         skill_dir = skill.source_file.parent
-        for disallowed in _COMMUNITY_DISALLOWED_SUBDIRS:
-            if (skill_dir / disallowed).is_dir():
-                errors.append(
-                    f"{source_label}: community skills may not contain a {disallowed}/ directory (markdown-only)."
-                )
+        if (skill_dir / "scripts").is_dir():
+            errors.append(f"{source_label}: community skills may not contain a scripts/ directory (markdown-only).")
         # Any .j2 inside references/ is disallowed too.
         for subdir_name in sorted(_ALLOWED_SUBDIRS):
             subdir = skill_dir / subdir_name

--- a/products/posthog_ai/scripts/build_skills.py
+++ b/products/posthog_ai/scripts/build_skills.py
@@ -12,8 +12,8 @@ Skills under products/community/skills/ are community-contributed and subject to
 stricter rules: markdown only (no .j2, no scripts/). See
 products/community/skills/CONTRIBUTING.md.
 
-Each skill must have YAML frontmatter validated against ``SkillFrontmatter`` —
-``name`` (lowercase-kebab-case) and ``description`` (20-1024 chars) are required.
+Each skill must have YAML frontmatter with ``name`` and ``description``, validated
+against ``SkillFrontmatter``.
 
 The build renders skills to dist/skills/{skill_name}/ (gitignored, human-readable)
 and produces three sets of artifacts, all published as release assets by CI:
@@ -51,7 +51,7 @@ from pydantic import BaseModel, Field, ValidationError
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-MANIFEST_VERSION = "2.0.0"
+MANIFEST_VERSION = "1.0.0"
 INDEX_SCHEMA_VERSION = "2.0.0"
 _ZIP_FIXED_TIME = (2025, 1, 1, 0, 0, 0)
 
@@ -107,14 +107,8 @@ def _assert_text_file(file_path: Path) -> None:
 
 
 class SkillFrontmatter(BaseModel):
-    """Frontmatter schema for skill SKILL.md files.
-
-    Constraints are Pydantic-validated at both lint time (cheap, no Django)
-    and build time.
-    """
-
-    name: str = Field(..., pattern=r"^[a-z0-9][a-z0-9-]{2,63}$")
-    description: str = Field(..., min_length=20, max_length=1024)
+    name: str
+    description: str
 
 
 class DiscoveredSkill(BaseModel):
@@ -675,7 +669,7 @@ class SkillBuilder:
         content = textwrap.dedent(f"""\
             ---
             name: {skill_name}
-            description: TODO — describe when and how agents should use this skill (20-1024 chars).
+            description: TODO
             ---
 
             # {display_name}

--- a/products/posthog_ai/scripts/build_skills.py
+++ b/products/posthog_ai/scripts/build_skills.py
@@ -652,15 +652,18 @@ class SkillBuilder:
 
             # {display_name}
 
-            TODO: Describe when and how to use this skill.
+            TODO: One-paragraph summary of the outcome this skill produces.
 
             ## When to use this skill
 
-            TODO
+            - TODO: user asks to …
+            - TODO: user describes a scenario that matches …
 
             ## Workflow
 
-            TODO
+            1. TODO: first step — which tool to call and with what arguments
+            2. TODO: next step — how to interpret the result
+            3. TODO: final step — how to present the outcome to the user
         """)
 
         skill_file = skill_dir / filename

--- a/products/posthog_ai/scripts/build_skills.py
+++ b/products/posthog_ai/scripts/build_skills.py
@@ -13,9 +13,7 @@ stricter rules: markdown only (no .j2, no scripts/). See
 products/community/skills/CONTRIBUTING.md.
 
 Each skill must have YAML frontmatter validated against ``SkillFrontmatter`` —
-``name`` (lowercase-kebab-case) and ``description`` (20-1024 chars) are required;
-other fields (version, tags, category, products, author, source, requires_scopes)
-are optional with sensible defaults for backwards compatibility.
+``name`` (lowercase-kebab-case) and ``description`` (20-1024 chars) are required.
 
 The build renders skills to dist/skills/{skill_name}/ (gitignored, human-readable)
 and produces three sets of artifacts, all published as release assets by CI:
@@ -45,7 +43,6 @@ import argparse
 import textwrap
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Literal
 
 import yaml
 from jinja2 import Environment, StrictUndefined, TemplateSyntaxError
@@ -112,31 +109,12 @@ def _assert_text_file(file_path: Path) -> None:
 class SkillFrontmatter(BaseModel):
     """Frontmatter schema for skill SKILL.md files.
 
-    All fields beyond `name` and `description` are optional for backwards
-    compatibility, but enforced where set. Constraints are Pydantic-validated
-    at both lint time (cheap, no Django) and build time.
+    Constraints are Pydantic-validated at both lint time (cheap, no Django)
+    and build time.
     """
 
     name: str = Field(..., pattern=r"^[a-z0-9][a-z0-9-]{2,63}$")
     description: str = Field(..., min_length=20, max_length=1024)
-    version: str = Field(default="0.1.0", pattern=r"^\d+\.\d+\.\d+$")
-    tags: list[str] = Field(default_factory=list, max_length=8)
-    category: Literal[
-        "analytics",
-        "flags",
-        "experiments",
-        "replay",
-        "errors",
-        "llm",
-        "surveys",
-        "workflows",
-        "data-warehouse",
-        "other",
-    ] = "other"
-    products: list[str] = Field(default_factory=list, max_length=8)
-    author: str | None = None
-    source: Literal["official", "community"] = "official"
-    requires_scopes: list[str] = Field(default_factory=list, max_length=16)
 
 
 class DiscoveredSkill(BaseModel):
@@ -160,7 +138,6 @@ class SkillResource(BaseModel):
     description: str
     files: list[SkillFile]
     source: str
-    frontmatter: SkillFrontmatter | None = None
 
 
 class SkillIndexEntry(BaseModel):
@@ -168,13 +145,6 @@ class SkillIndexEntry(BaseModel):
 
     name: str
     description: str
-    version: str
-    category: str
-    tags: list[str]
-    products: list[str]
-    author: str | None
-    source: str  # "official" | "community"
-    requires_scopes: list[str]
     archive_url: str
     sha256: str
     source_path: str
@@ -404,9 +374,7 @@ class SkillBuilder:
     def build_skill(self, skill: DiscoveredSkill, renderer: SkillRenderer) -> SkillResource:
         """Build a single skill and return a SkillResource.
 
-        Frontmatter is validated through ``SkillFrontmatter`` so that new fields
-        (version, tags, category, etc.) flow into the registry index. Skills
-        missing the required frontmatter fail at build time rather than
+        Skills missing the required frontmatter fail at build time rather than
         producing silently-underspecified index entries.
         """
         if skill.depth == 1:
@@ -432,26 +400,11 @@ class SkillBuilder:
 
         frontmatter = validate_frontmatter(entry_content, source_label)
 
-        # Enforce that skills placed under products/community/skills/ declare themselves
-        # as community in frontmatter. This keeps the "source" field trustworthy in the
-        # registry index — official skills can't accidentally live alongside community ones.
-        if skill.is_community and frontmatter.source != "community":
-            raise ValueError(
-                f"Skill at {source_label} is under products/community/skills/ but its frontmatter "
-                f"declares source: {frontmatter.source!r}. Community skills must set source: community."
-            )
-        if not skill.is_community and frontmatter.source == "community":
-            raise ValueError(
-                f"Skill at {source_label} declares source: community in frontmatter but is not under "
-                "products/community/skills/. Move it there or change source to official."
-            )
-
         return SkillResource(
             name=frontmatter.name,
             description=frontmatter.description,
             files=skill_files,
             source=source,
-            frontmatter=frontmatter,
         )
 
     def build_manifest(self, skills: list[DiscoveredSkill], renderer: SkillRenderer) -> SkillManifest:
@@ -527,24 +480,10 @@ class SkillBuilder:
         """
         entries: list[SkillIndexEntry] = []
         for resource in resources:
-            frontmatter = resource.frontmatter
-            if frontmatter is None:
-                # Defensive: build_skill() always populates frontmatter since the
-                # validator is mandatory, but keep a typed fallback rather than
-                # silently emitting a malformed index entry.
-                raise ValueError(f"Cannot index skill {resource.name}: missing validated frontmatter")
-
             entries.append(
                 SkillIndexEntry(
                     name=resource.name,
                     description=resource.description,
-                    version=frontmatter.version,
-                    category=frontmatter.category,
-                    tags=list(frontmatter.tags),
-                    products=list(frontmatter.products),
-                    author=frontmatter.author,
-                    source=frontmatter.source,
-                    requires_scopes=list(frontmatter.requires_scopes),
                     archive_url=f"{archive_url_prefix.rstrip('/')}/{resource.name}.zip",
                     sha256=checksums[resource.name],
                     source_path=resource.source,
@@ -615,8 +554,7 @@ class SkillBuilder:
         - Duplicate skill name detection (across products)
         - Jinja2 syntax validation via parse-only (all .j2 files)
         - Frontmatter validation for static .md entry points (schema + constraints)
-        - Community-skill restrictions: no .j2 templates, no scripts/ subdirectory,
-          frontmatter source must be "community"
+        - Community-skill restrictions: no .j2 templates, no scripts/ subdirectory
 
         Returns True if all checks pass, False otherwise.
         """
@@ -660,17 +598,17 @@ class SkillBuilder:
                 raw = skill.source_file.read_text()
                 source_label = str(skill.source_file.relative_to(self.repo_root))
                 try:
-                    frontmatter = validate_frontmatter(raw, source_label)
+                    validate_frontmatter(raw, source_label)
                 except ValueError as e:
                     errors.append(str(e))
-                else:
-                    errors.extend(self._lint_community_rules(skill, frontmatter))
             elif skill.is_community:
                 # .j2 already disallowed, but surface the error with a clearer message.
                 errors.append(
                     f"Community skill {skill.name} ({skill.source_file.relative_to(self.repo_root)}) "
                     "may not use .j2 templates. Use plain SKILL.md."
                 )
+
+            errors.extend(self._lint_community_rules(skill))
 
         if errors:
             for err in errors:
@@ -680,48 +618,37 @@ class SkillBuilder:
         print(f"OK: {len(skills)} skill(s) passed lint checks.")
         return True
 
-    def _lint_community_rules(self, skill: DiscoveredSkill, frontmatter: SkillFrontmatter) -> list[str]:
+    def _lint_community_rules(self, skill: DiscoveredSkill) -> list[str]:
         """Return any community-skill violations for a discovered skill.
 
         Called from lint_all so community PRs fail fast without Django, matching
         the stricter rules enforced at build time in ``collect_skill_files`` /
-        ``build_skill``.
+        ``build_skill``. Community vs official is determined solely by location
+        (``products/community/skills/``).
         """
         errors: list[str] = []
+        if not skill.is_community or skill.depth != 1:
+            return errors
+
         source_label = str(skill.source_file.relative_to(self.repo_root))
-
-        if skill.is_community:
-            if frontmatter.source != "community":
+        skill_dir = skill.source_file.parent
+        for disallowed in _COMMUNITY_DISALLOWED_SUBDIRS:
+            if (skill_dir / disallowed).is_dir():
                 errors.append(
-                    f"{source_label}: skills under products/community/skills/ must set "
-                    f"'source: community' in frontmatter (got '{frontmatter.source}')."
+                    f"{source_label}: community skills may not contain a {disallowed}/ directory (markdown-only)."
                 )
-            if skill.depth == 1:
-                skill_dir = skill.source_file.parent
-                for disallowed in _COMMUNITY_DISALLOWED_SUBDIRS:
-                    if (skill_dir / disallowed).is_dir():
+        # Any .j2 inside references/ is disallowed too.
+        for subdir_name in sorted(_ALLOWED_SUBDIRS):
+            subdir = skill_dir / subdir_name
+            if not subdir.is_dir():
+                continue
+            for root, _dirs, filenames in os.walk(subdir):
+                for filename in filenames:
+                    if filename.endswith(".j2"):
                         errors.append(
-                            f"{source_label}: community skills may not contain a {disallowed}/ "
-                            "directory (markdown-only)."
+                            f"{source_label}: community skills may not contain .j2 templates "
+                            f"(found {Path(root, filename).relative_to(self.repo_root)})."
                         )
-                # Any .j2 inside references/ is disallowed too.
-                for subdir_name in sorted(_ALLOWED_SUBDIRS):
-                    subdir = skill_dir / subdir_name
-                    if not subdir.is_dir():
-                        continue
-                    for root, _dirs, filenames in os.walk(subdir):
-                        for filename in filenames:
-                            if filename.endswith(".j2"):
-                                errors.append(
-                                    f"{source_label}: community skills may not contain .j2 templates "
-                                    f"(found {Path(root, filename).relative_to(self.repo_root)})."
-                                )
-        elif frontmatter.source == "community":
-            errors.append(
-                f"{source_label}: frontmatter declares 'source: community' but skill is not "
-                "under products/community/skills/. Move it there or change source to 'official'."
-            )
-
         return errors
 
     def init_skill(self, product_name: str, skill_name: str, *, template: bool = False) -> Path:
@@ -745,17 +672,10 @@ class SkillBuilder:
 
         display_name = skill_name.replace("-", " ").capitalize()
         filename = "SKILL.md.j2" if template else "SKILL.md"
-        source = "community" if product_name == _COMMUNITY_PRODUCT else "official"
         content = textwrap.dedent(f"""\
             ---
             name: {skill_name}
             description: TODO — describe when and how agents should use this skill (20-1024 chars).
-            version: 0.1.0
-            category: other
-            source: {source}
-            tags: []
-            products: []
-            requires_scopes: []
             ---
 
             # {display_name}

--- a/products/posthog_ai/scripts/build_skills.py
+++ b/products/posthog_ai/scripts/build_skills.py
@@ -52,7 +52,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 MANIFEST_VERSION = "1.0.0"
-INDEX_SCHEMA_VERSION = "2.0.0"
+INDEX_SCHEMA_VERSION = "1.0.0"
 _ZIP_FIXED_TIME = (2025, 1, 1, 0, 0, 0)
 
 # Stable URL prefix for per-skill archives published as release assets.
@@ -836,7 +836,7 @@ def _setup_django() -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description=textwrap.dedent(__doc__),
+        description=textwrap.dedent(__doc__ or ""),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(

--- a/products/posthog_ai/scripts/build_skills.py
+++ b/products/posthog_ai/scripts/build_skills.py
@@ -1,22 +1,33 @@
 #!/usr/bin/env python3
 # ruff: noqa: T201 allow print statements
 """
-Build coding agent skills from products/*/skills/ into rendered files and a ZIP
-archive for distribution.
+Build coding agent skills from products/*/skills/ into rendered files, per-skill
+archives, and a registry index for distribution.
 
 Skills can be:
 - Plain markdown (SKILL.md) — copied as-is
 - Jinja2 templates (SKILL.md.j2) — rendered with Python context including Pydantic schema helpers
 
-Each skill must have YAML frontmatter with at least ``name`` and ``description`` fields.
+Skills under products/community/skills/ are community-contributed and subject to
+stricter rules: markdown only (no .j2, no scripts/). See
+products/community/skills/CONTRIBUTING.md.
+
+Each skill must have YAML frontmatter validated against ``SkillFrontmatter`` —
+``name`` (lowercase-kebab-case) and ``description`` (20-1024 chars) are required;
+other fields (version, tags, category, products, author, source, requires_scopes)
+are optional with sensible defaults for backwards compatibility.
+
 The build renders skills to dist/skills/{skill_name}/ (gitignored, human-readable)
-and optionally packages them into dist/skills.zip (published as a GitHub release by CI).
+and produces three sets of artifacts, all published as release assets by CI:
+- dist/skills.zip              monolithic archive (preserved for existing consumers)
+- dist/<skill-name>.zip        per-skill archive for granular install
+- dist/skills-index.json       registry index consumed by agents, IDEs, and the MCP server
 
 Requires the project's Python environment (managed by uv) for template rendering
 that imports Pydantic models from product code.
 
 Usage:
-    hogli build:skills          # Build all product skills to dist/skills/ and dist/skills.zip
+    hogli build:skills          # Build all product skills + registry artifacts
     hogli build:skills --list   # List discovered skills without building
     hogli lint:skills           # Validate skill sources without rendering
 """
@@ -26,11 +37,15 @@ from __future__ import annotations
 import os
 import re
 import sys
+import json
 import shutil
+import hashlib
 import zipfile
 import argparse
 import textwrap
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import Literal
 
 import yaml
 from jinja2 import Environment, StrictUndefined, TemplateSyntaxError
@@ -39,12 +54,35 @@ from pydantic import BaseModel, Field, ValidationError
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-MANIFEST_VERSION = "1.0.0"
+MANIFEST_VERSION = "2.0.0"
+INDEX_SCHEMA_VERSION = "2.0.0"
 _ZIP_FIXED_TIME = (2025, 1, 1, 0, 0, 0)
+
+# Stable URL prefix for per-skill archives published as release assets.
+# The `agent-skills-latest` release is updated on every master build.
+DEFAULT_ARCHIVE_URL_PREFIX = "https://github.com/PostHog/posthog/releases/download/agent-skills-latest"
 
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 _BINARY_CHECK_SIZE = 8192
 _ALLOWED_SUBDIRS = {"references", "scripts"}
+
+# Community skills have stricter rules: markdown only, no templates, no scripts.
+# See products/community/skills/CONTRIBUTING.md.
+_COMMUNITY_PRODUCT = "community"
+_COMMUNITY_DISALLOWED_SUBDIRS = {"scripts"}
+
+_SKILL_CATEGORIES = (
+    "analytics",
+    "flags",
+    "experiments",
+    "replay",
+    "errors",
+    "llm",
+    "surveys",
+    "workflows",
+    "data-warehouse",
+    "other",
+)
 
 
 def _create_jinja_env(**extra_globals: object) -> Environment:
@@ -72,8 +110,33 @@ def _assert_text_file(file_path: Path) -> None:
 
 
 class SkillFrontmatter(BaseModel):
-    name: str
-    description: str
+    """Frontmatter schema for skill SKILL.md files.
+
+    All fields beyond `name` and `description` are optional for backwards
+    compatibility, but enforced where set. Constraints are Pydantic-validated
+    at both lint time (cheap, no Django) and build time.
+    """
+
+    name: str = Field(..., pattern=r"^[a-z0-9][a-z0-9-]{2,63}$")
+    description: str = Field(..., min_length=20, max_length=1024)
+    version: str = Field(default="0.1.0", pattern=r"^\d+\.\d+\.\d+$")
+    tags: list[str] = Field(default_factory=list, max_length=8)
+    category: Literal[
+        "analytics",
+        "flags",
+        "experiments",
+        "replay",
+        "errors",
+        "llm",
+        "surveys",
+        "workflows",
+        "data-warehouse",
+        "other",
+    ] = "other"
+    products: list[str] = Field(default_factory=list, max_length=8)
+    author: str | None = None
+    source: Literal["official", "community"] = "official"
+    requires_scopes: list[str] = Field(default_factory=list, max_length=16)
 
 
 class DiscoveredSkill(BaseModel):
@@ -81,6 +144,10 @@ class DiscoveredSkill(BaseModel):
     source_file: Path
     product_dir: Path
     depth: int
+
+    @property
+    def is_community(self) -> bool:
+        return self.product_dir.name == _COMMUNITY_PRODUCT
 
 
 class SkillFile(BaseModel):
@@ -93,6 +160,33 @@ class SkillResource(BaseModel):
     description: str
     files: list[SkillFile]
     source: str
+    frontmatter: SkillFrontmatter | None = None
+
+
+class SkillIndexEntry(BaseModel):
+    """Single entry in the registry index — metadata only, no file contents."""
+
+    name: str
+    description: str
+    version: str
+    category: str
+    tags: list[str]
+    products: list[str]
+    author: str | None
+    source: str  # "official" | "community"
+    requires_scopes: list[str]
+    archive_url: str
+    sha256: str
+    source_path: str
+
+
+class SkillsIndex(BaseModel):
+    """Registry index of all published skills. Consumed by agents, IDEs,
+    and the MCP server to list/filter skills without downloading archives."""
+
+    version: str = INDEX_SCHEMA_VERSION
+    generated_at: str
+    skills: list[SkillIndexEntry] = Field(default_factory=list)
 
 
 class SkillManifest(BaseModel):
@@ -170,6 +264,10 @@ class SkillDiscoverer:
                 continue
 
             for entry in sorted(skills_dir.iterdir()):
+                # Skip hidden entries (e.g. .template/, .gitignore). This keeps
+                # the community/skills/.template/ scaffold out of the registry.
+                if entry.name.startswith("."):
+                    continue
                 if entry.is_dir():
                     j2_file = entry / "SKILL.md.j2"
                     md_file = entry / "SKILL.md"
@@ -183,7 +281,7 @@ class SkillDiscoverer:
                         )
                 elif (
                     entry.is_file()
-                    and entry.name != "README.md"
+                    and entry.name not in {"README.md", "CONTRIBUTING.md"}
                     and (entry.name.endswith(".md.j2") or entry.name.endswith(".md"))
                 ):
                     if entry.name.endswith(".md") and (entry.parent / (entry.name + ".j2")).exists():
@@ -230,19 +328,34 @@ class SkillBuilder:
         self.skills_dist_dir = self.dist_dir / "skills"
         self.discoverer = SkillDiscoverer(products_dir)
 
-    def collect_skill_files(self, skill_dir: Path, renderer: SkillRenderer) -> list[SkillFile]:
+    def collect_skill_files(
+        self,
+        skill_dir: Path,
+        renderer: SkillRenderer,
+        *,
+        is_community: bool = False,
+    ) -> list[SkillFile]:
         """Collect and render files from a skill directory using an explicit allowlist.
 
         Only collects from three sources:
         1. Entry point: SKILL.md.j2 (preferred) or SKILL.md
         2. references/ directory (recursive)
-        3. scripts/ directory (recursive)
+        3. scripts/ directory (recursive) — disallowed for community skills
+
+        Community skills (under ``products/community/skills/``) are restricted to
+        markdown-only references so untrusted contributions can't smuggle in
+        executable Python or Jinja2 templates with access to Django internals.
 
         .j2 files are rendered through Jinja2 and have the .j2 extension stripped.
         Returns a list of SkillFile with SKILL.md always first.
         """
         j2_entry = skill_dir / "SKILL.md.j2"
         md_entry = skill_dir / "SKILL.md"
+        if is_community and j2_entry.exists():
+            raise ValueError(
+                f"Community skill {skill_dir.name} may not use SKILL.md.j2 (templates disabled for community). "
+                "Use plain SKILL.md instead."
+            )
         if j2_entry.exists():
             entry_path = j2_entry
         elif md_entry.exists():
@@ -254,8 +367,10 @@ class SkillBuilder:
         entry_content = renderer.render(entry_path)
         entry_point = SkillFile(path="SKILL.md", content=entry_content)
 
+        allowed_subdirs = _ALLOWED_SUBDIRS - _COMMUNITY_DISALLOWED_SUBDIRS if is_community else _ALLOWED_SUBDIRS
+
         files: list[SkillFile] = []
-        for subdir_name in sorted(_ALLOWED_SUBDIRS):
+        for subdir_name in sorted(allowed_subdirs):
             subdir = skill_dir / subdir_name
             if not subdir.is_dir():
                 continue
@@ -264,39 +379,79 @@ class SkillBuilder:
                 for filename in sorted(filenames):
                     file_path = Path(root) / filename
                     _assert_text_file(file_path)
+                    if is_community and file_path.suffix == ".j2":
+                        raise ValueError(
+                            f"Community skill {skill_dir.name} may not contain .j2 templates "
+                            f"(found {file_path.relative_to(skill_dir)}). Use plain markdown instead."
+                        )
                     content = renderer.render(file_path)
                     rel_path = str(file_path.relative_to(skill_dir))
                     if rel_path.endswith(".j2"):
                         rel_path = rel_path.removesuffix(".j2")
                     files.append(SkillFile(path=rel_path, content=content))
 
+        # Explicitly reject any subdirectory that community contributions tried to use.
+        if is_community:
+            for disallowed in _COMMUNITY_DISALLOWED_SUBDIRS:
+                if (skill_dir / disallowed).is_dir():
+                    raise ValueError(
+                        f"Community skill {skill_dir.name} may not contain a {disallowed}/ directory. "
+                        "Community skills are markdown-only."
+                    )
+
         return [entry_point, *files]
 
     def build_skill(self, skill: DiscoveredSkill, renderer: SkillRenderer) -> SkillResource:
-        """Build a single skill and return a SkillResource."""
+        """Build a single skill and return a SkillResource.
+
+        Frontmatter is validated through ``SkillFrontmatter`` so that new fields
+        (version, tags, category, etc.) flow into the registry index. Skills
+        missing the required frontmatter fail at build time rather than
+        producing silently-underspecified index entries.
+        """
         if skill.depth == 1:
             skill_dir = skill.source_file.parent
-            skill_files = self.collect_skill_files(skill_dir, renderer)
+            skill_files = self.collect_skill_files(skill_dir, renderer, is_community=skill.is_community)
             entry_content = skill_files[0].content
-            metadata, _body = parse_frontmatter(entry_content)
             source = str(skill_dir.relative_to(self.repo_root))
+            source_label = source
         else:
+            if skill.is_community and skill.source_file.suffix == ".j2":
+                raise ValueError(
+                    f"Community skill {skill.name} may not use .j2 templates "
+                    f"(found {skill.source_file.relative_to(self.repo_root)}). Use plain markdown."
+                )
             rendered = renderer.render(skill.source_file)
-            metadata, _body = parse_frontmatter(rendered)
+            entry_content = rendered
             out_name = skill.source_file.name
             if out_name.endswith(".j2"):
                 out_name = out_name.removesuffix(".j2")
             skill_files = [SkillFile(path=out_name, content=rendered.strip())]
             source = str(skill.source_file.relative_to(self.repo_root))
+            source_label = source
 
-        display_name = metadata.get("name", skill.name)
-        description = metadata.get("description", f"Skill: {skill.name}")
+        frontmatter = validate_frontmatter(entry_content, source_label)
+
+        # Enforce that skills placed under products/community/skills/ declare themselves
+        # as community in frontmatter. This keeps the "source" field trustworthy in the
+        # registry index — official skills can't accidentally live alongside community ones.
+        if skill.is_community and frontmatter.source != "community":
+            raise ValueError(
+                f"Skill at {source_label} is under products/community/skills/ but its frontmatter "
+                f"declares source: {frontmatter.source!r}. Community skills must set source: community."
+            )
+        if not skill.is_community and frontmatter.source == "community":
+            raise ValueError(
+                f"Skill at {source_label} declares source: community in frontmatter but is not under "
+                "products/community/skills/. Move it there or change source to official."
+            )
 
         return SkillResource(
-            name=display_name,
-            description=description,
+            name=frontmatter.name,
+            description=frontmatter.description,
             files=skill_files,
             source=source,
+            frontmatter=frontmatter,
         )
 
     def build_manifest(self, skills: list[DiscoveredSkill], renderer: SkillRenderer) -> SkillManifest:
@@ -327,7 +482,11 @@ class SkillBuilder:
         return self._zip_skills_dist()
 
     def _zip_skills_dist(self) -> Path:
-        """Create dist/skills.zip from the dist/skills/ directory."""
+        """Create dist/skills.zip from the dist/skills/ directory.
+
+        The monolithic zip is preserved as-is for backwards compatibility
+        with existing consumers that download ``skills.zip`` directly.
+        """
         zip_path = self.dist_dir / "skills.zip"
         with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
             for file_path in sorted(self.skills_dist_dir.rglob("*")):
@@ -336,6 +495,97 @@ class SkillBuilder:
                     info = zipfile.ZipInfo(arcname, date_time=_ZIP_FIXED_TIME)
                     zf.writestr(info, file_path.read_text())
         return zip_path
+
+    def _zip_individual_skill(self, resource: SkillResource) -> tuple[Path, str]:
+        """Create dist/<skill-name>.zip for a single skill and return (path, sha256).
+
+        Per-skill zips let agents and the registry install a single skill without
+        downloading the monolithic archive.
+        """
+        zip_path = self.dist_dir / f"{resource.name}.zip"
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for skill_file in resource.files:
+                info = zipfile.ZipInfo(skill_file.path, date_time=_ZIP_FIXED_TIME)
+                zf.writestr(info, skill_file.content)
+
+        sha = hashlib.sha256(zip_path.read_bytes()).hexdigest()
+        return zip_path, sha
+
+    def _build_index(
+        self,
+        resources: list[SkillResource],
+        checksums: dict[str, str],
+        *,
+        archive_url_prefix: str,
+        generated_at: str,
+    ) -> SkillsIndex:
+        """Build the SkillsIndex from built resources.
+
+        ``archive_url_prefix`` points at the GitHub release that will host the
+        per-skill zips. Defaults to the ``agent-skills-latest`` rolling release.
+        Override via ``HOGLI_SKILLS_ARCHIVE_URL_PREFIX`` for staging/testing.
+        """
+        entries: list[SkillIndexEntry] = []
+        for resource in resources:
+            frontmatter = resource.frontmatter
+            if frontmatter is None:
+                # Defensive: build_skill() always populates frontmatter since the
+                # validator is mandatory, but keep a typed fallback rather than
+                # silently emitting a malformed index entry.
+                raise ValueError(f"Cannot index skill {resource.name}: missing validated frontmatter")
+
+            entries.append(
+                SkillIndexEntry(
+                    name=resource.name,
+                    description=resource.description,
+                    version=frontmatter.version,
+                    category=frontmatter.category,
+                    tags=list(frontmatter.tags),
+                    products=list(frontmatter.products),
+                    author=frontmatter.author,
+                    source=frontmatter.source,
+                    requires_scopes=list(frontmatter.requires_scopes),
+                    archive_url=f"{archive_url_prefix.rstrip('/')}/{resource.name}.zip",
+                    sha256=checksums[resource.name],
+                    source_path=resource.source,
+                )
+            )
+
+        return SkillsIndex(generated_at=generated_at, skills=entries)
+
+    def pack_registry(self, *, archive_url_prefix: str | None = None) -> tuple[Path, Path, list[Path]]:
+        """Build skills and produce the full registry artifacts.
+
+        Returns a tuple of:
+          - the monolithic ``dist/skills.zip`` (unchanged layout, backwards compatible)
+          - ``dist/skills-index.json`` (the registry index)
+          - list of per-skill ``dist/<skill-name>.zip`` paths
+
+        This is the artifact set published by the ``release-skills`` CI job.
+        """
+        manifest = self.build_all()
+        monolithic = self._zip_skills_dist()
+
+        prefix = archive_url_prefix or os.environ.get("HOGLI_SKILLS_ARCHIVE_URL_PREFIX", DEFAULT_ARCHIVE_URL_PREFIX)
+        generated_at = os.environ.get("HOGLI_SKILLS_GENERATED_AT") or datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        checksums: dict[str, str] = {}
+        individual_zips: list[Path] = []
+        for resource in manifest.resources:
+            zip_path, sha = self._zip_individual_skill(resource)
+            checksums[resource.name] = sha
+            individual_zips.append(zip_path)
+
+        index = self._build_index(
+            manifest.resources,
+            checksums,
+            archive_url_prefix=prefix,
+            generated_at=generated_at,
+        )
+        index_path = self.dist_dir / "skills-index.json"
+        index_path.write_text(json.dumps(index.model_dump(), indent=2, sort_keys=False) + "\n")
+
+        return monolithic, index_path, individual_zips
 
     def _collect_lint_files(self, skill: DiscoveredSkill) -> list[Path]:
         """Collect all files for linting from a skill using the allowlist.
@@ -364,7 +614,9 @@ class SkillBuilder:
         - Binary file detection (only text files allowed)
         - Duplicate skill name detection (across products)
         - Jinja2 syntax validation via parse-only (all .j2 files)
-        - Frontmatter validation for static .md entry points (required: name, description)
+        - Frontmatter validation for static .md entry points (schema + constraints)
+        - Community-skill restrictions: no .j2 templates, no scripts/ subdirectory,
+          frontmatter source must be "community"
 
         Returns True if all checks pass, False otherwise.
         """
@@ -408,9 +660,17 @@ class SkillBuilder:
                 raw = skill.source_file.read_text()
                 source_label = str(skill.source_file.relative_to(self.repo_root))
                 try:
-                    validate_frontmatter(raw, source_label)
+                    frontmatter = validate_frontmatter(raw, source_label)
                 except ValueError as e:
                     errors.append(str(e))
+                else:
+                    errors.extend(self._lint_community_rules(skill, frontmatter))
+            elif skill.is_community:
+                # .j2 already disallowed, but surface the error with a clearer message.
+                errors.append(
+                    f"Community skill {skill.name} ({skill.source_file.relative_to(self.repo_root)}) "
+                    "may not use .j2 templates. Use plain SKILL.md."
+                )
 
         if errors:
             for err in errors:
@@ -419,6 +679,50 @@ class SkillBuilder:
 
         print(f"OK: {len(skills)} skill(s) passed lint checks.")
         return True
+
+    def _lint_community_rules(self, skill: DiscoveredSkill, frontmatter: SkillFrontmatter) -> list[str]:
+        """Return any community-skill violations for a discovered skill.
+
+        Called from lint_all so community PRs fail fast without Django, matching
+        the stricter rules enforced at build time in ``collect_skill_files`` /
+        ``build_skill``.
+        """
+        errors: list[str] = []
+        source_label = str(skill.source_file.relative_to(self.repo_root))
+
+        if skill.is_community:
+            if frontmatter.source != "community":
+                errors.append(
+                    f"{source_label}: skills under products/community/skills/ must set "
+                    f"'source: community' in frontmatter (got '{frontmatter.source}')."
+                )
+            if skill.depth == 1:
+                skill_dir = skill.source_file.parent
+                for disallowed in _COMMUNITY_DISALLOWED_SUBDIRS:
+                    if (skill_dir / disallowed).is_dir():
+                        errors.append(
+                            f"{source_label}: community skills may not contain a {disallowed}/ "
+                            "directory (markdown-only)."
+                        )
+                # Any .j2 inside references/ is disallowed too.
+                for subdir_name in sorted(_ALLOWED_SUBDIRS):
+                    subdir = skill_dir / subdir_name
+                    if not subdir.is_dir():
+                        continue
+                    for root, _dirs, filenames in os.walk(subdir):
+                        for filename in filenames:
+                            if filename.endswith(".j2"):
+                                errors.append(
+                                    f"{source_label}: community skills may not contain .j2 templates "
+                                    f"(found {Path(root, filename).relative_to(self.repo_root)})."
+                                )
+        elif frontmatter.source == "community":
+            errors.append(
+                f"{source_label}: frontmatter declares 'source: community' but skill is not "
+                "under products/community/skills/. Move it there or change source to 'official'."
+            )
+
+        return errors
 
     def init_skill(self, product_name: str, skill_name: str, *, template: bool = False) -> Path:
         """Scaffold a new skill directory with SKILL.md boilerplate.
@@ -441,15 +745,30 @@ class SkillBuilder:
 
         display_name = skill_name.replace("-", " ").capitalize()
         filename = "SKILL.md.j2" if template else "SKILL.md"
+        source = "community" if product_name == _COMMUNITY_PRODUCT else "official"
         content = textwrap.dedent(f"""\
             ---
             name: {skill_name}
-            description: TODO
+            description: TODO — describe when and how agents should use this skill (20-1024 chars).
+            version: 0.1.0
+            category: other
+            source: {source}
+            tags: []
+            products: []
+            requires_scopes: []
             ---
 
             # {display_name}
 
             TODO: Describe when and how to use this skill.
+
+            ## When to use this skill
+
+            TODO
+
+            ## Workflow
+
+            TODO
         """)
 
         skill_file = skill_dir / filename
@@ -690,14 +1009,17 @@ def main() -> None:
 
     _setup_django()
 
-    manifest = builder.build_all()
-    if not manifest.resources:
+    monolithic, index_path, individual_zips = builder.pack_registry()
+    if not individual_zips:
         print("No product skills found in products/*/skills/.")
         return
-    zip_path = builder._zip_skills_dist()
-    print(f"Built {len(manifest.resources)} skill(s) → {zip_path.relative_to(REPO_ROOT)}")
-    for r in manifest.resources:
-        print(f"  {r.name:<40} source={r.source}")
+
+    print(f"Built {len(individual_zips)} skill(s):")
+    print(f"  monolithic archive → {monolithic.relative_to(REPO_ROOT)}")
+    print(f"  registry index     → {index_path.relative_to(REPO_ROOT)}")
+    print(f"  per-skill archives → {builder.dist_dir.relative_to(REPO_ROOT)}/<skill>.zip")
+    for zip_path in individual_zips:
+        print(f"    {zip_path.name}")
 
 
 if __name__ == "__main__":

--- a/products/posthog_ai/scripts/test/test_build_skills.py
+++ b/products/posthog_ai/scripts/test/test_build_skills.py
@@ -19,10 +19,6 @@ from products.posthog_ai.scripts.build_skills import (
     validate_frontmatter,
 )
 
-# Descriptions must be >= 20 chars per SkillFrontmatter. Tests use this when the
-# exact description text isn't part of the assertion.
-_DESC = "A skill used for exercising the build pipeline in tests"
-
 
 @pytest.mark.parametrize(
     "text,expected_meta,expected_body_starts_with",
@@ -52,11 +48,10 @@ def test_parse_frontmatter(text: str, expected_meta: dict, expected_body_starts_
 
 
 def test_validate_frontmatter_valid() -> None:
-    description = "A useful skill for testing frontmatter validation"
-    text = f"---\nname: my-skill\ndescription: {description}\n---\n# Body\n"
+    text = "---\nname: my-skill\ndescription: A good skill\n---\n# Body\n"
     fm = validate_frontmatter(text, "test.md")
     assert fm.name == "my-skill"
-    assert fm.description == description
+    assert fm.description == "A good skill"
 
 
 @pytest.mark.parametrize(
@@ -194,10 +189,9 @@ def test_render_j2_strict_undefined_raises(tmp_path: Path) -> None:
 
 
 def test_build_skill_extracts_frontmatter(tmp_path: Path) -> None:
-    description = "A skill for testing frontmatter extraction"
     md_file = tmp_path / "products" / "foo" / "skills" / "bar" / "SKILL.md"
     md_file.parent.mkdir(parents=True)
-    md_file.write_text(f"---\nname: bar\ndescription: {description}\n---\n# Skill body\n")
+    md_file.write_text("---\nname: bar\ndescription: Bar skill\n---\n# Skill body\n")
 
     renderer = SkillRenderer()
     skill = DiscoveredSkill(name="bar", source_file=md_file, product_dir=tmp_path / "products" / "foo", depth=1)
@@ -205,7 +199,7 @@ def test_build_skill_extracts_frontmatter(tmp_path: Path) -> None:
     result = builder.build_skill(skill, renderer)
 
     assert result.name == "bar"
-    assert result.description == description
+    assert result.description == "Bar skill"
     assert result.files[0].path == "SKILL.md"
     assert "# Skill body" in result.files[0].content
     assert "name: bar" in result.files[0].content
@@ -228,7 +222,7 @@ def test_build_skill_requires_frontmatter(tmp_path: Path) -> None:
 def test_build_skill_collects_all_files(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "multi-file"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(f"---\nname: multi\ndescription: {_DESC}\n---\n# Main\n")
+    (skill_dir / "SKILL.md").write_text("---\nname: multi\ndescription: Multi\n---\n# Main\n")
     refs = skill_dir / "references"
     refs.mkdir()
     (refs / "example.md").write_text("# Example reference\n")
@@ -249,7 +243,7 @@ def test_build_skill_collects_all_files(tmp_path: Path) -> None:
 def test_build_skill_ignores_non_allowed_subdirs(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "with-extras"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(f"---\nname: tst\ndescription: {_DESC}\n---\n# Body\n")
+    (skill_dir / "SKILL.md").write_text("---\nname: t\ndescription: T\n---\n# Body\n")
     for subdir in ("test", "tests", "utils", "lib"):
         d = skill_dir / subdir
         d.mkdir()
@@ -269,7 +263,7 @@ def test_build_skill_ignores_non_allowed_subdirs(tmp_path: Path) -> None:
 def test_build_skill_ignores_root_files(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "root-files"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(f"---\nname: rfs\ndescription: {_DESC}\n---\n# Body\n")
+    (skill_dir / "SKILL.md").write_text("---\nname: rf\ndescription: RF\n---\n# Body\n")
     (skill_dir / "helper.py").write_text("x = 1")
     (skill_dir / "notes.txt").write_text("some notes")
 
@@ -287,7 +281,7 @@ def test_build_skill_ignores_root_files(tmp_path: Path) -> None:
 def test_build_skill_renders_j2_references(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "j2-refs"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md.j2").write_text(f"---\nname: j2r\ndescription: {_DESC}\n---\n# Main {{{{ 'content' }}}}\n")
+    (skill_dir / "SKILL.md.j2").write_text("---\nname: j2r\ndescription: J2R\n---\n# Main {{ 'content' }}\n")
     refs = skill_dir / "references"
     refs.mkdir()
     (refs / "example.md.j2").write_text("# Rendered {{ 'value' }}\n")
@@ -324,7 +318,7 @@ def test_build_skill_validates_entry_point(tmp_path: Path) -> None:
 def test_build_skill_entry_point_first(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "ordered"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(f"---\nname: ord\ndescription: {_DESC}\n---\n# Main\n")
+    (skill_dir / "SKILL.md").write_text("---\nname: ord\ndescription: Ord\n---\n# Main\n")
     refs = skill_dir / "references"
     refs.mkdir()
     (refs / "aaa.md").write_text("first alphabetically")
@@ -346,7 +340,7 @@ def test_build_manifest_produces_valid_structure(tmp_path: Path) -> None:
     for skill_name in ("skill-a", "skill-b"):
         skill_dir = products / "alpha" / "skills" / skill_name
         skill_dir.mkdir(parents=True)
-        (skill_dir / "SKILL.md").write_text(f"---\nname: {skill_name}\ndescription: {_DESC}\n---\n# Body\n")
+        (skill_dir / "SKILL.md").write_text(f"---\nname: {skill_name}\ndescription: desc\n---\n# Body\n")
 
     discoverer = SkillDiscoverer(products_dir=products)
     skills = discoverer.discover()
@@ -354,12 +348,12 @@ def test_build_manifest_produces_valid_structure(tmp_path: Path) -> None:
     builder = SkillBuilder(repo_root=tmp_path, products_dir=products, output_dir=tmp_path / "output")
     manifest = builder.build_manifest(skills, renderer)
 
-    assert manifest.version == "2.0.0"
+    assert manifest.version == "1.0.0"
     assert len(manifest.resources) == 2
     assert manifest.resources[0].name == "skill-a"
     assert manifest.resources[1].name == "skill-b"
     assert manifest.resources[0].files[0].path == "SKILL.md"
-    assert manifest.resources[0].description == _DESC
+    assert manifest.resources[0].description == "desc"
 
 
 def test_end_to_end_template_with_pydantic(tmp_path: Path) -> None:
@@ -421,11 +415,11 @@ def test_end_to_end_template_with_pydantic(tmp_path: Path) -> None:
 def test_lint_all_passes_for_valid_skills(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "good-skill"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(f"---\nname: good-skill\ndescription: {_DESC}\n---\n# Body\n")
+    (skill_dir / "SKILL.md").write_text("---\nname: good-skill\ndescription: A good skill\n---\n# Body\n")
 
     j2_dir = tmp_path / "products" / "alpha" / "skills" / "template-skill"
     j2_dir.mkdir(parents=True)
-    (j2_dir / "SKILL.md.j2").write_text(f"---\nname: tmpl\ndescription: {_DESC}\n---\n# {{{{ 'hello' }}}}\n")
+    (j2_dir / "SKILL.md.j2").write_text("---\nname: tmpl\ndescription: T\n---\n# {{ 'hello' }}\n")
 
     builder = SkillBuilder(
         repo_root=tmp_path,
@@ -438,7 +432,7 @@ def test_lint_all_passes_for_valid_skills(tmp_path: Path) -> None:
 def test_lint_all_passes_with_subdirectories(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "with-refs"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(f"---\nname: with-refs\ndescription: {_DESC}\n---\n# Body\n")
+    (skill_dir / "SKILL.md").write_text("---\nname: with-refs\ndescription: Has refs\n---\n# Body\n")
     refs = skill_dir / "references"
     refs.mkdir()
     (refs / "example.md").write_text("# Example\n")
@@ -480,7 +474,7 @@ def test_lint_all_catches_bad_jinja2_syntax(tmp_path: Path) -> None:
 def test_lint_all_catches_bad_jinja2_in_subdirectory(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "broken-ref-j2"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md.j2").write_text(f"---\nname: brj\ndescription: {_DESC}\n---\n# {{{{ 'ok' }}}}\n")
+    (skill_dir / "SKILL.md.j2").write_text("---\nname: brj\ndescription: B\n---\n# {{ 'ok' }}\n")
     refs = skill_dir / "references"
     refs.mkdir()
     (refs / "bad.md.j2").write_text("{% if unclosed %}\n")
@@ -497,7 +491,7 @@ def test_lint_all_catches_duplicate_skill_names(tmp_path: Path) -> None:
     for product in ("alpha", "beta"):
         skill_dir = tmp_path / "products" / product / "skills" / "same-name"
         skill_dir.mkdir(parents=True)
-        (skill_dir / "SKILL.md").write_text(f"---\nname: same\ndescription: {_DESC}\n---\nBody\n")
+        (skill_dir / "SKILL.md").write_text("---\nname: same\ndescription: Duplicate\n---\nBody\n")
 
     builder = SkillBuilder(
         repo_root=tmp_path,
@@ -510,7 +504,7 @@ def test_lint_all_catches_duplicate_skill_names(tmp_path: Path) -> None:
 def test_build_skill_rejects_binary_file(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "has-binary"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(f"---\nname: hbn\ndescription: {_DESC}\n---\n# Body\n")
+    (skill_dir / "SKILL.md").write_text("---\nname: hb\ndescription: HB\n---\n# Body\n")
     refs = skill_dir / "references"
     refs.mkdir()
     (refs / "image.png").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00")
@@ -528,7 +522,7 @@ def test_build_skill_rejects_binary_file(tmp_path: Path) -> None:
 def test_lint_catches_binary_file(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "has-binary"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(f"---\nname: hbn\ndescription: {_DESC}\n---\n# Body\n")
+    (skill_dir / "SKILL.md").write_text("---\nname: hb\ndescription: HB\n---\n# Body\n")
     refs = skill_dir / "references"
     refs.mkdir()
     (refs / "image.png").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00")
@@ -544,7 +538,7 @@ def test_lint_catches_binary_file(tmp_path: Path) -> None:
 def test_build_skill_collects_scripts(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "with-scripts"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(f"---\nname: wss\ndescription: {_DESC}\n---\n# Body\n")
+    (skill_dir / "SKILL.md").write_text("---\nname: ws\ndescription: WS\n---\n# Body\n")
     scripts = skill_dir / "scripts"
     scripts.mkdir()
     (scripts / "setup.sh").write_text("#!/bin/bash\necho hello\n")
@@ -567,7 +561,7 @@ def test_build_skill_collects_scripts(tmp_path: Path) -> None:
 def test_build_skill_renders_j2_scripts(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "j2-scripts"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(f"---\nname: jsk\ndescription: {_DESC}\n---\n# Body\n")
+    (skill_dir / "SKILL.md").write_text("---\nname: js\ndescription: JS\n---\n# Body\n")
     scripts = skill_dir / "scripts"
     scripts.mkdir()
     (scripts / "template.sh.j2").write_text("echo {{ 'rendered' }}\n")
@@ -606,7 +600,7 @@ def test_init_skill_creates_file(tmp_path: Path, template: bool, expected_filena
     content = skill_file.read_text()
     fm = validate_frontmatter(content, str(skill_file))
     assert fm.name == "my-new-skill"
-    assert fm.description.startswith("TODO")
+    assert fm.description == "TODO"
     assert "# My new skill" in content
 
     refs_dir = skill_file.parent / "references"

--- a/products/posthog_ai/scripts/test/test_build_skills.py
+++ b/products/posthog_ai/scripts/test/test_build_skills.py
@@ -19,6 +19,10 @@ from products.posthog_ai.scripts.build_skills import (
     validate_frontmatter,
 )
 
+# Descriptions must be >= 20 chars per SkillFrontmatter. Tests use this when the
+# exact description text isn't part of the assertion.
+_DESC = "A skill used for exercising the build pipeline in tests"
+
 
 @pytest.mark.parametrize(
     "text,expected_meta,expected_body_starts_with",
@@ -48,10 +52,11 @@ def test_parse_frontmatter(text: str, expected_meta: dict, expected_body_starts_
 
 
 def test_validate_frontmatter_valid() -> None:
-    text = "---\nname: my-skill\ndescription: A good skill\n---\n# Body\n"
+    description = "A useful skill for testing frontmatter validation"
+    text = f"---\nname: my-skill\ndescription: {description}\n---\n# Body\n"
     fm = validate_frontmatter(text, "test.md")
     assert fm.name == "my-skill"
-    assert fm.description == "A good skill"
+    assert fm.description == description
 
 
 @pytest.mark.parametrize(
@@ -189,9 +194,10 @@ def test_render_j2_strict_undefined_raises(tmp_path: Path) -> None:
 
 
 def test_build_skill_extracts_frontmatter(tmp_path: Path) -> None:
+    description = "A skill for testing frontmatter extraction"
     md_file = tmp_path / "products" / "foo" / "skills" / "bar" / "SKILL.md"
     md_file.parent.mkdir(parents=True)
-    md_file.write_text("---\nname: bar\ndescription: Bar skill\n---\n# Skill body\n")
+    md_file.write_text(f"---\nname: bar\ndescription: {description}\n---\n# Skill body\n")
 
     renderer = SkillRenderer()
     skill = DiscoveredSkill(name="bar", source_file=md_file, product_dir=tmp_path / "products" / "foo", depth=1)
@@ -199,14 +205,14 @@ def test_build_skill_extracts_frontmatter(tmp_path: Path) -> None:
     result = builder.build_skill(skill, renderer)
 
     assert result.name == "bar"
-    assert result.description == "Bar skill"
+    assert result.description == description
     assert result.files[0].path == "SKILL.md"
     assert "# Skill body" in result.files[0].content
     assert "name: bar" in result.files[0].content
     assert result.source == "products/foo/skills/bar"
 
 
-def test_build_skill_defaults_without_frontmatter(tmp_path: Path) -> None:
+def test_build_skill_requires_frontmatter(tmp_path: Path) -> None:
     md_file = tmp_path / "products" / "foo" / "skills" / "my-skill" / "SKILL.md"
     md_file.parent.mkdir(parents=True)
     md_file.write_text("# No frontmatter\nJust body.\n")
@@ -214,17 +220,15 @@ def test_build_skill_defaults_without_frontmatter(tmp_path: Path) -> None:
     renderer = SkillRenderer()
     skill = DiscoveredSkill(name="my-skill", source_file=md_file, product_dir=tmp_path / "products" / "foo", depth=1)
     builder = SkillBuilder(repo_root=tmp_path, products_dir=tmp_path / "products", output_dir=tmp_path / "output")
-    result = builder.build_skill(skill, renderer)
 
-    assert result.name == "my-skill"
-    assert result.description == "Skill: my-skill"
-    assert "# No frontmatter" in result.files[0].content
+    with pytest.raises(ValueError, match="Missing YAML frontmatter"):
+        builder.build_skill(skill, renderer)
 
 
 def test_build_skill_collects_all_files(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "multi-file"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: multi\ndescription: Multi\n---\n# Main\n")
+    (skill_dir / "SKILL.md").write_text(f"---\nname: multi\ndescription: {_DESC}\n---\n# Main\n")
     refs = skill_dir / "references"
     refs.mkdir()
     (refs / "example.md").write_text("# Example reference\n")
@@ -245,7 +249,7 @@ def test_build_skill_collects_all_files(tmp_path: Path) -> None:
 def test_build_skill_ignores_non_allowed_subdirs(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "with-extras"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: t\ndescription: T\n---\n# Body\n")
+    (skill_dir / "SKILL.md").write_text(f"---\nname: tst\ndescription: {_DESC}\n---\n# Body\n")
     for subdir in ("test", "tests", "utils", "lib"):
         d = skill_dir / subdir
         d.mkdir()
@@ -265,7 +269,7 @@ def test_build_skill_ignores_non_allowed_subdirs(tmp_path: Path) -> None:
 def test_build_skill_ignores_root_files(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "root-files"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: rf\ndescription: RF\n---\n# Body\n")
+    (skill_dir / "SKILL.md").write_text(f"---\nname: rfs\ndescription: {_DESC}\n---\n# Body\n")
     (skill_dir / "helper.py").write_text("x = 1")
     (skill_dir / "notes.txt").write_text("some notes")
 
@@ -283,7 +287,7 @@ def test_build_skill_ignores_root_files(tmp_path: Path) -> None:
 def test_build_skill_renders_j2_references(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "j2-refs"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md.j2").write_text("---\nname: j2r\ndescription: J2R\n---\n# Main {{ 'content' }}\n")
+    (skill_dir / "SKILL.md.j2").write_text(f"---\nname: j2r\ndescription: {_DESC}\n---\n# Main {{{{ 'content' }}}}\n")
     refs = skill_dir / "references"
     refs.mkdir()
     (refs / "example.md.j2").write_text("# Rendered {{ 'value' }}\n")
@@ -320,7 +324,7 @@ def test_build_skill_validates_entry_point(tmp_path: Path) -> None:
 def test_build_skill_entry_point_first(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "ordered"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: ord\ndescription: Ord\n---\n# Main\n")
+    (skill_dir / "SKILL.md").write_text(f"---\nname: ord\ndescription: {_DESC}\n---\n# Main\n")
     refs = skill_dir / "references"
     refs.mkdir()
     (refs / "aaa.md").write_text("first alphabetically")
@@ -342,7 +346,7 @@ def test_build_manifest_produces_valid_structure(tmp_path: Path) -> None:
     for skill_name in ("skill-a", "skill-b"):
         skill_dir = products / "alpha" / "skills" / skill_name
         skill_dir.mkdir(parents=True)
-        (skill_dir / "SKILL.md").write_text(f"---\nname: {skill_name}\ndescription: desc\n---\n# Body\n")
+        (skill_dir / "SKILL.md").write_text(f"---\nname: {skill_name}\ndescription: {_DESC}\n---\n# Body\n")
 
     discoverer = SkillDiscoverer(products_dir=products)
     skills = discoverer.discover()
@@ -350,12 +354,12 @@ def test_build_manifest_produces_valid_structure(tmp_path: Path) -> None:
     builder = SkillBuilder(repo_root=tmp_path, products_dir=products, output_dir=tmp_path / "output")
     manifest = builder.build_manifest(skills, renderer)
 
-    assert manifest.version == "1.0.0"
+    assert manifest.version == "2.0.0"
     assert len(manifest.resources) == 2
     assert manifest.resources[0].name == "skill-a"
     assert manifest.resources[1].name == "skill-b"
     assert manifest.resources[0].files[0].path == "SKILL.md"
-    assert manifest.resources[0].description == "desc"
+    assert manifest.resources[0].description == _DESC
 
 
 def test_end_to_end_template_with_pydantic(tmp_path: Path) -> None:
@@ -417,11 +421,11 @@ def test_end_to_end_template_with_pydantic(tmp_path: Path) -> None:
 def test_lint_all_passes_for_valid_skills(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "good-skill"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: good-skill\ndescription: A good skill\n---\n# Body\n")
+    (skill_dir / "SKILL.md").write_text(f"---\nname: good-skill\ndescription: {_DESC}\n---\n# Body\n")
 
     j2_dir = tmp_path / "products" / "alpha" / "skills" / "template-skill"
     j2_dir.mkdir(parents=True)
-    (j2_dir / "SKILL.md.j2").write_text("---\nname: tmpl\ndescription: T\n---\n# {{ 'hello' }}\n")
+    (j2_dir / "SKILL.md.j2").write_text(f"---\nname: tmpl\ndescription: {_DESC}\n---\n# {{{{ 'hello' }}}}\n")
 
     builder = SkillBuilder(
         repo_root=tmp_path,
@@ -434,7 +438,7 @@ def test_lint_all_passes_for_valid_skills(tmp_path: Path) -> None:
 def test_lint_all_passes_with_subdirectories(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "with-refs"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: with-refs\ndescription: Has refs\n---\n# Body\n")
+    (skill_dir / "SKILL.md").write_text(f"---\nname: with-refs\ndescription: {_DESC}\n---\n# Body\n")
     refs = skill_dir / "references"
     refs.mkdir()
     (refs / "example.md").write_text("# Example\n")
@@ -476,7 +480,7 @@ def test_lint_all_catches_bad_jinja2_syntax(tmp_path: Path) -> None:
 def test_lint_all_catches_bad_jinja2_in_subdirectory(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "broken-ref-j2"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md.j2").write_text("---\nname: brj\ndescription: B\n---\n# {{ 'ok' }}\n")
+    (skill_dir / "SKILL.md.j2").write_text(f"---\nname: brj\ndescription: {_DESC}\n---\n# {{{{ 'ok' }}}}\n")
     refs = skill_dir / "references"
     refs.mkdir()
     (refs / "bad.md.j2").write_text("{% if unclosed %}\n")
@@ -493,7 +497,7 @@ def test_lint_all_catches_duplicate_skill_names(tmp_path: Path) -> None:
     for product in ("alpha", "beta"):
         skill_dir = tmp_path / "products" / product / "skills" / "same-name"
         skill_dir.mkdir(parents=True)
-        (skill_dir / "SKILL.md").write_text("---\nname: same\ndescription: Duplicate\n---\nBody\n")
+        (skill_dir / "SKILL.md").write_text(f"---\nname: same\ndescription: {_DESC}\n---\nBody\n")
 
     builder = SkillBuilder(
         repo_root=tmp_path,
@@ -506,7 +510,7 @@ def test_lint_all_catches_duplicate_skill_names(tmp_path: Path) -> None:
 def test_build_skill_rejects_binary_file(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "has-binary"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: hb\ndescription: HB\n---\n# Body\n")
+    (skill_dir / "SKILL.md").write_text(f"---\nname: hbn\ndescription: {_DESC}\n---\n# Body\n")
     refs = skill_dir / "references"
     refs.mkdir()
     (refs / "image.png").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00")
@@ -524,7 +528,7 @@ def test_build_skill_rejects_binary_file(tmp_path: Path) -> None:
 def test_lint_catches_binary_file(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "has-binary"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: hb\ndescription: HB\n---\n# Body\n")
+    (skill_dir / "SKILL.md").write_text(f"---\nname: hbn\ndescription: {_DESC}\n---\n# Body\n")
     refs = skill_dir / "references"
     refs.mkdir()
     (refs / "image.png").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00")
@@ -540,7 +544,7 @@ def test_lint_catches_binary_file(tmp_path: Path) -> None:
 def test_build_skill_collects_scripts(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "with-scripts"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: ws\ndescription: WS\n---\n# Body\n")
+    (skill_dir / "SKILL.md").write_text(f"---\nname: wss\ndescription: {_DESC}\n---\n# Body\n")
     scripts = skill_dir / "scripts"
     scripts.mkdir()
     (scripts / "setup.sh").write_text("#!/bin/bash\necho hello\n")
@@ -563,7 +567,7 @@ def test_build_skill_collects_scripts(tmp_path: Path) -> None:
 def test_build_skill_renders_j2_scripts(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "j2-scripts"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text("---\nname: js\ndescription: JS\n---\n# Body\n")
+    (skill_dir / "SKILL.md").write_text(f"---\nname: jsk\ndescription: {_DESC}\n---\n# Body\n")
     scripts = skill_dir / "scripts"
     scripts.mkdir()
     (scripts / "template.sh.j2").write_text("echo {{ 'rendered' }}\n")
@@ -602,7 +606,7 @@ def test_init_skill_creates_file(tmp_path: Path, template: bool, expected_filena
     content = skill_file.read_text()
     fm = validate_frontmatter(content, str(skill_file))
     assert fm.name == "my-new-skill"
-    assert fm.description == "TODO"
+    assert fm.description.startswith("TODO")
     assert "# My new skill" in content
 
     refs_dir = skill_file.parent / "references"

--- a/products/posthog_ai/scripts/test/test_build_skills.py
+++ b/products/posthog_ai/scripts/test/test_build_skills.py
@@ -600,7 +600,7 @@ def test_init_skill_creates_file(tmp_path: Path, template: bool, expected_filena
     content = skill_file.read_text()
     fm = validate_frontmatter(content, str(skill_file))
     assert fm.name == "my-new-skill"
-    assert fm.description == "TODO"
+    assert fm.description.startswith("TODO")
     assert "# My new skill" in content
 
     refs_dir = skill_file.parent / "references"

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -448,7 +448,7 @@
         }
     },
     "skills-list": {
-        "description": "List PostHog agent skills published in the registry. Skills are job-to-be-done templates that teach agents how to accomplish specific PostHog tasks (e.g. cleaning up stale feature flags, auditing experiments). Use this BEFORE attempting a multi-step PostHog workflow to check whether a canonical skill exists — following an existing skill is almost always better than improvising. Filter by category, products, tags, source (official/community), or a substring search on name/description. Returns metadata only; call skills-get to download a specific skill.",
+        "description": "List PostHog agent skills published in the registry. Skills are job-to-be-done templates that teach agents how to accomplish specific PostHog tasks (e.g. cleaning up stale feature flags, auditing experiments). Use this BEFORE attempting a multi-step PostHog workflow to check whether a canonical skill exists — following an existing skill is almost always better than improvising. Optionally narrow the list with a substring search on name/description. Returns metadata only; call skills-get to download a specific skill.",
         "category": "Skills",
         "feature": "skills",
         "summary": "List published PostHog agent skills.",
@@ -463,7 +463,7 @@
         }
     },
     "skills-get": {
-        "description": "Fetch the full contents of a PostHog agent skill by name. Returns the skill's SKILL.md (entry point) plus any reference files under references/. Use this after skills-list identifies a relevant skill — the SKILL.md describes the workflow the agent should follow. Community skills are markdown-only; official skills may also include reference pages with HogQL examples and schema documentation.",
+        "description": "Fetch the full contents of a PostHog agent skill by name. Returns the skill's SKILL.md (entry point) plus any reference files under references/. Use this after skills-list identifies a relevant skill — the SKILL.md describes the workflow the agent should follow.",
         "category": "Skills",
         "feature": "skills",
         "summary": "Fetch a published PostHog agent skill.",

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -447,6 +447,36 @@
             "readOnlyHint": true
         }
     },
+    "skills-list": {
+        "description": "List PostHog agent skills published in the registry. Skills are job-to-be-done templates that teach agents how to accomplish specific PostHog tasks (e.g. cleaning up stale feature flags, auditing experiments). Use this BEFORE attempting a multi-step PostHog workflow to check whether a canonical skill exists — following an existing skill is almost always better than improvising. Filter by category, products, tags, source (official/community), or a substring search on name/description. Returns metadata only; call skills-get to download a specific skill.",
+        "category": "Skills",
+        "feature": "skills",
+        "summary": "List published PostHog agent skills.",
+        "title": "List skills",
+        "required_scopes": [],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "skills-get": {
+        "description": "Fetch the full contents of a PostHog agent skill by name. Returns the skill's SKILL.md (entry point) plus any reference files under references/. Use this after skills-list identifies a relevant skill — the SKILL.md describes the workflow the agent should follow. Community skills are markdown-only; official skills may also include reference pages with HogQL examples and schema documentation.",
+        "category": "Skills",
+        "feature": "skills",
+        "summary": "Fetch a published PostHog agent skill.",
+        "title": "Get skill",
+        "required_scopes": [],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "debug-mcp-ui-apps": {
         "description": "Debug tool for testing MCP Apps SDK integration. Returns sample data displayed in an interactive UI app with component showcase. Use this to verify that MCP Apps are working correctly.",
         "category": "Debug",

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -346,34 +346,7 @@ export const DebugMcpUiAppsSchema = z.object({
 })
 
 // Skills registry
-const SkillCategoryEnum = z.enum([
-    'analytics',
-    'flags',
-    'experiments',
-    'replay',
-    'errors',
-    'llm',
-    'surveys',
-    'workflows',
-    'data-warehouse',
-    'other',
-])
-
 export const SkillsListSchema = z.object({
-    category: SkillCategoryEnum.optional().describe(
-        'Filter by skill category. Skills are categorized by the PostHog surface they primarily operate on.'
-    ),
-    products: z
-        .array(z.string())
-        .optional()
-        .describe('Filter to skills that touch any of these product slugs (e.g. ["feature_flags", "experiments"]).'),
-    tags: z.array(z.string()).optional().describe('Filter to skills tagged with any of these tags.'),
-    source: z
-        .enum(['official', 'community'])
-        .optional()
-        .describe(
-            "Filter by who maintains the skill. 'official' is the PostHog team, 'community' is external contributors."
-        ),
     search: z.string().optional().describe('Case-insensitive substring match against skill name and description.'),
 })
 

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -345,6 +345,47 @@ export const DebugMcpUiAppsSchema = z.object({
     message: z.string().optional().describe('Optional message to include in the debug data'),
 })
 
+// Skills registry
+const SkillCategoryEnum = z.enum([
+    'analytics',
+    'flags',
+    'experiments',
+    'replay',
+    'errors',
+    'llm',
+    'surveys',
+    'workflows',
+    'data-warehouse',
+    'other',
+])
+
+export const SkillsListSchema = z.object({
+    category: SkillCategoryEnum.optional().describe(
+        'Filter by skill category. Skills are categorized by the PostHog surface they primarily operate on.'
+    ),
+    products: z
+        .array(z.string())
+        .optional()
+        .describe('Filter to skills that touch any of these product slugs (e.g. ["feature_flags", "experiments"]).'),
+    tags: z.array(z.string()).optional().describe('Filter to skills tagged with any of these tags.'),
+    source: z
+        .enum(['official', 'community'])
+        .optional()
+        .describe(
+            "Filter by who maintains the skill. 'official' is the PostHog team, 'community' is external contributors."
+        ),
+    search: z.string().optional().describe('Case-insensitive substring match against skill name and description.'),
+})
+
+export const SkillsGetSchema = z.object({
+    name: z
+        .string()
+        .min(1)
+        .describe(
+            'Exact skill name (lowercase-kebab-case) as returned by skills-list. Use skills-list first to discover available skills.'
+        ),
+})
+
 // PostHog AI tools
 export const ExecuteSQLSchema = z.object({
     query: z.string().min(1).describe('The final SQL query to be executed.'),

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -36,6 +36,8 @@ import generateHogQLFromQuestion from './query/generateHogQLFromQuestion'
 import queryRun from './query/run'
 // Search
 import entitySearch from './search/entitySearch'
+// Skills registry
+import { skillsGet, skillsList } from './skills'
 // Misc
 import {
     type ToolFilterOptions,
@@ -83,6 +85,10 @@ export const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
 
     // Search
     'entity-search': entitySearch,
+
+    // Skills registry
+    'skills-list': skillsList,
+    'skills-get': skillsGet,
 
     // Debug
     'debug-mcp-ui-apps': debugMcpUiApps,

--- a/services/mcp/src/tools/skills/index.ts
+++ b/services/mcp/src/tools/skills/index.ts
@@ -1,0 +1,2 @@
+export { default as skillsList } from './skillsList'
+export { default as skillsGet } from './skillsGet'

--- a/services/mcp/src/tools/skills/registryClient.ts
+++ b/services/mcp/src/tools/skills/registryClient.ts
@@ -1,0 +1,58 @@
+/**
+ * Fetches and caches the PostHog skills registry index.
+ *
+ * The index is published as a release asset alongside each agent-skills build
+ * (see .github/workflows/ci-agent-skills.yml). It's a small JSON document
+ * describing every published skill; we fetch it on demand and hold it in a
+ * module-level cache with a short TTL so successive tool calls are fast.
+ */
+
+export const SKILLS_INDEX_URL =
+    'https://github.com/PostHog/posthog/releases/download/agent-skills-latest/skills-index.json'
+
+const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
+
+export type SkillIndexEntry = {
+    name: string
+    description: string
+    version: string
+    category: string
+    tags: string[]
+    products: string[]
+    author: string | null
+    source: 'official' | 'community'
+    requires_scopes: string[]
+    archive_url: string
+    sha256: string
+    source_path: string
+}
+
+export type SkillsIndex = {
+    version: string
+    generated_at: string
+    skills: SkillIndexEntry[]
+}
+
+let cached: { at: number; value: SkillsIndex } | undefined
+
+export async function fetchSkillsIndex(): Promise<SkillsIndex> {
+    const now = Date.now()
+    if (cached && now - cached.at < CACHE_TTL_MS) {
+        return cached.value
+    }
+
+    // Use a standard Fetch; freshness is controlled by our in-process TTL above.
+    const response = await fetch(SKILLS_INDEX_URL, { cache: 'no-store' })
+
+    if (!response.ok) {
+        throw new Error(`Failed to fetch skills index (${response.status}): ${await response.text()}`)
+    }
+
+    const value = (await response.json()) as SkillsIndex
+    cached = { at: now, value }
+    return value
+}
+
+export function findSkill(index: SkillsIndex, name: string): SkillIndexEntry | undefined {
+    return index.skills.find((s) => s.name === name)
+}

--- a/services/mcp/src/tools/skills/registryClient.ts
+++ b/services/mcp/src/tools/skills/registryClient.ts
@@ -15,13 +15,6 @@ const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
 export type SkillIndexEntry = {
     name: string
     description: string
-    version: string
-    category: string
-    tags: string[]
-    products: string[]
-    author: string | null
-    source: 'official' | 'community'
-    requires_scopes: string[]
     archive_url: string
     sha256: string
     source_path: string

--- a/services/mcp/src/tools/skills/skillsGet.ts
+++ b/services/mcp/src/tools/skills/skillsGet.ts
@@ -1,0 +1,150 @@
+import type { z } from 'zod'
+
+import { SkillsGetSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+import { fetchSkillsIndex, findSkill, type SkillIndexEntry } from './registryClient'
+
+const schema = SkillsGetSchema
+
+type Params = z.infer<typeof schema>
+
+type SkillFilePayload = {
+    path: string
+    content: string
+}
+
+type Result = {
+    metadata: SkillIndexEntry
+    files: SkillFilePayload[]
+}
+
+const MAX_SKILL_BYTES = 2 * 1024 * 1024 // 2 MiB — skills are markdown; anything larger is a red flag.
+
+async function downloadSkillFiles(entry: SkillIndexEntry): Promise<SkillFilePayload[]> {
+    const response = await fetch(entry.archive_url)
+    if (!response.ok) {
+        throw new Error(
+            `Failed to fetch skill archive for '${entry.name}' (${response.status}): ${await response.text()}`
+        )
+    }
+
+    const buf = await response.arrayBuffer()
+    if (buf.byteLength > MAX_SKILL_BYTES) {
+        throw new Error(
+            `Skill '${entry.name}' archive is ${buf.byteLength} bytes, exceeding the ${MAX_SKILL_BYTES} byte limit.`
+        )
+    }
+
+    const files = await extractZipTextFiles(new Uint8Array(buf))
+    return files
+}
+
+/**
+ * Minimal pure-TS zip reader for text files — avoids pulling a zip library
+ * into the Worker bundle. Supports stored (method 0) and deflated (method 8)
+ * entries, which are the only ones produced by Python's zipfile in this repo.
+ */
+async function extractZipTextFiles(data: Uint8Array): Promise<SkillFilePayload[]> {
+    // Locate End of Central Directory record by scanning from the tail.
+    const EOCD_SIG = 0x06054b50
+    const CD_SIG = 0x02014b50
+    const LF_SIG = 0x04034b50
+
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength)
+
+    let eocdOffset = -1
+    for (let i = data.length - 22; i >= Math.max(0, data.length - 65557); i--) {
+        if (view.getUint32(i, true) === EOCD_SIG) {
+            eocdOffset = i
+            break
+        }
+    }
+    if (eocdOffset < 0) {
+        throw new Error('Invalid zip archive: EOCD not found')
+    }
+
+    const totalEntries = view.getUint16(eocdOffset + 10, true)
+    const cdOffset = view.getUint32(eocdOffset + 16, true)
+
+    const files: SkillFilePayload[] = []
+    let cursor = cdOffset
+    const decoder = new TextDecoder('utf-8', { fatal: false })
+
+    for (let i = 0; i < totalEntries; i++) {
+        if (view.getUint32(cursor, true) !== CD_SIG) {
+            throw new Error(`Invalid zip archive: bad CD signature at ${cursor}`)
+        }
+        const method = view.getUint16(cursor + 10, true)
+        const compressedSize = view.getUint32(cursor + 20, true)
+        const nameLen = view.getUint16(cursor + 28, true)
+        const extraLen = view.getUint16(cursor + 30, true)
+        const commentLen = view.getUint16(cursor + 32, true)
+        const localHeaderOffset = view.getUint32(cursor + 42, true)
+        const name = decoder.decode(data.slice(cursor + 46, cursor + 46 + nameLen))
+        cursor += 46 + nameLen + extraLen + commentLen
+
+        // Directories end with '/'.
+        if (name.endsWith('/')) {
+            continue
+        }
+
+        if (view.getUint32(localHeaderOffset, true) !== LF_SIG) {
+            throw new Error(`Invalid zip archive: bad local header for '${name}'`)
+        }
+        const lhNameLen = view.getUint16(localHeaderOffset + 26, true)
+        const lhExtraLen = view.getUint16(localHeaderOffset + 28, true)
+        const dataStart = localHeaderOffset + 30 + lhNameLen + lhExtraLen
+        const dataEnd = dataStart + compressedSize
+
+        let contentBytes: Uint8Array
+        if (method === 0) {
+            contentBytes = data.slice(dataStart, dataEnd)
+        } else if (method === 8) {
+            const ds = new DecompressionStream('deflate-raw')
+            const writable = ds.writable.getWriter()
+            await writable.write(data.slice(dataStart, dataEnd))
+            await writable.close()
+            contentBytes = new Uint8Array(await new Response(ds.readable).arrayBuffer())
+        } else {
+            throw new Error(`Unsupported zip compression method ${method} for '${name}'`)
+        }
+
+        files.push({ path: name, content: decoder.decode(contentBytes) })
+    }
+
+    // Keep SKILL.md first for easy consumption by agents that only read the entry point.
+    files.sort((a, b) => {
+        if (a.path === 'SKILL.md') {
+            return -1
+        }
+        if (b.path === 'SKILL.md') {
+            return 1
+        }
+        return a.path.localeCompare(b.path)
+    })
+
+    return files
+}
+
+export const skillsGetHandler: ToolBase<typeof schema, Result>['handler'] = async (
+    _context: Context,
+    params: Params
+) => {
+    const index = await fetchSkillsIndex()
+    const entry = findSkill(index, params.name)
+    if (!entry) {
+        throw new Error(`Skill '${params.name}' not found. Call skills-list to discover available skills.`)
+    }
+
+    const files = await downloadSkillFiles(entry)
+    return { metadata: entry, files }
+}
+
+const tool = (): ToolBase<typeof schema, Result> => ({
+    name: 'skills-get',
+    schema,
+    handler: skillsGetHandler,
+})
+
+export default tool

--- a/services/mcp/src/tools/skills/skillsList.ts
+++ b/services/mcp/src/tools/skills/skillsList.ts
@@ -27,30 +27,13 @@ export const skillsListHandler: ToolBase<typeof schema, Result>['handler'] = asy
     const index = await fetchSkillsIndex()
 
     const needle = params.search?.toLowerCase()
-    const tagSet = params.tags?.length ? new Set(params.tags) : undefined
-    const productSet = params.products?.length ? new Set(params.products) : undefined
 
-    const filtered = index.skills.filter((skill) => {
-        if (params.category && skill.category !== params.category) {
-            return false
-        }
-        if (params.source && skill.source !== params.source) {
-            return false
-        }
-        if (tagSet && !skill.tags.some((t) => tagSet.has(t))) {
-            return false
-        }
-        if (productSet && !skill.products.some((p) => productSet.has(p))) {
-            return false
-        }
-        if (needle) {
-            const haystack = `${skill.name}\n${skill.description}`.toLowerCase()
-            if (!haystack.includes(needle)) {
-                return false
-            }
-        }
-        return true
-    })
+    const filtered = needle
+        ? index.skills.filter((skill) => {
+              const haystack = `${skill.name}\n${skill.description}`.toLowerCase()
+              return haystack.includes(needle)
+          })
+        : index.skills
 
     const listed: ListedSkill[] = filtered.map(({ source_path: _sp, sha256: _sha, archive_url: _url, ...rest }) => rest)
 

--- a/services/mcp/src/tools/skills/skillsList.ts
+++ b/services/mcp/src/tools/skills/skillsList.ts
@@ -1,0 +1,71 @@
+import type { z } from 'zod'
+
+import { SkillsListSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+import { fetchSkillsIndex, type SkillIndexEntry } from './registryClient'
+
+const schema = SkillsListSchema
+
+type Params = z.infer<typeof schema>
+
+// Drop large fields (source_path, sha256) and per-archive URL from the list
+// response — those are only needed when fetching a single skill.
+type ListedSkill = Omit<SkillIndexEntry, 'source_path' | 'sha256' | 'archive_url'>
+
+type Result = {
+    index_version: string
+    generated_at: string
+    total: number
+    skills: ListedSkill[]
+}
+
+export const skillsListHandler: ToolBase<typeof schema, Result>['handler'] = async (
+    _context: Context,
+    params: Params
+) => {
+    const index = await fetchSkillsIndex()
+
+    const needle = params.search?.toLowerCase()
+    const tagSet = params.tags?.length ? new Set(params.tags) : undefined
+    const productSet = params.products?.length ? new Set(params.products) : undefined
+
+    const filtered = index.skills.filter((skill) => {
+        if (params.category && skill.category !== params.category) {
+            return false
+        }
+        if (params.source && skill.source !== params.source) {
+            return false
+        }
+        if (tagSet && !skill.tags.some((t) => tagSet.has(t))) {
+            return false
+        }
+        if (productSet && !skill.products.some((p) => productSet.has(p))) {
+            return false
+        }
+        if (needle) {
+            const haystack = `${skill.name}\n${skill.description}`.toLowerCase()
+            if (!haystack.includes(needle)) {
+                return false
+            }
+        }
+        return true
+    })
+
+    const listed: ListedSkill[] = filtered.map(({ source_path: _sp, sha256: _sha, archive_url: _url, ...rest }) => rest)
+
+    return {
+        index_version: index.version,
+        generated_at: index.generated_at,
+        total: listed.length,
+        skills: listed,
+    }
+}
+
+const tool = (): ToolBase<typeof schema, Result> => ({
+    name: 'skills-list',
+    schema,
+    handler: skillsListHandler,
+})
+
+export default tool

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/skills-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/skills-get.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "name": {
+            "description": "Exact skill name (lowercase-kebab-case) as returned by skills-list. Use skills-list first to discover available skills.",
+            "minLength": 1,
+            "type": "string"
+        }
+    },
+    "required": ["name"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/skills-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/skills-list.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "search": {
+            "description": "Case-insensitive substring match against skill name and description.",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

PostHog's agent skills are currently only writable by internal teams (there is no documented contribution path for outside collaborators) and the build pipeline only publishes one monolithic `skills.zip` archive, forcing every agent consumer to download every skill to use one. That's fine today but it blocks two things:

1. Opening the skills system up to contributors outside PostHog, with a trust boundary that keeps untrusted markdown from pulling in runtime context
2. Letting the MCP server (and other agents) discover and install a single skill at a time, with per-skill integrity verification

## Changes

- **Community namespace**: `products/community/skills/` with README, CONTRIBUTING, and a `.template/` scaffold. Community skills are restricted to plain markdown (no Jinja2, no `scripts/` subdir); the build rejects anything else. Community vs official is determined by location — no frontmatter flag.
- **Registry artifacts**: alongside the existing `skills.zip`, CI now emits `<skill-name>.zip` per skill plus `skills-index.json` — a small manifest with each skill's name, description, archive URL, and SHA-256. Published to the `agent-skills-v0.N.0` and `agent-skills-latest` releases.
- **MCP tools**: `skills-list` and `skills-get` consume the registry — agents can check for a canonical workflow before improvising. The registry fetcher has a short in-process TTL; the archive reader is a minimal pure-TS zip extractor that avoids bundling a zip library in the Worker.
- **Frontmatter stays minimal**: just `name` and `description`, matching Anthropic's Claude Code skills convention. We considered richer metadata (category, tags, products, author, `requires_scopes`) but couldn't find a cross-tool standard, so we kept the surface small.
- **Handbook page**: `contributing-skills.md` walks contributors through the end-to-end flow, with a safety checklist for reviewers.
- **CODEOWNERS-soft**: auto-requests review from the devex team for community-skill PRs.

## How did you test this code?

Automated only — I'm an agent, I didn't drive a live workflow end-to-end.
- `hogli lint:skills` passes on all 11 existing skills after the refactor
- `hogli build:skills` produces a valid `skills-index.json` and per-skill archives
- 40 unit tests in `test_build_skills.py` cover discovery, rendering, frontmatter validation, community-rule enforcement, and the init scaffold
- TypeScript `tsc --noEmit` clean on `services/mcp`

Not tested: actually running the `release-skills` CI job end-to-end against a GitHub release, or exercising the MCP tools against a live client.

## Publish to changelog?

no — internal developer tooling

## Docs update

The handbook page `docs/published/handbook/engineering/ai/contributing-skills.md` is included. No separate docs PR needed.

## 🤖 LLM context

Authored by Claude (Opus 4.7, 1M context) across a multi-turn session. The initial scaffold introduced a richer `SkillFrontmatter` schema (version, category, tags, products, author, source, requires_scopes); follow-up turns with the human pared it back to just `name`/`description` after confirming no cross-tool convention covered those fields. Further cleanup: removed dead `_SKILL_CATEGORIES` constant, simplified `_COMMUNITY_DISALLOWED_SUBDIRS` set-subtraction to a direct `_COMMUNITY_ALLOWED_SUBDIRS` + inline `scripts/` check, reset `MANIFEST_VERSION` and `INDEX_SCHEMA_VERSION` to `1.0.0` (registry is brand new — nothing to migrate from), and reworked the `init_skill` scaffold to guide authors toward the shape of real published skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)