### PR TITLE
fix(flags): return 403 for PAKs with insufficient scopes

### DIFF
--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -312,9 +312,7 @@ fn validate_personal_key_metadata(data: &TokenAuthData, team: &Team) -> Result<(
             // Check scopes — return 403 (not 401) when the key is valid but lacks permissions
             if let Some(scope_list) = scopes {
                 if scope_list.is_empty() {
-                    debug!(
-                        "Personal API key has an explicit empty scopes list; no access"
-                    );
+                    debug!("Personal API key has an explicit empty scopes list; no access");
                     return Err(FlagError::PersonalApiKeyInsufficientScopes);
                 }
 

--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -242,11 +242,6 @@ async fn load_personal_key_from_pg(
         INNER JOIN posthog_user u ON pak.user_id = u.id
         WHERE pak.secure_value = $1
           AND u.is_active = true
-          AND (
-              '*' = ANY(pak.scopes)
-              OR 'feature_flag:read' = ANY(pak.scopes)
-              OR 'feature_flag:write' = ANY(pak.scopes)
-          )
     "#;
 
     match sqlx::query(query)
@@ -273,7 +268,7 @@ async fn load_personal_key_from_pg(
             }))
         }
         None => {
-            warn!("Personal API key not found or doesn't have required scopes");
+            warn!("Personal API key not found");
             Ok(None)
         }
     }
@@ -314,15 +309,13 @@ fn validate_personal_key_metadata(data: &TokenAuthData, team: &Team) -> Result<(
                 }
             }
 
-            // Check scopes
+            // Check scopes — return 403 (not 401) when the key is valid but lacks permissions
             if let Some(scope_list) = scopes {
                 if scope_list.is_empty() {
-                    // In Django, an explicit empty scopes list means "no access".
-                    // Mirror that behavior here instead of treating it as "no restriction".
                     debug!(
-                        "Cached personal API key has an explicit empty scopes list; treating as no access"
+                        "Personal API key has an explicit empty scopes list; no access"
                     );
-                    return Err(FlagError::PersonalApiKeyInvalid);
+                    return Err(FlagError::PersonalApiKeyInsufficientScopes);
                 }
 
                 let has_access = scope_list.iter().any(|s| {
@@ -331,8 +324,8 @@ fn validate_personal_key_metadata(data: &TokenAuthData, team: &Team) -> Result<(
                         || s == SCOPE_FEATURE_FLAG_WRITE
                 });
                 if !has_access {
-                    debug!(scopes = ?scope_list, "Cached personal API key lacks feature flag scopes");
-                    return Err(FlagError::PersonalApiKeyInvalid);
+                    debug!(scopes = ?scope_list, "Personal API key lacks feature flag scopes");
+                    return Err(FlagError::PersonalApiKeyInsufficientScopes);
                 }
             }
 
@@ -926,7 +919,7 @@ mod tests {
 
         assert!(matches!(
             validate_personal_key_metadata(&data, &team),
-            Err(FlagError::PersonalApiKeyInvalid)
+            Err(FlagError::PersonalApiKeyInsufficientScopes)
         ));
     }
 

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -414,7 +414,7 @@ impl IntoResponse for FlagError {
             }
             FlagError::PersonalApiKeyInsufficientScopes => {
                 let response = AuthenticationErrorResponse {
-                    error_type: "permission_denied".to_string(),
+                    error_type: "authentication_error".to_string(),
                     code: "permission_denied".to_string(),
                     detail: "Personal API key lacks required scopes (feature_flag:read or feature_flag:write).".to_string(),
                     attr: None,

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -68,6 +68,8 @@ pub enum FlagError {
     TokenValidationError,
     #[error("Personal API key is invalid")]
     PersonalApiKeyInvalid,
+    #[error("Personal API key lacks required scopes")]
+    PersonalApiKeyInsufficientScopes,
     #[error("Secret API token is invalid")]
     SecretApiTokenInvalid,
     #[error("No authentication credentials provided")]
@@ -163,6 +165,7 @@ impl FlagError {
             FlagError::NoTokenError => ("missing_token", 401),
             FlagError::TokenValidationError => ("invalid_token", 401),
             FlagError::PersonalApiKeyInvalid => ("personal_api_key_invalid", 401),
+            FlagError::PersonalApiKeyInsufficientScopes => ("personal_api_key_insufficient_scopes", 403),
             FlagError::SecretApiTokenInvalid => ("secret_api_token_invalid", 401),
             FlagError::NoAuthenticationProvided => ("no_authentication", 401),
 
@@ -406,6 +409,15 @@ impl IntoResponse for FlagError {
                     attr: None,
                 };
                 return (StatusCode::UNAUTHORIZED, Json(response)).into_response();
+            }
+            FlagError::PersonalApiKeyInsufficientScopes => {
+                let response = AuthenticationErrorResponse {
+                    error_type: "permission_denied".to_string(),
+                    code: "permission_denied".to_string(),
+                    detail: "Personal API key lacks required scopes (feature_flag:read or feature_flag:write).".to_string(),
+                    attr: None,
+                };
+                return (StatusCode::FORBIDDEN, Json(response)).into_response();
             }
             FlagError::SecretApiTokenInvalid => {
                 let response = AuthenticationErrorResponse {
@@ -750,6 +762,7 @@ mod tests {
             FlagError::NoTokenError,
             FlagError::TokenValidationError,
             FlagError::PersonalApiKeyInvalid,
+            FlagError::PersonalApiKeyInsufficientScopes,
             FlagError::SecretApiTokenInvalid,
             FlagError::NoAuthenticationProvided,
             FlagError::RowNotFound,
@@ -971,6 +984,7 @@ mod tests {
             FlagError::NoTokenError,
             FlagError::TokenValidationError,
             FlagError::PersonalApiKeyInvalid,
+            FlagError::PersonalApiKeyInsufficientScopes,
             FlagError::SecretApiTokenInvalid,
             FlagError::NoAuthenticationProvided,
             FlagError::RowNotFound,

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -165,7 +165,9 @@ impl FlagError {
             FlagError::NoTokenError => ("missing_token", 401),
             FlagError::TokenValidationError => ("invalid_token", 401),
             FlagError::PersonalApiKeyInvalid => ("personal_api_key_invalid", 401),
-            FlagError::PersonalApiKeyInsufficientScopes => ("personal_api_key_insufficient_scopes", 403),
+            FlagError::PersonalApiKeyInsufficientScopes => {
+                ("personal_api_key_insufficient_scopes", 403)
+            }
             FlagError::SecretApiTokenInvalid => ("secret_api_token_invalid", 401),
             FlagError::NoAuthenticationProvided => ("no_authentication", 401),
 

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -284,7 +284,7 @@ async fn test_personal_api_key_authentication_without_feature_flag_scopes() {
     let server = common::ServerHandle::for_config(config.clone()).await;
     let client = reqwest::Client::new();
 
-    // Test that the endpoint returns 401 when API key doesn't have feature_flag scopes
+    // Test that the endpoint returns 403 when API key is valid but lacks feature_flag scopes
     let response = client
         .get(format!(
             "http://{}/flags/definitions?token={}",
@@ -295,7 +295,7 @@ async fn test_personal_api_key_authentication_without_feature_flag_scopes() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), 401);
+    assert_eq!(response.status(), 403);
 }
 
 #[tokio::test]

--- a/rust/feature-flags/tests/test_flag_definitions.rs
+++ b/rust/feature-flags/tests/test_flag_definitions.rs
@@ -295,7 +295,18 @@ async fn test_personal_api_key_authentication_without_feature_flag_scopes() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), 403);
+    let status = response.status();
+    let body_text = response.text().await.unwrap();
+    assert_eq!(status, 403);
+
+    let body: serde_json::Value = serde_json::from_str(&body_text).unwrap();
+    assert_eq!(body["type"], "authentication_error");
+    assert_eq!(body["code"], "permission_denied");
+    assert_eq!(
+        body["detail"],
+        "Personal API key lacks required scopes (feature_flag:read or feature_flag:write)."
+    );
+    assert_eq!(body["attr"], serde_json::Value::Null);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

The Rust definitions endpoint returns 401 for personal API keys that exist but lack `feature_flag:read/write` scopes. Django returns 403 for the same case, since the key is valid but doesn't have permission.

This happens because the scope check was in the SQL WHERE clause: PAKs without the right scopes weren't found at all, so Rust couldn't distinguish "key doesn't exist" from "key exists but wrong scopes".

## Changes

Removed scope filter from the PAK SQL query so the PAK is always loaded if it exists. Scopes are now checked in `validate_personal_key_metadata` (where org/team checks already happen), returning `PersonalApiKeyInsufficientScopes` (403) instead of `PersonalApiKeyInvalid` (401).

## How did you test this code?

Unit tests and integration test updated and passing.

## Publish to changelog?

no