### PR TITLE
feat(logs): add kind column to LogsAlertEvent

### DIFF
--- a/products/logs/backend/alerts_api.py
+++ b/products/logs/backend/alerts_api.py
@@ -100,7 +100,11 @@ class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
             # Subquery annotation yields either the error_message string or None.
             return cast(str | None, annotated)
         return (
-            LogsAlertEvent.objects.filter(alert=obj, error_message__isnull=False)
+            LogsAlertEvent.objects.filter(
+                alert=obj,
+                kind=LogsAlertEvent.Kind.CHECK,
+                error_message__isnull=False,
+            )
             .order_by("-created_at")
             .values_list("error_message", flat=True)
             .first()
@@ -464,7 +468,11 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         # Correlated subquery so list/retrieve can surface `last_error_message` in a
         # single round-trip instead of one extra query per alert.
         latest_error = (
-            LogsAlertEvent.objects.filter(alert=OuterRef("pk"), error_message__isnull=False)
+            LogsAlertEvent.objects.filter(
+                alert=OuterRef("pk"),
+                kind=LogsAlertEvent.Kind.CHECK,
+                error_message__isnull=False,
+            )
             .order_by("-created_at")
             .values("error_message")[:1]
         )

--- a/products/logs/backend/migrations/0005_logsalertevent_kind.py
+++ b/products/logs/backend/migrations/0005_logsalertevent_kind.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("logs", "0004_logsalertevent"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="logsalertevent",
+            name="kind",
+            field=models.CharField(
+                choices=[
+                    ("check", "Check"),
+                    ("reset", "Reset"),
+                    ("enable", "Enable"),
+                    ("disable", "Disable"),
+                    ("snooze", "Snooze"),
+                    ("unsnooze", "Unsnooze"),
+                    ("threshold_change", "Threshold change"),
+                ],
+                default="check",
+                max_length=32,
+            ),
+        ),
+    ]

--- a/products/logs/backend/migrations/0005_logsalertevent_kind.py
+++ b/products/logs/backend/migrations/0005_logsalertevent_kind.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("logs", "0004_rename_logsalertcheck_logsalertevent"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="logsalertevent",
+            name="kind",
+            field=models.CharField(
+                choices=[
+                    ("check", "Check"),
+                    ("reset", "Reset"),
+                    ("enable", "Enable"),
+                    ("disable", "Disable"),
+                    ("snooze", "Snooze"),
+                    ("unsnooze", "Unsnooze"),
+                    ("threshold_change", "Threshold change"),
+                ],
+                default="check",
+                max_length=32,
+            ),
+        ),
+    ]

--- a/products/logs/backend/migrations/max_migration.txt
+++ b/products/logs/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0004_logsalertevent
+0005_logsalertevent_kind

--- a/products/logs/backend/migrations/max_migration.txt
+++ b/products/logs/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0004_rename_logsalertcheck_logsalertevent
+0005_logsalertevent_kind

--- a/products/logs/backend/models.py
+++ b/products/logs/backend/models.py
@@ -134,9 +134,13 @@ class LogsAlertConfiguration(ModelActivityMixin, CreatedMetaFields, UpdatedMetaF
         )
 
     def get_recent_breaches(self) -> tuple[bool, ...]:
-        """Last M non-errored events' threshold_breached values, newest first."""
+        """Last M non-errored check events' threshold_breached values, newest first."""
         return tuple(
-            LogsAlertEvent.objects.filter(alert=self, error_message__isnull=True)
+            LogsAlertEvent.objects.filter(
+                alert=self,
+                kind=LogsAlertEvent.Kind.CHECK,
+                error_message__isnull=True,
+            )
             .order_by("-created_at")
             .values_list("threshold_breached", flat=True)[: self.evaluation_periods]
         )
@@ -179,11 +183,26 @@ class LogsAlertEvent(UUIDModel):
     # OK rows are capped by count (MAX_EVALUATION_PERIODS per alert) rather than by time.
     EVENT_RETENTION_DAYS = 90
 
+    class Kind(models.TextChoices):
+        # Worker-produced row from evaluating the ClickHouse check query. Only CHECK rows
+        # feed the N-of-M evaluator and are eligible for the inline prune. Control-plane
+        # kinds are reserved for user-initiated state transitions; writers are added in a
+        # follow-up PR (see spike 4.7). Every read path must filter by kind=CHECK to keep
+        # control-plane rows out of evaluator and prune windows.
+        CHECK = "check", "Check"
+        RESET = "reset", "Reset"
+        ENABLE = "enable", "Enable"
+        DISABLE = "disable", "Disable"
+        SNOOZE = "snooze", "Snooze"
+        UNSNOOZE = "unsnooze", "Unsnooze"
+        THRESHOLD_CHANGE = "threshold_change", "Threshold change"
+
     alert = models.ForeignKey(
         LogsAlertConfiguration,
         on_delete=models.CASCADE,
         related_name="events",
     )
+    kind = models.CharField(max_length=32, choices=Kind.choices, default=Kind.CHECK)
     created_at = models.DateTimeField(auto_now_add=True)
     result_count = models.PositiveIntegerField(null=True, blank=True)
     threshold_breached = models.BooleanField()

--- a/products/logs/backend/models.py
+++ b/products/logs/backend/models.py
@@ -134,9 +134,13 @@ class LogsAlertConfiguration(ModelActivityMixin, CreatedMetaFields, UpdatedMetaF
         )
 
     def get_recent_breaches(self) -> tuple[bool, ...]:
-        """Last M non-errored events' threshold_breached values, newest first."""
+        """Last M non-errored check events' threshold_breached values, newest first."""
         return tuple(
-            LogsAlertEvent.objects.filter(alert=self, error_message__isnull=True)
+            LogsAlertEvent.objects.filter(
+                alert=self,
+                kind=LogsAlertEvent.Kind.CHECK,
+                error_message__isnull=True,
+            )
             .order_by("-created_at")
             .values_list("threshold_breached", flat=True)[: self.evaluation_periods]
         )
@@ -154,11 +158,26 @@ class LogsAlertEvent(UUIDModel):
     # OK rows are capped by count (MAX_EVALUATION_PERIODS per alert) rather than by time.
     EVENT_RETENTION_DAYS = 90
 
+    class Kind(models.TextChoices):
+        # Worker-produced row from evaluating the ClickHouse check query. Only CHECK rows
+        # feed the N-of-M evaluator and are eligible for the inline prune. Control-plane
+        # kinds are reserved for user-initiated state transitions; writers are added in a
+        # follow-up PR (see spike 4.7). Every read path must filter by kind=CHECK to keep
+        # control-plane rows out of evaluator and prune windows.
+        CHECK = "check", "Check"
+        RESET = "reset", "Reset"
+        ENABLE = "enable", "Enable"
+        DISABLE = "disable", "Disable"
+        SNOOZE = "snooze", "Snooze"
+        UNSNOOZE = "unsnooze", "Unsnooze"
+        THRESHOLD_CHANGE = "threshold_change", "Threshold change"
+
     alert = models.ForeignKey(
         LogsAlertConfiguration,
         on_delete=models.CASCADE,
         related_name="events",
     )
+    kind = models.CharField(max_length=32, choices=Kind.choices, default=Kind.CHECK)
     created_at = models.DateTimeField(auto_now_add=True)
     result_count = models.PositiveIntegerField(null=True, blank=True)
     threshold_breached = models.BooleanField()

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -235,6 +235,7 @@ def _evaluate_single_alert(
         prunable_ids = list(
             LogsAlertEvent.objects.filter(
                 alert=alert,
+                kind=LogsAlertEvent.Kind.CHECK,
                 error_message__isnull=True,
                 state_before=F("state_after"),
             )

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -112,6 +112,35 @@ class TestLogsAlertAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["last_error_message"] == "Latest ClickHouse timeout"
 
+    @parameterized.expand([(k.value, k) for k in LogsAlertEvent.Kind if k != LogsAlertEvent.Kind.CHECK])
+    def test_last_error_message_excludes_non_check_kinds(self, _name, non_check_kind):
+        # A control-plane row that happens to carry an error_message (e.g. a failed reset
+        # audit row in a hypothetical future shape) must not bleed into the user-facing
+        # last_error_message field — only worker CHECK rows should source it.
+        created = self._create_via_api()
+        alert = LogsAlertConfiguration.objects.get(pk=created["id"])
+        LogsAlertEvent.objects.create(
+            alert=alert,
+            kind=LogsAlertEvent.Kind.CHECK,
+            threshold_breached=False,
+            state_before="not_firing",
+            state_after="errored",
+            error_message="Real CH timeout",
+        )
+        LogsAlertEvent.objects.create(
+            alert=alert,
+            kind=non_check_kind,
+            threshold_breached=False,
+            state_before="not_firing",
+            state_after="not_firing",
+            error_message="This should not surface",
+        )
+
+        response = self.client.get(f"{self.base_url}{created['id']}/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["last_error_message"] == "Real CH timeout"
+
     def test_update(self):
         created = self._create_via_api()
 

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -221,6 +221,37 @@ class TestEvaluateSingleAlert(APIBaseTest):
         # The errored row survives the cap — events are retention-managed, not count-managed.
         assert LogsAlertEvent.objects.filter(pk=errored.pk).exists()
 
+    @parameterized.expand([(k.value, k) for k in LogsAlertEvent.Kind if k != LogsAlertEvent.Kind.CHECK])
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_inline_prune_leaves_non_check_kinds_alone(self, _name, non_check_kind, _mock_produce, mock_query_cls):
+        # Control-plane rows are excluded from the prune candidate set by `kind=CHECK`.
+        # Without that filter, a hypothetical non-CHECK row with state_before=state_after
+        # would match the legacy "non-event" filter and get trimmed along with OK rows.
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        alert = self._make_alert()
+
+        for _ in range(MAX_EVALUATION_PERIODS + 5):
+            LogsAlertEvent.objects.create(
+                alert=alert,
+                kind=LogsAlertEvent.Kind.CHECK,
+                threshold_breached=False,
+                state_before="not_firing",
+                state_after="not_firing",
+            )
+        control = LogsAlertEvent.objects.create(
+            alert=alert,
+            kind=non_check_kind,
+            threshold_breached=False,
+            state_before="not_firing",
+            state_after="not_firing",
+        )
+
+        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
+
+        assert LogsAlertEvent.objects.filter(pk=control.pk).exists()
+
     @freeze_time("2025-01-01T00:01:00Z")
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")

--- a/products/logs/backend/test/test_models.py
+++ b/products/logs/backend/test/test_models.py
@@ -5,6 +5,8 @@ from posthog.test.base import BaseTest
 
 from django.core.exceptions import ValidationError
 
+from parameterized import parameterized
+
 from products.logs.backend.models import MAX_EVALUATION_PERIODS, LogsAlertConfiguration, LogsAlertEvent
 
 
@@ -112,6 +114,32 @@ class TestLogsAlertConfiguration(BaseTest):
 
         result = alert.get_recent_breaches()
         assert result == (False, True)
+
+    @parameterized.expand([(k.value, k) for k in LogsAlertEvent.Kind if k != LogsAlertEvent.Kind.CHECK])
+    def test_get_recent_breaches_excludes_non_check_kinds(self, _name, non_check_kind):
+        # Control-plane rows (resets, snoozes, etc.) must never participate in N-of-M.
+        # A non-CHECK row with threshold_breached=False would otherwise inject a spurious
+        # "not-breaching" data point into the evaluator's window.
+        alert = self._create_alert(evaluation_periods=3)
+        check = LogsAlertEvent.objects.create(
+            alert=alert,
+            kind=LogsAlertEvent.Kind.CHECK,
+            threshold_breached=True,
+            state_before="not_firing",
+            state_after="firing",
+        )
+        LogsAlertEvent.objects.filter(pk=check.pk).update(created_at=datetime(2026, 3, 19, 12, 0, tzinfo=UTC))
+        control = LogsAlertEvent.objects.create(
+            alert=alert,
+            kind=non_check_kind,
+            threshold_breached=False,
+            state_before="not_firing",
+            state_after="not_firing",
+        )
+        LogsAlertEvent.objects.filter(pk=control.pk).update(created_at=datetime(2026, 3, 19, 12, 1, tzinfo=UTC))
+
+        result = alert.get_recent_breaches()
+        assert result == (True,)
 
     def test_clean_valid_n_of_m(self):
         alert = self._create_alert(datapoints_to_alarm=2, evaluation_periods=3, filters={"severityLevels": ["error"]})


### PR DESCRIPTION
## Problem

The logs alerting system needs to distinguish between different types of events to properly handle alert evaluation and error reporting. Currently, all events are treated the same way, which can lead to control-plane events (like resets, snoozes, etc.) interfering with the N-of-M threshold evaluation logic and error message reporting.

## Changes

- Added a `kind` field to `LogsAlertEvent` model with choices for different event types: CHECK, RESET, ENABLE, DISABLE, SNOOZE, UNSNOOZE, and THRESHOLD_CHANGE
- Updated all alert evaluation queries to filter by `kind=CHECK` to exclude control-plane events from:
  - Recent breach calculations used in N-of-M evaluation
  - Last error message retrieval for API responses
  - Inline pruning of old OK events
- Added database migration to introduce the new `kind` field with a default value of "check"

## How did you test this code?

Added comprehensive unit tests covering:
- `test_last_error_message_excludes_non_check_kinds`: Verifies that control-plane events with error messages don't appear in API responses
- `test_inline_prune_leaves_non_check_kinds_alone`: Ensures control-plane events are not pruned during cleanup operations
- `test_get_recent_breaches_excludes_non_check_kinds`: Confirms that only CHECK events participate in N-of-M threshold evaluation

All existing tests continue to pass, ensuring backward compatibility with the default "check" kind for existing events.

## Publish to changelog?

No - this is an internal data model enhancement that doesn't affect user-facing functionality.

## Docs update

No docs update needed as this is an internal model change.