### PR TITLE
fix: Allow OAuth token refresh when only one of scoped_teams or scoped_organizations is set

### DIFF
--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -1046,6 +1046,7 @@ class TestOAuthAPI(APIBaseTest):
         db_token = OAuthAccessToken.objects.get(token=new_access_token)
         self.assertEqual(db_token.scoped_teams, [self.team.id])
 
+    @freeze_time("2026-01-01 00:00:00")
     def test_refresh_succeeds_when_only_scoped_teams_is_set(self):
         """scoped_teams and scoped_organizations are both nullable ArrayFields. Historically
         they could be set independently — a token scoped to a team often had

--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -1046,6 +1046,46 @@ class TestOAuthAPI(APIBaseTest):
         db_token = OAuthAccessToken.objects.get(token=new_access_token)
         self.assertEqual(db_token.scoped_teams, [self.team.id])
 
+    def test_refresh_succeeds_when_only_scoped_teams_is_set(self):
+        """scoped_teams and scoped_organizations are both nullable ArrayFields. Historically
+        they could be set independently — a token scoped to a team often had
+        scoped_organizations=None. Refresh should still succeed: the downstream permission
+        checks (posthog/permissions.py, team_access_cache.py, Rust flag service) already
+        treat None and [] as equivalent, so we only raise when BOTH are missing."""
+        access_token = OAuthAccessToken.objects.create(
+            application=self.confidential_application,
+            user=self.user,
+            token="test_legacy_access_token",
+            expires=timezone.now() + timedelta(hours=1),
+            scope="openid",
+            scoped_teams=[self.team.id],
+            scoped_organizations=None,
+        )
+        OAuthRefreshToken.objects.create(
+            application=self.confidential_application,
+            user=self.user,
+            token="test_legacy_refresh_token",
+            access_token=access_token,
+            scoped_teams=[self.team.id],
+            scoped_organizations=None,
+        )
+
+        refresh_response = self.post(
+            "/oauth/token/",
+            {
+                "grant_type": "refresh_token",
+                "refresh_token": "test_legacy_refresh_token",
+                "client_id": self.confidential_application.client_id,
+                "client_secret": "test_confidential_client_secret",
+            },
+        )
+        self.assertEqual(refresh_response.status_code, status.HTTP_200_OK)
+
+        new_access_token_value = refresh_response.json()["access_token"]
+        new_access_token = OAuthAccessToken.objects.get(token=new_access_token_value)
+        self.assertEqual(new_access_token.scoped_teams, [self.team.id])
+        self.assertIsNone(new_access_token.scoped_organizations)
+
     def test_revoked_refresh_token_invalidates_access_tokens(self):
         response = self.client.post("/oauth/authorize/", self.base_authorization_post_body)
         code = response.json()["redirect_to"].split("code=")[1].split("&")[0]

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -379,7 +379,9 @@ class OAuthValidator(OAuth2Validator):
             except OAuthGrant.DoesNotExist:
                 pass
 
-        if scoped_teams is None or scoped_organizations is None:
+        # Only raise when we have no scope information at all. A token scoped to just
+        # teams or just organizations is valid — we treat `None` and `[]` as equivalent.
+        if scoped_teams is None and scoped_organizations is None:
             raise OAuthToolkitError("Unable to find scoped_teams or scoped_organizations")
 
         return scoped_teams, scoped_organizations


### PR DESCRIPTION
## Problem

OAuth token refresh was failing for tokens where `scoped_teams` was set but `scoped_organizations` was `None`. The previous guard condition used `or`, meaning it would raise an error if either field was `None`, breaking refresh flows for these existing tokens. These tokens are very common: they're generated for Stripe Projects and the new Stripe apps as well.

## Changes

Changed the validation condition in `OAuthValidator` from `or` to `and`, so an error is only raised when **both** `scoped_teams` and `scoped_organizations` are `None`. A token with scope information in either field is considered valid, since downstream permission checks already treat `None` and `[]` as equivalent.

## How did you test this code?

A new test (`test_refresh_succeeds_when_only_scoped_teams_is_set`) covers the regression case: a token with `scoped_teams` set and `scoped_organizations=None` is refreshed successfully, and the resulting access token preserves `scoped_teams` while keeping `scoped_organizations` as `None`.

## Publish to changelog?

No