### PR TITLE
chore(rust): replace OnceLock once_cell with LazyLock for encoder

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2635,7 +2635,6 @@ dependencies = [
  "metrics",
  "mockall",
  "moka",
- "once_cell",
  "posthog-rs 0.3.7",
  "posthog-symbol-data",
  "proguard",

--- a/rust/cymbal/Cargo.toml
+++ b/rust/cymbal/Cargo.toml
@@ -41,7 +41,6 @@ rdkafka = { workspace = true }
 posthog-rs = { workspace = true }
 base64 = { workspace = true }
 regex = { workspace = true }
-once_cell = { workspace = true }
 futures.workspace = true
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 tower.workspace = true

--- a/rust/cymbal/src/lib.rs
+++ b/rust/cymbal/src/lib.rs
@@ -1,7 +1,7 @@
 use error::EventError;
 
-use std::sync::LazyLock;
 use regex::Regex;
+use std::sync::LazyLock;
 
 use serde_json::Value;
 use tracing::debug;

--- a/rust/cymbal/src/lib.rs
+++ b/rust/cymbal/src/lib.rs
@@ -1,6 +1,6 @@
 use error::EventError;
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use regex::Regex;
 
 use serde_json::Value;
@@ -64,7 +64,7 @@ pub fn recursively_sanitize_properties(
     Ok(())
 }
 
-static WHITESPACE_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"\s{50,}").unwrap());
+static WHITESPACE_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\s{50,}").unwrap());
 
 // Postgres doesn't like nulls (u0000) in strings, so we replace them with uFFFD. We also replace all 50-or-more whitespace sequences with "<ws trimmed>".
 pub fn sanitize_string(s: String) -> String {

--- a/rust/cymbal/src/tokenizer.rs
+++ b/rust/cymbal/src/tokenizer.rs
@@ -6,11 +6,11 @@
 //! emission and every stacktrace truncation check — so we cache it once for the
 //! lifetime of the process.
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use tiktoken_rs::{cl100k_base, CoreBPE};
 
-pub static CL100K_BPE: Lazy<CoreBPE> =
-    Lazy::new(|| cl100k_base().expect("cl100k_base encoder must be constructible"));
+pub static CL100K_BPE: LazyLock<CoreBPE> =
+    LazyLock::new(|| cl100k_base().expect("cl100k_base encoder must be constructible"));
 
 #[cfg(test)]
 mod tests {

--- a/rust/embedding-worker/src/lib.rs
+++ b/rust/embedding-worker/src/lib.rs
@@ -1,4 +1,3 @@
-use std::sync::OnceLock;
 use std::time::Duration;
 use std::{borrow::Cow, sync::Arc};
 
@@ -22,13 +21,10 @@ use crate::{
     organization::apply_ai_opt_in,
 };
 
-static CL100K_ENCODER: OnceLock<tiktoken_rs::CoreBPE> = OnceLock::new();
-
-fn cl100k_encoder() -> &'static tiktoken_rs::CoreBPE {
-    CL100K_ENCODER.get_or_init(|| {
+static CL100K_ENCODER: std::sync::LazyLock<tiktoken_rs::CoreBPE> =
+    std::sync::LazyLock::new(|| {
         tiktoken_rs::cl100k_base().expect("Failed to initialize cl100k_base encoder")
-    })
-}
+    });
 
 const MAX_RETRY_ATTEMPTS: usize = 4; // 1 initial + 3 retries
 const RETRY_BASE_SECS: u64 = 2;
@@ -202,7 +198,7 @@ pub fn generate_embedding_text<'a>(
     let content = model.escape_input(content);
     let (text, count) = match model {
         EmbeddingModel::OpenAITextEmbeddingSmall | EmbeddingModel::OpenAITextEmbeddingLarge => {
-            let encoder = cl100k_encoder();
+            let encoder = &*CL100K_ENCODER;
             let mut tokens: Vec<_> = encoder
                 .encode_with_special_tokens(&content)
                 .into_iter()

--- a/rust/embedding-worker/src/lib.rs
+++ b/rust/embedding-worker/src/lib.rs
@@ -21,10 +21,9 @@ use crate::{
     organization::apply_ai_opt_in,
 };
 
-static CL100K_ENCODER: std::sync::LazyLock<tiktoken_rs::CoreBPE> =
-    std::sync::LazyLock::new(|| {
-        tiktoken_rs::cl100k_base().expect("Failed to initialize cl100k_base encoder")
-    });
+static CL100K_ENCODER: std::sync::LazyLock<tiktoken_rs::CoreBPE> = std::sync::LazyLock::new(|| {
+    tiktoken_rs::cl100k_base().expect("Failed to initialize cl100k_base encoder")
+});
 
 const MAX_RETRY_ATTEMPTS: usize = 4; // 1 initial + 3 retries
 const RETRY_BASE_SECS: u64 = 2;


### PR DESCRIPTION
## Problem

  `tiktoken_rs::cl100k_base()` rebuilds the entire BPE encoder on every call (~50–200ms CPU).
  Both embedding-worker and cymbal cache it process-wide. The embedding-worker was using
  `OnceLock` + a wrapper function; cymbal was using `once_cell::sync::Lazy`. Since the project
  is on Rust 1.91.1 (≥1.80), `std::sync::LazyLock` is available in stdlib and replaces both.

 ## Changes

  - Replace `OnceLock` + wrapper function in `embedding-worker/src/lib.rs` with `std::sync::LazyLock`
  - Replace `once_cell::sync::Lazy` in `cymbal/src/tokenizer.rs` and `cymbal/src/lib.rs` with `std::sync::LazyLock`
  - Remove `once_cell` dependency from `cymbal/Cargo.toml`