### PR TITLE
feat: Add Cmd+K helper banner to project tree

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -14,6 +14,7 @@ import {
     IconStar,
 } from '@posthog/icons'
 
+import { commandLogic } from 'lib/components/Command/commandLogic'
 import { itemSelectModalLogic } from 'lib/components/FileSystem/ItemSelectModal/itemSelectModalLogic'
 import { dayjs } from 'lib/dayjs'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
@@ -31,12 +32,14 @@ import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture/ProfilePicture'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { ContextMenuGroup, ContextMenuItem } from 'lib/ui/ContextMenu/ContextMenu'
 import { DropdownMenuGroup } from 'lib/ui/DropdownMenu/DropdownMenu'
+import { isMobile } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { removeProjectIdIfPresent } from 'lib/utils/router-utils'
 import { sceneConfigurations } from 'scenes/scenes'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
 import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { customProductsLogic } from '~/layout/panel-layout/ProjectTree/customProductsLogic'
 import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
@@ -70,7 +73,8 @@ export const PROJECT_TREE_KEY = 'project-tree'
 let counter = 0
 
 const SHORTCUT_DISMISSAL_LOCAL_STORAGE_KEY = 'shortcut-dismissal'
-const CUSTOM_PRODUCT_DISMISSAL_LOCAL_STORAGE_KEY = 'custom-product-dismissal'
+const CUSTOM_PRODUCT_DISMISSAL_LOCAL_STORAGE_KEY = 'custom-product-dismissal-v2'
+const CMD_K_HELPER_DISMISSAL_LOCAL_STORAGE_KEY = 'cmd-k-helper-dismissal'
 const SEEN_CUSTOM_PRODUCTS_LOCAL_STORAGE_KEY = 'seen-custom-products'
 
 const USER_PRODUCT_LIST_REASON_DEFAULTS: { [key in UserProductListReason]?: string } = {
@@ -171,6 +175,7 @@ export function ProjectTree({
 
     const { customProducts, customProductsLoading } = useValues(customProductsLogic)
     const { seed } = useActions(customProductsLogic)
+    const { toggleCommand } = useActions(commandLogic)
 
     const [shortcutHelperDismissed, setShortcutHelperDismissed] = useLocalStorage<boolean>(
         SHORTCUT_DISMISSAL_LOCAL_STORAGE_KEY,
@@ -180,6 +185,14 @@ export function ProjectTree({
         CUSTOM_PRODUCT_DISMISSAL_LOCAL_STORAGE_KEY,
         false
     )
+    const [cmdKHelperDismissed, setCmdKHelperDismissed] = useLocalStorage<boolean>(
+        CMD_K_HELPER_DISMISSAL_LOCAL_STORAGE_KEY,
+        false
+    )
+    // Capture the original-banner dismissal state once on mount so the Cmd+K hint only appears
+    // on subsequent sessions — dismissing the first banner shouldn't swap in the second immediately.
+    const [originalDismissedOnMount] = useState<boolean>(() => customProductHelperDismissed === true)
+
     const [seenCustomProducts, setSeenCustomProducts] = useLocalStorage<string[]>(
         `${currentTeamId ?? '*'}-${SEEN_CUSTOM_PRODUCTS_LOCAL_STORAGE_KEY}`,
         []
@@ -250,8 +263,12 @@ export function ProjectTree({
                     item.reason === UserProductListReason.USED_ON_SEPARATE_TEAM
             )
 
-            if ((fullFileSystemFiltered.length === 0 || !customProductHelperDismissed) && !isAIFirst) {
-                const CustomIcon = isCustomProductsExperiment ? IconGear : IconPencil
+            const showOriginalBanner = fullFileSystemFiltered.length === 0 || !customProductHelperDismissed
+            const showCmdKBanner =
+                !showOriginalBanner && originalDismissedOnMount && !cmdKHelperDismissed && !isMobile()
+
+            if (showOriginalBanner) {
+                const CustomIcon = !isAIFirst && isCustomProductsExperiment ? IconGear : IconPencil
                 treeData.push({
                     id: 'products/custom-products-helper-category',
                     name: 'Example custom products',
@@ -259,7 +276,7 @@ export function ProjectTree({
                     displayName: (
                         <div
                             className={cn('border border-primary text-xs mb-2 font-normal rounded-xs p-2 -mx-1', {
-                                'mt-6': fullFileSystemFiltered.length === 0,
+                                'mt-6': fullFileSystemFiltered.length === 0 && !isAIFirst,
                             })}
                         >
                             You can display your preferred apps here. You can configure what items show up in here by
@@ -274,13 +291,36 @@ export function ProjectTree({
                                     Dismiss.
                                 </span>
                             )}
-                            <br />
-                            <br />
                             {!hasRecommendedProducts && fullFileSystemFiltered.length <= 3 && (
-                                <span className="cursor-pointer underline" onClick={seed}>
-                                    {customProductsLoading ? 'Adding...' : 'Add recommended products?'}
-                                </span>
+                                <>
+                                    <br />
+                                    <br />
+                                    <span className="cursor-pointer underline" onClick={seed}>
+                                        {customProductsLoading ? 'Adding...' : 'Add recommended products?'}
+                                    </span>
+                                </>
                             )}
+                        </div>
+                    ),
+                })
+            } else if (showCmdKBanner) {
+                treeData.push({
+                    id: 'products/cmd-k-helper-category',
+                    name: 'Quick search tip',
+                    type: 'category',
+                    displayName: (
+                        <div className="border border-primary text-xs mb-2 font-normal rounded-xs p-2 -mx-1">
+                            Want to browse all apps or jump back into something recent? Press{' '}
+                            <span
+                                className="cursor-pointer inline-flex items-center gap-1"
+                                onClick={() => toggleCommand()}
+                            >
+                                <KeyboardShortcut command k />
+                            </span>{' '}
+                            to open search. It's faster than hunting through the sidebar.{' '}
+                            <span className="cursor-pointer underline" onClick={() => setCmdKHelperDismissed(true)}>
+                                Dismiss.
+                            </span>
                         </div>
                     ),
                 })


### PR DESCRIPTION
After a user dismisses the custom products helper banner, a new contextual hint now appears in the project tree sidebar on their next session, informing them they can use `Cmd+K` to quickly search for apps and recent items. The hint includes a clickable keyboard shortcut that opens the command palette directly, and a dismiss link to hide it permanently.

The hint is intentionally deferred — dismissing the original banner during a session won't immediately replace it with the `Cmd+K` hint. It only appears in subsequent sessions where the original banner was already dismissed on load. The hint is also suppressed on mobile where the keyboard shortcut isn't relevant.

A versioned local storage key (`custom-product-dismissal-v2`) is introduced to reset the original banner dismissal state for existing users, and a separate key (`cmd-k-helper-dismissal`) tracks dismissal of the new hint independently.