### PR TITLE
feat(data-warehouse): log MySQL EXPLAIN plan before streaming sync query

### DIFF
--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -203,7 +203,7 @@ def _explain_query(cursor: Cursor, query: str, query_args: dict[str, Any], logge
     """
     try:
         explain_query = f"EXPLAIN {query}"
-        logger.debug(f"Running EXPLAIN on {explain_query}")
+        logger.debug(f"Running EXPLAIN on: {query}")
         cursor.execute(explain_query, query_args)
         rows = cursor.fetchall()
         column_names = [col[0] for col in cursor.description or []]

--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -193,6 +193,27 @@ def _build_query(
     }
 
 
+def _explain_query(cursor: Cursor, query: str, query_args: dict[str, Any], logger: FilteringBoundLogger) -> None:
+    """Log the MySQL EXPLAIN output for `query` at debug level.
+
+    Useful for diagnosing sync failures on large tables: reveals whether the
+    optimizer chose a full table scan + filesort (the failure mode where
+    nothing streams back before middlebox/query timeouts) vs. a range scan
+    on the incremental index.
+    """
+    try:
+        explain_query = f"EXPLAIN {query}"
+        logger.debug(f"Running EXPLAIN on {explain_query}")
+        cursor.execute(explain_query, query_args)
+        rows = cursor.fetchall()
+        column_names = [col[0] for col in cursor.description or []]
+        explain_lines = [str(dict(zip(column_names, row))) for row in rows]
+        logger.debug(f"EXPLAIN result: {' | '.join(explain_lines) if explain_lines else '(empty)'}")
+    except Exception as e:
+        logger.debug(f"EXPLAIN raised an exception: {e}", exc_info=e)
+        capture_exception(e)
+
+
 def _get_rows_to_sync(
     cursor: Cursor, inner_query: str, inner_query_args: dict[str, Any], logger: FilteringBoundLogger
 ) -> int:
@@ -719,6 +740,13 @@ def mysql_source(
                         db_incremental_field_last_value,
                     )
                     logger.debug(f"MySQL query: {query.format(args)}")
+
+                    # EXPLAIN before the streaming query to help diagnose
+                    # failures where MySQL picks full scan + filesort over
+                    # the incremental index. _explain_query consumes its
+                    # rows via fetchall(), leaving the cursor in a clean
+                    # state for the streaming execute() below.
+                    _explain_query(cursor, query, args, logger)
 
                     cursor.execute(query, args)
 


### PR DESCRIPTION
## Problem

When a MySQL sync fails on a large table — for example `(2013, 'Lost connection to MySQL server during query')` after several minutes with zero rows streamed — the most informative piece of debug state is the execution plan MySQL actually chose: full table scan + filesort vs. a range scan on the incremental index.

Until now we had no visibility into this from our logs. Debugging required asking the customer to run `EXPLAIN` against their own database and share the output.

The Postgres source already runs `_explain_query` before various metadata probes (`postgres.py:700` and its call sites), but not before the streaming query. This PR adds the equivalent helper for MySQL, and uses it specifically for the streaming query where it's most valuable for diagnosis.

## Changes

- New `_explain_query` helper that runs `EXPLAIN <query>` and logs each result row at debug level. Matches the signature and intent of the Postgres equivalent.
- Called once on the SSCursor immediately before the streaming `cursor.execute(...)` in `get_rows()`. `fetchall()` on the small EXPLAIN result leaves the cursor in a clean state for the streaming query.
- Failures (e.g. user lacks EXPLAIN privileges, proxy rejects the statement) are caught, logged at debug, and sent to `capture_exception`. Sync continues unaffected.

## How did you test this code?

Validated end-to-end against a real MySQL 9.4 instance:

- Seeded three tables (1,000 / 5,004 / 10,003 rows) with datetime incremental fields and no indexes (to force `type=ALL` + filesort — the failure-mode plan).
- Ran a sync; verified `Running EXPLAIN on ...` and `EXPLAIN result: {'id': 1, 'type': 'ALL', 'key': None, ...}` both appear in debug logs.
- Row counts in the synced warehouse tables match the source exactly: no regressions from the added EXPLAIN round-trip.
- Existing MySQL source tests continue to pass.

## Publish to changelog?

no

## 🤖 LLM context

Co-authored-by: Claude <noreply@anthropic.com>

Follow-up to the earlier timeout work (#54984 merged). That PR raised the MySQL sync timeouts to buy the query more time; this PR adds the diagnostic that tells us *why* the query is slow in the first place (plan choice). In the ongoing customer incident, EXPLAIN revealed that the customer's 40M-row table had a usable index on `created_at` but MySQL's cost model was picking a full scan + filesort due to high selectivity (~37% of rows matched). That diagnostic will now be available in production logs for any future MySQL sync failure without asking the customer to run anything.