### PR TITLE
feat(phrocs): Add grouping options for sidebar in phrocs

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -29,7 +29,9 @@ procs:
             echo ''
             printf '\033[38;5;245m  ─────────────────────────────────────\033[0m\n'
             printf '  \033[38;5;245mRun \033[0m\033[38;2;29;74;255mhogli dev:setup\033[0m\033[38;5;245m to tailor this to your workflow.\033[0m\n'
-        groups: { layer: pinned, tech: pinned }
+        groups:
+            layer: pinned
+            tech: pinned
 
     backend:
         shell: 'uv sync --active && bin/wait-for-docker && ./bin/start-backend'

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -36,26 +36,34 @@ procs:
     backend:
         shell: 'uv sync --active && bin/wait-for-docker && ./bin/start-backend'
         ready_pattern: 'Listening at'
-        groups: { layer: Application, tech: Python }
+        groups:
+            layer: Application
+            tech: Python
         # no capability: always_required via intent-map.yaml
 
     celery-worker:
         shell: 'uv sync --active && bin/wait-for-docker && ./bin/start-celery worker'
         capability: celery_workers
         ready_pattern: 'celery@'
-        groups: { layer: Processing, tech: Python }
+        groups:
+            layer: Processing
+            tech: Python
 
     celery-beat:
         shell: 'uv sync --active && bin/wait-for-docker && ./bin/start-celery beat'
         capability: celery_scheduler
         ready_pattern: 'celery beat'
-        groups: { layer: Processing, tech: Python }
+        groups:
+            layer: Processing
+            tech: Python
 
     nodejs:
         shell: 'bin/wait-for-docker && ./bin/posthog-node'
         capability: event_ingestion
         ready_pattern: 'All systems go'
-        groups: { layer: Processing, tech: Node }
+        groups:
+            layer: Processing
+            tech: Node
         # Node.js capabilities are controlled via NODEJS_CAPABILITY_GROUPS env var
         # Set by hogli dev:generate based on selected nodejs_* capabilities
         # Valid groups: cdp_workflows, realtime_cohorts, session_replay, logs, traces, feature_flags
@@ -65,43 +73,57 @@ procs:
         shell: 'bin/wait-for-docker && PLUGIN_SERVER_MODE=ingestion-errortracking HTTP_SERVER_PORT=6742 ./bin/posthog-node'
         capability: nodejs_error_tracking
         ready_pattern: 'All systems go'
-        groups: { layer: Ingestion pipeline, tech: Node }
+        groups:
+            layer: Ingestion pipeline
+            tech: Node
 
     ingestion-logs:
         shell: 'bin/wait-for-docker && PLUGIN_SERVER_MODE=ingestion-logs HTTP_SERVER_PORT=6743 ./bin/posthog-node'
         capability: nodejs_logs
         ready_pattern: 'All systems go'
-        groups: { layer: Ingestion pipeline, tech: Node }
+        groups:
+            layer: Ingestion pipeline
+            tech: Node
 
     ingestion-traces:
         shell: 'bin/wait-for-docker && PLUGIN_SERVER_MODE=ingestion-traces HTTP_SERVER_PORT=6744 ./bin/posthog-node'
         capability: nodejs_traces
         ready_pattern: 'All systems go'
-        groups: { layer: Ingestion pipeline, tech: Node }
+        groups:
+            layer: Ingestion pipeline
+            tech: Node
 
     ingestion:
         shell: 'bin/wait-for-docker && PLUGIN_SERVER_MODE=ingestion-v2-combined HTTP_SERVER_PORT=6739 ./bin/posthog-node'
         capability: event_ingestion
         ready_pattern: 'All systems go'
-        groups: { layer: Ingestion pipeline, tech: Node }
+        groups:
+            layer: Ingestion pipeline
+            tech: Node
 
     ingestion-sessionreplay:
         shell: 'bin/wait-for-docker && PLUGIN_SERVER_MODE=recordings-blob-ingestion-v2 HTTP_SERVER_PORT=6740 ./bin/posthog-node'
         capability: nodejs_session_replay
         ready_pattern: 'All systems go'
-        groups: { layer: Ingestion pipeline, tech: Node }
+        groups:
+            layer: Ingestion pipeline
+            tech: Node
 
     recording-api:
         shell: 'bin/wait-for-docker && PLUGIN_SERVER_MODE=recording-api HTTP_SERVER_PORT=6741 ./bin/posthog-node'
         capability: nodejs_session_replay
         ready_pattern: 'All systems go'
-        groups: { layer: Product services, tech: Node }
+        groups:
+            layer: Product services
+            tech: Node
 
     frontend:
         shell: './bin/start-frontend'
         autorestart: true
         ready_pattern: 'VITE.*ready in'
-        groups: { layer: Application, tech: Frontend }
+        groups:
+            layer: Application
+            tech: Frontend
         # no capability: always_required via intent-map.yaml
 
     typegen:
@@ -109,7 +131,9 @@ procs:
         autostart: false
         ask_skip: true # wizard asks if user wants to skip this
         ready_pattern: 'Starting TypeScript watch mode'
-        groups: { layer: Tools, tech: Frontend }
+        groups:
+            layer: Tools
+            tech: Frontend
 
     temporal-worker:
         shell: |-
@@ -122,13 +146,17 @@ procs:
                 nodemon -w common -w dags -w ee -w posthog -w products -w pyproject.toml -e py --signal SIGTERM --exec "python manage.py start_temporal_worker --task-queue development-task-queue --max-concurrent-workflow-tasks=1000 --max-concurrent-activities=1000"; \
             fi
         capability: temporal_workflows
-        groups: { layer: Processing, tech: Python }
+        groups:
+            layer: Processing
+            tech: Python
 
     stripe-mock:
         shell: 'bin/start-stripe-mock'
         capability: stripe_mock
         ready_pattern: 'Application startup complete'
-        groups: { layer: Product services, tech: Python }
+        groups:
+            layer: Product services
+            tech: Python
 
     recording-rasterizer:
         shell: |-
@@ -136,7 +164,9 @@ procs:
             bin/temporal-recording-rasterizer-worker
         capability: recording_rasterizer
         ready_pattern: 'worker started'
-        groups: { layer: Product services, tech: Other }
+        groups:
+            layer: Product services
+            tech: Other
         env:
             VIDEO_EXPORT_OBJECT_STORAGE_ENDPOINT: 'http://localhost:19000'
             VIDEO_EXPORT_OBJECT_STORAGE_REGION: 'us-east-1'
@@ -151,13 +181,17 @@ procs:
             dagster dev --workspace $DAGSTER_HOME/workspace.yaml -p $DAGSTER_UI_PORT
         capability: dagster_pipelines
         ready_pattern: 'Launching Dagster services'
-        groups: { layer: Processing, tech: Python }
+        groups:
+            layer: Processing
+            tech: Python
 
     docker-compose:
         shell: 'if [ "${POSTHOG_SANDBOX:-}" = "1" ]; then echo "Sandbox: infra managed by docker compose externally" && echo "docker-compose ready" && sleep infinity; else docker compose -f docker-compose.dev.yml up --pull always -d && echo "docker-compose ready" && docker compose -f docker-compose.dev.yml logs --tail=100 -f; fi'
         capability: core_infra
         ready_pattern: 'docker-compose ready'
-        groups: { layer: Infrastructure, tech: Docker }
+        groups:
+            layer: Infrastructure
+            tech: Docker
 
     cyclotron-janitor:
         shell: |-
@@ -165,7 +199,9 @@ procs:
             bin/start-rust-service cyclotron-janitor
         capability: cyclotron
         ready_pattern: 'Running janitor loop'
-        groups: { layer: Processing, tech: Rust }
+        groups:
+            layer: Processing
+            tech: Rust
 
     cymbal:
         shell: |-
@@ -173,7 +209,9 @@ procs:
             bin/start-rust-service cymbal
         capability: error_symbolication
         ready_pattern: 'Server started and listening on *'
-        groups: { layer: Product services, tech: Rust }
+        groups:
+            layer: Product services
+            tech: Rust
 
     embedding-worker:
         shell: |-
@@ -181,7 +219,9 @@ procs:
             bin/start-rust-service embedding-worker
         capability: embedding_service
         ready_pattern: 'Generated embedding'
-        groups: { layer: Product services, tech: Rust }
+        groups:
+            layer: Product services
+            tech: Rust
 
     feature-flags:
         shell: |-
@@ -189,7 +229,9 @@ procs:
             bin/start-rust-service feature-flags
         capability: flag_evaluation
         ready_pattern: 'listening on *'
-        groups: { layer: Product services, tech: Rust }
+        groups:
+            layer: Product services
+            tech: Rust
 
     hypercache-server:
         shell: |-
@@ -197,7 +239,9 @@ procs:
             bin/start-rust-service hypercache-server
         capability: hypercache
         ready_pattern: 'listening on *'
-        groups: { layer: Product services, tech: Rust }
+        groups:
+            layer: Product services
+            tech: Rust
 
     livestream:
         shell: |-
@@ -205,7 +249,9 @@ procs:
             bin/start-go-service livestream
         capability: livestream
         ready_pattern: 'Livestream service ready'
-        groups: { layer: Product services, tech: Other }
+        groups:
+            layer: Product services
+            tech: Other
 
     property-defs-rs:
         shell: |-
@@ -213,7 +259,9 @@ procs:
             bin/start-rust-service property-defs-rs
         capability: property_definitions
         ready_pattern: 'Subscribed to topic: *'
-        groups: { layer: Ingestion pipeline, tech: Rust }
+        groups:
+            layer: Ingestion pipeline
+            tech: Rust
 
     capture:
         shell: |-
@@ -221,7 +269,9 @@ procs:
             bin/start-rust-service capture
         capability: event_ingestion
         ready_pattern: 'listening on *'
-        groups: { layer: Ingestion pipeline, tech: Rust }
+        groups:
+            layer: Ingestion pipeline
+            tech: Rust
 
     capture-replay:
         shell: |-
@@ -229,7 +279,9 @@ procs:
             bin/start-rust-service capture-replay
         capability: replay_storage
         ready_pattern: 'listening on *'
-        groups: { layer: Ingestion pipeline, tech: Rust }
+        groups:
+            layer: Ingestion pipeline
+            tech: Rust
 
     capture-ai:
         shell: |-
@@ -237,14 +289,18 @@ procs:
             bin/start-rust-service capture-ai
         capability: ai_capture
         ready_pattern: 'listening on *'
-        groups: { layer: Ingestion pipeline, tech: Rust }
+        groups:
+            layer: Ingestion pipeline
+            tech: Rust
 
     batch-import-worker:
         shell: |-
             bin/wait-for-docker && \
             bin/start-rust-service batch-import-worker
         capability: batch_imports
-        groups: { layer: Ingestion pipeline, tech: Rust }
+        groups:
+            layer: Ingestion pipeline
+            tech: Rust
 
     personhog-replica:
         shell: |-
@@ -252,7 +308,9 @@ procs:
             bin/start-rust-service personhog-replica
         capability: personhog
         ready_pattern: 'Metrics server listening on *'
-        groups: { layer: Product services, tech: Rust }
+        groups:
+            layer: Product services
+            tech: Rust
 
     personhog-router:
         shell: |-
@@ -260,7 +318,9 @@ procs:
             bin/start-rust-service personhog-router
         capability: personhog
         ready_pattern: 'Metrics server listening on *'
-        groups: { layer: Product services, tech: Rust }
+        groups:
+            layer: Product services
+            tech: Rust
 
     personhog-leader:
         shell: |-
@@ -268,13 +328,17 @@ procs:
             bin/start-rust-service personhog-leader
         capability: personhog
         ready_pattern: 'Metrics server listening on *'
-        groups: { layer: Product services, tech: Rust }
+        groups:
+            layer: Product services
+            tech: Rust
 
     llm-gateway:
         shell: 'bin/wait-for-docker && bin/start-llm-gateway'
         capability: llm_gateway
         ready_pattern: 'Application startup complete'
-        groups: { layer: Product services, tech: Python }
+        groups:
+            layer: Product services
+            tech: Python
         env:
             LLM_GATEWAY_DEBUG: 'true'
             LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS: '{"1": 10}'
@@ -285,54 +349,72 @@ procs:
         shell: 'bin/start-mcp-server'
         capability: mcp_server
         ready_pattern: 'Ready on *'
-        groups: { layer: Product services, tech: Python }
+        groups:
+            layer: Product services
+            tech: Python
 
     mcp-ui-apps:
         shell: 'cd services/mcp && pnpm run build:ui-apps -- --watch'
         capability: mcp_server
         ready_pattern: 'Initial build complete'
-        groups: { layer: Product services, tech: Frontend }
+        groups:
+            layer: Product services
+            tech: Frontend
 
     mcp-inspector:
         shell: 'cd services/mcp && pnpm run inspector'
         capability: mcp_server
         autostart: false
         ready_pattern: 'MCP Inspector'
-        groups: { layer: Tools, tech: Frontend }
+        groups:
+            layer: Tools
+            tech: Frontend
 
     stripe-app:
         shell: 'bin/start-stripe-app'
         capability: stripe_app
-        groups: { layer: Product services, tech: Python }
+        groups:
+            layer: Product services
+            tech: Python
 
     migrate-postgres:
         shell: 'bin/wait-for-docker && bin/migrate --scope=postgres'
         capability: core_infra
         ready_pattern: 'All migrations completed successfully'
-        groups: { layer: Infrastructure, tech: Migrations }
+        groups:
+            layer: Infrastructure
+            tech: Migrations
 
     migrate-clickhouse:
         shell: 'bin/wait-for-docker && bin/migrate --scope=clickhouse'
         capability: core_infra
         ready_pattern: 'All migrations completed successfully'
-        groups: { layer: Infrastructure, tech: Migrations }
+        groups:
+            layer: Infrastructure
+            tech: Migrations
 
     migrate-cyclotron:
         shell: 'bin/wait-for-docker && bin/migrate --scope=cyclotron'
         capability: cyclotron
         ready_pattern: 'All migrations completed successfully'
-        groups: { layer: Infrastructure, tech: Migrations }
+        groups:
+            layer: Infrastructure
+            tech: Migrations
 
     migrate-persons-db:
         shell: 'bin/wait-for-docker && bin/migrate --scope=persons'
         ready_pattern: 'All migrations completed successfully'
-        groups: { layer: Infrastructure, tech: Migrations }
+        groups:
+            layer: Infrastructure
+            tech: Migrations
         # no capability - optional migration
 
     migrate-behavioral-cohorts:
         shell: 'bin/wait-for-docker && bin/migrate --scope=behavioral-cohorts'
         ready_pattern: 'All migrations completed successfully'
-        groups: { layer: Infrastructure, tech: Migrations }
+        groups:
+            layer: Infrastructure
+            tech: Migrations
         # no capability - optional migration
 
     generate-demo-data:
@@ -341,7 +423,9 @@ procs:
             ./manage.py generate_demo_data
         autostart: false
         ready_pattern: 'Demo data ready'
-        groups: { layer: Tools, tech: Python }
+        groups:
+            layer: Tools
+            tech: Python
         # no capability - manual start
 
     sync-feature-flags:
@@ -350,7 +434,9 @@ procs:
             ./manage.py sync_feature_flags
         autostart: false
         ready_pattern: 'Feature flag sync complete'
-        groups: { layer: Tools, tech: Python }
+        groups:
+            layer: Tools
+            tech: Python
         # no capability - manual start
 
     sync-hog-function-templates:
@@ -359,21 +445,27 @@ procs:
             ./manage.py sync_hog_function_templates
         autostart: false
         ready_pattern: 'Hog function template sync complete'
-        groups: { layer: Tools, tech: Python }
+        groups:
+            layer: Tools
+            tech: Python
         # no capability - manual start
 
     storybook:
         shell: 'pnpm --filter=@posthog/storybook install && pnpm run storybook'
         autostart: false
         ready_pattern: 'Storybook *'
-        groups: { layer: Tools, tech: Frontend }
+        groups:
+            layer: Tools
+            tech: Frontend
         # no capability - manual start
 
     hedgebox-dummy:
         shell: 'bin/wait-for-docker && cd tools/hedgebox-dummy && pnpm install && pnpm run dev'
         autostart: false
         ready_pattern: 'Ready in *'
-        groups: { layer: Tools, tech: Frontend }
+        groups:
+            layer: Tools
+            tech: Frontend
         # no capability - manual start
 
     warehouse-sources-load:
@@ -382,7 +474,9 @@ procs:
             python manage.py run_warehouse_sources_load --health-port 8090 --batch-size 100 --consumer-group warehouse-sources-load-dev
         autostart: false
         ready_pattern: 'health_server_started'
-        groups: { layer: Tools, tech: Python }
+        groups:
+            layer: Tools
+            tech: Python
         # no capability - manual start
 
 group_order:

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -29,26 +29,31 @@ procs:
             echo ''
             printf '\033[38;5;245m  ─────────────────────────────────────\033[0m\n'
             printf '  \033[38;5;245mRun \033[0m\033[38;2;29;74;255mhogli dev:setup\033[0m\033[38;5;245m to tailor this to your workflow.\033[0m\n'
+        groups: { layer: pinned, tech: pinned }
 
     backend:
         shell: 'uv sync --active && bin/wait-for-docker && ./bin/start-backend'
         ready_pattern: 'Listening at'
+        groups: { layer: Application, tech: Python }
         # no capability: always_required via intent-map.yaml
 
     celery-worker:
         shell: 'uv sync --active && bin/wait-for-docker && ./bin/start-celery worker'
         capability: celery_workers
         ready_pattern: 'celery@'
+        groups: { layer: Processing, tech: Python }
 
     celery-beat:
         shell: 'uv sync --active && bin/wait-for-docker && ./bin/start-celery beat'
         capability: celery_scheduler
         ready_pattern: 'celery beat'
+        groups: { layer: Processing, tech: Python }
 
     nodejs:
         shell: 'bin/wait-for-docker && ./bin/posthog-node'
         capability: event_ingestion
         ready_pattern: 'All systems go'
+        groups: { layer: Processing, tech: Node }
         # Node.js capabilities are controlled via NODEJS_CAPABILITY_GROUPS env var
         # Set by hogli dev:generate based on selected nodejs_* capabilities
         # Valid groups: cdp_workflows, realtime_cohorts, session_replay, logs, traces, feature_flags
@@ -58,36 +63,43 @@ procs:
         shell: 'bin/wait-for-docker && PLUGIN_SERVER_MODE=ingestion-errortracking HTTP_SERVER_PORT=6742 ./bin/posthog-node'
         capability: nodejs_error_tracking
         ready_pattern: 'All systems go'
+        groups: { layer: Ingestion pipeline, tech: Node }
 
     ingestion-logs:
         shell: 'bin/wait-for-docker && PLUGIN_SERVER_MODE=ingestion-logs HTTP_SERVER_PORT=6743 ./bin/posthog-node'
         capability: nodejs_logs
         ready_pattern: 'All systems go'
+        groups: { layer: Ingestion pipeline, tech: Node }
 
     ingestion-traces:
         shell: 'bin/wait-for-docker && PLUGIN_SERVER_MODE=ingestion-traces HTTP_SERVER_PORT=6744 ./bin/posthog-node'
         capability: nodejs_traces
         ready_pattern: 'All systems go'
+        groups: { layer: Ingestion pipeline, tech: Node }
 
     ingestion:
         shell: 'bin/wait-for-docker && PLUGIN_SERVER_MODE=ingestion-v2-combined HTTP_SERVER_PORT=6739 ./bin/posthog-node'
         capability: event_ingestion
         ready_pattern: 'All systems go'
+        groups: { layer: Ingestion pipeline, tech: Node }
 
     ingestion-sessionreplay:
         shell: 'bin/wait-for-docker && PLUGIN_SERVER_MODE=recordings-blob-ingestion-v2 HTTP_SERVER_PORT=6740 ./bin/posthog-node'
         capability: nodejs_session_replay
         ready_pattern: 'All systems go'
+        groups: { layer: Ingestion pipeline, tech: Node }
 
     recording-api:
         shell: 'bin/wait-for-docker && PLUGIN_SERVER_MODE=recording-api HTTP_SERVER_PORT=6741 ./bin/posthog-node'
         capability: nodejs_session_replay
         ready_pattern: 'All systems go'
+        groups: { layer: Product services, tech: Node }
 
     frontend:
         shell: './bin/start-frontend'
         autorestart: true
         ready_pattern: 'VITE.*ready in'
+        groups: { layer: Application, tech: Frontend }
         # no capability: always_required via intent-map.yaml
 
     typegen:
@@ -95,6 +107,7 @@ procs:
         autostart: false
         ask_skip: true # wizard asks if user wants to skip this
         ready_pattern: 'Starting TypeScript watch mode'
+        groups: { layer: Tools, tech: Frontend }
 
     temporal-worker:
         shell: |-
@@ -107,11 +120,13 @@ procs:
                 nodemon -w common -w dags -w ee -w posthog -w products -w pyproject.toml -e py --signal SIGTERM --exec "python manage.py start_temporal_worker --task-queue development-task-queue --max-concurrent-workflow-tasks=1000 --max-concurrent-activities=1000"; \
             fi
         capability: temporal_workflows
+        groups: { layer: Processing, tech: Python }
 
     stripe-mock:
         shell: 'bin/start-stripe-mock'
         capability: stripe_mock
         ready_pattern: 'Application startup complete'
+        groups: { layer: Product services, tech: Python }
 
     recording-rasterizer:
         shell: |-
@@ -119,6 +134,7 @@ procs:
             bin/temporal-recording-rasterizer-worker
         capability: recording_rasterizer
         ready_pattern: 'worker started'
+        groups: { layer: Product services, tech: Other }
         env:
             VIDEO_EXPORT_OBJECT_STORAGE_ENDPOINT: 'http://localhost:19000'
             VIDEO_EXPORT_OBJECT_STORAGE_REGION: 'us-east-1'
@@ -133,11 +149,13 @@ procs:
             dagster dev --workspace $DAGSTER_HOME/workspace.yaml -p $DAGSTER_UI_PORT
         capability: dagster_pipelines
         ready_pattern: 'Launching Dagster services'
+        groups: { layer: Processing, tech: Python }
 
     docker-compose:
         shell: 'if [ "${POSTHOG_SANDBOX:-}" = "1" ]; then echo "Sandbox: infra managed by docker compose externally" && echo "docker-compose ready" && sleep infinity; else docker compose -f docker-compose.dev.yml up --pull always -d && echo "docker-compose ready" && docker compose -f docker-compose.dev.yml logs --tail=100 -f; fi'
         capability: core_infra
         ready_pattern: 'docker-compose ready'
+        groups: { layer: Infrastructure, tech: Docker }
 
     cyclotron-janitor:
         shell: |-
@@ -145,6 +163,7 @@ procs:
             bin/start-rust-service cyclotron-janitor
         capability: cyclotron
         ready_pattern: 'Running janitor loop'
+        groups: { layer: Processing, tech: Rust }
 
     cymbal:
         shell: |-
@@ -152,6 +171,7 @@ procs:
             bin/start-rust-service cymbal
         capability: error_symbolication
         ready_pattern: 'Server started and listening on *'
+        groups: { layer: Product services, tech: Rust }
 
     embedding-worker:
         shell: |-
@@ -159,6 +179,7 @@ procs:
             bin/start-rust-service embedding-worker
         capability: embedding_service
         ready_pattern: 'Generated embedding'
+        groups: { layer: Product services, tech: Rust }
 
     feature-flags:
         shell: |-
@@ -166,6 +187,7 @@ procs:
             bin/start-rust-service feature-flags
         capability: flag_evaluation
         ready_pattern: 'listening on *'
+        groups: { layer: Product services, tech: Rust }
 
     hypercache-server:
         shell: |-
@@ -173,6 +195,7 @@ procs:
             bin/start-rust-service hypercache-server
         capability: hypercache
         ready_pattern: 'listening on *'
+        groups: { layer: Product services, tech: Rust }
 
     livestream:
         shell: |-
@@ -180,6 +203,7 @@ procs:
             bin/start-go-service livestream
         capability: livestream
         ready_pattern: 'Livestream service ready'
+        groups: { layer: Product services, tech: Other }
 
     property-defs-rs:
         shell: |-
@@ -187,6 +211,7 @@ procs:
             bin/start-rust-service property-defs-rs
         capability: property_definitions
         ready_pattern: 'Subscribed to topic: *'
+        groups: { layer: Ingestion pipeline, tech: Rust }
 
     capture:
         shell: |-
@@ -194,6 +219,7 @@ procs:
             bin/start-rust-service capture
         capability: event_ingestion
         ready_pattern: 'listening on *'
+        groups: { layer: Ingestion pipeline, tech: Rust }
 
     capture-replay:
         shell: |-
@@ -201,6 +227,7 @@ procs:
             bin/start-rust-service capture-replay
         capability: replay_storage
         ready_pattern: 'listening on *'
+        groups: { layer: Ingestion pipeline, tech: Rust }
 
     capture-ai:
         shell: |-
@@ -208,12 +235,14 @@ procs:
             bin/start-rust-service capture-ai
         capability: ai_capture
         ready_pattern: 'listening on *'
+        groups: { layer: Ingestion pipeline, tech: Rust }
 
     batch-import-worker:
         shell: |-
             bin/wait-for-docker && \
             bin/start-rust-service batch-import-worker
         capability: batch_imports
+        groups: { layer: Ingestion pipeline, tech: Rust }
 
     personhog-replica:
         shell: |-
@@ -221,6 +250,7 @@ procs:
             bin/start-rust-service personhog-replica
         capability: personhog
         ready_pattern: 'Metrics server listening on *'
+        groups: { layer: Product services, tech: Rust }
 
     personhog-router:
         shell: |-
@@ -228,6 +258,7 @@ procs:
             bin/start-rust-service personhog-router
         capability: personhog
         ready_pattern: 'Metrics server listening on *'
+        groups: { layer: Product services, tech: Rust }
 
     personhog-leader:
         shell: |-
@@ -235,11 +266,13 @@ procs:
             bin/start-rust-service personhog-leader
         capability: personhog
         ready_pattern: 'Metrics server listening on *'
+        groups: { layer: Product services, tech: Rust }
 
     llm-gateway:
         shell: 'bin/wait-for-docker && bin/start-llm-gateway'
         capability: llm_gateway
         ready_pattern: 'Application startup complete'
+        groups: { layer: Product services, tech: Python }
         env:
             LLM_GATEWAY_DEBUG: 'true'
             LLM_GATEWAY_TEAM_RATE_LIMIT_MULTIPLIERS: '{"1": 10}'
@@ -250,45 +283,54 @@ procs:
         shell: 'bin/start-mcp-server'
         capability: mcp_server
         ready_pattern: 'Ready on *'
+        groups: { layer: Product services, tech: Python }
 
     mcp-ui-apps:
         shell: 'cd services/mcp && pnpm run build:ui-apps -- --watch'
         capability: mcp_server
         ready_pattern: 'Initial build complete'
+        groups: { layer: Product services, tech: Frontend }
 
     mcp-inspector:
         shell: 'cd services/mcp && pnpm run inspector'
         capability: mcp_server
         autostart: false
         ready_pattern: 'MCP Inspector'
+        groups: { layer: Tools, tech: Frontend }
 
     stripe-app:
         shell: 'bin/start-stripe-app'
         capability: stripe_app
+        groups: { layer: Product services, tech: Python }
 
     migrate-postgres:
         shell: 'bin/wait-for-docker && bin/migrate --scope=postgres'
         capability: core_infra
         ready_pattern: 'All migrations completed successfully'
+        groups: { layer: Infrastructure, tech: Migrations }
 
     migrate-clickhouse:
         shell: 'bin/wait-for-docker && bin/migrate --scope=clickhouse'
         capability: core_infra
         ready_pattern: 'All migrations completed successfully'
+        groups: { layer: Infrastructure, tech: Migrations }
 
     migrate-cyclotron:
         shell: 'bin/wait-for-docker && bin/migrate --scope=cyclotron'
         capability: cyclotron
         ready_pattern: 'All migrations completed successfully'
+        groups: { layer: Infrastructure, tech: Migrations }
 
     migrate-persons-db:
         shell: 'bin/wait-for-docker && bin/migrate --scope=persons'
         ready_pattern: 'All migrations completed successfully'
+        groups: { layer: Infrastructure, tech: Migrations }
         # no capability - optional migration
 
     migrate-behavioral-cohorts:
         shell: 'bin/wait-for-docker && bin/migrate --scope=behavioral-cohorts'
         ready_pattern: 'All migrations completed successfully'
+        groups: { layer: Infrastructure, tech: Migrations }
         # no capability - optional migration
 
     generate-demo-data:
@@ -297,6 +339,7 @@ procs:
             ./manage.py generate_demo_data
         autostart: false
         ready_pattern: 'Demo data ready'
+        groups: { layer: Tools, tech: Python }
         # no capability - manual start
 
     sync-feature-flags:
@@ -305,6 +348,7 @@ procs:
             ./manage.py sync_feature_flags
         autostart: false
         ready_pattern: 'Feature flag sync complete'
+        groups: { layer: Tools, tech: Python }
         # no capability - manual start
 
     sync-hog-function-templates:
@@ -313,18 +357,21 @@ procs:
             ./manage.py sync_hog_function_templates
         autostart: false
         ready_pattern: 'Hog function template sync complete'
+        groups: { layer: Tools, tech: Python }
         # no capability - manual start
 
     storybook:
         shell: 'pnpm --filter=@posthog/storybook install && pnpm run storybook'
         autostart: false
         ready_pattern: 'Storybook *'
+        groups: { layer: Tools, tech: Frontend }
         # no capability - manual start
 
     hedgebox-dummy:
         shell: 'bin/wait-for-docker && cd tools/hedgebox-dummy && pnpm install && pnpm run dev'
         autostart: false
         ready_pattern: 'Ready in *'
+        groups: { layer: Tools, tech: Frontend }
         # no capability - manual start
 
     warehouse-sources-load:
@@ -333,7 +380,12 @@ procs:
             python manage.py run_warehouse_sources_load --health-port 8090 --batch-size 100 --consumer-group warehouse-sources-load-dev
         autostart: false
         ready_pattern: 'health_server_started'
+        groups: { layer: Tools, tech: Python }
         # no capability - manual start
+
+group_order:
+    layer: [Application, Processing, Ingestion pipeline, Infrastructure, Product services, Tools]
+    tech: [Python, Frontend, Node, Rust, Docker, Migrations, Other]
 
 mouse_scroll_speed: 1
 scrollback: 10000

--- a/common/hogli/devenv/generator.py
+++ b/common/hogli/devenv/generator.py
@@ -83,6 +83,7 @@ class MprocsConfig(BaseModel):
     """Represents an mprocs.yaml configuration."""
 
     procs: dict[str, dict[str, Any]]
+    group_order: dict[str, list[str]] = {}  # display order per grouping dimension
     mouse_scroll_speed: int = 1
     scrollback: int = 10000
     posthog_config: DevenvConfig | None = None  # embedded source config
@@ -93,6 +94,8 @@ class MprocsConfig(BaseModel):
         if self.posthog_config:
             result["_posthog"] = self.posthog_config.model_dump(exclude_defaults=True)
         result["procs"] = self.procs
+        if self.group_order:
+            result["group_order"] = self.group_order
         result["mouse_scroll_speed"] = self.mouse_scroll_speed
         result["scrollback"] = self.scrollback
         return result
@@ -122,7 +125,8 @@ class MprocsGenerator(ConfigGenerator):
         procs: dict[str, dict[str, Any]] = {}
 
         # Info process is always first
-        procs["info"] = self._build_info_process(resolved)
+        info_config = self.registry.get_process_config("info") or {}
+        procs["info"] = self._build_info_process(info_config, resolved)
 
         # Iterate in original mprocs.yaml order to preserve ordering
         for name in self.registry.get_processes():
@@ -159,7 +163,7 @@ class MprocsGenerator(ConfigGenerator):
 
             # Special handling for docker-compose
             if name == "docker-compose":
-                proc_config = self._generate_docker_compose_config(resolved.get_docker_profiles_list())
+                proc_config = self._generate_docker_compose_config(proc_config, resolved.get_docker_profiles_list())
 
             # Special handling for nodejs - set capability groups based on resolved nodejs_* capabilities
             if name == "nodejs":
@@ -186,13 +190,14 @@ class MprocsGenerator(ConfigGenerator):
 
         return MprocsConfig(
             procs=procs,
+            group_order=global_settings.get("group_order", {}),
             mouse_scroll_speed=global_settings.get("mouse_scroll_speed", 1),
             scrollback=global_settings.get("scrollback", 10000),
             posthog_config=source_config,
         )
 
-    def _build_info_process(self, resolved: ResolvedEnvironment) -> dict[str, Any]:
-        """Build the info process shell command with environment summary and news.
+    def _build_info_process(self, proc_config: dict[str, Any], resolved: ResolvedEnvironment) -> dict[str, Any]:
+        """Update the info process config with a generated shell command.
 
         News is read at runtime from devenv/news.txt so developers always see the
         latest items without re-running hogli dev:generate.
@@ -235,7 +240,8 @@ echo ''
 printf '  {bold}Log in with:{reset} test@posthog.com - {blue}12345678{reset}\\n'
 printf '  {gray}Run {reset}{blue}hogli dev:setup{reset}{gray} to tailor this to your workflow.{reset}\\n'
 """
-        return {"shell": shell}
+        proc_config["shell"] = shell
+        return proc_config
 
     def _add_startup_message(self, proc_config: dict[str, Any], process_name: str, reason: str) -> dict[str, Any]:
         """Add a startup message to a process config.
@@ -258,14 +264,15 @@ printf '  {gray}Run {reset}{blue}hogli dev:setup{reset}{gray} to tailor this to 
         proc_config["shell"] = message + original_shell
         return proc_config
 
-    def _generate_docker_compose_config(self, profiles: list[str]) -> dict[str, Any]:
-        """Generate docker-compose process config with profile flags.
+    def _generate_docker_compose_config(self, proc_config: dict[str, Any], profiles: list[str]) -> dict[str, Any]:
+        """Update docker-compose process config with profile flags.
 
         Args:
+            proc_config: The existing process configuration dict
             profiles: List of docker compose profiles to activate
 
         Returns:
-            Process configuration dict with modified shell command
+            Modified process configuration dict
         """
         profiles = sorted(profiles)
 
@@ -278,10 +285,9 @@ printf '  {gray}Run {reset}{blue}hogli dev:setup{reset}{gray} to tailor this to 
         up_cmd = build_docker_compose_command(profiles, "up --pull always -d")
         logs_cmd = build_docker_compose_command(profiles, "logs --tail=100 -f")
 
-        return {
-            "shell": f"{message}{up_cmd} && echo 'docker-compose ready' && {logs_cmd}",
-            "ready_pattern": "docker-compose ready",
-        }
+        proc_config["shell"] = f"{message}{up_cmd} && echo 'docker-compose ready' && {logs_cmd}"
+        proc_config["ready_pattern"] = "docker-compose ready"
+        return proc_config
 
     def _add_nodejs_capability_groups(
         self, proc_config: dict[str, Any], resolved: ResolvedEnvironment

--- a/tools/phrocs/README.md
+++ b/tools/phrocs/README.md
@@ -115,47 +115,12 @@ Prefers `htop` (tree view + PID filter), falls back to `btop` (unfiltered), then
 
 ### Grouping
 
-Press `g` to cycle through grouping dimensions.
-Groups are configured in the YAML config, each process can declare a `groups` map with one or more dimensions:
+Press `g` to cycle through grouping dimensions defined in the config.
+Each process can declare a `groups` map and an optional top-level `group_order` controls display order.
+See `bin/mprocs.yaml` for the config format.
 
-```yaml
-procs:
-  backend:
-    shell: './bin/start-backend'
-    groups:
-      layer: Application
-      tech: Python
-  capture:
-    shell: 'bin/start-rust-service capture'
-    groups:
-      layer: Ingestion pipeline
-      tech: Rust
-```
-
-An optional top-level `group_order` controls the display order per dimension.
-Groups not listed here appear alphabetically after the listed ones:
-
-```yaml
-group_order:
-  layer: [Application, Processing, Ingestion pipeline, Infrastructure]
-  tech: [Python, Frontend, Node, Rust, Docker, Migrations]
-```
-
-Processes without a matching `groups` appear under **Ungrouped** at the bottom.
-
-The reserved value `pinned` places a process at the top of the sidebar without a group header.
-A process can be pinned in one dimension and grouped normally in another:
-
-```yaml
-procs:
-  info:
-    shell: 'echo hello'
-    groups:
-      layer: pinned
-      tech: pinned
-```
-
-If no processes define `groups`, pressing `g` does nothing.
+Processes without a matching group appear under Ungrouped.
+The reserved value `pinned` places a process at the top without a header.
 
 ## Debug logging
 

--- a/tools/phrocs/README.md
+++ b/tools/phrocs/README.md
@@ -64,6 +64,7 @@ You typically run phrocs via `hogli start` rather than directly.
 | `c`    | Enter copy mode                                           |
 | `i`    | Show process info in pager                                |
 | `o`    | Sort processes by <name/CPU/RAM/status>                   |
+| `g`    | Cycle process grouping (from config `groups` field)       |
 | `/`    | Enter search mode (then `enter` to switch to filter mode) |
 | `esc`  | Exit copy, search, and filter modes                       |
 | `?`    | Toggle full help                                          |
@@ -111,6 +112,50 @@ Press `d` to open lazydocker with the relevant compose files.
 
 Press `p` to open a system process viewer filtered to the selected process's PID.
 Prefers `htop` (tree view + PID filter), falls back to `btop` (unfiltered), then `top` (PID filter).
+
+### Grouping
+
+Press `g` to cycle through grouping dimensions.
+Groups are configured in the YAML config, each process can declare a `groups` map with one or more dimensions:
+
+```yaml
+procs:
+  backend:
+    shell: './bin/start-backend'
+    groups:
+      layer: Application
+      tech: Python
+  capture:
+    shell: 'bin/start-rust-service capture'
+    groups:
+      layer: Ingestion pipeline
+      tech: Rust
+```
+
+An optional top-level `group_order` controls the display order per dimension.
+Groups not listed here appear alphabetically after the listed ones:
+
+```yaml
+group_order:
+  layer: [Application, Processing, Ingestion pipeline, Infrastructure]
+  tech: [Python, Frontend, Node, Rust, Docker, Migrations]
+```
+
+Processes without a matching `groups` appear under **Ungrouped** at the bottom.
+
+The reserved value `pinned` places a process at the top of the sidebar without a group header.
+A process can be pinned in one dimension and grouped normally in another:
+
+```yaml
+procs:
+  info:
+    shell: 'echo hello'
+    groups:
+      layer: pinned
+      tech: pinned
+```
+
+If no processes define `groups`, pressing `g` does nothing.
 
 ## Debug logging
 

--- a/tools/phrocs/internal/config/config.go
+++ b/tools/phrocs/internal/config/config.go
@@ -21,6 +21,7 @@ type ProcConfig struct {
 	AskSkip      bool              `yaml:"ask_skip"`
 	Env          map[string]string `yaml:"env"`
 	ReadyPattern string            `yaml:"ready_pattern"`
+	Groups       map[string]string `yaml:"groups"` // grouping dimensions, e.g. {"layer": "Application", "tech": "Python"}
 }
 
 // Reports whether the process should start automatically
@@ -33,6 +34,7 @@ func (p ProcConfig) ShouldAutostart() bool {
 type Config struct {
 	Shell            string                `yaml:"shell"`
 	Procs            map[string]ProcConfig `yaml:"procs"`
+	GroupOrder       map[string][]string   `yaml:"group_order"` // display order per dimension
 	HideKeymapWindow bool                  `yaml:"hide_keymap_window"`
 	MouseScrollSpeed int                   `yaml:"mouse_scroll_speed"`
 	ProcListWidth    int                   `yaml:"proc_list_width"`

--- a/tools/phrocs/internal/config/config.go
+++ b/tools/phrocs/internal/config/config.go
@@ -21,7 +21,7 @@ type ProcConfig struct {
 	AskSkip      bool              `yaml:"ask_skip"`
 	Env          map[string]string `yaml:"env"`
 	ReadyPattern string            `yaml:"ready_pattern"`
-	Groups       map[string]string `yaml:"groups"` // grouping dimensions, e.g. {"layer": "Application", "tech": "Python"}
+	Groups       map[string]string `yaml:"groups"` // user-defined grouping dimensions, using map here so new dimensions need no code changes
 }
 
 // Reports whether the process should start automatically

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -76,6 +76,11 @@ type Model struct {
 	servicesCursor int
 	servicesOffset int
 	sortMode       SortMode
+	groupDims      []string       // available grouping dimensions from config (e.g. ["layer", "tech"])
+	groupDimIndex  int            // -1 = no grouping, 0+ = index into groupDims
+	sidebarEntries []sidebarEntry // grouped view; rebuilt when grouping or services change
+	entryCursor    int            // cursor into sidebarEntries (skips headers and spacers)
+	cfg            *config.Config // retained for group_order lookups
 
 	// Docker container sidebar (visible when docker-compose proc is selected)
 	containers         []docker.DockerContainer
@@ -135,7 +140,7 @@ func New(mgr *process.Manager, cfg *config.Config, configPath string, logger *lo
 	h := help.New()
 	h.Styles = helpStyles()
 
-	return Model{
+	m := Model{
 		mgr:              mgr,
 		services:         mgr.Procs(),
 		servicesCursor:   0,
@@ -147,11 +152,16 @@ func New(mgr *process.Manager, cfg *config.Config, configPath string, logger *lo
 		hideHelp:         cfg.HideKeymapWindow,
 		procListWidth:    cfg.ProcListWidth,
 		configPath:       configPath,
+		cfg:              cfg,
+		groupDims:        groupDimensions(cfg),
+		groupDimIndex:    -1,
 		keys:             keys,
 		help:             h,
 		spinner:          spinner.New(spinner.WithSpinner(spinner.MiniDot)),
 		log:              logger,
 	}
+	m.rebuildSidebarEntries()
+	return m
 }
 
 func (m Model) dbg(format string, args ...any) {
@@ -330,16 +340,30 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.MouseWheelMsg:
 		if msg.X < sidebarWidth {
-			delta := 0
+			moved := false
 			switch msg.Button {
 			case tea.MouseWheelDown:
-				delta = 1
+				if m.isGrouped() {
+					moved = m.nextProcEntry()
+				} else {
+					newCursor := min(m.servicesCursor+1, len(m.services)-1)
+					if newCursor != m.servicesCursor {
+						m.servicesCursor = newCursor
+						moved = true
+					}
+				}
 			case tea.MouseWheelUp:
-				delta = -1
+				if m.isGrouped() {
+					moved = m.prevProcEntry()
+				} else {
+					newCursor := max(m.servicesCursor-1, 0)
+					if newCursor != m.servicesCursor {
+						m.servicesCursor = newCursor
+						moved = true
+					}
+				}
 			}
-			newCursor := max(0, min(m.servicesCursor+delta, len(m.services)-1))
-			if newCursor != m.servicesCursor {
-				m.servicesCursor = newCursor
+			if moved {
 				m.ensureSidebarCursorVisible()
 				m.updateProcKeys()
 				var loadCmds []tea.Cmd
@@ -622,7 +646,75 @@ func (m *Model) sortServices() {
 			break
 		}
 	}
+	m.rebuildSidebarEntries()
 	m.ensureSidebarCursorVisible()
+}
+
+// activeGroupDim returns the current grouping dimension name, or "" if grouping is off.
+func (m Model) activeGroupDim() string {
+	if m.groupDimIndex < 0 || m.groupDimIndex >= len(m.groupDims) {
+		return ""
+	}
+	return m.groupDims[m.groupDimIndex]
+}
+
+// isGrouped returns true when a grouping dimension is active.
+func (m Model) isGrouped() bool {
+	return m.activeGroupDim() != ""
+}
+
+// cycleGroup advances to the next grouping dimension, or back to no grouping.
+func (m *Model) cycleGroup() {
+	if len(m.groupDims) == 0 {
+		return
+	}
+	m.groupDimIndex++
+	if m.groupDimIndex >= len(m.groupDims) {
+		m.groupDimIndex = -1
+	}
+}
+
+// rebuildSidebarEntries regenerates the sidebar entries from the
+// current services slice and grouping dimension. It preserves the cursor on the
+// same process by finding its entry in the new list.
+func (m *Model) rebuildSidebarEntries() {
+	activeName := ""
+	if p := m.activeProc(); p != nil {
+		activeName = p.Name
+	}
+	m.sidebarEntries = buildGroupedEntries(m.services, m.activeGroupDim(), m.cfg)
+	// Restore entryCursor to the same process
+	m.entryCursor = 0
+	for i, e := range m.sidebarEntries {
+		if e.proc != nil && e.proc.Name == activeName {
+			m.entryCursor = i
+			break
+		}
+	}
+}
+
+// nextProcEntry moves the entryCursor forward to the next process entry, skipping headers and spacers.
+func (m *Model) nextProcEntry() bool {
+	for i := m.entryCursor + 1; i < len(m.sidebarEntries); i++ {
+		if !m.sidebarEntries[i].isNonSelectable() {
+			m.entryCursor = i
+			m.servicesCursor = m.sidebarEntries[i].procIndex
+			return true
+		}
+	}
+	return false
+}
+
+// prevProcEntry moves the entryCursor backward to the previous process entry, skipping headers and spacers.
+func (m *Model) prevProcEntry() bool {
+	for i := m.entryCursor - 1; i >= 0; i-- {
+		if !m.sidebarEntries[i].isNonSelectable() {
+			m.entryCursor = i
+			m.servicesCursor = m.sidebarEntries[i].procIndex
+			return true
+		}
+	}
+	return false
 }
 
 func (m Model) toggleMetricsOnSelectedProc() {

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -161,6 +161,7 @@ func New(mgr *process.Manager, cfg *config.Config, configPath string, logger *lo
 		log:              logger,
 	}
 	m.rebuildSidebarEntries()
+	m.keys.Group.SetEnabled(len(m.groupDims) > 0)
 	return m
 }
 

--- a/tools/phrocs/internal/tui/group.go
+++ b/tools/phrocs/internal/tui/group.go
@@ -133,9 +133,6 @@ func buildGroupedEntries(services []*process.Process, dim string, cfg *config.Co
 	sort.Strings(remaining)
 	for _, g := range remaining {
 		procs := groups[g]
-		if len(procs) == 0 {
-			continue
-		}
 		if !firstGroup {
 			entries = append(entries, sidebarEntry{spacer: true})
 		}

--- a/tools/phrocs/internal/tui/group.go
+++ b/tools/phrocs/internal/tui/group.go
@@ -1,0 +1,148 @@
+package tui
+
+import (
+	"sort"
+
+	"github.com/posthog/posthog/phrocs/internal/config"
+	"github.com/posthog/posthog/phrocs/internal/process"
+)
+
+const ungroupedName = "Ungrouped"
+const pinnedKey = "pinned" // reserved group value: pinned at the top, no header
+
+// sidebarEntry represents either a group header, a spacer, or a process in the grouped sidebar.
+type sidebarEntry struct {
+	// Only one of these is set.
+	groupHeader string           // non-empty for header rows
+	proc        *process.Process // non-nil for process rows
+	spacer      bool             // empty row for visual separation
+
+	// procIndex is the index into m.services for process entries,
+	// allowing navigation to map back to the flat services slice.
+	procIndex int
+}
+
+func (e sidebarEntry) isHeader() bool {
+	return e.groupHeader != ""
+}
+
+func (e sidebarEntry) isNonSelectable() bool {
+	return e.isHeader() || e.spacer
+}
+
+// groupDimensions discovers the available grouping dimensions from the config.
+// Returns dimension names sorted alphabetically, or ordered by group_order keys
+// if present.
+func groupDimensions(cfg *config.Config) []string {
+	seen := make(map[string]bool)
+	for _, pc := range cfg.Procs {
+		for dim := range pc.Groups {
+			seen[dim] = true
+		}
+	}
+	// Also include dimensions from group_order even if no process uses them yet
+	for dim := range cfg.GroupOrder {
+		seen[dim] = true
+	}
+
+	dims := make([]string, 0, len(seen))
+	for dim := range seen {
+		dims = append(dims, dim)
+	}
+	sort.Strings(dims)
+	return dims
+}
+
+// groupOrderFor returns the display order for a given dimension.
+// If group_order is configured, uses that. Otherwise discovers groups from
+// processes in the order they first appear.
+func groupOrderFor(dim string, cfg *config.Config, services []*process.Process) []string {
+	if order, ok := cfg.GroupOrder[dim]; ok && len(order) > 0 {
+		return order
+	}
+	// Discover from processes, preserving first-seen order
+	seen := make(map[string]bool)
+	var order []string
+	for _, p := range services {
+		if g, ok := p.Cfg.Groups[dim]; ok && !seen[g] {
+			seen[g] = true
+			order = append(order, g)
+		}
+	}
+	return order
+}
+
+// buildGroupedEntries creates an ordered list of sidebar entries with group headers
+// interspersed among processes.
+// When dim is empty, returns a flat list with no headers.
+func buildGroupedEntries(services []*process.Process, dim string, cfg *config.Config) []sidebarEntry {
+	if dim == "" {
+		entries := make([]sidebarEntry, len(services))
+		for i, p := range services {
+			entries[i] = sidebarEntry{proc: p, procIndex: i}
+		}
+		return entries
+	}
+
+	groupOrder := groupOrderFor(dim, cfg, services)
+
+	// Bucket processes by group; "pinned" processes go to the top without a header
+	var pinned []sidebarEntry
+	groups := make(map[string][]sidebarEntry)
+	for i, p := range services {
+		g, ok := p.Cfg.Groups[dim]
+		if !ok {
+			g = ungroupedName
+		}
+		if g == pinnedKey {
+			pinned = append(pinned, sidebarEntry{proc: p, procIndex: i})
+			continue
+		}
+		groups[g] = append(groups[g], sidebarEntry{proc: p, procIndex: i})
+	}
+
+	// Build ordered entries: pinned first, then groups with headers.
+	// A spacer row is inserted before each group header for visual separation.
+	entries := append([]sidebarEntry{}, pinned...)
+	firstGroup := len(pinned) == 0
+
+	// Emit groups in configured order first
+	emitted := make(map[string]bool)
+	for _, g := range groupOrder {
+		procs := groups[g]
+		if len(procs) == 0 {
+			continue
+		}
+		if !firstGroup {
+			entries = append(entries, sidebarEntry{spacer: true})
+		}
+		firstGroup = false
+		entries = append(entries, sidebarEntry{groupHeader: g})
+		entries = append(entries, procs...)
+		emitted[g] = true
+	}
+
+	// Emit any remaining groups not in the configured order (alphabetically),
+	// including "Ungrouped"
+	var remaining []string
+	for g := range groups {
+		if !emitted[g] {
+			remaining = append(remaining, g)
+		}
+	}
+	sort.Strings(remaining)
+	for _, g := range remaining {
+		procs := groups[g]
+		if len(procs) == 0 {
+			continue
+		}
+		if !firstGroup {
+			entries = append(entries, sidebarEntry{spacer: true})
+		}
+		firstGroup = false
+		entries = append(entries, sidebarEntry{groupHeader: g})
+		entries = append(entries, procs...)
+	}
+
+	return entries
+}

--- a/tools/phrocs/internal/tui/group_test.go
+++ b/tools/phrocs/internal/tui/group_test.go
@@ -211,65 +211,55 @@ func TestBuildGroupedEntries_ungroupedAppearsAfterConfiguredGroups(t *testing.T)
 	}
 }
 
-func TestGroupDimensions_extensible(t *testing.T) {
-	cfg := &config.Config{
-		Procs: map[string]config.ProcConfig{
-			"plain":   {Shell: "echo"},                                                                       // no groups
-			"simple":  {Shell: "echo", Groups: map[string]string{"layer": "App"}},                            // 1 dimension
-			"complex": {Shell: "echo", Groups: map[string]string{"tech": "Rust", "team": "Infra", "cost": "High"}}, // 3 different dimensions
-		},
-	}
-	dims := groupDimensions(cfg)
-	if len(dims) != 4 {
-		t.Fatalf("want 4 dimensions (cost, layer, team, tech), got %d: %v", len(dims), dims)
-	}
-	want := []string{"cost", "layer", "team", "tech"}
-	for i, d := range dims {
-		if d != want[i] {
-			t.Errorf("dimension %d: got %q, want %q (full: %v)", i, d, want[i], dims)
-		}
-	}
-}
-
 // ── groupDimensions ──────────────────────────────────────────────────────────
 
-func TestGroupDimensions_fromProcs(t *testing.T) {
-	cfg := &config.Config{
-		Procs: map[string]config.ProcConfig{
-			"a": {Groups: map[string]string{"layer": "App", "tech": "Python"}},
-			"b": {Groups: map[string]string{"layer": "Infra"}},
+func TestGroupDimensions(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		want []string
+	}{
+		{
+			name: "no groups",
+			cfg:  &config.Config{Procs: map[string]config.ProcConfig{"a": {Shell: "echo hi"}}},
+			want: nil,
+		},
+		{
+			name: "from procs",
+			cfg: &config.Config{Procs: map[string]config.ProcConfig{
+				"a": {Groups: map[string]string{"layer": "App", "tech": "Python"}},
+				"b": {Groups: map[string]string{"layer": "Infra"}},
+			}},
+			want: []string{"layer", "tech"},
+		},
+		{
+			name: "from group_order only",
+			cfg:  &config.Config{GroupOrder: map[string][]string{"team": {"Platform", "Product"}}},
+			want: []string{"team"},
+		},
+		{
+			name: "extensible — multiple procs, overlapping dims",
+			cfg: &config.Config{Procs: map[string]config.ProcConfig{
+				"plain":   {Shell: "echo"},
+				"simple":  {Shell: "echo", Groups: map[string]string{"layer": "App"}},
+				"complex": {Shell: "echo", Groups: map[string]string{"tech": "Rust", "team": "Infra", "cost": "High"}},
+			}},
+			want: []string{"cost", "layer", "team", "tech"},
 		},
 	}
-	dims := groupDimensions(cfg)
-	if len(dims) != 2 {
-		t.Fatalf("want 2 dimensions, got %d: %v", len(dims), dims)
-	}
-	if dims[0] != "layer" || dims[1] != "tech" {
-		t.Errorf("want [layer, tech], got %v", dims)
-	}
-}
-
-func TestGroupDimensions_includesGroupOrder(t *testing.T) {
-	cfg := &config.Config{
-		GroupOrder: map[string][]string{
-			"team": {"Platform", "Product"},
-		},
-	}
-	dims := groupDimensions(cfg)
-	if len(dims) != 1 || dims[0] != "team" {
-		t.Errorf("want [team], got %v", dims)
-	}
-}
-
-func TestGroupDimensions_empty(t *testing.T) {
-	cfg := &config.Config{
-		Procs: map[string]config.ProcConfig{
-			"a": {Shell: "echo hi"},
-		},
-	}
-	dims := groupDimensions(cfg)
-	if len(dims) != 0 {
-		t.Errorf("want no dimensions, got %v", dims)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dims := groupDimensions(tc.cfg)
+			if len(dims) != len(tc.want) {
+				t.Fatalf("got %v, want %v", dims, tc.want)
+			}
+			for i := range dims {
+				if dims[i] != tc.want[i] {
+					t.Errorf("got %v, want %v", dims, tc.want)
+					break
+				}
+			}
+		})
 	}
 }
 

--- a/tools/phrocs/internal/tui/group_test.go
+++ b/tools/phrocs/internal/tui/group_test.go
@@ -1,0 +1,580 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/posthog/posthog/phrocs/internal/config"
+	"github.com/posthog/posthog/phrocs/internal/process"
+)
+
+// ── buildGroupedEntries ──────────────────────────────────────────────────────
+
+func TestBuildGroupedEntries_noDimension(t *testing.T) {
+	procs := []*process.Process{
+		{Name: "alpha"},
+		{Name: "beta"},
+	}
+	cfg := &config.Config{}
+	entries := buildGroupedEntries(procs, "", cfg)
+	if len(entries) != 2 {
+		t.Fatalf("empty dim: want 2 entries, got %d", len(entries))
+	}
+	for i, e := range entries {
+		if e.isHeader() {
+			t.Errorf("entry %d should not be a header", i)
+		}
+		if e.proc != procs[i] {
+			t.Errorf("entry %d proc mismatch", i)
+		}
+	}
+}
+
+func TestBuildGroupedEntries_withDimension(t *testing.T) {
+	procs := []*process.Process{
+		{Name: "backend", Cfg: config.ProcConfig{Groups: map[string]string{"layer": "Application"}}},
+		{Name: "capture", Cfg: config.ProcConfig{Groups: map[string]string{"layer": "Ingestion"}}},
+		{Name: "docker", Cfg: config.ProcConfig{Groups: map[string]string{"layer": "Infrastructure"}}},
+	}
+	cfg := &config.Config{
+		GroupOrder: map[string][]string{
+			"layer": {"Application", "Ingestion", "Infrastructure"},
+		},
+	}
+	entries := buildGroupedEntries(procs, "layer", cfg)
+
+	// Count headers and processes (spacers don't count)
+	headers := 0
+	processes := 0
+	for _, e := range entries {
+		if e.isHeader() {
+			headers++
+		} else if !e.spacer {
+			processes++
+		}
+	}
+	if processes != 3 {
+		t.Errorf("want 3 process entries, got %d", processes)
+	}
+	if headers != 3 {
+		t.Errorf("want 3 group headers, got %d", headers)
+	}
+
+	// Application should come before Ingestion which comes before Infrastructure
+	var appIdx, ingIdx, infraIdx int
+	for i, e := range entries {
+		if e.isHeader() {
+			switch e.groupHeader {
+			case "Application":
+				appIdx = i
+			case "Ingestion":
+				ingIdx = i
+			case "Infrastructure":
+				infraIdx = i
+			}
+		}
+	}
+	if appIdx >= ingIdx {
+		t.Errorf("Application (%d) should come before Ingestion (%d)", appIdx, ingIdx)
+	}
+	if ingIdx >= infraIdx {
+		t.Errorf("Ingestion (%d) should come before Infrastructure (%d)", ingIdx, infraIdx)
+	}
+}
+
+func TestBuildGroupedEntries_emptyGroupsOmitted(t *testing.T) {
+	procs := []*process.Process{
+		{Name: "backend", Cfg: config.ProcConfig{Groups: map[string]string{"layer": "Application"}}},
+	}
+	cfg := &config.Config{
+		GroupOrder: map[string][]string{
+			"layer": {"Application", "Ingestion"},
+		},
+	}
+	entries := buildGroupedEntries(procs, "layer", cfg)
+
+	for _, e := range entries {
+		if e.isHeader() && e.groupHeader == "Ingestion" {
+			t.Error("Ingestion header should be omitted when no processes belong to it")
+		}
+	}
+}
+
+func TestBuildGroupedEntries_ungroupedFallback(t *testing.T) {
+	procs := []*process.Process{
+		{Name: "backend", Cfg: config.ProcConfig{Groups: map[string]string{"layer": "Application"}}},
+		{Name: "mystery", Cfg: config.ProcConfig{}}, // no groups at all
+	}
+	cfg := &config.Config{
+		GroupOrder: map[string][]string{
+			"layer": {"Application"},
+		},
+	}
+	entries := buildGroupedEntries(procs, "layer", cfg)
+
+	hasUngrouped := false
+	for _, e := range entries {
+		if e.isHeader() && e.groupHeader == ungroupedName {
+			hasUngrouped = true
+		}
+	}
+	if !hasUngrouped {
+		t.Error("process without groups should appear under Ungrouped header")
+	}
+}
+
+func TestBuildGroupedEntries_pinnedGroup(t *testing.T) {
+	procs := []*process.Process{
+		{Name: "backend", Cfg: config.ProcConfig{Groups: map[string]string{"layer": "Application"}}},
+		{Name: "info", Cfg: config.ProcConfig{Groups: map[string]string{"layer": "pinned"}}},
+	}
+	cfg := &config.Config{}
+	entries := buildGroupedEntries(procs, "layer", cfg)
+
+	// Pinned process should be first, before any headers
+	if len(entries) == 0 || entries[0].proc == nil || entries[0].proc.Name != "info" {
+		t.Error("process with groups.layer=pinned should be first entry")
+	}
+	// Pinned should not have a header above it
+	for _, e := range entries {
+		if e.isHeader() && e.groupHeader == "pinned" {
+			t.Error("pinned should not appear as a group header")
+		}
+	}
+}
+
+func TestBuildGroupedEntries_pinnedInOneDimensionGroupedInAnother(t *testing.T) {
+	procs := []*process.Process{
+		{Name: "info", Cfg: config.ProcConfig{Groups: map[string]string{"layer": "pinned", "tech": "Other"}}},
+		{Name: "backend", Cfg: config.ProcConfig{Groups: map[string]string{"layer": "Application", "tech": "Python"}}},
+	}
+	cfg := &config.Config{}
+
+	// Pinned in layer
+	layerEntries := buildGroupedEntries(procs, "layer", cfg)
+	if len(layerEntries) == 0 || layerEntries[0].proc == nil || layerEntries[0].proc.Name != "info" {
+		t.Error("info should be pinned when grouped by layer")
+	}
+
+	// Not pinned in tech — should appear under its group
+	techEntries := buildGroupedEntries(procs, "tech", cfg)
+	if len(techEntries) > 0 && techEntries[0].proc != nil && techEntries[0].proc.Name == "info" {
+		t.Error("info should not be pinned when grouped by tech (it has tech=Other)")
+	}
+}
+
+func TestBuildGroupedEntries_missingDimensionFallsToUngrouped(t *testing.T) {
+	// Process has groups but not the active dimension
+	procs := []*process.Process{
+		{Name: "backend", Cfg: config.ProcConfig{Groups: map[string]string{"tech": "Rust"}}},
+	}
+	cfg := &config.Config{}
+	entries := buildGroupedEntries(procs, "layer", cfg)
+
+	hasUngrouped := false
+	for _, e := range entries {
+		if e.isHeader() && e.groupHeader == ungroupedName {
+			hasUngrouped = true
+		}
+	}
+	if !hasUngrouped {
+		t.Error("process with groups but missing the active dimension should appear under Ungrouped")
+	}
+}
+
+func TestBuildGroupedEntries_ungroupedAppearsAfterConfiguredGroups(t *testing.T) {
+	procs := []*process.Process{
+		{Name: "backend", Cfg: config.ProcConfig{Groups: map[string]string{"layer": "Application"}}},
+		{Name: "mystery", Cfg: config.ProcConfig{}},
+	}
+	cfg := &config.Config{
+		GroupOrder: map[string][]string{
+			"layer": {"Application"},
+		},
+	}
+	entries := buildGroupedEntries(procs, "layer", cfg)
+
+	appIdx, ungroupedIdx := -1, -1
+	for i, e := range entries {
+		if e.isHeader() && e.groupHeader == "Application" {
+			appIdx = i
+		}
+		if e.isHeader() && e.groupHeader == ungroupedName {
+			ungroupedIdx = i
+		}
+	}
+	if appIdx < 0 || ungroupedIdx < 0 {
+		t.Fatalf("expected both Application and Ungrouped headers, got appIdx=%d ungroupedIdx=%d", appIdx, ungroupedIdx)
+	}
+	if ungroupedIdx <= appIdx {
+		t.Errorf("Ungrouped (%d) should come after Application (%d)", ungroupedIdx, appIdx)
+	}
+}
+
+func TestGroupDimensions_extensible(t *testing.T) {
+	cfg := &config.Config{
+		Procs: map[string]config.ProcConfig{
+			"plain":   {Shell: "echo"},                                                                       // no groups
+			"simple":  {Shell: "echo", Groups: map[string]string{"layer": "App"}},                            // 1 dimension
+			"complex": {Shell: "echo", Groups: map[string]string{"tech": "Rust", "team": "Infra", "cost": "High"}}, // 3 different dimensions
+		},
+	}
+	dims := groupDimensions(cfg)
+	if len(dims) != 4 {
+		t.Fatalf("want 4 dimensions (cost, layer, team, tech), got %d: %v", len(dims), dims)
+	}
+	want := []string{"cost", "layer", "team", "tech"}
+	for i, d := range dims {
+		if d != want[i] {
+			t.Errorf("dimension %d: got %q, want %q (full: %v)", i, d, want[i], dims)
+		}
+	}
+}
+
+// ── groupDimensions ──────────────────────────────────────────────────────────
+
+func TestGroupDimensions_fromProcs(t *testing.T) {
+	cfg := &config.Config{
+		Procs: map[string]config.ProcConfig{
+			"a": {Groups: map[string]string{"layer": "App", "tech": "Python"}},
+			"b": {Groups: map[string]string{"layer": "Infra"}},
+		},
+	}
+	dims := groupDimensions(cfg)
+	if len(dims) != 2 {
+		t.Fatalf("want 2 dimensions, got %d: %v", len(dims), dims)
+	}
+	if dims[0] != "layer" || dims[1] != "tech" {
+		t.Errorf("want [layer, tech], got %v", dims)
+	}
+}
+
+func TestGroupDimensions_includesGroupOrder(t *testing.T) {
+	cfg := &config.Config{
+		GroupOrder: map[string][]string{
+			"team": {"Platform", "Product"},
+		},
+	}
+	dims := groupDimensions(cfg)
+	if len(dims) != 1 || dims[0] != "team" {
+		t.Errorf("want [team], got %v", dims)
+	}
+}
+
+func TestGroupDimensions_empty(t *testing.T) {
+	cfg := &config.Config{
+		Procs: map[string]config.ProcConfig{
+			"a": {Shell: "echo hi"},
+		},
+	}
+	dims := groupDimensions(cfg)
+	if len(dims) != 0 {
+		t.Errorf("want no dimensions, got %v", dims)
+	}
+}
+
+// ── TUI integration ──────────────────────────────────────────────────────────
+
+func readyGroupModel(t *testing.T) Model {
+	t.Helper()
+	f := false
+	procs := map[string]config.ProcConfig{
+		"backend":        {Shell: "start-backend", Autostart: &f, Groups: map[string]string{"layer": "Application", "tech": "Python"}},
+		"capture":        {Shell: "start-rust-service capture", Autostart: &f, Groups: map[string]string{"layer": "Ingestion", "tech": "Rust"}},
+		"docker-compose": {Shell: "docker compose up", Autostart: &f, Groups: map[string]string{"layer": "Infrastructure", "tech": "Docker"}},
+		"celery-worker":  {Shell: "start-celery worker", Autostart: &f, Groups: map[string]string{"layer": "Processing", "tech": "Python"}},
+		"frontend":       {Shell: "start-frontend", Autostart: &f, Groups: map[string]string{"layer": "Application", "tech": "Frontend"}},
+	}
+	cfg := &config.Config{
+		Procs:            procs,
+		MouseScrollSpeed: 3,
+		Scrollback:       1000,
+		GroupOrder: map[string][]string{
+			"layer": {"Application", "Processing", "Ingestion", "Infrastructure"},
+			"tech":  {"Python", "Frontend", "Rust", "Docker"},
+		},
+	}
+	mgr := process.NewManager(cfg)
+	m := New(mgr, cfg, "", nil)
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	return next.(Model)
+}
+
+func TestGroup_cycleWithG(t *testing.T) {
+	m := readyGroupModel(t)
+	if m.isGrouped() {
+		t.Fatal("should start ungrouped")
+	}
+	m = update(m, keypress('g'))
+	if m.activeGroupDim() != "layer" {
+		t.Errorf("after first g: got %q, want layer", m.activeGroupDim())
+	}
+	m = update(m, keypress('g'))
+	if m.activeGroupDim() != "tech" {
+		t.Errorf("after second g: got %q, want tech", m.activeGroupDim())
+	}
+	m = update(m, keypress('g'))
+	if m.isGrouped() {
+		t.Errorf("after third g: should be ungrouped, got %q", m.activeGroupDim())
+	}
+}
+
+func TestGroup_cyclesThroughAllDimensions(t *testing.T) {
+	f := false
+	procs := map[string]config.ProcConfig{
+		"a": {Shell: "echo", Autostart: &f, Groups: map[string]string{"layer": "App", "tech": "Python", "team": "Platform", "cost": "High"}},
+		"b": {Shell: "echo", Autostart: &f, Groups: map[string]string{"layer": "Infra"}},
+	}
+	cfg := &config.Config{
+		Procs:            procs,
+		MouseScrollSpeed: 3,
+		Scrollback:       1000,
+	}
+	mgr := process.NewManager(cfg)
+	m := New(mgr, cfg, "", nil)
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = next.(Model)
+
+	// Should have 4 dimensions: cost, layer, team, tech (alphabetical)
+	if len(m.groupDims) != 4 {
+		t.Fatalf("want 4 dimensions, got %d: %v", len(m.groupDims), m.groupDims)
+	}
+
+	// Cycle through all 4, then back to none
+	expected := []string{"cost", "layer", "team", "tech", ""}
+	for _, want := range expected {
+		m = update(m, keypress('g'))
+		got := m.activeGroupDim()
+		if got != want {
+			t.Errorf("after g: got %q, want %q", got, want)
+		}
+	}
+}
+
+func TestGroup_sidebarEntriesHaveHeaders(t *testing.T) {
+	m := readyGroupModel(t)
+	m = update(m, keypress('g')) // layer
+	hasHeader := false
+	for _, e := range m.sidebarEntries {
+		if e.isHeader() {
+			hasHeader = true
+			break
+		}
+	}
+	if !hasHeader {
+		t.Error("grouped mode should have at least one header entry")
+	}
+}
+
+func TestGroup_navigationDownSkipsHeadersAndSpacers(t *testing.T) {
+	m := readyGroupModel(t)
+	m = update(m, keypress('g')) // layer
+
+	hasHeader, hasSpacer := false, false
+	for _, e := range m.sidebarEntries {
+		if e.isHeader() {
+			hasHeader = true
+		}
+		if e.spacer {
+			hasSpacer = true
+		}
+	}
+	if !hasHeader {
+		t.Fatal("test setup: expected at least one group header in entries")
+	}
+	if !hasSpacer {
+		t.Fatal("test setup: expected at least one spacer in entries")
+	}
+
+	for i := 0; i < len(m.sidebarEntries); i++ {
+		entry := m.sidebarEntries[m.entryCursor]
+		if entry.isHeader() {
+			t.Errorf("down: entryCursor %d landed on header %q", m.entryCursor, entry.groupHeader)
+		}
+		if entry.spacer {
+			t.Errorf("down: entryCursor %d landed on spacer", m.entryCursor)
+		}
+		m = update(m, keypress('j'))
+	}
+}
+
+func TestGroup_navigationUpSkipsHeadersAndSpacers(t *testing.T) {
+	m := readyGroupModel(t)
+	m = update(m, keypress('g')) // layer
+
+	// Navigate to the last process
+	for i := 0; i < len(m.sidebarEntries); i++ {
+		m = update(m, keypress('j'))
+	}
+
+	for i := 0; i < len(m.sidebarEntries); i++ {
+		entry := m.sidebarEntries[m.entryCursor]
+		if entry.isHeader() {
+			t.Errorf("up: entryCursor %d landed on header %q", m.entryCursor, entry.groupHeader)
+		}
+		if entry.spacer {
+			t.Errorf("up: entryCursor %d landed on spacer", m.entryCursor)
+		}
+		m = update(m, keypress('k'))
+	}
+}
+
+func TestGroup_navigationPreservesProcess(t *testing.T) {
+	m := readyGroupModel(t)
+	for i, p := range m.services {
+		if p.Name == "capture" {
+			m.servicesCursor = i
+			break
+		}
+	}
+	m = update(m, keypress('g')) // layer
+	if p := m.activeProc(); p == nil || p.Name != "capture" {
+		name := ""
+		if p != nil {
+			name = p.Name
+		}
+		t.Errorf("after grouping, active proc should be capture, got %q", name)
+	}
+}
+
+func TestGroup_sortWithinGroups(t *testing.T) {
+	m := readyGroupModel(t)
+	m = update(m, keypress('g')) // layer
+	m = update(m, keypress('o')) // SortCPU
+
+	hasHeader := false
+	for _, e := range m.sidebarEntries {
+		if e.isHeader() {
+			hasHeader = true
+			break
+		}
+	}
+	if !hasHeader {
+		t.Error("sort change should preserve group headers")
+	}
+	if !m.isGrouped() {
+		t.Error("should still be grouped after sort change")
+	}
+	if m.sortMode != SortCPU {
+		t.Errorf("sortMode should be SortCPU, got %v", m.sortMode)
+	}
+
+	// Each process should appear under its correct group
+	for i, e := range m.sidebarEntries {
+		if e.isHeader() || e.proc == nil {
+			continue
+		}
+		expectedGroup, ok := e.proc.Cfg.Groups["layer"]
+		if !ok {
+			expectedGroup = ungroupedName
+		}
+		foundHeader := ""
+		for j := i - 1; j >= 0; j-- {
+			if m.sidebarEntries[j].isHeader() {
+				foundHeader = m.sidebarEntries[j].groupHeader
+				break
+			}
+		}
+		if foundHeader != expectedGroup {
+			t.Errorf("process %q is under header %q, want %q", e.proc.Name, foundHeader, expectedGroup)
+		}
+	}
+}
+
+func TestGroup_cursorPreservedAcrossSortChange(t *testing.T) {
+	m := readyGroupModel(t)
+	m = update(m, keypress('g')) // layer
+
+	for i := 0; i < len(m.sidebarEntries); i++ {
+		if p := m.activeProc(); p != nil && p.Name == "frontend" {
+			break
+		}
+		m = update(m, keypress('j'))
+	}
+	if p := m.activeProc(); p == nil || p.Name != "frontend" {
+		t.Fatal("could not navigate to frontend")
+	}
+
+	m = update(m, keypress('o'))
+	if p := m.activeProc(); p == nil || p.Name != "frontend" {
+		name := ""
+		if p := m.activeProc(); p != nil {
+			name = p.Name
+		}
+		t.Errorf("after sort change, active proc should be frontend, got %q", name)
+	}
+}
+
+func TestGroup_backToNoneRestoresFlat(t *testing.T) {
+	m := readyGroupModel(t)
+	m = update(m, keypress('g')) // layer
+	m = update(m, keypress('g')) // tech
+	m = update(m, keypress('g')) // none
+
+	for _, e := range m.sidebarEntries {
+		if e.isHeader() {
+			t.Error("ungrouped should have no headers")
+		}
+	}
+	if len(m.sidebarEntries) != len(m.services) {
+		t.Errorf("ungrouped entries: got %d, want %d", len(m.sidebarEntries), len(m.services))
+	}
+}
+
+func TestGroup_ungroupedProcessIsNavigable(t *testing.T) {
+	f := false
+	procs := map[string]config.ProcConfig{
+		"backend": {Shell: "echo", Autostart: &f, Groups: map[string]string{"layer": "Application"}},
+		"mystery": {Shell: "echo", Autostart: &f}, // no groups
+	}
+	cfg := &config.Config{
+		Procs:            procs,
+		MouseScrollSpeed: 3,
+		Scrollback:       1000,
+		GroupOrder: map[string][]string{
+			"layer": {"Application"},
+		},
+	}
+	mgr := process.NewManager(cfg)
+	m := New(mgr, cfg, "", nil)
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = next.(Model)
+
+	m = update(m, keypress('g')) // layer
+
+	// Navigate down until we find "mystery"
+	found := false
+	for i := 0; i < len(m.sidebarEntries); i++ {
+		if p := m.activeProc(); p != nil && p.Name == "mystery" {
+			found = true
+			break
+		}
+		m = update(m, keypress('j'))
+	}
+	if !found {
+		t.Error("should be able to navigate to ungrouped process")
+	}
+}
+
+func TestGroup_noGroupDimsDisablesGrouping(t *testing.T) {
+	// Config with no groups at all
+	f := false
+	cfg := &config.Config{
+		Procs: map[string]config.ProcConfig{
+			"a": {Shell: "echo", Autostart: &f},
+			"b": {Shell: "echo", Autostart: &f},
+		},
+		MouseScrollSpeed: 3,
+		Scrollback:       1000,
+	}
+	mgr := process.NewManager(cfg)
+	m := New(mgr, cfg, "", nil)
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = next.(Model)
+
+	// Pressing g should do nothing
+	m = update(m, keypress('g'))
+	if m.isGrouped() {
+		t.Error("g should not enable grouping when no dimensions exist")
+	}
+}

--- a/tools/phrocs/internal/tui/keymap.go
+++ b/tools/phrocs/internal/tui/keymap.go
@@ -161,7 +161,7 @@ func defaultKeyMap() keyMap {
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Start, k.Stop, k.Restart, k.ClearLogs, k.SearchMode, k.CopyMode, k.InfoMode, k.Group, k.SetupMode, k.Quit, k.Help}
+	return []key.Binding{k.Start, k.Stop, k.Restart, k.ClearLogs, k.SearchMode, k.CopyMode, k.InfoMode, k.SetupMode, k.Quit, k.Help}
 }
 
 func (k keyMap) SearchModeHelp() []key.Binding {
@@ -174,8 +174,8 @@ func (k keyMap) FilterModeHelp() []key.Binding {
 
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{k.KeyDown, k.KeyUp, k.Sort, k.Group},
-		{k.ScrollUp, k.ScrollDown},
+		{k.KeyDown, k.KeyUp, k.Sort},
+		{k.ScrollUp, k.ScrollDown, k.Group},
 		{k.GotoTop, k.GotoBottom, k.ClearLogs},
 		{k.NextPane, k.PrevPane, k.LazyDocker, k.ProcViewer},
 		{k.Start, k.Stop, k.Restart, k.InfoMode},

--- a/tools/phrocs/internal/tui/keymap.go
+++ b/tools/phrocs/internal/tui/keymap.go
@@ -29,6 +29,7 @@ type keyMap struct {
 	Backspace    key.Binding
 	Hedgehog     key.Binding
 	Sort         key.Binding
+	Group        key.Binding
 	LazyDocker   key.Binding
 	ProcViewer   key.Binding
 	SetupMode    key.Binding
@@ -138,6 +139,10 @@ func defaultKeyMap() keyMap {
 			key.WithKeys("o"),
 			key.WithHelp("o:", "sort"),
 		),
+		Group: key.NewBinding(
+			key.WithKeys("g"),
+			key.WithHelp("g:", "group"),
+		),
 		LazyDocker: key.NewBinding(
 			key.WithKeys("d"),
 			key.WithHelp("d:", "lazydocker"),
@@ -156,7 +161,7 @@ func defaultKeyMap() keyMap {
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Start, k.Stop, k.Restart, k.ClearLogs, k.SearchMode, k.CopyMode, k.InfoMode, k.SetupMode, k.Quit, k.Help}
+	return []key.Binding{k.Start, k.Stop, k.Restart, k.ClearLogs, k.SearchMode, k.CopyMode, k.InfoMode, k.Group, k.SetupMode, k.Quit, k.Help}
 }
 
 func (k keyMap) SearchModeHelp() []key.Binding {
@@ -169,7 +174,7 @@ func (k keyMap) FilterModeHelp() []key.Binding {
 
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{k.KeyDown, k.KeyUp, k.Sort},
+		{k.KeyDown, k.KeyUp, k.Sort, k.Group},
 		{k.ScrollUp, k.ScrollDown},
 		{k.GotoTop, k.GotoBottom, k.ClearLogs},
 		{k.NextPane, k.PrevPane, k.LazyDocker, k.ProcViewer},

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -291,14 +291,6 @@ func (m Model) handleHedgehogKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []
 	return m, cmds, true
 }
 
-// updateGroupHelp updates the Group keybinding help text to reflect the current dimension.
-func (m *Model) updateGroupHelp() {
-	if dim := m.activeGroupDim(); dim != "" {
-		m.keys.Group.SetHelp("g:", "group:"+dim)
-	} else {
-		m.keys.Group.SetHelp("g:", "group")
-	}
-}
 
 // updateProcKeys enables/disables start, stop, and restart bindings
 // based on the active process state.
@@ -503,7 +495,6 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 		m.cycleGroup()
 		m.rebuildSidebarEntries()
 		m.ensureSidebarCursorVisible()
-		m.updateGroupHelp()
 		m.dbg("group: %s", m.activeGroupDim())
 
 	case key.Matches(msg, m.keys.InfoMode):

--- a/tools/phrocs/internal/tui/keys.go
+++ b/tools/phrocs/internal/tui/keys.go
@@ -291,6 +291,15 @@ func (m Model) handleHedgehogKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (Model, []
 	return m, cmds, true
 }
 
+// updateGroupHelp updates the Group keybinding help text to reflect the current dimension.
+func (m *Model) updateGroupHelp() {
+	if dim := m.activeGroupDim(); dim != "" {
+		m.keys.Group.SetHelp("g:", "group:"+dim)
+	} else {
+		m.keys.Group.SetHelp("g:", "group")
+	}
+}
+
 // updateProcKeys enables/disables start, stop, and restart bindings
 // based on the active process state.
 func (m *Model) updateProcKeys() {
@@ -382,12 +391,17 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 
 	case key.Matches(msg, m.keys.NextProc), key.Matches(msg, m.keys.KeyDown):
 		if m.focusedPane == focusServices {
-			if m.servicesCursor < len(m.services)-1 {
-				prev := m.servicesCursor
+			moved := false
+			if m.isGrouped() {
+				moved = m.nextProcEntry()
+			} else if m.servicesCursor < len(m.services)-1 {
 				m.servicesCursor++
+				moved = true
+			}
+			if moved {
 				m.ensureSidebarCursorVisible()
 				m.updateProcKeys()
-				m.dbg("proc selected: %d→%d (%s)", prev, m.servicesCursor, m.services[m.servicesCursor].Name)
+				m.dbg("proc selected: %s", m.services[m.servicesCursor].Name)
 				var loadCmds []tea.Cmd
 				m, loadCmds = m.loadActiveProc()
 				cmds = append(cmds, loadCmds...)
@@ -405,12 +419,17 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 
 	case key.Matches(msg, m.keys.PrevProc), key.Matches(msg, m.keys.KeyUp):
 		if m.focusedPane == focusServices {
-			if m.servicesCursor > 0 {
-				prev := m.servicesCursor
+			moved := false
+			if m.isGrouped() {
+				moved = m.prevProcEntry()
+			} else if m.servicesCursor > 0 {
 				m.servicesCursor--
+				moved = true
+			}
+			if moved {
 				m.ensureSidebarCursorVisible()
 				m.updateProcKeys()
-				m.dbg("proc selected: %d→%d (%s)", prev, m.servicesCursor, m.services[m.servicesCursor].Name)
+				m.dbg("proc selected: %s", m.services[m.servicesCursor].Name)
 				var loadCmds []tea.Cmd
 				m, loadCmds = m.loadActiveProc()
 				cmds = append(cmds, loadCmds...)
@@ -479,6 +498,13 @@ func (m Model) handleNormalKey(msg tea.KeyPressMsg, cmds []tea.Cmd) (tea.Model, 
 		m.sortMode = (m.sortMode + 1) % SortMode(sortModeCount)
 		m.sortServices()
 		m.dbg("sort: %s", m.sortMode)
+
+	case key.Matches(msg, m.keys.Group):
+		m.cycleGroup()
+		m.rebuildSidebarEntries()
+		m.ensureSidebarCursorVisible()
+		m.updateGroupHelp()
+		m.dbg("group: %s", m.activeGroupDim())
 
 	case key.Matches(msg, m.keys.InfoMode):
 		m.infoMode = true

--- a/tools/phrocs/internal/tui/mouse.go
+++ b/tools/phrocs/internal/tui/mouse.go
@@ -15,7 +15,27 @@ func (m Model) handleMouseClick(msg tea.MouseClickMsg, cmds []tea.Cmd) (tea.Mode
 				row--
 			}
 			idx := m.servicesOffset + row
-			if idx >= 0 && idx < len(m.services) {
+
+			if m.isGrouped() {
+				// In grouped mode, idx indexes into sidebarEntries
+				if idx >= 0 && idx < len(m.sidebarEntries) {
+					e := m.sidebarEntries[idx]
+					if e.isNonSelectable() {
+						// Click on group header or spacer — ignore
+						return m, tea.Batch(cmds...)
+					}
+					prev := m.servicesCursor
+					m.entryCursor = idx
+					m.servicesCursor = e.procIndex
+					m.ensureSidebarCursorVisible()
+					if prev != m.servicesCursor {
+						m.dbg("proc selected (mouse): %s", m.services[m.servicesCursor].Name)
+						var loadCmds []tea.Cmd
+						m, loadCmds = m.loadActiveProc()
+						return m, tea.Batch(loadCmds...)
+					}
+				}
+			} else if idx >= 0 && idx < len(m.services) {
 				prev := m.servicesCursor
 				m.servicesCursor = idx
 				m.ensureSidebarCursorVisible()

--- a/tools/phrocs/internal/tui/render.go
+++ b/tools/phrocs/internal/tui/render.go
@@ -57,9 +57,14 @@ func (m Model) renderHeader() string {
 		sortInfo = headerMetaStyle.Render(fmt.Sprintf("▼ %s", m.sortMode))
 	}
 
-	spacerW := max(m.width-lipgloss.Width(stripesStyle)-lipgloss.Width(brand)-lipgloss.Width(sortInfo)-lipgloss.Width(procInfo)-lipgloss.Width(meta)-1, 0)
+	var groupInfo string
+	if m.isGrouped() {
+		groupInfo = headerMetaStyle.Render(fmt.Sprintf("☰ %s", m.activeGroupDim()))
+	}
+
+	spacerW := max(m.width-lipgloss.Width(stripesStyle)-lipgloss.Width(brand)-lipgloss.Width(groupInfo)-lipgloss.Width(sortInfo)-lipgloss.Width(procInfo)-lipgloss.Width(meta)-1, 0)
 	spacer := lipgloss.NewStyle().Width(spacerW).Render("")
-	return lipgloss.JoinHorizontal(lipgloss.Top, stripesStyle, brand, spacer, sortInfo, procInfo, "•", meta)
+	return lipgloss.JoinHorizontal(lipgloss.Top, stripesStyle, brand, spacer, groupInfo, sortInfo, procInfo, "•", meta)
 }
 
 func (m Model) renderSidebar() string {
@@ -67,6 +72,10 @@ func (m Model) renderSidebar() string {
 
 	// Usable column width inside the border
 	innerW := m.effectiveSidebarWidth() - 1
+
+	if m.isGrouped() {
+		return m.renderGroupedSidebar(h, innerW)
+	}
 
 	// Determine the vertical slice of the services list to render based
 	// on the current cursor position and servicesOffset
@@ -116,6 +125,74 @@ func (m Model) renderSidebar() string {
 	return borderFor(m.isDark, m.focusedPane == focusServices).Height(h).Render(strings.Join(rows, "\n"))
 }
 
+// renderGroupedSidebar renders the sidebar with group headers interspersed.
+func (m Model) renderGroupedSidebar(h, innerW int) string {
+	entries := m.sidebarEntries
+	n := len(entries)
+
+	// Compute scroll state for entries (similar to sidebarScrollState but for entries)
+	start := min(max(m.servicesOffset, 0), max(0, n-1))
+	canScrollUp := start > 0
+	avail := h
+	if canScrollUp {
+		avail--
+	}
+	canScrollDown := start+avail < n
+	if canScrollDown {
+		avail--
+	}
+	avail = max(avail, 1)
+	visibleEnd := min(n, start+avail)
+
+	var rows []string
+
+	if canScrollUp {
+		rows = append(rows, scrollArrowStyle.Width(innerW).Render("▲"))
+	}
+
+	for i := start; i < visibleEnd; i++ {
+		e := entries[i]
+		if e.spacer {
+			rows = append(rows, procInactiveStyle.Width(innerW).Render(""))
+			continue
+		}
+		if e.isHeader() {
+			label := truncate(e.groupHeader, innerW-1)
+			rows = append(rows, groupHeaderStyle.Width(innerW).Render(label))
+			continue
+		}
+
+		p := e.proc
+		status := p.Status()
+		iconChar := statusIconChar(status)
+		if status == process.StatusPending {
+			iconChar = ansi.Strip(m.spinner.View())
+		}
+		iconColor := statusIconColor(status)
+
+		name := truncate(p.Name, innerW-3)
+		rows = append(rows, renderSidebarRow(sidebarRow{
+			icon:      iconChar,
+			name:      name,
+			iconColor: iconColor,
+			selected:  i == m.entryCursor,
+			unread:    p.Unread(),
+			innerW:    innerW,
+			isDark:    m.isDark,
+		}))
+	}
+
+	if canScrollDown {
+		rows = append(rows, scrollArrowStyle.Width(innerW).Render("▼"))
+	}
+
+	for len(rows) < h {
+		rows = append(rows, procInactiveStyle.Width(innerW).Render(""))
+	}
+
+	return borderFor(m.isDark, m.focusedPane == focusServices).Height(h).Render(strings.Join(rows, "\n"))
+}
+
 func (m Model) sidebarHeight() int {
 	fh := m.footerHeight()
 	h := m.height - headerHeight - fh
@@ -129,6 +206,9 @@ func (m Model) sidebarHeight() int {
 func (m Model) sidebarScrollState() (canScrollUp, canScrollDown bool, visibleH int) {
 	h := m.sidebarHeight()
 	n := len(m.services)
+	if m.isGrouped() {
+		n = len(m.sidebarEntries)
+	}
 	if n <= h {
 		return false, false, h
 	}
@@ -151,6 +231,10 @@ func (m Model) sidebarScrollState() (canScrollUp, canScrollDown bool, visibleH i
 // Keep selected process row within the visible
 // sidebar window by adjusting servicesOffset
 func (m *Model) ensureSidebarCursorVisible() {
+	if m.isGrouped() {
+		m.ensureGroupedCursorVisible()
+		return
+	}
 	_, _, h := m.sidebarScrollState()
 	if len(m.services) <= m.sidebarHeight() {
 		m.servicesOffset = 0
@@ -167,6 +251,45 @@ func (m *Model) ensureSidebarCursorVisible() {
 	}
 	if m.servicesCursor >= m.servicesOffset+h {
 		m.servicesOffset = m.servicesCursor - h + 1
+	}
+}
+
+// ensureGroupedCursorVisible keeps the entryCursor visible in grouped mode.
+func (m *Model) ensureGroupedCursorVisible() {
+	n := len(m.sidebarEntries)
+	h := m.sidebarHeight()
+
+	if n <= h {
+		m.servicesOffset = 0
+		return
+	}
+
+	// Compute available rows accounting for scroll arrows
+	canScrollUp := m.servicesOffset > 0
+	avail := h
+	if canScrollUp {
+		avail--
+	}
+	canScrollDown := m.servicesOffset+avail < n
+	if canScrollDown {
+		avail--
+	}
+	avail = max(avail, 1)
+
+	maxOffset := n - avail
+	if m.servicesOffset > maxOffset {
+		m.servicesOffset = max(maxOffset, 0)
+	}
+
+	if m.entryCursor < m.servicesOffset {
+		m.servicesOffset = m.entryCursor
+		// Show the group header above if immediately preceding
+		if m.entryCursor > 0 && m.sidebarEntries[m.entryCursor-1].isHeader() {
+			m.servicesOffset = m.entryCursor - 1
+		}
+	}
+	if m.entryCursor >= m.servicesOffset+avail {
+		m.servicesOffset = m.entryCursor - avail + 1
 	}
 }
 

--- a/tools/phrocs/internal/tui/styles.go
+++ b/tools/phrocs/internal/tui/styles.go
@@ -116,6 +116,12 @@ var (
 
 	hintStyle = lipgloss.NewStyle().
 			Foreground(colorBrightYellow)
+
+	// Group header in grouped sidebar mode
+	groupHeaderStyle = lipgloss.NewStyle().
+				PaddingLeft(1).
+				Bold(true).
+				Foreground(colorBrightBlack)
 )
 
 func statusIconChar(s process.Status) string {


### PR DESCRIPTION
## Problem

Our phrocs shows a flat list of processes. It's hard to keep an overview, and for new joiners specifically hard to get a glance over the infrastructure.

This PR introduces a flexible grouping feature. It also introduces spacer lines and captions for the sidebar.

## Changes

- New action `g` to cycle through grouping dimensions (e.g., layer, tech)
- Extend `bin/mprocs.yaml`: Each process declares `groups: {layer: Application, tech: Python}` and top-level `group_order` controls display order per dimension. `pinned` is a reserved placing a process at the top without a header
- Generator updated to preserve `groups` through docker-compose and info config rebuilds
- Matching logic for groups, processes without a matching group appear under "Ungrouped"
- Spacer rows between groups for readability
- Navigation (`j`/`k`, mouse wheel, mouse click) skips headers and spacers
- Works together with sort (`o`), i.e. apply sorting within group
- Tests covering discovery, entry building, pinning, ungrouped fallback, navigation, sort interaction, and dynamic dimension cycling

Example:

<img width="1505" height="878" alt="phrocs-grouping" src="https://github.com/user-attachments/assets/d960d348-1176-4057-9e7b-3067c1932d23" />


## How did you test this code?

- New test cases for this feature
- Open phrocs with some process, apply grouping, apply sorting, navigating with keyboard and mouse
- Generate new intention based file, do the same tests

## Publish to changelog?

No