### PR TITLE
feat(sql-editor): restore "add join"

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.test.ts
@@ -1,0 +1,15 @@
+import { shouldShowAddJoinForSidebarItem } from './QueryDatabase'
+
+describe('QueryDatabase', () => {
+    describe('shouldShowAddJoinForSidebarItem', () => {
+        test.each([
+            ['table rows keep add join in the table-specific menu', 'table', false],
+            ['views still expose add join', 'view', true],
+            ['managed views do not expose add join', 'managed-view', false],
+            ['endpoints do not expose add join', 'endpoint', false],
+            ['unknown row types do not expose add join', undefined, false],
+        ])('%s', (_name, recordType, expected) => {
+            expect(shouldShowAddJoinForSidebarItem(recordType)).toEqual(expected)
+        })
+    })
+})

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.test.ts
@@ -1,15 +1,28 @@
-import { shouldShowAddJoinForSidebarItem } from './QueryDatabase'
+import { getSidebarAddJoinSourceTableName } from './QueryDatabase'
 
 describe('QueryDatabase', () => {
-    describe('shouldShowAddJoinForSidebarItem', () => {
+    describe('getSidebarAddJoinSourceTableName', () => {
         test.each([
-            ['table rows keep add join in the table-specific menu', 'table', false],
-            ['views still expose add join', 'view', true],
-            ['managed views do not expose add join', 'managed-view', false],
-            ['endpoints do not expose add join', 'endpoint', false],
-            ['unknown row types do not expose add join', undefined, false],
-        ])('%s', (_name, recordType, expected) => {
-            expect(shouldShowAddJoinForSidebarItem(recordType)).toEqual(expected)
+            ['table rows keep add join in the table-specific menu', 'table', 'events', undefined, null],
+            ['views expose add join with the view name', 'view', 'my_view', undefined, 'my_view'],
+            [
+                'managed views expose add join with the view name',
+                'managed-view',
+                'managed_view',
+                undefined,
+                'managed_view',
+            ],
+            [
+                'endpoints expose add join with the underlying table name',
+                'endpoint',
+                'my endpoint',
+                'my_endpoint_v3',
+                'my_endpoint_v3',
+            ],
+            ['endpoints without a table name do not expose add join', 'endpoint', 'my endpoint', undefined, null],
+            ['unknown row types do not expose add join', undefined, 'mystery', undefined, null],
+        ])('%s', (_name, recordType, itemName, tableName, expected) => {
+            expect(getSidebarAddJoinSourceTableName(recordType, itemName, tableName)).toEqual(expected)
         })
     })
 })

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -44,6 +44,10 @@ import { draftsLogic } from '../draftsLogic'
 import { renderTableCount } from '../editorSceneLogic'
 import { isJoined, queryDatabaseLogic } from './queryDatabaseLogic'
 
+export function shouldShowAddJoinForSidebarItem(recordType?: string): boolean {
+    return recordType === 'view'
+}
+
 export const QueryDatabase = ({
     virtualizationScrollContainerRef,
 }: {
@@ -683,6 +687,17 @@ export const QueryDatabase = ({
                             >
                                 <ButtonPrimitive menuItem>Query</ButtonPrimitive>
                             </DropdownMenuItem>
+                            {shouldShowAddJoinForSidebarItem(item.record.type) ? (
+                                <DropdownMenuItem
+                                    asChild
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        selectSourceTable(item.name)
+                                    }}
+                                >
+                                    <ButtonPrimitive menuItem>Add join</ButtonPrimitive>
+                                </DropdownMenuItem>
+                            ) : null}
                             {item.record.type === 'view' ? (
                                 <DropdownMenuItem
                                     asChild

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -44,8 +44,20 @@ import { draftsLogic } from '../draftsLogic'
 import { renderTableCount } from '../editorSceneLogic'
 import { isJoined, queryDatabaseLogic } from './queryDatabaseLogic'
 
-export function shouldShowAddJoinForSidebarItem(recordType?: string): boolean {
-    return recordType === 'view'
+export function getSidebarAddJoinSourceTableName(
+    recordType: string | undefined,
+    itemName: string,
+    tableName?: string
+): string | null {
+    switch (recordType) {
+        case 'view':
+        case 'managed-view':
+            return itemName
+        case 'endpoint':
+            return tableName ?? null
+        default:
+            return null
+    }
 }
 
 export const QueryDatabase = ({
@@ -632,6 +644,11 @@ export const QueryDatabase = ({
                     item.record?.type === 'managed-view'
                 ) {
                     const editLabel = item.record.type === 'endpoint' ? 'Edit endpoint' : 'Edit view'
+                    const addJoinSourceTableName = getSidebarAddJoinSourceTableName(
+                        item.record.type,
+                        item.name,
+                        item.record.type === 'endpoint' ? item.record.tableName : undefined
+                    )
 
                     return (
                         <DropdownMenuGroup>
@@ -687,12 +704,12 @@ export const QueryDatabase = ({
                             >
                                 <ButtonPrimitive menuItem>Query</ButtonPrimitive>
                             </DropdownMenuItem>
-                            {shouldShowAddJoinForSidebarItem(item.record.type) ? (
+                            {addJoinSourceTableName ? (
                                 <DropdownMenuItem
                                     asChild
                                     onClick={(e) => {
                                         e.stopPropagation()
-                                        selectSourceTable(item.name)
+                                        selectSourceTable(addJoinSourceTableName)
                                     }}
                                 >
                                     <ButtonPrimitive menuItem>Add join</ButtonPrimitive>


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/55101

## Changes

Add the "Add join" option back into the "..." menu in the schema tree

<img width="344" height="264" alt="image" src="https://github.com/user-attachments/assets/c03d39e5-6672-4b86-a3dd-433daf0d404e" />


## How did you test this code?

Clicked around

## Publish to changelog?
no

## Docs update
no