### PR TITLE
chore(llma): remove paused-schedule scaffolding on eval-reports schedules

### DIFF
--- a/posthog/temporal/llm_analytics/eval_reports/schedule.py
+++ b/posthog/temporal/llm_analytics/eval_reports/schedule.py
@@ -5,14 +5,7 @@ from datetime import timedelta
 
 from django.conf import settings
 
-from temporalio.client import (
-    Client,
-    Schedule,
-    ScheduleActionStartWorkflow,
-    ScheduleIntervalSpec,
-    ScheduleSpec,
-    ScheduleState,
-)
+from temporalio.client import Client, Schedule, ScheduleActionStartWorkflow, ScheduleIntervalSpec, ScheduleSpec
 
 from posthog.temporal.common.schedule import a_create_schedule, a_schedule_exists, a_update_schedule
 from posthog.temporal.llm_analytics.eval_reports.constants import (
@@ -26,11 +19,6 @@ from posthog.temporal.llm_analytics.eval_reports.types import (
     ScheduleAllEvalReportsWorkflowInputs,
 )
 
-# Schedules are created paused on initial deploy so operators can verify the
-# specs in Temporal UI before they start firing. A follow-up PR will flip these
-# to paused=False once the first deploy is verified end-to-end.
-_INITIAL_PAUSED = True
-
 
 async def create_eval_reports_schedule(client: Client):
     """Create or update the hourly schedule for time-based evaluation reports."""
@@ -42,7 +30,6 @@ async def create_eval_reports_schedule(client: Client):
             task_queue=settings.LLMA_TASK_QUEUE,
         ),
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(hours=1))]),
-        state=ScheduleState(paused=_INITIAL_PAUSED, note="Paused on initial deploy; enable via follow-up PR"),
     )
 
     if await a_schedule_exists(client, SCHEDULE_ID):
@@ -61,7 +48,6 @@ async def create_count_trigger_schedule(client: Client):
             task_queue=settings.LLMA_TASK_QUEUE,
         ),
         spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(minutes=5))]),
-        state=ScheduleState(paused=_INITIAL_PAUSED, note="Paused on initial deploy; enable via follow-up PR"),
     )
 
     if await a_schedule_exists(client, COUNT_TRIGGER_SCHEDULE_ID):


### PR DESCRIPTION
## Problem

The eval-reports schedules ship with a \`ScheduleState(paused=_INITIAL_PAUSED, note=...)\` wrapper so they register paused on first deploy and operators could verify the specs in Temporal UI before anything fired. That phase is done — schedules have been exercised end-to-end via manual generate and behave as expected.

## Changes

Drop the \`_INITIAL_PAUSED\` constant, the \`state=ScheduleState(...)\` arg on both \`Schedule(...)\` constructors, and the now-unused \`ScheduleState\` import. Net -15 +1 lines.

Same shape every other LLMA product uses (clustering, summarization, sentiment) — schedules created unpaused by default.

## How did you test this code?

Agent — \`pytest posthog/temporal/llm_analytics/eval_reports/\` 133/133 pass, ruff clean.

## Deploy behaviour

- **New clusters** (e.g. a future region): schedules register unpaused immediately.
- **Existing prod clusters** (prod-us already has the paused schedules registered): the next manual \`schedule_temporal_workflows\` run calls \`a_update_schedule\`, which replaces the full schedule record. Since this PR removes the \`state=\` arg entirely, the updated schedule has no explicit pause state → Temporal's default of \`paused=False\` applies → schedules unpause.
- **Incident pause** still available: operators can pause any schedule in the Temporal UI with one click; no code change needed.

## Operator runbook after merge

1. Wait for CD to roll the LLMA worker with this change
2. Run \`python manage.py schedule_temporal_workflows\` in both prod-us and prod-eu (from the \`temporal-worker-llm-analytics\` pod per \`runbooks/docs/llm-analytics/temporal-workers.md\`) — this replaces the paused records with unpaused ones
3. Verify in Temporal Cloud UI that both schedules show as active and start firing on their next tick

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored follow-up to the llma-eval-reports 5-PR stack. Initial deploy used the \"ship schedules paused\" pattern from the stack's merge checklist; this removes the scaffolding now that verification is complete.