### PR TITLE
chore(visual-review): test VR with storybook snapshot change

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1713,9 +1713,9 @@ snapshots:
     lemon-ui-lemon-button--as-links--light:
         hash: v1.k794b7964.86b66c4c7692713a9582045c6ccb56086a9b9b62e0f884c4d8f0a9fc4307f80c.wZYzzp1aEnp-KdO4Ituo9ILC7-Hf0gOJxIhkisXI-P0
     lemon-ui-lemon-button--default--dark:
-        hash: v1.k794b7964.13be6185098d17920c06f3d6a8a9397070cd480b8410db6084941e6550df115a.VZ_I1T6nlNpILhvEOV6jDSOW6m_G9FsE7gaa5IAR7j0
+        hash: v1.k794b7964.cf43269d2f13304b59002f59f2b8fe7a684bcaaf6ab7ade449a109d32af8e752.yxVLTVX0RovuXCxLi1Z3vUhukycZ7jcFkRuNqlUiFpI
     lemon-ui-lemon-button--default--light:
-        hash: v1.k794b7964.702d6172244bc3cb1be17fc64398a9cad2f21f6d21d2b407aa3003cc2163aaa8.jr9wOBdkGWZ1UGTlhyPNexfRyfZ8GD48VYBImTlBKrg
+        hash: v1.k794b7964.f47e883832e995ec59425c0c095f645d503b30967f732b10f6855826a22c8587.labnq3GEiF1bGbdtkVJ9NGF9FRcqxp76b8ZKPLzTaZA
     lemon-ui-lemon-button--disabled-with-reason--dark:
         hash: v1.k794b7964.310e3d25697ffe3c603a08164cb1178f72bb252f7355e01e0bad954a24b2bb41.nqd1OSrN3KD9CaO4AwMT7Ok5ZRIbIByT-43wydiYIFo
     lemon-ui-lemon-button--disabled-with-reason--light:
@@ -1765,13 +1765,13 @@ snapshots:
     lemon-ui-lemon-button--with-button-wrapper--light:
         hash: v1.k794b7964.c6a36943d8d66aa573a9b39161bd3978d073596f023afacabe1b7ac30188eb1f.jnSx87iz5mRalm8jrp93iuPPUzx9HyY7gdVohDR_ssU
     lemon-ui-lemon-button--with-dropdown-to-the-bottom--dark:
-        hash: v1.k794b7964.9634e6b0fb0ff330851e4f2ec34f5f3bac7deb655786116f1cab85422a0baea3.2JfTw5PoFFsPV2PXjwFKeECDFzEdVQdMbiZZWLeahHA
+        hash: v1.k794b7964.cdc570bd5298e0f708b39c3f9050e950a7755775f0b381e9a081291c2d5fe1f5.uWpjNzBk4oir7Kanqf7DOcp7QlffXzYTMbNjVvoGC0M
     lemon-ui-lemon-button--with-dropdown-to-the-bottom--light:
-        hash: v1.k794b7964.17743ab85b1be62e392d4d28f7b5ba7eab9bbe8f343a33bf9fbf49402abb6da3.L_Av91el-slr0yCyIV_Rty9L6xyGy537oY7hBNYiKso
+        hash: v1.k794b7964.d010f10c4b4805a53598d0dbd5eaf0513fd6296d54b012254c801c3fb2d811a3.RDYTYGm35vNTEQKx7hV2wo-ol_x-CPCaoJT0j_EXnKU
     lemon-ui-lemon-button--with-dropdown-to-the-right--dark:
-        hash: v1.k794b7964.055479f0f52db1c858f8fde3dd5ce60d5e866b08a613d411a08a7176d60f7050.mfap6zzeYsZjugecnBlMmsSlx9n9zpUYCZKyDxomjBY
+        hash: v1.k794b7964.01b5398b7b0bce72720c3c3a4c7bf2ffd7339f6654da65ebc4ca1cf13149947b.C52uQnuP2eABvsKFRrsRiZtNt_tmRLf5wlxK0yQ5J48
     lemon-ui-lemon-button--with-dropdown-to-the-right--light:
-        hash: v1.k794b7964.1736c1037dc2dda4fb61be9d7de52770dc466d519ef4a371acbc3101ccfc8438.Rnj8GixtWHYA5u6I8tUqyeimQCfMC9zcFzE1HcJBpUY
+        hash: v1.k794b7964.808ea2fec3cdfac08e86e09418eb13a3e19184d871c7cf03d028e8a7f1efb04c.4n1bIUaPkNX2w_s_C-pNQfhZ6JPrHORWDpntvXraZsE
     lemon-ui-lemon-button--with-overflowing-content--dark:
         hash: v1.k794b7964.0b6fad8b9a1aa2f770834ba12115cf2bfe41af2a274c05bbfb3535316c2643e5.v66uhSO9Sf-P985qDADg2laSxQdk68jzusoefX0eFXU
     lemon-ui-lemon-button--with-overflowing-content--light:
@@ -1785,17 +1785,17 @@ snapshots:
     lemon-ui-lemon-button--with-side-icon--light:
         hash: v1.k794b7964.f967a9366f86118979b70e5f681cd45fa774714f696c4351d9e22d83aa908b83.Jr5F46xtxtoUPCDf4AlptwjcwfsTJlbYiEknBgpjjx4
     lemon-ui-lemon-button--with-tooltip--dark:
-        hash: v1.k794b7964.13be6185098d17920c06f3d6a8a9397070cd480b8410db6084941e6550df115a.eaqp04X74bVu3zItjq94iBxEkMCrmuugraLt-He4uqE
+        hash: v1.k794b7964.cf43269d2f13304b59002f59f2b8fe7a684bcaaf6ab7ade449a109d32af8e752.kEF60iWcrvr-MBiB7f-m_LHrKlx182oWp9imVEaugtA
     lemon-ui-lemon-button--with-tooltip--light:
-        hash: v1.k794b7964.702d6172244bc3cb1be17fc64398a9cad2f21f6d21d2b407aa3003cc2163aaa8.RQQ2cnY7sqSX5fRzHv9BSHnCgh-8-MMhTQMElhQ3gfw
+        hash: v1.k794b7964.f47e883832e995ec59425c0c095f645d503b30967f732b10f6855826a22c8587.akTwukLiSG3bMyZo59mWjCyYwdIbkFaqZJe17eGXBi8
     lemon-ui-lemon-button--with-tooltip-placement-and-arrow-offset--dark:
-        hash: v1.k794b7964.13be6185098d17920c06f3d6a8a9397070cd480b8410db6084941e6550df115a.K4K5sQRs6kijZAoYfV0N4Suwdoh9T6kMX2T2OBzCCtc
+        hash: v1.k794b7964.cf43269d2f13304b59002f59f2b8fe7a684bcaaf6ab7ade449a109d32af8e752.I2dVrNbgoEZKNbdgmUpD3kdS15SDxq9qcwZI-ckopFM
     lemon-ui-lemon-button--with-tooltip-placement-and-arrow-offset--light:
-        hash: v1.k794b7964.125d74483d9b19fe86fff5dd18fd2a1860bbbda24e53f590b4233eeb972ed3cc.4CUa8mUKvLYjKp3Mj_09bdlZCpT1MQItHA7R0Qxx5ZA
+        hash: v1.k794b7964.f47e883832e995ec59425c0c095f645d503b30967f732b10f6855826a22c8587.Irn-KfpNXBdL1G0NUeBXP73-2Ra42haoWz6GmOypGQA
     lemon-ui-lemon-button--with-very-long-popover-to-the-bottom--dark:
-        hash: v1.k794b7964.9634e6b0fb0ff330851e4f2ec34f5f3bac7deb655786116f1cab85422a0baea3.1TOkbMq1aC86I_ZcFZURVmBw29pOCq1fXjMGZm3-ge4
+        hash: v1.k794b7964.cdc570bd5298e0f708b39c3f9050e950a7755775f0b381e9a081291c2d5fe1f5.s_GIl00T_nIZu0SanlMT9PM7N731oFq4Juie85tVd00
     lemon-ui-lemon-button--with-very-long-popover-to-the-bottom--light:
-        hash: v1.k794b7964.17743ab85b1be62e392d4d28f7b5ba7eab9bbe8f343a33bf9fbf49402abb6da3.3E51PrBW7BfKXZfmhDZNEYh1vUpvSDiTaL0N6P4XZE0
+        hash: v1.k794b7964.d010f10c4b4805a53598d0dbd5eaf0513fd6296d54b012254c801c3fb2d811a3.u5Q_bgGBc5xNoQEsgt6iFmISIw51i1fWjjpAemxWMEw
     lemon-ui-lemon-calendar-lemon-calendar--custom-styles--dark:
         hash: v1.k794b7964.0ccf018dd7b2c6f5f47bfd2ae5249279d3d4c22926d9c2b5219ed1c418d51eba.y77Y_J1VR7c2tmPC358BX1KBCbw1CiuFqxeSGI21mNI
     lemon-ui-lemon-calendar-lemon-calendar--custom-styles--light:

--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.stories.tsx
@@ -40,8 +40,8 @@ export default meta
 
 export const Default: Story = {
     args: {
-        icon: <IconCalculate />,
-        children: 'Click me',
+        icon: <IconPlus />,
+        children: 'Create new',
     },
 }
 


### PR DESCRIPTION
**Problem**

Test PR to validate VR is working as the gate after rollout. Intentionally changes a LemonButton story to trigger a visual diff.

**Changes**

Changes the default LemonButton story icon and label.

**How did you test this code?**

VR should detect the snapshot change and post a commit status. This PR exists solely to verify that.

no

## 🤖 LLM context

Test PR created to validate VR rollout. Will be closed after verification.