### PR TITLE
fix(replay): add transient error banner for replay summary

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
@@ -1,9 +1,12 @@
+import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { IconChevronDown, IconMagicWand } from '@posthog/icons'
 import { LemonBanner, LemonButton, Spinner } from '@posthog/lemon-ui'
 
+import { Resizer } from 'lib/components/Resizer/Resizer'
+import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
@@ -13,7 +16,10 @@ import { sessionSummaryProgressLogic } from './player-meta/sessionSummaryProgres
 import { LoadingTimer, SessionSummary, SummarizationProgressView } from './PlayerSummaryViews'
 import { sessionRecordingPlayerLogic } from './sessionRecordingPlayerLogic'
 
-const EXPANDED_MAX_HEIGHT = 480
+const COLLAPSED_HEIGHT = 44
+const DEFAULT_EXPANDED_HEIGHT = 480
+const MIN_EXPANDED_HEIGHT = 120
+const MAX_EXPANDED_HEIGHT = 800
 
 export function PlayerSummaryDock(): JSX.Element | null {
     const { featureFlags } = useValues(featureFlagLogic)
@@ -31,10 +37,22 @@ export function PlayerSummaryDock(): JSX.Element | null {
     const { setSummaryOpen } = useActions(sessionSummaryProgressLogic)
     const { reportAISessionSummaryViewed } = useActions(sessionRecordingEventUsageLogic)
 
+    const dockRef = useRef<HTMLDivElement>(null)
+    const resizerProps: ResizerLogicProps = {
+        logicKey: 'player-summary-dock',
+        placement: 'top',
+        containerRef: dockRef,
+    }
+    const { desiredSize, isResizeInProgress } = useValues(resizerLogic(resizerProps))
+
     const isEnabled = featureFlags[FEATURE_FLAGS.AI_SESSION_SUMMARY]
     const hasSummary = !!sessionSummary
     const isOpen = !!openBySessionId[sessionRecordingId]
     const setIsOpen = (open: boolean): void => setSummaryOpen(sessionRecordingId, open)
+    const expandedHeight = Math.max(
+        MIN_EXPANDED_HEIGHT,
+        Math.min(MAX_EXPANDED_HEIGHT, desiredSize ?? DEFAULT_EXPANDED_HEIGHT)
+    )
 
     useEffect(() => {
         if (sessionRecordingId && isOpen) {
@@ -50,10 +68,15 @@ export function PlayerSummaryDock(): JSX.Element | null {
 
     return (
         <div
-            className="border-t bg-surface-primary overflow-hidden transition-[max-height] duration-300 ease-out flex flex-col"
-            style={{ maxHeight: isOpen ? EXPANDED_MAX_HEIGHT : 44 }}
+            ref={dockRef}
+            className={clsx(
+                'relative border-t bg-surface-primary overflow-hidden flex flex-col',
+                !isResizeInProgress && 'transition-[max-height] duration-300 ease-out'
+            )}
+            style={{ maxHeight: isOpen ? expandedHeight : COLLAPSED_HEIGHT }}
             data-attr="player-summary-dock"
         >
+            {isOpen && <Resizer {...resizerProps} />}
             <div className="flex items-center justify-between h-11 px-3 shrink-0">
                 {hasSummary ? (
                     <div className="flex items-center gap-2 font-semibold">

--- a/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSummaryDock.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
 import { IconChevronDown, IconMagicWand } from '@posthog/icons'
-import { LemonButton, Spinner } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, Spinner } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -18,9 +18,14 @@ const EXPANDED_MAX_HEIGHT = 480
 export function PlayerSummaryDock(): JSX.Element | null {
     const { featureFlags } = useValues(featureFlagLogic)
     const { logicProps, sessionRecordingId, sessionPlayerData } = useValues(sessionRecordingPlayerLogic)
-    const { sessionSummary, sessionSummaryLoading, summarizationProgress, summaryDisabledReason } = useValues(
-        playerMetaLogic(logicProps)
-    )
+    const {
+        sessionSummary,
+        sessionSummaryLoading,
+        summarizationProgress,
+        sessionSummaryError,
+        sessionSummaryHasRetried,
+        summaryDisabledReason,
+    } = useValues(playerMetaLogic(logicProps))
     const { summarizeSession } = useActions(playerMetaLogic(logicProps))
     const { openBySessionId } = useValues(sessionSummaryProgressLogic)
     const { setSummaryOpen } = useActions(sessionSummaryProgressLogic)
@@ -41,7 +46,7 @@ export function PlayerSummaryDock(): JSX.Element | null {
         return null
     }
 
-    const hasContentToExpand = hasSummary || sessionSummaryLoading
+    const hasContentToExpand = hasSummary || sessionSummaryLoading || !!sessionSummaryError
 
     return (
         <div
@@ -86,21 +91,42 @@ export function PlayerSummaryDock(): JSX.Element | null {
             {isOpen && (
                 <div className="flex-1 overflow-y-auto px-3 pb-3">
                     {sessionSummaryLoading ? (
-                        summarizationProgress ? (
-                            <SummarizationProgressView
-                                progress={summarizationProgress}
-                                sessionDurationMs={sessionPlayerData?.durationMs}
-                            />
-                        ) : (
-                            <div className="flex items-center justify-between">
-                                <div>
-                                    Researching the session... <Spinner />
+                        <>
+                            {sessionSummaryHasRetried && (
+                                <LemonBanner type="warning" className="mb-2">
+                                    <div className="text-sm font-normal">
+                                        Transient error generating the summary. Retrying...
+                                    </div>
+                                </LemonBanner>
+                            )}
+                            {summarizationProgress ? (
+                                <SummarizationProgressView
+                                    progress={summarizationProgress}
+                                    sessionDurationMs={sessionPlayerData?.durationMs}
+                                />
+                            ) : (
+                                <div className="flex items-center justify-between">
+                                    <div>
+                                        Researching the session... <Spinner />
+                                    </div>
+                                    <div className="flex items-center gap-1 ml-auto">
+                                        <LoadingTimer />
+                                    </div>
                                 </div>
-                                <div className="flex items-center gap-1 ml-auto">
-                                    <LoadingTimer />
-                                </div>
+                            )}
+                        </>
+                    ) : sessionSummaryError ? (
+                        <LemonBanner
+                            type="error"
+                            action={{
+                                children: 'Try again',
+                                onClick: () => summarizeSession(),
+                            }}
+                        >
+                            <div className="text-sm font-normal">
+                                <strong>Summary failed.</strong> {sessionSummaryError}
                             </div>
-                        )
+                        </LemonBanner>
                     ) : hasSummary ? (
                         <SessionSummary />
                     ) : null}

--- a/frontend/src/scenes/session-recordings/player/controller/Seekbar.scss
+++ b/frontend/src/scenes/session-recordings/player/controller/Seekbar.scss
@@ -71,7 +71,7 @@
             position: absolute;
             top: 0;
             left: 0;
-            z-index: 2;
+            z-index: 4;
             width: 100%;
             height: 100%;
             overflow: hidden;

--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
@@ -118,7 +118,14 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
             sessionRecordingPinnedPropertiesLogic,
             ['pinnedProperties'],
             sessionSummaryProgressLogic,
-            ['loadingBySessionId', 'progressBySessionId', 'summaryBySessionId', 'feedbackBySessionId'],
+            [
+                'loadingBySessionId',
+                'progressBySessionId',
+                'summaryBySessionId',
+                'feedbackBySessionId',
+                'errorBySessionId',
+                'retryStateBySessionId',
+            ],
             playerInspectorLogic(props),
             ['allItemsByMiniFilterKey'],
         ],
@@ -166,6 +173,14 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
             (s) => [s.progressBySessionId],
             (progressBySessionId): SummarizationProgress | null =>
                 progressBySessionId[props.sessionRecordingId] ?? null,
+        ],
+        sessionSummaryError: [
+            (s) => [s.errorBySessionId],
+            (errorBySessionId): string | null => errorBySessionId[props.sessionRecordingId] ?? null,
+        ],
+        sessionSummaryHasRetried: [
+            (s) => [s.retryStateBySessionId],
+            (retryStateBySessionId): boolean => !!retryStateBySessionId[props.sessionRecordingId]?.hasRetried,
         ],
         summaryHasHadFeedback: [
             (s) => [s.feedbackBySessionId],

--- a/frontend/src/scenes/session-recordings/player/player-meta/sessionSummaryProgressLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/player-meta/sessionSummaryProgressLogic.ts
@@ -82,13 +82,15 @@ export const sessionSummaryProgressLogic = kea<sessionSummaryProgressLogicType>(
                     [sessionId]: { maxStep: 0, hasRetried: false },
                 }),
                 setProgress: (state, { sessionId, progress }) => {
+                    if (!progress) {
+                        return state
+                    }
                     const existing = state[sessionId] ?? { maxStep: 0, hasRetried: false }
-                    const step = progress?.step ?? 0
                     return {
                         ...state,
                         [sessionId]: {
-                            maxStep: Math.max(existing.maxStep, step),
-                            hasRetried: existing.hasRetried || step < existing.maxStep,
+                            maxStep: Math.max(existing.maxStep, progress.step),
+                            hasRetried: existing.hasRetried || progress.step < existing.maxStep,
                         },
                     }
                 },

--- a/frontend/src/scenes/session-recordings/player/player-meta/sessionSummaryProgressLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/player-meta/sessionSummaryProgressLogic.ts
@@ -34,6 +34,7 @@ export const sessionSummaryProgressLogic = kea<sessionSummaryProgressLogicType>(
         setLoading: (sessionId: string, loading: boolean) => ({ sessionId, loading }),
         setProgress: (sessionId: string, progress: SummarizationProgress | null) => ({ sessionId, progress }),
         setSummary: (sessionId: string, summary: SessionSummaryContent | null) => ({ sessionId, summary }),
+        setError: (sessionId: string, error: string | null) => ({ sessionId, error }),
         markFeedbackGiven: (sessionId: string) => ({ sessionId }),
         setSummaryOpen: (sessionId: string, open: boolean) => ({ sessionId, open }),
     }),
@@ -44,6 +45,7 @@ export const sessionSummaryProgressLogic = kea<sessionSummaryProgressLogicType>(
                 startSummarization: (state, { sessionId }) => ({ ...state, [sessionId]: true }),
                 setLoading: (state, { sessionId, loading }) => ({ ...state, [sessionId]: loading }),
                 setSummary: (state, { sessionId }) => ({ ...state, [sessionId]: false }),
+                setError: (state, { sessionId }) => ({ ...state, [sessionId]: false }),
             },
         ],
         progressBySessionId: [
@@ -58,6 +60,38 @@ export const sessionSummaryProgressLogic = kea<sessionSummaryProgressLogicType>(
             {} as Record<string, SessionSummaryContent | null>,
             {
                 setSummary: (state, { sessionId, summary }) => ({ ...state, [sessionId]: summary }),
+            },
+        ],
+        errorBySessionId: [
+            {} as Record<string, string | null>,
+            {
+                startSummarization: (state, { sessionId }) => ({ ...state, [sessionId]: null }),
+                setError: (state, { sessionId, error }) => ({ ...state, [sessionId]: error }),
+                setSummary: (state, { sessionId }) => ({ ...state, [sessionId]: null }),
+            },
+        ],
+        retryStateBySessionId: [
+            {} as Record<string, { maxStep: number; hasRetried: boolean }>,
+            {
+                startSummarization: (state, { sessionId }) => ({
+                    ...state,
+                    [sessionId]: { maxStep: 0, hasRetried: false },
+                }),
+                setSummary: (state, { sessionId }) => ({
+                    ...state,
+                    [sessionId]: { maxStep: 0, hasRetried: false },
+                }),
+                setProgress: (state, { sessionId, progress }) => {
+                    const existing = state[sessionId] ?? { maxStep: 0, hasRetried: false }
+                    const step = progress?.step ?? 0
+                    return {
+                        ...state,
+                        [sessionId]: {
+                            maxStep: Math.max(existing.maxStep, step),
+                            hasRetried: existing.hasRetried || step < existing.maxStep,
+                        },
+                    }
+                },
             },
         ],
         feedbackBySessionId: [
@@ -98,7 +132,7 @@ export const sessionSummaryProgressLogic = kea<sessionSummaryProgressLogicType>(
                         try {
                             if (event === 'session-summary-error') {
                                 lemonToast.error(data)
-                                actions.setLoading(sessionId, false)
+                                actions.setError(sessionId, data)
                                 return
                             }
                             if (event === 'session-summary-progress') {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
When the temporal job restarts due to a failed job it retries a few times, the UI of progress bar reflects the reset but doesn't give any information on what's going on

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- added a banner in summary UI to inform transient error
- added a banner to inform when temporal job fails for good (user may miss the toast)
- Made the dock resizable
<img width="1524" height="1134" alt="Screenshot 2026-04-17 at 10 38 07" src="https://github.com/user-attachments/assets/4496062f-bf71-4f1c-9f43-d1df3d5c13cb" />
<img width="1524" height="261" alt="Screenshot 2026-04-17 at 10 38 28" src="https://github.com/user-attachments/assets/361d1b80-3701-45d7-a80c-4c47bf64fdc2" />

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
