### PR TITLE
feat(logs): add alert reset functionality

### DIFF
--- a/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
@@ -6,7 +6,11 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 
-import { LogsAlertConfigurationApi, ThresholdOperatorEnumApi } from 'products/logs/frontend/generated/api.schemas'
+import {
+    LogsAlertConfigurationApi,
+    LogsAlertConfigurationStateEnumApi,
+    ThresholdOperatorEnumApi,
+} from 'products/logs/frontend/generated/api.schemas'
 
 import { logsAlertingLogic } from './logsAlertingLogic'
 import { LogsAlertStateIndicator } from './LogsAlertStateIndicator'
@@ -17,8 +21,9 @@ function formatThreshold(alert: LogsAlertConfigurationApi): string {
 }
 
 export function LogsAlertList(): JSX.Element {
-    const { alerts, alertsLoading } = useValues(logsAlertingLogic)
-    const { setEditingAlert, setIsCreating, deleteAlert, toggleAlertEnabled } = useActions(logsAlertingLogic)
+    const { alerts, alertsLoading, resettingAlertIds } = useValues(logsAlertingLogic)
+    const { setEditingAlert, setIsCreating, deleteAlert, toggleAlertEnabled, resetAlert } =
+        useActions(logsAlertingLogic)
 
     const columns: LemonTableColumns<LogsAlertConfigurationApi> = [
         {
@@ -33,7 +38,9 @@ export function LogsAlertList(): JSX.Element {
         {
             title: 'Status',
             dataIndex: 'state',
-            render: (_, alert) => <LogsAlertStateIndicator state={alert.state} />,
+            render: (_, alert) => (
+                <LogsAlertStateIndicator state={alert.state} lastErrorMessage={alert.last_error_message} />
+            ),
         },
         {
             title: 'Threshold',
@@ -53,7 +60,15 @@ export function LogsAlertList(): JSX.Element {
             title: 'Enabled',
             dataIndex: 'enabled',
             render: (_, alert) => (
-                <LemonSwitch checked={alert.enabled ?? true} onChange={() => toggleAlertEnabled(alert)} />
+                <LemonSwitch
+                    checked={alert.enabled ?? true}
+                    onChange={() => toggleAlertEnabled(alert)}
+                    disabledReason={
+                        alert.state === LogsAlertConfigurationStateEnumApi.Broken
+                            ? 'Reset this alert to re-enable checks'
+                            : undefined
+                    }
+                />
             ),
         },
         {
@@ -67,6 +82,17 @@ export function LogsAlertList(): JSX.Element {
                                     label: 'Edit',
                                     onClick: () => setEditingAlert(alert),
                                 },
+                                ...(alert.state === LogsAlertConfigurationStateEnumApi.Broken
+                                    ? [
+                                          {
+                                              label: resettingAlertIds.has(alert.id) ? 'Resetting…' : 'Reset alert',
+                                              onClick: () => resetAlert(alert.id),
+                                              disabledReason: resettingAlertIds.has(alert.id)
+                                                  ? 'Reset in progress'
+                                                  : undefined,
+                                          },
+                                      ]
+                                    : []),
                                 {
                                     label: 'Delete',
                                     status: 'danger',

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertStateIndicator.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertStateIndicator.tsx
@@ -1,5 +1,7 @@
 import { LemonTag, LemonTagType } from '@posthog/lemon-ui'
 
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+
 import { LogsAlertConfigurationStateEnumApi } from 'products/logs/frontend/generated/api.schemas'
 
 const STATE_CONFIG: Record<LogsAlertConfigurationStateEnumApi, { label: string; type: LemonTagType }> = {
@@ -11,7 +13,22 @@ const STATE_CONFIG: Record<LogsAlertConfigurationStateEnumApi, { label: string; 
     [LogsAlertConfigurationStateEnumApi.Broken]: { label: 'Broken', type: 'danger' },
 }
 
-export function LogsAlertStateIndicator({ state }: { state: LogsAlertConfigurationStateEnumApi }): JSX.Element {
+const STATES_WITH_ERROR_TOOLTIP = new Set<LogsAlertConfigurationStateEnumApi>([
+    LogsAlertConfigurationStateEnumApi.Errored,
+    LogsAlertConfigurationStateEnumApi.Broken,
+])
+
+export function LogsAlertStateIndicator({
+    state,
+    lastErrorMessage,
+}: {
+    state: LogsAlertConfigurationStateEnumApi
+    lastErrorMessage?: string | null
+}): JSX.Element {
     const config = STATE_CONFIG[state] ?? { label: state, type: 'default' as LemonTagType }
-    return <LemonTag type={config.type}>{config.label}</LemonTag>
+    const tag = <LemonTag type={config.type}>{config.label}</LemonTag>
+    if (lastErrorMessage && STATES_WITH_ERROR_TOOLTIP.has(state)) {
+        return <Tooltip title={lastErrorMessage}>{tag}</Tooltip>
+    }
+    return tag
 }

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertingSection.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertingSection.tsx
@@ -2,11 +2,14 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 
 import { IconTestTube } from '@posthog/icons'
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
 
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
 
-import { LogsAlertConfigurationApi } from 'products/logs/frontend/generated/api.schemas'
+import {
+    LogsAlertConfigurationApi,
+    LogsAlertConfigurationStateEnumApi,
+} from 'products/logs/frontend/generated/api.schemas'
 
 import { LogsAlertForm } from './LogsAlertForm'
 import { logsAlertFormLogic } from './logsAlertFormLogic'
@@ -55,8 +58,12 @@ function LogsAlertModalContent({ editingAlert }: { editingAlert: LogsAlertConfig
         logsAlertFormLogic(formLogicProps)
     )
     const { openSimulationPanel, closeSimulationPanel } = useActions(logsAlertFormLogic(formLogicProps))
+    const { resetAlert } = useActions(logsAlertingLogic)
+    const { resettingAlertIds } = useValues(logsAlertingLogic)
     const { pendingNotifications } = useValues(logsAlertNotificationLogic(notifLogicProps))
     const hasPendingNotifications = pendingNotifications.length > 0
+    const isBroken = editingAlert?.state === LogsAlertConfigurationStateEnumApi.Broken
+    const isResetting = editingAlert ? resettingAlertIds.has(editingAlert.id) : false
 
     return (
         <BindLogic logic={logsAlertFormLogic} props={formLogicProps}>
@@ -73,6 +80,27 @@ function LogsAlertModalContent({ editingAlert }: { editingAlert: LogsAlertConfig
                         <p className="text-muted text-sm m-0">Alerts are checked every minute.</p>
                     </LemonModal.Header>
                     <LemonModal.Content>
+                        {isBroken && editingAlert && (
+                            <LemonBanner
+                                type="error"
+                                className="mb-3"
+                                action={{
+                                    children: isResetting ? 'Resetting…' : 'Reset alert',
+                                    onClick: () => resetAlert(editingAlert.id),
+                                    loading: isResetting,
+                                    disabledReason: isResetting ? 'Reset in progress' : undefined,
+                                }}
+                            >
+                                <div className="font-semibold">
+                                    This alert was auto-disabled after repeated check failures.
+                                </div>
+                                {editingAlert.last_error_message && (
+                                    <div className="text-xs text-muted-alt mt-1">
+                                        Last error: {editingAlert.last_error_message}
+                                    </div>
+                                )}
+                            </LemonBanner>
+                        )}
                         <LogsAlertForm />
                     </LemonModal.Content>
                     <LemonModal.Footer>

--- a/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertingLogic.test.ts
+++ b/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertingLogic.test.ts
@@ -1,0 +1,95 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { lemonToast } from '@posthog/lemon-ui'
+
+import { initKeaTests } from '~/test/init'
+
+import { logsAlertsList, logsAlertsResetCreate } from 'products/logs/frontend/generated/api'
+
+import { logsAlertingLogic } from '../logsAlertingLogic'
+
+jest.mock('products/logs/frontend/generated/api', () => ({
+    __esModule: true,
+    logsAlertsDestroy: jest.fn(),
+    logsAlertsList: jest.fn().mockResolvedValue({ results: [] }),
+    logsAlertsPartialUpdate: jest.fn(),
+    logsAlertsResetCreate: jest.fn(),
+}))
+
+jest.mock('@posthog/lemon-ui', () => ({
+    ...jest.requireActual('@posthog/lemon-ui'),
+    lemonToast: {
+        success: jest.fn(),
+        error: jest.fn(),
+    },
+}))
+
+const mockReset = logsAlertsResetCreate as jest.MockedFunction<typeof logsAlertsResetCreate>
+const mockList = logsAlertsList as jest.MockedFunction<typeof logsAlertsList>
+
+describe('logsAlertingLogic', () => {
+    beforeEach(() => {
+        initKeaTests()
+        jest.clearAllMocks()
+        mockList.mockResolvedValue({ results: [] } as any)
+    })
+
+    describe('resetAlert', () => {
+        it('calls the reset endpoint, reloads the list, and surfaces a success toast', async () => {
+            mockReset.mockResolvedValue(undefined as any)
+
+            const logic = logsAlertingLogic()
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            mockList.mockClear()
+
+            await expectLogic(logic, () => {
+                logic.actions.resetAlert('alert-1')
+            }).toFinishAllListeners()
+
+            expect(mockReset).toHaveBeenCalledWith(expect.any(String), 'alert-1')
+            expect(lemonToast.success).toHaveBeenCalledWith(expect.stringContaining('Alert reset'))
+            // loadAlerts runs on mount + after the successful reset.
+            expect(mockList).toHaveBeenCalledTimes(1)
+
+            logic.unmount()
+        })
+
+        it('updates editingAlert optimistically when the reset target matches the open modal', async () => {
+            const editing = { id: 'alert-1', name: 'broken', state: 'broken' } as any
+            const updated = { id: 'alert-1', name: 'broken', state: 'ok' } as any
+            mockReset.mockResolvedValue(updated)
+
+            const logic = logsAlertingLogic()
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            logic.actions.setEditingAlert(editing)
+
+            await expectLogic(logic, () => {
+                logic.actions.resetAlert('alert-1')
+            })
+                .toFinishAllListeners()
+                .toMatchValues({ editingAlert: updated })
+
+            logic.unmount()
+        })
+
+        it('surfaces an error toast and does not reload on failure', async () => {
+            mockReset.mockRejectedValue(new Error('boom'))
+
+            const logic = logsAlertingLogic()
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            mockList.mockClear()
+
+            await expectLogic(logic, () => {
+                logic.actions.resetAlert('alert-1')
+            }).toFinishAllListeners()
+
+            expect(lemonToast.error).toHaveBeenCalledWith('Failed to reset alert')
+            expect(mockList).not.toHaveBeenCalled()
+
+            logic.unmount()
+        })
+    })
+})

--- a/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
@@ -6,7 +6,12 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import { teamLogic } from 'scenes/teamLogic'
 
-import { logsAlertsDestroy, logsAlertsList, logsAlertsPartialUpdate } from 'products/logs/frontend/generated/api'
+import {
+    logsAlertsDestroy,
+    logsAlertsList,
+    logsAlertsPartialUpdate,
+    logsAlertsResetCreate,
+} from 'products/logs/frontend/generated/api'
 import { LogsAlertConfigurationApi } from 'products/logs/frontend/generated/api.schemas'
 
 import type { logsAlertingLogicType } from './logsAlertingLogicType'
@@ -25,6 +30,8 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
         setIsCreating: (isCreating: boolean) => ({ isCreating }),
         deleteAlert: (id: string) => ({ id }),
         toggleAlertEnabled: (alert: LogsAlertConfigurationApi) => ({ alert }),
+        resetAlert: (id: string) => ({ id }),
+        setResettingAlertId: (id: string, resetting: boolean) => ({ id, resetting }),
     }),
 
     reducers({
@@ -40,6 +47,13 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
             {
                 setIsCreating: (_, { isCreating }) => isCreating,
                 setEditingAlert: () => false,
+            },
+        ],
+        resettingAlertIds: [
+            new Set<string>(),
+            {
+                setResettingAlertId: (state, { id, resetting }) =>
+                    resetting ? new Set([...state, id]) : new Set([...state].filter((x) => x !== id)),
             },
         ],
     }),
@@ -89,6 +103,24 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
                 actions.loadAlerts()
             } catch {
                 lemonToast.error('Failed to update alert')
+            }
+        },
+        resetAlert: async ({ id }) => {
+            const projectId = String(values.currentTeamId)
+            actions.setResettingAlertId(id, true)
+            try {
+                const updated = await logsAlertsResetCreate(projectId, id)
+                lemonToast.success('Alert reset — next check will run shortly.')
+                // Refresh the modal's snapshot so the "broken" banner disappears without
+                // waiting for the list reload to round-trip.
+                if (values.editingAlert?.id === id) {
+                    actions.setEditingAlert(updated)
+                }
+                actions.loadAlerts()
+            } catch {
+                lemonToast.error('Failed to reset alert')
+            } finally {
+                actions.setResettingAlertId(id, false)
             }
         },
     })),


### PR DESCRIPTION
## Problem

Logs alerting needed better error handling and user experience when alerts enter broken states. Users had no way to recover from broken alerts or understand why they failed.

## Changes

### Alert Reset Functionality

- Added `resetAlert` action to `logsAlertingLogic` that calls the reset API endpoint
- Implemented reset button in alert list dropdown menu for broken alerts
- Added reset banner in alert modal for broken alerts with inline reset action
- Added loading states and progress indicators during reset operations

## How did you test this code?

Added comprehensive unit tests for the reset functionality:

- Tests successful reset flow with API call, toast notification, and list reload
- Tests error handling with proper error toast and no unnecessary reloads
- Mocked all external dependencies including API calls and toast notifications

## Publish to changelog?

Yes - this adds important alert recovery functionality for logs alerting.

## Docs update

The alert reset functionality should be documented for users managing logs alerts.