### PR TITLE
fix(flags): clarify blast radius "users" tooltip wording

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -5,7 +5,7 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { Fragment } from 'react'
 
-import { IconCopy, IconFlag, IconInfo, IconPlus, IconTrash } from '@posthog/icons'
+import { IconCopy, IconFlag, IconPlus, IconTrash } from '@posthog/icons'
 import { LemonLabel, LemonSelect, LemonSnack, Link, Tooltip } from '@posthog/lemon-ui'
 
 import { allOperatorsToHumanName } from 'lib/components/DefinitionPopover/utils'
@@ -47,6 +47,7 @@ import {
     FeatureFlagReleaseConditionsLogicProps,
     featureFlagReleaseConditionsLogic,
 } from './featureFlagReleaseConditionsLogic'
+import { MultipleProfilesTooltip } from './MultipleProfilesTooltip'
 
 function PropertyValueComponent({ property }: { property: AnyPropertyFilter }): JSX.Element {
     if (property.type === PropertyFilterType.Cohort) {
@@ -480,24 +481,7 @@ export function FeatureFlagReleaseConditions({
                                     return ''
                                 })()}{' '}
                                 <span>of total {aggregationTargetName(group.aggregation_group_type_index)}.</span>
-                                {filters.aggregation_group_type_index == null && (
-                                    <Tooltip
-                                        title={
-                                            <>
-                                                A user may have{' '}
-                                                <Link
-                                                    to="https://posthog.com/docs/data/persons#duplicate-person-profiles"
-                                                    target="_blank"
-                                                >
-                                                    multiple profiles
-                                                </Link>
-                                            </>
-                                        }
-                                        interactive
-                                    >
-                                        <IconInfo className="text-muted text-xs ml-0.5" />
-                                    </Tooltip>
-                                )}
+                                {filters.aggregation_group_type_index == null && <MultipleProfilesTooltip />}
                             </div>
                         </div>
                     )}

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -68,6 +68,7 @@ import {
     FeatureFlagGroupTypeWithSortKey,
     featureFlagReleaseConditionsLogic,
 } from './featureFlagReleaseConditionsLogic'
+import { MultipleProfilesTooltip } from './MultipleProfilesTooltip'
 
 interface FeatureFlagReleaseConditionsCollapsibleProps extends FeatureFlagReleaseConditionsLogicProps {
     flagId?: FeatureFlagLogicProps['id']
@@ -631,22 +632,7 @@ const ConditionContent = ({
                                                 })()}
                                                 {(group.aggregation_group_type_index ??
                                                     releaseFilters.aggregation_group_type_index) == null && (
-                                                    <Tooltip
-                                                        title={
-                                                            <>
-                                                                A user may have{' '}
-                                                                <Link
-                                                                    to="https://posthog.com/docs/data/persons#duplicate-person-profiles"
-                                                                    target="_blank"
-                                                                >
-                                                                    multiple profiles
-                                                                </Link>
-                                                            </>
-                                                        }
-                                                        interactive
-                                                    >
-                                                        <IconInfo className="text-muted text-xs ml-0.5" />
-                                                    </Tooltip>
+                                                    <MultipleProfilesTooltip />
                                                 )}
                                             </div>
                                         ) : (

--- a/frontend/src/scenes/feature-flags/MultipleProfilesTooltip.test.tsx
+++ b/frontend/src/scenes/feature-flags/MultipleProfilesTooltip.test.tsx
@@ -5,10 +5,8 @@ import { render } from '@testing-library/react'
 import { MULTIPLE_PROFILES_TOOLTIP_TEXT, MultipleProfilesTooltip } from './MultipleProfilesTooltip'
 
 describe('MultipleProfilesTooltip', () => {
-    it('clarifies that the count is matching person profiles, not distinct end users', () => {
-        expect(MULTIPLE_PROFILES_TOOLTIP_TEXT).toContain('person profiles')
-        expect(MULTIPLE_PROFILES_TOOLTIP_TEXT).toContain('multiple profiles')
-        expect(MULTIPLE_PROFILES_TOOLTIP_TEXT).toContain('distinct end users')
+    it.each(['person profiles', 'multiple profiles', 'distinct end users'])('tooltip text contains "%s"', (phrase) => {
+        expect(MULTIPLE_PROFILES_TOOLTIP_TEXT).toContain(phrase)
     })
 
     it('renders an info icon as the tooltip trigger', () => {

--- a/frontend/src/scenes/feature-flags/MultipleProfilesTooltip.test.tsx
+++ b/frontend/src/scenes/feature-flags/MultipleProfilesTooltip.test.tsx
@@ -1,0 +1,18 @@
+import '@testing-library/jest-dom'
+
+import { render } from '@testing-library/react'
+
+import { MULTIPLE_PROFILES_TOOLTIP_TEXT, MultipleProfilesTooltip } from './MultipleProfilesTooltip'
+
+describe('MultipleProfilesTooltip', () => {
+    it('clarifies that the count is matching person profiles, not distinct end users', () => {
+        expect(MULTIPLE_PROFILES_TOOLTIP_TEXT).toContain('person profiles')
+        expect(MULTIPLE_PROFILES_TOOLTIP_TEXT).toContain('multiple profiles')
+        expect(MULTIPLE_PROFILES_TOOLTIP_TEXT).toContain('distinct end users')
+    })
+
+    it('renders an info icon as the tooltip trigger', () => {
+        const { container } = render(<MultipleProfilesTooltip />)
+        expect(container.querySelector('svg')).toBeInTheDocument()
+    })
+})

--- a/frontend/src/scenes/feature-flags/MultipleProfilesTooltip.tsx
+++ b/frontend/src/scenes/feature-flags/MultipleProfilesTooltip.tsx
@@ -1,0 +1,23 @@
+import { IconInfo } from '@posthog/icons'
+import { Link, Tooltip } from '@posthog/lemon-ui'
+
+export const MULTIPLE_PROFILES_TOOLTIP_TEXT =
+    'This is the number of matching person profiles. A single user may have multiple profiles (e.g. one per device, or before logging in), so this can be higher than the number of distinct end users.'
+
+export function MultipleProfilesTooltip(): JSX.Element {
+    return (
+        <Tooltip
+            title={
+                <>
+                    {MULTIPLE_PROFILES_TOOLTIP_TEXT}{' '}
+                    <Link to="https://posthog.com/docs/data/persons#duplicate-person-profiles" target="_blank">
+                        Learn more
+                    </Link>
+                </>
+            }
+            interactive
+        >
+            <IconInfo className="text-muted text-xs ml-0.5" />
+        </Tooltip>
+    )
+}


### PR DESCRIPTION
## Problem

On the feature flag release-conditions UI, the count next to the matching-users readout shows person profiles, not unique end users. A single human user can have multiple person profiles (one per device, one before login, etc.), so the displayed number can look inflated to anyone reasoning about it as "real users."

The existing tooltip read only "A user may have multiple profiles," which doesn't actually explain why the number above it can be higher than the user expects.

Addresses #18109. This is a copy-only clarification — the underlying counting behavior is intentional (per @neilkakkar's earlier comment on the issue) and out of scope here. The semantic question of whether the count should de-duplicate users with the same email stays open for product input.

## Changes

- New `MultipleProfilesTooltip` component (`frontend/src/scenes/feature-flags/MultipleProfilesTooltip.tsx`) with clearer copy:
  > "This is the number of matching person profiles. A single user may have multiple profiles (e.g. one per device, or before logging in), so this can be higher than the number of distinct end users."
- Replaced two duplicated inline tooltip definitions in `FeatureFlagReleaseConditions.tsx` and `FeatureFlagReleaseConditionsCollapsible.tsx` with the shared component, so the copy now lives in one place.
- The "Learn more" link still goes to the duplicate-person-profiles section of the docs.

## How did you test this code?

- Added `MultipleProfilesTooltip.test.tsx` asserting the exported `MULTIPLE_PROFILES_TOOLTIP_TEXT` constant contains the key clarifying phrases ("person profiles," "multiple profiles," "distinct end users") and that the component renders an info icon trigger. Both pass locally via `bin/hogli test frontend/src/scenes/feature-flags/MultipleProfilesTooltip.test.tsx`.
- TypeScript check passes for the changed files (errors elsewhere in the diff are pre-existing on master).
- I'm an agent — I have NOT manually verified the rendered tooltip in a running PostHog instance. The Jest test guards the copy contract; visual placement is unchanged because the component renders the same icon at the same DOM position as the original inline JSX.

## Publish to changelog?

no

## Docs update

None needed.

## 🤖 LLM context

Authored with Claude (claude-opus-4-7, 1M context) under @ricardothe3rd's direction. Pre-flight included reading the issue thread, locating the duplicated tooltip JSX in two files, and posting a comment on #18109 with the proposed wording before pushing the PR.

Out of scope and intentionally not touched:
- The underlying profile-counting logic (intentional per @neilkakkar)
- Any change to the "users" word in the surrounding text — that's a `resolvedTargetName` value rendered from a hook and would require a wider semantic rethink