### PR TITLE
fix(llma): render runs in Reports tab, and make agent TZ-aware

### DIFF
--- a/posthog/temporal/llm_analytics/eval_reports/activities.py
+++ b/posthog/temporal/llm_analytics/eval_reports/activities.py
@@ -98,8 +98,11 @@ async def fetch_count_triggered_eval_reports_activity(
 
             # Count evals since last delivery (or since report creation if first run).
             # starts_at is nullable for count-triggered reports, so fall back to created_at.
+            # Pass the datetime directly to ast.Constant — HogQL's printer serializes it
+            # as toDateTime64(..., 6, <team_tz>) with correct TZ alignment. A bare string
+            # would be coerced in the team's timezone and silently shift the comparison
+            # by the team's offset.
             since = report.last_delivered_at or report.starts_at or report.created_at
-            since_str = since.strftime("%Y-%m-%d %H:%M:%S.%f")
 
             team = Team.objects.get(id=report.team_id)
             query = parse_select(
@@ -112,7 +115,7 @@ async def fetch_count_triggered_eval_reports_activity(
                 """,
                 placeholders={
                     "evaluation_id": ast.Constant(value=str(report.evaluation_id)),
-                    "since": ast.Constant(value=since_str),
+                    "since": ast.Constant(value=since),
                 },
             )
             result = execute_hogql_query(query=query, team=team)
@@ -152,7 +155,8 @@ def _find_nth_eval_timestamp(
     from posthog.models import Team
 
     team = Team.objects.get(id=team_id)
-    before_str = before.strftime("%Y-%m-%d %H:%M:%S.%f")
+    # Pass `before` as a datetime so HogQL serializes it as toDateTime64(..., 6, <team_tz>)
+    # instead of a bare string that would be coerced in the team's timezone.
     query = parse_select(
         """
         SELECT min(ts) FROM (
@@ -167,7 +171,7 @@ def _find_nth_eval_timestamp(
         """,
         placeholders={
             "evaluation_id": ast.Constant(value=evaluation_id),
-            "before": ast.Constant(value=before_str),
+            "before": ast.Constant(value=before),
             "limit": ast.Constant(value=int(n)),
         },
     )

--- a/posthog/temporal/llm_analytics/eval_reports/report_agent/test/test_tools.py
+++ b/posthog/temporal/llm_analytics/eval_reports/report_agent/test/test_tools.py
@@ -46,15 +46,23 @@ def _state_with_empty_report() -> dict:
 class TestChTs(SimpleTestCase):
     @parameterized.expand(
         [
-            ("iso_with_tz", "2026-03-12T10:05:48.034000+00:00", "2026-03-12 10:05:48.034000"),
-            ("iso_no_tz", "2026-03-12T10:05:48.034000", "2026-03-12 10:05:48.034000"),
-            ("iso_z_suffix", "2026-03-12T10:05:48.034000Z", "2026-03-12 10:05:48.034000"),
-            ("no_microseconds", "2026-03-12T10:05:48+00:00", "2026-03-12 10:05:48.000000"),
-            ("different_timezone", "2026-03-12T12:05:48+02:00", "2026-03-12 10:05:48.000000"),
+            (
+                "iso_with_tz",
+                "2026-03-12T10:05:48.034000+00:00",
+                dt.datetime(2026, 3, 12, 10, 5, 48, 34000, tzinfo=dt.UTC),
+            ),
+            ("iso_no_tz", "2026-03-12T10:05:48.034000", dt.datetime(2026, 3, 12, 10, 5, 48, 34000, tzinfo=dt.UTC)),
+            ("iso_z_suffix", "2026-03-12T10:05:48.034000Z", dt.datetime(2026, 3, 12, 10, 5, 48, 34000, tzinfo=dt.UTC)),
+            ("no_microseconds", "2026-03-12T10:05:48+00:00", dt.datetime(2026, 3, 12, 10, 5, 48, tzinfo=dt.UTC)),
+            ("different_timezone", "2026-03-12T12:05:48+02:00", dt.datetime(2026, 3, 12, 10, 5, 48, tzinfo=dt.UTC)),
         ]
     )
-    def test_converts_iso_to_clickhouse_format(self, _name, iso_input, expected):
-        self.assertEqual(_ch_ts(iso_input), expected)
+    def test_converts_iso_to_utc_datetime(self, _name, iso_input, expected):
+        result = _ch_ts(iso_input)
+        self.assertEqual(result, expected)
+        # Returning a datetime (not string) so HogQL serializes with correct TZ alignment.
+        self.assertIsInstance(result, dt.datetime)
+        self.assertEqual(result.tzinfo, dt.UTC)
 
 
 class TestWidenedTsWindow(SimpleTestCase):
@@ -64,20 +72,20 @@ class TestWidenedTsWindow(SimpleTestCase):
             "period_end": "2026-04-08T15:00:00+00:00",
         }
         ts_start, ts_end = _widened_ts_window(state)
-        self.assertEqual(ts_start, "2026-04-01 14:00:00.000000")
-        self.assertEqual(ts_end, "2026-04-09 15:00:00.000000")
+        self.assertEqual(ts_start, dt.datetime(2026, 4, 1, 14, 0, tzinfo=dt.UTC))
+        self.assertEqual(ts_end, dt.datetime(2026, 4, 9, 15, 0, tzinfo=dt.UTC))
 
     def test_falls_back_to_sentinels_on_missing_keys(self):
         ts_start, ts_end = _widened_ts_window({})
         # Wide sentinel bounds so a bad state doesn't prevent partition pruning
-        self.assertTrue(ts_start.startswith("2020-01-01"))
-        self.assertTrue(ts_end.startswith("2099-01-01"))
+        self.assertEqual(ts_start.year, 2020)
+        self.assertEqual(ts_end.year, 2099)
 
     def test_falls_back_on_malformed_timestamps(self):
         state = {"period_start": "not-a-timestamp", "period_end": "also-bad"}
         ts_start, ts_end = _widened_ts_window(state)
-        self.assertTrue(ts_start.startswith("2020-01-01"))
-        self.assertTrue(ts_end.startswith("2099-01-01"))
+        self.assertEqual(ts_start.year, 2020)
+        self.assertEqual(ts_end.year, 2099)
 
 
 class TestUuidRegex(SimpleTestCase):

--- a/posthog/temporal/llm_analytics/eval_reports/report_agent/tools.py
+++ b/posthog/temporal/llm_analytics/eval_reports/report_agent/tools.py
@@ -26,24 +26,28 @@ from posthog.temporal.llm_analytics.eval_reports.report_agent.schema import MAX_
 _UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
 
 
-def _ch_ts(iso_str: str) -> str:
-    """Convert an ISO-8601 timestamp to a ClickHouse-compatible format.
+def _ch_ts(iso_str: str) -> datetime:
+    """Parse an ISO-8601 timestamp and return a UTC-aware datetime.
 
-    ClickHouse DateTime64 can't parse 'T' separator or '+00:00' timezone directly.
-    Converts '2026-03-12T10:05:48.034000+00:00' → '2026-03-12 10:05:48.034000'.
+    Returns a datetime (not a string) so HogQL's printer serializes it as
+    `toDateTime64(..., 6, <team_tz>)` with correct timezone alignment against
+    the events.timestamp column (DateTime64(6, <team_tz>)). Passing a bare
+    string here caused ClickHouse to coerce via the team's timezone, silently
+    shifting UTC moments by the team's offset so every period query returned
+    zero matches.
     """
     dt = datetime.fromisoformat(iso_str)
-    if dt.tzinfo is not None:
-        dt = dt.astimezone(UTC).replace(tzinfo=None)
-    return dt.strftime("%Y-%m-%d %H:%M:%S.%f")
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
 
 
 _WIDENED_TS_START_SENTINEL = "2020-01-01T00:00:00+00:00"
 _WIDENED_TS_END_SENTINEL = "2099-01-01T00:00:00+00:00"
 
 
-def _widened_ts_window(state: dict) -> tuple[str, str]:
-    """Return (ts_start, ts_end) widened for generation-event lookups.
+def _widened_ts_window(state: dict) -> tuple[datetime, datetime]:
+    """Return (ts_start, ts_end) datetimes widened for generation-event lookups.
 
     Generations predate their evals, so widen the start by 7 days to catch the
     generating event. End is period_end + 1 day buffer for eval lag. Falls back
@@ -83,7 +87,9 @@ def _execute_hogql(team_id: int, query_str: str, placeholders: dict | None = Non
     return result.results or []
 
 
-def _fetch_period_counts(team_id: int, evaluation_id: str, ts_start: str, ts_end: str) -> tuple[int, int, int, int]:
+def _fetch_period_counts(
+    team_id: int, evaluation_id: str, ts_start: datetime, ts_end: datetime
+) -> tuple[int, int, int, int]:
     """Fetch pass/fail/NA/total counts for a single time window.
 
     Returns (pass_count, fail_count, na_count, total).

--- a/products/llm_analytics/frontend/evaluations/evaluationReportLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/evaluationReportLogic.ts
@@ -228,7 +228,9 @@ export const evaluationReportLogic = kea<evaluationReportLogicType>([
                     const response = await api.get(
                         `api/environments/${values.currentTeamId}/llm_analytics/evaluation_reports/${reportId}/runs/`
                     )
-                    return response || []
+                    // The runs endpoint is paginated (DRF envelope); unwrap results so the
+                    // reducer gets an array rather than the {count, next, previous, results} object.
+                    return response?.results || []
                 },
             },
         ],


### PR DESCRIPTION
## Problem

Two live bugs surfaced by the first manual dogfood of eval-reports on https://us.posthog.com/project/2/llm-analytics/evaluations/019c953d-5e56-0000-9813-254d2cf3cb0a:

1. **Runs don't render in the Reports tab.** The \`/evaluation_reports/<id>/runs/\` endpoint correctly returned \`{count: 2, results: [...]}\` but the tab showed \"No reports generated yet\".
2. **Agent reports \"0 evals in period\" despite the eval having 96k events in the last 30 days.** Every manual-generate run concluded \"no evaluation runs recorded — likely ingestion/scheduling issue.\"

## Changes

### Fix 1 — UI: unwrap paginated runs response (\`evaluationReportLogic.ts\`)

\`loadReportRuns\` was returning \`response\` (the full DRF-paginated envelope \`{count, next, previous, results}\`) instead of \`response.results\`. The \`reportRuns\` state expected an array, \`LemonTable dataSource\` couldn't iterate the envelope, and rendered the empty state. The sibling \`loadReports\` loader on the same logic already does \`return response.results || []\`.

One-line change.

### Fix 2 — Agent/workflow: pass \`datetime\` objects (not strings) to HogQL placeholders

Every eval-reports tool query and workflow activity was passing timestamps as formatted strings via \`ast.Constant\`. ClickHouse coerces bare strings using the team's timezone (\`DateTime64(6, 'US/Pacific')\` on team 2), silently shifting the comparison boundary by the team's offset — so every period query returned zero matches.

HogQL's printer (\`posthog/hogql/escape_sql.py:248-252\`) already knows how to serialize datetime objects as \`toDateTime64(str, 6, <team_tz>)\` with correct TZ alignment. The fix is to pass datetime objects (not strings) and let the printer handle serialization. Robust across any team timezone because the column is always stored in \`DateTime64(6, <team_tz>)\` and the printer uses the same \`<team_tz>\` for the constant.

Touch points:
- \`tools.py\` \`_ch_ts\` — returns UTC-aware \`datetime\` (was formatted string)
- \`tools.py\` \`_widened_ts_window\` — returns \`(datetime, datetime)\`
- \`tools.py\` \`_fetch_period_counts\` — signature accepts datetimes
- \`activities.py\` — drops \`.strftime()\` on \`since\`/\`before\` in \`fetch_count_triggered_eval_reports_activity\` and \`_find_nth_eval_timestamp\`, passes datetimes directly
- \`test_tools.py\` — assertions updated to expect UTC-aware datetime return values

## How did you test this code?

Agent — reproduced both bugs live via Playwright MCP and PostHog MCP on project 2:

**Fix 1 verification**: navigated to the eval page, clicked Reports tab, confirmed \`/runs/\` returned \`count=2\` but UI showed empty state. Traced through \`evaluationReportLogic.ts\` and spotted the envelope-vs-results mismatch.

**Fix 2 verification**: ran the agent's exact HogQL shape directly against the same period as a failed manual run. Bare string comparison (\`timestamp >= '2026-04-19 18:45:31.377000'\`) returned 0. Explicit \`toDateTime64(..., 6, 'UTC')\` cast of the same string returned 100. Confirmed ClickHouse was parsing the bare string in the team's US/Pacific TZ via the error \`Cannot parse string '...Z' as DateTime64(6, 'US/Pacific')\`.

Automated tests:
- \`DJANGO_SETTINGS_MODULE=posthog.settings pytest posthog/temporal/llm_analytics/eval_reports/\` — 133/133 pass
- \`ruff check posthog/temporal/llm_analytics/eval_reports/\` clean
- \`pnpm run format:frontend:check\` clean

Can't fully exercise the UI fix without a dev env build, but the change is logically identical to what \`loadReports\` on the same logic already does for the identically-shaped reports endpoint.

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored follow-up to the llma-eval-reports 5-PR stack (#54363–#54367, all merged). Discovered while dogfooding the manual \"Generate now\" flow on project 2. Both bugs affect all teams once deployed — the TZ bug especially, since every non-UTC-configured team would see empty agent reports regardless of actual event volume.