### PR TITLE
feat: persist invite modal open state in the URL

### DIFF
--- a/frontend/src/layout/GlobalModals.tsx
+++ b/frontend/src/layout/GlobalModals.tsx
@@ -9,6 +9,7 @@ import { superpowersLogic } from 'lib/components/Superpowers/superpowersLogic'
 import { TimeSensitiveAuthenticationModal } from 'lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication'
 import { GlobalCustomUnitModal } from 'lib/components/UnitPicker/GlobalCustomUnitModal'
 import { UpgradeModal } from 'lib/components/UpgradeModal/UpgradeModal'
+import { bindModalToUrl } from 'lib/logic/bindModalToUrl'
 import { TwoFactorSetupModal } from 'scenes/authentication/TwoFactorSetupModal'
 import { PaymentEntryModal } from 'scenes/billing/PaymentEntryModal'
 import { CreateOrganizationModal } from 'scenes/organization/CreateOrganizationModal'
@@ -47,6 +48,12 @@ export const globalModalsLogic = kea<globalModalsLogicType>([
                 hideCreateProjectModal: () => false,
             },
         ],
+    }),
+    bindModalToUrl({
+        urlKey: 'create-organization',
+        openActionKey: 'showCreateOrganizationModal',
+        closeActionKey: 'hideCreateOrganizationModal',
+        isOpenKey: 'isCreateOrganizationModalShown',
     }),
 ])
 

--- a/frontend/src/lib/logic/bindModalToUrl.test.ts
+++ b/frontend/src/lib/logic/bindModalToUrl.test.ts
@@ -1,0 +1,121 @@
+import { actions, kea, path, reducers } from 'kea'
+import { router } from 'kea-router'
+import { expectLogic } from 'kea-test-utils'
+
+import { initKeaTests } from '~/test/init'
+
+import { bindModalToUrl } from './bindModalToUrl'
+import type { testModalLogicType } from './bindModalToUrl.testType'
+
+// Minimal logic wired to `?modal=test-modal` for exercising bindModalToUrl
+const testModalLogic = kea<testModalLogicType>([
+    path(['bindModalToUrl', 'test']),
+    actions({
+        showModal: true,
+        hideModal: true,
+    }),
+    reducers({
+        isOpen: [
+            false,
+            {
+                showModal: () => true,
+                hideModal: () => false,
+            },
+        ],
+    }),
+    bindModalToUrl({
+        urlKey: 'test-modal',
+        openActionKey: 'showModal',
+        closeActionKey: 'hideModal',
+        isOpenKey: 'isOpen',
+    }),
+])
+
+describe('bindModalToUrl', () => {
+    let logic: ReturnType<typeof testModalLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        router.actions.push('/example')
+        logic = testModalLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    it('writes the modal key to the URL when the open action fires', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.showModal()
+        }).toMatchValues({ isOpen: true })
+
+        expect(router.values.searchParams.modal).toBe('test-modal')
+    })
+
+    it('strips the modal key from the URL when the close action fires', async () => {
+        logic.actions.showModal()
+        await expectLogic(router).delay(1)
+        expect(router.values.searchParams.modal).toBe('test-modal')
+
+        await expectLogic(logic, () => {
+            logic.actions.hideModal()
+        }).toMatchValues({ isOpen: false })
+
+        expect(router.values.searchParams.modal).toBeUndefined()
+    })
+
+    it('opens the modal when the URL already has the matching param on mount (deep link)', async () => {
+        logic.unmount()
+        router.actions.push('/example', { modal: 'test-modal' })
+        logic = testModalLogic()
+        logic.mount()
+
+        await expectLogic(logic).delay(1).toMatchValues({ isOpen: true })
+    })
+
+    it('closes the modal when the URL param is removed externally (e.g., back/forward navigation)', async () => {
+        logic.actions.showModal()
+        await expectLogic(router).delay(1)
+
+        router.actions.push('/example')
+
+        await expectLogic(logic).delay(1).toMatchValues({ isOpen: false })
+    })
+
+    it('ignores modal params that belong to a different urlKey', async () => {
+        router.actions.push('/example', { modal: 'some-other-modal' })
+
+        await expectLogic(logic).delay(1).toMatchValues({ isOpen: false })
+    })
+
+    it('preserves unrelated query params when opening and closing', async () => {
+        router.actions.push('/example', { tab: 'general', q: 'hello' })
+        await expectLogic(router).delay(1)
+
+        logic.actions.showModal()
+        await expectLogic(router).delay(1)
+        expect(router.values.searchParams).toEqual({ tab: 'general', q: 'hello', modal: 'test-modal' })
+
+        logic.actions.hideModal()
+        await expectLogic(router).delay(1)
+        expect(router.values.searchParams).toEqual({ tab: 'general', q: 'hello' })
+    })
+
+    it('does not re-dispatch when state already matches the URL (loop guard)', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.showModal()
+        })
+            .toDispatchActions(['showModal'])
+            .toNotHaveDispatchedActions(['showModal', 'showModal'])
+    })
+
+    it('does not stomp on another modal key in the URL on close', async () => {
+        router.actions.push('/example', { modal: 'unrelated-modal' })
+        await expectLogic(router).delay(1)
+
+        logic.actions.hideModal()
+        await expectLogic(router).delay(1)
+        expect(router.values.searchParams.modal).toBe('unrelated-modal')
+    })
+})

--- a/frontend/src/lib/logic/bindModalToUrl.ts
+++ b/frontend/src/lib/logic/bindModalToUrl.ts
@@ -1,0 +1,45 @@
+import { BuiltLogic, Logic } from 'kea'
+import { actionToUrl, router, urlToAction } from 'kea-router'
+
+export interface BindModalToUrlOptions<L extends Logic = Logic> {
+    urlKey: string
+    openActionKey: keyof L['actionCreators'] & string
+    closeActionKey: keyof L['actionCreators'] & string
+    /** Name of the selector/reducer that's truthy when the modal is open. Used as loop guard. */
+    isOpenKey: keyof L['values'] & string
+}
+
+/** Sync between a modal's open state and `?modal=<urlKey>`. Uses `replace`, preserves other params. */
+export function bindModalToUrl<L extends Logic = Logic>({
+    urlKey,
+    openActionKey,
+    closeActionKey,
+    isOpenKey,
+}: BindModalToUrlOptions<L>) {
+    const buildUrl = (open: boolean): [string, Record<string, any>, Record<string, any>, { replace: true }] => {
+        const { pathname, searchParams, hashParams } = router.values.currentLocation
+        const next = { ...searchParams }
+        if (open) {
+            next.modal = urlKey
+        } else if (next.modal === urlKey) {
+            delete next.modal
+        }
+        return [pathname, next, hashParams, { replace: true }]
+    }
+
+    return (logic: BuiltLogic<L>): void => {
+        actionToUrl(() => ({
+            [openActionKey]: () => buildUrl(true),
+            [closeActionKey]: () => buildUrl(false),
+        }))(logic)
+
+        urlToAction(({ actions, values }) => ({
+            '*': (_params, searchParams) => {
+                const shouldBeOpen = searchParams.modal === urlKey
+                if (shouldBeOpen !== !!values[isOpenKey]) {
+                    ;(actions as any)[shouldBeOpen ? openActionKey : closeActionKey]()
+                }
+            },
+        }))(logic)
+    }
+}

--- a/frontend/src/scenes/organization/CreateOrganizationModal.tsx
+++ b/frontend/src/scenes/organization/CreateOrganizationModal.tsx
@@ -29,7 +29,6 @@ export function CreateOrganizationModal({
     }
     const handleSubmit = (): void => {
         createOrganization(name)
-        closeModal()
     }
 
     return (

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -683,7 +683,7 @@ const redirectPipeline = (id: string, fallbackUrl: string): string => {
 
 // NOTE: These redirects will fully replace the URL. If you want to keep support for query and hash params then you should use a function (not string) redirect
 // NOTE: If you need a query param to be automatically forwarded to the redirect URL, add it to the forwardedRedirectQueryParams array
-export const forwardedRedirectQueryParams: string[] = ['invite_modal']
+export const forwardedRedirectQueryParams: string[] = ['modal']
 export const redirects: Record<
     string,
     string | ((params: Params, searchParams: Params, hashParams: Params) => string)

--- a/frontend/src/scenes/settings/organization/VerifiedDomains/AddDomainModal.tsx
+++ b/frontend/src/scenes/settings/organization/VerifiedDomains/AddDomainModal.tsx
@@ -11,7 +11,7 @@ import { verifiedDomainsLogic } from './verifiedDomainsLogic'
 
 export function AddDomainModal(): JSX.Element {
     const { addModalShown, verifiedDomainsLoading } = useValues(verifiedDomainsLogic)
-    const { setAddModalShown, addVerifiedDomain } = useActions(verifiedDomainsLogic)
+    const { hideAddDomainModal, addVerifiedDomain } = useActions(verifiedDomainsLogic)
     const [newDomain, setNewDomain] = useState('')
     const [submitted, setSubmitted] = useState(false)
 
@@ -23,7 +23,7 @@ export function AddDomainModal(): JSX.Element {
     }
 
     const handleClose = (): void => {
-        setAddModalShown(false)
+        hideAddDomainModal()
         clean()
     }
 

--- a/frontend/src/scenes/settings/organization/VerifiedDomains/VerifiedDomains.tsx
+++ b/frontend/src/scenes/settings/organization/VerifiedDomains/VerifiedDomains.tsx
@@ -32,7 +32,7 @@ import { VerifyDomainModal } from './VerifyDomainModal'
 
 export function VerifiedDomains(): JSX.Element {
     const { verifiedDomainsLoading, updatingDomainLoading } = useValues(verifiedDomainsLogic)
-    const { setAddModalShown } = useActions(verifiedDomainsLogic)
+    const { showAddDomainModal } = useActions(verifiedDomainsLogic)
 
     const restrictionReason = useRestrictedArea({
         minimumAccessLevel: OrganizationMembershipLevel.Admin,
@@ -49,7 +49,7 @@ export function VerifiedDomains(): JSX.Element {
             <VerifiedDomainsTable />
             <LemonButton
                 type="primary"
-                onClick={() => setAddModalShown(true)}
+                onClick={() => showAddDomainModal()}
                 className="mt-4"
                 disabledReason={verifiedDomainsLoading || updatingDomainLoading ? 'loading...' : restrictionReason}
             >

--- a/frontend/src/scenes/settings/organization/VerifiedDomains/verifiedDomainsLogic.ts
+++ b/frontend/src/scenes/settings/organization/VerifiedDomains/verifiedDomainsLogic.ts
@@ -5,6 +5,7 @@ import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { SECURE_URL_REGEX } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { bindModalToUrl } from 'lib/logic/bindModalToUrl'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { userLogic } from 'scenes/userLogic'
 
@@ -41,7 +42,8 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType>([
     connect(() => ({ values: [organizationLogic, ['currentOrganizationId']], logic: [userLogic] })),
     actions({
         replaceDomain: (domain: OrganizationDomainType) => ({ domain }),
-        setAddModalShown: (shown: boolean) => ({ shown }),
+        showAddDomainModal: true,
+        hideAddDomainModal: true,
         setConfigureSAMLModalId: (id: string | null) => ({ id }),
         setConfigureSCIMModalId: (id: string | null) => ({ id }),
         setScimLogsModalId: (id: string | null) => ({ id }),
@@ -65,7 +67,8 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType>([
         addModalShown: [
             false,
             {
-                setAddModalShown: (_, { shown }) => shown,
+                showAddDomainModal: () => true,
+                hideAddDomainModal: () => false,
                 addVerifiedDomainSuccess: () => false,
             },
         ],
@@ -305,6 +308,12 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType>([
         ],
     }),
     afterMount(({ actions }) => actions.loadVerifiedDomains()),
+    bindModalToUrl({
+        urlKey: 'add-domain',
+        openActionKey: 'showAddDomainModal',
+        closeActionKey: 'hideAddDomainModal',
+        isOpenKey: 'addModalShown',
+    }),
     forms(({ actions, values }) => ({
         samlConfig: {
             defaults: {} as SAMLConfigType,

--- a/frontend/src/scenes/settings/organization/inviteLogic.ts
+++ b/frontend/src/scenes/settings/organization/inviteLogic.ts
@@ -1,10 +1,10 @@
 import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { lazyLoaders, loaders } from 'kea-loaders'
-import { router, urlToAction } from 'kea-router'
 
 import api, { PaginatedResponse } from 'lib/api'
 import { OrganizationMembershipLevel } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { bindModalToUrl } from 'lib/logic/bindModalToUrl'
 import { pluralize } from 'lib/utils'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
@@ -35,7 +35,6 @@ export const inviteLogic = kea<inviteLogicType>([
     path(['scenes', 'organization', 'Settings', 'inviteLogic']),
     connect(() => ({
         values: [preflightLogic, ['preflight']],
-        actions: [router, ['locationChanged']],
     })),
     actions({
         showInviteModal: true,
@@ -130,7 +129,6 @@ export const inviteLogic = kea<inviteLogicType>([
             {
                 showInviteModal: () => true,
                 hideInviteModal: () => false,
-                locationChanged: () => false,
             },
         ],
         invitesToSend: [
@@ -240,11 +238,10 @@ export const inviteLogic = kea<inviteLogicType>([
             actions.loadProjectAccessControl(projectId)
         },
     })),
-    urlToAction(({ actions }) => ({
-        '*': (_, searchParams) => {
-            if (searchParams.invite_modal) {
-                actions.showInviteModal()
-            }
-        },
-    })),
+    bindModalToUrl({
+        urlKey: 'invite-members',
+        openActionKey: 'showInviteModal',
+        closeActionKey: 'hideInviteModal',
+        isOpenKey: 'isInviteModalShown',
+    }),
 ])


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

When a user triggers a sensitive action that requires re-authentication, for example clicking "Create organization" or "Invite members", the re-auth flow interrupts them, and once they come back the modal is gone, they have to find the button again and start over. 

Modal open state lives in memory, so nothing restores it after redirecting back from Google auth. 

We also can't link directly to a modal, useful for things like an "invite your team" CTA in an email. 

## Changes

- Introduce `bindModalToUrl`, a small kea builder that mirrors a modal's open state into a single `?modal=<key>` query param. 
- param name follows the same pattern as ?tab=… 
- Uses `history.replace` so the back button isn't hijacked by modal toggles
- 'modal' added to `forwardedRedirectQueryParams` so it survives scene-level redirects. 

**How it survives SSO/social re-auth:**

Those flows pass `next=...` param when redirecting to the provider, the provider redirects back to the
same URL, and urlToAction re-opens the modal. 

**Adopted in:**  
invite members modal  
create organization modal  
add verified domain modal

<img width="1699" height="1189" alt="2026-04-17 12 01 31" src="https://github.com/user-attachments/assets/593f5570-af9c-4a56-86e8-f0586531a7d1" />


<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

Logic tests 

To test manually you could add to .env:

```
SESSION_SENSITIVE_ACTIONS_AGE=60
```

## Publish to changelog?

no

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->