### PR TITLE
fix(ci): dismiss stamphog approval on push

### DIFF
--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -103,13 +103,11 @@ jobs:
     # Defense-in-depth: the master ruleset has dismiss_stale_reviews_on_push=false
     # and require_last_push_approval=false, so without this job a PR could be
     # approved while trivial and then receive malicious commits that inherit
-    # the stale github-actions[bot] approval. On every push to a PR carrying
-    # the stamphog label we dismiss the bot's approval and drop the label, so
-    # a human must explicitly re-apply it to request re-review.
+    # the stale github-actions[bot] approval. On every push to a PR we dismiss
+    # the bot's approval and drop the stamphog label if present, so a human
+    # must explicitly re-apply it to request re-review.
     dismiss-on-push:
-        if: >-
-            github.event.action == 'synchronize'
-            && contains(github.event.pull_request.labels.*.name, 'stamphog')
+        if: github.event.action == 'synchronize'
         runs-on: ubuntu-latest
         timeout-minutes: 5
 
@@ -137,4 +135,6 @@ jobs:
                         -f event=DISMISS
                   done
 
-                  gh pr edit "$PR" --remove-label stamphog --repo "$REPO"
+                  if gh api "repos/$REPO/issues/$PR/labels" --jq 'any(.name == "stamphog")' | grep -q true; then
+                      gh pr edit "$PR" --remove-label stamphog --repo "$REPO"
+                  fi

--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -2,7 +2,7 @@ name: PR Approval Agent
 
 on:
     pull_request:
-        types: [labeled, ready_for_review]
+        types: [labeled, ready_for_review, synchronize]
 
 permissions:
     contents: read
@@ -99,3 +99,42 @@ jobs:
                   name: review-${{ github.event.pull_request.number }}
                   path: /tmp/review.json
                   retention-days: 30
+
+    # Defense-in-depth: the master ruleset has dismiss_stale_reviews_on_push=false
+    # and require_last_push_approval=false, so without this job a PR could be
+    # approved while trivial and then receive malicious commits that inherit
+    # the stale github-actions[bot] approval. On every push to a PR carrying
+    # the stamphog label we dismiss the bot's approval and drop the label, so
+    # a human must explicitly re-apply it to request re-review.
+    dismiss-on-push:
+        if: >-
+            github.event.action == 'synchronize'
+            && contains(github.event.pull_request.labels.*.name, 'stamphog')
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+
+        steps:
+            - name: Dismiss stale bot approvals and remove stamphog label
+              env:
+                  # Same identity (github-actions[bot]) that posted the approval.
+                  GH_TOKEN: ${{ github.token }}
+                  PR: ${{ github.event.pull_request.number }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  set -euo pipefail
+
+                  # Only dismiss APPROVED reviews made by github-actions[bot] —
+                  # human reviews and non-approval reviews are untouched.
+                  mapfile -t REVIEW_IDS < <(
+                      gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
+                        --jq '.[] | select(.user.login == "github-actions[bot]" and .state == "APPROVED") | .id'
+                  )
+
+                  for id in "${REVIEW_IDS[@]}"; do
+                      [ -z "$id" ] && continue
+                      gh api -X PUT "repos/$REPO/pulls/$PR/reviews/$id/dismissals" \
+                        -f message="New commits pushed — stamphog approval dismissed. Re-apply the stamphog label to request a re-review." \
+                        -f event=DISMISS
+                  done
+
+                  gh pr edit "$PR" --remove-label stamphog --repo "$REPO"


### PR DESCRIPTION
## Problem

`stamphog` approves as `github-actions[bot]`, and its approval counts toward branch protection. The workflow only triggers on `labeled` / `ready_for_review`, and master's ruleset has `dismiss_stale_reviews_on_push: false` + `require_last_push_approval: false`. So: trivial PR → get stamphog approval → push malicious commits → merge. The stale bot review still satisfies the 1-approval requirement, and files without a CODEOWNERS entry have no further gate.

## Changes

- Add `synchronize` to the workflow triggers.
- New `dismiss-on-push` job, gated on `synchronize`: on every push to any PR, dismiss any `APPROVED` review by `github-actions[bot]` and drop the `stamphog` label if present, so re-review requires an explicit re-label. No label gate — the dismissal filter is a server-side query for bot+APPROVED reviews, so PRs without a bot approval are a no-op.
- `review` job condition is unchanged — `synchronize` does not auto-re-run review.
- Human reviews are untouched (filter is strict on `github-actions[bot]`).

A ruleset-level fix (`require_last_push_approval: true`) would be more robust but affects every reviewer; intentionally out of scope.

## How did you test this code?

Agent-authored. YAML + embedded bash parse-checked locally; no CI/workflow run yet. Smoke test after merge: label a throwaway PR with `stamphog`, push a commit, confirm `dismiss-on-push` runs, bot review is dismissed, label is removed.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Code (Opus 4.7). Chose `${{ github.token }}` over the app token (same identity as the approval, no extra token step) and scoped to future pushes only — no sweep of existing open PRs.
