### PR TITLE
feat(ingestion): add token-header filtering to DLQ replay workflow

### DIFF
--- a/posthog/temporal/dlq_replay/activities.py
+++ b/posthog/temporal/dlq_replay/activities.py
@@ -32,6 +32,9 @@ class ReplayPartitionInputs:
         start_timestamp_ms: The timestamp (in milliseconds) to start reading from.
         end_timestamp_ms: The timestamp (in milliseconds) to stop reading at.
         batch_size: Number of messages to process in each batch before flushing.
+        token_allowlist: Optional list of token values. When set, only messages whose
+            `token` Kafka header matches one of these values are replayed; all others
+            are skipped (including messages without a `token` header).
     """
 
     source_topic: str
@@ -40,6 +43,7 @@ class ReplayPartitionInputs:
     start_timestamp_ms: int
     end_timestamp_ms: int
     batch_size: int = 1000
+    token_allowlist: list[str] | None = None
 
 
 @dataclasses.dataclass
@@ -49,10 +53,12 @@ class ReplayPartitionResult:
     Attributes:
         partition: The partition that was replayed.
         messages_replayed: Number of messages replayed from this partition.
+        messages_skipped: Number of messages read but skipped by the token allowlist.
     """
 
     partition: int
     messages_replayed: int
+    messages_skipped: int = 0
 
 
 def configure_ssl_context() -> ssl.SSLContext | None:
@@ -141,6 +147,10 @@ async def replay_partition(inputs: ReplayPartitionInputs) -> ReplayPartitionResu
     )
 
     messages_replayed = 0
+    messages_skipped = 0
+    token_allowlist_bytes: set[bytes] | None = (
+        {token.encode() for token in inputs.token_allowlist} if inputs.token_allowlist is not None else None
+    )
 
     async with Heartbeater():
         await consumer.start()
@@ -166,7 +176,11 @@ async def replay_partition(inputs: ReplayPartitionInputs) -> ReplayPartitionResu
                 records = await consumer.getmany(tp, timeout_ms=5000, max_records=inputs.batch_size)
 
                 if not records or tp not in records or len(records[tp]) == 0:
-                    logger.info("No more messages available", messages_replayed=messages_replayed)
+                    logger.info(
+                        "No more messages available",
+                        messages_replayed=messages_replayed,
+                        messages_skipped=messages_skipped,
+                    )
                     break
 
                 batch = records[tp]
@@ -184,9 +198,16 @@ async def replay_partition(inputs: ReplayPartitionInputs) -> ReplayPartitionResu
                         reached_end = True
                         break
 
-                    # Produce the message to the target topic, preserving key, value, and headers
-                    # Convert headers to list as aiokafka producer expects list, not tuple
                     headers = list(record.headers) if record.headers else []
+
+                    if token_allowlist_bytes is not None:
+                        token = next((v for k, v in headers if k == "token"), None)
+                        if token not in token_allowlist_bytes:
+                            messages_skipped += 1
+                            continue
+
+                    # Produce the message to the target topic, preserving key, value, and headers.
+                    # aiokafka producer expects a list of header tuples, not the tuple-of-tuples the consumer returns.
                     future = await producer.send(
                         inputs.target_topic,
                         value=record.value,
@@ -206,10 +227,11 @@ async def replay_partition(inputs: ReplayPartitionInputs) -> ReplayPartitionResu
                     "Batch processed",
                     batch_size=len(batch),
                     messages_replayed=messages_replayed,
+                    messages_skipped=messages_skipped,
                 )
 
                 # Heartbeat for progress tracking
-                activity.heartbeat({"messages_replayed": messages_replayed})
+                activity.heartbeat({"messages_replayed": messages_replayed, "messages_skipped": messages_skipped})
 
                 if reached_end:
                     break
@@ -218,6 +240,14 @@ async def replay_partition(inputs: ReplayPartitionInputs) -> ReplayPartitionResu
             await consumer.stop()
             await producer.stop()
 
-    logger.info("Partition replay completed", messages_replayed=messages_replayed)
+    logger.info(
+        "Partition replay completed",
+        messages_replayed=messages_replayed,
+        messages_skipped=messages_skipped,
+    )
 
-    return ReplayPartitionResult(partition=inputs.partition, messages_replayed=messages_replayed)
+    return ReplayPartitionResult(
+        partition=inputs.partition,
+        messages_replayed=messages_replayed,
+        messages_skipped=messages_skipped,
+    )

--- a/posthog/temporal/dlq_replay/workflow.py
+++ b/posthog/temporal/dlq_replay/workflow.py
@@ -29,6 +29,8 @@ class DLQReplayWorkflowInputs:
         end_timestamp: ISO format datetime string for the end of the replay window.
             If None, defaults to current UTC time when the workflow starts.
         batch_size: Number of messages to process in each batch.
+        token_allowlist: Optional list of token values. When set, only messages whose
+            `token` Kafka header matches one of these values are replayed.
     """
 
     source_topic: str
@@ -36,6 +38,7 @@ class DLQReplayWorkflowInputs:
     start_timestamp: str
     end_timestamp: str | None = None
     batch_size: int = 1000
+    token_allowlist: list[str] | None = None
 
 
 @dataclasses.dataclass
@@ -44,10 +47,12 @@ class DLQReplayWorkflowResult:
 
     Attributes:
         total_messages_replayed: Total number of messages replayed across all partitions.
+        total_messages_skipped: Total number of messages read but skipped by the token allowlist.
         partition_results: Messages replayed per partition.
     """
 
     total_messages_replayed: int
+    total_messages_skipped: int
     partition_results: dict[int, int]
 
 
@@ -94,7 +99,11 @@ class DLQReplayWorkflow(PostHogWorkflow):
         )
 
         if not partitions:
-            return DLQReplayWorkflowResult(total_messages_replayed=0, partition_results={})
+            return DLQReplayWorkflowResult(
+                total_messages_replayed=0,
+                total_messages_skipped=0,
+                partition_results={},
+            )
 
         # Step 2: Replay each partition in parallel
         partition_tasks = []
@@ -108,6 +117,7 @@ class DLQReplayWorkflow(PostHogWorkflow):
                     start_timestamp_ms=start_timestamp_ms,
                     end_timestamp_ms=end_timestamp_ms,
                     batch_size=inputs.batch_size,
+                    token_allowlist=inputs.token_allowlist,
                 ),
                 start_to_close_timeout=dt.timedelta(hours=4),
                 heartbeat_timeout=dt.timedelta(minutes=2),
@@ -124,13 +134,16 @@ class DLQReplayWorkflow(PostHogWorkflow):
 
         # Step 3: Aggregate results
         total_messages_replayed = 0
+        total_messages_skipped = 0
         partition_results: dict[int, int] = {}
 
         for result in results:
             partition_results[result.partition] = result.messages_replayed
             total_messages_replayed += result.messages_replayed
+            total_messages_skipped += result.messages_skipped
 
         return DLQReplayWorkflowResult(
             total_messages_replayed=total_messages_replayed,
+            total_messages_skipped=total_messages_skipped,
             partition_results=partition_results,
         )

--- a/posthog/temporal/dlq_replay/workflow.py
+++ b/posthog/temporal/dlq_replay/workflow.py
@@ -52,8 +52,8 @@ class DLQReplayWorkflowResult:
     """
 
     total_messages_replayed: int
-    total_messages_skipped: int
     partition_results: dict[int, int]
+    total_messages_skipped: int = 0
 
 
 @workflow.defn(name="dlq-replay")

--- a/posthog/temporal/tests/dlq_replay/test_activities.py
+++ b/posthog/temporal/tests/dlq_replay/test_activities.py
@@ -265,6 +265,61 @@ async def test_replay_partition_respects_end_timestamp(
         assert record.value.decode().startswith("early_message_")
 
 
+async def test_replay_partition_filters_by_token_header(
+    activity_environment,
+    kafka_producer,
+    kafka_consumer,
+    test_topics,
+):
+    """Only messages whose `token` header matches the allowlist are replayed."""
+    source_topic = test_topics["source"]
+    target_topic = test_topics["target"]
+
+    base_time = dt.datetime.now(dt.UTC)
+    for i, token in enumerate([b"keep-1", b"drop", b"keep-2", None, b"keep-1"]):
+        headers = [("token", token)] if token is not None else []
+        await kafka_producer.send(
+            source_topic,
+            value=f"message_{i}".encode(),
+            key=f"key_{i}".encode(),
+            headers=headers,
+            partition=0,
+        )
+    await kafka_producer.flush()
+    await asyncio.sleep(1)
+
+    start_timestamp_ms = int((base_time - dt.timedelta(minutes=1)).timestamp() * 1000)
+    end_timestamp_ms = int((base_time + dt.timedelta(minutes=1)).timestamp() * 1000)
+
+    result = await activity_environment.run(
+        replay_partition,
+        ReplayPartitionInputs(
+            source_topic=source_topic,
+            target_topic=target_topic,
+            partition=0,
+            start_timestamp_ms=start_timestamp_ms,
+            end_timestamp_ms=end_timestamp_ms,
+            batch_size=100,
+            token_allowlist=["keep-1", "keep-2"],
+        ),
+    )
+
+    assert result.messages_replayed == 3
+    assert result.messages_skipped == 2
+
+    tp = TopicPartition(target_topic, 0)
+    kafka_consumer.assign([tp])
+    await kafka_consumer.seek_to_beginning(tp)
+
+    records = await kafka_consumer.getmany(tp, timeout_ms=5000, max_records=10)
+    replayed = records.get(tp, [])
+
+    assert [r.value for r in replayed] == [b"message_0", b"message_2", b"message_4"]
+    for record in replayed:
+        token_value = dict(record.headers).get("token")
+        assert token_value in (b"keep-1", b"keep-2")
+
+
 async def test_replay_partition_handles_empty_partition(
     activity_environment,
     test_topics,

--- a/posthog/temporal/tests/dlq_replay/test_workflow.py
+++ b/posthog/temporal/tests/dlq_replay/test_workflow.py
@@ -266,6 +266,7 @@ async def test_dlq_replay_workflow_aggregates_partition_results(activity_call_tr
 
 @pytest.mark.asyncio
 async def test_dlq_replay_workflow_passes_token_allowlist_to_activity(activity_call_tracker):
+    """Verify the workflow forwards token_allowlist to each partition activity and aggregates skipped counts."""
     replay_partition_calls = activity_call_tracker["replay_partition_calls"]
 
     @activity.defn(name="get_topic_partitions")

--- a/posthog/temporal/tests/dlq_replay/test_workflow.py
+++ b/posthog/temporal/tests/dlq_replay/test_workflow.py
@@ -260,6 +260,7 @@ async def test_dlq_replay_workflow_aggregates_partition_results(activity_call_tr
             )
 
     assert result.total_messages_replayed == 350
+    assert result.total_messages_skipped == 0
     assert result.partition_results == {0: 100, 1: 200, 2: 50}
 
 

--- a/posthog/temporal/tests/dlq_replay/test_workflow.py
+++ b/posthog/temporal/tests/dlq_replay/test_workflow.py
@@ -138,6 +138,7 @@ async def test_dlq_replay_workflow_passes_correct_inputs(activity_call_tracker):
     assert activity_inputs.start_timestamp_ms == int(start_time.timestamp() * 1000)
     assert activity_inputs.end_timestamp_ms == int(end_time.timestamp() * 1000)
     assert activity_inputs.batch_size == 250
+    assert activity_inputs.token_allowlist is None
 
 
 @pytest.mark.asyncio
@@ -260,3 +261,47 @@ async def test_dlq_replay_workflow_aggregates_partition_results(activity_call_tr
 
     assert result.total_messages_replayed == 350
     assert result.partition_results == {0: 100, 1: 200, 2: 50}
+
+
+@pytest.mark.asyncio
+async def test_dlq_replay_workflow_passes_token_allowlist_to_activity(activity_call_tracker):
+    replay_partition_calls = activity_call_tracker["replay_partition_calls"]
+
+    @activity.defn(name="get_topic_partitions")
+    async def mock_get_topic_partitions(inputs: GetTopicPartitionsInputs) -> list[int]:
+        return [0, 1]
+
+    @activity.defn(name="replay_partition")
+    async def mock_replay_partition(inputs: ReplayPartitionInputs) -> ReplayPartitionResult:
+        replay_partition_calls.append(inputs)
+        return ReplayPartitionResult(partition=inputs.partition, messages_replayed=10, messages_skipped=3)
+
+    task_queue_name = str(uuid.uuid4())
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=task_queue_name,
+            workflows=[DLQReplayWorkflow],
+            activities=[mock_get_topic_partitions, mock_replay_partition],
+            workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+        ):
+            start_time = datetime.now(UTC) - timedelta(hours=1)
+
+            result = await env.client.execute_workflow(
+                DLQReplayWorkflow.run,
+                DLQReplayWorkflowInputs(
+                    source_topic="events_dlq",
+                    target_topic="events",
+                    start_timestamp=start_time.isoformat(),
+                    token_allowlist=["token_a", "token_b"],
+                ),
+                id=str(uuid.uuid4()),
+                task_queue=task_queue_name,
+            )
+
+    assert len(replay_partition_calls) == 2
+    for call in replay_partition_calls:
+        assert call.token_allowlist == ["token_a", "token_b"]
+
+    assert result.total_messages_replayed == 20
+    assert result.total_messages_skipped == 6


### PR DESCRIPTION
## Problem

The DLQ replay workflow (`posthog/temporal/dlq_replay/`) copies every message from a source Kafka topic to a target topic within a time window. For targeted replays — e.g., re-delivering DLQ messages for a single team/customer after a bad deploy — we had no way to avoid re-producing unrelated traffic. The only workaround was writing a bespoke script.

## Changes

Added an optional `token_allowlist: list[str]` input to both `DLQReplayWorkflowInputs` and `ReplayPartitionInputs`. When set, the partition activity reads the `token` Kafka header from each record and only produces messages whose header value matches one of the allowlisted tokens; everything else is counted in a new `messages_skipped` stat and dropped. When unset, behavior is unchanged.

Key points:

- Filtering is done client-side (Kafka brokers don't inspect message bytes), but all messages still have to be consumed — this is a functional filter, not a bandwidth one.
- Headers are compared as `bytes` directly, avoiding per-message decode.
- `DLQReplayWorkflowResult` gains `total_messages_skipped` so operators can see how many messages were read but filtered out.
- Messages without a `token` header are skipped when an allowlist is set — this keeps the contract simple (allowlist means "only these tokens").

## How did you test this code?

- Added a workflow-level unit test verifying the allowlist is forwarded to each partition activity and that skipped counts are aggregated.
- Added an integration test in `test_activities.py` that produces mixed-token messages to a real Kafka topic and asserts only the allowlisted ones are replayed.
- Ran the existing + new workflow test suite locally (`hogli test posthog/temporal/tests/dlq_replay/test_workflow.py`): 7 passed.
- Activity-level integration tests require a live Kafka broker and run in CI.
- I'm an agent and have not manually run the workflow end-to-end against a real broker beyond the integration test.

## Publish to changelog?

no