### PR TITLE
chore(llma): prefix eval-reports workflow/schedule names with llma-eval-reports-

### DIFF
--- a/posthog/temporal/llm_analytics/eval_reports/constants.py
+++ b/posthog/temporal/llm_analytics/eval_reports/constants.py
@@ -9,12 +9,13 @@ EVAL_REPORT_AGENT_MODEL = "gpt-5.2"
 EVAL_REPORT_AGENT_RECURSION_LIMIT = 100
 EVAL_REPORT_AGENT_TIMEOUT = 600.0  # 10 minutes
 
-# Workflow names
-SCHEDULE_ALL_EVAL_REPORTS_WORKFLOW_NAME = "schedule-all-eval-reports"
-CHECK_COUNT_TRIGGERED_REPORTS_WORKFLOW_NAME = "check-count-triggered-eval-reports"
-GENERATE_EVAL_REPORT_WORKFLOW_NAME = "generate-and-deliver-eval-report"
-SCHEDULE_ID = "schedule-all-eval-reports-schedule"
-COUNT_TRIGGER_SCHEDULE_ID = "check-count-triggered-eval-reports-schedule"
+# Workflow names — all eval-reports Temporal surface is prefixed `llma-eval-reports-`
+# to match the convention used by other LLMA products (clustering, summarization, sentiment).
+SCHEDULE_ALL_EVAL_REPORTS_WORKFLOW_NAME = "llma-eval-reports-scheduled-coordinator"
+CHECK_COUNT_TRIGGERED_REPORTS_WORKFLOW_NAME = "llma-eval-reports-count-triggered-coordinator"
+GENERATE_EVAL_REPORT_WORKFLOW_NAME = "llma-eval-reports-generate-and-deliver"
+SCHEDULE_ID = "llma-eval-reports-scheduled-coordinator-schedule"
+COUNT_TRIGGER_SCHEDULE_ID = "llma-eval-reports-count-triggered-coordinator-schedule"
 
 # Workflow timeouts
 WORKFLOW_EXECUTION_TIMEOUT = timedelta(minutes=30)


### PR DESCRIPTION
## Problem

Every other LLMA Temporal surface uses the `llma-` prefix — `llma-trace-summarization`, `llma-trace-clustering-coordinator`, `llma-sentiment-classify`, etc. Eval-reports shipped without one, so it's the odd product out when grepping LLMA schedules or scanning the Temporal UI for LLMA-owned workflows.

## Changes

Rename the 3 workflow names + 2 schedule IDs in `posthog/temporal/llm_analytics/eval_reports/constants.py`. Also adopt the `-coordinator` / `-generate-and-deliver` suffixes used by summarization/clustering so the workflow purpose is legible from the name alone.

| Old | New |
|---|---|
| `schedule-all-eval-reports` | `llma-eval-reports-scheduled-coordinator` |
| `check-count-triggered-eval-reports` | `llma-eval-reports-count-triggered-coordinator` |
| `generate-and-deliver-eval-report` | `llma-eval-reports-generate-and-deliver` |
| `schedule-all-eval-reports-schedule` | `llma-eval-reports-scheduled-coordinator-schedule` |
| `check-count-triggered-eval-reports-schedule` | `llma-eval-reports-count-triggered-coordinator-schedule` |

This is safe to land because the existing schedules ship paused and no workflow runs have occurred — nothing is in-flight with the old names that a rename would orphan.

## How did you test this code?

I'm an agent — haven't manually tested in prod. Verified:
- `ruff check posthog/temporal/llm_analytics/eval_reports/` clean
- Full eval-reports test suite passes (133/133)
- No string literals of the old names anywhere in the repo — every `workflow.defn(name=...)` and `start_workflow(..., WORKFLOW_NAME, ...)` call site imports the constant rather than hardcoding

Post-merge operator steps:

1. Roll out the LLMA worker deployment so it picks up the new constants
2. Run `python manage.py schedule_temporal_workflows` in both prod-us and prod-eu (from the `temporal-worker-llm-analytics` pod). This creates the new paused schedules alongside the old ones
3. Delete the two old schedules (`schedule-all-eval-reports-schedule` + `check-count-triggered-eval-reports-schedule`) in Temporal UI or via `await client.get_schedule_handle(old_id).delete()`

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored as a small cleanup PR on top of the now-merged 5-PR eval-reports stack (#54363, #54364, #54365, #54366, #54367). Noticed during post-merge verification that the newly-registered schedules in prod-us (still paused) didn't match the `llma-` naming convention used by every other LLMA product. Constants-only rename, no behavior change.