### PR TITLE
feat(replay): add sampling rate visibility to mobile settings tab

### DIFF
--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -9,7 +9,7 @@ import { FeatureFlagTrigger, Trigger, TriggerType } from 'lib/components/Ingesti
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { isNumeric, pluralize } from 'lib/utils'
+import { pluralize } from 'lib/utils'
 import { ReplayPlatform, replayTriggersLogic } from 'scenes/settings/environment/replayTriggersLogic'
 import { Since } from 'scenes/settings/environment/SessionRecordingSettings'
 import { teamLogic } from 'scenes/teamLogic'
@@ -17,6 +17,11 @@ import { teamLogic } from 'scenes/teamLogic'
 import { AccessControlResourceType, AvailableFeature, TeamPublicType, TeamType } from '~/types'
 
 export const TRIGGER_GROUPS_MIN_SDK_VERSION = '1.369.0'
+
+/** Convert the stored sample-rate string (decimal 0–1) to a display percentage (0–100). */
+function toDisplaySampleRate(rate: string | null | undefined): number {
+    return typeof rate === 'string' ? Math.floor(parseFloat(rate) * 100) : 100
+}
 
 function TriggerPanelHeader({
     title,
@@ -212,17 +217,41 @@ function Sampling(): JSX.Element {
                         />
                     </LemonLabel>
                     <IngestionControls.SamplingTrigger
-                        initialSampleRate={
-                            typeof currentTeam?.session_recording_sample_rate === 'string'
-                                ? Math.floor(parseFloat(currentTeam?.session_recording_sample_rate) * 100)
-                                : 100
-                        }
+                        initialSampleRate={toDisplaySampleRate(currentTeam?.session_recording_sample_rate)}
                         onChange={(v) => updateCurrentTeam({ session_recording_sample_rate: v.toString() })}
                     />
                 </div>
                 <p>Choose how many sessions to record. 100% = record every session, 50% = record roughly half.</p>
             </div>
         </PayGateMini>
+    )
+}
+
+function MobileSampling(): JSX.Element {
+    const { currentTeam } = useValues(teamLogic)
+
+    const sampleRate = toDisplaySampleRate(currentTeam?.session_recording_sample_rate)
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex flex-row items-center gap-2">
+                <LemonLabel className="text-base">
+                    Sample rate{' '}
+                    <Since
+                        android={{ version: '3.34.0' }}
+                        ios={{ version: '3.42.0' }}
+                        reactNative={{ version: '4.37.0' }}
+                    />
+                </LemonLabel>
+                <Tooltip title="Sample rate is shared across web and mobile. Change it on the Web tab.">
+                    <span className="text-muted font-semibold">{sampleRate}%</span>
+                </Tooltip>
+            </div>
+            <p className="text-muted-alt">
+                Sample rate is shared across all platforms.{' '}
+                <span className="font-semibold">Change this setting on the Web tab.</span>
+            </p>
+        </div>
     )
 }
 
@@ -275,8 +304,7 @@ function useHeaderStatuses(currentTeam: TeamType | TeamPublicType | null): {
     const urlCount = urlTriggerConfig?.length ?? 0
     const eventCount = eventTriggerConfig?.length ?? 0
     const flagKey = currentTeam?.session_recording_linked_flag?.key
-    const sampleRate = currentTeam?.session_recording_sample_rate
-    const numericSampleRate = sampleRate ? Math.floor(parseFloat(sampleRate) * 100) : 100
+    const numericSampleRate = toDisplaySampleRate(currentTeam?.session_recording_sample_rate)
     const minDurationMs = currentTeam?.session_recording_minimum_duration_milliseconds
     const blocklistCount = currentTeam?.session_recording_url_blocklist_config?.length ?? 0
 
@@ -443,6 +471,7 @@ export function ReplayTriggers(): JSX.Element {
                         <RecordingTriggersSummary currentTeam={currentTeam} selectedPlatform={selectedPlatform} />
                     )}
                     <LinkedFlagSelector />
+                    <MobileSampling />
                 </div>
             ),
         },
@@ -498,8 +527,7 @@ const useTriggers = (currentTeam: TeamType | TeamPublicType, selectedPlatform: '
     const hasEventTriggers = (eventTriggerConfig?.length ?? 0) > 0
     const hasFeatureFlag = !!currentTeam.session_recording_linked_flag
     const sampleRate = currentTeam.session_recording_sample_rate
-    const numericSampleRate = sampleRate ? Math.floor(parseFloat(sampleRate) * 100) : null
-    const hasSampling = isNumeric(numericSampleRate) && numericSampleRate < 100
+    const hasSampling = toDisplaySampleRate(sampleRate) < 100
     const hasMinDuration = !!currentTeam.session_recording_minimum_duration_milliseconds
     const hasUrlBlocklist = (currentTeam.session_recording_url_blocklist_config?.length ?? 0) > 0
 
@@ -544,5 +572,12 @@ const useTriggers = (currentTeam: TeamType | TeamPublicType, selectedPlatform: '
         ]
     }
 
-    return [flagTrigger]
+    return [
+        flagTrigger,
+        {
+            type: TriggerType.SAMPLING,
+            enabled: hasSampling,
+            sampleRate: sampleRate ? parseFloat(sampleRate) : null,
+        },
+    ]
 }


### PR DESCRIPTION
## Problem

extremely misleading, if you have a sampling rate set on Web, its respected on mobile, but theres no visiblity to that

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes



![Screenshot 2026-04-17 at 3.28.23 PM.png](https://app.graphite.com/user-attachments/assets/9a531841-458e-4676-9f96-ec98c8bdfc11.png)



<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->