### PR TITLE
feat(experiments): push session_id set into raw_sessions join

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -20319,6 +20319,10 @@
                 "s3TableUseInvalidColumns": {
                     "type": "boolean"
                 },
+                "sessionIdPushdown": {
+                    "description": "Push a `session_id_v7 IN (SELECT … FROM events WHERE …)` predicate into the raw_sessions subquery to limit aggregation to sessions that participate in the outer events filter.",
+                    "type": "boolean"
+                },
                 "sessionTableVersion": {
                     "enum": ["auto", "v1", "v2", "v3"],
                     "type": "string"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -417,6 +417,8 @@ export interface HogQLQueryModifiers {
     inCohortVia?: 'auto' | 'leftjoin' | 'subquery' | 'leftjoin_conjoined'
     materializationMode?: 'auto' | 'legacy_null_as_string' | 'legacy_null_as_null' | 'disabled'
     optimizeJoinedFilters?: boolean
+    /** Push a `session_id_v7 IN (SELECT … FROM events WHERE …)` predicate into the raw_sessions subquery to limit aggregation to sessions that participate in the outer events filter. */
+    sessionIdPushdown?: boolean
     dataWarehouseEventsModifiers?: DataWarehouseEventsModifier[]
     debug?: boolean
     timings?: boolean

--- a/posthog/hogql/database/schema/sessions_v2.py
+++ b/posthog/hogql/database/schema/sessions_v2.py
@@ -21,7 +21,10 @@ from posthog.hogql.database.models import (
 )
 from posthog.hogql.database.schema.channel_type import DEFAULT_CHANNEL_TYPES, ChannelTypeExprs, create_channel_type_expr
 from posthog.hogql.database.schema.sessions_v1 import DEFAULT_BOUNCE_RATE_DURATION_SECONDS, null_if_empty
-from posthog.hogql.database.schema.util.where_clause_extractor import SessionMinTimestampWhereClauseExtractorV2
+from posthog.hogql.database.schema.util.where_clause_extractor import (
+    SessionMinTimestampWhereClauseExtractorV2,
+    build_session_id_v7_pushdown_predicate,
+)
 from posthog.hogql.errors import ResolutionError
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 
@@ -186,7 +189,10 @@ class RawSessionsTableV2(Table):
 
 
 def select_from_sessions_table_v2(
-    requested_fields: dict[str, list[str | int]], node: ast.SelectQuery, context: HogQLContext
+    requested_fields: dict[str, list[str | int]],
+    node: ast.SelectQuery,
+    context: HogQLContext,
+    extra_where: Optional[ast.Expr] = None,
 ):
     from posthog.hogql import ast
 
@@ -428,6 +434,8 @@ def select_from_sessions_table_v2(
             group_by_fields.append(ast.Field(chain=cast(list[str | int], [table_name]) + chain))
 
     where = SessionMinTimestampWhereClauseExtractorV2(context).get_inner_where(node)
+    if extra_where is not None:
+        where = ast.And(exprs=[where, extra_where]) if where is not None else extra_where
 
     return ast.SelectQuery(
         select=select_fields,
@@ -480,7 +488,21 @@ def join_events_table_to_sessions_table_v2(
     if not join_to_add.fields_accessed:
         raise ResolutionError("No fields requested from events")
 
-    join_expr = ast.JoinExpr(table=select_from_sessions_table_v2(join_to_add.fields_accessed, node, context))
+    extra_where: Optional[ast.Expr] = None
+    # Only push down in UUID join mode — the `$session_id` string mode would require wrapping
+    # the IN-subquery output in `_toUInt128(toUUID(...))` and isn't needed for the common path.
+    if context.modifiers.sessionIdPushdown and context.modifiers.sessionsV2JoinMode == SessionsV2JoinMode.UUID:
+        extra_where = build_session_id_v7_pushdown_predicate(
+            node,
+            join_to_add,
+            context,
+            session_id_v7_field=ast.Field(chain=["raw_sessions", "session_id_v7"]),
+            events_session_id_field=["$session_id_uuid"],
+        )
+
+    join_expr = ast.JoinExpr(
+        table=select_from_sessions_table_v2(join_to_add.fields_accessed, node, context, extra_where=extra_where)
+    )
     join_expr.join_type = "LEFT JOIN"
     join_expr.alias = join_to_add.to_table
     if context.modifiers.sessionsV2JoinMode == SessionsV2JoinMode.UUID:

--- a/posthog/hogql/database/schema/util/test/__snapshots__/test_session_v2_where_clause_extractor.ambr
+++ b/posthog/hogql/database/schema/util/test/__snapshots__/test_session_v2_where_clause_extractor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: TestSessionIdPushdownV2.test_experiment_shape_with_pushdown
+# name: TestSessionIdPushdownV2.test_experiment_shape_0_with_pushdown
   '''
   SELECT
       events.`$session_id` AS sid,
@@ -26,7 +26,7 @@
   LIMIT 50000
   '''
 # ---
-# name: TestSessionIdPushdownV2.test_experiment_shape_without_pushdown
+# name: TestSessionIdPushdownV2.test_experiment_shape_1_without_pushdown
   '''
   SELECT
       events.`$session_id` AS sid,

--- a/posthog/hogql/database/schema/util/test/__snapshots__/test_session_v2_where_clause_extractor.ambr
+++ b/posthog/hogql/database/schema/util/test/__snapshots__/test_session_v2_where_clause_extractor.ambr
@@ -1,4 +1,53 @@
 # serializer version: 1
+# name: TestSessionIdPushdownV2.test_experiment_shape_with_pushdown
+  '''
+  SELECT
+      events.`$session_id` AS sid,
+      events__session.`$entry_pathname` AS entry
+  FROM
+      events
+      LEFT JOIN (SELECT
+          path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), %(hogql_val_0)s), %(hogql_val_1)s)) AS `$entry_pathname`,
+          raw_sessions.session_id_v7 AS session_id_v7
+      FROM
+          raw_sessions
+      WHERE
+          and(equals(raw_sessions.team_id, <TEAM_ID>), and(greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_2)s, toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(%(hogql_val_3)s, toIntervalDay(3)))), globalIn(raw_sessions.session_id_v7, (SELECT
+                      DISTINCT events.`$session_id_uuid` AS `$session_id_uuid`
+                  FROM
+                      events
+                  WHERE
+                      and(equals(events.team_id, <TEAM_ID>), equals(events.event, %(hogql_val_4)s), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_5)s, 6, %(hogql_val_6)s)), lessOrEquals(events.timestamp, toDateTime64(%(hogql_val_7)s, 6, %(hogql_val_8)s))))))
+      GROUP BY
+          raw_sessions.session_id_v7,
+          raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+  WHERE
+      and(equals(events.team_id, <TEAM_ID>), equals(events.event, %(hogql_val_9)s), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_10)s, 6, %(hogql_val_11)s)), lessOrEquals(events.timestamp, toDateTime64(%(hogql_val_12)s, 6, %(hogql_val_13)s)), ifNull(equals(events__session.`$entry_pathname`, %(hogql_val_14)s), 0))
+  LIMIT 50000
+  '''
+# ---
+# name: TestSessionIdPushdownV2.test_experiment_shape_without_pushdown
+  '''
+  SELECT
+      events.`$session_id` AS sid,
+      events__session.`$entry_pathname` AS entry
+  FROM
+      events
+      LEFT JOIN (SELECT
+          path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), %(hogql_val_0)s), %(hogql_val_1)s)) AS `$entry_pathname`,
+          raw_sessions.session_id_v7 AS session_id_v7
+      FROM
+          raw_sessions
+      WHERE
+          and(equals(raw_sessions.team_id, <TEAM_ID>), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_2)s, toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(%(hogql_val_3)s, toIntervalDay(3))))
+      GROUP BY
+          raw_sessions.session_id_v7,
+          raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+  WHERE
+      and(equals(events.team_id, <TEAM_ID>), equals(events.event, %(hogql_val_4)s), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_5)s, 6, %(hogql_val_6)s)), lessOrEquals(events.timestamp, toDateTime64(%(hogql_val_7)s, 6, %(hogql_val_8)s)), ifNull(equals(events__session.`$entry_pathname`, %(hogql_val_9)s), 0))
+  LIMIT 50000
+  '''
+# ---
 # name: TestSessionsV2QueriesHogQLToClickhouse.test_join_with_events
   '''
   SELECT

--- a/posthog/hogql/database/schema/util/test/test_session_v2_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/test/test_session_v2_where_clause_extractor.py
@@ -563,3 +563,96 @@ WHERE subquery.session_id = '0199a58b-fdf2-785c-b6e3-6ba32b2380cf'
 """
         )
         assert self.generalize_sql(actual) == self.snapshot
+
+
+@pytest.mark.usefixtures("unittest_snapshot")
+class TestSessionIdPushdownV2(ClickhouseTestMixin, APIBaseTest):
+    """Tests for the sessionIdPushdown modifier, which pushes
+    ``session_id_v7 IN (SELECT $session_id_uuid FROM events WHERE <events-only>)``
+    into the raw_sessions subquery when a query joins events to sessions.
+    """
+
+    snapshot: Any
+
+    def print_query(self, query: str, pushdown: bool) -> str:
+        team = self.team
+        modifiers = create_default_modifiers_for_team(team)
+        modifiers.sessionTableVersion = SessionTableVersion.V2
+        modifiers.sessionIdPushdown = pushdown
+        context = HogQLContext(
+            team_id=team.pk,
+            team=team,
+            enable_select_queries=True,
+            modifiers=modifiers,
+        )
+        prepared_ast = prepare_ast_for_printing(node=parse(query), context=context, dialect="clickhouse")
+        if prepared_ast is None:
+            return ""
+        return print_prepared_ast(prepared_ast, context=context, dialect="clickhouse", pretty=True)
+
+    def _assert_pushdown_contains_in_subquery(self, sql: str) -> None:
+        # The raw_sessions subquery should now have an IN predicate on session_id_v7.
+        # ClickHouse's printer emits `globalIn(...)` or `in(...)` depending on optimizer settings.
+        normalized = " ".join(sql.split())
+        assert "in(raw_sessions.session_id_v7" in normalized or "globalIn(raw_sessions.session_id_v7" in normalized, (
+            f"Expected pushed-down IN predicate on raw_sessions.session_id_v7 in:\n{sql}"
+        )
+
+    def test_experiment_shape_with_pushdown(self):
+        """Mirrors the ExperimentQuery shape from
+        query-performance/analysis/2026-04-17-elevenlabs-experiment-sessions-oom.md:
+        events -> LEFT JOIN sessions filtered by a session-typed property."""
+        query = """
+SELECT
+    events.$session_id AS sid,
+    events.session.$entry_pathname AS entry
+FROM events
+WHERE events.event = '$pageview'
+  AND events.timestamp >= '2026-03-27 00:00:00'
+  AND events.timestamp <= '2026-03-31 23:59:59'
+  AND events.session.$entry_pathname = '/signup'
+"""
+        actual = self.print_query(query, pushdown=True)
+        self._assert_pushdown_contains_in_subquery(actual)
+        assert self.generalize_sql(actual) == self.snapshot
+
+    def test_experiment_shape_without_pushdown(self):
+        """Same query with pushdown disabled must not contain the IN subquery."""
+        query = """
+SELECT
+    events.$session_id AS sid,
+    events.session.$entry_pathname AS entry
+FROM events
+WHERE events.event = '$pageview'
+  AND events.timestamp >= '2026-03-27 00:00:00'
+  AND events.timestamp <= '2026-03-31 23:59:59'
+  AND events.session.$entry_pathname = '/signup'
+"""
+        actual = self.print_query(query, pushdown=False)
+        normalized = " ".join(actual.split())
+        assert "in(raw_sessions.session_id_v7" not in normalized
+        assert "globalIn(raw_sessions.session_id_v7" not in normalized
+        assert self.generalize_sql(actual) == self.snapshot
+
+    def test_pushdown_noop_for_sessions_only_query(self):
+        # A standalone sessions query has no events source to push down from — pushdown
+        # should not attempt to add anything, and the query should look identical to the
+        # pushdown-disabled version.
+        query = "SELECT session_id, $entry_pathname FROM sessions WHERE $start_timestamp >= '2026-03-27'"
+        with_pushdown = self.print_query(query, pushdown=True)
+        without_pushdown = self.print_query(query, pushdown=False)
+        assert with_pushdown == without_pushdown
+
+    def test_pushdown_drops_non_events_or_branches(self):
+        # An OR between an events predicate and a session-side predicate must not be
+        # pushed down: dropping the session-side half would change semantics. So the
+        # extracted events-only WHERE is None and pushdown is skipped.
+        query = """
+SELECT events.$session_id AS sid, events.session.$entry_pathname AS entry
+FROM events
+WHERE (events.event = '$pageview') OR (events.session.$entry_pathname = '/signup')
+"""
+        actual = self.print_query(query, pushdown=True)
+        normalized = " ".join(actual.split())
+        assert "in(raw_sessions.session_id_v7" not in normalized
+        assert "globalIn(raw_sessions.session_id_v7" not in normalized

--- a/posthog/hogql/database/schema/util/test/test_session_v2_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/test/test_session_v2_where_clause_extractor.py
@@ -4,6 +4,8 @@ from typing import Any, Optional, Union
 import pytest
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
+from parameterized import parameterized
+
 from posthog.schema import SessionTableVersion
 
 from posthog.hogql import ast
@@ -567,10 +569,8 @@ WHERE subquery.session_id = '0199a58b-fdf2-785c-b6e3-6ba32b2380cf'
 
 @pytest.mark.usefixtures("unittest_snapshot")
 class TestSessionIdPushdownV2(ClickhouseTestMixin, APIBaseTest):
-    """Tests for the sessionIdPushdown modifier, which pushes
-    ``session_id_v7 IN (SELECT $session_id_uuid FROM events WHERE <events-only>)``
-    into the raw_sessions subquery when a query joins events to sessions.
-    """
+    # Tests for the sessionIdPushdown modifier — see
+    # https://github.com/PostHog/query-performance-analysis/blob/main/analysis/2026-04-17-elevenlabs-experiment-sessions-oom.md
 
     snapshot: Any
 
@@ -590,18 +590,12 @@ class TestSessionIdPushdownV2(ClickhouseTestMixin, APIBaseTest):
             return ""
         return print_prepared_ast(prepared_ast, context=context, dialect="clickhouse", pretty=True)
 
-    def _assert_pushdown_contains_in_subquery(self, sql: str) -> None:
-        # The raw_sessions subquery should now have an IN predicate on session_id_v7.
-        # ClickHouse's printer emits `globalIn(...)` or `in(...)` depending on optimizer settings.
-        normalized = " ".join(sql.split())
-        assert "in(raw_sessions.session_id_v7" in normalized or "globalIn(raw_sessions.session_id_v7" in normalized, (
-            f"Expected pushed-down IN predicate on raw_sessions.session_id_v7 in:\n{sql}"
-        )
-
-    def test_experiment_shape_with_pushdown(self):
-        """Mirrors the ExperimentQuery shape from
-        query-performance/analysis/2026-04-17-elevenlabs-experiment-sessions-oom.md:
-        events -> LEFT JOIN sessions filtered by a session-typed property."""
+    @parameterized.expand([("with_pushdown", True), ("without_pushdown", False)])
+    def test_experiment_shape(self, _name: str, pushdown: bool):
+        # Mirrors the ExperimentQuery shape: events -> LEFT JOIN sessions filtered by a
+        # session-typed property. With the modifier on, the raw_sessions subquery must carry
+        # an IN-pushdown on session_id_v7 (printed as `globalIn(...)` or `in(...)` depending
+        # on optimizer settings); with it off, it must not.
         query = """
 SELECT
     events.$session_id AS sid,
@@ -612,26 +606,12 @@ WHERE events.event = '$pageview'
   AND events.timestamp <= '2026-03-31 23:59:59'
   AND events.session.$entry_pathname = '/signup'
 """
-        actual = self.print_query(query, pushdown=True)
-        self._assert_pushdown_contains_in_subquery(actual)
-        assert self.generalize_sql(actual) == self.snapshot
-
-    def test_experiment_shape_without_pushdown(self):
-        """Same query with pushdown disabled must not contain the IN subquery."""
-        query = """
-SELECT
-    events.$session_id AS sid,
-    events.session.$entry_pathname AS entry
-FROM events
-WHERE events.event = '$pageview'
-  AND events.timestamp >= '2026-03-27 00:00:00'
-  AND events.timestamp <= '2026-03-31 23:59:59'
-  AND events.session.$entry_pathname = '/signup'
-"""
-        actual = self.print_query(query, pushdown=False)
+        actual = self.print_query(query, pushdown=pushdown)
         normalized = " ".join(actual.split())
-        assert "in(raw_sessions.session_id_v7" not in normalized
-        assert "globalIn(raw_sessions.session_id_v7" not in normalized
+        has_in_pushdown = (
+            "in(raw_sessions.session_id_v7" in normalized or "globalIn(raw_sessions.session_id_v7" in normalized
+        )
+        assert has_in_pushdown == pushdown, f"Expected pushdown={pushdown} in:\n{actual}"
         assert self.generalize_sql(actual) == self.snapshot
 
     def test_pushdown_noop_for_sessions_only_query(self):

--- a/posthog/hogql/database/schema/util/test/test_session_v2_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/test/test_session_v2_where_clause_extractor.py
@@ -570,7 +570,7 @@ WHERE subquery.session_id = '0199a58b-fdf2-785c-b6e3-6ba32b2380cf'
 @pytest.mark.usefixtures("unittest_snapshot")
 class TestSessionIdPushdownV2(ClickhouseTestMixin, APIBaseTest):
     # Tests for the sessionIdPushdown modifier — see
-    # https://github.com/PostHog/query-performance-analysis/blob/main/analysis/2026-04-17-elevenlabs-experiment-sessions-oom.md
+    # https://github.com/PostHog/query-performance-analysis/blob/main/analysis/2026-04-17-experiment-sessions-oom.md
 
     snapshot: Any
 

--- a/posthog/hogql/database/schema/util/where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/where_clause_extractor.py
@@ -454,6 +454,10 @@ class EventsOnlyWhereClauseExtractor(WhereClauseExtractor):
     pushdown into the raw_sessions subquery, so aggregation state only covers sessions that
     actually participate in the outer events filter.
 
+    Background on the motivating ExperimentQuery OOM and why the pushdown must be scoped to
+    selective event filters (it regresses ``WebStatsTableQuery``):
+    https://github.com/PostHog/query-performance-analysis/blob/main/analysis/2026-04-17-elevenlabs-experiment-sessions-oom.md
+
     Inverts the field-tracking semantics of ``WhereClauseExtractor``: we keep fields that
     resolve to the EventsTable and tombstone everything else, letting the base AND/OR/NOT
     logic drop unsafe branches.

--- a/posthog/hogql/database/schema/util/where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/where_clause_extractor.py
@@ -447,6 +447,117 @@ class SessionMinTimestampWhereClauseExtractorV3(SessionMinTimestampWhereClauseEx
         return timestamp_expr
 
 
+class EventsOnlyWhereClauseExtractor(WhereClauseExtractor):
+    """Extract predicates from the outer WHERE that only reference the events table.
+
+    Used to build a ``session_id_v7 IN (SELECT $session_id_uuid FROM events WHERE <events-only>)``
+    pushdown into the raw_sessions subquery, so aggregation state only covers sessions that
+    actually participate in the outer events filter.
+
+    Inverts the field-tracking semantics of ``WhereClauseExtractor``: we keep fields that
+    resolve to the EventsTable and tombstone everything else, letting the base AND/OR/NOT
+    logic drop unsafe branches.
+    """
+
+    def visit_compare_operation(self, node: ast.CompareOperation) -> ast.Expr:
+        if has_tombstone(node, self.tombstone_string):
+            return ast.Constant(value=self.tombstone_string)
+
+        is_left_constant = is_time_or_interval_constant(node.left, self.tombstone_string)
+        is_right_constant = is_time_or_interval_constant(node.right, self.tombstone_string)
+        if is_left_constant and is_right_constant:
+            return ast.Constant(value=True)
+
+        left = self.visit(node.left)
+        if isinstance(node.right, ast.SelectQuery):
+            right = clone_expr(node.right, clear_types=False, clear_locations=False, inline_subquery_field_names=True)
+        else:
+            right = self.visit(node.right)
+
+        if has_tombstone(left, self.tombstone_string) or has_tombstone(right, self.tombstone_string):
+            return ast.Constant(value=self.tombstone_string)
+        return ast.CompareOperation(op=node.op, left=left, right=right)
+
+    def visit_field(self, node: ast.Field) -> ast.Expr:
+        if is_events_only_field(node):
+            return cast(ast.Field, clone_expr(node))
+        return ast.Constant(value=self.tombstone_string)
+
+
+def is_events_only_field(node: ast.Field) -> bool:
+    """True iff the field resolves to a direct field on the EventsTable (not a traversal to
+    person/groups/sessions/etc. via a virtual/lazy join)."""
+    from posthog.hogql.database.schema.events import EventsTable
+
+    type_ = node.type
+    if isinstance(type_, ast.PropertyType):
+        type_ = type_.field_type
+    if isinstance(type_, ast.FieldAliasType):
+        type_ = type_.type
+    if not isinstance(type_, ast.FieldType):
+        return False
+
+    table_type = type_.table_type
+    while isinstance(table_type, (ast.TableAliasType, ast.ColumnAliasedTableType)):
+        table_type = table_type.table_type
+    # Virtual tables (e.g. person, group) pivot to another underlying table, so they are not
+    # safely "events-only" even if they hang off an events row.
+
+    if isinstance(table_type, ast.TableType):
+        return isinstance(table_type.table, EventsTable)
+    return False
+
+
+def build_session_id_v7_pushdown_predicate(
+    outer_node: ast.SelectQuery,
+    join_to_add: LazyJoinToAdd,
+    context: HogQLContext,
+    session_id_v7_field: ast.Expr,
+    events_session_id_field: list[str | int],
+) -> Optional[ast.Expr]:
+    """Build ``raw_sessions.session_id_v7 IN (SELECT DISTINCT events.<session_id_field>
+    FROM events WHERE <events-only WHERE of outer query>)``.
+
+    Returns None if the outer query shape or WHERE can't be safely pushed down.
+    """
+    events_join = _find_join_for_alias(outer_node.select_from, join_to_add.from_table)
+    if events_join is None or not isinstance(events_join.table, ast.Field):
+        return None
+
+    events_where = EventsOnlyWhereClauseExtractor(context).get_inner_where(outer_node)
+    if events_where is None:
+        return None
+
+    events_alias = join_to_add.from_table
+    subquery = ast.SelectQuery(
+        select=[ast.Field(chain=[events_alias, *events_session_id_field])],
+        distinct=True,
+        select_from=ast.JoinExpr(
+            table=ast.Field(chain=list(events_join.table.chain)),
+            alias=events_alias,
+        ),
+        where=events_where,
+    )
+
+    return ast.CompareOperation(
+        op=CompareOperationOp.In,
+        left=session_id_v7_field,
+        right=subquery,
+    )
+
+
+def _find_join_for_alias(select_from: Optional[ast.JoinExpr], alias: str) -> Optional[ast.JoinExpr]:
+    ptr = select_from
+    while ptr:
+        current_alias = ptr.alias
+        if current_alias is None and isinstance(ptr.table, ast.Field) and ptr.table.chain:
+            current_alias = str(ptr.table.chain[0])
+        if current_alias == alias:
+            return ptr
+        ptr = ptr.next_join
+    return None
+
+
 def has_tombstone(expr: ast.Expr, tombstone_string: str) -> bool:
     visitor = HasTombstoneVisitor(tombstone_string)
     visitor.visit(expr)

--- a/posthog/hogql/database/schema/util/where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/where_clause_extractor.py
@@ -454,8 +454,16 @@ class EventsOnlyWhereClauseExtractor(WhereClauseExtractor):
     pushdown into the raw_sessions subquery, so aggregation state only covers sessions that
     actually participate in the outer events filter.
 
-    Background on the motivating ExperimentQuery OOM and why the pushdown must be scoped to
-    selective event filters (it regresses ``WebStatsTableQuery``):
+    **This is a targeted fix for one customer's ExperimentQuery OOMs, not a general-purpose
+    optimization.** Benchmarks in the analysis doc show the pushdown *regresses* most other
+    traffic — e.g. a healthy ``WebStatsTableQuery`` got +93% runtime / +32% memory once the
+    pushdown kicked in, because a ``$pageview OR $screen`` filter doesn't narrow the session
+    set and the ``GLOBAL IN`` broadcast + double events scan dominate. The modifier that
+    activates this code path (``sessionIdPushdown``) is therefore off by default and is only
+    turned on by ``ExperimentQueryRunner``, gated by a per-team feature flag so we can enable
+    it for the single affected team without touching anyone else.
+
+    Background, numbers, and the rollout decision:
     https://github.com/PostHog/query-performance-analysis/blob/main/analysis/2026-04-17-experiment-sessions-oom.md
 
     Inverts the field-tracking semantics of ``WhereClauseExtractor``: we keep fields that

--- a/posthog/hogql/database/schema/util/where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/where_clause_extractor.py
@@ -456,7 +456,7 @@ class EventsOnlyWhereClauseExtractor(WhereClauseExtractor):
 
     Background on the motivating ExperimentQuery OOM and why the pushdown must be scoped to
     selective event filters (it regresses ``WebStatsTableQuery``):
-    https://github.com/PostHog/query-performance-analysis/blob/main/analysis/2026-04-17-elevenlabs-experiment-sessions-oom.md
+    https://github.com/PostHog/query-performance-analysis/blob/main/analysis/2026-04-17-experiment-sessions-oom.md
 
     Inverts the field-tracking semantics of ``WhereClauseExtractor``: we keep fields that
     resolve to the EventsTable and tombstone everything else, letting the base AND/OR/NOT

--- a/posthog/hogql/modifiers.py
+++ b/posthog/hogql/modifiers.py
@@ -113,6 +113,9 @@ def set_default_modifier_values(modifiers: HogQLQueryModifiers, team: "Team"):
     if modifiers.inlineCohortCalculation is None:
         modifiers.inlineCohortCalculation = InlineCohortCalculation.AUTO
 
+    if modifiers.sessionIdPushdown is None:
+        modifiers.sessionIdPushdown = False
+
 
 def set_default_in_cohort_via(modifiers: HogQLQueryModifiers) -> HogQLQueryModifiers:
     if modifiers.inCohortVia is None or modifiers.inCohortVia == InCohortVia.AUTO:

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Optional
 
 import structlog
+import posthoganalytics
 from rest_framework.exceptions import ValidationError
 
 from posthog.schema import (
@@ -324,12 +325,23 @@ class ExperimentQueryRunner(QueryRunner):
         self.hogql = experiment_query_debug[0]
         self.clickhouse_sql = experiment_query_debug[1]
 
+        modifiers = create_default_modifiers_for_team(self.team)
+        if posthoganalytics.feature_enabled(
+            "hogql-session-id-pushdown",
+            str(self.team.id),
+            groups={"project": str(self.team.id)},
+            group_properties={"project": {"id": str(self.team.id)}},
+            only_evaluate_locally=True,
+            send_feature_flag_events=False,
+        ):
+            modifiers.sessionIdPushdown = True
+
         response = execute_hogql_query(
             query_type="ExperimentQuery",
             query=experiment_query_ast,
             team=self.team,
             timings=self.timings,
-            modifiers=create_default_modifiers_for_team(self.team),
+            modifiers=modifiers,
             settings=HogQLGlobalSettings(
                 max_execution_time=self.max_execution_time,
                 enable_analyzer=True,

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -166,6 +166,7 @@ class TestQueryRunner(BaseTest):
                 "optimizeProjections": True,
                 "personsArgMaxVersion": PersonsArgMaxVersion.AUTO,
                 "personsOnEventsMode": PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED,
+                "sessionIdPushdown": False,
                 "sessionTableVersion": SessionTableVersion.AUTO,
                 "sessionsV2JoinMode": SessionsV2JoinMode.UUID,
                 "useMaterializedViews": True,
@@ -247,7 +248,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_42_2e7695f8ad7a4ad5e296e1945fa866647d8cbccd0c6c3dfebc0ece67ecb878fc"
+        assert cache_key == "cache_42_68a2c8e2bf539173ac6e464a103418bb433834fbce3157ed121192f403d69a0c"
 
     def test_cache_key_runner_subclass(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -261,7 +262,7 @@ class TestQueryRunner(BaseTest):
         runner = TestSubclassQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_42_69c671108c15496f62a1f6a722891039279b5746f4d5f5ee401d9ebddf4d080e"
+        assert cache_key == "cache_42_4eb789b3c70480ba14a762c56a648f2bf7a117a3c31b60ed3c5cb826444ddf4c"
 
     def test_cache_key_different_timezone(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -272,7 +273,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_42_ff888ce61e00a0bf5be0521f24b4225b723fd59d67b74bb104a56b1f01cfb1c4"
+        assert cache_key == "cache_42_f67778c870f29df1c38c85726fd6f2b319b920f6f3414acf2de1927271503977"
 
     @mock.patch("django.db.transaction.on_commit")
     def test_cache_response(self, mock_on_commit):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -6906,6 +6906,14 @@ class HogQLQueryModifiers(BaseModel):
     personsOnEventsMode: PersonsOnEventsMode | None = None
     propertyGroupsMode: PropertyGroupsMode | None = None
     s3TableUseInvalidColumns: bool | None = None
+    sessionIdPushdown: bool | None = Field(
+        default=None,
+        description=(
+            "Push a `session_id_v7 IN (SELECT … FROM events WHERE …)` predicate into"
+            " the raw_sessions subquery to limit aggregation to sessions that"
+            " participate in the outer events filter."
+        ),
+    )
     sessionTableVersion: SessionTableVersion | None = None
     sessionsV2JoinMode: SessionsV2JoinMode | None = None
     timings: bool | None = None

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -455,6 +455,11 @@ export interface HogQLQueryModifiersApi {
     propertyGroupsMode?: PropertyGroupsModeApi | null
     /** @nullable */
     s3TableUseInvalidColumns?: boolean | null
+    /**
+     * Push a `session_id_v7 IN (SELECT … FROM events WHERE …)` predicate into the raw_sessions subquery to limit aggregation to sessions that participate in the outer events filter.
+     * @nullable
+     */
+    sessionIdPushdown?: boolean | null
     sessionTableVersion?: SessionTableVersionApi | null
     sessionsV2JoinMode?: SessionsV2JoinModeApi | null
     /** @nullable */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -1689,6 +1689,11 @@ export namespace Schemas {
       propertyGroupsMode?: PropertyGroupsMode | null;
       /** @nullable */
       s3TableUseInvalidColumns?: boolean | null;
+      /**
+       * Push a `session_id_v7 IN (SELECT … FROM events WHERE …)` predicate into the raw_sessions subquery to limit aggregation to sessions that participate in the outer events filter.
+       * @nullable
+       */
+      sessionIdPushdown?: boolean | null;
       sessionTableVersion?: SessionTableVersion | null;
       sessionsV2JoinMode?: SessionsV2JoinMode | null;
       /** @nullable */


### PR DESCRIPTION
## Problem

Several ExperimentQuery metrics on one customer's experiment OOM with `MEMORY_LIMIT_EXCEEDED` on the sessions cluster (8 failing metrics on a single experiment). Root cause: when a metric filters on a session-typed property, the generated query does a `LEFT JOIN (SELECT … FROM raw_sessions WHERE team_id = X AND <±3 day window> GROUP BY session_id_v7) AS events__session ON events.$session_id_uuid = events__session.session_id_v7`. The JOIN planner has no way to know which `session_id`s the outer events filter will actually need, so it `argMinMerge`-aggregates every session in the team's window. At this customer's session volume the aggregation state exceeds the 166 GiB per-query limit.

Full analysis: https://github.com/PostHog/query-performance-analysis/blob/main/analysis/2026-04-17-experiment-sessions-oom.md

## Changes

Adds a new HogQL modifier `sessionIdPushdown`. When enabled, `join_events_table_to_sessions_table_v2` walks the outer query's WHERE, extracts the events-only conjuncts, and wraps the raw_sessions subquery with an extra predicate:

```sql
AND raw_sessions.session_id_v7 IN (
    SELECT DISTINCT events.$session_id_uuid FROM events WHERE <events-only WHERE>
)
```

The events-only extraction reuses the tombstone-and-collapse infrastructure from `WhereClauseExtractor` (inverted: keep events-table fields, tombstone everything else), so it fails safe — if an `OR` mixes events and session predicates, no pushdown is applied.

`ExperimentQueryRunner` opts in per team via a `hogql-session-id-pushdown` feature flag. The modifier defaults to `False` and is **not** applied to non-experiment paths: a rollout test on a healthy `WebStatsTableQuery` showed pushdown regressed it (+93% runtime, +32% memory) because `$pageview OR $screen` filters don't narrow the session set, and the `GLOBAL IN` broadcast + double events scan outweigh any aggregation savings. So the fix is intentionally scoped to ExperimentQuery, where the feature-flag + event filter narrows the IN list sharply.

Pushdown is also limited to `SessionsV2JoinMode.UUID` (the default) — the string-mode join would need extra `_toUInt128(toUUID(…))` wrapping that isn't worth it for this rollout.

Measured on EU prod before the rollout (analysis doc has full numbers):

| Metric kind | Baseline | With pushdown |
|---|---|---|
| funnel (`$entry_pathname` + `$channel_type`) | OOM @ >166 GiB | 2.01 GiB, 28s |
| ratio (`$channel_type` × 2) | OOM @ >166 GiB | 1.90 GiB, 39s |
| funnel (`$is_bounce`) | OOM | 1.74 GiB, 37s |
| mean (`$session_duration`) | OOM | 5.19 GiB, 41s |

## How did you test this code?

Agent-authored; I did not run this manually on real prod data. Coverage is via automated tests only:

- `TestSessionIdPushdownV2` in `test_session_v2_where_clause_extractor.py` — parameterized test + snapshot asserting that the IN subquery is emitted when the modifier is on, absent when off, plus tests that correctly skip pushdown for an OR mixing events + session predicates, and for standalone `SELECT FROM sessions` queries.
- Existing 44 session-v2 extractor tests remain green — the pushdown is off by default.
- Experiment query runner regression sweep (`test_base.py`, `test_funnel_metric.py`, `test_session_properties.py`) — 73 passed, 1 skipped.
- Updated cache-key fixtures in `test_query_runner.py` since the new modifier field shifts the cache payload hash.

## Publish to changelog?

no

## 🤖 LLM context

Authored end-to-end by Claude (opus 4.7) in Claude Code. The initial pass defaulted the modifier globally via a per-user feature flag; an updated version of the analysis (with rollout testing on other teams) flagged that as unsafe, and the current shape — per-team flag wired only through `ExperimentQueryRunner` — is the revised plan.