### PR TITLE
feat(logs): write control-plane audit rows through apply_outcome

### DIFF
--- a/products/logs/backend/alert_state_machine.py
+++ b/products/logs/backend/alert_state_machine.py
@@ -18,7 +18,7 @@ from enum import Enum, StrEnum
 from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
-    from products.logs.backend.models import LogsAlertConfiguration
+    from products.logs.backend.models import LogsAlertConfiguration, LogsAlertEvent
 
 MAX_CONSECUTIVE_FAILURES = 5
 
@@ -221,12 +221,35 @@ def apply_threshold_change(snapshot: AlertSnapshot) -> ControlPlaneOutcome:
     return ControlPlaneOutcome(new_state=AlertState.NOT_FIRING, consecutive_failures=0)
 
 
-def apply_outcome(alert: LogsAlertConfiguration, outcome: Outcome) -> list[str]:
+def apply_outcome(
+    alert: LogsAlertConfiguration,
+    outcome: Outcome,
+    *,
+    kind: LogsAlertEvent.Kind | None = None,
+) -> list[str]:
     """Mutates `alert.state` and `alert.consecutive_failures` from an outcome.
     Returns modified field names for `save(update_fields=...)`.
+
+    If `kind` is provided, writes a `LogsAlertEvent` audit row — even when
+    state_before == state_after, because the caller has already decided the action
+    is audit-worthy (e.g. enabling an already-NOT_FIRING alert). Worker CHECK rows
+    are written by the temporal activity, not here.
     """
+    state_before = alert.state
     alert.state = outcome.new_state.value
     alert.consecutive_failures = outcome.consecutive_failures
+
+    if kind is not None:
+        from products.logs.backend.models import LogsAlertEvent
+
+        LogsAlertEvent.objects.create(
+            alert=alert,
+            kind=kind,
+            threshold_breached=False,
+            state_before=state_before,
+            state_after=outcome.new_state.value,
+        )
+
     return ["state", "consecutive_failures"]
 
 

--- a/products/logs/backend/alerts_api.py
+++ b/products/logs/backend/alerts_api.py
@@ -190,32 +190,36 @@ class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
         if "enabled" in validated_data and validated_data["enabled"] != instance.enabled:
             enabled_change = validated_data["enabled"]
 
-        # Resolve the state-machine transition in priority order: enable/disable wins over
-        # snooze, which wins over threshold/filter changes. Window-only edits don't touch
-        # state at all. All transitions return an Outcome; apply_outcome is the single
-        # place that actually writes to `state`/`consecutive_failures`.
-        snapshot = instance.to_snapshot()
-        if enabled_change is True:
-            apply_outcome(instance, apply_enable(snapshot))
-        elif enabled_change is False:
-            apply_outcome(instance, apply_disable(snapshot))
-        elif snooze_data is not _SENTINEL:
-            if snooze_data is None:
-                apply_outcome(instance, apply_unsnooze(snapshot))
-            else:
-                apply_outcome(instance, apply_snooze(snapshot))
-        elif threshold_changed:
-            apply_outcome(instance, apply_threshold_change(snapshot))
+        # Wrap the state-machine transition + LogsAlertEvent insert + super().save in one
+        # transaction so a save failure can't orphan an audit row (or vice versa). Matches
+        # the atomic guarantee the reset viewset action already provides.
+        with transaction.atomic():
+            # Resolve the state-machine transition in priority order: enable/disable wins over
+            # snooze, which wins over threshold/filter changes. Window-only edits don't touch
+            # state at all. All transitions return an Outcome; apply_outcome is the single
+            # place that actually writes to `state`/`consecutive_failures`.
+            snapshot = instance.to_snapshot()
+            if enabled_change is True:
+                apply_outcome(instance, apply_enable(snapshot), kind=LogsAlertEvent.Kind.ENABLE)
+            elif enabled_change is False:
+                apply_outcome(instance, apply_disable(snapshot), kind=LogsAlertEvent.Kind.DISABLE)
+            elif snooze_data is not _SENTINEL:
+                if snooze_data is None:
+                    apply_outcome(instance, apply_unsnooze(snapshot), kind=LogsAlertEvent.Kind.UNSNOOZE)
+                else:
+                    apply_outcome(instance, apply_snooze(snapshot), kind=LogsAlertEvent.Kind.SNOOZE)
+            elif threshold_changed:
+                apply_outcome(instance, apply_threshold_change(snapshot), kind=LogsAlertEvent.Kind.THRESHOLD_CHANGE)
 
-        # snooze_until is a timestamp column, not a state — carry it alongside the state
-        # transition so the serializer's single save persists both.
-        if snooze_data is not _SENTINEL:
-            instance.snooze_until = snooze_data
+            # snooze_until is a timestamp column, not a state — carry it alongside the state
+            # transition so the serializer's single save persists both.
+            if snooze_data is not _SENTINEL:
+                instance.snooze_until = snooze_data
 
-        if threshold_changed or window_changed:
-            instance.clear_next_check()
+            if threshold_changed or window_changed:
+                instance.clear_next_check()
 
-        return super().update(instance, validated_data)
+            return super().update(instance, validated_data)
 
     def create(self, validated_data: dict) -> LogsAlertConfiguration:
         validated_data["team_id"] = self.context["team_id"]
@@ -571,7 +575,7 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         except InvalidTransition:
             raise ValidationError({"state": "Only broken alerts can be reset."})
         with transaction.atomic():
-            update_fields = apply_outcome(alert, outcome)
+            update_fields = apply_outcome(alert, outcome, kind=LogsAlertEvent.Kind.RESET)
             update_fields.extend(alert.clear_next_check())
             alert.save(update_fields=update_fields)
             # The model's auto-signal skips these fields (signal_exclusions silences

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -791,6 +791,120 @@ class TestLogsAlertAPI(APIBaseTest):
         assert "state" in changed_fields
         assert "consecutive_failures" in changed_fields
 
+    # --- Control-plane event rows ---
+
+    def _assert_single_event_row(
+        self,
+        alert_id: str,
+        *,
+        kind: str,
+        state_before: str,
+        state_after: str,
+    ) -> None:
+        events = list(LogsAlertEvent.objects.filter(alert_id=alert_id).order_by("created_at"))
+        assert len(events) == 1, [(e.kind, e.state_before, e.state_after) for e in events]
+        event = events[0]
+        assert event.kind == kind
+        assert event.state_before == state_before
+        assert event.state_after == state_after
+        assert event.error_message is None
+        assert event.result_count is None
+
+    def test_reset_writes_reset_event_row(self):
+        created = self._create_via_api()
+        LogsAlertConfiguration.objects.filter(pk=created["id"]).update(
+            state=LogsAlertConfiguration.State.BROKEN,
+            consecutive_failures=5,
+        )
+
+        response = self.client.post(self._reset_url(created["id"]))
+        assert response.status_code == status.HTTP_200_OK
+
+        self._assert_single_event_row(
+            created["id"],
+            kind=LogsAlertEvent.Kind.RESET,
+            state_before=LogsAlertConfiguration.State.BROKEN.value,
+            state_after=LogsAlertConfiguration.State.NOT_FIRING.value,
+        )
+
+    @parameterized.expand(
+        [
+            (
+                "enable",
+                {"enabled": False, "state": LogsAlertConfiguration.State.NOT_FIRING},
+                {"enabled": True},
+                LogsAlertEvent.Kind.ENABLE,
+                LogsAlertConfiguration.State.NOT_FIRING.value,
+                LogsAlertConfiguration.State.NOT_FIRING.value,
+            ),
+            (
+                "disable",
+                {"enabled": True, "state": LogsAlertConfiguration.State.NOT_FIRING},
+                {"enabled": False},
+                LogsAlertEvent.Kind.DISABLE,
+                LogsAlertConfiguration.State.NOT_FIRING.value,
+                LogsAlertConfiguration.State.NOT_FIRING.value,
+            ),
+            (
+                "snooze",
+                {"state": LogsAlertConfiguration.State.NOT_FIRING},
+                {"snooze_until": (datetime.now(UTC) + timedelta(hours=1)).isoformat()},
+                LogsAlertEvent.Kind.SNOOZE,
+                LogsAlertConfiguration.State.NOT_FIRING.value,
+                LogsAlertConfiguration.State.SNOOZED.value,
+            ),
+            (
+                "unsnooze",
+                # snooze_until goes through .update() (ORM) here, not the API; hence the raw datetime.
+                {
+                    "state": LogsAlertConfiguration.State.SNOOZED,
+                    "snooze_until": datetime.now(UTC) + timedelta(hours=1),
+                },
+                {"snooze_until": None},
+                LogsAlertEvent.Kind.UNSNOOZE,
+                LogsAlertConfiguration.State.SNOOZED.value,
+                LogsAlertConfiguration.State.NOT_FIRING.value,
+            ),
+            (
+                "threshold_change",
+                {"state": LogsAlertConfiguration.State.NOT_FIRING, "threshold_count": 10},
+                {"threshold_count": 50},
+                LogsAlertEvent.Kind.THRESHOLD_CHANGE,
+                LogsAlertConfiguration.State.NOT_FIRING.value,
+                LogsAlertConfiguration.State.NOT_FIRING.value,
+            ),
+        ]
+    )
+    def test_update_writes_control_plane_event_row(
+        self,
+        _name: str,
+        initial_db_state: dict,
+        patch_payload: dict,
+        expected_kind: str,
+        expected_state_before: str,
+        expected_state_after: str,
+    ) -> None:
+        created = self._create_via_api()
+        LogsAlertConfiguration.objects.filter(pk=created["id"]).update(**initial_db_state)
+
+        response = self.client.patch(f"{self.base_url}{created['id']}/", patch_payload, format="json")
+        assert response.status_code == status.HTTP_200_OK, response.json()
+
+        self._assert_single_event_row(
+            created["id"],
+            kind=expected_kind,
+            state_before=expected_state_before,
+            state_after=expected_state_after,
+        )
+
+    def test_update_without_control_plane_change_does_not_write_event_row(self):
+        created = self._create_via_api()
+
+        response = self.client.patch(f"{self.base_url}{created['id']}/", {"name": "Renamed"}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+
+        assert not LogsAlertEvent.objects.filter(alert_id=created["id"]).exists()
+
     # --- Simulate ---
 
     def _simulate_url(self) -> str:


### PR DESCRIPTION
## Problem

Alert state changes in the logs backend need proper audit trails for debugging and compliance purposes. Currently, when users enable/disable alerts, snooze/unsnooze them, reset their state, or modify thresholds, these control plane actions are not being logged to the `LogsAlertEvent` table for audit purposes.

## Changes

- Enhanced `apply_outcome` function to accept an optional `kind` parameter that creates audit event rows in `LogsAlertEvent` when control plane actions occur
- Added audit logging for all alert state transitions: enable, disable, snooze, unsnooze, reset, and threshold changes
- Wrapped alert update operations in database transactions to ensure audit rows and state changes are persisted atomically
- Added comprehensive test coverage for all control plane event logging scenarios

The audit events capture the state before and after each transition, even when the state doesn't actually change (e.g., enabling an already non-firing alert), since the user action itself is audit-worthy.

## How did you test this code?

Added parameterized unit tests covering all control plane actions:

- `test_reset_writes_reset_event_row` - verifies reset actions create audit events
- `test_update_writes_control_plane_event_row` - parameterized test covering enable, disable, snooze, unsnooze, and threshold change scenarios
- `test_update_without_control_plane_change_does_not_write_event_row` - ensures non-state changes (like name updates) don't create unnecessary audit events

Each test verifies the correct event kind, before/after states, and that exactly one audit row is created per action.

## Publish to changelog?

No - this is an internal audit logging enhancement that doesn't affect user-facing functionality.

## Docs update

No documentation updates needed as this is an internal audit logging feature.