### PR TITLE
chore(rust): emit DWARF line tables in release for profiling

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -69,6 +69,16 @@ enum_glob_use = "deny"
 [patch.crates-io]
 js-source-scopes = { git = "https://github.com/getsentry/js-source-scopes", rev = "abea51a0e74840a8d1ec96a61ff36b488994f68c" }
 
+# Emit DWARF line tables in release builds so backtrace-rs can resolve frame
+# symbols for continuous profiling (pyroscope). Without this, release binaries
+# on Linux expose raw _ZN…E names in the pyroscope UI because gimli-symbolize
+# has no debug info to read from. line-tables-only is the cheapest level that
+# still gives usable function names + file:line info at sample time; expect
+# roughly 5–15% binary size increase on Linux. Debug info must stay embedded
+# (no split-debuginfo) since backtrace-rs reads it at runtime.
+[profile.release]
+debug = "line-tables-only"
+
 [workspace.dependencies]
 anyhow = "1.0"
 assert-json-diff = "2.0.2"


### PR DESCRIPTION
## Problem

Continuous profiling with Pyroscope shows Rust functions as raw mangled symbols like `_ZN5tokio7runtime4task7harness20Harness$LT$T$C$S$GT$4poll17h…E` instead of readable names like `tokio::runtime::task::harness::Harness<T,S>::poll`. This happens for every Rust service that uses `common-continuous-profiling` (cymbal and others), so flame graphs are painful to read.

Root cause: release binaries are built with `debug = false` (Cargo default). On Linux, `backtrace-rs` relies on `gimli` for symbolication, and `gimli` reads DWARF. With no DWARF in the binary, most frames either fail to resolve or surface the raw mangled name from the ELF symbol table without ever going through the demangle path.

## Changes

- Add a workspace `[profile.release]` override with `debug = "line-tables-only"`.
- That is the cheapest DWARF level that still gives `backtrace-rs` enough info to (a) resolve frames, (b) return demangled names, and (c) include `file:line` per frame in flame graphs.
- Debug info must stay embedded in the binary (no `split-debuginfo`) — the profiler reads DWARF from the running process at sample time.

Applies to every service in the `rust/` workspace, since all rust binaries ship the same pyroscope setup via `common-continuous-profiling`.

<img width="982" height="255" alt="image" src="https://github.com/user-attachments/assets/eb234f59-613d-4554-acd5-dc30832646fc" />


## How did you test this code?

Agent-authored PR. No manual deploy; all verification is local.

- Reproduced the sampler + upload path locally against a mock HTTP server standing in for Pyroscope, using `common-continuous-profiling` with a short tokio workload.
- Decoded the captured `pprof` protobuf bodies and inspected `Profile.function.name` strings in the string table.
- Before (`debug = false`): ~17–22 resolved functions per upload, generic params collapsed, `Harness<T,S>::poll` shape.
- After (`debug = "line-tables-only"`): ~78–81 resolved functions per upload, all demangled (`still-mangled=0`), full generic monomorphization visible — e.g. `poll<tokio::runtime::blocking::task::BlockingTask<…>, …>`.
- `cargo check --release --bin cymbal` passes.
- Binary size on macOS: 49 MB → 64 MB for cymbal. On Linux expect ~5–15% — line tables are much smaller than full DWARF.

Not tested against the production Pyroscope instance; a post-deploy spot-check of the cymbal flame graph is the real confirmation.

## Publish to changelog?

do not publish to changelog

## Docs update

n/a

## 🤖 LLM context

Investigated and authored by Claude (claude-opus-4-7) in a Claude Code session. The investigation walked through the demangle pipeline (`backtrace-rs` → `pprof2::Symbol::name()` → `symbolic-demangle` with `rust` feature → `pyroscope` pprof encoder → `Function.name`) to confirm demangling is already wired up and that the missing piece is DWARF in the release binary. End-to-end check used a custom mock HTTP server that captured the gzipped pprof uploads and decoded them via prost.