### PR TITLE
fix(web-analytics): resolve person property mat columns in prefilter via VirtualTableType unwrapping

### DIFF
--- a/posthog/hogql_queries/web_analytics/events_prefilter.py
+++ b/posthog/hogql_queries/web_analytics/events_prefilter.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Union
 
 from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
+from posthog.hogql.database.models import DatabaseField
 from posthog.hogql.visitor import TraversingVisitor
 
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
@@ -27,8 +28,18 @@ class _EventsFieldCollector(TraversingVisitor):
         field_type = node.type
         if isinstance(field_type, ast.PropertyType):
             ft = field_type.field_type
-            if ft.table_type == self.events_table_type and len(field_type.chain) >= 1:
-                self.property_accesses.add((str(field_type.chain[0]), ft.name))
+            table_type = ft.table_type
+            col_name = ft.name
+            # Unwrap VirtualTableType (e.g. poe for person properties) to check if this
+            # property ultimately lives on the events table, and resolve the actual DB
+            # column name (e.g. "person_properties" instead of "properties")
+            while isinstance(table_type, ast.VirtualTableType):
+                db_field = table_type.virtual_table.fields.get(ft.name)
+                if isinstance(db_field, DatabaseField):
+                    col_name = db_field.name
+                table_type = table_type.table_type
+            if table_type == self.events_table_type and len(field_type.chain) >= 1:
+                self.property_accesses.add((str(field_type.chain[0]), col_name))
             field_type = ft
         if isinstance(field_type, ast.FieldType) and field_type.table_type == self.events_table_type:
             self.fields.add(field_type.name)

--- a/posthog/hogql_queries/web_analytics/events_prefilter.py
+++ b/posthog/hogql_queries/web_analytics/events_prefilter.py
@@ -145,7 +145,8 @@ class EventsPrefilterTransformer(TraversingVisitor):
         For each property access (e.g. $pathname on properties), checks if a
         materialized column exists (mat_$pathname). If so, temporarily registers
         it on the events table schema and returns the name. If any property
-        lacks a mat column, keeps `properties` in events_columns for JSONExtractRaw.
+        lacks a mat column, keeps the corresponding JSON column (properties or
+        person_properties) in events_columns for JSONExtractRaw fallback.
         """
         from typing import cast
 
@@ -160,7 +161,7 @@ class EventsPrefilterTransformer(TraversingVisitor):
 
         mat_cols_map = get_enabled_materialized_columns("events")
         mat_column_names: set[str] = set()
-        has_unmaterialized = False
+        unmaterialized_json_columns: set[str] = set()
 
         for prop_name, table_col in property_accesses:
             key = (prop_name, cast(TableColumn, table_col))
@@ -173,11 +174,22 @@ class EventsPrefilterTransformer(TraversingVisitor):
                     table.fields[ch_name] = StringDatabaseField(name=ch_name)
                     self._temp_schema_fields.append((table, ch_name))
             else:
-                has_unmaterialized = True
+                unmaterialized_json_columns.add(table_col)
 
-        # Only keep properties if some accesses can't use mat columns
-        if not has_unmaterialized:
-            events_columns.discard("properties")
+        # Add JSON columns needed for unmaterialized property accesses and
+        # discard those fully covered by mat columns. person_properties is
+        # accessed via the poe virtual table so won't be in events_columns
+        # already — temporarily register it on the events table schema.
+        for json_col in unmaterialized_json_columns:
+            events_columns.add(json_col)
+            if json_col != "properties":
+                table = self._get_events_table(events_table_type)
+                if table is not None and json_col not in table.fields:
+                    table.fields[json_col] = StringDatabaseField(name=json_col)
+                    self._temp_schema_fields.append((table, json_col))
+        for json_col in {"properties", "person_properties"}:
+            if json_col not in unmaterialized_json_columns:
+                events_columns.discard(json_col)
 
         return mat_column_names
 

--- a/posthog/hogql_queries/web_analytics/test/test_events_prefilter.py
+++ b/posthog/hogql_queries/web_analytics/test/test_events_prefilter.py
@@ -1,7 +1,14 @@
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, also_test_with_materialized_columns
 from unittest.mock import patch
 
-from posthog.schema import DateRange, EventPropertyFilter, PropertyOperator, WebStatsBreakdown, WebStatsTableQuery
+from posthog.schema import (
+    DateRange,
+    EventPropertyFilter,
+    PersonPropertyFilter,
+    PropertyOperator,
+    WebStatsBreakdown,
+    WebStatsTableQuery,
+)
 
 from posthog.hogql_queries.web_analytics.stats_table import WebStatsTableQueryRunner
 
@@ -161,6 +168,24 @@ class TestEventsPrefilterTransformer(ClickhouseTestMixin, APIBaseTest):
         # properties blob must be in the subquery for JSONExtractRaw
         assert "events.properties" in sql
         assert "JSONExtractRaw(events.properties," in sql
+
+    @also_test_with_materialized_columns(
+        person_properties=["email"],
+        verify_no_jsonextract=False,
+    )
+    def test_bounce_with_person_property_filter(self):
+        sql = self._run_prefiltered_query(
+            includeBounceRate=True,
+            properties=[
+                PersonPropertyFilter(
+                    key="email",
+                    operator=PropertyOperator.IS_NOT,
+                    value=["test@example.com"],
+                )
+            ],
+        )
+
+        assert "toDate(events.timestamp)" in sql
 
     def test_initial_page_breakdown_with_bounce(self):
         sql = self._run_prefiltered_query(

--- a/posthog/hogql_queries/web_analytics/test/test_events_prefilter.py
+++ b/posthog/hogql_queries/web_analytics/test/test_events_prefilter.py
@@ -174,6 +174,11 @@ class TestEventsPrefilterTransformer(ClickhouseTestMixin, APIBaseTest):
         verify_no_jsonextract=False,
     )
     def test_bounce_with_person_property_filter(self):
+        from posthog.schema import PersonsOnEventsMode
+
+        self.team.modifiers = {"personsOnEventsMode": PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS}
+        self.team.save()
+
         sql = self._run_prefiltered_query(
             includeBounceRate=True,
             properties=[
@@ -186,6 +191,13 @@ class TestEventsPrefilterTransformer(ClickhouseTestMixin, APIBaseTest):
         )
 
         assert "toDate(events.timestamp)" in sql
+        # When materialized with PoE, mat_pp_email must be in the prefilter subquery
+        # SELECT — if missing, the query above would fail with UNKNOWN_IDENTIFIER.
+        # Also verify it appears in the generated SQL for the materialized case.
+        if "mat_pp_email" in sql:
+            assert sql.count("mat_pp_email") >= 2, (
+                "mat_pp_email should appear in both the subquery SELECT and outer WHERE"
+            )
 
     def test_initial_page_breakdown_with_bounce(self):
         sql = self._run_prefiltered_query(


### PR DESCRIPTION
## Problem

The events prefilter introduced in #54506 wraps `FROM events` in a subquery that only selects the columns the outer query needs. When a team has internal user filters referencing person properties (e.g. `person.properties.email` → `mat_pp_email`), the prefilter subquery didn't include `mat_pp_email` in its SELECT list, causing ClickHouse errors: `There's no column 'events.mat_pp_email' in table`.

## Changes

The `_EventsFieldCollector` had two bugs when handling person properties accessed via the `poe` (persons-on-events) virtual table:

1. **Table type comparison**: the collector compared `ft.table_type == self.events_table_type`, but for person properties `ft.table_type` is a `VirtualTableType` (the `poe` sub-table), not the events table type directly. Fixed by unwrapping `VirtualTableType` before comparing.

2. **Column name mismatch**: the collector recorded `ft.name` (HogQL name `"properties"`) instead of the DB column name (`"person_properties"`), so the mat_cols_map lookup failed. Fixed by resolving the actual DB column name from the virtual table's field definition.

## How did you test this code?

- Added `test_bounce_with_person_property_filter` with `@also_test_with_materialized_columns(person_properties=["email"])` — exercises both the non-materialized and materialized code paths
- All 14 prefilter tests pass

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored fix. The approach mirrors how the HogQL printer handles the same `VirtualTableType` unwrapping (see `printer/base.py:1273`).