### PR TITLE
fix(funnels): remove hard row cap that truncates breakdown series in weekly view

### DIFF
--- a/posthog/hogql_queries/insights/funnels/funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_trends.py
@@ -208,7 +208,7 @@ class FunnelTrendsUDF(FunnelUDFMixin, FunnelBase):
         if self.context.breakdown:
             breakdown_limit = self.get_breakdown_limit()
             if breakdown_limit:
-                limit = min(breakdown_limit * len(self._date_range().all_values()), limit)
+                limit = breakdown_limit * len(self._date_range().all_values())
 
             not_in_cohort_union = ""
             extra_placeholders: dict[str, ast.Expr] = {}


### PR DESCRIPTION
## Problem

Funnel trends ("Historical trends") with breakdowns silently drops the least popular breakdown series when using weekly or daily intervals, while the same series appears correctly in monthly view.

The root cause is a hard cap of 1,000 on total result rows (`period × breakdown` combinations). With many breakdown values and fine-grained intervals, this cap is insufficient:
- **Monthly**: 20 breakdowns × 12 months = 240 rows — fits in limit
- **Weekly**: 20 breakdowns × 52 weeks = 1,040 rows — exceeds 1,000 cap, least popular series truncated

This is the only insight type with an interval-dependent breakdown limit. Trends and regular funnels both limit by distinct breakdown values (via `row_number`), making them interval-independent.

## Changes

Remove the `min(..., 1000)` hard cap in `funnel_trends.py` so the limit scales as `breakdown_limit × num_periods`, consistent with other insight types. The `breakdown_limit` (default 25) already bounds the number of distinct breakdown values.

## How did you test this code?

This is an agent-authored PR. I have not tested this manually. The change is a single-line removal of a `min()` cap. Existing snapshot tests are unaffected (they cover non-breakdown cases which still use the default 1,000 limit).

Reviewers should verify by creating a funnel trends insight with >19 breakdown values over a long weekly date range and confirming all series now appear.

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored fix. The investigation traced through the funnel trends query builder (`funnel_trends.py`), compared limit handling across insight types (trends, regular funnels, funnel trends), and identified the hard row cap as the only interval-dependent limit pattern.