### PR TITLE
fix(experiments): remove metrics count warning tooltip

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/Metrics.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconInfo, IconList, IconWarning } from '@posthog/icons'
+import { IconInfo, IconList } from '@posthog/icons'
 import { LemonButton, Tooltip } from '@posthog/lemon-ui'
 
 import { IconAreaChart } from 'lib/lemon-ui/icons'
@@ -78,11 +78,6 @@ export function Metrics({ isSecondary }: { isSecondary?: boolean }): JSX.Element
                     <div className="ml-auto">
                         {metrics.length > 0 && (
                             <div className="mb-2 mt-4 justify-end flex items-center gap-2">
-                                {metrics.length >= 3 && (
-                                    <Tooltip title="Each additional metric is another result to interpret. Make sure each has a clear hypothesis.">
-                                        <IconWarning className="text-warning text-lg" />
-                                    </Tooltip>
-                                )}
                                 <AddMetricButton
                                     metricContext={isSecondary ? METRIC_CONTEXTS.secondary : METRIC_CONTEXTS.primary}
                                 />


### PR DESCRIPTION
## Problem

The warning tooltip and icon shown when 3+ metrics are added to an experiment is unnecessary noise.

## Changes

Removed the `IconWarning` tooltip from the metrics view and cleaned up the unused import.

## How did you test this code?

Visual inspection of the diff.

## 🤖 LLM context

Agent-authored PR.