### PR TITLE
feat(rbac): guest mode frontend (PR #3 of 3)

### DIFF
--- a/frontend/src/layout/navigation-3000/GuestMinimalLayout.tsx
+++ b/frontend/src/layout/navigation-3000/GuestMinimalLayout.tsx
@@ -1,0 +1,31 @@
+import { useValues } from 'kea'
+import React from 'react'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
+
+export function GuestMinimalLayout({ children }: { children: React.ReactNode }): JSX.Element {
+    const { user } = useValues(userLogic)
+
+    return (
+        <div className="flex flex-col h-screen">
+            <header className="flex items-center justify-between px-4 py-2 border-b bg-bg-light">
+                <div className="flex items-center gap-3">
+                    <img src="/static/posthog-icon.svg" alt="PostHog" className="h-6 w-6" />
+                    <span className="text-sm font-medium text-muted">Guest access</span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <LemonButton type="tertiary" size="small" to={urls.guest()}>
+                        Your shared content
+                    </LemonButton>
+                    <span className="text-sm text-muted">{user?.email}</span>
+                    <LemonButton type="tertiary" size="small" to="/logout">
+                        Log out
+                    </LemonButton>
+                </div>
+            </header>
+            <main className="flex-1 overflow-auto">{children}</main>
+        </div>
+    )
+}

--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -8,6 +8,7 @@ import { cn } from 'lib/utils/css-classes'
 import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { SceneConfig } from 'scenes/sceneTypes'
+import { userLogic } from 'scenes/userLogic'
 
 import { PanelLayout } from '~/layout/panel-layout/PanelLayout'
 import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
@@ -20,6 +21,7 @@ import { SceneLayout } from '../scenes/SceneLayout'
 import { sceneLayoutLogic } from '../scenes/sceneLayoutLogic'
 import { SceneTabs } from '../scenes/SceneTabs'
 import { MinimalNavigation } from './components/MinimalNavigation'
+import { GuestMinimalLayout } from './GuestMinimalLayout'
 import { navigation3000Logic } from './navigationLogic'
 import { SidePanel } from './sidepanel/SidePanel'
 import { sidePanelStateLogic } from './sidepanel/sidePanelStateLogic'
@@ -33,6 +35,7 @@ export function Navigation({
     sceneConfig: SceneConfig | null
 }): JSX.Element {
     useMountedLogic(maxGlobalLogic)
+    const { user } = useValues(userLogic)
     const { theme } = useValues(themeLogic)
     const { mobileLayout } = useValues(navigationLogic)
     const { mode } = useValues(navigation3000Logic)
@@ -73,6 +76,10 @@ export function Navigation({
             setMainContentRect(mainRef.current.getBoundingClientRect())
         }
     }, [mainRef, setMainContentRef, setMainContentRect])
+
+    if (user?.is_guest_in_current_project) {
+        return <GuestMinimalLayout>{children}</GuestMinimalLayout>
+    }
 
     if (mode !== 'full') {
         return (

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -312,6 +312,7 @@ export const FEATURE_FLAGS = {
     FLAG_EVALUATION_TAGS: 'flag-evaluation-tags', // owner: @dmarticus #team-feature-flags
     FLAGGED_FEATURE_INDICATOR: 'flagged-feature-indicator', // owner: @benjackwhite
     GROUP_PROFILE_EXPERIMENT: 'group-profile-experiment', // owner: @arthurdedeus #team-customer-analytics
+    GUEST_MODE: 'guest-mode', // owner: #team-platform-features, guest access control UI surface
     PRODUCT_ANALYTICS_HOME_TAB: 'product-analytics-home-tab', // owner: @anirudhpillai #team-product-analytics
     INTER_PROJECT_TRANSFERS: 'inter-project-transfers', // owner: @reecejones #team-platform-features
     LINKS: 'links', // owner: @marconlp #team-link (team doesn't exist for now, maybe will come back in the future)

--- a/frontend/src/lib/logic/apiStatusLogic.ts
+++ b/frontend/src/lib/logic/apiStatusLogic.ts
@@ -59,6 +59,13 @@ export const apiStatusLogic = kea<apiStatusLogicType>([
 
             try {
                 if (response?.status === 403) {
+                    // Guest users should never trigger fire-and-forget endpoints they can't access,
+                    // but if a future component regresses and does, we swallow the 403 handler here
+                    // rather than showing reauth/2FA modals. This is a safety net — the authoritative
+                    // fix is to add an `isGuest` early-return in the offending kea logic.
+                    if (userLogic.findMounted()?.values.user?.is_guest_in_current_project) {
+                        return
+                    }
                     const responseData = await response?.json()
                     if (responseData.code === 'sensitive_action_required_reauth') {
                         actions.setTimeSensitiveAuthenticationRequired(true)

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -135,4 +135,6 @@ export const appScenes: Record<Scene | string, () => any> = {
     [Scene.Wizard]: () => import('./wizard/Wizard'),
     [Scene.OrganizationDeactivated]: () => import('./organization/Deactivated'),
     [Scene.OrganizationPendingDeletion]: () => import('./organization/PendingDeletion'),
+    [Scene.GuestLanding]: () => import('./guest/GuestLandingScene'),
+    [Scene.GuestNotFound]: () => import('./guest/GuestNotFoundScene'),
 }

--- a/frontend/src/scenes/guest/GuestLandingScene.tsx
+++ b/frontend/src/scenes/guest/GuestLandingScene.tsx
@@ -1,0 +1,78 @@
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+import { useEffect } from 'react'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import type { SceneExport } from 'scenes/sceneTypes'
+
+import { GuestGrant } from '~/types'
+
+import { guestSceneLogic } from './guestSceneLogic'
+
+function grantUrl(grant: GuestGrant): string {
+    const { team_id, resource, resource_id } = grant
+    if (resource === 'dashboard') {
+        return `/project/${team_id}/dashboard/${resource_id}`
+    }
+    if (resource === 'insight') {
+        return `/project/${team_id}/insights/${resource_id}`
+    }
+    if (resource === 'notebook') {
+        return `/project/${team_id}/notebooks/${resource_id}`
+    }
+    return `/project/${team_id}`
+}
+
+function GrantCard({ grant }: { grant: GuestGrant }): JSX.Element {
+    return (
+        <LemonButton type="secondary" to={grantUrl(grant)} className="w-full justify-start capitalize">
+            {grant.resource} #{grant.resource_id}
+        </LemonButton>
+    )
+}
+
+export function GuestLandingScene(): JSX.Element {
+    const { grants, hasMultipleGrants, grantsByProject } = useValues(guestSceneLogic)
+    const { push } = useActions(router)
+
+    useEffect(() => {
+        if (grants.length === 1) {
+            push(grantUrl(grants[0]))
+        }
+    }, [grants, push])
+
+    if (grants.length === 0) {
+        return (
+            <div className="flex flex-col items-center justify-center h-full gap-4 p-8">
+                <h1 className="text-2xl font-bold">Your shared content</h1>
+                <p className="text-muted">No shared content is available to you at this time.</p>
+            </div>
+        )
+    }
+
+    if (!hasMultipleGrants) {
+        // Single grant — redirect in progress via useEffect
+        return <></>
+    }
+
+    return (
+        <div className="flex flex-col gap-6 p-8 max-w-2xl mx-auto">
+            <h1 className="text-2xl font-bold">Your shared content</h1>
+            {Object.entries(grantsByProject).map(([teamId, projectGrants]) => (
+                <div key={teamId} className="flex flex-col gap-2">
+                    <h2 className="text-sm font-semibold text-muted uppercase tracking-wide">Project {teamId}</h2>
+                    <div className="flex flex-col gap-2">
+                        {projectGrants.map((grant, i) => (
+                            <GrantCard key={i} grant={grant} />
+                        ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    )
+}
+
+export const scene: SceneExport = {
+    component: GuestLandingScene,
+    logic: guestSceneLogic,
+}

--- a/frontend/src/scenes/guest/GuestNotFoundScene.tsx
+++ b/frontend/src/scenes/guest/GuestNotFoundScene.tsx
@@ -1,0 +1,19 @@
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import type { SceneExport } from 'scenes/sceneTypes'
+import { urls } from 'scenes/urls'
+
+export function GuestNotFoundScene(): JSX.Element {
+    return (
+        <div className="flex flex-col items-center justify-center h-full gap-4 p-8">
+            <h1 className="text-2xl font-bold">This content isn't available to you</h1>
+            <p className="text-muted">You don't have permission to view this page.</p>
+            <LemonButton type="primary" to={urls.guest()}>
+                Back to your shared content
+            </LemonButton>
+        </div>
+    )
+}
+
+export const scene: SceneExport = {
+    component: GuestNotFoundScene,
+}

--- a/frontend/src/scenes/guest/__tests__/__snapshots__/guestSceneAllowlist.test.ts.snap
+++ b/frontend/src/scenes/guest/__tests__/__snapshots__/guestSceneAllowlist.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`guestSceneAllowlist contains the expected scenes 1`] = `
+[
+  "Dashboard",
+  "GuestLanding",
+  "GuestNotFound",
+  "Insight",
+  "Notebook",
+  "Settings",
+]
+`;

--- a/frontend/src/scenes/guest/__tests__/guestSceneAllowlist.test.ts
+++ b/frontend/src/scenes/guest/__tests__/guestSceneAllowlist.test.ts
@@ -1,0 +1,25 @@
+import { Scene } from 'scenes/sceneTypes'
+
+import { GUEST_ALLOWED_SCENES } from '../guestSceneAllowlist'
+
+describe('guestSceneAllowlist', () => {
+    it('contains the expected scenes', () => {
+        expect([...GUEST_ALLOWED_SCENES].sort()).toMatchSnapshot()
+    })
+
+    it.each([
+        [Scene.Dashboard, true],
+        [Scene.GuestLanding, true],
+        [Scene.GuestNotFound, true],
+        [Scene.Settings, true],
+    ] as const)('allows scene %s = %s', (scene, expected) => {
+        expect(GUEST_ALLOWED_SCENES.has(scene)).toBe(expected)
+    })
+
+    it.each([Scene.FeatureFlags, Scene.Experiments, Scene.Cohorts, Scene.DataWarehouseSource] as const)(
+        'blocks scene %s',
+        (scene) => {
+            expect(GUEST_ALLOWED_SCENES.has(scene)).toBe(false)
+        }
+    )
+})

--- a/frontend/src/scenes/guest/guestSceneAllowlist.ts
+++ b/frontend/src/scenes/guest/guestSceneAllowlist.ts
@@ -1,0 +1,10 @@
+import { Scene } from 'scenes/sceneTypes'
+
+export const GUEST_ALLOWED_SCENES: ReadonlySet<Scene> = new Set([
+    Scene.Dashboard,
+    Scene.Insight,
+    Scene.Notebook,
+    Scene.Settings,
+    Scene.GuestLanding,
+    Scene.GuestNotFound,
+])

--- a/frontend/src/scenes/guest/guestSceneLogic.ts
+++ b/frontend/src/scenes/guest/guestSceneLogic.ts
@@ -1,0 +1,31 @@
+import { connect, kea, path, selectors } from 'kea'
+
+import { GuestGrant } from '~/types'
+
+import { userLogic } from '../userLogic'
+import type { guestSceneLogicType } from './guestSceneLogicType'
+
+export const guestSceneLogic = kea<guestSceneLogicType>([
+    path(['scenes', 'guest', 'guestSceneLogic']),
+
+    connect(() => ({ values: [userLogic, ['user']] })),
+
+    selectors({
+        isGuest: [(s) => [s.user], (user): boolean => user?.is_guest_in_current_project ?? false],
+        grants: [(s) => [s.user], (user): GuestGrant[] => (user?.guest_grants as GuestGrant[]) ?? []],
+        hasMultipleGrants: [(s) => [s.grants], (grants): boolean => grants.length > 1],
+        grantsByProject: [
+            (s) => [s.grants],
+            (grants): Record<number, GuestGrant[]> => {
+                const byProject: Record<number, GuestGrant[]> = {}
+                for (const grant of grants) {
+                    if (!byProject[grant.team_id]) {
+                        byProject[grant.team_id] = []
+                    }
+                    byProject[grant.team_id].push(grant)
+                }
+                return byProject
+            },
+        ],
+    }),
+])

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -1136,7 +1136,7 @@ export const sceneLogic = kea<sceneLogicType>([
                 cache.lastTrackedSceneByTab[trackingKey] = { sceneId, sceneKey }
             }
         },
-        openScene: ({ tabId, sceneId, sceneKey, params, method }) => {
+        openScene: async ({ tabId, sceneId, sceneKey, params, method }) => {
             const sceneConfig = sceneConfigurations[sceneId] || {}
             const { user } = userLogic.values
             const { preflight } = preflightLogic.values
@@ -1165,6 +1165,15 @@ export const sceneLogic = kea<sceneLogicType>([
                         router.actions.replace(urls.default())
                     }
                     return
+                }
+
+                // Guest scene gate: restrict navigation to the guest allowlist
+                if (user.is_guest_in_current_project) {
+                    const { GUEST_ALLOWED_SCENES } = await import('scenes/guest/guestSceneAllowlist')
+                    if (!GUEST_ALLOWED_SCENES.has(sceneId)) {
+                        router.actions.push(urls.guest())
+                        return
+                    }
                 }
 
                 if (sceneId !== Scene.InviteSignup) {

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -195,6 +195,8 @@ export enum Scene {
     OrganizationDeactivated = 'OrganizationDeactivated',
     OrganizationPendingDeletion = 'OrganizationPendingDeletion',
     CustomerJourneyTemplates = 'CustomerJourneyTemplates',
+    GuestLanding = 'GuestLanding',
+    GuestNotFound = 'GuestNotFound',
 }
 
 export type SceneComponent<T> = (props: T) => JSX.Element | null
@@ -267,7 +269,14 @@ export interface SceneConfig {
      *
      * @default 'app'
      */
-    layout?: 'app' | 'app-raw' | 'app-container' | 'app-raw-no-header' | 'plain' | 'app-full-scene-height'
+    layout?:
+        | 'app'
+        | 'app-raw'
+        | 'app-container'
+        | 'app-raw-no-header'
+        | 'plain'
+        | 'app-full-scene-height'
+        | 'guest-minimal'
     /** Hides project notice (ProjectNotice.tsx). */
     hideProjectNotice?: boolean
     /** Personal account management (used e.g. by breadcrumbs) */

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -262,6 +262,14 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
     },
     [Scene.GroupsNew]: { projectBased: true, defaultDocsPath: '/docs/product-analytics/group-analytics' },
     [Scene.Groups]: { projectBased: true, name: 'Groups', defaultDocsPath: '/docs/product-analytics/group-analytics' },
+    [Scene.GuestLanding]: {
+        name: 'Your shared content',
+        layout: 'guest-minimal',
+    },
+    [Scene.GuestNotFound]: {
+        name: 'Not found',
+        layout: 'guest-minimal',
+    },
     [Scene.Heatmaps]: {
         projectBased: true,
         name: 'Heatmaps',
@@ -972,5 +980,6 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.hogFunctionNew(':templateId')]: [Scene.HogFunction, 'hogFunctionNew'],
     [urls.organizationDeactivated()]: [Scene.OrganizationDeactivated, 'organizationDeactivated'],
     [urls.organizationPendingDeletion()]: [Scene.OrganizationPendingDeletion, 'organizationPendingDeletion'],
+    [urls.guest()]: [Scene.GuestLanding, 'guest-landing'],
     ...productRoutes,
 }

--- a/frontend/src/scenes/settings/organization/GuestResourcePicker.tsx
+++ b/frontend/src/scenes/settings/organization/GuestResourcePicker.tsx
@@ -39,8 +39,9 @@ function useResourceOptions(resourceType: ResourceType): { options: LemonInputSe
                     if (!cancelled) {
                         setOptions(
                             (response.results ?? []).map((i: any) => ({
-                                key: String(i.id),
-                                label: i.name || i.derived_name || `Insight ${i.id}`,
+                                // Insights are addressed by short_id in URLs; store that as the grant identifier
+                                key: String(i.short_id || i.id),
+                                label: i.name || i.derived_name || `Insight ${i.short_id || i.id}`,
                             }))
                         )
                     }
@@ -95,7 +96,7 @@ export function GuestResourcePicker(): JSX.Element {
         const grant: GuestGrant = {
             team_id: currentTeamId,
             resource: resourceType,
-            resource_id: Number(key),
+            resource_id: key,
             label: option.label,
         }
         addGuestGrant(grant)

--- a/frontend/src/scenes/settings/organization/GuestResourcePicker.tsx
+++ b/frontend/src/scenes/settings/organization/GuestResourcePicker.tsx
@@ -1,0 +1,164 @@
+import { useActions, useValues } from 'kea'
+import { useEffect, useState } from 'react'
+
+import { IconTrash } from '@posthog/icons'
+import { LemonSelect } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonInputSelect, LemonInputSelectOption } from 'lib/lemon-ui/LemonInputSelect'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { GuestGrant, inviteLogic } from './inviteLogic'
+
+type ResourceType = 'dashboard' | 'insight' | 'notebook'
+
+function useResourceOptions(resourceType: ResourceType): { options: LemonInputSelectOption[]; loading: boolean } {
+    const [options, setOptions] = useState<LemonInputSelectOption[]>([])
+    const [loading, setLoading] = useState(false)
+
+    useEffect(() => {
+        let cancelled = false
+        setLoading(true)
+        setOptions([])
+
+        const fetchResources = async (): Promise<void> => {
+            try {
+                if (resourceType === 'dashboard') {
+                    const response = await api.get('api/projects/@current/dashboards/?limit=100')
+                    if (!cancelled) {
+                        setOptions(
+                            (response.results ?? []).map((d: any) => ({
+                                key: String(d.id),
+                                label: d.name || `Dashboard ${d.id}`,
+                            }))
+                        )
+                    }
+                } else if (resourceType === 'insight') {
+                    const response = await api.get('api/projects/@current/insights/?limit=100')
+                    if (!cancelled) {
+                        setOptions(
+                            (response.results ?? []).map((i: any) => ({
+                                key: String(i.id),
+                                label: i.name || i.derived_name || `Insight ${i.id}`,
+                            }))
+                        )
+                    }
+                } else if (resourceType === 'notebook') {
+                    const response = await api.get('api/projects/@current/notebooks/?limit=100')
+                    if (!cancelled) {
+                        setOptions(
+                            (response.results ?? []).map((n: any) => ({
+                                key: String(n.short_id),
+                                label: n.title || `Notebook ${n.short_id}`,
+                            }))
+                        )
+                    }
+                }
+            } catch {
+                // leave options empty on error
+            } finally {
+                if (!cancelled) {
+                    setLoading(false)
+                }
+            }
+        }
+
+        void fetchResources()
+        return () => {
+            cancelled = true
+        }
+    }, [resourceType])
+
+    return { options, loading }
+}
+
+export function GuestResourcePicker(): JSX.Element {
+    const { guestGrants } = useValues(inviteLogic)
+    const { addGuestGrant, removeGuestGrant } = useActions(inviteLogic)
+    const { currentTeamId } = useValues(teamLogic)
+
+    const [resourceType, setResourceType] = useState<ResourceType>('dashboard')
+    const [selectedKey, setSelectedKey] = useState<string[]>([])
+
+    const { options, loading } = useResourceOptions(resourceType)
+
+    const handleAdd = (): void => {
+        if (!selectedKey[0] || !currentTeamId) {
+            return
+        }
+        const key = selectedKey[0]
+        const option = options.find((o) => o.key === key)
+        if (!option) {
+            return
+        }
+        const grant: GuestGrant = {
+            team_id: currentTeamId,
+            resource: resourceType,
+            resource_id: Number(key),
+            label: option.label,
+        }
+        addGuestGrant(grant)
+        setSelectedKey([])
+    }
+
+    const resourceOptions: { value: ResourceType; label: string }[] = [
+        { value: 'dashboard', label: 'Dashboard' },
+        { value: 'insight', label: 'Insight' },
+        { value: 'notebook', label: 'Notebook' },
+    ]
+
+    return (
+        <div className="space-y-3">
+            <div className="text-sm font-medium">Grant access to specific resources</div>
+            <div className="flex gap-2 items-center">
+                <LemonSelect
+                    options={resourceOptions}
+                    value={resourceType}
+                    onChange={(v) => {
+                        if (v) {
+                            setResourceType(v)
+                            setSelectedKey([])
+                        }
+                    }}
+                    className="shrink-0"
+                />
+                <div className="flex-1">
+                    <LemonInputSelect
+                        mode="single"
+                        placeholder={loading ? 'Loading…' : `Search ${resourceType}s…`}
+                        loading={loading}
+                        options={options}
+                        value={selectedKey}
+                        onChange={setSelectedKey}
+                    />
+                </div>
+                <LemonButton
+                    type="primary"
+                    size="small"
+                    onClick={handleAdd}
+                    disabledReason={!selectedKey[0] ? 'Select a resource first' : undefined}
+                >
+                    Add
+                </LemonButton>
+            </div>
+
+            {guestGrants.length > 0 && (
+                <div className="space-y-1">
+                    {guestGrants.map((grant: GuestGrant, i: number) => (
+                        <div key={i} className="flex items-center gap-2 p-2 bg-bg-light rounded border">
+                            <span className="text-xs text-muted capitalize">{grant.resource}</span>
+                            <span className="flex-1 text-sm">{grant.label}</span>
+                            <LemonButton
+                                size="small"
+                                icon={<IconTrash />}
+                                status="danger"
+                                onClick={() => removeGuestGrant(i)}
+                            />
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/settings/organization/GuestsTab.tsx
+++ b/frontend/src/scenes/settings/organization/GuestsTab.tsx
@@ -1,0 +1,123 @@
+import { useActions, useValues } from 'kea'
+import { useState } from 'react'
+
+import { LemonBanner } from '@posthog/lemon-ui'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonModal } from 'lib/lemon-ui/LemonModal'
+import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
+import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
+import { fullName } from 'lib/utils'
+
+import { OrganizationMemberType } from '~/types'
+
+import { guestsTabLogic } from './guestsTabLogic'
+
+function PromoteGuestModal({
+    member,
+    onClose,
+    onConfirm,
+}: {
+    member: OrganizationMemberType
+    onClose: () => void
+    onConfirm: () => void
+}): JSX.Element {
+    return (
+        <LemonModal
+            isOpen
+            onClose={onClose}
+            title={`Promote ${fullName(member.user)} to member?`}
+            footer={
+                <>
+                    <LemonButton type="secondary" onClick={onClose}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton type="primary" status="danger" onClick={onConfirm}>
+                        Promote to member
+                    </LemonButton>
+                </>
+            }
+        >
+            <LemonBanner type="warning">
+                This will remove this user's guest status and delete all resource grants. You'll need to set up regular
+                access control afterward. This cannot be undone.
+            </LemonBanner>
+        </LemonModal>
+    )
+}
+
+export function GuestsTab(): JSX.Element {
+    const { guests, guestsLoading } = useValues(guestsTabLogic)
+    const { loadGuests, promoteGuest } = useActions(guestsTabLogic)
+
+    const [memberToPromote, setMemberToPromote] = useState<OrganizationMemberType | null>(null)
+
+    useOnMountEffect(loadGuests)
+
+    const columns: LemonTableColumns<OrganizationMemberType> = [
+        {
+            key: 'user_profile_picture',
+            render: (_, member) => <ProfilePicture user={member.user} />,
+            width: 32,
+        },
+        {
+            title: 'Name',
+            key: 'user_name',
+            render: (_, member) => <span className="ph-no-capture">{fullName(member.user)}</span>,
+            sorter: (a, b) => fullName(a.user).localeCompare(fullName(b.user)),
+        },
+        {
+            title: 'Email',
+            key: 'user_email',
+            render: (_, member) => <span className="ph-no-capture">{member.user.email}</span>,
+            sorter: (a, b) => a.user.email.localeCompare(b.user.email),
+        },
+        {
+            title: 'Joined',
+            dataIndex: 'joined_at',
+            key: 'joined_at',
+            render: (joinedAt) => (
+                <div className="whitespace-nowrap">
+                    <TZLabel time={joinedAt as string} />
+                </div>
+            ),
+            sorter: (a, b) => a.joined_at.localeCompare(b.joined_at),
+        },
+        {
+            key: 'actions',
+            width: 0,
+            render: (_, member) => (
+                <LemonButton type="secondary" size="small" onClick={() => setMemberToPromote(member)}>
+                    Promote to member
+                </LemonButton>
+            ),
+        },
+    ]
+
+    return (
+        <>
+            <LemonTable
+                dataSource={guests}
+                columns={columns}
+                rowKey="id"
+                loading={guestsLoading}
+                data-attr="org-guests-table"
+                emptyState="No guests found"
+                pagination={{ pageSize: 50 }}
+            />
+
+            {memberToPromote && (
+                <PromoteGuestModal
+                    member={memberToPromote}
+                    onClose={() => setMemberToPromote(null)}
+                    onConfirm={() => {
+                        promoteGuest(memberToPromote.user.uuid)
+                        setMemberToPromote(null)
+                    }}
+                />
+            )}
+        </>
+    )
+}

--- a/frontend/src/scenes/settings/organization/InviteModal.tsx
+++ b/frontend/src/scenes/settings/organization/InviteModal.tsx
@@ -7,7 +7,7 @@ import { LemonCheckbox, LemonInput, LemonSelect, LemonTextArea, Link, Tooltip } 
 
 import { useRestrictedArea } from 'lib/components/RestrictedArea'
 import { RestrictionScope } from 'lib/components/RestrictedArea'
-import { FEATURE_FLAGS, OrganizationMembershipLevel } from 'lib/constants'
+import { OrganizationMembershipLevel } from 'lib/constants'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -317,7 +317,7 @@ export function InviteTeamMatesComponent({
     const { appendInviteRow, updateMessage, setIsInviteConfirmed, setIsGuestInvite, setBypassSsoEnforcement } =
         useActions(inviteLogic)
 
-    const guestModeEnabled = useFeatureFlag(FEATURE_FLAGS.GUEST_MODE)
+    const guestModeEnabled = useFeatureFlag('GUEST_MODE')
 
     const areInvitesCreatable = invitesToSend.length + 1 < MAX_INVITES_AT_ONCE && !isGuestInvite
     const areInvitesDeletable = invitesToSend.length > 1

--- a/frontend/src/scenes/settings/organization/InviteModal.tsx
+++ b/frontend/src/scenes/settings/organization/InviteModal.tsx
@@ -3,11 +3,12 @@ import './InviteModal.scss'
 import { useActions, useValues } from 'kea'
 
 import { IconInfo, IconPlus, IconTrash } from '@posthog/icons'
-import { LemonInput, LemonSelect, LemonTextArea, Link, Tooltip } from '@posthog/lemon-ui'
+import { LemonCheckbox, LemonInput, LemonSelect, LemonTextArea, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { useRestrictedArea } from 'lib/components/RestrictedArea'
 import { RestrictionScope } from 'lib/components/RestrictedArea'
-import { OrganizationMembershipLevel } from 'lib/constants'
+import { FEATURE_FLAGS, OrganizationMembershipLevel } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
@@ -19,6 +20,7 @@ import { userLogic } from 'scenes/userLogic'
 
 import { AccessControlLevel, AvailableFeature } from '~/types'
 
+import { GuestResourcePicker } from './GuestResourcePicker'
 import { inviteLogic } from './inviteLogic'
 
 /** Shuffled placeholder names */
@@ -193,10 +195,12 @@ export function InviteRow({
     index,
     isDeletable,
     hideProjectAccessSelector = false,
+    hideOrgLevelSelector = false,
 }: {
     index: number
     isDeletable: boolean
     hideProjectAccessSelector?: boolean
+    hideOrgLevelSelector?: boolean
 }): JSX.Element {
     const name = PLACEHOLDER_NAMES[index % PLACEHOLDER_NAMES.length]
 
@@ -261,7 +265,7 @@ export function InviteRow({
                         />
                     </div>
                 )}
-                {allowedLevelsOptions.length > 1 && (
+                {allowedLevelsOptions.length > 1 && !hideOrgLevelSelector && (
                     <div className="flex-1 flex gap-1 items-center justify-between">
                         <LemonSelect
                             className="bg-bg-light"
@@ -309,13 +313,19 @@ export function InviteTeamMatesComponent({
     hideProjectAccessSelector?: boolean
 }): JSX.Element {
     const { preflight } = useValues(preflightLogic)
-    const { invitesToSend, inviteContainsOwnerLevel } = useValues(inviteLogic)
-    const { appendInviteRow, updateMessage, setIsInviteConfirmed } = useActions(inviteLogic)
+    const { invitesToSend, inviteContainsOwnerLevel, isGuestInvite, bypassSsoEnforcement } = useValues(inviteLogic)
+    const { appendInviteRow, updateMessage, setIsInviteConfirmed, setIsGuestInvite, setBypassSsoEnforcement } =
+        useActions(inviteLogic)
 
-    const areInvitesCreatable = invitesToSend.length + 1 < MAX_INVITES_AT_ONCE
+    const guestModeEnabled = useFeatureFlag(FEATURE_FLAGS.GUEST_MODE)
+
+    const areInvitesCreatable = invitesToSend.length + 1 < MAX_INVITES_AT_ONCE && !isGuestInvite
     const areInvitesDeletable = invitesToSend.length > 1
+    const hasMultipleInvites = invitesToSend.length > 1
 
     const { currentOrganization } = useValues(organizationLogic)
+    const { hasAvailableFeature } = useValues(userLogic)
+    const hasAdvancedPermissions = hasAvailableFeature(AvailableFeature.ADVANCED_PERMISSIONS)
 
     const myMembershipLevel = currentOrganization ? currentOrganization.membership_level : null
 
@@ -327,6 +337,8 @@ export function InviteTeamMatesComponent({
         value: level,
         label: OrganizationMembershipLevel[level],
     }))
+
+    const orgHasSsoEnforced = !!(currentOrganization as any)?.sso_enforcement
 
     return (
         <>
@@ -340,14 +352,15 @@ export function InviteTeamMatesComponent({
                 <div className="flex gap-2">
                     <b className="flex-2">Email address</b>
                     {preflight?.email_service_available && <b className="flex-1">Name (optional)</b>}
-                    {allowedLevelsOptions.length > 1 && <b className="flex-1">Organization level</b>}
+                    {allowedLevelsOptions.length > 1 && !isGuestInvite && <b className="flex-1">Organization level</b>}
                     {!preflight?.email_service_available && <b className="flex-1" />}
                     {areInvitesDeletable && <b className="w-12" />}
                 </div>
 
                 {invitesToSend.map((_, index) => (
                     <InviteRow
-                        hideProjectAccessSelector={hideProjectAccessSelector}
+                        hideProjectAccessSelector={hideProjectAccessSelector || isGuestInvite}
+                        hideOrgLevelSelector={isGuestInvite}
                         index={index}
                         key={index.toString()}
                         isDeletable={areInvitesDeletable}
@@ -362,7 +375,50 @@ export function InviteTeamMatesComponent({
                     )}
                 </div>
             </div>
-            {preflight?.email_service_available && (
+
+            {guestModeEnabled && hasAdvancedPermissions && (
+                <div className="mt-4 p-3 border rounded-md space-y-3">
+                    <div className="flex items-center gap-2">
+                        <LemonCheckbox
+                            checked={isGuestInvite}
+                            onChange={setIsGuestInvite}
+                            disabled={hasMultipleInvites}
+                            label="Invite as guest"
+                        />
+                        <Tooltip
+                            title={
+                                hasMultipleInvites
+                                    ? 'Guest invites are one at a time. Remove extra rows to enable.'
+                                    : "Guest users are external collaborators with read-only access to specific dashboards, insights, or notebooks you select. They don't appear in member pickers, filters, or @ mentions."
+                            }
+                        >
+                            <IconInfo className="text-muted-alt" />
+                        </Tooltip>
+                    </div>
+                    {isGuestInvite && (
+                        <>
+                            <GuestResourcePicker />
+                            {orgHasSsoEnforced && (
+                                <div className="space-y-2">
+                                    <LemonCheckbox
+                                        checked={bypassSsoEnforcement}
+                                        onChange={setBypassSsoEnforcement}
+                                        label="Bypass SSO enforcement for this guest"
+                                    />
+                                    {bypassSsoEnforcement && (
+                                        <LemonBanner type="warning">
+                                            I understand that enabling this lets this external collaborator access our
+                                            shared resources using email and password, bypassing our SSO provider.
+                                        </LemonBanner>
+                                    )}
+                                </div>
+                            )}
+                        </>
+                    )}
+                </div>
+            )}
+
+            {preflight?.email_service_available && !isGuestInvite && (
                 <div className="mt-4">
                     <div className="mb-2">
                         <b>Message (optional)</b>
@@ -375,7 +431,7 @@ export function InviteTeamMatesComponent({
                 </div>
             )}
 
-            {inviteContainsOwnerLevel && (
+            {inviteContainsOwnerLevel && !isGuestInvite && (
                 <div className="mt-4">
                     <b>Confirm owner-level invites</b>
 

--- a/frontend/src/scenes/settings/organization/InviteModal.tsx
+++ b/frontend/src/scenes/settings/organization/InviteModal.tsx
@@ -325,7 +325,7 @@ export function InviteTeamMatesComponent({
 
     const { currentOrganization } = useValues(organizationLogic)
     const { hasAvailableFeature } = useValues(userLogic)
-    const hasAdvancedPermissions = hasAvailableFeature(AvailableFeature.ADVANCED_PERMISSIONS)
+    const hasAccessControl = hasAvailableFeature(AvailableFeature.ACCESS_CONTROL)
 
     const myMembershipLevel = currentOrganization ? currentOrganization.membership_level : null
 
@@ -376,7 +376,7 @@ export function InviteTeamMatesComponent({
                 </div>
             </div>
 
-            {guestModeEnabled && hasAdvancedPermissions && (
+            {guestModeEnabled && hasAccessControl && (
                 <div className="mt-4 p-3 border rounded-md space-y-3">
                     <div className="flex items-center gap-2">
                         <LemonCheckbox

--- a/frontend/src/scenes/settings/organization/Members.tsx
+++ b/frontend/src/scenes/settings/organization/Members.tsx
@@ -1,13 +1,15 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
+import { useState } from 'react'
 
 import { IconInfo } from '@posthog/icons'
-import { LemonBanner, LemonInput, LemonSwitch } from '@posthog/lemon-ui'
+import { LemonBanner, LemonInput, LemonSwitch, LemonTabs } from '@posthog/lemon-ui'
 
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 import { useRestrictedArea } from 'lib/components/RestrictedArea'
 import { TZLabel } from 'lib/components/TZLabel'
 import { FEATURE_FLAGS, OrganizationMembershipLevel } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
@@ -30,6 +32,8 @@ import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { userLogic } from 'scenes/userLogic'
 
 import { AvailableFeature, OrganizationMemberType } from '~/types'
+
+import { GuestsTab } from './GuestsTab'
 
 function RemoveMemberModal({ member }: { member: OrganizationMemberType }): JSX.Element {
     const { user } = useValues(userLogic)
@@ -184,7 +188,7 @@ function ActionsComponent(_: any, member: OrganizationMemberType): JSX.Element |
     )
 }
 
-export function Members(): JSX.Element | null {
+function MembersContent(): JSX.Element | null {
     const { filteredMembers, membersLoading, search } = useValues(membersLogic)
     const { downloadMembersListDisabledReason } = useValues(membersExportLogic)
     const { currentOrganization } = useValues(organizationLogic)
@@ -416,5 +420,25 @@ export function Members(): JSX.Element | null {
                 </>
             )}
         </>
+    )
+}
+
+export function Members(): JSX.Element {
+    const guestModeEnabled = useFeatureFlag(FEATURE_FLAGS.GUEST_MODE)
+    const [activeTab, setActiveTab] = useState<'members' | 'guests'>('members')
+
+    if (!guestModeEnabled) {
+        return <MembersContent />
+    }
+
+    return (
+        <LemonTabs
+            activeKey={activeTab}
+            onChange={setActiveTab}
+            tabs={[
+                { key: 'members', label: 'Members', content: <MembersContent /> },
+                { key: 'guests', label: 'Guests', content: <GuestsTab /> },
+            ]}
+        />
     )
 }

--- a/frontend/src/scenes/settings/organization/Members.tsx
+++ b/frontend/src/scenes/settings/organization/Members.tsx
@@ -424,7 +424,7 @@ function MembersContent(): JSX.Element | null {
 }
 
 export function Members(): JSX.Element {
-    const guestModeEnabled = useFeatureFlag(FEATURE_FLAGS.GUEST_MODE)
+    const guestModeEnabled = useFeatureFlag('GUEST_MODE')
     const [activeTab, setActiveTab] = useState<'members' | 'guests'>('members')
 
     if (!guestModeEnabled) {

--- a/frontend/src/scenes/settings/organization/guestsTabLogic.ts
+++ b/frontend/src/scenes/settings/organization/guestsTabLogic.ts
@@ -1,0 +1,49 @@
+import { actions, kea, listeners, path } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api, { PaginatedResponse } from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { organizationLogic } from 'scenes/organizationLogic'
+
+import { OrganizationMemberType } from '~/types'
+
+import type { guestsTabLogicType } from './guestsTabLogicType'
+
+export const guestsTabLogic = kea<guestsTabLogicType>([
+    path(['scenes', 'organization', 'Settings', 'guestsTabLogic']),
+    actions({
+        promoteGuest: (userUuid: string) => ({ userUuid }),
+    }),
+    loaders(() => ({
+        guests: [
+            [] as OrganizationMemberType[],
+            {
+                loadGuests: async () => {
+                    const orgId = organizationLogic.values.currentOrganizationId
+                    if (!orgId) {
+                        return []
+                    }
+                    const response = await api.get<PaginatedResponse<OrganizationMemberType>>(
+                        `api/organizations/${orgId}/members/?is_guest=true`
+                    )
+                    return response.results
+                },
+            },
+        ],
+    })),
+    listeners(({ actions }) => ({
+        promoteGuest: async ({ userUuid }) => {
+            const orgId = organizationLogic.values.currentOrganizationId
+            if (!orgId) {
+                return
+            }
+            try {
+                await api.create(`api/organizations/${orgId}/members/${userUuid}/promote_to_member/`, {})
+                lemonToast.success('Guest promoted to member')
+                actions.loadGuests()
+            } catch {
+                lemonToast.error('Failed to promote guest to member')
+            }
+        },
+    })),
+])

--- a/frontend/src/scenes/settings/organization/inviteLogic.ts
+++ b/frontend/src/scenes/settings/organization/inviteLogic.ts
@@ -16,7 +16,7 @@ import type { inviteLogicType } from './inviteLogicType'
 export interface GuestGrant {
     team_id: number
     resource: string
-    resource_id: number
+    resource_id: string
     label: string
 }
 

--- a/frontend/src/scenes/settings/organization/inviteLogic.ts
+++ b/frontend/src/scenes/settings/organization/inviteLogic.ts
@@ -13,6 +13,13 @@ import { AccessControlLevel, OrganizationInviteType } from '~/types'
 
 import type { inviteLogicType } from './inviteLogicType'
 
+export interface GuestGrant {
+    team_id: number
+    resource: string
+    resource_id: number
+    label: string
+}
+
 /** State of a single invite row (with input data) in bulk invite creation. */
 export interface InviteRowState {
     target_email: string
@@ -52,6 +59,11 @@ export const inviteLogic = kea<inviteLogicType>([
             level,
         }),
         removeProjectAccess: (inviteIndex: number, projectId: number) => ({ inviteIndex, projectId }),
+        setIsGuestInvite: (isGuest: boolean) => ({ isGuest }),
+        addGuestGrant: (grant: GuestGrant) => ({ grant }),
+        removeGuestGrant: (index: number) => ({ index }),
+        resetGuestState: true,
+        setBypassSsoEnforcement: (bypass: boolean) => ({ bypass }),
     }),
     loaders(({ values }) => ({
         invitedTeamMembersInternal: [
@@ -60,6 +72,28 @@ export const inviteLogic = kea<inviteLogicType>([
                 inviteTeamMembers: async () => {
                     if (!values.canSubmit) {
                         return []
+                    }
+
+                    if (values.isGuestInvite) {
+                        const firstInvite = values.invitesToSend.find((invite) => invite.target_email)
+                        if (!firstInvite) {
+                            return []
+                        }
+                        const guestPayload = {
+                            target_email: firstInvite.target_email,
+                            first_name: firstInvite.first_name,
+                            is_guest: true,
+                            bypass_sso_enforcement: values.bypassSsoEnforcement,
+                            grants: values.guestGrants.map((g) => ({
+                                team_id: g.team_id,
+                                resource: g.resource,
+                                resource_id: g.resource_id,
+                            })),
+                        }
+                        return await api.create<OrganizationInviteType[]>(
+                            `api/organizations/${organizationLogic.values.currentOrganizationId}/invites/bulk/`,
+                            [guestPayload]
+                        )
                     }
 
                     const payload: Pick<
@@ -189,6 +223,31 @@ export const inviteLogic = kea<inviteLogicType>([
                 setIsInviteConfirmed: (_, { inviteConfirmed }) => inviteConfirmed,
             },
         ],
+        isGuestInvite: [
+            false,
+            {
+                setIsGuestInvite: (_, { isGuest }) => isGuest,
+                resetGuestState: () => false,
+                inviteTeamMembersSuccess: () => false,
+            },
+        ],
+        guestGrants: [
+            [] as GuestGrant[],
+            {
+                addGuestGrant: (state, { grant }) => [...state, grant],
+                removeGuestGrant: (state, { index }) => state.filter((_, i) => i !== index),
+                resetGuestState: () => [],
+                inviteTeamMembersSuccess: () => [],
+            },
+        ],
+        bypassSsoEnforcement: [
+            false,
+            {
+                setBypassSsoEnforcement: (_, { bypass }) => bypass,
+                resetGuestState: () => false,
+                inviteTeamMembersSuccess: () => false,
+            },
+        ],
     })),
     selectors({
         inviteContainsOwnerLevel: [
@@ -230,6 +289,7 @@ export const inviteLogic = kea<inviteLogicType>([
 
             organizationLogic.actions.loadCurrentOrganization()
             actions.loadInvites()
+            actions.resetGuestState()
 
             if (values.preflight?.email_service_available) {
                 actions.hideInviteModal()

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -27,6 +27,7 @@ export const urls = {
     ...productUrls,
     absolute: (path = ''): string => window.location.origin + path,
     default: (): string => '/',
+    guest: (): string => '/guest',
     project: (id: string | number, path = ''): string => `/project/${id}` + path,
     currentProject: (path = ''): string => urls.project(getCurrentTeamId(), path),
     newTab: () => '/search',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -318,6 +318,12 @@ export interface SceneDashboardChoice {
 export type UserTheme = 'light' | 'dark' | 'system'
 export type UserShortcutPosition = 'above' | 'below' | 'hidden'
 
+export interface GuestGrant {
+    team_id: number
+    resource: string
+    resource_id: string
+}
+
 /** Full User model. */
 export interface UserType extends UserBaseType {
     date_joined: string
@@ -350,6 +356,8 @@ export interface UserType extends UserBaseType {
     allow_sidebar_suggestions?: boolean
     role_at_organization?: UserRole | null
     passkeys_enabled_for_2fa?: boolean
+    is_guest_in_current_project?: boolean
+    guest_grants?: GuestGrant[]
 }
 
 export type HedgehogColorOptions =


### PR DESCRIPTION
> **Stacked on #55019** — rebase and retarget to `master` after PR #2 merges.

## Problem

PRs #1 and #2 shipped the data model and backend enforcement dark. This PR adds the frontend surface so guest users actually see a working, restricted UI, and admins can invite guests and manage their grants.

## Changes

- Register `guest-mode` feature flag and `guest-minimal` layout type
- Add `GuestLandingScene` (grant cards, auto-redirect for single grant, grouped by project) and `GuestNotFoundScene` (friendly "not available" page)
- Scene allowlist + `sceneLogic` gate — guests navigating to non-allowed scenes redirect to landing
- `GuestMinimalLayout` — stripped header (logo, "Guest access" label, email, logout), no sidebar/search/notifications; `Navigation` coerces to this layout for guest users
- Suppress 403 handling in `apiStatusLogic` for guests (safety net against stray loader toasts)
- Invite modal: "Invite as guest" checkbox (disabled when multiple rows), searchable resource picker (`GuestResourcePicker`) for dashboards/insights/notebooks, SSO bypass toggle with warning banner
- Members page: "Guests" tab via `LemonTabs` (gated on feature flag) with `LemonTable` listing guests and "Promote to member" button with confirmation modal
- Jest tests for the scene allowlist (9 tests: snapshot + parameterized allow/block assertions)

## How did you test this code?

- 9 Jest tests for the scene allowlist (snapshot + parameterized)
- TypeScript check clean (kea-typegen ran for new logic files)
- Format clean
- Visual verification requires a running dev server with the `guest-mode` flag enabled and a guest user created via PR #2's API

## Publish to changelog?

no