### PR TITLE
fix: Use `ph_scoped_capture` for CIMD Celery task analytics

### DIFF
--- a/posthog/api/oauth/cimd.py
+++ b/posthog/api/oauth/cimd.py
@@ -21,6 +21,7 @@ from django.utils import timezone
 
 import requests
 import structlog
+import posthoganalytics
 from celery import shared_task
 from oauth2_provider.models import AbstractApplication
 from rest_framework.throttling import SimpleRateThrottle
@@ -327,7 +328,7 @@ def _update_cimd_application(app: OAuthApplication, metadata: CIMDMetadataDocume
     return app
 
 
-def fetch_and_upsert_cimd_application(url: str) -> OAuthApplication | None:
+def fetch_and_upsert_cimd_application(url: str, capture_ph_event=posthoganalytics.capture) -> OAuthApplication | None:
     """
     Fetch CIMD metadata and create or update the application.
 
@@ -341,58 +342,58 @@ def fetch_and_upsert_cimd_application(url: str) -> OAuthApplication | None:
     if not cache.add(fetch_lock, True, timeout=CIMD_FETCH_TIMEOUT_SECONDS * 3):
         return None
 
-    with ph_scoped_capture() as capture_ph_event:  # This runs inside Celery, needs this to capture event
-        try:
-            metadata, cache_ttl = fetch_cimd_metadata(url)
-            cache.set(_cache_key(url), True, timeout=cache_ttl)
+    try:
+        metadata, cache_ttl = fetch_cimd_metadata(url)
+        cache.set(_cache_key(url), True, timeout=cache_ttl)
 
+        app = OAuthApplication.objects.filter(cimd_metadata_url=url).first()
+        if app:
+            updated = _update_cimd_application(app, metadata)
+            logger.debug("cimd_app_updated", url=url, app_id=str(updated.pk))
+            capture_ph_event(
+                distinct_id=url,
+                event="cimd_application_metadata_refreshed",
+                properties={
+                    "cimd_url": url,
+                    "client_name": metadata.get("client_name"),
+                    "app_id": str(updated.pk),
+                    "cache_ttl": cache_ttl,
+                },
+            )
+            return updated
+
+        try:
+            new_app = _create_cimd_application(url, metadata)
+            logger.debug("cimd_app_created", url=url, app_id=str(new_app.pk), client_name=new_app.name)
+            capture_ph_event(
+                distinct_id=url,
+                event="cimd_application_created",
+                properties={
+                    "cimd_url": url,
+                    "client_name": new_app.name,
+                    "app_id": str(new_app.pk),
+                    "redirect_uris_count": len(metadata.get("redirect_uris", [])),
+                    "has_logo": bool(metadata.get("logo_uri")),
+                    "cache_ttl": cache_ttl,
+                },
+            )
+            return new_app
+        except (IntegrityError, ValidationError):
             app = OAuthApplication.objects.filter(cimd_metadata_url=url).first()
             if app:
-                updated = _update_cimd_application(app, metadata)
-                logger.debug("cimd_app_updated", url=url, app_id=str(updated.pk))
-                capture_ph_event(
-                    distinct_id=url,
-                    event="cimd_application_metadata_refreshed",
-                    properties={
-                        "cimd_url": url,
-                        "client_name": metadata.get("client_name"),
-                        "app_id": str(updated.pk),
-                        "cache_ttl": cache_ttl,
-                    },
-                )
-                return updated
-
-            try:
-                new_app = _create_cimd_application(url, metadata)
-                logger.debug("cimd_app_created", url=url, app_id=str(new_app.pk), client_name=new_app.name)
-                capture_ph_event(
-                    distinct_id=url,
-                    event="cimd_application_created",
-                    properties={
-                        "cimd_url": url,
-                        "client_name": new_app.name,
-                        "app_id": str(new_app.pk),
-                        "redirect_uris_count": len(metadata.get("redirect_uris", [])),
-                        "has_logo": bool(metadata.get("logo_uri")),
-                        "cache_ttl": cache_ttl,
-                    },
-                )
-                return new_app
-            except (IntegrityError, ValidationError):
-                app = OAuthApplication.objects.filter(cimd_metadata_url=url).first()
-                if app:
-                    logger.debug("cimd_app_race_resolved", url=url, app_id=str(app.pk))
-                    return app
-                raise
-        finally:
-            cache.delete(fetch_lock)
+                logger.debug("cimd_app_race_resolved", url=url, app_id=str(app.pk))
+                return app
+            raise
+    finally:
+        cache.delete(fetch_lock)
 
 
 @shared_task(ignore_result=True, time_limit=30)
 def refresh_cimd_metadata_task(url: str) -> None:
     """Celery task wrapper: refresh CIMD metadata in the background."""
     try:
-        fetch_and_upsert_cimd_application(url)
+        with ph_scoped_capture() as capture_ph_event:  # This runs inside Celery, needs this to capture event
+            fetch_and_upsert_cimd_application(url, capture_ph_event=capture_ph_event)
     except (CIMDFetchError, CIMDValidationError) as e:
         logger.warning("cimd_background_refresh_failed", url=url, error=str(e))
         capture_exception(e)

--- a/posthog/api/oauth/cimd.py
+++ b/posthog/api/oauth/cimd.py
@@ -21,13 +21,13 @@ from django.utils import timezone
 
 import requests
 import structlog
-import posthoganalytics
 from celery import shared_task
 from oauth2_provider.models import AbstractApplication
 from rest_framework.throttling import SimpleRateThrottle
 
 from posthog.exceptions_capture import capture_exception
 from posthog.models.oauth import OAuthApplication
+from posthog.ph_client import ph_scoped_capture
 from posthog.rate_limit import IPThrottle
 from posthog.security.url_validation import is_url_allowed
 
@@ -341,50 +341,51 @@ def fetch_and_upsert_cimd_application(url: str) -> OAuthApplication | None:
     if not cache.add(fetch_lock, True, timeout=CIMD_FETCH_TIMEOUT_SECONDS * 3):
         return None
 
-    try:
-        metadata, cache_ttl = fetch_cimd_metadata(url)
-        cache.set(_cache_key(url), True, timeout=cache_ttl)
-
-        app = OAuthApplication.objects.filter(cimd_metadata_url=url).first()
-        if app:
-            updated = _update_cimd_application(app, metadata)
-            logger.debug("cimd_app_updated", url=url, app_id=str(updated.pk))
-            posthoganalytics.capture(
-                distinct_id=url,
-                event="cimd_application_metadata_refreshed",
-                properties={
-                    "cimd_url": url,
-                    "client_name": metadata.get("client_name"),
-                    "app_id": str(updated.pk),
-                    "cache_ttl": cache_ttl,
-                },
-            )
-            return updated
-
+    with ph_scoped_capture() as capture_ph_event:  # This runs inside Celery, needs this to capture event
         try:
-            new_app = _create_cimd_application(url, metadata)
-            logger.debug("cimd_app_created", url=url, app_id=str(new_app.pk), client_name=new_app.name)
-            posthoganalytics.capture(
-                distinct_id=url,
-                event="cimd_application_created",
-                properties={
-                    "cimd_url": url,
-                    "client_name": new_app.name,
-                    "app_id": str(new_app.pk),
-                    "redirect_uris_count": len(metadata.get("redirect_uris", [])),
-                    "has_logo": bool(metadata.get("logo_uri")),
-                    "cache_ttl": cache_ttl,
-                },
-            )
-            return new_app
-        except (IntegrityError, ValidationError):
+            metadata, cache_ttl = fetch_cimd_metadata(url)
+            cache.set(_cache_key(url), True, timeout=cache_ttl)
+
             app = OAuthApplication.objects.filter(cimd_metadata_url=url).first()
             if app:
-                logger.debug("cimd_app_race_resolved", url=url, app_id=str(app.pk))
-                return app
-            raise
-    finally:
-        cache.delete(fetch_lock)
+                updated = _update_cimd_application(app, metadata)
+                logger.debug("cimd_app_updated", url=url, app_id=str(updated.pk))
+                capture_ph_event(
+                    distinct_id=url,
+                    event="cimd_application_metadata_refreshed",
+                    properties={
+                        "cimd_url": url,
+                        "client_name": metadata.get("client_name"),
+                        "app_id": str(updated.pk),
+                        "cache_ttl": cache_ttl,
+                    },
+                )
+                return updated
+
+            try:
+                new_app = _create_cimd_application(url, metadata)
+                logger.debug("cimd_app_created", url=url, app_id=str(new_app.pk), client_name=new_app.name)
+                capture_ph_event(
+                    distinct_id=url,
+                    event="cimd_application_created",
+                    properties={
+                        "cimd_url": url,
+                        "client_name": new_app.name,
+                        "app_id": str(new_app.pk),
+                        "redirect_uris_count": len(metadata.get("redirect_uris", [])),
+                        "has_logo": bool(metadata.get("logo_uri")),
+                        "cache_ttl": cache_ttl,
+                    },
+                )
+                return new_app
+            except (IntegrityError, ValidationError):
+                app = OAuthApplication.objects.filter(cimd_metadata_url=url).first()
+                if app:
+                    logger.debug("cimd_app_race_resolved", url=url, app_id=str(app.pk))
+                    return app
+                raise
+        finally:
+            cache.delete(fetch_lock)
 
 
 @shared_task(ignore_result=True, time_limit=30)


### PR DESCRIPTION
## Problem

PostHog analytics events captured inside Celery tasks were not being flushed correctly because `posthoganalytics.capture` relies on a long-running process to flush its queue, which doesn't apply in Celery workers. This meant CIMD application creation and refresh events were being silently dropped.

## Changes

Replaced direct `posthoganalytics.capture` calls in `fetch_and_upsert_cimd_application` with `ph_scoped_capture`, a context manager designed for use in Celery tasks that ensures events are properly flushed after the task completes. The logic is otherwise unchanged.

## How did you test this code?

The existing test coverage for CIMD application creation and refresh flows covers the behavioral correctness. The key change is the capture mechanism, which `ph_scoped_capture` handles internally with its own flush guarantees.

## Publish to changelog?

No