### PR TITLE
fix(cli): degrade gracefully when release already exists

### DIFF
--- a/cli/src/api/client.rs
+++ b/cli/src/api/client.rs
@@ -63,10 +63,10 @@ impl From<reqwest::Error> for ClientError {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ApiErrorResponse {
-    r#type: String,
-    code: String,
-    detail: String,
-    attr: Option<String>,
+    pub(crate) r#type: String,
+    pub(crate) code: String,
+    pub(crate) detail: String,
+    pub(crate) attr: Option<String>,
 }
 
 impl Display for ApiErrorResponse {

--- a/cli/src/api/releases.rs
+++ b/cli/src/api/releases.rs
@@ -138,12 +138,29 @@ impl ReleaseBuilder {
                 self.missing().join(", ")
             )
         }
-        let version = self.version.as_ref().unwrap();
-        let project = self.name.as_ref().unwrap();
-        if let Some(release) = Release::lookup(project, version)? {
-            Ok(release)
-        } else {
-            self.create_release()
+        // Clone so we can re-lookup if a concurrent caller wins the create race
+        // (e.g. the inject and upload phases of `sourcemap process` both reach
+        // `fetch_or_create` for the same release).
+        let name = self.name.clone().expect("can_create() ensured name is set");
+        let version = self
+            .version
+            .clone()
+            .expect("can_create() ensured version is set");
+
+        if let Some(release) = Release::lookup(&name, &version)? {
+            return Ok(release);
+        }
+
+        match self.create_release() {
+            Ok(release) => Ok(release),
+            Err(err) if is_hash_already_in_use(&err) => {
+                warn!(
+                    "Release {}@{} reported as already in use on create; re-fetching",
+                    name, version
+                );
+                Release::lookup(&name, &version)?.ok_or(err)
+            }
+            Err(err) => Err(err),
         }
     }
 
@@ -184,5 +201,53 @@ impl ReleaseBuilder {
             request.project, request.version, response.id
         );
         Ok(response)
+    }
+}
+
+/// Returns true if `err` (including wrapped causes) is the PostHog API
+/// `validation_error` that signals a release with this `hash_id` already
+/// exists. Used to make `fetch_or_create` tolerant of GET/POST races where
+/// `Release::lookup` returns 404 for a release that a concurrent caller
+/// (or a prior phase of the same `sourcemap process` run) just created.
+fn is_hash_already_in_use(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<ClientError>(),
+            Some(ClientError::ApiError(_, _, body)) if body.contains("already in use")
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::Url;
+
+    fn releases_url() -> Box<Url> {
+        Box::new(
+            Url::parse("https://us.posthog.com/api/projects/1/error_tracking/releases").unwrap(),
+        )
+    }
+
+    #[test]
+    fn detects_hash_already_in_use_error() {
+        let body = r#"{"type":"validation_error","code":"invalid_input","detail":"Hash id abc123 already in use","attr":null}"#;
+        let client_err = ClientError::ApiError(400, releases_url(), body.to_string());
+        let wrapped = anyhow::Error::new(client_err).context("Failed to create release");
+        assert!(is_hash_already_in_use(&wrapped));
+    }
+
+    #[test]
+    fn ignores_unrelated_api_errors() {
+        let client_err =
+            ClientError::ApiError(500, releases_url(), "internal server error".to_string());
+        let wrapped = anyhow::Error::new(client_err).context("Failed to create release");
+        assert!(!is_hash_already_in_use(&wrapped));
+    }
+
+    #[test]
+    fn ignores_non_api_errors() {
+        let err = anyhow::anyhow!("something totally unrelated");
+        assert!(!is_hash_already_in_use(&err));
     }
 }

--- a/cli/src/api/releases.rs
+++ b/cli/src/api/releases.rs
@@ -138,29 +138,12 @@ impl ReleaseBuilder {
                 self.missing().join(", ")
             )
         }
-        // Clone so we can re-lookup if a concurrent caller wins the create race
-        // (e.g. the inject and upload phases of `sourcemap process` both reach
-        // `fetch_or_create` for the same release).
-        let name = self.name.clone().expect("can_create() ensured name is set");
-        let version = self
-            .version
-            .clone()
-            .expect("can_create() ensured version is set");
-
-        if let Some(release) = Release::lookup(&name, &version)? {
-            return Ok(release);
-        }
-
-        match self.create_release() {
-            Ok(release) => Ok(release),
-            Err(err) if is_hash_already_in_use(&err) => {
-                warn!(
-                    "Release {}@{} reported as already in use on create; re-fetching",
-                    name, version
-                );
-                Release::lookup(&name, &version)?.ok_or(err)
-            }
-            Err(err) => Err(err),
+        let version = self.version.as_ref().unwrap();
+        let project = self.name.as_ref().unwrap();
+        if let Some(release) = Release::lookup(project, version)? {
+            Ok(release)
+        } else {
+            self.create_release()
         }
     }
 
@@ -206,10 +189,13 @@ impl ReleaseBuilder {
 
 /// Returns true if `err` (including wrapped causes) is the PostHog API
 /// `validation_error` that signals a release with this `hash_id` already
-/// exists. Used to make `fetch_or_create` tolerant of GET/POST races where
-/// `Release::lookup` returns 404 for a release that a concurrent caller
-/// (or a prior phase of the same `sourcemap process` run) just created.
-fn is_hash_already_in_use(err: &anyhow::Error) -> bool {
+/// exists. Used by the sourcemap inject/upload flows to degrade gracefully
+/// when another step (or a concurrent invocation) has just created the
+/// release — `Release::lookup`'s `by_hash` endpoint can briefly serve a
+/// stale 404 afterwards, so callers can't reliably re-fetch and should
+/// fall back to whatever release_id they already have on their source
+/// pairs instead of aborting.
+pub(crate) fn is_hash_already_in_use(err: &anyhow::Error) -> bool {
     err.chain().any(|cause| {
         matches!(
             cause.downcast_ref::<ClientError>(),

--- a/cli/src/api/releases.rs
+++ b/cli/src/api/releases.rs
@@ -7,10 +7,15 @@ use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::{
-    api::client::ClientError,
+    api::client::{ApiErrorResponse, ClientError},
     invocation_context::context,
     utils::{files::content_hash, git::GitInfo},
 };
+
+/// Path segment the `ReleaseViewSet` is mounted under. Used by
+/// `is_hash_already_in_use` to avoid matching unrelated endpoints that might
+/// coincidentally return a `validation_error` containing "already in use".
+const RELEASES_PATH_SEGMENT: &str = "/error_tracking/releases";
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Release {
@@ -187,20 +192,40 @@ impl ReleaseBuilder {
     }
 }
 
-/// Returns true if `err` (including wrapped causes) is the PostHog API
-/// `validation_error` that signals a release with this `hash_id` already
-/// exists. Used by the sourcemap inject/upload flows to degrade gracefully
-/// when another step (or a concurrent invocation) has just created the
-/// release — `Release::lookup`'s `by_hash` endpoint can briefly serve a
-/// stale 404 afterwards, so callers can't reliably re-fetch and should
-/// fall back to whatever release_id they already have on their source
-/// pairs instead of aborting.
+/// Returns true if `err` (including wrapped causes) is the specific PostHog
+/// API `validation_error` that signals a release with this `hash_id` already
+/// exists. Used by the sourcemap upload flow to degrade gracefully when a
+/// concurrent step has just created the release — `Release::lookup`'s
+/// `by_hash` endpoint can briefly serve a stale 404 afterwards, so callers
+/// that already have the correct release_id on their source pairs should
+/// fall back to it instead of aborting.
+///
+/// The match is gated on all of:
+/// - `ClientError::ApiError` with HTTP status `400`
+/// - request URL path containing the releases endpoint
+/// - JSON body parses as `ApiErrorResponse` with `code == "invalid_input"`
+///   and `detail` containing "already in use"
+///
+/// The multiple gates are intentional: the raw response body is not a stable
+/// wire contract, and a looser match could silently swallow unrelated 4xx
+/// errors (e.g. a future endpoint that happens to emit the same English
+/// phrase) and mask real bugs.
 pub(crate) fn is_hash_already_in_use(err: &anyhow::Error) -> bool {
     err.chain().any(|cause| {
-        matches!(
-            cause.downcast_ref::<ClientError>(),
-            Some(ClientError::ApiError(_, _, body)) if body.contains("already in use")
-        )
+        let Some(ClientError::ApiError(status, url, body)) = cause.downcast_ref::<ClientError>()
+        else {
+            return false;
+        };
+        if *status != 400 {
+            return false;
+        }
+        if !url.path().contains(RELEASES_PATH_SEGMENT) {
+            return false;
+        }
+        let Ok(api_err) = serde_json::from_str::<ApiErrorResponse>(body) else {
+            return false;
+        };
+        api_err.code == "invalid_input" && api_err.detail.contains("already in use")
     })
 }
 
@@ -215,25 +240,62 @@ mod tests {
         )
     }
 
+    fn api_err(status: u16, url: Box<Url>, body: &str) -> anyhow::Error {
+        anyhow::Error::new(ClientError::ApiError(status, url, body.to_string()))
+            .context("Failed to create release")
+    }
+
+    const HASH_IN_USE_BODY: &str = r#"{"type":"validation_error","code":"invalid_input","detail":"Hash id abc123 already in use","attr":null}"#;
+
     #[test]
     fn detects_hash_already_in_use_error() {
-        let body = r#"{"type":"validation_error","code":"invalid_input","detail":"Hash id abc123 already in use","attr":null}"#;
-        let client_err = ClientError::ApiError(400, releases_url(), body.to_string());
-        let wrapped = anyhow::Error::new(client_err).context("Failed to create release");
-        assert!(is_hash_already_in_use(&wrapped));
+        assert!(is_hash_already_in_use(&api_err(
+            400,
+            releases_url(),
+            HASH_IN_USE_BODY
+        )));
     }
 
     #[test]
-    fn ignores_unrelated_api_errors() {
-        let client_err =
-            ClientError::ApiError(500, releases_url(), "internal server error".to_string());
-        let wrapped = anyhow::Error::new(client_err).context("Failed to create release");
-        assert!(!is_hash_already_in_use(&wrapped));
+    fn ignores_non_400_status() {
+        assert!(!is_hash_already_in_use(&api_err(
+            500,
+            releases_url(),
+            HASH_IN_USE_BODY
+        )));
+    }
+
+    #[test]
+    fn ignores_wrong_endpoint() {
+        let other_url = Box::new(
+            Url::parse("https://us.posthog.com/api/projects/1/error_tracking/symbol_sets").unwrap(),
+        );
+        assert!(!is_hash_already_in_use(&api_err(
+            400,
+            other_url,
+            HASH_IN_USE_BODY
+        )));
+    }
+
+    #[test]
+    fn ignores_non_validation_error_code() {
+        let body = r#"{"type":"validation_error","code":"unique_constraint","detail":"Hash id abc123 already in use","attr":null}"#;
+        assert!(!is_hash_already_in_use(&api_err(400, releases_url(), body)));
+    }
+
+    #[test]
+    fn ignores_non_json_body() {
+        assert!(!is_hash_already_in_use(&api_err(
+            400,
+            releases_url(),
+            "Hash id abc already in use"
+        )));
     }
 
     #[test]
     fn ignores_non_api_errors() {
-        let err = anyhow::anyhow!("something totally unrelated");
-        assert!(!is_hash_already_in_use(&err));
+        assert!(!is_hash_already_in_use(&anyhow::anyhow!(
+            "something totally unrelated"
+        )));
     }
 }

--- a/cli/src/sourcemaps/hermes/upload.rs
+++ b/cli/src/sourcemaps/hermes/upload.rs
@@ -46,17 +46,18 @@ pub fn upload(args: &Args) -> Result<()> {
     let maps = read_maps(&directory);
 
     // Get or create a release if project/version are provided or if any map is missing a release_id.
-    // If a concurrent step has just created the release, the `by_hash` GET used inside
+    //
+    // If a prior step has just created the release, the `by_hash` GET used inside
     // `get_release_for_maps` can briefly serve a stale 404 — the follow-up POST then fails with
-    // `Hash id ... already in use`. In that case proceed without overriding map release_ids
-    // rather than aborting.
+    // `Hash id ... already in use`. We only swallow that error when every map already carries a
+    // `release_id`; otherwise skipping would silently upload orphan symbol sets.
     let created_release_id = match get_release_for_maps(&directory, release.clone(), maps.iter()) {
         Ok(result) => result.map(|r| r.id.to_string()),
-        Err(err) if is_hash_already_in_use(&err) => {
+        Err(err) if is_hash_already_in_use(&err) && maps.iter().all(|m| m.has_release_id()) => {
             warn!(
-                    "release already exists (created concurrently); keeping release_ids on existing maps: {}",
-                    err
-                );
+                "release already exists (likely created by a prior step in this run); keeping release_ids on existing maps: {}",
+                err
+            );
             None
         }
         Err(err) => return Err(err),

--- a/cli/src/sourcemaps/hermes/upload.rs
+++ b/cli/src/sourcemaps/hermes/upload.rs
@@ -5,6 +5,7 @@ use serde_json::json;
 use tracing::{info, warn};
 use walkdir::WalkDir;
 
+use crate::api::releases::is_hash_already_in_use;
 use crate::api::symbol_sets::{self, SymbolSetUpload};
 use crate::invocation_context::context;
 use crate::sourcemaps::args::ReleaseArgs;
@@ -44,9 +45,22 @@ pub fn upload(args: &Args) -> Result<()> {
     info!("Processing directory: {}", directory.display());
     let maps = read_maps(&directory);
 
-    // Get or create a release if project/version are provided or if any map is missing a release_id
-    let created_release_id =
-        get_release_for_maps(&directory, release.clone(), maps.iter())?.map(|r| r.id.to_string());
+    // Get or create a release if project/version are provided or if any map is missing a release_id.
+    // If a concurrent step has just created the release, the `by_hash` GET used inside
+    // `get_release_for_maps` can briefly serve a stale 404 — the follow-up POST then fails with
+    // `Hash id ... already in use`. In that case proceed without overriding map release_ids
+    // rather than aborting.
+    let created_release_id = match get_release_for_maps(&directory, release.clone(), maps.iter()) {
+        Ok(result) => result.map(|r| r.id.to_string()),
+        Err(err) if is_hash_already_in_use(&err) => {
+            warn!(
+                    "release already exists (created concurrently); keeping release_ids on existing maps: {}",
+                    err
+                );
+            None
+        }
+        Err(err) => return Err(err),
+    };
 
     let mut uploads: Vec<SymbolSetUpload> = Vec::new();
     for mut map in maps.into_iter() {

--- a/cli/src/sourcemaps/inject.rs
+++ b/cli/src/sourcemaps/inject.rs
@@ -1,10 +1,10 @@
 use anyhow::{bail, Result};
 use std::path::Path;
-use tracing::info;
+use tracing::{info, warn};
 use walkdir::DirEntry;
 
 use crate::{
-    api::releases::{Release, ReleaseBuilder},
+    api::releases::{is_hash_already_in_use, Release, ReleaseBuilder},
     sourcemaps::{
         args::{FileSelectionArgs, ReleaseArgs},
         content::SourceMapFile,
@@ -55,10 +55,25 @@ pub fn inject_impl(args: &InjectArgs, matcher: impl Fn(&DirEntry) -> bool + 'sta
 
     let cwd = std::env::current_dir()?;
 
-    let created_release_id =
-        get_release_for_maps(&cwd, release.clone(), pairs.iter().map(|p| &p.sourcemap))?
-            .as_ref()
-            .map(|r| r.id.to_string());
+    // If a concurrent CLI invocation has already created the release, the `by_hash` GET used
+    // inside `get_release_for_maps` can briefly serve a stale 404 — the follow-up POST then
+    // fails with `Hash id ... already in use`. Treat that as a signal to proceed without a
+    // release association (chunk_ids still get injected) rather than aborting the run.
+    let created_release_id = match get_release_for_maps(
+        &cwd,
+        release.clone(),
+        pairs.iter().map(|p| &p.sourcemap),
+    ) {
+        Ok(release) => release.as_ref().map(|r| r.id.to_string()),
+        Err(err) if is_hash_already_in_use(&err) => {
+            warn!(
+                    "release already exists (created concurrently); injecting chunk ids without a release association: {}",
+                    err
+                );
+            None
+        }
+        Err(err) => return Err(err),
+    };
 
     pairs = inject_pairs(pairs, created_release_id)?;
 

--- a/cli/src/sourcemaps/inject.rs
+++ b/cli/src/sourcemaps/inject.rs
@@ -1,10 +1,10 @@
 use anyhow::{bail, Result};
 use std::path::Path;
-use tracing::{info, warn};
+use tracing::info;
 use walkdir::DirEntry;
 
 use crate::{
-    api::releases::{is_hash_already_in_use, Release, ReleaseBuilder},
+    api::releases::{Release, ReleaseBuilder},
     sourcemaps::{
         args::{FileSelectionArgs, ReleaseArgs},
         content::SourceMapFile,
@@ -55,25 +55,10 @@ pub fn inject_impl(args: &InjectArgs, matcher: impl Fn(&DirEntry) -> bool + 'sta
 
     let cwd = std::env::current_dir()?;
 
-    // If a concurrent CLI invocation has already created the release, the `by_hash` GET used
-    // inside `get_release_for_maps` can briefly serve a stale 404 — the follow-up POST then
-    // fails with `Hash id ... already in use`. Treat that as a signal to proceed without a
-    // release association (chunk_ids still get injected) rather than aborting the run.
-    let created_release_id = match get_release_for_maps(
-        &cwd,
-        release.clone(),
-        pairs.iter().map(|p| &p.sourcemap),
-    ) {
-        Ok(release) => release.as_ref().map(|r| r.id.to_string()),
-        Err(err) if is_hash_already_in_use(&err) => {
-            warn!(
-                    "release already exists (created concurrently); injecting chunk ids without a release association: {}",
-                    err
-                );
-            None
-        }
-        Err(err) => return Err(err),
-    };
+    let created_release_id =
+        get_release_for_maps(&cwd, release.clone(), pairs.iter().map(|p| &p.sourcemap))?
+            .as_ref()
+            .map(|r| r.id.to_string());
 
     pairs = inject_pairs(pairs, created_release_id)?;
 

--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -67,11 +67,15 @@ pub fn upload(args: &Args) -> Result<()> {
     info!("Found {} chunks to upload", pairs.len());
 
     // Get or create a release if project/version are provided or if any pair is missing a release_id.
-    // If a concurrent step (typically the inject phase of `sourcemap process`, or a parallel CLI
+    //
+    // If a prior step (typically the inject phase of `sourcemap process`, or a parallel CLI
     // invocation) has just created the release, the `by_hash` GET used inside `get_release_for_maps`
     // can briefly serve a stale 404 — the follow-up POST then fails with `Hash id ... already in use`.
-    // In that case, keep whatever release_id the pairs already have (set by inject) and proceed
-    // with the upload rather than failing the whole run.
+    //
+    // We only swallow that error when every pair already carries a `release_id` (i.e. inject has
+    // already associated them with the correct release). Without that precondition, skipping
+    // `get_release_for_maps` would silently upload orphan symbol sets with no release attribution,
+    // which masks configuration bugs in standalone `sourcemap upload` runs.
     let cwd = std::env::current_dir()?;
     let created_release_id = match get_release_for_maps(
         &cwd,
@@ -79,9 +83,12 @@ pub fn upload(args: &Args) -> Result<()> {
         pairs.iter().map(|p| &p.sourcemap),
     ) {
         Ok(result) => result.map(|r| r.id.to_string()),
-        Err(err) if is_hash_already_in_use(&err) => {
+        Err(err)
+            if is_hash_already_in_use(&err)
+                && pairs.iter().all(|p| p.sourcemap.has_release_id()) =>
+        {
             warn!(
-                "release already exists (created concurrently); keeping release_ids from source pairs: {}",
+                "release already exists (likely created by a prior step in this run); keeping release_ids from source pairs: {}",
                 err
             );
             None

--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -2,10 +2,13 @@ use std::time::Instant;
 
 use anyhow::{Context, Result};
 use serde_json::json;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{
-    api::symbol_sets::{self, SymbolSetUpload},
+    api::{
+        releases::is_hash_already_in_use,
+        symbol_sets::{self, SymbolSetUpload},
+    },
     invocation_context::context,
     sourcemaps::{
         args::{FileSelectionArgs, ReleaseArgs},
@@ -63,14 +66,28 @@ pub fn upload(args: &Args) -> Result<()> {
         .collect::<Vec<_>>();
     info!("Found {} chunks to upload", pairs.len());
 
-    // Get or create a release if project/version are provided or if any pair is missing a release_id
+    // Get or create a release if project/version are provided or if any pair is missing a release_id.
+    // If a concurrent step (typically the inject phase of `sourcemap process`, or a parallel CLI
+    // invocation) has just created the release, the `by_hash` GET used inside `get_release_for_maps`
+    // can briefly serve a stale 404 — the follow-up POST then fails with `Hash id ... already in use`.
+    // In that case, keep whatever release_id the pairs already have (set by inject) and proceed
+    // with the upload rather than failing the whole run.
     let cwd = std::env::current_dir()?;
-    let created_release_id = get_release_for_maps(
+    let created_release_id = match get_release_for_maps(
         &cwd,
         args.release.clone(),
         pairs.iter().map(|p| &p.sourcemap),
-    )?
-    .map(|r| r.id.to_string());
+    ) {
+        Ok(result) => result.map(|r| r.id.to_string()),
+        Err(err) if is_hash_already_in_use(&err) => {
+            warn!(
+                "release already exists (created concurrently); keeping release_ids from source pairs: {}",
+                err
+            );
+            None
+        }
+        Err(err) => return Err(err),
+    };
 
     // Override release_id if we created/fetched one
     if let Some(ref release_id) = created_release_id {


### PR DESCRIPTION
## Problem

`posthog-cli sourcemap process` (and, by extension, `@posthog/nextjs-config`'s `runAfterProductionCompile` hook) fails the user's build with:

```
ERROR posthog_cli::commands: Oops! Failed to create release

Caused by:
    API error: error='validation_error' code='invalid_input' details='Hash id <hash> already in use'
```

### Root cause

`SourcemapCommand::Process` calls `plain::inject::inject` and then `plain::upload::upload` sequentially (`cli/src/commands.rs`). Both phases independently invoke `get_release_for_maps` → `ReleaseBuilder::fetch_or_create` — inject has since #39680, and upload has since #44421.

For the same `(release_name, release_version)`, `fetch_or_create` does `GET /error_tracking/releases/hash/<hash>` and falls back to `POST /error_tracking/releases` on 404. After a successful POST, that `by_hash` GET continues to serve a stale 404 for **30+ seconds** — not a sub-second replica lag, and not defeatable by cache-busting query params or `Cache-Control: no-cache`. During that window the upload phase 404s on the release inject just created, falls through to POST, and hits `validate_hash_id` with `Hash id ... already in use`.

Because `fetch_or_create` surfaces that as an error, `runAfterProductionCompile` aborts and the whole production build fails.

Observed log pattern (single CLI invocation):

```
INFO  sourcemaps::inject:        injecting selection: [...]
WARN  api::releases:             release foo@<ver> not found
INFO  api::releases:             Release foo@<ver> created successfully! <id>
INFO  sourcemaps::inject:        injecting done
INFO  sourcemaps::plain::upload: Found N chunks to upload
WARN  api::releases:             release foo@<ver> not found       # stale read (~30s+ window)
ERROR commands:                  Hash id <hash> already in use     # POST conflicts
```

## Changes

Tighten the only caller that actually hits this failure mode in the real bug — the upload phase — and narrow the error-matching contract so the workaround can't swallow unrelated errors.

### `cli/src/api/releases.rs`

- Added `pub(crate) fn is_hash_already_in_use(&anyhow::Error) -> bool`. Walks the anyhow error chain, looks for a `ClientError::ApiError`, and only returns true when **all** of the following hold:
  - HTTP status is `400`
  - request URL path is under `/error_tracking/releases`
  - the response body parses as `ApiErrorResponse` with `code == "invalid_input"` and `detail` containing `"already in use"`

  The multi-gate match is deliberate: the raw response body is not a stable wire contract, and a looser `body.contains("already in use")` match could silently swallow unrelated 4xx errors (e.g. a future endpoint that happens to emit the same English phrase) and mask real bugs.
- `fetch_or_create` itself is unchanged.

### `cli/src/sourcemaps/plain/upload.rs`

On `get_release_for_maps` → `Err(err)`:
- If `is_hash_already_in_use(&err)` **and** every pair in the batch already carries a `release_id` (i.e. inject has already associated them with the correct release), log a warning and proceed with `created_release_id = None`. The pairs keep the release_id inject wrote; the override step is skipped.
- Otherwise, propagate.

The pair-level precondition is important: without it, skipping `get_release_for_maps` in a standalone `sourcemap upload` run would silently upload orphan symbol sets with no release attribution.

### `cli/src/sourcemaps/hermes/upload.rs`

Parity fix for the Hermes path with the same precondition (`maps.iter().all(|m| m.has_release_id())`).

### `cli/src/sourcemaps/inject.rs`

No change. An earlier iteration of this PR added the same `is_hash_already_in_use` fallback to inject, but inject's only recovery would be to write `created_release_id = None` into the pairs on disk — producing orphan chunk IDs for any downstream upload. For the real Vercel bug (single-process `sourcemap process`), inject is the step that *creates* the release, so it never reaches this error path in practice; adding the fallback there was dead code for the actual failure mode and actively harmful in any concurrent scenario. Propagating is correct.

### `cli/src/api/client.rs`

`ApiErrorResponse`'s fields promoted to `pub(crate)` so the releases module can inspect them.

### Related: server-side follow-up

The `GET /error_tracking/releases/hash/<hash>` behavior is the ultimate root cause. Empirically:
- Returns 404 for 30+ seconds after a successful POST that created the release
- `GET /error_tracking/releases/{id}` returns 200 immediately for the same release
- `list` includes the release immediately
- `?_=<ts>` cache-buster and `Cache-Control: no-cache` don't help

That's an inconsistency specific to the `by_hash` endpoint in `products/error_tracking/backend/api/releases.py` — either a cache that isn't invalidated on POST, or a queryset/view-level inconsistency vs `validate_hash_id`'s `exists()` check. A server-side fix (e.g. making the POST conflict response include the existing release id, or fixing the 404-cache) would eliminate the need for this client-side workaround entirely. Happy to file a separate PR for that if useful.

## How did you test this code?

**Automated:**

- `cargo test --all-features` ✅ — 77 tests pass, including **6 new unit tests** for `is_hash_already_in_use` covering: the happy-path match, non-400 status rejection, wrong-endpoint rejection, wrong-`code` rejection, non-JSON body rejection, non-`ClientError` rejection.
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- `cargo update --workspace --locked` ✅ (`Cargo.lock` unchanged)

**End-to-end against a live PostHog staging environment** — built the forked CLI in release mode, ran `sourcemap process` via two paths:

| Scenario | Binary | Exit | Observed |
|---|---|---|---|
| Single CLI invocation | unpatched 0.7.5 | **1** | inject creates release; upload 404s on `by_hash`; POST `Hash id ... already in use`; fatal. Reproduces the `runAfterProductionCompile` build failure exactly. |
| Single CLI invocation | this PR | **0** | Same inject-create / upload-404 / POST-conflict, but now upload logs `release already exists (likely created by a prior step in this run); keeping release_ids from source pairs` and proceeds. |
| Full Next.js 16 production build through `@posthog/nextjs-config`'s `runAfterProductionCompile` hook (real `.next` dir, 1316 JS/sourcemap pairs, Turbopack, forked binary wired via `cliBinaryPath`) | this PR | **0** | Exact log pattern: inject 404 → create 201 → upload 404 (stale, +1.2s) → WARN from the fix → 1316 symbol sets uploaded in 27 batches → `All done, happy hogging!` → `next build` succeeds. |

> Caveat: live-staging testing is signal, not proof. Confounds include staging vs prod, darwin-arm64 local binary vs Linux deploy targets, and the use of a fresh timestamped `release_version` that bypasses stable-version-reuse scenarios. The unit tests cover the helper deterministically; the end-to-end test exercises the real pipeline against real staging infrastructure.

> Disclosure: I'm an AI agent contributing under the author's direction. See the LLM context section below.

## Publish to changelog?

no — please bundle into the next release entry when cutting a version.

## Docs update

n/a — internal CLI behavior only.

## 🤖 LLM context

Authored with Claude Opus 4.7 (Anthropic). The human author drove the investigation (git archaeology identifying #44421 as the introducing PR, empirical characterization of the 30+ second stale-read window, end-to-end validation through a real Next.js production build) and iterated twice on the approach after adversarial review:
- v1: retry inside `fetch_or_create` — abandoned when live testing showed the re-lookup hits the same stale cache.
- v2: graceful degradation in inject + both uploads — abandoned on review as over-broad.
- v3 (this PR): tightened error detection, gated upload fallback on pair-level release_id precondition, dropped the inject fallback entirely.

Every local check was run by the author and each iteration was validated end-to-end against live PostHog staging before pushing.