### PR TITLE
chore(mcp): optimize token usage for cdp-functions and templates list

### DIFF
--- a/products/cdp/mcp/cdp_function_templates.yaml
+++ b/products/cdp/mcp/cdp_function_templates.yaml
@@ -25,6 +25,17 @@ tools:
             (Slack, webhooks, email, etc.) and transformations (GeoIP, etc.). Filter by type (destination,
             site_destination, site_app, transformation, etc.) via the 'type' query parameter. Results are sorted by
             popularity (number of active functions using each template).
+        response:
+            include:
+                - id
+                - name
+                - description
+                - type
+                - status
+                - category
+                - free
+                - icon_url
+                - code_language
     cdp-function-templates-retrieve:
         operation: hog_function_templates_retrieve
         enabled: true

--- a/products/cdp/mcp/cdp_functions.yaml
+++ b/products/cdp/mcp/cdp_functions.yaml
@@ -25,6 +25,20 @@ tools:
             each function's name, type, enabled status, execution order, and template info. Filter by type (destination,
             site_destination, internal_destination, source_webhook, warehouse_source_webhook, site_app, transformation)
             and enabled status via query parameters.
+        response:
+            include:
+                - id
+                - type
+                - name
+                - description
+                - enabled
+                - execution_order
+                - icon_url
+                - template.id
+                - status
+                - created_at
+                - updated_at
+                - created_by
     cdp-functions-create:
         operation: hog_functions_create
         enabled: true

--- a/services/mcp/src/tools/generated/cdp_function_templates.ts
+++ b/services/mcp/src/tools/generated/cdp_function_templates.ts
@@ -6,7 +6,7 @@ import {
     HogFunctionTemplatesListQueryParams,
     HogFunctionTemplatesRetrieveParams,
 } from '@/generated/cdp_function_templates/api'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const CdpFunctionTemplatesListSchema = HogFunctionTemplatesListQueryParams
@@ -30,7 +30,23 @@ const cdpFunctionTemplatesList = (): ToolBase<
                 types: params.types,
             },
         })
-        return await withPostHogUrl(context, result, '/pipeline/templates')
+        const filtered = {
+            ...result,
+            results: (result.results ?? []).map((item: any) =>
+                pickResponseFields(item, [
+                    'id',
+                    'name',
+                    'description',
+                    'type',
+                    'status',
+                    'category',
+                    'free',
+                    'icon_url',
+                    'code_language',
+                ])
+            ),
+        } as typeof result
+        return await withPostHogUrl(context, filtered, '/pipeline/templates')
     },
 })
 

--- a/services/mcp/src/tools/generated/cdp_functions.ts
+++ b/services/mcp/src/tools/generated/cdp_functions.ts
@@ -13,7 +13,7 @@ import {
     HogFunctionsRearrangePartialUpdateBody,
     HogFunctionsRetrieveParams,
 } from '@/generated/cdp_functions/api'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const CdpFunctionsListSchema = HogFunctionsListQueryParams
@@ -41,7 +41,26 @@ const cdpFunctionsList = (): ToolBase<
                 updated_at: params.updated_at,
             },
         })
-        return await withPostHogUrl(context, result, '/pipeline')
+        const filtered = {
+            ...result,
+            results: (result.results ?? []).map((item: any) =>
+                pickResponseFields(item, [
+                    'id',
+                    'type',
+                    'name',
+                    'description',
+                    'enabled',
+                    'execution_order',
+                    'icon_url',
+                    'template.id',
+                    'status',
+                    'created_at',
+                    'updated_at',
+                    'created_by',
+                ])
+            ),
+        } as typeof result
+        return await withPostHogUrl(context, filtered, '/pipeline')
     },
 })
 


### PR DESCRIPTION
## Problem

`cdp-functions-list` and `cdp-function-templates-list` returned the full serializer payload for every row, which in practice was dominated by a handful of large fields that MCP clients (and the LLMs reading them) don't need at scan time:

- `cdp-functions-list` inlines a full nested `template` object via `HogFunctionTemplateSerializer` on every row (up to ~50 KB each) alongside `hog` source code and `filters` JSON.
- `cdp-function-templates-list` returns `code`, `inputs_schema`, `filters`, `masking`, and nested `mapping_templates` — all only relevant once a specific template has been chosen to create a function from.

For agents listing functions or browsing available templates, the result was a lot of token spend with very little navigational value.

## Changes

Add `response.include` allowlists to the two list tools, matching the convention already used in `products/persons/mcp/tools.yaml` and `products/conversations/mcp/tools.yaml`:

- `cdp-functions-list` → `id, type, name, description, enabled, execution_order, icon_url, template.id, status, created_at, updated_at, created_by`
- `cdp-function-templates-list` → `id, name, description, type, status, category, free, icon_url, code_language`

`template.id` is kept on `cdp-functions-list` so agents can still chain into `cdp-function-templates-retrieve` for the full template body when they need it. Both retrieve tools are unchanged and continue to return the full serializer output.

Generated MCP tool code (`services/mcp/src/tools/generated/cdp_*.ts`) regenerated via `hogli build:openapi`.

## Stats

### `cdp-functions-list`

  | Field | Master | Optimized |
  |---|---|---|
  | `id` | ✅ | ✅ |
  | `type` | ✅ | ✅ |
  | `name` | ✅ | ✅ |
  | `description` | ✅ | ✅ |
  | `enabled` | ✅ | ✅ |
  | `execution_order` | ✅ | ✅ |
  | `icon_url` | ✅ | ✅ |
  | `status` | ✅ | ✅ |
  | `created_at` | ✅ | ✅ |
  | `updated_at` | ✅ | ✅ |
  | `created_by` | ✅ | ✅ |
  | `template` | Full object (id, name, description, code, code_language, inputs_schema, type, status, category, free, icon_url, filters, masking, mapping_templates) | id only |
  | `hog` | Full source code (~2KB) | ❌ |
  | `filters` | With bytecode | ❌ |

  ### `cdp-function-templates-list`

  | Field | Master | Optimized |
  |---|---|---|
  | `id` | ✅ | ✅ |
  | `name` | ✅ | ✅ |
  | `description` | ✅ | ✅ |
  | `type` | ✅ | ✅ |
  | `status` | ✅ | ✅ |
  | `category` | ✅ | ✅ |
  | `free` | ✅ | ✅ |
  | `icon_url` | ✅ | ✅ |
  | `code_language` | ✅ | ✅ |
  | `code` | Full source code per template | ❌ |
  | `inputs_schema` | Full schema with all fields | ❌ |
  | `filters` | ✅ | ❌ |
  | `masking` | ✅ | ❌ |
  | `mapping_templates` | Full mapping objects | ❌ |

  ### Token usage

  | Tool | Master | Optimized | Reduction |
  |---|---|---|---|
  | `cdp-functions-list` | ~1,490 | ~148 | 10x |
  | `cdp-function-templates-list` | ~23,654 | ~7,485 | 3.2x |
  | **Total** | **~25,144** | **~7,634** | **3.3x** |

## How did you test this code?

- `pnpm --filter=@posthog/mcp run typecheck` passes.
- `pnpm --filter=@posthog/mcp test -- tests/unit` passes (the only failing test is the unrelated `tests/integration/manifest.test.ts` which depends on network access to GitHub releases).
- Manual test

## Publish to changelog?

no
