### PR TITLE
chore(tasks): add validation tests for shell_execute command params

### DIFF
--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -702,6 +702,7 @@ class TaskRunCommandRequestSerializer(serializers.Serializer):
         "close",
         "permission_response",
         "set_config_option",
+        "shell_execute",
     ]
 
     jsonrpc = serializers.ChoiceField(
@@ -745,6 +746,28 @@ class TaskRunCommandRequestSerializer(serializers.Serializer):
         elif method == "set_config_option":
             self._require_nonempty_string(params, "configId")
             self._require_nonempty_string(params, "value")
+        elif method == "shell_execute":
+            self._require_nonempty_string(params, "command")
+            cwd = params.get("cwd")
+            if cwd is not None and not isinstance(cwd, str):
+                raise serializers.ValidationError({"params": "cwd must be a string"})
+            timeout_ms = params.get("timeoutMs")
+            if timeout_ms is not None:
+                if (
+                    not isinstance(timeout_ms, int)
+                    or isinstance(timeout_ms, bool)
+                    or timeout_ms <= 0
+                    or timeout_ms > 600_000
+                ):
+                    raise serializers.ValidationError(
+                        {"params": "timeoutMs must be a positive integer no greater than 600000"}
+                    )
+            execution_id = params.get("executionId")
+            if execution_id is not None:
+                if not isinstance(execution_id, str) or not execution_id.strip() or len(execution_id) > 128:
+                    raise serializers.ValidationError(
+                        {"params": "executionId must be a non-empty string no longer than 128 characters"}
+                    )
         return attrs
 
 

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -699,6 +699,7 @@ class TaskRunCommandRequestSerializer(serializers.Serializer):
         "close",
         "permission_response",
         "set_config_option",
+        "shell_execute",
     ]
 
     jsonrpc = serializers.ChoiceField(
@@ -732,6 +733,30 @@ class TaskRunCommandRequestSerializer(serializers.Serializer):
             content = params.get("content")
             if not content or not isinstance(content, str) or not content.strip():
                 raise serializers.ValidationError({"params": "content is required and must be a non-empty string"})
+        if method == "shell_execute":
+            command = params.get("command")
+            if not command or not isinstance(command, str) or not command.strip():
+                raise serializers.ValidationError({"params": "command is required and must be a non-empty string"})
+            cwd = params.get("cwd")
+            if cwd is not None and not isinstance(cwd, str):
+                raise serializers.ValidationError({"params": "cwd must be a string"})
+            timeout_ms = params.get("timeoutMs")
+            if timeout_ms is not None:
+                if (
+                    not isinstance(timeout_ms, int)
+                    or isinstance(timeout_ms, bool)
+                    or timeout_ms <= 0
+                    or timeout_ms > 600_000
+                ):
+                    raise serializers.ValidationError(
+                        {"params": "timeoutMs must be a positive integer no greater than 600000"}
+                    )
+            execution_id = params.get("executionId")
+            if execution_id is not None:
+                if not isinstance(execution_id, str) or not execution_id.strip() or len(execution_id) > 128:
+                    raise serializers.ValidationError(
+                        {"params": "executionId must be a non-empty string no longer than 128 characters"}
+                    )
         return attrs
 
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -2796,6 +2796,42 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("No active sandbox", response.json()["error"])
 
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
+    @patch("products.tasks.backend.api.http_requests.post")
+    def test_command_proxies_shell_execute(self, mock_post):
+        get_sandbox_jwt_public_key.cache_clear()
+        self._mock_agent_response(
+            mock_post,
+            {
+                "jsonrpc": "2.0",
+                "id": "req-shell",
+                "result": {"executionId": "exec-xyz"},
+            },
+        )
+
+        task = self.create_task()
+        run = self._create_run_with_sandbox(task)
+
+        response = self.client.post(
+            self._command_url(task, run),
+            {
+                "jsonrpc": "2.0",
+                "method": "shell_execute",
+                "params": {"command": "echo vojta"},
+                "id": "req-shell",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["result"]["executionId"], "exec-xyz")
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args[1]
+        self.assertEqual(call_kwargs["json"]["method"], "shell_execute")
+        self.assertEqual(call_kwargs["json"]["params"]["command"], "echo vojta")
+
     @parameterized.expand(
         [
             ("missing_jsonrpc", {"method": "user_message", "params": {"content": "hi"}}),
@@ -2826,6 +2862,56 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
             (
                 "set_config_option_empty_params",
                 {"jsonrpc": "2.0", "method": "set_config_option", "params": {}},
+            ),
+            ("shell_execute_missing_command", {"jsonrpc": "2.0", "method": "shell_execute", "params": {}}),
+            ("shell_execute_empty_command", {"jsonrpc": "2.0", "method": "shell_execute", "params": {"command": "  "}}),
+            (
+                "shell_execute_timeout_too_large",
+                {
+                    "jsonrpc": "2.0",
+                    "method": "shell_execute",
+                    "params": {"command": "ls", "timeoutMs": 600001},
+                },
+            ),
+            (
+                "shell_execute_negative_timeout",
+                {
+                    "jsonrpc": "2.0",
+                    "method": "shell_execute",
+                    "params": {"command": "ls", "timeoutMs": -1},
+                },
+            ),
+            (
+                "shell_execute_bool_timeout",
+                {
+                    "jsonrpc": "2.0",
+                    "method": "shell_execute",
+                    "params": {"command": "ls", "timeoutMs": True},
+                },
+            ),
+            (
+                "shell_execute_non_string_cwd",
+                {
+                    "jsonrpc": "2.0",
+                    "method": "shell_execute",
+                    "params": {"command": "ls", "cwd": 123},
+                },
+            ),
+            (
+                "shell_execute_empty_execution_id",
+                {
+                    "jsonrpc": "2.0",
+                    "method": "shell_execute",
+                    "params": {"command": "ls", "executionId": ""},
+                },
+            ),
+            (
+                "shell_execute_execution_id_too_long",
+                {
+                    "jsonrpc": "2.0",
+                    "method": "shell_execute",
+                    "params": {"command": "ls", "executionId": "x" * 129},
+                },
             ),
         ]
     )

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -2381,6 +2381,42 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("No active sandbox", response.json()["error"])
 
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
+    @patch("products.tasks.backend.api.http_requests.post")
+    def test_command_proxies_shell_execute(self, mock_post):
+        get_sandbox_jwt_public_key.cache_clear()
+        self._mock_agent_response(
+            mock_post,
+            {
+                "jsonrpc": "2.0",
+                "id": "req-shell",
+                "result": {"executionId": "exec-xyz"},
+            },
+        )
+
+        task = self.create_task()
+        run = self._create_run_with_sandbox(task)
+
+        response = self.client.post(
+            self._command_url(task, run),
+            {
+                "jsonrpc": "2.0",
+                "method": "shell_execute",
+                "params": {"command": "echo vojta"},
+                "id": "req-shell",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["result"]["executionId"], "exec-xyz")
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args[1]
+        self.assertEqual(call_kwargs["json"]["method"], "shell_execute")
+        self.assertEqual(call_kwargs["json"]["params"]["command"], "echo vojta")
+
     @parameterized.expand(
         [
             ("missing_jsonrpc", {"method": "user_message", "params": {"content": "hi"}}),
@@ -2388,6 +2424,56 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
             ("unknown_method", {"jsonrpc": "2.0", "method": "unknown_method", "params": {}}),
             ("user_message_empty_content", {"jsonrpc": "2.0", "method": "user_message", "params": {"content": ""}}),
             ("user_message_missing_content", {"jsonrpc": "2.0", "method": "user_message", "params": {}}),
+            ("shell_execute_missing_command", {"jsonrpc": "2.0", "method": "shell_execute", "params": {}}),
+            ("shell_execute_empty_command", {"jsonrpc": "2.0", "method": "shell_execute", "params": {"command": "  "}}),
+            (
+                "shell_execute_timeout_too_large",
+                {
+                    "jsonrpc": "2.0",
+                    "method": "shell_execute",
+                    "params": {"command": "ls", "timeoutMs": 600001},
+                },
+            ),
+            (
+                "shell_execute_negative_timeout",
+                {
+                    "jsonrpc": "2.0",
+                    "method": "shell_execute",
+                    "params": {"command": "ls", "timeoutMs": -1},
+                },
+            ),
+            (
+                "shell_execute_bool_timeout",
+                {
+                    "jsonrpc": "2.0",
+                    "method": "shell_execute",
+                    "params": {"command": "ls", "timeoutMs": True},
+                },
+            ),
+            (
+                "shell_execute_non_string_cwd",
+                {
+                    "jsonrpc": "2.0",
+                    "method": "shell_execute",
+                    "params": {"command": "ls", "cwd": 123},
+                },
+            ),
+            (
+                "shell_execute_empty_execution_id",
+                {
+                    "jsonrpc": "2.0",
+                    "method": "shell_execute",
+                    "params": {"command": "ls", "executionId": ""},
+                },
+            ),
+            (
+                "shell_execute_execution_id_too_long",
+                {
+                    "jsonrpc": "2.0",
+                    "method": "shell_execute",
+                    "params": {"command": "ls", "executionId": "x" * 129},
+                },
+            ),
         ]
     )
     def test_command_rejects_invalid_payloads(self, _name, payload):

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -792,6 +792,7 @@ export const JsonrpcEnumApi = {
  * `close` - close
  * `permission_response` - permission_response
  * `set_config_option` - set_config_option
+ * `shell_execute` - shell_execute
  */
 export type MethodEnumApi = (typeof MethodEnumApi)[keyof typeof MethodEnumApi]
 
@@ -801,6 +802,7 @@ export const MethodEnumApi = {
     Close: 'close',
     PermissionResponse: 'permission_response',
     SetConfigOption: 'set_config_option',
+    ShellExecute: 'shell_execute',
 } as const
 
 /**
@@ -817,7 +819,8 @@ export interface TaskRunCommandRequestApi {
 * `cancel` - cancel
 * `close` - close
 * `permission_response` - permission_response
-* `set_config_option` - set_config_option */
+* `set_config_option` - set_config_option
+* `shell_execute` - shell_execute */
     method: MethodEnumApi
     /** Parameters for the command */
     params?: TaskRunCommandRequestApiParams

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -748,6 +748,7 @@ export const JsonrpcEnumApi = {
  * `close` - close
  * `permission_response` - permission_response
  * `set_config_option` - set_config_option
+ * `shell_execute` - shell_execute
  */
 export type MethodEnumApi = (typeof MethodEnumApi)[keyof typeof MethodEnumApi]
 
@@ -757,6 +758,7 @@ export const MethodEnumApi = {
     Close: 'close',
     PermissionResponse: 'permission_response',
     SetConfigOption: 'set_config_option',
+    ShellExecute: 'shell_execute',
 } as const
 
 /**
@@ -773,7 +775,8 @@ export interface TaskRunCommandRequestApi {
 * `cancel` - cancel
 * `close` - close
 * `permission_response` - permission_response
-* `set_config_option` - set_config_option */
+* `set_config_option` - set_config_option
+* `shell_execute` - shell_execute */
     method: MethodEnumApi
     /** Parameters for the command */
     params?: TaskRunCommandRequestApiParams

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -20421,6 +20421,7 @@ export namespace Schemas {
     * `close` - close
     * `permission_response` - permission_response
     * `set_config_option` - set_config_option
+    * `shell_execute` - shell_execute
      */
     export type MethodEnum = typeof MethodEnum[keyof typeof MethodEnum];
 
@@ -20431,6 +20432,7 @@ export namespace Schemas {
       Close: 'close',
       PermissionResponse: 'permission_response',
       SetConfigOption: 'set_config_option',
+      ShellExecute: 'shell_execute',
     } as const;
 
     export interface MinimalPerson {
@@ -32458,7 +32460,8 @@ export namespace Schemas {
     * `cancel` - cancel
     * `close` - close
     * `permission_response` - permission_response
-    * `set_config_option` - set_config_option */
+    * `set_config_option` - set_config_option
+    * `shell_execute` - shell_execute */
       method: MethodEnum;
       /** Parameters for the command */
       params?: TaskRunCommandRequestParams;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -20062,6 +20062,7 @@ export namespace Schemas {
     * `close` - close
     * `permission_response` - permission_response
     * `set_config_option` - set_config_option
+    * `shell_execute` - shell_execute
      */
     export type MethodEnum = typeof MethodEnum[keyof typeof MethodEnum];
 
@@ -20072,6 +20073,7 @@ export namespace Schemas {
       Close: 'close',
       PermissionResponse: 'permission_response',
       SetConfigOption: 'set_config_option',
+      ShellExecute: 'shell_execute',
     } as const;
 
     export interface MinimalPerson {
@@ -31886,7 +31888,8 @@ export namespace Schemas {
     * `cancel` - cancel
     * `close` - close
     * `permission_response` - permission_response
-    * `set_config_option` - set_config_option */
+    * `set_config_option` - set_config_option
+    * `shell_execute` - shell_execute */
       method: MethodEnum;
       /** Parameters for the command */
       params?: TaskRunCommandRequestParams;


### PR DESCRIPTION
## Problem

  The `shell_execute` command was added to the task run command proxy but lacked thorough validation test coverage for its parameters (`cwd`,
  `timeoutMs`, `executionId`).

  ## Changes

  - Add `shell_execute` command validation in `TaskRunCommandRequestSerializer` for `command`, `cwd`, `timeoutMs`, and `executionId` params
  - Add happy-path proxy test for `shell_execute`
  - Add parameterized rejection tests: missing/empty command, boolean timeout, negative timeout, timeout exceeding max, non-string cwd, empty
  executionId, too-long executionId

  ## How did you test this code?

Together with related [Posthog Code change](https://github.com/PostHog/code/pull/1707)

  ## Publish to changelog?

  No

  ## Docs update

  N/A