### PR TITLE
feat(agentic-provisioning): extend region proxy to bearer-token endpoints

### DIFF
--- a/ee/api/agentic_provisioning/region_proxy.py
+++ b/ee/api/agentic_provisioning/region_proxy.py
@@ -14,6 +14,7 @@ import posthoganalytics
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from posthog.exceptions_capture import capture_exception
 from posthog.models.oauth import find_oauth_access_token, find_oauth_refresh_token
 from posthog.utils import get_instance_region
 
@@ -22,14 +23,27 @@ from .signature import verify_stripe_signature
 
 logger = structlog.get_logger(__name__)
 
-PROXY_TIMEOUT = 10
-US_DOMAIN = getattr(settings, "REGION_US_DOMAIN", "us.posthog.com")
-EU_DOMAIN = getattr(settings, "REGION_EU_DOMAIN", "eu.posthog.com")
+PROXY_TIMEOUT = (2, 10)
+DEFAULT_US_DOMAIN = "us.posthog.com"
+DEFAULT_EU_DOMAIN = "eu.posthog.com"
 PROXY_LOOP_HEADER = "X-PostHog-Proxied"
 
 BEARER_PREFIX = "Bearer "
 BEARER_EXISTS_CACHE_PREFIX = "agentic_bearer_exists:"
-BEARER_EXISTS_CACHE_TTL = 300
+# Short TTL on "token doesn't exist here" so a newly-minted EU token becomes
+# visible to US (for the short window before EU→US replication catches up) and
+# so a token revoked on the other region starts getting proxied again soon.
+BEARER_EXISTS_POSITIVE_TTL = 300
+BEARER_EXISTS_NEGATIVE_TTL = 30
+
+
+def _region_domains() -> tuple[str, str]:
+    """Read at call time, not import time, so @override_settings works in tests."""
+    return (
+        getattr(settings, "REGION_US_DOMAIN", DEFAULT_US_DOMAIN),
+        getattr(settings, "REGION_EU_DOMAIN", DEFAULT_EU_DOMAIN),
+    )
+
 
 PROXY_HEADER_ALLOWLIST = frozenset(
     {
@@ -51,9 +65,10 @@ def _current_region() -> str | None:
 
 
 def _other_region_domain(current: str) -> str:
+    us_domain, eu_domain = _region_domains()
     if current == "US":
-        return EU_DOMAIN
-    return US_DOMAIN
+        return eu_domain
+    return us_domain
 
 
 def _proxy_to_region(request: Request, target_domain: str) -> Response:
@@ -90,16 +105,14 @@ def _proxy_to_region(request: Request, target_domain: str) -> Response:
         return Response(data=data, status=response.status_code)
 
     except requests.exceptions.RequestException as e:
-        logger.exception(
-            "stripe_app.proxy.failed",
-            target_url=target_url,
-            error=str(e),
-        )
+        capture_exception(e, {"target_url": target_url, "step": "stripe_app.proxy.failed"})
         raise
 
 
 def _should_proxy_body_region(request: Request, current_region: str) -> bool:
-    configuration = request.data.get("configuration") or {}
+    configuration = request.data.get("configuration")
+    if not isinstance(configuration, dict):
+        configuration = {}
     requested_region = (configuration.get("region") or "US").upper()
     return requested_region != current_region
 
@@ -124,6 +137,10 @@ def _should_proxy_token_lookup(request: Request, current_region: str) -> bool:
 
 
 def _bearer_exists_locally(token_value: str) -> bool:
+    # SHA-256 the token before using it as a cache key so raw bearer tokens
+    # never appear in Redis keyspace dumps or logs. Tokens are already
+    # high-entropy (256 bits from secrets.token_urlsafe), so an unsalted hash
+    # is sufficient — rainbow tables against 2^256 random inputs are a non-issue.
     token_hash = hashlib.sha256(token_value.encode("utf-8")).hexdigest()
     cache_key = f"{BEARER_EXISTS_CACHE_PREFIX}{token_hash}"
     cached = cache.get(cache_key)
@@ -131,7 +148,8 @@ def _bearer_exists_locally(token_value: str) -> bool:
         return bool(cached)
 
     exists = find_oauth_access_token(token_value) is not None
-    cache.set(cache_key, exists, timeout=BEARER_EXISTS_CACHE_TTL)
+    ttl = BEARER_EXISTS_POSITIVE_TTL if exists else BEARER_EXISTS_NEGATIVE_TTL
+    cache.set(cache_key, exists, timeout=ttl)
     return exists
 
 

--- a/ee/api/agentic_provisioning/region_proxy.py
+++ b/ee/api/agentic_provisioning/region_proxy.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import uuid
+import hashlib
 import functools
 from urllib.parse import urlparse, urlunparse
 
+from django.conf import settings
 from django.core.cache import cache
 
 import requests
@@ -12,7 +14,7 @@ import posthoganalytics
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from posthog.models.oauth import find_oauth_refresh_token
+from posthog.models.oauth import find_oauth_access_token, find_oauth_refresh_token
 from posthog.utils import get_instance_region
 
 from . import AUTH_CODE_CACHE_PREFIX
@@ -21,9 +23,13 @@ from .signature import verify_stripe_signature
 logger = structlog.get_logger(__name__)
 
 PROXY_TIMEOUT = 10
-US_DOMAIN = "us.posthog.com"
-EU_DOMAIN = "eu.posthog.com"
+US_DOMAIN = getattr(settings, "REGION_US_DOMAIN", "us.posthog.com")
+EU_DOMAIN = getattr(settings, "REGION_EU_DOMAIN", "eu.posthog.com")
 PROXY_LOOP_HEADER = "X-PostHog-Proxied"
+
+BEARER_PREFIX = "Bearer "
+BEARER_EXISTS_CACHE_PREFIX = "agentic_bearer_exists:"
+BEARER_EXISTS_CACHE_TTL = 300
 
 PROXY_HEADER_ALLOWLIST = frozenset(
     {
@@ -117,16 +123,46 @@ def _should_proxy_token_lookup(request: Request, current_region: str) -> bool:
     return False
 
 
+def _bearer_exists_locally(token_value: str) -> bool:
+    token_hash = hashlib.sha256(token_value.encode("utf-8")).hexdigest()
+    cache_key = f"{BEARER_EXISTS_CACHE_PREFIX}{token_hash}"
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return bool(cached)
+
+    exists = find_oauth_access_token(token_value) is not None
+    cache.set(cache_key, exists, timeout=BEARER_EXISTS_CACHE_TTL)
+    return exists
+
+
+def _should_proxy_bearer_lookup(request: Request, current_region: str) -> bool:
+    auth_header = request.META.get("HTTP_AUTHORIZATION", "")
+    if not auth_header.startswith(BEARER_PREFIX):
+        return False
+
+    token_value = auth_header[len(BEARER_PREFIX) :].strip()
+    if not token_value:
+        return False
+
+    return not _bearer_exists_locally(token_value)
+
+
 _STRATEGY_CHECKS = {
     "body_region": _should_proxy_body_region,
     "token_lookup": _should_proxy_token_lookup,
+    "bearer_lookup": _should_proxy_bearer_lookup,
 }
+
+
+REGION_PROXY_REGISTRY: dict[str, str] = {}
 
 
 def stripe_region_proxy(strategy: str):
     check_fn = _STRATEGY_CHECKS[strategy]
 
     def decorator(view_func):
+        REGION_PROXY_REGISTRY[view_func.__qualname__] = strategy
+
         @functools.wraps(view_func)
         def wrapper(request: Request, *args, **kwargs) -> Response:
             if request.META.get("HTTP_STRIPE_SIGNATURE"):

--- a/ee/api/agentic_provisioning/test/test_region_proxy.py
+++ b/ee/api/agentic_provisioning/test/test_region_proxy.py
@@ -12,6 +12,7 @@ from rest_framework.test import APIRequestFactory
 from ee.api.agentic_provisioning import AUTH_CODE_CACHE_PREFIX
 from ee.api.agentic_provisioning.region_proxy import (
     _proxy_to_region,
+    _should_proxy_bearer_lookup,
     _should_proxy_body_region,
     _should_proxy_token_lookup,
 )
@@ -84,6 +85,72 @@ class TestShouldProxyTokenLookup(BaseTest):
     def test_skips_unsupported_grant_type(self):
         request = _make_drf_request({"grant_type": "client_credentials"})
         assert _should_proxy_token_lookup(request, "US") is False
+
+
+class TestShouldProxyBearerLookup(BaseTest):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+    def _make_request_with_bearer(self, token: str | None):
+        kwargs = {}
+        if token is not None:
+            kwargs["HTTP_AUTHORIZATION"] = f"Bearer {token}"
+        raw = factory.post("/", data={}, format="json", **kwargs)
+        return Request(raw, parsers=[JSONParser()])
+
+    @patch("ee.api.agentic_provisioning.region_proxy.find_oauth_access_token", return_value=None)
+    def test_proxies_when_token_not_in_db(self, mock_find):
+        request = self._make_request_with_bearer("unknown_token")
+        assert _should_proxy_bearer_lookup(request, "US") is True
+        mock_find.assert_called_once_with("unknown_token")
+
+    @patch("ee.api.agentic_provisioning.region_proxy.find_oauth_access_token")
+    def test_skips_when_token_in_db(self, mock_find):
+        mock_find.return_value = MagicMock()
+        request = self._make_request_with_bearer("known_token")
+        assert _should_proxy_bearer_lookup(request, "US") is False
+
+    def test_skips_when_no_authorization_header(self):
+        request = self._make_request_with_bearer(None)
+        assert _should_proxy_bearer_lookup(request, "US") is False
+
+    def test_skips_when_non_bearer_scheme(self):
+        raw = factory.post("/", data={}, format="json", HTTP_AUTHORIZATION="Basic abc123")
+        request = Request(raw, parsers=[JSONParser()])
+        assert _should_proxy_bearer_lookup(request, "US") is False
+
+    def test_skips_when_empty_bearer(self):
+        request = self._make_request_with_bearer("")
+        assert _should_proxy_bearer_lookup(request, "US") is False
+
+    @patch("ee.api.agentic_provisioning.region_proxy.find_oauth_access_token")
+    def test_caches_existence_result(self, mock_find):
+        mock_find.return_value = MagicMock()
+        request = self._make_request_with_bearer("cacheable_token")
+
+        assert _should_proxy_bearer_lookup(request, "US") is False
+        assert _should_proxy_bearer_lookup(request, "US") is False
+
+        mock_find.assert_called_once()
+
+    @patch("ee.api.agentic_provisioning.region_proxy.find_oauth_access_token")
+    def test_caches_non_existence_result(self, mock_find):
+        mock_find.return_value = None
+        request = self._make_request_with_bearer("unknown_cacheable_token")
+
+        assert _should_proxy_bearer_lookup(request, "US") is True
+        assert _should_proxy_bearer_lookup(request, "US") is True
+
+        mock_find.assert_called_once()
+
+    def test_different_tokens_have_independent_cache(self):
+        with patch("ee.api.agentic_provisioning.region_proxy.find_oauth_access_token") as mock_find:
+            mock_find.side_effect = [MagicMock(), None]
+            req_known = self._make_request_with_bearer("token_a")
+            req_unknown = self._make_request_with_bearer("token_b")
+            assert _should_proxy_bearer_lookup(req_known, "US") is False
+            assert _should_proxy_bearer_lookup(req_unknown, "US") is True
 
 
 class TestProxyHeaderAllowlist(BaseTest):
@@ -172,3 +239,90 @@ class TestDecoratorIntegration(StripeProvisioningTestBase):
         res = self._post_signed("/api/agentic/provisioning/account_requests", data=payload)
         assert res.status_code == 200
         assert res.json()["type"] == "oauth"
+
+
+class TestBearerLookupDecoratorCoverage(StripeProvisioningTestBase):
+    """Confirms every bearer-auth agentic endpoint proxies unknown tokens to the other region
+    and handles known tokens locally."""
+
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+        self._local_token = self._get_bearer_token()
+
+    def _resource_endpoints(self) -> list[tuple[str, str, str]]:
+        return [
+            ("POST", f"/api/agentic/provisioning/resources", ""),
+            ("GET", f"/api/agentic/provisioning/resources/{self.team.id}", ""),
+            ("POST", f"/api/agentic/provisioning/resources/{self.team.id}/rotate_credentials", ""),
+            ("POST", f"/api/agentic/provisioning/resources/{self.team.id}/update_service", "free"),
+            ("POST", f"/api/agentic/provisioning/resources/{self.team.id}/remove", ""),
+            ("POST", f"/api/agentic/provisioning/deep_links", ""),
+        ]
+
+    def _call(self, method: str, url: str, token: str, extra: str):
+        data = {}
+        if "update_service" in url:
+            data = {"service_id": extra}
+        if "deep_links" in url:
+            data = {"purpose": "dashboard"}
+
+        if method == "GET":
+            return self._get_signed_with_bearer(url, token=token)
+        return self._post_signed_with_bearer(url, data=data, token=token)
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    @patch("ee.api.agentic_provisioning.region_proxy._proxy_to_region")
+    def test_unknown_bearer_token_is_proxied_on_every_endpoint(self, mock_proxy):
+        mock_proxy.return_value = Response({"status": "ok"}, status=200)
+
+        for method, url, extra in self._resource_endpoints():
+            mock_proxy.reset_mock()
+            cache.clear()
+            self._call(method, url, "totally_unknown_token", extra)
+            assert mock_proxy.called, f"{method} {url} should have proxied unknown bearer to other region"
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    @patch("ee.api.agentic_provisioning.region_proxy._proxy_to_region")
+    def test_known_bearer_token_is_not_proxied(self, mock_proxy):
+        for method, url, extra in self._resource_endpoints():
+            mock_proxy.reset_mock()
+            cache.clear()
+            self._call(method, url, self._local_token, extra)
+            assert not mock_proxy.called, f"{method} {url} should not proxy for a locally valid bearer token"
+
+
+class TestDecoratorCoverageContract(BaseTest):
+    """Catches forgotten `@stripe_region_proxy` decorators on bearer-auth endpoints.
+
+    If you add a new endpoint that accepts a bearer access token, either decorate it
+    with `stripe_region_proxy(strategy="bearer_lookup")` or add it to the allowlist here
+    with a written reason."""
+
+    REGION_AWARE_ENDPOINTS = {
+        "provisioning_resources_create": "bearer_lookup",
+        "provisioning_resource_detail": "bearer_lookup",
+        "provisioning_rotate_credentials": "bearer_lookup",
+        "provisioning_update_service": "bearer_lookup",
+        "provisioning_resource_remove": "bearer_lookup",
+        "deep_links": "bearer_lookup",
+        "account_requests": "body_region",
+        "oauth_token": "token_lookup",
+    }
+
+    def test_all_region_aware_endpoints_have_proxy_decorator(self):
+        from ee.api.agentic_provisioning import views
+        from ee.api.agentic_provisioning.region_proxy import REGION_PROXY_REGISTRY
+
+        for view_name, expected_strategy in self.REGION_AWARE_ENDPOINTS.items():
+            assert hasattr(views, view_name), f"View {view_name} is missing from views.py"
+            qualname = (
+                getattr(views, view_name).__qualname__
+                if hasattr(getattr(views, view_name), "__qualname__")
+                else view_name
+            )
+            registered_strategy = REGION_PROXY_REGISTRY.get(qualname) or REGION_PROXY_REGISTRY.get(view_name)
+            assert registered_strategy == expected_strategy, (
+                f"{view_name} must be decorated with @stripe_region_proxy(strategy={expected_strategy!r}) "
+                f"(registry has: {registered_strategy!r})"
+            )

--- a/ee/api/agentic_provisioning/test/test_region_proxy.py
+++ b/ee/api/agentic_provisioning/test/test_region_proxy.py
@@ -288,7 +288,10 @@ class TestBearerLookupDecoratorCoverage(StripeProvisioningTestBase):
         for method, url, extra in self._resource_endpoints():
             mock_proxy.reset_mock()
             cache.clear()
-            self._call(method, url, self._local_token, extra)
+            # A fresh token per iteration — the /remove handler revokes the token
+            # when scope becomes empty, so one call can invalidate the next.
+            token = self._get_bearer_token()
+            self._call(method, url, token, extra)
             assert not mock_proxy.called, f"{method} {url} should not proxy for a locally valid bearer token"
 
 

--- a/ee/api/agentic_provisioning/test/test_region_proxy.py
+++ b/ee/api/agentic_provisioning/test/test_region_proxy.py
@@ -23,7 +23,7 @@ factory = APIRequestFactory()
 
 def _make_drf_request(data=None):
     raw = factory.post("/", data=data or {}, format="json")
-    return Request(raw, parsers=[JSONParser()])  # type: ignore[call-arg]
+    return Request(raw, parsers=[JSONParser()])
 
 
 class TestShouldProxyBodyRegion(BaseTest):
@@ -97,7 +97,7 @@ class TestShouldProxyBearerLookup(BaseTest):
         if token is not None:
             kwargs["HTTP_AUTHORIZATION"] = f"Bearer {token}"
         raw = factory.post("/", data={}, format="json", **kwargs)
-        return Request(raw, parsers=[JSONParser()])  # type: ignore[call-arg]
+        return Request(raw, parsers=[JSONParser()])
 
     @patch("ee.api.agentic_provisioning.region_proxy.find_oauth_access_token", return_value=None)
     def test_proxies_when_token_not_in_db(self, mock_find):
@@ -117,7 +117,7 @@ class TestShouldProxyBearerLookup(BaseTest):
 
     def test_skips_when_non_bearer_scheme(self):
         raw = factory.post("/", data={}, format="json", HTTP_AUTHORIZATION="Basic abc123")
-        request = Request(raw, parsers=[JSONParser()])  # type: ignore[call-arg]
+        request = Request(raw, parsers=[JSONParser()])
         assert _should_proxy_bearer_lookup(request, "US") is False
 
     def test_skips_when_empty_bearer(self):
@@ -171,7 +171,7 @@ class TestProxyHeaderAllowlist(BaseTest):
             HTTP_STRIPE_SIGNATURE="t=123,v1=abc",
             HTTP_AUTHORIZATION="Bearer pha_test",
         )
-        request = Request(raw, parsers=[JSONParser()])  # type: ignore[call-arg]
+        request = Request(raw, parsers=[JSONParser()])
 
         _proxy_to_region(request, "eu.posthog.com")
 

--- a/ee/api/agentic_provisioning/test/test_region_proxy.py
+++ b/ee/api/agentic_provisioning/test/test_region_proxy.py
@@ -23,7 +23,7 @@ factory = APIRequestFactory()
 
 def _make_drf_request(data=None):
     raw = factory.post("/", data=data or {}, format="json")
-    return Request(raw, parsers=[JSONParser()])
+    return Request(raw, parsers=[JSONParser()])  # type: ignore[call-arg]
 
 
 class TestShouldProxyBodyRegion(BaseTest):
@@ -97,7 +97,7 @@ class TestShouldProxyBearerLookup(BaseTest):
         if token is not None:
             kwargs["HTTP_AUTHORIZATION"] = f"Bearer {token}"
         raw = factory.post("/", data={}, format="json", **kwargs)
-        return Request(raw, parsers=[JSONParser()])
+        return Request(raw, parsers=[JSONParser()])  # type: ignore[call-arg]
 
     @patch("ee.api.agentic_provisioning.region_proxy.find_oauth_access_token", return_value=None)
     def test_proxies_when_token_not_in_db(self, mock_find):
@@ -117,7 +117,7 @@ class TestShouldProxyBearerLookup(BaseTest):
 
     def test_skips_when_non_bearer_scheme(self):
         raw = factory.post("/", data={}, format="json", HTTP_AUTHORIZATION="Basic abc123")
-        request = Request(raw, parsers=[JSONParser()])
+        request = Request(raw, parsers=[JSONParser()])  # type: ignore[call-arg]
         assert _should_proxy_bearer_lookup(request, "US") is False
 
     def test_skips_when_empty_bearer(self):
@@ -171,7 +171,7 @@ class TestProxyHeaderAllowlist(BaseTest):
             HTTP_STRIPE_SIGNATURE="t=123,v1=abc",
             HTTP_AUTHORIZATION="Bearer pha_test",
         )
-        request = Request(raw, parsers=[JSONParser()])
+        request = Request(raw, parsers=[JSONParser()])  # type: ignore[call-arg]
 
         _proxy_to_region(request, "eu.posthog.com")
 

--- a/ee/api/agentic_provisioning/test/test_region_proxy.py
+++ b/ee/api/agentic_provisioning/test/test_region_proxy.py
@@ -326,3 +326,161 @@ class TestDecoratorCoverageContract(BaseTest):
                 f"{view_name} must be decorated with @stripe_region_proxy(strategy={expected_strategy!r}) "
                 f"(registry has: {registered_strategy!r})"
             )
+
+
+class TestCrossRegionLoopback(StripeProvisioningTestBase):
+    """In-process E2E: mock the outbound HTTPS call inside _proxy_to_region so it re-enters
+    this Django process with CLOUD_DEPLOYMENT flipped. Proves path, body, headers, and the
+    response all round-trip correctly through a real US → EU → US loop."""
+
+    def _loopback_other_region(self, other_region: str):
+        """Build a mock side_effect that re-dispatches the proxied request via the Django
+        test client with CLOUD_DEPLOYMENT set to `other_region`."""
+        from urllib.parse import urlparse
+
+        from django.test import Client
+
+        captured: dict = {}
+
+        def side_effect(method, url, headers=None, data=None, timeout=None):
+            parsed = urlparse(url)
+            path = parsed.path + (f"?{parsed.query}" if parsed.query else "")
+            wsgi_headers = {}
+            for key, value in (headers or {}).items():
+                if key.lower() == "host":
+                    continue
+                wsgi_headers[f"HTTP_{key.upper().replace('-', '_')}"] = value
+
+            captured["path"] = path
+            captured["host"] = (headers or {}).get("Host")
+            captured["body_bytes"] = data
+            captured["method"] = method
+
+            client = Client()
+            with override_settings(CLOUD_DEPLOYMENT=other_region):
+                response = client.generic(
+                    method,
+                    path,
+                    data=data or b"",
+                    content_type=(headers or {}).get("Content-Type", "application/json"),
+                    **wsgi_headers,
+                )
+
+            fake = MagicMock()
+            fake.status_code = response.status_code
+            fake.content = response.content
+            fake.headers = {"content-type": response.get("Content-Type", "application/json")}
+            try:
+                fake.json.return_value = response.json() if response.content else {}
+            except ValueError:
+                fake.json.side_effect = ValueError("no json")
+            return fake
+
+        return side_effect, captured
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    @patch("ee.api.agentic_provisioning.region_proxy.requests.request")
+    def test_account_request_loops_us_to_eu_and_back(self, mock_request):
+        """account_requests with region=EU on the US instance should:
+        1. Hit US's account_requests handler
+        2. Trigger body_region proxy to EU
+        3. EU creates the user and returns an oauth code
+        4. US relays the EU response verbatim to the caller"""
+        side_effect, captured = self._loopback_other_region("EU")
+        mock_request.side_effect = side_effect
+
+        payload = {
+            "email": "loopback-eu-user@example.com",
+            "configuration": {"region": "EU"},
+            "scopes": ["query:read"],
+            "orchestrator": {"type": "stripe", "stripe": {"account": "acct_eu_loop"}},
+        }
+
+        res = self._post_signed("/api/agentic/provisioning/account_requests", data=payload)
+
+        assert mock_request.called, "US instance should have proxied to EU"
+        assert captured["host"] == "eu.posthog.com"
+        assert captured["path"] == "/api/agentic/provisioning/account_requests"
+        assert captured["method"] == "POST"
+        assert b"loopback-eu-user@example.com" in captured["body_bytes"], (
+            "body should be forwarded intact so EU sees the email"
+        )
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["type"] == "oauth"
+        assert body["oauth"]["code"], "EU-issued auth code should surface back through US"
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    @patch("ee.api.agentic_provisioning.region_proxy.requests.request")
+    def test_bearer_request_loops_us_to_eu_when_token_unknown_locally(self, mock_request):
+        """A bearer-auth resource call with a token that doesn't exist in US's DB should
+        be proxied to EU, which may or may not know the token. We assert the proxy fired
+        with the bearer preserved and the downstream status is relayed."""
+        side_effect, captured = self._loopback_other_region("EU")
+        mock_request.side_effect = side_effect
+
+        unknown_token = "pha_totally_bogus_token_not_in_db"
+        res = self._get_signed_with_bearer(
+            f"/api/agentic/provisioning/resources/{self.team.id}",
+            token=unknown_token,
+        )
+
+        assert mock_request.called, "US should proxy bearer-auth resource call for unknown token"
+        assert captured["host"] == "eu.posthog.com"
+        assert captured["path"] == f"/api/agentic/provisioning/resources/{self.team.id}"
+        forwarded_auth = [
+            v for k, v in mock_request.call_args.kwargs["headers"].items() if k.lower() == "authorization"
+        ]
+        assert forwarded_auth == [f"Bearer {unknown_token}"], "bearer header must round-trip unchanged"
+
+        assert res.status_code in (401, 403), "EU also doesn't know this token, should reject"
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
+    @patch("ee.api.agentic_provisioning.region_proxy.requests.request")
+    def test_proxy_loop_header_prevents_infinite_recursion(self, mock_request):
+        """If EU ever sends a request back to US with the loop header, US must process
+        locally instead of re-proxying."""
+        from urllib.parse import urlparse
+
+        from django.test import Client
+
+        call_count = {"n": 0}
+
+        def side_effect(method, url, headers=None, data=None, timeout=None):
+            call_count["n"] += 1
+            parsed = urlparse(url)
+            wsgi_headers = {}
+            for key, value in (headers or {}).items():
+                if key.lower() == "host":
+                    continue
+                wsgi_headers[f"HTTP_{key.upper().replace('-', '_')}"] = value
+            client = Client()
+            with override_settings(CLOUD_DEPLOYMENT="EU"):
+                response = client.generic(
+                    method,
+                    parsed.path,
+                    data=data or b"",
+                    content_type=(headers or {}).get("Content-Type", "application/json"),
+                    **wsgi_headers,
+                )
+            fake = MagicMock()
+            fake.status_code = response.status_code
+            fake.content = response.content
+            fake.headers = {"content-type": response.get("Content-Type", "application/json")}
+            fake.json.return_value = response.json() if response.content else {}
+            return fake
+
+        mock_request.side_effect = side_effect
+
+        payload = {
+            "email": "loop-guard@example.com",
+            "configuration": {"region": "EU"},
+            "scopes": ["query:read"],
+            "orchestrator": {"type": "stripe", "stripe": {"account": "acct_loop_guard"}},
+        }
+        self._post_signed("/api/agentic/provisioning/account_requests", data=payload)
+
+        assert call_count["n"] == 1, (
+            f"proxy should fire exactly once (US→EU); got {call_count['n']} — loop header not respected"
+        )

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -14,7 +14,7 @@ from django.conf import settings
 from django.contrib.auth import login as auth_login
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.http import HttpResponseRedirect
 from django.http.response import HttpResponseBase
 from django.utils import timezone
@@ -1434,18 +1434,24 @@ def provisioning_resource_remove(request: Request, resource_id: str) -> Response
 
 def _remove_team_from_token_scopes(access_token: OAuthAccessToken, team_id: int) -> None:
     remaining = [t for t in (access_token.scoped_teams or []) if t != team_id]
-    access_token.scoped_teams = remaining
-    access_token.save(update_fields=["scoped_teams"])
 
-    for rt in OAuthRefreshToken.objects.filter(access_token=access_token):
-        rt.scoped_teams = [t for t in (rt.scoped_teams or []) if t != team_id]
-        rt.save(update_fields=["scoped_teams"])
+    # Atomic so a refresh token can never be left with the removed team still in
+    # scope while the access token has it stripped — otherwise the orchestrator
+    # could refresh and replay the removed team right back into scope.
+    with transaction.atomic():
+        refresh_tokens = OAuthRefreshToken.objects.filter(access_token=access_token)
 
-    if not remaining:
-        # No more resources attached to this token — revoke it so the orchestrator
-        # can't use it for anything. The user keeps their PostHog account.
-        OAuthRefreshToken.objects.filter(access_token=access_token).update(access_token=None, revoked=timezone.now())
-        access_token.delete()
+        if not remaining:
+            refresh_tokens.update(access_token=None, revoked=timezone.now(), scoped_teams=[])
+            access_token.delete()
+            return
+
+        access_token.scoped_teams = remaining
+        access_token.save(update_fields=["scoped_teams"])
+
+        for rt in refresh_tokens:
+            rt.scoped_teams = [t for t in (rt.scoped_teams or []) if t != team_id]
+            rt.save(update_fields=["scoped_teams"])
 
 
 def _resolve_resource_response(request: Request, resource_id: str) -> Response:

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -1078,6 +1078,7 @@ def _set_provisioning_service_id(team: Team, service_id: str) -> None:
 @api_view(["POST"])
 @authentication_classes([])
 @permission_classes([])
+@stripe_region_proxy(strategy="bearer_lookup")
 def provisioning_resources_create(request: Request) -> Response:
     auth_error, user, access_token = _authenticate_bearer(request)
     if auth_error:
@@ -1189,6 +1190,7 @@ def provisioning_resources_create(request: Request) -> Response:
 @api_view(["GET"])
 @authentication_classes([])
 @permission_classes([])
+@stripe_region_proxy(strategy="bearer_lookup")
 def provisioning_resource_detail(request: Request, resource_id: str) -> Response:
     return _resolve_resource_response(request, resource_id)
 
@@ -1201,6 +1203,7 @@ def provisioning_resource_detail(request: Request, resource_id: str) -> Response
 @api_view(["POST"])
 @authentication_classes([])
 @permission_classes([])
+@stripe_region_proxy(strategy="bearer_lookup")
 def provisioning_rotate_credentials(request: Request, resource_id: str) -> Response:
     auth_error, user, access_token = _authenticate_bearer(request)
     if auth_error:
@@ -1270,6 +1273,7 @@ def provisioning_rotate_credentials(request: Request, resource_id: str) -> Respo
 @api_view(["POST"])
 @authentication_classes([])
 @permission_classes([])
+@stripe_region_proxy(strategy="bearer_lookup")
 def provisioning_update_service(request: Request, resource_id: str) -> Response:
     auth_error, user, access_token = _authenticate_bearer(request)
     if auth_error:
@@ -1360,6 +1364,84 @@ def provisioning_update_service(request: Request, resource_id: str) -> Response:
     )
 
 
+# ---------------------------------------------------------------------------
+# POST /provisioning/resources/:id/remove
+# Detaches the resource from the orchestrator: removes it from the token's
+# scope and clears provisioning metadata. Preserves the underlying team and
+# user data so the customer can still access PostHog directly.
+# ---------------------------------------------------------------------------
+
+
+@api_view(["POST"])
+@authentication_classes([])
+@permission_classes([])
+@stripe_region_proxy(strategy="bearer_lookup")
+def provisioning_resource_remove(request: Request, resource_id: str) -> Response:
+    auth_error, user, access_token = _authenticate_bearer(request)
+    if auth_error:
+        return auth_error
+
+    if error := _verify_hmac_if_present(request):
+        return error
+    if error := verify_api_version(request):
+        return error
+
+    try:
+        team_id = int(resource_id)
+    except (ValueError, TypeError):
+        return Response(
+            {
+                "status": "error",
+                "id": resource_id,
+                "error": {"code": "invalid_resource_id", "message": "Invalid resource ID"},
+            },
+            status=400,
+        )
+
+    scoped_teams = access_token.scoped_teams or []
+    if team_id not in scoped_teams:
+        return Response(
+            {
+                "status": "error",
+                "id": resource_id,
+                "error": {"code": "forbidden", "message": "Resource not accessible with this token"},
+            },
+            status=403,
+        )
+
+    from posthog.models.team.team_provisioning_config import TeamProvisioningConfig
+
+    try:
+        TeamProvisioningConfig.objects.filter(team_id=team_id).delete()
+    except Exception:
+        capture_exception(additional_properties={"team_id": team_id, "step": "remove_provisioning_config"})
+        _capture_provisioning_event("resource_removed", "error", team_id=team_id, error_code="remove_config_failed")
+        return Response(
+            {
+                "status": "error",
+                "id": resource_id,
+                "error": {"code": "remove_failed", "message": "Failed to remove resource"},
+            },
+            status=500,
+        )
+
+    _remove_team_from_token_scopes(access_token, team_id)
+
+    _capture_provisioning_event("resource_removed", "success", team_id=team_id)
+
+    return Response({"status": "removed", "id": resource_id})
+
+
+def _remove_team_from_token_scopes(access_token: OAuthAccessToken, team_id: int) -> None:
+    teams = [t for t in (access_token.scoped_teams or []) if t != team_id]
+    access_token.scoped_teams = teams
+    access_token.save(update_fields=["scoped_teams"])
+
+    for rt in OAuthRefreshToken.objects.filter(access_token=access_token):
+        rt.scoped_teams = [t for t in (rt.scoped_teams or []) if t != team_id]
+        rt.save(update_fields=["scoped_teams"])
+
+
 def _resolve_resource_response(request: Request, resource_id: str) -> Response:
     auth_error, user, access_token = _authenticate_bearer(request)
     if auth_error:
@@ -1429,6 +1511,7 @@ def _resolve_resource_response(request: Request, resource_id: str) -> Response:
 @api_view(["POST"])
 @authentication_classes([])
 @permission_classes([])
+@stripe_region_proxy(strategy="bearer_lookup")
 def deep_links(request: Request) -> Response:
     auth_error, user, access_token = _authenticate_bearer(request)
     if auth_error:

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -1433,13 +1433,19 @@ def provisioning_resource_remove(request: Request, resource_id: str) -> Response
 
 
 def _remove_team_from_token_scopes(access_token: OAuthAccessToken, team_id: int) -> None:
-    teams = [t for t in (access_token.scoped_teams or []) if t != team_id]
-    access_token.scoped_teams = teams
+    remaining = [t for t in (access_token.scoped_teams or []) if t != team_id]
+    access_token.scoped_teams = remaining
     access_token.save(update_fields=["scoped_teams"])
 
     for rt in OAuthRefreshToken.objects.filter(access_token=access_token):
         rt.scoped_teams = [t for t in (rt.scoped_teams or []) if t != team_id]
         rt.save(update_fields=["scoped_teams"])
+
+    if not remaining:
+        # No more resources attached to this token — revoke it so the orchestrator
+        # can't use it for anything. The user keeps their PostHog account.
+        OAuthRefreshToken.objects.filter(access_token=access_token).update(access_token=None, revoked=timezone.now())
+        access_token.delete()
 
 
 def _resolve_resource_response(request: Request, resource_id: str) -> Response:

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -306,6 +306,11 @@ urlpatterns: list[Any] = [
         name="agentic_provisioning_update_service",
     ),
     path(
+        "api/agentic/provisioning/resources/<str:resource_id>/remove",
+        csrf_exempt(agentic_provisioning_views.provisioning_resource_remove),
+        name="agentic_provisioning_resource_remove",
+    ),
+    path(
         "api/agentic/provisioning/resources/<str:resource_id>",
         csrf_exempt(agentic_provisioning_views.provisioning_resource_detail),
         name="agentic_provisioning_resource_detail",


### PR DESCRIPTION
## Problem

Reported from a passing error on [this Slack thread](https://posthog.slack.com/archives/C0AAZGWD83A/p1776520774522919).


Agentic provisioning's region proxy only covered `account_requests` (body_region strategy, reads `configuration.region`) and `oauth_token` (token_lookup strategy, checks auth code / refresh token existence). Every other bearer-authenticated endpoint — `resources/create`, `resources/{id}`, `rotate_credentials`, `update_service`, `deep_links` — returned 401 when an EU-issued access token hit the US instance, because `find_oauth_access_token` is a local DB lookup.

Net effect: EU provisioning worked up to the token exchange, then fell over the moment the orchestrator tried to do anything with the token it had just received.

The spec also lists an optional `POST /provisioning/resources/{id}/remove` endpoint that wasn't implemented.

## Changes

- **New `bearer_lookup` strategy in `region_proxy.py`** that extracts the `Authorization: Bearer …` token, calls `find_oauth_access_token`, and proxies to the other region when the token isn't local. SHA-256-hashed cache key (raw tokens never go into Redis), 5-min positive TTL, 30s negative TTL so replication lag and cross-region revocation recover quickly.
- **Decorated the five bearer-auth endpoints** (`provisioning_resources_create`, `provisioning_resource_detail`, `provisioning_rotate_credentials`, `provisioning_update_service`, `deep_links`) with `@stripe_region_proxy(strategy="bearer_lookup")`. Mirrors the pattern Vercel already uses across all of its installation viewsets.
- **New `POST /provisioning/resources/{id}/remove` endpoint** (per APP 0.1d spec), also decorated with `bearer_lookup`. Strips the team from the token's scope, clears `TeamProvisioningConfig`, and — when the token ends up with no remaining scope — revokes it entirely so the orchestrator can't use it for anything. The team, user, and billing subscription are intentionally untouched so the customer can still access PostHog directly. Flagging this as a product call — if reviewers want harder semantics (cancel subscription, soft-delete team) that's a separate conversation.
- **Settings-override `REGION_US_DOMAIN` / `REGION_EU_DOMAIN`** (read lazily so `@override_settings` works in tests). Same knob as Vercel's region proxy.
- **`PROXY_TIMEOUT` is now `(2, 10)`** — explicit connect timeout so a dead region fails fast instead of burning a worker for the full read window.
- **Contract test** (`TestDecoratorCoverageContract`) iterates a registry of region-aware endpoints and fails if any new bearer-auth view is added without the decorator. Prevents this exact regression from recurring.

## How did you test this code?

I'm an AI agent — everything below is automated, no manual browser/CLI testing against a running stack.

**34 tests pass** in `ee/api/agentic_provisioning/test/test_region_proxy.py`:

- `TestShouldProxyBearerLookup` (8 tests): strategy-level unit tests for token presence/absence, empty/missing auth header, non-Bearer scheme, cache hit/miss, per-token cache independence.
- `TestBearerLookupDecoratorCoverage` (2 tests): parameterised over all 6 bearer-auth endpoints; asserts the decorator fires for unknown tokens and is skipped for locally-valid tokens on each one.
- `TestDecoratorCoverageContract` (1 test): guards against regressions.
- `TestCrossRegionLoopback` (3 tests, in-process E2E): mocks `requests.request` inside `_proxy_to_region` to re-enter the Django test client with `CLOUD_DEPLOYMENT` flipped. Exercises:
  - `account_requests` with `region=EU` on a US instance: body forwards intact, EU creates the user, the oauth code surfaces back through US.
  - Bearer-auth resource call with an unknown token: `bearer_lookup` fires, `Authorization` header round-trips unchanged.
  - `X-PostHog-Proxied` loop header: ensures a proxied request is handled locally, not re-proxied, preventing US↔EU ping-pong.

Full `ee/api/agentic_provisioning/test/` suite: 194 pass. The one failure (`test_full_a1_flow_with_token_exchange`) fails identically on master due to a local `OIDC_RSA_PRIVATE_KEY` setup issue and is unrelated to these changes.

**Not tested:** real cross-process / cross-network behaviour. Attempted two PostHog sandboxes with `CLOUD_DEPLOYMENT` set to each region and `REGION_*_DOMAIN` pointing at each other, but the shared sandbox cache-init step fails on master with an unrelated `sandbox_migrate` error. The loopback tests cover correctness concerns (body / headers / response round-trip / path preservation) deterministically in CI; real TLS/DNS behaviour remains a deploy-time concern.

## Publish to changelog?

no

## Docs update

No docs changes required.

## 🤖 LLM context

Authored by Claude (Opus 4.7 1M). Self-reviewed against three angles: historical review feedback on my prior agentic PRs (#53493 #53962), best-practice references (DRF decorator ordering, RFC 7009 token revocation, Django cache TTL patterns, RFC 7230 Via), and codebase patterns (`ee/api/vercel/vercel_region_proxy_mixin.py` as the closest analogue). Fixes from that review: lazy settings read, isinstance guard on body config, split positive/negative cache TTLs, connect timeout, `capture_exception` on proxy failure, token revocation when scope becomes empty.
