### PR TITLE
fix(llma): stop sentiment from blocking traces list message columns

### DIFF
--- a/products/llm_analytics/frontend/llmAnalyticsColumnRenderers.tsx
+++ b/products/llm_analytics/frontend/llmAnalyticsColumnRenderers.tsx
@@ -198,9 +198,14 @@ function LazySentimentColumnCell({ traceId }: { traceId: string }): JSX.Element 
     const cached = sentimentByTraceId[traceId]
     const loading = isTraceLoading(traceId)
 
-    if (cached === undefined && !loading) {
-        ensureSentimentLoaded(traceId, dateFilter)
-    }
+    // Deferred via effect so trace-messages/persons effects (which also run
+    // after commit) get a chance to dispatch before sentiment's batched
+    // fan-out claims the browser's connection pool.
+    useEffect(() => {
+        if (cached === undefined && !loading) {
+            ensureSentimentLoaded(traceId, dateFilter)
+        }
+    }, [traceId, cached, loading, dateFilter, ensureSentimentLoaded])
 
     if (loading || cached === undefined) {
         return <AIDataLoading variant="inline" />
@@ -221,9 +226,11 @@ function LazyGenerationSentimentCell({ generationEventId }: { generationEventId:
     const cached = sentimentByGenerationId[generationEventId]
     const loading = isGenerationLoading(generationEventId)
 
-    if (cached === undefined && !loading) {
-        ensureGenerationSentimentLoaded(generationEventId, dateFilter)
-    }
+    useEffect(() => {
+        if (cached === undefined && !loading) {
+            ensureGenerationSentimentLoaded(generationEventId, dateFilter)
+        }
+    }, [generationEventId, cached, loading, dateFilter, ensureGenerationSentimentLoaded])
 
     if (loading || cached === undefined) {
         return <AIDataLoading variant="inline" />

--- a/products/llm_analytics/frontend/llmGenerationSentimentLazyLoaderLogic.ts
+++ b/products/llm_analytics/frontend/llmGenerationSentimentLazyLoaderLogic.ts
@@ -5,6 +5,7 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import type { llmGenerationSentimentLazyLoaderLogicType } from './llmGenerationSentimentLazyLoaderLogicType'
 import type { GenerationSentiment } from './llmSentimentLazyLoaderLogic'
+import { runWithConcurrency } from './utils'
 
 export interface GenerationSentimentDateRange {
     dateFrom?: string | null
@@ -31,20 +32,6 @@ function chunk<T>(arr: T[], size: number): T[][] {
         chunks.push(arr.slice(i, i + size))
     }
     return chunks
-}
-
-async function runWithConcurrency<T>(items: T[], limit: number, worker: (item: T) => Promise<void>): Promise<void> {
-    if (items.length === 0) {
-        return
-    }
-    let cursor = 0
-    const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
-        while (cursor < items.length) {
-            const index = cursor++
-            await worker(items[index])
-        }
-    })
-    await Promise.all(runners)
 }
 
 export const llmGenerationSentimentLazyLoaderLogic = kea<llmGenerationSentimentLazyLoaderLogicType>([

--- a/products/llm_analytics/frontend/llmGenerationSentimentLazyLoaderLogic.ts
+++ b/products/llm_analytics/frontend/llmGenerationSentimentLazyLoaderLogic.ts
@@ -20,6 +20,10 @@ function isValidGenerationSentiment(value: unknown): value is GenerationSentimen
 }
 
 const BATCH_MAX_SIZE = 5
+// Mirrors llmSentimentLazyLoaderLogic: capping in-flight requests per flush
+// keeps sentiment from starving sibling lazy loaders on list pages with many
+// rows, given the browser's per-origin connection limit (~6).
+const MAX_CONCURRENT_BATCHES = 2
 
 function chunk<T>(arr: T[], size: number): T[][] {
     const chunks: T[][] = []
@@ -27,6 +31,20 @@ function chunk<T>(arr: T[], size: number): T[][] {
         chunks.push(arr.slice(i, i + size))
     }
     return chunks
+}
+
+async function runWithConcurrency<T>(items: T[], limit: number, worker: (item: T) => Promise<void>): Promise<void> {
+    if (items.length === 0) {
+        return
+    }
+    let cursor = 0
+    const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+        while (cursor < items.length) {
+            const index = cursor++
+            await worker(items[index])
+        }
+    })
+    await Promise.all(runners)
 }
 
 export const llmGenerationSentimentLazyLoaderLogic = kea<llmGenerationSentimentLazyLoaderLogicType>([
@@ -174,32 +192,30 @@ export const llmGenerationSentimentLazyLoaderLogic = kea<llmGenerationSentimentL
 
                     const chunks = chunk(allIds, BATCH_MAX_SIZE)
 
-                    await Promise.allSettled(
-                        chunks.map(async (batch) => {
-                            try {
-                                const response = await api.create<BatchGenerationSentimentResponse>(
-                                    `api/environments/${teamId}/llm_analytics/sentiment/`,
-                                    {
-                                        ids: batch,
-                                        analysis_level: 'generation',
-                                        date_from: dateRangeForBatch?.dateFrom || undefined,
-                                        date_to: dateRangeForBatch?.dateTo || undefined,
-                                    }
-                                )
-
-                                const results: Record<string, GenerationSentiment | null> = {}
-
-                                for (const generationId of batch) {
-                                    const raw = response.results[generationId]
-                                    results[generationId] = isValidGenerationSentiment(raw) ? raw : null
+                    await runWithConcurrency(chunks, MAX_CONCURRENT_BATCHES, async (batch) => {
+                        try {
+                            const response = await api.create<BatchGenerationSentimentResponse>(
+                                `api/environments/${teamId}/llm_analytics/sentiment/`,
+                                {
+                                    ids: batch,
+                                    analysis_level: 'generation',
+                                    date_from: dateRangeForBatch?.dateFrom || undefined,
+                                    date_to: dateRangeForBatch?.dateTo || undefined,
                                 }
+                            )
 
-                                actions.loadGenerationSentimentBatchSuccess(results, batch)
-                            } catch {
-                                actions.loadGenerationSentimentBatchFailure(batch)
+                            const results: Record<string, GenerationSentiment | null> = {}
+
+                            for (const generationId of batch) {
+                                const raw = response.results[generationId]
+                                results[generationId] = isValidGenerationSentiment(raw) ? raw : null
                             }
-                        })
-                    )
+
+                            actions.loadGenerationSentimentBatchSuccess(results, batch)
+                        } catch {
+                            actions.loadGenerationSentimentBatchFailure(batch)
+                        }
+                    })
                 }, 0)
             },
         }

--- a/products/llm_analytics/frontend/llmSentimentLazyLoaderLogic.test.ts
+++ b/products/llm_analytics/frontend/llmSentimentLazyLoaderLogic.test.ts
@@ -346,6 +346,7 @@ describe('llmSentimentLazyLoaderLogic', () => {
             // Fake timers isolate this test from setTimeout leaks in prior cases
             // (the listener doesn't cancel its batch timer on unmount).
             jest.useFakeTimers()
+            let createSpy: jest.SpyInstance | undefined
             try {
                 // Fifteen trace IDs at BATCH_MAX_SIZE=5 → three chunks. With the
                 // concurrency cap of 2, at most two api.create calls should be
@@ -354,7 +355,7 @@ describe('llmSentimentLazyLoaderLogic', () => {
                 let inFlight = 0
                 let peakInFlight = 0
 
-                const createSpy = jest.spyOn(api, 'create').mockImplementation(
+                createSpy = jest.spyOn(api, 'create').mockImplementation(
                     () =>
                         new Promise((resolve) => {
                             inFlight++
@@ -393,6 +394,7 @@ describe('llmSentimentLazyLoaderLogic', () => {
                     await Promise.resolve()
                 }
             } finally {
+                createSpy?.mockRestore()
                 jest.useRealTimers()
             }
         })

--- a/products/llm_analytics/frontend/llmSentimentLazyLoaderLogic.test.ts
+++ b/products/llm_analytics/frontend/llmSentimentLazyLoaderLogic.test.ts
@@ -1,5 +1,7 @@
 import { expectLogic } from 'kea-test-utils'
 
+import api from 'lib/api'
+
 import { initKeaTests } from '~/test/init'
 
 import { SentimentResult, llmSentimentLazyLoaderLogic } from './llmSentimentLazyLoaderLogic'
@@ -338,6 +340,61 @@ describe('llmSentimentLazyLoaderLogic', () => {
 
             logic.actions.loadSentimentBatchSuccess({ 'trace-1': result2 }, ['trace-1'])
             expect(logic.values.getTraceSentiment('trace-1')).toEqual(result2)
+        })
+
+        it('should cap concurrent in-flight sentiment batches at 2', async () => {
+            // Fake timers isolate this test from setTimeout leaks in prior cases
+            // (the listener doesn't cancel its batch timer on unmount).
+            jest.useFakeTimers()
+            try {
+                // Fifteen trace IDs at BATCH_MAX_SIZE=5 → three chunks. With the
+                // concurrency cap of 2, at most two api.create calls should be
+                // in flight at once; the third chunk must wait for a slot.
+                const release: Array<() => void> = []
+                let inFlight = 0
+                let peakInFlight = 0
+
+                const createSpy = jest.spyOn(api, 'create').mockImplementation(
+                    () =>
+                        new Promise((resolve) => {
+                            inFlight++
+                            peakInFlight = Math.max(peakInFlight, inFlight)
+                            release.push(() => {
+                                inFlight--
+                                resolve({ results: {} } as any)
+                            })
+                        })
+                )
+
+                const traceIds = Array.from({ length: 15 }, (_, i) => `trace-${i}`)
+                for (const id of traceIds) {
+                    logic.actions.ensureSentimentLoaded(id)
+                }
+
+                // Fire the listener's setTimeout(0) and let the first two
+                // runners start their api.create calls.
+                jest.advanceTimersByTime(0)
+                await Promise.resolve()
+                await Promise.resolve()
+
+                expect(peakInFlight).toBe(2)
+                expect(createSpy).toHaveBeenCalledTimes(2)
+
+                // Releasing the first in-flight promise frees a slot so the
+                // third chunk can start. Peak must remain at 2.
+                release.shift()!()
+                await Promise.resolve()
+                await Promise.resolve()
+                expect(peakInFlight).toBe(2)
+                expect(createSpy).toHaveBeenCalledTimes(3)
+
+                while (release.length > 0) {
+                    release.shift()!()
+                    await Promise.resolve()
+                }
+            } finally {
+                jest.useRealTimers()
+            }
         })
 
         it('should handle partial batch success with some nulls', () => {

--- a/products/llm_analytics/frontend/llmSentimentLazyLoaderLogic.ts
+++ b/products/llm_analytics/frontend/llmSentimentLazyLoaderLogic.ts
@@ -41,6 +41,10 @@ function isValidSentimentResult(value: unknown): value is SentimentResult {
 }
 
 const BATCH_MAX_SIZE = 5
+// Cap on in-flight sentiment requests per flush. Browsers limit to ~6 concurrent
+// connections per origin; fanning out all chunks at once starves sibling lazy
+// loaders (trace messages, persons) on page loads with many rows.
+const MAX_CONCURRENT_BATCHES = 2
 
 function chunk<T>(arr: T[], size: number): T[][] {
     const chunks: T[][] = []
@@ -48,6 +52,20 @@ function chunk<T>(arr: T[], size: number): T[][] {
         chunks.push(arr.slice(i, i + size))
     }
     return chunks
+}
+
+async function runWithConcurrency<T>(items: T[], limit: number, worker: (item: T) => Promise<void>): Promise<void> {
+    if (items.length === 0) {
+        return
+    }
+    let cursor = 0
+    const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+        while (cursor < items.length) {
+            const index = cursor++
+            await worker(items[index])
+        }
+    })
+    await Promise.all(runners)
 }
 
 export const llmSentimentLazyLoaderLogic = kea<llmSentimentLazyLoaderLogicType>([
@@ -189,32 +207,30 @@ export const llmSentimentLazyLoaderLogic = kea<llmSentimentLazyLoaderLogicType>(
 
                     const chunks = chunk(allIds, BATCH_MAX_SIZE)
 
-                    await Promise.allSettled(
-                        chunks.map(async (batch) => {
-                            try {
-                                const response = await api.create<BatchSentimentResponse>(
-                                    `api/environments/${teamId}/llm_analytics/sentiment/`,
-                                    {
-                                        ids: batch,
-                                        analysis_level: 'trace',
-                                        date_from: dateRangeForBatch?.dateFrom || undefined,
-                                        date_to: dateRangeForBatch?.dateTo || undefined,
-                                    }
-                                )
-
-                                const results: Record<string, SentimentResult | null> = {}
-
-                                for (const traceId of batch) {
-                                    const raw = response.results[traceId]
-                                    results[traceId] = isValidSentimentResult(raw) ? raw : null
+                    await runWithConcurrency(chunks, MAX_CONCURRENT_BATCHES, async (batch) => {
+                        try {
+                            const response = await api.create<BatchSentimentResponse>(
+                                `api/environments/${teamId}/llm_analytics/sentiment/`,
+                                {
+                                    ids: batch,
+                                    analysis_level: 'trace',
+                                    date_from: dateRangeForBatch?.dateFrom || undefined,
+                                    date_to: dateRangeForBatch?.dateTo || undefined,
                                 }
+                            )
 
-                                actions.loadSentimentBatchSuccess(results, batch)
-                            } catch {
-                                actions.loadSentimentBatchFailure(batch)
+                            const results: Record<string, SentimentResult | null> = {}
+
+                            for (const traceId of batch) {
+                                const raw = response.results[traceId]
+                                results[traceId] = isValidSentimentResult(raw) ? raw : null
                             }
-                        })
-                    )
+
+                            actions.loadSentimentBatchSuccess(results, batch)
+                        } catch {
+                            actions.loadSentimentBatchFailure(batch)
+                        }
+                    })
                 }, 0)
             },
         }

--- a/products/llm_analytics/frontend/llmSentimentLazyLoaderLogic.ts
+++ b/products/llm_analytics/frontend/llmSentimentLazyLoaderLogic.ts
@@ -4,6 +4,7 @@ import api from 'lib/api'
 import { teamLogic } from 'scenes/teamLogic'
 
 import type { llmSentimentLazyLoaderLogicType } from './llmSentimentLazyLoaderLogicType'
+import { runWithConcurrency } from './utils'
 
 export interface SentimentDateRange {
     dateFrom?: string | null
@@ -52,20 +53,6 @@ function chunk<T>(arr: T[], size: number): T[][] {
         chunks.push(arr.slice(i, i + size))
     }
     return chunks
-}
-
-async function runWithConcurrency<T>(items: T[], limit: number, worker: (item: T) => Promise<void>): Promise<void> {
-    if (items.length === 0) {
-        return
-    }
-    let cursor = 0
-    const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
-        while (cursor < items.length) {
-            const index = cursor++
-            await worker(items[index])
-        }
-    })
-    await Promise.all(runners)
 }
 
 export const llmSentimentLazyLoaderLogic = kea<llmSentimentLazyLoaderLogicType>([

--- a/products/llm_analytics/frontend/utils.ts
+++ b/products/llm_analytics/frontend/utils.ts
@@ -51,6 +51,27 @@ export interface PagedSearchOrderFilters {
     order_by: string
 }
 
+// Runs an async worker across `items` with at most `limit` promises in flight.
+// Intended for lazy loaders that otherwise fan out enough parallel requests to
+// starve the browser's per-origin connection pool.
+export async function runWithConcurrency<T>(
+    items: T[],
+    limit: number,
+    worker: (item: T) => Promise<void>
+): Promise<void> {
+    if (items.length === 0) {
+        return
+    }
+    let cursor = 0
+    const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+        while (cursor < items.length) {
+            const index = cursor++
+            await worker(items[index])
+        }
+    })
+    await Promise.all(runners)
+}
+
 export interface SanitizeTraceUrlSearchParamsOptions {
     removeSearch?: boolean
 }


### PR DESCRIPTION
## Problem

On the LLM analytics traces list page, input/output message columns appeared to wait for the sentiment column to finish loading on first render. The columns are backed by independent kea logics with no direct coupling, but sentiment was exhausting the browser's per-origin connection pool before sibling lazy loaders (trace messages, persons) could dispatch.

Root cause:

- `LazySentimentColumnCell` dispatched `ensureSentimentLoaded` **during render**, while `useTraceMessagesForRow` dispatched its load in a `useEffect` — so sentiment always fired first.
- The sentiment listener fanned out all chunks in parallel via `Promise.allSettled(chunks.map(...))`. At 50 rows with `BATCH_MAX_SIZE = 5`, that's 10 concurrent `POST /sentiment/` requests, which (combined with the main traces query) saturates the ~6 concurrent connections browsers allow per origin. Messages and persons requests ended up queued behind the sentiment flood.

## Changes

- Added a small `runWithConcurrency` helper in both sentiment loaders and capped in-flight batches at `MAX_CONCURRENT_BATCHES = 2`, leaving ~4 connection slots free for sibling loaders. `BATCH_MAX_SIZE` is unchanged, so the backend contract is untouched.
- Moved `ensureSentimentLoaded` / `ensureGenerationSentimentLoaded` out of render and into a `useEffect` in `LazySentimentColumnCell` / `LazyGenerationSentimentCell`. This matches the pattern used by the sibling `useTraceMessagesForRow` and `LazyTraceReviewColumnCell` hooks in the same file, and removes a render-time side effect.

## How did you test this code?

- Added a kea logic test in `llmSentimentLazyLoaderLogic.test.ts` that stubs `api.create` with controllable pending promises and asserts the peak in-flight batch count stays at 2 across a 15-trace fan-out (3 chunks). Also verifies that releasing an in-flight slot lets the third chunk start. 32/32 tests in the sentiment loader and 32/32 in the generation loader pass.
- I'm an agent and have not manually verified behavior in a browser. A human reviewer should load the traces list with the `LLM_ANALYTICS_SENTIMENT` flag on under DevTools network throttling and confirm that Input/Output columns populate before (or independently of) the sentiment column.

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code. Diagnosis assumed a browser-level connection-pool bottleneck rather than explicit code coupling; the fix reduces sentiment's concurrent fan-out rather than bumping batch size (which was intentionally reduced in `5a5767a2e1`, `f204adcbaa`).

Follow-ups worth considering (not done here):
- Add `afterMount`/`beforeUnmount` cleanup to the sentiment loaders to cancel pending `batchTimer` on unmount (mirrors `traceMessagesLazyLoaderLogic`); this would let the new test drop `jest.useFakeTimers()`.
- Mirror the concurrency test to `llmGenerationSentimentLazyLoaderLogic.test.ts`.
- Extract `runWithConcurrency` into a shared util.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*