### PR TITLE
feat(llma): add outline field to prompt api and mcp tools

### DIFF
--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, cast
 
 from django.conf import settings
@@ -184,7 +185,7 @@ class LLMPromptViewSet(
             prompt.pop("prompt", None)
         elif content_mode == "preview":
             original = prompt.pop("prompt", "")
-            display_value = original if isinstance(original, str) else ""
+            display_value = original if isinstance(original, str) else json.dumps(original, ensure_ascii=False)
             prompt["prompt_preview"] = display_value[:160] + ("..." if len(display_value) > 160 else "")
         return prompt
 

--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -18,6 +18,7 @@ from posthog.api.capture import capture_internal
 from posthog.api.llm_prompt_serializers import (
     LLMPromptDuplicateSerializer,
     LLMPromptFetchQuerySerializer,
+    LLMPromptGetByNameQuerySerializer,
     LLMPromptListQuerySerializer,
     LLMPromptListSerializer,
     LLMPromptPublicSerializer,
@@ -52,6 +53,7 @@ from posthog.auth import (
 from posthog.event_usage import report_team_action, report_user_action
 from posthog.exceptions_capture import capture_exception
 from posthog.models import LLMPrompt, User
+from posthog.models.llm_prompt import get_prompt_outline
 from posthog.permissions import AccessControlPermission, get_organization_from_view
 from posthog.rate_limit import BurstRateThrottle, LLMPromptPublishBurstRateThrottle, SustainedRateThrottle
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
@@ -165,10 +167,26 @@ class LLMPromptViewSet(
         serializer.is_valid(raise_exception=True)
         return serializer.validated_data
 
+    def _get_get_by_name_params(self, request: Request) -> dict[str, Any]:
+        serializer = LLMPromptGetByNameQuerySerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+        return serializer.validated_data
+
     def _get_resolve_query_params(self, request: Request) -> dict[str, Any]:
         serializer = LLMPromptResolveQuerySerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         return serializer.validated_data
+
+    def _apply_content_mode(self, prompt: dict[str, Any], content_mode: str) -> dict[str, Any]:
+        prompt = dict(prompt)
+        prompt["outline"] = get_prompt_outline(prompt.get("prompt"))
+        if content_mode == "none":
+            prompt.pop("prompt", None)
+        elif content_mode == "preview":
+            original = prompt.pop("prompt", "")
+            display_value = original if isinstance(original, str) else ""
+            prompt["prompt_preview"] = display_value[:160] + ("..." if len(display_value) > 160 else "")
+        return prompt
 
     def _track_prompt_fetch(self, prompt: dict[str, Any]) -> None:
         if not settings.TEST:
@@ -251,21 +269,22 @@ class LLMPromptViewSet(
         )
 
     @extend_schema(
-        parameters=[LLMPromptFetchQuerySerializer],
+        parameters=[LLMPromptGetByNameQuerySerializer],
         responses={200: LLMPromptPublicSerializer},
     )
     @action(methods=["GET"], detail=False, url_path=r"name/(?P<prompt_name>[^/]+)")
     @llma_track_latency("llma_prompts_get_by_name")
     @monitor(feature=None, endpoint="llma_prompts_get_by_name", method="GET")
     def get_by_name(self, request: Request, prompt_name: str = "", **kwargs) -> Response:
-        version_params = self._get_requested_version_params(request)
-        version = cast(int | None, version_params.get("version"))
+        query_params = self._get_get_by_name_params(request)
+        version = cast(int | None, query_params.get("version"))
+        content_mode = cast(str, query_params.get("content", "full"))
         prompt = get_prompt_by_name_from_cache(self.team, prompt_name, version)
         if prompt is None:
             return self._prompt_not_found_response(prompt_name)
 
         self._track_prompt_fetch(prompt)
-        return Response(prompt)
+        return Response(self._apply_content_mode(prompt, content_mode))
 
     @extend_schema(request=LLMPromptPublishSerializer, responses={200: LLMPromptSerializer})
     @get_by_name.mapping.patch

--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -2,10 +2,17 @@ import re
 import json
 from typing import Any
 
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from posthog.api.shared import UserBasicSerializer
-from posthog.models.llm_prompt import LLMPrompt, normalize_prompt_to_string
+from posthog.models.llm_prompt import LLMPrompt, get_prompt_outline, normalize_prompt_to_string
+
+
+class LLMPromptOutlineEntrySerializer(serializers.Serializer):
+    level = serializers.IntegerField(min_value=1, max_value=6, help_text="Markdown heading level (1-6).")
+    text = serializers.CharField(help_text="Heading text with markdown link syntax preserved.")
+
 
 RESERVED_PROMPT_NAMES = {"new"}
 DEFAULT_VERSION_PAGE_SIZE = 50
@@ -36,11 +43,28 @@ def validate_prompt_payload_size(prompt_payload: Any) -> Any:
     return prompt_payload
 
 
+CONTENT_MODE_CHOICES = ["full", "preview", "none"]
+CONTENT_MODE_HELP = (
+    "Controls how much prompt content is included in the response. "
+    "'full' includes the full prompt, 'preview' includes a short prompt_preview, "
+    "and 'none' omits prompt content entirely. The outline field is always included."
+)
+
+
 class LLMPromptFetchQuerySerializer(serializers.Serializer):
     version = serializers.IntegerField(
         min_value=1,
         required=False,
         help_text="Specific prompt version to fetch. If omitted, the latest version is returned.",
+    )
+
+
+class LLMPromptGetByNameQuerySerializer(LLMPromptFetchQuerySerializer):
+    content = serializers.ChoiceField(
+        choices=CONTENT_MODE_CHOICES,
+        required=False,
+        default="full",
+        help_text=CONTENT_MODE_HELP,
     )
 
 
@@ -51,14 +75,10 @@ class LLMPromptListQuerySerializer(serializers.Serializer):
         help_text="Optional substring filter applied to prompt names and prompt content.",
     )
     content = serializers.ChoiceField(
-        choices=["full", "preview", "none"],
+        choices=CONTENT_MODE_CHOICES,
         required=False,
         default="full",
-        help_text=(
-            "Controls how much prompt content is included in list results. "
-            "'full' includes the full prompt, 'preview' includes a short prompt_preview, "
-            "and 'none' omits prompt content entirely."
-        ),
+        help_text=CONTENT_MODE_HELP,
     )
 
 
@@ -145,6 +165,7 @@ class LLMPromptSerializer(serializers.ModelSerializer):
     latest_version = serializers.SerializerMethodField()
     version_count = serializers.SerializerMethodField()
     first_version_created_at = serializers.SerializerMethodField()
+    outline = serializers.SerializerMethodField()
 
     class Meta:
         model = LLMPrompt
@@ -161,6 +182,7 @@ class LLMPromptSerializer(serializers.ModelSerializer):
             "latest_version",
             "version_count",
             "first_version_created_at",
+            "outline",
         ]
         read_only_fields = [
             "id",
@@ -173,11 +195,16 @@ class LLMPromptSerializer(serializers.ModelSerializer):
             "latest_version",
             "version_count",
             "first_version_created_at",
+            "outline",
         ]
         extra_kwargs = {
             "name": {"help_text": "Unique prompt name using letters, numbers, hyphens, and underscores only."},
             "prompt": {"help_text": "Prompt payload as JSON or string data."},
         }
+
+    @extend_schema_field(LLMPromptOutlineEntrySerializer(many=True))
+    def get_outline(self, instance: LLMPrompt) -> list[dict[str, Any]]:
+        return get_prompt_outline(instance.prompt)
 
     def get_is_latest(self, instance: LLMPrompt) -> bool:
         return bool(getattr(instance, "is_latest", False))
@@ -290,7 +317,18 @@ class LLMPromptVersionSummarySerializer(serializers.ModelSerializer):
 class LLMPromptPublicSerializer(serializers.Serializer):
     id = serializers.UUIDField()
     name = serializers.CharField()
-    prompt = serializers.JSONField()
+    prompt = serializers.JSONField(
+        required=False,
+        help_text="Full prompt content. Omitted when 'content=preview' or 'content=none'.",
+    )
+    prompt_preview = serializers.CharField(
+        required=False,
+        help_text="First 160 characters of the prompt. Only present when 'content=preview'.",
+    )
+    outline = LLMPromptOutlineEntrySerializer(
+        many=True,
+        help_text="Flat list of markdown headings parsed from the prompt. Useful as a lightweight table of contents.",
+    )
     version = serializers.IntegerField()
     created_at = serializers.DateTimeField()
     updated_at = serializers.DateTimeField()

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -190,6 +190,37 @@ class TestLLMPromptAPI(APIBaseTest):
         if has_preview:
             assert len(prompt["prompt_preview"]) <= 163
 
+    def test_list_includes_outline_parsed_from_prompt_markdown(self, mock_feature_enabled):
+        self.create_prompt_version(name="outlined", prompt="# Role\nYou are helpful.\n## Tools\nsearch")
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/")
+
+        assert response.status_code == status.HTTP_200_OK
+        prompt = response.json()["results"][0]
+        assert prompt["outline"] == [
+            {"level": 1, "text": "Role"},
+            {"level": 2, "text": "Tools"},
+        ]
+
+    def test_list_outline_is_present_even_when_content_none(self, mock_feature_enabled):
+        self.create_prompt_version(name="outlined", prompt="# Role\n# Output")
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/?content=none")
+
+        assert response.status_code == status.HTTP_200_OK
+        prompt = response.json()["results"][0]
+        assert "prompt" not in prompt
+        assert "prompt_preview" not in prompt
+        assert prompt["outline"] == [{"level": 1, "text": "Role"}, {"level": 1, "text": "Output"}]
+
+    def test_list_outline_empty_for_non_markdown_prompt(self, mock_feature_enabled):
+        self.create_prompt_version(name="plain", prompt="just text, no headings")
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["results"][0]["outline"] == []
+
     def test_list_can_order_by_prompt_size_bytes(self, mock_feature_enabled):
         self.create_prompt_version(name="small", prompt="abc")
         self.create_prompt_version(name="large", prompt="x" * 50)
@@ -216,6 +247,36 @@ class TestLLMPromptAPI(APIBaseTest):
             "+00:00", "Z"
         )
         assert "created_by" not in response.json()
+
+    def test_fetch_prompt_by_name_includes_outline(self, mock_feature_enabled):
+        self.create_prompt_version(name="outlined", prompt="# Role\n## Tools")
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/name/outlined/")
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["prompt"] == "# Role\n## Tools"
+        assert body["outline"] == [{"level": 1, "text": "Role"}, {"level": 2, "text": "Tools"}]
+
+    @parameterized.expand(
+        [
+            ("full", True, False),
+            ("preview", False, True),
+            ("none", False, False),
+        ]
+    )
+    def test_fetch_prompt_by_name_respects_content_mode(self, mock_feature_enabled, mode, has_prompt, has_preview):
+        self.create_prompt_version(name="outlined", prompt="# Role\n" + ("x" * 300))
+
+        response = self.client.get(f"/api/environments/{self.team.id}/llm_prompts/name/outlined/?content={mode}")
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert ("prompt" in body) is has_prompt
+        assert ("prompt_preview" in body) is has_preview
+        assert body["outline"] == [{"level": 1, "text": "Role"}]
+        if has_preview:
+            assert len(body["prompt_preview"]) <= 163
 
     def test_fetch_prompt_by_name_with_explicit_version_returns_historical_version(self, mock_feature_enabled):
         first_version = self.create_prompt_version(name="test-prompt", version=1, is_latest=False, prompt="v1")

--- a/posthog/models/llm_prompt.py
+++ b/posthog/models/llm_prompt.py
@@ -1,3 +1,4 @@
+import re
 import json
 from typing import Any
 
@@ -10,6 +11,8 @@ from django.utils import timezone
 from posthog.exceptions_capture import capture_exception
 from posthog.models.utils import UUIDModel
 
+_MARKDOWN_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
+
 
 def normalize_prompt_to_string(value: Any) -> str:
     if isinstance(value, str):
@@ -18,6 +21,24 @@ def normalize_prompt_to_string(value: Any) -> str:
         return json.dumps(value, ensure_ascii=False)
     except Exception:
         return ""
+
+
+def get_prompt_outline(value: Any) -> list[dict[str, Any]]:
+    """Extract a flat list of markdown headings from a prompt payload.
+
+    Agents consuming the MCP/API can use this as a lightweight table of contents
+    without pulling the full prompt content. Returns `[]` for non-markdown
+    payloads (e.g. message arrays serialized to JSON).
+    """
+    text = normalize_prompt_to_string(value)
+    if not text:
+        return []
+    outline: list[dict[str, Any]] = []
+    for line in text.split("\n"):
+        match = _MARKDOWN_HEADING_RE.match(line.strip())
+        if match:
+            outline.append({"level": len(match.group(1)), "text": match.group(2).strip()})
+    return outline
 
 
 class LLMPrompt(UUIDModel):

--- a/posthog/models/llm_prompt.py
+++ b/posthog/models/llm_prompt.py
@@ -11,7 +11,11 @@ from django.utils import timezone
 from posthog.exceptions_capture import capture_exception
 from posthog.models.utils import UUIDModel
 
-_MARKDOWN_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
+# Linear-time heading parser. `[ \t]+` / `(.*)` don't overlap with each other, so no catastrophic
+# backtracking. ATX closing hashes must be preceded by whitespace per CommonMark, which also
+# preserves literal trailing `#` in text like `C#` or `F#`.
+_MARKDOWN_HEADING_RE = re.compile(r"^(#{1,6})[ \t]+(.*)$")
+_ATX_CLOSE_RE = re.compile(r"[ \t]+#+[ \t]*$")
 
 
 def normalize_prompt_to_string(value: Any) -> str:
@@ -36,8 +40,11 @@ def get_prompt_outline(value: Any) -> list[dict[str, Any]]:
     outline: list[dict[str, Any]] = []
     for line in text.split("\n"):
         match = _MARKDOWN_HEADING_RE.match(line.strip())
-        if match:
-            outline.append({"level": len(match.group(1)), "text": match.group(2).strip()})
+        if not match:
+            continue
+        heading = _ATX_CLOSE_RE.sub("", match.group(2)).rstrip()
+        if heading:
+            outline.append({"level": len(match.group(1)), "text": heading})
     return outline
 
 

--- a/posthog/models/test/test_llm_prompt.py
+++ b/posthog/models/test/test_llm_prompt.py
@@ -48,9 +48,23 @@ class TestGetPromptOutline(TestCase):
                 [{"level": 1, "text": "Heading with [link](https://example.com)"}],
             ),
             (
-                "trims_trailing_hashes",
+                "strips_atx_close_preceded_by_whitespace",
                 "# Heading ###",
                 [{"level": 1, "text": "Heading"}],
+            ),
+            (
+                "preserves_literal_hash_suffix_in_text",
+                "## C#\n# F#\n# Heading#",
+                [
+                    {"level": 2, "text": "C#"},
+                    {"level": 1, "text": "F#"},
+                    {"level": 1, "text": "Heading#"},
+                ],
+            ),
+            (
+                "preserves_inline_hashes",
+                "# Heading has # inline",
+                [{"level": 1, "text": "Heading has # inline"}],
             ),
             (
                 "ignores_inline_hashes",
@@ -61,6 +75,11 @@ class TestGetPromptOutline(TestCase):
                 "ignores_deeper_than_h6",
                 "####### too deep\n# real",
                 [{"level": 1, "text": "real"}],
+            ),
+            (
+                "handles_adversarial_whitespace_runs_without_hanging",
+                "# x" + (" " * 5000) + "!",
+                [{"level": 1, "text": "x" + (" " * 5000) + "!"}],
             ),
             ("json_array_payload", [{"role": "user", "content": "hi"}], []),
             ("none_payload", None, []),

--- a/posthog/models/test/test_llm_prompt.py
+++ b/posthog/models/test/test_llm_prompt.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from parameterized import parameterized
 
-from posthog.models.llm_prompt import normalize_prompt_to_string
+from posthog.models.llm_prompt import get_prompt_outline, normalize_prompt_to_string
 
 
 class TestNormalizePromptToString(TestCase):
@@ -20,3 +20,51 @@ class TestNormalizePromptToString(TestCase):
     )
     def test_normalize_prompt_to_string(self, _name: str, value: object, expected: str) -> None:
         assert normalize_prompt_to_string(value) == expected
+
+
+class TestGetPromptOutline(TestCase):
+    @parameterized.expand(
+        [
+            ("empty_string", "", []),
+            ("no_headings", "just some text\nwith two lines", []),
+            (
+                "flat_h1s",
+                "# First\ncontent\n# Second",
+                [{"level": 1, "text": "First"}, {"level": 1, "text": "Second"}],
+            ),
+            (
+                "nested_levels",
+                "# Role\n## Tools\n### Search\n## Output",
+                [
+                    {"level": 1, "text": "Role"},
+                    {"level": 2, "text": "Tools"},
+                    {"level": 3, "text": "Search"},
+                    {"level": 2, "text": "Output"},
+                ],
+            ),
+            (
+                "preserves_markdown_in_text",
+                "# Heading with [link](https://example.com)",
+                [{"level": 1, "text": "Heading with [link](https://example.com)"}],
+            ),
+            (
+                "trims_trailing_hashes",
+                "# Heading ###",
+                [{"level": 1, "text": "Heading"}],
+            ),
+            (
+                "ignores_inline_hashes",
+                "not a heading # inline",
+                [],
+            ),
+            (
+                "ignores_deeper_than_h6",
+                "####### too deep\n# real",
+                [{"level": 1, "text": "real"}],
+            ),
+            ("json_array_payload", [{"role": "user", "content": "hi"}], []),
+            ("none_payload", None, []),
+        ]
+    )
+    def test_get_prompt_outline(self, _name: str, value: object, expected: list[dict[str, object]]) -> None:
+        assert get_prompt_outline(value) == expected

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -1057,6 +1057,17 @@ export interface PatchedTraceReviewUpdateApi {
     queue_id?: string | null
 }
 
+export interface LLMPromptOutlineEntryApi {
+    /**
+     * Markdown heading level (1-6).
+     * @minimum 1
+     * @maximum 6
+     */
+    level: number
+    /** Heading text with markdown link syntax preserved. */
+    text: string
+}
+
 export interface LLMPromptListApi {
     readonly id: string
     /** Unique prompt name using letters, numbers, hyphens, and underscores only. */
@@ -1072,6 +1083,7 @@ export interface LLMPromptListApi {
     readonly latest_version: number
     readonly version_count: number
     readonly first_version_created_at: string
+    readonly outline: readonly LLMPromptOutlineEntryApi[]
     readonly prompt_preview: string
     readonly prompt_size_bytes: number
 }
@@ -1103,12 +1115,18 @@ export interface LLMPromptApi {
     readonly latest_version: number
     readonly version_count: number
     readonly first_version_created_at: string
+    readonly outline: readonly LLMPromptOutlineEntryApi[]
 }
 
 export interface LLMPromptPublicApi {
     id: string
     name: string
-    prompt: unknown
+    /** Full prompt content. Omitted when 'content=preview' or 'content=none'. */
+    prompt?: unknown
+    /** First 160 characters of the prompt. Only present when 'content=preview'. */
+    prompt_preview?: string
+    /** Flat list of markdown headings parsed from the prompt. Useful as a lightweight table of contents. */
+    outline: LLMPromptOutlineEntryApi[]
     version: number
     created_at: string
     updated_at: string
@@ -1463,7 +1481,7 @@ export type LlmAnalyticsTraceReviewsListParams = {
 
 export type LlmPromptsListParams = {
     /**
- * Controls how much prompt content is included in list results. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely.
+ * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
 
 * `full` - full
 * `preview` - preview
@@ -1495,11 +1513,29 @@ export const LlmPromptsListContent = {
 
 export type LlmPromptsNameRetrieveParams = {
     /**
+ * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
+
+* `full` - full
+* `preview` - preview
+* `none` - none
+ * @minLength 1
+ */
+    content?: LlmPromptsNameRetrieveContent
+    /**
      * Specific prompt version to fetch. If omitted, the latest version is returned.
      * @minimum 1
      */
     version?: number
 }
+
+export type LlmPromptsNameRetrieveContent =
+    (typeof LlmPromptsNameRetrieveContent)[keyof typeof LlmPromptsNameRetrieveContent]
+
+export const LlmPromptsNameRetrieveContent = {
+    Full: 'full',
+    Preview: 'preview',
+    None: 'none',
+} as const
 
 export type LlmPromptsResolveNameRetrieveParams = {
     /**

--- a/products/llm_analytics/mcp/prompts.yaml
+++ b/products/llm_analytics/mcp/prompts.yaml
@@ -21,7 +21,9 @@ tools:
         title: List prompts
         description: >
             List all LLM prompts stored for the current team. Optionally filter by name. Returns paginated prompt
-            summaries. By default, only prompt metadata is returned, not full prompt content.
+            summaries. By default, only prompt metadata is returned, not full prompt content. Every result also
+            includes `outline`, a flat list of markdown headings parsed from the prompt — use it as a lightweight
+            table of contents, and pair with `content=none` to keep responses small.
         input_schema: PromptListInputSchema
         response_type: >-
             Omit<Schemas.PaginatedLLMPromptListList, 'results'> & {
@@ -38,7 +40,10 @@ tools:
             idempotent: true
         title: Get prompt
         description: |
-            Get a specific LLM prompt by name, including its full content. Uses the cached endpoint for fast retrieval.
+            Get a specific LLM prompt by name. Uses the cached endpoint for fast retrieval.
+            The response always includes `outline`, a flat list of markdown headings parsed from the prompt — useful
+            as a lightweight table of contents. Pass `content=none` to get the outline without the prompt payload,
+            or `content=preview` for a short `prompt_preview` snippet instead of the full prompt.
     prompt-create:
         operation: llm_prompts_create
         enabled: true

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2251,7 +2251,7 @@
         }
     },
     "prompt-list": {
-        "description": "List all LLM prompts stored for the current team. Optionally filter by name. Returns paginated prompt summaries. By default, only prompt metadata is returned, not full prompt content.",
+        "description": "List all LLM prompts stored for the current team. Optionally filter by name. Returns paginated prompt summaries. By default, only prompt metadata is returned, not full prompt content. Every result also includes `outline`, a flat list of markdown headings parsed from the prompt — use it as a lightweight table of contents, and pair with `content=none` to keep responses small.",
         "category": "Prompts",
         "feature": "prompts",
         "summary": "List prompts",
@@ -2266,7 +2266,7 @@
         }
     },
     "prompt-get": {
-        "description": "Get a specific LLM prompt by name, including its full content. Uses the cached endpoint for fast retrieval.",
+        "description": "Get a specific LLM prompt by name. Uses the cached endpoint for fast retrieval.\nThe response always includes `outline`, a flat list of markdown headings parsed from the prompt — useful\nas a lightweight table of contents. Pass `content=none` to get the outline without the prompt payload,\nor `content=preview` for a short `prompt_preview` snippet instead of the full prompt.",
         "category": "Prompts",
         "feature": "prompts",
         "summary": "Get prompt",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2730,7 +2730,7 @@
         }
     },
     "prompt-list": {
-        "description": "List all LLM prompts stored for the current team. Optionally filter by name. Returns paginated prompt summaries. By default, only prompt metadata is returned, not full prompt content.",
+        "description": "List all LLM prompts stored for the current team. Optionally filter by name. Returns paginated prompt summaries. By default, only prompt metadata is returned, not full prompt content. Every result also includes `outline`, a flat list of markdown headings parsed from the prompt — use it as a lightweight table of contents, and pair with `content=none` to keep responses small.",
         "category": "Prompts",
         "feature": "prompts",
         "summary": "List prompts",
@@ -2745,7 +2745,7 @@
         }
     },
     "prompt-get": {
-        "description": "Get a specific LLM prompt by name, including its full content. Uses the cached endpoint for fast retrieval.",
+        "description": "Get a specific LLM prompt by name. Uses the cached endpoint for fast retrieval.\nThe response always includes `outline`, a flat list of markdown headings parsed from the prompt — useful\nas a lightweight table of contents. Pass `content=none` to get the outline without the prompt payload,\nor `content=preview` for a short `prompt_preview` snippet instead of the full prompt.",
         "category": "Prompts",
         "feature": "prompts",
         "summary": "Get prompt",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -19339,6 +19339,17 @@ export namespace Schemas {
       Boolean: 'boolean',
     } as const;
 
+    export interface LLMPromptOutlineEntry {
+      /**
+       * Markdown heading level (1-6).
+       * @minimum 1
+       * @maximum 6
+       */
+      level: number;
+      /** Heading text with markdown link syntax preserved. */
+      text: string;
+    }
+
     export interface LLMPrompt {
       readonly id: string;
       /**
@@ -19357,6 +19368,7 @@ export namespace Schemas {
       readonly latest_version: number;
       readonly version_count: number;
       readonly first_version_created_at: string;
+      readonly outline: readonly LLMPromptOutlineEntry[];
     }
 
     export interface LLMPromptDuplicate {
@@ -19389,6 +19401,7 @@ export namespace Schemas {
       readonly latest_version: number;
       readonly version_count: number;
       readonly first_version_created_at: string;
+      readonly outline: readonly LLMPromptOutlineEntry[];
       readonly prompt_preview: string;
       readonly prompt_size_bytes: number;
     }
@@ -19396,7 +19409,12 @@ export namespace Schemas {
     export interface LLMPromptPublic {
       id: string;
       name: string;
-      prompt: unknown;
+      /** Full prompt content. Omitted when 'content=preview' or 'content=none'. */
+      prompt?: unknown;
+      /** First 160 characters of the prompt. Only present when 'content=preview'. */
+      prompt_preview?: string;
+      /** Flat list of markdown headings parsed from the prompt. Useful as a lightweight table of contents. */
+      outline: LLMPromptOutlineEntry[];
       version: number;
       created_at: string;
       updated_at: string;
@@ -34832,7 +34850,7 @@ export namespace Schemas {
 
     export type LlmPromptsListParams = {
     /**
-     * Controls how much prompt content is included in list results. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely.
+     * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
 
     * `full` - full
     * `preview` - preview
@@ -34865,11 +34883,29 @@ export namespace Schemas {
 
     export type LlmPromptsNameRetrieveParams = {
     /**
+     * Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.
+
+    * `full` - full
+    * `preview` - preview
+    * `none` - none
+     * @minLength 1
+     */
+    content?: LlmPromptsNameRetrieveContent;
+    /**
      * Specific prompt version to fetch. If omitted, the latest version is returned.
      * @minimum 1
      */
     version?: number;
     };
+
+    export type LlmPromptsNameRetrieveContent = typeof LlmPromptsNameRetrieveContent[keyof typeof LlmPromptsNameRetrieveContent];
+
+
+    export const LlmPromptsNameRetrieveContent = {
+      Full: 'full',
+      Preview: 'preview',
+      None: 'none',
+    } as const;
 
     export type LlmPromptsResolveNameRetrieveParams = {
     /**

--- a/services/mcp/src/generated/prompts/api.ts
+++ b/services/mcp/src/generated/prompts/api.ts
@@ -23,7 +23,7 @@ export const LlmPromptsListQueryParams = /* @__PURE__ */ zod.object({
         .enum(['full', 'preview', 'none'])
         .default(llmPromptsListQueryContentDefault)
         .describe(
-            "Controls how much prompt content is included in list results. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely.\n\n* `full` - full\n* `preview` - preview\n* `none` - none"
+            "Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.\n\n* `full` - full\n* `preview` - preview\n* `none` - none"
         ),
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
@@ -59,7 +59,15 @@ export const LlmPromptsNameRetrieveParams = /* @__PURE__ */ zod.object({
     prompt_name: zod.string().regex(llmPromptsNameRetrievePathPromptNameRegExp),
 })
 
+export const llmPromptsNameRetrieveQueryContentDefault = `full`
+
 export const LlmPromptsNameRetrieveQueryParams = /* @__PURE__ */ zod.object({
+    content: zod
+        .enum(['full', 'preview', 'none'])
+        .default(llmPromptsNameRetrieveQueryContentDefault)
+        .describe(
+            "Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.\n\n* `full` - full\n* `preview` - preview\n* `none` - none"
+        ),
     version: zod
         .number()
         .min(1)

--- a/services/mcp/src/tools/generated/prompts.ts
+++ b/services/mcp/src/tools/generated/prompts.ts
@@ -53,6 +53,7 @@ const promptGet = (): ToolBase<typeof PromptGetSchema, Schemas.LLMPromptPublic> 
             method: 'GET',
             path: `/api/environments/${encodeURIComponent(String(projectId))}/llm_prompts/name/${encodeURIComponent(String(params.prompt_name))}/`,
             query: {
+                content: params.content,
                 version: params.version,
             },
         })

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/prompt-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/prompt-get.json
@@ -1,6 +1,12 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "content": {
+            "default": "full",
+            "description": "Controls how much prompt content is included in the response. 'full' includes the full prompt, 'preview' includes a short prompt_preview, and 'none' omits prompt content entirely. The outline field is always included.\n\n* `full` - full\n* `preview` - preview\n* `none` - none",
+            "enum": ["full", "preview", "none"],
+            "type": "string"
+        },
         "prompt_name": {
             "pattern": "^[^/]+$",
             "type": "string"

--- a/services/mcp/tests/unit/prompts-generated.test.ts
+++ b/services/mcp/tests/unit/prompts-generated.test.ts
@@ -24,8 +24,16 @@ describe('Generated prompt tools', () => {
         const tool = getToolByName(GENERATED_TOOLS, 'prompt-get')
 
         const parsed = tool.schema.parse({ prompt_name: 'checkout_prompt', version: 2 })
-        expect(parsed).toEqual({ prompt_name: 'checkout_prompt', version: 2 })
+        expect(parsed).toEqual({ prompt_name: 'checkout_prompt', version: 2, content: 'full' })
         expect(() => tool.schema.parse({ name: 'checkout_prompt' })).toThrow()
+    })
+
+    it('exposes content mode on the prompt-get schema so agents can fetch outline-only', () => {
+        const tool = getToolByName(GENERATED_TOOLS, 'prompt-get')
+
+        const parsed = tool.schema.parse({ prompt_name: 'checkout_prompt', content: 'none' })
+        expect(parsed).toEqual({ prompt_name: 'checkout_prompt', content: 'none' })
+        expect(() => tool.schema.parse({ prompt_name: 'checkout_prompt', content: 'bogus' })).toThrow()
     })
 
     it('uses prompt_name (not name) in generated prompt-update schema', () => {


### PR DESCRIPTION
## Problem

When an agent uses the PostHog MCP to list or fetch LLM prompts, today it either gets the full prompt payload or nothing useful — there is no middle ground for "show me what's in this prompt" without pulling everything. For agents deciding which of several prompts to load, or just wanting to understand a prompt's structure, this is clunky and wastes tokens.

## Changes

- Adds an `outline` field to every LLM prompt API response. It is a flat list of `{level, text}` entries parsed from markdown headings (H1–H6) in the prompt, so it behaves like a lightweight table of contents. Empty list for non-markdown prompts (e.g. message arrays).
- Extends the by-name endpoint (`GET /prompts/name/<name>/`) with the `content=full|preview|none` query param that the list endpoint already supports. Pair with `content=none` to fetch just the outline for a known prompt.
- Outline is computed on the fly in the serializer — no storage, no migration, no frontend change. The existing frontend `PromptOutline` component keeps its own client-side parser since it also needs heading slugs for scroll-anchor navigation.
- Updates the MCP tool descriptions for `prompt-list` and `prompt-get` so agents know the outline field exists and how to use the content modes.

## How did you test this code?

- 10 parameterized unit tests for the outline parser (markdown shapes, nesting, non-markdown payloads, edge cases).
- 7 new API tests: list outline presence, list outline with `content=none`, list outline for non-markdown, by-name outline, and a parameterized content-mode test for the by-name endpoint.
- Full `test_llm_prompt.py` suite: 72 passed.
- Prompt cache storage tests: 14 passed.
- Regenerated OpenAPI and MCP tool definitions with `hogli build:openapi`; updated the existing MCP schema snapshot and generated-prompts unit test for the new `content` param. Full MCP test suite: 570 passed.
- No manual UI testing — this is a backend + MCP change and the frontend is unaffected.

## Publish to changelog?

no