### PR TITLE
fix: Remove settings check

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -2,7 +2,6 @@ import { connect, kea, path, selectors } from 'kea'
 import { combineUrl, router, urlToAction } from 'kea-router'
 
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
-import { settingsLogic } from 'scenes/settings/settingsLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -36,16 +35,14 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
             ['scenePanelIsPresent'],
             preflightLogic,
             ['isCloudOrDev'],
-            settingsLogic({}),
-            ['sections as settingsSections'],
         ],
         actions: [sidePanelStateLogic, ['closeSidePanel', 'openSidePanel']],
     })),
 
     selectors({
         enabledTabs: [
-            (s) => [s.sceneSidePanelContext, s.currentTeam, s.scenePanelIsPresent, s.isCloudOrDev, s.settingsSections],
-            (sceneSidePanelContext, currentTeam, scenePanelIsPresent, isCloudOrDev, settingsSections) => {
+            (s) => [s.sceneSidePanelContext, s.currentTeam, s.scenePanelIsPresent, s.isCloudOrDev],
+            (sceneSidePanelContext, currentTeam, scenePanelIsPresent, isCloudOrDev) => {
                 const tabs: SidePanelTab[] = []
 
                 if (scenePanelIsPresent) {
@@ -71,10 +68,7 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
                     tabs.push(SidePanelTab.Support)
                 }
 
-                if (
-                    sceneSidePanelContext.settings_section &&
-                    settingsSections.some((section) => section.id === sceneSidePanelContext.settings_section)
-                ) {
+                if (sceneSidePanelContext.settings_section) {
                     tabs.push(SidePanelTab.Settings)
                 }
 


### PR DESCRIPTION
We don't need to check this here and it's also causing some problems because we're not loading the settings early enough which is causing us to not render the settings at all.