### PR TITLE
feat: Bulk update support ticket tags

### DIFF
--- a/frontend/src/lib/logic/listSelectionLogic.ts
+++ b/frontend/src/lib/logic/listSelectionLogic.ts
@@ -17,7 +17,7 @@ export interface BulkUpdateTagsResult {
     skipped: Array<{ id: number; reason: string }>
 }
 
-export type BulkTaggableResource = 'feature_flags' | 'dashboards' | 'insights'
+export type BulkTaggableResource = 'feature_flags' | 'dashboards' | 'insights' | 'tickets'
 
 export interface PageItem {
     id: number
@@ -26,6 +26,8 @@ export interface PageItem {
 
 export interface ListSelectionLogicProps {
     resource: BulkTaggableResource
+    /** API path segment if it differs from the resource key (e.g. 'conversations/tickets' for tickets). */
+    apiPath?: string
 }
 
 /**
@@ -118,8 +120,9 @@ export const listSelectionLogic = kea<listSelectionLogicType>([
             null as BulkUpdateTagsResult | null,
             {
                 bulkUpdateTags: async ({ action, tags }: { action: BulkTagAction; tags: string[] }) => {
+                    const path = logicProps.apiPath ?? logicProps.resource
                     const response = await api.create(
-                        `api/projects/${values.currentProjectId}/${logicProps.resource}/bulk_update_tags/`,
+                        `api/projects/${values.currentProjectId}/${path}/bulk_update_tags/`,
                         { ids: values.selectedIds, action, tags }
                     )
                     return response as BulkUpdateTagsResult

--- a/posthog/api/tagged_item.py
+++ b/posthog/api/tagged_item.py
@@ -164,8 +164,19 @@ class TaggedItemViewSetMixin(viewsets.GenericViewSet):
         tag_action: str = validated["action"]
         tags: list[str] = validated["tags"]
 
-        # Build queryset from the viewset's own queryset (inherits team/project scoping)
-        queryset = self.get_queryset().filter(id__in=validated_ids)
+        # Build queryset from the viewset's own queryset (inherits team/project scoping).
+        # Subclasses can set ``bulk_tag_lookup_field`` to look up by a natural key
+        # instead of ``id`` (e.g. ``ticket_number`` for UUID-keyed models).
+        # Explicit branches (rather than a dynamic dict key) are intentional to
+        # avoid ORM field-injection patterns that semgrep blocks; adding another
+        # lookup field means adding another branch here.
+        lookup_field = getattr(self, "bulk_tag_lookup_field", "id")
+        if lookup_field == "id":
+            queryset = self.get_queryset().filter(id__in=validated_ids)
+        elif lookup_field == "ticket_number":
+            queryset = self.get_queryset().filter(ticket_number__in=validated_ids)
+        else:
+            raise ValueError(f"Unsupported bulk_tag_lookup_field: {lookup_field!r}")
         queryset = self.prefetch_tagged_items_if_available(queryset)
         objects = list(queryset)
 
@@ -188,10 +199,10 @@ class TaggedItemViewSetMixin(viewsets.GenericViewSet):
             if user_access_level and access_level_satisfied_for_resource(scope_object, user_access_level, "editor"):
                 editable_objects.append(obj)
             else:
-                errors.append({"id": obj.id, "reason": "Permission denied"})
+                errors.append({"id": getattr(obj, lookup_field), "reason": "Permission denied"})
 
         # Track missing IDs
-        found_ids = {obj.id for obj in objects}
+        found_ids = {getattr(obj, lookup_field) for obj in objects}
         for obj_id in validated_ids:
             if obj_id not in found_ids:
                 errors.append({"id": obj_id, "reason": "Not found"})
@@ -222,7 +233,7 @@ class TaggedItemViewSetMixin(viewsets.GenericViewSet):
                 new_tags = set(normalized_tags)
 
             set_tags_on_object(list(new_tags), obj)
-            updated.append({"id": obj.id, "tags": sorted(new_tags)})
+            updated.append({"id": getattr(obj, lookup_field), "tags": sorted(new_tags)})
 
         # Cleanup orphan tags once at the end
         if team_id is not None:

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -882,6 +882,75 @@ class TestTicketAssignment(APIBaseTest):
 
 
 @patch.object(transaction, "on_commit", side_effect=immediate_on_commit)
+class TestBulkUpdateTagsTickets(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.ticket1 = Ticket.objects.create_with_number(
+            team=self.team, channel_source=Channel.WIDGET, distinct_id="u1", status=Status.NEW
+        )
+        self.ticket2 = Ticket.objects.create_with_number(
+            team=self.team, channel_source=Channel.WIDGET, distinct_id="u2", status=Status.NEW
+        )
+
+    def _url(self):
+        return f"/api/projects/{self.team.id}/conversations/tickets/bulk_update_tags/"
+
+    def test_add_tags_by_ticket_number(self, _mock):
+        response = self.client.post(
+            self._url(),
+            {"ids": [self.ticket1.ticket_number], "action": "add", "tags": ["urgent"]},
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data["updated"]) == 1
+        assert data["updated"][0]["id"] == self.ticket1.ticket_number
+        assert "urgent" in data["updated"][0]["tags"]
+
+    def test_set_tags_across_multiple_tickets(self, _mock):
+        response = self.client.post(
+            self._url(),
+            {
+                "ids": [self.ticket1.ticket_number, self.ticket2.ticket_number],
+                "action": "set",
+                "tags": ["billing", "vip"],
+            },
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data["updated"]) == 2
+        for item in data["updated"]:
+            assert sorted(item["tags"]) == ["billing", "vip"]
+
+    def test_missing_ticket_number_reported_as_skipped(self, _mock):
+        response = self.client.post(
+            self._url(),
+            {"ids": [999999], "action": "add", "tags": ["nope"]},
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data["updated"]) == 0
+        assert len(data["skipped"]) == 1
+        assert data["skipped"][0]["id"] == 999999
+
+    def test_remove_tag(self, _mock):
+        self.client.post(
+            self._url(),
+            {"ids": [self.ticket1.ticket_number], "action": "set", "tags": ["keep", "remove-me"]},
+            content_type="application/json",
+        )
+        response = self.client.post(
+            self._url(),
+            {"ids": [self.ticket1.ticket_number], "action": "remove", "tags": ["remove-me"]},
+            content_type="application/json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["updated"][0]["tags"] == ["keep"]
+
+
+@patch.object(transaction, "on_commit", side_effect=immediate_on_commit)
 class TestUnreadCountEndpoint(APIBaseTest):
     def setUp(self):
         super().setUp()

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -668,6 +668,11 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, viewsets.Mod
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
 
+    # Use ticket_number instead of id for bulk tag lookups.
+    # The shared BulkUpdateTagsRequestSerializer sends integer IDs but
+    # ticket PKs are UUIDs — the frontend selects by ticket_number.
+    bulk_tag_lookup_field = "ticket_number"
+
     @extend_schema(
         request=None,
         responses={

--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -15,9 +15,12 @@ import {
     LemonTag,
 } from '@posthog/lemon-ui'
 
+import { BulkActionToolbar } from 'lib/components/BulkActions/BulkActionToolbar'
+import { SelectionCheckbox } from 'lib/components/BulkActions/SelectionCheckbox'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { TZLabel } from 'lib/components/TZLabel'
+import { getSelectionState, listSelectionLogic } from 'lib/logic/listSelectionLogic'
 import { newInternalTab } from 'lib/utils/newInternalTab'
 import { stripMarkdown } from 'lib/utils/stripMarkdown'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
@@ -50,7 +53,12 @@ import {
     slaOptions,
     statusMultiselectOptions,
 } from '../../types'
-import { SUPPORT_TICKETS_PAGE_SIZE, supportTicketsSceneLogic } from './supportTicketsSceneLogic'
+import {
+    SUPPORT_TICKETS_PAGE_SIZE,
+    TICKET_API_PATH,
+    TICKET_RESOURCE,
+    supportTicketsSceneLogic,
+} from './supportTicketsSceneLogic'
 
 export const scene: SceneExport = {
     component: SupportTicketsScene,
@@ -221,58 +229,109 @@ export function SupportTicketsTable({ embedded = false }: SupportTicketsTablePro
     const { setCurrentPage, setSorting } = useActions(logic)
     const { push } = useActions(router)
 
+    const ticketSelection = listSelectionLogic({ resource: TICKET_RESOURCE, apiPath: TICKET_API_PATH })
+    const { selectedIds } = useValues(ticketSelection)
+    const { selectAllOnPage } = useActions(ticketSelection)
+
+    const allPageItems = tickets.map((ticket) => ({
+        id: ticket.ticket_number,
+        isEditable: true,
+    }))
+    const { isAllSelected, isSomeSelected } = getSelectionState(
+        selectedIds,
+        allPageItems.map((item) => item.id)
+    )
+
+    const selectionColumn: LemonTableColumns<Ticket> = embedded
+        ? []
+        : [
+              {
+                  key: 'selection',
+                  width: 32,
+                  title: (
+                      <LemonCheckbox
+                          checked={isSomeSelected ? 'indeterminate' : isAllSelected}
+                          onChange={() => selectAllOnPage(allPageItems)}
+                          aria-label="Select all tickets on this page"
+                      />
+                  ),
+                  render: function Render(_: unknown, ticket: Ticket, index: number) {
+                      return (
+                          <SelectionCheckbox
+                              resource={TICKET_RESOURCE}
+                              id={ticket.ticket_number}
+                              index={index}
+                              allPageItems={allPageItems}
+                              ariaLabel={`Select ticket #${ticket.ticket_number}`}
+                          />
+                      )
+                  },
+              },
+          ]
+
+    const baseColumns = embedded
+        ? SUPPORT_TICKETS_TABLE_COLUMNS.filter((col) => 'key' in col && col.key !== 'customer')
+        : SUPPORT_TICKETS_TABLE_COLUMNS
+
     return (
-        <LemonTable<Ticket>
-            dataSource={tickets}
-            rowKey="id"
-            loading={ticketsLoading}
-            embedded={embedded}
-            sorting={sorting}
-            onSort={(newSorting) => setSorting(newSorting)}
-            noSortingCancellation
-            pagination={{
-                controlled: true,
-                currentPage,
-                pageSize: SUPPORT_TICKETS_PAGE_SIZE,
-                entryCount: totalCount,
-                onBackward: currentPage > 1 ? () => setCurrentPage(currentPage - 1) : undefined,
-                onForward:
-                    currentPage * SUPPORT_TICKETS_PAGE_SIZE < totalCount
-                        ? () => setCurrentPage(currentPage + 1)
-                        : undefined,
-            }}
-            onRow={(ticket) => {
-                const ticketUrl = urls.supportTicketDetail(ticket.ticket_number)
-                return {
-                    onClick: (e: React.MouseEvent) => {
-                        if (e.metaKey || e.ctrlKey) {
-                            e.preventDefault()
-                            e.stopPropagation()
-                            newInternalTab(ticketUrl)
-                        } else {
-                            push(ticketUrl)
-                        }
-                    },
-                    onAuxClick: (e: React.MouseEvent) => {
-                        if (e.button === 1) {
-                            e.preventDefault()
-                            e.stopPropagation()
-                            newInternalTab(ticketUrl)
-                        }
-                    },
+        <>
+            {!embedded && selectedIds.length > 0 && (
+                <div className="flex items-center justify-end min-h-9 mb-2">
+                    <BulkActionToolbar resource={TICKET_RESOURCE} />
+                </div>
+            )}
+            <LemonTable<Ticket>
+                dataSource={tickets}
+                rowKey="id"
+                loading={ticketsLoading}
+                embedded={embedded}
+                sorting={sorting}
+                onSort={(newSorting) => setSorting(newSorting)}
+                noSortingCancellation
+                pagination={{
+                    controlled: true,
+                    currentPage,
+                    pageSize: SUPPORT_TICKETS_PAGE_SIZE,
+                    entryCount: totalCount,
+                    onBackward: currentPage > 1 ? () => setCurrentPage(currentPage - 1) : undefined,
+                    onForward:
+                        currentPage * SUPPORT_TICKETS_PAGE_SIZE < totalCount
+                            ? () => setCurrentPage(currentPage + 1)
+                            : undefined,
+                }}
+                onRow={(ticket) => {
+                    const ticketUrl = urls.supportTicketDetail(ticket.ticket_number)
+                    return {
+                        onClick: (e: React.MouseEvent) => {
+                            // Prevent navigation when clicking on selection checkbox
+                            if ((e.target as HTMLElement).closest('.LemonCheckbox')) {
+                                return
+                            }
+                            if (e.metaKey || e.ctrlKey) {
+                                e.preventDefault()
+                                e.stopPropagation()
+                                newInternalTab(ticketUrl)
+                            } else {
+                                push(ticketUrl)
+                            }
+                        },
+                        onAuxClick: (e: React.MouseEvent) => {
+                            if (e.button === 1) {
+                                e.preventDefault()
+                                e.stopPropagation()
+                                newInternalTab(ticketUrl)
+                            }
+                        },
+                    }
+                }}
+                rowClassName={(ticket) =>
+                    clsx({
+                        'bg-primary-alt-highlight': ticket.unread_team_count > 0,
+                    })
                 }
-            }}
-            rowClassName={(ticket) =>
-                clsx({
-                    'bg-primary-alt-highlight': ticket.unread_team_count > 0,
-                })
-            }
-            columns={
-                embedded
-                    ? SUPPORT_TICKETS_TABLE_COLUMNS.filter((col) => 'key' in col && col.key !== 'customer')
-                    : SUPPORT_TICKETS_TABLE_COLUMNS
-            }
-        />
+                columns={[...selectionColumn, ...baseColumns]}
+            />
+        </>
     )
 }
 

--- a/products/conversations/frontend/scenes/tickets/supportTicketsSceneLogic.ts
+++ b/products/conversations/frontend/scenes/tickets/supportTicketsSceneLogic.ts
@@ -5,6 +5,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { Sorting } from 'lib/lemon-ui/LemonTable/sorting'
+import { listSelectionLogic } from 'lib/logic/listSelectionLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import type {
@@ -20,6 +21,8 @@ import type {
 import type { supportTicketsSceneLogicType } from './supportTicketsSceneLogicType'
 
 export const SUPPORT_TICKETS_PAGE_SIZE = 20
+export const TICKET_RESOURCE = 'tickets' as const
+export const TICKET_API_PATH = 'conversations/tickets'
 
 export interface SupportTicketsSceneLogicProps {
     key?: string
@@ -209,115 +212,123 @@ export const supportTicketsSceneLogic = kea<supportTicketsSceneLogicType>([
             }),
         ],
     }),
-    listeners(({ actions, values, props }) => ({
-        loadTickets: async (_, breakpoint) => {
-            await breakpoint(300)
-            const params: Record<string, any> = {}
+    listeners(({ actions, values, props }) => {
+        const ticketSelection = listSelectionLogic({ resource: TICKET_RESOURCE, apiPath: TICKET_API_PATH })
 
-            if (props.distinctIds && props.distinctIds.length > 0) {
-                params.distinct_ids = props.distinctIds.join(',')
-            }
+        return {
+            [ticketSelection.actionTypes.bulkUpdateTagsSuccess]: () => {
+                actions.loadTickets()
+            },
+            loadTickets: async (_, breakpoint) => {
+                await breakpoint(300)
+                const params: Record<string, any> = {}
 
-            if (values.statusFilter.length > 0) {
-                params.status = values.statusFilter.join(',')
-            }
-            if (values.priorityFilter.length > 0) {
-                params.priority = values.priorityFilter.join(',')
-            }
-            if (values.channelFilter !== 'all') {
-                params.channel_source = values.channelFilter
-            }
-            if (values.slaFilter !== 'all') {
-                params.sla = values.slaFilter
-            }
-            if (values.assigneeFilter !== 'all') {
-                if (values.assigneeFilter === 'unassigned') {
-                    params.assignee = 'unassigned'
-                } else if (values.assigneeFilter && typeof values.assigneeFilter === 'object') {
-                    params.assignee = `${values.assigneeFilter.type}:${values.assigneeFilter.id}`
+                if (props.distinctIds && props.distinctIds.length > 0) {
+                    params.distinct_ids = props.distinctIds.join(',')
                 }
-            }
-            if (values.tagsFilter.length > 0) {
-                params.tags = JSON.stringify(values.tagsFilter)
-            }
-            if (values.searchQuery) {
-                params.search = values.searchQuery
-            }
-            if (values.dateFrom) {
-                params.date_from = values.dateFrom
-            }
-            if (values.dateTo) {
-                params.date_to = values.dateTo
-            }
-            params.order_by = values.orderBy
-            params.limit = SUPPORT_TICKETS_PAGE_SIZE
-            params.offset = (values.currentPage - 1) * SUPPORT_TICKETS_PAGE_SIZE
 
-            try {
-                const response = await api.conversationsTickets.list(params)
-                actions.setTickets(response.results || [])
-                actions.setTotalCount(response.count ?? response.results?.length ?? 0)
-            } catch {
-                lemonToast.error('Failed to load tickets')
-                actions.setTicketsLoading(false)
-            }
-        },
-        applyViewFilters: () => {
-            actions.setCurrentPage(1)
-        },
-        setCurrentPage: () => {
-            actions.loadTickets()
-        },
-        setSearchQuery: () => {
-            actions.clearActiveView()
-            actions.setCurrentPage(1)
-        },
-        setStatusFilter: () => {
-            actions.clearActiveView()
-            actions.setCurrentPage(1)
-        },
-        setPriorityFilter: () => {
-            actions.clearActiveView()
-            actions.setCurrentPage(1)
-        },
-        setChannelFilter: () => {
-            actions.clearActiveView()
-            actions.setCurrentPage(1)
-        },
-        setSlaFilter: () => {
-            actions.clearActiveView()
-            actions.setCurrentPage(1)
-        },
-        setAssigneeFilter: () => {
-            actions.clearActiveView()
-            actions.setCurrentPage(1)
-        },
-        setTagsFilter: () => {
-            actions.clearActiveView()
-            actions.setCurrentPage(1)
-        },
-        setDateRange: () => {
-            actions.clearActiveView()
-            actions.setCurrentPage(1)
-        },
-        setSorting: () => {
-            actions.clearActiveView()
-            actions.setCurrentPage(1)
-        },
-        setActiveView: ({ view }) => {
-            if (view) {
+                if (values.statusFilter.length > 0) {
+                    params.status = values.statusFilter.join(',')
+                }
+                if (values.priorityFilter.length > 0) {
+                    params.priority = values.priorityFilter.join(',')
+                }
+                if (values.channelFilter !== 'all') {
+                    params.channel_source = values.channelFilter
+                }
+                if (values.slaFilter !== 'all') {
+                    params.sla = values.slaFilter
+                }
+                if (values.assigneeFilter !== 'all') {
+                    if (values.assigneeFilter === 'unassigned') {
+                        params.assignee = 'unassigned'
+                    } else if (values.assigneeFilter && typeof values.assigneeFilter === 'object') {
+                        params.assignee = `${values.assigneeFilter.type}:${values.assigneeFilter.id}`
+                    }
+                }
+                if (values.tagsFilter.length > 0) {
+                    params.tags = JSON.stringify(values.tagsFilter)
+                }
+                if (values.searchQuery) {
+                    params.search = values.searchQuery
+                }
+                if (values.dateFrom) {
+                    params.date_from = values.dateFrom
+                }
+                if (values.dateTo) {
+                    params.date_to = values.dateTo
+                }
+                params.order_by = values.orderBy
+                params.limit = SUPPORT_TICKETS_PAGE_SIZE
+                params.offset = (values.currentPage - 1) * SUPPORT_TICKETS_PAGE_SIZE
+
+                try {
+                    const response = await api.conversationsTickets.list(params)
+                    actions.setTickets(response.results || [])
+                    actions.setTotalCount(response.count ?? response.results?.length ?? 0)
+                } catch {
+                    lemonToast.error('Failed to load tickets')
+                    actions.setTicketsLoading(false)
+                }
+            },
+            applyViewFilters: () => {
+                actions.setCurrentPage(1)
+            },
+            setCurrentPage: () => {
+                ticketSelection.actions.clearSelection()
+                actions.loadTickets()
+            },
+            setSearchQuery: () => {
+                actions.clearActiveView()
+                actions.setCurrentPage(1)
+            },
+            setStatusFilter: () => {
+                actions.clearActiveView()
+                actions.setCurrentPage(1)
+            },
+            setPriorityFilter: () => {
+                actions.clearActiveView()
+                actions.setCurrentPage(1)
+            },
+            setChannelFilter: () => {
+                actions.clearActiveView()
+                actions.setCurrentPage(1)
+            },
+            setSlaFilter: () => {
+                actions.clearActiveView()
+                actions.setCurrentPage(1)
+            },
+            setAssigneeFilter: () => {
+                actions.clearActiveView()
+                actions.setCurrentPage(1)
+            },
+            setTagsFilter: () => {
+                actions.clearActiveView()
+                actions.setCurrentPage(1)
+            },
+            setDateRange: () => {
+                actions.clearActiveView()
+                actions.setCurrentPage(1)
+            },
+            setSorting: () => {
+                actions.clearActiveView()
+                actions.setCurrentPage(1)
+            },
+            setActiveView: ({ view }) => {
+                if (view) {
+                    const { searchParams } = router.values
+                    router.actions.replace(router.values.location.pathname, { ...searchParams, view: view.short_id })
+                }
+            },
+            clearActiveView: () => {
                 const { searchParams } = router.values
-                router.actions.replace(router.values.location.pathname, { ...searchParams, view: view.short_id })
-            }
-        },
-        clearActiveView: () => {
-            const { searchParams } = router.values
-            if (searchParams.view) {
-                const { view: _, ...rest } = searchParams
-                router.actions.replace(router.values.location.pathname, rest)
-            }
-        },
-    })),
+                if (searchParams.view) {
+                    const { view: _, ...rest } = searchParams
+                    router.actions.replace(router.values.location.pathname, rest)
+                }
+            },
+        }
+    }),
     afterMount(({ actions }) => {
         const { searchParams } = router.values
         const viewShortId = searchParams.view


### PR DESCRIPTION
## Problem

Bulk update ticket tags.

## Changes

I recently added support for this to FFs/dashboards/insights ([stack of PRs](https://app.graphite.com/github/pr/PostHog/posthog/50945?utm_source=stack-comment-icon)), so it kind of comes for free to add it to tickets too. I thought I'd have a go at it while it was fresh in my mind - we could eventually use the same mechanism for bulk updating other ticket properties (e.g. assignment).


https://github.com/user-attachments/assets/c74c2293-9006-42c2-b8e0-36b20b205be5

## How did you test this code?

Tested locally.