### PR TITLE
fix(playwright): stabilize sql editor e2e

### DIFF
--- a/playwright/e2e/sql-editor.spec.ts
+++ b/playwright/e2e/sql-editor.spec.ts
@@ -1,100 +1,129 @@
-import { expect, test } from '../utils/playwright-test-base'
+import { Page } from '@playwright/test'
+
+import { SqlInsight } from '../page-models/insights/sqlInsight'
+import { expect, test, PlaywrightWorkspaceSetupResult } from '../utils/workspace-test-base'
+
+async function dismissQuickStart(page: Page): Promise<void> {
+    await page
+        .getByRole('button', { name: 'Minimize' })
+        .click({ timeout: 1000 })
+        .catch(() => {})
+}
+
+async function goToSqlEditor(page: Page): Promise<void> {
+    await page.goto('/sql')
+    await expect(page).toHaveURL(/\/sql(?:[?#].*)?$/)
+    await expect(page.getByTestId('editor-scene')).toBeVisible({ timeout: 60000 })
+    await expect(page.getByTestId('hogql-query-editor')).toBeVisible()
+    await expect(page.getByText('Loading...', { exact: true })).toHaveCount(0, { timeout: 60000 })
+    await dismissQuickStart(page)
+}
+
+async function runQueryAndWaitForResults(page: Page, query: string = 'SELECT 1 AS result'): Promise<void> {
+    const sqlInsight = new SqlInsight(page)
+    const runButton = page.getByTestId('sql-editor-run-button')
+
+    await sqlInsight.writeQuery(query)
+    await sqlInsight.run()
+
+    await expect(runButton).toContainText('Cancel')
+    await expect(runButton).toContainText('Run', { timeout: 60000 })
+    await expect(page.getByRole('columnheader', { name: /result/i })).toBeVisible()
+    await expect(page.getByRole('gridcell', { name: '1' })).toBeVisible()
+    await expect(page.getByText('Showing one row')).toBeVisible()
+}
 
 test.describe('SQL Editor', () => {
+    test.describe.configure({ mode: 'serial' })
+    test.setTimeout(120000)
+
+    let workspace: PlaywrightWorkspaceSetupResult | null = null
+
+    test.beforeAll(async ({ playwrightSetup }) => {
+        workspace = await playwrightSetup.createWorkspace({
+            skip_onboarding: true,
+            use_current_time: true,
+        })
+    })
+
     test.describe('Basic flow', () => {
-        test.beforeEach(async ({ page }) => {
-            await page.goToMenuItem('sql-editor')
+        test.beforeEach(async ({ page, playwrightSetup }) => {
+            await playwrightSetup.loginAndNavigateToTeam(page, workspace!)
+            await goToSqlEditor(page)
         })
 
         test('See SQL Editor', async ({ page }) => {
-            await expect(page.locator('[data-attr=editor-scene]')).toBeVisible()
-            await expect(page.locator('[data-attr=sql-editor-source-empty-state]')).toBeVisible()
+            await expect(page.getByTestId('editor-scene')).toBeVisible()
+            await expect(page.getByText('Sources', { exact: true })).toBeVisible()
+            await expect(page.getByTestId('sql-editor-add-source')).toBeVisible()
+            await expect(page.getByTestId('sql-editor-output-pane-empty-state')).toBeVisible()
             await expect(page.locator('.scene-name h1 span').getByText('New SQL query', { exact: true })).toBeVisible()
         })
 
         test('Add source link', async ({ page }) => {
-            await page.locator('[data-attr=sql-editor-add-source]').click()
+            await page.getByTestId('sql-editor-add-source').click()
             await expect(page).toHaveURL(/.*\/data-warehouse\/new-source/)
         })
 
         test('Run query', async ({ page }) => {
-            await expect(page.locator('[data-attr=sql-editor-output-pane-empty-state]')).toBeVisible()
-            await page.locator('[data-attr=hogql-query-editor]').click()
-            await page.locator('[data-attr=hogql-query-editor]').pressSequentially('SELECT 1')
-            await page.locator('[data-attr=sql-editor-run-button]').click()
-
-            // query run
-            await expect(page.locator('[data-attr=sql-editor-output-pane-empty-state]')).not.toBeVisible()
+            await expect(page.getByTestId('sql-editor-output-pane-empty-state')).toBeVisible()
+            await runQueryAndWaitForResults(page)
         })
 
         test('Save view', async ({ page }) => {
-            // Wait for the query editor to be visible and ready
-            await expect(page.locator('[data-attr=hogql-query-editor]')).toBeVisible()
-            await page.locator('[data-attr=hogql-query-editor]').click()
-            await page.locator('[data-attr=hogql-query-editor]').pressSequentially('SELECT 1')
-            await page.locator('[data-attr=sql-editor-run-button]').click()
-            await expect(page.locator('[data-attr=sql-editor-output-pane-empty-state]')).not.toBeVisible()
+            await runQueryAndWaitForResults(page)
+            await dismissQuickStart(page)
 
-            // Open save options, then click save as view
-            await expect(page.locator('[data-attr=sql-editor-save-options-button]')).toBeEnabled()
-            await page.locator('[data-attr=sql-editor-save-options-button]').click()
+            await expect(page.getByTestId('sql-editor-save-options-button')).toBeEnabled()
+            await page.getByTestId('sql-editor-save-options-button').click()
             await page.getByText('Save as view', { exact: true }).click()
 
-            // Wait for the modal/dialog to appear and be ready
-            const nameInput = page.locator('[data-attr=sql-editor-input-save-view-name]')
-            await expect(nameInput).toBeVisible()
-
-            // Use a unique name to avoid conflicts with retries
-            const uniqueViewName = `test_view_${Date.now()}`
-            await nameInput.fill(uniqueViewName)
-
-            // Wait for the Submit button to be enabled (form validation may need time)
+            const nameInput = page.getByTestId('sql-editor-input-save-view-name')
+            const uniqueViewName = `test_view_${test.info().repeatEachIndex}_${Date.now()}`
             const submitButton = page.getByRole('button', { name: 'Submit' })
-            await expect(submitButton).toBeEnabled()
+            const saveViewModal = page.getByRole('dialog', { name: 'Save as view' })
 
-            // Click submit
+            await expect(nameInput).toBeVisible()
+            await nameInput.fill(uniqueViewName)
+            await expect(submitButton).toBeEnabled()
             await submitButton.click()
 
-            // Wait for the success message which confirms the API call completed
-            await expect(page.getByText(`${uniqueViewName} successfully created`)).toBeVisible()
-            await expect(page.locator('.scene-name h1 span').getByText(uniqueViewName, { exact: true })).toBeVisible()
+            await expect(saveViewModal).not.toBeVisible({ timeout: 60000 })
+            await expect(page.locator('.scene-name h1 span').getByText(uniqueViewName, { exact: true })).toBeVisible({
+                timeout: 60000,
+            })
         })
 
         test('Materialize view pane', async ({ page }) => {
-            await expect(page.locator('[data-attr=hogql-query-editor]')).toBeVisible()
-            await page.locator('[data-attr=hogql-query-editor]').click()
-            await page.locator('[data-attr=hogql-query-editor]').pressSequentially('SELECT 1')
-            await page.locator('[data-attr=sql-editor-run-button]').click()
-            await expect(page.locator('[data-attr=sql-editor-output-pane-empty-state]')).not.toBeVisible()
+            await runQueryAndWaitForResults(page)
+            await dismissQuickStart(page)
 
-            await expect(page.locator('[data-attr=sql-editor-save-options-button]')).toBeEnabled()
-            await page.locator('[data-attr=sql-editor-save-options-button]').click()
+            await expect(page.getByTestId('sql-editor-save-options-button')).toBeEnabled()
+            await page.getByTestId('sql-editor-save-options-button').click()
             await page.getByText('Save as view', { exact: true }).click()
 
-            const uniqueViewName = `materialized_test_view_${Date.now()}`
-            const nameInput = page.locator('[data-attr=sql-editor-input-save-view-name]')
+            const uniqueViewName = `materialized_test_view_${test.info().repeatEachIndex}_${Date.now()}`
+            const nameInput = page.getByTestId('sql-editor-input-save-view-name')
+            const saveViewModal = page.getByRole('dialog', { name: 'Save as view' })
+
             await expect(nameInput).toBeVisible()
             await nameInput.fill(uniqueViewName)
             await page.getByRole('button', { name: 'Submit' }).click()
-            await expect(page.getByText(`${uniqueViewName} successfully created`)).toBeVisible()
+            await expect(saveViewModal).not.toBeVisible({ timeout: 60000 })
+            await expect(page.locator('.scene-name h1 span').getByText(uniqueViewName, { exact: true })).toBeVisible({
+                timeout: 60000,
+            })
 
-            await expect(page.locator('.scene-name h1 span').getByText(uniqueViewName, { exact: true })).toBeVisible()
-            // Dismiss the quickstart popover if visible, as it can overlay the button
-            const quickstart = page.locator('[data-attr=global-product-setup-button]')
-            if (await quickstart.isVisible({ timeout: 1000 }).catch(() => false)) {
-                await quickstart.click()
-                await expect(async () => {
-                    await page.getByRole('button', { name: 'Minimize' }).click()
-                }).toPass()
-            }
-
-            await page.locator('[data-attr=sql-editor-materialization-button]').click()
-            await expect(page.locator('[data-attr=sql-editor-sidebar-query-info-pane]')).toBeVisible()
+            await dismissQuickStart(page)
+            await page.getByTestId('sql-editor-materialization-button').click({ force: true })
+            await expect(page.getByTestId('sql-editor-sidebar-query-info-pane')).toBeVisible()
         })
 
         test('Query variables pane', async ({ page }) => {
-            await page.getByText('Variables').click()
-            await expect(page.locator('[data-attr=sql-editor-variables-button]')).toBeVisible()
+            await page.getByTestId('sql-editor-variables-button').click()
+            await expect(page.getByPlaceholder('Search variables')).toBeVisible({ timeout: 60000 })
+            await expect(page.getByText('No variables found', { exact: true })).toBeVisible({ timeout: 60000 })
+            await expect(page.getByText('Manage SQL variables', { exact: true })).toBeVisible({ timeout: 60000 })
         })
     })
 })

--- a/playwright/utils/playwright-setup.ts
+++ b/playwright/utils/playwright-setup.ts
@@ -258,13 +258,22 @@ export class PlaywrightSetup {
     }
 
     async login(page: Page, workspace: PlaywrightWorkspaceSetupResult): Promise<void> {
-        // Use page.request to share cookies/session with the browser context
-        await page.request.post(`${this.baseURL}/api/login/`, {
-            data: {
+        await page.goto(`${this.baseURL}/login`)
+        await page.evaluate(
+            async ({ email, password }) => {
+                await fetch('/api/login/', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({ email, password }),
+                })
+            },
+            {
                 email: workspace.user_email,
                 password: LOGIN_PASSWORD,
-            },
-        })
+            }
+        )
     }
 
     /**


### PR DESCRIPTION
The SQL editor E2E test was flaking a lot. Here's an attempt to fix it. The new version passed CI and also ran without flakes 10x in a row. I've been struggling with this test all day, so this is a great result:

<img width="935" height="505" alt="image" src="https://github.com/user-attachments/assets/d489554b-1a2e-4132-a3f1-215e649104b5" />


AI slop below:


## Problem

The SQL editor Playwright coverage was flaky for a few different reasons:
- it depended on shared demo-user state instead of creating an isolated workspace for the spec
- it navigated via sidebar chrome instead of entering the SQL editor directly
- it typed into the editor and asserted on weak intermediate UI states instead of waiting for stable query results
- it could race editor source loading and hit `Error loading data` late in repeated runs
- product setup UI could overlap action buttons during save/materialization flows

## Changes

- moved `playwright/e2e/sql-editor.spec.ts` onto the workspace-based Playwright setup so the file gets its own seeded workspace and login flow
- replaced sidebar navigation and brittle editor typing with direct SQL editor navigation plus the shared `SqlInsight` page-model query writer
- tightened query assertions around actual result-table state, save modal completion, and variables menu readiness
- added readiness waits for the SQL editor source panel to finish loading before running queries
- updated `playwright/utils/playwright-setup.ts` login to authenticate through the browser context so workspace-created users consistently establish a usable session

## How did you test this code?

- `BASE_URL='http://localhost:8010' pnpm --filter=@posthog/playwright exec playwright test e2e/sql-editor.spec.ts --workers=1 --retries=0 --max-failures=1`
- `BASE_URL='http://localhost:8010' pnpm --filter=@posthog/playwright exec playwright test e2e/sql-editor.spec.ts --workers=1 --repeat-each=10 --retries=0 --max-failures=1`

The file passed cleanly in a single full run.

The first 10x flake-verification run reached 57/60 tests before surfacing a late `Error loading data` race while the source tree was still loading. This PR includes a fix for that readiness issue.

A second 10x run was restarted after the fix and progressed cleanly through multiple repetitions, but it was not allowed to finish because I was asked to publish the branch and open the PR.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 LLM context

This PR was authored by Codex.

Local E2E work was run against `http://localhost:8010`.

The SQL editor spec was rewritten to use isolated workspace setup and stronger readiness/assertion checks. The draft PR is intentionally being opened before a fully clean post-fix 10x repeat run completed, because the publish step was requested mid-verification.