### PR TITLE
chore: skip snapshot testing for SessionTimeline stories

### DIFF
--- a/frontend/src/lib/components/SessionTimeline/SessionTimeline.stories.tsx
+++ b/frontend/src/lib/components/SessionTimeline/SessionTimeline.stories.tsx
@@ -9,6 +9,7 @@ import { ItemCategory, ItemCollector, ItemLoader, ItemRenderer, TimelineItem } f
 
 const meta: Meta = {
     title: 'Components/SessionTimeline',
+    tags: ['test-skip'],
     parameters: {
         layout: 'centered',
         viewMode: 'story',
@@ -279,7 +280,6 @@ export const SlowLoading: StoryFn = () => {
         </div>
     )
 }
-SlowLoading.tags = ['test-skip']
 
 /** Many items — 200 per category, for scroll performance testing. */
 export const ManyItems: StoryFn = () => {


### PR DESCRIPTION
## Problem

SessionTimeline snapshot tests are noisy and not providing value — the component uses randomized UUIDs and async loading, making snapshots flaky.

## Changes

- Added `tags: ['test-skip']` to the SessionTimeline story meta to skip snapshot testing for all stories
- Removed the now-redundant per-story `test-skip` tag from `SlowLoading`

## How did you test this code?

Verified the story file is valid TypeScript. The `test-skip` tag is an established pattern in the codebase for opting out of Chromatic snapshot tests.

## Publish to changelog?

no