### PR TITLE
feat(cdp): ses rate limiter

### DIFF
--- a/nodejs/src/capabilities.ts
+++ b/nodejs/src/capabilities.ts
@@ -24,6 +24,7 @@ export const CAPABILITIES_CDP_WORKFLOWS: PluginServerCapabilities = {
     ...CAPABILITIES_CDP,
     cdpBatchHogFlow: true,
     cdpCyclotronWorkerHogFlow: true,
+    cdpCyclotronWorkerEmail: true,
     cdpCyclotronV2Janitor: isDevEnv(),
     cdpHogflowScheduler: isDevEnv(),
 }
@@ -123,6 +124,10 @@ export function getPluginServerCapabilities(
         case PluginServerMode.cdp_cyclotron_worker_hogflow:
             return {
                 cdpCyclotronWorkerHogFlow: true,
+            }
+        case PluginServerMode.cdp_cyclotron_worker_email:
+            return {
+                cdpCyclotronWorkerEmail: true,
             }
         case PluginServerMode.cdp_precalculated_filters:
             return {

--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -43,6 +43,7 @@ export interface CdpCoreServices {
     nativeDestinationExecutorService: NativeDestinationExecutorService
     segmentDestinationExecutorService: SegmentDestinationExecutorService
     recipientTokensService: RecipientTokensService
+    emailService: EmailService
 }
 
 export type CdpCoreServicesConfig = Pick<
@@ -77,6 +78,7 @@ export type CdpCoreServicesConfig = Pick<
         | 'CDP_FETCH_RETRIES'
         | 'CDP_FETCH_BACKOFF_BASE_MS'
         | 'CDP_FETCH_BACKOFF_MAX_MS'
+        | 'CDP_EMAIL_QUEUE_ROUTING'
         | 'HOG_FUNCTION_MONITORING_APP_METRICS_TOPIC'
         | 'HOG_FUNCTION_MONITORING_LOG_ENTRIES_TOPIC'
     >
@@ -156,6 +158,7 @@ export function createCdpCoreServices(
             fetchRetries: config.CDP_FETCH_RETRIES,
             fetchBackoffBaseMs: config.CDP_FETCH_BACKOFF_BASE_MS,
             fetchBackoffMaxMs: config.CDP_FETCH_BACKOFF_MAX_MS,
+            emailQueueRouting: config.CDP_EMAIL_QUEUE_ROUTING,
         },
         { teamManager: deps.teamManager, siteUrl: config.SITE_URL },
         hogInputsService,
@@ -211,5 +214,6 @@ export function createCdpCoreServices(
         nativeDestinationExecutorService,
         segmentDestinationExecutorService,
         recipientTokensService,
+        emailService,
     }
 }

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -37,6 +37,10 @@ export type CdpConfig = {
     // Examples: '' (disabled), '123,456' (specific teams), '*:0.1' (10% of traffic),
     //           '123,*:0.05' (team 123 + 5% of rest), '*' (all traffic)
     CDP_EMAIL_QUEUE_ROUTING: string
+    // Global SES rate limiter. Set both to > 0 to enable.
+    // Disabled by default (0). Example: bucket=500, refill=500 → max 500 emails/sec sustained.
+    CDP_EMAIL_GLOBAL_RATE_LIMIT_BUCKET_SIZE: number
+    CDP_EMAIL_GLOBAL_RATE_LIMIT_REFILL_RATE: number
 
     CDP_LEGACY_EVENT_CONSUMER_GROUP_ID: string
     CDP_LEGACY_EVENT_CONSUMER_TOPIC: string
@@ -132,6 +136,8 @@ export function getDefaultCdpConfig(): CdpConfig {
         CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_FORCE_SCHEDULED_TO_POSTGRES: false,
         CDP_CYCLOTRON_STRIP_PERSON_FROM_STATE_TEAMS: '',
         CDP_EMAIL_QUEUE_ROUTING: '',
+        CDP_EMAIL_GLOBAL_RATE_LIMIT_BUCKET_SIZE: 0,
+        CDP_EMAIL_GLOBAL_RATE_LIMIT_REFILL_RATE: 0,
 
         CDP_LEGACY_EVENT_CONSUMER_GROUP_ID: 'clickhouse-plugin-server-async-onevent',
         CDP_LEGACY_EVENT_CONSUMER_TOPIC: KAFKA_EVENTS_JSON,

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -32,6 +32,11 @@ export type CdpConfig = {
     CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_TEAM_MAPPING: string
     CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_FORCE_SCHEDULED_TO_POSTGRES: boolean
     CDP_CYCLOTRON_STRIP_PERSON_FROM_STATE_TEAMS: string
+    // Controls which teams route email sends to the dedicated email queue.
+    // Supports team IDs, percentage rollout, or both.
+    // Examples: '' (disabled), '123,456' (specific teams), '*:0.1' (10% of traffic),
+    //           '123,*:0.05' (team 123 + 5% of rest), '*' (all traffic)
+    CDP_EMAIL_QUEUE_ROUTING: string
 
     CDP_LEGACY_EVENT_CONSUMER_GROUP_ID: string
     CDP_LEGACY_EVENT_CONSUMER_TOPIC: string
@@ -126,6 +131,7 @@ export function getDefaultCdpConfig(): CdpConfig {
         CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_TEAM_MAPPING: '',
         CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_FORCE_SCHEDULED_TO_POSTGRES: false,
         CDP_CYCLOTRON_STRIP_PERSON_FROM_STATE_TEAMS: '',
+        CDP_EMAIL_QUEUE_ROUTING: '',
 
         CDP_LEGACY_EVENT_CONSUMER_GROUP_ID: 'clickhouse-plugin-server-async-onevent',
         CDP_LEGACY_EVENT_CONSUMER_TOPIC: KAFKA_EVENTS_JSON,

--- a/nodejs/src/cdp/consumers/cdp-base.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-base.consumer.ts
@@ -20,6 +20,7 @@ import { HogFunctionManagerService } from '../services/managers/hog-function-man
 import { HogFunctionTemplateManagerService } from '../services/managers/hog-function-template-manager.service'
 import { PersonsManagerService } from '../services/managers/persons-manager.service'
 import { RecipientsManagerService } from '../services/managers/recipients-manager.service'
+import { EmailService } from '../services/messaging/email.service'
 import { RecipientPreferencesService } from '../services/messaging/recipient-preferences.service'
 import { HogFunctionMonitoringService } from '../services/monitoring/hog-function-monitoring.service'
 import { HogMaskerService } from '../services/monitoring/hog-masker.service'
@@ -60,6 +61,7 @@ export abstract class CdpConsumerBase<TConfig extends CdpConsumerBaseConfig = Cd
     personsManager: PersonsManagerService
     recipientsManager: RecipientsManagerService
 
+    emailService: EmailService
     hogFunctionMonitoringService: HogFunctionMonitoringService
     nativeDestinationExecutorService: NativeDestinationExecutorService
     pluginDestinationExecutorService: LegacyPluginExecutorService
@@ -88,6 +90,7 @@ export abstract class CdpConsumerBase<TConfig extends CdpConsumerBaseConfig = Cd
         this.recipientsManager = services.recipientsManager
         this.recipientPreferencesService = services.recipientPreferencesService
         this.hogFlowExecutor = services.hogFlowExecutor
+        this.emailService = services.emailService
         this.hogFunctionMonitoringService = services.hogFunctionMonitoringService
         this.nativeDestinationExecutorService = services.nativeDestinationExecutorService
         this.segmentDestinationExecutorService = services.segmentDestinationExecutorService

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email.consumer.test.ts
@@ -1,0 +1,33 @@
+import { createCdpConsumerDeps } from '~/tests/helpers/cdp'
+import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
+
+import { Hub } from '../../types'
+import { closeHub, createHub } from '../../utils/db/hub'
+import { CdpCyclotronWorkerEmail } from './cdp-cyclotron-worker-email.consumer'
+
+jest.setTimeout(5000)
+
+describe('CdpCyclotronWorkerEmail', () => {
+    let hub: Hub
+
+    beforeEach(async () => {
+        await resetTestDatabase()
+        hub = await createHub()
+        await getFirstTeam(hub.postgres)
+    })
+
+    afterEach(async () => {
+        jest.setTimeout(10000)
+        await closeHub(hub)
+    })
+
+    it('should set queue to email', () => {
+        const worker = new CdpCyclotronWorkerEmail(hub, createCdpConsumerDeps(hub))
+        expect(worker['queue']).toBe('email')
+    })
+
+    it('should extend CdpCyclotronWorkerHogFlow', () => {
+        const worker = new CdpCyclotronWorkerEmail(hub, createCdpConsumerDeps(hub))
+        expect(worker['name']).toBe('CdpCyclotronWorkerEmail')
+    })
+})

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email.consumer.test.ts
@@ -3,9 +3,34 @@ import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 
 import { Hub } from '../../types'
 import { closeHub, createHub } from '../../utils/db/hub'
+import { createHogExecutionGlobals } from '../_tests/fixtures'
+import { BASE_REDIS_KEY } from '../services/monitoring/hog-rate-limiter.service'
+import { CyclotronJobInvocation } from '../types'
 import { CdpCyclotronWorkerEmail } from './cdp-cyclotron-worker-email.consumer'
 
 jest.setTimeout(5000)
+
+const createEmailInvocation = (id: string, teamId: number): CyclotronJobInvocation => ({
+    id,
+    teamId,
+    functionId: 'function-1',
+    queue: 'email',
+    queuePriority: 0,
+    queueParameters: {
+        type: 'email',
+        to: { email: 'user@example.com' },
+        from: { email: 'noreply@posthog.com', integrationId: 1 },
+        subject: 'Test',
+        text: 'Hello',
+        html: '<p>Hello</p>',
+    },
+    state: {
+        globals: createHogExecutionGlobals({}),
+        vmState: null,
+        timings: [],
+        attempts: 0,
+    },
+})
 
 describe('CdpCyclotronWorkerEmail', () => {
     let hub: Hub
@@ -14,6 +39,15 @@ describe('CdpCyclotronWorkerEmail', () => {
         await resetTestDatabase()
         hub = await createHub()
         await getFirstTeam(hub.postgres)
+
+        // Flush rate limiter keys to avoid cross-test contamination
+        const worker = new CdpCyclotronWorkerEmail(hub, createCdpConsumerDeps(hub))
+        await worker['redis'].useClient({ name: 'test-cleanup' }, async (client) => {
+            const keys = await client.keys(`${BASE_REDIS_KEY}/*`)
+            if (keys.length > 0) {
+                await client.del(...keys)
+            }
+        })
     })
 
     afterEach(async () => {
@@ -26,8 +60,117 @@ describe('CdpCyclotronWorkerEmail', () => {
         expect(worker['queue']).toBe('email')
     })
 
-    it('should extend CdpCyclotronWorkerHogFlow', () => {
-        const worker = new CdpCyclotronWorkerEmail(hub, createCdpConsumerDeps(hub))
-        expect(worker['name']).toBe('CdpCyclotronWorkerEmail')
+    describe('rate limiting', () => {
+        it('should not create rate limiter when config is 0', () => {
+            const worker = new CdpCyclotronWorkerEmail(hub, createCdpConsumerDeps(hub))
+            expect(worker['emailRateLimiter']).toBeNull()
+        })
+
+        it('should create rate limiter when config is set', () => {
+            const worker = new CdpCyclotronWorkerEmail(
+                {
+                    ...hub,
+                    CDP_EMAIL_GLOBAL_RATE_LIMIT_BUCKET_SIZE: 500,
+                    CDP_EMAIL_GLOBAL_RATE_LIMIT_REFILL_RATE: 500,
+                },
+                createCdpConsumerDeps(hub)
+            )
+            expect(worker['emailRateLimiter']).not.toBeNull()
+        })
+
+        it('should defer invocations when rate limit is exceeded', async () => {
+            const worker = new CdpCyclotronWorkerEmail(
+                {
+                    ...hub,
+                    CDP_EMAIL_GLOBAL_RATE_LIMIT_BUCKET_SIZE: 2,
+                    CDP_EMAIL_GLOBAL_RATE_LIMIT_REFILL_RATE: 1,
+                },
+                createCdpConsumerDeps(hub)
+            )
+
+            // Mock parent processInvocations to avoid needing full hogflow setup
+            jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(worker)), 'processInvocations').mockResolvedValue([])
+
+            const invocations = [
+                createEmailInvocation('email-1', 1),
+                createEmailInvocation('email-2', 1),
+                createEmailInvocation('email-3', 1),
+            ]
+
+            const results = await worker.processInvocations(invocations)
+
+            // 2 processed (bucket size), 1 deferred
+            const deferred = results.filter((r) => !r.finished && r.invocation.queueScheduledAt)
+            expect(deferred).toHaveLength(1)
+            expect(deferred[0].invocation.queueScheduledAt).toBeDefined()
+        })
+
+        it('should defer all invocations when bucket is empty', async () => {
+            const worker = new CdpCyclotronWorkerEmail(
+                {
+                    ...hub,
+                    CDP_EMAIL_GLOBAL_RATE_LIMIT_BUCKET_SIZE: 1,
+                    CDP_EMAIL_GLOBAL_RATE_LIMIT_REFILL_RATE: 0.001,
+                },
+                createCdpConsumerDeps(hub)
+            )
+
+            jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(worker)), 'processInvocations').mockResolvedValue([])
+
+            // Exhaust the bucket (1 token)
+            await worker.processInvocations([createEmailInvocation('setup-1', 1)])
+
+            // Now all should be deferred (refill is negligible at 0.001/sec)
+            const results = await worker.processInvocations([
+                createEmailInvocation('email-1', 1),
+                createEmailInvocation('email-2', 1),
+            ])
+
+            const deferred = results.filter((r) => !r.finished && r.invocation.queueScheduledAt)
+            // At least 1 deferred since bucket was exhausted (exact count depends on timing/refill)
+            expect(deferred.length).toBeGreaterThanOrEqual(1)
+        })
+
+        it('should process all invocations when rate limiting is disabled', async () => {
+            const worker = new CdpCyclotronWorkerEmail(hub, createCdpConsumerDeps(hub))
+
+            const parentSpy = jest
+                .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(worker)), 'processInvocations')
+                .mockResolvedValue([{ finished: true }, { finished: true }, { finished: true }])
+
+            const invocations = [
+                createEmailInvocation('email-1', 1),
+                createEmailInvocation('email-2', 1),
+                createEmailInvocation('email-3', 1),
+            ]
+
+            const results = await worker.processInvocations(invocations)
+
+            // All passed through to parent — no rate limiting
+            expect(parentSpy).toHaveBeenCalledWith(invocations)
+            expect(results).toHaveLength(3)
+        })
+
+        it('should not create rate limiter when only one config value is set', () => {
+            const worker1 = new CdpCyclotronWorkerEmail(
+                {
+                    ...hub,
+                    CDP_EMAIL_GLOBAL_RATE_LIMIT_BUCKET_SIZE: 500,
+                    CDP_EMAIL_GLOBAL_RATE_LIMIT_REFILL_RATE: 0,
+                },
+                createCdpConsumerDeps(hub)
+            )
+            expect(worker1['emailRateLimiter']).toBeNull()
+
+            const worker2 = new CdpCyclotronWorkerEmail(
+                {
+                    ...hub,
+                    CDP_EMAIL_GLOBAL_RATE_LIMIT_BUCKET_SIZE: 0,
+                    CDP_EMAIL_GLOBAL_RATE_LIMIT_REFILL_RATE: 500,
+                },
+                createCdpConsumerDeps(hub)
+            )
+            expect(worker2['emailRateLimiter']).toBeNull()
+        })
     })
 })

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email.consumer.test.ts
@@ -131,6 +131,46 @@ describe('CdpCyclotronWorkerEmail', () => {
             expect(deferred.length).toBeGreaterThanOrEqual(1)
         })
 
+        it('should add jitter to deferred invocation delays', async () => {
+            const worker = new CdpCyclotronWorkerEmail(
+                {
+                    ...hub,
+                    CDP_EMAIL_GLOBAL_RATE_LIMIT_BUCKET_SIZE: 1,
+                    CDP_EMAIL_GLOBAL_RATE_LIMIT_REFILL_RATE: 0.001,
+                },
+                createCdpConsumerDeps(hub)
+            )
+
+            jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(worker)), 'processInvocations').mockResolvedValue([])
+
+            // Exhaust the bucket
+            await worker.processInvocations([createEmailInvocation('setup-1', 1)])
+
+            // Mock Math.random to return different values for each deferred invocation
+            let callCount = 0
+            jest.spyOn(Math, 'random').mockImplementation(() => {
+                callCount++
+                return (callCount * 0.3) % 1
+            })
+
+            // Defer multiple — their delays should not all be identical
+            const results = await worker.processInvocations([
+                createEmailInvocation('email-1', 1),
+                createEmailInvocation('email-2', 1),
+                createEmailInvocation('email-3', 1),
+            ])
+
+            const deferred = results.filter((r) => !r.finished && r.invocation.queueScheduledAt)
+            expect(deferred.length).toBeGreaterThanOrEqual(1)
+
+            // When multiple are deferred, their delays should vary due to jitter
+            if (deferred.length >= 2) {
+                const delays = deferred.map((r) => r.invocation.queueScheduledAt!.toMillis())
+                const allSame = delays.every((d) => d === delays[0])
+                expect(allSame).toBe(false)
+            }
+        })
+
         it('should process all invocations when rate limiting is disabled', async () => {
             const worker = new CdpCyclotronWorkerEmail(hub, createCdpConsumerDeps(hub))
 

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email.consumer.ts
@@ -1,18 +1,96 @@
+import { DateTime } from 'luxon'
+import { Counter, Gauge } from 'prom-client'
+
 import { PluginsServerConfig } from '~/types'
 
+import { logger } from '../../utils/logger'
+import { HogRateLimiterService } from '../services/monitoring/hog-rate-limiter.service'
+import { CyclotronJobInvocation, CyclotronJobInvocationResult } from '../types'
+import { createInvocationResult } from '../utils/invocation-utils'
 import { CdpConsumerBaseDeps } from './cdp-base.consumer'
 import { CdpCyclotronWorkerHogFlow } from './cdp-cyclotron-worker-hogflow.consumer'
 
+const emailRateLimitedTotal = new Counter({
+    name: 'cdp_email_rate_limited_total',
+    help: 'Total emails deferred by global rate limiting',
+})
+
+const emailRateLimitTokensAvailable = new Gauge({
+    name: 'cdp_email_rate_limit_tokens_available',
+    help: 'Available tokens in the global email rate limit bucket',
+})
+
+const RATE_LIMIT_RETRY_BASE_MS = 500
+const RATE_LIMIT_JITTER_MS = 200
+
 export class CdpCyclotronWorkerEmail extends CdpCyclotronWorkerHogFlow {
     protected override name = 'CdpCyclotronWorkerEmail'
+    private emailRateLimiter: HogRateLimiterService | null = null
 
     constructor(config: PluginsServerConfig, deps: CdpConsumerBaseDeps) {
         super(config, deps)
         this.queue = 'email'
+
+        if (config.CDP_EMAIL_GLOBAL_RATE_LIMIT_BUCKET_SIZE > 0 && config.CDP_EMAIL_GLOBAL_RATE_LIMIT_REFILL_RATE > 0) {
+            this.emailRateLimiter = new HogRateLimiterService(
+                {
+                    bucketSize: config.CDP_EMAIL_GLOBAL_RATE_LIMIT_BUCKET_SIZE,
+                    refillRate: config.CDP_EMAIL_GLOBAL_RATE_LIMIT_REFILL_RATE,
+                    ttl: 60 * 60 * 24,
+                },
+                this.redis
+            )
+        }
     }
 
     public override async start() {
         const consumerMode = this.config.CYCLOTRON_NODE_DATABASE_URL ? 'postgres-v2' : undefined
         await super.start(consumerMode)
+    }
+
+    public override async processInvocations(
+        invocations: CyclotronJobInvocation[]
+    ): Promise<CyclotronJobInvocationResult[]> {
+        if (!this.emailRateLimiter || invocations.length === 0) {
+            return super.processInvocations(invocations)
+        }
+
+        // Atomic consume: request all tokens in one call, then check how many we over-consumed.
+        // This eliminates the race window where multiple workers peek the same token count.
+        const [[, rateLimit]] = await this.emailRateLimiter.rateLimitMany([['global-email', invocations.length]])
+        const overConsumed = Math.max(0, -Math.floor(rateLimit.tokens))
+        const toProcess = invocations.slice(0, invocations.length - overConsumed)
+        const toDefer = invocations.slice(toProcess.length)
+
+        emailRateLimitTokensAvailable.set(Math.max(0, Math.floor(rateLimit.tokens)))
+
+        if (toDefer.length === 0) {
+            return super.processInvocations(invocations)
+        }
+
+        logger.info('Email rate limit applied', {
+            batchSize: invocations.length,
+            processing: toProcess.length,
+            deferred: toDefer.length,
+        })
+
+        // Process what we can
+        const results = toProcess.length > 0 ? await super.processInvocations(toProcess) : []
+
+        // Defer the rest with staggered delays
+        for (let i = 0; i < toDefer.length; i++) {
+            const jitterMs = Math.floor(Math.random() * RATE_LIMIT_JITTER_MS)
+            const delayMs = RATE_LIMIT_RETRY_BASE_MS + jitterMs
+            results.push(
+                createInvocationResult(
+                    toDefer[i],
+                    { queueScheduledAt: DateTime.now().plus({ milliseconds: delayMs }) },
+                    { finished: false }
+                )
+            )
+            emailRateLimitedTotal.inc()
+        }
+
+        return results
     }
 }

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email.consumer.ts
@@ -57,7 +57,15 @@ export class CdpCyclotronWorkerEmail extends CdpCyclotronWorkerHogFlow {
 
         // Atomic consume: request all tokens in one call, then check how many we over-consumed.
         // This eliminates the race window where multiple workers peek the same token count.
-        const [[, rateLimit]] = await this.emailRateLimiter.rateLimitMany([['global-email', invocations.length]])
+        // Fail open: if Redis is down, process the full batch without rate limiting.
+        let rateLimit: { tokens: number; isRateLimited: boolean }
+        try {
+            ;[[, rateLimit]] = await this.emailRateLimiter.rateLimitMany([['global-email', invocations.length]])
+        } catch (err) {
+            logger.error('Email rate limiter failed, processing batch without rate limiting', { error: String(err) })
+            return super.processInvocations(invocations)
+        }
+
         const overConsumed = Math.max(0, -Math.floor(rateLimit.tokens))
         const toProcess = invocations.slice(0, invocations.length - overConsumed)
         const toDefer = invocations.slice(toProcess.length)

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email.consumer.ts
@@ -1,0 +1,18 @@
+import { PluginsServerConfig } from '~/types'
+
+import { CdpConsumerBaseDeps } from './cdp-base.consumer'
+import { CdpCyclotronWorkerHogFlow } from './cdp-cyclotron-worker-hogflow.consumer'
+
+export class CdpCyclotronWorkerEmail extends CdpCyclotronWorkerHogFlow {
+    protected override name = 'CdpCyclotronWorkerEmail'
+
+    constructor(config: PluginsServerConfig, deps: CdpConsumerBaseDeps) {
+        super(config, deps)
+        this.queue = 'email'
+    }
+
+    public override async start() {
+        const consumerMode = this.config.CYCLOTRON_NODE_DATABASE_URL ? 'postgres-v2' : undefined
+        await super.start(consumerMode)
+    }
+}

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email.consumer.ts
@@ -1,18 +1,101 @@
+import { DateTime } from 'luxon'
+import { Counter, Gauge } from 'prom-client'
+
 import { PluginsServerConfig } from '~/types'
 
+import { logger } from '../../utils/logger'
+import { HogRateLimiterService } from '../services/monitoring/hog-rate-limiter.service'
+import { CyclotronJobInvocation, CyclotronJobInvocationResult } from '../types'
+import { createInvocationResult } from '../utils/invocation-utils'
 import { CdpConsumerBaseDeps } from './cdp-base.consumer'
 import { CdpCyclotronWorkerHogFlow } from './cdp-cyclotron-worker-hogflow.consumer'
 
+const emailRateLimitedTotal = new Counter({
+    name: 'cdp_email_rate_limited_total',
+    help: 'Total emails deferred by global rate limiting',
+})
+
+const emailRateLimitTokensAvailable = new Gauge({
+    name: 'cdp_email_rate_limit_tokens_available',
+    help: 'Available tokens in the global email rate limit bucket',
+})
+
+const RATE_LIMIT_RETRY_BASE_MS = 500
+const RATE_LIMIT_JITTER_MS = 200
+
 export class CdpCyclotronWorkerEmail extends CdpCyclotronWorkerHogFlow {
     protected name = 'CdpCyclotronWorkerEmail'
+    private emailRateLimiter: HogRateLimiterService | null = null
 
     constructor(config: PluginsServerConfig, deps: CdpConsumerBaseDeps) {
         super(config, deps)
         this.queue = 'email'
+
+        if (config.CDP_EMAIL_GLOBAL_RATE_LIMIT_BUCKET_SIZE > 0 && config.CDP_EMAIL_GLOBAL_RATE_LIMIT_REFILL_RATE > 0) {
+            this.emailRateLimiter = new HogRateLimiterService(
+                {
+                    bucketSize: config.CDP_EMAIL_GLOBAL_RATE_LIMIT_BUCKET_SIZE,
+                    refillRate: config.CDP_EMAIL_GLOBAL_RATE_LIMIT_REFILL_RATE,
+                    ttl: 60 * 60 * 24,
+                },
+                this.redis
+            )
+        }
     }
 
     public async start() {
         const consumerMode = this.config.CYCLOTRON_NODE_DATABASE_URL ? 'postgres-v2' : undefined
         await super.start(consumerMode)
+    }
+
+    public async processInvocations(invocations: CyclotronJobInvocation[]): Promise<CyclotronJobInvocationResult[]> {
+        if (!this.emailRateLimiter || invocations.length === 0) {
+            return super.processInvocations(invocations)
+        }
+
+        // Pre-flight rate limit: check how many emails we can process this batch
+        const [[, rateLimit]] = await this.emailRateLimiter.rateLimitMany([['global-email', 0]])
+        const availableTokens = Math.max(0, Math.floor(rateLimit.tokens))
+        emailRateLimitTokensAvailable.set(availableTokens)
+
+        if (availableTokens >= invocations.length) {
+            // Enough tokens — consume them and process the full batch
+            await this.emailRateLimiter.rateLimitMany([['global-email', invocations.length]])
+            return super.processInvocations(invocations)
+        }
+
+        // Not enough tokens — split the batch
+        const toProcess = invocations.slice(0, availableTokens)
+        const toDefer = invocations.slice(availableTokens)
+
+        logger.info('Email rate limit applied', {
+            batchSize: invocations.length,
+            processing: toProcess.length,
+            deferred: toDefer.length,
+            availableTokens,
+        })
+
+        if (toProcess.length > 0) {
+            await this.emailRateLimiter.rateLimitMany([['global-email', toProcess.length]])
+        }
+
+        // Process what we can
+        const results = toProcess.length > 0 ? await super.processInvocations(toProcess) : []
+
+        // Defer the rest with staggered delays
+        for (let i = 0; i < toDefer.length; i++) {
+            const jitterMs = Math.floor(Math.random() * RATE_LIMIT_JITTER_MS)
+            const delayMs = RATE_LIMIT_RETRY_BASE_MS + jitterMs
+            results.push(
+                createInvocationResult(
+                    toDefer[i],
+                    { queueScheduledAt: DateTime.now().plus({ milliseconds: delayMs }) },
+                    { finished: false }
+                )
+            )
+            emailRateLimitedTotal.inc()
+        }
+
+        return results
     }
 }

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -10,6 +10,7 @@ import {
     CyclotronJobInvocationHogFunction,
     CyclotronJobInvocationResult,
     CyclotronJobQueueKind,
+    CyclotronJobQueueSource,
 } from '../types'
 import { isLegacyPluginHogFunction, isNativeHogFunction, isSegmentPluginHogFunction } from '../utils'
 import { CdpConsumerBase, CdpConsumerBaseDeps } from './cdp-base.consumer'
@@ -166,9 +167,9 @@ export class CdpCyclotronWorker<
         await this.cyclotronJobQueue.queueInvocationResults(invocations)
     }
 
-    public override async start() {
+    public override async start(consumerModeOverride?: CyclotronJobQueueSource) {
         await super.start()
-        await this.cyclotronJobQueue.start(this.queue, (batch) => this.processBatch(batch))
+        await this.cyclotronJobQueue.start(this.queue, (batch) => this.processBatch(batch), consumerModeOverride)
     }
 
     public override async stop() {

--- a/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -452,6 +452,7 @@ export function createHogTransformerService(
             fetchRetries: config.CDP_FETCH_RETRIES,
             fetchBackoffBaseMs: config.CDP_FETCH_BACKOFF_BASE_MS,
             fetchBackoffMaxMs: config.CDP_FETCH_BACKOFF_MAX_MS,
+            emailQueueRouting: config.CDP_EMAIL_QUEUE_ROUTING,
         },
         { teamManager: deps.teamManager, siteUrl: config.SITE_URL },
         hogInputsService,

--- a/nodejs/src/cdp/services/cyclotron-v2/types.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/types.ts
@@ -33,7 +33,7 @@ export interface CyclotronV2DequeuedJob {
 
     ack(): Promise<void>
     fail(): Promise<void>
-    reschedule(options?: { scheduledAt?: Date; state?: Buffer | null }): Promise<void>
+    reschedule(options?: { scheduledAt?: Date; state?: Buffer | null; queueName?: string }): Promise<void>
     cancel(): Promise<void>
     heartbeat(): Promise<void>
 }

--- a/nodejs/src/cdp/services/cyclotron-v2/worker.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/worker.ts
@@ -166,10 +166,15 @@ export class CyclotronV2Worker {
                 )
             },
 
-            async reschedule(options?: { scheduledAt?: Date; state?: Buffer | null }): Promise<void> {
+            async reschedule(options?: {
+                scheduledAt?: Date
+                state?: Buffer | null
+                queueName?: string
+            }): Promise<void> {
                 releaseGuard('reschedule')
                 const scheduled = options?.scheduledAt ?? new Date()
                 const hasStateUpdate = options?.state !== undefined
+                const newQueueName = options?.queueName ?? row.queue_name
 
                 if (hasStateUpdate) {
                     await pool.query(
@@ -177,18 +182,20 @@ export class CyclotronV2Worker {
                          SET status = 'available', lock_id = NULL, last_heartbeat = NULL,
                              last_transition = NOW(), transition_count = transition_count + 1,
                              scheduled = $3,
-                             state = $4
+                             state = $4,
+                             queue_name = $5
                          WHERE id = $1 AND lock_id = $2`,
-                        [row.id, lockId, scheduled, options!.state ?? null]
+                        [row.id, lockId, scheduled, options!.state ?? null, newQueueName]
                     )
                 } else {
                     await pool.query(
                         `UPDATE cyclotron_jobs
                          SET status = 'available', lock_id = NULL, last_heartbeat = NULL,
                              last_transition = NOW(), transition_count = transition_count + 1,
-                             scheduled = $3
+                             scheduled = $3,
+                             queue_name = $4
                          WHERE id = $1 AND lock_id = $2`,
-                        [row.id, lockId, scheduled]
+                        [row.id, lockId, scheduled, newQueueName]
                     )
                 }
             },

--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -70,6 +70,7 @@ describe('Hog Executor', () => {
                 fetchRetries: hub.CDP_FETCH_RETRIES,
                 fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
+                emailQueueRouting: hub.CDP_EMAIL_QUEUE_ROUTING,
             },
             { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
             hogInputsService,
@@ -1467,6 +1468,177 @@ describe('Hog Executor', () => {
             [undefined, false],
         ])('returns %s for %j', (error, expected) => {
             expect(isConnectionLevelError(error)).toBe(expected)
+        })
+    })
+
+    describe('routeEmailToQueue', () => {
+        it('should route the invocation to the email queue', () => {
+            const hogFunction = createHogFunction({
+                name: 'Email function',
+                metadata: { message_category_type: 'marketing' },
+            })
+
+            const invocation: CyclotronJobInvocationHogFunction = {
+                ...createExampleInvocation(hogFunction),
+                queue: 'hogflow',
+                queueParameters: {
+                    type: 'email',
+                    to: { email: 'user@example.com' },
+                    from: { email: 'noreply@posthog.com', integrationId: 1 },
+                    subject: 'Test',
+                    text: 'Hello',
+                    html: '<p>Hello</p>',
+                },
+            }
+            invocation.state.vmState = { stack: [] } as any
+
+            const result = (executor as any).routeEmailToQueue(invocation)
+
+            expect(result.finished).toBe(false)
+            expect(result.invocation.queue).toBe('email')
+            expect(result.invocation.queueMetadata?.originQueue).toBe('hogflow')
+            expect(result.metrics).toContainEqual(
+                expect.objectContaining({
+                    metric_name: 'email_queued',
+                    metric_kind: 'email',
+                })
+            )
+        })
+
+        it('should preserve the same job ID (no new job created)', () => {
+            const hogFunction = createHogFunction({ name: 'Email function' })
+            const invocation: CyclotronJobInvocationHogFunction = {
+                ...createExampleInvocation(hogFunction),
+                queueParameters: {
+                    type: 'email',
+                    to: { email: 'user@example.com' },
+                    from: { email: 'noreply@posthog.com', integrationId: 1 },
+                    subject: 'Test',
+                    text: 'Hello',
+                    html: '<p>Hello</p>',
+                },
+            }
+            invocation.state.vmState = { stack: [] } as any
+
+            const result = (executor as any).routeEmailToQueue(invocation)
+
+            expect(result.invocation.id).toBe(invocation.id)
+        })
+    })
+
+    describe('email queue routing config', () => {
+        const createEmailInvocation = (): CyclotronJobInvocationHogFunction => {
+            const hogFunction = createHogFunction({ name: 'Email function', team_id: 123 })
+            const invocation: CyclotronJobInvocationHogFunction = {
+                ...createExampleInvocation(hogFunction),
+                teamId: 123,
+                queueParameters: {
+                    type: 'email',
+                    to: { email: 'user@example.com' },
+                    from: { email: 'noreply@posthog.com', integrationId: 1 },
+                    subject: 'Test',
+                    text: 'Hello',
+                    html: '<p>Hello</p>',
+                },
+            }
+            invocation.state.vmState = { stack: [] } as any
+            return invocation
+        }
+
+        const createExecutorWithRouting = (emailQueueRouting: string): HogExecutorService => {
+            const hogInputsService = new HogInputsService(
+                hub.integrationManager,
+                hub.ENCRYPTION_SALT_KEYS,
+                hub.SITE_URL
+            )
+            const emailService = new EmailService(
+                {
+                    sesAccessKeyId: hub.SES_ACCESS_KEY_ID,
+                    sesSecretAccessKey: hub.SES_SECRET_ACCESS_KEY,
+                    sesRegion: hub.SES_REGION,
+                    sesEndpoint: hub.SES_ENDPOINT,
+                },
+                hub.integrationManager,
+                hub.ENCRYPTION_SALT_KEYS,
+                hub.SITE_URL
+            )
+            const recipientTokensService = new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
+            return new HogExecutorService(
+                {
+                    hogCostTimingUpperMs: hub.CDP_WATCHER_HOG_COST_TIMING_UPPER_MS,
+                    googleAdwordsDeveloperToken: hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN,
+                    fetchRetries: hub.CDP_FETCH_RETRIES,
+                    fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
+                    fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
+                    emailQueueRouting,
+                },
+                { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
+                hogInputsService,
+                emailService,
+                recipientTokensService
+            )
+        }
+
+        it('should send inline when routing is empty', async () => {
+            const exec = createExecutorWithRouting('')
+            const invocation = createEmailInvocation()
+
+            const result = await exec.executeWithAsyncFunctions(invocation)
+
+            expect(result.invocation.queue).not.toBe('email')
+            expect(result.finished).toBe(true)
+        })
+
+        it('should route to email queue when team matches', async () => {
+            const exec = createExecutorWithRouting('123')
+            const invocation = createEmailInvocation()
+
+            const result = await exec.executeWithAsyncFunctions(invocation)
+
+            expect(result.invocation.queue).toBe('email')
+            expect(result.finished).toBe(false)
+        })
+
+        it('should send inline when team does not match', async () => {
+            const exec = createExecutorWithRouting('456')
+            const invocation = createEmailInvocation()
+
+            const result = await exec.executeWithAsyncFunctions(invocation)
+
+            expect(result.invocation.queue).not.toBe('email')
+            expect(result.finished).toBe(true)
+        })
+
+        it('should route based on percentage when under threshold', async () => {
+            const exec = createExecutorWithRouting('*:0.5')
+            const invocation = createEmailInvocation()
+
+            jest.spyOn(Math, 'random').mockReturnValue(0.3)
+            const result = await exec.executeWithAsyncFunctions(invocation)
+
+            expect(result.invocation.queue).toBe('email')
+            expect(result.finished).toBe(false)
+        })
+
+        it('should send inline when percentage roll is above threshold', async () => {
+            const exec = createExecutorWithRouting('*:0.5')
+            const invocation = createEmailInvocation()
+
+            jest.spyOn(Math, 'random').mockReturnValue(0.7)
+            const result = await exec.executeWithAsyncFunctions(invocation)
+
+            expect(result.invocation.queue).not.toBe('email')
+        })
+
+        it('should route all teams when config is *', async () => {
+            const exec = createExecutorWithRouting('*')
+            const invocation = createEmailInvocation()
+
+            const result = await exec.executeWithAsyncFunctions(invocation)
+
+            expect(result.invocation.queue).toBe('email')
+            expect(result.invocation.queueMetadata?.originQueue).toBeDefined()
+            expect(result.finished).toBe(false)
         })
     })
 })

--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -8,7 +8,8 @@ import { ACCESS_TOKEN_PLACEHOLDER } from '~/config/constants'
 import { FetchOptions, FetchResponse, InvalidRequestError, SecureRequestError, fetch } from '~/utils/request'
 import { tryCatch } from '~/utils/try-catch'
 
-import { PluginsServerConfig } from '../../types'
+import { buildIntegerMatcherWithPercentage } from '../../config/config'
+import { PluginsServerConfig, ValueMatcher } from '../../types'
 import { parseJSON } from '../../utils/json-parse'
 import { logger } from '../../utils/logger'
 import { TeamManager } from '../../utils/team-manager'
@@ -46,12 +47,18 @@ export interface HogExecutorConfig {
     fetchRetries: number
     fetchBackoffBaseMs: number
     fetchBackoffMaxMs: number
+    emailQueueRouting: string
 }
 
 export interface HogExecutorAsyncContext {
     teamManager: TeamManager
     siteUrl: string
 }
+
+const cdpEmailQueuedTotal = new Counter({
+    name: 'cdp_email_queued_total',
+    help: 'Total emails routed to the dedicated email queue',
+})
 
 const cdpHttpRequests = new Counter({
     name: 'cdp_http_requests',
@@ -179,13 +186,17 @@ export type HogExecutorExecuteAsyncOptions = HogExecutorExecuteOptions & {
 }
 
 export class HogExecutorService {
+    private emailQueueMatcher: ValueMatcher<number>
+
     constructor(
         private config: HogExecutorConfig,
         private asyncContext: HogExecutorAsyncContext,
         private hogInputsService: HogInputsService,
         private emailService: EmailService,
         private recipientTokensService: RecipientTokensService
-    ) {}
+    ) {
+        this.emailQueueMatcher = buildIntegerMatcherWithPercentage(config.emailQueueRouting)
+    }
 
     async buildInputsWithGlobals(
         hogFunction: HogFunctionType,
@@ -338,10 +349,33 @@ export class HogExecutorService {
                     break
                 }
 
+                // Queue-aware routing: each worker can execute some actions inline
+                // and routes others to a specialized queue. The email worker sends
+                // emails inline but routes fetches back to hogflow. The hogflow
+                // worker does fetches inline but routes emails to the email queue
+                // (when the team is configured for it via CDP_EMAIL_QUEUE_ROUTING).
+                //
+                // Future: once we add an execution time budget, the email worker
+                // will also handle fetches inline. The only reason to reschedule
+                // back to hogflow will be when overall execution time exceeds the
+                // budget, to avoid blocking the queue.
                 if (queueParamsType === 'fetch') {
-                    result = await this.executeFetch(nextInvocation, options)
+                    if (invocation.queue === 'email') {
+                        result = this.routeToQueue(
+                            nextInvocation,
+                            nextInvocation.queueMetadata?.originQueue ?? 'hogflow'
+                        )
+                    } else {
+                        result = await this.executeFetch(nextInvocation, options)
+                    }
                 } else if (queueParamsType === 'email') {
-                    result = await this.emailService.executeSendEmail(nextInvocation)
+                    // Route to the email queue only if we're not already there
+                    // and the team is configured for it. Otherwise send inline.
+                    if (invocation.queue !== 'email' && this.emailQueueMatcher(nextInvocation.teamId)) {
+                        result = this.routeEmailToQueue(nextInvocation)
+                    } else {
+                        result = await this.emailService.executeSendEmail(nextInvocation)
+                    }
                 } else {
                     throw new Error(`Unknown queue type: ${queueParamsType}`)
                 }
@@ -355,8 +389,8 @@ export class HogExecutorService {
             logs.push(...result.logs)
             metrics.push(...result.metrics)
 
-            // If we have finished _or_ something has been scheduled to run later _or_ we have reached the max async functions then we break the loop
-            if (result.finished || result.invocation.queueScheduledAt) {
+            // If we have finished _or_ something has been scheduled to run later _or_ the job was routed to a different queue then we break the loop
+            if (result.finished || result.invocation.queueScheduledAt || result.invocation.queue !== invocation.queue) {
                 break
             }
         }
@@ -373,6 +407,56 @@ export class HogExecutorService {
         result.metrics = metrics
 
         return result
+    }
+
+    /**
+     * Routes an email send to the dedicated email queue instead of sending inline.
+     * The email worker will pick this up, send via SES, and return the job to the
+     * original queue so the workflow can continue.
+     */
+    private routeEmailToQueue(
+        invocation: CyclotronJobInvocationHogFunction
+    ): CyclotronJobInvocationResult<CyclotronJobInvocationHogFunction> {
+        const result = createInvocationResult<CyclotronJobInvocationHogFunction>(
+            invocation,
+            {
+                queue: 'email',
+                queueParameters: invocation.queueParameters,
+                queueMetadata: {
+                    ...invocation.queueMetadata,
+                    originQueue: invocation.queue,
+                },
+            },
+            { finished: false }
+        )
+
+        result.metrics.push({
+            team_id: invocation.teamId,
+            app_source_id: invocation.parentRunId ?? invocation.functionId,
+            instance_id: invocation.state.actionId || invocation.id,
+            metric_kind: 'email',
+            metric_name: 'email_queued',
+            count: 1,
+        })
+
+        cdpEmailQueuedTotal.inc()
+
+        return result
+    }
+
+    private routeToQueue(
+        invocation: CyclotronJobInvocationHogFunction,
+        targetQueue: string
+    ): CyclotronJobInvocationResult<CyclotronJobInvocationHogFunction> {
+        return createInvocationResult<CyclotronJobInvocationHogFunction>(
+            invocation,
+            {
+                queue: targetQueue as CyclotronJobInvocationHogFunction['queue'],
+                queueParameters: invocation.queueParameters,
+                queueMetadata: undefined,
+            },
+            { finished: false }
+        )
     }
 
     @instrumented({ key: 'hog-executor.execute', sendException: false })

--- a/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
@@ -60,6 +60,7 @@ describe('HogFunctionHandler', () => {
                 fetchRetries: hub.CDP_FETCH_RETRIES,
                 fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
+                emailQueueRouting: hub.CDP_EMAIL_QUEUE_ROUTING,
             },
             { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
             hogInputsService,

--- a/nodejs/src/cdp/services/hogflows/actions/hog_function.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/hog_function.ts
@@ -54,8 +54,10 @@ export class HogFunctionHandler implements ActionHandler {
         if (!functionResult.finished) {
             // Set the state of the function result on the substate of the flow for the next execution
             result.invocation.state.currentAction!.hogFunctionState = functionResult.invocation.state
-            // Also the queueParameters are required
+            // Preserve queue routing and parameters from the function result
+            result.invocation.queue = functionResult.invocation.queue
             result.invocation.queueParameters = functionResult.invocation.queueParameters
+            result.invocation.queueMetadata = functionResult.invocation.queueMetadata
             return {
                 scheduledAt: functionResult.invocation.queueScheduledAt ?? DateTime.now(),
             }

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -80,6 +80,7 @@ describe('Hogflow Executor', () => {
                 fetchRetries: hub.CDP_FETCH_RETRIES,
                 fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
+                emailQueueRouting: hub.CDP_EMAIL_QUEUE_ROUTING,
             },
             { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
             hogInputsService,
@@ -1788,6 +1789,380 @@ describe('Hogflow Executor', () => {
         })
     })
 
+    describe('email queue routing', () => {
+        it('should route email actions to the email queue when routing is configured', async () => {
+            const team = await getFirstTeam(hub.postgres)
+
+            await insertIntegration(hub.postgres, team.id, {
+                id: 1,
+                kind: 'email',
+                config: {
+                    email: 'test@posthog.com',
+                    name: 'Test User',
+                    domain: 'posthog.com',
+                    verified: true,
+                    provider: 'maildev',
+                },
+            })
+
+            await insertHogFunctionTemplate(hub.postgres, {
+                id: 'template-email-routing-test',
+                name: 'Email Routing Test',
+                code: `sendEmail(inputs.email)`,
+                inputs_schema: [
+                    {
+                        type: 'native_email',
+                        key: 'email',
+                        label: 'Email message',
+                        integration: 'email',
+                        required: true,
+                        default: {
+                            to: { email: '', name: '' },
+                            from: { email: '', name: '' },
+                            subject: '',
+                            text: 'Hello!',
+                            html: '<div>Hello!</div>',
+                        },
+                        secret: false,
+                        description: '',
+                        templating: 'liquid',
+                    },
+                ],
+            })
+
+            // Create executor with email queue routing enabled for all teams
+            const routingExecutor = new HogFlowExecutorService(
+                new HogFlowFunctionsService(
+                    hub.SITE_URL,
+                    new HogFunctionTemplateManagerService(hub.postgres),
+                    new HogExecutorService(
+                        {
+                            hogCostTimingUpperMs: hub.CDP_WATCHER_HOG_COST_TIMING_UPPER_MS,
+                            googleAdwordsDeveloperToken: hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN,
+                            fetchRetries: hub.CDP_FETCH_RETRIES,
+                            fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
+                            fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
+                            emailQueueRouting: '*',
+                        },
+                        { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
+                        new HogInputsService(hub.integrationManager, hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL),
+                        new EmailService(
+                            {
+                                sesAccessKeyId: hub.SES_ACCESS_KEY_ID,
+                                sesSecretAccessKey: hub.SES_SECRET_ACCESS_KEY,
+                                sesRegion: hub.SES_REGION,
+                                sesEndpoint: hub.SES_ENDPOINT,
+                            },
+                            hub.integrationManager,
+                            hub.ENCRYPTION_SALT_KEYS,
+                            hub.SITE_URL
+                        ),
+                        new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
+                    )
+                ),
+                new RecipientPreferencesService(new RecipientsManagerService(hub.postgres))
+            )
+
+            const hogFlow = new FixtureHogFlowBuilder()
+                .withTeamId(team.id)
+                .withExitCondition('exit_only_at_end')
+                .withWorkflow({
+                    actions: {
+                        trigger: {
+                            type: 'trigger',
+                            config: {
+                                type: 'event',
+                                filters: HOG_FILTERS_EXAMPLES.no_filters.filters ?? {},
+                            },
+                        },
+                        email_1: {
+                            type: 'function_email',
+                            config: {
+                                template_id: 'template-email-routing-test',
+                                inputs: {
+                                    email: {
+                                        value: {
+                                            to: { email: 'recipient@example.com', name: 'Recipient' },
+                                            from: { integrationId: 1, email: 'test@posthog.com' },
+                                            subject: 'Test Email',
+                                            text: 'Test',
+                                            html: '<p>Test</p>',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    edges: [
+                        { from: 'trigger', to: 'email_1', type: 'continue' },
+                        { from: 'email_1', to: 'exit', type: 'continue' },
+                    ],
+                })
+                .build()
+
+            const invocation = createExampleHogFlowInvocation(hogFlow, {
+                event: {
+                    ...createHogExecutionGlobals().event,
+                    event: '$pageview',
+                },
+            })
+
+            const result = await routingExecutor.execute(invocation)
+
+            // Should be routed to email queue, not finished
+            expect(result.finished).toBe(false)
+            expect(result.invocation.queue).toBe('email')
+            expect(result.invocation.queueMetadata?.originQueue).toBeDefined()
+            expect(result.invocation.queueParameters).toBeDefined()
+            expect(result.invocation.queueParameters?.type).toBe('email')
+        })
+
+        it('should send email inline when routing is not configured', async () => {
+            const team = await getFirstTeam(hub.postgres)
+
+            await insertIntegration(hub.postgres, team.id, {
+                id: 1,
+                kind: 'email',
+                config: {
+                    email: 'test@posthog.com',
+                    name: 'Test User',
+                    domain: 'posthog.com',
+                    verified: true,
+                    provider: 'maildev',
+                },
+            })
+
+            const hogFlow = new FixtureHogFlowBuilder()
+                .withTeamId(team.id)
+                .withExitCondition('exit_only_at_end')
+                .withWorkflow({
+                    actions: {
+                        trigger: {
+                            type: 'trigger',
+                            config: {
+                                type: 'event',
+                                filters: HOG_FILTERS_EXAMPLES.no_filters.filters ?? {},
+                            },
+                        },
+                        email_1: {
+                            type: 'function_email',
+                            config: {
+                                template_id: 'template-email-routing-test',
+                                inputs: {
+                                    email: {
+                                        value: {
+                                            to: { email: 'recipient@example.com', name: 'Recipient' },
+                                            from: { integrationId: 1, email: 'test@posthog.com' },
+                                            subject: 'Test Email',
+                                            text: 'Test',
+                                            html: '<p>Test</p>',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    edges: [
+                        { from: 'trigger', to: 'email_1', type: 'continue' },
+                        { from: 'email_1', to: 'exit', type: 'continue' },
+                    ],
+                })
+                .build()
+
+            const invocation = createExampleHogFlowInvocation(hogFlow, {
+                event: {
+                    ...createHogExecutionGlobals().event,
+                    event: '$pageview',
+                },
+            })
+
+            // Default executor has emailQueueRouting = '' (inline)
+            let result = await executor.execute(invocation)
+            while (!result.finished) {
+                result = await executor.execute(result.invocation)
+            }
+
+            // Should send inline and complete
+            expect(result.finished).toBe(true)
+            expect(result.invocation.queue).not.toBe('email')
+        })
+
+        it('should complete the full round-trip: hogflow → email queue → email sent → workflow continues', async () => {
+            const team = await getFirstTeam(hub.postgres)
+
+            await insertIntegration(hub.postgres, team.id, {
+                id: 1,
+                kind: 'email',
+                config: {
+                    email: 'test@posthog.com',
+                    name: 'Test User',
+                    domain: 'posthog.com',
+                    verified: true,
+                    provider: 'maildev',
+                },
+            })
+
+            await insertHogFunctionTemplate(hub.postgres, {
+                id: 'template-email-routing-test',
+                name: 'Email Routing Test',
+                code: `sendEmail(inputs.email)`,
+                inputs_schema: [
+                    {
+                        type: 'native_email',
+                        key: 'email',
+                        label: 'Email message',
+                        integration: 'email',
+                        required: true,
+                        default: {
+                            to: { email: '', name: '' },
+                            from: { email: '', name: '' },
+                            subject: '',
+                            text: 'Hello!',
+                            html: '<div>Hello!</div>',
+                        },
+                        secret: false,
+                        description: '',
+                        templating: 'liquid',
+                    },
+                ],
+            })
+
+            // Executor with routing enabled (simulates hogflow worker)
+            const hogflowExecutor = new HogFlowExecutorService(
+                new HogFlowFunctionsService(
+                    hub.SITE_URL,
+                    new HogFunctionTemplateManagerService(hub.postgres),
+                    new HogExecutorService(
+                        {
+                            hogCostTimingUpperMs: hub.CDP_WATCHER_HOG_COST_TIMING_UPPER_MS,
+                            googleAdwordsDeveloperToken: hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN,
+                            fetchRetries: hub.CDP_FETCH_RETRIES,
+                            fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
+                            fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
+                            emailQueueRouting: '*',
+                        },
+                        { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
+                        new HogInputsService(hub.integrationManager, hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL),
+                        new EmailService(
+                            {
+                                sesAccessKeyId: hub.SES_ACCESS_KEY_ID,
+                                sesSecretAccessKey: hub.SES_SECRET_ACCESS_KEY,
+                                sesRegion: hub.SES_REGION,
+                                sesEndpoint: hub.SES_ENDPOINT,
+                            },
+                            hub.integrationManager,
+                            hub.ENCRYPTION_SALT_KEYS,
+                            hub.SITE_URL
+                        ),
+                        new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
+                    )
+                ),
+                new RecipientPreferencesService(new RecipientsManagerService(hub.postgres))
+            )
+
+            // Executor with no routing (simulates email worker — emails are inline)
+            const emailExecutor = new HogFlowExecutorService(
+                new HogFlowFunctionsService(
+                    hub.SITE_URL,
+                    new HogFunctionTemplateManagerService(hub.postgres),
+                    new HogExecutorService(
+                        {
+                            hogCostTimingUpperMs: hub.CDP_WATCHER_HOG_COST_TIMING_UPPER_MS,
+                            googleAdwordsDeveloperToken: hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN,
+                            fetchRetries: hub.CDP_FETCH_RETRIES,
+                            fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
+                            fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
+                            emailQueueRouting: '',
+                        },
+                        { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
+                        new HogInputsService(hub.integrationManager, hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL),
+                        new EmailService(
+                            {
+                                sesAccessKeyId: hub.SES_ACCESS_KEY_ID,
+                                sesSecretAccessKey: hub.SES_SECRET_ACCESS_KEY,
+                                sesRegion: hub.SES_REGION,
+                                sesEndpoint: hub.SES_ENDPOINT,
+                            },
+                            hub.integrationManager,
+                            hub.ENCRYPTION_SALT_KEYS,
+                            hub.SITE_URL
+                        ),
+                        new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
+                    )
+                ),
+                new RecipientPreferencesService(new RecipientsManagerService(hub.postgres))
+            )
+
+            const hogFlow = new FixtureHogFlowBuilder()
+                .withTeamId(team.id)
+                .withExitCondition('exit_only_at_end')
+                .withWorkflow({
+                    actions: {
+                        trigger: {
+                            type: 'trigger',
+                            config: {
+                                type: 'event',
+                                filters: HOG_FILTERS_EXAMPLES.no_filters.filters ?? {},
+                            },
+                        },
+                        email_1: {
+                            type: 'function_email',
+                            config: {
+                                template_id: 'template-email-routing-test',
+                                inputs: {
+                                    email: {
+                                        value: {
+                                            to: { email: 'recipient@example.com', name: 'Recipient' },
+                                            from: { integrationId: 1, email: 'test@posthog.com' },
+                                            subject: 'Test Email',
+                                            text: 'Test text',
+                                            html: '<p>Test html</p>',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        exit: {
+                            type: 'exit',
+                            config: {},
+                        },
+                    },
+                    edges: [
+                        { from: 'trigger', to: 'email_1', type: 'continue' },
+                        { from: 'email_1', to: 'exit', type: 'continue' },
+                    ],
+                })
+                .build()
+
+            const invocation = createExampleHogFlowInvocation(hogFlow, {
+                event: {
+                    ...createHogExecutionGlobals().event,
+                    event: '$pageview',
+                },
+            })
+
+            // Step 1: Hogflow worker executes — should route to email queue
+            const hogflowResult = await hogflowExecutor.execute(invocation)
+            expect(hogflowResult.finished).toBe(false)
+            expect(hogflowResult.invocation.queue).toBe('email')
+            expect(hogflowResult.invocation.queueParameters?.type).toBe('email')
+
+            // Step 2: Email worker picks up the job — should send the email and continue
+            let emailResult = await emailExecutor.execute(hogflowResult.invocation)
+            while (!emailResult.finished) {
+                emailResult = await emailExecutor.execute(emailResult.invocation)
+            }
+
+            // Workflow should complete
+            expect(emailResult.finished).toBe(true)
+            expect(emailResult.error).toBeUndefined()
+
+            // Verify email_sent metric was emitted
+            const emailSentMetrics = emailResult.metrics.filter((m) => m.metric_name === 'email_sent')
+            expect(emailSentMetrics).toHaveLength(1)
+        })
+    })
+
     function createTestExecutor(redis?: any): HogFlowExecutorService {
         return new HogFlowExecutorService(
             new HogFlowFunctionsService(
@@ -1800,6 +2175,7 @@ describe('Hogflow Executor', () => {
                         fetchRetries: hub.CDP_FETCH_RETRIES,
                         fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
                         fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
+                        emailQueueRouting: hub.CDP_EMAIL_QUEUE_ROUTING,
                     },
                     { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
                     new HogInputsService(hub.integrationManager, hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL),

--- a/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.ts
@@ -157,6 +157,7 @@ export class CyclotronJobQueuePostgresV2 {
                     await job.reschedule({
                         state: stateBuffer,
                         scheduledAt: result.invocation.queueScheduledAt?.toJSDate(),
+                        queueName: result.invocation.queue,
                     })
                 }
             })

--- a/nodejs/src/cdp/services/messaging/email.service.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.ts
@@ -112,8 +112,8 @@ export class EmailService {
             result.finished = true
         }
 
-        // Finally we create the response object as the VM expects
-        result.invocation.state.vmState!.stack.push({
+        // Push the response to the VM stack if running inline (not from the email queue)
+        result.invocation.state.vmState?.stack.push({
             success,
         })
 
@@ -226,7 +226,7 @@ export class EmailService {
             FeedbackForwardingEmailAddress: params.from.email,
         }
 
-        const isTransactionalEmail = result.invocation.hogFunction.metadata?.message_category_type === 'transactional'
+        const isTransactionalEmail = result.invocation.hogFunction?.metadata?.message_category_type === 'transactional'
         // Automatically add unsubscribe headers for non-transactional emails
         if (sendEmailParams.Content?.Simple && !isTransactionalEmail) {
             sendEmailParams.Content.Simple.Headers = this.generateUnsubscribeHeaders({

--- a/nodejs/src/cdp/templates/test/test-helpers.ts
+++ b/nodejs/src/cdp/templates/test/test-helpers.ts
@@ -208,6 +208,7 @@ export class TemplateTester {
                 fetchRetries: config.CDP_FETCH_RETRIES,
                 fetchBackoffBaseMs: config.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: config.CDP_FETCH_BACKOFF_MAX_MS,
+                emailQueueRouting: config.CDP_EMAIL_QUEUE_ROUTING,
             },
             { teamManager: undefined as any, siteUrl: config.SITE_URL },
             hogInputsService,

--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -225,6 +225,7 @@ export type MinimalAppMetric = {
         | 'fetch'
         | 'billable_invocation'
         | 'dropped'
+        | 'email_queued'
         | 'email_sent'
         | 'email_delivered'
         | 'email_failed'
@@ -249,7 +250,7 @@ export interface HogFunctionTiming {
 }
 
 // IMPORTANT: All queue names should be lowercase and only [A-Z0-9] characters are allowed.
-export const CYCLOTRON_INVOCATION_JOB_QUEUES = ['hog', 'hogoverflow', 'hogflow'] as const
+export const CYCLOTRON_INVOCATION_JOB_QUEUES = ['hog', 'hogoverflow', 'hogflow', 'email'] as const
 export type CyclotronJobQueueKind = (typeof CYCLOTRON_INVOCATION_JOB_QUEUES)[number]
 
 export const CYCLOTRON_JOB_QUEUE_SOURCES = ['postgres', 'postgres-v2', 'kafka'] as const

--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -32,6 +32,7 @@ export enum PluginServerMode {
     cdp_precalculated_filters = 'cdp-precalculated-filters',
     cdp_cohort_membership = 'cdp-cohort-membership',
     cdp_cyclotron_worker_hogflow = 'cdp-cyclotron-worker-hogflow',
+    cdp_cyclotron_worker_email = 'cdp-cyclotron-worker-email',
     cdp_api = 'cdp-api',
     cdp_legacy_on_event = 'cdp-legacy-on-event',
     evaluation_scheduler = 'evaluation-scheduler',

--- a/nodejs/src/config/config.test.ts
+++ b/nodejs/src/config/config.test.ts
@@ -1,0 +1,19 @@
+import { buildIntegerMatcherWithPercentage } from './config'
+
+describe('buildIntegerMatcherWithPercentage', () => {
+    it.each([
+        ['', 123, false],
+        [undefined, 123, false],
+        ['*', 123, true],
+        ['*', 456, true],
+        ['123,456', 123, true],
+        ['123,456', 456, true],
+        ['123,456', 789, false],
+        ['*:1.0', 123, true],
+        ['*:0', 123, false],
+        ['123,*:0', 123, true],
+        ['123,*:0', 456, false],
+    ])('buildIntegerMatcherWithPercentage(%s)(%s) === %s', (config, id, expected) => {
+        expect(buildIntegerMatcherWithPercentage(config as string | undefined)(id as number)).toBe(expected)
+    })
+})

--- a/nodejs/src/config/config.ts
+++ b/nodejs/src/config/config.ts
@@ -128,6 +128,50 @@ export function buildIntegerMatcher(config: string | undefined, allowStar: boole
     }
 }
 
+/**
+ * Builds a matcher that supports team IDs and/or percentage-based rollout.
+ *
+ * Formats:
+ *   ''          → no match
+ *   '*'         → match all
+ *   '123,456'   → only teams 123 and 456
+ *   '*:0.1'     → 10% of all traffic (random per call)
+ *   '123,*:0.05' → team 123 always + 5% of all other teams
+ */
+export function buildIntegerMatcherWithPercentage(config: string | undefined): ValueMatcher<number> {
+    if (!config || config.trim().length === 0) {
+        return () => false
+    }
+    if (config.trim() === '*') {
+        return () => true
+    }
+
+    const parts = config.split(',').map((s) => s.trim())
+    const teamIds = new Set<number>()
+    let percentage = 0
+
+    for (const part of parts) {
+        if (part.startsWith('*:')) {
+            percentage = parseFloat(part.slice(2))
+        } else {
+            const num = parseInt(part)
+            if (!isNaN(num)) {
+                teamIds.add(num)
+            }
+        }
+    }
+
+    return (teamId: number) => {
+        if (teamIds.has(teamId)) {
+            return true
+        }
+        if (percentage > 0) {
+            return Math.random() < percentage
+        }
+        return false
+    }
+}
+
 export function buildStringMatcher(config: string | undefined, allowStar: boolean): ValueMatcher<string> {
     // Builds a ValueMatcher on a comma-separated list of values.
     // Optionally, supports a '*' value to match everything

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -8,6 +8,7 @@ import { CdpApi } from './cdp/cdp-api'
 import { CdpConsumerBaseDeps } from './cdp/consumers/cdp-base.consumer'
 import { CdpBatchHogFlowRequestsConsumer } from './cdp/consumers/cdp-batch-hogflow.consumer'
 import { CdpCohortMembershipConsumer } from './cdp/consumers/cdp-cohort-membership.consumer'
+import { CdpCyclotronWorkerEmail } from './cdp/consumers/cdp-cyclotron-worker-email.consumer'
 import { CdpCyclotronWorkerHogFlow } from './cdp/consumers/cdp-cyclotron-worker-hogflow.consumer'
 import { CdpCyclotronWorker } from './cdp/consumers/cdp-cyclotron-worker.consumer'
 import { CdpDatawarehouseEventsConsumer } from './cdp/consumers/cdp-data-warehouse-events.consumer'
@@ -223,6 +224,14 @@ export class PluginServer implements NodeServer {
         if (capabilities.cdpCyclotronWorkerHogFlow) {
             serviceLoaders.push(async () => {
                 const worker = new CdpCyclotronWorkerHogFlow(this.config, cdpDeps!)
+                await worker.start()
+                return worker.service
+            })
+        }
+
+        if (capabilities.cdpCyclotronWorkerEmail) {
+            serviceLoaders.push(async () => {
+                const worker = new CdpCyclotronWorkerEmail(this.config, cdpDeps!)
                 await worker.start()
                 return worker.service
             })

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -160,6 +160,7 @@ export interface PluginServerCapabilities {
     cdpBatchHogFlow?: boolean
     cdpCyclotronWorker?: boolean
     cdpCyclotronWorkerHogFlow?: boolean
+    cdpCyclotronWorkerEmail?: boolean
     cdpPrecalculatedFilters?: boolean
     cdpCohortMembership?: boolean
     cdpApi?: boolean


### PR DESCRIPTION
### Problem    

When sending emails through workflows, we have no way to control the send rate. A large batch workflow triggering for 100k users can blast SES with all emails at once, risking SES throttling and delivery failures.
                                                                                                       
### Changes
                                                                                                       
Adds a global Redis token bucket rate limiter to the email worker. Reuses the existing HogRateLimiterService (same infrastructure as per-function rate limiting).

  - Before processing a batch, the worker checks how many tokens are available in the shared global-email Redis bucket               
  - If enough tokens → process the full batch                                                          
  - If not enough → process what's available, reschedule the rest with a short delay (500ms + jitter)  
  - All email worker pods share the same bucket, so the global send rate is enforced across the fleet
                                                                                                       
### Config (disabled by default):                             
  - CDP_EMAIL_GLOBAL_RATE_LIMIT_BUCKET_SIZE — max burst (e.g., 500)                                    
  - CDP_EMAIL_GLOBAL_RATE_LIMIT_REFILL_RATE — sustained emails/sec (e.g., 500)                         
                                                                                                       
  Metrics:                                                                                             
  - cdp_email_rate_limited_total — counter of deferred emails                                          
  - cdp_email_rate_limit_tokens_available — gauge of available tokens
                                                                                                       
  Stacks on top of #54418 (dedicated email queue).          
                                                                                                       
### How did you test this code?                               
                                                                                                       
  - Unit tests for rate limiter initialization (enabled/disabled based on config)                      
  - Passthrough test when rate limiting is disabled      


### Things to monitor:                                                                                   
  - With aggressive rate limiting and large email volumes, deferred jobs accumulate in the queue. If the queue depth approaches CYCLOTRON_SHARD_DEPTH_LIMIT (default 1M), new jobs will be rejected. Monitor cdp_cyclotron_v2_queue_depth for the email queue alongside cdp_email_rate_limit_tokens_available to catch this early.                                           
  - The janitor won't interfere — rate-limited jobs are properly rescheduled to available status with a future scheduled timestamp, not left in running, so stall detection and poison pill logic don't apply.                                                                                               
             