### PR TITLE
feat(ingestion): per-producer kafka metrics

### DIFF
--- a/nodejs/src/ingestion/outputs/kafka-producer-registry-builder.test.ts
+++ b/nodejs/src/ingestion/outputs/kafka-producer-registry-builder.test.ts
@@ -27,7 +27,8 @@ describe('KafkaProducerRegistryBuilder', () => {
         expect(KafkaProducerWrapper.createWithConfig).toHaveBeenCalledTimes(1)
         expect(KafkaProducerWrapper.createWithConfig).toHaveBeenCalledWith(
             undefined,
-            expect.objectContaining({ 'metadata.broker.list': 'kafka:9092', 'linger.ms': 20 })
+            expect.objectContaining({ 'metadata.broker.list': 'kafka:9092', 'linger.ms': 20 }),
+            'DEFAULT'
         )
         expect(registry.getProducer('DEFAULT')).toBeDefined()
     })
@@ -49,11 +50,13 @@ describe('KafkaProducerRegistryBuilder', () => {
         expect(KafkaProducerWrapper.createWithConfig).toHaveBeenCalledTimes(2)
         expect(KafkaProducerWrapper.createWithConfig).toHaveBeenCalledWith(
             undefined,
-            expect.objectContaining({ 'metadata.broker.list': 'kafka-primary:9092' })
+            expect.objectContaining({ 'metadata.broker.list': 'kafka-primary:9092' }),
+            'PRIMARY'
         )
         expect(KafkaProducerWrapper.createWithConfig).toHaveBeenCalledWith(
             undefined,
-            expect.objectContaining({ 'metadata.broker.list': 'kafka-secondary:9092' })
+            expect.objectContaining({ 'metadata.broker.list': 'kafka-secondary:9092' }),
+            'SECONDARY'
         )
         expect(registry.getProducer('PRIMARY')).toBeDefined()
         expect(registry.getProducer('SECONDARY')).toBeDefined()
@@ -65,7 +68,7 @@ describe('KafkaProducerRegistryBuilder', () => {
 
         await new KafkaProducerRegistryBuilder('us-east-1a').register('DEFAULT', configMap).build(config)
 
-        expect(KafkaProducerWrapper.createWithConfig).toHaveBeenCalledWith('us-east-1a', expect.any(Object))
+        expect(KafkaProducerWrapper.createWithConfig).toHaveBeenCalledWith('us-east-1a', expect.any(Object), 'DEFAULT')
     })
 
     it('skips empty config values and falls back to zod defaults', async () => {
@@ -78,7 +81,8 @@ describe('KafkaProducerRegistryBuilder', () => {
             expect.objectContaining({
                 'metadata.broker.list': 'kafka:9092',
                 'linger.ms': 20,
-            })
+            }),
+            'DEFAULT'
         )
     })
 

--- a/nodejs/src/ingestion/outputs/kafka-producer-registry-builder.ts
+++ b/nodejs/src/ingestion/outputs/kafka-producer-registry-builder.ts
@@ -76,7 +76,11 @@ export class KafkaProducerRegistryBuilder<P extends string = never, CK extends s
 
                 const resolvedConfig = parseProducerConfig(values)
                 logger.info('📝', `Creating producer "${name}"`, { config: redactConfig(resolvedConfig) })
-                producers[name] = await KafkaProducerWrapper.createWithConfig(this.kafkaClientRack, resolvedConfig)
+                producers[name] = await KafkaProducerWrapper.createWithConfig(
+                    this.kafkaClientRack,
+                    resolvedConfig,
+                    name
+                )
             })
         )
 

--- a/nodejs/src/kafka/kafka-producer-metrics.test.ts
+++ b/nodejs/src/kafka/kafka-producer-metrics.test.ts
@@ -233,4 +233,18 @@ describe('ProducerStatsTracker', () => {
         const tracker = new ProducerStatsTracker('DEFAULT')
         expect(() => tracker.track('not json')).not.toThrow()
     })
+
+    it('swallows payloads that fail schema validation without emitting metrics', async () => {
+        const tracker = new ProducerStatsTracker('DEFAULT')
+        // msg_cnt should be a number — librdkafka suddenly emitting a string shape
+        // means we've drifted. Don't throw, don't emit bogus metrics.
+        expect(() => tracker.track(JSON.stringify({ msg_cnt: 'oops' }))).not.toThrow()
+        expect(await gaugeValue(kafkaProducerQueueMessages, { producer_name: 'DEFAULT' })).toBeUndefined()
+    })
+
+    it('ignores unknown top-level fields', async () => {
+        const tracker = new ProducerStatsTracker('DEFAULT')
+        tracker.track(makeStats({ msg_cnt: 5, some_new_upstream_field: 'hello' }))
+        expect(await gaugeValue(kafkaProducerQueueMessages, { producer_name: 'DEFAULT' })).toBe(5)
+    })
 })

--- a/nodejs/src/kafka/kafka-producer-metrics.test.ts
+++ b/nodejs/src/kafka/kafka-producer-metrics.test.ts
@@ -2,18 +2,25 @@ import { Counter, Gauge, register } from 'prom-client'
 
 import {
     ProducerStatsTracker,
+    kafkaProducerAnyBrokersDown,
+    kafkaProducerBrokerConnected,
     kafkaProducerBrokerDisconnectsTotal,
     kafkaProducerBrokerInflightRequests,
     kafkaProducerBrokerOutbufMessages,
+    kafkaProducerBrokerOutbufRequests,
     kafkaProducerBrokerRequestTimeoutsTotal,
-    kafkaProducerBrokerRttP99Microseconds,
-    kafkaProducerBrokerThrottleP99Milliseconds,
+    kafkaProducerBrokerRttMicroseconds,
+    kafkaProducerBrokerRxErrorsTotal,
+    kafkaProducerBrokerThrottleMilliseconds,
     kafkaProducerBrokerTxErrorsTotal,
     kafkaProducerBrokerTxRetriesTotal,
+    kafkaProducerCallbackQueueDepth,
     kafkaProducerQueueBytes,
     kafkaProducerQueueMaxBytes,
     kafkaProducerQueueMaxMessages,
     kafkaProducerQueueMessages,
+    kafkaProducerTopicBatchCountAvg,
+    kafkaProducerTopicBatchSizeBytesAvg,
 } from './kafka-producer-metrics'
 
 async function gaugeValue(metric: Gauge<string>, labels: Record<string, string>): Promise<number | undefined> {
@@ -32,7 +39,9 @@ function makeStats(overrides: Record<string, any> = {}): string {
         msg_size: 1024,
         msg_max: 100_000,
         msg_size_max: 1_073_741_824,
+        replyq: 0,
         brokers: {},
+        topics: {},
         ...overrides,
     })
 }
@@ -41,6 +50,8 @@ function makeBroker(overrides: Record<string, any> = {}): any {
     return {
         name: 'kafka-1:9092/1',
         nodeid: 1,
+        state: 'UP',
+        outbuf_cnt: 0,
         outbuf_msg_cnt: 0,
         waitresp_cnt: 0,
         tx: 0,
@@ -48,8 +59,9 @@ function makeBroker(overrides: Record<string, any> = {}): any {
         txretries: 0,
         req_timeouts: 0,
         disconnects: 0,
-        rtt: { p99: 0 },
-        throttle: { p99: 0 },
+        rxerrs: 0,
+        rtt: { p50: 0, p90: 0, p95: 0, p99: 0 },
+        throttle: { p50: 0, p90: 0, p95: 0, p99: 0 },
         ...overrides,
     }
 }
@@ -62,36 +74,76 @@ describe('ProducerStatsTracker', () => {
     it('sets top-level queue gauges', async () => {
         const tracker = new ProducerStatsTracker('DEFAULT')
 
-        tracker.track(makeStats({ msg_cnt: 42, msg_size: 9000, msg_max: 100_000, msg_size_max: 1_000_000 }))
+        tracker.track(makeStats({ msg_cnt: 42, msg_size: 9000, msg_max: 100_000, msg_size_max: 1_000_000, replyq: 7 }))
 
         const labels = { producer_name: 'DEFAULT' }
         expect(await gaugeValue(kafkaProducerQueueMessages, labels)).toBe(42)
         expect(await gaugeValue(kafkaProducerQueueBytes, labels)).toBe(9000)
         expect(await gaugeValue(kafkaProducerQueueMaxMessages, labels)).toBe(100_000)
         expect(await gaugeValue(kafkaProducerQueueMaxBytes, labels)).toBe(1_000_000)
+        expect(await gaugeValue(kafkaProducerCallbackQueueDepth, labels)).toBe(7)
     })
 
-    it('sets per-broker gauges including rtt and throttle p99', async () => {
+    it('sets per-broker gauges including state, outbuf, rtt and throttle quantiles', async () => {
         const tracker = new ProducerStatsTracker('DEFAULT')
 
         tracker.track(
             makeStats({
                 brokers: {
                     'kafka-1:9092/1': makeBroker({
+                        state: 'UP',
+                        outbuf_cnt: 2,
                         outbuf_msg_cnt: 5,
                         waitresp_cnt: 3,
-                        rtt: { p99: 1234 },
-                        throttle: { p99: 50 },
+                        rtt: { p50: 100, p90: 500, p95: 800, p99: 1234 },
+                        throttle: { p50: 0, p90: 10, p95: 25, p99: 50 },
                     }),
                 },
             })
         )
 
         const labels = { producer_name: 'DEFAULT', broker: 'kafka-1:9092/1' }
+        expect(await gaugeValue(kafkaProducerBrokerConnected, labels)).toBe(1)
         expect(await gaugeValue(kafkaProducerBrokerOutbufMessages, labels)).toBe(5)
+        expect(await gaugeValue(kafkaProducerBrokerOutbufRequests, labels)).toBe(2)
         expect(await gaugeValue(kafkaProducerBrokerInflightRequests, labels)).toBe(3)
-        expect(await gaugeValue(kafkaProducerBrokerRttP99Microseconds, labels)).toBe(1234)
-        expect(await gaugeValue(kafkaProducerBrokerThrottleP99Milliseconds, labels)).toBe(50)
+        expect(await gaugeValue(kafkaProducerBrokerRttMicroseconds, { ...labels, quantile: 'p50' })).toBe(100)
+        expect(await gaugeValue(kafkaProducerBrokerRttMicroseconds, { ...labels, quantile: 'p99' })).toBe(1234)
+        expect(await gaugeValue(kafkaProducerBrokerThrottleMilliseconds, { ...labels, quantile: 'p99' })).toBe(50)
+    })
+
+    it('flags any broker not UP via kafkaProducerAnyBrokersDown', async () => {
+        const tracker = new ProducerStatsTracker('DEFAULT')
+
+        tracker.track(
+            makeStats({
+                brokers: {
+                    'kafka-1:9092/1': makeBroker({ state: 'UP' }),
+                    'kafka-2:9092/2': makeBroker({ state: 'DOWN' }),
+                },
+            })
+        )
+
+        expect(await gaugeValue(kafkaProducerAnyBrokersDown, { producer_name: 'DEFAULT' })).toBe(1)
+        expect(
+            await gaugeValue(kafkaProducerBrokerConnected, { producer_name: 'DEFAULT', broker: 'kafka-2:9092/2' })
+        ).toBe(0)
+    })
+
+    it('sets per-topic batching gauges', async () => {
+        const tracker = new ProducerStatsTracker('DEFAULT')
+
+        tracker.track(
+            makeStats({
+                topics: {
+                    events_plugin_ingestion: { batchsize: { avg: 8192 }, batchcnt: { avg: 42 } },
+                },
+            })
+        )
+
+        const labels = { producer_name: 'DEFAULT', topic: 'events_plugin_ingestion' }
+        expect(await gaugeValue(kafkaProducerTopicBatchSizeBytesAvg, labels)).toBe(8192)
+        expect(await gaugeValue(kafkaProducerTopicBatchCountAvg, labels)).toBe(42)
     })
 
     it('skips the first observation for cumulative counters to avoid spurious jumps', async () => {
@@ -117,14 +169,23 @@ describe('ProducerStatsTracker', () => {
         const labels = { producer_name: 'DEFAULT', broker: 'kafka-1:9092/1' }
 
         tracker.track(
-            makeStats({ brokers: { 'kafka-1:9092/1': makeBroker({ txerrs: 5, txretries: 10, req_timeouts: 1 }) } })
+            makeStats({
+                brokers: {
+                    'kafka-1:9092/1': makeBroker({ txerrs: 5, txretries: 10, req_timeouts: 1, rxerrs: 4 }),
+                },
+            })
         )
         tracker.track(
-            makeStats({ brokers: { 'kafka-1:9092/1': makeBroker({ txerrs: 8, txretries: 12, req_timeouts: 1 }) } })
+            makeStats({
+                brokers: {
+                    'kafka-1:9092/1': makeBroker({ txerrs: 8, txretries: 12, req_timeouts: 1, rxerrs: 9 }),
+                },
+            })
         )
 
         expect(await counterValue(kafkaProducerBrokerTxErrorsTotal, labels)).toBe(3)
         expect(await counterValue(kafkaProducerBrokerTxRetriesTotal, labels)).toBe(2)
+        expect(await counterValue(kafkaProducerBrokerRxErrorsTotal, labels)).toBe(5)
         expect(await counterValue(kafkaProducerBrokerRequestTimeoutsTotal, labels)).toBeUndefined()
     })
 

--- a/nodejs/src/kafka/kafka-producer-metrics.test.ts
+++ b/nodejs/src/kafka/kafka-producer-metrics.test.ts
@@ -1,19 +1,8 @@
-import { Counter, Gauge, register } from 'prom-client'
+import { Gauge, register } from 'prom-client'
 
 import {
     ProducerStatsTracker,
     kafkaProducerAnyBrokersDown,
-    kafkaProducerBrokerConnected,
-    kafkaProducerBrokerDisconnectsTotal,
-    kafkaProducerBrokerInflightRequests,
-    kafkaProducerBrokerOutbufMessages,
-    kafkaProducerBrokerOutbufRequests,
-    kafkaProducerBrokerRequestTimeoutsTotal,
-    kafkaProducerBrokerRttMicroseconds,
-    kafkaProducerBrokerRxErrorsTotal,
-    kafkaProducerBrokerThrottleMilliseconds,
-    kafkaProducerBrokerTxErrorsTotal,
-    kafkaProducerBrokerTxRetriesTotal,
     kafkaProducerCallbackQueueDepth,
     kafkaProducerQueueBytes,
     kafkaProducerQueueMaxBytes,
@@ -24,11 +13,6 @@ import {
 } from './kafka-producer-metrics'
 
 async function gaugeValue(metric: Gauge<string>, labels: Record<string, string>): Promise<number | undefined> {
-    const snapshot = await metric.get()
-    return snapshot.values.find((v) => JSON.stringify(v.labels) === JSON.stringify(labels))?.value
-}
-
-async function counterValue(metric: Counter<string>, labels: Record<string, string>): Promise<number | undefined> {
     const snapshot = await metric.get()
     return snapshot.values.find((v) => JSON.stringify(v.labels) === JSON.stringify(labels))?.value
 }
@@ -44,26 +28,6 @@ function makeStats(overrides: Record<string, any> = {}): string {
         topics: {},
         ...overrides,
     })
-}
-
-function makeBroker(overrides: Record<string, any> = {}): any {
-    return {
-        name: 'kafka-1:9092/1',
-        nodeid: 1,
-        state: 'UP',
-        outbuf_cnt: 0,
-        outbuf_msg_cnt: 0,
-        waitresp_cnt: 0,
-        tx: 0,
-        txerrs: 0,
-        txretries: 0,
-        req_timeouts: 0,
-        disconnects: 0,
-        rxerrs: 0,
-        rtt: { p50: 0, p90: 0, p95: 0, p99: 0 },
-        throttle: { p50: 0, p90: 0, p95: 0, p99: 0 },
-        ...overrides,
-    }
 }
 
 describe('ProducerStatsTracker', () => {
@@ -84,50 +48,31 @@ describe('ProducerStatsTracker', () => {
         expect(await gaugeValue(kafkaProducerCallbackQueueDepth, labels)).toBe(7)
     })
 
-    it('sets per-broker gauges including state, outbuf, rtt and throttle quantiles', async () => {
-        const tracker = new ProducerStatsTracker('DEFAULT')
-
-        tracker.track(
-            makeStats({
-                brokers: {
-                    'kafka-1:9092/1': makeBroker({
-                        state: 'UP',
-                        outbuf_cnt: 2,
-                        outbuf_msg_cnt: 5,
-                        waitresp_cnt: 3,
-                        rtt: { p50: 100, p90: 500, p95: 800, p99: 1234 },
-                        throttle: { p50: 0, p90: 10, p95: 25, p99: 50 },
-                    }),
-                },
-            })
-        )
-
-        const labels = { producer_name: 'DEFAULT', broker: 'kafka-1:9092/1' }
-        expect(await gaugeValue(kafkaProducerBrokerConnected, labels)).toBe(1)
-        expect(await gaugeValue(kafkaProducerBrokerOutbufMessages, labels)).toBe(5)
-        expect(await gaugeValue(kafkaProducerBrokerOutbufRequests, labels)).toBe(2)
-        expect(await gaugeValue(kafkaProducerBrokerInflightRequests, labels)).toBe(3)
-        expect(await gaugeValue(kafkaProducerBrokerRttMicroseconds, { ...labels, quantile: 'p50' })).toBe(100)
-        expect(await gaugeValue(kafkaProducerBrokerRttMicroseconds, { ...labels, quantile: 'p99' })).toBe(1234)
-        expect(await gaugeValue(kafkaProducerBrokerThrottleMilliseconds, { ...labels, quantile: 'p99' })).toBe(50)
-    })
-
     it('flags any broker not UP via kafkaProducerAnyBrokersDown', async () => {
         const tracker = new ProducerStatsTracker('DEFAULT')
 
         tracker.track(
             makeStats({
                 brokers: {
-                    'kafka-1:9092/1': makeBroker({ state: 'UP' }),
-                    'kafka-2:9092/2': makeBroker({ state: 'DOWN' }),
+                    'kafka-1:9092/1': { state: 'UP' },
+                    'kafka-2:9092/2': { state: 'DOWN' },
                 },
             })
         )
 
         expect(await gaugeValue(kafkaProducerAnyBrokersDown, { producer_name: 'DEFAULT' })).toBe(1)
-        expect(
-            await gaugeValue(kafkaProducerBrokerConnected, { producer_name: 'DEFAULT', broker: 'kafka-2:9092/2' })
-        ).toBe(0)
+    })
+
+    it('reports zero when all known brokers are UP', async () => {
+        const tracker = new ProducerStatsTracker('DEFAULT')
+
+        tracker.track(
+            makeStats({
+                brokers: { 'kafka-1:9092/1': { state: 'UP' }, 'kafka-2:9092/2': { state: 'UP' } },
+            })
+        )
+
+        expect(await gaugeValue(kafkaProducerAnyBrokersDown, { producer_name: 'DEFAULT' })).toBe(0)
     })
 
     it('sets per-topic batching gauges', async () => {
@@ -144,89 +89,6 @@ describe('ProducerStatsTracker', () => {
         const labels = { producer_name: 'DEFAULT', topic: 'events_plugin_ingestion' }
         expect(await gaugeValue(kafkaProducerTopicBatchSizeBytesAvg, labels)).toBe(8192)
         expect(await gaugeValue(kafkaProducerTopicBatchCountAvg, labels)).toBe(42)
-    })
-
-    it('skips the first observation for cumulative counters to avoid spurious jumps', async () => {
-        const tracker = new ProducerStatsTracker('DEFAULT')
-        const labels = { producer_name: 'DEFAULT', broker: 'kafka-1:9092/1' }
-
-        tracker.track(
-            makeStats({
-                brokers: {
-                    'kafka-1:9092/1': makeBroker({ txerrs: 7, txretries: 3, req_timeouts: 2, disconnects: 1 }),
-                },
-            })
-        )
-
-        expect(await counterValue(kafkaProducerBrokerTxErrorsTotal, labels)).toBeUndefined()
-        expect(await counterValue(kafkaProducerBrokerTxRetriesTotal, labels)).toBeUndefined()
-        expect(await counterValue(kafkaProducerBrokerRequestTimeoutsTotal, labels)).toBeUndefined()
-        expect(await counterValue(kafkaProducerBrokerDisconnectsTotal, labels)).toBeUndefined()
-    })
-
-    it('increments counters by delta between observations', async () => {
-        const tracker = new ProducerStatsTracker('DEFAULT')
-        const labels = { producer_name: 'DEFAULT', broker: 'kafka-1:9092/1' }
-
-        tracker.track(
-            makeStats({
-                brokers: {
-                    'kafka-1:9092/1': makeBroker({ txerrs: 5, txretries: 10, req_timeouts: 1, rxerrs: 4 }),
-                },
-            })
-        )
-        tracker.track(
-            makeStats({
-                brokers: {
-                    'kafka-1:9092/1': makeBroker({ txerrs: 8, txretries: 12, req_timeouts: 1, rxerrs: 9 }),
-                },
-            })
-        )
-
-        expect(await counterValue(kafkaProducerBrokerTxErrorsTotal, labels)).toBe(3)
-        expect(await counterValue(kafkaProducerBrokerTxRetriesTotal, labels)).toBe(2)
-        expect(await counterValue(kafkaProducerBrokerRxErrorsTotal, labels)).toBe(5)
-        expect(await counterValue(kafkaProducerBrokerRequestTimeoutsTotal, labels)).toBeUndefined()
-    })
-
-    it('does not decrement counters when librdkafka resets (safety net)', async () => {
-        const tracker = new ProducerStatsTracker('DEFAULT')
-        const labels = { producer_name: 'DEFAULT', broker: 'kafka-1:9092/1' }
-
-        tracker.track(makeStats({ brokers: { 'kafka-1:9092/1': makeBroker({ txerrs: 10 }) } }))
-        tracker.track(makeStats({ brokers: { 'kafka-1:9092/1': makeBroker({ txerrs: 15 }) } }))
-        tracker.track(makeStats({ brokers: { 'kafka-1:9092/1': makeBroker({ txerrs: 5 }) } }))
-        tracker.track(makeStats({ brokers: { 'kafka-1:9092/1': makeBroker({ txerrs: 8 }) } }))
-
-        expect(await counterValue(kafkaProducerBrokerTxErrorsTotal, labels)).toBe(5 + 3)
-    })
-
-    it('tracks deltas independently per broker', async () => {
-        const tracker = new ProducerStatsTracker('DEFAULT')
-
-        tracker.track(
-            makeStats({
-                brokers: {
-                    'kafka-1:9092/1': makeBroker({ txerrs: 1 }),
-                    'kafka-2:9092/2': makeBroker({ txerrs: 100 }),
-                },
-            })
-        )
-        tracker.track(
-            makeStats({
-                brokers: {
-                    'kafka-1:9092/1': makeBroker({ txerrs: 3 }),
-                    'kafka-2:9092/2': makeBroker({ txerrs: 105 }),
-                },
-            })
-        )
-
-        expect(
-            await counterValue(kafkaProducerBrokerTxErrorsTotal, { producer_name: 'DEFAULT', broker: 'kafka-1:9092/1' })
-        ).toBe(2)
-        expect(
-            await counterValue(kafkaProducerBrokerTxErrorsTotal, { producer_name: 'DEFAULT', broker: 'kafka-2:9092/2' })
-        ).toBe(5)
     })
 
     it('swallows invalid JSON', () => {

--- a/nodejs/src/kafka/kafka-producer-metrics.test.ts
+++ b/nodejs/src/kafka/kafka-producer-metrics.test.ts
@@ -1,0 +1,175 @@
+import { Counter, Gauge, register } from 'prom-client'
+
+import {
+    ProducerStatsTracker,
+    kafkaProducerBrokerDisconnectsTotal,
+    kafkaProducerBrokerInflightRequests,
+    kafkaProducerBrokerOutbufMessages,
+    kafkaProducerBrokerRequestTimeoutsTotal,
+    kafkaProducerBrokerRttP99Microseconds,
+    kafkaProducerBrokerThrottleP99Milliseconds,
+    kafkaProducerBrokerTxErrorsTotal,
+    kafkaProducerBrokerTxRetriesTotal,
+    kafkaProducerQueueBytes,
+    kafkaProducerQueueMaxBytes,
+    kafkaProducerQueueMaxMessages,
+    kafkaProducerQueueMessages,
+} from './kafka-producer-metrics'
+
+async function gaugeValue(metric: Gauge<string>, labels: Record<string, string>): Promise<number | undefined> {
+    const snapshot = await metric.get()
+    return snapshot.values.find((v) => JSON.stringify(v.labels) === JSON.stringify(labels))?.value
+}
+
+async function counterValue(metric: Counter<string>, labels: Record<string, string>): Promise<number | undefined> {
+    const snapshot = await metric.get()
+    return snapshot.values.find((v) => JSON.stringify(v.labels) === JSON.stringify(labels))?.value
+}
+
+function makeStats(overrides: Record<string, any> = {}): string {
+    return JSON.stringify({
+        msg_cnt: 10,
+        msg_size: 1024,
+        msg_max: 100_000,
+        msg_size_max: 1_073_741_824,
+        brokers: {},
+        ...overrides,
+    })
+}
+
+function makeBroker(overrides: Record<string, any> = {}): any {
+    return {
+        name: 'kafka-1:9092/1',
+        nodeid: 1,
+        outbuf_msg_cnt: 0,
+        waitresp_cnt: 0,
+        tx: 0,
+        txerrs: 0,
+        txretries: 0,
+        req_timeouts: 0,
+        disconnects: 0,
+        rtt: { p99: 0 },
+        throttle: { p99: 0 },
+        ...overrides,
+    }
+}
+
+describe('ProducerStatsTracker', () => {
+    beforeEach(() => {
+        register.resetMetrics()
+    })
+
+    it('sets top-level queue gauges', async () => {
+        const tracker = new ProducerStatsTracker('DEFAULT')
+
+        tracker.track(makeStats({ msg_cnt: 42, msg_size: 9000, msg_max: 100_000, msg_size_max: 1_000_000 }))
+
+        const labels = { producer_name: 'DEFAULT' }
+        expect(await gaugeValue(kafkaProducerQueueMessages, labels)).toBe(42)
+        expect(await gaugeValue(kafkaProducerQueueBytes, labels)).toBe(9000)
+        expect(await gaugeValue(kafkaProducerQueueMaxMessages, labels)).toBe(100_000)
+        expect(await gaugeValue(kafkaProducerQueueMaxBytes, labels)).toBe(1_000_000)
+    })
+
+    it('sets per-broker gauges including rtt and throttle p99', async () => {
+        const tracker = new ProducerStatsTracker('DEFAULT')
+
+        tracker.track(
+            makeStats({
+                brokers: {
+                    'kafka-1:9092/1': makeBroker({
+                        outbuf_msg_cnt: 5,
+                        waitresp_cnt: 3,
+                        rtt: { p99: 1234 },
+                        throttle: { p99: 50 },
+                    }),
+                },
+            })
+        )
+
+        const labels = { producer_name: 'DEFAULT', broker: 'kafka-1:9092/1' }
+        expect(await gaugeValue(kafkaProducerBrokerOutbufMessages, labels)).toBe(5)
+        expect(await gaugeValue(kafkaProducerBrokerInflightRequests, labels)).toBe(3)
+        expect(await gaugeValue(kafkaProducerBrokerRttP99Microseconds, labels)).toBe(1234)
+        expect(await gaugeValue(kafkaProducerBrokerThrottleP99Milliseconds, labels)).toBe(50)
+    })
+
+    it('skips the first observation for cumulative counters to avoid spurious jumps', async () => {
+        const tracker = new ProducerStatsTracker('DEFAULT')
+        const labels = { producer_name: 'DEFAULT', broker: 'kafka-1:9092/1' }
+
+        tracker.track(
+            makeStats({
+                brokers: {
+                    'kafka-1:9092/1': makeBroker({ txerrs: 7, txretries: 3, req_timeouts: 2, disconnects: 1 }),
+                },
+            })
+        )
+
+        expect(await counterValue(kafkaProducerBrokerTxErrorsTotal, labels)).toBeUndefined()
+        expect(await counterValue(kafkaProducerBrokerTxRetriesTotal, labels)).toBeUndefined()
+        expect(await counterValue(kafkaProducerBrokerRequestTimeoutsTotal, labels)).toBeUndefined()
+        expect(await counterValue(kafkaProducerBrokerDisconnectsTotal, labels)).toBeUndefined()
+    })
+
+    it('increments counters by delta between observations', async () => {
+        const tracker = new ProducerStatsTracker('DEFAULT')
+        const labels = { producer_name: 'DEFAULT', broker: 'kafka-1:9092/1' }
+
+        tracker.track(
+            makeStats({ brokers: { 'kafka-1:9092/1': makeBroker({ txerrs: 5, txretries: 10, req_timeouts: 1 }) } })
+        )
+        tracker.track(
+            makeStats({ brokers: { 'kafka-1:9092/1': makeBroker({ txerrs: 8, txretries: 12, req_timeouts: 1 }) } })
+        )
+
+        expect(await counterValue(kafkaProducerBrokerTxErrorsTotal, labels)).toBe(3)
+        expect(await counterValue(kafkaProducerBrokerTxRetriesTotal, labels)).toBe(2)
+        expect(await counterValue(kafkaProducerBrokerRequestTimeoutsTotal, labels)).toBeUndefined()
+    })
+
+    it('does not decrement counters when librdkafka resets (safety net)', async () => {
+        const tracker = new ProducerStatsTracker('DEFAULT')
+        const labels = { producer_name: 'DEFAULT', broker: 'kafka-1:9092/1' }
+
+        tracker.track(makeStats({ brokers: { 'kafka-1:9092/1': makeBroker({ txerrs: 10 }) } }))
+        tracker.track(makeStats({ brokers: { 'kafka-1:9092/1': makeBroker({ txerrs: 15 }) } }))
+        tracker.track(makeStats({ brokers: { 'kafka-1:9092/1': makeBroker({ txerrs: 5 }) } }))
+        tracker.track(makeStats({ brokers: { 'kafka-1:9092/1': makeBroker({ txerrs: 8 }) } }))
+
+        expect(await counterValue(kafkaProducerBrokerTxErrorsTotal, labels)).toBe(5 + 3)
+    })
+
+    it('tracks deltas independently per broker', async () => {
+        const tracker = new ProducerStatsTracker('DEFAULT')
+
+        tracker.track(
+            makeStats({
+                brokers: {
+                    'kafka-1:9092/1': makeBroker({ txerrs: 1 }),
+                    'kafka-2:9092/2': makeBroker({ txerrs: 100 }),
+                },
+            })
+        )
+        tracker.track(
+            makeStats({
+                brokers: {
+                    'kafka-1:9092/1': makeBroker({ txerrs: 3 }),
+                    'kafka-2:9092/2': makeBroker({ txerrs: 105 }),
+                },
+            })
+        )
+
+        expect(
+            await counterValue(kafkaProducerBrokerTxErrorsTotal, { producer_name: 'DEFAULT', broker: 'kafka-1:9092/1' })
+        ).toBe(2)
+        expect(
+            await counterValue(kafkaProducerBrokerTxErrorsTotal, { producer_name: 'DEFAULT', broker: 'kafka-2:9092/2' })
+        ).toBe(5)
+    })
+
+    it('swallows invalid JSON', () => {
+        const tracker = new ProducerStatsTracker('DEFAULT')
+        expect(() => tracker.track('not json')).not.toThrow()
+    })
+})

--- a/nodejs/src/kafka/kafka-producer-metrics.ts
+++ b/nodejs/src/kafka/kafka-producer-metrics.ts
@@ -2,7 +2,7 @@ import { Counter, Gauge } from 'prom-client'
 
 import { parseJSON } from '../utils/json-parse'
 import { logger } from '../utils/logger'
-import { BrokerStats, parseBrokerStatistics } from './kafka-client-metrics'
+import { BrokerStats, TopicStats, producerStatsSchema } from './kafka-producer-stats-schema'
 
 export const kafkaProducerQueueMessages = new Gauge({
     name: 'kafka_producer_queue_messages',
@@ -128,11 +128,6 @@ type CumulativeBrokerStats = {
     rxerrs: number
 }
 
-type TopicStats = {
-    batchsize?: { avg?: number }
-    batchcnt?: { avg?: number }
-}
-
 /**
  * Tracks per-broker cumulative counter deltas so we can expose librdkafka's
  * monotonic counters as Prometheus counters. Stateful per producer instance.
@@ -146,47 +141,58 @@ export class ProducerStatsTracker {
     }
 
     track(statsJson: string): void {
-        let parsed: any
+        let raw: unknown
         try {
-            parsed = parseJSON(statsJson)
+            raw = parseJSON(statsJson)
         } catch (error) {
-            logger.error('📊', 'Failed to parse producer statistics', {
+            logger.warn('📊', 'Failed to parse producer statistics JSON', {
                 producer_name: this.producerName,
                 error: error instanceof Error ? error.message : String(error),
             })
             return
         }
 
+        const result = producerStatsSchema.safeParse(raw)
+        if (!result.success) {
+            logger.warn('📊', 'Producer statistics did not match expected schema', {
+                producer_name: this.producerName,
+                issues: result.error.issues,
+            })
+            return
+        }
+        const stats = result.data
+
         const labels = { producer_name: this.producerName }
 
-        if (typeof parsed.msg_cnt === 'number') {
-            kafkaProducerQueueMessages.set(labels, parsed.msg_cnt)
+        if (stats.msg_cnt !== undefined) {
+            kafkaProducerQueueMessages.set(labels, stats.msg_cnt)
         }
-        if (typeof parsed.msg_size === 'number') {
-            kafkaProducerQueueBytes.set(labels, parsed.msg_size)
+        if (stats.msg_size !== undefined) {
+            kafkaProducerQueueBytes.set(labels, stats.msg_size)
         }
-        if (typeof parsed.msg_max === 'number') {
-            kafkaProducerQueueMaxMessages.set(labels, parsed.msg_max)
+        if (stats.msg_max !== undefined) {
+            kafkaProducerQueueMaxMessages.set(labels, stats.msg_max)
         }
-        if (typeof parsed.msg_size_max === 'number') {
-            kafkaProducerQueueMaxBytes.set(labels, parsed.msg_size_max)
+        if (stats.msg_size_max !== undefined) {
+            kafkaProducerQueueMaxBytes.set(labels, stats.msg_size_max)
         }
-        if (typeof parsed.replyq === 'number') {
-            kafkaProducerCallbackQueueDepth.set(labels, parsed.replyq)
-        }
-
-        const brokers = parseBrokerStatistics(parsed)
-        if (brokers.size > 0) {
-            const anyDown = [...brokers.values()].some((b) => b.state !== 'UP')
-            kafkaProducerAnyBrokersDown.set(labels, anyDown ? 1 : 0)
+        if (stats.replyq !== undefined) {
+            kafkaProducerCallbackQueueDepth.set(labels, stats.replyq)
         }
 
-        for (const [brokerName, broker] of brokers) {
-            this.trackBroker(brokerName, broker)
+        if (stats.brokers) {
+            const brokerEntries = Object.entries(stats.brokers)
+            if (brokerEntries.length > 0) {
+                const anyDown = brokerEntries.some(([, b]) => b.state !== 'UP')
+                kafkaProducerAnyBrokersDown.set(labels, anyDown ? 1 : 0)
+            }
+            for (const [brokerName, broker] of brokerEntries) {
+                this.trackBroker(brokerName, broker)
+            }
         }
 
-        if (parsed.topics && typeof parsed.topics === 'object') {
-            for (const [topic, topicStats] of Object.entries(parsed.topics as Record<string, TopicStats>)) {
+        if (stats.topics) {
+            for (const [topic, topicStats] of Object.entries(stats.topics)) {
                 this.trackTopic(topic, topicStats)
             }
         }
@@ -202,7 +208,7 @@ export class ProducerStatsTracker {
         if (broker.rtt) {
             for (const q of RTT_QUANTILES) {
                 const value = broker.rtt[q]
-                if (typeof value === 'number') {
+                if (value !== undefined) {
                     kafkaProducerBrokerRttMicroseconds.set({ ...labels, quantile: q }, value)
                 }
             }
@@ -210,7 +216,7 @@ export class ProducerStatsTracker {
         if (broker.throttle) {
             for (const q of RTT_QUANTILES) {
                 const value = broker.throttle[q]
-                if (typeof value === 'number') {
+                if (value !== undefined) {
                     kafkaProducerBrokerThrottleMilliseconds.set({ ...labels, quantile: q }, value)
                 }
             }
@@ -239,10 +245,10 @@ export class ProducerStatsTracker {
 
     private trackTopic(topic: string, stats: TopicStats): void {
         const labels = { producer_name: this.producerName, topic }
-        if (typeof stats.batchsize?.avg === 'number') {
+        if (stats.batchsize?.avg !== undefined) {
             kafkaProducerTopicBatchSizeBytesAvg.set(labels, stats.batchsize.avg)
         }
-        if (typeof stats.batchcnt?.avg === 'number') {
+        if (stats.batchcnt?.avg !== undefined) {
             kafkaProducerTopicBatchCountAvg.set(labels, stats.batchcnt.avg)
         }
     }

--- a/nodejs/src/kafka/kafka-producer-metrics.ts
+++ b/nodejs/src/kafka/kafka-producer-metrics.ts
@@ -1,0 +1,166 @@
+import { Counter, Gauge } from 'prom-client'
+
+import { parseJSON } from '../utils/json-parse'
+import { logger } from '../utils/logger'
+import { BrokerStats, parseBrokerStatistics } from './kafka-client-metrics'
+
+export const kafkaProducerQueueMessages = new Gauge({
+    name: 'kafka_producer_queue_messages',
+    help: 'Current number of messages in the producer queue.',
+    labelNames: ['producer_name'],
+})
+
+export const kafkaProducerQueueBytes = new Gauge({
+    name: 'kafka_producer_queue_bytes',
+    help: 'Current size in bytes of messages in the producer queue.',
+    labelNames: ['producer_name'],
+})
+
+export const kafkaProducerQueueMaxMessages = new Gauge({
+    name: 'kafka_producer_queue_max_messages',
+    help: 'Maximum number of messages allowed in the producer queue.',
+    labelNames: ['producer_name'],
+})
+
+export const kafkaProducerQueueMaxBytes = new Gauge({
+    name: 'kafka_producer_queue_max_bytes',
+    help: 'Maximum size in bytes allowed in the producer queue.',
+    labelNames: ['producer_name'],
+})
+
+export const kafkaProducerBrokerOutbufMessages = new Gauge({
+    name: 'kafka_producer_broker_outbuf_messages',
+    help: 'Messages awaiting transmission to the broker.',
+    labelNames: ['producer_name', 'broker'],
+})
+
+export const kafkaProducerBrokerInflightRequests = new Gauge({
+    name: 'kafka_producer_broker_inflight_requests',
+    help: 'Requests sent to broker awaiting response.',
+    labelNames: ['producer_name', 'broker'],
+})
+
+export const kafkaProducerBrokerRttP99Microseconds = new Gauge({
+    name: 'kafka_producer_broker_rtt_p99_microseconds',
+    help: 'Broker round-trip time p99 over the rolling librdkafka window, in microseconds.',
+    labelNames: ['producer_name', 'broker'],
+})
+
+export const kafkaProducerBrokerThrottleP99Milliseconds = new Gauge({
+    name: 'kafka_producer_broker_throttle_p99_milliseconds',
+    help: 'Broker throttle duration p99 over the rolling librdkafka window, in milliseconds.',
+    labelNames: ['producer_name', 'broker'],
+})
+
+export const kafkaProducerBrokerTxErrorsTotal = new Counter({
+    name: 'kafka_producer_broker_tx_errors_total',
+    help: 'Broker transmit errors reported by librdkafka.',
+    labelNames: ['producer_name', 'broker'],
+})
+
+export const kafkaProducerBrokerTxRetriesTotal = new Counter({
+    name: 'kafka_producer_broker_tx_retries_total',
+    help: 'Broker transmit retries reported by librdkafka.',
+    labelNames: ['producer_name', 'broker'],
+})
+
+export const kafkaProducerBrokerRequestTimeoutsTotal = new Counter({
+    name: 'kafka_producer_broker_request_timeouts_total',
+    help: 'Broker request timeouts reported by librdkafka.',
+    labelNames: ['producer_name', 'broker'],
+})
+
+export const kafkaProducerBrokerDisconnectsTotal = new Counter({
+    name: 'kafka_producer_broker_disconnects_total',
+    help: 'Broker disconnects reported by librdkafka.',
+    labelNames: ['producer_name', 'broker'],
+})
+
+type CumulativeBrokerStats = {
+    txerrs: number
+    txretries: number
+    req_timeouts: number
+    disconnects: number
+}
+
+/**
+ * Tracks per-broker cumulative counter deltas so we can expose librdkafka's
+ * monotonic counters as Prometheus counters. Stateful per producer instance.
+ */
+export class ProducerStatsTracker {
+    private producerName: string
+    private lastBrokerCounters = new Map<string, CumulativeBrokerStats>()
+
+    constructor(producerName: string) {
+        this.producerName = producerName
+    }
+
+    track(statsJson: string): void {
+        let parsed: any
+        try {
+            parsed = parseJSON(statsJson)
+        } catch (error) {
+            logger.error('📊', 'Failed to parse producer statistics', {
+                producer_name: this.producerName,
+                error: error instanceof Error ? error.message : String(error),
+            })
+            return
+        }
+
+        const labels = { producer_name: this.producerName }
+
+        if (typeof parsed.msg_cnt === 'number') {
+            kafkaProducerQueueMessages.set(labels, parsed.msg_cnt)
+        }
+        if (typeof parsed.msg_size === 'number') {
+            kafkaProducerQueueBytes.set(labels, parsed.msg_size)
+        }
+        if (typeof parsed.msg_max === 'number') {
+            kafkaProducerQueueMaxMessages.set(labels, parsed.msg_max)
+        }
+        if (typeof parsed.msg_size_max === 'number') {
+            kafkaProducerQueueMaxBytes.set(labels, parsed.msg_size_max)
+        }
+
+        for (const [brokerName, broker] of parseBrokerStatistics(parsed)) {
+            this.trackBroker(brokerName, broker)
+        }
+    }
+
+    private trackBroker(brokerName: string, broker: BrokerStats): void {
+        const labels = { producer_name: this.producerName, broker: brokerName }
+
+        kafkaProducerBrokerOutbufMessages.set(labels, broker.outbuf_msg_cnt ?? 0)
+        kafkaProducerBrokerInflightRequests.set(labels, broker.waitresp_cnt ?? 0)
+        if (broker.rtt?.p99) {
+            kafkaProducerBrokerRttP99Microseconds.set(labels, broker.rtt.p99)
+        }
+        if (broker.throttle?.p99) {
+            kafkaProducerBrokerThrottleP99Milliseconds.set(labels, broker.throttle.p99)
+        }
+
+        const current: CumulativeBrokerStats = {
+            txerrs: broker.txerrs ?? 0,
+            txretries: broker.txretries ?? 0,
+            req_timeouts: broker.req_timeouts ?? 0,
+            disconnects: broker.disconnects ?? 0,
+        }
+
+        // Skip the first observation per broker — otherwise we'd jump the Prom counter by
+        // whatever librdkafka accumulated before our first tick (usually zero, but not always).
+        const last = this.lastBrokerCounters.get(brokerName)
+        if (last) {
+            incIfIncreased(kafkaProducerBrokerTxErrorsTotal, labels, current.txerrs, last.txerrs)
+            incIfIncreased(kafkaProducerBrokerTxRetriesTotal, labels, current.txretries, last.txretries)
+            incIfIncreased(kafkaProducerBrokerRequestTimeoutsTotal, labels, current.req_timeouts, last.req_timeouts)
+            incIfIncreased(kafkaProducerBrokerDisconnectsTotal, labels, current.disconnects, last.disconnects)
+        }
+        this.lastBrokerCounters.set(brokerName, current)
+    }
+}
+
+function incIfIncreased(counter: Counter<string>, labels: Record<string, string>, current: number, last: number): void {
+    if (current > last) {
+        counter.inc(labels, current - last)
+    }
+}

--- a/nodejs/src/kafka/kafka-producer-metrics.ts
+++ b/nodejs/src/kafka/kafka-producer-metrics.ts
@@ -1,8 +1,8 @@
-import { Counter, Gauge } from 'prom-client'
+import { Gauge } from 'prom-client'
 
 import { parseJSON } from '../utils/json-parse'
 import { logger } from '../utils/logger'
-import { BrokerStats, TopicStats, producerStatsSchema } from './kafka-producer-stats-schema'
+import { producerStatsSchema } from './kafka-producer-stats-schema'
 
 export const kafkaProducerQueueMessages = new Gauge({
     name: 'kafka_producer_queue_messages',
@@ -36,7 +36,7 @@ export const kafkaProducerCallbackQueueDepth = new Gauge({
 
 export const kafkaProducerAnyBrokersDown = new Gauge({
     name: 'kafka_producer_any_brokers_down',
-    help: '1 if any broker is not in the UP state, 0 otherwise.',
+    help: '1 if any broker the producer knows about is not in the UP state, 0 otherwise.',
     labelNames: ['producer_name'],
 })
 
@@ -52,89 +52,15 @@ export const kafkaProducerTopicBatchCountAvg = new Gauge({
     labelNames: ['producer_name', 'topic'],
 })
 
-export const kafkaProducerBrokerConnected = new Gauge({
-    name: 'kafka_producer_broker_connected',
-    help: '1 if the broker is in the UP state, 0 otherwise.',
-    labelNames: ['producer_name', 'broker'],
-})
-
-export const kafkaProducerBrokerOutbufMessages = new Gauge({
-    name: 'kafka_producer_broker_outbuf_messages',
-    help: 'Messages awaiting transmission to the broker.',
-    labelNames: ['producer_name', 'broker'],
-})
-
-export const kafkaProducerBrokerOutbufRequests = new Gauge({
-    name: 'kafka_producer_broker_outbuf_requests',
-    help: 'Protocol requests awaiting transmission to the broker.',
-    labelNames: ['producer_name', 'broker'],
-})
-
-export const kafkaProducerBrokerInflightRequests = new Gauge({
-    name: 'kafka_producer_broker_inflight_requests',
-    help: 'Requests sent to broker awaiting response.',
-    labelNames: ['producer_name', 'broker'],
-})
-
-export const kafkaProducerBrokerRttMicroseconds = new Gauge({
-    name: 'kafka_producer_broker_rtt_microseconds',
-    help: 'Broker round-trip time in microseconds, over the rolling librdkafka window. Labelled by quantile.',
-    labelNames: ['producer_name', 'broker', 'quantile'],
-})
-
-export const kafkaProducerBrokerThrottleMilliseconds = new Gauge({
-    name: 'kafka_producer_broker_throttle_milliseconds',
-    help: 'Broker throttle duration in milliseconds, over the rolling librdkafka window. Labelled by quantile.',
-    labelNames: ['producer_name', 'broker', 'quantile'],
-})
-
-export const kafkaProducerBrokerTxErrorsTotal = new Counter({
-    name: 'kafka_producer_broker_tx_errors_total',
-    help: 'Broker transmit errors reported by librdkafka.',
-    labelNames: ['producer_name', 'broker'],
-})
-
-export const kafkaProducerBrokerRxErrorsTotal = new Counter({
-    name: 'kafka_producer_broker_rx_errors_total',
-    help: 'Broker receive errors reported by librdkafka.',
-    labelNames: ['producer_name', 'broker'],
-})
-
-export const kafkaProducerBrokerTxRetriesTotal = new Counter({
-    name: 'kafka_producer_broker_tx_retries_total',
-    help: 'Broker transmit retries reported by librdkafka.',
-    labelNames: ['producer_name', 'broker'],
-})
-
-export const kafkaProducerBrokerRequestTimeoutsTotal = new Counter({
-    name: 'kafka_producer_broker_request_timeouts_total',
-    help: 'Broker request timeouts reported by librdkafka.',
-    labelNames: ['producer_name', 'broker'],
-})
-
-export const kafkaProducerBrokerDisconnectsTotal = new Counter({
-    name: 'kafka_producer_broker_disconnects_total',
-    help: 'Broker disconnects reported by librdkafka.',
-    labelNames: ['producer_name', 'broker'],
-})
-
-const RTT_QUANTILES = ['p50', 'p90', 'p95', 'p99'] as const
-
-type CumulativeBrokerStats = {
-    txerrs: number
-    txretries: number
-    req_timeouts: number
-    disconnects: number
-    rxerrs: number
-}
-
 /**
- * Tracks per-broker cumulative counter deltas so we can expose librdkafka's
- * monotonic counters as Prometheus counters. Stateful per producer instance.
+ * Translates the librdkafka stats JSON emitted by the producer into Prometheus series.
+ *
+ * Deliberately does NOT fan out per-broker series: the {producer_name, broker} cross
+ * product would explode cardinality. Broker-level observability is available via the
+ * Kafka broker's own metrics — here we keep only client-level rollups.
  */
 export class ProducerStatsTracker {
     private producerName: string
-    private lastBrokerCounters = new Map<string, CumulativeBrokerStats>()
 
     constructor(producerName: string) {
         this.producerName = producerName
@@ -181,81 +107,23 @@ export class ProducerStatsTracker {
         }
 
         if (stats.brokers) {
-            const brokerEntries = Object.entries(stats.brokers)
-            if (brokerEntries.length > 0) {
-                const anyDown = brokerEntries.some(([, b]) => b.state !== 'UP')
+            const brokers = Object.values(stats.brokers)
+            if (brokers.length > 0) {
+                const anyDown = brokers.some((b) => b.state !== 'UP')
                 kafkaProducerAnyBrokersDown.set(labels, anyDown ? 1 : 0)
-            }
-            for (const [brokerName, broker] of brokerEntries) {
-                this.trackBroker(brokerName, broker)
             }
         }
 
         if (stats.topics) {
             for (const [topic, topicStats] of Object.entries(stats.topics)) {
-                this.trackTopic(topic, topicStats)
-            }
-        }
-    }
-
-    private trackBroker(brokerName: string, broker: BrokerStats): void {
-        const labels = { producer_name: this.producerName, broker: brokerName }
-
-        kafkaProducerBrokerConnected.set(labels, broker.state === 'UP' ? 1 : 0)
-        kafkaProducerBrokerOutbufMessages.set(labels, broker.outbuf_msg_cnt ?? 0)
-        kafkaProducerBrokerOutbufRequests.set(labels, broker.outbuf_cnt ?? 0)
-        kafkaProducerBrokerInflightRequests.set(labels, broker.waitresp_cnt ?? 0)
-        if (broker.rtt) {
-            for (const q of RTT_QUANTILES) {
-                const value = broker.rtt[q]
-                if (value !== undefined) {
-                    kafkaProducerBrokerRttMicroseconds.set({ ...labels, quantile: q }, value)
+                const topicLabels = { producer_name: this.producerName, topic }
+                if (topicStats.batchsize?.avg !== undefined) {
+                    kafkaProducerTopicBatchSizeBytesAvg.set(topicLabels, topicStats.batchsize.avg)
+                }
+                if (topicStats.batchcnt?.avg !== undefined) {
+                    kafkaProducerTopicBatchCountAvg.set(topicLabels, topicStats.batchcnt.avg)
                 }
             }
         }
-        if (broker.throttle) {
-            for (const q of RTT_QUANTILES) {
-                const value = broker.throttle[q]
-                if (value !== undefined) {
-                    kafkaProducerBrokerThrottleMilliseconds.set({ ...labels, quantile: q }, value)
-                }
-            }
-        }
-
-        const current: CumulativeBrokerStats = {
-            txerrs: broker.txerrs ?? 0,
-            txretries: broker.txretries ?? 0,
-            req_timeouts: broker.req_timeouts ?? 0,
-            disconnects: broker.disconnects ?? 0,
-            rxerrs: broker.rxerrs ?? 0,
-        }
-
-        // Skip the first observation per broker — otherwise we'd jump the Prom counter by
-        // whatever librdkafka accumulated before our first tick (usually zero, but not always).
-        const last = this.lastBrokerCounters.get(brokerName)
-        if (last) {
-            incIfIncreased(kafkaProducerBrokerTxErrorsTotal, labels, current.txerrs, last.txerrs)
-            incIfIncreased(kafkaProducerBrokerRxErrorsTotal, labels, current.rxerrs, last.rxerrs)
-            incIfIncreased(kafkaProducerBrokerTxRetriesTotal, labels, current.txretries, last.txretries)
-            incIfIncreased(kafkaProducerBrokerRequestTimeoutsTotal, labels, current.req_timeouts, last.req_timeouts)
-            incIfIncreased(kafkaProducerBrokerDisconnectsTotal, labels, current.disconnects, last.disconnects)
-        }
-        this.lastBrokerCounters.set(brokerName, current)
-    }
-
-    private trackTopic(topic: string, stats: TopicStats): void {
-        const labels = { producer_name: this.producerName, topic }
-        if (stats.batchsize?.avg !== undefined) {
-            kafkaProducerTopicBatchSizeBytesAvg.set(labels, stats.batchsize.avg)
-        }
-        if (stats.batchcnt?.avg !== undefined) {
-            kafkaProducerTopicBatchCountAvg.set(labels, stats.batchcnt.avg)
-        }
-    }
-}
-
-function incIfIncreased(counter: Counter<string>, labels: Record<string, string>, current: number, last: number): void {
-    if (current > last) {
-        counter.inc(labels, current - last)
     }
 }

--- a/nodejs/src/kafka/kafka-producer-metrics.ts
+++ b/nodejs/src/kafka/kafka-producer-metrics.ts
@@ -28,9 +28,45 @@ export const kafkaProducerQueueMaxBytes = new Gauge({
     labelNames: ['producer_name'],
 })
 
+export const kafkaProducerCallbackQueueDepth = new Gauge({
+    name: 'kafka_producer_callback_queue_depth',
+    help: 'Number of delivery-report callbacks queued for the main thread to process.',
+    labelNames: ['producer_name'],
+})
+
+export const kafkaProducerAnyBrokersDown = new Gauge({
+    name: 'kafka_producer_any_brokers_down',
+    help: '1 if any broker is not in the UP state, 0 otherwise.',
+    labelNames: ['producer_name'],
+})
+
+export const kafkaProducerTopicBatchSizeBytesAvg = new Gauge({
+    name: 'kafka_producer_topic_batch_size_bytes_avg',
+    help: 'Average Kafka produce batch size in bytes, per topic, over the rolling librdkafka window.',
+    labelNames: ['producer_name', 'topic'],
+})
+
+export const kafkaProducerTopicBatchCountAvg = new Gauge({
+    name: 'kafka_producer_topic_batch_count_avg',
+    help: 'Average number of messages per produce batch, per topic, over the rolling librdkafka window.',
+    labelNames: ['producer_name', 'topic'],
+})
+
+export const kafkaProducerBrokerConnected = new Gauge({
+    name: 'kafka_producer_broker_connected',
+    help: '1 if the broker is in the UP state, 0 otherwise.',
+    labelNames: ['producer_name', 'broker'],
+})
+
 export const kafkaProducerBrokerOutbufMessages = new Gauge({
     name: 'kafka_producer_broker_outbuf_messages',
     help: 'Messages awaiting transmission to the broker.',
+    labelNames: ['producer_name', 'broker'],
+})
+
+export const kafkaProducerBrokerOutbufRequests = new Gauge({
+    name: 'kafka_producer_broker_outbuf_requests',
+    help: 'Protocol requests awaiting transmission to the broker.',
     labelNames: ['producer_name', 'broker'],
 })
 
@@ -40,21 +76,27 @@ export const kafkaProducerBrokerInflightRequests = new Gauge({
     labelNames: ['producer_name', 'broker'],
 })
 
-export const kafkaProducerBrokerRttP99Microseconds = new Gauge({
-    name: 'kafka_producer_broker_rtt_p99_microseconds',
-    help: 'Broker round-trip time p99 over the rolling librdkafka window, in microseconds.',
-    labelNames: ['producer_name', 'broker'],
+export const kafkaProducerBrokerRttMicroseconds = new Gauge({
+    name: 'kafka_producer_broker_rtt_microseconds',
+    help: 'Broker round-trip time in microseconds, over the rolling librdkafka window. Labelled by quantile.',
+    labelNames: ['producer_name', 'broker', 'quantile'],
 })
 
-export const kafkaProducerBrokerThrottleP99Milliseconds = new Gauge({
-    name: 'kafka_producer_broker_throttle_p99_milliseconds',
-    help: 'Broker throttle duration p99 over the rolling librdkafka window, in milliseconds.',
-    labelNames: ['producer_name', 'broker'],
+export const kafkaProducerBrokerThrottleMilliseconds = new Gauge({
+    name: 'kafka_producer_broker_throttle_milliseconds',
+    help: 'Broker throttle duration in milliseconds, over the rolling librdkafka window. Labelled by quantile.',
+    labelNames: ['producer_name', 'broker', 'quantile'],
 })
 
 export const kafkaProducerBrokerTxErrorsTotal = new Counter({
     name: 'kafka_producer_broker_tx_errors_total',
     help: 'Broker transmit errors reported by librdkafka.',
+    labelNames: ['producer_name', 'broker'],
+})
+
+export const kafkaProducerBrokerRxErrorsTotal = new Counter({
+    name: 'kafka_producer_broker_rx_errors_total',
+    help: 'Broker receive errors reported by librdkafka.',
     labelNames: ['producer_name', 'broker'],
 })
 
@@ -76,11 +118,19 @@ export const kafkaProducerBrokerDisconnectsTotal = new Counter({
     labelNames: ['producer_name', 'broker'],
 })
 
+const RTT_QUANTILES = ['p50', 'p90', 'p95', 'p99'] as const
+
 type CumulativeBrokerStats = {
     txerrs: number
     txretries: number
     req_timeouts: number
     disconnects: number
+    rxerrs: number
+}
+
+type TopicStats = {
+    batchsize?: { avg?: number }
+    batchcnt?: { avg?: number }
 }
 
 /**
@@ -121,22 +171,49 @@ export class ProducerStatsTracker {
         if (typeof parsed.msg_size_max === 'number') {
             kafkaProducerQueueMaxBytes.set(labels, parsed.msg_size_max)
         }
+        if (typeof parsed.replyq === 'number') {
+            kafkaProducerCallbackQueueDepth.set(labels, parsed.replyq)
+        }
 
-        for (const [brokerName, broker] of parseBrokerStatistics(parsed)) {
+        const brokers = parseBrokerStatistics(parsed)
+        if (brokers.size > 0) {
+            const anyDown = [...brokers.values()].some((b) => b.state !== 'UP')
+            kafkaProducerAnyBrokersDown.set(labels, anyDown ? 1 : 0)
+        }
+
+        for (const [brokerName, broker] of brokers) {
             this.trackBroker(brokerName, broker)
+        }
+
+        if (parsed.topics && typeof parsed.topics === 'object') {
+            for (const [topic, topicStats] of Object.entries(parsed.topics as Record<string, TopicStats>)) {
+                this.trackTopic(topic, topicStats)
+            }
         }
     }
 
     private trackBroker(brokerName: string, broker: BrokerStats): void {
         const labels = { producer_name: this.producerName, broker: brokerName }
 
+        kafkaProducerBrokerConnected.set(labels, broker.state === 'UP' ? 1 : 0)
         kafkaProducerBrokerOutbufMessages.set(labels, broker.outbuf_msg_cnt ?? 0)
+        kafkaProducerBrokerOutbufRequests.set(labels, broker.outbuf_cnt ?? 0)
         kafkaProducerBrokerInflightRequests.set(labels, broker.waitresp_cnt ?? 0)
-        if (broker.rtt?.p99) {
-            kafkaProducerBrokerRttP99Microseconds.set(labels, broker.rtt.p99)
+        if (broker.rtt) {
+            for (const q of RTT_QUANTILES) {
+                const value = broker.rtt[q]
+                if (typeof value === 'number') {
+                    kafkaProducerBrokerRttMicroseconds.set({ ...labels, quantile: q }, value)
+                }
+            }
         }
-        if (broker.throttle?.p99) {
-            kafkaProducerBrokerThrottleP99Milliseconds.set(labels, broker.throttle.p99)
+        if (broker.throttle) {
+            for (const q of RTT_QUANTILES) {
+                const value = broker.throttle[q]
+                if (typeof value === 'number') {
+                    kafkaProducerBrokerThrottleMilliseconds.set({ ...labels, quantile: q }, value)
+                }
+            }
         }
 
         const current: CumulativeBrokerStats = {
@@ -144,6 +221,7 @@ export class ProducerStatsTracker {
             txretries: broker.txretries ?? 0,
             req_timeouts: broker.req_timeouts ?? 0,
             disconnects: broker.disconnects ?? 0,
+            rxerrs: broker.rxerrs ?? 0,
         }
 
         // Skip the first observation per broker — otherwise we'd jump the Prom counter by
@@ -151,11 +229,22 @@ export class ProducerStatsTracker {
         const last = this.lastBrokerCounters.get(brokerName)
         if (last) {
             incIfIncreased(kafkaProducerBrokerTxErrorsTotal, labels, current.txerrs, last.txerrs)
+            incIfIncreased(kafkaProducerBrokerRxErrorsTotal, labels, current.rxerrs, last.rxerrs)
             incIfIncreased(kafkaProducerBrokerTxRetriesTotal, labels, current.txretries, last.txretries)
             incIfIncreased(kafkaProducerBrokerRequestTimeoutsTotal, labels, current.req_timeouts, last.req_timeouts)
             incIfIncreased(kafkaProducerBrokerDisconnectsTotal, labels, current.disconnects, last.disconnects)
         }
         this.lastBrokerCounters.set(brokerName, current)
+    }
+
+    private trackTopic(topic: string, stats: TopicStats): void {
+        const labels = { producer_name: this.producerName, topic }
+        if (typeof stats.batchsize?.avg === 'number') {
+            kafkaProducerTopicBatchSizeBytesAvg.set(labels, stats.batchsize.avg)
+        }
+        if (typeof stats.batchcnt?.avg === 'number') {
+            kafkaProducerTopicBatchCountAvg.set(labels, stats.batchcnt.avg)
+        }
     }
 }
 

--- a/nodejs/src/kafka/kafka-producer-stats-schema.ts
+++ b/nodejs/src/kafka/kafka-producer-stats-schema.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod'
+
+/**
+ * Zod schema for the subset of the librdkafka stats JSON we consume.
+ *
+ * See the source-of-truth schema at
+ * https://github.com/confluentinc/librdkafka/blob/master/STATISTICS.md — no
+ * upstream ships a typed definition. Every field is optional because
+ * librdkafka's payload varies by version, producer vs consumer, and whether
+ * a given broker/topic has been interacted with yet. Unknown fields are
+ * stripped (zod's default object behavior) so new additions upstream don't
+ * break the parse.
+ */
+
+const windowQuantilesSchema = z
+    .object({
+        p50: z.number().optional(),
+        p90: z.number().optional(),
+        p95: z.number().optional(),
+        p99: z.number().optional(),
+    })
+    .optional()
+
+const brokerStatsSchema = z.object({
+    state: z.string().optional(),
+    outbuf_cnt: z.number().optional(),
+    outbuf_msg_cnt: z.number().optional(),
+    waitresp_cnt: z.number().optional(),
+    txerrs: z.number().optional(),
+    txretries: z.number().optional(),
+    req_timeouts: z.number().optional(),
+    disconnects: z.number().optional(),
+    rxerrs: z.number().optional(),
+    rtt: windowQuantilesSchema,
+    throttle: windowQuantilesSchema,
+})
+
+const topicStatsSchema = z.object({
+    batchsize: z.object({ avg: z.number().optional() }).optional(),
+    batchcnt: z.object({ avg: z.number().optional() }).optional(),
+})
+
+export const producerStatsSchema = z.object({
+    msg_cnt: z.number().optional(),
+    msg_size: z.number().optional(),
+    msg_max: z.number().optional(),
+    msg_size_max: z.number().optional(),
+    replyq: z.number().optional(),
+    brokers: z.record(z.string(), brokerStatsSchema).optional(),
+    topics: z.record(z.string(), topicStatsSchema).optional(),
+})
+
+export type ProducerStats = z.infer<typeof producerStatsSchema>
+export type BrokerStats = z.infer<typeof brokerStatsSchema>
+export type TopicStats = z.infer<typeof topicStatsSchema>

--- a/nodejs/src/kafka/kafka-producer-stats-schema.ts
+++ b/nodejs/src/kafka/kafka-producer-stats-schema.ts
@@ -12,27 +12,8 @@ import { z } from 'zod'
  * break the parse.
  */
 
-const windowQuantilesSchema = z
-    .object({
-        p50: z.number().optional(),
-        p90: z.number().optional(),
-        p95: z.number().optional(),
-        p99: z.number().optional(),
-    })
-    .optional()
-
 const brokerStatsSchema = z.object({
     state: z.string().optional(),
-    outbuf_cnt: z.number().optional(),
-    outbuf_msg_cnt: z.number().optional(),
-    waitresp_cnt: z.number().optional(),
-    txerrs: z.number().optional(),
-    txretries: z.number().optional(),
-    req_timeouts: z.number().optional(),
-    disconnects: z.number().optional(),
-    rxerrs: z.number().optional(),
-    rtt: windowQuantilesSchema,
-    throttle: windowQuantilesSchema,
 })
 
 const topicStatsSchema = z.object({

--- a/nodejs/src/kafka/producer.ts
+++ b/nodejs/src/kafka/producer.ts
@@ -16,6 +16,7 @@ import { instrumentFn } from '../common/tracing/tracing-utils'
 import { DependencyUnavailableError, MessageSizeTooLarge } from '../utils/db/error'
 import { logger } from '../utils/logger'
 import { KafkaConfigTarget, getKafkaConfigFromEnv } from './config'
+import { ProducerStatsTracker } from './kafka-producer-metrics'
 
 /** This class is a wrapper around the rdkafka producer, and does very little.
  *
@@ -57,6 +58,7 @@ export class KafkaProducerWrapper {
         'retry.backoff.ms': 500, // Backoff between retry attempts
         'socket.timeout.ms': 30000, // Timeout for socket operations
         'max.in.flight.requests.per.connection': 5, // Required for idempotence ordering
+        'statistics.interval.ms': 30000, // Emit internal statistics every 30s for observability
     }
 
     static async create(kafkaClientRack: string | undefined, mode: KafkaConfigTarget = 'PRODUCER') {
@@ -111,6 +113,11 @@ export class KafkaProducerWrapper {
     constructor(producer: HighLevelProducer, name?: string) {
         this.producer = producer
         this.name = name
+
+        if (name) {
+            const statsTracker = new ProducerStatsTracker(name)
+            producer.on('event.stats', (event) => statsTracker.track(event.message))
+        }
     }
 
     async produce({

--- a/nodejs/src/kafka/producer.ts
+++ b/nodejs/src/kafka/producer.ts
@@ -242,6 +242,8 @@ export class KafkaProducerWrapper {
         logger.info('🔌', 'Disconnecting producer. Flushing...')
         await this.flush()
 
+        this.producer.removeAllListeners('event.stats')
+
         logger.info('🔌', 'Disconnecting producer. Disconnecting...')
         await new Promise<ClientMetrics>((resolve, reject) =>
             this.producer.disconnect((error: any, data: ClientMetrics) => {

--- a/nodejs/src/kafka/producer.ts
+++ b/nodejs/src/kafka/producer.ts
@@ -68,7 +68,8 @@ export class KafkaProducerWrapper {
     /** Create a producer with a pre-built rdkafka config (merged over defaults). */
     static async createWithConfig(
         kafkaClientRack: string | undefined,
-        config: ProducerGlobalConfig
+        config: ProducerGlobalConfig,
+        name?: string
     ): Promise<KafkaProducerWrapper> {
         const producerConfig: ProducerGlobalConfig = {
             ...KafkaProducerWrapper.PRODUCER_DEFAULTS,
@@ -101,14 +102,15 @@ export class KafkaProducerWrapper {
             })
         )
 
-        return new KafkaProducerWrapper(producer)
+        return new KafkaProducerWrapper(producer, name)
     }
 
     /** Optional human-readable name (e.g. 'DEFAULT', 'WARPSTREAM') used in metrics labels. */
-    public name?: string
+    public readonly name?: string
 
-    constructor(producer: HighLevelProducer) {
+    constructor(producer: HighLevelProducer, name?: string) {
         this.producer = producer
+        this.name = name
     }
 
     async produce({

--- a/nodejs/src/kafka/producer.ts
+++ b/nodejs/src/kafka/producer.ts
@@ -10,7 +10,7 @@ import {
     MessageKey as RdKafkaMessageKey,
 } from 'node-rdkafka'
 import { hostname } from 'os'
-import { Counter, Summary } from 'prom-client'
+import { Counter, Histogram, Summary } from 'prom-client'
 
 import { instrumentFn } from '../common/tracing/tracing-utils'
 import { DependencyUnavailableError, MessageSizeTooLarge } from '../utils/db/error'
@@ -138,6 +138,9 @@ export class KafkaProducerWrapper {
         try {
             const produceTimer = ingestEventKafkaProduceLatency.labels(labels).startTimer()
             kafkaProducerMessagesQueuedCounter.labels(labels).inc()
+            if (value) {
+                kafkaProducerMessageSizeBytes.labels(labels).observe(value.length)
+            }
             logger.debug('📤', 'Producing message', { topic: topic })
 
             // NOTE: The MessageHeader type is super weird. Essentially you are passing in a record and it expects a string key and a string or buffer value.
@@ -173,10 +176,16 @@ export class KafkaProducerWrapper {
             logger.debug('📤', 'Produced message', { topic: topic, offset: result })
             produceTimer()
         } catch (error) {
-            kafkaProducerMessagesFailedCounter.labels(labels).inc()
+            const errorCode = (error as LibrdKafkaError)?.code
+            const failureLabels = {
+                ...labels,
+                error_code: typeof errorCode === 'number' ? String(errorCode) : 'unknown',
+            }
+            kafkaProducerMessagesFailedCounter.labels(failureLabels).inc()
             logger.error('⚠️', 'kafka_produce_error', {
                 error: typeof error?.message === 'string' ? error.message : JSON.stringify(error),
                 topic: topic,
+                error_code: errorCode,
             })
 
             if ((error as LibrdKafkaError).isRetriable) {
@@ -295,8 +304,8 @@ export const kafkaProducerMessagesWrittenCounter = new Counter({
 
 export const kafkaProducerMessagesFailedCounter = new Counter({
     name: 'kafka_producer_messages_failed_total',
-    help: 'Count of write failures by the Kafka producer, by destination topic.',
-    labelNames: ['topic_name', 'producer_name'],
+    help: 'Count of write failures by the Kafka producer, by destination topic and librdkafka error code.',
+    labelNames: ['topic_name', 'producer_name', 'error_code'],
 })
 
 export const ingestEventKafkaProduceLatency = new Summary({
@@ -304,4 +313,12 @@ export const ingestEventKafkaProduceLatency = new Summary({
     help: 'Wait time for individual Kafka produces',
     labelNames: ['topic_name', 'producer_name'],
     percentiles: [0.5, 0.9, 0.95, 0.99],
+})
+
+export const kafkaProducerMessageSizeBytes = new Histogram({
+    name: 'kafka_producer_message_size_bytes',
+    help: 'Size distribution of messages produced to Kafka, measured at queue time.',
+    labelNames: ['topic_name', 'producer_name'],
+    // Targeting typical event sizes (~1 KB) up to max request size (~1 MB).
+    buckets: [64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304],
 })

--- a/nodejs/src/kafka/producer.ts
+++ b/nodejs/src/kafka/producer.ts
@@ -58,8 +58,10 @@ export class KafkaProducerWrapper {
         'retry.backoff.ms': 500, // Backoff between retry attempts
         'socket.timeout.ms': 30000, // Timeout for socket operations
         'max.in.flight.requests.per.connection': 5, // Required for idempotence ordering
-        'statistics.interval.ms': 30000, // Emit internal statistics every 30s for observability
     }
+
+    /** Emit librdkafka stats every 30s so ProducerStatsTracker can export them as Prom metrics. */
+    private static readonly STATS_INTERVAL_MS = 30000
 
     static async create(kafkaClientRack: string | undefined, mode: KafkaConfigTarget = 'PRODUCER') {
         // NOTE: In addition to some defaults we allow overriding any setting via env vars.
@@ -76,6 +78,9 @@ export class KafkaProducerWrapper {
         const producerConfig: ProducerGlobalConfig = {
             ...KafkaProducerWrapper.PRODUCER_DEFAULTS,
             'client.rack': kafkaClientRack,
+            // Only emit librdkafka stats when there's a named wrapper to consume them — avoids
+            // the per-interval serialization cost on unnamed producers that have no listener.
+            ...(name ? { 'statistics.interval.ms': KafkaProducerWrapper.STATS_INTERVAL_MS } : {}),
             ...config,
             dr_cb: true,
         }

--- a/nodejs/tests/helpers/mocks/producer.mock.ts
+++ b/nodejs/tests/helpers/mocks/producer.mock.ts
@@ -17,6 +17,8 @@ jest.mock('../../../src/kafka/producer', () => {
         flush: jest.fn((...args) => args[args.length - 1]?.()),
         disconnect: jest.fn((...args) => args[args.length - 1]?.()),
         connect: jest.fn((...args) => args[args.length - 1]?.()),
+        on: jest.fn(),
+        removeAllListeners: jest.fn(),
         getMetadata: jest.fn((opts: any, cb: any) =>
             cb(null, {
                 topics: opts?.topic


### PR DESCRIPTION
## Problem

The Node.js ingestion pipeline recently introduced a `KafkaProducerRegistry` so services can hold multiple named producers, but:

1. The registry never forwarded the producer's name to `KafkaProducerWrapper`, so the `producer_name` label on the existing `kafka_producer_*` metrics was always empty — dashboards can't tell one producer apart from another.
2. We only track app-level counters (queued / written / failed). Nothing reflects librdkafka's internal view: queue depth, batching effectiveness, or broker reachability. When produce latency spikes there's no signal pointing at a queue-full condition.
3. `kafka_producer_messages_failed_total` has no error classification — a timeout, an auth failure, and a message-too-large all look identical.
4. Capture (Rust) already exposes comparable librdkafka stats; the Node side had nothing.

## Changes

Six commits, each independently reviewable:

- **`fix(ingestion): pass producer name to KafkaProducerWrapper from registry`** — threads the registration name through `createWithConfig` → constructor so the `producer_name` label is populated. `name` is now `readonly` and set once at construction. No existing call sites changed (the param is optional).

- **`feat(ingestion): export librdkafka producer stats per producer`** — wires `event.stats` (gated on producer name) to a new `ProducerStatsTracker`. Emits client-level rollups sourced from the librdkafka stats JSON. Follow-up commits trimmed the series set to keep cardinality bounded.

- **`feat(ingestion): observe kafka message size and failure error codes`** —
  - `kafka_producer_message_size_bytes` histogram (64 B … 4 MB buckets), labelled by `topic_name` and `producer_name`.
  - Adds an `error_code` label to `kafka_producer_messages_failed_total`, sourced from `LibrdKafkaError.code` (or `unknown`), so timeouts / auth / queue-full can be distinguished in Prom.

- **`refactor(ingestion): validate librdkafka producer stats with a zod schema`** — replaces the ad-hoc `any` typing in `ProducerStatsTracker` with a zod schema covering the fields we consume. Parse failures log a warning and drop the tick instead of silently emitting bogus metrics.

- **`refactor(ingestion): drop per-broker producer metrics to cap cardinality`** — removes all `kafka_producer_broker_*` series. The `{producer_name, broker}` cross product was the cardinality concern raised in review. Broker-level observability is available from the broker side.

- **`chore(ingestion): drop stats listener when disconnecting producer`** — `removeAllListeners('event.stats')` in `disconnect()` so the tracker doesn't linger past shutdown.

### Final metrics surface

Per-producer (one series per named wrapper):
- `kafka_producer_queue_messages`, `kafka_producer_queue_bytes`, `kafka_producer_queue_max_messages`, `kafka_producer_queue_max_bytes`
- `kafka_producer_callback_queue_depth`
- `kafka_producer_any_brokers_down`

Per-producer × topic:
- `kafka_producer_topic_batch_size_bytes_avg`, `kafka_producer_topic_batch_count_avg`
- `kafka_producer_message_size_bytes` histogram

Existing counters now carry the `producer_name` label (and `error_code` on failures):
- `kafka_producer_messages_queued_total`, `kafka_producer_messages_written_total`, `kafka_producer_messages_failed_total`

## How did you test this code?

- New unit tests in `nodejs/src/kafka/kafka-producer-metrics.test.ts` cover the tracker's queue gauges, `any_brokers_down` rollup, per-topic batching, schema-validation failure path, invalid-JSON handling, and unknown-field tolerance.
- Updated `nodejs/src/ingestion/outputs/kafka-producer-registry-builder.test.ts` to assert the name is passed through.
- Updated the shared producer mock in `nodejs/tests/helpers/mocks/producer.mock.ts` with `on` / `removeAllListeners` so consumers of the mock compile against the new listener lifecycle.
- **Live-verified on local dev cluster** against the ingestion server at `http://127.0.0.1:6739/metrics` after restarting it on this branch. Confirmed:
  - `kafka_producer_queue_messages` emits three series, one per producer (`DEFAULT`, `INGESTION`, `WARPSTREAM`) — proof the name fix works end-to-end.
  - `kafka_producer_topic_batch_size_bytes_avg{topic="clickhouse_events_json"} = 38841` showed librdkafka stats actually flowing with real traffic.
  - `kafka_producer_message_size_bytes_count{topic="clickhouse_events_json"} = 130` matched `kafka_producer_messages_queued_total`, confirming histogram wiring.
  - **No** `kafka_producer_broker_*` series present, confirming the cardinality trim.

## Publish to changelog?

no