### PR TITLE
feat(llma): add OpenTelemetry onboarding docs page

### DIFF
--- a/docs/onboarding/llm-analytics/opentelemetry.tsx
+++ b/docs/onboarding/llm-analytics/opentelemetry.tsx
@@ -120,6 +120,16 @@ export const getOpenTelemetrySteps = (ctx: OnboardingComponentsContext): StepDef
                             },
                         ]}
                     />
+
+                    <Markdown>
+                        {dedent`
+                            PostHog identifies each event using the \`posthog.distinct_id\` attribute on the OpenTelemetry
+                            **Resource** (with \`user.id\` as a fallback, then a random UUID if neither is set). Because
+                            the Resource applies to every span in a batched export, you only need to set the distinct ID
+                            once — there's no need for a \`BaggageSpanProcessor\` or per-span propagation. Any other
+                            Resource or span attributes pass through as event properties.
+                        `}
+                    </Markdown>
                 </>
             ),
         },
@@ -192,15 +202,67 @@ export const getOpenTelemetrySteps = (ctx: OnboardingComponentsContext): StepDef
             ),
         },
         {
-            title: 'Send OTLP traces directly (advanced)',
+            title: 'How attributes map to event properties',
+            badge: 'recommended',
+            content: (
+                <>
+                    <Markdown>
+                        PostHog translates standard OpenTelemetry GenAI semantic convention attributes into the same
+                        `$ai_*` event properties our native SDK wrappers emit, so traces look the same in PostHog
+                        whether they arrive through OpenTelemetry or a native wrapper. The most common mappings:
+                    </Markdown>
+
+                    <Markdown>
+                        {dedent`
+                            | OpenTelemetry attribute | PostHog event property |
+                            | --- | --- |
+                            | \`gen_ai.response.model\` (or \`gen_ai.request.model\`) | \`$ai_model\` |
+                            | \`gen_ai.provider.name\` (or \`gen_ai.system\`) | \`$ai_provider\` |
+                            | \`gen_ai.input.messages\` | \`$ai_input\` |
+                            | \`gen_ai.output.messages\` | \`$ai_output_choices\` |
+                            | \`gen_ai.usage.input_tokens\` (or \`gen_ai.usage.prompt_tokens\`) | \`$ai_input_tokens\` |
+                            | \`gen_ai.usage.output_tokens\` (or \`gen_ai.usage.completion_tokens\`) | \`$ai_output_tokens\` |
+                            | \`server.address\` | \`$ai_base_url\` |
+                            | \`telemetry.sdk.name\` / \`telemetry.sdk.version\` | \`$ai_lib\` / \`$ai_lib_version\` |
+                            | Span start/end timestamps | \`$ai_latency\` (computed in seconds) |
+                            | Span name | \`$ai_span_name\` |
+                        `}
+                    </Markdown>
+
+                    <Markdown>Additional behavior worth knowing:</Markdown>
+
+                    <Markdown>
+                        {dedent`
+                            - **Custom attributes pass through.** Any Resource or span attribute that isn't part of the known mapping is forwarded onto the event as-is, so you can add dimensions like \`conversation_id\` or \`tenant_id\` and filter on them in PostHog.
+                            - **Trace and span IDs are preserved** as \`$ai_trace_id\`, \`$ai_span_id\`, and \`$ai_parent_id\`, so multi-step traces reconstruct correctly.
+                            - **Events are classified by operation.** \`gen_ai.operation.name=chat\` becomes an \`$ai_generation\` event; \`embeddings\` becomes \`$ai_embedding\`. Spans without a recognized operation become \`$ai_span\` (or \`$ai_trace\` if they're the root of a trace).
+                            - **Vercel AI SDK, Pydantic AI, and Traceloop/OpenLLMetry** emit their own namespaces (\`ai.*\`, \`pydantic_ai.*\`, \`traceloop.*\`) and PostHog normalizes those to the same \`$ai_*\` properties.
+                            - **Noisy resource attributes are dropped.** OpenTelemetry auto-detected attributes under \`host.*\`, \`process.*\`, \`os.*\`, and \`telemetry.*\` (except \`telemetry.sdk.name\` / \`telemetry.sdk.version\`) don't pollute event properties.
+                        `}
+                    </Markdown>
+                </>
+            ),
+        },
+        {
+            title: 'Other instrumentations, direct OTLP, and troubleshooting',
             badge: 'optional',
             content: (
                 <>
                     <Markdown>
-                        If you already run an OpenTelemetry collector, or you want to export from a language other than
-                        Python or Node.js, point any OTLP/HTTP exporter directly at PostHog's AI ingestion endpoint.
-                        PostHog accepts OTLP over HTTP in both `application/x-protobuf` and `application/json`,
-                        authenticated with a `Bearer` token.
+                        {dedent`
+                            **Alternative instrumentation libraries.** Any library that emits standard \`gen_ai.*\` spans (or \`ai.*\` / \`traceloop.*\` / \`pydantic_ai.*\`) works with the setup above. Swap \`@opentelemetry/instrumentation-openai\` / \`opentelemetry-instrumentation-openai-v2\` for one of these to broaden provider coverage:
+
+                            - [OpenLIT](https://github.com/openlit/openlit) — single instrumentation that covers many providers, vector DBs, and frameworks.
+                            - [OpenLLMetry](https://github.com/traceloop/openllmetry) (Traceloop) — broad provider and framework support in Python and JavaScript.
+                            - [OpenInference](https://github.com/Arize-ai/openinference) (Arize) — provider- and framework-specific instrumentations for Python and JavaScript.
+                            - [MLflow tracing](https://mlflow.org/docs/latest/llms/tracing/index.html) — if you already run MLflow.
+                        `}
+                    </Markdown>
+
+                    <Markdown>
+                        {dedent`
+                            **Direct OTLP export.** If you run an OpenTelemetry Collector, or want to export from a language that isn't Python or Node.js, point any OTLP/HTTP exporter directly at PostHog's AI ingestion endpoint. PostHog accepts OTLP over HTTP in both \`application/x-protobuf\` and \`application/json\`, authenticated with a \`Bearer\` token. The endpoint is signal-specific (traces only), so use the \`OTEL_EXPORTER_OTLP_TRACES_*\` variants rather than the general \`OTEL_EXPORTER_OTLP_*\` ones (the SDK appends \`/v1/traces\` to the latter and would 404).
+                        `}
                     </Markdown>
 
                     <CodeBlock
@@ -217,6 +279,19 @@ export const getOpenTelemetrySteps = (ctx: OnboardingComponentsContext): StepDef
                                 language: 'yaml',
                                 file: 'Collector',
                                 code: dedent`
+                                    receivers:
+                                      otlp:
+                                        protocols:
+                                          http:
+                                            endpoint: 0.0.0.0:4318
+
+                                    processors:
+                                      batch:
+                                      memory_limiter:
+                                        check_interval: 5s
+                                        limit_mib: 1500
+                                        spike_limit_mib: 512
+
                                     exporters:
                                       otlphttp/posthog:
                                         traces_endpoint: "<ph_client_api_host>/i/v0/ai/otel"
@@ -227,7 +302,7 @@ export const getOpenTelemetrySteps = (ctx: OnboardingComponentsContext): StepDef
                                       pipelines:
                                         traces:
                                           receivers: [otlp]
-                                          processors: [batch]
+                                          processors: [memory_limiter, batch]
                                           exporters: [otlphttp/posthog]
                                 `,
                             },
@@ -235,9 +310,14 @@ export const getOpenTelemetrySteps = (ctx: OnboardingComponentsContext): StepDef
                     />
 
                     <Markdown>
-                        The endpoint only ingests AI-related spans — those whose name or attribute keys start with
-                        `gen_ai.`, `llm.`, `ai.`, or `traceloop.`. Every other span is dropped server-side, so it's safe
-                        to send a mixed trace stream.
+                        {dedent`
+                            **Limits and troubleshooting.**
+
+                            - **Only AI spans are ingested.** Spans whose name and attribute keys don't start with \`gen_ai.\`, \`llm.\`, \`ai.\`, or \`traceloop.\` are dropped server-side, so it's safe to send a mixed trace stream.
+                            - **HTTP only, no gRPC.** The endpoint speaks OTLP over HTTP in either \`application/x-protobuf\` or \`application/json\`. If your collector or SDK is configured for gRPC, switch to HTTP.
+                            - **Request body is capped at 4 MB.** Large or unbounded traces (for example, long chat histories with base64-encoded images) can exceed this. Use a collector with the \`batch\` processor to keep individual exports small.
+                            - **Missing traces?** Make sure you're pointing at the traces-specific OTLP variable (\`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT\` / \`traces_endpoint\`) rather than the general one, and that your project token is set correctly in the \`Authorization: Bearer\` header.
+                        `}
                     </Markdown>
                 </>
             ),

--- a/docs/onboarding/llm-analytics/opentelemetry.tsx
+++ b/docs/onboarding/llm-analytics/opentelemetry.tsx
@@ -44,14 +44,14 @@ export const getOpenTelemetrySteps = (ctx: OnboardingComponentsContext): StepDef
                                 language: 'bash',
                                 file: 'Python',
                                 code: dedent`
-                                    pip install opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
+                                    pip install openai opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
                                 `,
                             },
                             {
                                 language: 'bash',
                                 file: 'Node',
                                 code: dedent`
-                                    npm install @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
+                                    npm install openai @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
                                 `,
                             },
                         ]}
@@ -218,8 +218,8 @@ export const getOpenTelemetrySteps = (ctx: OnboardingComponentsContext): StepDef
                                 language: 'bash',
                                 file: 'Environment',
                                 code: dedent`
-                                    OTEL_EXPORTER_OTLP_ENDPOINT="<ph_client_api_host>/i/v0/ai/otel"
-                                    OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <ph_project_token>"
+                                    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="<ph_client_api_host>/i/v0/ai/otel"
+                                    OTEL_EXPORTER_OTLP_TRACES_HEADERS="Authorization=Bearer <ph_project_token>"
                                 `,
                             },
                             {
@@ -228,7 +228,7 @@ export const getOpenTelemetrySteps = (ctx: OnboardingComponentsContext): StepDef
                                 code: dedent`
                                     exporters:
                                       otlphttp/posthog:
-                                        endpoint: "<ph_client_api_host>/i/v0/ai/otel"
+                                        traces_endpoint: "<ph_client_api_host>/i/v0/ai/otel"
                                         headers:
                                           Authorization: "Bearer <ph_project_token>"
 

--- a/docs/onboarding/llm-analytics/opentelemetry.tsx
+++ b/docs/onboarding/llm-analytics/opentelemetry.tsx
@@ -1,0 +1,257 @@
+import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/OnboardingDocsContentWrapper'
+
+import { StepDefinition } from '../steps'
+
+export const getOpenTelemetrySteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
+    const { CodeBlock, CalloutBox, Markdown, Blockquote, dedent, snippets } = ctx
+
+    const NotableGenerationProperties = snippets?.NotableGenerationProperties
+
+    return [
+        {
+            title: 'Install dependencies',
+            badge: 'required',
+            content: (
+                <>
+                    <CalloutBox type="info" icon="IconInfo" title="Using our SDKs? You probably don't need this page">
+                        <Markdown>
+                            If you're using our [Python](/docs/libraries/python) or [Node.js](/docs/libraries/node) SDKs
+                            with a supported provider (OpenAI, Anthropic, Gemini, and more), use the [native
+                            wrappers](/docs/llm-analytics/installation) instead. This page is for OpenTelemetry-native
+                            setups, OpenTelemetry collectors, and frameworks that don't have a PostHog SDK wrapper yet.
+                        </Markdown>
+                    </CalloutBox>
+
+                    <CalloutBox type="fyi" icon="IconInfo" title="Full working examples">
+                        <Markdown>
+                            The [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-openai)
+                            and
+                            [Python](https://github.com/PostHog/posthog-python/tree/master/examples/example-ai-openai)
+                            OpenAI examples show a complete end-to-end OpenTelemetry setup. Swap the instrumentation for
+                            any other `gen_ai.*`-emitting library to trace a different provider or framework.
+                        </Markdown>
+                    </CalloutBox>
+
+                    <Markdown>
+                        Install the OpenTelemetry SDK, PostHog's OpenTelemetry helper, and an OpenTelemetry
+                        instrumentation for the provider you want to trace. The examples below use the OpenAI
+                        instrumentation, but any library that emits `gen_ai.*` spans will work.
+                    </Markdown>
+
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Python',
+                                code: dedent`
+                                    pip install opentelemetry-sdk posthog[otel] opentelemetry-instrumentation-openai-v2
+                                `,
+                            },
+                            {
+                                language: 'bash',
+                                file: 'Node',
+                                code: dedent`
+                                    npm install @posthog/ai @opentelemetry/sdk-node @opentelemetry/resources @opentelemetry/instrumentation-openai
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Set up OpenTelemetry tracing',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        Configure OpenTelemetry to export spans to PostHog via the `PostHogSpanProcessor`. The processor
+                        only forwards AI-related spans — spans whose name or attribute keys start with `gen_ai.`,
+                        `llm.`, `ai.`, or `traceloop.` — and drops everything else. PostHog converts `gen_ai.*` spans
+                        into `$ai_generation` events automatically.
+                    </Markdown>
+
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'Python',
+                                code: dedent`
+                                    from opentelemetry import trace
+                                    from opentelemetry.sdk.trace import TracerProvider
+                                    from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+                                    from posthog.ai.otel import PostHogSpanProcessor
+                                    from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
+
+                                    resource = Resource(attributes={
+                                        SERVICE_NAME: "my-app",
+                                        "posthog.distinct_id": "user_123", # optional: identifies the user in PostHog
+                                        "foo": "bar", # custom properties are passed through
+                                    })
+
+                                    provider = TracerProvider(resource=resource)
+                                    provider.add_span_processor(
+                                        PostHogSpanProcessor(
+                                            api_key="<ph_project_token>",
+                                            host="<ph_client_api_host>",
+                                        )
+                                    )
+                                    trace.set_tracer_provider(provider)
+
+                                    OpenAIInstrumentor().instrument()
+                                `,
+                            },
+                            {
+                                language: 'typescript',
+                                file: 'Node',
+                                code: dedent`
+                                    import { NodeSDK } from '@opentelemetry/sdk-node'
+                                    import { resourceFromAttributes } from '@opentelemetry/resources'
+                                    import { PostHogSpanProcessor } from '@posthog/ai/otel'
+                                    import { OpenAIInstrumentation } from '@opentelemetry/instrumentation-openai'
+
+                                    const sdk = new NodeSDK({
+                                      resource: resourceFromAttributes({
+                                        'service.name': 'my-app',
+                                        'posthog.distinct_id': 'user_123', // optional: identifies the user in PostHog
+                                        foo: 'bar', // custom properties are passed through
+                                      }),
+                                      spanProcessors: [
+                                        new PostHogSpanProcessor({
+                                          apiKey: '<ph_project_token>',
+                                          host: '<ph_client_api_host>',
+                                        }),
+                                      ],
+                                      instrumentations: [new OpenAIInstrumentation()],
+                                    })
+                                    sdk.start()
+                                `,
+                            },
+                        ]}
+                    />
+                </>
+            ),
+        },
+        {
+            title: 'Make an LLM call',
+            badge: 'required',
+            content: (
+                <>
+                    <Markdown>
+                        With the processor and instrumentation wired up, any LLM call made through the instrumented SDK
+                        is captured. PostHog receives the emitted `gen_ai.*` span and converts it into an
+                        `$ai_generation` event.
+                    </Markdown>
+
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'python',
+                                file: 'Python',
+                                code: dedent`
+                                    import openai
+
+                                    client = openai.OpenAI(api_key="<openai_api_key>")
+
+                                    response = client.chat.completions.create(
+                                        model="gpt-5-mini",
+                                        messages=[
+                                            {"role": "user", "content": "Tell me a fun fact about hedgehogs"}
+                                        ],
+                                    )
+
+                                    print(response.choices[0].message.content)
+                                `,
+                            },
+                            {
+                                language: 'typescript',
+                                file: 'Node',
+                                code: dedent`
+                                    import OpenAI from 'openai'
+
+                                    const client = new OpenAI({ apiKey: '<openai_api_key>' })
+
+                                    const response = await client.chat.completions.create({
+                                      model: 'gpt-5-mini',
+                                      messages: [{ role: 'user', content: 'Tell me a fun fact about hedgehogs' }],
+                                    })
+
+                                    console.log(response.choices[0].message.content)
+                                `,
+                            },
+                        ]}
+                    />
+
+                    <Blockquote>
+                        <Markdown>
+                            {dedent`
+                            **Note:** If you want to capture LLM events anonymously, omit the \`posthog.distinct_id\` resource attribute. See our docs on [anonymous vs identified events](https://posthog.com/docs/data/anonymous-vs-identified-events) to learn more.
+                            `}
+                        </Markdown>
+                    </Blockquote>
+
+                    <Markdown>
+                        {dedent`
+                            You can expect captured \`$ai_generation\` events to have the following properties:
+                        `}
+                    </Markdown>
+
+                    {NotableGenerationProperties && <NotableGenerationProperties />}
+                </>
+            ),
+        },
+        {
+            title: 'Send OTLP traces directly (advanced)',
+            badge: 'optional',
+            content: (
+                <>
+                    <Markdown>
+                        If you already run an OpenTelemetry collector, or you want to export from a language other than
+                        Python or Node.js, point any OTLP/HTTP exporter directly at PostHog's AI ingestion endpoint.
+                        PostHog accepts OTLP over HTTP in both `application/x-protobuf` and `application/json`,
+                        authenticated with a `Bearer` token.
+                    </Markdown>
+
+                    <CodeBlock
+                        blocks={[
+                            {
+                                language: 'bash',
+                                file: 'Environment',
+                                code: dedent`
+                                    OTEL_EXPORTER_OTLP_ENDPOINT="<ph_client_api_host>/i/v0/ai/otel"
+                                    OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <ph_project_token>"
+                                `,
+                            },
+                            {
+                                language: 'yaml',
+                                file: 'Collector',
+                                code: dedent`
+                                    exporters:
+                                      otlphttp/posthog:
+                                        endpoint: "<ph_client_api_host>/i/v0/ai/otel"
+                                        headers:
+                                          Authorization: "Bearer <ph_project_token>"
+
+                                    service:
+                                      pipelines:
+                                        traces:
+                                          receivers: [otlp]
+                                          processors: [batch]
+                                          exporters: [otlphttp/posthog]
+                                `,
+                            },
+                        ]}
+                    />
+
+                    <Markdown>
+                        The endpoint only ingests AI-related spans — those whose name or attribute keys start with
+                        `gen_ai.`, `llm.`, `ai.`, or `traceloop.`. Every other span is dropped server-side, so it's safe
+                        to send a mixed trace stream.
+                    </Markdown>
+                </>
+            ),
+        },
+    ]
+}
+
+export const OpenTelemetryInstallation = createInstallation(getOpenTelemetrySteps)

--- a/docs/onboarding/llm-analytics/opentelemetry.tsx
+++ b/docs/onboarding/llm-analytics/opentelemetry.tsx
@@ -13,15 +13,6 @@ export const getOpenTelemetrySteps = (ctx: OnboardingComponentsContext): StepDef
             badge: 'required',
             content: (
                 <>
-                    <CalloutBox type="info" icon="IconInfo" title="Using our SDKs? You probably don't need this page">
-                        <Markdown>
-                            If you're using our [Python](/docs/libraries/python) or [Node.js](/docs/libraries/node) SDKs
-                            with a supported provider (OpenAI, Anthropic, Gemini, and more), use the [native
-                            wrappers](/docs/llm-analytics/installation) instead. This page is for OpenTelemetry-native
-                            setups, OpenTelemetry collectors, and frameworks that don't have a PostHog SDK wrapper yet.
-                        </Markdown>
-                    </CalloutBox>
-
                     <CalloutBox type="fyi" icon="IconInfo" title="Full working examples">
                         <Markdown>
                             The [Node.js](https://github.com/PostHog/posthog-js/tree/main/examples/example-ai-openai)

--- a/frontend/src/scenes/onboarding/sdks/allSDKs.tsx
+++ b/frontend/src/scenes/onboarding/sdks/allSDKs.tsx
@@ -460,6 +460,13 @@ export const ALL_SDKS: SDK[] = [
         docsLink: 'https://posthog.com/docs/llm-analytics/manual-capture',
     },
     {
+        name: 'OpenTelemetry',
+        key: SDKKey.OPENTELEMETRY,
+        tags: [SDKTag.INTEGRATION],
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/opentelemetry_afb29df5ab.svg',
+        docsLink: 'https://posthog.com/docs/llm-analytics/installation/opentelemetry',
+    },
+    {
         name: 'iOS',
         key: SDKKey.IOS,
         tags: [SDKTag.MOBILE],

--- a/frontend/src/scenes/onboarding/sdks/llm-analytics/LLMAnalyticsSDKInstructions.tsx
+++ b/frontend/src/scenes/onboarding/sdks/llm-analytics/LLMAnalyticsSDKInstructions.tsx
@@ -33,6 +33,7 @@ import { OllamaInstallation } from '@posthog/shared-onboarding/llm-analytics/oll
 import { OpenAIInstallation } from '@posthog/shared-onboarding/llm-analytics/openai'
 import { OpenAIAgentsInstallation } from '@posthog/shared-onboarding/llm-analytics/openai-agents'
 import { OpenRouterInstallation } from '@posthog/shared-onboarding/llm-analytics/openrouter'
+import { OpenTelemetryInstallation } from '@posthog/shared-onboarding/llm-analytics/opentelemetry'
 import { PerplexityInstallation } from '@posthog/shared-onboarding/llm-analytics/perplexity'
 import { PortkeyInstallation } from '@posthog/shared-onboarding/llm-analytics/portkey'
 import { PydanticAIInstallation } from '@posthog/shared-onboarding/llm-analytics/pydantic-ai'
@@ -218,6 +219,10 @@ const LLMDedalusInstructionsWrapper = withOnboardingDocsWrapper({
     Installation: DedalusInstallation,
     snippets: PROVIDER_SNIPPETS,
 })
+const LLMOpenTelemetryInstructionsWrapper = withOnboardingDocsWrapper({
+    Installation: OpenTelemetryInstallation,
+    snippets: PROVIDER_SNIPPETS,
+})
 
 export const LLMAnalyticsSDKTagOverrides: SDKTagOverrides = {
     [SDKKey.HELICONE]: [SDKTag.GATEWAY],
@@ -262,5 +267,6 @@ export const LLMAnalyticsSDKInstructions: SDKInstructionsMap = {
     [SDKKey.HUGGING_FACE]: LLMHuggingFaceInstructionsWrapper,
     [SDKKey.XAI]: LLMXAIInstructionsWrapper,
     [SDKKey.OPENAI_AGENTS]: LLMOpenAIAgentsInstructionsWrapper,
+    [SDKKey.OPENTELEMETRY]: LLMOpenTelemetryInstructionsWrapper,
     [SDKKey.MANUAL_CAPTURE]: LLMManualInstructionsWrapper,
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6213,6 +6213,7 @@ export enum SDKKey {
     OPENAI = 'openai',
     OPENAI_AGENTS = 'openai_agents',
     OPENROUTER = 'openrouter',
+    OPENTELEMETRY = 'opentelemetry',
     PERPLEXITY = 'perplexity',
     PHP = 'php',
     PORTKEY = 'portkey',


### PR DESCRIPTION
## Problem

We've had users unsure whether PostHog supports OpenTelemetry because there wasn't a dedicated installation page for it — the OTel setup was only visible as a building block inside provider-specific pages. This adds a top-level "OpenTelemetry" onboarding page so anyone emitting OTel GenAI spans natively (from any framework or language) can find clear, generic instructions.

## Changes

- New `docs/onboarding/llm-analytics/opentelemetry.tsx` onboarding page with four steps:
  1. Install dependencies (OTel SDK + PostHog OTel helper + an instrumentation of choice)
  2. Set up OpenTelemetry tracing with `PostHogSpanProcessor`
  3. Make an LLM call (OpenAI shown as a concrete example)
  4. Send OTLP traces directly (advanced) — documents the raw `POST {host}/i/v0/ai/otel` endpoint for collectors and other languages
- Top callout steers SDK users to native wrappers first; "Full working examples" callout links to `example-ai-openai` in posthog-js and posthog-python
- New `SDKKey.OPENTELEMETRY` in `frontend/src/types.ts`, registration in `LLMAnalyticsSDKInstructions.tsx` and `allSDKs.tsx` (tagged `INTEGRATION`, using the OpenTelemetry logo)

## How did you test this code?

Agent-authored — I have not manually run the onboarding flow in the app. Typechecking and existing unit tests should cover correctness of the new SDK key / registration; content of the page mirrors the structure of existing OTel-based onboarding pages.

## Publish to changelog?

no

## 🤖 LLM context

Paired with https://github.com/PostHog/posthog.com/pull/16424 which adds the matching MDX wrapper and sidebar entry.
