### PR TITLE
fix(ux): suppress stray outline on radix menu items after window refocus

### DIFF
--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -1127,6 +1127,14 @@
         outline: 2px solid var(--color-accent);
     }
 
+    /* Radix menus emit data-highlighted on pointer-move; suppress outline unless
+      focus is truly keyboard-driven */
+    [data-radix-menu-content] [data-highlighted]:not(:focus-visible),
+    [data-radix-context-menu-content] [data-highlighted]:not(:focus-visible),
+    [data-radix-select-content] [data-highlighted]:not(:focus-visible) {
+        outline: none;
+    }
+
     .input-like {
         --input-ring-color: var(--color-bg-fill-highlight-75);
         --input-ring-size: 3px;

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -1127,12 +1127,15 @@
         outline: 2px solid var(--color-accent);
     }
 
-    /* Radix menus emit data-highlighted on pointer-move; suppress outline unless
-      focus is truly keyboard-driven */
-    [data-radix-menu-content] [data-highlighted]:not(:focus-visible),
-    [data-radix-context-menu-content] [data-highlighted]:not(:focus-visible),
-    [data-radix-select-content] [data-highlighted]:not(:focus-visible) {
+    /* Radix menus highlight items on pointer-move; only show the outline for
+       keyboard focus, and render it inset so the container's rounded
+       overflow:hidden mask can't clip the corners */
+    .primitive-menu-content [data-highlighted]:not(:focus-visible) {
         outline: none;
+    }
+
+    .primitive-menu-content [data-highlighted]:focus-visible {
+        outline-offset: -2px;
     }
 
     .input-like {


### PR DESCRIPTION
## Problem

Two related rendering bugs on our shared menu surfaces (DropdownMenu / ContextMenu / SelectPrimitive / PopoverPrimitive):

1. **Stray outline on mouse use after window refocus.** Opening a Radix menu, alt/cmd-tabbing away, and returning sometimes left an item showing an orange outline as the pointer moved over siblings. Reproducible on the error tracking session timeline row-actions menu.

   Cause: Radix sets `data-highlighted` on pointer-move via programmatic focus. Our global `[data-highlighted]:not(:hover)` outline rule in `frontend/src/styles/base.scss` was designed for keyboard highlights but was also matching these transient pointer-driven ones (especially across window blur/focus transitions where the hover/focus timing skews).

2. **Broken corners when keyboard-focused.** When tabbing to an item, the outline showed visibly squared-off corners at the top-right / bottom-right edges of the menu.

   Cause: `.primitive-menu-content` uses `overflow: hidden` + `border-radius: 0.625rem`. The outer rounded clipping mask cuts through the area where a 2px outline with `outline-offset: 0` would render at the container's corners.

## Changes

Two scoped rules inside `.primitive-menu-content`:

- `[data-highlighted]:not(:focus-visible)` → `outline: none`. Keeps the outline off for pointer-driven highlights.
- `[data-highlighted]:focus-visible` → `outline-offset: -2px`. Renders the focus ring inset so it always hugs the item's own border-radius and can't be clipped by the container mask. (Same technique already used for the AI-first homepage grid virtual cursor via the `-outline-offset-2` utility.)

Scope: only our four Radix-based primitive menu surfaces (`DropdownMenu`, `ContextMenu`, `SelectPrimitive`, `PopoverPrimitive`). The global `[data-highlighted]:not(:hover)` rule is left untouched so other consumers (e.g. `HomepageInput.tsx` virtual cursor, Base UI Autocomplete in `Search.tsx`) are unaffected.

## How did you test this code?

Manually in the PostHog dev app:

- Error tracking session timeline row-actions menu: hover behavior clean; alt-tab away and back, no stray outline.
- Tab-navigate the menu: outline appears, now hugs the item border-radius without clipping.
- Arrow-key navigation inside the menu: outline follows the highlighted item correctly.
- Sanity-checked other menus.

before:
<img width="240" height="122" alt="image" src="https://github.com/user-attachments/assets/c59a4889-2731-4f82-9170-4e24ac41c4c0" />

after:

<img width="207" height="81" alt="image" src="https://github.com/user-attachments/assets/c9f3ee5c-ef28-4e6f-a2e1-5a25eccdc000" />


## Publish to changelog?

no

<!-- ## 🤖 LLM context -->