### PR TITLE
feat(batch-exports): add logs URL memo to temporal workflows

### DIFF
--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -30,6 +30,8 @@ TEMPORAL_COMBINED_METRICS_SERVER_ENABLED: bool = get_from_env(
     "TEMPORAL_COMBINED_METRICS_SERVER_ENABLED", True, type_cast=str_to_bool
 )
 
+TEMPORAL_LOGS_PROJECT_ID: str | None = os.getenv("TEMPORAL_LOGS_PROJECT_ID", "1" if DEBUG else None)
+
 TEMPORAL_LOG_LEVEL: str = os.getenv("TEMPORAL_LOG_LEVEL", "INFO")
 TEMPORAL_OTEL_PLUGIN_ENABLED: bool = get_from_env("TEMPORAL_OTEL_PLUGIN_ENABLED", False, type_cast=str_to_bool)
 TEMPORAL_OTEL_LIBRARIES_TO_INSTRUMENT: list[str] = get_list(os.getenv("TEMPORAL_OTEL_LIBRARIES_TO_INSTRUMENT", ""))

--- a/posthog/temporal/common/schedule.py
+++ b/posthog/temporal/common/schedule.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from asgiref.sync import async_to_sync
 from temporalio.client import Client, Schedule, ScheduleOverlapPolicy, ScheduleUpdate, ScheduleUpdateInput
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
     from temporalio.common import TypedSearchAttributes
 
 
@@ -32,7 +30,6 @@ async def create_schedule(
     schedule: Schedule,
     trigger_immediately: bool = False,
     search_attributes: TypedSearchAttributes | None = None,
-    memo: Mapping[str, Any] | None = None,
 ):
     """Create a Temporal Schedule."""
     return await temporal.create_schedule(
@@ -40,7 +37,6 @@ async def create_schedule(
         schedule=schedule,
         trigger_immediately=trigger_immediately,
         search_attributes=search_attributes,
-        memo=memo,
     )
 
 
@@ -50,7 +46,6 @@ async def a_create_schedule(
     schedule: Schedule,
     trigger_immediately: bool = False,
     search_attributes: TypedSearchAttributes | None = None,
-    memo: Mapping[str, Any] | None = None,
 ):
     """Async create a Temporal Schedule."""
     return await temporal.create_schedule(
@@ -58,7 +53,6 @@ async def a_create_schedule(
         schedule=schedule,
         trigger_immediately=trigger_immediately,
         search_attributes=search_attributes,
-        memo=memo,
     )
 
 

--- a/posthog/temporal/common/schedule.py
+++ b/posthog/temporal/common/schedule.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from asgiref.sync import async_to_sync
 from temporalio.client import Client, Schedule, ScheduleOverlapPolicy, ScheduleUpdate, ScheduleUpdateInput
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from temporalio.common import TypedSearchAttributes
 
 
@@ -30,6 +32,7 @@ async def create_schedule(
     schedule: Schedule,
     trigger_immediately: bool = False,
     search_attributes: TypedSearchAttributes | None = None,
+    memo: Mapping[str, Any] | None = None,
 ):
     """Create a Temporal Schedule."""
     return await temporal.create_schedule(
@@ -37,6 +40,7 @@ async def create_schedule(
         schedule=schedule,
         trigger_immediately=trigger_immediately,
         search_attributes=search_attributes,
+        memo=memo,
     )
 
 
@@ -46,6 +50,7 @@ async def a_create_schedule(
     schedule: Schedule,
     trigger_immediately: bool = False,
     search_attributes: TypedSearchAttributes | None = None,
+    memo: Mapping[str, Any] | None = None,
 ):
     """Async create a Temporal Schedule."""
     return await temporal.create_schedule(
@@ -53,6 +58,7 @@ async def a_create_schedule(
         schedule=schedule,
         trigger_immediately=trigger_immediately,
         search_attributes=search_attributes,
+        memo=memo,
     )
 
 

--- a/products/batch_exports/backend/service.py
+++ b/products/batch_exports/backend/service.py
@@ -12,6 +12,7 @@ import structlog
 import temporalio
 import temporalio.common
 from asgiref.sync import async_to_sync
+from temporalio.api.common.v1 import Payload
 from temporalio.client import (
     Client,
     Schedule,
@@ -790,6 +791,7 @@ async def start_backfill_batch_export_workflow(
         inputs,
         id=workflow_id,
         task_queue=settings.BATCH_EXPORTS_TASK_QUEUE,
+        memo=_build_batch_export_memo(workflow_id=workflow_id),
     )
 
     return workflow_id
@@ -958,10 +960,16 @@ def _get_schedule_spec(batch_export: BatchExport) -> ScheduleSpec:
         )
 
 
-def _build_batch_export_memo(workflow_id: str) -> dict[str, str] | None:
+def _build_batch_export_memo(workflow_id: str) -> dict[str, Payload] | None:
     """Build a memo with a logs URL for a batch export workflow.
 
     Returns None if TEMPORAL_LOGS_PROJECT_ID is not configured.
+
+    Memo values are returned as pre-encoded ``Payload`` objects with
+    ``encoding: json/plain``. The Temporal Python SDK treats already-encoded
+    memo values as opaque and does not run the ``payload_codec`` on them, so
+    passing a Payload here bypasses ``EncryptionCodec``. This lets the
+    Temporal UI render the memo without a codec server.
     """
     project_id = settings.TEMPORAL_LOGS_PROJECT_ID
     if not project_id:
@@ -993,7 +1001,12 @@ def _build_batch_export_memo(workflow_id: str) -> dict[str, str] | None:
         },
         quote_via=quote,
     )
-    return {"logs_url": f"{base_url}?{query_string}"}
+    return {
+        "logs_url": Payload(
+            metadata={"encoding": b"json/plain"},
+            data=json.dumps(f"{base_url}?{query_string}").encode(),
+        ),
+    }
 
 
 def sync_batch_export(batch_export: BatchExport, created: bool):
@@ -1051,16 +1064,15 @@ def sync_batch_export(batch_export: BatchExport, created: bool):
                 maximum_attempts=2,
                 non_retryable_error_types=["ActivityError", "ApplicationError", "CancelledError"],
             ),
+            memo=_build_batch_export_memo(workflow_id=str(batch_export.id)),
         ),
         spec=_get_schedule_spec(batch_export),
         state=state,
         policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.ALLOW_ALL),
     )
 
-    memo = _build_batch_export_memo(workflow_id=str(batch_export.id))
-
     if created:
-        create_schedule(temporal, id=str(batch_export.id), schedule=schedule, memo=memo)
+        create_schedule(temporal, id=str(batch_export.id), schedule=schedule)
     else:
         update_schedule(temporal, id=str(batch_export.id), schedule=schedule)
 

--- a/products/batch_exports/backend/service.py
+++ b/products/batch_exports/backend/service.py
@@ -3,6 +3,7 @@ import types
 import typing
 import datetime as dt
 from dataclasses import Field, asdict, dataclass, fields
+from urllib.parse import quote, urlencode
 from uuid import UUID
 
 from django.conf import settings
@@ -957,6 +958,44 @@ def _get_schedule_spec(batch_export: BatchExport) -> ScheduleSpec:
         )
 
 
+def _build_batch_export_memo(workflow_id: str) -> dict[str, str] | None:
+    """Build a memo with a logs URL for a batch export workflow.
+
+    Returns None if TEMPORAL_LOGS_PROJECT_ID is not configured.
+    """
+    project_id = settings.TEMPORAL_LOGS_PROJECT_ID
+    if not project_id:
+        return None
+
+    base_url = f"{settings.SITE_URL}/project/{project_id}/logs"
+    filter_group = json.dumps(
+        {
+            "type": "AND",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "workflow_id",
+                            "value": [workflow_id],
+                            "operator": "exact",
+                            "type": "log_attribute",
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    query_string = urlencode(
+        {
+            "serviceNames": json.dumps(["temporal-worker-batch-exports"]),
+            "filterGroup": filter_group,
+        },
+        quote_via=quote,
+    )
+    return {"logs_url": f"{base_url}?{query_string}"}
+
+
 def sync_batch_export(batch_export: BatchExport, created: bool):
     workflow, workflow_inputs = DESTINATION_WORKFLOWS[batch_export.destination.type]
     state = ScheduleState(
@@ -1018,8 +1057,10 @@ def sync_batch_export(batch_export: BatchExport, created: bool):
         policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.ALLOW_ALL),
     )
 
+    memo = _build_batch_export_memo(workflow_id=str(batch_export.id))
+
     if created:
-        create_schedule(temporal, id=str(batch_export.id), schedule=schedule)
+        create_schedule(temporal, id=str(batch_export.id), schedule=schedule, memo=memo)
     else:
         update_schedule(temporal, id=str(batch_export.id), schedule=schedule)
 

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -727,6 +727,7 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
                     task_timeout=schedule_action.task_timeout,
                     id_reuse_policy=temporalio.common.WorkflowIDReusePolicy.ALLOW_DUPLICATE,
                     search_attributes=temporalio.common.TypedSearchAttributes(search_attributes=search_attributes),
+                    memo=schedule_action.memo,
                 )
             except temporalio.exceptions.WorkflowAlreadyStartedError:
                 workflow_handle = client.get_workflow_handle(f"{description.id}-{backfill_end_at:%Y-%m-%dT%H:%M:%S}Z")


### PR DESCRIPTION
## Problem

We're missing valuable metadata when browsing Temporal workflows in the UI.

Example:

Debugging batch export runs requires jumping between the Temporal UI (to find the workflow) and PostHog logs (filtered by the workflow ID). There's no direct link between the two surfaces.

## Changes

This is currently a PoC