### PR TITLE
perf(experiments): narrow session-id pushdown IN to session-referencing OR branches

### DIFF
--- a/posthog/hogql/database/schema/util/test/test_session_v2_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/test/test_session_v2_where_clause_extractor.py
@@ -636,3 +636,77 @@ WHERE (events.event = '$pageview') OR (events.session.$entry_pathname = '/signup
         normalized = " ".join(actual.split())
         assert "in(raw_sessions.session_id_v7" not in normalized
         assert "globalIn(raw_sessions.session_id_v7" not in normalized
+
+    def _extract_in_subquery(self, actual: str) -> str:
+        # The IN subquery is printed as ``globalIn(raw_sessions.session_id_v7, (SELECT … ))``
+        # (or ``in(…)`` when the printer bypasses the global rewrite). We scan for the start
+        # and then walk parens to find the matching close, since the body itself contains
+        # nested parens.
+        for prefix in ("globalIn(raw_sessions.session_id_v7, ", "in(raw_sessions.session_id_v7, "):
+            start = actual.find(prefix)
+            if start == -1:
+                continue
+            body_start = start + len(prefix)
+            if actual[body_start] != "(":
+                continue
+            depth = 0
+            for i in range(body_start, len(actual)):
+                if actual[i] == "(":
+                    depth += 1
+                elif actual[i] == ")":
+                    depth -= 1
+                    if depth == 0:
+                        return actual[body_start : i + 1]
+        raise AssertionError(f"Could not locate IN subquery in:\n{actual}")
+
+    def test_pushdown_narrows_in_to_session_referencing_or_branch(self):
+        # Mirrors ExperimentQuery funnel shape:
+        # ``WHERE timestamp_range AND (exposure_event OR (step_1_event AND session.filter))``.
+        # The exposure branch has no session reference, so rows matching it don't consult
+        # ``events__session.*``; their LEFT JOIN to NULL is fine. Only the step_1 branch
+        # needs its sessions in the IN list — narrowing the IN avoids pulling millions of
+        # exposure-event session_ids through the DISTINCT and GLOBAL IN broadcast.
+        query = """
+SELECT
+    events.$session_id AS sid,
+    events.session.$entry_pathname AS entry
+FROM events
+WHERE events.timestamp >= '2026-03-27 00:00:00'
+  AND events.timestamp <= '2026-03-31 23:59:59'
+  AND (
+    events.event = '$feature_flag_called'
+    OR (events.event = '$pageview' AND events.session.$entry_pathname = '/signup')
+  )
+"""
+        actual = self.print_query(query, pushdown=True)
+        normalized = " ".join(actual.split())
+        # Sanity: pushdown is in place.
+        assert "in(raw_sessions.session_id_v7" in normalized or "globalIn(raw_sessions.session_id_v7" in normalized
+        in_subquery = self._extract_in_subquery(actual)
+        # After narrowing, only the step_1 branch survives — one event equality, no OR.
+        assert in_subquery.count("equals(events.event,") == 1, (
+            f"Expected a single event equality in narrowed IN; got:\n{in_subquery}"
+        )
+        assert "or(" not in in_subquery, f"Expected no OR in narrowed IN; got:\n{in_subquery}"
+
+    def test_pushdown_preserves_or_when_all_branches_reference_session(self):
+        # If every OR disjunct references the session join, narrowing is a no-op: the IN
+        # subquery keeps both event equalities joined by OR (the session-side halves still
+        # drop out via the events-only extractor's tombstone logic).
+        query = """
+SELECT
+    events.$session_id AS sid,
+    events.session.$entry_pathname AS entry
+FROM events
+WHERE events.timestamp >= '2026-03-27 00:00:00'
+  AND (
+    (events.event = '$pageview' AND events.session.$entry_pathname = '/signup')
+    OR (events.event = 'custom_click' AND events.session.$entry_pathname = '/home')
+  )
+"""
+        actual = self.print_query(query, pushdown=True)
+        in_subquery = self._extract_in_subquery(actual)
+        assert in_subquery.count("equals(events.event,") == 2, (
+            f"Expected both event equalities in IN; got:\n{in_subquery}"
+        )
+        assert "or(" in in_subquery, f"Expected OR preserved in IN; got:\n{in_subquery}"

--- a/posthog/hogql/database/schema/util/test/test_session_v2_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/test/test_session_v2_where_clause_extractor.py
@@ -659,14 +659,17 @@ WHERE (events.event = '$pageview') OR (events.session.$entry_pathname = '/signup
                         return actual[body_start : i + 1]
         raise AssertionError(f"Could not locate IN subquery in:\n{actual}")
 
-    def test_pushdown_narrows_in_to_session_referencing_or_branch(self):
-        # Mirrors ExperimentQuery funnel shape:
-        # ``WHERE timestamp_range AND (exposure_event OR (step_1_event AND session.filter))``.
-        # The exposure branch has no session reference, so rows matching it don't consult
-        # ``events__session.*``; their LEFT JOIN to NULL is fine. Only the step_1 branch
-        # needs its sessions in the IN list — narrowing the IN avoids pulling millions of
-        # exposure-event session_ids through the DISTINCT and GLOBAL IN broadcast.
-        query = """
+    @parameterized.expand(
+        [
+            # Mirrors ExperimentQuery funnel shape:
+            # ``WHERE timestamp_range AND (exposure_event OR (step_1_event AND session.filter))``.
+            # The exposure branch has no session reference, so rows matching it don't consult
+            # ``events__session.*``; their LEFT JOIN to NULL is fine. Only the step_1 branch
+            # needs its sessions in the IN list — narrowing avoids pulling millions of
+            # exposure-event session_ids through the DISTINCT and GLOBAL IN broadcast.
+            (
+                "narrow_drops_non_session_branch",
+                """
 SELECT
     events.$session_id AS sid,
     events.session.$entry_pathname AS entry
@@ -677,23 +680,16 @@ WHERE events.timestamp >= '2026-03-27 00:00:00'
     events.event = '$feature_flag_called'
     OR (events.event = '$pageview' AND events.session.$entry_pathname = '/signup')
   )
-"""
-        actual = self.print_query(query, pushdown=True)
-        normalized = " ".join(actual.split())
-        # Sanity: pushdown is in place.
-        assert "in(raw_sessions.session_id_v7" in normalized or "globalIn(raw_sessions.session_id_v7" in normalized
-        in_subquery = self._extract_in_subquery(actual)
-        # After narrowing, only the step_1 branch survives — one event equality, no OR.
-        assert in_subquery.count("equals(events.event,") == 1, (
-            f"Expected a single event equality in narrowed IN; got:\n{in_subquery}"
-        )
-        assert "or(" not in in_subquery, f"Expected no OR in narrowed IN; got:\n{in_subquery}"
-
-    def test_pushdown_preserves_or_when_all_branches_reference_session(self):
-        # If every OR disjunct references the session join, narrowing is a no-op: the IN
-        # subquery keeps both event equalities joined by OR (the session-side halves still
-        # drop out via the events-only extractor's tombstone logic).
-        query = """
+""",
+                1,  # expected event equality count after narrowing
+                False,  # expected OR in IN subquery
+            ),
+            # When every disjunct references the session join, narrowing is a no-op: both
+            # event equalities survive (joined by OR); the session-side halves drop via
+            # the events-only extractor's tombstone logic.
+            (
+                "preserve_or_when_all_branches_touch_session",
+                """
 SELECT
     events.$session_id AS sid,
     events.session.$entry_pathname AS entry
@@ -703,10 +699,19 @@ WHERE events.timestamp >= '2026-03-27 00:00:00'
     (events.event = '$pageview' AND events.session.$entry_pathname = '/signup')
     OR (events.event = 'custom_click' AND events.session.$entry_pathname = '/home')
   )
-"""
+""",
+                2,
+                True,
+            ),
+        ]
+    )
+    def test_pushdown_or_narrowing(self, _name: str, query: str, expected_event_eq_count: int, expected_has_or: bool):
         actual = self.print_query(query, pushdown=True)
         in_subquery = self._extract_in_subquery(actual)
-        assert in_subquery.count("equals(events.event,") == 2, (
-            f"Expected both event equalities in IN; got:\n{in_subquery}"
+        assert in_subquery.count("equals(events.event,") == expected_event_eq_count, (
+            f"Expected {expected_event_eq_count} event equality/equalities in IN subquery; got:\n{in_subquery}"
         )
-        assert "or(" in in_subquery, f"Expected OR preserved in IN; got:\n{in_subquery}"
+        if expected_has_or:
+            assert "or(" in in_subquery, f"Expected OR preserved in IN; got:\n{in_subquery}"
+        else:
+            assert "or(" not in in_subquery, f"Expected no OR in narrowed IN; got:\n{in_subquery}"

--- a/posthog/hogql/database/schema/util/where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/where_clause_extractor.py
@@ -8,7 +8,7 @@ from django.core.cache import cache
 from posthog.hogql import ast
 from posthog.hogql.ast import CompareOperationOp
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.models import DatabaseField, LazyJoinToAdd, LazyTableToAdd
+from posthog.hogql.database.models import DatabaseField, LazyJoin, LazyJoinToAdd, LazyTableToAdd
 from posthog.hogql.database.schema.util.uuid import (
     uuid_uint128_expr_to_timestamp_expr_v2,
     uuid_uint128_expr_to_timestamp_expr_v3,
@@ -469,7 +469,32 @@ class EventsOnlyWhereClauseExtractor(WhereClauseExtractor):
     Inverts the field-tracking semantics of ``WhereClauseExtractor``: we keep fields that
     resolve to the EventsTable and tombstone everything else, letting the base AND/OR/NOT
     logic drop unsafe branches.
+
+    When ``session_lazy_join`` is set, an extra narrowing step drops OR disjuncts that
+    don't reference the session join. Rows matching those dropped disjuncts don't consult
+    ``events__session.*`` columns, so their LEFT JOIN producing NULL is semantically
+    equivalent to their original behavior — keeping them in the IN subquery just inflates
+    the session set without narrowing. See the 2026-04-17 analysis doc for the follow-up
+    benchmark showing 4.5× speedup on rare-step-1 funnels.
     """
+
+    session_lazy_join: Optional[LazyJoin] = None
+
+    def __init__(self, context: HogQLContext, session_lazy_join: Optional[LazyJoin] = None):
+        super().__init__(context)
+        self.session_lazy_join = session_lazy_join
+
+    def visit_or(self, node: ast.Or) -> ast.Expr:
+        if self.session_lazy_join is not None:
+            # Flatten nested ORs so narrowing is based on leaf disjuncts, then keep
+            # only those that reference the session lazy join.
+            flattened = flatten_ors(node.exprs)
+            kept = [expr for expr in flattened if _expr_references_lazy_join(expr, self.session_lazy_join)]
+            if kept and len(kept) < len(flattened):
+                if len(kept) == 1:
+                    return self.visit(kept[0])
+                return super().visit_or(ast.Or(exprs=kept))
+        return super().visit_or(node)
 
     def visit_compare_operation(self, node: ast.CompareOperation) -> ast.Expr:
         if has_tombstone(node, self.tombstone_string):
@@ -494,6 +519,37 @@ class EventsOnlyWhereClauseExtractor(WhereClauseExtractor):
         if is_events_only_field(node):
             return cast(ast.Field, clone_expr(node))
         return ast.Constant(value=self.tombstone_string)
+
+
+def _expr_references_lazy_join(expr: ast.Expr, lazy_join: LazyJoin) -> bool:
+    """True iff ``expr`` contains any field whose resolved type traverses ``lazy_join``."""
+    visitor = _ReferencesLazyJoinVisitor(lazy_join)
+    visitor.visit(expr)
+    return visitor.found
+
+
+class _ReferencesLazyJoinVisitor(TraversingVisitor):
+    found: bool = False
+    lazy_join: LazyJoin
+
+    def __init__(self, lazy_join: LazyJoin):
+        self.lazy_join = lazy_join
+
+    def visit_field(self, node: ast.Field):
+        if self.found:
+            return
+        type_ = node.type
+        if isinstance(type_, ast.PropertyType):
+            type_ = type_.field_type
+        if isinstance(type_, ast.FieldAliasType):
+            type_ = type_.type
+        if not isinstance(type_, ast.FieldType):
+            return
+        table_type = type_.table_type
+        while isinstance(table_type, (ast.TableAliasType, ast.ColumnAliasedTableType)):
+            table_type = table_type.table_type
+        if isinstance(table_type, ast.LazyJoinType) and table_type.lazy_join is self.lazy_join:
+            self.found = True
 
 
 def is_events_only_field(node: ast.Field) -> bool:
@@ -536,7 +592,9 @@ def build_session_id_v7_pushdown_predicate(
     if events_join is None or not isinstance(events_join.table, ast.Field):
         return None
 
-    events_where = EventsOnlyWhereClauseExtractor(context).get_inner_where(outer_node)
+    events_where = EventsOnlyWhereClauseExtractor(context, session_lazy_join=join_to_add.lazy_join).get_inner_where(
+        outer_node
+    )
     if events_where is None:
         return None
 


### PR DESCRIPTION
## Problem

Follow-up to #55127.

After session-id pushdown shipped to team 11870, ExperimentQuery funnels on experiment 77300 no longer OOM — but funnels with rare step_1 events still took 40-50s, I/O-bound on a ~100-200 GiB scan. The deployed pushdown emits an IN subquery whose `WHERE` mirrors the full outer events `WHERE`, i.e. `(step_0 conditions) OR (step_1 conditions)`. For every ExperimentQuery funnel, step_0 is `$feature_flag_called` and its rows don't reference `events__session.*` — only step_1 rows do. Including step_0 events in the IN just inflates the DISTINCT set and GLOBAL IN broadcast without changing the LEFT JOIN result.

## Changes

- `EventsOnlyWhereClauseExtractor` gains an optional `session_lazy_join` parameter. When set, `visit_or` drops disjuncts that don't contain any field traversing that lazy join, before the events-only extraction runs.
- `build_session_id_v7_pushdown_predicate` threads `join_to_add.lazy_join` into the extractor so the narrowing activates whenever the pushdown path does — no new modifier, no behavior change for queries without mixed OR branches.

Correctness rests on: rows matching dropped disjuncts don't read `events__session.*` in the WHERE, so their LEFT JOIN producing NULL is semantically equivalent to the original behavior.

## How did you test this code?

I'm an agent, so this is code-based testing only.

- Added two parameterized tests in `TestSessionIdPushdownV2` covering: (a) mixed OR where narrowing drops the non-session branch, (b) all-branches-session-referring where the IN keeps both event equalities joined by OR.
- Ran the full `test_session_v2_where_clause_extractor.py` file (50 tests) and the `test_session_properties.py` ExperimentQueryRunner suite — all green.

Pre-PR benchmarks on EU prod (from the analysis doc):

| Funnel | Step_1 event | Current (broad IN) | Narrowed IN | Win |
|---|---|---|---|---|
| MW Nav Primary | `mw_nav_primary_link` (rare) | 50.8s / 117 GiB / 833M rows | **11.3s** / 108 GiB / 718M rows | **4.5× faster** |
| Sign ups (Organic Search) | `$pageview` (common) | 45.9s / 197 GiB / 964M rows | 42.0s / 189 GiB / 857M rows | 1.1× faster |

Win scales with step_1 selectivity — rare nav-click funnels benefit most. No regression expected for web-analytics / session-replay queries because the `sessionIdPushdown` modifier is still off for them.

## Publish to changelog?

no

## 🤖 LLM context

Authored end-to-end by Claude Opus 4.7 (1M context) working from the 2026-04-17 ElevenLabs sessions OOM analysis. The analysis already identified the code site (`build_session_id_v7_pushdown_predicate`), benchmarked the fix on EU prod, and confirmed safety — this PR lands that plan.