### PR TITLE
feat: Add analytics capture for project tree item and folder clicks

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -1,5 +1,6 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { router } from 'kea-router'
+import posthog from 'posthog-js'
 import { RefObject, useCallback, useEffect, useRef, useState } from 'react'
 
 import {
@@ -383,6 +384,14 @@ export function ProjectTree({
                     return
                 }
 
+                posthog.capture('project tree item clicked', {
+                    root: root ?? null,
+                    item_type: item?.type ?? null,
+                    record_type: item?.record?.type ?? null,
+                    has_href: !!item?.record?.href,
+                    name: item?.name ?? null,
+                })
+
                 if (item?.record?.href) {
                     router.actions.push(
                         typeof item.record.href === 'function' ? item.record.href(item.record.ref) : item.record.href
@@ -406,6 +415,11 @@ export function ProjectTree({
             }}
             onFolderClick={(folder, isExpanded) => {
                 if (folder) {
+                    posthog.capture('project tree folder toggled', {
+                        root: root ?? null,
+                        is_expanded: isExpanded,
+                        name: folder.name ?? null,
+                    })
                     toggleFolderOpen(folder?.id || '', isExpanded)
                 }
             }}


### PR DESCRIPTION
Adds PostHog event tracking to the project tree for item clicks and folder toggles. When a user clicks an item, it captures the root, item type, record type, whether the item has an href, and the item name. When a folder is toggled, it captures the root, expanded state, and folder name.