### PR TITLE
feat(query): surface user-facing errors and emit telemetry on async query failures

### DIFF
--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -54,10 +54,10 @@ QUERY_ASYNC_FAILURE_COUNTER = Counter(
 )
 
 # Shown to users when an async query fails with an error that's not on the allow-list of
-# user-safe errors. Without a message here, the retrieve endpoint returns HTTP 500 with an
-# empty body, which the frontend historically surfaced as generic failure or prolonged
-# loading. A generic message plus the query_id lets the UI render a real error state and
-# gives support a handle to look the failure up.
+# user-safe errors. Without a message here, the retrieve endpoint returns HTTP 500 with no
+# error_message in the body — the frontend stops polling but can only show a generic
+# failure with no explanation and no query id for support look-ups. Populating a generic
+# message here lets the UI render something actionable.
 GENERIC_INTERNAL_ERROR_MESSAGE = (
     "The query failed due to an internal error. Please retry. "
     "If the problem persists, contact support with query id: {query_id}"
@@ -328,9 +328,9 @@ def execute_process_query(
             query_status.error_message = str(err)
         else:
             # Never leave error_message empty — the /api/query/:id/ retrieve endpoint maps an
-            # empty message to HTTP 500 with no body, which surfaces to the client as either
-            # a generic failure or (worse) prolonged loading. A generic message lets the UI
-            # render a real error state and gives support a query id to look up.
+            # empty message to HTTP 500, and while the client does stop polling, the error
+            # bubbles up without any explanation or query id. A generic message gives the
+            # UI something to display and gives support a handle to look up the failure.
             query_status.error_message = GENERIC_INTERNAL_ERROR_MESSAGE.format(query_id=query_id)
 
         error_type = clickhouse_error_type(err)

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Optional
 import orjson as json
 import structlog
 import posthoganalytics
-from prometheus_client import Histogram
+from prometheus_client import Counter, Histogram
 from pydantic import BaseModel
 from rest_framework.exceptions import APIException, NotFound
 
@@ -17,8 +17,14 @@ from posthog.hogql.errors import ExposedHogQLError
 from posthog import celery, redis
 from posthog.clickhouse.client.async_task_chain import add_task_to_on_commit
 from posthog.clickhouse.query_tagging import get_query_tags, tag_queries
-from posthog.errors import CHQueryErrorTooManySimultaneousQueries, ExposedCHQueryError
+from posthog.errors import (
+    CHQueryErrorTooManySimultaneousQueries,
+    ExposedCHQueryError,
+    classify_query_error,
+    clickhouse_error_type,
+)
 from posthog.exceptions_capture import capture_exception
+from posthog.ph_client import ph_scoped_capture
 from posthog.renderers import SafeJSONRenderer
 from posthog.tasks.tasks import process_query_task
 
@@ -39,6 +45,22 @@ QUERY_WAIT_TIME = Histogram(
 
 QUERY_PROCESS_TIME = Histogram(
     "query_process_time_seconds", "Time from query pick-up to result", labelnames=["team"], buckets=CUSTOM_BUCKETS
+)
+
+QUERY_ASYNC_FAILURE_COUNTER = Counter(
+    "query_async_failure_total",
+    "Async queries that finished with an error, labelled by exception class and category",
+    labelnames=["error_type", "category"],
+)
+
+# Shown to users when an async query fails with an error that's not on the allow-list of
+# user-safe errors. Without a message here, the retrieve endpoint returns HTTP 500 with an
+# empty body, which the frontend historically surfaced as generic failure or prolonged
+# loading. A generic message plus the query_id lets the UI render a real error state and
+# gives support a handle to look the failure up.
+GENERIC_INTERNAL_ERROR_MESSAGE = (
+    "The query failed due to an internal error. Please retry. "
+    "If the problem persists, contact support with query id: {query_id}"
 )
 
 
@@ -174,6 +196,59 @@ class QueryStatusManager:
         self.redis_client.hdel(self.running_queries_key, cache_key)
 
 
+def _capture_async_query_failure_event(
+    *,
+    team,
+    team_id: int,
+    user,
+    query_id: str,
+    query_json: dict,
+    query_status: QueryStatus,
+    err: Exception,
+    error_type: str,
+    error_category: str,
+    user_safe_message: bool,
+) -> None:
+    """Emit a PostHog product-analytics event for an async query failure.
+
+    Runs inside a Celery task, so we use ph_scoped_capture to get a dedicated client
+    that flushes on context-manager exit — the global client's background flush is
+    unreliable in worker processes. Exceptions here are swallowed to avoid turning a
+    telemetry failure into a query failure.
+    """
+    try:
+        with ph_scoped_capture() as capture_ph_event:
+            distinct_id = str(getattr(user, "distinct_id", None) or getattr(team, "uuid", f"team_{team_id}"))
+            query_kind = query_json.get("kind") if isinstance(query_json, dict) else None
+            if query_kind is None and isinstance(query_json, dict):
+                source = query_json.get("source")
+                if isinstance(source, dict):
+                    query_kind = source.get("kind")
+            capture_ph_event(
+                distinct_id=distinct_id,
+                event="$async_query_failed",
+                properties={
+                    "team_id": team_id,
+                    "organization_id": getattr(team, "organization_id", None),
+                    "query_id": query_id,
+                    "query_kind": query_kind,
+                    "insight_id": query_status.insight_id,
+                    "dashboard_id": query_status.dashboard_id,
+                    "error_type": error_type,
+                    "error_category": error_category,
+                    "exception_class": type(err).__name__,
+                    "user_safe_message": user_safe_message,
+                },
+            )
+    except Exception as telemetry_err:
+        logger.exception(
+            "Failed to emit $async_query_failed event",
+            team_id=team_id,
+            query_id=query_id,
+            error=telemetry_err,
+        )
+
+
 def execute_process_query(
     team_id: int,
     user_id: Optional[int],
@@ -244,12 +319,37 @@ def execute_process_query(
         from posthog.rbac.user_access_control import UserAccessControlError
 
         query_status.results = None  # Clear results in case they are faulty
-        if (
+        is_user_safe_error = (
             isinstance(err, APIException | ExposedHogQLError | ExposedCHQueryError | UserAccessControlError)
             or is_staff_user
-        ):
+        )
+        if is_user_safe_error:
             # We can only expose the error message if it's a known safe error OR if the user is PostHog staff
             query_status.error_message = str(err)
+        else:
+            # Never leave error_message empty — the /api/query/:id/ retrieve endpoint maps an
+            # empty message to HTTP 500 with no body, which surfaces to the client as either
+            # a generic failure or (worse) prolonged loading. A generic message lets the UI
+            # render a real error state and gives support a query id to look up.
+            query_status.error_message = GENERIC_INTERNAL_ERROR_MESSAGE.format(query_id=query_id)
+
+        error_type = clickhouse_error_type(err)
+        error_category = classify_query_error(err).value
+        QUERY_ASYNC_FAILURE_COUNTER.labels(error_type=error_type, category=error_category).inc()
+
+        _capture_async_query_failure_event(
+            team=team,
+            team_id=team_id,
+            user=user,
+            query_id=query_id,
+            query_json=query_json,
+            query_status=query_status,
+            err=err,
+            error_type=error_type,
+            error_category=error_category,
+            user_safe_message=is_user_safe_error,
+        )
+
         logger.exception("Error processing query async", team_id=team_id, query_id=query_id, exc_info=True)
         capture_exception(err)
         # Do not raise here, the task itself did its job and we cannot recover

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -136,6 +136,119 @@ class TestExecuteProcessQuery(TestCase):
         args_loaded = json.loads(args[1])
         self.assertEqual(args_loaded["results"], [None, None, None, 1.0, "👍"])
 
+    @patch("posthog.clickhouse.client.execute_async.ph_scoped_capture")
+    @patch("posthog.clickhouse.client.execute_async.redis.get_client")
+    @patch("posthog.api.services.query.process_query_dict")
+    def test_non_safe_error_sets_generic_message_and_emits_event(
+        self, mock_process_query_dict, mock_redis_client, mock_ph_scoped
+    ):
+        # Regression test for the historical behaviour where internal errors left
+        # error_message empty, which the /api/query/:id/ endpoint mapped to HTTP 500 with an
+        # empty body — surfacing as "Loading results…" forever (or a generic failure).
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = json.dumps(
+            {"id": self.query_id, "team_id": self.team.id, "complete": False, "error": False}
+        ).encode()
+        mock_redis_client.return_value = mock_redis
+
+        captured_events: list[dict] = []
+
+        def fake_capture(*args, **kwargs):
+            captured_events.append(kwargs)
+
+        mock_ph_scoped.return_value.__enter__.return_value = fake_capture
+        mock_ph_scoped.return_value.__exit__.return_value = None
+
+        mock_process_query_dict.side_effect = RuntimeError("something unexpected exploded")
+
+        execute_process_query(
+            self.team.id,
+            self.user.id,
+            self.query_id,
+            {"kind": "TrendsQuery", "source": {"kind": "TrendsQuery"}},
+            self.limit_context,
+        )
+
+        # Final status write must have a non-empty user-facing error message with the query_id.
+        final_payload = json.loads(mock_redis.set.call_args_list[-1].args[1])
+        self.assertTrue(final_payload["error"])
+        self.assertTrue(final_payload["complete"])
+        assert final_payload["error_message"]
+        self.assertIn(self.query_id, final_payload["error_message"])
+
+        # A telemetry event was emitted with enough context to slice failures by query kind,
+        # error type, team, and whether we surfaced a real message to the user.
+        self.assertEqual(len(captured_events), 1)
+        event = captured_events[0]
+        self.assertEqual(event["event"], "$async_query_failed")
+        props = event["properties"]
+        self.assertEqual(props["team_id"], self.team.id)
+        self.assertEqual(props["query_id"], self.query_id)
+        self.assertEqual(props["query_kind"], "TrendsQuery")
+        self.assertEqual(props["exception_class"], "RuntimeError")
+        self.assertFalse(props["user_safe_message"])
+
+    @patch("posthog.clickhouse.client.execute_async.ph_scoped_capture")
+    @patch("posthog.clickhouse.client.execute_async.redis.get_client")
+    @patch("posthog.api.services.query.process_query_dict")
+    def test_safe_error_preserves_exact_message_and_emits_event(
+        self, mock_process_query_dict, mock_redis_client, mock_ph_scoped
+    ):
+        # Safe errors (ExposedHogQLError, ExposedCHQueryError, APIException, UserAccessControlError)
+        # must continue to expose their exact message to the user — we only replace missing
+        # messages with a generic fallback.
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = json.dumps(
+            {"id": self.query_id, "team_id": self.team.id, "complete": False, "error": False}
+        ).encode()
+        mock_redis_client.return_value = mock_redis
+
+        captured_events: list[dict] = []
+        mock_ph_scoped.return_value.__enter__.return_value = lambda *a, **kw: captured_events.append(kw)
+        mock_ph_scoped.return_value.__exit__.return_value = None
+
+        from posthog.hogql.errors import ExposedHogQLError
+
+        mock_process_query_dict.side_effect = ExposedHogQLError("invalid cohort reference")
+
+        execute_process_query(self.team.id, self.user.id, self.query_id, {"kind": "HogQLQuery"}, self.limit_context)
+
+        final_payload = json.loads(mock_redis.set.call_args_list[-1].args[1])
+        self.assertEqual(final_payload["error_message"], "invalid cohort reference")
+
+        self.assertEqual(len(captured_events), 1)
+        self.assertTrue(captured_events[0]["properties"]["user_safe_message"])
+
+    @patch("posthog.clickhouse.client.execute_async.logger")
+    @patch("posthog.clickhouse.client.execute_async.ph_scoped_capture")
+    @patch("posthog.clickhouse.client.execute_async.redis.get_client")
+    @patch("posthog.api.services.query.process_query_dict")
+    def test_telemetry_failure_does_not_break_query_task(
+        self, mock_process_query_dict, mock_redis_client, mock_ph_scoped, mock_logger
+    ):
+        # A misbehaving PostHog client must never fail the Celery task — the client is
+        # already dealing with a query error, we don't want to compound that.
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = json.dumps(
+            {"id": self.query_id, "team_id": self.team.id, "complete": False, "error": False}
+        ).encode()
+        mock_redis_client.return_value = mock_redis
+        mock_ph_scoped.side_effect = RuntimeError("ph client exploded")
+        mock_process_query_dict.side_effect = RuntimeError("actual query error")
+
+        # Must not raise — telemetry is best-effort.
+        execute_process_query(self.team.id, self.user.id, self.query_id, {"kind": "TrendsQuery"}, self.limit_context)
+
+        # The query status was still persisted with the generic user-facing message.
+        final_payload = json.loads(mock_redis.set.call_args_list[-1].args[1])
+        self.assertTrue(final_payload["error"])
+        assert final_payload["error_message"]
+        # And we logged the telemetry failure.
+        self.assertTrue(
+            any("Failed to emit" in str(call) for call in mock_logger.exception.call_args_list),
+            "expected a log entry for the telemetry failure",
+        )
+
 
 class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
     def setUp(self):

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -143,8 +143,9 @@ class TestExecuteProcessQuery(TestCase):
         self, mock_process_query_dict, mock_redis_client, mock_ph_scoped
     ):
         # Regression test for the historical behaviour where internal errors left
-        # error_message empty, which the /api/query/:id/ endpoint mapped to HTTP 500 with an
-        # empty body — surfacing as "Loading results…" forever (or a generic failure).
+        # error_message empty, which the /api/query/:id/ endpoint mapped to HTTP 500 with no
+        # error_message — the client stopped polling but surfaced a generic failure with no
+        # explanation or query id the user could report.
         mock_redis = MagicMock()
         mock_redis.get.return_value = json.dumps(
             {"id": self.query_id, "team_id": self.team.id, "complete": False, "error": False}


### PR DESCRIPTION
## Problem

Two related observability issues in the async query pipeline that came up while investigating "experiment metrics failing with no useful error" reports:

1. **Errors that aren't on the user-safe allow-list were effectively invisible to the client.** When `execute_process_query` caught an exception that isn't `APIException`, `ExposedHogQLError`, `ExposedCHQueryError`, or `UserAccessControlError` (and the user isn't staff), it left `QueryStatus.error_message=None`. The `/api/query/:id/` retrieve endpoint maps that to HTTP 500 with no `error_message` in the body. The frontend's `pollForResults` catches non-2xx and throws, so the user sees a generic failure — but with no explanation of what went wrong and no query id to report. There's no way for them to tell whether it's a transient infrastructure hiccup worth retrying or something a support ticket should surface.

2. **We had no app-level signal for these failures beyond Sentry.** There's no dimension in Prometheus for async-query failure rates broken down by error type, and no product-analytics event we can query to see how often this bites users, which teams are affected, or which query kinds (experiment metrics vs. trends vs. HogQL) fail most.

## Changes

- Populate `query_status.error_message` with a generic user-facing message (includes the `query_id` for support look-ups) whenever the raw exception isn't safe to expose. Safe errors still surface their exact message — only previously-swallowed errors change.
- Add `QUERY_ASYNC_FAILURE_COUNTER` Prometheus counter labelled by `error_type` and `category` (reusing `clickhouse_error_type` / `classify_query_error` from `posthog/errors.py`).
- Emit a `$async_query_failed` PostHog event with `team_id`, `organization_id`, `query_id`, `query_kind`, `insight_id`, `dashboard_id`, `error_type`, `error_category`, `exception_class`, and `user_safe_message`. This uses `ph_scoped_capture` because we're inside a Celery task — per the AGENTS.md note, the global client's background flush isn't reliable in workers.
- Telemetry emission is wrapped in a try/except so a misbehaving PostHog client never cascades into a query failure.

No behaviour change for the success path, for safe errors, or for the `CHQueryErrorTooManySimultaneousQueries` re-raise path.

## How did you test this code?

I am an agent and have not exercised this against a live Celery worker or ClickHouse. Verification was via automated tests only:

- **`test_non_safe_error_sets_generic_message_and_emits_event`** — asserts that a bare `RuntimeError` now produces a non-empty `error_message` containing the `query_id`, and that exactly one `$async_query_failed` event fires with the expected properties (team_id, query_kind extracted from `query_json`, exception_class, `user_safe_message=False`).
- **`test_safe_error_preserves_exact_message_and_emits_event`** — asserts that `ExposedHogQLError` still exposes its exact message (no regression for the user-safe path) and that the event fires with `user_safe_message=True`.
- **`test_telemetry_failure_does_not_break_query_task`** — asserts that a crashing `ph_scoped_capture` doesn't raise out of `execute_process_query`, the status is still persisted with a generic message, and the telemetry failure is logged.
- Full `test_execute_async.py` suite: 30 passed.

Reviewers can verify manually by triggering any non-safe error in `process_query_dict` (e.g., raise `RuntimeError` in a query runner path) and observing that the client now receives a real error with a query id instead of an unexplained 500.

## Publish to changelog?

no

## Docs update

No docs changes.

## 🤖 LLM context

Authored in a Claude Code session investigating an "experiment metrics failing silently" report. The broader investigation surfaced several gaps in the async query pipeline (retry-clobber bug, worker-loss reaper, transient-error retry) which are being split into separate PRs. This PR covers only the two lowest-risk pieces — user-facing error surfacing and observability — which don't change retry behaviour or introduce new scheduled tasks.