### PR TITLE
feat(llma): deep-link prompt outline sections via URL hash

### DIFF
--- a/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
+++ b/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { combineUrl } from 'kea-router'
+import { combineUrl, router } from 'kea-router'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { IconChevronRight, IconColumns, IconMarkdown, IconMarkdownFilled } from '@posthog/icons'
@@ -179,8 +179,9 @@ function PromptOutline({
             const target = container.querySelector(`#${CSS.escape(slug)}`)
             if (target) {
                 target.scrollIntoView({ behavior: 'smooth', block: 'start' })
-                // Update URL hash so the current section can be deep-linked / shared
-                window.history.replaceState(null, '', `#${slug}`)
+                // Update URL hash via kea-router so its location state stays in sync
+                // (direct history.replaceState would leave router.values.location.hash stale)
+                router.actions.replace(router.values.location.pathname, router.values.searchParams, `#${slug}`)
             }
         },
         [containerRef]

--- a/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
+++ b/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { combineUrl } from 'kea-router'
-import { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { IconChevronRight, IconColumns, IconMarkdown, IconMarkdownFilled } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonSelect, LemonTag, LemonTextArea, Link, Tooltip } from '@posthog/lemon-ui'
@@ -179,10 +179,36 @@ function PromptOutline({
             const target = container.querySelector(`#${CSS.escape(slug)}`)
             if (target) {
                 target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                // Update URL hash so the current section can be deep-linked / shared
+                window.history.replaceState(null, '', `#${slug}`)
             }
         },
         [containerRef]
     )
+
+    // On mount (and when the hash changes), scroll to the heading referenced by the URL hash.
+    // This enables deep links like /llm-analytics/prompts/<name>#research-agent.
+    useEffect(() => {
+        const scrollToHash = (): void => {
+            const rawHash = window.location.hash.slice(1)
+            if (!rawHash) {
+                return
+            }
+            const slug = decodeURIComponent(rawHash)
+            const container = containerRef.current
+            if (!container) {
+                return
+            }
+            const target = container.querySelector(`#${CSS.escape(slug)}`)
+            if (target) {
+                target.scrollIntoView({ block: 'start' })
+            }
+        }
+
+        scrollToHash()
+        window.addEventListener('hashchange', scrollToHash)
+        return () => window.removeEventListener('hashchange', scrollToHash)
+    }, [containerRef, promptText])
 
     if (headings.length === 0) {
         return null

--- a/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
+++ b/products/llm_analytics/frontend/prompts/promptSceneComponents.tsx
@@ -194,7 +194,13 @@ function PromptOutline({
             if (!rawHash) {
                 return
             }
-            const slug = decodeURIComponent(rawHash)
+            // Guard against malformed percent-encoding (e.g. `#%`) which would throw URIError
+            let slug: string
+            try {
+                slug = decodeURIComponent(rawHash)
+            } catch {
+                return
+            }
             const container = containerRef.current
             if (!container) {
                 return


### PR DESCRIPTION
## Problem

On a prompt's view page in LLM analytics, the prompt outline lets you click a heading to scroll to that section of the prompt. But there was no way to share a link directly to a specific section — navigating to `/llm-analytics/prompts/<name>#research-agent` would land at the top of the page regardless.

## Changes

- In `PromptOutline`, read `window.location.hash` on mount (and subscribe to `hashchange`) and scroll to the matching heading inside the markdown container.
- When the user clicks a heading in the outline, update the URL hash via `window.history.replaceState` so the current section is reflected in the URL and can be copied/shared.

Heading IDs are already generated by `LemonMarkdown` with `generateHeadingIds` using `slugifyHeading`, so existing slugs (e.g. `## Research Agent` → `research-agent`) just work.

## How did you test this code?

I'm an agent and have not manually exercised this in a browser — the change is limited to client-side DOM behavior and relies on existing heading-id generation. I confirmed the edit compiles (unrelated pre-existing tsc errors exist in `evaluationReportLogicType.ts`).

Suggested manual check:

- Open a prompt in view mode (markdown rendering on).
- Click a heading in the outline and confirm the URL hash updates.
- Reload the page with the hash present and confirm the view scrolls to that section.
- Paste a link containing a hash into a new tab and confirm it jumps.

## Publish to changelog?

no

## Docs update

No docs change needed.