### PR TITLE
fix(ci): bump hogql-parser pin to 1.3.39

### DIFF
--- a/common/hogql_parser/package.json
+++ b/common/hogql_parser/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/hogql-parser",
-    "version": "1.3.39",
+    "version": "1.3.40",
     "description": "WebAssembly HogQL Parser - Parse HogQL queries in JavaScript/TypeScript",
     "keywords": [
         "antlr4",

--- a/common/hogql_parser/setup.py
+++ b/common/hogql_parser/setup.py
@@ -36,7 +36,7 @@ module = Extension(
 
 setup(
     name="hogql_parser",
-    version="1.3.39",
+    version="1.3.40",
     url="https://github.com/PostHog/posthog/tree/master/common/hogql_parser",
     description="HogQL parser for internal PostHog use",
     author="PostHog Inc.",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,7 +65,7 @@
         "@posthog/docs-onboarding": "workspace:*",
         "@posthog/esbuilder": "workspace:*",
         "@posthog/hedgehog-mode": "^0.0.48",
-        "@posthog/hogql-parser": "1.3.38",
+        "@posthog/hogql-parser": "1.3.40",
         "@posthog/hogvm": "workspace:*",
         "@posthog/icons": "^0.36.6",
         "@posthog/mosaic": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,7 +275,7 @@ importers:
         version: 3.12.1
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.8.3))
+        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3))
       oxfmt:
         specifier: 'catalog:'
         version: 0.35.0
@@ -464,7 +464,7 @@ importers:
         version: 7.6.4(@babel/core@7.26.0)(@swc/core@1.15.18)(encoding@0.1.13)(esbuild@0.18.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.41.0)(typescript@5.8.3)(webpack-cli@5.1.4)(webpack-hot-middleware@2.25.4)
       '@storybook/test-runner':
         specifier: ^0.16.0
-        version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3))
+        version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)
       '@storybook/theming':
         specifier: ^7.6.4
         version: 7.6.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -597,8 +597,8 @@ importers:
         specifier: ^0.0.48
         version: 0.0.48(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/hogql-parser':
-        specifier: 1.3.38
-        version: 1.3.38
+        specifier: 1.3.40
+        version: 1.3.40
       '@posthog/hogvm':
         specifier: workspace:*
         version: link:../common/hogvm/typescript
@@ -1310,7 +1310,7 @@ importers:
         version: 29.7.0
       jest-image-snapshot:
         specifier: ^6.1.0
-        version: 6.4.0(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3)))
+        version: 6.4.0(jest@29.7.0(@types/node@22.18.8))
       kea-typegen:
         specifier: 3.6.2-leakfix.5
         version: 3.6.2-leakfix.5(typescript@5.8.3)
@@ -1814,7 +1814,7 @@ importers:
         version: 7.6.24(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.52.4)(typescript@5.8.3)(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))
       '@storybook/test-runner':
         specifier: ^0.16.0
-        version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3))
+        version: 0.16.0(@types/node@22.18.8)(encoding@0.1.13)
       '@tailwindcss/vite':
         specifier: ^4.1.17
         version: 4.2.2(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))
@@ -1832,7 +1832,7 @@ importers:
         version: 4.7.0(vite@5.4.21(@types/node@22.18.8)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3)))
+        version: 6.4.0(jest@29.7.0(@types/node@22.18.8))
       storybook:
         specifier: ^7.6.4
         version: 7.6.4(encoding@0.1.13)
@@ -8833,8 +8833,8 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1
 
-  '@posthog/hogql-parser@1.3.38':
-    resolution: {integrity: sha512-znIUzwSEUIDaWIXjcXf3tpLXBmP5Or5dROAlyHDKTGk/YW/Z84w/kDpO+8Fgc7em6PhA3xcK+nqM8QRgK6c48A==}
+  '@posthog/hogql-parser@1.3.40':
+    resolution: {integrity: sha512-OKEpuT1iqoL75sG/1Ims4RxoLQsrqVsK7GKO7BUZmtbl5J83qTFL8enQs4UJaJ2+aEcUB2zcJqMvqb1L1q+A2Q==}
 
   '@posthog/icons@0.36.4':
     resolution: {integrity: sha512-xnusbGNz/5vSMUWdEViWuai7D/gxiMZSDDnP6s/acndMqzN+W4asPUgUNnTUps7OyAS1IKaO9zxhdikFrtooJA==}
@@ -29135,41 +29135,6 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.8.3))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 22.18.8
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.8.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3))':
     dependencies:
       '@jest/console': 29.7.0
@@ -31938,7 +31903,7 @@ snapshots:
     transitivePeerDependencies:
       - prop-types
 
-  '@posthog/hogql-parser@1.3.38': {}
+  '@posthog/hogql-parser@1.3.40': {}
 
   '@posthog/icons@0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -34646,7 +34611,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/test-runner@0.16.0(@types/node@22.18.8)(encoding@0.1.13)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3))':
+  '@storybook/test-runner@0.16.0(@types/node@22.18.8)(encoding@0.1.13)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -34667,10 +34632,10 @@ snapshots:
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
-      jest-playwright-preset: 4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3)))
+      jest-playwright-preset: 4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@22.18.8))
       jest-runner: 29.7.0
       jest-serializer-html: 7.1.0
-      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3)))
+      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@22.18.8))
       node-fetch: 2.7.0(encoding@0.1.13)
       playwright: 1.45.0
       read-pkg-up: 7.0.1
@@ -38648,21 +38613,6 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
 
-  create-jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.8.3)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.8.3))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   create-jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3)):
     dependencies:
       '@jest/types': 29.6.3
@@ -42150,25 +42100,6 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest-cli@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.8.3)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.8.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.8.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.8.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3))
@@ -42240,37 +42171,6 @@ snapshots:
       - canvas
       - supports-color
       - utf-8-validate
-
-  jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.8.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.18.8
-      ts-node: 10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
 
   jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3)):
     dependencies:
@@ -42522,7 +42422,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  jest-image-snapshot@6.4.0(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3))):
+  jest-image-snapshot@6.4.0(jest@29.7.0(@types/node@22.18.8)):
     dependencies:
       chalk: 4.1.2
       get-stdin: 5.0.1
@@ -42679,7 +42579,7 @@ snapshots:
       '@types/node': 22.18.8
       jest-util: 30.0.5
 
-  jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3))):
+  jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0(@types/node@22.18.8)):
     dependencies:
       expect-playwright: 0.8.0
       jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3))
@@ -43102,7 +43002,7 @@ snapshots:
       leven: 3.1.0
       pretty-format: 30.0.5
 
-  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3))):
+  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@22.18.8)):
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 5.6.2
@@ -43177,18 +43077,6 @@ snapshots:
       - supports-color
       - ts-node
       - utf-8-validate
-
-  jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.8.3)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.8.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.8.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
 
   jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3)):
     dependencies:
@@ -49499,27 +49387,6 @@ snapshots:
       safe-stable-stringify: 2.5.0
       tslib: 2.8.1
       typescript: 5.8.3
-
-  ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@5.8.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 22.18.8
-      acorn: 8.15.0
-      acorn-walk: 8.3.2
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.8.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.11.4
-    optional: true
 
   ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@5.8.3):
     dependencies:

--- a/posthog/hogql/transforms/property_types.py
+++ b/posthog/hogql/transforms/property_types.py
@@ -239,6 +239,7 @@ class PropertySwapper(CloningVisitor):
         qualify = self.visit(node.qualify)
         group_by = [self.visit(expr) for expr in node.group_by] if node.group_by else None
         order_by = [self.visit(expr) for expr in node.order_by] if node.order_by else None
+        interpolate = [self.visit(expr) for expr in node.interpolate] if node.interpolate is not None else None
 
         self._inside_where_depth = saved_where_depth  # restore parent scope
 
@@ -258,6 +259,7 @@ class PropertySwapper(CloningVisitor):
             group_by=group_by,
             group_by_mode=node.group_by_mode,
             order_by=order_by,
+            interpolate=interpolate,
             limit_by=self.visit(node.limit_by),
             limit=self.visit(node.limit),
             limit_with_ties=node.limit_with_ties,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
     "grimp~=3.14",
     "grpcio~=1.71.0",
     "gspread==6.2.1",
-    "hogql-parser==1.3.39",
+    "hogql-parser==1.3.40",
     "infi-clickhouse-orm",
     "jsonref==1.1.0",
     "kafka-python==2.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
     "grimp~=3.14",
     "grpcio~=1.71.0",
     "gspread==6.2.1",
-    "hogql-parser==1.3.38",
+    "hogql-parser==1.3.39",
     "infi-clickhouse-orm",
     "jsonref==1.1.0",
     "kafka-python==2.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-10T13:54:40.643803Z"
+exclude-newer = "2026-04-10T14:48:21.685649Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -2925,14 +2925,14 @@ wheels = [
 
 [[package]]
 name = "hogql-parser"
-version = "1.3.39"
+version = "1.3.40"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/56/2c/7fae662fb087463e892f0722c9fc923c711a4507f83f0a85ea3f6b752b2f/hogql_parser-1.3.39.tar.gz", hash = "sha256:83717e8ccac2f5b5be39f29d1ef9e2c5d0322b504721726a2dc9f253cb41b847", size = 90061, upload-time = "2026-04-16T15:18:54.834Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/f9/11a8d6e8c63c90a76f9e7acc481ba0909f5bca28c3b4498827e126a3b528/hogql_parser-1.3.40.tar.gz", hash = "sha256:e6d3237f24c5ed126d1da075b81a430b2fd82862f27f9a2fd241f7750bff9edd", size = 90110, upload-time = "2026-04-17T14:44:34.952Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/b2/d4b7782d3fc808f2b306890fe2168700e4cdb614d04c6a8750833a01f86d/hogql_parser-1.3.39-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:993e007b28b7e7084972092947ea3b3cd4d72708d125e85f41d3297af9639d85", size = 660030, upload-time = "2026-04-16T15:18:41.217Z" },
-    { url = "https://files.pythonhosted.org/packages/70/92/753dd1e0f618d0279badb9f345144d724e6212974df22b4889da1fa3aaed/hogql_parser-1.3.39-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:06b0ef7054eba6c969315c9f5c605ad7f1c709fb072e060d09d0609adcc1eaa7", size = 662645, upload-time = "2026-04-16T15:18:43.027Z" },
-    { url = "https://files.pythonhosted.org/packages/83/4f/96c0eb9e3debdb0464c71ea712391fe56f740a5680e87d5ec93ac0a3c390/hogql_parser-1.3.39-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9645e6cd85c016697919e1881a4abd5fa1a7aac5ca76aee5a160edf1ecba4d8b", size = 5015959, upload-time = "2026-04-16T15:18:44.575Z" },
-    { url = "https://files.pythonhosted.org/packages/84/9c/3270f1e0254488a81d6b6f59f1b4093f3a69e4d0660fe60a09c07ca6d425/hogql_parser-1.3.39-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d30c19d0bb09cf7db6f7d3fccd193a83fc16c269c56a41317fcbc872d7f6e388", size = 5120884, upload-time = "2026-04-16T15:18:46.246Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a7/9c9f70b5d68dc788e9a65df8902d6d036316325f483c6339796b7cd5b132/hogql_parser-1.3.40-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:1d95e6b3281ca3268d9a00c1d33e2717da7b842b47838f4f6057d6aaa1f67cb5", size = 660095, upload-time = "2026-04-17T14:44:16.44Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d6/7b89850ed5cafbe961ea378dd9e1391c0e8ab9d4bdd3bffde837ff935b58/hogql_parser-1.3.40-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:a213237f36828e1855e8da3617ad8bc00a7ac175a1cb26ecfbd4d4ac31ad3487", size = 662763, upload-time = "2026-04-17T14:44:18.328Z" },
+    { url = "https://files.pythonhosted.org/packages/11/e6/b31f66411dc0fbc22f5bad5e1b521aa90d863d6a5602fe294987a3b3d92e/hogql_parser-1.3.40-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:44efd85f1551500ec09871388edf70b4b1160ccaaa846f1373b46478bc29b3bf", size = 5019414, upload-time = "2026-04-17T14:44:20.739Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f0/c7cc320b4d164f0eaf432b177f5c6c24944a800285b60eb9fc5646ec1bb4/hogql_parser-1.3.40-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b91786ce9d3943b51dc647209d32995bcd1951738578ed8c0a9c73f579b5a201", size = 5123934, upload-time = "2026-04-17T14:44:23.593Z" },
 ]
 
 [[package]]
@@ -5350,7 +5350,7 @@ requires-dist = [
     { name = "grimp", specifier = "~=3.14" },
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
-    { name = "hogql-parser", specifier = "==1.3.39" },
+    { name = "hogql-parser", specifier = "==1.3.40" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
     { name = "jsonref", specifier = "==1.1.0" },
     { name = "kafka-python", specifier = "==2.3.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-08T06:10:13.845708Z"
+exclude-newer = "2026-04-10T13:54:40.643803Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -2925,14 +2925,14 @@ wheels = [
 
 [[package]]
 name = "hogql-parser"
-version = "1.3.38"
+version = "1.3.39"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e9/b5/fb1ca364e80dc3066048245b3ab490916c37257a16d697d384ecea63afb5/hogql_parser-1.3.38.tar.gz", hash = "sha256:1ff1efb682d04d94d9db00f989608c4a918b129c0998a93e7a7f0b2331b59359", size = 88681, upload-time = "2026-04-13T13:00:38.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/2c/7fae662fb087463e892f0722c9fc923c711a4507f83f0a85ea3f6b752b2f/hogql_parser-1.3.39.tar.gz", hash = "sha256:83717e8ccac2f5b5be39f29d1ef9e2c5d0322b504721726a2dc9f253cb41b847", size = 90061, upload-time = "2026-04-16T15:18:54.834Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/70/59a094abe1a5aba0e2aacb403809d98610d0d30ee61bf15f8ccffffe4f02/hogql_parser-1.3.38-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:5ec9613ecfce170e4ec3e0391352b9f3e96d545e22bda44549f05693789e9ca8", size = 653581, upload-time = "2026-04-13T13:00:22.971Z" },
-    { url = "https://files.pythonhosted.org/packages/15/45/af91400a2f09981fa0be6e46ce8afc913ee852a3a7b58dc65eac4a6b65fa/hogql_parser-1.3.38-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:9935708aba669d4dc3fca28abe8b7d5af144fc5cb10e7f4ceb435f354b666837", size = 659654, upload-time = "2026-04-13T13:00:24.413Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/5b/2ba9e9432b6483c971b11ed754c880ad5c43961c2220ff431dff68038de5/hogql_parser-1.3.38-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:95fca76b246364683f90bc603e1762aa7150e4acb9c5fb61d27b87733e4bff7c", size = 4957867, upload-time = "2026-04-13T13:00:26.491Z" },
-    { url = "https://files.pythonhosted.org/packages/92/6e/32d21e33dd9184dcdb4806b2c26cb365d537ee4a071a38f6443a0838ef8e/hogql_parser-1.3.38-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f2e8ba4d9f03ce733e49becda43923e3a89c36fd3564c62ac55db9d6712c616a", size = 5061055, upload-time = "2026-04-13T13:00:28.38Z" },
+    { url = "https://files.pythonhosted.org/packages/14/b2/d4b7782d3fc808f2b306890fe2168700e4cdb614d04c6a8750833a01f86d/hogql_parser-1.3.39-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:993e007b28b7e7084972092947ea3b3cd4d72708d125e85f41d3297af9639d85", size = 660030, upload-time = "2026-04-16T15:18:41.217Z" },
+    { url = "https://files.pythonhosted.org/packages/70/92/753dd1e0f618d0279badb9f345144d724e6212974df22b4889da1fa3aaed/hogql_parser-1.3.39-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:06b0ef7054eba6c969315c9f5c605ad7f1c709fb072e060d09d0609adcc1eaa7", size = 662645, upload-time = "2026-04-16T15:18:43.027Z" },
+    { url = "https://files.pythonhosted.org/packages/83/4f/96c0eb9e3debdb0464c71ea712391fe56f740a5680e87d5ec93ac0a3c390/hogql_parser-1.3.39-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9645e6cd85c016697919e1881a4abd5fa1a7aac5ca76aee5a160edf1ecba4d8b", size = 5015959, upload-time = "2026-04-16T15:18:44.575Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9c/3270f1e0254488a81d6b6f59f1b4093f3a69e4d0660fe60a09c07ca6d425/hogql_parser-1.3.39-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d30c19d0bb09cf7db6f7d3fccd193a83fc16c269c56a41317fcbc872d7f6e388", size = 5120884, upload-time = "2026-04-16T15:18:46.246Z" },
 ]
 
 [[package]]
@@ -5350,7 +5350,7 @@ requires-dist = [
     { name = "grimp", specifier = "~=3.14" },
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
-    { name = "hogql-parser", specifier = "==1.3.38" },
+    { name = "hogql-parser", specifier = "==1.3.39" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
     { name = "jsonref", specifier = "==1.1.0" },
     { name = "kafka-python", specifier = "==2.3.0" },


### PR DESCRIPTION
## Problem

Master Backend CI is failing on every "Django tests – Core" shard with:

```
posthog.hogql.errors.SyntaxError: no viable alternative at input '... WITH'
```

Example: [run 24566908933](https://github.com/PostHog/posthog/actions/runs/24566908933) — 11 deterministic failures in C++-parser `WITH FILL` tests.

#54934 bumped the in-tree hogql-parser to `1.3.39` and [published it to PyPI](https://pypi.org/project/hogql-parser/1.3.39/), but `pyproject.toml` / `uv.lock` still pin `1.3.38`. On master CI the source-build step is skipped, so `uv sync` pulls the stale wheel without the `WITH FILL` grammar.

## Changes

- Bump `hogql-parser` pin to `1.3.39`
- Regenerate `uv.lock`

## How did you test this code?

Verified `uv sync --reinstall-package hogql-parser` installs `1.3.39` locally. Relying on PR CI to confirm the previously-failing `WITH FILL` tests pass.

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored dependency pin catch-up to unblock master.