### PR TITLE
fix(experiments): block on cache miss when fetching AI summary data

### DIFF
--- a/products/experiments/backend/experiment_summary_data_service.py
+++ b/products/experiments/backend/experiment_summary_data_service.py
@@ -196,7 +196,7 @@ class ExperimentSummaryDataService:
                         workload=Workload.ONLINE,
                     )
                     result = query_runner.run(
-                        execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
+                        execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
                         analytics_props={"source": EventSource.POSTHOG_AI},
                     )
                 refresh_time = getattr(result, "last_refresh", None)
@@ -247,7 +247,7 @@ class ExperimentSummaryDataService:
                             team=experiment.team,
                         )
                         exposure_result = exposure_runner.run(
-                            execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
+                            execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
                             analytics_props={"source": EventSource.POSTHOG_AI},
                         )
 

--- a/products/experiments/backend/test/test_experiment_summary_tool.py
+++ b/products/experiments/backend/test/test_experiment_summary_tool.py
@@ -353,3 +353,19 @@ class TestExperimentSummaryDataService(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(context.exposures, {"control": 500.0, "test": 500.0})
         self.assertIsNotNone(last_refresh)
         self.assertFalse(pending_calculation)
+
+    @freeze_time("2020-01-10T12:00:00Z")
+    async def test_fetch_experiment_data_executes_queries_on_cold_cache(self):
+        """
+        On a cold cache, queries must execute synchronously rather than
+        returning a CacheMissResponse. Previously the data service used
+        RECENT_CACHE_CALCULATE_ASYNC_IF_STALE which returned immediately
+        on cache miss, giving the AI zero results and causing hallucinations.
+        """
+        experiment = await self.acreate_experiment(name="cold-cache-test", with_metrics=True)
+
+        data_service = ExperimentSummaryDataService(self.team)
+        context, last_refresh, pending_calculation = await data_service.fetch_experiment_data(experiment.id)
+
+        self.assertFalse(pending_calculation)
+        self.assertIsNotNone(last_refresh)

--- a/products/experiments/backend/test/test_experiment_summary_tool.py
+++ b/products/experiments/backend/test/test_experiment_summary_tool.py
@@ -362,7 +362,15 @@ class TestExperimentSummaryDataService(ClickhouseTestMixin, APIBaseTest):
         RECENT_CACHE_CALCULATE_ASYNC_IF_STALE which returned immediately
         on cache miss, giving the AI zero results and causing hallucinations.
         """
-        experiment = await self.acreate_experiment(name="cold-cache-test", with_metrics=True)
+        experiment = await self.acreate_experiment(name="cold-cache-test", with_metrics=False)
+        experiment.metrics = [
+            {
+                "metric_type": "mean",
+                "source": {"kind": "EventsNode", "event": "purchase"},
+                "name": "Purchase value",
+            }
+        ]
+        await experiment.asave(update_fields=["metrics"])
 
         data_service = ExperimentSummaryDataService(self.team)
         context, last_refresh, pending_calculation = await data_service.fetch_experiment_data(experiment.id)


### PR DESCRIPTION
## Problem

The experiment AI summary tool used an async execution mode for its ClickHouse queries. On cache miss, queries were fire-and-forgeted and the tool immediately received empty results. The AI then got "No metrics results available yet" and hallucinated its analysis.

## Changes

Switch metric and exposure queries from `RECENT_CACHE_CALCULATE_ASYNC_IF_STALE` to `RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS`. On cache miss, queries now execute synchronously. Stale cache fast path is unchanged.

## How did you test this code?

Added integration test that calls `fetch_experiment_data` against real ClickHouse with a cold cache and asserts queries execute synchronously (`pending=False`, `last_refresh` set).