### PR TITLE
fix(funnels): breakdown for funnel trends (limit + actors)

### DIFF
--- a/frontend/src/scenes/funnels/FunnelLineGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelLineGraph.tsx
@@ -5,13 +5,16 @@ import { dayjs } from 'lib/dayjs'
 import { capitalizeFirstLetter, shortTimeZone } from 'lib/utils'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { getFormattedDate } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
+import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { LineGraph } from 'scenes/insights/views/LineGraph/LineGraph'
 import { teamLogic } from 'scenes/teamLogic'
 import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 
+import { cohortsModel } from '~/models/cohortsModel'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { FunnelsActorsQuery, NodeKind, TrendsFilter } from '~/queries/schema/schema-general'
 import { isInsightQueryNode } from '~/queries/utils'
-import { ChartParams, GraphDataset, GraphType } from '~/types'
+import { BreakdownKeyType, ChartParams, GraphDataset, GraphType } from '~/types'
 
 import { funnelDataLogic } from './funnelDataLogic'
 import { funnelPersonsModalLogic } from './funnelPersonsModalLogic'
@@ -40,10 +43,13 @@ export function FunnelLineGraph({
         insightData,
         showValuesOnSeries,
         funnelsFilter,
+        breakdownFilter,
         labelGroupType,
     } = useValues(funnelDataLogic(insightProps))
     const { weekStartDay, timezone } = useValues(teamLogic)
     const { canOpenPersonModal } = useValues(funnelPersonsModalLogic(insightProps))
+    const { allCohorts } = useValues(cohortsModel)
+    const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
 
     if (!isInsightQueryNode(querySource)) {
         return null
@@ -98,6 +104,20 @@ export function FunnelLineGraph({
                                   ? points.pointsIntersectingClick[0].dataset
                                   : points.pointsIntersectingLine[0].dataset
                               const day = dataset?.days?.[index] ?? ''
+                              const breakdownValue = (dataset as { breakdown_value?: BreakdownKeyType })
+                                  ?.breakdown_value
+                              const hasBreakdown =
+                                  breakdownValue !== undefined &&
+                                  breakdownValue !== 'Baseline' &&
+                                  !(Array.isArray(breakdownValue) && breakdownValue[0] === 'Baseline')
+                              const breakdownLabel = hasBreakdown
+                                  ? formatBreakdownLabel(
+                                        breakdownValue,
+                                        breakdownFilter,
+                                        allCohorts.results,
+                                        formatPropertyValueForDisplay
+                                    )
+                                  : null
 
                               const title = (
                                   <>
@@ -109,6 +129,7 @@ export function FunnelLineGraph({
                                           weekStartDay={weekStartDay}
                                           date={day?.toString() || ''}
                                       />
+                                      {breakdownLabel ? <> • {breakdownLabel}</> : null}
                                   </>
                               )
 
@@ -118,6 +139,7 @@ export function FunnelLineGraph({
                                   funnelTrendsDropOff: false,
                                   includeRecordings: true,
                                   funnelTrendsEntrancePeriodStart: dayjs(day).format('YYYY-MM-DD HH:mm:ss'),
+                                  ...(hasBreakdown ? { funnelStepBreakdown: breakdownValue } : {}),
                               }
                               openPersonsModal({
                                   title,

--- a/posthog/hogql_queries/insights/funnels/funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_trends.py
@@ -293,7 +293,7 @@ class FunnelTrendsUDF(FunnelUDFMixin, FunnelBase):
         self,
         extra_fields: Optional[list[str]] = None,
     ) -> ast.SelectQuery:
-        team, actorsQuery = self.context.team, self.context.actorsQuery
+        team, actorsQuery, breakdownType = self.context.team, self.context.actorsQuery, self.context.breakdownType
 
         if actorsQuery is None:
             raise ValidationError("No actors query present.")
@@ -322,16 +322,28 @@ class FunnelTrendsUDF(FunnelUDFMixin, FunnelBase):
             select.append(ast.Alias(alias="person_id", expr=ast.Field(chain=["person_id"])))
         select_from = ast.JoinExpr(table=self._inner_aggregation_query())
 
-        where = ast.And(
-            exprs=[
-                parse_expr("success_bool != 1") if actorsQuery.funnelTrendsDropOff else parse_expr("success_bool = 1"),
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.Eq,
-                    left=parse_expr("entrance_period_start"),
-                    right=ast.Constant(value=entrancePeriodStart),
-                ),
-            ]
-        )
+        where_exprs: list[ast.Expr] = [
+            parse_expr("success_bool != 1") if actorsQuery.funnelTrendsDropOff else parse_expr("success_bool = 1"),
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.Eq,
+                left=parse_expr("entrance_period_start"),
+                right=ast.Constant(value=entrancePeriodStart),
+            ),
+        ]
+
+        funnelStepBreakdown = actorsQuery.funnelStepBreakdown
+        if funnelStepBreakdown is not None:
+            if isinstance(funnelStepBreakdown, int | float) and breakdownType != "cohort":
+                funnelStepBreakdown = str(int(funnelStepBreakdown))
+
+            where_exprs.append(
+                parse_expr(
+                    "arrayFlatten(array(breakdown)) = arrayFlatten(array({funnelStepBreakdown}))",
+                    {"funnelStepBreakdown": ast.Constant(value=funnelStepBreakdown)},
+                )
+            )
+
+        where = ast.And(exprs=where_exprs)
         order_by = [ast.OrderExpr(expr=ast.Field(chain=["aggregation_target"]))]
 
         return ast.SelectQuery(

--- a/posthog/hogql_queries/insights/funnels/funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_trends.py
@@ -208,7 +208,7 @@ class FunnelTrendsUDF(FunnelUDFMixin, FunnelBase):
         if self.context.breakdown:
             breakdown_limit = self.get_breakdown_limit()
             if breakdown_limit:
-                limit = min(breakdown_limit * len(self._date_range().all_values()), limit)
+                limit = breakdown_limit * len(self._date_range().all_values())
 
             not_in_cohort_union = ""
             extra_placeholders: dict[str, ast.Expr] = {}

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_actors.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_actors.ambr
@@ -1,4 +1,168 @@
 # serializer version: 1
+# name: TestFunnelTrendsActors.test_funnel_trend_persons_filters_by_breakdown
+  '''
+  SELECT source.id,
+         source.id AS id
+  FROM
+    (SELECT aggregation_target AS actor_id,
+            actor_id AS id
+     FROM
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toUInt64(toDateTime(toStartOfDay(timestamp), 'UTC')), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               argMinIf(prop_basic, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop_basic))) AS prop,
+               arrayJoin(aggregate_funnel_array_trends(1, 3, 3, 1209600, 'first_touch', 'ordered', [if(empty(prop), [''], prop)], events_array)) AS af_tuple,
+               toTimeZone(toDateTime(toUInt64(af_tuple.1), 'UTC'), 'UTC') AS entrance_period_start,
+               af_tuple.2 AS success_bool,
+               af_tuple.3 AS breakdown,
+               aggregation_target AS aggregation_target
+        FROM
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  if(equals(e.event, 'step one'), 1, 0) AS step_0,
+                  if(equals(e.event, 'step two'), 1, 0) AS step_1,
+                  if(equals(e.event, 'step three'), 1, 0) AS step_2,
+                  [ifNull(toString(nullIf(nullIf(e.`mat_$browser`, ''), 'null')), '')] AS prop_basic,
+                  prop_basic AS prop
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('today', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))
+        GROUP BY aggregation_target SETTINGS date_time_output_format='iso',
+                                             date_time_input_format='best_effort')
+     WHERE and(ifNull(equals(success_bool, 1), 0), ifNull(equals(entrance_period_start, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array(['Chrome']))), isNull(arrayFlatten(array(breakdown)))
+                                                                                                                                     and isNull(arrayFlatten(array(['Chrome'])))))
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
+  ORDER BY source.id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
+                    join_algorithm='auto',
+                    readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    enable_analyzer=1,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestFunnelTrendsActors.test_funnel_trend_persons_filters_by_breakdown.1
+  '''
+  SELECT source.id,
+         source.id AS id
+  FROM
+    (SELECT aggregation_target AS actor_id,
+            actor_id AS id
+     FROM
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toUInt64(toDateTime(toStartOfDay(timestamp), 'UTC')), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               argMinIf(prop_basic, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop_basic))) AS prop,
+               arrayJoin(aggregate_funnel_array_trends(1, 3, 3, 1209600, 'first_touch', 'ordered', [if(empty(prop), [''], prop)], events_array)) AS af_tuple,
+               toTimeZone(toDateTime(toUInt64(af_tuple.1), 'UTC'), 'UTC') AS entrance_period_start,
+               af_tuple.2 AS success_bool,
+               af_tuple.3 AS breakdown,
+               aggregation_target AS aggregation_target
+        FROM
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  if(equals(e.event, 'step one'), 1, 0) AS step_0,
+                  if(equals(e.event, 'step two'), 1, 0) AS step_1,
+                  if(equals(e.event, 'step three'), 1, 0) AS step_2,
+                  [ifNull(toString(nullIf(nullIf(e.`mat_$browser`, ''), 'null')), '')] AS prop_basic,
+                  prop_basic AS prop
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('today', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))
+        GROUP BY aggregation_target SETTINGS date_time_output_format='iso',
+                                             date_time_input_format='best_effort')
+     WHERE and(ifNull(equals(success_bool, 1), 0), ifNull(equals(entrance_period_start, toDateTime64('today', 6, 'UTC')), 0), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array(['Safari']))), isNull(arrayFlatten(array(breakdown)))
+                                                                                                                                     and isNull(arrayFlatten(array(['Safari'])))))
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
+  ORDER BY source.id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
+                    join_algorithm='auto',
+                    readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    enable_analyzer=1,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestFunnelTrendsActors.test_funnel_trend_persons_filters_by_breakdown.2
+  '''
+  SELECT source.id,
+         source.id AS id
+  FROM
+    (SELECT aggregation_target AS actor_id,
+            actor_id AS id
+     FROM
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toUInt64(toDateTime(toStartOfDay(timestamp), 'UTC')), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               argMinIf(prop_basic, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop_basic))) AS prop,
+               arrayJoin(aggregate_funnel_array_trends(1, 3, 3, 1209600, 'first_touch', 'ordered', [if(empty(prop), [''], prop)], events_array)) AS af_tuple,
+               toTimeZone(toDateTime(toUInt64(af_tuple.1), 'UTC'), 'UTC') AS entrance_period_start,
+               af_tuple.2 AS success_bool,
+               af_tuple.3 AS breakdown,
+               aggregation_target AS aggregation_target
+        FROM
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  if(equals(e.event, 'step one'), 1, 0) AS step_0,
+                  if(equals(e.event, 'step two'), 1, 0) AS step_1,
+                  if(equals(e.event, 'step three'), 1, 0) AS step_2,
+                  [ifNull(toString(nullIf(nullIf(e.`mat_$browser`, ''), 'null')), '')] AS prop_basic,
+                  prop_basic AS prop
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('today', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))
+        GROUP BY aggregation_target SETTINGS date_time_output_format='iso',
+                                             date_time_input_format='best_effort')
+     WHERE and(ifNull(equals(success_bool, 1), 0), ifNull(equals(entrance_period_start, toDateTime64('today', 6, 'UTC')), 0))
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
+  ORDER BY source.id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
+                    join_algorithm='auto',
+                    readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    enable_analyzer=1,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
 # name: TestFunnelTrendsActors.test_funnel_trend_persons_returns_recordings
   '''
   SELECT source.id,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_actors.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_actors.ambr
@@ -9,7 +9,7 @@
      FROM
        (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toUInt64(toDateTime(toStartOfDay(timestamp), 'UTC')), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
                argMinIf(prop_basic, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop_basic))) AS prop,
-               arrayJoin(aggregate_funnel_array_trends(1, 3, 3, 1209600, 'first_touch', 'ordered', [if(empty(prop), [''], prop)], events_array)) AS af_tuple,
+               arrayJoin(aggregate_funnel_array_trends_v11(1, 3, 3, 1209600, 'first_touch', 'ordered', [if(empty(prop), [''], prop)], events_array)) AS af_tuple,
                toTimeZone(toDateTime(toUInt64(af_tuple.1), 'UTC'), 'UTC') AS entrance_period_start,
                af_tuple.2 AS success_bool,
                af_tuple.3 AS breakdown,
@@ -21,7 +21,7 @@
                   if(equals(e.event, 'step one'), 1, 0) AS step_0,
                   if(equals(e.event, 'step two'), 1, 0) AS step_1,
                   if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                  [ifNull(toString(nullIf(nullIf(e.`mat_$browser`, ''), 'null')), '')] AS prop_basic,
+                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -64,7 +64,7 @@
      FROM
        (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toUInt64(toDateTime(toStartOfDay(timestamp), 'UTC')), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
                argMinIf(prop_basic, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop_basic))) AS prop,
-               arrayJoin(aggregate_funnel_array_trends(1, 3, 3, 1209600, 'first_touch', 'ordered', [if(empty(prop), [''], prop)], events_array)) AS af_tuple,
+               arrayJoin(aggregate_funnel_array_trends_v11(1, 3, 3, 1209600, 'first_touch', 'ordered', [if(empty(prop), [''], prop)], events_array)) AS af_tuple,
                toTimeZone(toDateTime(toUInt64(af_tuple.1), 'UTC'), 'UTC') AS entrance_period_start,
                af_tuple.2 AS success_bool,
                af_tuple.3 AS breakdown,
@@ -76,7 +76,7 @@
                   if(equals(e.event, 'step one'), 1, 0) AS step_0,
                   if(equals(e.event, 'step two'), 1, 0) AS step_1,
                   if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                  [ifNull(toString(nullIf(nullIf(e.`mat_$browser`, ''), 'null')), '')] AS prop_basic,
+                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -119,7 +119,7 @@
      FROM
        (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toUInt64(toDateTime(toStartOfDay(timestamp), 'UTC')), uuid, arrayMap(x -> ifNull(x, ''), prop_basic), arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
                argMinIf(prop_basic, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop_basic))) AS prop,
-               arrayJoin(aggregate_funnel_array_trends(1, 3, 3, 1209600, 'first_touch', 'ordered', [if(empty(prop), [''], prop)], events_array)) AS af_tuple,
+               arrayJoin(aggregate_funnel_array_trends_v11(1, 3, 3, 1209600, 'first_touch', 'ordered', [if(empty(prop), [''], prop)], events_array)) AS af_tuple,
                toTimeZone(toDateTime(toUInt64(af_tuple.1), 'UTC'), 'UTC') AS entrance_period_start,
                af_tuple.2 AS success_bool,
                af_tuple.3 AS breakdown,
@@ -131,7 +131,7 @@
                   if(equals(e.event, 'step one'), 1, 0) AS step_0,
                   if(equals(e.event, 'step two'), 1, 0) AS step_1,
                   if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                  [ifNull(toString(nullIf(nullIf(e.`mat_$browser`, ''), 'null')), '')] AS prop_basic,
+                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
@@ -1537,31 +1537,6 @@ class TestFunnelTrendsUDF(ClickhouseTestMixin, APIBaseTest):
         actual_limit = cast(ast.Constant, runner.to_query().limit).value
         self.assertEqual(actual_limit, expected_limit)
 
-    def test_breakdown_limit_above_legacy_1000_cap(self):
-        # Pick a combo that would have been clamped by the previous
-        # min(breakdown_limit * num_periods, 1_000) cap.
-        query = FunnelsQuery(
-            dateRange=DateRange(date_from="2021-01-01 00:00:00", date_to="2021-12-31 23:59:59"),
-            interval="week",
-            series=[
-                EventsNode(event="step one"),
-                EventsNode(event="step two"),
-            ],
-            breakdownFilter=BreakdownFilter(
-                breakdown="$browser",
-                breakdown_type="event",
-                breakdown_limit=25,
-            ),
-            funnelsFilter=FunnelsFilter(
-                funnelVizType="trends",
-                funnelWindowInterval=7,
-                funnelWindowIntervalUnit="day",
-            ),
-        )
-        runner = FunnelsQueryRunner(query=query, team=self.team)
-        actual_limit = cast(ast.Constant, runner.to_query().limit).value
-        self.assertGreater(actual_limit, 1_000)
-
     def test_funnel_step_breakdown_person(self):
         _create_person(distinct_ids=["user_one"], team=self.team, properties={"$browser": "Chrome"})
         _create_person(distinct_ids=["user_two"], team=self.team, properties={"$browser": "Chrome"})

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime, timedelta
-from typing import Optional
+from typing import Optional, cast
 from zoneinfo import ZoneInfo
 
 from freezegun.api import freeze_time
@@ -27,6 +27,8 @@ from posthog.schema import (
     IntervalType,
     PropertyOperator,
 )
+
+from posthog.hogql import ast
 
 from posthog.constants import FunnelOrderType
 from posthog.hogql_queries.insights.funnels.funnels_query_runner import FunnelsQueryRunner
@@ -1498,6 +1500,67 @@ class TestFunnelTrendsUDF(ClickhouseTestMixin, APIBaseTest):
             ],
         )
         self.assertEqual(results[0]["breakdown_value"], ["Chrome"])
+
+    @parameterized.expand(
+        [
+            # (interval, date_from, date_to, breakdown_limit) — cases chosen so
+            # breakdown_limit × num_periods straddles the old 1_000 hard cap.
+            ("week", "2021-01-01 00:00:00", "2021-12-31 23:59:59", 25),
+            ("day", "2021-01-01 00:00:00", "2021-02-19 23:59:59", 25),
+            ("day", "2021-05-01 00:00:00", "2021-05-14 23:59:59", 25),
+            ("hour", "2021-05-01 00:00:00", "2021-05-01 23:59:59", 10),
+        ]
+    )
+    def test_breakdown_limit_scales_with_periods(self, interval, date_from, date_to, breakdown_limit):
+        query = FunnelsQuery(
+            dateRange=DateRange(date_from=date_from, date_to=date_to),
+            interval=interval,
+            series=[
+                EventsNode(event="step one"),
+                EventsNode(event="step two"),
+            ],
+            breakdownFilter=BreakdownFilter(
+                breakdown="$browser",
+                breakdown_type="event",
+                breakdown_limit=breakdown_limit,
+            ),
+            funnelsFilter=FunnelsFilter(
+                funnelVizType="trends",
+                funnelWindowInterval=7,
+                funnelWindowIntervalUnit="day",
+            ),
+        )
+        runner = FunnelsQueryRunner(query=query, team=self.team)
+        num_periods = len(runner.funnel_class._date_range().all_values())
+        expected_limit = breakdown_limit * num_periods
+
+        actual_limit = cast(ast.Constant, runner.to_query().limit).value
+        self.assertEqual(actual_limit, expected_limit)
+
+    def test_breakdown_limit_above_legacy_1000_cap(self):
+        # Pick a combo that would have been clamped by the previous
+        # min(breakdown_limit * num_periods, 1_000) cap.
+        query = FunnelsQuery(
+            dateRange=DateRange(date_from="2021-01-01 00:00:00", date_to="2021-12-31 23:59:59"),
+            interval="week",
+            series=[
+                EventsNode(event="step one"),
+                EventsNode(event="step two"),
+            ],
+            breakdownFilter=BreakdownFilter(
+                breakdown="$browser",
+                breakdown_type="event",
+                breakdown_limit=25,
+            ),
+            funnelsFilter=FunnelsFilter(
+                funnelVizType="trends",
+                funnelWindowInterval=7,
+                funnelWindowIntervalUnit="day",
+            ),
+        )
+        runner = FunnelsQueryRunner(query=query, team=self.team)
+        actual_limit = cast(ast.Constant, runner.to_query().limit).value
+        self.assertGreater(actual_limit, 1_000)
 
     def test_funnel_step_breakdown_person(self):
         _create_person(distinct_ids=["user_one"], team=self.team, properties={"$browser": "Chrome"})

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_actors.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_actors.py
@@ -3,7 +3,15 @@ from datetime import datetime, timedelta
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, snapshot_clickhouse_queries
 
-from posthog.schema import DateRange, EventsNode, FunnelsFilter, FunnelsQuery, FunnelVizType, IntervalType
+from posthog.schema import (
+    BreakdownFilter,
+    DateRange,
+    EventsNode,
+    FunnelsFilter,
+    FunnelsQuery,
+    FunnelVizType,
+    IntervalType,
+)
 
 from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
@@ -126,6 +134,80 @@ class TestFunnelTrendsActors(ClickhouseTestMixin, APIBaseTest):
             # [person["matched_recordings"][0]["session_id"] for person in results],
             [next(iter(results[0][2]))["session_id"]],
             ["s1c"],
+        )
+
+    @snapshot_clickhouse_queries
+    def test_funnel_trend_persons_filters_by_breakdown(self):
+        persons = journeys_for(
+            {
+                "chrome_user": [
+                    {
+                        "event": "step one",
+                        "timestamp": datetime(2021, 5, 1),
+                        "properties": {"$browser": "Chrome"},
+                    },
+                    {
+                        "event": "step two",
+                        "timestamp": datetime(2021, 5, 1, 1),
+                        "properties": {"$browser": "Chrome"},
+                    },
+                    {
+                        "event": "step three",
+                        "timestamp": datetime(2021, 5, 1, 2),
+                        "properties": {"$browser": "Chrome"},
+                    },
+                ],
+                "safari_user": [
+                    {
+                        "event": "step one",
+                        "timestamp": datetime(2021, 5, 1),
+                        "properties": {"$browser": "Safari"},
+                    },
+                    {
+                        "event": "step two",
+                        "timestamp": datetime(2021, 5, 1, 1),
+                        "properties": {"$browser": "Safari"},
+                    },
+                    {
+                        "event": "step three",
+                        "timestamp": datetime(2021, 5, 1, 2),
+                        "properties": {"$browser": "Safari"},
+                    },
+                ],
+            },
+            self.team,
+        )
+
+        breakdown_query = funnels_query.model_copy(
+            update={"breakdownFilter": BreakdownFilter(breakdown="$browser", breakdown_type="event")}
+        )
+
+        chrome_results = get_actors(
+            breakdown_query,
+            self.team,
+            funnel_trends_drop_off=False,
+            funnel_trends_entrance_period_start="2021-05-01 00:00:00",
+            funnel_step_breakdown=["Chrome"],
+        )
+        assert [row[0] for row in chrome_results] == [persons["chrome_user"].uuid]
+
+        safari_results = get_actors(
+            breakdown_query,
+            self.team,
+            funnel_trends_drop_off=False,
+            funnel_trends_entrance_period_start="2021-05-01 00:00:00",
+            funnel_step_breakdown=["Safari"],
+        )
+        assert [row[0] for row in safari_results] == [persons["safari_user"].uuid]
+
+        all_results = get_actors(
+            breakdown_query,
+            self.team,
+            funnel_trends_drop_off=False,
+            funnel_trends_entrance_period_start="2021-05-01 00:00:00",
+        )
+        assert sorted(row[0] for row in all_results) == sorted(
+            [persons["chrome_user"].uuid, persons["safari_user"].uuid]
         )
 
     @snapshot_clickhouse_queries


### PR DESCRIPTION
## Problem

Two related funnel-trends breakdown bugs. 
- Can't filter persons modal via breakdown in funnel trends view
- Wasn't seeing some of the latest data, due to the 1000 row limit 
https://posthoghelp.zendesk.com/agent/tickets/55612 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/56903)

## Changes


https://github.com/user-attachments/assets/5f3824ac-2a36-4f92-8862-af6c2c17d227


- When clicking into a breakdown on the funnel trends view, you now see the persons modal filtered correctly

- `funnel_trends.py` — drop the `min(..., 1000)` cap; limit now scales as `breakdown_limit × num_periods` (downstream `MAX_SELECT_RETURNED_ROWS=50000` still clamps the absolute ceiling).


## How did you test this code?

Manuall/tests, see video

## Publish to changelog?
no

## 🤖 LLM context

Replaces PR #55034 (limit removal only); the actors-filter work was combined in here after review discussion determined they were closely related breakdown bugs.