### PR TITLE
perf(logs): use regex-only PII scrub on log bodies

### DIFF
--- a/frontend/src/scenes/settings/environment/LogsCaptureSettings.tsx
+++ b/frontend/src/scenes/settings/environment/LogsCaptureSettings.tsx
@@ -103,8 +103,9 @@ export function LogsPiiScrubSettings(): JSX.Element {
                 />
             </AccessControlAction>
             <p className="text-secondary text-sm max-w-200 mt-2">
-                When enabled, common patterns (emails, card numbers, authorization headers, sensitive attribute keys)
-                are replaced with a fixed placeholder before storage. This is lossy redaction, not reversible hashing.
+                When enabled, common patterns in log text (emails, card numbers, authorization headers) and values under
+                sensitive attribute keys are replaced with a fixed placeholder before storage. This is lossy redaction,
+                not reversible hashing.
             </p>
         </>
     )

--- a/nodejs/src/logs-ingestion/log-pii-scrub.test.ts
+++ b/nodejs/src/logs-ingestion/log-pii-scrub.test.ts
@@ -83,6 +83,10 @@ describe('log-pii-scrub', () => {
             expect(unwrapAttributeCell('plain')).toBe('plain')
         })
 
+        it('returns raw value when quotes look like a string but escapes are invalid', () => {
+            expect(unwrapAttributeCell('"bad\\zescape"')).toBe('"bad\\zescape"')
+        })
+
         it('encodes semantic strings as JSON string cells for CH', () => {
             expect(encodeAttributeCell(PII_REDACTED)).toBe(JSON.stringify(PII_REDACTED))
             expect(encodeAttributeCell('ok')).toBe('"ok"')
@@ -107,9 +111,9 @@ describe('log-pii-scrub', () => {
             attributes: null,
         })
 
-        it('walks JSON body and scrubs string leaves', () => {
+        it('scrubs JSON-shaped body with regex only (patterns inside string values)', () => {
             const r = baseRecord()
-            // Use a non-sensitive key so the value is pattern-scrubbed (key `token` would full-redact the whole value).
+            // Use a non-sensitive key so the value is pattern-scrubbed (key `token` would full-redact in attributes only).
             r.body = JSON.stringify({ user: 'a@b.co', nested: { line: 'Bearer xyz' } })
             scrubLogRecord(r)
             const parsed = parseJSON(r.body!) as { user: string; nested: { line: string } }
@@ -117,7 +121,7 @@ describe('log-pii-scrub', () => {
             expect(parsed.nested.line).toBe(`Bearer ${PII_REDACTED}`)
         })
 
-        it('redacts JSON body object values for sensitive keys (same rules as attribute maps)', () => {
+        it('does not redact JSON body values by key name (regex-only body)', () => {
             const r = baseRecord()
             r.body = JSON.stringify({
                 password: 'hunter2',
@@ -126,8 +130,8 @@ describe('log-pii-scrub', () => {
             })
             scrubLogRecord(r)
             const parsed = parseJSON(r.body!) as { password: string; api_key: string; note: string }
-            expect(parsed.password).toBe(PII_REDACTED)
-            expect(parsed.api_key).toBe(PII_REDACTED)
+            expect(parsed.password).toBe('hunter2')
+            expect(parsed.api_key).toBe('secret-value')
             expect(parsed.note).toBe('no patterns')
         })
 
@@ -136,6 +140,13 @@ describe('log-pii-scrub', () => {
             r.body = 'plain err@mail.com log'
             scrubLogRecord(r)
             expect(r.body).toBe(`plain ${PII_REDACTED} log`)
+        })
+
+        it('falls back to plain scrub when body looks like JSON but is invalid', () => {
+            const r = baseRecord()
+            r.body = '{ not valid json } scrub-me@invalid-json.invalid'
+            scrubLogRecord(r)
+            expect(r.body).toBe(`{ not valid json } ${PII_REDACTED}`)
         })
 
         it('redacts values for sensitive attribute keys as JSON cells', () => {
@@ -170,44 +181,45 @@ describe('log-pii-scrub', () => {
             expect(r.resource_attributes!.note).toBe(encodeAttributeCell(PII_REDACTED))
         })
 
-        it('scrubs root JSON array elements (sensitive keys vs pattern scrub)', () => {
+        it('scrubs root JSON array string values by pattern only (not by key name in body)', () => {
             const r = baseRecord()
             r.body = JSON.stringify([{ password: 'hunter2' }, { note: 'a@b.co' }])
             scrubLogRecord(r)
             const parsed = parseJSON(r.body!) as [{ password: string }, { note: string }]
-            expect(parsed[0].password).toBe(PII_REDACTED)
+            expect(parsed[0].password).toBe('hunter2')
             expect(parsed[1].note).toBe(PII_REDACTED)
         })
 
-        it('replaces sensitive-key JSON object values with a redacted string', () => {
+        it('leaves sensitive-key object values unchanged in JSON body (regex-only)', () => {
             const r = baseRecord()
             r.body = JSON.stringify({ password: { nested: true }, note: 'ok' })
             scrubLogRecord(r)
-            const parsed = parseJSON(r.body!) as { password: string; note: string }
-            expect(parsed.password).toBe(PII_REDACTED)
+            const parsed = parseJSON(r.body!) as { password: { nested: boolean }; note: string }
+            expect(parsed.password).toEqual({ nested: true })
             expect(parsed.note).toBe('ok')
         })
 
         it.each([
-            ['number', 4242424242424242],
+            // Use a 16-digit value that fails Luhn so card-like regex does not rewrite the JSON number token.
+            ['number', 4242424242424243],
             ['null', null],
-        ] as const)('replaces sensitive-key %s leaf with redacted string', (_, leaf) => {
+        ] as const)('does not redact sensitive-key %s leaf in body by key name', (_, leaf) => {
             const r = baseRecord()
             r.body = JSON.stringify({ api_key: leaf, ok: true })
             scrubLogRecord(r)
-            const parsed = parseJSON(r.body!) as { api_key: string; ok: boolean }
-            expect(parsed.api_key).toBe(PII_REDACTED)
+            const parsed = parseJSON(r.body!) as { api_key: number | null; ok: boolean }
+            expect(parsed.api_key).toBe(leaf)
             expect(parsed.ok).toBe(true)
         })
 
-        it('scrubs deeply nested sensitive keys inside JSON body', () => {
+        it('scrubs nested email in JSON body but not opaque secrets without patterns', () => {
             const r = baseRecord()
             r.body = JSON.stringify({ outer: { inner: { refresh_token: 'rt-secret', label: 'x@y.co' } } })
             scrubLogRecord(r)
             const parsed = parseJSON(r.body!) as {
                 outer: { inner: { refresh_token: string; label: string } }
             }
-            expect(parsed.outer.inner.refresh_token).toBe(PII_REDACTED)
+            expect(parsed.outer.inner.refresh_token).toBe('rt-secret')
             expect(parsed.outer.inner.label).toBe(PII_REDACTED)
         })
 

--- a/nodejs/src/logs-ingestion/log-pii-scrub.ts
+++ b/nodejs/src/logs-ingestion/log-pii-scrub.ts
@@ -1,16 +1,18 @@
 /**
- * Lossy ingestion scrub: replace matches with PII_REDACTED ({{REDACTED}}). Plain text applies Bearer-token,
- * Stripe sk_*-shaped, email, and Luhn-valid 13–19 digit (card-like) patterns. JSON bodies are parsed when possible
- * and scrubbed recursively (object keys use the same sensitive-key substrings as attribute maps); opaque bodies get
- * plain rules only. Attribute maps redact the whole value on sensitive
- * key substrings, otherwise pattern-scrub values. Map values are JSON-string cells (JSON.stringify) so ClickHouse
- * JSONExtractString matches Rust OTLP encoding. Misses: secrets without those shapes, digit runs that fail Luhn,
- * keys outside the sensitive substring list (those values still get plain-text patterns only).
+ * Lossy ingestion scrub: replace matches with PII_REDACTED ({{REDACTED}}).
  *
- * The four main match rules use RE2 (via createTrackedRE2) for linear-time matching and consistency with other
- * nodejs regex paths; patterns use ASCII-explicit classes so behavior stays stable under node-re2’s Unicode mode.
+ * Bodies and plain-text metadata: one pass of regex rules (Bearer-shaped tail, Stripe sk_*,
+ * email, Luhn-valid card-like digit runs) via RE2 — no JSON parse or structured walk of the body.
+ * Under-scrub: values only protected today by JSON *key names* inside the body may remain unless
+ * they match a pattern (attribute maps still use sensitive-key redaction).
+ *
+ * Attribute maps: sensitive key → full redact; else unwrap OTLP JSON-string cells
+ * (tryDecodeJsonStringDocument — a single string literal, not a full document parse), pattern-scrub,
+ * then encodeAttributeCell for ClickHouse / Rust OTLP parity.
+ *
+ * The four main match rules use RE2 (via createTrackedRE2) for linear-time matching and consistency
+ * with other nodejs regex paths; patterns use ASCII-explicit classes under node-re2’s Unicode mode.
  */
-import { parseJSON } from '../utils/json-parse'
 import { createTrackedRE2 } from '../utils/tracked-re2'
 import type { LogRecord } from './log-record-avro'
 
@@ -45,17 +47,101 @@ export function isSensitiveAttributeKey(key: string): boolean {
     return SENSITIVE_KEY_SUBSTRINGS.some((s) => lower.includes(s))
 }
 
+/**
+ * If `raw` is a JSON document consisting of a single string literal, return its decoded Unicode value; otherwise null.
+ * Avoids JSON.parse so scrub stays off the hot parse metrics path; only handles the OTLP/CH string-cell shape.
+ */
+function tryDecodeJsonStringDocument(raw: string): string | null {
+    const s = raw.trim()
+    if (s.length < 2 || s.charCodeAt(0) !== 0x22 || s.charCodeAt(s.length - 1) !== 0x22) {
+        return null
+    }
+    let i = 1
+    const end = s.length - 1
+    let out = ''
+    while (i < end) {
+        const c = s.charCodeAt(i)
+        if (c !== 0x5c) {
+            if (c < 0x20) {
+                return null
+            }
+            out += s[i]
+            i++
+            continue
+        }
+        i++
+        if (i >= end) {
+            return null
+        }
+        const esc = s[i]
+        switch (esc) {
+            case '"':
+                out += '"'
+                i++
+                break
+            case '\\':
+                out += '\\'
+                i++
+                break
+            case '/':
+                out += '/'
+                i++
+                break
+            case 'b':
+                out += '\b'
+                i++
+                break
+            case 'f':
+                out += '\f'
+                i++
+                break
+            case 'n':
+                out += '\n'
+                i++
+                break
+            case 'r':
+                out += '\r'
+                i++
+                break
+            case 't':
+                out += '\t'
+                i++
+                break
+            case 'u': {
+                if (i + 4 >= end) {
+                    return null
+                }
+                const hex = s.slice(i + 1, i + 5)
+                if (!/^[0-9a-fA-F]{4}$/.test(hex)) {
+                    return null
+                }
+                let cp = parseInt(hex, 16)
+                i += 5
+                if (cp >= 0xd800 && cp <= 0xdbff && i + 5 < end && s[i] === '\\' && s[i + 1] === 'u') {
+                    const hexLow = s.slice(i + 2, i + 6)
+                    if (/^[0-9a-fA-F]{4}$/.test(hexLow)) {
+                        const low = parseInt(hexLow, 16)
+                        if (low >= 0xdc00 && low <= 0xdfff) {
+                            cp = 0x10000 + ((cp - 0xd800) << 10) + (low - 0xdc00)
+                            out += String.fromCodePoint(cp)
+                            i += 6
+                            break
+                        }
+                    }
+                }
+                out += String.fromCharCode(cp)
+                break
+            }
+            default:
+                return null
+        }
+    }
+    return i === end ? out : null
+}
+
 /** Rust OTLP path stores string attrs as serde_json string values; unwrap one JSON string layer if present. */
 export function unwrapAttributeCell(value: string): string {
-    try {
-        const parsed = parseJSON(value)
-        if (typeof parsed === 'string') {
-            return parsed
-        }
-    } catch {
-        // not valid JSON — treat whole cell as semantic text
-    }
-    return value
+    return tryDecodeJsonStringDocument(value) ?? value
 }
 
 /** Match Rust serde_json::Value::String(s).to_string() / CH kafka_logs_avro_mv JSONExtractString expectations. */
@@ -100,44 +186,11 @@ export function scrubPlainString(input: string): string {
     return s
 }
 
-/** Walk parsed JSON: scrub strings, recurse arrays and objects; leave numbers/bools/null unchanged. */
-function scrubJsonValue(value: unknown): unknown {
-    if (typeof value === 'string') {
-        return scrubPlainString(value)
-    }
-    if (Array.isArray(value)) {
-        return value.map(scrubJsonValue)
-    }
-    if (value !== null && typeof value === 'object') {
-        const out: Record<string, unknown> = {}
-        for (const [k, v] of Object.entries(value)) {
-            out[k] = isSensitiveAttributeKey(k) ? PII_REDACTED : scrubJsonValue(v)
-        }
-        return out
-    }
-    return value
-}
-
-/** If body is JSON object/array, scrub nested strings and re-serialize; if invalid JSON, scrub as plain text. */
 function scrubBodyField(record: LogRecord): void {
     if (record.body == null) {
         return
     }
-    const body = record.body
-    try {
-        const parsed = parseJSON(body)
-        if (parsed !== null && typeof parsed === 'object') {
-            record.body = JSON.stringify(scrubJsonValue(parsed))
-            return
-        }
-        if (typeof parsed === 'string') {
-            record.body = JSON.stringify(scrubPlainString(parsed))
-            return
-        }
-        // JSON primitives other than string (number, boolean, null): keep canonical serialization
-    } catch {
-        record.body = scrubPlainString(body)
-    }
+    record.body = scrubPlainString(record.body)
 }
 
 /** Copy string map: full redaction for sensitive keys, else pattern-scrub semantic values; CH-safe JSON cells. */

--- a/nodejs/src/logs-ingestion/log-record-avro.test.ts
+++ b/nodejs/src/logs-ingestion/log-record-avro.test.ts
@@ -572,7 +572,8 @@ describe('log-record-avro', () => {
             })
             const [_, __, decoded] = await decodeLogRecords(outputBuffer)
             const body = parseJSON(decoded[0]?.body || '{}') as { meta: { api_key: string }; ok: string }
-            expect(body.meta.api_key).toBe(PII_REDACTED)
+            // Body is regex-only scrub: non-pattern secret strings stay in raw JSON; flattened attrs still redact by key.
+            expect(body.meta.api_key).toBe('leak-value')
             expect(body.ok).toBe('keep')
             expect(decoded[0]?.attributes).toEqual({
                 'meta.api_key': encodeAttributeCell(PII_REDACTED),


### PR DESCRIPTION
## Problem

Ingest-time PII scrubbing walked JSON **bodies** with a streaming parser (decode string leaves, sensitive-key branches, re-emit JSON). That is **CPU-heavy** on large JSON log payloads (full-body scan + per-leaf work) and adds latency on the hot `processLogMessageBuffer` path. We still want scrubbing to be **cheap** while redacting common patterns and sensitive **attribute** keys.

## Changes

- **`nodejs/src/logs-ingestion/log-pii-scrub.ts`:** Remove the streaming JSON body implementation (`scrubJsonBodyStreaming` and helpers). **`body`** is scrubbed with a **single** `scrubPlainString` pass on the raw string (regex only: Bearer-shaped tail, Stripe `sk_*`, email, Luhn card-like runs via RE2).
- **Tradeoff:** Redaction by **JSON key names inside the serialized body** no longer applies; values only “protected” that way may remain unless a regex hits them. **Attribute maps** are unchanged: sensitive-key full redact, OTLP JSON-string cell unwrap (`tryDecodeJsonStringDocument`), pattern scrub, `encodeAttributeCell` for ClickHouse parity.
- **`log-pii-scrub.test.ts` / `log-record-avro.test.ts`:** Expectations updated for regex-only body; nested flatten integration keeps attribute redaction while **body** may still contain non-pattern secrets.
- **`frontend/src/scenes/settings/environment/LogsCaptureSettings.tsx`:** Helper text clarified: patterns in log text + sensitive **attribute** keys.

Still needs some JSON structure awareness to not break json format downstream when we replace with {{REDEACTED}}

Proof PII scrubbing is still working:
<img width="2574" height="598" alt="image" src="https://github.com/user-attachments/assets/9cd23119-87be-4ed6-8f55-c957fcb0bc74" />


## How did you test this code?

- `CI=true pnpm exec jest src/logs-ingestion/log-pii-scrub.test.ts src/logs-ingestion/log-record-avro.test.ts --watchAll=false` from `nodejs/` (passing).

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?


## Docs update


## LLM context
