### PR TITLE
feat: Add workflow type as attribute of activity metrics

### DIFF
--- a/products/batch_exports/backend/temporal/metrics.py
+++ b/products/batch_exports/backend/temporal/metrics.py
@@ -127,6 +127,8 @@ class _BatchExportsMetricsActivityInboundInterceptor(ActivityInboundInterceptor)
         histogram_attributes: Attributes = {
             "interval": interval,
         }
+        if activity_info.workflow_type is not None:
+            histogram_attributes["workflow_type"] = activity_info.workflow_type
 
         meter = get_metric_meter(histogram_attributes)
 

--- a/products/batch_exports/backend/tests/temporal/test_metrics.py
+++ b/products/batch_exports/backend/tests/temporal/test_metrics.py
@@ -112,11 +112,7 @@ async def test_interceptor_calls_histogram_metrics(
         )
 
         mocked_meter.assert_any_call(
-            {
-                "interval": "hour",
-                "status": "COMPLETED",
-                "exception": "",
-            }
+            {"interval": "hour", "status": "COMPLETED", "exception": "", "workflow_type": "postgres-export"}
         )
         mocked_meter.return_value.create_histogram_timedelta.assert_any_call(
             name="batch_exports_workflow_interval_execution_latency",


### PR DESCRIPTION
## Problem

Temporal doesn't automatically add a `workflow_type` label to histogram metrics when in an activity context. This makes it annoying to filter metrics by specific workflows.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Add workflow_type to metric attributes.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Have not 
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

No
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
