### PR TITLE
feat(llma): add Options dropdown for input/output on traces list

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
@@ -44,6 +44,12 @@ export function LLMAnalyticsTraces(): JSX.Element {
     const { propertyFilters: currentPropertyFilters } = useValues(llmAnalyticsSharedLogic)
     const { tracesQuery } = useValues(llmAnalyticsTracesTabLogic)
 
+    const baseContext = useTracesQueryContext()
+    const context: QueryContext<DataTableNode> = {
+        ...baseContext,
+        customActions: <TracesOptionsMenu key="traces-options-menu" />,
+    }
+
     return (
         <div data-attr="llm-trace-table">
             <DataTable
@@ -65,7 +71,7 @@ export function LLMAnalyticsTraces(): JSX.Element {
                         setPropertyFilters(newPropertyFilters)
                     }
                 }}
-                context={useTracesQueryContext()}
+                context={context}
                 uniqueKey="llm-analytics-traces"
             />
         </div>
@@ -118,7 +124,6 @@ export const useTracesQueryContext = (): QueryContext<DataTableNode> => {
         emptyStateHeading: 'There were no traces in this period',
         emptyStateDetail: 'Try changing the date range or filters.',
         dataTableMaxPaginationLimit: LLM_TRACES_PAGE_SIZE,
-        customActions: <TracesOptionsMenu key="traces-options-menu" />,
         columns: {
             id: {
                 title: 'ID',

--- a/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
@@ -2,12 +2,15 @@ import { useActions, useMountedLogic, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 import { useEffect } from 'react'
 
-import { LemonTag } from '@posthog/lemon-ui'
+import { IconGear } from '@posthog/icons'
+import { LemonButton, LemonDropdown, LemonSwitch, LemonTag } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { objectsEqual } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
@@ -69,11 +72,53 @@ export function LLMAnalyticsTraces(): JSX.Element {
     )
 }
 
+function TracesOptionsMenu(): JSX.Element | null {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { showInputOutputColumns } = useValues(llmAnalyticsTracesTabLogic)
+    const { setShowInputOutputColumns } = useActions(llmAnalyticsTracesTabLogic)
+
+    const showInputOutputToggleEnabled = !!featureFlags[FEATURE_FLAGS.LLM_OBSERVABILITY_SHOW_INPUT_OUTPUT]
+
+    if (!showInputOutputToggleEnabled) {
+        return null
+    }
+
+    return (
+        <LemonDropdown
+            closeOnClickInside={false}
+            placement="bottom-end"
+            overlay={
+                <div className="flex flex-col gap-2 py-1 px-2 min-w-64">
+                    <LemonSwitch
+                        checked={showInputOutputColumns}
+                        onChange={setShowInputOutputColumns}
+                        label="Show input/output"
+                        fullWidth
+                        tooltip="Preview each trace's first input and last output in the table. Turn off for a denser view."
+                        data-attr="llm-traces-show-input-output-toggle"
+                    />
+                </div>
+            }
+        >
+            <LemonButton
+                type="secondary"
+                size="small"
+                icon={<IconGear />}
+                tooltip="Customize traces view"
+                data-attr="llm-traces-options-menu"
+            >
+                Options
+            </LemonButton>
+        </LemonDropdown>
+    )
+}
+
 export const useTracesQueryContext = (): QueryContext<DataTableNode> => {
     return {
         emptyStateHeading: 'There were no traces in this period',
         emptyStateDetail: 'Try changing the date range or filters.',
         dataTableMaxPaginationLimit: LLM_TRACES_PAGE_SIZE,
+        customActions: <TracesOptionsMenu key="traces-options-menu" />,
         columns: {
             id: {
                 title: 'ID',

--- a/products/llm_analytics/frontend/tabs/llmAnalyticsTracesTabLogic.ts
+++ b/products/llm_analytics/frontend/tabs/llmAnalyticsTracesTabLogic.ts
@@ -44,6 +44,7 @@ export const llmAnalyticsTracesTabLogic = kea<llmAnalyticsTracesTabLogicType>([
 
     actions({
         setTracesQuery: (query: DataTableNode) => ({ query }),
+        setShowInputOutputColumns: (show: boolean) => ({ show }),
     }),
 
     reducers({
@@ -51,6 +52,13 @@ export const llmAnalyticsTracesTabLogic = kea<llmAnalyticsTracesTabLogicType>([
             null as DataTableNode | null,
             {
                 setTracesQuery: (_, { query }) => query,
+            },
+        ],
+        showInputOutputColumns: [
+            true as boolean,
+            { persist: true },
+            {
+                setShowInputOutputColumns: (_, { show }) => show,
             },
         ],
     }),
@@ -72,6 +80,7 @@ export const llmAnalyticsTracesTabLogic = kea<llmAnalyticsTracesTabLogicType>([
                 s.groupsTaxonomicTypes,
                 s.featureFlags,
                 s.user,
+                s.showInputOutputColumns,
             ],
             (
                 dateFilter: { dateFrom: string | null; dateTo: string | null },
@@ -82,7 +91,8 @@ export const llmAnalyticsTracesTabLogic = kea<llmAnalyticsTracesTabLogicType>([
                 group: { groupKey: string; groupTypeIndex: number } | undefined,
                 groupsTaxonomicTypes: TaxonomicFilterGroupType[],
                 featureFlags: { [flag: string]: boolean | string | undefined },
-                user: { is_impersonated?: boolean } | null
+                user: { is_impersonated?: boolean } | null,
+                showInputOutputColumns: boolean
             ): DataTableNode => {
                 // For impersonated users (support agents), default to showing support traces
                 // For regular users, always filter out support traces
@@ -107,7 +117,7 @@ export const llmAnalyticsTracesTabLogic = kea<llmAnalyticsTracesTabLogicType>([
                     columns: [
                         'id',
                         'traceName',
-                        ...(featureFlags[FEATURE_FLAGS.LLM_OBSERVABILITY_SHOW_INPUT_OUTPUT]
+                        ...(featureFlags[FEATURE_FLAGS.LLM_OBSERVABILITY_SHOW_INPUT_OUTPUT] && showInputOutputColumns
                             ? ['inputState', 'outputState']
                             : []),
                         'person',


### PR DESCRIPTION
## Problem

PR #54157 generalized the trace input/output preview columns on the LLM analytics traces list so they populate for every SDK shape (OpenAI, Anthropic, Vercel, langchain) rather than only langchain-shaped traces. The plan is to roll the `llm-observability-show-input-output` flag to 100% so the preview is on by default for everyone. Some users prefer a denser view without those columns, so we need a safety hatch they can opt out with.

## Changes

<img width="2784" height="914" alt="image" src="https://github.com/user-attachments/assets/bb2bd9a7-4269-43c5-a2d3-e89f3dae0f49" />
<img width="2780" height="840" alt="image" src="https://github.com/user-attachments/assets/e4daa837-203e-4691-860a-a205a11bb8bc" />


- Add a persisted `showInputOutputColumns` reducer (default `true`) to `llmAnalyticsTracesTabLogic`. The `inputState` / `outputState` columns are now gated on both the feature flag and this user preference.
- Add a `TracesOptionsMenu` component in `LLMAnalyticsTracesScene.tsx` — a `LemonDropdown` with a gear-icon `Options` button that opens a small overlay holding the "Show input/output" switch. Wired in via `QueryContext.customActions` so it slots cleanly into the `DataTable` header row alongside Export instead of floating above the table.
- The menu only renders when the flag is enabled. Scaffolded as an "Options" menu so we can add more view-customisation toggles here over time without adding further top-level buttons.

Screenshots to follow in a comment.

## How did you test this code?

Verified locally against the demo project (team 1) with the flag overridden on: the Options button slots neatly next to Export, toggling the switch shows/hides the Input message / Output message columns immediately, and the preference persists across reloads (kea `persist: true`).

I'm an agent — no manual end-to-end browser testing was performed beyond the scripted Playwright checks above, and no new automated tests were added for this change. `tsc --noEmit` passes clean for the frontend.

## Publish to changelog?

no

## Docs update

No docs update needed.