### PR TITLE
fix(error-tracking): guard hasProjectNoticeRestriction against null api response

### DIFF
--- a/frontend/src/lib/logic/eventIngestionRestrictionLogic.test.ts
+++ b/frontend/src/lib/logic/eventIngestionRestrictionLogic.test.ts
@@ -110,4 +110,20 @@ describe('eventIngestionRestrictionLogic', () => {
                 hasProjectNoticeRestriction: false,
             })
     })
+
+    it('coerces null api response to empty array', async () => {
+        // api.get resolves to null when the response body isn't valid JSON
+        // (e.g. 204 No Content, CDN/proxy HTML error pages) — guard against it
+        jest.spyOn(api, 'get').mockResolvedValue(null)
+
+        logic.mount()
+        logic.values.eventIngestionRestrictions
+
+        await expectLogic(logic)
+            .toDispatchActions(['loadEventIngestionRestrictions', 'loadEventIngestionRestrictionsSuccess'])
+            .toMatchValues({
+                eventIngestionRestrictions: [],
+                hasProjectNoticeRestriction: false,
+            })
+    })
 })

--- a/frontend/src/lib/logic/eventIngestionRestrictionLogic.ts
+++ b/frontend/src/lib/logic/eventIngestionRestrictionLogic.ts
@@ -30,7 +30,8 @@ export const eventIngestionRestrictionLogic = kea<eventIngestionRestrictionLogic
                     const response = await api.get(
                         `api/environments/${values.currentTeamIdStrict}/event_ingestion_restrictions/`
                     )
-                    return response
+                    // api.get resolves to null on non-JSON responses (204, CDN error pages, etc.) — coerce to []
+                    return Array.isArray(response) ? response : []
                 } catch (error) {
                     console.error('Failed to load event ingestion restrictions:', error)
                     return []


### PR DESCRIPTION
## Problem

A user reported a `TypeError: Cannot read properties of null (reading 'some')` surfacing in Error tracking, originating in `hasProjectNoticeRestriction` → `projectNoticeVariant`.

Root cause: `api.get()` uses `getJSONOrNull()` which resolves to `null` when a response body isn't valid JSON — CDN/proxy HTML error pages, aborted responses, etc (I think in this case it was a proxy page). That `null` flows through the kea `lazyLoader` and overwrites the `[]` default on `eventIngestionRestrictions`, so the `.some()` call in the selector throws.

The existing `try/catch` in the loader doesn't help because `api.get` never throws in this path — it silently resolves to `null`.

## Changes

- Coerce the loader return in [eventIngestionRestrictionLogic.ts](frontend/src/lib/logic/eventIngestionRestrictionLogic.ts) to an array (`Array.isArray(response) ? response : []`).
- Add a regression test covering a `null` API response.

## How did you test this code?

Agent-authored — verified via the existing Jest suite; no manual browser verification.

- `pnpm --filter=@posthog/frontend exec jest frontend/src/lib/logic/eventIngestionRestrictionLogic.test.ts` — all 5 tests pass, including the new `coerces null api response to empty array` case.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Code (Opus 4.7). Investigation: grepped the minified symbol `hasProjectNoticeRestriction` → traced through `eventIngestionRestrictionLogic` and `kea-loaders` reducer semantics → confirmed `getJSONOrNull` as the null source in `api.ts`.