### PR TITLE
fix(llma): generate $session_entry_search_engine via shared mapping

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -2240,12 +2240,13 @@
             "label": "Session entry sccid"
         },
         "$session_entry_search_engine": {
-            "description": "The search engine the user came from at the start of the session.",
+            "description": "The search engine the user came in from (if any). Captured at the start of the session and remains constant for the duration of the session.",
             "examples": [
                 "Google",
                 "DuckDuckGo"
             ],
-            "label": "Session entry search engine"
+            "ignored_in_assistant": true,
+            "label": "Session entry Search engine"
         },
         "$session_entry_ttclid": {
             "description": "TikTok Click ID Captured at the start of the session and remains constant for the duration of the session.",
@@ -5621,14 +5622,6 @@
             "description": "Snapchat Click ID Captured at the start of the session and remains constant for the duration of the session.",
             "ignored_in_assistant": true,
             "label": "Session entry sccid"
-        },
-        "$session_entry_search_engine": {
-            "description": "The search engine the user came from at the start of the session.",
-            "examples": [
-                "Google",
-                "DuckDuckGo"
-            ],
-            "label": "Session entry search engine"
         },
         "$session_entry_ttclid": {
             "description": "TikTok Click ID Captured at the start of the session and remains constant for the duration of the session.",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -103,6 +103,7 @@ SESSION_PROPERTIES_ALSO_INCLUDED_IN_EVENTS = {
     "$host",
     "$pathname",
     "$referrer",
+    "$search_engine",
     *SESSION_INITIAL_PROPERTIES_ADAPTED_FROM_EVENTS,
 }
 
@@ -1406,11 +1407,6 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$search_engine": {
             "label": "Search engine",
             "description": "The search engine the user came in from (if any).",
-            "examples": ["Google", "DuckDuckGo"],
-        },
-        "$session_entry_search_engine": {
-            "label": "Session entry search engine",
-            "description": "The search engine the user came from at the start of the session.",
             "examples": ["Google", "DuckDuckGo"],
         },
         "$active_feature_flags": {


### PR DESCRIPTION
## Problem

`$session_entry_search_engine` was added as a one-off literal in #54960 instead of being derived via the existing `SESSION_PROPERTIES_ALSO_INCLUDED_IN_EVENTS` mapping. This meant it was missing the `ignored_in_assistant` metadata that every other `$session_entry_*` property gets, and could drift if `$search_engine`'s label/description changes.

## Changes

- Add `$search_engine` to `SESSION_PROPERTIES_ALSO_INCLUDED_IN_EVENTS`
- Remove the manual `$session_entry_search_engine` entry from event_properties

The auto-generation loop now creates the entry with the correct description suffix, `ignored_in_assistant: True`, and stays in sync with the base `$search_engine` property.

## How did you test this code?

This PR was authored by an agent. Manual testing was not performed.

- Ran taxonomy test suite — all 4 tests pass
- Verified regenerated JSON has `ignored_in_assistant: true` on the entry
- Confirmed the label and description are derived from the base property

## Publish to changelog?

no

## 🤖 LLM context

Follow-up to #54960 based on [review feedback](https://github.com/PostHog/posthog/pull/54960#discussion_r3094872611).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*