### PR TITLE
fix(ingestion): strip posthog-js persistence cache properties from events

### DIFF
--- a/nodejs/src/ingestion/error-tracking/prepare-event-step.test.ts
+++ b/nodejs/src/ingestion/error-tracking/prepare-event-step.test.ts
@@ -4,6 +4,7 @@ import { createTestPluginEvent } from '~/tests/helpers/plugin-event'
 import { createTestTeam } from '~/tests/helpers/team'
 import { EventHeaders, Person } from '~/types'
 
+import { BLOAT_PROPERTIES } from '../event-processing/strip-bloat-properties'
 import { PipelineResultType, isOkResult } from '../pipelines/results'
 import { createErrorTrackingPrepareEventStep } from './prepare-event-step'
 
@@ -163,6 +164,26 @@ describe('createErrorTrackingPrepareEventStep', () => {
         if (isOkResult(result)) {
             expect(result.value.preparedEvent.properties['$ip']).toBeUndefined()
             expect(result.value.preparedEvent.properties['other']).toBe('kept')
+        }
+    })
+
+    it('should strip bloat properties from $exception events', async () => {
+        const bloat = Object.fromEntries([...BLOAT_PROPERTIES].map((key) => [key, { heavy: 'cache-blob' }]))
+        const event = createTestPluginEvent({
+            event: '$exception',
+            properties: {
+                ...bloat,
+                $exception_list: [{ type: 'Error', value: 'Test' }],
+            },
+        })
+
+        const result = await step({ event, team, person: null, headers: createTestHeaders() })
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (isOkResult(result)) {
+            expect(result.value.preparedEvent.properties).toEqual({
+                $exception_list: [{ type: 'Error', value: 'Test' }],
+            })
         }
     })
 

--- a/nodejs/src/ingestion/error-tracking/prepare-event-step.ts
+++ b/nodejs/src/ingestion/error-tracking/prepare-event-step.ts
@@ -1,6 +1,7 @@
 import { PluginEvent } from '~/plugin-scaffold'
 import { EventHeaders, ISOTimestamp, Person, PreIngestionEvent, Team } from '~/types'
 
+import { stripBloatProperties } from '../event-processing/strip-bloat-properties'
 import { ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
 
@@ -54,6 +55,8 @@ export function createErrorTrackingPrepareEventStep<T extends ErrorTrackingPrepa
         if (properties['$ip'] && input.team.anonymize_ips) {
             delete properties['$ip']
         }
+
+        stripBloatProperties(properties)
 
         // Timestamp is already validated by the cymbal processing step
         const timestamp = event.timestamp as ISOTimestamp

--- a/nodejs/src/ingestion/event-processing/prepare-event-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/prepare-event-step.test.ts
@@ -138,7 +138,8 @@ describe('createPrepareEventStep', () => {
             properties: {
                 ph_product_tours_foo: 'kept',
                 my_ph_product_tours: 'kept',
-                $surveys_activated_at: 'kept',
+                $product_tours_activated_at: 'kept',
+                my_$override_feature_flag_payloads: 'kept',
             },
         })
 
@@ -149,7 +150,8 @@ describe('createPrepareEventStep', () => {
         if (result.type === PipelineResultType.OK) {
             expect(result.value.preparedEvent.properties).toHaveProperty('ph_product_tours_foo', 'kept')
             expect(result.value.preparedEvent.properties).toHaveProperty('my_ph_product_tours', 'kept')
-            expect(result.value.preparedEvent.properties).toHaveProperty('$surveys_activated_at', 'kept')
+            expect(result.value.preparedEvent.properties).toHaveProperty('$product_tours_activated_at', 'kept')
+            expect(result.value.preparedEvent.properties).toHaveProperty('my_$override_feature_flag_payloads', 'kept')
         }
     })
 

--- a/nodejs/src/ingestion/event-processing/prepare-event-step.test.ts
+++ b/nodejs/src/ingestion/event-processing/prepare-event-step.test.ts
@@ -12,6 +12,7 @@ import { EventHeaders, Person, Team } from '../../types'
 import { parseEventTimestamp } from '../../worker/ingestion/timestamps'
 import { PipelineResultType } from '../pipelines/results'
 import { createPrepareEventStep } from './prepare-event-step'
+import { BLOAT_PROPERTIES } from './strip-bloat-properties'
 
 jest.mock('../../worker/ingestion/timestamps')
 
@@ -96,6 +97,59 @@ describe('createPrepareEventStep', () => {
         if (result.type === PipelineResultType.OK) {
             expect(result.value.preparedEvent.properties).not.toHaveProperty('$ip')
             expect(result.value.preparedEvent.properties).toHaveProperty('other', 'kept')
+        }
+    })
+
+    it.each([...BLOAT_PROPERTIES])(
+        'should strip bloat property %s while preserving unrelated properties',
+        async (bloatKey) => {
+            const event = createTestPluginEvent({
+                properties: { [bloatKey]: { heavy: 'cache-blob' }, other: 'kept' },
+            })
+
+            const step = createPrepareEventStep<TestInput>()
+            const result = await step(createInput({ normalizedEvent: event }))
+
+            expect(result.type).toBe(PipelineResultType.OK)
+            if (result.type === PipelineResultType.OK) {
+                expect(result.value.preparedEvent.properties).not.toHaveProperty(bloatKey)
+                expect(result.value.preparedEvent.properties).toHaveProperty('other', 'kept')
+            }
+        }
+    )
+
+    it('should strip all bloat properties present in a single event', async () => {
+        const bloat = Object.fromEntries([...BLOAT_PROPERTIES].map((key) => [key, { heavy: 'cache-blob' }]))
+        const event = createTestPluginEvent({
+            properties: { ...bloat, other: 'kept' },
+        })
+
+        const step = createPrepareEventStep<TestInput>()
+        const result = await step(createInput({ normalizedEvent: event }))
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (result.type === PipelineResultType.OK) {
+            expect(result.value.preparedEvent.properties).toEqual({ other: 'kept' })
+        }
+    })
+
+    it('should only strip exact matches, not substring matches', async () => {
+        const event = createTestPluginEvent({
+            properties: {
+                ph_product_tours_foo: 'kept',
+                my_ph_product_tours: 'kept',
+                $surveys_activated_at: 'kept',
+            },
+        })
+
+        const step = createPrepareEventStep<TestInput>()
+        const result = await step(createInput({ normalizedEvent: event }))
+
+        expect(result.type).toBe(PipelineResultType.OK)
+        if (result.type === PipelineResultType.OK) {
+            expect(result.value.preparedEvent.properties).toHaveProperty('ph_product_tours_foo', 'kept')
+            expect(result.value.preparedEvent.properties).toHaveProperty('my_ph_product_tours', 'kept')
+            expect(result.value.preparedEvent.properties).toHaveProperty('$surveys_activated_at', 'kept')
         }
     })
 

--- a/nodejs/src/ingestion/event-processing/prepare-event-step.ts
+++ b/nodejs/src/ingestion/event-processing/prepare-event-step.ts
@@ -7,6 +7,7 @@ import { parseEventTimestamp } from '../../worker/ingestion/timestamps'
 import { PipelineWarning } from '../pipelines/pipeline.interface'
 import { ok } from '../pipelines/results'
 import { ProcessingStep } from '../pipelines/steps'
+import { stripBloatProperties } from './strip-bloat-properties'
 
 export type PrepareEventStepInput = {
     normalizedEvent: PluginEvent
@@ -39,6 +40,8 @@ export function createPrepareEventStep<TInput extends PrepareEventStepInput>(): 
         if (properties['$ip'] && input.team.anonymize_ips) {
             delete properties['$ip']
         }
+
+        stripBloatProperties(properties)
 
         const timestamp = parseEventTimestamp(normalizedEvent, invalidTimestampCallback)
 

--- a/nodejs/src/ingestion/event-processing/strip-bloat-properties.test.ts
+++ b/nodejs/src/ingestion/event-processing/strip-bloat-properties.test.ts
@@ -1,0 +1,66 @@
+import { droppedBloatPropertyCounter } from '../../worker/ingestion/event-pipeline/metrics'
+import { BLOAT_PROPERTIES, stripBloatProperties } from './strip-bloat-properties'
+
+jest.mock('../../worker/ingestion/event-pipeline/metrics', () => ({
+    droppedBloatPropertyCounter: {
+        labels: jest.fn().mockReturnValue({ inc: jest.fn() }),
+    },
+}))
+
+const mockLabels = jest.mocked(droppedBloatPropertyCounter.labels)
+
+describe('stripBloatProperties', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it.each([...BLOAT_PROPERTIES])('deletes %s and increments the counter for that label', (bloatKey) => {
+        const properties: Record<string, any> = { [bloatKey]: { heavy: 'cache-blob' }, other: 'kept' }
+
+        stripBloatProperties(properties)
+
+        expect(properties).not.toHaveProperty(bloatKey)
+        expect(properties).toEqual({ other: 'kept' })
+        expect(mockLabels).toHaveBeenCalledTimes(1)
+        expect(mockLabels).toHaveBeenCalledWith(bloatKey)
+    })
+
+    it('strips every bloat property present and increments the counter once per stripped key', () => {
+        const properties = Object.fromEntries([...BLOAT_PROPERTIES].map((key) => [key, 'v']))
+        properties.other = 'kept'
+
+        stripBloatProperties(properties)
+
+        expect(properties).toEqual({ other: 'kept' })
+        expect(mockLabels).toHaveBeenCalledTimes(BLOAT_PROPERTIES.size)
+        for (const key of BLOAT_PROPERTIES) {
+            expect(mockLabels).toHaveBeenCalledWith(key)
+        }
+    })
+
+    it('does not increment the counter when no bloat properties are present', () => {
+        const properties = { other: 'kept', another: 'also-kept' }
+
+        stripBloatProperties(properties)
+
+        expect(properties).toEqual({ other: 'kept', another: 'also-kept' })
+        expect(mockLabels).not.toHaveBeenCalled()
+    })
+
+    it('only strips exact matches, not substring matches', () => {
+        const properties = {
+            ph_product_tours_foo: 'kept',
+            my_ph_product_tours: 'kept',
+            $surveys_activated_at: 'kept',
+        }
+
+        stripBloatProperties(properties)
+
+        expect(properties).toEqual({
+            ph_product_tours_foo: 'kept',
+            my_ph_product_tours: 'kept',
+            $surveys_activated_at: 'kept',
+        })
+        expect(mockLabels).not.toHaveBeenCalled()
+    })
+})

--- a/nodejs/src/ingestion/event-processing/strip-bloat-properties.test.ts
+++ b/nodejs/src/ingestion/event-processing/strip-bloat-properties.test.ts
@@ -51,7 +51,8 @@ describe('stripBloatProperties', () => {
         const properties = {
             ph_product_tours_foo: 'kept',
             my_ph_product_tours: 'kept',
-            $surveys_activated_at: 'kept',
+            $product_tours_activated_at: 'kept',
+            my_$override_feature_flag_payloads: 'kept',
         }
 
         stripBloatProperties(properties)
@@ -59,7 +60,8 @@ describe('stripBloatProperties', () => {
         expect(properties).toEqual({
             ph_product_tours_foo: 'kept',
             my_ph_product_tours: 'kept',
-            $surveys_activated_at: 'kept',
+            $product_tours_activated_at: 'kept',
+            my_$override_feature_flag_payloads: 'kept',
         })
         expect(mockLabels).not.toHaveBeenCalled()
     })

--- a/nodejs/src/ingestion/event-processing/strip-bloat-properties.ts
+++ b/nodejs/src/ingestion/event-processing/strip-bloat-properties.ts
@@ -1,0 +1,24 @@
+import { droppedBloatPropertyCounter } from '../../worker/ingestion/event-pipeline/metrics'
+
+// Persistence cache keys that leak from older posthog-js versions into event
+// payloads. The SDK stopped sending these in posthog-js#3392; this server-side
+// strip covers in-flight and pinned clients. `ph_product_tours` alone embeds
+// full tour definitions up to 247 KB per event.
+export const BLOAT_PROPERTIES: ReadonlySet<string> = new Set([
+    'ph_product_tours',
+    '$session_recording_remote_config',
+    '$product_tours_activated',
+    '$product_tours_enabled_server_side',
+    '$surveys_activated',
+    '$feature_flag_payloads',
+    '$override_feature_flag_payloads',
+])
+
+export function stripBloatProperties(properties: Record<string, any>): void {
+    for (const key of BLOAT_PROPERTIES) {
+        if (key in properties) {
+            delete properties[key]
+            droppedBloatPropertyCounter.labels(key).inc()
+        }
+    }
+}

--- a/nodejs/src/ingestion/event-processing/strip-bloat-properties.ts
+++ b/nodejs/src/ingestion/event-processing/strip-bloat-properties.ts
@@ -10,7 +10,6 @@ export const BLOAT_PROPERTIES: ReadonlySet<string> = new Set([
     '$product_tours_activated',
     '$product_tours_enabled_server_side',
     '$surveys_activated',
-    '$feature_flag_payloads',
     '$override_feature_flag_payloads',
 ])
 

--- a/nodejs/src/ingestion/event-processing/strip-bloat-properties.ts
+++ b/nodejs/src/ingestion/event-processing/strip-bloat-properties.ts
@@ -6,10 +6,7 @@ import { droppedBloatPropertyCounter } from '../../worker/ingestion/event-pipeli
 // full tour definitions up to 247 KB per event.
 export const BLOAT_PROPERTIES: ReadonlySet<string> = new Set([
     'ph_product_tours',
-    '$session_recording_remote_config',
     '$product_tours_activated',
-    '$product_tours_enabled_server_side',
-    '$surveys_activated',
     '$override_feature_flag_payloads',
 ])
 

--- a/nodejs/src/worker/ingestion/event-pipeline/metrics.ts
+++ b/nodejs/src/worker/ingestion/event-pipeline/metrics.ts
@@ -43,3 +43,9 @@ export const tokenOrTeamPresentCounter = new Counter({
     help: 'Count of events by presence of the team_id and token field.',
     labelNames: ['team_id_present', 'token_present'],
 })
+
+export const droppedBloatPropertyCounter = new Counter({
+    name: 'ingestion_dropped_bloat_property_total',
+    help: 'Count of deprecated posthog-js persistence-cache properties stripped from event payloads before ClickHouse write (see strip-bloat-properties.ts BLOAT_PROPERTIES).',
+    labelNames: ['property'],
+})


### PR DESCRIPTION
## Problem

A small set of posthog-js persistence-cache keys leak into event payloads on older or pinned SDK versions. These keys are never useful in ClickHouse and can be large. `ph_product_tours` alone has been seen embedding full tour definitions up to ~247 KB per event.

This is a server-side follow-up to the client-side fixes shipped in:

- https://github.com/PostHog/posthog-js/pull/3392
- https://github.com/PostHog/posthog-js/pull/3393

Client-side changes take time to propagate (users on pinned SDK versions may never upgrade). Stripping server-side covers in-flight and pinned clients immediately.

## Changes

Adds a shared helper `stripBloatProperties()` that deletes the following keys from event `properties` before the event is emitted to ClickHouse, and increments a Prometheus counter per key stripped:

- `ph_product_tours`
- `$product_tours_activated`
- `$override_feature_flag_payloads`

The list is intentionally conservative. These three keys leak from older SDKs but are **not declared in `posthog/taxonomy/taxonomy.py`**, so no customer can have selected them through the property picker or built an insight that references them. Other persistence-cache keys considered (`$session_recording_remote_config`, `$product_tours_enabled_server_side`, `$surveys_activated`, `$feature_flag_payloads`) are defined in the taxonomy — even when flagged `used_for_debug: True` — and may back customer queries, so they are deliberately left in place. A later pass can tighten this further after an audit.

The helper runs in both `nodejs` ingestion pipelines:

- `nodejs/src/ingestion/event-processing/prepare-event-step.ts` — analytics (feeds analytics event-subpipeline, heatmap, ai-event)
- `nodejs/src/ingestion/error-tracking/prepare-event-step.ts` — error-tracking (`$exception`)

New Prometheus metric: `ingestion_dropped_bloat_property_total{property="<key>"}`.

## How did you test this code?

Unit tests drive `it.each` directly from the `BLOAT_PROPERTIES` set, so coverage cannot silently drift from the production list:

- `nodejs/src/ingestion/event-processing/strip-bloat-properties.test.ts` — helper-level unit tests that also assert the Prometheus counter is incremented exactly once per stripped key and not at all for non-bloat or substring-matching keys.
- `nodejs/src/ingestion/event-processing/prepare-event-step.test.ts` — analytics pipeline integration.
- `nodejs/src/ingestion/error-tracking/prepare-event-step.test.ts` — error-tracking pipeline integration.

Manual end-to-end verification on local dev (`hogli start`):

1. Baseline the Prometheus counter on both workers:
   - analytics: `curl -s http://localhost:6739/metrics | grep ingestion_dropped_bloat_property_total`
   - error-tracking: `curl -s http://localhost:6742/metrics | grep ingestion_dropped_bloat_property_total`
2. Fire a `$pageview` containing all three bloat keys + a canary property via rust capture (`http://localhost:3307/i/v0/e/`).
3. Fire a `$exception` containing the same bloat payload.
4. Re-read the metrics — each `property="<key>"` series incremented by 1 on the matching worker, confirming each strip fired exactly once per event.
5. Since the local ClickHouse `events` table happened to be in readonly mode (unrelated Zookeeper issue), verified the post-strip payload by reading the downstream `clickhouse_events_json` Kafka topic directly via `rpk topic consume`. The canary and `kept_property` were present; none of the three bloat keys appeared.

## Publish to changelog?

no

## Docs update

n/a