### PR TITLE
fix(llma): decode older-spec OTel GenAI span events into $ai_input/$ai_output_choices

### DIFF
--- a/nodejs/src/ingestion/ai/metrics.ts
+++ b/nodejs/src/ingestion/ai/metrics.ts
@@ -41,3 +41,9 @@ export const aiOtelEventTypeCounter = new Counter({
     help: 'OTel events by type and library',
     labelNames: ['event_type', 'library'],
 })
+
+export const aiOtelOlderSpecEventsCounter = new Counter({
+    name: 'llma_ai_otel_older_spec_events_total',
+    help: 'Outcome of decoding the older OTel GenAI span-events `events` attribute',
+    labelNames: ['outcome'],
+})

--- a/nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts
+++ b/nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts
@@ -341,20 +341,17 @@ describe('mapOtelAttributes', () => {
             expect(extractToolCallNames(event.properties!.$ai_output_choices)).toEqual(['final_result', 'get_weather'])
         })
 
-        it('infers role="tool" for gen_ai.tool.message entries without explicit role', () => {
-            const events = [
-                {
-                    content: 'Paris is the capital of France.',
-                    tool_call_id: 'call_xyz',
-                    'event.name': 'gen_ai.tool.message',
-                },
-            ]
+        it.each([
+            ['gen_ai.system.message', 'system'],
+            ['gen_ai.user.message', 'user'],
+            ['gen_ai.assistant.message', 'assistant'],
+            ['gen_ai.tool.message', 'tool'],
+        ])('infers role "%s" → "%s" when the entry has no explicit role', (eventName, expectedRole) => {
+            const events = [{ content: 'body', 'event.name': eventName }]
             const event = createEvent('$ai_generation', { events: JSON.stringify(events) })
             mapOtelAttributes(event)
 
-            expect(event.properties!.$ai_input).toEqual([
-                { role: 'tool', content: 'Paris is the capital of France.', tool_call_id: 'call_xyz' },
-            ])
+            expect(event.properties!.$ai_input).toEqual([{ role: expectedRole, content: 'body' }])
         })
 
         it('does not throw on malformed `events` JSON and still strips the property', () => {

--- a/nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts
+++ b/nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts
@@ -1,5 +1,6 @@
 import { PluginEvent } from '~/plugin-scaffold'
 
+import { extractToolCallNames } from '../tools/extract-tool-calls'
 import { mapOtelAttributes } from './attribute-mapping'
 
 const createEvent = (event: string, properties: Record<string, unknown>): PluginEvent => ({
@@ -232,5 +233,170 @@ describe('mapOtelAttributes', () => {
         })
         mapOtelAttributes(event)
         expect(event.event).toBe('$ai_generation')
+    })
+
+    describe('older-spec span events (`events` attribute)', () => {
+        it('reconstructs $ai_input and $ai_output_choices from span-events-style `events`', () => {
+            const events = [
+                {
+                    role: 'system',
+                    content: 'Extract city information.',
+                    'gen_ai.message.index': 0,
+                    'event.name': 'gen_ai.system.message',
+                },
+                {
+                    role: 'user',
+                    content: 'Tell me about Montreal, Canada.',
+                    'gen_ai.message.index': 0,
+                    'event.name': 'gen_ai.user.message',
+                },
+                {
+                    index: 0,
+                    message: {
+                        role: 'assistant',
+                        content: 'Montreal is a city in Canada.',
+                    },
+                    'event.name': 'gen_ai.choice',
+                },
+            ]
+            const event = createEvent('$ai_generation', { events: JSON.stringify(events) })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([
+                { role: 'system', content: 'Extract city information.' },
+                { role: 'user', content: 'Tell me about Montreal, Canada.' },
+            ])
+            expect(event.properties!.$ai_output_choices).toEqual([
+                { role: 'assistant', content: 'Montreal is a city in Canada.' },
+            ])
+            expect(event.properties!.events).toBeUndefined()
+        })
+
+        it('orders $ai_input by gen_ai.message.index when all entries have one', () => {
+            const events = [
+                { role: 'assistant', 'gen_ai.message.index': 2, 'event.name': 'gen_ai.assistant.message' },
+                { role: 'user', 'gen_ai.message.index': 1, 'event.name': 'gen_ai.user.message' },
+                { role: 'system', 'gen_ai.message.index': 0, 'event.name': 'gen_ai.system.message' },
+            ]
+            const event = createEvent('$ai_generation', { events: JSON.stringify(events) })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([{ role: 'system' }, { role: 'user' }, { role: 'assistant' }])
+        })
+
+        it('preserves array order when entries lack gen_ai.message.index', () => {
+            const events = [
+                { role: 'system', content: 'S', 'event.name': 'gen_ai.system.message' },
+                { role: 'user', content: 'U', 'event.name': 'gen_ai.user.message' },
+            ]
+            const event = createEvent('$ai_generation', { events: JSON.stringify(events) })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([
+                { role: 'system', content: 'S' },
+                { role: 'user', content: 'U' },
+            ])
+        })
+
+        it('prefers newer gen_ai.input.messages over older `events` but still strips `events`', () => {
+            const newer = [{ role: 'user', content: 'newer' }]
+            const older = [{ role: 'user', content: 'older', 'event.name': 'gen_ai.user.message' }]
+            const event = createEvent('$ai_generation', {
+                'gen_ai.input.messages': JSON.stringify(newer),
+                events: JSON.stringify(older),
+            })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual(newer)
+            expect(event.properties!.events).toBeUndefined()
+        })
+
+        it('produces $ai_output_choices that downstream tool extraction can read', () => {
+            const events = [
+                {
+                    index: 0,
+                    message: {
+                        role: 'assistant',
+                        tool_calls: [
+                            {
+                                id: 'call_abc',
+                                type: 'function',
+                                function: { name: 'final_result', arguments: '{}' },
+                            },
+                            {
+                                id: 'call_def',
+                                type: 'function',
+                                function: { name: 'get_weather', arguments: '{}' },
+                            },
+                        ],
+                    },
+                    'event.name': 'gen_ai.choice',
+                },
+            ]
+            const event = createEvent('$ai_generation', { events: JSON.stringify(events) })
+            mapOtelAttributes(event)
+
+            expect(extractToolCallNames(event.properties!.$ai_output_choices)).toEqual(['final_result', 'get_weather'])
+        })
+
+        it('infers role="tool" for gen_ai.tool.message entries without explicit role', () => {
+            const events = [
+                {
+                    content: 'Paris is the capital of France.',
+                    tool_call_id: 'call_xyz',
+                    'event.name': 'gen_ai.tool.message',
+                },
+            ]
+            const event = createEvent('$ai_generation', { events: JSON.stringify(events) })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([
+                { role: 'tool', content: 'Paris is the capital of France.', tool_call_id: 'call_xyz' },
+            ])
+        })
+
+        it('does not throw on malformed `events` JSON and still strips the property', () => {
+            const event = createEvent('$ai_generation', { events: 'not { valid json' })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toBeUndefined()
+            expect(event.properties!.$ai_output_choices).toBeUndefined()
+            expect(event.properties!.events).toBeUndefined()
+        })
+
+        it('does not throw when `events` parses to a non-array and still strips the property', () => {
+            const event = createEvent('$ai_generation', { events: JSON.stringify({ foo: 1 }) })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toBeUndefined()
+            expect(event.properties!.$ai_output_choices).toBeUndefined()
+            expect(event.properties!.events).toBeUndefined()
+        })
+
+        it('accepts `events` as an already-parsed array', () => {
+            const events = [
+                { role: 'user', content: 'hi', 'event.name': 'gen_ai.user.message' },
+                { index: 0, message: { role: 'assistant', content: 'hello' }, 'event.name': 'gen_ai.choice' },
+            ]
+            const event = createEvent('$ai_generation', { events })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([{ role: 'user', content: 'hi' }])
+            expect(event.properties!.$ai_output_choices).toEqual([{ role: 'assistant', content: 'hello' }])
+            expect(event.properties!.events).toBeUndefined()
+        })
+
+        it('ignores entries with unknown event.name but reconstructs recognised ones', () => {
+            const events = [
+                { role: 'user', content: 'hi', 'event.name': 'gen_ai.user.message' },
+                { role: 'spurious', 'event.name': 'gen_ai.unknown.thing' },
+                { index: 0, message: { role: 'assistant', content: 'hello' }, 'event.name': 'gen_ai.choice' },
+            ]
+            const event = createEvent('$ai_generation', { events: JSON.stringify(events) })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([{ role: 'user', content: 'hi' }])
+            expect(event.properties!.$ai_output_choices).toEqual([{ role: 'assistant', content: 'hello' }])
+        })
     })
 })

--- a/nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts
+++ b/nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts
@@ -1,7 +1,9 @@
 import { PluginEvent } from '~/plugin-scaffold'
 
+import { parseJSON } from '../../../utils/json-parse'
 import { extractToolCallNames } from '../tools/extract-tool-calls'
 import { mapOtelAttributes } from './attribute-mapping'
+import { convertOtelEvent } from './index'
 
 const createEvent = (event: string, properties: Record<string, unknown>): PluginEvent => ({
     event,
@@ -397,6 +399,124 @@ describe('mapOtelAttributes', () => {
 
             expect(event.properties!.$ai_input).toEqual([{ role: 'user', content: 'hi' }])
             expect(event.properties!.$ai_output_choices).toEqual([{ role: 'assistant', content: 'hello' }])
+        })
+
+        it('preserves array order when only some entries have gen_ai.message.index', () => {
+            const events = [
+                { role: 'system', content: 'S', 'gen_ai.message.index': 5, 'event.name': 'gen_ai.system.message' },
+                { role: 'user', content: 'U', 'event.name': 'gen_ai.user.message' },
+                {
+                    role: 'assistant',
+                    content: 'A',
+                    'gen_ai.message.index': 0,
+                    'event.name': 'gen_ai.assistant.message',
+                },
+            ]
+            const event = createEvent('$ai_generation', { events: JSON.stringify(events) })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([
+                { role: 'system', content: 'S' },
+                { role: 'user', content: 'U' },
+                { role: 'assistant', content: 'A' },
+            ])
+        })
+
+        it('preserves tool_calls on gen_ai.assistant.message entries in $ai_input', () => {
+            const toolCalls = [
+                { id: 'call_1', type: 'function', function: { name: 'search', arguments: '{"q":"paris"}' } },
+            ]
+            const events = [
+                { role: 'user', content: 'find paris', 'event.name': 'gen_ai.user.message' },
+                { role: 'assistant', tool_calls: toolCalls, 'event.name': 'gen_ai.assistant.message' },
+                {
+                    role: 'tool',
+                    content: 'ok',
+                    tool_call_id: 'call_1',
+                    'event.name': 'gen_ai.tool.message',
+                },
+            ]
+            const event = createEvent('$ai_generation', { events: JSON.stringify(events) })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toEqual([
+                { role: 'user', content: 'find paris' },
+                { role: 'assistant', tool_calls: toolCalls },
+                { role: 'tool', content: 'ok', tool_call_id: 'call_1' },
+            ])
+        })
+
+        it('treats pre-existing null $ai_input as already set and does not overwrite', () => {
+            const events = [{ role: 'user', content: 'hi', 'event.name': 'gen_ai.user.message' }]
+            const event = createEvent('$ai_generation', { $ai_input: null, events: JSON.stringify(events) })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toBeNull()
+            expect(event.properties!.events).toBeUndefined()
+        })
+
+        it('does not mutate $ai_output_choices by reference into the parsed events payload', () => {
+            const events = [
+                {
+                    message: { role: 'assistant', content: 'original' },
+                    'event.name': 'gen_ai.choice',
+                },
+            ]
+            const eventsString = JSON.stringify(events)
+            const event = createEvent('$ai_generation', { events: eventsString })
+            mapOtelAttributes(event)
+
+            // Mutating the emitted choice must not affect any shared transient
+            // structure — we shallow-copy the inner message in reconstructOutputChoice.
+            const choices = event.properties!.$ai_output_choices as Record<string, unknown>[]
+            ;(choices[0] as Record<string, unknown>).content = 'mutated'
+            // Re-parse the original events string to confirm nothing leaked back.
+            const reparsed = parseJSON(eventsString) as { message: { content: string } }[]
+            expect(reparsed[0].message.content).toBe('original')
+        })
+
+        it('skips parsing when `events` string exceeds the size guard and still strips it', () => {
+            const oversized = 'x'.repeat(500_001)
+            const event = createEvent('$ai_generation', { events: oversized })
+            mapOtelAttributes(event)
+
+            expect(event.properties!.$ai_input).toBeUndefined()
+            expect(event.properties!.$ai_output_choices).toBeUndefined()
+            expect(event.properties!.events).toBeUndefined()
+        })
+    })
+
+    describe('older-spec span events composed with pydantic-ai middleware', () => {
+        it('reconstructs $ai_input/$ai_output_choices alongside pydantic-ai framework attributes', () => {
+            // Realistic runtime path: pydantic-ai middleware runs, calls
+            // `next()` which invokes `mapOtelAttributes` (and therefore our
+            // `convertOlderSpecEvents` fallback), then the middleware applies
+            // its own post-processing.
+            const olderEvents = [
+                { role: 'user', content: 'Hello', 'event.name': 'gen_ai.user.message' },
+                {
+                    message: { role: 'assistant', content: 'Hi there!' },
+                    'event.name': 'gen_ai.choice',
+                },
+            ]
+            const event = createEvent('$ai_span', {
+                $ai_ingestion_source: 'otel',
+                'telemetry.sdk.name': 'opentelemetry',
+                'logfire.msg': 'chat gpt-4o-mini',
+                'llm.request.type': 'chat',
+                'gen_ai.response.model': 'gpt-4o-mini-2024-07-18',
+                events: JSON.stringify(olderEvents),
+            })
+
+            convertOtelEvent(event)
+
+            expect(event.event).toBe('$ai_generation')
+            expect(event.properties!.$ai_lib).toBe('opentelemetry/pydantic-ai')
+            expect(event.properties!.$ai_span_name).toBe('chat gpt-4o-mini')
+            expect(event.properties!.$ai_model).toBe('gpt-4o-mini-2024-07-18')
+            expect(event.properties!.$ai_input).toEqual([{ role: 'user', content: 'Hello' }])
+            expect(event.properties!.$ai_output_choices).toEqual([{ role: 'assistant', content: 'Hi there!' }])
+            expect(event.properties!.events).toBeUndefined()
         })
     })
 })

--- a/nodejs/src/ingestion/ai/otel/attribute-mapping.ts
+++ b/nodejs/src/ingestion/ai/otel/attribute-mapping.ts
@@ -1,6 +1,7 @@
 import { PluginEvent } from '~/plugin-scaffold'
 
 import { parseJSON } from '../../../utils/json-parse'
+import { aiOtelOlderSpecEventsCounter } from '../metrics'
 
 const ATTRIBUTE_MAP: Record<string, string> = {
     'gen_ai.input.messages': '$ai_input',
@@ -43,6 +44,12 @@ const OLDER_SPEC_INPUT_EVENT_NAMES: Record<string, string> = {
     'gen_ai.tool.message': 'tool',
 }
 const OLDER_SPEC_CHOICE_EVENT_NAME = 'gen_ai.choice'
+
+// Upper bound on the serialized size of an older-spec `events` attribute we
+// will parse. Chosen to match the existing tool-call extraction guard
+// (`MAX_OUTPUT_CHOICES_LENGTH`). Pathological payloads would otherwise force
+// `parseJSON` into multi-megabyte input and pressure the ingestion worker.
+const MAX_OLDER_SPEC_EVENTS_LENGTH = 500_000
 
 const REQUEST_TYPE_TO_EVENT: Record<string, string> = {
     chat: '$ai_generation',
@@ -127,21 +134,29 @@ function promoteRootSpanToTrace(event: PluginEvent): void {
     }
 }
 
-function parseOlderSpecEventsAttribute(raw: unknown): Record<string, unknown>[] | undefined {
+type ParseOutcome = 'parsed' | 'too_large' | 'malformed' | 'non_array'
+
+function parseOlderSpecEventsAttribute(
+    raw: unknown
+): { outcome: 'parsed'; entries: Record<string, unknown>[] } | { outcome: Exclude<ParseOutcome, 'parsed'> } {
     let value: unknown = raw
     if (typeof value === 'string') {
+        if (value.length > MAX_OLDER_SPEC_EVENTS_LENGTH) {
+            return { outcome: 'too_large' }
+        }
         try {
             value = parseJSON(value)
         } catch {
-            return undefined
+            return { outcome: 'malformed' }
         }
     }
     if (!Array.isArray(value)) {
-        return undefined
+        return { outcome: 'non_array' }
     }
-    return value.filter(
+    const entries = value.filter(
         (item): item is Record<string, unknown> => typeof item === 'object' && item !== null && !Array.isArray(item)
     )
+    return { outcome: 'parsed', entries }
 }
 
 function reconstructInputMessage(entry: Record<string, unknown>, eventName: string): Record<string, unknown> | null {
@@ -168,7 +183,9 @@ function reconstructOutputChoice(entry: Record<string, unknown>): Record<string,
     // would only be unwrapped by `isLiteLLMChoice`, which requires a
     // `finish_reason` field we don't have.
     if (typeof entry.message === 'object' && entry.message !== null && !Array.isArray(entry.message)) {
-        return entry.message as Record<string, unknown>
+        // Shallow-copy so the downstream $ai_output_choices array does not
+        // share references with the transient parsed `events` payload.
+        return { ...(entry.message as Record<string, unknown>) }
     }
     if ('role' in entry || 'content' in entry || 'tool_calls' in entry) {
         const message: Record<string, unknown> = {}
@@ -192,17 +209,19 @@ function convertOlderSpecEvents(event: PluginEvent): void {
         return
     }
 
+    let outcome: ParseOutcome | 'empty' | 'unexpected_error' = 'parsed'
     try {
-        const entries = parseOlderSpecEventsAttribute(props.events)
-        if (!entries) {
+        const parsed = parseOlderSpecEventsAttribute(props.events)
+        if (parsed.outcome !== 'parsed') {
+            outcome = parsed.outcome
             return
         }
 
         const inputs: { message: Record<string, unknown>; index: number; order: number }[] = []
         const choices: Record<string, unknown>[] = []
 
-        for (let order = 0; order < entries.length; order++) {
-            const entry = entries[order]
+        for (let order = 0; order < parsed.entries.length; order++) {
+            const entry = parsed.entries[order]
             const eventName = typeof entry['event.name'] === 'string' ? (entry['event.name'] as string) : undefined
             if (!eventName) {
                 continue
@@ -225,18 +244,34 @@ function convertOlderSpecEvents(event: PluginEvent): void {
             }
         }
 
+        // Only populate if the primary / fallback attribute maps did not already
+        // set these keys — strictly `=== undefined` so any non-undefined value
+        // (including null or empty array) is treated as "already set".
         if (inputs.length > 0 && props['$ai_input'] === undefined) {
             const allIndexed = inputs.every((i) => Number.isFinite(i.index))
-            const sorted = allIndexed ? [...inputs].sort((a, b) => a.index - b.index || a.order - b.order) : inputs
+            // Comparator avoids subtraction so extreme numeric indices cannot
+            // overflow float precision.
+            const sorted = allIndexed
+                ? [...inputs].sort((a, b) => (a.index > b.index ? 1 : a.index < b.index ? -1 : 0) || a.order - b.order)
+                : inputs
             props['$ai_input'] = sorted.map((i) => i.message)
         }
 
         if (choices.length > 0 && props['$ai_output_choices'] === undefined) {
             props['$ai_output_choices'] = choices
         }
+
+        if (inputs.length === 0 && choices.length === 0) {
+            outcome = 'empty'
+        }
     } catch {
         // Never let malformed data break the rest of the mapping pipeline.
+        outcome = 'unexpected_error'
     } finally {
+        // `delete` runs in all exit paths — including early returns from the
+        // `parsed.outcome !== 'parsed'` short-circuit and the outer catch —
+        // so a single unparseable event cannot leak the raw string forward.
         delete props.events
+        aiOtelOlderSpecEventsCounter.labels({ outcome }).inc()
     }
 }

--- a/nodejs/src/ingestion/ai/otel/attribute-mapping.ts
+++ b/nodejs/src/ingestion/ai/otel/attribute-mapping.ts
@@ -33,6 +33,17 @@ const STRIP_ATTRIBUTES = new Set([
 
 const JSON_PARSE_PROPERTIES = new Set(['$ai_input', '$ai_output_choices'])
 
+// Older OTel GenAI spec emits messages as span events rather than
+// `gen_ai.input.messages` / `gen_ai.output.messages` attributes. Logfire
+// serializes those span events into a single `events` span attribute.
+const OLDER_SPEC_INPUT_EVENT_NAMES: Record<string, string> = {
+    'gen_ai.system.message': 'system',
+    'gen_ai.user.message': 'user',
+    'gen_ai.assistant.message': 'assistant',
+    'gen_ai.tool.message': 'tool',
+}
+const OLDER_SPEC_CHOICE_EVENT_NAME = 'gen_ai.choice'
+
 const REQUEST_TYPE_TO_EVENT: Record<string, string> = {
     chat: '$ai_generation',
     completion: '$ai_generation',
@@ -79,6 +90,8 @@ export function mapOtelAttributes(event: PluginEvent): void {
         delete event.properties[otelKey]
     }
 
+    convertOlderSpecEvents(event)
+
     computeLatency(event)
     promoteRootSpanToTrace(event)
 
@@ -111,5 +124,119 @@ function computeLatency(event: PluginEvent): void {
 function promoteRootSpanToTrace(event: PluginEvent): void {
     if (event.event === '$ai_span' && !event.properties!['$ai_parent_id']) {
         event.event = '$ai_trace'
+    }
+}
+
+function parseOlderSpecEventsAttribute(raw: unknown): Record<string, unknown>[] | undefined {
+    let value: unknown = raw
+    if (typeof value === 'string') {
+        try {
+            value = parseJSON(value)
+        } catch {
+            return undefined
+        }
+    }
+    if (!Array.isArray(value)) {
+        return undefined
+    }
+    return value.filter(
+        (item): item is Record<string, unknown> => typeof item === 'object' && item !== null && !Array.isArray(item)
+    )
+}
+
+function reconstructInputMessage(entry: Record<string, unknown>, eventName: string): Record<string, unknown> | null {
+    const role = typeof entry.role === 'string' ? entry.role : OLDER_SPEC_INPUT_EVENT_NAMES[eventName]
+    if (!role) {
+        return null
+    }
+    const message: Record<string, unknown> = { role }
+    if ('content' in entry) {
+        message.content = entry.content
+    }
+    if ('tool_calls' in entry) {
+        message.tool_calls = entry.tool_calls
+    }
+    if ('tool_call_id' in entry) {
+        message.tool_call_id = entry.tool_call_id
+    }
+    return message
+}
+
+function reconstructOutputChoice(entry: Record<string, unknown>): Record<string, unknown> | null {
+    // Emit flat messages (matching newer-spec `gen_ai.output.messages`) so the
+    // frontend renderer picks them up directly. A `{ index, message }` wrapper
+    // would only be unwrapped by `isLiteLLMChoice`, which requires a
+    // `finish_reason` field we don't have.
+    if (typeof entry.message === 'object' && entry.message !== null && !Array.isArray(entry.message)) {
+        return entry.message as Record<string, unknown>
+    }
+    if ('role' in entry || 'content' in entry || 'tool_calls' in entry) {
+        const message: Record<string, unknown> = {}
+        if ('role' in entry) {
+            message.role = entry.role
+        }
+        if ('content' in entry) {
+            message.content = entry.content
+        }
+        if ('tool_calls' in entry) {
+            message.tool_calls = entry.tool_calls
+        }
+        return message
+    }
+    return null
+}
+
+function convertOlderSpecEvents(event: PluginEvent): void {
+    const props = event.properties!
+    if (!('events' in props)) {
+        return
+    }
+
+    try {
+        const entries = parseOlderSpecEventsAttribute(props.events)
+        if (!entries) {
+            return
+        }
+
+        const inputs: { message: Record<string, unknown>; index: number; order: number }[] = []
+        const choices: Record<string, unknown>[] = []
+
+        for (let order = 0; order < entries.length; order++) {
+            const entry = entries[order]
+            const eventName = typeof entry['event.name'] === 'string' ? (entry['event.name'] as string) : undefined
+            if (!eventName) {
+                continue
+            }
+
+            if (eventName in OLDER_SPEC_INPUT_EVENT_NAMES) {
+                const message = reconstructInputMessage(entry, eventName)
+                if (message) {
+                    const index =
+                        typeof entry['gen_ai.message.index'] === 'number'
+                            ? (entry['gen_ai.message.index'] as number)
+                            : Number.NaN
+                    inputs.push({ message, index, order })
+                }
+            } else if (eventName === OLDER_SPEC_CHOICE_EVENT_NAME) {
+                const choice = reconstructOutputChoice(entry)
+                if (choice) {
+                    choices.push(choice)
+                }
+            }
+        }
+
+        if (inputs.length > 0 && props['$ai_input'] === undefined) {
+            const allIndexed = inputs.every((i) => Number.isFinite(i.index))
+            const sorted = allIndexed ? [...inputs].sort((a, b) => a.index - b.index || a.order - b.order) : inputs
+            props['$ai_input'] = sorted.map((i) => i.message)
+        }
+
+        if (choices.length > 0 && props['$ai_output_choices'] === undefined) {
+            props['$ai_output_choices'] = choices
+        }
+    } catch {
+        // Never let malformed data break the rest of the mapping pipeline.
+    } finally {
+        delete props.events
     }
 }


### PR DESCRIPTION
## Problem

Pydantic AI / Logfire emit GenAI messages using the *older* OTel GenAI semantic convention — as span events (`gen_ai.system.message`, `gen_ai.user.message`, `gen_ai.assistant.message`, `gen_ai.tool.message`, `gen_ai.choice`) rather than the newer `gen_ai.input.messages` / `gen_ai.output.messages` span attributes. Logfire serializes those span events into a single `events` span attribute (a JSON-encoded array of event objects).

Stage 2 in `nodejs/src/ingestion/ai/otel/attribute-mapping.ts` only handled the newer attribute names, so the older `events` blob passed through untouched onto `$ai_generation` events. `$ai_input` / `$ai_output_choices` were left unset and the LLM analytics UI showed nothing for input/output across every Pydantic AI generation.

## Changes

Stage 2 fallback `convertOlderSpecEvents`, wired into `mapOtelAttributes` after the primary + fallback attribute maps so newer-spec attributes still win when present.

- Parse `events` (string or already-parsed array), then walk entries by `event.name`:
  - `gen_ai.(system|user|assistant|tool).message` → reconstruct flat `$ai_input` messages `{ role, content?, tool_calls?, tool_call_id? }`. Role is inferred from `event.name` when not explicit.
  - `gen_ai.choice` → reconstruct flat `$ai_output_choices` messages (unwrapped, matching newer-spec `gen_ai.output.messages`). Wrapping in `{ index, message }` would require a `finish_reason` for the UI's `isLiteLLMChoice` unwrap, which the older spec does not carry. The downstream tool-call extractor (`extract-tool-calls.ts`) already handles flat messages, so `$ai_tools_called` / `$ai_tool_call_count` continue to populate.
- Order `$ai_input` by `gen_ai.message.index` when every entry has one (stable tiebreak by array order), otherwise preserve array order. Sort comparator avoids float subtraction to stay safe against extreme index values.
- Always strip the raw `events` property in a `finally` block — even on early returns (size guard, malformed, non-array) and the outer catch — so a bad payload cannot leak the raw string forward.
- `MAX_OLDER_SPEC_EVENTS_LENGTH = 500_000` guard before `parseJSON` to match `MAX_OUTPUT_CHOICES_LENGTH` and avoid multi-MB payloads pressuring the ingestion worker.
- `reconstructOutputChoice` shallow-copies `entry.message` so the emitted `$ai_output_choices` does not share references with the transient parsed `events` payload.
- New Prometheus counter `llma_ai_otel_older_spec_events_total` labeled `{outcome}` with values `parsed`, `malformed`, `non_array`, `too_large`, `empty`, `unexpected_error` — gives ops a way to detect Logfire shape changes without relying on UI reports.

Design principle (per `llm-analytics-apps/scripts/OTEL_TESTING_REFERENCE.md`): spec-version differences live in stages 1–2 with fallbacks, not in framework-specific middleware. The fix is in `attribute-mapping.ts`, not in `middleware/pydantic-ai.ts`.

### Files

- `nodejs/src/ingestion/ai/metrics.ts` — new `aiOtelOlderSpecEventsCounter`.
- `nodejs/src/ingestion/ai/otel/attribute-mapping.ts` — `convertOlderSpecEvents` helper + wiring + size guard + metric emission.
- `nodejs/src/ingestion/ai/otel/attribute-mapping.test.ts` — new describe blocks.

## How did you test this code?

- Added unit tests in `attribute-mapping.test.ts` covering:
  - Older-style-only payload produces `$ai_input` + `$ai_output_choices` and strips `events`.
  - Ordering by `gen_ai.message.index` (all-indexed) and array-order fallback (not all indexed, or none indexed).
  - Newer-spec precedence: `gen_ai.input.messages` wins, `events` still stripped.
  - Tool-call choice → downstream `extractToolCallNames` round-trip.
  - Role inference parameterized across all four `OLDER_SPEC_INPUT_EVENT_NAMES` entries.
  - `tool_calls` preservation on `gen_ai.assistant.message` entries in `$ai_input`.
  - Pre-existing `null` `$ai_input` is treated as already-set (not overwritten).
  - Shallow-copy reference safety.
  - Malformed JSON / non-array / already-parsed-array / unknown `event.name` edge cases.
  - Oversize `events` string (>500KB) skips parsing and still strips the key.
  - Integration test composing `convertOtelEvent` with the pydantic-ai middleware on a realistic `events`-carrying `$ai_span` payload, asserting reclassification, `$ai_lib`, `$ai_span_name`, `$ai_model`, and reconstructed input/output.
- Full otel (132 tests) + tools (75 tests) suites pass; lint clean.
- Manually reproduced end-to-end by running `llm-analytics-apps/scripts/test_pydantic_ai_otel.py` against a local PostHog running this branch: confirmed `$ai_generation` events arrive with populated `$ai_input` / `$ai_output_choices`, no top-level `events`, and the LLM analytics UI renders input/output (including tool-call cards with `$ai_tools_called` set) correctly.

## Publish to changelog?

no

## Docs update

No docs changes needed — transparent ingestion fix for existing Pydantic AI / Logfire users.

## 🤖 LLM context

Authored with PostHog Code. Design reviewed via an implementation plan that explicitly considered whether the Rust stage-1 layer (`rust/capture/src/otel/fan_out.rs`) needed changes; it only reads `span.attributes`, and Logfire pre-packs span events into the `events` attribute, so no Rust changes are required. The first pass wrapped choices as `{ index, message }`; manual UI verification revealed that the renderer needs flat messages (unwrap requires `finish_reason`), which this PR now emits. A follow-up commit added a Prometheus counter, a 500KB size guard, a defensive shallow-copy, a non-subtracting sort comparator, and additional tests in response to review feedback.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*