### PR TITLE
fix(query): don't persist complete=True when re-raising for Celery retry

### DIFF
--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -217,6 +217,12 @@ def execute_process_query(
         wait_duration = (query_status.pickup_time - query_status.start_time) / datetime.timedelta(seconds=1)
         QUERY_WAIT_TIME.labels(team=team_id, mode=trigger).observe(wait_duration)
 
+    # When we re-raise an error for Celery to retry (via the task's autoretry_for), the finally
+    # block must NOT persist the pre-emptive complete=True/error=True defaults set above.
+    # Otherwise the next retry would read complete=True from Redis and short-circuit at the
+    # early-return at the top of this function, silently turning retries into no-ops.
+    persist_final_status = True
+
     try:
         results = process_query_dict(
             team=team,
@@ -239,6 +245,7 @@ def execute_process_query(
         )
         QUERY_PROCESS_TIME.labels(team=team_id).observe(process_duration)
     except CHQueryErrorTooManySimultaneousQueries:
+        persist_final_status = False
         raise
     except Exception as err:
         from posthog.rbac.user_access_control import UserAccessControlError
@@ -254,16 +261,17 @@ def execute_process_query(
         capture_exception(err)
         # Do not raise here, the task itself did its job and we cannot recover
     finally:
-        query_status.end_time = datetime.datetime.now(datetime.UTC)
-        manager.store_query_status(query_status)
-        cache_key = None
-        try:
-            if query_status.results:
-                cache_key = query_status.results.get("cache_key")
-                if cache_key:
-                    manager.unregister_cache_key_mapping(cache_key)
-        except Exception as e:
-            capture_exception(e, {"cache_key": cache_key})
+        if persist_final_status:
+            query_status.end_time = datetime.datetime.now(datetime.UTC)
+            manager.store_query_status(query_status)
+            cache_key = None
+            try:
+                if query_status.results:
+                    cache_key = query_status.results.get("cache_key")
+                    if cache_key:
+                        manager.unregister_cache_key_mapping(cache_key)
+            except Exception as e:
+                capture_exception(e, {"cache_key": cache_key})
 
 
 def enqueue_process_query_task(

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -182,6 +182,7 @@ def execute_process_query(
     limit_context: Optional[LimitContext],
     is_query_service: bool = False,
     analytics_props: Optional["AnalyticsProps"] = None,
+    is_final_attempt: bool = True,
 ):
     tag_queries(client_query_id=query_id, team_id=team_id, user_id=user_id)
     manager = QueryStatusManager(query_id, team_id)
@@ -217,10 +218,13 @@ def execute_process_query(
         wait_duration = (query_status.pickup_time - query_status.start_time) / datetime.timedelta(seconds=1)
         QUERY_WAIT_TIME.labels(team=team_id, mode=trigger).observe(wait_duration)
 
-    # When we re-raise an error for Celery to retry (via the task's autoretry_for), the finally
-    # block must NOT persist the pre-emptive complete=True/error=True defaults set above.
-    # Otherwise the next retry would read complete=True from Redis and short-circuit at the
-    # early-return at the top of this function, silently turning retries into no-ops.
+    # When we re-raise an error and another Celery retry will actually be scheduled, the
+    # finally block must NOT persist the pre-emptive complete=True/error=True defaults set
+    # above — the next retry would read complete=True and short-circuit at the early-return
+    # at the top of this function, silently turning retries into no-ops.
+    # On the FINAL attempt (retries exhausted) we must still persist a terminal status so
+    # pollers and cache-key deduplication see a real failure rather than an in-flight entry
+    # that only clears when its TTL expires.
     persist_final_status = True
 
     try:
@@ -245,7 +249,17 @@ def execute_process_query(
         )
         QUERY_PROCESS_TIME.labels(team=team_id).observe(process_duration)
     except CHQueryErrorTooManySimultaneousQueries:
-        persist_final_status = False
+        if is_final_attempt:
+            # Retries exhausted — persist a terminal error so clients see a real failure.
+            # The pre-emptive complete=True/error=True set above is what we want here; we
+            # only need a user-facing message since the raw CH error is not safe to expose.
+            query_status.results = None
+            query_status.error_message = (
+                "ClickHouse is at capacity and could not schedule this query after several "
+                f"retries. Please retry in a few seconds. Query id: {query_id}"
+            )
+        else:
+            persist_final_status = False
         raise
     except Exception as err:
         from posthog.rbac.user_access_control import UserAccessControlError

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -138,7 +138,7 @@ class TestExecuteProcessQuery(TestCase):
 
     @patch("posthog.clickhouse.client.execute_async.redis.get_client")
     @patch("posthog.api.services.query.process_query_dict")
-    def test_transient_error_does_not_persist_complete_true(self, mock_process_query_dict, mock_redis_client):
+    def test_transient_error_skips_persistence_when_retry_scheduled(self, mock_process_query_dict, mock_redis_client):
         # Regression test: the finally block used to always call store_query_status with the
         # pre-emptive complete=True/error=True defaults, including when we re-raise for retry.
         # This turned Celery's autoretry_for into a silent no-op because the retry would read
@@ -151,13 +151,53 @@ class TestExecuteProcessQuery(TestCase):
         mock_process_query_dict.side_effect = CHQueryErrorTooManySimultaneousQueries("busy", code=202)
 
         with self.assertRaises(CHQueryErrorTooManySimultaneousQueries):
-            execute_process_query(self.team.id, self.user.id, self.query_id, self.query_json, self.limit_context)
+            execute_process_query(
+                self.team.id,
+                self.user.id,
+                self.query_id,
+                self.query_json,
+                self.limit_context,
+                is_final_attempt=False,
+            )
 
         # Only one write: the pickup-time write with complete=False. No completion write.
         self.assertEqual(mock_redis.set.call_count, 1)
         payload = json.loads(mock_redis.set.call_args_list[0].args[1])
         self.assertFalse(payload["complete"])
         self.assertFalse(payload["error"])
+
+    @patch("posthog.clickhouse.client.execute_async.redis.get_client")
+    @patch("posthog.api.services.query.process_query_dict")
+    def test_transient_error_persists_terminal_status_on_final_attempt(
+        self, mock_process_query_dict, mock_redis_client
+    ):
+        # When retries are exhausted, we must persist a terminal error status — otherwise
+        # pollers and cache-key deduplication treat the query as still in flight until the
+        # 20-minute Redis TTL expires.
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = json.dumps(
+            {"id": self.query_id, "team_id": self.team.id, "complete": False, "error": False}
+        ).encode()
+        mock_redis_client.return_value = mock_redis
+        mock_process_query_dict.side_effect = CHQueryErrorTooManySimultaneousQueries("busy", code=202)
+
+        with self.assertRaises(CHQueryErrorTooManySimultaneousQueries):
+            execute_process_query(
+                self.team.id,
+                self.user.id,
+                self.query_id,
+                self.query_json,
+                self.limit_context,
+                is_final_attempt=True,
+            )
+
+        # Two writes: pickup (complete=False), then final terminal status (complete=True).
+        self.assertEqual(mock_redis.set.call_count, 2)
+        final_payload = json.loads(mock_redis.set.call_args_list[-1].args[1])
+        self.assertTrue(final_payload["complete"])
+        self.assertTrue(final_payload["error"])
+        assert final_payload["error_message"]
+        self.assertIn(self.query_id, final_payload["error_message"])
 
 
 class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
@@ -242,9 +282,10 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
             except Exception:
                 pass
 
-        # The error re-raises for Celery to retry. Redis must stay in "in-flight" shape
-        # (complete=False, error=False) — otherwise the retry would read complete=True
-        # and short-circuit at the early-return in execute_process_query.
+        # _test_only_bypass_celery goes through the task wrapper, so current_task is set
+        # with retries=0 < max_retries — process_query_task treats this as a non-final
+        # attempt and re-raises without persisting, leaving the in-flight state for the
+        # (hypothetical) retry to pick up.
         result = client.get_query_status(self.team.id, query_id)
         self.assertFalse(result.complete)
         self.assertFalse(result.error)
@@ -252,6 +293,45 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
         self.assertIsNotNone(result.start_time)
         self.assertIsNotNone(result.pickup_time)
         self.assertIsNone(result.end_time)
+
+    def test_async_query_server_errors_persist_terminal_status_on_final_retry(self):
+        # Simulate Celery having exhausted its retries for a capacity error — the task's
+        # request.retries has reached max_retries. process_query_task must then persist a
+        # terminal error status so pollers see a real failure instead of an in-flight
+        # entry that only clears at TTL.
+        query = build_query("SELECT * FROM events")
+        query_id = uuid.uuid4().hex
+
+        from posthog.tasks.tasks import process_query_task
+
+        # Patch current_task inside tasks module to report retries == max_retries.
+        class _FakeRequest:
+            retries = process_query_task.max_retries
+
+        class _FakeTask:
+            request = _FakeRequest()
+            max_retries = process_query_task.max_retries
+
+        with (
+            patch(
+                "posthog.api.services.query.process_query_dict",
+                side_effect=CHQueryErrorTooManySimultaneousQueries("bla"),
+            ),
+            patch("posthog.tasks.tasks.current_task", _FakeTask()),
+        ):
+            try:
+                client.enqueue_process_query_task(
+                    self.team, self.user.id, query, query_id=query_id, _test_only_bypass_celery=True
+                )
+            except Exception:
+                pass
+
+        result = client.get_query_status(self.team.id, query_id)
+        self.assertTrue(result.complete)
+        self.assertTrue(result.error)
+        assert result.error_message
+        self.assertIn(query_id, result.error_message)
+        self.assertIsNotNone(result.end_time)
 
     def test_async_query_client_uuid(self):
         query = build_query("SELECT toUUID('00000000-0000-0000-0000-000000000000')")

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -136,6 +136,29 @@ class TestExecuteProcessQuery(TestCase):
         args_loaded = json.loads(args[1])
         self.assertEqual(args_loaded["results"], [None, None, None, 1.0, "👍"])
 
+    @patch("posthog.clickhouse.client.execute_async.redis.get_client")
+    @patch("posthog.api.services.query.process_query_dict")
+    def test_transient_error_does_not_persist_complete_true(self, mock_process_query_dict, mock_redis_client):
+        # Regression test: the finally block used to always call store_query_status with the
+        # pre-emptive complete=True/error=True defaults, including when we re-raise for retry.
+        # This turned Celery's autoretry_for into a silent no-op because the retry would read
+        # complete=True from Redis and exit early.
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = json.dumps(
+            {"id": self.query_id, "team_id": self.team.id, "complete": False, "error": False}
+        ).encode()
+        mock_redis_client.return_value = mock_redis
+        mock_process_query_dict.side_effect = CHQueryErrorTooManySimultaneousQueries("busy", code=202)
+
+        with self.assertRaises(CHQueryErrorTooManySimultaneousQueries):
+            execute_process_query(self.team.id, self.user.id, self.query_id, self.query_json, self.limit_context)
+
+        # Only one write: the pickup-time write with complete=False. No completion write.
+        self.assertEqual(mock_redis.set.call_count, 1)
+        payload = json.loads(mock_redis.set.call_args_list[0].args[1])
+        self.assertFalse(payload["complete"])
+        self.assertFalse(payload["error"])
+
 
 class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
     def setUp(self):
@@ -219,12 +242,16 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
             except Exception:
                 pass
 
+        # The error re-raises for Celery to retry. Redis must stay in "in-flight" shape
+        # (complete=False, error=False) — otherwise the retry would read complete=True
+        # and short-circuit at the early-return in execute_process_query.
         result = client.get_query_status(self.team.id, query_id)
-        self.assertTrue(result.error)
-        assert result.error_message is None
+        self.assertFalse(result.complete)
+        self.assertFalse(result.error)
+        self.assertIsNone(result.error_message)
         self.assertIsNotNone(result.start_time)
         self.assertIsNotNone(result.pickup_time)
-        self.assertIsNotNone(result.end_time)
+        self.assertIsNone(result.end_time)
 
     def test_async_query_client_uuid(self):
         query = build_query("SELECT toUUID('00000000-0000-0000-0000-000000000000')")

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -11,7 +11,7 @@ from django.db import connection
 from django.utils import timezone
 
 import requests
-from celery import shared_task
+from celery import current_task, shared_task
 from prometheus_client import Counter, Gauge
 from redis import Redis
 from structlog import get_logger
@@ -125,6 +125,16 @@ def process_query_task(
     if is_query_service:
         tag_queries(chargeable=1)
 
+    # Determine whether another retry will actually be scheduled if we re-raise a retryable
+    # error. Celery's autoretry_for calls self.retry() which raises MaxRetriesExceededError
+    # once retries >= max_retries; from this side, that means the current attempt is terminal.
+    is_final_attempt = True
+    task_request = getattr(current_task, "request", None) if current_task is not None else None
+    if task_request is not None:
+        retries = task_request.retries or 0
+        max_retries = getattr(current_task, "max_retries", 0) or 0
+        is_final_attempt = retries >= max_retries
+
     execute_process_query(
         team_id=team_id,
         user_id=user_id,
@@ -133,6 +143,7 @@ def process_query_task(
         limit_context=limit_context,
         is_query_service=is_query_service,
         analytics_props=analytics_props,
+        is_final_attempt=is_final_attempt,
     )
 
 


### PR DESCRIPTION
## Problem

The async query task `process_query_task` has `autoretry_for=(CHQueryErrorTooManySimultaneousQueries, ConcurrencyLimitExceeded)`, but the retry has been a silent no-op.

When `process_query_dict` raises `CHQueryErrorTooManySimultaneousQueries`, the `except` branch re-raises so Celery can retry. But the `finally` block runs first, and it unconditionally called `store_query_status(query_status)` with the local `query_status` where lines 209–210 had pre-emptively set `complete=True, error=True` as a defensive default. So Redis ended up holding a completed-looking status before the re-raise propagated.

When Celery redelivered the task, the new worker called `manager.get_query_status()` at the top of `execute_process_query` and hit the early return at `if query_status.complete: return`. The retry never actually ran the query.

This has implications beyond the `TOO_MANY_SIMULTANEOUS_QUERIES` code — any transient ClickHouse error we'd want to add to `autoretry_for` in the future would be similarly neutralised.

## Changes

- Introduce a `persist_final_status` flag inside `execute_process_query` — default `True`, set to `False` in the `except CHQueryErrorTooManySimultaneousQueries` branch before re-raising.
- Gate the finally block's `store_query_status` + cache-key cleanup behind `persist_final_status`. When we re-raise for retry, Redis keeps the in-flight state written at pickup time (`complete=False, pickup_time=T`), which is exactly what the retry needs to pick up.

No behavior change for the success or non-transient-error paths.

## How did you test this code?

- Updated `test_async_query_server_errors` — the previous assertion `result.error` / `result.error_message is None` / `result.end_time is not None` was locking in the buggy state. New assertions verify the in-flight shape (`complete=False, error=False, error_message=None, end_time=None`) that enables retry.
- Added `test_transient_error_does_not_persist_complete_true` in `TestExecuteProcessQuery` — a unit-level regression test at the Redis-write layer: asserts that only a single `redis.set` call is made (the pickup write) and that its payload has `complete=False`, `error=False`.
- Full `test_execute_async.py` suite: 28 passed.

Reviewers wanting to verify manually could follow scenario A in the investigation that prompted this PR: trigger a query that raises `CHQueryErrorTooManySimultaneousQueries` from `process_query_dict`, then observe that the Celery task actually retries the query instead of short-circuiting on the second pickup.

## Publish to changelog?

no

## Docs update

No docs changes.

## 🤖 LLM context

Authored in a Claude Code session while investigating a separate "experiment metrics stuck in Loading..." bug. While tracing the async query pipeline to explain the behaviour, we noticed the finally-block clobbers the retry state. This PR is the isolated fix for that pre-existing bug; follow-up PRs will cover broader transient-error retries, stuck-query reaping, and better error-message surfacing for internal errors.