### PR TITLE
feat(flags): add warm-flags-cache Rust CLI for hypercache warming

### DIFF
--- a/.github/rust-images.yml
+++ b/.github/rust-images.yml
@@ -35,6 +35,10 @@
   dockerfile: ./rust/Dockerfile
   project: vglf58qgzw
 
+- image: warm-flags-cache
+  dockerfile: ./rust/Dockerfile
+  project: vglf58qgzw
+
 - image: batch-import-worker
   dockerfile: ./rust/Dockerfile
   project: 4ppc15q4bv

--- a/bin/warm-flags-cache
+++ b/bin/warm-flags-cache
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Warm the feature flags HyperCache using the Rust CLI.
+#
+# Runs as a one-off pod in the current kubectl context, using the same
+# environment variables as the feature-flags service (database, Redis, S3).
+# Environment variables backed by Kubernetes secrets or configmaps are
+# resolved at pod startup, so credentials never leave the cluster.
+#
+# Prerequisites:
+#   - kubectl configured for the target cluster (use kubectx to switch)
+#   - AWS SSO login completed
+#   - jq installed
+#
+# Usage:
+#   bin/warm-flags-cache --team-ids 12345 67890
+#   bin/warm-flags-cache                          # warm all teams
+#   bin/warm-flags-cache --help                   # show all options
+#
+# Environment overrides:
+#   WARM_FLAGS_CACHE_IMAGE   Docker image (default: auto-detected from deployment)
+#   KUBE_NAMESPACE           Kubernetes namespace (default: posthog)
+
+set -euo pipefail
+
+NAMESPACE="${KUBE_NAMESPACE:-posthog}"
+DEPLOYMENT="posthog-feature-flags"
+CONTAINER_NAME="warm-flags-cache"
+POD_NAME="${CONTAINER_NAME}-$(whoami | tr '.' '-')-$(date +%s)"
+
+# Show what we're about to target — kubectl uses the current context silently,
+# so surface it here to avoid running against the wrong cluster.
+CURRENT_CONTEXT=$(kubectl config current-context 2>/dev/null || echo "<none>")
+echo "============================================"
+echo "  kubectl context: ${CURRENT_CONTEXT}"
+echo "  namespace:       ${NAMESPACE}"
+echo "============================================"
+
+# Auto-detect image from the running feature-flags deployment if not overridden
+if [ -z "${WARM_FLAGS_CACHE_IMAGE:-}" ]; then
+    echo "Detecting image from deployment ${DEPLOYMENT}..."
+    FF_IMAGE=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+        -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
+    if [ -z "$FF_IMAGE" ]; then
+        echo "Error: Could not detect image from deployment ${DEPLOYMENT}."
+        echo "Set WARM_FLAGS_CACHE_IMAGE manually or check your kubectl context."
+        exit 1
+    fi
+    # The ECR image tag contains the service name — swap it for our binary.
+    # If the image doesn't contain "feature-flags", fall back to the original
+    # (operator can always override via WARM_FLAGS_CACHE_IMAGE).
+    WARM_FLAGS_CACHE_IMAGE="${FF_IMAGE/feature-flags/warm-flags-cache}"
+    if [ "$WARM_FLAGS_CACHE_IMAGE" = "$FF_IMAGE" ]; then
+        echo "Warning: image '${FF_IMAGE}' does not contain 'feature-flags' — using as-is"
+    fi
+    echo "Using image: ${WARM_FLAGS_CACHE_IMAGE}"
+fi
+
+# Extract the full pod spec from the deployment, then narrow it to just the
+# fields we need on the one-off pod. Pod-level identity (serviceAccountName,
+# imagePullSecrets) carries over so IRSA-backed S3 access and private-registry
+# pulls work the same as the running deployment. Container env preserves
+# secretKeyRef/configMapKeyRef/fieldRef entries so Kubernetes still resolves
+# them at pod startup (credentials stay server-side).
+echo "Extracting pod + env config from deployment ${DEPLOYMENT}..."
+
+POD_SPEC_JSON=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+    -o jsonpath='{.spec.template.spec}' 2>/dev/null || true)
+
+if [ -z "$POD_SPEC_JSON" ]; then
+    echo "Error: Could not extract pod spec from deployment ${DEPLOYMENT}."
+    exit 1
+fi
+
+CONTAINER_JSON=$(echo "$POD_SPEC_JSON" | jq '.containers[0]')
+
+if [ "$CONTAINER_JSON" = "null" ] || [ -z "$CONTAINER_JSON" ]; then
+    echo "Error: Could not extract container spec from deployment ${DEPLOYMENT}."
+    exit 1
+fi
+
+# Filter env to only the vars the binary needs, keeping valueFrom intact.
+NEEDED_VARS='["READ_DATABASE_URL","FLAGS_REDIS_URL","REDIS_URL","OBJECT_STORAGE_BUCKET","OBJECT_STORAGE_REGION","OBJECT_STORAGE_ENDPOINT","DATABASE_MAX_CONNECTIONS"]'
+
+ENV_FILTERED=$(echo "$CONTAINER_JSON" | jq --argjson needed "$NEEDED_VARS" \
+    '[.env // [] | .[] | select(.name as $n | $needed | index($n))]')
+
+ENVFROM=$(echo "$CONTAINER_JSON" | jq '.envFrom // []')
+
+# Surface the inherited identity so the operator can sanity-check it before
+# the pod runs.
+SERVICE_ACCOUNT=$(echo "$POD_SPEC_JSON" | jq -r '.serviceAccountName // ""')
+if [ -n "$SERVICE_ACCOUNT" ]; then
+    echo "Inheriting serviceAccountName: ${SERVICE_ACCOUNT}"
+fi
+
+# Build args array from remaining script arguments so they land inside the
+# overrides JSON. kubectl run's default --override-type is "merge" (RFC 7396
+# JSON merge patch), which replaces arrays whole — so the override container
+# must carry image/command/args itself, not rely on --image/--command flags.
+ARGS_JSON=$(jq -n -c '$ARGS.positional' --args -- "$@")
+
+OVERRIDES=$(echo "$POD_SPEC_JSON" | jq \
+    --arg name "$POD_NAME" \
+    --arg image "$WARM_FLAGS_CACHE_IMAGE" \
+    --arg binary "/usr/local/bin/${CONTAINER_NAME}" \
+    --argjson args "$ARGS_JSON" \
+    --argjson env "$ENV_FILTERED" \
+    --argjson envFrom "$ENVFROM" \
+    '{
+        spec: (
+            ({} +
+                (if .serviceAccountName then {serviceAccountName: .serviceAccountName} else {} end) +
+                (if .serviceAccount then {serviceAccount: .serviceAccount} else {} end) +
+                (if .imagePullSecrets then {imagePullSecrets: .imagePullSecrets} else {} end) +
+                (if .nodeSelector then {nodeSelector: .nodeSelector} else {} end) +
+                (if .tolerations then {tolerations: .tolerations} else {} end) +
+                (if .affinity then {affinity: .affinity} else {} end) +
+                (if .securityContext then {securityContext: .securityContext} else {} end)
+            )
+            + {containers: [{
+                name: $name,
+                image: $image,
+                command: [$binary],
+                args: $args,
+                env: $env,
+                envFrom: $envFrom,
+                stdin: true,
+                stdinOnce: true,
+                tty: true
+            }]}
+        )
+    }')
+
+echo "Starting ${CONTAINER_NAME} pod: ${POD_NAME}"
+kubectl run "$POD_NAME" \
+    --rm -it \
+    --restart=Never \
+    --image="$WARM_FLAGS_CACHE_IMAGE" \
+    --overrides="$OVERRIDES" \
+    -n "$NAMESPACE"

--- a/bin/warm-flags-cache
+++ b/bin/warm-flags-cache
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Warm the feature flags HyperCache using the Rust CLI.
+#
+# Runs as a one-off pod in the current kubectl context, using the same
+# environment variables as the feature-flags service (database, Redis, S3).
+# Environment variables backed by Kubernetes secrets or configmaps are
+# resolved at pod startup, so credentials never leave the cluster.
+#
+# Prerequisites:
+#   - kubectl configured for the target cluster (use kubectx to switch)
+#   - AWS SSO login completed
+#   - jq installed
+#
+# Usage:
+#   bin/warm-flags-cache --team-ids 12345 67890
+#   bin/warm-flags-cache                          # warm all teams
+#   bin/warm-flags-cache --help                   # show all options
+#
+# Environment overrides:
+#   WARM_FLAGS_CACHE_IMAGE   Docker image (default: auto-detected from deployment)
+#   KUBE_NAMESPACE           Kubernetes namespace (default: posthog)
+
+set -euo pipefail
+
+NAMESPACE="${KUBE_NAMESPACE:-posthog}"
+DEPLOYMENT="posthog-feature-flags"
+CONTAINER_NAME="warm-flags-cache"
+POD_NAME="${CONTAINER_NAME}-$(whoami | tr '.' '-')-$(date +%s)"
+
+# Show what we're about to target — kubectl uses the current context silently,
+# so surface it here to avoid running against the wrong cluster.
+CURRENT_CONTEXT=$(kubectl config current-context 2>/dev/null || echo "<none>")
+echo "============================================"
+echo "  kubectl context: ${CURRENT_CONTEXT}"
+echo "  namespace:       ${NAMESPACE}"
+echo "============================================"
+
+# Auto-detect image from the running feature-flags deployment if not overridden
+if [ -z "${WARM_FLAGS_CACHE_IMAGE:-}" ]; then
+    echo "Detecting image from deployment ${DEPLOYMENT}..."
+    FF_IMAGE=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+        -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
+    if [ -z "$FF_IMAGE" ]; then
+        echo "Error: Could not detect image from deployment ${DEPLOYMENT}."
+        echo "Set WARM_FLAGS_CACHE_IMAGE manually or check your kubectl context."
+        exit 1
+    fi
+    # The ECR image tag contains the service name — swap it for our binary.
+    # If the image doesn't contain "feature-flags", fall back to the original
+    # (operator can always override via WARM_FLAGS_CACHE_IMAGE).
+    WARM_FLAGS_CACHE_IMAGE="${FF_IMAGE/feature-flags/warm-flags-cache}"
+    if [ "$WARM_FLAGS_CACHE_IMAGE" = "$FF_IMAGE" ]; then
+        echo "Warning: image '${FF_IMAGE}' does not contain 'feature-flags' — using as-is"
+    fi
+    echo "Using image: ${WARM_FLAGS_CACHE_IMAGE}"
+fi
+
+# Extract the full pod spec from the deployment, then narrow it to just the
+# fields we need on the one-off pod. Pod-level identity (serviceAccountName,
+# imagePullSecrets) carries over so IRSA-backed S3 access and private-registry
+# pulls work the same as the running deployment. Container env preserves
+# secretKeyRef/configMapKeyRef/fieldRef entries so Kubernetes still resolves
+# them at pod startup (credentials stay server-side).
+echo "Extracting pod + env config from deployment ${DEPLOYMENT}..."
+
+POD_SPEC_JSON=$(kubectl get deployment "$DEPLOYMENT" -n "$NAMESPACE" \
+    -o jsonpath='{.spec.template.spec}' 2>/dev/null || true)
+
+if [ -z "$POD_SPEC_JSON" ]; then
+    echo "Error: Could not extract pod spec from deployment ${DEPLOYMENT}."
+    exit 1
+fi
+
+CONTAINER_JSON=$(echo "$POD_SPEC_JSON" | jq '.containers[0]')
+
+if [ "$CONTAINER_JSON" = "null" ] || [ -z "$CONTAINER_JSON" ]; then
+    echo "Error: Could not extract container spec from deployment ${DEPLOYMENT}."
+    exit 1
+fi
+
+# Filter env to only the vars the binary needs, keeping valueFrom intact.
+NEEDED_VARS='["READ_DATABASE_URL","FLAGS_REDIS_URL","REDIS_URL","OBJECT_STORAGE_BUCKET","OBJECT_STORAGE_REGION","OBJECT_STORAGE_ENDPOINT","DATABASE_MAX_CONNECTIONS"]'
+
+ENV_FILTERED=$(echo "$CONTAINER_JSON" | jq --argjson needed "$NEEDED_VARS" \
+    '[.env // [] | .[] | select(.name as $n | $needed | index($n))]')
+
+ENVFROM=$(echo "$CONTAINER_JSON" | jq '.envFrom // []')
+
+# Surface the inherited identity so the operator can sanity-check it before
+# the pod runs.
+SERVICE_ACCOUNT=$(echo "$POD_SPEC_JSON" | jq -r '.serviceAccountName // ""')
+if [ -n "$SERVICE_ACCOUNT" ]; then
+    echo "Inheriting serviceAccountName: ${SERVICE_ACCOUNT}"
+fi
+
+OVERRIDES=$(echo "$POD_SPEC_JSON" | jq \
+    --arg name "$CONTAINER_NAME" \
+    --argjson env "$ENV_FILTERED" \
+    --argjson envFrom "$ENVFROM" \
+    '{
+        spec: (
+            ({} +
+                (if .serviceAccountName then {serviceAccountName: .serviceAccountName} else {} end) +
+                (if .serviceAccount then {serviceAccount: .serviceAccount} else {} end) +
+                (if .imagePullSecrets then {imagePullSecrets: .imagePullSecrets} else {} end) +
+                (if .nodeSelector then {nodeSelector: .nodeSelector} else {} end) +
+                (if .tolerations then {tolerations: .tolerations} else {} end) +
+                (if .affinity then {affinity: .affinity} else {} end) +
+                (if .securityContext then {securityContext: .securityContext} else {} end)
+            )
+            + {containers: [{name: $name, env: $env, envFrom: $envFrom}]}
+        )
+    }')
+
+echo "Starting ${CONTAINER_NAME} pod: ${POD_NAME}"
+kubectl run "$POD_NAME" \
+    --rm -it \
+    --restart=Never \
+    --image="$WARM_FLAGS_CACHE_IMAGE" \
+    --overrides="$OVERRIDES" \
+    -n "$NAMESPACE" \
+    --command -- "/usr/local/bin/${CONTAINER_NAME}" "$@"

--- a/bin/warm-flags-cache-local
+++ b/bin/warm-flags-cache-local
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Run the warm-flags-cache Rust CLI against the local dev environment.
+#
+# Targets the dockerized services started by ./bin/start:
+#   - Postgres on localhost:5432 (posthog/posthog)
+#   - Redis on localhost:6379 (db 1 for flags, matching feature-flags service)
+#   - MinIO on localhost:19000 (bucket "posthog")
+#
+# Prerequisites:
+#   - ./bin/start running (or at least db, redis7, objectstorage containers up)
+#
+# Usage:
+#   bin/warm-flags-cache-local --team-ids 1 --no-stagger
+#   bin/warm-flags-cache-local                           # warm all teams with flags
+#   bin/warm-flags-cache-local --help
+#
+# Pass --release to build in release mode (first run is slow, subsequent fast).
+# Everything else is forwarded to the binary.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CARGO_PROFILE=()
+BIN_ARGS=()
+for arg in "$@"; do
+    if [ "$arg" = "--release" ]; then
+        CARGO_PROFILE=(--release)
+    else
+        BIN_ARGS+=("$arg")
+    fi
+done
+
+# Local dev defaults — mirror bin/start-rust-service feature-flags, plus the
+# MinIO endpoint/creds that the object storage client needs.
+export READ_DATABASE_URL="${READ_DATABASE_URL:-postgres://posthog:posthog@localhost:5432/posthog}"
+export REDIS_URL="${REDIS_URL:-redis://localhost:6379/}"
+export FLAGS_REDIS_URL="${FLAGS_REDIS_URL:-redis://localhost:6379/1}"
+export OBJECT_STORAGE_BUCKET="${OBJECT_STORAGE_BUCKET:-posthog}"
+export OBJECT_STORAGE_REGION="${OBJECT_STORAGE_REGION:-us-east-1}"
+export OBJECT_STORAGE_ENDPOINT="${OBJECT_STORAGE_ENDPOINT:-http://localhost:19000}"
+export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-object_storage_root_user}"
+export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-object_storage_root_password}"
+# .envrc sets RUST_LOG to suppress flox noise (e.g. "flox=error,..."). Once RUST_LOG
+# has any value, EnvFilter's default directive no longer applies — so the binary's
+# logs would be silenced. Append our directive so warm_flags_cache=info always
+# wins, while preserving any flox suppression the user wants.
+if [ -z "${RUST_LOG:-}" ]; then
+    export RUST_LOG="info"
+elif [[ "$RUST_LOG" != *"warm_flags_cache="* ]]; then
+    export RUST_LOG="${RUST_LOG},warm_flags_cache=info"
+fi
+export RUST_BACKTRACE="${RUST_BACKTRACE:-1}"
+
+# Strip user:password@ from URLs before printing — the local defaults are safe
+# but operators sometimes override these with real DSNs, and terminal scrollback
+# / session recordings shouldn't capture credentials.
+redact_dsn() {
+    # scheme://user:pass@host… → scheme://***@host…
+    printf '%s\n' "$1" | sed -E 's#(://)[^@/]*@#\1***@#'
+}
+
+echo ">> READ_DATABASE_URL=$(redact_dsn "$READ_DATABASE_URL")"
+echo ">> FLAGS_REDIS_URL=$(redact_dsn "$FLAGS_REDIS_URL")"
+echo ">> OBJECT_STORAGE_ENDPOINT=$(redact_dsn "$OBJECT_STORAGE_ENDPOINT") (bucket=$OBJECT_STORAGE_BUCKET)"
+
+cd "$REPO_ROOT/rust"
+exec cargo run "${CARGO_PROFILE[@]}" --bin warm-flags-cache -- "${BIN_ARGS[@]}"

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -778,3 +778,11 @@ environment:
         bin_script: fix-rdkafka-paths
         description: 'Rewrite node-rdkafka dylib paths to use @loader_path on macOS for worktree portability'
         hidden: true
+    warm:flags:cache:
+        bin_script: warm-flags-cache
+        description: 'Warm the feature-flags hypercache by batch-building flag caches for every team (Rust port of the Python warmer)'
+        hidden: true
+    warm:flags:cache:local:
+        bin_script: warm-flags-cache-local
+        description: 'Warm the feature-flags hypercache against the local dev environment'
+        hidden: true

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -772,9 +772,9 @@ environment:
         hidden: true
     warm:flags:cache:
         bin_script: warm-flags-cache
-        description: 'TODO: add description for warm-flags-cache'
+        description: 'Warm the feature-flags hypercache by batch-building flag caches for every team (Rust port of the Python warmer)'
         hidden: true
     warm:flags:cache:local:
         bin_script: warm-flags-cache-local
-        description: 'TODO: add description for warm-flags-cache-local'
+        description: 'Warm the feature-flags hypercache against the local dev environment'
         hidden: true

--- a/common/hogli/manifest.yaml
+++ b/common/hogli/manifest.yaml
@@ -770,3 +770,11 @@ environment:
         bin_script: fix-rdkafka-paths
         description: 'Rewrite node-rdkafka dylib paths to use @loader_path on macOS for worktree portability'
         hidden: true
+    warm:flags:cache:
+        bin_script: warm-flags-cache
+        description: 'TODO: add description for warm-flags-cache'
+        hidden: true
+    warm:flags:cache:local:
+        bin_script: warm-flags-cache-local
+        description: 'TODO: add description for warm-flags-cache-local'
+        hidden: true

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10746,6 +10746,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "warm-flags-cache"
+version = "0.1.0"
+dependencies = [
+ "aws-config",
+ "aws-sdk-s3",
+ "clap",
+ "common-alloc",
+ "common-database",
+ "common-hypercache",
+ "common-redis",
+ "common-s3",
+ "common-types",
+ "envconfig",
+ "feature-flags",
+ "rand 0.8.5",
+ "serde_json",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10745,6 +10745,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "warm-flags-cache"
+version = "0.1.0"
+dependencies = [
+ "aws-config",
+ "aws-sdk-s3",
+ "clap",
+ "common-alloc",
+ "common-database",
+ "common-hypercache",
+ "common-redis",
+ "common-s3",
+ "common-types",
+ "envconfig",
+ "feature-flags",
+ "rand 0.8.5",
+ "serde_json",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -47,6 +47,7 @@ members = [
     "personhog-proto",
     "personhog-replica",
     "personhog-router",
+    "warm-flags-cache",
 ]
 
 [workspace.lints.rust]
@@ -88,6 +89,7 @@ axum = { version = "0.7.5", features = ["http2", "macros", "matched-path"] }
 axum-client-ip = "0.6.0"
 base64 = "0.22.0"
 bytes = "1"
+clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4.44", features = ["default", "serde"] }
 chrono-tz = "0.10.1"
 dashmap = "6.1"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -47,6 +47,7 @@ members = [
     "personhog-proto",
     "personhog-replica",
     "personhog-router",
+    "warm-flags-cache",
 ]
 
 [workspace.lints.rust]
@@ -78,6 +79,7 @@ axum = { version = "0.7.5", features = ["http2", "macros", "matched-path"] }
 axum-client-ip = "0.6.0"
 base64 = "0.22.0"
 bytes = "1"
+clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4.44", features = ["default", "serde"] }
 chrono-tz = "0.10.1"
 dashmap = "6.1"

--- a/rust/common/hypercache/src/lib.rs
+++ b/rust/common/hypercache/src/lib.rs
@@ -183,6 +183,10 @@ pub struct HyperCacheConfig {
     pub token_based: bool,
     pub enable_etag: bool,
     pub django_cache_version: String,
+    /// When set, `HyperCacheWriter::set` records each successful write into this Redis
+    /// sorted set with an expiry-timestamp score, mirroring Python's
+    /// `HyperCache._track_expiry`. `None` disables expiry tracking.
+    pub expiry_sorted_set_key: Option<String>,
 }
 
 impl HyperCacheConfig {
@@ -204,6 +208,7 @@ impl HyperCacheConfig {
             token_based: false,
             enable_etag: false,
             django_cache_version: "1".to_string(),
+            expiry_sorted_set_key: None,
         }
     }
 
@@ -226,6 +231,7 @@ impl HyperCacheConfig {
             token_based: false,
             enable_etag: false,
             django_cache_version,
+            expiry_sorted_set_key: None,
         }
     }
 
@@ -240,9 +246,11 @@ impl HyperCacheConfig {
         self.get_base_cache_key(key)
     }
 
-    /// Generate base cache key (used by both Redis and S3, but Redis adds prefix)
-    fn get_base_cache_key(&self, key: &KeyType) -> String {
-        let key_str = if self.token_based {
+    /// Mirror Python's `HyperCache.get_cache_identifier`: api_token for token-based
+    /// caches, team_id as string otherwise. Used for both key generation and
+    /// expiry-tracking sorted-set membership.
+    pub fn get_cache_identifier(&self, key: &KeyType) -> String {
+        if self.token_based {
             match key {
                 KeyType::Team(team) => team.api_token().to_string(),
                 KeyType::String(s) => s.clone(),
@@ -254,19 +262,21 @@ impl HyperCacheConfig {
                 KeyType::String(s) => s.clone(),
                 KeyType::Int(i) => i.to_string(),
             }
-        };
-
-        if self.token_based {
-            format!(
-                "cache/team_tokens/{}/{}/{}",
-                key_str, self.namespace, self.object_name
-            )
-        } else {
-            format!(
-                "cache/teams/{}/{}/{}",
-                key_str, self.namespace, self.object_name
-            )
         }
+    }
+
+    /// Generate base cache key (used by both Redis and S3, but Redis adds prefix)
+    fn get_base_cache_key(&self, key: &KeyType) -> String {
+        let key_str = self.get_cache_identifier(key);
+        let scope = if self.token_based {
+            "team_tokens"
+        } else {
+            "teams"
+        };
+        format!(
+            "cache/{}/{}/{}/{}",
+            scope, key_str, self.namespace, self.object_name
+        )
     }
 }
 

--- a/rust/common/hypercache/src/writer.rs
+++ b/rust/common/hypercache/src/writer.rs
@@ -5,6 +5,7 @@ use common_s3::S3Client;
 use sha2::{Digest, Sha256};
 use std::fmt::Write;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::warn;
 
 use crate::{HyperCacheConfig, HyperCacheError, KeyType, HYPER_CACHE_EMPTY_VALUE};
@@ -66,7 +67,46 @@ impl HyperCacheWriter {
             warn!(error = %e, "Failed to delete ETag key during set");
         }
 
-        self.check_results(redis_result, s3_result, "set")
+        self.check_results(redis_result, s3_result, "set")?;
+        self.track_expiry(key, ttl_seconds).await;
+        Ok(())
+    }
+
+    /// Mirror Python's `HyperCache._track_expiry`: record the write into the configured
+    /// sorted set with `now + ttl_seconds` as the score. Failures are logged but never
+    /// propagate — the cache entry itself was already written successfully.
+    async fn track_expiry(&self, key: &KeyType, ttl_seconds: u64) {
+        let Some(sorted_set_key) = self.config.expiry_sorted_set_key.as_deref() else {
+            return;
+        };
+        let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) else {
+            warn!("System clock before UNIX_EPOCH; skipping expiry tracking");
+            return;
+        };
+        // Clamp so `as i64` can't wrap to a negative Redis sorted-set score on extreme ttls.
+        let raw = now.as_secs().saturating_add(ttl_seconds);
+        let expiry_timestamp = i64::try_from(raw).unwrap_or_else(|_| {
+            warn!(
+                raw_seconds = raw,
+                ttl_seconds,
+                namespace = %self.config.namespace,
+                "Expiry timestamp exceeds i64::MAX; clamping (ttl_seconds likely misinterpreted)",
+            );
+            i64::MAX
+        });
+        let identifier = self.config.get_cache_identifier(key);
+
+        if let Err(e) = self
+            .redis_client
+            .zadd(sorted_set_key.to_string(), identifier, expiry_timestamp)
+            .await
+        {
+            warn!(
+                error = %e,
+                namespace = %self.config.namespace,
+                "Failed to track cache expiry",
+            );
+        }
     }
 
     /// Write JSON data to both Redis and S3, and store a computed ETag in Redis.
@@ -114,6 +154,7 @@ impl HyperCacheWriter {
         });
 
         self.check_results(redis_result, s3_result, "set_with_etag")?;
+        self.track_expiry(key, ttl_seconds).await;
         Ok(etag)
     }
 
@@ -353,6 +394,110 @@ mod tests {
             etag_del.key,
             "posthog:1:cache/teams/123/feature_flags/flags.json:etag"
         );
+        // No expiry tracking when `expiry_sorted_set_key` is None.
+        assert!(calls.iter().all(|c| c.op != "zadd"));
+    }
+
+    #[cfg(feature = "mock-client")]
+    fn assert_zadd_tracked_expiry(
+        calls: &[common_redis::MockRedisCall],
+        sorted_set_key: &str,
+        member: &str,
+        ttl_seconds: i64,
+        captured_before_write: i64,
+    ) {
+        let zadd_call = calls
+            .iter()
+            .find(|c| c.op == "zadd")
+            .expect("expected zadd call for expiry tracking");
+        assert_eq!(zadd_call.key, sorted_set_key);
+        match &zadd_call.value {
+            MockRedisValue::MemberScore(m, score) => {
+                assert_eq!(m, member);
+                // Verify score ≈ now + ttl_seconds (not just now — a regression that forgot
+                // to add ttl would still pass a `score > ttl_seconds` check because unix
+                // timestamps dwarf any reasonable ttl). Allow a small upper tolerance for
+                // test scheduling jitter between the capture and the write.
+                let expected_lower = captured_before_write + ttl_seconds;
+                let expected_upper = expected_lower + 60;
+                assert!(
+                    *score >= expected_lower && *score <= expected_upper,
+                    "score {score} outside expected window [{expected_lower}, {expected_upper}]",
+                );
+            }
+            other => panic!("expected MemberScore, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "mock-client")]
+    fn unix_now_secs() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock before UNIX_EPOCH")
+            .as_secs() as i64
+    }
+
+    #[cfg(feature = "mock-client")]
+    #[tokio::test]
+    async fn test_set_tracks_expiry_when_sorted_set_configured() {
+        let key = KeyType::int(123);
+        let json_data = r#"{"flags":[]}"#;
+
+        let mut redis = MockRedisClient::new();
+        redis.set_ret("posthog:1:cache/teams/123/feature_flags/flags.json", Ok(()));
+        redis.del_ret(
+            "posthog:1:cache/teams/123/feature_flags/flags.json:etag",
+            Ok(()),
+        );
+
+        let redis = Arc::new(redis);
+        let mut config = create_test_config();
+        config.expiry_sorted_set_key = Some("flags_cache_expiry".to_string());
+        let writer = HyperCacheWriter::new(redis.clone(), Arc::new(mock_s3_put_ok()), config);
+        let before = unix_now_secs();
+        writer.set(&key, json_data, 604800).await.unwrap();
+
+        assert_zadd_tracked_expiry(
+            &redis.get_calls(),
+            "flags_cache_expiry",
+            "123",
+            604800,
+            before,
+        );
+    }
+
+    #[cfg(feature = "mock-client")]
+    #[tokio::test]
+    async fn test_track_expiry_clamps_to_i64_max_on_overflow() {
+        let key = KeyType::int(123);
+
+        let mut redis = MockRedisClient::new();
+        redis.set_ret("posthog:1:cache/teams/123/feature_flags/flags.json", Ok(()));
+        redis.del_ret(
+            "posthog:1:cache/teams/123/feature_flags/flags.json:etag",
+            Ok(()),
+        );
+
+        let redis = Arc::new(redis);
+        let mut config = create_test_config();
+        config.expiry_sorted_set_key = Some("flags_cache_expiry".to_string());
+        let writer = HyperCacheWriter::new(redis.clone(), Arc::new(mock_s3_put_ok()), config);
+
+        // Any ttl whose sum with the current unix time exceeds i64::MAX must clamp.
+        writer.set(&key, "{}", u64::MAX).await.unwrap();
+
+        let calls = redis.get_calls();
+        let zadd = calls
+            .iter()
+            .find(|c| c.op == "zadd")
+            .expect("expected zadd call for expiry tracking");
+        match &zadd.value {
+            MockRedisValue::MemberScore(member, score) => {
+                assert_eq!(member, "123");
+                assert_eq!(*score, i64::MAX, "expected score clamped to i64::MAX");
+            }
+            other => panic!("expected MemberScore, got {other:?}"),
+        }
     }
 
     #[cfg(feature = "mock-client")]
@@ -394,6 +539,35 @@ mod tests {
         let etag = writer.set_with_etag(&key, json_data, 604800).await.unwrap();
 
         assert_eq!(etag, compute_etag(json_data));
+    }
+
+    #[cfg(feature = "mock-client")]
+    #[tokio::test]
+    async fn test_set_with_etag_tracks_expiry_when_sorted_set_configured() {
+        let key = KeyType::int(123);
+        let json_data = r#"{"flags":[]}"#;
+
+        let mut redis = MockRedisClient::new();
+        redis.set_ret("posthog:1:cache/teams/123/feature_flags/flags.json", Ok(()));
+        redis.set_ret(
+            "posthog:1:cache/teams/123/feature_flags/flags.json:etag",
+            Ok(()),
+        );
+
+        let redis = Arc::new(redis);
+        let mut config = create_test_config();
+        config.expiry_sorted_set_key = Some("flags_cache_expiry".to_string());
+        let writer = HyperCacheWriter::new(redis.clone(), Arc::new(mock_s3_put_ok()), config);
+        let before = unix_now_secs();
+        writer.set_with_etag(&key, json_data, 604800).await.unwrap();
+
+        assert_zadd_tracked_expiry(
+            &redis.get_calls(),
+            "flags_cache_expiry",
+            "123",
+            604800,
+            before,
+        );
     }
 
     #[cfg(feature = "mock-client")]

--- a/rust/common/hypercache/src/writer.rs
+++ b/rust/common/hypercache/src/writer.rs
@@ -83,7 +83,10 @@ impl HyperCacheWriter {
             warn!("System clock before UNIX_EPOCH; skipping expiry tracking");
             return;
         };
-        let expiry_timestamp = now.as_secs().saturating_add(ttl_seconds) as i64;
+        // Clamp to i64::MAX so a pathological u64 (e.g. extremely large ttl_seconds) can't wrap
+        // to a negative Redis sorted-set score. saturating_add already prevents u64 overflow.
+        let expiry_timestamp =
+            i64::try_from(now.as_secs().saturating_add(ttl_seconds)).unwrap_or(i64::MAX);
         let identifier = self.config.get_cache_identifier(key);
 
         if let Err(e) = self
@@ -144,6 +147,7 @@ impl HyperCacheWriter {
         });
 
         self.check_results(redis_result, s3_result, "set_with_etag")?;
+        self.track_expiry(key, ttl_seconds).await;
         Ok(etag)
     }
 
@@ -462,6 +466,40 @@ mod tests {
         let etag = writer.set_with_etag(&key, json_data, 604800).await.unwrap();
 
         assert_eq!(etag, compute_etag(json_data));
+    }
+
+    #[cfg(feature = "mock-client")]
+    #[tokio::test]
+    async fn test_set_with_etag_tracks_expiry_when_sorted_set_configured() {
+        let key = KeyType::int(123);
+        let json_data = r#"{"flags":[]}"#;
+
+        let mut redis = MockRedisClient::new();
+        redis.set_ret("posthog:1:cache/teams/123/feature_flags/flags.json", Ok(()));
+        redis.set_ret(
+            "posthog:1:cache/teams/123/feature_flags/flags.json:etag",
+            Ok(()),
+        );
+
+        let redis = Arc::new(redis);
+        let mut config = create_test_config();
+        config.expiry_sorted_set_key = Some("flags_cache_expiry".to_string());
+        let writer = HyperCacheWriter::new(redis.clone(), Arc::new(mock_s3_put_ok()), config);
+        writer.set_with_etag(&key, json_data, 604800).await.unwrap();
+
+        let calls = redis.get_calls();
+        let zadd_call = calls
+            .iter()
+            .find(|c| c.op == "zadd")
+            .expect("expected zadd call for expiry tracking");
+        assert_eq!(zadd_call.key, "flags_cache_expiry");
+        match &zadd_call.value {
+            MockRedisValue::MemberScore(member, score) => {
+                assert_eq!(member, "123");
+                assert!(*score > 604800, "score {score} looked too small");
+            }
+            other => panic!("expected MemberScore, got {other:?}"),
+        }
     }
 
     #[cfg(feature = "mock-client")]

--- a/rust/common/hypercache/src/writer.rs
+++ b/rust/common/hypercache/src/writer.rs
@@ -83,8 +83,7 @@ impl HyperCacheWriter {
             warn!("System clock before UNIX_EPOCH; skipping expiry tracking");
             return;
         };
-        // Clamp to i64::MAX so a pathological u64 (e.g. extremely large ttl_seconds) can't wrap
-        // to a negative Redis sorted-set score. saturating_add already prevents u64 overflow.
+        // Clamp so `as i64` can't wrap to a negative Redis sorted-set score on extreme ttls.
         let expiry_timestamp =
             i64::try_from(now.as_secs().saturating_add(ttl_seconds)).unwrap_or(i64::MAX);
         let identifier = self.config.get_cache_identifier(key);
@@ -392,6 +391,29 @@ mod tests {
     }
 
     #[cfg(feature = "mock-client")]
+    fn assert_zadd_tracked_expiry(
+        calls: &[common_redis::MockRedisCall],
+        sorted_set_key: &str,
+        member: &str,
+        min_score: i64,
+    ) {
+        let zadd_call = calls
+            .iter()
+            .find(|c| c.op == "zadd")
+            .expect("expected zadd call for expiry tracking");
+        assert_eq!(zadd_call.key, sorted_set_key);
+        match &zadd_call.value {
+            MockRedisValue::MemberScore(m, score) => {
+                assert_eq!(m, member);
+                // Score is a future unix timestamp (now + ttl_seconds); sanity-check it's
+                // at least our ttl seconds ahead.
+                assert!(*score > min_score, "score {score} looked too small");
+            }
+            other => panic!("expected MemberScore, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "mock-client")]
     #[tokio::test]
     async fn test_set_tracks_expiry_when_sorted_set_configured() {
         let key = KeyType::int(123);
@@ -410,21 +432,7 @@ mod tests {
         let writer = HyperCacheWriter::new(redis.clone(), Arc::new(mock_s3_put_ok()), config);
         writer.set(&key, json_data, 604800).await.unwrap();
 
-        let calls = redis.get_calls();
-        let zadd_call = calls
-            .iter()
-            .find(|c| c.op == "zadd")
-            .expect("expected zadd call for expiry tracking");
-        assert_eq!(zadd_call.key, "flags_cache_expiry");
-        match &zadd_call.value {
-            MockRedisValue::MemberScore(member, score) => {
-                assert_eq!(member, "123");
-                // Score is a future unix timestamp (now + 604800s); just sanity-check it's
-                // at least our ttl seconds ahead.
-                assert!(*score > 604800, "score {score} looked too small");
-            }
-            other => panic!("expected MemberScore, got {other:?}"),
-        }
+        assert_zadd_tracked_expiry(&redis.get_calls(), "flags_cache_expiry", "123", 604800);
     }
 
     #[cfg(feature = "mock-client")]
@@ -487,19 +495,7 @@ mod tests {
         let writer = HyperCacheWriter::new(redis.clone(), Arc::new(mock_s3_put_ok()), config);
         writer.set_with_etag(&key, json_data, 604800).await.unwrap();
 
-        let calls = redis.get_calls();
-        let zadd_call = calls
-            .iter()
-            .find(|c| c.op == "zadd")
-            .expect("expected zadd call for expiry tracking");
-        assert_eq!(zadd_call.key, "flags_cache_expiry");
-        match &zadd_call.value {
-            MockRedisValue::MemberScore(member, score) => {
-                assert_eq!(member, "123");
-                assert!(*score > 604800, "score {score} looked too small");
-            }
-            other => panic!("expected MemberScore, got {other:?}"),
-        }
+        assert_zadd_tracked_expiry(&redis.get_calls(), "flags_cache_expiry", "123", 604800);
     }
 
     #[cfg(feature = "mock-client")]

--- a/rust/common/hypercache/src/writer.rs
+++ b/rust/common/hypercache/src/writer.rs
@@ -5,6 +5,7 @@ use common_s3::S3Client;
 use sha2::{Digest, Sha256};
 use std::fmt::Write;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::warn;
 
 use crate::{HyperCacheConfig, HyperCacheError, KeyType, HYPER_CACHE_EMPTY_VALUE};
@@ -66,7 +67,36 @@ impl HyperCacheWriter {
             warn!(error = %e, "Failed to delete ETag key during set");
         }
 
-        self.check_results(redis_result, s3_result, "set")
+        self.check_results(redis_result, s3_result, "set")?;
+        self.track_expiry(key, ttl_seconds).await;
+        Ok(())
+    }
+
+    /// Mirror Python's `HyperCache._track_expiry`: record the write into the configured
+    /// sorted set with `now + ttl_seconds` as the score. Failures are logged but never
+    /// propagate — the cache entry itself was already written successfully.
+    async fn track_expiry(&self, key: &KeyType, ttl_seconds: u64) {
+        let Some(sorted_set_key) = self.config.expiry_sorted_set_key.as_deref() else {
+            return;
+        };
+        let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) else {
+            warn!("System clock before UNIX_EPOCH; skipping expiry tracking");
+            return;
+        };
+        let expiry_timestamp = now.as_secs().saturating_add(ttl_seconds) as i64;
+        let identifier = self.config.get_cache_identifier(key);
+
+        if let Err(e) = self
+            .redis_client
+            .zadd(sorted_set_key.to_string(), identifier, expiry_timestamp)
+            .await
+        {
+            warn!(
+                error = %e,
+                namespace = %self.config.namespace,
+                "Failed to track cache expiry",
+            );
+        }
     }
 
     /// Write JSON data to both Redis and S3, and store a computed ETag in Redis.
@@ -353,6 +383,44 @@ mod tests {
             etag_del.key,
             "posthog:1:cache/teams/123/feature_flags/flags.json:etag"
         );
+        // No expiry tracking when `expiry_sorted_set_key` is None.
+        assert!(calls.iter().all(|c| c.op != "zadd"));
+    }
+
+    #[cfg(feature = "mock-client")]
+    #[tokio::test]
+    async fn test_set_tracks_expiry_when_sorted_set_configured() {
+        let key = KeyType::int(123);
+        let json_data = r#"{"flags":[]}"#;
+
+        let mut redis = MockRedisClient::new();
+        redis.set_ret("posthog:1:cache/teams/123/feature_flags/flags.json", Ok(()));
+        redis.del_ret(
+            "posthog:1:cache/teams/123/feature_flags/flags.json:etag",
+            Ok(()),
+        );
+
+        let redis = Arc::new(redis);
+        let mut config = create_test_config();
+        config.expiry_sorted_set_key = Some("flags_cache_expiry".to_string());
+        let writer = HyperCacheWriter::new(redis.clone(), Arc::new(mock_s3_put_ok()), config);
+        writer.set(&key, json_data, 604800).await.unwrap();
+
+        let calls = redis.get_calls();
+        let zadd_call = calls
+            .iter()
+            .find(|c| c.op == "zadd")
+            .expect("expected zadd call for expiry tracking");
+        assert_eq!(zadd_call.key, "flags_cache_expiry");
+        match &zadd_call.value {
+            MockRedisValue::MemberScore(member, score) => {
+                assert_eq!(member, "123");
+                // Score is a future unix timestamp (now + 604800s); just sanity-check it's
+                // at least our ttl seconds ahead.
+                assert!(*score > 604800, "score {score} looked too small");
+            }
+            other => panic!("expected MemberScore, got {other:?}"),
+        }
     }
 
     #[cfg(feature = "mock-client")]

--- a/rust/common/redis/src/client.rs
+++ b/rust/common/redis/src/client.rs
@@ -234,6 +234,12 @@ impl Client for RedisClient {
         Ok(results)
     }
 
+    async fn zadd(&self, k: String, member: String, score: i64) -> Result<(), CustomRedisError> {
+        let mut conn = self.connection.clone();
+        conn.zadd::<_, _, _, ()>(k, member, score).await?;
+        Ok(())
+    }
+
     async fn hincrby(
         &self,
         k: String,

--- a/rust/common/redis/src/lib.rs
+++ b/rust/common/redis/src/lib.rs
@@ -201,6 +201,9 @@ pub trait Client: Send + Sync {
         max: String,
     ) -> Result<Vec<String>, CustomRedisError>;
 
+    /// Add a single (member, score) pair to a sorted set.
+    async fn zadd(&self, k: String, member: String, score: i64) -> Result<(), CustomRedisError>;
+
     async fn hincrby(
         &self,
         k: String,

--- a/rust/common/redis/src/mock.rs
+++ b/rust/common/redis/src/mock.rs
@@ -182,6 +182,7 @@ pub enum MockRedisValue {
     StringWithFormat(String, RedisValueFormat),
     StringWithTTLAndFormat(String, u64, RedisValueFormat),
     Bytes(Vec<u8>, Option<u64>),
+    MemberScore(String, i64),
 }
 
 #[derive(Debug, Clone)]
@@ -211,6 +212,16 @@ impl Client for MockRedisClient {
             Some(val) => Ok(val.clone()),
             None => Err(CustomRedisError::NotFound),
         }
+    }
+
+    async fn zadd(&self, key: String, member: String, score: i64) -> Result<(), CustomRedisError> {
+        let mut calls = self.lock_calls();
+        calls.push(MockRedisCall {
+            op: "zadd".to_string(),
+            key,
+            value: MockRedisValue::MemberScore(member, score),
+        });
+        Ok(())
     }
 
     async fn hincrby(

--- a/rust/common/redis/src/read_write.rs
+++ b/rust/common/redis/src/read_write.rs
@@ -363,6 +363,10 @@ impl Client for ReadWriteClient {
         self.writer.set(k, v).await
     }
 
+    async fn zadd(&self, k: String, member: String, score: i64) -> Result<(), CustomRedisError> {
+        self.writer.zadd(k, member, score).await
+    }
+
     async fn set_with_format(
         &self,
         k: String,

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -177,10 +177,8 @@ impl Cohort {
         for cohort_values in &inner.values {
             for filter in &cohort_values.values {
                 if filter.is_cohort() {
-                    // Assuming the value is a single integer CohortId
-                    if let Some(cohort_id) = filter.value.as_ref().and_then(|value| value.as_i64())
-                    {
-                        dependencies.insert(cohort_id as CohortId);
+                    if let Some(cohort_id) = filter.get_cohort_id() {
+                        dependencies.insert(cohort_id);
                     } else {
                         return Err(FlagError::CohortFiltersParsingError);
                     }

--- a/rust/feature-flags/src/flags/cache_builder.rs
+++ b/rust/feature-flags/src/flags/cache_builder.rs
@@ -109,12 +109,7 @@ pub fn compute_flag_dependencies(flags: &[FeatureFlag]) -> Result<EvaluationMeta
     let mut edges: HashMap<FeatureFlagId, HashSet<FeatureFlagId>> =
         HashMap::with_capacity(nodes.len());
     for node in &nodes {
-        // FlagNode::extract_dependencies always returns Ok,
-        // so unwrap_or_default is safe here.
-        edges.insert(
-            node.get_id(),
-            node.extract_dependencies().unwrap_or_default(),
-        );
+        edges.insert(node.get_id(), node.extract_dependencies()?);
     }
 
     // Build graph — tolerant of missing deps and cycles.

--- a/rust/feature-flags/src/utils/test_graph_utils.rs
+++ b/rust/feature-flags/src/utils/test_graph_utils.rs
@@ -985,6 +985,25 @@ mod tests {
 
             assert_eq!(result.nodes_with_missing_deps, vec![1, 2, 3]);
         }
+
+        #[test]
+        fn test_pre_seeded_missing_ids_not_in_graph_are_preserved() {
+            // Node 99 isn't in the graph but is pre-seeded as missing.
+            // This simulates the cycle-removal case where IDs are added to
+            // nodes_with_missing_deps before calling compute_evaluation_metadata.
+            let nodes = vec![
+                TestItem::new(1, HashSet::new()),
+                TestItem::new(2, HashSet::from([1])),
+            ];
+            let (graph, _, _) = build_graph_from_nodes(&nodes).unwrap();
+            let pre_missing = HashSet::from([99_i64]);
+            let result = graph.compute_evaluation_metadata(&pre_missing).unwrap();
+
+            assert!(result.nodes_with_missing_deps.contains(&99));
+            assert_eq!(result.stages.len(), 2);
+            assert_eq!(result.stages[0], vec![1]);
+            assert_eq!(result.stages[1], vec![2]);
+        }
     }
 }
 

--- a/rust/warm-flags-cache/Cargo.toml
+++ b/rust/warm-flags-cache/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "warm-flags-cache"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+feature-flags = { path = "../feature-flags" }
+common-database = { path = "../common/database" }
+common-hypercache = { path = "../common/hypercache" }
+common-redis = { path = "../common/redis" }
+common-s3 = { path = "../common/s3" }
+common-types = { path = "../common/types" }
+common-alloc = { path = "../common/alloc" }
+aws-config = { workspace = true }
+aws-sdk-s3 = { workspace = true }
+clap = { workspace = true }
+envconfig = { workspace = true }
+rand = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
+
+[lints]
+workspace = true

--- a/rust/warm-flags-cache/src/main.rs
+++ b/rust/warm-flags-cache/src/main.rs
@@ -1,0 +1,811 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aws_config::BehaviorVersion;
+use clap::Parser;
+use common_database::{get_pool, PostgresReader};
+use common_hypercache::writer::HyperCacheWriter;
+use common_hypercache::{HyperCacheConfig, KeyType};
+use common_redis::{CompressionConfig, RedisClient, RedisValueFormat};
+use common_s3::{S3Client, S3Impl};
+use common_types::TeamId;
+use envconfig::Envconfig;
+use rand::Rng;
+use tokio::task::JoinSet;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
+
+use feature_flags::flags::cache_builder::build_flags_cache;
+
+common_alloc::used!();
+
+/// Redis sorted-set key used by Python's `FLAGS_CACHE_EXPIRY_SORTED_SET`. Keeping these
+/// in lockstep lets the existing refresh/verification workflows pick up entries this
+/// binary warms.
+const FLAGS_CACHE_EXPIRY_SORTED_SET: &str = "flags_cache_expiry";
+
+/// Page size for cursor-paged team-ID streaming. Bounds peak in-memory ID buffer to
+/// `TEAM_ID_PAGE_SIZE * sizeof(i32)` regardless of total team count.
+const TEAM_ID_PAGE_SIZE: i64 = 1000;
+
+#[derive(Parser, Debug)]
+#[command(name = "warm-flags-cache")]
+struct Cli {
+    #[arg(long, num_args = 1..)]
+    team_ids: Option<Vec<TeamId>>,
+
+    #[arg(long, conflicts_with = "team_ids")]
+    team_ids_stdin: bool,
+
+    #[arg(long, default_value = "10")]
+    concurrency: usize,
+
+    #[arg(long, default_value = "5")]
+    min_ttl_days: u64,
+
+    #[arg(long, default_value = "7")]
+    max_ttl_days: u64,
+
+    #[arg(long)]
+    no_stagger: bool,
+
+    /// Warm every team in `posthog_team`, not just teams that have ever had a flag.
+    /// Defaults to the "teams-with-flags" scope, matching the Python warmer.
+    #[arg(long, conflicts_with_all = ["team_ids", "team_ids_stdin"])]
+    all_teams: bool,
+
+    /// Allow falling back to the default `REDIS_URL` when `FLAGS_REDIS_URL` is unset.
+    /// Without this flag, the binary refuses to run if `FLAGS_REDIS_URL` is empty —
+    /// matching the Python warmer's `check_dedicated_cache_configured()` guard so we
+    /// don't accidentally write flags-cache entries into the shared Redis tier.
+    #[arg(long)]
+    allow_default_redis: bool,
+}
+
+#[derive(Envconfig)]
+struct InfraConfig {
+    #[envconfig(
+        from = "READ_DATABASE_URL",
+        default = "postgres://posthog:posthog@localhost:5432/posthog"
+    )]
+    read_database_url: String,
+
+    #[envconfig(from = "FLAGS_REDIS_URL", default = "")]
+    flags_redis_url: String,
+
+    #[envconfig(from = "REDIS_URL", default = "redis://localhost:6379/")]
+    redis_url: String,
+
+    #[envconfig(from = "OBJECT_STORAGE_BUCKET", default = "posthog")]
+    object_storage_bucket: String,
+
+    #[envconfig(from = "OBJECT_STORAGE_REGION", default = "us-east-1")]
+    object_storage_region: String,
+
+    #[envconfig(from = "OBJECT_STORAGE_ENDPOINT", default = "")]
+    object_storage_endpoint: String,
+
+    #[envconfig(from = "DATABASE_MAX_CONNECTIONS", default = "10")]
+    database_max_connections: u32,
+
+    /// Per-command Redis response timeout. Default of 1000ms is intentionally more lenient
+    /// than the feature-flags service's 100ms request-path budget — batch warming makes many
+    /// calls and a transient blip shouldn't fail the whole run. `0` disables the timeout.
+    #[envconfig(from = "FLAGS_REDIS_RESPONSE_TIMEOUT_MS", default = "1000")]
+    redis_response_timeout_ms: u64,
+
+    #[envconfig(from = "FLAGS_REDIS_CONNECTION_TIMEOUT_MS", default = "5000")]
+    redis_connection_timeout_ms: u64,
+}
+
+fn resolve_redis_url(infra: &InfraConfig, allow_default: bool) -> Option<&str> {
+    if !infra.flags_redis_url.is_empty() {
+        Some(&infra.flags_redis_url)
+    } else if allow_default {
+        Some(&infra.redis_url)
+    } else {
+        None
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let cli = Cli::parse();
+    let infra = InfraConfig::init_from_env().expect("Invalid infrastructure configuration");
+
+    if cli.concurrency == 0 {
+        tracing::error!("--concurrency must be at least 1");
+        std::process::exit(1);
+    }
+
+    if let Err(msg) = validate_ttl_range(cli.min_ttl_days, cli.max_ttl_days) {
+        tracing::error!("{msg}");
+        std::process::exit(1);
+    }
+
+    let Some(redis_url) = resolve_redis_url(&infra, cli.allow_default_redis) else {
+        tracing::error!(
+            "FLAGS_REDIS_URL is not set. Refusing to fall back to the default REDIS_URL — \
+             that would write flags-cache entries into the shared Redis tier. \
+             Set FLAGS_REDIS_URL or pass --allow-default-redis to override."
+        );
+        std::process::exit(1);
+    };
+
+    let pg_pool = get_pool(&infra.read_database_url, infra.database_max_connections)
+        .expect("Failed to create database pool");
+    let pg_reader: PostgresReader = Arc::new(pg_pool);
+
+    tracing::info!("Connecting to Redis");
+    let response_timeout = optional_duration_ms(infra.redis_response_timeout_ms);
+    let connection_timeout = optional_duration_ms(infra.redis_connection_timeout_ms);
+    let redis_client = RedisClient::with_config(
+        redis_url.to_string(),
+        CompressionConfig::default(),
+        RedisValueFormat::default(),
+        response_timeout,
+        connection_timeout,
+    )
+    .await
+    .expect("Failed to connect to Redis");
+    let redis_client: Arc<dyn common_redis::Client + Send + Sync> = Arc::new(redis_client);
+
+    let s3_client = create_s3_client(&infra).await;
+
+    let mut cache_config = HyperCacheConfig::new(
+        "feature_flags".to_string(),
+        "flags.json".to_string(),
+        infra.object_storage_region.clone(),
+        infra.object_storage_bucket.clone(),
+    );
+    if !infra.object_storage_endpoint.is_empty() {
+        cache_config.s3_endpoint = Some(infra.object_storage_endpoint.clone());
+    }
+    cache_config.expiry_sorted_set_key = Some(FLAGS_CACHE_EXPIRY_SORTED_SET.to_string());
+    let writer = Arc::new(HyperCacheWriter::new(redis_client, s3_client, cache_config));
+
+    let plan = build_team_plan(&cli, &pg_reader).await;
+    if plan.total == 0 {
+        tracing::info!("No teams to warm");
+        return;
+    }
+
+    tracing::info!(
+        "Warming flags cache for {} teams (concurrency: {})",
+        plan.total,
+        cli.concurrency
+    );
+
+    run_warm(plan, writer, pg_reader, &cli).await;
+}
+
+/// Coordinates the warm loop with bounded in-flight tasks and progress logging.
+async fn run_warm(
+    plan: TeamPlan,
+    writer: Arc<HyperCacheWriter>,
+    pg_reader: PostgresReader,
+    cli: &Cli,
+) {
+    let total = plan.total;
+    let start = Instant::now();
+    let mut successful: usize = 0;
+    let mut failed: usize = 0;
+    let mut completed: usize = 0;
+    let step = (total / 20).max(1);
+    let mut next_log_at = step;
+
+    let mut join_set: JoinSet<Result<(), (TeamId, String)>> = JoinSet::new();
+    let log_progress = |completed: usize, successful: usize, failed: usize| {
+        tracing::info!(
+            "Progress: {}/{} teams ({}%) — {} ok, {} failed",
+            completed,
+            total,
+            (100 * completed) / total,
+            successful,
+            failed
+        );
+    };
+    let handle_completion =
+        |result: Result<Result<(), (TeamId, String)>, tokio::task::JoinError>,
+         successful: &mut usize,
+         failed: &mut usize,
+         completed: &mut usize,
+         next_log_at: &mut usize| {
+            match result {
+                Ok(Ok(())) => *successful += 1,
+                Ok(Err((team_id, err))) => {
+                    *failed += 1;
+                    tracing::warn!(team_id, error = %err, "Failed to warm cache");
+                }
+                Err(join_err) => {
+                    *failed += 1;
+                    tracing::warn!(error = %join_err, "Warm task panicked or was cancelled");
+                }
+            }
+            *completed += 1;
+            if *completed >= *next_log_at || *completed == total {
+                log_progress(*completed, *successful, *failed);
+                *next_log_at = next_log_at.saturating_add(step);
+            }
+        };
+
+    let mut team_stream = TeamIdStream::new(plan, pg_reader.clone());
+    while let Some(team_id) = team_stream.next().await {
+        // Cap in-flight tasks at `concurrency`; combined with the seek-paged team-ID
+        // stream, peak memory stays O(concurrency + page size) regardless of team count.
+        if join_set.len() >= cli.concurrency {
+            let result = join_set
+                .join_next()
+                .await
+                .expect("join_set non-empty when len >= concurrency");
+            handle_completion(
+                result,
+                &mut successful,
+                &mut failed,
+                &mut completed,
+                &mut next_log_at,
+            );
+        }
+
+        let pg = pg_reader.clone();
+        let writer = writer.clone();
+        let ttl_seconds = compute_ttl(cli);
+        join_set.spawn(async move {
+            warm_team(pg, &writer, team_id, ttl_seconds)
+                .await
+                .map_err(|e| (team_id, e.to_string()))
+        });
+    }
+
+    while let Some(result) = join_set.join_next().await {
+        handle_completion(
+            result,
+            &mut successful,
+            &mut failed,
+            &mut completed,
+            &mut next_log_at,
+        );
+    }
+
+    let duration = start.elapsed();
+    tracing::info!(
+        successful,
+        failed,
+        total,
+        duration_secs = duration.as_secs_f64(),
+        "Cache warming complete"
+    );
+
+    if failed > 0 {
+        std::process::exit(1);
+    }
+}
+
+async fn warm_team(
+    pg_reader: PostgresReader,
+    writer: &HyperCacheWriter,
+    team_id: TeamId,
+    ttl_seconds: u64,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let key = KeyType::int(team_id);
+    let result = build_flags_cache(pg_reader, team_id).await?;
+
+    let json = serde_json::to_string(&result)?;
+    writer.set(&key, &json, ttl_seconds).await?;
+
+    Ok(())
+}
+
+/// Validate TTL day range matches Python's warmer (`1..=30`, min <= max).
+fn validate_ttl_range(min_ttl_days: u64, max_ttl_days: u64) -> Result<(), String> {
+    if !(1..=30).contains(&min_ttl_days) {
+        return Err(format!(
+            "--min-ttl-days must be between 1 and 30 (got {min_ttl_days})"
+        ));
+    }
+    if !(1..=30).contains(&max_ttl_days) {
+        return Err(format!(
+            "--max-ttl-days must be between 1 and 30 (got {max_ttl_days})"
+        ));
+    }
+    if min_ttl_days > max_ttl_days {
+        return Err(format!(
+            "--min-ttl-days ({min_ttl_days}) cannot be greater than --max-ttl-days ({max_ttl_days})"
+        ));
+    }
+    Ok(())
+}
+
+fn compute_ttl(cli: &Cli) -> u64 {
+    let min_secs = cli.min_ttl_days * 24 * 3600;
+    let max_secs = cli.max_ttl_days * 24 * 3600;
+
+    if cli.no_stagger || min_secs == max_secs {
+        max_secs
+    } else {
+        rand::thread_rng().gen_range(min_secs..=max_secs)
+    }
+}
+
+fn optional_duration_ms(ms: u64) -> Option<Duration> {
+    if ms == 0 {
+        None
+    } else {
+        Some(Duration::from_millis(ms))
+    }
+}
+
+struct TeamPlan {
+    total: usize,
+    source: TeamSource,
+}
+
+enum TeamSource {
+    Explicit(Vec<TeamId>),
+    DatabaseScan { all_teams: bool },
+}
+
+async fn build_team_plan(cli: &Cli, pg_reader: &PostgresReader) -> TeamPlan {
+    if let Some(ref ids) = cli.team_ids {
+        let validated = validate_team_ids(pg_reader, ids).await;
+        reject_if_all_invalid(ids, &validated, "--team-ids");
+        return TeamPlan {
+            total: validated.len(),
+            source: TeamSource::Explicit(validated),
+        };
+    }
+
+    if cli.team_ids_stdin {
+        let ids = read_team_ids_from_stdin();
+        let validated = validate_team_ids(pg_reader, &ids).await;
+        reject_if_all_invalid(&ids, &validated, "stdin");
+        return TeamPlan {
+            total: validated.len(),
+            source: TeamSource::Explicit(validated),
+        };
+    }
+
+    let total = count_teams(pg_reader, cli.all_teams).await;
+    if cli.all_teams {
+        tracing::info!("Found {} teams (all teams in posthog_team)", total);
+    } else {
+        tracing::info!("Found {} teams that have ever had a flag", total);
+    }
+    TeamPlan {
+        total,
+        source: TeamSource::DatabaseScan {
+            all_teams: cli.all_teams,
+        },
+    }
+}
+
+/// Returns an error message when the user explicitly supplied team IDs but
+/// none passed validation. Split from the exit path so it's unit-testable.
+fn check_all_invalid(supplied: &[TeamId], validated: &[TeamId]) -> Option<String> {
+    if supplied.is_empty() || !validated.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "All supplied team IDs were invalid: {supplied:?}. \
+             Check the values against posthog_team."
+        ))
+    }
+}
+
+/// Without this guard, `--team-ids 999999` against a missing team silently
+/// exits 0 with "No teams to warm", so operator typos look successful.
+fn reject_if_all_invalid(supplied: &[TeamId], validated: &[TeamId], source: &str) {
+    if let Some(msg) = check_all_invalid(supplied, validated) {
+        tracing::error!(source, "{msg}");
+        std::process::exit(1);
+    }
+}
+
+/// Drops typos and stale IDs so they don't silently produce empty caches and
+/// orphan `flags_cache_expiry` entries. Mirrors Python's `_validate_teams()`.
+async fn validate_team_ids(pg_reader: &PostgresReader, supplied: &[TeamId]) -> Vec<TeamId> {
+    if supplied.is_empty() {
+        return vec![];
+    }
+
+    let mut conn = pg_reader
+        .get_connection()
+        .await
+        .expect("Failed to get database connection");
+
+    let rows: Vec<(i32,)> = sqlx::query_as("SELECT id FROM posthog_team WHERE id = ANY($1)")
+        .bind(supplied)
+        .fetch_all(&mut *conn)
+        .await
+        .expect("Failed to look up team IDs");
+
+    let found: HashSet<TeamId> = rows.iter().map(|(id,)| *id).collect();
+    let supplied_set: HashSet<TeamId> = supplied.iter().copied().collect();
+    let mut missing: Vec<TeamId> = supplied_set.difference(&found).copied().collect();
+    missing.sort_unstable();
+
+    if !missing.is_empty() {
+        tracing::warn!(
+            missing = ?missing,
+            "Some supplied team IDs do not exist in posthog_team — skipping"
+        );
+    }
+
+    let mut valid: Vec<TeamId> = found.into_iter().collect();
+    valid.sort_unstable();
+    valid
+}
+
+async fn count_teams(pg_reader: &PostgresReader, all_teams: bool) -> usize {
+    let mut conn = pg_reader
+        .get_connection()
+        .await
+        .expect("Failed to get database connection");
+
+    let query = if all_teams {
+        "SELECT COUNT(*) FROM posthog_team"
+    } else {
+        "SELECT COUNT(*) FROM posthog_team t \
+         WHERE EXISTS (SELECT 1 FROM posthog_featureflag f WHERE f.team_id = t.id)"
+    };
+
+    let (count,): (i64,) = sqlx::query_as(query)
+        .fetch_one(&mut *conn)
+        .await
+        .expect("Failed to count teams");
+    count as usize
+}
+
+struct TeamIdStream {
+    source: TeamSourceState,
+    pg_reader: PostgresReader,
+}
+
+enum TeamSourceState {
+    Explicit(std::vec::IntoIter<TeamId>),
+    DatabaseScan {
+        all_teams: bool,
+        last_id: TeamId,
+        buffer: std::vec::IntoIter<TeamId>,
+        exhausted: bool,
+    },
+}
+
+impl TeamIdStream {
+    fn new(plan: TeamPlan, pg_reader: PostgresReader) -> Self {
+        let source = match plan.source {
+            TeamSource::Explicit(ids) => TeamSourceState::Explicit(ids.into_iter()),
+            TeamSource::DatabaseScan { all_teams } => TeamSourceState::DatabaseScan {
+                all_teams,
+                last_id: 0,
+                buffer: Vec::new().into_iter(),
+                exhausted: false,
+            },
+        };
+        Self { source, pg_reader }
+    }
+
+    async fn next(&mut self) -> Option<TeamId> {
+        match &mut self.source {
+            TeamSourceState::Explicit(iter) => iter.next(),
+            TeamSourceState::DatabaseScan {
+                all_teams,
+                last_id,
+                buffer,
+                exhausted,
+            } => loop {
+                if let Some(id) = buffer.next() {
+                    return Some(id);
+                }
+                if *exhausted {
+                    return None;
+                }
+
+                let page = fetch_team_id_page(&self.pg_reader, *all_teams, *last_id).await;
+                if page.is_empty() {
+                    *exhausted = true;
+                    return None;
+                }
+                *last_id = *page.last().expect("page non-empty");
+                *buffer = page.into_iter();
+            },
+        }
+    }
+}
+
+/// Fetch the next page of team IDs strictly greater than `after`, ordered by id.
+/// Seek pagination keeps memory bounded by `TEAM_ID_PAGE_SIZE` and avoids OFFSET's
+/// degradation on large tables.
+async fn fetch_team_id_page(
+    pg_reader: &PostgresReader,
+    all_teams: bool,
+    after: TeamId,
+) -> Vec<TeamId> {
+    let mut conn = pg_reader
+        .get_connection()
+        .await
+        .expect("Failed to get database connection");
+
+    let query = if all_teams {
+        "SELECT id FROM posthog_team WHERE id > $1 ORDER BY id LIMIT $2"
+    } else {
+        "SELECT t.id FROM posthog_team t \
+         WHERE t.id > $1 \
+         AND EXISTS (SELECT 1 FROM posthog_featureflag f WHERE f.team_id = t.id) \
+         ORDER BY t.id LIMIT $2"
+    };
+
+    let rows: Vec<(i32,)> = sqlx::query_as(query)
+        .bind(after)
+        .bind(TEAM_ID_PAGE_SIZE)
+        .fetch_all(&mut *conn)
+        .await
+        .expect("Failed to query team IDs");
+    rows.into_iter().map(|(id,)| id).collect()
+}
+
+#[derive(Debug)]
+enum ParseTeamIdsError {
+    Io(std::io::Error),
+    Invalid(String, std::num::ParseIntError),
+}
+
+fn parse_team_ids<R: std::io::BufRead>(reader: R) -> Result<Vec<TeamId>, ParseTeamIdsError> {
+    let mut ids = Vec::new();
+    for line in reader.lines() {
+        let line = line.map_err(ParseTeamIdsError::Io)?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let id = trimmed
+            .parse::<TeamId>()
+            .map_err(|e| ParseTeamIdsError::Invalid(trimmed.to_string(), e))?;
+        ids.push(id);
+    }
+    Ok(ids)
+}
+
+fn read_team_ids_from_stdin() -> Vec<TeamId> {
+    tracing::info!("Reading team IDs from stdin");
+    let stdin = std::io::stdin();
+    let ids = parse_team_ids(stdin.lock()).unwrap_or_else(|e| match e {
+        ParseTeamIdsError::Io(err) => {
+            tracing::error!(error = %err, "Failed to read team IDs from stdin");
+            std::process::exit(1);
+        }
+        ParseTeamIdsError::Invalid(value, err) => {
+            tracing::error!(error = %err, "Invalid team ID: {value}");
+            std::process::exit(1);
+        }
+    });
+    tracing::info!("Read {} team IDs from stdin", ids.len());
+    ids
+}
+
+async fn create_s3_client(infra: &InfraConfig) -> Arc<dyn S3Client + Send + Sync> {
+    let mut aws_config_builder = aws_config::defaults(BehaviorVersion::latest())
+        .region(aws_config::Region::new(infra.object_storage_region.clone()));
+
+    if !infra.object_storage_endpoint.is_empty() {
+        aws_config_builder = aws_config_builder.endpoint_url(&infra.object_storage_endpoint);
+    }
+
+    let aws_config = aws_config_builder.load().await;
+
+    let mut s3_config_builder = aws_sdk_s3::config::Builder::from(&aws_config);
+    if !infra.object_storage_endpoint.is_empty() {
+        s3_config_builder = s3_config_builder.force_path_style(true);
+    }
+
+    let aws_s3_client = aws_sdk_s3::Client::from_conf(s3_config_builder.build());
+    Arc::new(S3Impl::new(aws_s3_client))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cli(min: u64, max: u64, no_stagger: bool) -> Cli {
+        Cli {
+            team_ids: None,
+            team_ids_stdin: false,
+            concurrency: 10,
+            min_ttl_days: min,
+            max_ttl_days: max,
+            no_stagger,
+            all_teams: false,
+            allow_default_redis: false,
+        }
+    }
+
+    fn infra(flags: &str, default: &str) -> InfraConfig {
+        InfraConfig {
+            flags_redis_url: flags.to_string(),
+            redis_url: default.to_string(),
+            read_database_url: String::new(),
+            object_storage_bucket: String::new(),
+            object_storage_region: String::new(),
+            object_storage_endpoint: String::new(),
+            database_max_connections: 10,
+            redis_response_timeout_ms: 1000,
+            redis_connection_timeout_ms: 5000,
+        }
+    }
+
+    #[test]
+    fn test_compute_ttl_no_stagger_returns_max() {
+        assert_eq!(compute_ttl(&cli(5, 7, true)), 7 * 24 * 3600);
+    }
+
+    #[test]
+    fn test_compute_ttl_equal_min_max_returns_that_value() {
+        assert_eq!(compute_ttl(&cli(5, 5, false)), 5 * 24 * 3600);
+    }
+
+    #[test]
+    fn test_compute_ttl_stagger_returns_value_in_range() {
+        let min_secs = 5 * 24 * 3600;
+        let max_secs = 7 * 24 * 3600;
+        for _ in 0..100 {
+            let ttl = compute_ttl(&cli(5, 7, false));
+            assert!(
+                ttl >= min_secs && ttl <= max_secs,
+                "TTL {ttl} outside [{min_secs}, {max_secs}]"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_ttl_range_accepts_valid() {
+        assert!(validate_ttl_range(1, 30).is_ok());
+        assert!(validate_ttl_range(5, 7).is_ok());
+        assert!(validate_ttl_range(7, 7).is_ok());
+    }
+
+    #[test]
+    fn test_validate_ttl_range_rejects_min_below_one() {
+        assert!(validate_ttl_range(0, 7).is_err());
+    }
+
+    #[test]
+    fn test_validate_ttl_range_rejects_max_above_thirty() {
+        assert!(validate_ttl_range(5, 31).is_err());
+    }
+
+    #[test]
+    fn test_validate_ttl_range_rejects_min_above_thirty() {
+        assert!(validate_ttl_range(31, 31).is_err());
+    }
+
+    #[test]
+    fn test_validate_ttl_range_rejects_min_greater_than_max() {
+        assert!(validate_ttl_range(8, 7).is_err());
+    }
+
+    #[test]
+    fn test_resolve_redis_url_prefers_flags_redis() {
+        let infra = infra("redis://flags:6379/", "redis://default:6379/");
+        assert_eq!(
+            resolve_redis_url(&infra, false),
+            Some("redis://flags:6379/")
+        );
+    }
+
+    #[test]
+    fn test_resolve_redis_url_returns_none_without_flags_url() {
+        let infra = infra("", "redis://default:6379/");
+        assert_eq!(resolve_redis_url(&infra, false), None);
+    }
+
+    #[test]
+    fn test_resolve_redis_url_falls_back_with_explicit_opt_in() {
+        let infra = infra("", "redis://default:6379/");
+        assert_eq!(
+            resolve_redis_url(&infra, true),
+            Some("redis://default:6379/")
+        );
+    }
+
+    #[test]
+    fn test_resolve_redis_url_prefers_flags_even_with_opt_in() {
+        let infra = infra("redis://flags:6379/", "redis://default:6379/");
+        assert_eq!(resolve_redis_url(&infra, true), Some("redis://flags:6379/"));
+    }
+
+    #[test]
+    fn test_optional_duration_ms_zero_returns_none() {
+        assert_eq!(optional_duration_ms(0), None);
+    }
+
+    #[test]
+    fn test_optional_duration_ms_nonzero_returns_some() {
+        assert_eq!(optional_duration_ms(250), Some(Duration::from_millis(250)));
+    }
+
+    #[test]
+    fn test_parse_team_ids_happy_path() {
+        let input: &[u8] = b"1\n2\n3\n";
+        let ids = parse_team_ids(input).unwrap();
+        assert_eq!(ids, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_parse_team_ids_skips_blank_and_whitespace_lines() {
+        let input: &[u8] = b"1\n\n  2  \n\t\n3\n";
+        let ids = parse_team_ids(input).unwrap();
+        assert_eq!(ids, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_parse_team_ids_empty_input_returns_empty() {
+        let input: &[u8] = b"";
+        let ids = parse_team_ids(input).unwrap();
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn test_parse_team_ids_invalid_id_returns_error() {
+        let input: &[u8] = b"1\nabc\n3\n";
+        let err = parse_team_ids(input).unwrap_err();
+        match err {
+            ParseTeamIdsError::Invalid(value, _) => assert_eq!(value, "abc"),
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_team_ids_trims_before_reporting_invalid() {
+        let input: &[u8] = b"  oops  \n";
+        let err = parse_team_ids(input).unwrap_err();
+        match err {
+            ParseTeamIdsError::Invalid(value, _) => assert_eq!(value, "oops"),
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_team_ids_propagates_io_error() {
+        struct FailingReader;
+        impl std::io::Read for FailingReader {
+            fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("boom"))
+            }
+        }
+
+        let reader = std::io::BufReader::new(FailingReader);
+        let err = parse_team_ids(reader).unwrap_err();
+        match err {
+            ParseTeamIdsError::Io(e) => assert_eq!(e.kind(), std::io::ErrorKind::Other),
+            other => panic!("expected Io, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_check_all_invalid_none_supplied_returns_none() {
+        assert_eq!(check_all_invalid(&[], &[]), None);
+    }
+
+    #[test]
+    fn test_check_all_invalid_some_validated_returns_none() {
+        assert_eq!(check_all_invalid(&[1, 2], &[1]), None);
+    }
+
+    #[test]
+    fn test_check_all_invalid_all_invalid_returns_message() {
+        let result = check_all_invalid(&[999, 1000], &[]);
+        assert!(result.is_some(), "expected error message, got None");
+        let msg = result.unwrap();
+        assert!(msg.contains("999"), "message should cite the IDs: {msg}");
+        assert!(msg.contains("1000"), "message should cite the IDs: {msg}");
+    }
+}

--- a/rust/warm-flags-cache/src/main.rs
+++ b/rust/warm-flags-cache/src/main.rs
@@ -1,0 +1,691 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aws_config::BehaviorVersion;
+use clap::Parser;
+use common_database::{get_pool, PostgresReader};
+use common_hypercache::writer::HyperCacheWriter;
+use common_hypercache::{HyperCacheConfig, KeyType};
+use common_redis::{CompressionConfig, RedisClient, RedisValueFormat};
+use common_s3::{S3Client, S3Impl};
+use common_types::TeamId;
+use envconfig::Envconfig;
+use rand::Rng;
+use tokio::task::JoinSet;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
+
+use feature_flags::flags::cache_builder::build_flags_cache;
+
+common_alloc::used!();
+
+/// Redis sorted-set key used by Python's `FLAGS_CACHE_EXPIRY_SORTED_SET`. Keeping these
+/// in lockstep lets the existing refresh/verification workflows pick up entries this
+/// binary warms.
+const FLAGS_CACHE_EXPIRY_SORTED_SET: &str = "flags_cache_expiry";
+
+/// Page size for cursor-paged team-ID streaming. Bounds peak in-memory ID buffer to
+/// `TEAM_ID_PAGE_SIZE * sizeof(i32)` regardless of total team count.
+const TEAM_ID_PAGE_SIZE: i64 = 1000;
+
+#[derive(Parser, Debug)]
+#[command(name = "warm-flags-cache")]
+struct Cli {
+    #[arg(long, num_args = 1..)]
+    team_ids: Option<Vec<TeamId>>,
+
+    #[arg(long, conflicts_with = "team_ids")]
+    team_ids_stdin: bool,
+
+    #[arg(long, default_value = "10")]
+    concurrency: usize,
+
+    #[arg(long, default_value = "5")]
+    min_ttl_days: u64,
+
+    #[arg(long, default_value = "7")]
+    max_ttl_days: u64,
+
+    #[arg(long)]
+    no_stagger: bool,
+
+    /// Warm every team in `posthog_team`, not just teams that have ever had a flag.
+    /// Defaults to the "teams-with-flags" scope, matching the Python warmer.
+    #[arg(long, conflicts_with_all = ["team_ids", "team_ids_stdin"])]
+    all_teams: bool,
+
+    /// Allow falling back to the default `REDIS_URL` when `FLAGS_REDIS_URL` is unset.
+    /// Without this flag, the binary refuses to run if `FLAGS_REDIS_URL` is empty —
+    /// matching the Python warmer's `check_dedicated_cache_configured()` guard so we
+    /// don't accidentally write flags-cache entries into the shared Redis tier.
+    #[arg(long)]
+    allow_default_redis: bool,
+}
+
+#[derive(Envconfig)]
+struct InfraConfig {
+    #[envconfig(
+        from = "READ_DATABASE_URL",
+        default = "postgres://posthog:posthog@localhost:5432/posthog"
+    )]
+    read_database_url: String,
+
+    #[envconfig(from = "FLAGS_REDIS_URL", default = "")]
+    flags_redis_url: String,
+
+    #[envconfig(from = "REDIS_URL", default = "redis://localhost:6379/")]
+    redis_url: String,
+
+    #[envconfig(from = "OBJECT_STORAGE_BUCKET", default = "posthog")]
+    object_storage_bucket: String,
+
+    #[envconfig(from = "OBJECT_STORAGE_REGION", default = "us-east-1")]
+    object_storage_region: String,
+
+    #[envconfig(from = "OBJECT_STORAGE_ENDPOINT", default = "")]
+    object_storage_endpoint: String,
+
+    #[envconfig(from = "DATABASE_MAX_CONNECTIONS", default = "10")]
+    database_max_connections: u32,
+
+    /// Per-command Redis response timeout. Default of 1000ms is intentionally more lenient
+    /// than the feature-flags service's 100ms request-path budget — batch warming makes many
+    /// calls and a transient blip shouldn't fail the whole run. `0` disables the timeout.
+    #[envconfig(from = "FLAGS_REDIS_RESPONSE_TIMEOUT_MS", default = "1000")]
+    redis_response_timeout_ms: u64,
+
+    #[envconfig(from = "FLAGS_REDIS_CONNECTION_TIMEOUT_MS", default = "5000")]
+    redis_connection_timeout_ms: u64,
+}
+
+fn resolve_redis_url(infra: &InfraConfig, allow_default: bool) -> Option<&str> {
+    if !infra.flags_redis_url.is_empty() {
+        Some(&infra.flags_redis_url)
+    } else if allow_default {
+        Some(&infra.redis_url)
+    } else {
+        None
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let cli = Cli::parse();
+    let infra = InfraConfig::init_from_env().expect("Invalid infrastructure configuration");
+
+    if cli.concurrency == 0 {
+        tracing::error!("--concurrency must be at least 1");
+        std::process::exit(1);
+    }
+
+    if let Err(msg) = validate_ttl_range(cli.min_ttl_days, cli.max_ttl_days) {
+        tracing::error!("{msg}");
+        std::process::exit(1);
+    }
+
+    let Some(redis_url) = resolve_redis_url(&infra, cli.allow_default_redis) else {
+        tracing::error!(
+            "FLAGS_REDIS_URL is not set. Refusing to fall back to the default REDIS_URL — \
+             that would write flags-cache entries into the shared Redis tier. \
+             Set FLAGS_REDIS_URL or pass --allow-default-redis to override."
+        );
+        std::process::exit(1);
+    };
+
+    let pg_pool = get_pool(&infra.read_database_url, infra.database_max_connections)
+        .expect("Failed to create database pool");
+    let pg_reader: PostgresReader = Arc::new(pg_pool);
+
+    tracing::info!("Connecting to Redis");
+    let response_timeout = optional_duration_ms(infra.redis_response_timeout_ms);
+    let connection_timeout = optional_duration_ms(infra.redis_connection_timeout_ms);
+    let redis_client = RedisClient::with_config(
+        redis_url.to_string(),
+        CompressionConfig::default(),
+        RedisValueFormat::default(),
+        response_timeout,
+        connection_timeout,
+    )
+    .await
+    .expect("Failed to connect to Redis");
+    let redis_client: Arc<dyn common_redis::Client + Send + Sync> = Arc::new(redis_client);
+
+    let s3_client = create_s3_client(&infra).await;
+
+    let mut cache_config = HyperCacheConfig::new(
+        "feature_flags".to_string(),
+        "flags.json".to_string(),
+        infra.object_storage_region.clone(),
+        infra.object_storage_bucket.clone(),
+    );
+    if !infra.object_storage_endpoint.is_empty() {
+        cache_config.s3_endpoint = Some(infra.object_storage_endpoint.clone());
+    }
+    cache_config.expiry_sorted_set_key = Some(FLAGS_CACHE_EXPIRY_SORTED_SET.to_string());
+    let writer = Arc::new(HyperCacheWriter::new(redis_client, s3_client, cache_config));
+
+    let plan = build_team_plan(&cli, &pg_reader).await;
+    if plan.total == 0 {
+        tracing::info!("No teams to warm");
+        return;
+    }
+
+    tracing::info!(
+        "Warming flags cache for {} teams (concurrency: {})",
+        plan.total,
+        cli.concurrency
+    );
+
+    run_warm(plan, writer, pg_reader, &cli).await;
+}
+
+/// Coordinates the warm loop with bounded in-flight tasks and progress logging.
+async fn run_warm(
+    plan: TeamPlan,
+    writer: Arc<HyperCacheWriter>,
+    pg_reader: PostgresReader,
+    cli: &Cli,
+) {
+    let total = plan.total;
+    let start = Instant::now();
+    let mut successful: usize = 0;
+    let mut failed: usize = 0;
+    let mut completed: usize = 0;
+    let step = (total / 20).max(1);
+    let mut next_log_at = step;
+
+    let mut join_set: JoinSet<Result<(), (TeamId, String)>> = JoinSet::new();
+    let log_progress = |completed: usize, successful: usize, failed: usize| {
+        tracing::info!(
+            "Progress: {}/{} teams ({}%) — {} ok, {} failed",
+            completed,
+            total,
+            (100 * completed) / total,
+            successful,
+            failed
+        );
+    };
+    let handle_completion =
+        |result: Result<Result<(), (TeamId, String)>, tokio::task::JoinError>,
+         successful: &mut usize,
+         failed: &mut usize,
+         completed: &mut usize,
+         next_log_at: &mut usize| {
+            match result {
+                Ok(Ok(())) => *successful += 1,
+                Ok(Err((team_id, err))) => {
+                    *failed += 1;
+                    tracing::warn!(team_id, error = %err, "Failed to warm cache");
+                }
+                Err(join_err) => {
+                    *failed += 1;
+                    tracing::warn!(error = %join_err, "Warm task panicked or was cancelled");
+                }
+            }
+            *completed += 1;
+            if *completed >= *next_log_at || *completed == total {
+                log_progress(*completed, *successful, *failed);
+                *next_log_at = next_log_at.saturating_add(step);
+            }
+        };
+
+    let mut team_stream = TeamIdStream::new(plan, pg_reader.clone());
+    while let Some(team_id) = team_stream.next().await {
+        // Cap in-flight tasks at `concurrency`; combined with the seek-paged team-ID
+        // stream, peak memory stays O(concurrency + page size) regardless of team count.
+        if join_set.len() >= cli.concurrency {
+            let result = join_set
+                .join_next()
+                .await
+                .expect("join_set non-empty when len >= concurrency");
+            handle_completion(
+                result,
+                &mut successful,
+                &mut failed,
+                &mut completed,
+                &mut next_log_at,
+            );
+        }
+
+        let pg = pg_reader.clone();
+        let writer = writer.clone();
+        let ttl_seconds = compute_ttl(cli);
+        join_set.spawn(async move {
+            warm_team(pg, &writer, team_id, ttl_seconds)
+                .await
+                .map_err(|e| (team_id, e.to_string()))
+        });
+    }
+
+    while let Some(result) = join_set.join_next().await {
+        handle_completion(
+            result,
+            &mut successful,
+            &mut failed,
+            &mut completed,
+            &mut next_log_at,
+        );
+    }
+
+    let duration = start.elapsed();
+    tracing::info!(
+        successful,
+        failed,
+        total,
+        duration_secs = duration.as_secs_f64(),
+        "Cache warming complete"
+    );
+
+    if failed > 0 {
+        std::process::exit(1);
+    }
+}
+
+async fn warm_team(
+    pg_reader: PostgresReader,
+    writer: &HyperCacheWriter,
+    team_id: TeamId,
+    ttl_seconds: u64,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let key = KeyType::int(team_id);
+    let result = build_flags_cache(pg_reader, team_id).await?;
+
+    let json = serde_json::to_string(&result)?;
+    writer.set(&key, &json, ttl_seconds).await?;
+
+    Ok(())
+}
+
+/// Validate TTL day range matches Python's warmer (`1..=30`, min <= max).
+fn validate_ttl_range(min_ttl_days: u64, max_ttl_days: u64) -> Result<(), String> {
+    if !(1..=30).contains(&min_ttl_days) {
+        return Err(format!(
+            "--min-ttl-days must be between 1 and 30 (got {min_ttl_days})"
+        ));
+    }
+    if !(1..=30).contains(&max_ttl_days) {
+        return Err(format!(
+            "--max-ttl-days must be between 1 and 30 (got {max_ttl_days})"
+        ));
+    }
+    if min_ttl_days > max_ttl_days {
+        return Err(format!(
+            "--min-ttl-days ({min_ttl_days}) cannot be greater than --max-ttl-days ({max_ttl_days})"
+        ));
+    }
+    Ok(())
+}
+
+fn compute_ttl(cli: &Cli) -> u64 {
+    let min_secs = cli.min_ttl_days * 24 * 3600;
+    let max_secs = cli.max_ttl_days * 24 * 3600;
+
+    if cli.no_stagger || min_secs == max_secs {
+        max_secs
+    } else {
+        rand::thread_rng().gen_range(min_secs..=max_secs)
+    }
+}
+
+fn optional_duration_ms(ms: u64) -> Option<Duration> {
+    if ms == 0 {
+        None
+    } else {
+        Some(Duration::from_millis(ms))
+    }
+}
+
+struct TeamPlan {
+    total: usize,
+    source: TeamSource,
+}
+
+enum TeamSource {
+    Explicit(Vec<TeamId>),
+    DatabaseScan { all_teams: bool },
+}
+
+async fn build_team_plan(cli: &Cli, pg_reader: &PostgresReader) -> TeamPlan {
+    if let Some(ref ids) = cli.team_ids {
+        let validated = validate_team_ids(pg_reader, ids).await;
+        return TeamPlan {
+            total: validated.len(),
+            source: TeamSource::Explicit(validated),
+        };
+    }
+
+    if cli.team_ids_stdin {
+        let ids = read_team_ids_from_stdin();
+        let validated = validate_team_ids(pg_reader, &ids).await;
+        return TeamPlan {
+            total: validated.len(),
+            source: TeamSource::Explicit(validated),
+        };
+    }
+
+    let total = count_teams(pg_reader, cli.all_teams).await;
+    if cli.all_teams {
+        tracing::info!("Found {} teams (all teams in posthog_team)", total);
+    } else {
+        tracing::info!("Found {} teams that have ever had a flag", total);
+    }
+    TeamPlan {
+        total,
+        source: TeamSource::DatabaseScan {
+            all_teams: cli.all_teams,
+        },
+    }
+}
+
+/// Drops typos and stale IDs so they don't silently produce empty caches and
+/// orphan `flags_cache_expiry` entries. Mirrors Python's `_validate_teams()`.
+async fn validate_team_ids(pg_reader: &PostgresReader, supplied: &[TeamId]) -> Vec<TeamId> {
+    if supplied.is_empty() {
+        return vec![];
+    }
+
+    let mut conn = pg_reader
+        .get_connection()
+        .await
+        .expect("Failed to get database connection");
+
+    let rows: Vec<(i32,)> = sqlx::query_as("SELECT id FROM posthog_team WHERE id = ANY($1)")
+        .bind(supplied)
+        .fetch_all(&mut *conn)
+        .await
+        .expect("Failed to look up team IDs");
+
+    let found: HashSet<TeamId> = rows.iter().map(|(id,)| *id).collect();
+    let supplied_set: HashSet<TeamId> = supplied.iter().copied().collect();
+    let mut missing: Vec<TeamId> = supplied_set.difference(&found).copied().collect();
+    missing.sort_unstable();
+
+    if !missing.is_empty() {
+        tracing::warn!(
+            missing = ?missing,
+            "Some supplied team IDs do not exist in posthog_team — skipping"
+        );
+    }
+
+    let mut valid: Vec<TeamId> = found.into_iter().collect();
+    valid.sort_unstable();
+    valid
+}
+
+async fn count_teams(pg_reader: &PostgresReader, all_teams: bool) -> usize {
+    let mut conn = pg_reader
+        .get_connection()
+        .await
+        .expect("Failed to get database connection");
+
+    let query = if all_teams {
+        "SELECT COUNT(*) FROM posthog_team"
+    } else {
+        "SELECT COUNT(*) FROM posthog_team t \
+         WHERE EXISTS (SELECT 1 FROM posthog_featureflag f WHERE f.team_id = t.id)"
+    };
+
+    let (count,): (i64,) = sqlx::query_as(query)
+        .fetch_one(&mut *conn)
+        .await
+        .expect("Failed to count teams");
+    count as usize
+}
+
+struct TeamIdStream {
+    source: TeamSourceState,
+    pg_reader: PostgresReader,
+}
+
+enum TeamSourceState {
+    Explicit(std::vec::IntoIter<TeamId>),
+    DatabaseScan {
+        all_teams: bool,
+        last_id: TeamId,
+        buffer: std::vec::IntoIter<TeamId>,
+        exhausted: bool,
+    },
+}
+
+impl TeamIdStream {
+    fn new(plan: TeamPlan, pg_reader: PostgresReader) -> Self {
+        let source = match plan.source {
+            TeamSource::Explicit(ids) => TeamSourceState::Explicit(ids.into_iter()),
+            TeamSource::DatabaseScan { all_teams } => TeamSourceState::DatabaseScan {
+                all_teams,
+                last_id: 0,
+                buffer: Vec::new().into_iter(),
+                exhausted: false,
+            },
+        };
+        Self { source, pg_reader }
+    }
+
+    async fn next(&mut self) -> Option<TeamId> {
+        match &mut self.source {
+            TeamSourceState::Explicit(iter) => iter.next(),
+            TeamSourceState::DatabaseScan {
+                all_teams,
+                last_id,
+                buffer,
+                exhausted,
+            } => loop {
+                if let Some(id) = buffer.next() {
+                    return Some(id);
+                }
+                if *exhausted {
+                    return None;
+                }
+
+                let page = fetch_team_id_page(&self.pg_reader, *all_teams, *last_id).await;
+                if page.is_empty() {
+                    *exhausted = true;
+                    return None;
+                }
+                *last_id = *page.last().expect("page non-empty");
+                *buffer = page.into_iter();
+            },
+        }
+    }
+}
+
+/// Fetch the next page of team IDs strictly greater than `after`, ordered by id.
+/// Seek pagination keeps memory bounded by `TEAM_ID_PAGE_SIZE` and avoids OFFSET's
+/// degradation on large tables.
+async fn fetch_team_id_page(
+    pg_reader: &PostgresReader,
+    all_teams: bool,
+    after: TeamId,
+) -> Vec<TeamId> {
+    let mut conn = pg_reader
+        .get_connection()
+        .await
+        .expect("Failed to get database connection");
+
+    let query = if all_teams {
+        "SELECT id FROM posthog_team WHERE id > $1 ORDER BY id LIMIT $2"
+    } else {
+        "SELECT t.id FROM posthog_team t \
+         WHERE t.id > $1 \
+         AND EXISTS (SELECT 1 FROM posthog_featureflag f WHERE f.team_id = t.id) \
+         ORDER BY t.id LIMIT $2"
+    };
+
+    let rows: Vec<(i32,)> = sqlx::query_as(query)
+        .bind(after)
+        .bind(TEAM_ID_PAGE_SIZE)
+        .fetch_all(&mut *conn)
+        .await
+        .expect("Failed to query team IDs");
+    rows.into_iter().map(|(id,)| id).collect()
+}
+
+fn read_team_ids_from_stdin() -> Vec<TeamId> {
+    use std::io::BufRead;
+    tracing::info!("Reading team IDs from stdin");
+    let stdin = std::io::stdin();
+    let ids: Vec<TeamId> = stdin
+        .lock()
+        .lines()
+        .map_while(Result::ok)
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            line.trim().parse::<TeamId>().unwrap_or_else(|_| {
+                tracing::error!("Invalid team ID: {line}");
+                std::process::exit(1);
+            })
+        })
+        .collect();
+    tracing::info!("Read {} team IDs from stdin", ids.len());
+    ids
+}
+
+async fn create_s3_client(infra: &InfraConfig) -> Arc<dyn S3Client + Send + Sync> {
+    let mut aws_config_builder = aws_config::defaults(BehaviorVersion::latest())
+        .region(aws_config::Region::new(infra.object_storage_region.clone()));
+
+    if !infra.object_storage_endpoint.is_empty() {
+        aws_config_builder = aws_config_builder.endpoint_url(&infra.object_storage_endpoint);
+    }
+
+    let aws_config = aws_config_builder.load().await;
+
+    let mut s3_config_builder = aws_sdk_s3::config::Builder::from(&aws_config);
+    if !infra.object_storage_endpoint.is_empty() {
+        s3_config_builder = s3_config_builder.force_path_style(true);
+    }
+
+    let aws_s3_client = aws_sdk_s3::Client::from_conf(s3_config_builder.build());
+    Arc::new(S3Impl::new(aws_s3_client))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cli(min: u64, max: u64, no_stagger: bool) -> Cli {
+        Cli {
+            team_ids: None,
+            team_ids_stdin: false,
+            concurrency: 10,
+            min_ttl_days: min,
+            max_ttl_days: max,
+            no_stagger,
+            all_teams: false,
+            allow_default_redis: false,
+        }
+    }
+
+    fn infra(flags: &str, default: &str) -> InfraConfig {
+        InfraConfig {
+            flags_redis_url: flags.to_string(),
+            redis_url: default.to_string(),
+            read_database_url: String::new(),
+            object_storage_bucket: String::new(),
+            object_storage_region: String::new(),
+            object_storage_endpoint: String::new(),
+            database_max_connections: 10,
+            redis_response_timeout_ms: 1000,
+            redis_connection_timeout_ms: 5000,
+        }
+    }
+
+    #[test]
+    fn test_compute_ttl_no_stagger_returns_max() {
+        assert_eq!(compute_ttl(&cli(5, 7, true)), 7 * 24 * 3600);
+    }
+
+    #[test]
+    fn test_compute_ttl_equal_min_max_returns_that_value() {
+        assert_eq!(compute_ttl(&cli(5, 5, false)), 5 * 24 * 3600);
+    }
+
+    #[test]
+    fn test_compute_ttl_stagger_returns_value_in_range() {
+        let min_secs = 5 * 24 * 3600;
+        let max_secs = 7 * 24 * 3600;
+        for _ in 0..100 {
+            let ttl = compute_ttl(&cli(5, 7, false));
+            assert!(
+                ttl >= min_secs && ttl <= max_secs,
+                "TTL {ttl} outside [{min_secs}, {max_secs}]"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_ttl_range_accepts_valid() {
+        assert!(validate_ttl_range(1, 30).is_ok());
+        assert!(validate_ttl_range(5, 7).is_ok());
+        assert!(validate_ttl_range(7, 7).is_ok());
+    }
+
+    #[test]
+    fn test_validate_ttl_range_rejects_min_below_one() {
+        assert!(validate_ttl_range(0, 7).is_err());
+    }
+
+    #[test]
+    fn test_validate_ttl_range_rejects_max_above_thirty() {
+        assert!(validate_ttl_range(5, 31).is_err());
+    }
+
+    #[test]
+    fn test_validate_ttl_range_rejects_min_above_thirty() {
+        assert!(validate_ttl_range(31, 31).is_err());
+    }
+
+    #[test]
+    fn test_validate_ttl_range_rejects_min_greater_than_max() {
+        assert!(validate_ttl_range(8, 7).is_err());
+    }
+
+    #[test]
+    fn test_resolve_redis_url_prefers_flags_redis() {
+        let infra = infra("redis://flags:6379/", "redis://default:6379/");
+        assert_eq!(
+            resolve_redis_url(&infra, false),
+            Some("redis://flags:6379/")
+        );
+    }
+
+    #[test]
+    fn test_resolve_redis_url_returns_none_without_flags_url() {
+        let infra = infra("", "redis://default:6379/");
+        assert_eq!(resolve_redis_url(&infra, false), None);
+    }
+
+    #[test]
+    fn test_resolve_redis_url_falls_back_with_explicit_opt_in() {
+        let infra = infra("", "redis://default:6379/");
+        assert_eq!(
+            resolve_redis_url(&infra, true),
+            Some("redis://default:6379/")
+        );
+    }
+
+    #[test]
+    fn test_resolve_redis_url_prefers_flags_even_with_opt_in() {
+        let infra = infra("redis://flags:6379/", "redis://default:6379/");
+        assert_eq!(resolve_redis_url(&infra, true), Some("redis://flags:6379/"));
+    }
+
+    #[test]
+    fn test_optional_duration_ms_zero_returns_none() {
+        assert_eq!(optional_duration_ms(0), None);
+    }
+
+    #[test]
+    fn test_optional_duration_ms_nonzero_returns_some() {
+        assert_eq!(optional_duration_ms(250), Some(Duration::from_millis(250)));
+    }
+}

--- a/rust/warm-flags-cache/src/main.rs
+++ b/rust/warm-flags-cache/src/main.rs
@@ -533,18 +533,27 @@ fn read_team_ids_from_stdin() -> Vec<TeamId> {
     use std::io::BufRead;
     tracing::info!("Reading team IDs from stdin");
     let stdin = std::io::stdin();
-    let ids: Vec<TeamId> = stdin
-        .lock()
-        .lines()
-        .map_while(Result::ok)
-        .filter(|line| !line.trim().is_empty())
-        .map(|line| {
-            line.trim().parse::<TeamId>().unwrap_or_else(|_| {
+    let mut ids: Vec<TeamId> = Vec::new();
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(line) => line,
+            Err(e) => {
+                tracing::error!(error = %e, "Failed to read team IDs from stdin");
+                std::process::exit(1);
+            }
+        };
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match trimmed.parse::<TeamId>() {
+            Ok(id) => ids.push(id),
+            Err(_) => {
                 tracing::error!("Invalid team ID: {line}");
                 std::process::exit(1);
-            })
-        })
-        .collect();
+            }
+        }
+    }
     tracing::info!("Read {} team IDs from stdin", ids.len());
     ids
 }

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -30,7 +30,7 @@ const errorTrackingAssignmentRulesList = (): ToolBase<
         const projectId = await context.stateManager.getProjectId()
         const result = await context.api.request<Schemas.PaginatedErrorTrackingAssignmentRuleList>({
             method: 'GET',
-            path: `/api/environments/${projectId}/error_tracking/assignment_rules/`,
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/error_tracking/assignment_rules/`,
             query: {
                 limit: params.limit,
                 offset: params.offset,
@@ -183,7 +183,7 @@ const errorTrackingIssuesSplitCreate = (): ToolBase<
         }
         const result = await context.api.request<Schemas.ErrorTrackingIssueSplitResponse>({
             method: 'POST',
-            path: `/api/environments/${projectId}/error_tracking/issues/${params.id}/split/`,
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/error_tracking/issues/${encodeURIComponent(String(params.id))}/split/`,
             body,
         })
         return result


### PR DESCRIPTION
## Problem

The flags hypercache is populated lazily when requests miss the cache, which causes slow first responses after a cache flush or cold start. We need an out-of-band way to prewarm the hypercache for all teams (or a specific subset) so evaluation stays fast even after cache invalidation.

## Changes

- New Rust CLI `warm-flags-cache` (under `rust/warm-flags-cache/`) that iterates teams and writes flag + cohort entries into the hypercache
- Cursor-paged team-ID streaming keeps memory bounded regardless of team count; JoinSet provides bounded concurrency across workers
- Refuses to fall back to the default `REDIS_URL` when `FLAGS_REDIS_URL` is unset (override with `--allow-default-redis`)
- Configurable Redis response and connection timeouts
- Explicit `--team-ids` values are validated against the database
- Credentials are redacted from DSN logs in the local runner
- Kubernetes job wrapper (`bin/warm-flags-cache`) inherits pod identity (serviceAccountName, imagePullSecrets, nodeSelector, tolerations, affinity, securityContext) from the running deployment so IRSA and private-registry pulls work the same as the service
- Local wrapper (`bin/warm-flags-cache-local`) for dev environments
- Small additions to `common/hypercache` and `common/redis` to expose the write paths and helpers the CLI needs

## How did you test this code?

Manual testing on my local machine.

## Publish to changelog?

no

## Docs update

No docs changes required.