### PR TITLE
chore(web-analytics): bump pre-aggregated job memory limit from 100GB to 140GB

### DIFF
--- a/products/web_analytics/dags/web_preaggregated_utils.py
+++ b/products/web_analytics/dags/web_preaggregated_utils.py
@@ -32,8 +32,8 @@ web_analytics_retry_policy_def = RetryPolicy(
 # Shared ClickHouse settings for web analytics pre-aggregation
 WEB_PRE_AGGREGATED_CLICKHOUSE_SETTINGS = {
     "max_execution_time": WEB_PRE_AGGREGATED_CLICKHOUSE_TIMEOUT,
-    "max_bytes_before_external_group_by": "51474836480",
-    "max_memory_usage": "107374182400",
+    "max_bytes_before_external_group_by": "75161927680",
+    "max_memory_usage": "150323855360",
     "distributed_aggregation_memory_efficient": "1",
     "s3_truncate_on_insert": "1",
 }


### PR DESCRIPTION
## Problem

Pre-aggregated web analytics jobs are hitting memory limits on the ClickHouse cluster.

## Changes

- `max_memory_usage`: 100GB → 140GB
- `max_bytes_before_external_group_by`: ~48GB → ~70GB (maintains ~50% ratio)

Leaves headroom for OS, cache/buffer, and other queries.

## How did you test this code?

Config-only change, no logic affected.

## Publish to changelog?

no