### PR TITLE
feat(phrocs): Infer capability group from the intent/capability system

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -32,6 +32,7 @@ procs:
         groups:
             layer: pinned
             tech: pinned
+            capability: pinned
 
     backend:
         shell: 'uv sync --active && bin/wait-for-docker && ./bin/start-backend'
@@ -482,6 +483,9 @@ procs:
 group_order:
     layer: [Application, Processing, Ingestion pipeline, Infrastructure, Product services, Tools]
     tech: [Python, Frontend, Node, Rust, Docker, Migrations, Other]
+    # `capability` is inferred: each proc's `capability:` is copied into
+    # Groups["capability"] at load time. Display order falls back to the order
+    # capabilities first appear across procs.
 
 mouse_scroll_speed: 1
 scrollback: 10000

--- a/common/hogli/devenv/generator.py
+++ b/common/hogli/devenv/generator.py
@@ -144,9 +144,18 @@ class MprocsGenerator(ConfigGenerator):
             # Copy config to avoid mutating registry's internal state
             proc_config = proc_config.copy()
 
-            # Remove metadata fields - not mprocs config
-            proc_config.pop("capability", None)
+            # Remove metadata fields - not mprocs config.
+            # (note that capability is kept, because it's used in groups)
             proc_config.pop("ask_skip", None)
+
+            # Give procs without an explicit capability a synthetic one so they
+            # don't all fall into "Ungrouped" when the user groups by capability,
+            # as many important ones are in that category (e.g. backend, frontend).
+            if not proc_config.get("capability"):
+                if name in resolved.always_required:
+                    proc_config["capability"] = "always_required"
+                elif is_manual_start:
+                    proc_config["capability"] = "tools"
 
             # Set autostart: false for skipped processes
             if name in resolved.skip_autostart:

--- a/common/hogli/devenv/resolver.py
+++ b/common/hogli/devenv/resolver.py
@@ -109,6 +109,7 @@ class ResolvedEnvironment:
     unit_provenance: dict[str, str] = field(default_factory=dict)  # unit -> reason
     skip_autostart: set[str] = field(default_factory=set)  # units to include but not auto-start
     enable_autostart: set[str] = field(default_factory=set)  # units to enable autostart (override source)
+    always_required: set[str] = field(default_factory=set)
 
     def get_unit_list(self) -> list[str]:
         """Get sorted list of units for consistent output."""
@@ -234,6 +235,7 @@ class IntentResolver:
             unit_provenance=unit_provenance,
             skip_autostart=set(skip_autostart),
             enable_autostart=set(enable_autostart),
+            always_required=set(self.intent_map.always_required),
         )
 
     def _intents_to_capabilities(self, intents: list[str]) -> set[str]:

--- a/common/hogli/tests/test_devenv.py
+++ b/common/hogli/tests/test_devenv.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+import yaml
 from hogli.devenv.generator import DevenvConfig, MprocsGenerator, load_devenv_config
 from hogli.devenv.registry import ProcessRegistry, create_mprocs_registry
 from hogli.devenv.resolver import Capability, Intent, IntentMap, IntentResolver, load_intent_map
@@ -574,6 +575,110 @@ class TestMprocsGeneratorRegression:
         assert "feature-flags" in config.procs
         assert "property-defs-rs" in config.procs
         assert "docker-compose" in config.procs
+
+
+class TestMprocsGeneratorPreservesCapability:
+    """Generated procs retain `capability:` so phrocs can group by capability.
+
+    phrocs copies ProcConfig.Capability into Groups["capability"] at load
+    time; the generator must therefore pass the field through.
+    """
+
+    def test_capability_preserved_in_generated_procs(self) -> None:
+        intent_map = create_test_intent_map()
+        registry = create_test_registry()
+        resolver = IntentResolver(intent_map, registry)
+        resolved = resolver.resolve(["session_replay"])
+        config = MprocsGenerator(registry).generate(resolved)
+
+        # Spot-check procs from different capabilities
+        assert config.procs["capture"].get("capability") == "event_ingestion"
+        assert config.procs["capture-replay"].get("capability") == "replay_storage"
+        assert config.procs["docker-compose"].get("capability") == "core_infra"
+
+    def test_always_required_without_capability_gets_synthetic_bucket(self) -> None:
+        """Procs in always_required that don't declare a capability get "always_required"."""
+        intent_map = create_test_intent_map()  # always_required = [backend, frontend, docker-compose]
+        registry = create_test_registry()
+        # Register backend/frontend without a capability (they're the app itself)
+        registry._processes["backend"] = {"shell": "./bin/start-backend", "capability": ""}
+        registry._processes["frontend"] = {"shell": "./bin/start-frontend", "capability": ""}
+        resolver = IntentResolver(intent_map, registry)
+        resolved = resolver.resolve(["product_analytics"])
+        config = MprocsGenerator(registry).generate(resolved)
+
+        assert config.procs["backend"].get("capability") == "always_required"
+        assert config.procs["frontend"].get("capability") == "always_required"
+        # docker-compose has a real capability; synthetic bucket must not overwrite it
+        assert config.procs["docker-compose"].get("capability") == "core_infra"
+
+    def test_manual_start_without_capability_gets_tools_bucket(self) -> None:
+        """Procs with autostart: false and no capability get "tools"."""
+        intent_map = create_test_intent_map()
+        registry = create_test_registry()
+        # Manual-start tool: no capability, autostart: false, not in always_required
+        registry._processes["storybook"] = {
+            "shell": "pnpm storybook",
+            "capability": "",
+            "autostart": False,
+        }
+        resolver = IntentResolver(intent_map, registry)
+        resolved = resolver.resolve(["product_analytics"])
+        config = MprocsGenerator(registry).generate(resolved)
+
+        assert "storybook" in config.procs
+        assert config.procs["storybook"].get("capability") == "tools"
+
+    def test_always_required_wins_over_manual_start(self) -> None:
+        """A proc that is both always_required and autostart: false (e.g. typegen)
+        goes to the "always_required" bucket, not "tools"."""
+        intent_map = create_test_intent_map()
+        intent_map.always_required = [*intent_map.always_required, "typegen"]
+        registry = create_test_registry()
+        registry._processes["typegen"] = {
+            "shell": "pnpm typegen:watch",
+            "capability": "",
+            "autostart": False,
+        }
+        resolver = IntentResolver(intent_map, registry)
+        resolved = resolver.resolve(["product_analytics"])
+        config = MprocsGenerator(registry).generate(resolved)
+
+        assert config.procs["typegen"].get("capability") == "always_required"
+
+    def test_capability_survives_yaml_round_trip(self, tmp_path: Path) -> None:
+        """End-to-end check: generator output -> YAML file -> parse.
+
+        phrocs' Go-side inference (inferGroupFromCapability) relies on the
+        `capability:` field being present on each emitted proc. This test
+        catches regressions where the generator, yaml.dump, or MprocsConfig
+        serialization silently drops the field somewhere in the pipeline.
+        The Go side has its own tests that the field, once present in YAML,
+        is copied into Groups["capability"].
+        """
+        # Use the real intent-map and registry so we exercise the live wiring,
+        # including the synthetic always_required/tools buckets.
+        intent_map = load_intent_map()
+        registry = create_mprocs_registry()
+        resolver = IntentResolver(intent_map, registry)
+        resolved = resolver.resolve(["product_analytics"])
+        config = MprocsGenerator(registry).generate(resolved)
+
+        out = tmp_path / "mprocs.yaml"
+        MprocsGenerator(registry).save(config, out)
+
+        with open(out) as f:
+            data = yaml.safe_load(f)
+
+        # Every proc in the output (except info, which is pinned by YAML) must
+        # carry a non-empty capability so the capability dimension has content.
+        missing = [name for name, cfg in data["procs"].items() if name != "info" and not cfg.get("capability")]
+        assert not missing, f"procs missing capability in serialized YAML: {missing}"
+
+        # Spot-check the three flavors: real, always_required, tools.
+        assert data["procs"]["capture"]["capability"] == "event_ingestion"
+        assert data["procs"]["backend"]["capability"] == "always_required"
+        assert data["procs"]["storybook"]["capability"] == "tools"
 
 
 class TestPersonhogEnvInjection:

--- a/common/hogli/tests/test_devenv.py
+++ b/common/hogli/tests/test_devenv.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -20,7 +21,9 @@ class MockRegistry(ProcessRegistry):
     def __init__(self, capability_units: dict[str, list[str]], ask_skip: list[str] | None = None):
         self._capability_units = capability_units
         self._ask_skip = ask_skip or []
-        self._processes = {
+        # dict[str, Any] since proc configs are heterogeneous
+        # (shell: str, capability: str, autostart: bool, ...)
+        self._processes: dict[str, dict[str, Any]] = {
             unit: {"shell": f"./bin/start-{unit}", "capability": cap}
             for cap, units in capability_units.items()
             for unit in units

--- a/tools/phrocs/internal/config/config.go
+++ b/tools/phrocs/internal/config/config.go
@@ -9,6 +9,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// CapabilityGroupKey is the reserved key under ProcConfig.Groups that carries
+// the capability dimension inferred from ProcConfig.Capability
+const CapabilityGroupKey = "capability"
+
 // Mirrors a single entry under mprocs.yaml's "procs" key
 type ProcConfig struct {
 	Shell        string            `yaml:"shell"`
@@ -78,7 +82,30 @@ func Load(path string) (*Config, error) {
 	if cfg.MouseScrollSpeed == 0 {
 		cfg.MouseScrollSpeed = 3
 	}
+	inferGroupFromCapability(&cfg)
 	return &cfg, nil
+}
+
+// inferGroupFromCapability copies each proc's "capability:" field into
+// "groups:" map, so the TUI's grouping dimension cycle ("g" key) picks
+// it up alongside user-declared dimensions.
+// An explicit Groups[CapabilityGroupKey] in YAML takes precedence.
+func inferGroupFromCapability(cfg *Config) {
+	for name, pc := range cfg.Procs {
+		if pc.Capability == "" {
+			// Procs without a capability fall under "Ungrouped"
+			continue
+		}
+		if _, ok := pc.Groups[CapabilityGroupKey]; ok {
+			// Any explicit entry is respected, setting to "" leads to "Ungrouped"
+			continue
+		}
+		if pc.Groups == nil {
+			pc.Groups = make(map[string]string)
+		}
+		pc.Groups[CapabilityGroupKey] = pc.Capability
+		cfg.Procs[name] = pc
+	}
 }
 
 // Intent is a minimal representation of an intent from intent-map.yaml.

--- a/tools/phrocs/internal/config/config_test.go
+++ b/tools/phrocs/internal/config/config_test.go
@@ -223,6 +223,92 @@ func TestLoad_globalShell(t *testing.T) {
 	}
 }
 
+func TestLoad_infersCapabilityGroup(t *testing.T) {
+	tests := []struct {
+		name       string
+		yaml       string
+		proc       string
+		wantCap    string // expected Groups["capability"] value (may be "")
+		wantAbsent bool   // if true, expect the key to be missing entirely
+	}{
+		{
+			name:    "copies capability into groups",
+			yaml:    "procs:\n  svc:\n    shell: echo hi\n    capability: event_ingestion\n",
+			proc:    "svc",
+			wantCap: "event_ingestion",
+		},
+		{
+			name:       "missing capability field leaves groups untouched",
+			yaml:       "procs:\n  svc:\n    shell: echo hi\n",
+			proc:       "svc",
+			wantAbsent: true,
+		},
+		{
+			name:    "explicit groups.capability in YAML takes precedence",
+			yaml:    "procs:\n  svc:\n    shell: echo hi\n    capability: event_ingestion\n    groups:\n      capability: pinned\n",
+			proc:    "svc",
+			wantCap: "pinned",
+		},
+		{
+			// Explicit empty override opts the proc out of capability grouping
+			// (i.e. later put into Ungrouped)
+			name:    "empty explicit override opts out of inference",
+			yaml:    "procs:\n  svc:\n    shell: echo hi\n    capability: event_ingestion\n    groups:\n      capability: \"\"\n",
+			proc:    "svc",
+			wantCap: "",
+		},
+		{
+			name:    "preserves sibling groups while adding capability",
+			yaml:    "procs:\n  svc:\n    shell: echo hi\n    capability: flag_evaluation\n    groups:\n      layer: Product services\n",
+			proc:    "svc",
+			wantCap: "flag_evaluation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeYAML(t, tt.yaml)
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, ok := cfg.Procs[tt.proc].Groups["capability"]
+			if tt.wantAbsent {
+				if ok {
+					t.Errorf("unexpected Groups[\"capability\"]=%q, want absent", got)
+				}
+				return
+			}
+			if !ok {
+				t.Fatalf("Groups[\"capability\"] missing, want %q", tt.wantCap)
+			}
+			if got != tt.wantCap {
+				t.Errorf("Groups[\"capability\"]: got %q, want %q", got, tt.wantCap)
+			}
+		})
+	}
+}
+
+func TestLoad_inferCapabilityPreservesLayerAndTech(t *testing.T) {
+	path := writeYAML(t, `
+procs:
+  svc:
+    shell: echo hi
+    capability: event_ingestion
+    groups:
+      layer: Processing
+      tech: Rust
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := cfg.Procs["svc"].Groups
+	if g["layer"] != "Processing" || g["tech"] != "Rust" || g["capability"] != "event_ingestion" {
+		t.Errorf("expected layer=Processing tech=Rust capability=event_ingestion, got %+v", g)
+	}
+}
+
 func TestLoad_cwd(t *testing.T) {
 	path := writeYAML(t, "procs:\n  svc:\n    shell: echo hi\n    cwd: /tmp/mydir\n")
 	cfg, err := Load(path)

--- a/tools/phrocs/internal/tui/group.go
+++ b/tools/phrocs/internal/tui/group.go
@@ -31,8 +31,8 @@ func (e sidebarEntry) isNonSelectable() bool {
 }
 
 // groupDimensions discovers the available grouping dimensions from the config.
-// Returns dimension names sorted alphabetically, or ordered by group_order keys
-// if present.
+// User-declared dimensions (from `groups:` on each proc) come first, the
+// inferred `capability` dimension is appended.
 func groupDimensions(cfg *config.Config) []string {
 	seen := make(map[string]bool)
 	for _, pc := range cfg.Procs {
@@ -45,11 +45,17 @@ func groupDimensions(cfg *config.Config) []string {
 		seen[dim] = true
 	}
 
-	dims := make([]string, 0, len(seen))
+	hasCapability := seen[config.CapabilityGroupKey]
+	delete(seen, config.CapabilityGroupKey)
+
+	dims := make([]string, 0, len(seen)+1)
 	for dim := range seen {
 		dims = append(dims, dim)
 	}
 	sort.Strings(dims)
+	if hasCapability {
+		dims = append(dims, config.CapabilityGroupKey)
+	}
 	return dims
 }
 

--- a/tools/phrocs/internal/tui/group_test.go
+++ b/tools/phrocs/internal/tui/group_test.go
@@ -211,6 +211,94 @@ func TestBuildGroupedEntries_ungroupedAppearsAfterConfiguredGroups(t *testing.T)
 	}
 }
 
+// ── capability dimension ─────────────────────────────────────────────────────
+
+// The capability dimension is inferred by config.Load() (it copies each
+// proc's Capability field into Groups["capability"]). These tests exercise
+// the TUI layer: once Groups["capability"] is populated, all the existing
+// grouping mechanics should work unchanged.
+
+func TestBuildGroupedEntries_capabilityDimension(t *testing.T) {
+	procs := []*process.Process{
+		{Name: "capture", Cfg: config.ProcConfig{Groups: map[string]string{"capability": "event_ingestion"}}},
+		{Name: "nodejs", Cfg: config.ProcConfig{Groups: map[string]string{"capability": "event_ingestion"}}},
+		{Name: "feature-flags", Cfg: config.ProcConfig{Groups: map[string]string{"capability": "flag_evaluation"}}},
+	}
+	cfg := &config.Config{
+		GroupOrder: map[string][]string{
+			"capability": {"event_ingestion", "flag_evaluation"},
+		},
+	}
+	entries := buildGroupedEntries(procs, "capability", cfg)
+
+	var headerOrder []string
+	procsUnder := map[string][]string{}
+	currentHeader := ""
+	for _, e := range entries {
+		switch {
+		case e.isHeader():
+			headerOrder = append(headerOrder, e.groupHeader)
+			currentHeader = e.groupHeader
+		case e.proc != nil:
+			procsUnder[currentHeader] = append(procsUnder[currentHeader], e.proc.Name)
+		}
+	}
+
+	if len(headerOrder) != 2 || headerOrder[0] != "event_ingestion" || headerOrder[1] != "flag_evaluation" {
+		t.Errorf("header order: got %v, want [event_ingestion flag_evaluation]", headerOrder)
+	}
+	if len(procsUnder["event_ingestion"]) != 2 {
+		t.Errorf("event_ingestion: got %v, want 2 procs", procsUnder["event_ingestion"])
+	}
+	if len(procsUnder["flag_evaluation"]) != 1 || procsUnder["flag_evaluation"][0] != "feature-flags" {
+		t.Errorf("flag_evaluation: got %v, want [feature-flags]", procsUnder["flag_evaluation"])
+	}
+}
+
+func TestBuildGroupedEntries_capabilityUngroupedFallback(t *testing.T) {
+	// Procs without a capability (e.g. backend, frontend, manual tools) have
+	// no Groups["capability"], so they fall under Ungrouped — matching how
+	// layer/tech behave today.
+	procs := []*process.Process{
+		{Name: "capture", Cfg: config.ProcConfig{Groups: map[string]string{"capability": "event_ingestion"}}},
+		{Name: "backend", Cfg: config.ProcConfig{}},
+	}
+	cfg := &config.Config{
+		GroupOrder: map[string][]string{"capability": {"event_ingestion"}},
+	}
+	entries := buildGroupedEntries(procs, "capability", cfg)
+
+	hasUngrouped := false
+	for _, e := range entries {
+		if e.isHeader() && e.groupHeader == ungroupedName {
+			hasUngrouped = true
+		}
+	}
+	if !hasUngrouped {
+		t.Error("proc without capability should appear under Ungrouped")
+	}
+}
+
+func TestBuildGroupedEntries_capabilityPinned(t *testing.T) {
+	// The `info` proc uses capability=pinned to stay at the top regardless
+	// of the active dimension, matching its layer=pinned / tech=pinned.
+	procs := []*process.Process{
+		{Name: "capture", Cfg: config.ProcConfig{Groups: map[string]string{"capability": "event_ingestion"}}},
+		{Name: "info", Cfg: config.ProcConfig{Groups: map[string]string{"capability": "pinned"}}},
+	}
+	cfg := &config.Config{}
+	entries := buildGroupedEntries(procs, "capability", cfg)
+
+	if len(entries) == 0 || entries[0].proc == nil || entries[0].proc.Name != "info" {
+		t.Error("info should be pinned at the top of capability grouping")
+	}
+	for _, e := range entries {
+		if e.isHeader() && e.groupHeader == "pinned" {
+			t.Error("pinned should never appear as a group header")
+		}
+	}
+}
+
 // ── groupDimensions ──────────────────────────────────────────────────────────
 
 func TestGroupDimensions(t *testing.T) {
@@ -245,6 +333,23 @@ func TestGroupDimensions(t *testing.T) {
 				"complex": {Shell: "echo", Groups: map[string]string{"tech": "Rust", "team": "Infra", "cost": "High"}},
 			}},
 			want: []string{"cost", "layer", "team", "tech"},
+		},
+		{
+			// capability is inferred from ProcConfig.Capability and always
+			// sorts after user-declared dims so the `g` cycle ends on it.
+			name: "capability is always last",
+			cfg: &config.Config{Procs: map[string]config.ProcConfig{
+				"a": {Groups: map[string]string{"layer": "App", "tech": "Python", "capability": "event_ingestion"}},
+				"b": {Groups: map[string]string{"capability": "flag_evaluation"}},
+			}},
+			want: []string{"layer", "tech", "capability"},
+		},
+		{
+			name: "capability only",
+			cfg: &config.Config{Procs: map[string]config.ProcConfig{
+				"a": {Groups: map[string]string{"capability": "event_ingestion"}},
+			}},
+			want: []string{"capability"},
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Problem

Since we now have groups (https://github.com/PostHog/posthog/pull/55058), it would be nice to visually show the capability system so devs can explore it without reading config files, as an easy/visual way to learn our infra. This is especially powerful with the ability to show all processes (https://github.com/PostHog/posthog/pull/55174)

## Changes

- Infer capability group from the defined capabilities
- Can be overwritten if manually set in the mprocs.yaml, as done for pinning info at the top

Example: capability group (with show-all toggled on)
<img width="1499" height="873" alt="phrocs-capability-group" src="https://github.com/user-attachments/assets/ad2604e2-9aa6-4761-aa8d-73fbde14a263" />

## How did you test this code?

- New test cases
- Manually

## Publish to changelog?

No
