### PR TITLE
fix(web-analytics): unify web vitals details and chart card

### DIFF
--- a/frontend/src/queries/nodes/WebVitals/WebVitals.tsx
+++ b/frontend/src/queries/nodes/WebVitals/WebVitals.tsx
@@ -15,13 +15,14 @@ import {
     AnyResponseType,
     ProductIntentContext,
     ProductKey,
+    WebVitalsMetric,
     WebVitalsQuery,
     WebVitalsQueryResponse,
 } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 
 import { dataNodeLogic } from '../DataNode/dataNodeLogic'
-import { getMetric } from './definitions'
+import { LONG_METRIC_NAME, getMetric } from './definitions'
 import { WebVitalsContent } from './WebVitalsContent'
 import { WebVitalsTab } from './WebVitalsTab'
 
@@ -49,6 +50,8 @@ export function WebVitals(props: {
     const { webVitalsPercentile, webVitalsTab, webVitalsMetricQuery } = useValues(webAnalyticsLogic)
     const { setWebVitalsTab } = useActions(webAnalyticsLogic)
     const { response, responseLoading } = useValues(logic)
+
+    const metricLongName = LONG_METRIC_NAME[webVitalsTab as WebVitalsMetric]
 
     // Manually handle loading state when loading to avoid showing stale data while refreshing
     const webVitalsQueryResponse = responseLoading ? undefined : (response as WebVitalsQueryResponse | undefined)
@@ -111,33 +114,40 @@ export function WebVitals(props: {
                 </span>
             </div>
 
-            <div className="flex flex-col sm:flex-row gap-2">
-                <WebVitalsContent webVitalsQueryResponse={webVitalsQueryResponse} isLoading={responseLoading} />
-                <div className="flex flex-col flex-1 bg-surface-primary rounded border p-4">
-                    <Query
-                        key={webVitalsTab}
-                        query={webVitalsMetricQuery}
-                        readOnly
-                        embedded
-                        context={{ renderEmptyStateAsSkeleton: true }}
-                    />
-
-                    <div className="flex w-full justify-end">
-                        <LemonButton
-                            to={urls.insightNew({ query: webVitalsMetricQuery })}
-                            icon={<IconOpenInNew />}
-                            size="small"
-                            type="secondary"
-                            onClick={() => {
-                                void addProductIntentForCrossSell({
-                                    from: ProductKey.WEB_ANALYTICS,
-                                    to: ProductKey.PRODUCT_ANALYTICS,
-                                    intent_context: ProductIntentContext.WEB_VITALS_INSIGHT,
-                                })
+            <div className="flex flex-col bg-surface-primary rounded border">
+                <div className="flex flex-row items-center justify-between gap-2 p-4 border-b">
+                    <h3 className="text-base font-semibold m-0">{metricLongName}</h3>
+                    <LemonButton
+                        to={urls.insightNew({ query: webVitalsMetricQuery })}
+                        icon={<IconOpenInNew />}
+                        size="small"
+                        type="secondary"
+                        onClick={() => {
+                            void addProductIntentForCrossSell({
+                                from: ProductKey.WEB_ANALYTICS,
+                                to: ProductKey.PRODUCT_ANALYTICS,
+                                intent_context: ProductIntentContext.WEB_VITALS_INSIGHT,
+                            })
+                        }}
+                    >
+                        Open as new Insight
+                    </LemonButton>
+                </div>
+                <div className="flex flex-col sm:flex-row">
+                    <WebVitalsContent webVitalsQueryResponse={webVitalsQueryResponse} isLoading={responseLoading} />
+                    <div className="flex flex-col flex-1 p-4">
+                        <Query
+                            key={webVitalsTab}
+                            query={webVitalsMetricQuery}
+                            readOnly
+                            embedded
+                            context={{
+                                renderEmptyStateAsSkeleton: true,
+                                emptyStateHeading: `No ${metricLongName} data to plot for this range`,
+                                emptyStateDetail:
+                                    'The tiles above show the latest recorded value. Try widening the date range or removing filters to populate the chart.',
                             }}
-                        >
-                            Open as new Insight
-                        </LemonButton>
+                        />
                     </div>
                 </div>
             </div>

--- a/frontend/src/queries/nodes/WebVitals/WebVitalsContent.tsx
+++ b/frontend/src/queries/nodes/WebVitals/WebVitalsContent.tsx
@@ -12,7 +12,6 @@ import {
     EXPERIENCE_PER_BAND,
     GRADE_PER_BAND,
     ICON_PER_BAND,
-    LONG_METRIC_NAME,
     METRIC_DESCRIPTION,
     POSITIONING_PER_BAND,
     QUANTIFIER_PER_BAND,
@@ -44,13 +43,17 @@ export const WebVitalsContent = ({ webVitalsQueryResponse, isLoading }: WebVital
 
     // Show skeleton only when loading
     if (isLoading) {
-        return <LemonSkeleton fade className="w-full h-full rounded sm:w-[30%]" />
+        return (
+            <div className="w-full p-4 sm:w-[30%] border-b sm:border-b-0 sm:border-r">
+                <LemonSkeleton fade className="w-full h-full" />
+            </div>
+        )
     }
 
     // Show no data message when not loading and value is undefined
     if (value === undefined || band === 'none') {
         return (
-            <div className="w-full p-4 sm:w-[30%] flex flex-col gap-2 bg-surface-primary rounded border items-center justify-center">
+            <div className="w-full p-4 sm:w-[30%] flex flex-col gap-2 border-b sm:border-b-0 sm:border-r items-center justify-center">
                 <span className="text-sm text-text-tertiary">No data for the selected date range</span>
             </div>
         )
@@ -69,11 +72,7 @@ export const WebVitalsContent = ({ webVitalsQueryResponse, isLoading }: WebVital
     const unit = webVitalsTab === 'CLS' ? '' : 'ms'
 
     return (
-        <div className="w-full p-4 sm:w-[30%] flex flex-col gap-2 bg-surface-primary rounded border">
-            <span className="text-lg">
-                <strong>{LONG_METRIC_NAME[webVitalsTab]}</strong>
-            </span>
-
+        <div className="w-full p-4 sm:w-[30%] flex flex-col gap-2 border-b sm:border-b-0 sm:border-r">
             <div className="flex flex-col">
                 <Tooltip
                     title={


### PR DESCRIPTION
## Problem

A colleague reported that the large chart on the Web Vitals tab (Web analytics → Web vitals) renders without any visible header — when it empty-states, the user has no way to tell what it was supposed to show. The left-hand details card was intended to act as the chart's header/context, but both blocks use identical card styling and sit side-by-side with a gap, so they read as two peers rather than header + content.

## Changes

- **Merge details + chart into one card.** Wrap both halves in a single `bg-surface-primary rounded border` container with a shared header row on top. The internal split becomes a divider (`border-r` on sm+, `border-b` below sm).
- **Always-visible metric title.** Header row shows `LONG_METRIC_NAME[webVitalsTab]` (e.g. "Interaction to Next Paint") regardless of loading / empty state. "Open as new Insight" moves into that header so the chart area gets more vertical room.
- **Web vitals-specific empty state.** Pass `emptyStateHeading` / `emptyStateDetail` through `QueryContext` (already consumed by `ActionsLineGraph`). Chart now shows "No {metric} data to plot for this range" with a hint about widening the date range / filters, instead of the generic "There are no matching events for this query".
- Drop the now-duplicate metric title from `WebVitalsContent` and remove its outer card styling so it sits inside the unified card.

## How did you test this code?

I'm an AI agent — I did not run this in a browser. I verified:
- TypeScript check: pre-existing TS errors on the branch count is unchanged (one TS7053 removed, zero added; net -1).
- `oxfmt` formatted both files.
- Code review of layout classes against the existing Tailwind tokens used throughout web analytics.

Reviewers should visually confirm on `/web/web-vitals`:
1. Details + chart render as one card with a shared header that updates on tab switch (INP / LCP / FCP / CLS).
2. Empty state on the chart shows the web-vitals-specific copy.
3. Responsive: `<sm` stacks with a horizontal divider; `sm+` side-by-side with a vertical divider.
4. Dark and light mode both look cohesive.

## Publish to changelog?

no

## 🤖 LLM context

Authored by [PostHog Code](https://posthog.com/code?ref=pr). The tile-vs-chart data discrepancy also reported by Lucas in the papercut thread ("top tiles show values but chart is empty") was not fixed in this PR — the custom empty-state copy mitigates the UX impact, but the underlying cause (sparse `\$web_vitals` buckets summing to zero, tripping `ActionsLineGraph`'s all-zero empty-state check at `frontend/src/scenes/trends/viz/ActionsLineGraph.tsx:88-91`) should be investigated separately.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*