### PR TITLE
feat(error-tracking): add distributed symbol resolution for cymbal

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2646,6 +2646,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "siphasher 1.0.2",
  "sourcemap",
  "sqlx",
  "symbolic",

--- a/rust/cymbal/Cargo.toml
+++ b/rust/cymbal/Cargo.toml
@@ -43,6 +43,7 @@ base64 = { workspace = true }
 regex = { workspace = true }
 once_cell = { workspace = true }
 futures.workspace = true
+siphasher = { workspace = true }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 tower.workspace = true
 tiktoken-rs.workspace = true

--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -39,6 +39,7 @@ pub struct AppContext {
     pub team_manager: TeamManager,
     pub issue_buckets_redis_client: Arc<dyn RedisClientTrait + Send + Sync>,
     pub signal_client: MaybeSignalClient,
+    pub http_client: reqwest::Client,
 }
 
 impl AppContext {
@@ -185,6 +186,7 @@ impl AppContext {
             issue_buckets_redis_client,
             signal_client,
             symbol_resolver,
+            http_client: reqwest::Client::new(),
         })
     }
 }

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -118,6 +118,22 @@ pub struct Config {
     #[envconfig(default = "60000")]
     pub process_slow_log_threshold_ms: u64,
 
+    // Enables distributed symbol resolution fanout from /process using headless service DNS.
+    #[envconfig(default = "false")]
+    pub distributed_resolution_enabled: bool,
+
+    // Headless service host used to discover Cymbal pod IPs for distributed routing.
+    #[envconfig(default = "")]
+    pub distributed_headless_host: String,
+
+    // Timeout for internal distributed resolution HTTP calls.
+    #[envconfig(default = "60000")]
+    pub distributed_remote_timeout_ms: u64,
+
+    // Current pod IP for local-vs-remote routing decisions.
+    #[envconfig(default = "")]
+    pub pod_ip: String,
+
     #[envconfig(default = "300")]
     pub team_cache_ttl_secs: u64,
 

--- a/rust/cymbal/src/distributed/mod.rs
+++ b/rust/cymbal/src/distributed/mod.rs
@@ -27,6 +27,7 @@ pub struct DistributedContext {
     http_client: reqwest::Client,
     distributed_headless_host: String,
     distributed_remote_timeout_ms: u64,
+    internal_api_secret: String,
     pod_ip: String,
     port: u16,
 }
@@ -42,6 +43,7 @@ impl DistributedContext {
             http_client: app_context.http_client.clone(),
             distributed_headless_host: app_context.config.distributed_headless_host.clone(),
             distributed_remote_timeout_ms: app_context.config.distributed_remote_timeout_ms,
+            internal_api_secret: app_context.config.internal_api_secret.clone(),
             pod_ip: app_context.config.pod_ip.clone(),
             port: app_context.config.port,
         }
@@ -257,7 +259,11 @@ impl DistributedContext {
 
         let response = tokio::time::timeout(
             Duration::from_millis(self.distributed_remote_timeout_ms),
-            self.http_client.post(url).json(&request).send(),
+            self.http_client
+                .post(url)
+                .header("X-Internal-Api-Secret", &self.internal_api_secret)
+                .json(&request)
+                .send(),
         )
         .await
         .map_err(|_| RemoteError::Timeout)?

--- a/rust/cymbal/src/distributed/mod.rs
+++ b/rust/cymbal/src/distributed/mod.rs
@@ -134,10 +134,9 @@ impl DistributedContext {
     }
 
     async fn resolve_endpoints(&self) -> Result<Vec<String>, RemoteError> {
-        let addrs =
-            tokio::net::lookup_host((self.distributed_headless_host.as_str(), self.port))
-                .await
-                .map_err(RemoteError::DnsError)?;
+        let addrs = tokio::net::lookup_host((self.distributed_headless_host.as_str(), self.port))
+            .await
+            .map_err(RemoteError::DnsError)?;
 
         let mut endpoints: Vec<String> = addrs
             .map(|addr| addr.ip().to_string())

--- a/rust/cymbal/src/distributed/mod.rs
+++ b/rust/cymbal/src/distributed/mod.rs
@@ -39,7 +39,7 @@ impl DistributedContext {
         );
         Self {
             resolution,
-            http_client: reqwest::Client::new(),
+            http_client: app_context.http_client.clone(),
             distributed_headless_host: app_context.config.distributed_headless_host.clone(),
             distributed_remote_timeout_ms: app_context.config.distributed_remote_timeout_ms,
             pod_ip: app_context.config.pod_ip.clone(),

--- a/rust/cymbal/src/distributed/mod.rs
+++ b/rust/cymbal/src/distributed/mod.rs
@@ -1,0 +1,439 @@
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
+use reqwest::StatusCode;
+use siphasher::sip::SipHasher13;
+use std::hash::{Hash, Hasher};
+use tracing::warn;
+
+use crate::{
+    error::{RemoteError, UnhandledError},
+    metric_consts::{
+        DISTRIBUTED_FALLBACK_TOTAL, DISTRIBUTED_REMOTE_REQUEST_DURATION_SECONDS,
+        DISTRIBUTED_TASKS_TOTAL, INTERNAL_RESOLVE_TASKS_TOTAL,
+    },
+    stages::resolution::LocalResolutionStage,
+};
+
+pub mod tasks;
+
+use tasks::{ResolveBatchRequest, ResolveBatchResponse, ResolveTask, ResolveTaskResult};
+
+#[derive(Clone)]
+pub struct DistributedContext {
+    pub(crate) resolution: LocalResolutionStage,
+    http_client: reqwest::Client,
+    distributed_headless_host: String,
+    distributed_remote_timeout_ms: u64,
+    pod_ip: String,
+    port: u16,
+}
+
+impl DistributedContext {
+    pub fn new(app_context: &crate::app_context::AppContext) -> Self {
+        let resolution = LocalResolutionStage::from_parts(
+            app_context.symbol_resolver.clone(),
+            app_context.symbol_resolution_limiter.clone(),
+        );
+        Self {
+            resolution,
+            http_client: reqwest::Client::new(),
+            distributed_headless_host: app_context.config.distributed_headless_host.clone(),
+            distributed_remote_timeout_ms: app_context.config.distributed_remote_timeout_ms,
+            pod_ip: app_context.config.pod_ip.clone(),
+            port: app_context.config.port,
+        }
+    }
+
+    /// Resolve a set of tasks, routing each one locally or to a remote pod
+    /// based on consistent hashing. The caller doesn't need to know how
+    /// routing works — it just submits tasks and gets results.
+    pub(crate) async fn resolve_tasks(
+        &self,
+        tasks: Vec<ResolveTask>,
+    ) -> Result<HashMap<u64, ResolveTaskResult>, UnhandledError> {
+        if self.distributed_headless_host.is_empty() {
+            return self.execute_local_tasks(tasks).await;
+        }
+
+        let endpoints = self.resolve_endpoints().await;
+        let local_ip = self.local_ip();
+
+        let mut local_tasks = Vec::new();
+        let mut remote_tasks: HashMap<String, Vec<ResolveTask>> = HashMap::new();
+
+        for task in tasks {
+            match route_task(&task, endpoints.as_deref(), local_ip) {
+                Route::Local(reason) => {
+                    metrics::counter!(
+                        DISTRIBUTED_TASKS_TOTAL,
+                        "task_type" => task.task_type_label(),
+                        "route" => reason
+                    )
+                    .increment(1);
+                    local_tasks.push(task);
+                }
+                Route::Remote(ip) => {
+                    metrics::counter!(
+                        DISTRIBUTED_TASKS_TOTAL,
+                        "task_type" => task.task_type_label(),
+                        "route" => "remote"
+                    )
+                    .increment(1);
+                    remote_tasks.entry(ip).or_default().push(task);
+                }
+            }
+        }
+
+        self.execute_task_plan(local_tasks, remote_tasks).await
+    }
+
+    pub async fn process_internal_request(
+        &self,
+        request: ResolveBatchRequest,
+    ) -> Result<ResolveBatchResponse, UnhandledError> {
+        let mut results = Vec::with_capacity(request.tasks.len());
+
+        for task in request.tasks {
+            let task_type = task.task_type_label();
+            match self.execute_task_locally(&task).await {
+                Ok(result) => {
+                    metrics::counter!(
+                        INTERNAL_RESOLVE_TASKS_TOTAL,
+                        "task_type" => task_type,
+                        "outcome" => "success"
+                    )
+                    .increment(1);
+                    results.push(result);
+                }
+                Err(err) => {
+                    metrics::counter!(
+                        INTERNAL_RESOLVE_TASKS_TOTAL,
+                        "task_type" => task_type,
+                        "outcome" => "error"
+                    )
+                    .increment(1);
+                    return Err(err);
+                }
+            }
+        }
+
+        Ok(ResolveBatchResponse { results })
+    }
+
+    // -- private transport internals --
+
+    fn local_ip(&self) -> Option<&str> {
+        if self.pod_ip.trim().is_empty() {
+            None
+        } else {
+            Some(self.pod_ip.as_str())
+        }
+    }
+
+    async fn resolve_endpoints(&self) -> Option<Vec<String>> {
+        let lookup_result =
+            tokio::net::lookup_host((self.distributed_headless_host.as_str(), self.port)).await;
+
+        match lookup_result {
+            Err(e) => {
+                warn!(
+                    host = %self.distributed_headless_host,
+                    error = %e,
+                    "DNS lookup failed for headless service"
+                );
+                metrics::counter!(DISTRIBUTED_FALLBACK_TOTAL, "reason" => "dns_error")
+                    .increment(1);
+                None
+            }
+            Ok(addrs) => {
+                let mut endpoints: Vec<String> = addrs
+                    .map(|addr| addr.ip().to_string())
+                    .collect::<std::collections::HashSet<_>>()
+                    .into_iter()
+                    .collect();
+
+                if endpoints.is_empty() {
+                    warn!(
+                        host = %self.distributed_headless_host,
+                        "DNS lookup returned no addresses"
+                    );
+                    metrics::counter!(DISTRIBUTED_FALLBACK_TOTAL, "reason" => "dns_error")
+                        .increment(1);
+                    return None;
+                }
+
+                endpoints.sort();
+                Some(endpoints)
+            }
+        }
+    }
+
+    async fn execute_task_plan(
+        &self,
+        local_tasks: Vec<ResolveTask>,
+        remote_tasks: HashMap<String, Vec<ResolveTask>>,
+    ) -> Result<HashMap<u64, ResolveTaskResult>, UnhandledError> {
+        let mut results = self.execute_local_tasks(local_tasks).await?;
+
+        // Dispatch remote batches concurrently — requests to different pods are independent
+        let remote_futures: Vec<_> = remote_tasks
+            .into_iter()
+            .map(|(destination_ip, tasks)| {
+                let ctx = self.clone();
+                async move {
+                    (
+                        destination_ip.clone(),
+                        ctx.execute_remote_tasks(&destination_ip, &tasks).await,
+                        tasks,
+                    )
+                }
+            })
+            .collect();
+
+        let remote_outcomes = futures::future::join_all(remote_futures).await;
+
+        for (destination_ip, outcome, tasks) in remote_outcomes {
+            match outcome {
+                Ok(remote_results) => {
+                    let mut remote_map: HashMap<u64, ResolveTaskResult> = remote_results
+                        .into_iter()
+                        .map(|result| (result.task_id(), result))
+                        .collect();
+
+                    for task in tasks {
+                        if let Some(result) = remote_map.remove(&task.task_id()) {
+                            results.insert(task.task_id(), result);
+                        } else {
+                            warn!(
+                                task_id = task.task_id(),
+                                destination = %destination_ip,
+                                "remote pod did not return result for task, falling back to local"
+                            );
+                            metrics::counter!(
+                                DISTRIBUTED_FALLBACK_TOTAL,
+                                "reason" => "missing_result"
+                            )
+                            .increment(1);
+                            let result = self.execute_task_locally(&task).await?;
+                            results.insert(task.task_id(), result);
+                        }
+                    }
+                }
+                Err(err) => {
+                    warn!(
+                        destination = %destination_ip,
+                        error = %err,
+                        task_count = tasks.len(),
+                        "remote resolution failed, falling back to local"
+                    );
+                    metrics::counter!(
+                        DISTRIBUTED_FALLBACK_TOTAL,
+                        "reason" => err.fallback_label()
+                    )
+                    .increment(1);
+                    for task in tasks {
+                        let result = self.execute_task_locally(&task).await?;
+                        results.insert(task.task_id(), result);
+                    }
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
+    async fn execute_local_tasks(
+        &self,
+        tasks: Vec<ResolveTask>,
+    ) -> Result<HashMap<u64, ResolveTaskResult>, UnhandledError> {
+        let mut results = HashMap::new();
+        for task in tasks {
+            let result = self.execute_task_locally(&task).await?;
+            results.insert(task.task_id(), result);
+        }
+        Ok(results)
+    }
+
+    async fn execute_remote_tasks(
+        &self,
+        destination_ip: &str,
+        tasks: &[ResolveTask],
+    ) -> Result<Vec<ResolveTaskResult>, RemoteError> {
+        let started = Instant::now();
+        let result = self.send_remote_request(destination_ip, tasks).await;
+
+        metrics::histogram!(
+            DISTRIBUTED_REMOTE_REQUEST_DURATION_SECONDS,
+            "outcome" => result.as_ref().map_or_else(|e| e.histogram_label(), |_| "success")
+        )
+        .record(started.elapsed().as_secs_f64());
+
+        result
+    }
+
+    async fn send_remote_request(
+        &self,
+        destination_ip: &str,
+        tasks: &[ResolveTask],
+    ) -> Result<Vec<ResolveTaskResult>, RemoteError> {
+        let url = format!(
+            "http://{}:{}/_internal/resolve-batch",
+            destination_ip, self.port
+        );
+        let request = ResolveBatchRequest {
+            tasks: tasks.to_vec(),
+        };
+
+        let response = tokio::time::timeout(
+            Duration::from_millis(self.distributed_remote_timeout_ms),
+            self.http_client.post(url).json(&request).send(),
+        )
+        .await
+        .map_err(|_| RemoteError::Timeout)?
+        .map_err(RemoteError::RequestFailed)?;
+
+        if response.status() != StatusCode::OK {
+            return Err(RemoteError::BadStatus(response.status()));
+        }
+
+        response
+            .json::<ResolveBatchResponse>()
+            .await
+            .map(|r| r.results)
+            .map_err(RemoteError::InvalidResponse)
+    }
+
+    async fn execute_task_locally(
+        &self,
+        task: &ResolveTask,
+    ) -> Result<ResolveTaskResult, UnhandledError> {
+        let _permit = self.resolution.acquire_symbol_resolution_permit().await?;
+        task.execute(&*self.resolution.symbol_resolver).await
+    }
+}
+
+// -- routing (private) --
+
+enum Route {
+    Local(&'static str),
+    Remote(String),
+}
+
+fn route_task(
+    task: &ResolveTask,
+    endpoints: Option<&[String]>,
+    local_ip: Option<&str>,
+) -> Route {
+    let Some(routing_ref) = task.routing_ref() else {
+        return Route::Local("no_ref");
+    };
+
+    let Some(endpoints) = endpoints else {
+        return Route::Local("no_endpoints");
+    };
+
+    if endpoints.is_empty() {
+        return Route::Local("no_endpoints");
+    }
+
+    let destination = endpoint_for_ref(task.team_id(), routing_ref, endpoints);
+    if local_ip == Some(destination.as_str()) {
+        Route::Local("local")
+    } else {
+        Route::Remote(destination)
+    }
+}
+
+fn endpoint_for_ref(team_id: i32, routing_ref: &str, endpoints: &[String]) -> String {
+    let key = stable_key(team_id, routing_ref);
+    let bucket = jump_consistent_hash(key, endpoints.len() as i32) as usize;
+    endpoints[bucket].clone()
+}
+
+// Uses SipHash-1-3 with fixed keys for deterministic hashing that is stable
+// across Rust toolchain versions. DefaultHasher's output is explicitly not
+// guaranteed to be stable.
+const SIP_KEY0: u64 = 0x7a31_6f39_5e12_d8b1;
+const SIP_KEY1: u64 = 0x4f2a_c891_e5d7_36c0;
+
+fn stable_key(team_id: i32, routing_ref: &str) -> u64 {
+    let mut hasher = SipHasher13::new_with_keys(SIP_KEY0, SIP_KEY1);
+    team_id.hash(&mut hasher);
+    ":".hash(&mut hasher);
+    routing_ref.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn jump_consistent_hash(mut key: u64, num_buckets: i32) -> i32 {
+    let mut b: i64 = -1;
+    let mut j: i64 = 0;
+
+    while j < num_buckets as i64 {
+        b = j;
+        key = key.wrapping_mul(2862933555777941757).wrapping_add(1);
+        j = (((b + 1) as f64) * ((1_u64 << 31) as f64 / ((key >> 33) + 1) as f64)) as i64;
+    }
+
+    b as i32
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn jump_hash_stays_in_bucket_range() {
+        for key in [1_u64, 2, 3, 42, 123456789] {
+            let bucket = jump_consistent_hash(key, 7);
+            assert!((0..7).contains(&bucket));
+        }
+    }
+
+    #[test]
+    fn route_task_local_when_no_endpoints() {
+        let task = test_task(Some("ref"));
+        let route = route_task(&task, None, Some("10.0.0.1"));
+        assert!(matches!(route, Route::Local(_)));
+    }
+
+    #[test]
+    fn route_task_remote_without_local_ip() {
+        let task = test_task(Some("ref"));
+        let endpoints = vec!["10.0.0.1".to_string()];
+        let route = route_task(&task, Some(&endpoints), None);
+        assert!(matches!(route, Route::Remote(_)));
+    }
+
+    #[test]
+    fn route_task_local_when_no_routing_ref() {
+        let task = test_task(None);
+        let endpoints = vec!["10.0.0.1".to_string()];
+        let route = route_task(&task, Some(&endpoints), None);
+        assert!(matches!(route, Route::Local("no_ref")));
+    }
+
+    fn test_task(routing_ref: Option<&str>) -> ResolveTask {
+        use crate::distributed::tasks::DartExceptionTask;
+
+        ResolveTask::DartException(DartExceptionTask {
+            task_id: 1,
+            team_id: 1,
+            exception_type: "test".to_string(),
+            chunk_id: "chunk".to_string(),
+            routing_ref: routing_ref.map(String::from),
+        })
+    }
+
+    #[test]
+    fn stable_key_is_deterministic() {
+        let a = stable_key(42, "debug-id-abc");
+        let b = stable_key(42, "debug-id-abc");
+        assert_eq!(a, b);
+
+        let c = stable_key(42, "debug-id-xyz");
+        assert_ne!(a, c);
+    }
+}

--- a/rust/cymbal/src/distributed/mod.rs
+++ b/rust/cymbal/src/distributed/mod.rs
@@ -11,8 +11,8 @@ use tracing::warn;
 use crate::{
     error::{RemoteError, UnhandledError},
     metric_consts::{
-        DISTRIBUTED_FALLBACK_TOTAL, DISTRIBUTED_REMOTE_REQUEST_DURATION_SECONDS,
-        DISTRIBUTED_TASKS_TOTAL, INTERNAL_RESOLVE_TASKS_TOTAL,
+        DISTRIBUTED_REMOTE_REQUEST_DURATION_SECONDS, DISTRIBUTED_TASKS_TOTAL,
+        INTERNAL_RESOLVE_TASKS_TOTAL,
     },
     stages::resolution::LocalResolutionStage,
 };
@@ -58,14 +58,14 @@ impl DistributedContext {
             return self.execute_local_tasks(tasks).await;
         }
 
-        let endpoints = self.resolve_endpoints().await;
+        let endpoints = self.resolve_endpoints().await?;
         let local_ip = self.local_ip();
 
         let mut local_tasks = Vec::new();
         let mut remote_tasks: HashMap<String, Vec<ResolveTask>> = HashMap::new();
 
         for task in tasks {
-            match route_task(&task, endpoints.as_deref(), local_ip) {
+            match route_task(&task, &endpoints, local_ip) {
                 Route::Local(reason) => {
                     metrics::counter!(
                         DISTRIBUTED_TASKS_TOTAL,
@@ -133,42 +133,24 @@ impl DistributedContext {
         }
     }
 
-    async fn resolve_endpoints(&self) -> Option<Vec<String>> {
-        let lookup_result =
-            tokio::net::lookup_host((self.distributed_headless_host.as_str(), self.port)).await;
+    async fn resolve_endpoints(&self) -> Result<Vec<String>, RemoteError> {
+        let addrs =
+            tokio::net::lookup_host((self.distributed_headless_host.as_str(), self.port))
+                .await
+                .map_err(RemoteError::DnsError)?;
 
-        match lookup_result {
-            Err(e) => {
-                warn!(
-                    host = %self.distributed_headless_host,
-                    error = %e,
-                    "DNS lookup failed for headless service"
-                );
-                metrics::counter!(DISTRIBUTED_FALLBACK_TOTAL, "reason" => "dns_error")
-                    .increment(1);
-                None
-            }
-            Ok(addrs) => {
-                let mut endpoints: Vec<String> = addrs
-                    .map(|addr| addr.ip().to_string())
-                    .collect::<std::collections::HashSet<_>>()
-                    .into_iter()
-                    .collect();
+        let mut endpoints: Vec<String> = addrs
+            .map(|addr| addr.ip().to_string())
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
 
-                if endpoints.is_empty() {
-                    warn!(
-                        host = %self.distributed_headless_host,
-                        "DNS lookup returned no addresses"
-                    );
-                    metrics::counter!(DISTRIBUTED_FALLBACK_TOTAL, "reason" => "dns_error")
-                        .increment(1);
-                    return None;
-                }
-
-                endpoints.sort();
-                Some(endpoints)
-            }
+        if endpoints.is_empty() {
+            return Err(RemoteError::NoEndpoints);
         }
+
+        endpoints.sort();
+        Ok(endpoints)
     }
 
     async fn execute_task_plan(
@@ -196,49 +178,30 @@ impl DistributedContext {
         let remote_outcomes = futures::future::join_all(remote_futures).await;
 
         for (destination_ip, outcome, tasks) in remote_outcomes {
-            match outcome {
-                Ok(remote_results) => {
-                    let mut remote_map: HashMap<u64, ResolveTaskResult> = remote_results
-                        .into_iter()
-                        .map(|result| (result.task_id(), result))
-                        .collect();
+            let remote_results = outcome.map_err(|err| {
+                warn!(
+                    destination = %destination_ip,
+                    error = %err,
+                    task_count = tasks.len(),
+                    "remote resolution failed"
+                );
+                err
+            })?;
 
-                    for task in tasks {
-                        if let Some(result) = remote_map.remove(&task.task_id()) {
-                            results.insert(task.task_id(), result);
-                        } else {
-                            warn!(
-                                task_id = task.task_id(),
-                                destination = %destination_ip,
-                                "remote pod did not return result for task, falling back to local"
-                            );
-                            metrics::counter!(
-                                DISTRIBUTED_FALLBACK_TOTAL,
-                                "reason" => "missing_result"
-                            )
-                            .increment(1);
-                            let result = self.execute_task_locally(&task).await?;
-                            results.insert(task.task_id(), result);
-                        }
-                    }
-                }
-                Err(err) => {
-                    warn!(
-                        destination = %destination_ip,
-                        error = %err,
-                        task_count = tasks.len(),
-                        "remote resolution failed, falling back to local"
-                    );
-                    metrics::counter!(
-                        DISTRIBUTED_FALLBACK_TOTAL,
-                        "reason" => err.fallback_label()
-                    )
-                    .increment(1);
-                    for task in tasks {
-                        let result = self.execute_task_locally(&task).await?;
-                        results.insert(task.task_id(), result);
-                    }
-                }
+            let mut remote_map: HashMap<u64, ResolveTaskResult> = remote_results
+                .into_iter()
+                .map(|result| (result.task_id(), result))
+                .collect();
+
+            for task in tasks {
+                let result = remote_map.remove(&task.task_id()).ok_or_else(|| {
+                    RemoteError::InvalidResponse(format!(
+                        "remote pod {} did not return result for task {}",
+                        destination_ip,
+                        task.task_id()
+                    ))
+                })?;
+                results.insert(task.task_id(), result);
             }
         }
 
@@ -249,10 +212,16 @@ impl DistributedContext {
         &self,
         tasks: Vec<ResolveTask>,
     ) -> Result<HashMap<u64, ResolveTaskResult>, UnhandledError> {
+        let futs: Vec<_> = tasks
+            .iter()
+            .map(|task| self.execute_task_locally(task))
+            .collect();
+
+        let outcomes = futures::future::join_all(futs).await;
+
         let mut results = HashMap::new();
-        for task in tasks {
-            let result = self.execute_task_locally(&task).await?;
-            results.insert(task.task_id(), result);
+        for (task, outcome) in tasks.iter().zip(outcomes) {
+            results.insert(task.task_id(), outcome?);
         }
         Ok(results)
     }
@@ -303,7 +272,7 @@ impl DistributedContext {
             .json::<ResolveBatchResponse>()
             .await
             .map(|r| r.results)
-            .map_err(RemoteError::InvalidResponse)
+            .map_err(RemoteError::InvalidResponseBody)
     }
 
     async fn execute_task_locally(
@@ -322,22 +291,10 @@ enum Route {
     Remote(String),
 }
 
-fn route_task(
-    task: &ResolveTask,
-    endpoints: Option<&[String]>,
-    local_ip: Option<&str>,
-) -> Route {
+fn route_task(task: &ResolveTask, endpoints: &[String], local_ip: Option<&str>) -> Route {
     let Some(routing_ref) = task.routing_ref() else {
         return Route::Local("no_ref");
     };
-
-    let Some(endpoints) = endpoints else {
-        return Route::Local("no_endpoints");
-    };
-
-    if endpoints.is_empty() {
-        return Route::Local("no_endpoints");
-    }
 
     let destination = endpoint_for_ref(task.team_id(), routing_ref, endpoints);
     if local_ip == Some(destination.as_str()) {
@@ -393,17 +350,10 @@ mod test {
     }
 
     #[test]
-    fn route_task_local_when_no_endpoints() {
-        let task = test_task(Some("ref"));
-        let route = route_task(&task, None, Some("10.0.0.1"));
-        assert!(matches!(route, Route::Local(_)));
-    }
-
-    #[test]
     fn route_task_remote_without_local_ip() {
         let task = test_task(Some("ref"));
         let endpoints = vec!["10.0.0.1".to_string()];
-        let route = route_task(&task, Some(&endpoints), None);
+        let route = route_task(&task, &endpoints, None);
         assert!(matches!(route, Route::Remote(_)));
     }
 
@@ -411,7 +361,7 @@ mod test {
     fn route_task_local_when_no_routing_ref() {
         let task = test_task(None);
         let endpoints = vec!["10.0.0.1".to_string()];
-        let route = route_task(&task, Some(&endpoints), None);
+        let route = route_task(&task, &endpoints, None);
         assert!(matches!(route, Route::Local("no_ref")));
     }
 

--- a/rust/cymbal/src/distributed/tasks.rs
+++ b/rust/cymbal/src/distributed/tasks.rs
@@ -51,10 +51,18 @@ macro_rules! delegate {
 }
 
 impl ResolveTask {
-    pub fn task_id(&self) -> u64 { delegate!(self, task_id) }
-    pub fn team_id(&self) -> i32 { delegate!(self, team_id) }
-    pub fn task_type_label(&self) -> &'static str { delegate!(self, task_type_label) }
-    pub fn routing_ref(&self) -> Option<&str> { delegate!(self, routing_ref) }
+    pub fn task_id(&self) -> u64 {
+        delegate!(self, task_id)
+    }
+    pub fn team_id(&self) -> i32 {
+        delegate!(self, team_id)
+    }
+    pub fn task_type_label(&self) -> &'static str {
+        delegate!(self, task_type_label)
+    }
+    pub fn routing_ref(&self) -> Option<&str> {
+        delegate!(self, routing_ref)
+    }
 
     pub async fn execute(
         &self,

--- a/rust/cymbal/src/distributed/tasks.rs
+++ b/rust/cymbal/src/distributed/tasks.rs
@@ -35,7 +35,7 @@ pub trait TaskExecutor {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ResolveTask {
-    Frame(FrameTask),
+    Frame(Box<FrameTask>),
     JavaException(JavaExceptionTask),
     DartException(DartExceptionTask),
 }
@@ -311,7 +311,7 @@ pub fn extract_tasks(event: &ExceptionProperties, next_task_id: &mut u64) -> Vec
             };
 
             tasks.push(PlannedTask {
-                task: ResolveTask::Frame(task),
+                task: ResolveTask::Frame(Box::new(task)),
                 location: TaskLocation {
                     exception_index,
                     frame_index: Some(frame_index),

--- a/rust/cymbal/src/distributed/tasks.rs
+++ b/rust/cymbal/src/distributed/tasks.rs
@@ -1,0 +1,371 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::{ResolveError, UnhandledError},
+    frames::{Frame, RawFrame},
+    langs::{apple::AppleDebugImage, java::RawJavaFrame},
+    stages::resolution::symbol::SymbolResolver,
+    types::{exception_properties::ExceptionProperties, Exception, Stacktrace},
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolveBatchRequest {
+    pub tasks: Vec<ResolveTask>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolveBatchResponse {
+    pub results: Vec<ResolveTaskResult>,
+}
+
+/// Contract for a distributable resolution task.
+/// Adding a new task variant requires implementing this trait,
+/// which ensures the routing metadata and execution logic are co-located.
+pub trait TaskExecutor {
+    fn task_id(&self) -> u64;
+    fn team_id(&self) -> i32;
+    fn task_type_label(&self) -> &'static str;
+    fn routing_ref(&self) -> Option<&str>;
+    fn execute(
+        &self,
+        resolver: &dyn SymbolResolver,
+    ) -> impl std::future::Future<Output = Result<ResolveTaskResult, UnhandledError>> + Send;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ResolveTask {
+    Frame(FrameTask),
+    JavaException(JavaExceptionTask),
+    DartException(DartExceptionTask),
+}
+
+macro_rules! delegate {
+    ($self:ident, $method:ident $(, $arg:expr)*) => {
+        match $self {
+            ResolveTask::Frame(t) => t.$method($($arg),*),
+            ResolveTask::JavaException(t) => t.$method($($arg),*),
+            ResolveTask::DartException(t) => t.$method($($arg),*),
+        }
+    };
+}
+
+impl ResolveTask {
+    pub fn task_id(&self) -> u64 { delegate!(self, task_id) }
+    pub fn team_id(&self) -> i32 { delegate!(self, team_id) }
+    pub fn task_type_label(&self) -> &'static str { delegate!(self, task_type_label) }
+    pub fn routing_ref(&self) -> Option<&str> { delegate!(self, routing_ref) }
+
+    pub async fn execute(
+        &self,
+        resolver: &dyn SymbolResolver,
+    ) -> Result<ResolveTaskResult, UnhandledError> {
+        match self {
+            ResolveTask::Frame(t) => t.execute(resolver).await,
+            ResolveTask::JavaException(t) => t.execute(resolver).await,
+            ResolveTask::DartException(t) => t.execute(resolver).await,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FrameTask {
+    pub task_id: u64,
+    pub team_id: i32,
+    pub frame: RawFrame,
+    pub apple_debug_image: Option<AppleDebugImage>,
+    /// Used only by the local routing planner — intentionally not sent over the wire.
+    #[serde(skip)]
+    pub routing_ref: Option<String>,
+}
+
+impl TaskExecutor for FrameTask {
+    fn task_id(&self) -> u64 {
+        self.task_id
+    }
+
+    fn team_id(&self) -> i32 {
+        self.team_id
+    }
+
+    fn task_type_label(&self) -> &'static str {
+        match self.frame {
+            RawFrame::Apple(_) => "apple_frame",
+            _ => "frame",
+        }
+    }
+
+    fn routing_ref(&self) -> Option<&str> {
+        self.routing_ref.as_deref()
+    }
+
+    async fn execute(
+        &self,
+        resolver: &dyn SymbolResolver,
+    ) -> Result<ResolveTaskResult, UnhandledError> {
+        let debug_images: Vec<_> = self.apple_debug_image.clone().into_iter().collect();
+        let frames = resolver
+            .resolve_raw_frame(self.team_id, &self.frame, &debug_images)
+            .await?;
+        Ok(ResolveTaskResult::Frame {
+            task_id: self.task_id,
+            frames,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JavaExceptionTask {
+    pub task_id: u64,
+    pub team_id: i32,
+    pub module: String,
+    pub exception_type: String,
+    pub java_frame: RawJavaFrame,
+    /// Used only by the local routing planner — intentionally not sent over the wire.
+    #[serde(skip)]
+    pub routing_ref: Option<String>,
+}
+
+impl TaskExecutor for JavaExceptionTask {
+    fn task_id(&self) -> u64 {
+        self.task_id
+    }
+
+    fn team_id(&self) -> i32 {
+        self.team_id
+    }
+
+    fn task_type_label(&self) -> &'static str {
+        "java_exception"
+    }
+
+    fn routing_ref(&self) -> Option<&str> {
+        self.routing_ref.as_deref()
+    }
+
+    async fn execute(
+        &self,
+        resolver: &dyn SymbolResolver,
+    ) -> Result<ResolveTaskResult, UnhandledError> {
+        let exception = Exception {
+            exception_id: None,
+            exception_type: self.exception_type.clone(),
+            exception_message: String::new(),
+            mechanism: None,
+            module: Some(self.module.clone()),
+            thread_id: None,
+            stack: Some(Stacktrace::Raw {
+                frames: vec![RawFrame::Java(self.java_frame.clone())],
+            }),
+        };
+        let resolved = resolver
+            .resolve_java_exception(self.team_id, exception)
+            .await?;
+        Ok(ResolveTaskResult::JavaException {
+            task_id: self.task_id,
+            module: resolved.module,
+            exception_type: resolved.exception_type,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DartExceptionTask {
+    pub task_id: u64,
+    pub team_id: i32,
+    pub exception_type: String,
+    pub chunk_id: String,
+    /// Used only by the local routing planner — intentionally not sent over the wire.
+    #[serde(skip)]
+    pub routing_ref: Option<String>,
+}
+
+impl TaskExecutor for DartExceptionTask {
+    fn task_id(&self) -> u64 {
+        self.task_id
+    }
+
+    fn team_id(&self) -> i32 {
+        self.team_id
+    }
+
+    fn task_type_label(&self) -> &'static str {
+        "dart_exception"
+    }
+
+    fn routing_ref(&self) -> Option<&str> {
+        self.routing_ref.as_deref()
+    }
+
+    async fn execute(
+        &self,
+        resolver: &dyn SymbolResolver,
+    ) -> Result<ResolveTaskResult, UnhandledError> {
+        let exception_type = match resolver
+            .resolve_dart_minified_name(self.team_id, self.chunk_id.clone(), &self.exception_type)
+            .await
+        {
+            Ok(value) => value,
+            Err(ResolveError::ResolutionError(_)) => self.exception_type.clone(),
+            Err(ResolveError::UnhandledError(err)) => return Err(err),
+        };
+        Ok(ResolveTaskResult::DartException {
+            task_id: self.task_id,
+            exception_type,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ResolveTaskResult {
+    Frame {
+        task_id: u64,
+        frames: Vec<Frame>,
+    },
+    JavaException {
+        task_id: u64,
+        module: Option<String>,
+        exception_type: String,
+    },
+    DartException {
+        task_id: u64,
+        exception_type: String,
+    },
+}
+
+impl ResolveTaskResult {
+    pub fn task_id(&self) -> u64 {
+        match self {
+            ResolveTaskResult::Frame { task_id, .. }
+            | ResolveTaskResult::JavaException { task_id, .. }
+            | ResolveTaskResult::DartException { task_id, .. } => *task_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct TaskLocation {
+    pub exception_index: usize,
+    pub frame_index: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PlannedTask {
+    pub task: ResolveTask,
+    pub location: TaskLocation,
+}
+
+pub fn extract_tasks(event: &ExceptionProperties, next_task_id: &mut u64) -> Vec<PlannedTask> {
+    let mut tasks = Vec::new();
+
+    for (exception_index, exception) in event.exception_list.iter().enumerate() {
+        if let Some(java_task) = build_java_exception_task(event.team_id, exception, next_task_id) {
+            tasks.push(PlannedTask {
+                task: ResolveTask::JavaException(java_task),
+                location: TaskLocation {
+                    exception_index,
+                    frame_index: None,
+                },
+            });
+        }
+
+        if let Some(dart_task) = build_dart_exception_task(event.team_id, exception, next_task_id) {
+            tasks.push(PlannedTask {
+                task: ResolveTask::DartException(dart_task),
+                location: TaskLocation {
+                    exception_index,
+                    frame_index: None,
+                },
+            });
+        }
+
+        let Some(Stacktrace::Raw { frames }) = &exception.stack else {
+            continue;
+        };
+
+        for (frame_index, frame) in frames.iter().enumerate() {
+            let (routing_ref, apple_debug_image) = match frame {
+                RawFrame::Apple(apple_frame) => {
+                    let debug_image = apple_frame.matching_debug_image(&event.debug_images);
+                    let routing_ref = debug_image.as_ref().map(|image| image.debug_id.clone());
+                    (routing_ref, debug_image)
+                }
+                _ => (frame.symbol_set_ref(), None),
+            };
+
+            let task = FrameTask {
+                task_id: next_id(next_task_id),
+                team_id: event.team_id,
+                frame: frame.clone(),
+                apple_debug_image,
+                routing_ref,
+            };
+
+            tasks.push(PlannedTask {
+                task: ResolveTask::Frame(task),
+                location: TaskLocation {
+                    exception_index,
+                    frame_index: Some(frame_index),
+                },
+            });
+        }
+    }
+
+    tasks
+}
+
+fn build_java_exception_task(
+    team_id: i32,
+    exception: &crate::types::Exception,
+    next_task_id: &mut u64,
+) -> Option<JavaExceptionTask> {
+    let module = exception.module.clone()?;
+
+    let Some(RawFrame::Java(java_frame)) = exception.get_first_raw_frame() else {
+        return None;
+    };
+
+    Some(JavaExceptionTask {
+        task_id: next_id(next_task_id),
+        team_id,
+        module,
+        exception_type: exception.exception_type.clone(),
+        java_frame: java_frame.clone(),
+        routing_ref: java_frame.symbol_set_ref(),
+    })
+}
+
+fn build_dart_exception_task(
+    team_id: i32,
+    exception: &crate::types::Exception,
+    next_task_id: &mut u64,
+) -> Option<DartExceptionTask> {
+    if !exception.exception_type.starts_with("minified:") {
+        return None;
+    }
+
+    let chunk_id = exception
+        .get_raw_frame()
+        .iter()
+        .find_map(|frame| match frame {
+            RawFrame::JavaScriptWeb(js_frame) => js_frame.chunk_id.clone(),
+            RawFrame::JavaScriptNode(node_frame) => node_frame.chunk_id.clone(),
+            RawFrame::LegacyJS(js_frame) => js_frame.chunk_id.clone(),
+            _ => None,
+        })?;
+
+    Some(DartExceptionTask {
+        task_id: next_id(next_task_id),
+        team_id,
+        exception_type: exception.exception_type.clone(),
+        chunk_id: chunk_id.clone(),
+        routing_ref: Some(chunk_id),
+    })
+}
+
+fn next_id(next_task_id: &mut u64) -> u64 {
+    let task_id = *next_task_id;
+    *next_task_id += 1;
+    task_id
+}

--- a/rust/cymbal/src/error.rs
+++ b/rust/cymbal/src/error.rs
@@ -59,6 +59,10 @@ pub enum UnhandledError {
 
 #[derive(Debug, Error)]
 pub enum RemoteError {
+    #[error("DNS lookup failed for headless service: {0}")]
+    DnsError(std::io::Error),
+    #[error("DNS lookup returned no addresses")]
+    NoEndpoints,
     #[error("request timed out")]
     Timeout,
     #[error("request failed: {0}")]
@@ -66,7 +70,9 @@ pub enum RemoteError {
     #[error("unexpected status {0}")]
     BadStatus(reqwest::StatusCode),
     #[error("invalid response body: {0}")]
-    InvalidResponse(reqwest::Error),
+    InvalidResponseBody(reqwest::Error),
+    #[error("invalid response: {0}")]
+    InvalidResponse(String),
 }
 
 impl RemoteError {
@@ -74,15 +80,6 @@ impl RemoteError {
         match self {
             RemoteError::Timeout => "timeout",
             _ => "error",
-        }
-    }
-
-    pub fn fallback_label(&self) -> &'static str {
-        match self {
-            RemoteError::Timeout => "timeout",
-            RemoteError::RequestFailed(_) => "request_error",
-            RemoteError::BadStatus(_) => "bad_status",
-            RemoteError::InvalidResponse(_) => "invalid_response",
         }
     }
 }

--- a/rust/cymbal/src/error.rs
+++ b/rust/cymbal/src/error.rs
@@ -51,8 +51,40 @@ pub enum UnhandledError {
     SerdeError(#[from] serde_json::Error),
     #[error("Unhandled redis error: {0}")]
     RedisError(#[from] CustomRedisError),
+    #[error("Distributed resolution error: {0}")]
+    DistributedError(#[from] RemoteError),
     #[error("Unhandled error: {0}")]
     Other(String),
+}
+
+#[derive(Debug, Error)]
+pub enum RemoteError {
+    #[error("request timed out")]
+    Timeout,
+    #[error("request failed: {0}")]
+    RequestFailed(reqwest::Error),
+    #[error("unexpected status {0}")]
+    BadStatus(reqwest::StatusCode),
+    #[error("invalid response body: {0}")]
+    InvalidResponse(reqwest::Error),
+}
+
+impl RemoteError {
+    pub fn histogram_label(&self) -> &'static str {
+        match self {
+            RemoteError::Timeout => "timeout",
+            _ => "error",
+        }
+    }
+
+    pub fn fallback_label(&self) -> &'static str {
+        match self {
+            RemoteError::Timeout => "timeout",
+            RemoteError::RequestFailed(_) => "request_error",
+            RemoteError::BadStatus(_) => "bad_status",
+            RemoteError::InvalidResponse(_) => "invalid_response",
+        }
+    }
 }
 
 // These are errors that occur during frame resolution. This excludes e.g. network errors,

--- a/rust/cymbal/src/langs/apple.rs
+++ b/rust/cymbal/src/langs/apple.rs
@@ -274,6 +274,25 @@ impl RawAppleFrame {
         Err(AppleError::NoMatchingDebugImage)
     }
 
+    pub fn matching_debug_image(
+        &self,
+        debug_images: &[AppleDebugImage],
+    ) -> Option<AppleDebugImage> {
+        let instruction_addr = self
+            .instruction_addr
+            .as_ref()
+            .and_then(|addr| parse_hex_address(addr).ok())?;
+
+        self.find_debug_image(instruction_addr, debug_images)
+            .ok()
+            .cloned()
+    }
+
+    pub fn symbol_set_ref(&self, debug_images: &[AppleDebugImage]) -> Option<String> {
+        self.matching_debug_image(debug_images)
+            .map(|image| image.debug_id)
+    }
+
     fn calculate_relative_addr(
         &self,
         instruction_addr: u64,

--- a/rust/cymbal/src/lib.rs
+++ b/rust/cymbal/src/lib.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 pub mod app_context;
 pub mod assignment_rules;
 pub mod config;
+pub mod distributed;
 pub mod error;
 pub mod fingerprinting;
 pub mod frames;

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -55,6 +55,13 @@ pub const PROCESS_REQUEST_DURATION_SECONDS: &str = "cymbal_process_request_durat
 pub const PROCESS_BATCH_EVENTS: &str = "cymbal_process_batch_events";
 pub const PROCESS_IN_FLIGHT: &str = "cymbal_process_in_flight";
 
+// Distributed resolution metrics (strict minimum set)
+pub const DISTRIBUTED_TASKS_TOTAL: &str = "cymbal_distributed_tasks_total";
+pub const DISTRIBUTED_REMOTE_REQUEST_DURATION_SECONDS: &str =
+    "cymbal_distributed_remote_request_duration_seconds";
+pub const DISTRIBUTED_FALLBACK_TOTAL: &str = "cymbal_distributed_fallback_total";
+pub const INTERNAL_RESOLVE_TASKS_TOTAL: &str = "cymbal_internal_resolve_tasks_total";
+
 // Spike detection metrics
 pub const SPIKE_INCREMENT_ISSUE_BUCKETS_TIME: &str = "cymbal_spike_increment_issue_buckets_time";
 pub const SPIKE_INCREMENT_TEAM_BUCKETS_TIME: &str = "cymbal_spike_increment_team_buckets_time";

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -59,7 +59,6 @@ pub const PROCESS_IN_FLIGHT: &str = "cymbal_process_in_flight";
 pub const DISTRIBUTED_TASKS_TOTAL: &str = "cymbal_distributed_tasks_total";
 pub const DISTRIBUTED_REMOTE_REQUEST_DURATION_SECONDS: &str =
     "cymbal_distributed_remote_request_duration_seconds";
-pub const DISTRIBUTED_FALLBACK_TOTAL: &str = "cymbal_distributed_fallback_total";
 pub const INTERNAL_RESOLVE_TASKS_TOTAL: &str = "cymbal_internal_resolve_tasks_total";
 
 // Spike detection metrics

--- a/rust/cymbal/src/router/internal.rs
+++ b/rust/cymbal/src/router/internal.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use axum::{extract::State, response::IntoResponse, Json};
 use reqwest::StatusCode;
 use serde_json::json;
+use tracing::{debug, error, info};
 
 use crate::{
     app_context::AppContext,
@@ -14,17 +15,22 @@ pub async fn resolve_batch_internal(
     State(ctx): State<Arc<AppContext>>,
     Json(request): Json<ResolveBatchRequest>,
 ) -> impl IntoResponse {
+    let task_count = request.tasks.len();
+    debug!(task_count, "internal resolve-batch received");
     let resolution_ctx = DistributedContext::new(&ctx);
 
     match resolution_ctx.process_internal_request(request).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
-        Err(err) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({
-                "error": "internal resolution failed",
-                "details": err.to_string(),
-            })),
-        )
-            .into_response(),
+        Ok(response) => {
+            info!(task_count, result_count = response.results.len(), "internal resolve-batch completed");
+            (StatusCode::OK, Json(response)).into_response()
+        }
+        Err(err) => {
+            error!(task_count, error = %err, "internal resolve-batch failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "internal resolution failed" })),
+            )
+                .into_response()
+        }
     }
 }

--- a/rust/cymbal/src/router/internal.rs
+++ b/rust/cymbal/src/router/internal.rs
@@ -21,7 +21,11 @@ pub async fn resolve_batch_internal(
 
     match resolution_ctx.process_internal_request(request).await {
         Ok(response) => {
-            info!(task_count, result_count = response.results.len(), "internal resolve-batch completed");
+            info!(
+                task_count,
+                result_count = response.results.len(),
+                "internal resolve-batch completed"
+            );
             (StatusCode::OK, Json(response)).into_response()
         }
         Err(err) => {

--- a/rust/cymbal/src/router/internal.rs
+++ b/rust/cymbal/src/router/internal.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use axum::{extract::State, response::IntoResponse, Json};
+use reqwest::StatusCode;
+use serde_json::json;
+
+use crate::{
+    app_context::AppContext,
+    distributed::{tasks::ResolveBatchRequest, DistributedContext},
+};
+
+#[axum::debug_handler]
+pub async fn resolve_batch_internal(
+    State(ctx): State<Arc<AppContext>>,
+    Json(request): Json<ResolveBatchRequest>,
+) -> impl IntoResponse {
+    let resolution_ctx = DistributedContext::new(&ctx);
+
+    match resolution_ctx.process_internal_request(request).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({
+                "error": "internal resolution failed",
+                "details": err.to_string(),
+            })),
+        )
+            .into_response(),
+    }
+}

--- a/rust/cymbal/src/router/internal.rs
+++ b/rust/cymbal/src/router/internal.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use axum::{extract::State, response::IntoResponse, Json};
+use axum::{extract::State, http::HeaderMap, response::IntoResponse, Json};
 use reqwest::StatusCode;
 use serde_json::json;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     app_context::AppContext,
@@ -13,8 +13,25 @@ use crate::{
 #[axum::debug_handler]
 pub async fn resolve_batch_internal(
     State(ctx): State<Arc<AppContext>>,
+    headers: HeaderMap,
     Json(request): Json<ResolveBatchRequest>,
 ) -> impl IntoResponse {
+    let expected = &ctx.config.internal_api_secret;
+    if !expected.is_empty() {
+        let provided = headers
+            .get("X-Internal-Api-Secret")
+            .and_then(|v| v.to_str().ok());
+
+        if provided != Some(expected) {
+            warn!("internal resolve-batch rejected: invalid or missing secret");
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({ "error": "unauthorized" })),
+            )
+                .into_response();
+        }
+    }
+
     let task_count = request.tasks.len();
     debug!(task_count, "internal resolve-batch received");
     let resolution_ctx = DistributedContext::new(&ctx);

--- a/rust/cymbal/src/router/mod.rs
+++ b/rust/cymbal/src/router/mod.rs
@@ -1,9 +1,11 @@
 mod event;
+mod internal;
 
 use axum::routing::{get, post};
 use axum::{extract::State, response::IntoResponse, Router};
 
 pub use event::*;
+pub use internal::*;
 
 use health::HealthStatus;
 use reqwest::StatusCode;
@@ -28,6 +30,7 @@ pub fn get_router(context: Arc<AppContext>) -> Router {
     Router::new()
         .route("/", get(index))
         .route("/process", post(process_events))
+        .route("/_internal/resolve-batch", post(resolve_batch_internal))
         .route("/_readiness", get(index))
         .route("/_liveness", get(liveness))
         .fallback(not_found)

--- a/rust/cymbal/src/stages/pipeline.rs
+++ b/rust/cymbal/src/stages/pipeline.rs
@@ -12,7 +12,7 @@ use crate::{
         linking::LinkingStage,
         post_processing::{PostProcessingHandler, PostProcessingStage},
         pre_processing::{PreProcessingContext, PreProcessingStage},
-        resolution::ResolutionStage,
+        resolution::{DistributedResolutionStage, LocalResolutionStage},
     },
     types::{
         batch::Batch,
@@ -45,10 +45,19 @@ impl Stage for ExceptionEventPipeline {
     }
 
     async fn process(self, batch: Batch<Self::Input>) -> StageResult<Self> {
+        let batch = if self.app_context.config.distributed_resolution_enabled {
+            batch
+                // Resolve stack traces with distributed routing
+                .apply_stage(DistributedResolutionStage::from(&self.app_context))
+                .await?
+        } else {
+            batch
+                // Resolve stack traces locally
+                .apply_stage(LocalResolutionStage::from(&self.app_context))
+                .await?
+        };
+
         batch
-            // Resolve stack traces
-            .apply_stage(ResolutionStage::from(&self.app_context))
-            .await?
             // Group events by fingerprint
             .apply_stage(GroupingStage::from(&self.app_context))
             .await?

--- a/rust/cymbal/src/stages/resolution/distributed.rs
+++ b/rust/cymbal/src/stages/resolution/distributed.rs
@@ -9,10 +9,7 @@ use crate::{
     error::UnhandledError,
     frames::Frame,
     metric_consts::RESOLUTION_STAGE,
-    stages::{
-        pipeline::ExceptionEventPipelineItem,
-        resolution::properties::PropertiesResolver,
-    },
+    stages::{pipeline::ExceptionEventPipelineItem, resolution::properties::PropertiesResolver},
     types::{
         batch::Batch,
         stage::{Stage, StageResult},

--- a/rust/cymbal/src/stages/resolution/distributed.rs
+++ b/rust/cymbal/src/stages/resolution/distributed.rs
@@ -1,0 +1,232 @@
+use std::{collections::HashMap, sync::Arc};
+
+use crate::{
+    app_context::AppContext,
+    distributed::{
+        tasks::{extract_tasks, ResolveTaskResult, TaskLocation},
+        DistributedContext,
+    },
+    error::UnhandledError,
+    frames::Frame,
+    metric_consts::{DISTRIBUTED_FALLBACK_TOTAL, RESOLUTION_STAGE},
+    stages::{
+        pipeline::ExceptionEventPipelineItem,
+        resolution::{frame::FrameResolver, properties::PropertiesResolver},
+    },
+    types::{
+        batch::Batch,
+        stage::{Stage, StageResult},
+        Stacktrace,
+    },
+};
+
+#[derive(Clone)]
+pub struct DistributedResolutionStage {
+    context: DistributedContext,
+}
+
+impl From<&Arc<AppContext>> for DistributedResolutionStage {
+    fn from(app_context: &Arc<AppContext>) -> Self {
+        Self {
+            context: DistributedContext::new(app_context),
+        }
+    }
+}
+
+impl Stage for DistributedResolutionStage {
+    type Input = ExceptionEventPipelineItem;
+    type Output = ExceptionEventPipelineItem;
+
+    fn name(&self) -> &'static str {
+        RESOLUTION_STAGE
+    }
+
+    async fn process(self, batch: Batch<Self::Input>) -> StageResult<Self> {
+        let mut output: Vec<ExceptionEventPipelineItem> = Vec::from(batch);
+        let mut states = collect_event_states(&output);
+
+        if !states.is_empty() {
+            let (tasks, bindings) = extract_all_tasks(&states);
+            let results = self.context.resolve_tasks(tasks).await?;
+
+            apply_results_to_states(&mut states, &bindings, results)?;
+            materialize_resolved_frames(&mut states, &self.context).await?;
+
+            for state in states {
+                output[state.batch_index] = Ok(state.event);
+            }
+        }
+
+        Batch::from(output)
+            .apply_operator(PropertiesResolver, self.context.resolution.clone())
+            .await
+    }
+}
+
+// -- batch orchestration (private) --
+
+#[derive(Debug, Clone)]
+struct EventState {
+    batch_index: usize,
+    event: crate::types::exception_properties::ExceptionProperties,
+    frame_overrides: HashMap<(usize, usize), Vec<Frame>>,
+}
+
+#[derive(Debug, Clone)]
+struct TaskBinding {
+    state_index: usize,
+    location: TaskLocation,
+}
+
+fn collect_event_states(output: &[ExceptionEventPipelineItem]) -> Vec<EventState> {
+    output
+        .iter()
+        .enumerate()
+        .filter_map(|(batch_index, item)| {
+            item.as_ref().ok().map(|event| EventState {
+                batch_index,
+                event: event.clone(),
+                frame_overrides: HashMap::new(),
+            })
+        })
+        .collect()
+}
+
+fn extract_all_tasks(
+    states: &[EventState],
+) -> (
+    Vec<crate::distributed::tasks::ResolveTask>,
+    HashMap<u64, TaskBinding>,
+) {
+    let mut tasks = Vec::new();
+    let mut bindings = HashMap::new();
+    let mut next_task_id: u64 = 1;
+
+    for (state_index, state) in states.iter().enumerate() {
+        for planned in extract_tasks(&state.event, &mut next_task_id) {
+            bindings.insert(
+                planned.task.task_id(),
+                TaskBinding {
+                    state_index,
+                    location: planned.location,
+                },
+            );
+            tasks.push(planned.task);
+        }
+    }
+
+    (tasks, bindings)
+}
+
+fn apply_results_to_states(
+    states: &mut [EventState],
+    bindings: &HashMap<u64, TaskBinding>,
+    results: HashMap<u64, ResolveTaskResult>,
+) -> Result<(), UnhandledError> {
+    for (task_id, result) in results {
+        let Some(binding) = bindings.get(&task_id) else {
+            continue;
+        };
+
+        let Some(state) = states.get_mut(binding.state_index) else {
+            metrics::counter!(DISTRIBUTED_FALLBACK_TOTAL, "reason" => "merge_error").increment(1);
+            continue;
+        };
+
+        match result {
+            ResolveTaskResult::Frame { frames, .. } => {
+                let Some(frame_index) = binding.location.frame_index else {
+                    metrics::counter!(DISTRIBUTED_FALLBACK_TOTAL, "reason" => "merge_error")
+                        .increment(1);
+                    continue;
+                };
+
+                state
+                    .frame_overrides
+                    .insert((binding.location.exception_index, frame_index), frames);
+            }
+            ResolveTaskResult::JavaException {
+                module,
+                exception_type,
+                ..
+            } => {
+                if let Some(exception) = state
+                    .event
+                    .exception_list
+                    .get_mut(binding.location.exception_index)
+                {
+                    exception.module = module;
+                    exception.exception_type = exception_type;
+                } else {
+                    metrics::counter!(DISTRIBUTED_FALLBACK_TOTAL, "reason" => "merge_error")
+                        .increment(1);
+                }
+            }
+            ResolveTaskResult::DartException { exception_type, .. } => {
+                if let Some(exception) = state
+                    .event
+                    .exception_list
+                    .get_mut(binding.location.exception_index)
+                {
+                    exception.exception_type = exception_type;
+                } else {
+                    metrics::counter!(DISTRIBUTED_FALLBACK_TOTAL, "reason" => "merge_error")
+                        .increment(1);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn materialize_resolved_frames(
+    states: &mut [EventState],
+    ctx: &DistributedContext,
+) -> Result<(), UnhandledError> {
+    for state in states.iter_mut() {
+        for exception_index in 0..state.event.exception_list.len() {
+            let Some(Stacktrace::Raw { frames: raw_frames }) =
+                state.event.exception_list[exception_index].stack.clone()
+            else {
+                continue;
+            };
+
+            let mut merged_frames = Vec::new();
+            let mut complete = true;
+
+            for frame_index in 0..raw_frames.len() {
+                if let Some(mut frames) = state
+                    .frame_overrides
+                    .remove(&(exception_index, frame_index))
+                {
+                    merged_frames.append(&mut frames);
+                } else {
+                    complete = false;
+                    break;
+                }
+            }
+
+            if complete {
+                state.event.exception_list[exception_index].stack =
+                    Some(Stacktrace::Resolved {
+                        frames: merged_frames,
+                    });
+                continue;
+            }
+
+            metrics::counter!(DISTRIBUTED_FALLBACK_TOTAL, "reason" => "merge_error").increment(1);
+            let unresolved = state.event.exception_list[exception_index].clone();
+            let resolved = FrameResolver::resolve_exception_frames(
+                state.event.team_id,
+                unresolved,
+                &state.event.debug_images,
+                ctx.resolution.clone(),
+            )
+            .await?;
+            state.event.exception_list[exception_index] = resolved;
+        }
+    }
+
+    Ok(())
+}

--- a/rust/cymbal/src/stages/resolution/distributed.rs
+++ b/rust/cymbal/src/stages/resolution/distributed.rs
@@ -8,10 +8,10 @@ use crate::{
     },
     error::UnhandledError,
     frames::Frame,
-    metric_consts::{DISTRIBUTED_FALLBACK_TOTAL, RESOLUTION_STAGE},
+    metric_consts::RESOLUTION_STAGE,
     stages::{
         pipeline::ExceptionEventPipelineItem,
-        resolution::{frame::FrameResolver, properties::PropertiesResolver},
+        resolution::properties::PropertiesResolver,
     },
     types::{
         batch::Batch,
@@ -50,7 +50,7 @@ impl Stage for DistributedResolutionStage {
             let results = self.context.resolve_tasks(tasks).await?;
 
             apply_results_to_states(&mut states, &bindings, results)?;
-            materialize_resolved_frames(&mut states, &self.context).await?;
+            materialize_resolved_frames(&mut states)?;
 
             for state in states {
                 output[state.batch_index] = Ok(state.event);
@@ -129,15 +129,12 @@ fn apply_results_to_states(
         };
 
         let Some(state) = states.get_mut(binding.state_index) else {
-            metrics::counter!(DISTRIBUTED_FALLBACK_TOTAL, "reason" => "merge_error").increment(1);
             continue;
         };
 
         match result {
             ResolveTaskResult::Frame { frames, .. } => {
                 let Some(frame_index) = binding.location.frame_index else {
-                    metrics::counter!(DISTRIBUTED_FALLBACK_TOTAL, "reason" => "merge_error")
-                        .increment(1);
                     continue;
                 };
 
@@ -157,9 +154,6 @@ fn apply_results_to_states(
                 {
                     exception.module = module;
                     exception.exception_type = exception_type;
-                } else {
-                    metrics::counter!(DISTRIBUTED_FALLBACK_TOTAL, "reason" => "merge_error")
-                        .increment(1);
                 }
             }
             ResolveTaskResult::DartException { exception_type, .. } => {
@@ -169,9 +163,6 @@ fn apply_results_to_states(
                     .get_mut(binding.location.exception_index)
                 {
                     exception.exception_type = exception_type;
-                } else {
-                    metrics::counter!(DISTRIBUTED_FALLBACK_TOTAL, "reason" => "merge_error")
-                        .increment(1);
                 }
             }
         }
@@ -180,10 +171,7 @@ fn apply_results_to_states(
     Ok(())
 }
 
-async fn materialize_resolved_frames(
-    states: &mut [EventState],
-    ctx: &DistributedContext,
-) -> Result<(), UnhandledError> {
+fn materialize_resolved_frames(states: &mut [EventState]) -> Result<(), UnhandledError> {
     for state in states.iter_mut() {
         for exception_index in 0..state.event.exception_list.len() {
             let Some(Stacktrace::Raw { frames: raw_frames }) =
@@ -193,38 +181,23 @@ async fn materialize_resolved_frames(
             };
 
             let mut merged_frames = Vec::new();
-            let mut complete = true;
 
             for frame_index in 0..raw_frames.len() {
-                if let Some(mut frames) = state
+                let Some(mut frames) = state
                     .frame_overrides
                     .remove(&(exception_index, frame_index))
-                {
-                    merged_frames.append(&mut frames);
-                } else {
-                    complete = false;
-                    break;
-                }
+                else {
+                    return Err(UnhandledError::Other(format!(
+                        "missing resolved frames for exception {} frame {}",
+                        exception_index, frame_index
+                    )));
+                };
+                merged_frames.append(&mut frames);
             }
 
-            if complete {
-                state.event.exception_list[exception_index].stack =
-                    Some(Stacktrace::Resolved {
-                        frames: merged_frames,
-                    });
-                continue;
-            }
-
-            metrics::counter!(DISTRIBUTED_FALLBACK_TOTAL, "reason" => "merge_error").increment(1);
-            let unresolved = state.event.exception_list[exception_index].clone();
-            let resolved = FrameResolver::resolve_exception_frames(
-                state.event.team_id,
-                unresolved,
-                &state.event.debug_images,
-                ctx.resolution.clone(),
-            )
-            .await?;
-            state.event.exception_list[exception_index] = resolved;
+            state.event.exception_list[exception_index].stack = Some(Stacktrace::Resolved {
+                frames: merged_frames,
+            });
         }
     }
 

--- a/rust/cymbal/src/stages/resolution/exception.rs
+++ b/rust/cymbal/src/stages/resolution/exception.rs
@@ -2,7 +2,7 @@ use crate::{
     error::UnhandledError,
     frames::RawFrame,
     metric_consts::EXCEPTION_RESOLVER_OPERATOR,
-    stages::{pipeline::HandledError, resolution::ResolutionStage},
+    stages::{pipeline::HandledError, resolution::LocalResolutionStage},
     types::{
         batch::Batch,
         exception_properties::ExceptionProperties,
@@ -33,7 +33,7 @@ impl ExceptionResolver {
 }
 
 impl ValueOperator for ExceptionResolver {
-    type Context = ResolutionStage;
+    type Context = LocalResolutionStage;
     type Item = ExceptionProperties;
     type HandledError = HandledError;
     type UnhandledError = UnhandledError;
@@ -45,7 +45,7 @@ impl ValueOperator for ExceptionResolver {
     async fn execute_value(
         &self,
         mut evt: ExceptionProperties,
-        ctx: ResolutionStage,
+        ctx: LocalResolutionStage,
     ) -> OperatorResult<Self> {
         evt.exception_list = Batch::from(evt.exception_list.0)
             .apply_func(

--- a/rust/cymbal/src/stages/resolution/frame.rs
+++ b/rust/cymbal/src/stages/resolution/frame.rs
@@ -5,7 +5,7 @@ use crate::{
     frames::{Frame, RawFrame},
     langs::apple::AppleDebugImage,
     metric_consts::FRAME_RESOLVER_OPERATOR,
-    stages::{pipeline::HandledError, resolution::ResolutionStage},
+    stages::{pipeline::HandledError, resolution::LocalResolutionStage},
     types::{
         batch::Batch,
         exception_properties::ExceptionProperties,
@@ -22,7 +22,7 @@ impl FrameResolver {
         team_id: i32,
         list: ExceptionList,
         debug_images: Arc<Vec<AppleDebugImage>>,
-        ctx: ResolutionStage,
+        ctx: LocalResolutionStage,
     ) -> Result<ExceptionList, UnhandledError> {
         let res = Batch::from(list.0)
             .apply_func(
@@ -43,7 +43,7 @@ impl FrameResolver {
         team_id: i32,
         mut exc: Exception,
         debug_images: &[AppleDebugImage],
-        ctx: ResolutionStage,
+        ctx: LocalResolutionStage,
     ) -> Result<Exception, UnhandledError> {
         exc.stack = match exc.stack {
             Some(Stacktrace::Raw { frames }) => {
@@ -73,7 +73,7 @@ impl FrameResolver {
         team_id: i32,
         frame: &RawFrame,
         debug_images: &[AppleDebugImage],
-        ctx: ResolutionStage,
+        ctx: LocalResolutionStage,
     ) -> Result<Vec<Frame>, UnhandledError> {
         let _permit = ctx.acquire_symbol_resolution_permit().await?;
 
@@ -84,7 +84,7 @@ impl FrameResolver {
 }
 
 impl ValueOperator for FrameResolver {
-    type Context = ResolutionStage;
+    type Context = LocalResolutionStage;
     type Item = ExceptionProperties;
     type HandledError = HandledError;
     type UnhandledError = UnhandledError;
@@ -96,7 +96,7 @@ impl ValueOperator for FrameResolver {
     async fn execute_value(
         &self,
         mut evt: ExceptionProperties,
-        ctx: ResolutionStage,
+        ctx: LocalResolutionStage,
     ) -> OperatorResult<Self> {
         let debug_images = Arc::new(evt.debug_images.clone());
         evt.exception_list = FrameResolver::resolve_exception_list_frames(

--- a/rust/cymbal/src/stages/resolution/local.rs
+++ b/rust/cymbal/src/stages/resolution/local.rs
@@ -1,0 +1,33 @@
+use crate::{
+    metric_consts::RESOLUTION_STAGE,
+    stages::{
+        pipeline::ExceptionEventPipelineItem,
+        resolution::{
+            exception::ExceptionResolver, frame::FrameResolver, properties::PropertiesResolver,
+            LocalResolutionStage,
+        },
+    },
+    types::{
+        batch::Batch,
+        stage::{Stage, StageResult},
+    },
+};
+
+impl Stage for LocalResolutionStage {
+    type Input = ExceptionEventPipelineItem;
+    type Output = ExceptionEventPipelineItem;
+
+    fn name(&self) -> &'static str {
+        RESOLUTION_STAGE
+    }
+
+    async fn process(self, batch: Batch<Self::Input>) -> StageResult<Self> {
+        batch
+            .apply_operator(ExceptionResolver, self.clone())
+            .await?
+            .apply_operator(FrameResolver, self.clone())
+            .await?
+            .apply_operator(PropertiesResolver, self.clone())
+            .await
+    }
+}

--- a/rust/cymbal/src/stages/resolution/mod.rs
+++ b/rust/cymbal/src/stages/resolution/mod.rs
@@ -2,42 +2,36 @@ use std::sync::Arc;
 
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
+pub mod distributed;
 pub mod exception;
 pub mod frame;
+mod local;
 pub mod properties;
 pub mod symbol;
 
-use crate::{
-    app_context::AppContext,
-    error::UnhandledError,
-    metric_consts::RESOLUTION_STAGE,
-    stages::pipeline::ExceptionEventPipelineItem,
-    stages::resolution::{
-        exception::ExceptionResolver, frame::FrameResolver, properties::PropertiesResolver,
-        symbol::SymbolResolver,
-    },
-    types::{
-        batch::Batch,
-        stage::{Stage, StageResult},
-    },
-};
+use crate::{app_context::AppContext, error::UnhandledError};
+
+pub use distributed::DistributedResolutionStage;
+
+use symbol::SymbolResolver;
 
 #[derive(Clone)]
-pub struct ResolutionStage {
+pub struct LocalResolutionStage {
     pub symbol_resolver: Arc<dyn SymbolResolver>,
     pub symbol_resolution_limiter: Arc<Semaphore>,
 }
 
-impl From<&Arc<AppContext>> for ResolutionStage {
-    fn from(app_context: &Arc<AppContext>) -> Self {
+impl LocalResolutionStage {
+    pub fn from_parts(
+        symbol_resolver: Arc<dyn SymbolResolver>,
+        symbol_resolution_limiter: Arc<Semaphore>,
+    ) -> Self {
         Self {
-            symbol_resolver: app_context.as_ref().symbol_resolver.clone(),
-            symbol_resolution_limiter: app_context.as_ref().symbol_resolution_limiter.clone(),
+            symbol_resolver,
+            symbol_resolution_limiter,
         }
     }
-}
 
-impl ResolutionStage {
     pub async fn acquire_symbol_resolution_permit(
         &self,
     ) -> Result<OwnedSemaphorePermit, UnhandledError> {
@@ -49,21 +43,11 @@ impl ResolutionStage {
     }
 }
 
-impl Stage for ResolutionStage {
-    type Input = ExceptionEventPipelineItem;
-    type Output = ExceptionEventPipelineItem;
-
-    fn name(&self) -> &'static str {
-        RESOLUTION_STAGE
-    }
-
-    async fn process(self, batch: Batch<Self::Input>) -> StageResult<Self> {
-        batch
-            .apply_operator(ExceptionResolver, self.clone())
-            .await?
-            .apply_operator(FrameResolver, self.clone())
-            .await?
-            .apply_operator(PropertiesResolver, self.clone())
-            .await
+impl From<&Arc<AppContext>> for LocalResolutionStage {
+    fn from(app_context: &Arc<AppContext>) -> Self {
+        Self::from_parts(
+            app_context.as_ref().symbol_resolver.clone(),
+            app_context.as_ref().symbol_resolution_limiter.clone(),
+        )
     }
 }

--- a/rust/cymbal/src/stages/resolution/properties.rs
+++ b/rust/cymbal/src/stages/resolution/properties.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::UnhandledError,
     metric_consts::PROPERTIES_RESOLVER_OPERATOR,
-    stages::{pipeline::HandledError, resolution::ResolutionStage},
+    stages::{pipeline::HandledError, resolution::LocalResolutionStage},
     types::{
         exception_properties::ExceptionProperties,
         operator::{OperatorResult, ValueOperator},
@@ -13,7 +13,7 @@ pub struct PropertiesResolver;
 
 impl ValueOperator for PropertiesResolver {
     type Item = ExceptionProperties;
-    type Context = ResolutionStage;
+    type Context = LocalResolutionStage;
     type HandledError = HandledError;
     type UnhandledError = UnhandledError;
 
@@ -24,7 +24,7 @@ impl ValueOperator for PropertiesResolver {
     async fn execute_value(
         &self,
         mut event: ExceptionProperties,
-        _: ResolutionStage,
+        _: LocalResolutionStage,
     ) -> OperatorResult<Self> {
         // Implement property resolution logic here
         event.exception_functions = Some(event.exception_list.get_unique_functions());


### PR DESCRIPTION
## Problem

Cymbal pods each maintain their own symbol set caches (sourcemaps, dSYMs, proguard maps). When multiple pods resolve frames for the same app version, every pod fetches and caches the same symbols independently — wasting memory and increasing latency for cache misses.

## Changes

- **Distributed task routing** (`distributed/mod.rs`, `distributed/tasks.rs`): Routes resolution tasks to specific pods via consistent hashing (jump consistent hash + SipHash-1-3) on symbol set references and team ID. Each task type implements a `TaskExecutor` trait that co-locates routing metadata with execution logic.
- **Transport layer**: Pods communicate via an internal `/_internal/resolve-batch` HTTP endpoint. Remote calls are dispatched concurrently per destination pod with timeout, fallback to local on failure, and structured `RemoteError` types that preserve context for logging.
- **Resolution stages** (`stages/resolution/local.rs`, `stages/resolution/distributed.rs`): Two stage implementations — `LocalResolutionStage` (operator-based, existing behavior) and `DistributedResolutionStage` (task-based with routing). The pipeline selects based on `distributed_resolution_enabled` config flag.
- **Config**: New env vars `DISTRIBUTED_RESOLUTION_ENABLED`, `DISTRIBUTED_HEADLESS_HOST`, `DISTRIBUTED_REMOTE_TIMEOUT_MS` (default 60s), `POD_IP`.
- **Error handling**: `RemoteError` enum integrated into `UnhandledError` hierarchy. All failure paths emit structured tracing warnings with destination IP, error details, and task counts.
- **Apple frame helpers** (`langs/apple.rs`): `matching_debug_image` and `symbol_set_ref` methods for extracting routing refs from Apple frames.

## How did you test this code?

All 96 existing cymbal tests pass. New unit tests cover consistent hashing bucket range, routing decisions (no endpoints, no routing ref, remote without local IP), and stable key determinism.

This PR was authored by an LLM agent. Manual integration testing with a multi-pod deployment has not been performed.

## Publish to changelog?

no

## Docs update

No docs changes needed — this is an internal infrastructure change controlled by config flags.

## 🤖 LLM context

Co-authored by Claude Code (Opus 4.6). The session covered iterative design: starting from a initial implementation, then refactoring through several rounds to improve separation of concerns (transport vs stage orchestration), introduce a `TaskExecutor` trait, add proper error types, reduce duplication, and consolidate module structure.