### PR TITLE
fix(error-tracking): use dedicated logs query runner for checking logs existence

### DIFF
--- a/products/error_tracking/backend/api/recommendations.py
+++ b/products/error_tracking/backend/api/recommendations.py
@@ -3,7 +3,9 @@ from typing import override
 from django.db import IntegrityError
 from django.utils import timezone
 
+import structlog
 from drf_spectacular.utils import extend_schema
+from posthoganalytics import capture_exception
 from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.request import Request
@@ -15,6 +17,8 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 
 from products.error_tracking.backend.models import ErrorTrackingRecommendation
 from products.error_tracking.backend.recommendations import RECOMMENDATIONS, RECOMMENDATIONS_BY_TYPE
+
+logger = structlog.get_logger(__name__)
 
 
 class ErrorTrackingRecommendationSerializer(serializers.ModelSerializer):
@@ -36,22 +40,35 @@ def _compute_if_stale(team_id: int, team) -> None:
     now = timezone.now()
     for rec in RECOMMENDATIONS:
         try:
-            obj = ErrorTrackingRecommendation.objects.get(team_id=team_id, type=rec.type)
-        except ErrorTrackingRecommendation.DoesNotExist:
-            try:
-                ErrorTrackingRecommendation.objects.create(
-                    team_id=team_id,
-                    type=rec.type,
-                    meta=rec.compute(team),
-                    computed_at=now,
-                )
-            except IntegrityError:
-                pass
-            continue
-        if obj.computed_at is None or now >= obj.computed_at + rec.refresh_interval:
-            obj.meta = rec.compute(team)
-            obj.computed_at = now
-            obj.save(update_fields=["meta", "computed_at", "updated_at"])
+            _compute_single(rec, team_id, team, now)
+        except Exception as e:
+            capture_exception(e)
+            logger.warning(
+                "error_tracking_recommendation_compute_failed",
+                team_id=team_id,
+                recommendation_type=rec.type,
+                exc_info=True,
+            )
+
+
+def _compute_single(rec, team_id: int, team, now) -> None:
+    try:
+        obj = ErrorTrackingRecommendation.objects.get(team_id=team_id, type=rec.type)
+    except ErrorTrackingRecommendation.DoesNotExist:
+        try:
+            ErrorTrackingRecommendation.objects.create(
+                team_id=team_id,
+                type=rec.type,
+                meta=rec.compute(team),
+                computed_at=now,
+            )
+        except IntegrityError:
+            pass
+        return
+    if obj.computed_at is None or now >= obj.computed_at + rec.refresh_interval:
+        obj.meta = rec.compute(team)
+        obj.computed_at = now
+        obj.save(update_fields=["meta", "computed_at", "updated_at"])
 
 
 @extend_schema(tags=[ProductKey.ERROR_TRACKING])

--- a/products/error_tracking/backend/api/recommendations.py
+++ b/products/error_tracking/backend/api/recommendations.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import override
 
 from django.db import IntegrityError
@@ -14,9 +15,11 @@ from rest_framework.response import Response
 from posthog.schema import ProductKey
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.models.team.team import Team
 
 from products.error_tracking.backend.models import ErrorTrackingRecommendation
 from products.error_tracking.backend.recommendations import RECOMMENDATIONS, RECOMMENDATIONS_BY_TYPE
+from products.error_tracking.backend.recommendations.base import Recommendation
 
 logger = structlog.get_logger(__name__)
 
@@ -36,7 +39,7 @@ class ErrorTrackingRecommendationSerializer(serializers.ModelSerializer):
         return (obj.computed_at + rec.refresh_interval).isoformat()
 
 
-def _compute_if_stale(team_id: int, team) -> None:
+def _compute_if_stale(team_id: int, team: Team) -> None:
     now = timezone.now()
     for rec in RECOMMENDATIONS:
         try:
@@ -51,7 +54,7 @@ def _compute_if_stale(team_id: int, team) -> None:
             )
 
 
-def _compute_single(rec, team_id: int, team, now) -> None:
+def _compute_single(rec: Recommendation, team_id: int, team: Team, now: datetime) -> None:
     try:
         obj = ErrorTrackingRecommendation.objects.get(team_id=team_id, type=rec.type)
     except ErrorTrackingRecommendation.DoesNotExist:

--- a/products/error_tracking/backend/recommendations/cross_sell.py
+++ b/products/error_tracking/backend/recommendations/cross_sell.py
@@ -1,18 +1,11 @@
 from datetime import timedelta
 from typing import Any
 
-from posthog.clickhouse.client import sync_execute
 from posthog.models.team.team import Team
 
+from products.logs.backend.has_logs_query_runner import team_has_logs
+
 from .base import Recommendation
-
-
-def _team_has_logs(team_id: int) -> bool:
-    result = sync_execute(
-        "SELECT 1 FROM logs_distributed WHERE team_id = %(team_id)s LIMIT 1",
-        {"team_id": team_id},
-    )
-    return len(result) > 0
 
 
 class CrossSellRecommendation(Recommendation):
@@ -28,7 +21,7 @@ class CrossSellRecommendation(Recommendation):
                 },
                 {
                     "key": "logs",
-                    "enabled": _team_has_logs(team.id),
+                    "enabled": team_has_logs(team),
                 },
             ]
         }

--- a/products/logs/backend/api.py
+++ b/products/logs/backend/api.py
@@ -3,7 +3,6 @@ import json
 import base64
 import datetime as dt
 
-from django.core.cache import cache
 from django.utils import timezone
 
 from drf_spectacular.utils import extend_schema
@@ -37,7 +36,7 @@ from posthog.tasks.exporter import export_asset
 
 from products.logs.backend.alerts_api import LogsAlertViewSet
 from products.logs.backend.explain import LogExplainViewSet
-from products.logs.backend.has_logs_query_runner import HasLogsQueryRunner
+from products.logs.backend.has_logs_query_runner import team_has_logs
 from products.logs.backend.log_attributes_query_runner import LogAttributesQueryRunner
 from products.logs.backend.log_values_query_runner import LogValuesQueryRunner
 from products.logs.backend.logs_query_runner import CachedLogsQueryResponse, LogsQueryResponse, LogsQueryRunner
@@ -563,24 +562,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
 
     @action(detail=False, methods=["GET"], required_scopes=["logs:read"])
     def has_logs(self, request: Request, *args, **kwargs) -> Response:
-        cache_key = f"team:{self.team.id}:has_logs"
-        cached = cache.get(cache_key)
-        if cached is True:
-            report_user_action(
-                request.user,
-                "logs has_logs checked",
-                {"has_logs": True},
-                team=self.team,
-                request=request,
-            )
-            return Response({"hasLogs": True}, status=status.HTTP_200_OK)
-
-        runner = HasLogsQueryRunner(self.team)
-        has_logs = runner.run()
-
-        # Only cache positive results (once you have logs, you always have logs)
-        if has_logs:
-            cache.set(cache_key, True, int(dt.timedelta(days=7).total_seconds()))
+        has_logs = team_has_logs(self.team)
 
         report_user_action(
             request.user,

--- a/products/logs/backend/has_logs_query_runner.py
+++ b/products/logs/backend/has_logs_query_runner.py
@@ -35,7 +35,7 @@ def team_has_logs(team: Team) -> bool:
     if cache.get(cache_key) is True:
         return True
 
-    result = HasLogsQueryRunner(team).run()
-    if result:
+    has_logs = HasLogsQueryRunner(team).run()
+    if has_logs:
         cache.set(cache_key, True, HAS_LOGS_CACHE_TTL)
-    return result
+    return has_logs

--- a/products/logs/backend/has_logs_query_runner.py
+++ b/products/logs/backend/has_logs_query_runner.py
@@ -1,9 +1,15 @@
+import datetime as dt
+
+from django.core.cache import cache
+
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.client.connection import Workload
 from posthog.models import Team
+
+HAS_LOGS_CACHE_TTL = int(dt.timedelta(days=7).total_seconds())
 
 
 class HasLogsQueryRunner:
@@ -22,3 +28,14 @@ class HasLogsQueryRunner:
         )
 
         return len(response.results) > 0
+
+
+def team_has_logs(team: Team) -> bool:
+    cache_key = f"team:{team.id}:has_logs"
+    if cache.get(cache_key) is True:
+        return True
+
+    result = HasLogsQueryRunner(team).run()
+    if result:
+        cache.set(cache_key, True, HAS_LOGS_CACHE_TTL)
+    return result

--- a/products/logs/backend/test/test_has_logs_query_runner.py
+++ b/products/logs/backend/test/test_has_logs_query_runner.py
@@ -105,7 +105,7 @@ class TestHasLogsAPI(ClickhouseTestMixin, APIBaseTest):
 
         # First call should hit the database and cache the result
         with (
-            patch("products.logs.backend.api.HasLogsQueryRunner") as mock_runner,
+            patch("products.logs.backend.has_logs_query_runner.HasLogsQueryRunner") as mock_runner,
             patch("products.logs.backend.api.report_user_action") as mock_report,
         ):
             mock_runner.return_value.run.return_value = True
@@ -130,7 +130,7 @@ class TestHasLogsAPI(ClickhouseTestMixin, APIBaseTest):
     def test_has_logs_api_does_not_cache_negative_results(self):
         cache.clear()
 
-        with patch("products.logs.backend.api.HasLogsQueryRunner") as mock_runner:
+        with patch("products.logs.backend.has_logs_query_runner.HasLogsQueryRunner") as mock_runner:
             mock_runner.return_value.run.return_value = False
 
             # First call returns False

--- a/tach.toml
+++ b/tach.toml
@@ -209,6 +209,7 @@ path = "products.error_tracking"
 depends_on = [
     "ee",
     "posthog",
+    "products.logs",
 ]
 layer = "modules"
 


### PR DESCRIPTION
Context - I am doing recommendation center for ET and want to promote logs as a good cross sell product. I need to know if a team has some logs. It is behind a FF for posthog employees only. It is already live - this PR just changes the approach

Previous approach worked locally but didn't work on prod. I am now switching to what team-logs are using and added a small abstraction so we can also use it

Tested it locally and it works
<img width="1220" height="868" alt="CleanShot 2026-04-18 at 13 16 08@2x" src="https://github.com/user-attachments/assets/7325d26b-9112-416b-84c6-d676bd5fa2ce" />
