### PR TITLE
fix(subscriptions): allow disabling summary when AI consent revoked

### DIFF
--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -439,7 +439,7 @@ export function EditSubscription({
                                             label="Include an automatic AI summary"
                                             fullWidth
                                             disabledReason={
-                                                !dataProcessingAccepted
+                                                !dataProcessingAccepted && !value
                                                     ? 'Your organization needs to approve AI data processing before enabling AI summaries'
                                                     : undefined
                                             }


### PR DESCRIPTION
## Problem

Follow-up to #55022. The `disabledReason` on the `summary_enabled` switch fired whenever `dataProcessingAccepted` was false, which blocked **both** enabling *and* disabling the toggle.

Because organization admins can later turn AI processing off in organization settings (`OrgAI`), any subscription already created with `summary_enabled=true` would become stuck on: the user could not correct the setting from the form, and the backend would keep rejecting summary generation until they managed to edit the row some other way.

## Changes

Only apply `disabledReason` when the user is trying to *turn on* the switch (i.e. the current form value is `false`). Turning the switch off is always allowed — the server-side `validate()` already no-ops on a falsy `summary_enabled`, so disabling with revoked consent is the correct path.

## How did you test this code?

Agent-authored. Not manually tested end-to-end in a browser — only code-level reasoning against the existing validate logic in `ee/api/subscription.py`. A manual smoke test would be: enable AI consent, create a subscription with summary enabled, revoke AI consent, reopen the edit form, confirm the switch can be toggled off and saved (returning 200).

## Publish to changelog?

no

## 🤖 LLM context

PostHog Code session. The original PR (#55022) was merged but the AI reviewer's comment about the stuck-on case was missed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*