### PR TITLE
fix(llma): remember test-account filter toggle across visits

### DIFF
--- a/products/llm_analytics/frontend/llmAnalyticsSharedLogic.ts
+++ b/products/llm_analytics/frontend/llmAnalyticsSharedLogic.ts
@@ -9,6 +9,7 @@ import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
 import { objectsEqual } from 'lib/utils'
 import { hasRecentAIEvents } from 'lib/utils/aiEventsUtils'
 import { sceneLogic } from 'scenes/sceneLogic'
+import { filterTestAccountsDefaultsLogic } from 'scenes/settings/environment/filterTestAccountDefaultsLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
@@ -63,8 +64,17 @@ export const llmAnalyticsSharedLogic = kea<llmAnalyticsSharedLogicType>([
     props({} as LLMAnalyticsSharedLogicProps),
     key((props: LLMAnalyticsSharedLogicProps) => `${props?.personId || 'llmAnalyticsScene'}::${props?.tabId || ''}`),
     connect(() => ({
-        values: [sceneLogic, ['sceneKey'], featureFlagLogic, ['featureFlags'], userLogic, ['user']],
-        actions: [teamLogic, ['addProductIntent']],
+        values: [
+            sceneLogic,
+            ['sceneKey'],
+            featureFlagLogic,
+            ['featureFlags'],
+            userLogic,
+            ['user'],
+            filterTestAccountsDefaultsLogic,
+            ['filterTestAccountsDefault'],
+        ],
+        actions: [teamLogic, ['addProductIntent'], filterTestAccountsDefaultsLogic, ['setLocalDefault']],
     })),
 
     actions({
@@ -141,10 +151,16 @@ export const llmAnalyticsSharedLogic = kea<llmAnalyticsSharedLogicType>([
         },
     })),
 
-    listeners(() => ({
+    listeners(({ actions, values }) => ({
         loadAIEventDefinitionSuccess: ({ hasSentAiEvent }) => {
             if (hasSentAiEvent) {
                 globalSetupLogic.findMounted()?.actions.markTaskAsCompleted(SetupTaskId.IngestFirstLlmEvent)
+            }
+        },
+        setShouldFilterTestAccounts: ({ shouldFilterTestAccounts }) => {
+            const divergesFromEffectiveDefault = shouldFilterTestAccounts !== values.filterTestAccountsDefault
+            if (divergesFromEffectiveDefault) {
+                actions.setLocalDefault(shouldFilterTestAccounts)
             }
         },
     })),
@@ -321,6 +337,11 @@ export const llmAnalyticsSharedLogic = kea<llmAnalyticsSharedLogicType>([
                 product_type: ProductKey.LLM_ANALYTICS,
                 intent_context: ProductIntentContext.LLM_ANALYTICS_VIEWED,
             })
+        }
+
+        const urlHasTestAccountsParam = 'filter_test_accounts' in router.values.searchParams
+        if (!urlHasTestAccountsParam && values.filterTestAccountsDefault !== values.shouldFilterTestAccounts) {
+            actions.setShouldFilterTestAccounts(values.filterTestAccountsDefault)
         }
     }),
 ])


### PR DESCRIPTION
## Problem

QA Swarm review of #55196 flagged that LLM analytics scenes have the same class of bug as activity/explore but with a different implementation. On every LLM analytics tab the scene-level "Filter out internal and test users" switch binds to `llmAnalyticsSharedLogic.shouldFilterTestAccounts`, which:

- defaults to `false`
- has no `persist` and no `connect` to `filterTestAccountsDefaultsLogic`
- uses the URL param `filter_test_accounts` as the only persistence mechanism (lost on nav-link click)

So toggling anywhere else in the app (activity/explore, insights) is ignored here, and toggling here writes nothing to the user-wide preference.

## Changes

Three focused additions to `products/llm_analytics/frontend/llmAnalyticsSharedLogic.ts`:

1. **`connect`** `filterTestAccountsDefaultsLogic` for `filterTestAccountsDefault` and `setLocalDefault`.
2. **Listener** on `setShouldFilterTestAccounts` — dispatches `setLocalDefault(value)`, so toggling here now participates in the user-wide preference, matching the shared `DataNode/TestAccountFilters` contract.
3. **`afterMount`** — if the URL did not carry `filter_test_accounts` and the reducer value differs from the persisted default, seed `shouldFilterTestAccounts` from `filterTestAccountsDefault`. The URL-param presence check avoids clobbering a shared URL that explicitly sets the value.

No per-tab logic changes — every tab already reads `shouldFilterTestAccounts` reactively and bakes it into its `EventsQuery.filterTestAccounts`.

**Stacked on:** #55196

## How did you test this code?

I am an agent; I ran `pnpm typegen:write` and `pnpm --filter=@posthog/frontend typescript:check` (no errors in touched files). No automated tests added. Manual browser verification was **not** performed — suggested steps for a reviewer:

- Clear `localStorage['default_filter_test_accounts']`. Visit `/llm-analytics/generations`, toggle on, navigate away via the LLM analytics nav link, return — switch should stay on.
- Toggle on activity/explore first, then open `/llm-analytics/generations` fresh — switch should reflect the preference.
- Open `/llm-analytics/generations?filter_test_accounts=false` while persisted default is `true` — URL should win.

Known limitation (out of scope): each LLM tab's query also sets `showTestAccountFilters: true`, rendering a second inline switch inside the `DataTable` that binds to `query.source.filterTestAccounts` and writes `setLocalDefault` directly via the component. Toggling the inline switch won't visibly update the scene switch until next mount.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 LLM context

Authored via PostHog Code. Plan file captures the diagnosis and smallest-fix reasoning. Stacked on #55196 so that PR's helper and pattern are available; can be rebased to master if the parent ships separately. Considered a more invasive null-default reducer + selector design to make the scene switch reactive to cross-surface toggles within a session — left out for scope and smallest-fix.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*