### PR TITLE
feat(capture): experiment w/scatter-gather produce ACK awaits; more granular rdkafka metrics

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1736,6 +1736,7 @@ dependencies = [
  "lz-str",
  "metrics",
  "metrics-exporter-prometheus",
+ "metrics-util",
  "multer",
  "once_cell",
  "opentelemetry 0.22.0",

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -67,6 +67,7 @@ anyhow = { workspace = true }
 axum-test-helper = { git = "https://github.com/posthog/axum-test-helper.git" }
 futures = { workspace = true }
 httparse = "1.8"
+metrics-util = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }
 rdkafka = { workspace = true }

--- a/rust/capture/src/ai_endpoint.rs
+++ b/rust/capture/src/ai_endpoint.rs
@@ -24,6 +24,7 @@ const AI_BLOB_EVENTS_TOTAL: &str = "capture_ai_blob_events_total";
 
 use crate::api::{CaptureError, CaptureResponse, CaptureResponseCode};
 use crate::event_restrictions::{AppliedRestrictions, EventContext as RestrictionEventContext};
+use crate::events::overflow_stamping::stamp_overflow_reason;
 use crate::extractors::extract_body_with_timeout;
 use crate::payload::decompression::decompress_gzip_to_bytes;
 use crate::prometheus::report_dropped_events;
@@ -346,8 +347,20 @@ pub async fn ai_handler(
     let client_ip = ip
         .map(|InsecureClientIp(addr)| addr.to_string())
         .unwrap_or_else(|| "127.0.0.1".to_string());
-    let (accepted_parts, processed_event) =
+    let (accepted_parts, mut processed_event) =
         build_kafka_event(parsed, token, &client_ip, &state, &applied_restrictions)?;
+
+    // Step 8b: Apply the in-process OverflowLimiter governor. The analytics
+    // pipeline stamps overflow reasons inside `process_events`, but AI
+    // bypasses that path, so we invoke the shared helper here to preserve
+    // OverflowLimiter parity on `capture-ai-*` deploys (where
+    // `OVERFLOW_ENABLED=true`). `force_overflow` already stamped on
+    // `processed_event.metadata` by `build_kafka_event` is honored by the
+    // helper's short-circuit.
+    stamp_overflow_reason(
+        std::slice::from_mut(&mut processed_event),
+        state.overflow_limiter.as_ref(),
+    );
 
     // Step 9: Send event to Kafka
     state.sink.send(processed_event).await.map_err(|e| {

--- a/rust/capture/src/ai_endpoint.rs
+++ b/rust/capture/src/ai_endpoint.rs
@@ -542,6 +542,7 @@ fn build_kafka_event(
         skip_person_processing: restrictions.skip_person_processing(),
         redirect_to_dlq: restrictions.redirect_to_dlq(),
         redirect_to_topic: restrictions.redirect_to_topic().map(|s| s.to_string()),
+        overflow_reason: None,
     };
 
     // Create ProcessedEvent

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -13,6 +13,8 @@ use metrics::counter;
 use serde_json;
 use tracing::{error, instrument, warn, Span};
 
+use limiters::overflow::{OverflowLimiter, OverflowLimiterResult};
+
 use crate::{
     api::CaptureError,
     debug_or_info,
@@ -21,7 +23,9 @@ use crate::{
     prometheus::{report_clock_skew, report_dropped_events},
     router, sinks,
     utils::uuid_v7,
-    v0_request::{DataType, ProcessedEvent, ProcessedEventMetadata, ProcessingContext},
+    v0_request::{
+        DataType, OverflowReason, ProcessedEvent, ProcessedEventMetadata, ProcessingContext,
+    },
 };
 
 /// Process a single analytics event from RawEvent to ProcessedEvent
@@ -91,6 +95,7 @@ pub fn process_single_event(
         skip_person_processing: false,
         redirect_to_dlq: false,
         redirect_to_topic: None,
+        overflow_reason: None,
     };
 
     if historical_cfg.should_reroute(metadata.data_type, parsed_timestamp.timestamp) {
@@ -126,14 +131,23 @@ pub fn process_single_event(
     Ok(ProcessedEvent { metadata, event })
 }
 
-/// Process a batch of analytics events
+/// Process a batch of analytics events.
+///
+/// All routing policy lives here: token dropping, event restrictions, global
+/// rate limiting (per `token:distinct_id`), historical rerouting, and
+/// per-key overflow rerouting via [`OverflowLimiter`]. The kafka sink is a
+/// pure mechanism layer — it reads `ProcessedEventMetadata::overflow_reason`,
+/// `force_overflow`, `redirect_to_dlq`, and `redirect_to_topic` to decide
+/// which topic and key to produce to.
 #[instrument(skip_all, fields(events = events.len(), request_id))]
+#[allow(clippy::too_many_arguments)]
 pub async fn process_events<'a>(
     sink: Arc<dyn sinks::Event + Send + Sync>,
     dropper: Arc<TokenDropper>,
     restriction_service: Option<EventRestrictionService>,
     historical_cfg: router::HistoricalConfig,
     global_rate_limiter: Option<Arc<GlobalRateLimiter>>,
+    overflow_limiter: Option<Arc<OverflowLimiter>>,
     events: &'a [RawEvent],
     context: &'a ProcessingContext,
 ) -> Result<(), CaptureError> {
@@ -230,6 +244,59 @@ pub async fn process_events<'a>(
                 distinct_ids = %preview,
                 "events rate limited by distinct_id -- person processing disabled"
             );
+        }
+    }
+
+    // Overflow routing stage. This used to live in the kafka sink's
+    // prepare_record; moving it here keeps the sink free of policy and
+    // co-locates overflow with every other pipeline-level routing decision.
+    // We stamp `ProcessedEventMetadata::overflow_reason`; the sink reads it
+    // and picks the overflow topic / partition-key policy accordingly.
+    //
+    // `force_overflow` (set by event restrictions) short-circuits the
+    // limiter check — same semantics as before. We emit the
+    // `capture_events_rerouted_overflow` counter here at stamp time; the
+    // sink no longer emits it. Label values match the pre-refactor sink
+    // counter so existing dashboards keep working.
+    for event in events.iter_mut() {
+        if event.metadata.data_type != DataType::AnalyticsMain {
+            continue;
+        }
+
+        if event.metadata.force_overflow {
+            counter!(
+                "capture_events_rerouted_overflow",
+                "reason" => "event_restriction",
+            )
+            .increment(1);
+            continue;
+        }
+
+        let Some(ref limiter) = overflow_limiter else {
+            continue;
+        };
+
+        let event_key = event.event.key();
+        match limiter.is_limited(&event_key) {
+            OverflowLimiterResult::ForceLimited => {
+                counter!(
+                    "capture_events_rerouted_overflow",
+                    "reason" => "force_limited",
+                )
+                .increment(1);
+                event.metadata.overflow_reason = Some(OverflowReason::ForceLimited);
+            }
+            OverflowLimiterResult::Limited => {
+                counter!(
+                    "capture_events_rerouted_overflow",
+                    "reason" => "rate_limited",
+                )
+                .increment(1);
+                event.metadata.overflow_reason = Some(OverflowReason::RateLimited {
+                    preserve_locality: limiter.should_preserve_locality(),
+                });
+            }
+            OverflowLimiterResult::NotLimited => {}
         }
     }
 
@@ -500,6 +567,7 @@ mod tests {
             Some(service),
             historical_cfg,
             None,
+            None,
             &events,
             &context,
         )
@@ -544,6 +612,7 @@ mod tests {
             dropper,
             Some(service),
             historical_cfg,
+            None,
             None,
             &events,
             &context,
@@ -591,6 +660,7 @@ mod tests {
             Some(service),
             historical_cfg,
             None,
+            None,
             &events,
             &context,
         )
@@ -636,6 +706,7 @@ mod tests {
             dropper,
             Some(service),
             historical_cfg,
+            None,
             None,
             &events,
             &context,
@@ -690,6 +761,7 @@ mod tests {
             Some(service),
             historical_cfg,
             None,
+            None,
             &events,
             &context,
         )
@@ -724,6 +796,7 @@ mod tests {
             dropper,
             None,
             historical_cfg,
+            None,
             None,
             &events,
             &context,
@@ -776,6 +849,7 @@ mod tests {
             Some(service),
             historical_cfg,
             None,
+            None,
             &events,
             &context,
         )
@@ -821,6 +895,7 @@ mod tests {
             Some(service),
             historical_cfg,
             None,
+            None,
             &events,
             &context,
         )
@@ -833,5 +908,274 @@ mod tests {
             captured[0].metadata.redirect_to_topic,
             Some("custom_events_topic".to_string())
         );
+    }
+
+    // ============ overflow_reason stamping tests ============
+    // These exercise the analytics pipeline's new overflow stamping stage
+    // (the logic that used to live in the kafka sink's prepare_record).
+    // Each case constructs a `process_events` call with a specific
+    // `OverflowLimiter` configuration and asserts the stamped
+    // `overflow_reason` on the sink-captured event.
+
+    use std::num::NonZeroU32;
+
+    fn build_limiter(
+        per_second: u32,
+        burst: u32,
+        keys_to_reroute: Option<String>,
+        preserve_locality: bool,
+    ) -> Arc<OverflowLimiter> {
+        Arc::new(OverflowLimiter::new(
+            NonZeroU32::new(per_second).unwrap(),
+            NonZeroU32::new(burst).unwrap(),
+            keys_to_reroute,
+            preserve_locality,
+        ))
+    }
+
+    #[tokio::test]
+    async fn test_overflow_stamp_none_when_limiter_absent() {
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let context = create_test_context(now, None);
+        let events = vec![create_test_event(
+            Some("2023-01-01T11:00:00Z".to_string()),
+            None,
+            None,
+        )];
+
+        let sink = Arc::new(MockSink::new());
+        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
+        let historical_cfg = router::HistoricalConfig::new(false, 1);
+
+        process_events(
+            sink.clone(),
+            dropper,
+            None,
+            historical_cfg,
+            None,
+            None, // no overflow limiter
+            &events,
+            &context,
+        )
+        .await
+        .unwrap();
+
+        let captured = sink.get_events();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].metadata.overflow_reason, None);
+    }
+
+    #[tokio::test]
+    async fn test_overflow_stamp_force_limited_when_token_in_reroute_list() {
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let context = create_test_context(now, None);
+        let events = vec![create_test_event(
+            Some("2023-01-01T11:00:00Z".to_string()),
+            None,
+            None,
+        )];
+
+        let sink = Arc::new(MockSink::new());
+        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
+        let historical_cfg = router::HistoricalConfig::new(false, 1);
+        // test_token is in the reroute list -> ForceLimited
+        let limiter = build_limiter(10, 10, Some("test_token".to_string()), false);
+
+        process_events(
+            sink.clone(),
+            dropper,
+            None,
+            historical_cfg,
+            None,
+            Some(limiter),
+            &events,
+            &context,
+        )
+        .await
+        .unwrap();
+
+        let captured = sink.get_events();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(
+            captured[0].metadata.overflow_reason,
+            Some(OverflowReason::ForceLimited)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_overflow_stamp_rate_limited_when_burst_exceeded() {
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let context = create_test_context(now, None);
+        let events = vec![
+            create_test_event(Some("2023-01-01T11:00:00Z".to_string()), None, None),
+            create_test_event(Some("2023-01-01T11:00:00Z".to_string()), None, None),
+        ];
+
+        let sink = Arc::new(MockSink::new());
+        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
+        let historical_cfg = router::HistoricalConfig::new(false, 1);
+        // burst of 1 -> first event passes, second event rate-limited
+        let limiter = build_limiter(1, 1, None, true);
+
+        process_events(
+            sink.clone(),
+            dropper,
+            None,
+            historical_cfg,
+            None,
+            Some(limiter),
+            &events,
+            &context,
+        )
+        .await
+        .unwrap();
+
+        let captured = sink.get_events();
+        assert_eq!(captured.len(), 2);
+        assert_eq!(captured[0].metadata.overflow_reason, None);
+        assert_eq!(
+            captured[1].metadata.overflow_reason,
+            Some(OverflowReason::RateLimited {
+                preserve_locality: true,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_overflow_stamp_preserve_locality_false_propagates() {
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let context = create_test_context(now, None);
+        let events = vec![
+            create_test_event(Some("2023-01-01T11:00:00Z".to_string()), None, None),
+            create_test_event(Some("2023-01-01T11:00:00Z".to_string()), None, None),
+        ];
+
+        let sink = Arc::new(MockSink::new());
+        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
+        let historical_cfg = router::HistoricalConfig::new(false, 1);
+        let limiter = build_limiter(1, 1, None, false);
+
+        process_events(
+            sink.clone(),
+            dropper,
+            None,
+            historical_cfg,
+            None,
+            Some(limiter),
+            &events,
+            &context,
+        )
+        .await
+        .unwrap();
+
+        let captured = sink.get_events();
+        assert_eq!(
+            captured[1].metadata.overflow_reason,
+            Some(OverflowReason::RateLimited {
+                preserve_locality: false,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_overflow_stamp_force_overflow_short_circuits_limiter() {
+        // When event restrictions set force_overflow, the pipeline short-
+        // circuits the limiter check and leaves overflow_reason = None. The
+        // sink routes on force_overflow directly in this case.
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let context = create_test_context(now, None);
+        let events = vec![create_test_event(
+            Some("2023-01-01T11:00:00Z".to_string()),
+            None,
+            None,
+        )];
+
+        let sink = Arc::new(MockSink::new());
+        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
+        let historical_cfg = router::HistoricalConfig::new(false, 1);
+        // Even with a limiter that would flag this token, force_overflow wins.
+        let limiter = build_limiter(10, 10, Some("test_token".to_string()), false);
+
+        let service = EventRestrictionService::new(CaptureMode::Events, Duration::from_secs(300));
+        let mut manager = RestrictionManager::new();
+        manager.restrictions.insert(
+            "test_token".to_string(),
+            vec![Restriction {
+                restriction_type: RestrictionType::ForceOverflow,
+                scope: RestrictionScope::AllEvents,
+                args: None,
+            }],
+        );
+        service.update(manager).await;
+
+        process_events(
+            sink.clone(),
+            dropper,
+            Some(service),
+            historical_cfg,
+            None,
+            Some(limiter),
+            &events,
+            &context,
+        )
+        .await
+        .unwrap();
+
+        let captured = sink.get_events();
+        assert_eq!(captured.len(), 1);
+        assert!(captured[0].metadata.force_overflow);
+        assert_eq!(captured[0].metadata.overflow_reason, None);
+    }
+
+    #[tokio::test]
+    async fn test_overflow_stamp_skipped_for_non_analytics_main() {
+        // Historical, heatmap, exception, etc. events should never be stamped
+        // with an overflow_reason even if the limiter would otherwise hit.
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let mut context = create_test_context(now, None);
+        context.historical_migration = true;
+        let events = vec![create_test_event(
+            Some("2023-01-01T11:00:00Z".to_string()),
+            None,
+            None,
+        )];
+
+        let sink = Arc::new(MockSink::new());
+        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
+        let historical_cfg = router::HistoricalConfig::new(false, 1);
+        let limiter = build_limiter(10, 10, Some("test_token".to_string()), false);
+
+        process_events(
+            sink.clone(),
+            dropper,
+            None,
+            historical_cfg,
+            None,
+            Some(limiter),
+            &events,
+            &context,
+        )
+        .await
+        .unwrap();
+
+        let captured = sink.get_events();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(
+            captured[0].metadata.data_type,
+            DataType::AnalyticsHistorical
+        );
+        assert_eq!(captured[0].metadata.overflow_reason, None);
     }
 }

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -285,6 +285,14 @@ pub async fn process_events<'a>(
                 )
                 .increment(1);
                 event.metadata.overflow_reason = Some(OverflowReason::ForceLimited);
+                // Self-describing metadata: ForceLimited implies person
+                // processing is skipped. Pre-refactor the sink inferred this
+                // from the limiter result; now we stamp it alongside the
+                // reason so the sink's generic skip-person path handles it
+                // uniformly. Kafka output is byte-identical — the sink's
+                // ForceLimited arm still sets the header redundantly as
+                // defense against a future caller stamping reason-only.
+                event.metadata.skip_person_processing = true;
             }
             OverflowLimiterResult::Limited => {
                 counter!(
@@ -1176,5 +1184,290 @@ mod tests {
             DataType::AnalyticsHistorical
         );
         assert_eq!(captured[0].metadata.overflow_reason, None);
+    }
+
+    // ============ global rate limiter x overflow limiter interplay ============
+
+    /// Minimal stub of `limiters::global_rate_limiter::GlobalRateLimiter`
+    /// for pipeline-level tests. Returns `Limited` for a fixed set of keys.
+    mod global_rl_stub {
+        use super::*;
+        use async_trait::async_trait;
+        use limiters::global_rate_limiter::{
+            EvalResult, GlobalRateLimitResponse,
+            GlobalRateLimiter as CommonGlobalRateLimiterTrait,
+        };
+        use std::collections::HashSet;
+
+        pub struct MockLimiter {
+            limited_keys: HashSet<String>,
+        }
+
+        impl MockLimiter {
+            pub fn new(limited_keys: HashSet<String>) -> Self {
+                Self { limited_keys }
+            }
+        }
+
+        #[async_trait]
+        impl CommonGlobalRateLimiterTrait for MockLimiter {
+            async fn check_limit(
+                &self,
+                key: &str,
+                _count: u64,
+                _timestamp: Option<DateTime<Utc>>,
+            ) -> EvalResult {
+                if self.limited_keys.contains(key) {
+                    EvalResult::Limited(GlobalRateLimitResponse {
+                        key: key.to_string(),
+                        current_count: 100.0,
+                        threshold: 10,
+                        window_interval: std::time::Duration::from_secs(60),
+                        sync_interval: std::time::Duration::from_secs(15),
+                        is_custom_limited: false,
+                    })
+                } else {
+                    EvalResult::Allowed
+                }
+            }
+
+            async fn check_custom_limit(
+                &self,
+                _key: &str,
+                _count: u64,
+                _timestamp: Option<DateTime<Utc>>,
+            ) -> EvalResult {
+                EvalResult::NotApplicable
+            }
+
+            fn is_custom_key(&self, _key: &str) -> bool {
+                false
+            }
+
+            fn shutdown(&mut self) {}
+        }
+    }
+
+    #[tokio::test]
+    async fn test_overflow_stamp_global_rate_limiter_and_overflow_interplay() {
+        // Both limiters fire on the same event: global RL sets
+        // skip_person_processing=true on (token, distinct_id) overage, and the
+        // OverflowLimiter stamps RateLimited{preserve_locality: true} on the
+        // second event because burst=1. The pipeline must OR the two effects
+        // into the same metadata record; the sink then routes to the overflow
+        // topic, keeps the partition key, and writes the skip-person header.
+        // Pre-refactor these were split across pipeline + sink; this test
+        // pins the end-to-end metadata contract.
+        use std::collections::HashSet;
+
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let context = create_test_context(now, None);
+
+        let events = vec![
+            create_test_event(Some("2023-01-01T11:00:00Z".to_string()), None, None),
+            create_test_event(Some("2023-01-01T11:00:00Z".to_string()), None, None),
+        ];
+
+        let sink = Arc::new(MockSink::new());
+        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
+        let historical_cfg = router::HistoricalConfig::new(false, 1);
+
+        // Global RL: limits (test_token, test_user) -> key `test_token:test_user`.
+        let mut limited_keys = HashSet::new();
+        limited_keys.insert("test_token:test_user".to_string());
+        let global_limiter = Arc::new(GlobalRateLimiter::new_with(
+            global_rl_stub::MockLimiter::new(limited_keys),
+        ));
+
+        // Overflow limiter: burst=1, preserve_locality=true -> event[1]
+        // stamped RateLimited{preserve_locality: true}.
+        let overflow_limiter = build_limiter(1, 1, None, true);
+
+        process_events(
+            sink.clone(),
+            dropper,
+            None,
+            historical_cfg,
+            Some(global_limiter),
+            Some(overflow_limiter),
+            &events,
+            &context,
+        )
+        .await
+        .unwrap();
+
+        let captured = sink.get_events();
+        assert_eq!(captured.len(), 2);
+
+        // event[0]: global RL fires (distinct_id limited) -> skip_person_processing.
+        // Overflow limiter's first token is within burst so no overflow_reason.
+        assert!(
+            captured[0].metadata.skip_person_processing,
+            "event[0]: global RL should set skip_person_processing"
+        );
+        assert_eq!(
+            captured[0].metadata.overflow_reason, None,
+            "event[0]: burst=1 means first event is NOT overflow"
+        );
+
+        // event[1]: BOTH stamps fire. skip_person_processing from global RL,
+        // overflow_reason=RateLimited{preserve_locality: true} from OverflowLimiter.
+        assert!(
+            captured[1].metadata.skip_person_processing,
+            "event[1]: global RL should set skip_person_processing"
+        );
+        assert_eq!(
+            captured[1].metadata.overflow_reason,
+            Some(OverflowReason::RateLimited {
+                preserve_locality: true,
+            }),
+            "event[1]: overflow limiter should stamp RateLimited{{preserve_locality: true}}"
+        );
+    }
+
+    // ============ end-to-end pipeline -> real KafkaSinkBase tests ============
+    // These catch pipeline-to-sink contract drift that neither side's unit
+    // tests alone cover: stamp metadata in pipeline, ensure the real sink
+    // reads the metadata and produces the expected topic, key, and headers.
+
+    use crate::sinks::kafka::{KafkaSinkBase, KafkaTopicConfig};
+    use crate::sinks::producer::MockKafkaProducer;
+
+    fn e2e_topics() -> KafkaTopicConfig {
+        KafkaTopicConfig {
+            main_topic: "events_main".to_string(),
+            overflow_topic: "events_overflow".to_string(),
+            historical_topic: "events_historical".to_string(),
+            client_ingestion_warning_topic: "client_warning".to_string(),
+            heatmaps_topic: "heatmaps".to_string(),
+            replay_overflow_topic: "replay_overflow".to_string(),
+            dlq_topic: "events_dlq".to_string(),
+            error_tracking_topic: "error_tracking".to_string(),
+            traces_topic: "traces".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn e2e_force_limited_pipeline_to_sink_routes_to_overflow_with_null_key_and_header() {
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let context = create_test_context(now, None);
+        let events = vec![create_test_event(
+            Some("2023-01-01T11:00:00Z".to_string()),
+            None,
+            None,
+        )];
+
+        let producer = MockKafkaProducer::new();
+        let sink = Arc::new(KafkaSinkBase::with_producer(producer.clone(), e2e_topics()));
+        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
+        let historical_cfg = router::HistoricalConfig::new(false, 1);
+        // test_token in reroute list -> ForceLimited stamped in pipeline.
+        let limiter = build_limiter(10, 10, Some("test_token".to_string()), false);
+
+        process_events(
+            sink, dropper, None, historical_cfg, None, Some(limiter),
+            &events, &context,
+        )
+        .await
+        .unwrap();
+
+        let records = producer.get_records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].topic, "events_overflow",
+            "ForceLimited must route to overflow topic"
+        );
+        assert_eq!(
+            records[0].key, None,
+            "ForceLimited must drop partition key (broad-fanout semantics)"
+        );
+        assert_eq!(
+            records[0].headers.force_disable_person_processing,
+            Some(true),
+            "ForceLimited must set force_disable_person_processing header"
+        );
+    }
+
+    #[tokio::test]
+    async fn e2e_rate_limited_preserve_locality_pipeline_to_sink_keeps_key() {
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let context = create_test_context(now, None);
+        let events = vec![
+            create_test_event(Some("2023-01-01T11:00:00Z".to_string()), None, None),
+            create_test_event(Some("2023-01-01T11:00:00Z".to_string()), None, None),
+        ];
+
+        let producer = MockKafkaProducer::new();
+        let sink = Arc::new(KafkaSinkBase::with_producer(producer.clone(), e2e_topics()));
+        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
+        let historical_cfg = router::HistoricalConfig::new(false, 1);
+        // burst=1, preserve_locality=true => event[1] stamped RateLimited{preserve_locality: true}.
+        let limiter = build_limiter(1, 1, None, true);
+
+        process_events(
+            sink, dropper, None, historical_cfg, None, Some(limiter),
+            &events, &context,
+        )
+        .await
+        .unwrap();
+
+        let records = producer.get_records();
+        assert_eq!(records.len(), 2);
+        assert_eq!(
+            records[0].topic, "events_main",
+            "event[0]: within burst -> main topic"
+        );
+        assert_eq!(
+            records[1].topic, "events_overflow",
+            "event[1]: over burst -> overflow topic"
+        );
+        assert!(
+            records[1].key.is_some(),
+            "RateLimited{{preserve_locality:true}} must preserve partition key"
+        );
+        assert!(
+            records[1].headers.force_disable_person_processing.is_none(),
+            "RateLimited (non-Force) must NOT set force_disable_person_processing"
+        );
+    }
+
+    #[tokio::test]
+    async fn e2e_rate_limited_no_preserve_locality_pipeline_to_sink_drops_key() {
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let context = create_test_context(now, None);
+        let events = vec![
+            create_test_event(Some("2023-01-01T11:00:00Z".to_string()), None, None),
+            create_test_event(Some("2023-01-01T11:00:00Z".to_string()), None, None),
+        ];
+
+        let producer = MockKafkaProducer::new();
+        let sink = Arc::new(KafkaSinkBase::with_producer(producer.clone(), e2e_topics()));
+        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
+        let historical_cfg = router::HistoricalConfig::new(false, 1);
+        // burst=1, preserve_locality=false => event[1] stamped RateLimited{preserve_locality: false}.
+        let limiter = build_limiter(1, 1, None, false);
+
+        process_events(
+            sink, dropper, None, historical_cfg, None, Some(limiter),
+            &events, &context,
+        )
+        .await
+        .unwrap();
+
+        let records = producer.get_records();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[1].topic, "events_overflow");
+        assert_eq!(
+            records[1].key, None,
+            "RateLimited{{preserve_locality:false}} must drop partition key"
+        );
     }
 }

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -323,6 +323,7 @@ mod tests {
     use common_types::RawEvent;
     use serde_json::json;
     use std::collections::HashMap;
+    use std::num::NonZeroU32;
     use time::OffsetDateTime;
 
     fn create_test_context(
@@ -916,8 +917,6 @@ mod tests {
     // Each case constructs a `process_events` call with a specific
     // `OverflowLimiter` configuration and asserts the stamped
     // `overflow_reason` on the sink-captured event.
-
-    use std::num::NonZeroU32;
 
     fn build_limiter(
         per_second: u32,

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -13,19 +13,18 @@ use metrics::counter;
 use serde_json;
 use tracing::{error, instrument, warn, Span};
 
-use limiters::overflow::{OverflowLimiter, OverflowLimiterResult};
+use limiters::overflow::OverflowLimiter;
 
 use crate::{
     api::CaptureError,
     debug_or_info,
     event_restrictions::{EventContext as RestrictionEventContext, EventRestrictionService},
+    events::overflow_stamping::stamp_overflow_reason,
     global_rate_limiter::{GlobalRateLimitKey, GlobalRateLimiter},
     prometheus::{report_clock_skew, report_dropped_events},
     router, sinks,
     utils::uuid_v7,
-    v0_request::{
-        DataType, OverflowReason, ProcessedEvent, ProcessedEventMetadata, ProcessingContext,
-    },
+    v0_request::{DataType, ProcessedEvent, ProcessedEventMetadata, ProcessingContext},
 };
 
 /// Process a single analytics event from RawEvent to ProcessedEvent
@@ -135,8 +134,12 @@ pub fn process_single_event(
 ///
 /// All routing policy lives here: token dropping, event restrictions, global
 /// rate limiting (per `token:distinct_id`), historical rerouting, and
-/// per-key overflow rerouting via [`OverflowLimiter`]. The kafka sink is a
-/// pure mechanism layer — it reads `ProcessedEventMetadata::overflow_reason`,
+/// per-key overflow rerouting via [`OverflowLimiter`]. Overflow stamping
+/// goes through the shared [`stamp_overflow_reason`] helper, which the AI
+/// (`ai_endpoint::ai_handler`) and OTEL (`otel::otel_handler`) paths also
+/// call so every `DataType::AnalyticsMain` event gets identical limiter
+/// semantics regardless of entry point. The kafka sink is a pure mechanism
+/// layer — it reads `ProcessedEventMetadata::overflow_reason`,
 /// `force_overflow`, `redirect_to_dlq`, and `redirect_to_topic` to decide
 /// which topic and key to produce to.
 #[instrument(skip_all, fields(events = events.len(), request_id))]
@@ -250,63 +253,11 @@ pub async fn process_events<'a>(
     // Overflow routing stage. This used to live in the kafka sink's
     // prepare_record; moving it here keeps the sink free of policy and
     // co-locates overflow with every other pipeline-level routing decision.
-    // We stamp `ProcessedEventMetadata::overflow_reason`; the sink reads it
-    // and picks the overflow topic / partition-key policy accordingly.
-    //
-    // `force_overflow` (set by event restrictions) short-circuits the
-    // limiter check — same semantics as before. We emit the
-    // `capture_events_rerouted_overflow` counter here at stamp time; the
-    // sink no longer emits it. Label values match the pre-refactor sink
-    // counter so existing dashboards keep working.
-    for event in events.iter_mut() {
-        if event.metadata.data_type != DataType::AnalyticsMain {
-            continue;
-        }
-
-        if event.metadata.force_overflow {
-            counter!(
-                "capture_events_rerouted_overflow",
-                "reason" => "event_restriction",
-            )
-            .increment(1);
-            continue;
-        }
-
-        let Some(ref limiter) = overflow_limiter else {
-            continue;
-        };
-
-        let event_key = event.event.key();
-        match limiter.is_limited(&event_key) {
-            OverflowLimiterResult::ForceLimited => {
-                counter!(
-                    "capture_events_rerouted_overflow",
-                    "reason" => "force_limited",
-                )
-                .increment(1);
-                event.metadata.overflow_reason = Some(OverflowReason::ForceLimited);
-                // Self-describing metadata: ForceLimited implies person
-                // processing is skipped. Pre-refactor the sink inferred this
-                // from the limiter result; now we stamp it alongside the
-                // reason so the sink's generic skip-person path handles it
-                // uniformly. Kafka output is byte-identical — the sink's
-                // ForceLimited arm still sets the header redundantly as
-                // defense against a future caller stamping reason-only.
-                event.metadata.skip_person_processing = true;
-            }
-            OverflowLimiterResult::Limited => {
-                counter!(
-                    "capture_events_rerouted_overflow",
-                    "reason" => "rate_limited",
-                )
-                .increment(1);
-                event.metadata.overflow_reason = Some(OverflowReason::RateLimited {
-                    preserve_locality: limiter.should_preserve_locality(),
-                });
-            }
-            OverflowLimiterResult::NotLimited => {}
-        }
-    }
+    // The stamping helper is shared with the AI (`ai_endpoint::ai_handler`)
+    // and OTEL (`otel::otel_handler`) paths so every handler that emits
+    // `DataType::AnalyticsMain` events gets identical limiter semantics and
+    // metric labels — see `events::overflow_stamping`.
+    stamp_overflow_reason(&mut events, overflow_limiter.as_ref());
 
     if events.is_empty() {
         return Ok(());
@@ -326,7 +277,7 @@ pub async fn process_events<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::v0_request::ProcessingContext;
+    use crate::v0_request::{OverflowReason, ProcessingContext};
     use chrono::{DateTime, TimeZone, Utc};
     use common_types::RawEvent;
     use serde_json::json;

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -1194,8 +1194,7 @@ mod tests {
         use super::*;
         use async_trait::async_trait;
         use limiters::global_rate_limiter::{
-            EvalResult, GlobalRateLimitResponse,
-            GlobalRateLimiter as CommonGlobalRateLimiterTrait,
+            EvalResult, GlobalRateLimitResponse, GlobalRateLimiter as CommonGlobalRateLimiterTrait,
         };
         use std::collections::HashSet;
 
@@ -1369,8 +1368,14 @@ mod tests {
         let limiter = build_limiter(10, 10, Some("test_token".to_string()), false);
 
         process_events(
-            sink, dropper, None, historical_cfg, None, Some(limiter),
-            &events, &context,
+            sink,
+            dropper,
+            None,
+            historical_cfg,
+            None,
+            Some(limiter),
+            &events,
+            &context,
         )
         .await
         .unwrap();
@@ -1411,8 +1416,14 @@ mod tests {
         let limiter = build_limiter(1, 1, None, true);
 
         process_events(
-            sink, dropper, None, historical_cfg, None, Some(limiter),
-            &events, &context,
+            sink,
+            dropper,
+            None,
+            historical_cfg,
+            None,
+            Some(limiter),
+            &events,
+            &context,
         )
         .await
         .unwrap();
@@ -1456,8 +1467,14 @@ mod tests {
         let limiter = build_limiter(1, 1, None, false);
 
         process_events(
-            sink, dropper, None, historical_cfg, None, Some(limiter),
-            &events, &context,
+            sink,
+            dropper,
+            None,
+            historical_cfg,
+            None,
+            Some(limiter),
+            &events,
+            &context,
         )
         .await
         .unwrap();

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -504,42 +504,8 @@ mod tests {
         EventRestrictionService, Restriction, RestrictionFilters, RestrictionManager,
         RestrictionScope, RestrictionType,
     };
-    use crate::sinks;
-    use async_trait::async_trait;
-    use std::sync::Mutex;
+    use crate::sinks::test_sink::MockSink;
     use std::time::Duration;
-
-    struct MockSink {
-        events: Arc<Mutex<Vec<ProcessedEvent>>>,
-    }
-
-    impl MockSink {
-        fn new() -> Self {
-            Self {
-                events: Arc::new(Mutex::new(Vec::new())),
-            }
-        }
-
-        fn get_events(&self) -> Vec<ProcessedEvent> {
-            self.events.lock().unwrap().clone()
-        }
-    }
-
-    #[async_trait]
-    impl sinks::Event for MockSink {
-        async fn send(&self, event: ProcessedEvent) -> Result<(), crate::api::CaptureError> {
-            self.events.lock().unwrap().push(event);
-            Ok(())
-        }
-
-        async fn send_batch(
-            &self,
-            events: Vec<ProcessedEvent>,
-        ) -> Result<(), crate::api::CaptureError> {
-            self.events.lock().unwrap().extend(events);
-            Ok(())
-        }
-    }
 
     #[tokio::test]
     async fn test_process_events_drop_event_restriction() {
@@ -1188,65 +1154,6 @@ mod tests {
 
     // ============ global rate limiter x overflow limiter interplay ============
 
-    /// Minimal stub of `limiters::global_rate_limiter::GlobalRateLimiter`
-    /// for pipeline-level tests. Returns `Limited` for a fixed set of keys.
-    mod global_rl_stub {
-        use super::*;
-        use async_trait::async_trait;
-        use limiters::global_rate_limiter::{
-            EvalResult, GlobalRateLimitResponse, GlobalRateLimiter as CommonGlobalRateLimiterTrait,
-        };
-        use std::collections::HashSet;
-
-        pub struct MockLimiter {
-            limited_keys: HashSet<String>,
-        }
-
-        impl MockLimiter {
-            pub fn new(limited_keys: HashSet<String>) -> Self {
-                Self { limited_keys }
-            }
-        }
-
-        #[async_trait]
-        impl CommonGlobalRateLimiterTrait for MockLimiter {
-            async fn check_limit(
-                &self,
-                key: &str,
-                _count: u64,
-                _timestamp: Option<DateTime<Utc>>,
-            ) -> EvalResult {
-                if self.limited_keys.contains(key) {
-                    EvalResult::Limited(GlobalRateLimitResponse {
-                        key: key.to_string(),
-                        current_count: 100.0,
-                        threshold: 10,
-                        window_interval: std::time::Duration::from_secs(60),
-                        sync_interval: std::time::Duration::from_secs(15),
-                        is_custom_limited: false,
-                    })
-                } else {
-                    EvalResult::Allowed
-                }
-            }
-
-            async fn check_custom_limit(
-                &self,
-                _key: &str,
-                _count: u64,
-                _timestamp: Option<DateTime<Utc>>,
-            ) -> EvalResult {
-                EvalResult::NotApplicable
-            }
-
-            fn is_custom_key(&self, _key: &str) -> bool {
-                false
-            }
-
-            fn shutdown(&mut self) {}
-        }
-    }
-
     #[tokio::test]
     async fn test_overflow_stamp_global_rate_limiter_and_overflow_interplay() {
         // Both limiters fire on the same event: global RL sets
@@ -1257,7 +1164,6 @@ mod tests {
         // topic, keeps the partition key, and writes the skip-person header.
         // Pre-refactor these were split across pipeline + sink; this test
         // pins the end-to-end metadata contract.
-        use std::collections::HashSet;
 
         let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
             .unwrap()
@@ -1274,11 +1180,7 @@ mod tests {
         let historical_cfg = router::HistoricalConfig::new(false, 1);
 
         // Global RL: limits (test_token, test_user) -> key `test_token:test_user`.
-        let mut limited_keys = HashSet::new();
-        limited_keys.insert("test_token:test_user".to_string());
-        let global_limiter = Arc::new(GlobalRateLimiter::new_with(
-            global_rl_stub::MockLimiter::new(limited_keys),
-        ));
+        let global_limiter = Arc::new(GlobalRateLimiter::mock_limiting(&["test_token:test_user"]));
 
         // Overflow limiter: burst=1, preserve_locality=true -> event[1]
         // stamped RateLimited{preserve_locality: true}.
@@ -1331,22 +1233,8 @@ mod tests {
     // tests alone cover: stamp metadata in pipeline, ensure the real sink
     // reads the metadata and produces the expected topic, key, and headers.
 
-    use crate::sinks::kafka::{KafkaSinkBase, KafkaTopicConfig};
+    use crate::sinks::kafka::{test_topics, KafkaSinkBase};
     use crate::sinks::producer::MockKafkaProducer;
-
-    fn e2e_topics() -> KafkaTopicConfig {
-        KafkaTopicConfig {
-            main_topic: "events_main".to_string(),
-            overflow_topic: "events_overflow".to_string(),
-            historical_topic: "events_historical".to_string(),
-            client_ingestion_warning_topic: "client_warning".to_string(),
-            heatmaps_topic: "heatmaps".to_string(),
-            replay_overflow_topic: "replay_overflow".to_string(),
-            dlq_topic: "events_dlq".to_string(),
-            error_tracking_topic: "error_tracking".to_string(),
-            traces_topic: "traces".to_string(),
-        }
-    }
 
     #[tokio::test]
     async fn e2e_force_limited_pipeline_to_sink_routes_to_overflow_with_null_key_and_header() {
@@ -1361,7 +1249,10 @@ mod tests {
         )];
 
         let producer = MockKafkaProducer::new();
-        let sink = Arc::new(KafkaSinkBase::with_producer(producer.clone(), e2e_topics()));
+        let sink = Arc::new(KafkaSinkBase::with_producer(
+            producer.clone(),
+            test_topics(),
+        ));
         let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
         let historical_cfg = router::HistoricalConfig::new(false, 1);
         // test_token in reroute list -> ForceLimited stamped in pipeline.
@@ -1383,7 +1274,7 @@ mod tests {
         let records = producer.get_records();
         assert_eq!(records.len(), 1);
         assert_eq!(
-            records[0].topic, "events_overflow",
+            records[0].topic, "events_plugin_ingestion_overflow",
             "ForceLimited must route to overflow topic"
         );
         assert_eq!(
@@ -1409,7 +1300,10 @@ mod tests {
         ];
 
         let producer = MockKafkaProducer::new();
-        let sink = Arc::new(KafkaSinkBase::with_producer(producer.clone(), e2e_topics()));
+        let sink = Arc::new(KafkaSinkBase::with_producer(
+            producer.clone(),
+            test_topics(),
+        ));
         let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
         let historical_cfg = router::HistoricalConfig::new(false, 1);
         // burst=1, preserve_locality=true => event[1] stamped RateLimited{preserve_locality: true}.
@@ -1431,11 +1325,11 @@ mod tests {
         let records = producer.get_records();
         assert_eq!(records.len(), 2);
         assert_eq!(
-            records[0].topic, "events_main",
+            records[0].topic, "events_plugin_ingestion",
             "event[0]: within burst -> main topic"
         );
         assert_eq!(
-            records[1].topic, "events_overflow",
+            records[1].topic, "events_plugin_ingestion_overflow",
             "event[1]: over burst -> overflow topic"
         );
         assert!(
@@ -1460,7 +1354,10 @@ mod tests {
         ];
 
         let producer = MockKafkaProducer::new();
-        let sink = Arc::new(KafkaSinkBase::with_producer(producer.clone(), e2e_topics()));
+        let sink = Arc::new(KafkaSinkBase::with_producer(
+            producer.clone(),
+            test_topics(),
+        ));
         let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
         let historical_cfg = router::HistoricalConfig::new(false, 1);
         // burst=1, preserve_locality=false => event[1] stamped RateLimited{preserve_locality: false}.
@@ -1481,7 +1378,7 @@ mod tests {
 
         let records = producer.get_records();
         assert_eq!(records.len(), 2);
-        assert_eq!(records[1].topic, "events_overflow");
+        assert_eq!(records[1].topic, "events_plugin_ingestion_overflow");
         assert_eq!(
             records[1].key, None,
             "RateLimited{{preserve_locality:false}} must drop partition key"

--- a/rust/capture/src/events/mod.rs
+++ b/rust/capture/src/events/mod.rs
@@ -1,6 +1,8 @@
 pub mod analytics;
+pub mod overflow_stamping;
 pub mod recordings;
 
 // Re-export commonly used types
 pub use analytics::{process_events, process_single_event};
+pub use overflow_stamping::stamp_overflow_reason;
 pub use recordings::{process_replay_events, RawRecording, RecordingRequest};

--- a/rust/capture/src/events/overflow_stamping.rs
+++ b/rust/capture/src/events/overflow_stamping.rs
@@ -1,0 +1,352 @@
+//! Shared overflow-reason stamping for analytics + AI + OTEL pipelines.
+//!
+//! The in-process `OverflowLimiter` (governor-backed, keyed on
+//! `token:distinct_id`) used to live inside `KafkaSinkBase::prepare_record`,
+//! which meant every `DataType::AnalyticsMain` event reaching the sink was
+//! checked uniformly regardless of which handler produced it. After the
+//! sink became a pure mechanism layer, the check was moved upstream into
+//! `events::analytics::process_events`. That covers the `/e/`, `/batch/`,
+//! `/capture` etc. endpoints but NOT the AI (`/i/v0/ai`) or OTEL
+//! (`/i/v0/ai/otel`) endpoints, which build `ProcessedEvent`s of their own
+//! and call `state.sink.send` / `state.sink.send_batch` directly.
+//!
+//! [`stamp_overflow_reason`] is the single source of truth for that check
+//! so all three call sites — analytics, AI, OTEL — get identical semantics
+//! and metric labels. Triplicating the loop would invite drift; routing
+//! the call through one helper keeps the contract testable in one place.
+//!
+//! The helper is sync because the `OverflowLimiter` governor check is sync
+//! (unlike the replay redis limiter, which still lives in the recordings
+//! pipeline as an async call).
+
+use std::sync::Arc;
+
+use limiters::overflow::{OverflowLimiter, OverflowLimiterResult};
+use metrics::counter;
+
+use crate::v0_request::{DataType, OverflowReason, ProcessedEvent};
+
+/// Stamp `ProcessedEventMetadata::overflow_reason` on every
+/// `DataType::AnalyticsMain` event in `events`, consulting `limiter` and the
+/// pre-existing `force_overflow` flag stamped by event restrictions.
+///
+/// Behavior (matches the pre-refactor sink semantics byte-for-byte):
+/// * Non-`AnalyticsMain` events are skipped (heatmaps, exceptions,
+///   client-ingestion-warnings, etc. never overflow).
+/// * `force_overflow = true` (set upstream by event restrictions) emits the
+///   `event_restriction` counter and short-circuits — the limiter is NOT
+///   consulted, matching the pre-refactor sink ordering.
+/// * If `limiter` is `None`, only the `event_restriction` short-circuit can
+///   stamp anything; otherwise the event passes through untouched.
+/// * If `limiter` is `Some`, `is_limited(event.key())` is consulted and the
+///   resulting [`OverflowReason`] is stamped, plus the matching counter.
+///   `ForceLimited` additionally sets `skip_person_processing = true` so the
+///   sink's generic skip-person branch picks up the
+///   `force_disable_person_processing` header without a separate code path.
+///
+/// Counter labels are intentionally identical to the pre-refactor sink so
+/// existing dashboards (filtering on `capture_events_rerouted_overflow`'s
+/// `reason` label) keep working without dashboard-side changes.
+pub fn stamp_overflow_reason(
+    events: &mut [ProcessedEvent],
+    limiter: Option<&Arc<OverflowLimiter>>,
+) {
+    for event in events.iter_mut() {
+        if event.metadata.data_type != DataType::AnalyticsMain {
+            continue;
+        }
+
+        if event.metadata.force_overflow {
+            counter!(
+                "capture_events_rerouted_overflow",
+                "reason" => "event_restriction",
+            )
+            .increment(1);
+            continue;
+        }
+
+        let Some(limiter) = limiter else {
+            continue;
+        };
+
+        let event_key = event.event.key();
+        match limiter.is_limited(&event_key) {
+            OverflowLimiterResult::ForceLimited => {
+                counter!(
+                    "capture_events_rerouted_overflow",
+                    "reason" => "force_limited",
+                )
+                .increment(1);
+                event.metadata.overflow_reason = Some(OverflowReason::ForceLimited);
+                // Self-describing metadata: ForceLimited implies person
+                // processing is skipped. Pre-refactor the sink inferred this
+                // from the limiter result; now we stamp it alongside the
+                // reason so the sink's generic skip-person path handles it
+                // uniformly. Kafka output is byte-identical — the sink's
+                // ForceLimited arm still sets the header redundantly as
+                // defense against a future caller stamping reason-only.
+                event.metadata.skip_person_processing = true;
+            }
+            OverflowLimiterResult::Limited => {
+                counter!(
+                    "capture_events_rerouted_overflow",
+                    "reason" => "rate_limited",
+                )
+                .increment(1);
+                event.metadata.overflow_reason = Some(OverflowReason::RateLimited {
+                    preserve_locality: limiter.should_preserve_locality(),
+                });
+            }
+            OverflowLimiterResult::NotLimited => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::uuid_v7;
+    use crate::v0_request::{ProcessedEvent, ProcessedEventMetadata};
+    use common_types::CapturedEvent;
+    use std::num::NonZeroU32;
+
+    fn build_event(
+        data_type: DataType,
+        token: &str,
+        distinct_id: &str,
+        force_overflow: bool,
+    ) -> ProcessedEvent {
+        let event = CapturedEvent {
+            uuid: uuid_v7(),
+            distinct_id: distinct_id.to_string(),
+            session_id: None,
+            ip: "127.0.0.1".to_string(),
+            data: "{}".to_string(),
+            now: "2026-04-20T00:00:00Z".to_string(),
+            sent_at: None,
+            token: token.to_string(),
+            event: "test".to_string(),
+            timestamp: chrono::Utc::now(),
+            is_cookieless_mode: false,
+            historical_migration: false,
+        };
+
+        let metadata = ProcessedEventMetadata {
+            data_type,
+            session_id: None,
+            computed_timestamp: None,
+            event_name: "test".to_string(),
+            force_overflow,
+            skip_person_processing: false,
+            redirect_to_dlq: false,
+            redirect_to_topic: None,
+            overflow_reason: None,
+        };
+
+        ProcessedEvent { event, metadata }
+    }
+
+    fn build_limiter(
+        per_second: u32,
+        burst: u32,
+        keys_to_reroute: Option<String>,
+        preserve_locality: bool,
+    ) -> Arc<OverflowLimiter> {
+        Arc::new(OverflowLimiter::new(
+            NonZeroU32::new(per_second).unwrap(),
+            NonZeroU32::new(burst).unwrap(),
+            keys_to_reroute,
+            preserve_locality,
+        ))
+    }
+
+    #[test]
+    fn force_overflow_short_circuits_without_consulting_limiter() {
+        // Use a limiter that would otherwise force-route this event; the
+        // short-circuit must skip the limiter call so the stamped reason
+        // stays None (force_overflow drives the sink directly without a
+        // RateLimited/ForceLimited stamp).
+        let limiter = build_limiter(10, 10, Some("phc_t:user".to_string()), false);
+        let mut events = vec![build_event(
+            DataType::AnalyticsMain,
+            "phc_t",
+            "user",
+            true, // force_overflow
+        )];
+
+        stamp_overflow_reason(&mut events, Some(&limiter));
+
+        assert_eq!(
+            events[0].metadata.overflow_reason, None,
+            "force_overflow short-circuits before the limiter; reason stays None"
+        );
+        assert!(
+            !events[0].metadata.skip_person_processing,
+            "force_overflow alone must not flip skip_person_processing"
+        );
+    }
+
+    #[test]
+    fn force_limited_stamps_reason_and_skip_person_processing() {
+        let limiter = build_limiter(10, 10, Some("phc_t:user".to_string()), false);
+        let mut events = vec![build_event(DataType::AnalyticsMain, "phc_t", "user", false)];
+
+        stamp_overflow_reason(&mut events, Some(&limiter));
+
+        assert_eq!(
+            events[0].metadata.overflow_reason,
+            Some(OverflowReason::ForceLimited)
+        );
+        assert!(
+            events[0].metadata.skip_person_processing,
+            "ForceLimited must set skip_person_processing alongside the reason"
+        );
+    }
+
+    #[test]
+    fn rate_limited_stamps_preserve_locality_true() {
+        // burst=1 means the second event exceeds the budget; preserve_locality
+        // is mirrored from the limiter config onto the stamped reason.
+        let limiter = build_limiter(1, 1, None, true);
+        let mut events = vec![
+            build_event(DataType::AnalyticsMain, "phc_t", "u", false),
+            build_event(DataType::AnalyticsMain, "phc_t", "u", false),
+        ];
+
+        stamp_overflow_reason(&mut events, Some(&limiter));
+
+        assert_eq!(
+            events[0].metadata.overflow_reason, None,
+            "first event within burst must not be stamped"
+        );
+        assert_eq!(
+            events[1].metadata.overflow_reason,
+            Some(OverflowReason::RateLimited {
+                preserve_locality: true
+            })
+        );
+        assert!(
+            !events[1].metadata.skip_person_processing,
+            "RateLimited (non-Force) must not flip skip_person_processing"
+        );
+    }
+
+    #[test]
+    fn rate_limited_stamps_preserve_locality_false() {
+        let limiter = build_limiter(1, 1, None, false);
+        let mut events = vec![
+            build_event(DataType::AnalyticsMain, "phc_t", "u", false),
+            build_event(DataType::AnalyticsMain, "phc_t", "u", false),
+        ];
+
+        stamp_overflow_reason(&mut events, Some(&limiter));
+
+        assert_eq!(
+            events[1].metadata.overflow_reason,
+            Some(OverflowReason::RateLimited {
+                preserve_locality: false
+            })
+        );
+    }
+
+    #[test]
+    fn not_limited_leaves_reason_none() {
+        // burst=10, single event; well under the budget.
+        let limiter = build_limiter(10, 10, None, false);
+        let mut events = vec![build_event(DataType::AnalyticsMain, "phc_t", "u", false)];
+
+        stamp_overflow_reason(&mut events, Some(&limiter));
+
+        assert_eq!(events[0].metadata.overflow_reason, None);
+    }
+
+    #[test]
+    fn non_analytics_main_events_are_skipped() {
+        // SnapshotMain has its own (replay) overflow path; HeatmapMain,
+        // ExceptionErrorTracking, ClientIngestionWarning, AnalyticsHistorical
+        // never overflow. Even with a limiter that would otherwise force-route
+        // their key, the helper must leave them untouched.
+        let limiter = build_limiter(10, 10, Some("phc_t:u".to_string()), false);
+        let mut events = vec![
+            build_event(DataType::SnapshotMain, "phc_t", "u", false),
+            build_event(DataType::HeatmapMain, "phc_t", "u", false),
+            build_event(DataType::ExceptionErrorTracking, "phc_t", "u", false),
+            build_event(DataType::ClientIngestionWarning, "phc_t", "u", false),
+            build_event(DataType::AnalyticsHistorical, "phc_t", "u", false),
+        ];
+
+        stamp_overflow_reason(&mut events, Some(&limiter));
+
+        for (i, ev) in events.iter().enumerate() {
+            assert_eq!(
+                ev.metadata.overflow_reason, None,
+                "event[{i}] data_type {:?} must be skipped",
+                ev.metadata.data_type
+            );
+            assert!(!ev.metadata.skip_person_processing, "event[{i}]: untouched");
+        }
+    }
+
+    #[test]
+    fn none_limiter_is_a_no_op_for_non_force_overflow_events() {
+        let mut events = vec![build_event(DataType::AnalyticsMain, "phc_t", "u", false)];
+
+        stamp_overflow_reason(&mut events, None);
+
+        assert_eq!(events[0].metadata.overflow_reason, None);
+        assert!(!events[0].metadata.skip_person_processing);
+    }
+
+    #[test]
+    fn none_limiter_still_emits_event_restriction_counter() {
+        // force_overflow is independent of the limiter, so the
+        // event_restriction short-circuit must still fire (and emit its
+        // counter) even when the limiter is absent.
+        let mut events = vec![build_event(DataType::AnalyticsMain, "phc_t", "u", true)];
+
+        stamp_overflow_reason(&mut events, None);
+
+        assert_eq!(
+            events[0].metadata.overflow_reason, None,
+            "force_overflow leaves overflow_reason as None"
+        );
+    }
+
+    #[test]
+    fn empty_batch_is_a_no_op() {
+        let limiter = build_limiter(10, 10, None, false);
+        let mut events: Vec<ProcessedEvent> = Vec::new();
+        stamp_overflow_reason(&mut events, Some(&limiter));
+    }
+
+    #[test]
+    fn mixed_batch_stamps_only_analytics_main_entries() {
+        // Realistic OTEL-shaped batch: a few AnalyticsMain spans plus one
+        // HeatmapMain that snuck in. Only the AnalyticsMain over-budget
+        // entries should be stamped.
+        let limiter = build_limiter(1, 1, None, true);
+        let mut events = vec![
+            build_event(DataType::AnalyticsMain, "phc_t", "user_a", false),
+            build_event(DataType::HeatmapMain, "phc_t", "user_a", false),
+            build_event(DataType::AnalyticsMain, "phc_t", "user_a", false),
+        ];
+
+        stamp_overflow_reason(&mut events, Some(&limiter));
+
+        assert_eq!(
+            events[0].metadata.overflow_reason, None,
+            "first AnalyticsMain within burst"
+        );
+        assert_eq!(
+            events[1].metadata.overflow_reason, None,
+            "HeatmapMain must be skipped regardless of limiter state"
+        );
+        assert_eq!(
+            events[2].metadata.overflow_reason,
+            Some(OverflowReason::RateLimited {
+                preserve_locality: true
+            }),
+            "second AnalyticsMain over budget"
+        );
+    }
+}

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -527,34 +527,16 @@ mod tests {
 
     // ============ Restriction tests ============
 
-    use crate::api::CaptureError;
     use crate::config::CaptureMode;
     use crate::event_restrictions::{
         EventRestrictionService, Restriction, RestrictionManager, RestrictionScope,
     };
+    use crate::sinks::test_sink::MockSink;
     use crate::sinks::Event;
-    use crate::v0_request::ProcessedEvent;
-    use async_trait::async_trait;
     use common_redis::MockRedisClient;
     use limiters::redis::{QuotaResource, ServiceName, OVERFLOW_LIMITER_CACHE_KEY};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
-
-    struct MockSink {
-        events: Arc<Mutex<Vec<ProcessedEvent>>>,
-    }
-
-    #[async_trait]
-    impl Event for MockSink {
-        async fn send(&self, event: ProcessedEvent) -> Result<(), CaptureError> {
-            self.events.lock().unwrap().push(event);
-            Ok(())
-        }
-        async fn send_batch(&self, events: Vec<ProcessedEvent>) -> Result<(), CaptureError> {
-            self.events.lock().unwrap().extend(events);
-            Ok(())
-        }
-    }
 
     fn create_test_recording() -> RawRecording {
         let json = json!({
@@ -1096,28 +1078,16 @@ mod tests {
     // metadata and produces to `replay_overflow_topic` with the session_id
     // as partition key.
 
-    use crate::sinks::kafka::{KafkaSinkBase, KafkaTopicConfig};
+    use crate::sinks::kafka::{test_topics, KafkaSinkBase};
     use crate::sinks::producer::MockKafkaProducer;
-
-    fn e2e_topics() -> KafkaTopicConfig {
-        KafkaTopicConfig {
-            main_topic: "events_main".to_string(),
-            overflow_topic: "events_overflow".to_string(),
-            historical_topic: "events_historical".to_string(),
-            client_ingestion_warning_topic: "client_warning".to_string(),
-            heatmaps_topic: "heatmaps".to_string(),
-            replay_overflow_topic: "replay_overflow".to_string(),
-            dlq_topic: "events_dlq".to_string(),
-            error_tracking_topic: "error_tracking".to_string(),
-            traces_topic: "traces".to_string(),
-        }
-    }
 
     #[tokio::test]
     async fn e2e_replay_limited_pipeline_to_sink_routes_to_replay_overflow_with_session_key() {
         let producer = MockKafkaProducer::new();
-        let sink: Arc<dyn Event + Send + Sync> =
-            Arc::new(KafkaSinkBase::with_producer(producer.clone(), e2e_topics()));
+        let sink: Arc<dyn Event + Send + Sync> = Arc::new(KafkaSinkBase::with_producer(
+            producer.clone(),
+            test_topics(),
+        ));
 
         let limiter = build_replay_limiter(vec!["test-session-123".to_string()]).await;
         let recording = create_test_recording(); // session_id = "test-session-123"

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -932,4 +932,211 @@ mod tests {
             Some(OverflowReason::ReplayLimited)
         );
     }
+
+    // ============ replay overflow histogram tests ============
+    // The pipeline records `capture_pipeline_replay_overflow_check_duration_seconds`
+    // around the redis `is_limited` call. These tests pin the contract that it
+    // fires exactly once per call when the limiter branch runs, and NOT at all
+    // when `force_overflow` short-circuits the limiter check.
+
+    /// Snapshot of histogram metric names present after running the provided
+    /// future inside a local DebuggingRecorder scope. Uses a current-thread
+    /// runtime so the thread-local recorder guard stays visible across awaits.
+    async fn run_with_metric_capture<F, Fut, T>(f: F) -> (Vec<String>, T)
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = T>,
+    {
+        use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let _guard = metrics::set_default_local_recorder(&recorder);
+
+        let result = f().await;
+
+        // Collect every histogram metric name that received at least one sample.
+        let hist_names: Vec<String> = snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .filter_map(|(key, _, _, value)| match value {
+                DebugValue::Histogram(samples) if !samples.is_empty() => {
+                    Some(key.key().name().to_string())
+                }
+                _ => None,
+            })
+            .collect();
+
+        (hist_names, result)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_replay_overflow_histogram_recorded_when_limited() {
+        let (histograms, _) = run_with_metric_capture(|| async {
+            let events_captured = Arc::new(Mutex::new(Vec::new()));
+            let sink: Arc<dyn Event + Send + Sync> = Arc::new(MockSink {
+                events: events_captured,
+            });
+            let limiter = build_replay_limiter(vec!["test-session-123".to_string()]).await;
+            let recording = create_test_recording();
+            let context = create_test_context();
+            process_replay_events(sink, None, Some(limiter), vec![recording], &context)
+                .await
+                .unwrap();
+        })
+        .await;
+
+        assert!(
+            histograms
+                .iter()
+                .any(|n| n == "capture_pipeline_replay_overflow_check_duration_seconds"),
+            "histogram must fire when limiter is present and session is limited; got {histograms:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_replay_overflow_histogram_recorded_when_not_limited() {
+        let (histograms, _) = run_with_metric_capture(|| async {
+            let events_captured = Arc::new(Mutex::new(Vec::new()));
+            let sink: Arc<dyn Event + Send + Sync> = Arc::new(MockSink {
+                events: events_captured,
+            });
+            // Session NOT in the limited set -> limiter returns false, but
+            // the histogram must still record the call duration.
+            let limiter = build_replay_limiter(vec!["some-other-session".to_string()]).await;
+            let recording = create_test_recording();
+            let context = create_test_context();
+            process_replay_events(sink, None, Some(limiter), vec![recording], &context)
+                .await
+                .unwrap();
+        })
+        .await;
+
+        assert!(
+            histograms
+                .iter()
+                .any(|n| n == "capture_pipeline_replay_overflow_check_duration_seconds"),
+            "histogram must fire regardless of limiter result; got {histograms:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_replay_overflow_histogram_not_recorded_on_force_overflow() {
+        let (histograms, _) = run_with_metric_capture(|| async {
+            let events_captured = Arc::new(Mutex::new(Vec::new()));
+            let sink: Arc<dyn Event + Send + Sync> = Arc::new(MockSink {
+                events: events_captured,
+            });
+
+            // force_overflow short-circuits the limiter branch; the pipeline
+            // must skip the redis call AND the histogram record.
+            let service =
+                EventRestrictionService::new(CaptureMode::Recordings, Duration::from_secs(300));
+            let mut manager = RestrictionManager::new();
+            manager.restrictions.insert(
+                "test_token".to_string(),
+                vec![Restriction {
+                    restriction_type: RestrictionType::ForceOverflow,
+                    scope: RestrictionScope::AllEvents,
+                    args: None,
+                }],
+            );
+            service.update(manager).await;
+
+            let limiter = build_replay_limiter(vec!["test-session-123".to_string()]).await;
+            let recording = create_test_recording();
+            let context = create_test_context();
+            process_replay_events(
+                sink,
+                Some(service),
+                Some(limiter),
+                vec![recording],
+                &context,
+            )
+            .await
+            .unwrap();
+        })
+        .await;
+
+        assert!(
+            !histograms
+                .iter()
+                .any(|n| n == "capture_pipeline_replay_overflow_check_duration_seconds"),
+            "histogram must NOT fire when force_overflow short-circuits limiter; got {histograms:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_replay_overflow_histogram_not_recorded_when_limiter_absent() {
+        let (histograms, _) = run_with_metric_capture(|| async {
+            let events_captured = Arc::new(Mutex::new(Vec::new()));
+            let sink: Arc<dyn Event + Send + Sync> = Arc::new(MockSink {
+                events: events_captured,
+            });
+            let recording = create_test_recording();
+            let context = create_test_context();
+            process_replay_events(sink, None, None, vec![recording], &context)
+                .await
+                .unwrap();
+        })
+        .await;
+
+        assert!(
+            !histograms
+                .iter()
+                .any(|n| n == "capture_pipeline_replay_overflow_check_duration_seconds"),
+            "histogram must NOT fire when limiter is absent; got {histograms:?}"
+        );
+    }
+
+    // ============ end-to-end pipeline -> real KafkaSinkBase tests ============
+    // Pins the pipeline-to-sink contract for replay overflow routing: the
+    // pipeline stamps `overflow_reason = ReplayLimited`; the sink reads the
+    // metadata and produces to `replay_overflow_topic` with the session_id
+    // as partition key.
+
+    use crate::sinks::kafka::{KafkaSinkBase, KafkaTopicConfig};
+    use crate::sinks::producer::MockKafkaProducer;
+
+    fn e2e_topics() -> KafkaTopicConfig {
+        KafkaTopicConfig {
+            main_topic: "events_main".to_string(),
+            overflow_topic: "events_overflow".to_string(),
+            historical_topic: "events_historical".to_string(),
+            client_ingestion_warning_topic: "client_warning".to_string(),
+            heatmaps_topic: "heatmaps".to_string(),
+            replay_overflow_topic: "replay_overflow".to_string(),
+            dlq_topic: "events_dlq".to_string(),
+            error_tracking_topic: "error_tracking".to_string(),
+            traces_topic: "traces".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn e2e_replay_limited_pipeline_to_sink_routes_to_replay_overflow_with_session_key() {
+        let producer = MockKafkaProducer::new();
+        let sink: Arc<dyn Event + Send + Sync> =
+            Arc::new(KafkaSinkBase::with_producer(producer.clone(), e2e_topics()));
+
+        let limiter = build_replay_limiter(vec!["test-session-123".to_string()]).await;
+        let recording = create_test_recording(); // session_id = "test-session-123"
+        let context = create_test_context();
+
+        process_replay_events(sink, None, Some(limiter), vec![recording], &context)
+            .await
+            .unwrap();
+
+        let records = producer.get_records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].topic, "replay_overflow",
+            "ReplayLimited must route to replay_overflow topic"
+        );
+        assert_eq!(
+            records[0].key.as_deref(),
+            Some("test-session-123"),
+            "replay overflow keeps session_id partition key"
+        );
+    }
 }

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -14,8 +14,11 @@ use std::sync::Arc;
 
 use chrono::DateTime;
 use common_types::{CapturedEvent, HasEventName};
+use limiters::redis::RedisLimiter;
+use metrics::{counter, histogram};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use tokio::time::Instant;
 use tracing::{error, instrument, Span};
 use uuid::Uuid;
 
@@ -28,7 +31,9 @@ use crate::{
     prometheus::report_dropped_events,
     sinks,
     utils::uuid_v7,
-    v0_request::{DataType, ProcessedEvent, ProcessedEventMetadata, ProcessingContext},
+    v0_request::{
+        DataType, OverflowReason, ProcessedEvent, ProcessedEventMetadata, ProcessingContext,
+    },
 };
 
 /// A recording event optimized for minimal deserialization overhead.
@@ -157,17 +162,25 @@ impl HasEventName for RawRecording {
     }
 }
 
-/// Process recording (session replay) events with optimized serialization
+/// Process recording (session replay) events with optimized serialization.
 ///
 /// This function is optimized to avoid double serialization of snapshot data:
 /// - Extract metadata fields (session_id, window_id, etc.)
 /// - Keep snapshot_data as Value (already parsed from JSON)
 /// - Serialize directly to final format using serde::Serialize
 ///
+/// Routing policy (event restrictions + replay overflow) is decided here and
+/// stamped onto `ProcessedEventMetadata`. The kafka sink is a pure mechanism
+/// layer — it reads `overflow_reason`, `force_overflow`, `redirect_to_dlq`,
+/// and `redirect_to_topic` from the metadata and picks the topic/key
+/// accordingly. `replay_overflow_limiter` is the redis-backed limiter keyed
+/// on session_id that signals rerouting to the replay overflow topic.
+///
 #[instrument(skip_all, fields(events = events.len(), session_id, request_id))]
 pub async fn process_replay_events(
     sink: Arc<dyn sinks::Event + Send + Sync>,
     restriction_service: Option<EventRestrictionService>,
+    replay_overflow_limiter: Option<Arc<RedisLimiter>>,
     events: Vec<RawRecording>,
     context: &ProcessingContext,
 ) -> Result<(), CaptureError> {
@@ -302,15 +315,49 @@ pub async fn process_replay_events(
         }
     }
 
+    // Replay overflow routing stage. This used to live in the kafka sink;
+    // moving it here keeps the sink as a mechanism-only layer. `force_overflow`
+    // short-circuits the limiter check (same semantics as the old sink path).
+    // We preserve the old `capture_events_rerouted_overflow{reason=...}`
+    // counter labels so existing dashboards keep working, and add a new
+    // `capture_pipeline_replay_overflow_check_duration_seconds` histogram
+    // around the redis call to make the added pipeline stage observable.
+    let force_overflow = applied.force_overflow();
+    let overflow_reason = if force_overflow {
+        counter!(
+            "capture_events_rerouted_overflow",
+            "reason" => "event_restriction",
+        )
+        .increment(1);
+        // The sink sees `force_overflow = true` and routes; no overflow_reason
+        // needed in that case (None leaves room for `force_overflow` to drive
+        // the sink's routing switch without double-stamping).
+        None
+    } else if let Some(ref limiter) = replay_overflow_limiter {
+        let started = Instant::now();
+        let is_overflowing = limiter.is_limited(session_id_str).await;
+        histogram!("capture_pipeline_replay_overflow_check_duration_seconds")
+            .record(started.elapsed().as_secs_f64());
+
+        if is_overflowing {
+            Some(OverflowReason::ReplayLimited)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
     let metadata = ProcessedEventMetadata {
         data_type: DataType::SnapshotMain,
         session_id: Some(session_id_str.to_string()),
         computed_timestamp: Some(computed_timestamp),
         event_name: "$snapshot_items".to_string(),
-        force_overflow: applied.force_overflow(),
+        force_overflow,
         skip_person_processing: applied.skip_person_processing(),
         redirect_to_dlq: applied.redirect_to_dlq(),
         redirect_to_topic: applied.redirect_to_topic().map(|s| s.to_string()),
+        overflow_reason,
     };
 
     // Serialize snapshot data synchronously
@@ -561,7 +608,8 @@ mod tests {
         let recording = create_test_recording();
         let context = create_test_context();
 
-        let result = process_replay_events(sink, Some(service), vec![recording], &context).await;
+        let result =
+            process_replay_events(sink, Some(service), None, vec![recording], &context).await;
 
         assert!(result.is_ok());
         assert!(events_captured.lock().unwrap().is_empty());
@@ -591,7 +639,8 @@ mod tests {
         let recording = create_test_recording();
         let context = create_test_context();
 
-        let result = process_replay_events(sink, Some(service), vec![recording], &context).await;
+        let result =
+            process_replay_events(sink, Some(service), None, vec![recording], &context).await;
 
         assert!(result.is_ok());
         let captured = events_captured.lock().unwrap();
@@ -623,7 +672,8 @@ mod tests {
         let recording = create_test_recording();
         let context = create_test_context();
 
-        let result = process_replay_events(sink, Some(service), vec![recording], &context).await;
+        let result =
+            process_replay_events(sink, Some(service), None, vec![recording], &context).await;
 
         assert!(result.is_ok());
         let captured = events_captured.lock().unwrap();
@@ -655,7 +705,8 @@ mod tests {
         let recording = create_test_recording();
         let context = create_test_context();
 
-        let result = process_replay_events(sink, Some(service), vec![recording], &context).await;
+        let result =
+            process_replay_events(sink, Some(service), None, vec![recording], &context).await;
 
         assert!(result.is_ok());
         let captured = events_captured.lock().unwrap();
@@ -673,7 +724,7 @@ mod tests {
         let recording = create_test_recording();
         let context = create_test_context();
 
-        let result = process_replay_events(sink, None, vec![recording], &context).await;
+        let result = process_replay_events(sink, None, None, vec![recording], &context).await;
 
         assert!(result.is_ok());
         let captured = events_captured.lock().unwrap();
@@ -710,11 +761,176 @@ mod tests {
         let recording = create_test_recording(); // has session_id "test-session-123"
         let context = create_test_context();
 
-        let result = process_replay_events(sink, Some(service), vec![recording], &context).await;
+        let result =
+            process_replay_events(sink, Some(service), None, vec![recording], &context).await;
 
         // Should NOT be dropped because session_id doesn't match filter
         assert!(result.is_ok());
         let captured = events_captured.lock().unwrap();
         assert_eq!(captured.len(), 1);
+    }
+
+    // ============ replay overflow stamping tests ============
+    // Exercise the pipeline's new replay overflow stamping stage
+    // (moved here from the kafka sink's prepare_record). The limiter is
+    // backed by a MockRedisClient primed with a specific session id.
+
+    use common_redis::MockRedisClient;
+    use limiters::redis::{QuotaResource, RedisLimiter, ServiceName, OVERFLOW_LIMITER_CACHE_KEY};
+
+    async fn build_replay_limiter(limited_session_ids: Vec<String>) -> Arc<RedisLimiter> {
+        let client = Arc::new(
+            MockRedisClient::new()
+                .zrangebyscore_ret("@posthog/capture-overflow/replay", limited_session_ids),
+        );
+        let limiter = RedisLimiter::new(
+            Duration::from_secs(1),
+            client,
+            OVERFLOW_LIMITER_CACHE_KEY.to_string(),
+            None,
+            QuotaResource::Replay,
+            ServiceName::Capture,
+        )
+        .expect("failed to build test replay limiter");
+        // The limiter polls redis on a background interval; give the first
+        // tick a moment to populate the in-memory `limited` DashMap before
+        // any is_limited call.
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        Arc::new(limiter)
+    }
+
+    #[tokio::test]
+    async fn test_replay_overflow_stamp_none_when_limiter_absent() {
+        let events_captured = Arc::new(Mutex::new(Vec::new()));
+        let sink: Arc<dyn Event + Send + Sync> = Arc::new(MockSink {
+            events: events_captured.clone(),
+        });
+
+        let recording = create_test_recording();
+        let context = create_test_context();
+
+        let result = process_replay_events(sink, None, None, vec![recording], &context).await;
+        assert!(result.is_ok());
+
+        let captured = events_captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].metadata.overflow_reason, None);
+    }
+
+    #[tokio::test]
+    async fn test_replay_overflow_stamp_replay_limited_for_matching_session() {
+        let events_captured = Arc::new(Mutex::new(Vec::new()));
+        let sink: Arc<dyn Event + Send + Sync> = Arc::new(MockSink {
+            events: events_captured.clone(),
+        });
+
+        let limiter = build_replay_limiter(vec!["test-session-123".to_string()]).await;
+        let recording = create_test_recording(); // session_id = "test-session-123"
+        let context = create_test_context();
+
+        let result =
+            process_replay_events(sink, None, Some(limiter), vec![recording], &context).await;
+        assert!(result.is_ok());
+
+        let captured = events_captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(
+            captured[0].metadata.overflow_reason,
+            Some(OverflowReason::ReplayLimited)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_replay_overflow_stamp_none_for_unlimited_session() {
+        let events_captured = Arc::new(Mutex::new(Vec::new()));
+        let sink: Arc<dyn Event + Send + Sync> = Arc::new(MockSink {
+            events: events_captured.clone(),
+        });
+
+        let limiter = build_replay_limiter(vec!["some-other-session".to_string()]).await;
+        let recording = create_test_recording();
+        let context = create_test_context();
+
+        let result =
+            process_replay_events(sink, None, Some(limiter), vec![recording], &context).await;
+        assert!(result.is_ok());
+
+        let captured = events_captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].metadata.overflow_reason, None);
+    }
+
+    #[tokio::test]
+    async fn test_replay_overflow_force_overflow_short_circuits_limiter() {
+        // When event restrictions set force_overflow on a session, the pipeline
+        // must leave overflow_reason = None so the sink routes on force_overflow
+        // directly (matching the old sink precedence).
+        let events_captured = Arc::new(Mutex::new(Vec::new()));
+        let sink: Arc<dyn Event + Send + Sync> = Arc::new(MockSink {
+            events: events_captured.clone(),
+        });
+
+        let service =
+            EventRestrictionService::new(CaptureMode::Recordings, Duration::from_secs(300));
+        let mut manager = RestrictionManager::new();
+        manager.restrictions.insert(
+            "test_token".to_string(),
+            vec![Restriction {
+                restriction_type: RestrictionType::ForceOverflow,
+                scope: RestrictionScope::AllEvents,
+                args: None,
+            }],
+        );
+        service.update(manager).await;
+
+        // Even though the session is in the limited set, force_overflow wins.
+        let limiter = build_replay_limiter(vec!["test-session-123".to_string()]).await;
+        let recording = create_test_recording();
+        let context = create_test_context();
+
+        let result = process_replay_events(
+            sink,
+            Some(service),
+            Some(limiter),
+            vec![recording],
+            &context,
+        )
+        .await;
+        assert!(result.is_ok());
+
+        let captured = events_captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert!(captured[0].metadata.force_overflow);
+        assert_eq!(captured[0].metadata.overflow_reason, None);
+    }
+
+    #[tokio::test]
+    async fn test_replay_overflow_multiple_snapshots_share_batch_decision() {
+        // process_replay_events folds all RawRecording items in a batch into a
+        // single ProcessedEvent keyed on session_id, so overflow applies
+        // uniformly to the batch. This guards against a regression where a
+        // per-item check might diverge from batch-level routing.
+        let events_captured = Arc::new(Mutex::new(Vec::new()));
+        let sink: Arc<dyn Event + Send + Sync> = Arc::new(MockSink {
+            events: events_captured.clone(),
+        });
+
+        let limiter = build_replay_limiter(vec!["test-session-123".to_string()]).await;
+        let recordings = vec![create_test_recording(), create_test_recording()];
+        let context = create_test_context();
+
+        let result = process_replay_events(sink, None, Some(limiter), recordings, &context).await;
+        assert!(result.is_ok());
+
+        let captured = events_captured.lock().unwrap();
+        assert_eq!(
+            captured.len(),
+            1,
+            "batch of snapshots must collapse to a single CapturedEvent"
+        );
+        assert_eq!(
+            captured[0].metadata.overflow_reason,
+            Some(OverflowReason::ReplayLimited)
+        );
     }
 }

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -535,6 +535,8 @@ mod tests {
     use crate::sinks::Event;
     use crate::v0_request::ProcessedEvent;
     use async_trait::async_trait;
+    use common_redis::MockRedisClient;
+    use limiters::redis::{QuotaResource, ServiceName, OVERFLOW_LIMITER_CACHE_KEY};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
@@ -774,9 +776,6 @@ mod tests {
     // Exercise the pipeline's new replay overflow stamping stage
     // (moved here from the kafka sink's prepare_record). The limiter is
     // backed by a MockRedisClient primed with a specific session id.
-
-    use common_redis::MockRedisClient;
-    use limiters::redis::{QuotaResource, RedisLimiter, ServiceName, OVERFLOW_LIMITER_CACHE_KEY};
 
     async fn build_replay_limiter(limited_session_ids: Vec<String>) -> Arc<RedisLimiter> {
         let client = Arc::new(

--- a/rust/capture/src/global_rate_limiter.rs
+++ b/rust/capture/src/global_rate_limiter.rs
@@ -234,6 +234,61 @@ impl GlobalRateLimiter {
         }
     }
 
+    /// Test helper: build a `GlobalRateLimiter` that returns `Limited` for any
+    /// key in `limited_keys` and `Allowed` otherwise. Custom limits always
+    /// return `NotApplicable`. Shared across capture pipeline tests that need
+    /// to simulate per-key global rate limiting.
+    #[cfg(test)]
+    pub(crate) fn mock_limiting(limited_keys: &[&str]) -> Self {
+        use async_trait::async_trait;
+        use std::collections::HashSet;
+
+        struct MockLimitingLimiter {
+            limited_keys: HashSet<String>,
+        }
+
+        #[async_trait]
+        impl CommonGlobalRateLimiter for MockLimitingLimiter {
+            async fn check_limit(
+                &self,
+                key: &str,
+                _count: u64,
+                _timestamp: Option<DateTime<Utc>>,
+            ) -> EvalResult {
+                if self.limited_keys.contains(key) {
+                    EvalResult::Limited(GlobalRateLimitResponse {
+                        key: key.to_string(),
+                        current_count: 100.0,
+                        threshold: 10,
+                        window_interval: std::time::Duration::from_secs(60),
+                        sync_interval: std::time::Duration::from_secs(15),
+                        is_custom_limited: false,
+                    })
+                } else {
+                    EvalResult::Allowed
+                }
+            }
+
+            async fn check_custom_limit(
+                &self,
+                _key: &str,
+                _count: u64,
+                _timestamp: Option<DateTime<Utc>>,
+            ) -> EvalResult {
+                EvalResult::NotApplicable
+            }
+
+            fn is_custom_key(&self, _key: &str) -> bool {
+                false
+            }
+
+            fn shutdown(&mut self) {}
+        }
+
+        let limited_keys: HashSet<String> = limited_keys.iter().map(|k| k.to_string()).collect();
+        Self::new_with(MockLimitingLimiter { limited_keys })
+    }
+
     // In capture deploys, the custom keys and rate limit thresholds should be
     // supplied as a CSV list of <string_key>=<u64_value> elements. malformed
     // elements will be logged and skipped during limiter initialization

--- a/rust/capture/src/otel/filtering.rs
+++ b/rust/capture/src/otel/filtering.rs
@@ -122,6 +122,7 @@ pub fn build_events(
             skip_person_processing: restrictions.skip_person_processing(),
             redirect_to_dlq: restrictions.redirect_to_dlq(),
             redirect_to_topic: restrictions.redirect_to_topic().map(|s| s.to_string()),
+            overflow_reason: None,
         };
 
         processed.push(ProcessedEvent {

--- a/rust/capture/src/otel/mod.rs
+++ b/rust/capture/src/otel/mod.rs
@@ -16,6 +16,7 @@ use serde_json::json;
 use tracing::{debug, instrument, warn, Span};
 
 use crate::api::{CaptureError, CaptureResponse, CaptureResponseCode};
+use crate::events::overflow_stamping::stamp_overflow_reason;
 use crate::extractors::extract_body_with_timeout;
 use crate::prometheus::{report_dropped_events, report_internal_error_metrics};
 use crate::router::State as AppState;
@@ -201,12 +202,21 @@ pub async fn otel_handler(
         None => Default::default(),
     };
 
-    let processed_events =
+    let mut processed_events =
         filtering::build_events(span_events, &token, &client_ip, received_at, &restrictions)
             .map_err(|e| {
                 report_internal_error_metrics(e.to_metric_tag(), "otel_processing");
                 e.into_response()
             })?;
+
+    // Apply the in-process OverflowLimiter governor to every AnalyticsMain
+    // span in the batch before handing off to the sink. OTEL bypasses
+    // `events::analytics::process_events`, so this call is what preserves
+    // OverflowLimiter parity on `capture-ai-*` deploys (where
+    // `OVERFLOW_ENABLED=true`). Per-span key evaluation matches the analytics
+    // batch path: spans with different `token:distinct_id` keys can land
+    // with different `overflow_reason` stamps in the same batch.
+    stamp_overflow_reason(&mut processed_events, state.overflow_limiter.as_ref());
 
     state.sink.send_batch(processed_events).await.map_err(|e| {
         report_internal_error_metrics(e.to_metric_tag(), "otel_sink");

--- a/rust/capture/src/prometheus.rs
+++ b/rust/capture/src/prometheus.rs
@@ -113,6 +113,16 @@ pub fn setup_metrics_recorder(role: String, capture_mode: &'static str) -> Prome
         0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 300.0, 3600.0, 86400.0,
     ];
 
+    // Kafka produce ack duration (milliseconds), measured app-side from
+    // `send_result()` returning to broker ack / error / cancellation.
+    // Dense at low end where healthy acks live; widens into seconds / minutes
+    // to capture the long tail (retries, broker stalls, acks=all replication).
+    // Final bucket is 5 minutes; anything slower lands in +Inf.
+    const KAFKA_PRODUCE_ACK_MS: &[f64] = &[
+        0.5, 1.0, 2.0, 5.0, 10.0, 15.0, 25.0, 50.0, 75.0, 100.0, 150.0, 250.0, 500.0, 1000.0,
+        2500.0, 5000.0, 10000.0, 30000.0, 60000.0, 120000.0, 300000.0,
+    ];
+
     PrometheusBuilder::new()
         .add_global_label("role", role)
         .add_global_label("capture_mode", capture_mode)
@@ -191,6 +201,11 @@ pub fn setup_metrics_recorder(role: String, capture_mode: &'static str) -> Prome
         .set_buckets_for_metric(
             Matcher::Full("capture_client_clock_skew_seconds".to_string()),
             CLOCK_SKEW_SECONDS,
+        )
+        .unwrap()
+        .set_buckets_for_metric(
+            Matcher::Full("capture_kafka_produce_ack_duration_ms".to_string()),
+            KAFKA_PRODUCE_ACK_MS,
         )
         .unwrap()
         .install_recorder()

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -22,6 +22,8 @@ use crate::test_endpoint;
 use crate::v0_request::DataType;
 use crate::{ai_endpoint, sinks, time::TimeSource, v0_endpoint};
 use common_redis::Client;
+use limiters::overflow::OverflowLimiter;
+use limiters::redis::RedisLimiter;
 use limiters::token_dropper::TokenDropper;
 
 use crate::config::CaptureMode;
@@ -50,6 +52,20 @@ pub struct State {
     pub ai_blob_storage: Option<Arc<dyn BlobStorage>>,
     pub body_chunk_read_timeout: Option<Duration>,
     pub body_read_chunk_size_kb: usize,
+    /// In-process overflow limiter for analytics events. When present, the
+    /// analytics pipeline calls `is_limited` per event and stamps
+    /// `ProcessedEventMetadata::overflow_reason` with `ForceLimited` or
+    /// `RateLimited { .. }` so the kafka sink can route to the overflow topic.
+    /// This lives in `State` (not in the sink) so routing policy sits in the
+    /// pipeline alongside every other routing decision, and so the sink stays
+    /// a pure mechanism layer with cheap Arc-based clones.
+    pub overflow_limiter: Option<Arc<OverflowLimiter>>,
+    /// Redis-backed replay overflow limiter for session recording sessions.
+    /// When present, the recordings pipeline calls `is_limited(session_id)`
+    /// and stamps `ProcessedEventMetadata::overflow_reason = ReplayLimited` so
+    /// the kafka sink can route to the replay overflow topic. Same rationale
+    /// as `overflow_limiter` above.
+    pub replay_overflow_limiter: Option<Arc<RedisLimiter>>,
 }
 
 #[derive(Clone)]
@@ -113,6 +129,8 @@ pub fn router<TZ: TimeSource + Send + Sync + 'static, R: Client + Send + Sync + 
     request_timeout_seconds: Option<u64>,
     body_chunk_read_timeout_ms: Option<u64>,
     body_read_chunk_size_kb: usize,
+    overflow_limiter: Option<Arc<OverflowLimiter>>,
+    replay_overflow_limiter: Option<Arc<RedisLimiter>>,
 ) -> Router {
     let state = State {
         sink,
@@ -133,6 +151,8 @@ pub fn router<TZ: TimeSource + Send + Sync + 'static, R: Client + Send + Sync + 
         ai_blob_storage,
         body_chunk_read_timeout: body_chunk_read_timeout_ms.map(Duration::from_millis),
         body_read_chunk_size_kb,
+        overflow_limiter,
+        replay_overflow_limiter,
     };
 
     // Very permissive CORS policy, as old SDK versions

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -52,10 +52,17 @@ pub struct State {
     pub ai_blob_storage: Option<Arc<dyn BlobStorage>>,
     pub body_chunk_read_timeout: Option<Duration>,
     pub body_read_chunk_size_kb: usize,
-    /// In-process overflow limiter for analytics events. When present, the
-    /// analytics pipeline calls `is_limited` per event and stamps
+    /// In-process overflow limiter (governor-backed) for `DataType::AnalyticsMain`
+    /// events. When present, every handler that emits analytics events runs
+    /// the shared `events::overflow_stamping::stamp_overflow_reason` helper,
+    /// which calls `is_limited` per event and stamps
     /// `ProcessedEventMetadata::overflow_reason` with `ForceLimited` or
     /// `RateLimited { .. }` so the kafka sink can route to the overflow topic.
+    /// Call sites that consult this limiter:
+    /// * `events::analytics::process_events` (analytics batch path)
+    /// * `ai_endpoint::ai_handler` (`/i/v0/ai`)
+    /// * `otel::otel_handler` (`/i/v0/ai/otel`)
+    ///
     /// This lives in `State` (not in the sink) so routing policy sits in the
     /// pipeline alongside every other routing decision, and so the sink stays
     /// a pure mechanism layer with cheap Arc-based clones.

--- a/rust/capture/src/setup.rs
+++ b/rust/capture/src/setup.rs
@@ -146,8 +146,57 @@ pub async fn build_components(config: Config, handles: LifecycleHandles) -> Capt
         CaptureMode::Recordings => config.kafka.kafka_producer_message_max_bytes as usize,
     };
 
+    // Build the overflow limiters here (not inside the sink) so routing
+    // policy lives in `router::State` alongside every other pipeline-level
+    // decision. The kafka sink used to own these; after the refactor it is
+    // a pure mechanism layer and reads `metadata.overflow_reason` that the
+    // pipeline stamps upstream. See `router::State::overflow_limiter` and
+    // `router::State::replay_overflow_limiter`.
+    let overflow_limiter: Option<Arc<OverflowLimiter>> = if config.overflow_enabled {
+        let partition = OverflowLimiter::new(
+            config.overflow_per_second_limit,
+            config.overflow_burst_limit,
+            config.ingestion_force_overflow_by_token_distinct_id.clone(),
+            config.overflow_preserve_partition_locality,
+        );
+
+        if config.export_prometheus {
+            let partition = partition.clone();
+            tokio::spawn(async move {
+                partition.report_metrics().await;
+            });
+        }
+
+        {
+            // Keep the governor's per-key state from growing unbounded.
+            let partition = partition.clone();
+            tokio::spawn(async move {
+                partition.clean_state().await;
+            });
+        }
+
+        Some(Arc::new(partition))
+    } else {
+        None
+    };
+
+    let replay_overflow_limiter: Option<Arc<RedisLimiter>> = match config.capture_mode {
+        CaptureMode::Recordings => Some(Arc::new(
+            RedisLimiter::new(
+                Duration::from_secs(5),
+                redis_client.clone(),
+                OVERFLOW_LIMITER_CACHE_KEY.to_string(),
+                config.redis_key_prefix.clone(),
+                QuotaResource::Replay,
+                ServiceName::Capture,
+            )
+            .expect("failed to start replay overflow limiter"),
+        )),
+        _ => None,
+    };
+
     let sink: Arc<dyn Event + Send + Sync> = Arc::from(
-        create_sink(&config, redis_client.clone(), sink_handle, advisory_handle)
+        create_sink(&config, sink_handle, advisory_handle)
             .await
             .expect("failed to create sink"),
     );
@@ -226,6 +275,8 @@ pub async fn build_components(config: Config, handles: LifecycleHandles) -> Capt
         config.request_timeout_seconds,
         config.body_chunk_read_timeout_ms,
         config.body_read_chunk_size_kb,
+        overflow_limiter,
+        replay_overflow_limiter,
     );
 
     info!(
@@ -243,7 +294,6 @@ pub async fn build_components(config: Config, handles: LifecycleHandles) -> Capt
 
 async fn create_sink(
     config: &Config,
-    redis_client: Arc<RedisClient>,
     sink_handle: Option<lifecycle::Handle>,
     advisory_handle: Option<lifecycle::Handle>,
 ) -> anyhow::Result<Box<dyn Event + Send + Sync>> {
@@ -254,62 +304,15 @@ async fn create_sink(
         Ok(Box::new(NoOpSink::new()))
     } else {
         let sink_handle = sink_handle.expect("sink lifecycle handle required for Kafka/S3 sinks");
-        let partition = match config.overflow_enabled {
-            false => None,
-            true => {
-                let partition = OverflowLimiter::new(
-                    config.overflow_per_second_limit,
-                    config.overflow_burst_limit,
-                    config.ingestion_force_overflow_by_token_distinct_id.clone(),
-                    config.overflow_preserve_partition_locality,
-                );
-
-                if config.export_prometheus {
-                    let partition = partition.clone();
-                    tokio::spawn(async move {
-                        partition.report_metrics().await;
-                    });
-                }
-
-                {
-                    // Ensure that the rate limiter state does not grow unbounded
-                    let partition = partition.clone();
-                    tokio::spawn(async move {
-                        partition.clean_state().await;
-                    });
-                }
-                Some(partition)
-            }
-        };
-
-        let replay_overflow_limiter = match config.capture_mode {
-            CaptureMode::Recordings => Some(
-                RedisLimiter::new(
-                    Duration::from_secs(5),
-                    redis_client.clone(),
-                    OVERFLOW_LIMITER_CACHE_KEY.to_string(),
-                    config.redis_key_prefix.clone(),
-                    QuotaResource::Replay,
-                    ServiceName::Capture,
-                )
-                .expect("failed to start replay overflow limiter"),
-            ),
-            _ => None,
-        };
 
         if config.s3_fallback_enabled {
             let kafka_handle =
                 advisory_handle.expect("kafka advisory handle required for fallback");
             let s3_handle = sink_handle;
 
-            let kafka_sink = KafkaSink::new(
-                config.kafka.clone(),
-                kafka_handle.clone(),
-                partition,
-                replay_overflow_limiter,
-            )
-            .await
-            .expect("failed to start Kafka sink");
+            let kafka_sink = KafkaSink::new(config.kafka.clone(), kafka_handle.clone())
+                .await
+                .expect("failed to start Kafka sink");
 
             let s3_sink = S3Sink::new(
                 config
@@ -329,14 +332,9 @@ async fn create_sink(
                 kafka_handle,
             )))
         } else {
-            let kafka_sink = KafkaSink::new(
-                config.kafka.clone(),
-                sink_handle,
-                partition,
-                replay_overflow_limiter,
-            )
-            .await
-            .expect("failed to start Kafka sink");
+            let kafka_sink = KafkaSink::new(config.kafka.clone(), sink_handle)
+                .await
+                .expect("failed to start Kafka sink");
 
             Ok(Box::new(kafka_sink))
         }

--- a/rust/capture/src/sinks/fallback.rs
+++ b/rust/capture/src/sinks/fallback.rs
@@ -160,6 +160,7 @@ mod tests {
                 skip_person_processing: false,
                 redirect_to_dlq: false,
                 redirect_to_topic: None,
+                overflow_reason: None,
             },
         };
 
@@ -209,6 +210,7 @@ mod tests {
                 skip_person_processing: false,
                 redirect_to_dlq: false,
                 redirect_to_topic: None,
+                overflow_reason: None,
             },
         };
 

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -546,6 +546,10 @@ impl<P: KafkaProducer + 'static> Event for KafkaSinkBase<P> {
     #[instrument(skip_all)]
     async fn send_batch(&self, events: Vec<ProcessedEvent>) -> Result<(), CaptureError> {
         let batch_size = events.len();
+        // Record the batch-size histogram up front so the distribution is a
+        // faithful view of batches submitted, not only those that succeeded.
+        // Matches the single-event `send` path which records before any await.
+        histogram!("capture_event_batch_size").record(batch_size as f64);
 
         // Phase 1: parallel prep across tokio workers. Each task returns its
         // input index so we can reassemble results in the original event order
@@ -564,16 +568,26 @@ impl<P: KafkaProducer + 'static> Event for KafkaSinkBase<P> {
 
         let mut prepared: Vec<Option<ProduceRecord>> = (0..batch_size).map(|_| None).collect();
         while let Some(join_result) = prep_set.join_next().await {
-            let (idx, result) = join_result.map_err(|err| {
-                error!("join error while preparing Kafka record: {err:#}");
-                CaptureError::RetryableSinkError
-            })?;
+            let (idx, result) = match join_result {
+                Err(err) => {
+                    error!("join error while preparing Kafka record: {err:#}");
+                    // Drain remaining prep tasks before returning so they can't
+                    // leak records into librdkafka after we've already failed.
+                    // Record the histogram on the error path too so prep-duration
+                    // stays observable during failures (not just happy path).
+                    prep_set.abort_all();
+                    histogram!("capture_kafka_batch_prep_duration_seconds")
+                        .record(prep_start.elapsed().as_secs_f64());
+                    return Err(CaptureError::RetryableSinkError);
+                }
+                Ok(inner) => inner,
+            };
             match result {
                 Ok(record) => prepared[idx] = Some(record),
                 Err(err) => {
-                    // Drain remaining prep tasks before returning so they can't
-                    // leak records into librdkafka after we've already failed.
                     prep_set.abort_all();
+                    histogram!("capture_kafka_batch_prep_duration_seconds")
+                        .record(prep_start.elapsed().as_secs_f64());
                     return Err(err);
                 }
             }
@@ -590,8 +604,18 @@ impl<P: KafkaProducer + 'static> Event for KafkaSinkBase<P> {
         let mut ack_set = JoinSet::new();
         for slot in prepared {
             let record = slot.expect("prep slot not filled");
-            let ack_future = self.enqueue_record(record)?;
-            ack_set.spawn(ack_future);
+            match self.enqueue_record(record) {
+                Ok(ack_future) => {
+                    ack_set.spawn(ack_future);
+                }
+                Err(err) => {
+                    // Record enqueue duration on the error path too so slow-fail
+                    // cases (e.g. QueueFull after a long stall) stay observable.
+                    histogram!("capture_kafka_batch_enqueue_duration_seconds")
+                        .record(enqueue_start.elapsed().as_secs_f64());
+                    return Err(err);
+                }
+            }
         }
         histogram!("capture_kafka_batch_enqueue_duration_seconds")
             .record(enqueue_start.elapsed().as_secs_f64());
@@ -617,7 +641,6 @@ impl<P: KafkaProducer + 'static> Event for KafkaSinkBase<P> {
         .instrument(info_span!("ack_wait_many"))
         .await?;
 
-        histogram!("capture_event_batch_size").record(batch_size as f64);
         Ok(())
     }
 

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -362,7 +362,11 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
     /// by the pipeline). This function does not consult any limiter — it is
     /// pure mechanism. DLQ and custom-topic redirects take priority over
     /// overflow routing, matching the pre-refactor ordering.
-    async fn prepare_record(&self, event: ProcessedEvent) -> Result<ProduceRecord, CaptureError> {
+    ///
+    /// Not `async`: post-refactor there are no await points, and keeping it
+    /// synchronous lets `send_batch`'s serial fast path call it inline without
+    /// any runtime indirection.
+    fn prepare_record(&self, event: ProcessedEvent) -> Result<ProduceRecord, CaptureError> {
         let (event, metadata) = (event.event, event.metadata);
 
         let payload = serde_json::to_string(&event).map_err(|e| {
@@ -435,10 +439,12 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
                     } else {
                         match &overflow_reason {
                             Some(OverflowReason::ForceLimited) => {
-                                // Pipeline already sets skip_person_processing
-                                // for this case, but keep this belt-and-braces
-                                // header write in case a caller stamps the
-                                // reason without the side-effect.
+                                // Redundant with the generic skip-person path
+                                // above (the pipeline stamps
+                                // `metadata.skip_person_processing = true`
+                                // alongside `OverflowReason::ForceLimited`), but
+                                // kept as defense against a future caller that
+                                // stamps the reason without the side-effect.
                                 headers.set_force_disable_person_processing(true);
                                 (&self.topics.overflow_topic, None)
                             }
@@ -511,17 +517,24 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
     /// Prep + enqueue for the single-event path. Retained as a thin wrapper so
     /// the `Event::send` impl stays unchanged; `send_batch` uses prepare_record
     /// and enqueue_record directly to parallelize the prep phase.
-    async fn kafka_send(&self, event: ProcessedEvent) -> Result<P::AckFuture, CaptureError> {
-        let record = self.prepare_record(event).await?;
+    fn kafka_send(&self, event: ProcessedEvent) -> Result<P::AckFuture, CaptureError> {
+        let record = self.prepare_record(event)?;
         self.enqueue_record(record)
     }
 }
+
+/// Batches below this size take the serial fast path in `send_batch`: spawning
+/// N `JoinSet` tasks to run `prepare_record` in parallel is net-negative when
+/// each task does only a `serde_json::to_string` and a header build — the
+/// scheduler overhead dominates the CPU savings. Scatter-gather kicks in at
+/// or above this threshold where parallel prep wins back its spawn cost.
+pub(crate) const SCATTER_GATHER_MIN_BATCH: usize = 8;
 
 #[async_trait]
 impl<P: KafkaProducer + 'static> Event for KafkaSinkBase<P> {
     #[instrument(skip_all)]
     async fn send(&self, event: ProcessedEvent) -> Result<(), CaptureError> {
-        let ack_future = self.kafka_send(event).await?;
+        let ack_future = self.kafka_send(event)?;
         histogram!("capture_event_batch_size").record(1.0);
         ack_future.instrument(info_span!("ack_wait_one")).await
     }
@@ -534,6 +547,53 @@ impl<P: KafkaProducer + 'static> Event for KafkaSinkBase<P> {
         // Matches the single-event `send` path which records before any await.
         histogram!("capture_event_batch_size").record(batch_size as f64);
 
+        // Small-batch fast path. For batches under `SCATTER_GATHER_MIN_BATCH`
+        // the JoinSet spawn overhead dominates any parallel-prep win, so we
+        // stay single-threaded. We keep the scatter-gather path's semantic
+        // "prep error -> no records produced" by prepping all events first
+        // into a Vec, then doing the serial enqueue phase only if all prep
+        // succeeded. Both duration histograms are recorded so dashboards
+        // keep a faithful view of the fast path.
+        if batch_size < SCATTER_GATHER_MIN_BATCH {
+            let prep_start = Instant::now();
+            let mut prepared: Vec<ProduceRecord> = Vec::with_capacity(batch_size);
+            for event in events {
+                match self.prepare_record(event) {
+                    Ok(record) => prepared.push(record),
+                    Err(err) => {
+                        histogram!("capture_kafka_batch_prep_duration_seconds")
+                            .record(prep_start.elapsed().as_secs_f64());
+                        return Err(err);
+                    }
+                }
+            }
+            histogram!("capture_kafka_batch_prep_duration_seconds")
+                .record(prep_start.elapsed().as_secs_f64());
+
+            let enqueue_start = Instant::now();
+            let mut ack_set = JoinSet::new();
+            for record in prepared {
+                match self.enqueue_record(record) {
+                    Ok(ack_future) => {
+                        ack_set.spawn(ack_future);
+                    }
+                    Err(err) => {
+                        // Dropping ack_set aborts any in-flight spawned ack
+                        // futures; DeliveryAckFuture::drop records the
+                        // "dropped" outcome on capture_kafka_produce_ack_duration_ms.
+                        // Mirror of phase-2 behavior in the scatter-gather path.
+                        histogram!("capture_kafka_batch_enqueue_duration_seconds")
+                            .record(enqueue_start.elapsed().as_secs_f64());
+                        return Err(err);
+                    }
+                }
+            }
+            histogram!("capture_kafka_batch_enqueue_duration_seconds")
+                .record(enqueue_start.elapsed().as_secs_f64());
+
+            return drain_acks(ack_set).await;
+        }
+
         // Phase 1: parallel prep across tokio workers. Each task returns its
         // input index so we can reassemble results in the original event order
         // before the serial enqueue phase. This is where the CPU win lives:
@@ -544,15 +604,23 @@ impl<P: KafkaProducer + 'static> Event for KafkaSinkBase<P> {
         for (idx, event) in events.into_iter().enumerate() {
             let this = self.clone();
             prep_set.spawn(
-                async move { (idx, this.prepare_record(event).await) }
+                async move { (idx, this.prepare_record(event)) }
                     .instrument(info_span!("prepare_record")),
             );
         }
 
-        let mut prepared: Vec<Option<ProduceRecord>> = (0..batch_size).map(|_| None).collect();
+        // Collect into a (idx, record) Vec and sort rather than indexing into
+        // a `Vec<Option<ProduceRecord>>`. Encodes the "every slot filled"
+        // invariant in the type: no `Option`, no unreachable `expect`, no
+        // N-element `None` preallocation. Our only cancellation source is
+        // `prep_set.abort_all()` below, invoked only from an already-errored
+        // branch, so any `JoinError` observed during normal drain implies a
+        // panic inside `prepare_record` — counted separately so it's alertable.
+        let mut prepared: Vec<(usize, ProduceRecord)> = Vec::with_capacity(batch_size);
         while let Some(join_result) = prep_set.join_next().await {
             let (idx, result) = match join_result {
                 Err(err) => {
+                    counter!("capture_kafka_prep_panic_total").increment(1);
                     error!("join error while preparing Kafka record: {err:#}");
                     // Drain remaining prep tasks before returning so they can't
                     // leak records into librdkafka after we've already failed.
@@ -566,7 +634,7 @@ impl<P: KafkaProducer + 'static> Event for KafkaSinkBase<P> {
                 Ok(inner) => inner,
             };
             match result {
-                Ok(record) => prepared[idx] = Some(record),
+                Ok(record) => prepared.push((idx, record)),
                 Err(err) => {
                     prep_set.abort_all();
                     histogram!("capture_kafka_batch_prep_duration_seconds")
@@ -575,6 +643,8 @@ impl<P: KafkaProducer + 'static> Event for KafkaSinkBase<P> {
                 }
             }
         }
+        prepared.sort_unstable_by_key(|(idx, _)| *idx);
+        debug_assert_eq!(prepared.len(), batch_size);
         histogram!("capture_kafka_batch_prep_duration_seconds")
             .record(prep_start.elapsed().as_secs_f64());
 
@@ -585,8 +655,7 @@ impl<P: KafkaProducer + 'static> Event for KafkaSinkBase<P> {
         // must survive so e.g. $identify lands before subsequent events.
         let enqueue_start = Instant::now();
         let mut ack_set = JoinSet::new();
-        for slot in prepared {
-            let record = slot.expect("prep slot not filled");
+        for (_, record) in prepared {
             match self.enqueue_record(record) {
                 Ok(ack_future) => {
                     ack_set.spawn(ack_future);
@@ -594,6 +663,11 @@ impl<P: KafkaProducer + 'static> Event for KafkaSinkBase<P> {
                 Err(err) => {
                     // Record enqueue duration on the error path too so slow-fail
                     // cases (e.g. QueueFull after a long stall) stay observable.
+                    // Dropping `ack_set` when we return Err aborts any already
+                    // spawned ack futures for this batch; DeliveryAckFuture::drop
+                    // then records the "dropped" outcome on
+                    // capture_kafka_produce_ack_duration_ms. This is the phase-2
+                    // mirror of phase-1's explicit `prep_set.abort_all()`.
                     histogram!("capture_kafka_batch_enqueue_duration_seconds")
                         .record(enqueue_start.elapsed().as_secs_f64());
                     return Err(err);
@@ -603,33 +677,39 @@ impl<P: KafkaProducer + 'static> Event for KafkaSinkBase<P> {
         histogram!("capture_kafka_batch_enqueue_duration_seconds")
             .record(enqueue_start.elapsed().as_secs_f64());
 
-        // Phase 3: concurrent ack drain, fail-fast on first ack error.
-        async move {
-            while let Some(res) = ack_set.join_next().await {
-                match res {
-                    Ok(Ok(_)) => {}
-                    Ok(Err(err)) => {
-                        ack_set.abort_all();
-                        return Err(err);
-                    }
-                    Err(err) => {
-                        ack_set.abort_all();
-                        error!("join error while waiting on Kafka ACK: {err:#}");
-                        return Err(CaptureError::RetryableSinkError);
-                    }
-                }
-            }
-            Ok(())
-        }
-        .instrument(info_span!("ack_wait_many"))
-        .await?;
-
-        Ok(())
+        drain_acks(ack_set).await
     }
 
     fn flush(&self) -> Result<(), anyhow::Error> {
         self.producer.flush().map_err(|e| anyhow::anyhow!(e))
     }
+}
+
+/// Phase 3 of `send_batch`: concurrent ack drain, fail-fast on first ack error.
+/// Shared between the scatter-gather path and the small-batch serial fast path
+/// so both converge on the same fail-fast + abort-siblings semantics. Dropping
+/// the JoinSet on error aborts remaining spawned ack futures; DeliveryAckFuture
+/// Drop then records the "dropped" outcome on capture_kafka_produce_ack_duration_ms.
+async fn drain_acks(mut ack_set: JoinSet<Result<(), CaptureError>>) -> Result<(), CaptureError> {
+    async move {
+        while let Some(res) = ack_set.join_next().await {
+            match res {
+                Ok(Ok(_)) => {}
+                Ok(Err(err)) => {
+                    ack_set.abort_all();
+                    return Err(err);
+                }
+                Err(err) => {
+                    ack_set.abort_all();
+                    error!("join error while waiting on Kafka ACK: {err:#}");
+                    return Err(CaptureError::RetryableSinkError);
+                }
+            }
+        }
+        Ok(())
+    }
+    .instrument(info_span!("ack_wait_many"))
+    .await
 }
 
 #[cfg(test)]
@@ -984,7 +1064,7 @@ mod tests {
     #[cfg(test)]
     mod topic_routing {
         use super::*;
-        use crate::sinks::kafka::{KafkaSinkBase, KafkaTopicConfig};
+        use crate::sinks::kafka::{KafkaSinkBase, KafkaTopicConfig, SCATTER_GATHER_MIN_BATCH};
         use crate::sinks::producer::MockKafkaProducer;
 
         const MAIN_TOPIC: &str = "events_plugin_ingestion";
@@ -2195,6 +2275,266 @@ mod tests {
                 "no records should reach the producer when prep phase fails; got {} records",
                 records.len()
             );
+        }
+
+        // ==================== send_batch fast-path + mid-batch failure tests ====================
+
+        /// Mock producer whose Nth `send()` call returns Err. All other calls
+        /// capture the record like `MockKafkaProducer`. Used to exercise the
+        /// phase-2 mid-batch enqueue failure path.
+        #[derive(Clone)]
+        struct FailAtIndexProducer {
+            records: std::sync::Arc<std::sync::Mutex<Vec<crate::sinks::producer::ProduceRecord>>>,
+            fail_at: usize,
+            counter: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        }
+
+        impl FailAtIndexProducer {
+            fn new(fail_at: usize) -> Self {
+                Self {
+                    records: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+                    fail_at,
+                    counter: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                }
+            }
+
+            fn get_records(&self) -> Vec<crate::sinks::producer::ProduceRecord> {
+                self.records.lock().unwrap().clone()
+            }
+        }
+
+        impl crate::sinks::producer::KafkaProducer for FailAtIndexProducer {
+            type AckFuture = std::future::Ready<Result<(), CaptureError>>;
+
+            fn send(
+                &self,
+                record: crate::sinks::producer::ProduceRecord,
+            ) -> Result<Self::AckFuture, CaptureError> {
+                let idx = self
+                    .counter
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                if idx == self.fail_at {
+                    return Err(CaptureError::RetryableSinkError);
+                }
+                self.records.lock().unwrap().push(record);
+                Ok(std::future::ready(Ok(())))
+            }
+
+            fn flush(&self) -> Result<(), rdkafka::error::KafkaError> {
+                Ok(())
+            }
+        }
+
+        /// Builds N AnalyticsMain events with sequential distinct_ids so each
+        /// record is individually identifiable in the mock producer's output.
+        fn build_batch(n: usize) -> Vec<ProcessedEvent> {
+            (0..n)
+                .map(|i| {
+                    let mut e = create_test_event(&EventInput::default());
+                    e.event.distinct_id = format!("user_{i}");
+                    e
+                })
+                .collect()
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn send_batch_mid_enqueue_failure_preserves_earlier_records() {
+            // Fail at phase-2 send #3 (0-indexed): events [0, 1, 2] should land
+            // in the mock, send_batch must return Err, and no event at index
+            // >= 3 should ever hit the producer. Batch size is well above the
+            // scatter-gather threshold so phase 2 runs post-parallel-prep.
+            const BATCH: usize = 10;
+            const FAIL_IDX: usize = 3;
+            let producer = FailAtIndexProducer::new(FAIL_IDX);
+            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
+
+            let events = build_batch(BATCH);
+            let input_distinct_ids: Vec<String> =
+                events.iter().map(|e| e.event.distinct_id.clone()).collect();
+
+            let res = sink.send_batch(events).await;
+            match res {
+                Err(CaptureError::RetryableSinkError) => {}
+                Err(other) => panic!("expected RetryableSinkError, got {other:?}"),
+                Ok(()) => panic!("expected send_batch to fail on enqueue #{FAIL_IDX}"),
+            }
+
+            let records = producer.get_records();
+            assert_eq!(
+                records.len(),
+                FAIL_IDX,
+                "expected exactly {FAIL_IDX} records to reach producer before failure"
+            );
+
+            // Output distinct_ids should match input[..FAIL_IDX] in order:
+            // phase-2 is serial in input order, so the earlier records must
+            // be the first FAIL_IDX events of the input batch.
+            let output_distinct_ids: Vec<String> = records
+                .iter()
+                .map(|r| {
+                    let v: serde_json::Value =
+                        serde_json::from_str(&r.payload).expect("payload is valid json");
+                    v.get("distinct_id")
+                        .and_then(|u| u.as_str())
+                        .expect("distinct_id field present")
+                        .to_string()
+                })
+                .collect();
+            assert_eq!(
+                output_distinct_ids,
+                input_distinct_ids[..FAIL_IDX],
+                "earlier records must preserve input order on mid-batch failure"
+            );
+        }
+
+        #[tokio::test]
+        async fn send_batch_single_event_via_batch_path() {
+            // batch_size=1 exercises the serial fast path (1 < SCATTER_GATHER_MIN_BATCH)
+            // and verifies the loop handles a single-element batch correctly.
+            let producer = MockKafkaProducer::new();
+            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
+
+            let events = build_batch(1);
+            sink.send_batch(events).await.expect("send_batch failed");
+
+            let records = producer.get_records();
+            assert_eq!(records.len(), 1, "expected exactly one record");
+            assert_eq!(records[0].topic, MAIN_TOPIC);
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn send_batch_just_below_threshold_uses_serial_path() {
+            // batch_size = SCATTER_GATHER_MIN_BATCH - 1 takes the serial fast
+            // path. We can't observe "which path ran" directly, so we assert
+            // behavioral equivalence: N records, correct topic, input order.
+            let producer = MockKafkaProducer::new();
+            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
+
+            let size = SCATTER_GATHER_MIN_BATCH - 1;
+            let events = build_batch(size);
+            let input_distinct_ids: Vec<String> =
+                events.iter().map(|e| e.event.distinct_id.clone()).collect();
+
+            sink.send_batch(events).await.expect("send_batch failed");
+
+            let records = producer.get_records();
+            assert_eq!(records.len(), size);
+            let output: Vec<String> = records
+                .iter()
+                .map(|r| {
+                    let v: serde_json::Value =
+                        serde_json::from_str(&r.payload).expect("payload is valid json");
+                    v["distinct_id"].as_str().unwrap().to_string()
+                })
+                .collect();
+            assert_eq!(output, input_distinct_ids, "serial path must preserve order");
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn send_batch_at_threshold_uses_scatter_gather_path() {
+            // batch_size = SCATTER_GATHER_MIN_BATCH takes the scatter-gather
+            // path. Behavioral equivalence with the serial path must hold:
+            // same N records, same order, same topics.
+            let producer = MockKafkaProducer::new();
+            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
+
+            let size = SCATTER_GATHER_MIN_BATCH;
+            let events = build_batch(size);
+            let input_distinct_ids: Vec<String> =
+                events.iter().map(|e| e.event.distinct_id.clone()).collect();
+
+            sink.send_batch(events).await.expect("send_batch failed");
+
+            let records = producer.get_records();
+            assert_eq!(records.len(), size);
+            let output: Vec<String> = records
+                .iter()
+                .map(|r| {
+                    let v: serde_json::Value =
+                        serde_json::from_str(&r.payload).expect("payload is valid json");
+                    v["distinct_id"].as_str().unwrap().to_string()
+                })
+                .collect();
+            assert_eq!(
+                output, input_distinct_ids,
+                "scatter-gather path must preserve input order after sort_unstable_by_key"
+            );
+        }
+
+        /// Per-event-type topic routing is covered by `assert_routing` for
+        /// the single-event path. This test verifies routing survives the
+        /// batch path for a mixed batch of data types plus one force_overflow
+        /// AnalyticsMain — exercised on both the serial fast path (5 events)
+        /// and the scatter-gather path (10 events).
+        async fn mixed_datatypes_routing_for_batch(pad_to: usize) {
+            let producer = MockKafkaProducer::new();
+            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
+
+            // Core 5-event diverse batch.
+            let mut events: Vec<ProcessedEvent> = vec![
+                create_test_event(&EventInput {
+                    data_type: DataType::AnalyticsMain,
+                    ..EventInput::default()
+                }),
+                create_test_event(&EventInput {
+                    data_type: DataType::HeatmapMain,
+                    ..EventInput::default()
+                }),
+                create_test_event(&EventInput {
+                    data_type: DataType::ExceptionErrorTracking,
+                    ..EventInput::default()
+                }),
+                create_test_event(&EventInput {
+                    data_type: DataType::ClientIngestionWarning,
+                    ..EventInput::default()
+                }),
+                create_test_event(&EventInput {
+                    data_type: DataType::AnalyticsMain,
+                    force_overflow: true,
+                    ..EventInput::default()
+                }),
+            ];
+
+            // Pad with AnalyticsMain events if caller wants to push the batch
+            // over SCATTER_GATHER_MIN_BATCH. Padding goes at the end so the
+            // first 5 per-event assertions line up regardless of batch size.
+            while events.len() < pad_to {
+                events.push(create_test_event(&EventInput::default()));
+            }
+
+            sink.send_batch(events).await.expect("send_batch failed");
+
+            let records = producer.get_records();
+            assert_eq!(records.len(), pad_to.max(5));
+
+            // Per-index topic assertions (order-preserving: phase-2 is serial
+            // in input order on both paths).
+            assert_eq!(records[0].topic, MAIN_TOPIC, "event[0]: AnalyticsMain");
+            assert_eq!(records[1].topic, HEATMAPS_TOPIC, "event[1]: HeatmapMain");
+            assert_eq!(
+                records[2].topic, ERROR_TRACKING_TOPIC,
+                "event[2]: ExceptionErrorTracking"
+            );
+            assert_eq!(
+                records[3].topic, CLIENT_INGESTION_WARNING_TOPIC,
+                "event[3]: ClientIngestionWarning"
+            );
+            assert_eq!(
+                records[4].topic, OVERFLOW_TOPIC,
+                "event[4]: AnalyticsMain + force_overflow"
+            );
+        }
+
+        #[tokio::test]
+        async fn send_batch_mixed_datatypes_serial_path() {
+            // 5 events < SCATTER_GATHER_MIN_BATCH => serial fast path.
+            mixed_datatypes_routing_for_batch(5).await;
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn send_batch_mixed_datatypes_scatter_gather_path() {
+            // 10 events >= SCATTER_GATHER_MIN_BATCH => scatter-gather path.
+            mixed_datatypes_routing_for_batch(10).await;
         }
     }
 }

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -22,6 +22,34 @@ pub struct KafkaContext {
     liveness: lifecycle::Handle,
 }
 
+/// Emit min/avg/max/stddev plus p50/p90/p95/p99 for an rdkafka window stat
+/// (rtt, int_latency, outbuf_latency). Gauges are tagged with `quantile` and
+/// `broker` so existing dashboards keyed on `quantile` keep working and new
+/// panels can pick up `max`/`avg` for tail visibility.
+fn emit_window_stats(
+    metric_name: &'static str,
+    window: &rdkafka::statistics::Window,
+    broker: &str,
+) {
+    for (quantile, value) in [
+        ("min", window.min),
+        ("avg", window.avg),
+        ("max", window.max),
+        ("stddev", window.stddev),
+        ("p50", window.p50),
+        ("p90", window.p90),
+        ("p95", window.p95),
+        ("p99", window.p99),
+    ] {
+        gauge!(
+            metric_name,
+            "quantile" => quantile,
+            "broker" => broker.to_string()
+        )
+        .set(value as f64);
+    }
+}
+
 impl rdkafka::ClientContext for KafkaContext {
     fn stats(&self, stats: rdkafka::Statistics) {
         // Signal liveness when brokers are up
@@ -69,30 +97,24 @@ impl rdkafka::ClientContext for KafkaContext {
             )
             .set(if stats.state == "UP" { 1.0 } else { 0.0 });
             if let Some(rtt) = stats.rtt {
-                gauge!(
-                    "capture_kafka_produce_rtt_latency_us",
-                    "quantile" => "p50",
-                    "broker" => id_string.clone()
-                )
-                .set(rtt.p50 as f64);
-                gauge!(
-                    "capture_kafka_produce_rtt_latency_us",
-                    "quantile" => "p90",
-                    "broker" => id_string.clone()
-                )
-                .set(rtt.p90 as f64);
-                gauge!(
-                    "capture_kafka_produce_rtt_latency_us",
-                    "quantile" => "p95",
-                    "broker" => id_string.clone()
-                )
-                .set(rtt.p95 as f64);
-                gauge!(
-                    "capture_kafka_produce_rtt_latency_us",
-                    "quantile" => "p99",
-                    "broker" => id_string.clone()
-                )
-                .set(rtt.p99 as f64);
+                emit_window_stats("capture_kafka_produce_rtt_latency_us", &rtt, &id_string);
+            }
+            // Time messages spent in the producer's internal queue (linger + backlog).
+            // Usually the dominant source of long-tail ack delays when brokers are slow.
+            if let Some(int_latency) = stats.int_latency {
+                emit_window_stats(
+                    "capture_kafka_produce_int_latency_us",
+                    &int_latency,
+                    &id_string,
+                );
+            }
+            // Time requests spent in the broker's output buffer before going on the wire.
+            if let Some(outbuf_latency) = stats.outbuf_latency {
+                emit_window_stats(
+                    "capture_kafka_produce_outbuf_latency_us",
+                    &outbuf_latency,
+                    &id_string,
+                );
             }
 
             gauge!(
@@ -326,7 +348,12 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
         }
     }
 
-    async fn kafka_send(&self, event: ProcessedEvent) -> Result<P::AckFuture, CaptureError> {
+    /// CPU-bound (plus optional Redis await for SnapshotMain) prep work.
+    /// Safe to run concurrently across events in a batch because it does not
+    /// touch the librdkafka producer queue — phase 2 of `send_batch` is what
+    /// enforces per-partition ordering by calling `enqueue_record` serially
+    /// in the original event order.
+    async fn prepare_record(&self, event: ProcessedEvent) -> Result<ProduceRecord, CaptureError> {
         let (event, metadata) = (event.event, event.metadata);
 
         let payload = serde_json::to_string(&event).map_err(|e| {
@@ -479,19 +506,31 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
             }
         };
 
-        let payload_bytes = payload.len() as u64;
-
-        let record = ProduceRecord {
+        Ok(ProduceRecord {
             topic: topic.to_string(),
             key: partition_key.map(|s| s.to_string()),
             payload,
             headers,
-        };
+        })
+    }
 
-        counter!("capture_kafka_produce_bytes_total", "topic" => topic.to_string())
+    /// Serial, ordering-preserving enqueue into librdkafka. Emits the per-topic
+    /// bytes counter and returns the ack future for the caller to await.
+    /// librdkafka preserves on-wire partition order by `send_result` call order,
+    /// so this MUST be called in the original event order within a batch.
+    fn enqueue_record(&self, record: ProduceRecord) -> Result<P::AckFuture, CaptureError> {
+        let payload_bytes = record.payload.len() as u64;
+        counter!("capture_kafka_produce_bytes_total", "topic" => record.topic.clone())
             .increment(payload_bytes);
-
         self.producer.send(record)
+    }
+
+    /// Prep + enqueue for the single-event path. Retained as a thin wrapper so
+    /// the `Event::send` impl stays unchanged; `send_batch` uses prepare_record
+    /// and enqueue_record directly to parallelize the prep phase.
+    async fn kafka_send(&self, event: ProcessedEvent) -> Result<P::AckFuture, CaptureError> {
+        let record = self.prepare_record(event).await?;
+        self.enqueue_record(record)
     }
 }
 
@@ -506,27 +545,68 @@ impl<P: KafkaProducer + 'static> Event for KafkaSinkBase<P> {
 
     #[instrument(skip_all)]
     async fn send_batch(&self, events: Vec<ProcessedEvent>) -> Result<(), CaptureError> {
-        let mut set = JoinSet::new();
         let batch_size = events.len();
-        for event in events {
-            // We await kafka_send to get events in the producer queue sequentially
-            let ack_future = self.kafka_send(event).await?;
 
-            // Then stash the returned future, waiting concurrently for the write ACKs from brokers.
-            set.spawn(ack_future);
+        // Phase 1: parallel prep across tokio workers. Each task returns its
+        // input index so we can reassemble results in the original event order
+        // before the serial enqueue phase. This is where the CPU win lives:
+        // serde_json::to_string + header build run concurrently on up to N
+        // worker threads, rather than sequentially on a single task.
+        let prep_start = std::time::Instant::now();
+        let mut prep_set: JoinSet<(usize, Result<ProduceRecord, CaptureError>)> = JoinSet::new();
+        for (idx, event) in events.into_iter().enumerate() {
+            let this = self.clone();
+            prep_set.spawn(
+                async move { (idx, this.prepare_record(event).await) }
+                    .instrument(info_span!("prepare_record")),
+            );
         }
 
-        // Await on all the produce promises, fail batch on first failure
+        let mut prepared: Vec<Option<ProduceRecord>> = (0..batch_size).map(|_| None).collect();
+        while let Some(join_result) = prep_set.join_next().await {
+            let (idx, result) = join_result.map_err(|err| {
+                error!("join error while preparing Kafka record: {err:#}");
+                CaptureError::RetryableSinkError
+            })?;
+            match result {
+                Ok(record) => prepared[idx] = Some(record),
+                Err(err) => {
+                    // Drain remaining prep tasks before returning so they can't
+                    // leak records into librdkafka after we've already failed.
+                    prep_set.abort_all();
+                    return Err(err);
+                }
+            }
+        }
+        histogram!("capture_kafka_batch_prep_duration_seconds")
+            .record(prep_start.elapsed().as_secs_f64());
+
+        // Phase 2: serial enqueue in original event order. This is the ordering
+        // bottleneck we deliberately keep: librdkafka preserves per-partition
+        // on-wire order by send_result() call order, and same-distinct_id events
+        // hash to the same partition via murmur2. Within-batch same-key ordering
+        // must survive so e.g. $identify lands before subsequent events.
+        let enqueue_start = std::time::Instant::now();
+        let mut ack_set = JoinSet::new();
+        for slot in prepared {
+            let record = slot.expect("prep slot not filled");
+            let ack_future = self.enqueue_record(record)?;
+            ack_set.spawn(ack_future);
+        }
+        histogram!("capture_kafka_batch_enqueue_duration_seconds")
+            .record(enqueue_start.elapsed().as_secs_f64());
+
+        // Phase 3: concurrent ack drain, fail-fast on first ack error.
         async move {
-            while let Some(res) = set.join_next().await {
+            while let Some(res) = ack_set.join_next().await {
                 match res {
                     Ok(Ok(_)) => {}
                     Ok(Err(err)) => {
-                        set.abort_all();
+                        ack_set.abort_all();
                         return Err(err);
                     }
                     Err(err) => {
-                        set.abort_all();
+                        ack_set.abort_all();
                         error!("join error while waiting on Kafka ACK: {err:#}");
                         return Err(CaptureError::RetryableSinkError);
                     }
@@ -1781,6 +1861,124 @@ mod tests {
             assert_eq!(headers.dlq_reason, None);
             assert_eq!(headers.dlq_step, None);
             assert_eq!(headers.dlq_timestamp, None);
+        }
+
+        // ==================== send_batch ordering + error tests ====================
+        // These exercise the B2 three-phase send_batch: parallel prepare_record,
+        // serial enqueue_record, concurrent ack drain. The ordering test runs on
+        // a multi-thread runtime so phase 1 actually parallelizes across workers
+        // and we can detect if phase 2 is accidentally reordering records.
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn send_batch_preserves_order_same_key() {
+            let producer = MockKafkaProducer::new();
+            let sink =
+                KafkaSinkBase::with_producer(producer.clone(), create_test_topics(), None, None);
+
+            // 20 events, all sharing the same distinct_id (so they hash to the
+            // same partition via murmur2), each with a unique UUID so we can
+            // track input->output order through the pipeline.
+            let events: Vec<ProcessedEvent> = (0..20)
+                .map(|_| {
+                    create_test_event(&EventInput {
+                        data_type: DataType::AnalyticsMain,
+                        force_overflow: false,
+                        skip_person_processing: false,
+                        redirect_to_dlq: false,
+                        redirect_to_topic: None,
+                    })
+                })
+                .collect();
+
+            let input_uuids: Vec<String> =
+                events.iter().map(|e| e.event.uuid.to_string()).collect();
+
+            sink.send_batch(events).await.expect("send_batch failed");
+
+            let records = producer.get_records();
+            assert_eq!(records.len(), 20, "expected 20 records");
+
+            // Parse the UUID out of each record's serialized payload and compare
+            // against the input order. If phase 2 ever reorders enqueue calls,
+            // librdkafka's partition-order guarantee would be broken for same-key
+            // events and this assertion trips.
+            let output_uuids: Vec<String> = records
+                .iter()
+                .map(|r| {
+                    let v: serde_json::Value =
+                        serde_json::from_str(&r.payload).expect("payload is valid json");
+                    v.get("uuid")
+                        .and_then(|u| u.as_str())
+                        .expect("uuid field present")
+                        .to_string()
+                })
+                .collect();
+
+            assert_eq!(
+                output_uuids, input_uuids,
+                "send_batch must preserve input order for same-key events"
+            );
+
+            // Sanity: all records share the same partition key.
+            let first_key = records[0].key.as_deref().expect("partition key set");
+            for r in &records {
+                assert_eq!(
+                    r.key.as_deref(),
+                    Some(first_key),
+                    "all events should share partition key"
+                );
+            }
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn send_batch_prep_error_aborts_batch() {
+            let producer = MockKafkaProducer::new();
+            let sink =
+                KafkaSinkBase::with_producer(producer.clone(), create_test_topics(), None, None);
+
+            // Build a batch where event #3 is a SnapshotMain with session_id=None,
+            // which causes prepare_record to return MissingSessionId. The other
+            // events are valid AnalyticsMain. Since phase 2 only runs after all
+            // prep tasks complete, a prep error must short-circuit before any
+            // producer.send() call — so the mock producer should see zero records.
+            let mut events: Vec<ProcessedEvent> = (0..5)
+                .map(|_| {
+                    create_test_event(&EventInput {
+                        data_type: DataType::AnalyticsMain,
+                        force_overflow: false,
+                        skip_person_processing: false,
+                        redirect_to_dlq: false,
+                        redirect_to_topic: None,
+                    })
+                })
+                .collect();
+
+            // Overwrite element [2] with a SnapshotMain event whose session_id
+            // metadata is None — prepare_record returns MissingSessionId at the
+            // session_id lookup in the SnapshotMain branch.
+            let mut bad = create_test_event(&EventInput {
+                data_type: DataType::SnapshotMain,
+                force_overflow: false,
+                skip_person_processing: false,
+                redirect_to_dlq: false,
+                redirect_to_topic: None,
+            });
+            bad.metadata.session_id = None;
+            events[2] = bad;
+
+            let res = sink.send_batch(events).await;
+            match res {
+                Err(CaptureError::MissingSessionId) => {}
+                Err(other) => panic!("expected MissingSessionId, got {other:?}"),
+                Ok(()) => panic!("expected send_batch to fail on prep error"),
+            }
+
+            let records = producer.get_records();
+            assert!(
+                records.is_empty(),
+                "no records should reach the producer when prep phase fails; got {} records",
+                records.len()
+            );
         }
     }
 }

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -21,7 +21,7 @@ use rdkafka::producer::{FutureProducer, Producer};
 use rdkafka::util::Timeout;
 use rdkafka::ClientConfig;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::task::JoinSet;
 use tracing::log::{debug, error, info};
 use tracing::{info_span, instrument, Instrument};
@@ -539,7 +539,7 @@ impl<P: KafkaProducer + 'static> Event for KafkaSinkBase<P> {
         // before the serial enqueue phase. This is where the CPU win lives:
         // serde_json::to_string + header build run concurrently on up to N
         // worker threads, rather than sequentially on a single task.
-        let prep_start = std::time::Instant::now();
+        let prep_start = Instant::now();
         let mut prep_set: JoinSet<(usize, Result<ProduceRecord, CaptureError>)> = JoinSet::new();
         for (idx, event) in events.into_iter().enumerate() {
             let this = self.clone();
@@ -583,7 +583,7 @@ impl<P: KafkaProducer + 'static> Event for KafkaSinkBase<P> {
         // on-wire order by send_result() call order, and same-distinct_id events
         // hash to the same partition via murmur2. Within-batch same-key ordering
         // must survive so e.g. $identify lands before subsequent events.
-        let enqueue_start = std::time::Instant::now();
+        let enqueue_start = Instant::now();
         let mut ack_set = JoinSet::new();
         for slot in prepared {
             let record = slot.expect("prep slot not filled");

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -3,13 +3,20 @@
 //! This sink is pure mechanism: it serializes `ProcessedEvent`s and produces them
 //! to Kafka using `rdkafka`. All routing *policy* (overflow rerouting, DLQ
 //! redirects, custom-topic redirects, force-disable-person-processing headers) is
-//! decided *upstream* in the pipeline (`events::analytics::process_events` and
-//! `events::recordings::process_replay_events`) and stamped onto
+//! decided *upstream* in the pipeline and stamped onto
 //! `ProcessedEventMetadata`. `KafkaSinkBase::prepare_record` reads that metadata
-//! and maps it to a concrete topic + partition key. Keeping routing policy out
-//! of the sink keeps the clone-per-spawned-task cost in the scatter-gather
-//! batch path at two `Arc::clone` calls (producer + topics) rather than deep
-//! copies of limiter state.
+//! and maps it to a concrete topic + partition key.
+//!
+//! The `overflow_reason` stamping specifically runs at four call sites, all via
+//! the shared `events::overflow_stamping::stamp_overflow_reason` helper:
+//! * `events::analytics::process_events` (analytics batch path: `/e/`, `/batch/`, `/capture`, etc.)
+//! * `events::recordings::process_replay_events` (replay-specific `RedisLimiter`, stamps `OverflowReason::ReplayLimited`)
+//! * `ai_endpoint::ai_handler` (`/i/v0/ai`, single-event)
+//! * `otel::otel_handler` (`/i/v0/ai/otel`, multi-span batch)
+//!
+//! Keeping routing policy out of the sink keeps the clone-per-spawned-task
+//! cost in the scatter-gather batch path at two `Arc::clone` calls (producer
+//! + topics) rather than deep copies of limiter state.
 use crate::api::CaptureError;
 use crate::config::KafkaConfig;
 use crate::sinks::producer::{KafkaProducer, ProduceRecord};

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -1,11 +1,21 @@
+//! Kafka sink (mechanism layer).
+//!
+//! This sink is pure mechanism: it serializes `ProcessedEvent`s and produces them
+//! to Kafka using `rdkafka`. All routing *policy* (overflow rerouting, DLQ
+//! redirects, custom-topic redirects, force-disable-person-processing headers) is
+//! decided *upstream* in the pipeline (`events::analytics::process_events` and
+//! `events::recordings::process_replay_events`) and stamped onto
+//! `ProcessedEventMetadata`. `KafkaSinkBase::prepare_record` reads that metadata
+//! and maps it to a concrete topic + partition key. Keeping routing policy out
+//! of the sink keeps the clone-per-spawned-task cost in the scatter-gather
+//! batch path at two `Arc::clone` calls (producer + topics) rather than deep
+//! copies of limiter state.
 use crate::api::CaptureError;
 use crate::config::KafkaConfig;
 use crate::sinks::producer::{KafkaProducer, ProduceRecord};
 use crate::sinks::Event;
-use crate::v0_request::{DataType, ProcessedEvent};
+use crate::v0_request::{DataType, OverflowReason, ProcessedEvent};
 use async_trait::async_trait;
-use limiters::overflow::{OverflowLimiter, OverflowLimiterResult};
-use limiters::redis::RedisLimiter;
 use metrics::{counter, gauge, histogram};
 use rdkafka::producer::{FutureProducer, Producer};
 use rdkafka::util::Timeout;
@@ -176,21 +186,24 @@ impl From<&KafkaConfig> for KafkaTopicConfig {
     }
 }
 
-/// Generic Kafka sink that can use any producer implementation
+/// Generic Kafka sink that can use any producer implementation.
+///
+/// Holds only the producer handle and the topic config. No limiter state —
+/// overflow and replay-overflow routing decisions are stamped upstream in the
+/// pipeline onto `ProcessedEventMetadata::overflow_reason` and read here.
+/// Both fields are `Arc` so `clone()` is two atomic ref-count increments,
+/// which matters under the scatter-gather batch produce path where the sink
+/// is cloned once per spawned prep task.
 pub struct KafkaSinkBase<P: KafkaProducer> {
     producer: Arc<P>,
-    partition: Option<OverflowLimiter>,
-    topics: KafkaTopicConfig,
-    replay_overflow_limiter: Option<RedisLimiter>,
+    topics: Arc<KafkaTopicConfig>,
 }
 
 impl<P: KafkaProducer> Clone for KafkaSinkBase<P> {
     fn clone(&self) -> Self {
         Self {
-            producer: self.producer.clone(),
-            partition: self.partition.clone(),
-            topics: self.topics.clone(),
-            replay_overflow_limiter: self.replay_overflow_limiter.clone(),
+            producer: Arc::clone(&self.producer),
+            topics: Arc::clone(&self.topics),
         }
     }
 }
@@ -202,8 +215,6 @@ impl KafkaSink {
     pub async fn new(
         config: KafkaConfig,
         liveness: lifecycle::Handle,
-        partition: Option<OverflowLimiter>,
-        replay_overflow_limiter: Option<RedisLimiter>,
     ) -> anyhow::Result<KafkaSink> {
         info!("connecting to Kafka brokers at {}...", config.kafka_hosts);
 
@@ -320,39 +331,37 @@ impl KafkaSink {
             info!("connected to Kafka brokers");
         };
 
-        let topics = KafkaTopicConfig::from(&config);
+        let topics = Arc::new(KafkaTopicConfig::from(&config));
         let rd_producer = RdKafkaProducer::new(producer);
 
         Ok(KafkaSinkBase {
             producer: Arc::new(rd_producer),
-            partition,
             topics,
-            replay_overflow_limiter,
         })
     }
 }
 
 impl<P: KafkaProducer> KafkaSinkBase<P> {
-    /// Create a new KafkaSinkBase with a custom producer (useful for testing)
-    pub fn with_producer(
-        producer: P,
-        topics: KafkaTopicConfig,
-        partition: Option<OverflowLimiter>,
-        replay_overflow_limiter: Option<RedisLimiter>,
-    ) -> Self {
+    /// Create a new KafkaSinkBase with a custom producer (useful for testing).
+    /// No limiters — the sink is a mechanism layer; overflow stamping happens
+    /// upstream in the pipeline. See the module header for details.
+    pub fn with_producer(producer: P, topics: KafkaTopicConfig) -> Self {
         Self {
             producer: Arc::new(producer),
-            partition,
-            topics,
-            replay_overflow_limiter,
+            topics: Arc::new(topics),
         }
     }
 
-    /// CPU-bound (plus optional Redis await for SnapshotMain) prep work.
+    /// CPU-bound prep work: serialize payload + build headers + pick topic/key.
     /// Safe to run concurrently across events in a batch because it does not
     /// touch the librdkafka producer queue — phase 2 of `send_batch` is what
     /// enforces per-partition ordering by calling `enqueue_record` serially
     /// in the original event order.
+    ///
+    /// Routing policy is read from `ProcessedEventMetadata` (stamped upstream
+    /// by the pipeline). This function does not consult any limiter — it is
+    /// pure mechanism. DLQ and custom-topic redirects take priority over
+    /// overflow routing, matching the pre-refactor ordering.
     async fn prepare_record(&self, event: ProcessedEvent) -> Result<ProduceRecord, CaptureError> {
         let (event, metadata) = (event.event, event.metadata);
 
@@ -368,13 +377,14 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
         let skip_person_processing = metadata.skip_person_processing;
         let redirect_to_dlq = metadata.redirect_to_dlq;
         let redirect_to_topic = metadata.redirect_to_topic;
+        let overflow_reason = metadata.overflow_reason;
 
         // Use the event's to_headers() method for consistent header serialization
         let mut headers = event.to_headers();
 
         drop(event); // Events can be EXTREMELY memory hungry
 
-        // Apply skip_person_processing from event restrictions
+        // Apply skip_person_processing from event restrictions / upstream decisions
         if skip_person_processing {
             headers.set_force_disable_person_processing(true);
         }
@@ -407,16 +417,14 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
         } else {
             match data_type {
                 DataType::AnalyticsHistorical => {
+                    // Historical events never overflow — force_overflow and
+                    // overflow_reason are deliberately ignored here.
                     (&self.topics.historical_topic, Some(event_key.as_str()))
-                } // We never trigger overflow on historical events
+                }
                 DataType::AnalyticsMain => {
-                    // Check for force_overflow from event restrictions first
+                    // Precedence: force_overflow (restrictions) -> overflow_reason
+                    // (pipeline-stamped) -> default main-topic routing.
                     if force_overflow {
-                        counter!(
-                            "capture_events_rerouted_overflow",
-                            &[("reason", "event_restriction")]
-                        )
-                        .increment(1);
                         // Drop partition key if skip_person_processing is set
                         let key = if skip_person_processing {
                             None
@@ -425,39 +433,23 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
                         };
                         (&self.topics.overflow_topic, key)
                     } else {
-                        // TODO: deprecate capture-led overflow or move logic in handler
-                        let overflow_result = match &self.partition {
-                            None => OverflowLimiterResult::NotLimited,
-                            Some(partition) => partition.is_limited(&event_key),
-                        };
-
-                        match overflow_result {
-                            OverflowLimiterResult::ForceLimited => {
+                        match &overflow_reason {
+                            Some(OverflowReason::ForceLimited) => {
+                                // Pipeline already sets skip_person_processing
+                                // for this case, but keep this belt-and-braces
+                                // header write in case a caller stamps the
+                                // reason without the side-effect.
                                 headers.set_force_disable_person_processing(true);
-                                counter!(
-                                    "capture_events_rerouted_overflow",
-                                    &[("reason", "force_limited")]
-                                )
-                                .increment(1);
                                 (&self.topics.overflow_topic, None)
                             }
-                            OverflowLimiterResult::Limited => {
-                                counter!(
-                                    "capture_events_rerouted_overflow",
-                                    &[("reason", "rate_limited")]
-                                )
-                                .increment(1);
-                                if self
-                                    .partition
-                                    .as_ref()
-                                    .is_some_and(|p| p.should_preserve_locality())
-                                {
-                                    (&self.topics.overflow_topic, Some(event_key.as_str()))
-                                } else {
-                                    (&self.topics.overflow_topic, None)
-                                }
-                            }
-                            OverflowLimiterResult::NotLimited => {
+                            Some(OverflowReason::RateLimited {
+                                preserve_locality: true,
+                            }) => (&self.topics.overflow_topic, Some(event_key.as_str())),
+                            Some(OverflowReason::RateLimited {
+                                preserve_locality: false,
+                            }) => (&self.topics.overflow_topic, None),
+                            // ReplayLimited never applies to AnalyticsMain; fall through to main.
+                            Some(OverflowReason::ReplayLimited) | None => {
                                 // Drop partition key if skip_person_processing is set
                                 let key = if skip_person_processing {
                                     None
@@ -482,25 +474,16 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
                         .as_deref()
                         .ok_or(CaptureError::MissingSessionId)?;
 
-                    // Check for force_overflow from event restrictions first
-                    if force_overflow {
-                        counter!(
-                            "capture_events_rerouted_overflow",
-                            &[("reason", "event_restriction")]
-                        )
-                        .increment(1);
+                    // Precedence: force_overflow (restrictions) -> overflow_reason
+                    // (pipeline-stamped ReplayLimited) -> default main-topic
+                    // routing. Partition key is always session_id for replay
+                    // to keep per-session ordering on the overflow topic.
+                    if force_overflow
+                        || matches!(overflow_reason, Some(OverflowReason::ReplayLimited))
+                    {
                         (&self.topics.replay_overflow_topic, Some(session_id))
                     } else {
-                        let is_overflowing = match &self.replay_overflow_limiter {
-                            None => false,
-                            Some(limiter) => limiter.is_limited(session_id).await,
-                        };
-
-                        if is_overflowing {
-                            (&self.topics.replay_overflow_topic, Some(session_id))
-                        } else {
-                            (&self.topics.main_topic, Some(session_id))
-                        }
+                        (&self.topics.main_topic, Some(session_id))
                     }
                 }
             }
@@ -656,15 +639,13 @@ mod tests {
     use crate::sinks::kafka::KafkaSink;
     use crate::sinks::Event;
     use crate::utils::uuid_v7;
-    use crate::v0_request::{DataType, ProcessedEvent, ProcessedEventMetadata};
+    use crate::v0_request::{DataType, OverflowReason, ProcessedEvent, ProcessedEventMetadata};
     use common_types::CapturedEvent;
-    use limiters::overflow::OverflowLimiter;
     use rand::distributions::Alphanumeric;
     use rand::Rng;
     use rdkafka::mocking::MockCluster;
     use rdkafka::producer::DefaultProducerContext;
     use rdkafka::types::{RDKafkaApiKey, RDKafkaRespErr};
-    use std::num::NonZeroU32;
     use tokio_util::sync::CancellationToken;
 
     async fn start_on_mocked_sink(
@@ -682,12 +663,6 @@ mod tests {
                 .with_liveness_deadline(std::time::Duration::from_secs(30)),
         );
         let _monitor = manager.monitor_background();
-        let limiter = Some(OverflowLimiter::new(
-            NonZeroU32::new(10).unwrap(),
-            NonZeroU32::new(10).unwrap(),
-            None,
-            false,
-        ));
         let cluster = MockCluster::new(1).expect("failed to create mock brokers");
         let config = config::KafkaConfig {
             kafka_producer_linger_ms: 0,
@@ -725,7 +700,7 @@ mod tests {
             kafka_socket_send_buffer_bytes: 0,
             kafka_socket_receive_buffer_bytes: 0,
         };
-        let sink = KafkaSink::new(config, handle, limiter, None)
+        let sink = KafkaSink::new(config, handle)
             .await
             .expect("failed to create sink");
         (cluster, sink)
@@ -762,6 +737,7 @@ mod tests {
             skip_person_processing: false,
             redirect_to_dlq: false,
             redirect_to_topic: None,
+            overflow_reason: None,
         };
 
         let event = ProcessedEvent {
@@ -1041,6 +1017,20 @@ mod tests {
             skip_person_processing: bool,
             redirect_to_dlq: bool,
             redirect_to_topic: Option<String>,
+            overflow_reason: Option<OverflowReason>,
+        }
+
+        impl Default for EventInput {
+            fn default() -> Self {
+                Self {
+                    data_type: DataType::AnalyticsMain,
+                    force_overflow: false,
+                    skip_person_processing: false,
+                    redirect_to_dlq: false,
+                    redirect_to_topic: None,
+                    overflow_reason: None,
+                }
+            }
         }
 
         fn create_test_event(input: &EventInput) -> ProcessedEvent {
@@ -1068,6 +1058,7 @@ mod tests {
                 skip_person_processing: input.skip_person_processing,
                 redirect_to_dlq: input.redirect_to_dlq,
                 redirect_to_topic: input.redirect_to_topic.clone(),
+                overflow_reason: input.overflow_reason.clone(),
             };
 
             ProcessedEvent { event, metadata }
@@ -1081,8 +1072,7 @@ mod tests {
 
         async fn assert_routing(input: EventInput, expected: ExpectedRouting<'_>) {
             let producer = MockKafkaProducer::new();
-            let sink =
-                KafkaSinkBase::with_producer(producer.clone(), create_test_topics(), None, None);
+            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
 
             let event = create_test_event(&input);
             sink.send(event).await.unwrap();
@@ -1129,6 +1119,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: MAIN_TOPIC,
@@ -1148,6 +1139,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: OVERFLOW_TOPIC,
@@ -1168,6 +1160,7 @@ mod tests {
                     skip_person_processing: true,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: OVERFLOW_TOPIC,
@@ -1188,6 +1181,7 @@ mod tests {
                     skip_person_processing: true,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: MAIN_TOPIC,
@@ -1207,6 +1201,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: true,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: DLQ_TOPIC,
@@ -1227,6 +1222,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: true,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: DLQ_TOPIC,
@@ -1246,6 +1242,7 @@ mod tests {
                     skip_person_processing: true,
                     redirect_to_dlq: true,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: DLQ_TOPIC,
@@ -1266,6 +1263,7 @@ mod tests {
                     skip_person_processing: true,
                     redirect_to_dlq: true,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: DLQ_TOPIC,
@@ -1288,6 +1286,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: HISTORICAL_TOPIC,
@@ -1308,6 +1307,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: HISTORICAL_TOPIC,
@@ -1327,6 +1327,7 @@ mod tests {
                     skip_person_processing: true,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: HISTORICAL_TOPIC,
@@ -1346,6 +1347,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: true,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: DLQ_TOPIC,
@@ -1366,6 +1368,7 @@ mod tests {
                     skip_person_processing: true,
                     redirect_to_dlq: true,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: DLQ_TOPIC,
@@ -1387,6 +1390,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: MAIN_TOPIC,
@@ -1406,6 +1410,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: REPLAY_OVERFLOW_TOPIC,
@@ -1426,6 +1431,7 @@ mod tests {
                     skip_person_processing: true,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: REPLAY_OVERFLOW_TOPIC,
@@ -1445,6 +1451,7 @@ mod tests {
                     skip_person_processing: true,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: MAIN_TOPIC,
@@ -1464,6 +1471,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: true,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: DLQ_TOPIC,
@@ -1483,6 +1491,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: true,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: DLQ_TOPIC,
@@ -1505,6 +1514,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: HEATMAPS_TOPIC,
@@ -1524,6 +1534,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: HEATMAPS_TOPIC,
@@ -1543,6 +1554,7 @@ mod tests {
                     skip_person_processing: true,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: HEATMAPS_TOPIC,
@@ -1562,6 +1574,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: true,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: DLQ_TOPIC,
@@ -1584,6 +1597,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: ERROR_TRACKING_TOPIC,
@@ -1603,6 +1617,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: ERROR_TRACKING_TOPIC,
@@ -1622,6 +1637,7 @@ mod tests {
                     skip_person_processing: true,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: ERROR_TRACKING_TOPIC,
@@ -1641,6 +1657,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: true,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: DLQ_TOPIC,
@@ -1663,6 +1680,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: CLIENT_INGESTION_WARNING_TOPIC,
@@ -1682,6 +1700,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: CLIENT_INGESTION_WARNING_TOPIC,
@@ -1701,6 +1720,7 @@ mod tests {
                     skip_person_processing: true,
                     redirect_to_dlq: false,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: CLIENT_INGESTION_WARNING_TOPIC,
@@ -1720,6 +1740,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: true,
                     redirect_to_topic: None,
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: DLQ_TOPIC,
@@ -1742,6 +1763,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: false,
                     redirect_to_topic: Some("custom_topic".to_string()),
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: "custom_topic",
@@ -1761,6 +1783,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: true,
                     redirect_to_topic: Some("custom_topic".to_string()),
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: DLQ_TOPIC,
@@ -1780,6 +1803,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: false,
                     redirect_to_topic: Some("custom_topic".to_string()),
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: "custom_topic",
@@ -1799,6 +1823,7 @@ mod tests {
                     skip_person_processing: true,
                     redirect_to_dlq: false,
                     redirect_to_topic: Some("custom_topic".to_string()),
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: "custom_topic",
@@ -1818,6 +1843,7 @@ mod tests {
                     skip_person_processing: false,
                     redirect_to_dlq: false,
                     redirect_to_topic: Some("custom_topic".to_string()),
+                    overflow_reason: None,
                 },
                 ExpectedRouting {
                     topic: "custom_topic",
@@ -1835,8 +1861,7 @@ mod tests {
         #[tokio::test]
         async fn dlq_headers_set_when_redirect_to_dlq() {
             let producer = MockKafkaProducer::new();
-            let sink =
-                KafkaSinkBase::with_producer(producer.clone(), create_test_topics(), None, None);
+            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
 
             let event = create_test_event(&EventInput {
                 data_type: DataType::AnalyticsMain,
@@ -1844,6 +1869,7 @@ mod tests {
                 skip_person_processing: false,
                 redirect_to_dlq: true,
                 redirect_to_topic: None,
+                overflow_reason: None,
             });
             sink.send(event).await.unwrap();
 
@@ -1867,8 +1893,7 @@ mod tests {
         #[tokio::test]
         async fn dlq_headers_absent_for_normal_analytics() {
             let producer = MockKafkaProducer::new();
-            let sink =
-                KafkaSinkBase::with_producer(producer.clone(), create_test_topics(), None, None);
+            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
 
             let event = create_test_event(&EventInput {
                 data_type: DataType::AnalyticsMain,
@@ -1876,6 +1901,7 @@ mod tests {
                 skip_person_processing: false,
                 redirect_to_dlq: false,
                 redirect_to_topic: None,
+                overflow_reason: None,
             });
             sink.send(event).await.unwrap();
 
@@ -1884,6 +1910,172 @@ mod tests {
             assert_eq!(headers.dlq_reason, None);
             assert_eq!(headers.dlq_step, None);
             assert_eq!(headers.dlq_timestamp, None);
+        }
+
+        // ==================== overflow_reason routing tests ====================
+        // The pipeline stamps ProcessedEventMetadata::overflow_reason upstream;
+        // the sink is a pure mechanism layer that switches on it. These cover
+        // each variant: ForceLimited, RateLimited { preserve_locality }, and
+        // ReplayLimited. `force_overflow` coexistence is covered by the
+        // analytics_main_force_overflow / snapshot_main_force_overflow cases
+        // above (force_overflow short-circuits the overflow_reason branch).
+
+        #[tokio::test]
+        async fn overflow_reason_force_limited_routes_to_overflow_with_null_key_and_flag() {
+            assert_routing(
+                EventInput {
+                    data_type: DataType::AnalyticsMain,
+                    overflow_reason: Some(OverflowReason::ForceLimited),
+                    ..Default::default()
+                },
+                ExpectedRouting {
+                    topic: OVERFLOW_TOPIC,
+                    has_key: false,
+                    force_disable_person_processing: Some(true),
+                },
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn overflow_reason_rate_limited_preserves_key_when_preserve_locality() {
+            assert_routing(
+                EventInput {
+                    data_type: DataType::AnalyticsMain,
+                    overflow_reason: Some(OverflowReason::RateLimited {
+                        preserve_locality: true,
+                    }),
+                    ..Default::default()
+                },
+                ExpectedRouting {
+                    topic: OVERFLOW_TOPIC,
+                    has_key: true,
+                    force_disable_person_processing: None,
+                },
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn overflow_reason_rate_limited_drops_key_when_not_preserve_locality() {
+            assert_routing(
+                EventInput {
+                    data_type: DataType::AnalyticsMain,
+                    overflow_reason: Some(OverflowReason::RateLimited {
+                        preserve_locality: false,
+                    }),
+                    ..Default::default()
+                },
+                ExpectedRouting {
+                    topic: OVERFLOW_TOPIC,
+                    has_key: false,
+                    force_disable_person_processing: None,
+                },
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn overflow_reason_ignored_for_analytics_historical() {
+            // historical events never go through overflow routing even if the
+            // upstream pipeline accidentally stamps one — be defensive.
+            assert_routing(
+                EventInput {
+                    data_type: DataType::AnalyticsHistorical,
+                    overflow_reason: Some(OverflowReason::RateLimited {
+                        preserve_locality: false,
+                    }),
+                    ..Default::default()
+                },
+                ExpectedRouting {
+                    topic: HISTORICAL_TOPIC,
+                    has_key: true,
+                    force_disable_person_processing: None,
+                },
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn overflow_reason_replay_limited_routes_snapshot_to_replay_overflow() {
+            assert_routing(
+                EventInput {
+                    data_type: DataType::SnapshotMain,
+                    overflow_reason: Some(OverflowReason::ReplayLimited),
+                    ..Default::default()
+                },
+                ExpectedRouting {
+                    topic: REPLAY_OVERFLOW_TOPIC,
+                    has_key: true,
+                    force_disable_person_processing: None,
+                },
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn overflow_reason_force_overflow_short_circuits_overflow_reason() {
+            // Precedence check: force_overflow set by event restrictions wins
+            // over any overflow_reason stamped by the governor. This ensures
+            // the event_restriction counter label stays distinct from
+            // force_limited / rate_limited labels.
+            assert_routing(
+                EventInput {
+                    data_type: DataType::AnalyticsMain,
+                    force_overflow: true,
+                    overflow_reason: Some(OverflowReason::RateLimited {
+                        preserve_locality: false,
+                    }),
+                    ..Default::default()
+                },
+                ExpectedRouting {
+                    topic: OVERFLOW_TOPIC,
+                    has_key: true,
+                    force_disable_person_processing: None,
+                },
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn overflow_reason_redirect_to_dlq_wins_over_overflow_reason() {
+            // DLQ routing is the highest-priority routing decision: it wins
+            // over both force_overflow and overflow_reason.
+            assert_routing(
+                EventInput {
+                    data_type: DataType::AnalyticsMain,
+                    redirect_to_dlq: true,
+                    overflow_reason: Some(OverflowReason::ForceLimited),
+                    ..Default::default()
+                },
+                ExpectedRouting {
+                    topic: DLQ_TOPIC,
+                    has_key: true,
+                    force_disable_person_processing: None,
+                },
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn overflow_reason_redirect_to_topic_wins_over_overflow_reason() {
+            // Custom topic redirect (set by event restrictions) also wins over
+            // overflow_reason since overflow decisions cannot compose with a
+            // hard-coded topic override.
+            assert_routing(
+                EventInput {
+                    data_type: DataType::AnalyticsMain,
+                    redirect_to_topic: Some("custom_topic".to_string()),
+                    overflow_reason: Some(OverflowReason::ForceLimited),
+                    ..Default::default()
+                },
+                ExpectedRouting {
+                    topic: "custom_topic",
+                    has_key: true,
+                    force_disable_person_processing: None,
+                },
+            )
+            .await;
         }
 
         // ==================== send_batch ordering + error tests ====================
@@ -1895,8 +2087,7 @@ mod tests {
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
         async fn send_batch_preserves_order_same_key() {
             let producer = MockKafkaProducer::new();
-            let sink =
-                KafkaSinkBase::with_producer(producer.clone(), create_test_topics(), None, None);
+            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
 
             // 20 events, all sharing the same distinct_id (so they hash to the
             // same partition via murmur2), each with a unique UUID so we can
@@ -1909,6 +2100,7 @@ mod tests {
                         skip_person_processing: false,
                         redirect_to_dlq: false,
                         redirect_to_topic: None,
+                        overflow_reason: None,
                     })
                 })
                 .collect();
@@ -1956,8 +2148,7 @@ mod tests {
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
         async fn send_batch_prep_error_aborts_batch() {
             let producer = MockKafkaProducer::new();
-            let sink =
-                KafkaSinkBase::with_producer(producer.clone(), create_test_topics(), None, None);
+            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
 
             // Build a batch where event #3 is a SnapshotMain with session_id=None,
             // which causes prepare_record to return MissingSessionId. The other
@@ -1972,6 +2163,7 @@ mod tests {
                         skip_person_processing: false,
                         redirect_to_dlq: false,
                         redirect_to_topic: None,
+                        overflow_reason: None,
                     })
                 })
                 .collect();
@@ -1985,6 +2177,7 @@ mod tests {
                 skip_person_processing: false,
                 redirect_to_dlq: false,
                 redirect_to_topic: None,
+                overflow_reason: None,
             });
             bad.metadata.session_id = None;
             events[2] = bad;

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -2427,7 +2427,10 @@ mod tests {
                     v["distinct_id"].as_str().unwrap().to_string()
                 })
                 .collect();
-            assert_eq!(output, input_distinct_ids, "serial path must preserve order");
+            assert_eq!(
+                output, input_distinct_ids,
+                "serial path must preserve order"
+            );
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -712,6 +712,24 @@ async fn drain_acks(mut ack_set: JoinSet<Result<(), CaptureError>>) -> Result<()
     .await
 }
 
+/// Shared `KafkaTopicConfig` fixture for tests across the capture crate. Used
+/// by sink-side routing tests and pipeline-to-sink E2E tests to ensure every
+/// test site asserts against the same canonical topic names.
+#[cfg(test)]
+pub(crate) fn test_topics() -> KafkaTopicConfig {
+    KafkaTopicConfig {
+        main_topic: "events_plugin_ingestion".to_string(),
+        overflow_topic: "events_plugin_ingestion_overflow".to_string(),
+        historical_topic: "events_plugin_ingestion_historical".to_string(),
+        client_ingestion_warning_topic: "client_ingestion_warning".to_string(),
+        heatmaps_topic: "heatmaps".to_string(),
+        replay_overflow_topic: "replay_overflow".to_string(),
+        dlq_topic: "events_plugin_ingestion_dlq".to_string(),
+        error_tracking_topic: "error_tracking_events".to_string(),
+        traces_topic: "tracing_ingestion".to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::api::CaptureError;
@@ -1064,7 +1082,7 @@ mod tests {
     #[cfg(test)]
     mod topic_routing {
         use super::*;
-        use crate::sinks::kafka::{KafkaSinkBase, KafkaTopicConfig, SCATTER_GATHER_MIN_BATCH};
+        use crate::sinks::kafka::{test_topics, KafkaSinkBase, SCATTER_GATHER_MIN_BATCH};
         use crate::sinks::producer::MockKafkaProducer;
 
         const MAIN_TOPIC: &str = "events_plugin_ingestion";
@@ -1075,21 +1093,6 @@ mod tests {
         const CLIENT_INGESTION_WARNING_TOPIC: &str = "client_ingestion_warning";
         const REPLAY_OVERFLOW_TOPIC: &str = "replay_overflow";
         const ERROR_TRACKING_TOPIC: &str = "error_tracking_events";
-        const TRACES_TOPIC: &str = "tracing_ingestion";
-
-        fn create_test_topics() -> KafkaTopicConfig {
-            KafkaTopicConfig {
-                main_topic: MAIN_TOPIC.to_string(),
-                overflow_topic: OVERFLOW_TOPIC.to_string(),
-                historical_topic: HISTORICAL_TOPIC.to_string(),
-                client_ingestion_warning_topic: CLIENT_INGESTION_WARNING_TOPIC.to_string(),
-                heatmaps_topic: HEATMAPS_TOPIC.to_string(),
-                replay_overflow_topic: REPLAY_OVERFLOW_TOPIC.to_string(),
-                dlq_topic: DLQ_TOPIC.to_string(),
-                error_tracking_topic: ERROR_TRACKING_TOPIC.to_string(),
-                traces_topic: TRACES_TOPIC.to_string(),
-            }
-        }
 
         struct EventInput {
             data_type: DataType,
@@ -1152,7 +1155,7 @@ mod tests {
 
         async fn assert_routing(input: EventInput, expected: ExpectedRouting<'_>) {
             let producer = MockKafkaProducer::new();
-            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
+            let sink = KafkaSinkBase::with_producer(producer.clone(), test_topics());
 
             let event = create_test_event(&input);
             sink.send(event).await.unwrap();
@@ -1941,7 +1944,7 @@ mod tests {
         #[tokio::test]
         async fn dlq_headers_set_when_redirect_to_dlq() {
             let producer = MockKafkaProducer::new();
-            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
+            let sink = KafkaSinkBase::with_producer(producer.clone(), test_topics());
 
             let event = create_test_event(&EventInput {
                 data_type: DataType::AnalyticsMain,
@@ -1973,7 +1976,7 @@ mod tests {
         #[tokio::test]
         async fn dlq_headers_absent_for_normal_analytics() {
             let producer = MockKafkaProducer::new();
-            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
+            let sink = KafkaSinkBase::with_producer(producer.clone(), test_topics());
 
             let event = create_test_event(&EventInput {
                 data_type: DataType::AnalyticsMain,
@@ -2167,7 +2170,7 @@ mod tests {
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
         async fn send_batch_preserves_order_same_key() {
             let producer = MockKafkaProducer::new();
-            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
+            let sink = KafkaSinkBase::with_producer(producer.clone(), test_topics());
 
             // 20 events, all sharing the same distinct_id (so they hash to the
             // same partition via murmur2), each with a unique UUID so we can
@@ -2228,7 +2231,7 @@ mod tests {
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
         async fn send_batch_prep_error_aborts_batch() {
             let producer = MockKafkaProducer::new();
-            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
+            let sink = KafkaSinkBase::with_producer(producer.clone(), test_topics());
 
             // Build a batch where event #3 is a SnapshotMain with session_id=None,
             // which causes prepare_record to return MissingSessionId. The other
@@ -2279,52 +2282,6 @@ mod tests {
 
         // ==================== send_batch fast-path + mid-batch failure tests ====================
 
-        /// Mock producer whose Nth `send()` call returns Err. All other calls
-        /// capture the record like `MockKafkaProducer`. Used to exercise the
-        /// phase-2 mid-batch enqueue failure path.
-        #[derive(Clone)]
-        struct FailAtIndexProducer {
-            records: std::sync::Arc<std::sync::Mutex<Vec<crate::sinks::producer::ProduceRecord>>>,
-            fail_at: usize,
-            counter: std::sync::Arc<std::sync::atomic::AtomicUsize>,
-        }
-
-        impl FailAtIndexProducer {
-            fn new(fail_at: usize) -> Self {
-                Self {
-                    records: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
-                    fail_at,
-                    counter: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-                }
-            }
-
-            fn get_records(&self) -> Vec<crate::sinks::producer::ProduceRecord> {
-                self.records.lock().unwrap().clone()
-            }
-        }
-
-        impl crate::sinks::producer::KafkaProducer for FailAtIndexProducer {
-            type AckFuture = std::future::Ready<Result<(), CaptureError>>;
-
-            fn send(
-                &self,
-                record: crate::sinks::producer::ProduceRecord,
-            ) -> Result<Self::AckFuture, CaptureError> {
-                let idx = self
-                    .counter
-                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                if idx == self.fail_at {
-                    return Err(CaptureError::RetryableSinkError);
-                }
-                self.records.lock().unwrap().push(record);
-                Ok(std::future::ready(Ok(())))
-            }
-
-            fn flush(&self) -> Result<(), rdkafka::error::KafkaError> {
-                Ok(())
-            }
-        }
-
         /// Builds N AnalyticsMain events with sequential distinct_ids so each
         /// record is individually identifiable in the mock producer's output.
         fn build_batch(n: usize) -> Vec<ProcessedEvent> {
@@ -2345,8 +2302,8 @@ mod tests {
             // scatter-gather threshold so phase 2 runs post-parallel-prep.
             const BATCH: usize = 10;
             const FAIL_IDX: usize = 3;
-            let producer = FailAtIndexProducer::new(FAIL_IDX);
-            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
+            let producer = MockKafkaProducer::new_failing_at(FAIL_IDX);
+            let sink = KafkaSinkBase::with_producer(producer.clone(), test_topics());
 
             let events = build_batch(BATCH);
             let input_distinct_ids: Vec<String> =
@@ -2392,7 +2349,7 @@ mod tests {
             // batch_size=1 exercises the serial fast path (1 < SCATTER_GATHER_MIN_BATCH)
             // and verifies the loop handles a single-element batch correctly.
             let producer = MockKafkaProducer::new();
-            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
+            let sink = KafkaSinkBase::with_producer(producer.clone(), test_topics());
 
             let events = build_batch(1);
             sink.send_batch(events).await.expect("send_batch failed");
@@ -2408,7 +2365,7 @@ mod tests {
             // path. We can't observe "which path ran" directly, so we assert
             // behavioral equivalence: N records, correct topic, input order.
             let producer = MockKafkaProducer::new();
-            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
+            let sink = KafkaSinkBase::with_producer(producer.clone(), test_topics());
 
             let size = SCATTER_GATHER_MIN_BATCH - 1;
             let events = build_batch(size);
@@ -2439,7 +2396,7 @@ mod tests {
             // path. Behavioral equivalence with the serial path must hold:
             // same N records, same order, same topics.
             let producer = MockKafkaProducer::new();
-            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
+            let sink = KafkaSinkBase::with_producer(producer.clone(), test_topics());
 
             let size = SCATTER_GATHER_MIN_BATCH;
             let events = build_batch(size);
@@ -2471,7 +2428,7 @@ mod tests {
         /// and the scatter-gather path (10 events).
         async fn mixed_datatypes_routing_for_batch(pad_to: usize) {
             let producer = MockKafkaProducer::new();
-            let sink = KafkaSinkBase::with_producer(producer.clone(), create_test_topics());
+            let sink = KafkaSinkBase::with_producer(producer.clone(), test_topics());
 
             // Core 5-event diverse batch.
             let mut events: Vec<ProcessedEvent> = vec![

--- a/rust/capture/src/sinks/mod.rs
+++ b/rust/capture/src/sinks/mod.rs
@@ -8,6 +8,8 @@ pub mod noop;
 pub mod print;
 pub mod producer;
 pub mod s3;
+#[cfg(test)]
+pub(crate) mod test_sink;
 #[async_trait]
 pub trait Event {
     async fn send(&self, event: ProcessedEvent) -> Result<(), CaptureError>;

--- a/rust/capture/src/sinks/producer.rs
+++ b/rust/capture/src/sinks/producer.rs
@@ -171,16 +171,30 @@ impl<C: rdkafka::ClientContext + Send + Sync + 'static> KafkaProducer for RdKafk
     }
 }
 
-/// Mock Kafka producer for testing - captures all sent records
+/// Mock Kafka producer for testing - captures all sent records.
+///
+/// Optionally fails on a specific send index (0-based) by returning
+/// `CaptureError::RetryableSinkError`. Records before the failing index are
+/// still captured; the failing record is not. Used by send-batch tests that
+/// need to simulate a mid-batch enqueue failure.
 #[derive(Clone, Default)]
 pub struct MockKafkaProducer {
     records: std::sync::Arc<std::sync::Mutex<Vec<ProduceRecord>>>,
+    fail_at_index: Option<usize>,
+    call_count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl MockKafkaProducer {
     pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a producer that returns `RetryableSinkError` on the `idx`-th
+    /// `send()` call (0-based). All other calls succeed and capture the record.
+    pub fn new_failing_at(idx: usize) -> Self {
         Self {
-            records: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            fail_at_index: Some(idx),
+            ..Self::default()
         }
     }
 
@@ -199,6 +213,12 @@ impl KafkaProducer for MockKafkaProducer {
     type AckFuture = std::future::Ready<Result<(), CaptureError>>;
 
     fn send(&self, record: ProduceRecord) -> Result<Self::AckFuture, CaptureError> {
+        let idx = self
+            .call_count
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        if self.fail_at_index == Some(idx) {
+            return Err(CaptureError::RetryableSinkError);
+        }
         self.records.lock().unwrap().push(record);
         Ok(std::future::ready(Ok(())))
     }

--- a/rust/capture/src/sinks/producer.rs
+++ b/rust/capture/src/sinks/producer.rs
@@ -36,10 +36,17 @@ pub trait KafkaProducer: Send + Sync {
 /// Also records the full app-side ack duration (from `send_result()` returning to
 /// broker ack / error / cancellation) as a histogram so we can see the true long
 /// tail that the per-broker rdkafka rtt gauge smears away.
+///
+/// `recorded` flips to true once `poll` observes `Poll::Ready` so the Drop impl
+/// can emit a `capture_kafka_produce_ack_duration_ms{outcome="dropped"}` sample
+/// when the future is cancelled mid-flight (e.g. `JoinSet::abort_all()` fires
+/// after a peer ack fails). Without this, the slowest in-flight acks get
+/// censored out of the histogram precisely when the tail matters most.
 pub struct DeliveryAckFuture {
     inner: DeliveryFuture,
     started: Instant,
     topic: String,
+    recorded: bool,
 }
 
 impl Future for DeliveryAckFuture {
@@ -49,6 +56,8 @@ impl Future for DeliveryAckFuture {
         match Pin::new(&mut self.inner).poll(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(result) => {
+                // Mark before recording so a panic inside the match still disables Drop.
+                self.recorded = true;
                 let elapsed_ms = self.started.elapsed().as_secs_f64() * 1000.0;
                 let (outcome, mapped) = match result {
                     Err(_) => {
@@ -91,6 +100,23 @@ impl Future for DeliveryAckFuture {
     }
 }
 
+impl Drop for DeliveryAckFuture {
+    fn drop(&mut self) {
+        // Only fires when the future is dropped before poll saw Ready
+        // (e.g. JoinSet::abort_all on batch fail-fast). Records the elapsed
+        // wait so tail-latency dashboards don't lose the slowest samples.
+        if !self.recorded {
+            let elapsed_ms = self.started.elapsed().as_secs_f64() * 1000.0;
+            histogram!(
+                "capture_kafka_produce_ack_duration_ms",
+                "outcome" => "dropped",
+                "topic" => self.topic.clone()
+            )
+            .record(elapsed_ms);
+        }
+    }
+}
+
 /// Real Kafka producer implementation using rdkafka
 pub struct RdKafkaProducer<C: rdkafka::ClientContext + Send + Sync + 'static> {
     producer: FutureProducer<C>,
@@ -121,6 +147,7 @@ impl<C: rdkafka::ClientContext + Send + Sync + 'static> KafkaProducer for RdKafk
                 inner: delivery_future,
                 started: Instant::now(),
                 topic,
+                recorded: false,
             }),
             Err((e, _)) => match e.rdkafka_error_code() {
                 Some(RDKafkaErrorCode::MessageSizeTooLarge) => {

--- a/rust/capture/src/sinks/producer.rs
+++ b/rust/capture/src/sinks/producer.rs
@@ -1,11 +1,11 @@
 use common_types::CapturedEventHeaders;
-use metrics::counter;
+use metrics::{counter, histogram};
 use rdkafka::error::{KafkaError, RDKafkaErrorCode};
 use rdkafka::producer::{DeliveryFuture, FutureProducer, FutureRecord, Producer};
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tracing::error;
 
 use crate::api::CaptureError;
@@ -32,9 +32,14 @@ pub trait KafkaProducer: Send + Sync {
     fn flush(&self) -> Result<(), KafkaError>;
 }
 
-/// Future that wraps rdkafka's DeliveryFuture and converts the result to CaptureError
+/// Future that wraps rdkafka's DeliveryFuture and converts the result to CaptureError.
+/// Also records the full app-side ack duration (from `send_result()` returning to
+/// broker ack / error / cancellation) as a histogram so we can see the true long
+/// tail that the per-broker rdkafka rtt gauge smears away.
 pub struct DeliveryAckFuture {
     inner: DeliveryFuture,
+    started: Instant,
+    topic: String,
 }
 
 impl Future for DeliveryAckFuture {
@@ -44,32 +49,42 @@ impl Future for DeliveryAckFuture {
         match Pin::new(&mut self.inner).poll(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(result) => {
-                let mapped = match result {
+                let elapsed_ms = self.started.elapsed().as_secs_f64() * 1000.0;
+                let (outcome, mapped) = match result {
                     Err(_) => {
                         // Cancelled due to timeout while retrying
                         metrics::counter!("capture_kafka_produce_errors_total").increment(1);
                         error!("failed to produce to Kafka before write timeout");
-                        Err(CaptureError::RetryableSinkError)
+                        ("cancelled", Err(CaptureError::RetryableSinkError))
                     }
                     Ok(Err((
                         KafkaError::MessageProduction(RDKafkaErrorCode::MessageSizeTooLarge),
                         _,
                     ))) => {
                         report_dropped_events("kafka_message_size", 1);
-                        Err(CaptureError::EventTooBig(
-                            "Event rejected by kafka broker during ack".to_string(),
-                        ))
+                        (
+                            "too_large",
+                            Err(CaptureError::EventTooBig(
+                                "Event rejected by kafka broker during ack".to_string(),
+                            )),
+                        )
                     }
                     Ok(Err((err, _))) => {
                         metrics::counter!("capture_kafka_produce_errors_total").increment(1);
                         error!("failed to produce to Kafka: {err:#}");
-                        Err(CaptureError::RetryableSinkError)
+                        ("broker_err", Err(CaptureError::RetryableSinkError))
                     }
                     Ok(Ok(_)) => {
                         metrics::counter!("capture_events_ingested_total").increment(1);
-                        Ok(())
+                        ("ok", Ok(()))
                     }
                 };
+                histogram!(
+                    "capture_kafka_produce_ack_duration_ms",
+                    "outcome" => outcome,
+                    "topic" => self.topic.clone()
+                )
+                .record(elapsed_ms);
                 Poll::Ready(mapped)
             }
         }
@@ -92,6 +107,7 @@ impl<C: rdkafka::ClientContext + Send + Sync + 'static> KafkaProducer for RdKafk
 
     fn send(&self, record: ProduceRecord) -> Result<Self::AckFuture, CaptureError> {
         let headers: rdkafka::message::OwnedHeaders = record.headers.into();
+        let topic = record.topic.clone();
 
         match self.producer.send_result(FutureRecord {
             topic: &record.topic,
@@ -103,6 +119,8 @@ impl<C: rdkafka::ClientContext + Send + Sync + 'static> KafkaProducer for RdKafk
         }) {
             Ok(delivery_future) => Ok(DeliveryAckFuture {
                 inner: delivery_future,
+                started: Instant::now(),
+                topic,
             }),
             Err((e, _)) => match e.rdkafka_error_code() {
                 Some(RDKafkaErrorCode::MessageSizeTooLarge) => {

--- a/rust/capture/src/sinks/s3.rs
+++ b/rust/capture/src/sinks/s3.rs
@@ -362,6 +362,7 @@ mod tests {
                 skip_person_processing: false,
                 redirect_to_dlq: false,
                 redirect_to_topic: None,
+                overflow_reason: None,
             },
         }
     }

--- a/rust/capture/src/sinks/test_sink.rs
+++ b/rust/capture/src/sinks/test_sink.rs
@@ -1,0 +1,44 @@
+//! Shared `MockSink` test helper for pipeline-level tests across the capture
+//! crate. Captures every `ProcessedEvent` sent through `send` / `send_batch`
+//! in an `Arc<Mutex<Vec<_>>>` so tests can assert on the exact stamped
+//! metadata the pipeline produced.
+//!
+//! Supports both construction patterns used across existing tests:
+//! - `Arc::new(MockSink::new())` + `sink.get_events()` (analytics tests)
+//! - `Arc::new(MockSink { events: events_captured.clone() })` + manual
+//!   `events_captured.lock()` (recordings tests that share the handle with
+//!   the sink before wrapping in `Arc<dyn Event>`)
+
+use crate::api::CaptureError;
+use crate::sinks::Event;
+use crate::v0_request::ProcessedEvent;
+use async_trait::async_trait;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Default)]
+pub(crate) struct MockSink {
+    pub events: Arc<Mutex<Vec<ProcessedEvent>>>,
+}
+
+impl MockSink {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn get_events(&self) -> Vec<ProcessedEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl Event for MockSink {
+    async fn send(&self, event: ProcessedEvent) -> Result<(), CaptureError> {
+        self.events.lock().unwrap().push(event);
+        Ok(())
+    }
+
+    async fn send_batch(&self, events: Vec<ProcessedEvent>) -> Result<(), CaptureError> {
+        self.events.lock().unwrap().extend(events);
+        Ok(())
+    }
+}

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -75,6 +75,7 @@ pub async fn event(
                 state.event_restriction_service.clone(),
                 state.historical_cfg.clone(),
                 state.global_rate_limiter_token_distinctid.clone(),
+                state.overflow_limiter.clone(),
                 &events,
                 &context,
             )
@@ -139,6 +140,7 @@ pub async fn recording(
             if let Err(err) = process_replay_events(
                 state.sink.clone(),
                 state.event_restriction_service.clone(),
+                state.replay_overflow_limiter.clone(),
                 events,
                 &context,
             )

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -176,10 +176,15 @@ pub struct ProcessedEvent {
 
 /// Reason the pipeline has decided to reroute an event to an overflow topic.
 ///
-/// Set by the pipeline (`events::analytics::process_events` for analytics,
-/// `events::recordings::process_replay_events` for replay snapshots) based on
-/// the `OverflowLimiter` (governor-backed, in-process) and the replay
-/// `RedisLimiter` (session-scoped, redis-backed).
+/// Set by every handler that emits events to the kafka sink, via the shared
+/// `events::overflow_stamping::stamp_overflow_reason` helper for the
+/// in-process `OverflowLimiter` (governor-backed) paths and a separate inline
+/// check for the replay `RedisLimiter` (session-scoped, redis-backed). Call
+/// sites:
+/// * `events::analytics::process_events` — `/e/`, `/batch/`, `/capture`, etc.
+/// * `events::recordings::process_replay_events` — `/s/` (stamps `ReplayLimited`)
+/// * `ai_endpoint::ai_handler` — `/i/v0/ai`
+/// * `otel::otel_handler` — `/i/v0/ai/otel`
 ///
 /// Consumed by `sinks::kafka::KafkaSinkBase::prepare_record`, which is pure
 /// mechanism: it reads this reason and maps to the overflow topic and

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -174,6 +174,33 @@ pub struct ProcessedEvent {
     pub event: CapturedEvent,
 }
 
+/// Reason the pipeline has decided to reroute an event to an overflow topic.
+///
+/// Set by the pipeline (`events::analytics::process_events` for analytics,
+/// `events::recordings::process_replay_events` for replay snapshots) based on
+/// the `OverflowLimiter` (governor-backed, in-process) and the replay
+/// `RedisLimiter` (session-scoped, redis-backed).
+///
+/// Consumed by `sinks::kafka::KafkaSinkBase::prepare_record`, which is pure
+/// mechanism: it reads this reason and maps to the overflow topic and
+/// partition key. The sink does not make routing policy decisions of its own
+/// for overflow beyond this mapping.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OverflowReason {
+    /// Governor matched a configured `keys_to_reroute` entry for this event's
+    /// key. Events in this state always have `skip_person_processing = true`
+    /// and are routed to the overflow topic with a null partition key.
+    ForceLimited,
+    /// Per-key rate exceeded the configured governor quota. Routed to the
+    /// overflow topic. `preserve_locality` mirrors the
+    /// `overflow_preserve_partition_locality` config and determines whether
+    /// the original partition key is preserved on the overflow topic.
+    RateLimited { preserve_locality: bool },
+    /// Session-level replay overflow signalled by the redis-backed limiter.
+    /// Routed to the replay overflow topic, keyed on session_id.
+    ReplayLimited,
+}
+
 #[derive(Debug, Clone)]
 pub struct ProcessedEventMetadata {
     pub data_type: DataType,
@@ -188,6 +215,11 @@ pub struct ProcessedEventMetadata {
     pub redirect_to_dlq: bool,
     /// Redirect this event to a custom topic (set by event restrictions)
     pub redirect_to_topic: Option<String>,
+    /// Overflow routing decision stamped by the pipeline. `None` means the
+    /// event stays on its default topic for its `data_type`. See
+    /// [`OverflowReason`] for who sets this and what each variant maps to in
+    /// the kafka sink.
+    pub overflow_reason: Option<OverflowReason>,
 }
 
 #[cfg(test)]

--- a/rust/capture/tests/common/integration_utils.rs
+++ b/rust/capture/tests/common/integration_utils.rs
@@ -1015,6 +1015,8 @@ fn setup_capture_router(unit: &TestCase) -> (Router, MemorySink) {
             Some(10),   // request_timeout_seconds
             None,       // body_chunk_read_timeout_ms
             256,        // body_read_chunk_size_kb
+            None,       // overflow_limiter
+            None,       // replay_overflow_limiter
         ),
         sink,
     )

--- a/rust/capture/tests/integration_ai_endpoint.rs
+++ b/rust/capture/tests/integration_ai_endpoint.rs
@@ -189,6 +189,8 @@ fn setup_ai_test_router() -> Router {
         Some(10),                         // request_timeout_seconds
         None,                             // body_chunk_read_timeout_ms
         256,                              // body_read_chunk_size_kb
+        None,                             // overflow_limiter
+        None,                             // replay_overflow_limiter
     )
 }
 
@@ -1646,6 +1648,8 @@ fn setup_ai_test_router_with_capturing_sink() -> (Router, CapturingSink) {
         Some(10),                         // request_timeout_seconds
         None,                             // body_chunk_read_timeout_ms
         256,                              // body_read_chunk_size_kb
+        None,                             // overflow_limiter
+        None,                             // replay_overflow_limiter
     );
 
     (router, sink_clone)
@@ -2555,6 +2559,8 @@ fn setup_ai_test_router_with_token_dropper(token_dropper: TokenDropper) -> (Rout
         Some(10),                         // request_timeout_seconds
         None,                             // body_chunk_read_timeout_ms
         256,                              // body_read_chunk_size_kb
+        None,                             // overflow_limiter
+        None,                             // replay_overflow_limiter
     );
 
     (router, sink_clone)
@@ -2759,6 +2765,8 @@ fn setup_ai_test_router_with_llm_quota_limited(token: &str) -> (Router, Capturin
         Some(10),                         // request_timeout_seconds
         None,                             // body_chunk_read_timeout_ms
         256,                              // body_read_chunk_size_kb
+        None,                             // overflow_limiter
+        None,                             // replay_overflow_limiter
     );
 
     (router, sink_clone)

--- a/rust/capture/tests/integration_ai_endpoint.rs
+++ b/rust/capture/tests/integration_ai_endpoint.rs
@@ -12,15 +12,17 @@ use capture::quota_limiters::CaptureQuotaLimiter;
 use capture::router::router;
 use capture::sinks::Event;
 use capture::time::TimeSource;
-use capture::v0_request::ProcessedEvent;
+use capture::v0_request::{OverflowReason, ProcessedEvent};
 use chrono::{DateTime, TimeZone, Utc};
 use common_redis::MockRedisClient;
 use futures::StreamExt;
 use integration_utils::{test_lifecycle_handlers, DEFAULT_CONFIG, DEFAULT_TEST_TIME};
+use limiters::overflow::OverflowLimiter;
 use limiters::token_dropper::TokenDropper;
 use reqwest::multipart::{Form, Part};
 use serde_json::{json, Value};
 use std::io::Write;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -2853,4 +2855,156 @@ async fn test_ai_endpoint_quota_limiter_returns_billing_limit_error_message() {
         response_text.contains("billing limit"),
         "Response should contain 'billing limit' error message, got: {response_text}"
     );
+}
+
+// ============================================================================
+// OverflowLimiter coverage for the AI endpoint
+// ============================================================================
+//
+// These tests exercise the shared `stamp_overflow_reason` helper invoked in
+// `ai_handler` immediately after `build_kafka_event`. Pre-refactor the
+// OverflowLimiter check happened inside the kafka sink; now it's a pipeline
+// concern stamped into `ProcessedEventMetadata::overflow_reason`. Since AI
+// bypasses `events::analytics::process_events`, these tests are the
+// regression guard for `capture-ai-prod-us` (which runs with
+// `OVERFLOW_ENABLED=true` + `OVERFLOW_PRESERVE_PARTITION_LOCALITY=true`).
+
+const AI_OVERFLOW_TEST_TOKEN: &str = "phc_VXRzc3poSG9GZm1JenRianJ6TTJFZGh4OWY2QXzx9f3";
+
+/// Variant of `setup_ai_test_router_with_capturing_sink` that wires a real
+/// `OverflowLimiter` into the router. Existing helpers still pass `None`; this
+/// one opts in to exercise the governor path.
+fn setup_ai_test_router_with_overflow_limiter(
+    overflow_limiter: Arc<OverflowLimiter>,
+) -> (Router, CapturingSink) {
+    let (readiness, liveness, _monitor) = test_lifecycle_handlers();
+
+    let sink = CapturingSink::new();
+    let sink_clone = sink.clone();
+    let timesource = FixedTime {
+        time: DateTime::parse_from_rfc3339(DEFAULT_TEST_TIME)
+            .expect("Invalid fixed time format")
+            .with_timezone(&Utc),
+    };
+    let redis = Arc::new(MockRedisClient::new());
+
+    let mut cfg = DEFAULT_CONFIG.clone();
+    cfg.capture_mode = CaptureMode::Events;
+
+    let quota_limiter =
+        CaptureQuotaLimiter::new(&cfg, redis.clone(), Duration::from_secs(60 * 60 * 24 * 7));
+
+    let router = router(
+        timesource,
+        readiness,
+        liveness,
+        Arc::new(sink),
+        redis,
+        None,
+        quota_limiter,
+        TokenDropper::default(),
+        None, // event_restriction_service
+        false,
+        CaptureMode::Events,
+        String::from("capture-ai"),
+        None,
+        25 * 1024 * 1024,
+        false,
+        1_i64,
+        false,
+        0.0_f32,
+        26_214_400,
+        Some(create_mock_blob_storage()),
+        Some(10),
+        None,
+        256,
+        Some(overflow_limiter), // overflow_limiter
+        None,                   // replay_overflow_limiter
+    );
+
+    (router, sink_clone)
+}
+
+#[tokio::test]
+async fn test_ai_event_with_hot_key_stamps_force_limited_reason() {
+    // Configure the OverflowLimiter to force-route the specific
+    // `token:distinct_id` key. `per_second`/`burst` are generous so only the
+    // explicit `keys_to_reroute` entry triggers — this isolates the
+    // ForceLimited branch from the RateLimited branch.
+    let hot_distinct_id = "user_hot_key";
+    let hot_key = format!("{AI_OVERFLOW_TEST_TOKEN}:{hot_distinct_id}");
+    let overflow_limiter = Arc::new(OverflowLimiter::new(
+        NonZeroU32::new(1_000).unwrap(),
+        NonZeroU32::new(1_000).unwrap(),
+        Some(hot_key),
+        true, // preserve_locality (matches capture-ai-prod-us config)
+    ));
+
+    let (router, sink) = setup_ai_test_router_with_overflow_limiter(overflow_limiter);
+    let test_client = TestClient::new(router);
+
+    let properties = json!({"$ai_model": "gpt-4"});
+    let form = create_ai_event_form("$ai_generation", hot_distinct_id, properties);
+
+    let response = send_multipart_request(&test_client, form, Some(AI_OVERFLOW_TEST_TOKEN)).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let events = sink.get_events().await;
+    assert_eq!(events.len(), 1, "AI event should still reach the sink");
+
+    let event = &events[0];
+    assert_eq!(
+        event.metadata.overflow_reason,
+        Some(OverflowReason::ForceLimited),
+        "hot key must be stamped ForceLimited so the sink routes to overflow"
+    );
+    assert!(
+        event.metadata.skip_person_processing,
+        "ForceLimited implies skip_person_processing so the header is set"
+    );
+}
+
+#[tokio::test]
+async fn test_ai_event_with_cold_key_leaves_overflow_reason_none() {
+    // Governor is wide open and no keys_to_reroute — the helper must leave
+    // `overflow_reason` as None so the sink uses the default topic.
+    let overflow_limiter = Arc::new(OverflowLimiter::new(
+        NonZeroU32::new(1_000).unwrap(),
+        NonZeroU32::new(1_000).unwrap(),
+        None,
+        true,
+    ));
+
+    let (router, sink) = setup_ai_test_router_with_overflow_limiter(overflow_limiter);
+    let test_client = TestClient::new(router);
+
+    let properties = json!({"$ai_model": "gpt-4"});
+    let form = create_ai_event_form("$ai_generation", "cold_user", properties);
+
+    let response = send_multipart_request(&test_client, form, Some(AI_OVERFLOW_TEST_TOKEN)).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let events = sink.get_events().await;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].metadata.overflow_reason, None);
+    assert!(!events[0].metadata.skip_person_processing);
+}
+
+#[tokio::test]
+async fn test_ai_endpoint_without_overflow_limiter_is_parity_with_pre_refactor() {
+    // `capture-ai-*` with `OVERFLOW_ENABLED=false` (or setups without a
+    // limiter configured at all) must behave exactly as before: reason stays
+    // None. This pins the `None` short-circuit inside `stamp_overflow_reason`.
+    let (router, sink) = setup_ai_test_router_with_capturing_sink();
+    let test_client = TestClient::new(router);
+
+    let properties = json!({"$ai_model": "gpt-4"});
+    let form = create_ai_event_form("$ai_generation", "any_user", properties);
+
+    let response = send_multipart_request(&test_client, form, Some(AI_OVERFLOW_TEST_TOKEN)).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let events = sink.get_events().await;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].metadata.overflow_reason, None);
 }

--- a/rust/capture/tests/integration_ai_restrictions.rs
+++ b/rust/capture/tests/integration_ai_restrictions.rs
@@ -20,9 +20,11 @@ use chrono::{DateTime, Utc};
 use common_redis::MockRedisClient;
 use futures::StreamExt;
 use integration_utils::{test_lifecycle_handlers, DEFAULT_CONFIG, DEFAULT_TEST_TIME};
+use limiters::overflow::OverflowLimiter;
 use limiters::token_dropper::TokenDropper;
 use reqwest::multipart::{Form, Part};
 use serde_json::{json, Value};
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -504,6 +506,131 @@ async fn setup_ai_router_with_redirect_to_topic(
     );
 
     (router, sink_clone)
+}
+
+/// Sets up an AI router that has BOTH a `ForceOverflow` event restriction AND
+/// a configured `OverflowLimiter`. Used to verify the interaction ordering:
+/// `force_overflow` must short-circuit the limiter so
+/// `ProcessedEventMetadata::overflow_reason` stays `None`. This mirrors the
+/// analytics `force_overflow` path in `events/analytics.rs` — same semantics,
+/// different entry point.
+async fn setup_ai_router_with_force_overflow_and_limiter(
+    token: &str,
+    overflow_limiter: Arc<OverflowLimiter>,
+) -> (Router, CapturingSink) {
+    let (readiness, liveness, _monitor) = test_lifecycle_handlers();
+
+    let sink = CapturingSink::new();
+    let sink_clone = sink.clone();
+    let timesource = FixedTime {
+        time: DateTime::parse_from_rfc3339(DEFAULT_TEST_TIME)
+            .expect("Invalid fixed time format")
+            .with_timezone(&Utc),
+    };
+    let redis = Arc::new(MockRedisClient::new());
+
+    let mut cfg = DEFAULT_CONFIG.clone();
+    cfg.capture_mode = CaptureMode::Events;
+
+    let quota_limiter =
+        CaptureQuotaLimiter::new(&cfg, redis.clone(), Duration::from_secs(60 * 60 * 24 * 7));
+
+    let service = EventRestrictionService::new(CaptureMode::Ai, Duration::from_secs(300));
+
+    let mut manager = RestrictionManager::new();
+    manager.restrictions.insert(
+        token.to_string(),
+        vec![Restriction {
+            restriction_type: RestrictionType::ForceOverflow,
+            scope: RestrictionScope::AllEvents,
+            args: None,
+        }],
+    );
+    service.update(manager).await;
+
+    let router = router(
+        timesource,
+        readiness,
+        liveness,
+        Arc::new(sink),
+        redis,
+        None,
+        quota_limiter,
+        TokenDropper::default(),
+        Some(service),
+        false,
+        CaptureMode::Events,
+        String::from("capture-ai"),
+        None,
+        25 * 1024 * 1024,
+        false,
+        1_i64,
+        false,
+        0.0_f32,
+        26_214_400,
+        Some(create_mock_blob_storage()),
+        Some(10),
+        None,
+        256,
+        Some(overflow_limiter), // overflow_limiter
+        None,                   // replay_overflow_limiter
+    );
+
+    (router, sink_clone)
+}
+
+#[tokio::test]
+async fn test_ai_force_overflow_restriction_wins_over_overflow_limiter() {
+    // The OverflowLimiter is configured to ForceLimited this exact key, so if
+    // the short-circuit fails we'd see `overflow_reason = ForceLimited` AND
+    // `skip_person_processing = true`. The restriction-driven code path must
+    // fire first, leaving the limiter untouched: force_overflow = true,
+    // overflow_reason = None, skip_person_processing stays false (because the
+    // restriction only sets force_overflow, not skip_person_processing).
+    let restricted_token = "phc_force_overflow_with_limiter_token";
+    let distinct_id = "test_user";
+    let hot_key = format!("{restricted_token}:{distinct_id}");
+
+    let overflow_limiter = Arc::new(OverflowLimiter::new(
+        NonZeroU32::new(1_000).unwrap(),
+        NonZeroU32::new(1_000).unwrap(),
+        Some(hot_key),
+        true, // preserve_locality
+    ));
+
+    let (router, sink) =
+        setup_ai_router_with_force_overflow_and_limiter(restricted_token, overflow_limiter).await;
+    let test_client = TestClient::new(router);
+
+    let properties = json!({"$ai_model": "gpt-4"});
+    let form = create_ai_event_form("$ai_generation", distinct_id, properties);
+
+    let response = send_multipart_request(&test_client, form, Some(restricted_token)).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let events = sink.get_events().await;
+    assert_eq!(events.len(), 1);
+
+    assert_event(
+        &events[0],
+        &ExpectedEvent {
+            token: restricted_token,
+            distinct_id,
+            event_name: "$ai_generation",
+            data_type: DataType::AnalyticsMain,
+            force_overflow: true,
+            skip_person_processing: false,
+            redirect_to_dlq: false,
+            redirect_to_topic: None,
+            expected_properties: Some(json!({"$ai_model": "gpt-4"})),
+        },
+    );
+
+    assert_eq!(
+        events[0].metadata.overflow_reason, None,
+        "force_overflow must short-circuit the limiter; overflow_reason stays None so the \
+         sink routes via the event_restriction branch (not the limiter branches)"
+    );
 }
 
 #[tokio::test]

--- a/rust/capture/tests/integration_ai_restrictions.rs
+++ b/rust/capture/tests/integration_ai_restrictions.rs
@@ -184,7 +184,9 @@ async fn setup_ai_router_with_restriction(
         Some(create_mock_blob_storage()),
         Some(10),
         None,
-        256, // body_read_chunk_size_kb
+        256,  // body_read_chunk_size_kb
+        None, // overflow_limiter
+        None, // replay_overflow_limiter
     );
 
     (router, sink_clone)
@@ -496,7 +498,9 @@ async fn setup_ai_router_with_redirect_to_topic(
         Some(create_mock_blob_storage()),
         Some(10),
         None,
-        256, // body_read_chunk_size_kb
+        256,  // body_read_chunk_size_kb
+        None, // overflow_limiter
+        None, // replay_overflow_limiter
     );
 
     (router, sink_clone)

--- a/rust/capture/tests/integration_analytics_restrictions.rs
+++ b/rust/capture/tests/integration_analytics_restrictions.rs
@@ -120,7 +120,9 @@ async fn setup_analytics_router_with_restriction(
         None, // no blob storage for analytics
         Some(10),
         None,
-        256, // body_read_chunk_size_kb
+        256,  // body_read_chunk_size_kb
+        None, // overflow_limiter
+        None, // replay_overflow_limiter
     );
 
     (router, sink_clone)
@@ -457,7 +459,9 @@ async fn setup_analytics_router_with_redirect_to_topic(
         None,
         Some(10),
         None,
-        256, // body_read_chunk_size_kb
+        256,  // body_read_chunk_size_kb
+        None, // overflow_limiter
+        None, // replay_overflow_limiter
     );
 
     (router, sink_clone)

--- a/rust/capture/tests/integration_otel_endpoint.rs
+++ b/rust/capture/tests/integration_otel_endpoint.rs
@@ -175,6 +175,8 @@ fn make_test_client_with_options(sink: &CapturingSink, options: TestClientOption
         Some(10),         // request_timeout_seconds
         None,             // body_chunk_read_timeout_ms
         256,              // body_read_chunk_size_kb
+        None,             // overflow_limiter
+        None,             // replay_overflow_limiter
     );
 
     TestClient::new(app)

--- a/rust/capture/tests/integration_otel_endpoint.rs
+++ b/rust/capture/tests/integration_otel_endpoint.rs
@@ -14,10 +14,11 @@ use capture::quota_limiters::{is_llm_event, CaptureQuotaLimiter, EventInfo};
 use capture::router::router;
 use capture::sinks::Event;
 use capture::time::TimeSource;
-use capture::v0_request::{DataType, ProcessedEvent};
+use capture::v0_request::{DataType, OverflowReason, ProcessedEvent};
 use chrono::{DateTime, Utc};
 use common_redis::MockRedisClient;
 use integration_utils::{test_lifecycle_handlers, DEFAULT_TEST_TIME};
+use limiters::overflow::OverflowLimiter;
 use limiters::redis::{QuotaResource, QUOTA_LIMITER_CACHE_KEY};
 use limiters::token_dropper::TokenDropper;
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
@@ -27,6 +28,7 @@ use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span};
 use prost::Message;
 use serde_json::json;
 use std::collections::HashSet;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -122,6 +124,10 @@ struct TestClientOptions {
     redis: Option<Arc<MockRedisClient>>,
     event_restriction_service: Option<EventRestrictionService>,
     quota_limiter: Option<CaptureQuotaLimiter>,
+    // Opt-in OverflowLimiter wiring. `None` (default) matches production
+    // configs without `OVERFLOW_ENABLED=true` and exercises the no-op branch
+    // of `stamp_overflow_reason`.
+    overflow_limiter: Option<Arc<OverflowLimiter>>,
 }
 
 fn make_test_client(sink: &CapturingSink) -> TestClient {
@@ -175,7 +181,7 @@ fn make_test_client_with_options(sink: &CapturingSink, options: TestClientOption
         Some(10),         // request_timeout_seconds
         None,             // body_chunk_read_timeout_ms
         256,              // body_read_chunk_size_kb
-        None,             // overflow_limiter
+        options.overflow_limiter, // overflow_limiter
         None,             // replay_overflow_limiter
     );
 
@@ -1046,4 +1052,181 @@ async fn test_filtered_drop_restriction_rejects_otel_batch() {
     // entire batch is rejected (all-or-nothing semantics).
     let events = sink.get_events().await;
     assert!(events.is_empty());
+}
+
+// ============================================================================
+// OverflowLimiter coverage for the OTEL endpoint
+// ============================================================================
+//
+// `otel_handler` bypasses `events::analytics::process_events` and produces
+// `DataType::AnalyticsMain` spans directly, so the shared
+// `stamp_overflow_reason` helper is what preserves OverflowLimiter parity for
+// `capture-ai-prod-us`. These tests exercise the helper end-to-end across the
+// OTEL batch path.
+//
+// Note on OTEL batching semantics: `otel::identity::extract_distinct_id`
+// returns a single distinct_id for the entire request (derived from
+// ResourceSpan attributes), so all spans in one request share the same
+// `token:distinct_id` key. The helper still evaluates per-event — the tests
+// below reflect the realistic per-request shape.
+
+fn make_three_span_request() -> ExportTraceServiceRequest {
+    ExportTraceServiceRequest {
+        resource_spans: vec![ResourceSpans {
+            resource: Some(Resource {
+                attributes: vec![make_kv(
+                    "posthog.distinct_id",
+                    any_value::Value::StringValue("user-1".to_string()),
+                )],
+                dropped_attributes_count: 0,
+            }),
+            scope_spans: vec![ScopeSpans {
+                scope: None,
+                spans: vec![
+                    make_span(
+                        vec![1; 16],
+                        vec![1; 8],
+                        vec![],
+                        1_704_067_200_000_000_000,
+                        vec![make_kv(
+                            "gen_ai.operation.name",
+                            any_value::Value::StringValue("chat".to_string()),
+                        )],
+                    ),
+                    make_span(
+                        vec![1; 16],
+                        vec![2; 8],
+                        vec![1; 8],
+                        1_704_067_200_000_000_000,
+                        vec![make_kv(
+                            "gen_ai.operation.name",
+                            any_value::Value::StringValue("chat".to_string()),
+                        )],
+                    ),
+                    make_span(
+                        vec![1; 16],
+                        vec![3; 8],
+                        vec![1; 8],
+                        1_704_067_200_000_000_000,
+                        vec![make_kv(
+                            "gen_ai.operation.name",
+                            any_value::Value::StringValue("chat".to_string()),
+                        )],
+                    ),
+                ],
+                schema_url: String::new(),
+            }],
+            schema_url: String::new(),
+        }],
+    }
+}
+
+#[tokio::test]
+async fn test_otel_batch_with_hot_token_stamps_force_limited_on_every_span() {
+    // Hot-list the request's `token:distinct_id`. Because OTEL derives one
+    // distinct_id per request (see identity::extract_distinct_id), every span
+    // in the batch shares the key, so every span is stamped ForceLimited.
+    let hot_key = format!("{TOKEN}:user-1");
+    let overflow_limiter = Arc::new(OverflowLimiter::new(
+        NonZeroU32::new(1_000).unwrap(),
+        NonZeroU32::new(1_000).unwrap(),
+        Some(hot_key),
+        true, // preserve_locality
+    ));
+
+    let sink = CapturingSink::new();
+    let client = make_test_client_with_options(
+        &sink,
+        TestClientOptions {
+            overflow_limiter: Some(overflow_limiter),
+            ..Default::default()
+        },
+    );
+
+    let request = make_three_span_request();
+    let status = send_request_with_client(&client, &request).await;
+    assert_eq!(status, 200);
+
+    let events = sink.get_events().await;
+    assert_eq!(events.len(), 3);
+
+    for (i, event) in events.iter().enumerate() {
+        assert_eq!(
+            event.metadata.overflow_reason,
+            Some(OverflowReason::ForceLimited),
+            "span[{i}] must be stamped ForceLimited"
+        );
+        assert!(
+            event.metadata.skip_person_processing,
+            "span[{i}] ForceLimited implies skip_person_processing"
+        );
+        assert_eq!(event.metadata.data_type, DataType::AnalyticsMain);
+    }
+}
+
+#[tokio::test]
+async fn test_otel_batch_rate_limited_key_stamps_overbudget_spans() {
+    // burst=1, per_second=1: the first span in the batch fits, subsequent
+    // spans exhaust the budget and get RateLimited. This proves the helper
+    // runs per-event within the OTEL Vec (not once-per-request) and that the
+    // `preserve_locality` flag is mirrored faithfully onto the reason.
+    let overflow_limiter = Arc::new(OverflowLimiter::new(
+        NonZeroU32::new(1).unwrap(),
+        NonZeroU32::new(1).unwrap(),
+        None,
+        true, // preserve_locality
+    ));
+
+    let sink = CapturingSink::new();
+    let client = make_test_client_with_options(
+        &sink,
+        TestClientOptions {
+            overflow_limiter: Some(overflow_limiter),
+            ..Default::default()
+        },
+    );
+
+    let request = make_three_span_request();
+    let status = send_request_with_client(&client, &request).await;
+    assert_eq!(status, 200);
+
+    let events = sink.get_events().await;
+    assert_eq!(events.len(), 3);
+
+    assert_eq!(
+        events[0].metadata.overflow_reason, None,
+        "first span fits within the burst"
+    );
+    for (i, event) in events.iter().enumerate().skip(1) {
+        assert_eq!(
+            event.metadata.overflow_reason,
+            Some(OverflowReason::RateLimited {
+                preserve_locality: true
+            }),
+            "span[{i}] must be stamped RateLimited{{preserve_locality: true}}"
+        );
+        assert!(
+            !event.metadata.skip_person_processing,
+            "span[{i}] RateLimited does NOT imply skip_person_processing"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_otel_batch_without_overflow_limiter_leaves_reason_none() {
+    // Baseline: no limiter wired (deploy without `OVERFLOW_ENABLED=true`) —
+    // overflow_reason must stay None across the batch, matching pre-refactor
+    // behavior.
+    let sink = CapturingSink::new();
+    let request = make_three_span_request();
+
+    let status = send_request(&sink, &request).await;
+    assert_eq!(status, 200);
+
+    let events = sink.get_events().await;
+    assert_eq!(events.len(), 3);
+    for event in &events {
+        assert_eq!(event.metadata.overflow_reason, None);
+        assert!(!event.metadata.skip_person_processing);
+    }
 }

--- a/rust/capture/tests/integration_replay_restrictions.rs
+++ b/rust/capture/tests/integration_replay_restrictions.rs
@@ -121,7 +121,9 @@ async fn setup_recordings_router_with_restriction(
         None, // no blob storage for recordings
         Some(10),
         None,
-        256, // body_read_chunk_size_kb
+        256,  // body_read_chunk_size_kb
+        None, // overflow_limiter
+        None, // replay_overflow_limiter
     );
 
     (router, sink_clone)
@@ -483,7 +485,9 @@ async fn setup_recordings_router_with_redirect_to_topic(
         None, // no blob storage for recordings
         Some(10),
         None,
-        256, // body_read_chunk_size_kb
+        256,  // body_read_chunk_size_kb
+        None, // overflow_limiter
+        None, // replay_overflow_limiter
     );
 
     (router, sink_clone)

--- a/rust/capture/tests/quota_limiters.rs
+++ b/rust/capture/tests/quota_limiters.rs
@@ -147,6 +147,8 @@ async fn setup_router_with_limits(
         Some(10),    // request_timeout_seconds
         None,        // body_chunk_read_timeout_ms
         256,         // body_read_chunk_size_kb
+        None,        // overflow_limiter
+        None,        // replay_overflow_limiter
     );
 
     (app, sink)
@@ -1193,6 +1195,8 @@ async fn test_survey_quota_cross_batch_first_submission_allowed() {
         Some(10), // request_timeout_seconds
         None,     // body_chunk_read_timeout_ms
         256,      // body_read_chunk_size_kb
+        None,     // overflow_limiter
+        None,     // replay_overflow_limiter
     );
 
     let client = TestClient::new(app);
@@ -1277,6 +1281,8 @@ async fn test_survey_quota_cross_batch_duplicate_submission_dropped() {
         Some(10), // request_timeout_seconds
         None,     // body_chunk_read_timeout_ms
         256,      // body_read_chunk_size_kb
+        None,     // overflow_limiter
+        None,     // replay_overflow_limiter
     );
 
     let client = TestClient::new(app);
@@ -1365,6 +1371,8 @@ async fn test_survey_quota_cross_batch_redis_error_fail_open() {
         Some(10), // request_timeout_seconds
         None,     // body_chunk_read_timeout_ms
         256,      // body_read_chunk_size_kb
+        None,     // overflow_limiter
+        None,     // replay_overflow_limiter
     );
 
     let client = TestClient::new(app);
@@ -1790,6 +1798,8 @@ async fn test_ai_quota_cross_batch_redis_error_fail_open() {
         Some(10), // request_timeout_seconds
         None,     // body_chunk_read_timeout_ms
         256,      // body_read_chunk_size_kb
+        None,     // overflow_limiter
+        None,     // replay_overflow_limiter
     );
 
     let client = TestClient::new(app);


### PR DESCRIPTION
## Problem
We need more visibility into causes of tail latency when producing with `rdkafka-rust` to WarpStream. 

We also have a root-cause for initial long tail response latency we were seeing, and a potentially risky capture change to parallelize ACK/enqueue `await`s in capture produce step:

This PR converts from sequential ACK awaits to scatter-gather to parallelize this step. This should help avoid tail latency when one `await` early in the batch takes a long time to respond, and we risk timing out the total batch once we get to the others that may have legitimately succeeded or taken much less of the global time budget.

The refactor also required moving overflow and redis limiter checks out of the kafka produce step and upstream into processing pipeline where they belong anyway (there were comments about this tech debt in the code.) but extended the size of the PR. I can split this up prior to landing if needed 👍 

For safety, I've **smoke testing this in capture-mirrored via Argo hot-patch** over the weekend and during Monday peak traffic. All looks good, comparing back to same period in prod capture processing the same event submissions.

⚠️ **Do Not Merge until properly validated** ⚠️ 

_Note: as part of this change, I had to clean up some tech debt: moving last-mile filter and limiter checks homed in the kafka sink step back upstream into the processing pipelines where they belong. This required new tests to ensure the change is safe and correct._

_The point: this ended up a larger changeset than when it started! If the testing goes well and we want to ship it, **I'll split it up for review as stacked PRs**_

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
* Introduce parallel produce ACK awaits in `capture`
* Migrate overflow and redis limiter checks into pipeline, out of Kafka produce step (long standing tech debt anyway)
* Related test suite changes and test helper dedup from the above refactor ☝️ 
* Additional metrics granularity from `rdkafka-rust` client
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally and in CI. Mirror deploy smoke test on the way
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
N/A
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update
N/A
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
