### PR TITLE
feat(replay): replace filter button with textbox

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -3247,17 +3247,17 @@ snapshots:
     replay-tabs-home-failure--not-found--light:
         hash: v1.k794b7964.d543024ba562e1364dc547cd1310125c8558a103cc126e343815ecdadb85e996.HC_NcrA2Nx-HCKzyqfZm36sVHJeNZ3cqrkEEi8cZ8qg
     replay-tabs-home-success--filters-expanded--dark:
-        hash: v1.k794b7964.158cfef61171b056e16120205bcedfdc95cd162af61b5ddf878319de50f37795.pJZuo6hpYVagqLFKOAY73Ocl4EqkRSQzvYNZlBiYLAo
+        hash: v1.k794b7964.da116250fd9441fdbc634c5eb1ae42148482c6e6495fd4781eec7bacde68a862.yRf-_7VEW1y9LHjjRGoZBfl9AeEfBmkseu1h0wuP43E
     replay-tabs-home-success--filters-expanded--light:
-        hash: v1.k794b7964.efc082fb8c989d59f8e08a3e50a8e05116bb3e3eb6b4e0ccfbe5c7a0462ba36e.XFwIB4UYPSJwpK0I0XQaMR9dXALDJDHh8bQ2bTBZurk
+        hash: v1.k794b7964.54305a18574e54115c3f5830384c4a61d9ef9759084326b6c2786ccc3367e443.sOqqSlcx-0j315alwz7YozBbhiPL1PwPshxoJWpGszY
     replay-tabs-home-success--filters-expanded-lots-of-results--dark:
-        hash: v1.k794b7964.a292c82f838be6a015cb068c0dc81abdade13dd677edfcb2082b9ae57488e32a.M-9FW5s2Pw9ocsPt827tP79_pIKbHWz6FpbfoMpIRyQ
+        hash: v1.k794b7964.8c4aac078522c120898a949a88506edebc44a08b7754142f6fd9e8469cb75d6f.kJVuGPYRhl3ABYW3-EYKY5BhHdhilBFLRHCiRdCI1OU
     replay-tabs-home-success--filters-expanded-lots-of-results--light:
-        hash: v1.k794b7964.58ccc2f7677d669c288b15bdc12aefd0c7b6ba76e1f3fd110967c1bc79a3c741.MetklNmQAumhuv5UlRyN1Yu1x8A6R5jdOpU4GKiSmFA
+        hash: v1.k794b7964.eda1f1f63a9c3c78474e692c5bdb4e4f3d8fba3c63bcbf529d760aa582a5f1c7.zwzgW_kXvSpuVS18L64uaWCbgJf9FjGwSjASwEWa-44
     replay-tabs-home-success--filters-expanded-lots-of-results-narrow--dark:
-        hash: v1.k794b7964.195acddc1c595516618604f8bf6a355a3e3cad9292416c5ff8a85989b057b21c.DTbPDZNo11g9gyHpmbpx-O5mpnlQKPVwY3qmo7QI0w0
+        hash: v1.k794b7964.cb4f3112e5036f6cda528ad24ffa2d52b156bd6774a65ad24b35d5a32291e297.OaRd0jazkuhplOybw4xjUAGpEOetPIB0HvD5UlqEyXQ
     replay-tabs-home-success--filters-expanded-lots-of-results-narrow--light:
-        hash: v1.k794b7964.118092e7aa1b1f33a3df79f5eee2f763aaa869269955a2f73ce6202c04073731.zQQRY3bGmcc254TBgob-Mf5BL0AGtrQxMuF8yv72nbY
+        hash: v1.k794b7964.ce63b941242bd17bd52f72334970d932043233e16af07d71322aa58e4a455049.i5WByIlOQmoxd2hEJfwl1Wkswem6UBmHnA54lyXeLSg
     replay-tabs-home-success--recent-recordings--dark:
         hash: v1.k794b7964.a22d6e5f278f717196ff17166ed63fe9a6b78e3f9eeb513cc19932ce4e53be76.XVRcNv7ACq7ePrJdyfS3Gkkoar-OLGyPE1lpDvC_jBc
     replay-tabs-home-success--recent-recordings--light:

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -52,6 +52,8 @@ export function TaxonomicFilter({
     definitionPopoverRenderer,
     minSearchQueryLength,
     suggestedFiltersLabel,
+    hideSearchInput,
+    searchQuery: controlledSearchQuery,
 }: TaxonomicFilterProps): JSX.Element {
     // Generate a unique key for each unique TaxonomicFilter that's rendered
     const taxonomicFilterLogicKey = useMemo(
@@ -93,7 +95,14 @@ export function TaxonomicFilter({
 
     const logic = taxonomicFilterLogic(taxonomicFilterLogicProps)
     const { activeTab } = useValues(logic)
+    const { setSearchQuery } = useActions(logic)
     const [refReady, setRefReady] = useState(false)
+
+    useEffect(() => {
+        if (controlledSearchQuery !== undefined) {
+            setSearchQuery(controlledSearchQuery)
+        }
+    }, [controlledSearchQuery, setSearchQuery])
 
     useEffect(() => {
         if (groupType !== TaxonomicFilterGroupType.HogQLExpression) {
@@ -126,7 +135,8 @@ export function TaxonomicFilter({
                 // eslint-disable-next-line react/forbid-dom-props
                 style={style}
             >
-                {activeTab !== TaxonomicFilterGroupType.HogQLExpression || taxonomicGroupTypes.length > 1 ? (
+                {!hideSearchInput &&
+                (activeTab !== TaxonomicFilterGroupType.HogQLExpression || taxonomicGroupTypes.length > 1) ? (
                     <div className="relative">
                         <TaxonomicFilterSearchInput searchInputRef={searchInputRef} onClose={onClose} />
                     </div>

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -106,6 +106,10 @@ export interface TaxonomicFilterProps {
     minSearchQueryLength?: number
     /** Override the "Suggested filters" tab label for specific contexts. */
     suggestedFiltersLabel?: string
+    /** Hide the built-in search input (useful when an external input drives the search query). */
+    hideSearchInput?: boolean
+    /** Controlled search query — synced into the logic on each change. Use with hideSearchInput for external input control. */
+    searchQuery?: string
 }
 
 export interface DataWarehousePopoverField {

--- a/frontend/src/lib/components/UniversalFilters/UniversalFilters.tsx
+++ b/frontend/src/lib/components/UniversalFilters/UniversalFilters.tsx
@@ -220,9 +220,15 @@ const AddFilterButton = (props: Omit<LemonButtonProps, 'onClick' | 'sideAction' 
 const PureTaxonomicFilter = ({
     fullWidth = true,
     onChange,
+    initialSearchQuery,
+    hideSearchInput,
+    searchQuery,
 }: {
     fullWidth?: boolean
     onChange: () => void
+    initialSearchQuery?: string
+    hideSearchInput?: boolean
+    searchQuery?: string
 }): JSX.Element => {
     const { taxonomicGroupTypes } = useValues(universalFiltersLogic)
     const { addGroupFilter } = useActions(universalFiltersLogic)
@@ -235,6 +241,9 @@ const PureTaxonomicFilter = ({
                 addGroupFilter(taxonomicGroup, value, item)
             }}
             taxonomicGroupTypes={taxonomicGroupTypes}
+            initialSearchQuery={initialSearchQuery}
+            hideSearchInput={hideSearchInput}
+            searchQuery={searchQuery}
         />
     )
 }

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -14,6 +14,7 @@ import {
     IconPlus,
     IconRefresh,
     IconRevert,
+    IconSearch,
     IconTrash,
     IconX,
 } from '@posthog/icons'
@@ -497,6 +498,7 @@ const ReplayFiltersTab = ({
     const [isSaveFiltersModalOpen, setIsSaveFiltersModalOpen] = useState(false)
 
     const [isPopoverVisible, setIsPopoverVisible] = useState(false)
+    const [addFilterSearchQuery, setAddFilterSearchQuery] = useState('')
 
     useMountedLogic(cohortsModel)
     useMountedLogic(actionsModel)
@@ -666,9 +668,8 @@ const ReplayFiltersTab = ({
                 taxonomicGroupTypes={taxonomicGroupTypes}
                 onChange={(filterGroup) => setFilters({ filter_group: filterGroup })}
             >
-                <div className="flex items-center gap-2 px-2 mt-2">
-                    <span className="font-medium">Add filters:</span>
-                    {/* Add filter button scoped to the first nested group */}
+                <div className="px-2 mt-2 min-w-0">
+                    {/* Add filter search input scoped to the first nested group */}
                     {filters.filter_group.values.length > 0 &&
                         isUniversalGroupFilterLike(filters.filter_group.values[0]) && (
                             <UniversalFilters
@@ -687,28 +688,52 @@ const ReplayFiltersTab = ({
                                     overlay={
                                         <UniversalFilters.PureTaxonomicFilter
                                             fullWidth={false}
-                                            onChange={() => setIsPopoverVisible(false)}
+                                            onChange={() => {
+                                                setIsPopoverVisible(false)
+                                                setAddFilterSearchQuery('')
+                                            }}
+                                            searchQuery={addFilterSearchQuery}
+                                            hideSearchInput
                                         />
                                     }
-                                    placement="bottom"
+                                    placement="bottom-start"
                                     visible={isPopoverVisible}
-                                    onClickOutside={() => setIsPopoverVisible(false)}
+                                    onClickOutside={() => {
+                                        setIsPopoverVisible(false)
+                                        setAddFilterSearchQuery('')
+                                    }}
                                 >
-                                    <LemonButton
-                                        type="secondary"
-                                        size="small"
-                                        data-attr="replay-filters-add-filter-button"
-                                        icon={<IconPlus />}
-                                        onClick={() => setIsPopoverVisible(!isPopoverVisible)}
-                                    >
-                                        Add filter
-                                    </LemonButton>
+                                    <div className="w-full max-w-[600px] shrink grow-0">
+                                        <LemonInput
+                                            type="search"
+                                            size="small"
+                                            fullWidth
+                                            data-attr="replay-filters-add-filter-input"
+                                            prefix={<IconSearch />}
+                                            placeholder="Search suggested filters, URLs, email addresses, recent, pinned..."
+                                            value={addFilterSearchQuery}
+                                            onChange={(value) => {
+                                                setAddFilterSearchQuery(value)
+                                                if (!isPopoverVisible) {
+                                                    setIsPopoverVisible(true)
+                                                }
+                                            }}
+                                            onFocus={() => setIsPopoverVisible(true)}
+                                            onKeyDown={(e) => {
+                                                if (e.key === 'Escape') {
+                                                    setIsPopoverVisible(false)
+                                                    setAddFilterSearchQuery('')
+                                                    e.preventDefault()
+                                                }
+                                            }}
+                                        />
+                                    </div>
                                 </Popover>
                             </UniversalFilters>
                         )}
                 </div>
 
-                <div className="flex justify-between flex-wrap gap-2 px-2 mt-2">
+                <div className="flex justify-between flex-wrap gap-2 px-2 mt-4">
                     <div className="flex flex-wrap gap-2 items-center">
                         <div className="py-2 font-medium">Applied filters:</div>
                         <DateFilter


### PR DESCRIPTION
## Problem

came up with a screenshare with a customer

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

For replay filtesr, have the taxonomic filter triggered by a text box, not a button

## How did you test this code?

[text_box_taxonomic.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/01584ef4-ac8e-4ed0-9796-178fab83de61.mov" />](https://app.graphite.com/user-attachments/video/01584ef4-ac8e-4ed0-9796-178fab83de61.mov)

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->mic