### PR TITLE
feat(subscriptions): gate AI summary toggle on org AI data processing consent

### DIFF
--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -14,7 +14,7 @@ from drf_spectacular.utils import (
     extend_schema_field,
     extend_schema_view,
 )
-from rest_framework import filters, serializers, status, viewsets
+from rest_framework import exceptions, filters, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.pagination import CursorPagination
@@ -187,6 +187,13 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         prompt_guide = attrs.get("summary_prompt_guide")
         if prompt_guide and len(prompt_guide) > 500:
             raise ValidationError({"summary_prompt_guide": ["AI summary context must be 500 characters or fewer."]})
+
+        if attrs.get("summary_enabled"):
+            organization = self.context["get_organization"]()
+            if not organization.is_ai_data_processing_approved:
+                raise exceptions.PermissionDenied(
+                    "AI data processing must be approved by your organization before enabling AI summaries"
+                )
 
         return attrs
 

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -415,6 +415,55 @@ class TestSubscriptionTemporal(APILicensedTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "require a Slack integration" in response.json()["detail"]
 
+    def test_cannot_create_subscription_with_summary_enabled_without_ai_consent(self):
+        self.organization.is_ai_data_processing_approved = False
+        self.organization.save()
+
+        response = self._create_subscription(summary_enabled=True)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "AI data processing must be approved" in response.json()["detail"]
+        self.mock_temporal_client.start_workflow.assert_not_called()
+
+    def test_can_create_subscription_with_summary_enabled_when_ai_consent_given(self):
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save()
+
+        response = self._create_subscription(summary_enabled=True)
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["summary_enabled"] is True
+
+    def test_cannot_patch_summary_enabled_true_without_ai_consent(self):
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save()
+        create_response = self._create_subscription()
+        subscription_id = create_response.json()["id"]
+
+        self.organization.is_ai_data_processing_approved = False
+        self.organization.save()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/subscriptions/{subscription_id}",
+            {"summary_enabled": True},
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "AI data processing must be approved" in response.json()["detail"]
+
+    def test_can_patch_unrelated_fields_when_summary_enabled_and_ai_consent_revoked(self):
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save()
+        create_response = self._create_subscription(summary_enabled=True)
+        subscription_id = create_response.json()["id"]
+
+        self.organization.is_ai_data_processing_approved = False
+        self.organization.save()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/subscriptions/{subscription_id}",
+            {"title": "Updated title"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["title"] == "Updated title"
+
     def test_deliver_subscription(self):
         mock_client = MagicMock()
         mock_client.start_workflow = AsyncMock()

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -21,8 +21,10 @@ import { LemonModal } from 'lib/lemon-ui/LemonModal'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
+import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 import { membersLogic } from 'scenes/organization/membersLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { AIConsentPopoverWrapper } from 'scenes/settings/organization/AIConsentPopoverWrapper'
 
 import { DashboardType, InsightShortId } from '~/types'
 
@@ -76,6 +78,7 @@ export function EditSubscription({
     const { preflight, siteUrlMisconfigured } = useValues(preflightLogic)
     const { deleteSubscription } = useActions(subscriptionslogic)
     const { slackIntegrations, integrations } = useValues(integrationsLogic)
+    const { dataProcessingAccepted } = useValues(maxGlobalLogic)
 
     const emailDisabled = !preflight?.email_service_available
 
@@ -428,13 +431,20 @@ export function EditSubscription({
                         <FlaggedFeature flag={FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS}>
                             <LemonField name="summary_enabled">
                                 {({ value, onChange }) => (
-                                    <LemonSwitch
-                                        checked={value}
-                                        onChange={onChange}
-                                        bordered
-                                        label="Include an automatic AI summary"
-                                        fullWidth
-                                    />
+                                    <AIConsentPopoverWrapper hidden={dataProcessingAccepted}>
+                                        <LemonSwitch
+                                            checked={value}
+                                            onChange={onChange}
+                                            bordered
+                                            label="Include an automatic AI summary"
+                                            fullWidth
+                                            disabledReason={
+                                                !dataProcessingAccepted
+                                                    ? 'Your organization needs to approve AI data processing before enabling AI summaries'
+                                                    : undefined
+                                            }
+                                        />
+                                    </AIConsentPopoverWrapper>
                                 )}
                             </LemonField>
 

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -431,7 +431,7 @@ export function EditSubscription({
                         <FlaggedFeature flag={FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS}>
                             <LemonField name="summary_enabled">
                                 {({ value, onChange }) => (
-                                    <AIConsentPopoverWrapper hidden={dataProcessingAccepted}>
+                                    <AIConsentPopoverWrapper>
                                         <LemonSwitch
                                             checked={value}
                                             onChange={onChange}

--- a/posthog/temporal/subscriptions/snapshot_activities.py
+++ b/posthog/temporal/subscriptions/snapshot_activities.py
@@ -23,6 +23,10 @@ SUBSCRIPTION_SUMMARY_FAILURE = Counter(
     "AI summary generation failed for a subscription delivery",
     ["reason"],
 )
+SUBSCRIPTION_SUMMARY_SKIPPED_NO_AI_CONSENT = Counter(
+    "posthog_subscription_ai_summary_skipped_no_ai_consent_total",
+    "AI summary skipped because the organization has not approved AI data processing",
+)
 
 
 def _get_query_kind_from_insight(insight: Insight) -> str:
@@ -105,11 +109,20 @@ async def snapshot_subscription_insights(inputs: SnapshotInsightsInputs) -> Snap
     )
 
     subscription = await database_sync_to_async(
-        Subscription.objects.select_related("team").get,
+        Subscription.objects.select_related("team__organization").get,
         thread_sensitive=False,
     )(pk=inputs.subscription_id)
 
     if not subscription.summary_enabled:
+        return SnapshotInsightsResult()
+
+    if not subscription.team.organization.is_ai_data_processing_approved:
+        SUBSCRIPTION_SUMMARY_SKIPPED_NO_AI_CONSENT.inc()
+        await LOGGER.ainfo(
+            "snapshot_subscription_insights.skipped_no_ai_consent",
+            subscription_id=inputs.subscription_id,
+            organization_id=str(subscription.team.organization_id),
+        )
         return SnapshotInsightsResult()
 
     if not inputs.delivery_id:

--- a/posthog/temporal/subscriptions/test_snapshot_ai_consent.py
+++ b/posthog/temporal/subscriptions/test_snapshot_ai_consent.py
@@ -1,0 +1,124 @@
+import uuid
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from asgiref.sync import sync_to_async
+from temporalio.testing import ActivityEnvironment
+
+from posthog.models.insight import Insight
+from posthog.models.subscription import Subscription, SubscriptionDelivery
+from posthog.temporal.subscriptions.snapshot_activities import snapshot_subscription_insights
+from posthog.temporal.subscriptions.types import SnapshotInsightsInputs
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.django_db(transaction=True)]
+
+
+async def _run(inputs: SnapshotInsightsInputs):
+    env = ActivityEnvironment()
+    return await env.run(snapshot_subscription_insights, inputs)
+
+
+@sync_to_async
+def _set_ai_consent(subscription: Subscription, approved: bool) -> None:
+    subscription.team.organization.is_ai_data_processing_approved = approved
+    subscription.team.organization.save()
+
+
+@sync_to_async
+def _create_subscription(team, user, *, summary_enabled: bool = True) -> Subscription:
+    insight = Insight.objects.create(team=team, name="Pageviews", created_by=user)
+    return Subscription.objects.create(
+        team=team,
+        insight=insight,
+        created_by=user,
+        target_type=Subscription.SubscriptionTarget.EMAIL,
+        target_value="test@posthog.com",
+        frequency=Subscription.SubscriptionFrequency.WEEKLY,
+        start_date=datetime(2022, 1, 1, 9, 0, tzinfo=ZoneInfo("UTC")),
+        summary_enabled=summary_enabled,
+    )
+
+
+@sync_to_async
+def _create_delivery(subscription: Subscription, content_snapshot: dict) -> SubscriptionDelivery:
+    return SubscriptionDelivery.objects.create(
+        subscription=subscription,
+        team=subscription.team,
+        status=SubscriptionDelivery.Status.STARTING,
+        content_snapshot=content_snapshot,
+    )
+
+
+async def test_skips_summary_when_org_has_not_approved_ai(team, user):
+    subscription = await _create_subscription(team, user)
+    await _set_ai_consent(subscription, approved=False)
+    delivery = await _create_delivery(
+        subscription,
+        {"insights": [{"id": subscription.insight_id, "name": "Pageviews", "query_results": {"result": []}}]},
+    )
+
+    result = await _run(
+        SnapshotInsightsInputs(
+            subscription_id=subscription.id,
+            team_id=subscription.team_id,
+            delivery_id=str(delivery.id),
+        )
+    )
+
+    assert result.summary_text is None
+
+
+async def test_runs_summary_when_org_has_approved_ai(team, user, monkeypatch):
+    subscription = await _create_subscription(team, user)
+    await _set_ai_consent(subscription, approved=True)
+    delivery = await _create_delivery(
+        subscription,
+        {
+            "insights": [
+                {
+                    "id": subscription.insight_id,
+                    "name": "Pageviews",
+                    "query_results": {"result": [{"label": "Pageviews", "data": [1, 2, 3]}]},
+                }
+            ]
+        },
+    )
+
+    called = {}
+
+    def fake_generate(previous_states, current_states, **kwargs):
+        called["ran"] = True
+        return "- Pageviews is trending up"
+
+    monkeypatch.setattr(
+        "posthog.temporal.subscriptions.snapshot_activities.generate_change_summary",
+        fake_generate,
+    )
+
+    result = await _run(
+        SnapshotInsightsInputs(
+            subscription_id=subscription.id,
+            team_id=subscription.team_id,
+            delivery_id=str(delivery.id),
+        )
+    )
+
+    assert called.get("ran") is True
+    assert result.summary_text == "- Pageviews is trending up"
+
+
+async def test_skips_summary_when_summary_not_enabled(team, user):
+    subscription = await _create_subscription(team, user, summary_enabled=False)
+    await _set_ai_consent(subscription, approved=True)
+
+    result = await _run(
+        SnapshotInsightsInputs(
+            subscription_id=subscription.id,
+            team_id=subscription.team_id,
+            delivery_id=str(uuid.uuid4()),
+        )
+    )
+
+    assert result.summary_text is None


### PR DESCRIPTION
## Problem

The AI summary toggle on subscriptions is only gated by a feature flag. This PR closes two gaps:

1. The UI didn't check whether the organization had opted in to AI data processing — users on orgs without consent could enable summaries.
2. More importantly, the server had no equivalent check. A caller with a valid API key could PATCH the subscription with `summary_enabled: true`, the backend would persist the value, and the Temporal workflow would call OpenAI without ever verifying `organization.is_ai_data_processing_approved`.

Every other AI-using endpoint in the codebase (insight AI analysis, LLM analytics summarization, surveys, dashboards, log explain, conversations) raises 403 when `is_ai_data_processing_approved` is falsy. The subscription serializer and temporal activity were the only places skipping this check. For organisations that explicitly set `is_ai_data_processing_approved=False` for compliance reasons, this meant a team member could cause analytics data to be sent to external AI providers against the org's recorded consent decision.

## Changes

**Frontend (`EditSubscription.tsx`)**
- Wrap `Include an automatic AI summary` `LemonSwitch` in `AIConsentPopoverWrapper`
- Read `dataProcessingAccepted` from `maxGlobalLogic`, add a `disabledReason` when not opted in, and show the admin approval popover
- Pattern matches existing consumers (`SurveyHeadline.tsx`, `InsightAIAnalysis.tsx`)

**Backend serializer (`ee/api/subscription.py`)**
- In `validate()`, when `summary_enabled` is `True` in the incoming payload, raise `PermissionDenied` ("AI data processing must be approved...") if the org hasn't opted in
- Check is targeted: only runs when the caller is explicitly setting the field to `True`, so unrelated PATCHes to an already-enabled subscription still work

**Temporal activity (`snapshot_activities.py`)**
- Defensive second-line check: if consent is revoked after a subscription was enabled, skip summary generation
- Added `posthog_subscription_ai_summary_skipped_no_ai_consent_total` Prometheus counter for observability
- Subscription query now `select_related("team__organization")` to avoid an extra round-trip

**Tests**
- 4 new API tests covering create/patch with and without consent, plus the unrelated-PATCH passthrough case
- 3 new temporal tests covering consent-revoked, consent-granted, and `summary_enabled=False` paths

## How did you test this code?

Agent-authored. All 59 existing subscription API tests pass; 38 temporal subscription tests pass including the 3 new consent tests. Not manually tested end-to-end in a browser.

## Publish to changelog?

no

## 🤖 LLM context

PostHog Code session. Second round of changes: the initial PR only added the frontend gate, but a reviewer correctly pointed out that the UI change was cosmetic without server-side enforcement. This round adds the serializer check (returning 403 matching the convention of other AI endpoints) and a defensive check in the temporal activity.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*