### PR TITLE
fix(llma): batch setQuery URL updates to prevent rapid URL change warnings

### DIFF
--- a/products/llm_analytics/frontend/LLMAnalyticsErrors.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsErrors.tsx
@@ -15,12 +15,13 @@ import { isHogQLQuery } from '~/queries/utils'
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { useSortableColumns } from './hooks/useSortableColumns'
-import { llmAnalyticsSharedLogic } from './llmAnalyticsSharedLogic'
+import { buildApplyUrlStatePayload, llmAnalyticsSharedLogic } from './llmAnalyticsSharedLogic'
 import { llmAnalyticsErrorsLogic } from './tabs/llmAnalyticsErrorsLogic'
 
 export function LLMAnalyticsErrors(): JSX.Element {
     const sharedLogic = useMountedLogic(llmAnalyticsSharedLogic)
-    const { setDates, setShouldFilterTestAccounts, setPropertyFilters } = useActions(llmAnalyticsSharedLogic)
+    const { applyUrlState } = useActions(llmAnalyticsSharedLogic)
+    const { dateFilter, propertyFilters: currentPropertyFilters } = useValues(llmAnalyticsSharedLogic)
     const { setErrorsSort } = useActions(llmAnalyticsErrorsLogic)
     const { errorsQuery, errorsSort, buildErrorTrendQuery, buildAllErrorsTrendQuery } =
         useValues(llmAnalyticsErrorsLogic)
@@ -42,9 +43,16 @@ export function LLMAnalyticsErrors(): JSX.Element {
                 }
                 const { filters = {} } = query.source
                 const { dateRange = {} } = filters
-                setDates(dateRange.date_from || null, dateRange.date_to || null)
-                setShouldFilterTestAccounts(filters.filterTestAccounts || false)
-                setPropertyFilters(filters.properties || [])
+                applyUrlState(
+                    buildApplyUrlStatePayload({
+                        dateFrom: dateRange.date_from || null,
+                        dateTo: dateRange.date_to || null,
+                        shouldFilterTestAccounts: filters.filterTestAccounts || false,
+                        propertyFilters: filters.properties || [],
+                        currentDateFilter: dateFilter,
+                        currentPropertyFilters,
+                    })
+                )
             }}
             context={{
                 customActions: [

--- a/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsScene.tsx
@@ -42,7 +42,11 @@ import { LLMAnalyticsErrors } from './LLMAnalyticsErrors'
 import { LLMAnalyticsReloadAction } from './LLMAnalyticsReloadAction'
 import { LLMAnalyticsSessionsScene } from './LLMAnalyticsSessionsScene'
 import { LLMAnalyticsSetupPrompt } from './LLMAnalyticsSetupPrompt'
-import { LLM_ANALYTICS_DATA_COLLECTION_NODE_ID, llmAnalyticsSharedLogic } from './llmAnalyticsSharedLogic'
+import {
+    buildApplyUrlStatePayload,
+    LLM_ANALYTICS_DATA_COLLECTION_NODE_ID,
+    llmAnalyticsSharedLogic,
+} from './llmAnalyticsSharedLogic'
 import { LLMAnalyticsTools } from './LLMAnalyticsTools'
 import { LLMAnalyticsTraces } from './LLMAnalyticsTracesScene'
 import { LLMAnalyticsUsers } from './LLMAnalyticsUsers'
@@ -174,8 +178,8 @@ function LLMAnalyticsDashboard(): JSX.Element {
 }
 
 function LLMAnalyticsGenerations(): JSX.Element {
-    const { setDates, setShouldFilterTestAccounts, setPropertyFilters } = useActions(llmAnalyticsSharedLogic)
-    const { propertyFilters: currentPropertyFilters } = useValues(llmAnalyticsSharedLogic)
+    const { applyUrlState } = useActions(llmAnalyticsSharedLogic)
+    const { dateFilter, propertyFilters: currentPropertyFilters } = useValues(llmAnalyticsSharedLogic)
     const { searchParams } = useValues(router)
     const { setGenerationsColumns, toggleGenerationExpanded, setGenerationsSort } =
         useActions(llmAnalyticsGenerationsLogic)
@@ -236,13 +240,16 @@ function LLMAnalyticsGenerations(): JSX.Element {
                 if (!isEventsQuery(query.source)) {
                     throw new Error('Invalid query')
                 }
-                setDates(query.source.after || null, query.source.before || null)
-                setShouldFilterTestAccounts(query.source.filterTestAccounts || false)
-
-                const newPropertyFilters = query.source.properties || []
-                if (!objectsEqual(newPropertyFilters, currentPropertyFilters)) {
-                    setPropertyFilters(newPropertyFilters)
-                }
+                applyUrlState(
+                    buildApplyUrlStatePayload({
+                        dateFrom: query.source.after || null,
+                        dateTo: query.source.before || null,
+                        shouldFilterTestAccounts: query.source.filterTestAccounts || false,
+                        propertyFilters: query.source.properties || [],
+                        currentDateFilter: dateFilter,
+                        currentPropertyFilters,
+                    })
+                )
 
                 if (query.source.select) {
                     setGenerationsColumns(query.source.select)

--- a/products/llm_analytics/frontend/LLMAnalyticsSessionsScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsSessionsScene.tsx
@@ -16,13 +16,13 @@ import { isHogQLQuery } from '~/queries/utils'
 
 import { LLMAnalyticsTraceEvents } from './components/LLMAnalyticsTraceEvents'
 import { useSortableColumns } from './hooks/useSortableColumns'
-import { llmAnalyticsSharedLogic } from './llmAnalyticsSharedLogic'
+import { buildApplyUrlStatePayload, llmAnalyticsSharedLogic } from './llmAnalyticsSharedLogic'
 import { llmAnalyticsSessionsViewLogic } from './tabs/llmAnalyticsSessionsViewLogic'
 import { formatLLMCost, getTraceTimestamp, sanitizeTraceUrlSearchParams } from './utils'
 
 export function LLMAnalyticsSessionsScene(): JSX.Element {
-    const { setDates, setShouldFilterTestAccounts, setPropertyFilters } = useActions(llmAnalyticsSharedLogic)
-    const { dateFilter } = useValues(llmAnalyticsSharedLogic)
+    const { applyUrlState } = useActions(llmAnalyticsSharedLogic)
+    const { dateFilter, propertyFilters: currentPropertyFilters } = useValues(llmAnalyticsSharedLogic)
     const { searchParams } = useValues(router)
     const traceSearchParams = sanitizeTraceUrlSearchParams(searchParams, { removeSearch: true })
 
@@ -56,9 +56,16 @@ export function LLMAnalyticsSessionsScene(): JSX.Element {
                 }
                 const { filters = {} } = query.source
                 const { dateRange = {} } = filters
-                setDates(dateRange.date_from || null, dateRange.date_to || null)
-                setShouldFilterTestAccounts(filters.filterTestAccounts || false)
-                setPropertyFilters(filters.properties || [])
+                applyUrlState(
+                    buildApplyUrlStatePayload({
+                        dateFrom: dateRange.date_from || null,
+                        dateTo: dateRange.date_to || null,
+                        shouldFilterTestAccounts: filters.filterTestAccounts || false,
+                        propertyFilters: filters.properties || [],
+                        currentDateFilter: dateFilter,
+                        currentPropertyFilters,
+                    })
+                )
             }}
             context={{
                 emptyStateHeading: 'There were no AI sessions in this period',

--- a/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTools.tsx
@@ -17,11 +17,12 @@ import { isHogQLQuery } from '~/queries/utils'
 import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { useSortableColumns } from './hooks/useSortableColumns'
-import { llmAnalyticsSharedLogic } from './llmAnalyticsSharedLogic'
+import { buildApplyUrlStatePayload, llmAnalyticsSharedLogic } from './llmAnalyticsSharedLogic'
 import { llmAnalyticsToolsLogic } from './tabs/llmAnalyticsToolsLogic'
 
 export function LLMAnalyticsTools(): JSX.Element {
-    const { setDates, setShouldFilterTestAccounts, setPropertyFilters } = useActions(llmAnalyticsSharedLogic)
+    const { applyUrlState } = useActions(llmAnalyticsSharedLogic)
+    const { dateFilter, propertyFilters: currentPropertyFilters } = useValues(llmAnalyticsSharedLogic)
     const { setToolsSort } = useActions(llmAnalyticsToolsLogic)
     const {
         toolsQuery,
@@ -51,9 +52,16 @@ export function LLMAnalyticsTools(): JSX.Element {
                 }
                 const { filters = {} } = query.source
                 const { dateRange = {} } = filters
-                setDates(dateRange.date_from || null, dateRange.date_to || null)
-                setShouldFilterTestAccounts(filters.filterTestAccounts || false)
-                setPropertyFilters(filters.properties || [])
+                applyUrlState(
+                    buildApplyUrlStatePayload({
+                        dateFrom: dateRange.date_from || null,
+                        dateTo: dateRange.date_to || null,
+                        shouldFilterTestAccounts: filters.filterTestAccounts || false,
+                        propertyFilters: filters.properties || [],
+                        currentDateFilter: dateFilter,
+                        currentPropertyFilters,
+                    })
+                )
             }}
             context={{
                 customActions: showToolsCharts

--- a/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsTracesScene.tsx
@@ -11,7 +11,6 @@ import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { objectsEqual } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
@@ -21,7 +20,7 @@ import { isTracesQuery } from '~/queries/utils'
 
 import { LLMMessageDisplay } from './ConversationDisplay/ConversationMessagesDisplay'
 import { llmAnalyticsColumnRenderers } from './llmAnalyticsColumnRenderers'
-import { llmAnalyticsSharedLogic } from './llmAnalyticsSharedLogic'
+import { buildApplyUrlStatePayload, llmAnalyticsSharedLogic } from './llmAnalyticsSharedLogic'
 import { llmAnalyticsTracesTabLogic } from './tabs/llmAnalyticsTracesTabLogic'
 import { TraceMessages, traceMessagesLazyLoaderLogic } from './traceMessagesLazyLoaderLogic'
 import { traceReviewsLazyLoaderLogic } from './traceReviews/traceReviewsLazyLoaderLogic'
@@ -39,9 +38,8 @@ export function LLMAnalyticsTraces(): JSX.Element {
     useMountedLogic(traceReviewsLazyLoaderLogic)
     useMountedLogic(traceMessagesLazyLoaderLogic)
 
-    const { setDates, setShouldFilterTestAccounts, setShouldFilterSupportTraces, setPropertyFilters } =
-        useActions(llmAnalyticsSharedLogic)
-    const { propertyFilters: currentPropertyFilters } = useValues(llmAnalyticsSharedLogic)
+    const { applyUrlState, setShouldFilterSupportTraces } = useActions(llmAnalyticsSharedLogic)
+    const { dateFilter, propertyFilters: currentPropertyFilters } = useValues(llmAnalyticsSharedLogic)
     const { tracesQuery } = useValues(llmAnalyticsTracesTabLogic)
 
     const baseContext = useTracesQueryContext()
@@ -62,14 +60,23 @@ export function LLMAnalyticsTraces(): JSX.Element {
                     if (!isTracesQuery(query.source)) {
                         throw new Error('Invalid query')
                     }
-                    setDates(query.source.dateRange?.date_from || null, query.source.dateRange?.date_to || null)
-                    setShouldFilterTestAccounts(query.source.filterTestAccounts || false)
+                    // filterSupportTraces has no actionToUrl mapping, so keep it
+                    // separate — it cannot contribute to the URL-change counter.
                     setShouldFilterSupportTraces(query.source.filterSupportTraces ?? true)
 
-                    const newPropertyFilters = query.source.properties || []
-                    if (!objectsEqual(newPropertyFilters, currentPropertyFilters)) {
-                        setPropertyFilters(newPropertyFilters)
-                    }
+                    // Batch the remaining three URL-synced fields into a single
+                    // applyUrlState dispatch so the DataTable's setQuery emits
+                    // one URL change instead of three.
+                    applyUrlState(
+                        buildApplyUrlStatePayload({
+                            dateFrom: query.source.dateRange?.date_from || null,
+                            dateTo: query.source.dateRange?.date_to || null,
+                            shouldFilterTestAccounts: query.source.filterTestAccounts || false,
+                            propertyFilters: query.source.properties || [],
+                            currentDateFilter: dateFilter,
+                            currentPropertyFilters,
+                        })
+                    )
                 }}
                 context={context}
                 uniqueKey="llm-analytics-traces"

--- a/products/llm_analytics/frontend/LLMAnalyticsUsers.tsx
+++ b/products/llm_analytics/frontend/LLMAnalyticsUsers.tsx
@@ -7,11 +7,12 @@ import { isHogQLQuery } from '~/queries/utils'
 
 import { useSortableColumns } from './hooks/useSortableColumns'
 import { llmAnalyticsColumnRenderers } from './llmAnalyticsColumnRenderers'
-import { llmAnalyticsSharedLogic } from './llmAnalyticsSharedLogic'
+import { buildApplyUrlStatePayload, llmAnalyticsSharedLogic } from './llmAnalyticsSharedLogic'
 import { llmAnalyticsUsersLogic } from './tabs/llmAnalyticsUsersLogic'
 
 export function LLMAnalyticsUsers(): JSX.Element {
-    const { setDates, setShouldFilterTestAccounts, setPropertyFilters } = useActions(llmAnalyticsSharedLogic)
+    const { applyUrlState } = useActions(llmAnalyticsSharedLogic)
+    const { dateFilter, propertyFilters: currentPropertyFilters } = useValues(llmAnalyticsSharedLogic)
     const { setUsersSort } = useActions(llmAnalyticsUsersLogic)
     const { usersQuery, usersSort } = useValues(llmAnalyticsUsersLogic)
 
@@ -31,9 +32,16 @@ export function LLMAnalyticsUsers(): JSX.Element {
                 }
                 const { filters = {} } = query.source
                 const { dateRange = {} } = filters
-                setDates(dateRange.date_from || null, dateRange.date_to || null)
-                setShouldFilterTestAccounts(filters.filterTestAccounts || false)
-                setPropertyFilters(filters.properties || [])
+                applyUrlState(
+                    buildApplyUrlStatePayload({
+                        dateFrom: dateRange.date_from || null,
+                        dateTo: dateRange.date_to || null,
+                        shouldFilterTestAccounts: filters.filterTestAccounts || false,
+                        propertyFilters: filters.properties || [],
+                        currentDateFilter: dateFilter,
+                        currentPropertyFilters,
+                    })
+                )
             }}
             context={{
                 columns: {

--- a/products/llm_analytics/frontend/llmAnalyticsSharedLogic.test.ts
+++ b/products/llm_analytics/frontend/llmAnalyticsSharedLogic.test.ts
@@ -1,0 +1,107 @@
+import { AnyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
+
+import { buildApplyUrlStatePayload } from './llmAnalyticsSharedLogic'
+
+describe('buildApplyUrlStatePayload', () => {
+    const currentDateFilter = { dateFrom: '-1h', dateTo: null }
+    const currentPropertyFilters: AnyPropertyFilter[] = []
+
+    it('flags datesChanged=true when dateFrom differs', () => {
+        const payload = buildApplyUrlStatePayload({
+            dateFrom: '-7d',
+            dateTo: null,
+            shouldFilterTestAccounts: false,
+            propertyFilters: [],
+            currentDateFilter,
+            currentPropertyFilters,
+        })
+        expect(payload.datesChanged).toBe(true)
+    })
+
+    it('flags datesChanged=true when dateTo differs', () => {
+        const payload = buildApplyUrlStatePayload({
+            dateFrom: '-1h',
+            dateTo: '2026-04-01',
+            shouldFilterTestAccounts: false,
+            propertyFilters: [],
+            currentDateFilter,
+            currentPropertyFilters,
+        })
+        expect(payload.datesChanged).toBe(true)
+    })
+
+    it('flags datesChanged=false when both dates match current', () => {
+        const payload = buildApplyUrlStatePayload({
+            dateFrom: '-1h',
+            dateTo: null,
+            shouldFilterTestAccounts: true,
+            propertyFilters: [],
+            currentDateFilter,
+            currentPropertyFilters,
+        })
+        expect(payload.datesChanged).toBe(false)
+    })
+
+    it('preserves propertyFilters reference when contents equal', () => {
+        const existing: AnyPropertyFilter[] = [
+            {
+                type: PropertyFilterType.Event,
+                key: '$ai_model',
+                operator: PropertyOperator.Exact,
+                value: ['gpt-4o'],
+            },
+        ]
+        const equivalentCopy: AnyPropertyFilter[] = [
+            {
+                type: PropertyFilterType.Event,
+                key: '$ai_model',
+                operator: PropertyOperator.Exact,
+                value: ['gpt-4o'],
+            },
+        ]
+        const payload = buildApplyUrlStatePayload({
+            dateFrom: '-1h',
+            dateTo: null,
+            shouldFilterTestAccounts: false,
+            propertyFilters: equivalentCopy,
+            currentDateFilter,
+            currentPropertyFilters: existing,
+        })
+        expect(payload.propertyFilters).toBe(existing)
+    })
+
+    it('returns new propertyFilters reference when contents differ', () => {
+        const existing: AnyPropertyFilter[] = []
+        const next: AnyPropertyFilter[] = [
+            {
+                type: PropertyFilterType.Event,
+                key: '$ai_model',
+                operator: PropertyOperator.Exact,
+                value: ['gpt-4o'],
+            },
+        ]
+        const payload = buildApplyUrlStatePayload({
+            dateFrom: '-1h',
+            dateTo: null,
+            shouldFilterTestAccounts: false,
+            propertyFilters: next,
+            currentDateFilter,
+            currentPropertyFilters: existing,
+        })
+        expect(payload.propertyFilters).toBe(next)
+    })
+
+    it('passes through shouldFilterTestAccounts and date values unchanged', () => {
+        const payload = buildApplyUrlStatePayload({
+            dateFrom: '-30d',
+            dateTo: '-1d',
+            shouldFilterTestAccounts: true,
+            propertyFilters: [],
+            currentDateFilter,
+            currentPropertyFilters,
+        })
+        expect(payload.dateFrom).toBe('-30d')
+        expect(payload.dateTo).toBe('-1d')
+        expect(payload.shouldFilterTestAccounts).toBe(true)
+    })
+})

--- a/products/llm_analytics/frontend/llmAnalyticsSharedLogic.test.ts
+++ b/products/llm_analytics/frontend/llmAnalyticsSharedLogic.test.ts
@@ -3,92 +3,54 @@ import { AnyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types
 import { buildApplyUrlStatePayload } from './llmAnalyticsSharedLogic'
 
 describe('buildApplyUrlStatePayload', () => {
-    const currentDateFilter = { dateFrom: '-1h', dateTo: null }
+    const currentDateFilter = { dateFrom: '-1h', dateTo: null as string | null }
     const currentPropertyFilters: AnyPropertyFilter[] = []
 
-    it('flags datesChanged=true when dateFrom differs', () => {
+    it.each([
+        { desc: 'dateFrom differs', dateFrom: '-7d', dateTo: null as string | null, expected: true },
+        { desc: 'dateTo differs', dateFrom: '-1h', dateTo: '2026-04-01', expected: true },
+        { desc: 'both match current', dateFrom: '-1h', dateTo: null as string | null, expected: false },
+    ])('flags datesChanged=$expected when $desc', ({ dateFrom, dateTo, expected }) => {
         const payload = buildApplyUrlStatePayload({
-            dateFrom: '-7d',
-            dateTo: null,
+            dateFrom,
+            dateTo,
             shouldFilterTestAccounts: false,
             propertyFilters: [],
             currentDateFilter,
             currentPropertyFilters,
         })
-        expect(payload.datesChanged).toBe(true)
+        expect(payload.datesChanged).toBe(expected)
     })
 
-    it('flags datesChanged=true when dateTo differs', () => {
-        const payload = buildApplyUrlStatePayload({
-            dateFrom: '-1h',
-            dateTo: '2026-04-01',
-            shouldFilterTestAccounts: false,
-            propertyFilters: [],
-            currentDateFilter,
-            currentPropertyFilters,
-        })
-        expect(payload.datesChanged).toBe(true)
-    })
-
-    it('flags datesChanged=false when both dates match current', () => {
-        const payload = buildApplyUrlStatePayload({
-            dateFrom: '-1h',
-            dateTo: null,
-            shouldFilterTestAccounts: true,
-            propertyFilters: [],
-            currentDateFilter,
-            currentPropertyFilters,
-        })
-        expect(payload.datesChanged).toBe(false)
-    })
-
-    it('preserves propertyFilters reference when contents equal', () => {
-        const existing: AnyPropertyFilter[] = [
-            {
-                type: PropertyFilterType.Event,
-                key: '$ai_model',
-                operator: PropertyOperator.Exact,
-                value: ['gpt-4o'],
-            },
-        ]
-        const equivalentCopy: AnyPropertyFilter[] = [
-            {
-                type: PropertyFilterType.Event,
-                key: '$ai_model',
-                operator: PropertyOperator.Exact,
-                value: ['gpt-4o'],
-            },
-        ]
-        const payload = buildApplyUrlStatePayload({
-            dateFrom: '-1h',
-            dateTo: null,
-            shouldFilterTestAccounts: false,
-            propertyFilters: equivalentCopy,
-            currentDateFilter,
-            currentPropertyFilters: existing,
-        })
-        expect(payload.propertyFilters).toBe(existing)
-    })
-
-    it('returns new propertyFilters reference when contents differ', () => {
-        const existing: AnyPropertyFilter[] = []
-        const next: AnyPropertyFilter[] = [
-            {
-                type: PropertyFilterType.Event,
-                key: '$ai_model',
-                operator: PropertyOperator.Exact,
-                value: ['gpt-4o'],
-            },
-        ]
+    const modelFilter: AnyPropertyFilter = {
+        type: PropertyFilterType.Event,
+        key: '$ai_model',
+        operator: PropertyOperator.Exact,
+        value: ['gpt-4o'],
+    }
+    it.each([
+        {
+            desc: 'contents equal — returns current reference',
+            current: [modelFilter],
+            next: [{ ...modelFilter }],
+            expectCurrentRef: true,
+        },
+        {
+            desc: 'contents differ — returns next reference',
+            current: [] as AnyPropertyFilter[],
+            next: [modelFilter],
+            expectCurrentRef: false,
+        },
+    ])('propertyFilters: $desc', ({ current, next, expectCurrentRef }) => {
         const payload = buildApplyUrlStatePayload({
             dateFrom: '-1h',
             dateTo: null,
             shouldFilterTestAccounts: false,
             propertyFilters: next,
             currentDateFilter,
-            currentPropertyFilters: existing,
+            currentPropertyFilters: current,
         })
-        expect(payload.propertyFilters).toBe(next)
+        expect(payload.propertyFilters).toBe(expectCurrentRef ? current : next)
     })
 
     it('passes through shouldFilterTestAccounts and date values unchanged', () => {

--- a/products/llm_analytics/frontend/llmAnalyticsSharedLogic.ts
+++ b/products/llm_analytics/frontend/llmAnalyticsSharedLogic.ts
@@ -58,6 +58,48 @@ export interface LLMAnalyticsSharedLogicProps {
     }
 }
 
+export interface ApplyUrlStatePayload {
+    propertyFilters: AnyPropertyFilter[]
+    dateFrom: string | null
+    dateTo: string | null
+    shouldFilterTestAccounts: boolean
+    datesChanged: boolean
+}
+
+interface BuildApplyUrlStatePayloadInput {
+    dateFrom: string | null
+    dateTo: string | null
+    shouldFilterTestAccounts: boolean
+    propertyFilters: AnyPropertyFilter[]
+    currentDateFilter: { dateFrom: string | null; dateTo: string | null }
+    currentPropertyFilters: AnyPropertyFilter[]
+}
+
+/**
+ * Build the payload for `applyUrlState` from a DataTable's query source. Preserves
+ * reference identity on unchanged `propertyFilters` so Kea selectors short-circuit,
+ * and computes `datesChanged` so the dashboard-tab date picker is not overwritten
+ * when only filters change.
+ */
+export function buildApplyUrlStatePayload({
+    dateFrom,
+    dateTo,
+    shouldFilterTestAccounts,
+    propertyFilters,
+    currentDateFilter,
+    currentPropertyFilters,
+}: BuildApplyUrlStatePayloadInput): ApplyUrlStatePayload {
+    return {
+        propertyFilters: objectsEqual(propertyFilters, currentPropertyFilters)
+            ? currentPropertyFilters
+            : propertyFilters,
+        dateFrom,
+        dateTo,
+        shouldFilterTestAccounts,
+        datesChanged: dateFrom !== currentDateFilter.dateFrom || dateTo !== currentDateFilter.dateTo,
+    }
+}
+
 export const llmAnalyticsSharedLogic = kea<llmAnalyticsSharedLogicType>([
     path(['products', 'llm_analytics', 'frontend', 'llmAnalyticsSharedLogic']),
     props({} as LLMAnalyticsSharedLogicProps),
@@ -73,15 +115,9 @@ export const llmAnalyticsSharedLogic = kea<llmAnalyticsSharedLogicType>([
         setShouldFilterSupportTraces: (shouldFilterSupportTraces: boolean) => ({ shouldFilterSupportTraces }),
         setPropertyFilters: (propertyFilters: AnyPropertyFilter[]) => ({ propertyFilters }),
         // Batched action for URL-to-state sync. Dispatched once from urlToAction
-        // instead of multiple individual actions, producing a single actionToUrl
-        // URL change instead of 3-4 separate ones.
-        applyUrlState: (state: {
-            propertyFilters: AnyPropertyFilter[]
-            dateFrom: string | null
-            dateTo: string | null
-            shouldFilterTestAccounts: boolean
-            datesChanged: boolean
-        }) => state,
+        // or scene-level setQuery handlers instead of multiple individual actions,
+        // producing a single actionToUrl URL change instead of 3-4 separate ones.
+        applyUrlState: (state: ApplyUrlStatePayload) => state,
     }),
 
     reducers({


### PR DESCRIPTION
## Problem

Follow-up to #54896. That PR batched the `urlToAction` path in `llmAnalyticsSharedLogic` so the initial URL → state sync emits one URL change. But scene-level DataTable `setQuery` handlers (traces, errors, tools, sessions, users, generations) were still dispatching three separate URL-synced actions per user interaction (`setDates`, `setShouldFilterTestAccounts`, `setPropertyFilters`). Each has its own `tabAwareActionToUrl` handler and each increments the per-logic tracker, so two user filter changes in quick succession pushed the counter past the `>4 changes / 3s` threshold and retripped `Rapid URL changes detected in kea router` (issue `019d9b3c-16fc-7423-acc3-41e4556c9d36`, first seen 2026-04-17).

## Changes

- Extract `buildApplyUrlStatePayload` in `llmAnalyticsSharedLogic` — centralises `datesChanged` computation and `propertyFilters` reference preservation, and exposes the `ApplyUrlStatePayload` type used by the existing `applyUrlState` action.
- Rewrite the `setQuery` handlers in the six LLM analytics scenes to dispatch a single `applyUrlState(...)` via the helper. `setShouldFilterSupportTraces` (no `actionToUrl` mapping) and `setGenerationsColumns` (orthogonal to URL state) stay separate.
- Unit tests for the helper covering datesChanged flagging and propertyFilters reference behaviour.

No visible UI change — the difference is one URL `replaceState` per user interaction instead of three.

## How did you test this code?

I'm an agent — I did not manually test this in a browser. What was verified automatically:

- New unit tests in `llmAnalyticsSharedLogic.test.ts` (6 cases) all pass locally via jest.
- Ran the full `products/llm_analytics/frontend/` jest suite: 0 test failures on this branch vs. 6 on master (unrelated environmental module-resolution failures exist on both).
- `tsc --noEmit` surfaces only pre-existing environmental errors (present on master, `Cannot find module 'kea'` etc. from the sandbox setup) — no new type errors attributable to this change.

Reviewer manual verification suggested:
1. Load `/llm-analytics/traces?filters=...&date_from=-7d` and rapidly toggle property filters / date range / test-accounts switch; confirm no `[PostHog] Rapid URL changes detected` warning in the console.
2. Open a trace detail and navigate back; stale params (`back_to`, `timestamp`, `event`, `msg`) are still stripped by the existing `urlToAction` path.
3. Repeat on errors / tools / sessions / users / generations tabs.

## Publish to changelog?

no

## Docs update

No docs update needed — internal bug fix with no user-visible surface change.

## 🤖 LLM context

Authored by PostHog Code agent after investigating error `019d9b3c-16fc-7423-acc3-41e4556c9d36`. The fix extends the batching approach from #54896 to the remaining URL-syncing code path (scene-level `setQuery` callbacks). Helper extraction and tests were added after a self-review flagged duplication across six near-identical call sites.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*