### PR TITLE
fix(query): surface failed async query tasks

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -37,7 +37,13 @@ from posthog.api.query_coalescer import QueryCoalescingMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.services.query import process_query_model
 from posthog.api.utils import action, is_async_query, is_insight_actors_options_query, is_insight_actors_query
-from posthog.clickhouse.client.execute_async import cancel_query, get_query_status
+from posthog.clickhouse.client.execute_async import (
+    ASYNC_QUERY_TASK_FAILED_ERROR_MESSAGE,
+    ASYNC_QUERY_TASK_REVOKED_ERROR_MESSAGE,
+    ASYNC_QUERY_WORKER_LOST_ERROR_MESSAGE,
+    cancel_query,
+    get_query_status,
+)
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.clickhouse.query_tagging import get_query_tag_value, get_query_tags, tag_queries
 from posthog.constants import AvailableFeature
@@ -70,6 +76,12 @@ QUERY_VALIDATION_ERROR_TOTAL = Counter(
     "Query validation failures returned from the query API.",
     labelnames=["query_type", "validation_code"],
 )
+
+ASYNC_QUERY_INFRASTRUCTURE_ERROR_MESSAGES = {
+    ASYNC_QUERY_TASK_FAILED_ERROR_MESSAGE,
+    ASYNC_QUERY_TASK_REVOKED_ERROR_MESSAGE,
+    ASYNC_QUERY_WORKER_LOST_ERROR_MESSAGE,
+}
 
 
 def _extract_validation_code(error: ValidationError) -> str:
@@ -271,7 +283,9 @@ class QueryViewSet(QueryCoalescingMixin, TeamAndOrgViewSetMixin, PydanticModelMi
 
         http_code: int = status.HTTP_202_ACCEPTED
         if query_status.error:
-            if query_status.error_message:
+            if query_status.error_message in ASYNC_QUERY_INFRASTRUCTURE_ERROR_MESSAGES:
+                http_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+            elif query_status.error_message:
                 http_code = status.HTTP_400_BAD_REQUEST  # An error where a user can likely take an action to resolve it
             else:
                 http_code = status.HTTP_500_INTERNAL_SERVER_ERROR  # An internal surprise

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -34,6 +34,7 @@ from posthog.schema import (
 from posthog.hogql.constants import LimitContext
 
 from posthog.api.services.query import process_query_dict, process_query_model
+from posthog.clickhouse.client.execute_async import ASYNC_QUERY_WORKER_LOST_ERROR_MESSAGE
 from posthog.clickhouse.query_tagging import QueryTags
 from posthog.models.insight_variable import InsightVariable
 from posthog.models.utils import UUIDT
@@ -1164,6 +1165,30 @@ class TestQueryRetrieve(APIBaseTest):
         response = self.client.get(f"/api/environments/{self.team.id}/query/{self.valid_query_id}/")
         self.assertEqual(response.status_code, 202)
         self.assertFalse(response.json()["query_status"]["complete"])
+
+    @patch("posthog.clickhouse.client.execute_async.celery.app.AsyncResult")
+    def test_running_query_with_worker_lost_task_returns_error(self, async_result_mock):
+        class WorkerLostError(Exception):
+            pass
+
+        task_result = mock.Mock()
+        task_result.state = "FAILURE"
+        task_result.result = WorkerLostError()
+        async_result_mock.return_value = task_result
+
+        self.redis_client_mock.get.return_value = json.dumps(
+            {
+                "id": self.valid_query_id,
+                "team_id": self.team_id,
+                "complete": False,
+                "task_id": "celery-task-id",
+            }
+        ).encode()
+        response = self.client.get(f"/api/environments/{self.team.id}/query/{self.valid_query_id}/")
+        self.assertEqual(response.status_code, 500)
+        self.assertTrue(response.json()["query_status"]["complete"])
+        self.assertTrue(response.json()["query_status"]["error"])
+        self.assertEqual(response.json()["query_status"]["error_message"], ASYNC_QUERY_WORKER_LOST_ERROR_MESSAGE)
 
     def test_failed_query_with_internal_error(self):
         self.redis_client_mock.get.return_value = json.dumps(

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -4,13 +4,17 @@ import time
 from django.dispatch import receiver
 
 import structlog
-from celery import Celery
+from celery import (
+    Celery,
+    states as celery_states,
+)
 from celery.signals import (
     setup_logging,
     task_failure,
     task_postrun,
     task_prerun,
     task_retry,
+    task_revoked,
     task_success,
     worker_process_init,
 )
@@ -81,6 +85,8 @@ app.conf.broker_pool_limit = 0
 app.steps["worker"].add(DjangoStructLogInitStep)
 
 task_timings: dict[str, float] = {}
+
+PROCESS_QUERY_TASK_NAME = "posthog.tasks.tasks.process_query_task"
 
 
 def _initialize_worker_metrics() -> None:
@@ -181,6 +187,54 @@ def success_signal_handler(sender, **kwargs):
 @task_failure.connect
 def failure_signal_handler(sender, **kwargs):
     CELERY_TASK_FAILURE_COUNTER.labels(task_name=sender.name).inc()
+    _mark_process_query_task_failed_from_signal(sender, kwargs, state=celery_states.FAILURE)
+
+
+@task_revoked.connect
+def revoked_signal_handler(sender=None, request=None, **kwargs):
+    _mark_process_query_task_failed_from_signal(sender, {**kwargs, "request": request}, state=celery_states.REVOKED)
+
+
+def _get_signal_task_name(sender, request) -> str | None:
+    request_task = getattr(request, "task", None)
+    return (
+        getattr(sender, "name", None)
+        or getattr(request_task, "name", None)
+        or getattr(request, "name", None)
+        or (request_task if isinstance(request_task, str) else None)
+    )
+
+
+def _mark_process_query_task_failed_from_signal(sender, signal_kwargs, *, state: str) -> None:
+    request = signal_kwargs.get("request")
+    task_name = _get_signal_task_name(sender, request)
+    if task_name != PROCESS_QUERY_TASK_NAME:
+        return
+
+    args = signal_kwargs.get("args") or getattr(request, "args", None) or ()
+    task_kwargs = signal_kwargs.get("kwargs") or getattr(request, "kwargs", None) or {}
+    task_id = signal_kwargs.get("task_id") or getattr(request, "id", None)
+
+    team_id = task_kwargs.get("team_id")
+    query_id = task_kwargs.get("query_id")
+    if team_id is None and len(args) >= 1:
+        team_id = args[0]
+    if query_id is None and len(args) >= 3:
+        query_id = args[2]
+
+    if team_id is None or query_id is None:
+        logger.warning("failed_to_mark_async_query_task_failed", task_id=task_id, state=state)
+        return
+
+    from posthog.clickhouse.client.execute_async import mark_process_query_task_failed
+
+    mark_process_query_task_failed(
+        team_id=int(team_id),
+        query_id=str(query_id),
+        task_id=str(task_id) if task_id else None,
+        exception=signal_kwargs.get("exception"),
+        state=state,
+    )
 
 
 @task_retry.connect

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING, Optional
 import orjson as json
 import structlog
 import posthoganalytics
-from prometheus_client import Histogram
+from celery import states as celery_states
+from prometheus_client import Counter, Histogram
 from pydantic import BaseModel
 from rest_framework.exceptions import APIException, NotFound
 
@@ -39,6 +40,20 @@ QUERY_WAIT_TIME = Histogram(
 
 QUERY_PROCESS_TIME = Histogram(
     "query_process_time_seconds", "Time from query pick-up to result", labelnames=["team"], buckets=CUSTOM_BUCKETS
+)
+
+QUERY_ASYNC_TASK_FAILURE_TOTAL = Counter(
+    "query_async_task_failure_total",
+    "Async query statuses marked as failed due to a terminal Celery task state.",
+    labelnames=["reason"],
+)
+
+ASYNC_QUERY_WORKER_LOST_ERROR_MESSAGE = (
+    "The worker processing this query stopped before returning results. Please retry the query."
+)
+ASYNC_QUERY_TASK_FAILED_ERROR_MESSAGE = "The async query task failed before returning results. Please retry the query."
+ASYNC_QUERY_TASK_REVOKED_ERROR_MESSAGE = (
+    "The async query task was canceled before returning results. Please retry the query."
 )
 
 
@@ -138,13 +153,84 @@ class QueryStatusManager:
             logger.exception("Clickhouse Status Check Failed", error=e)
             return None
 
-    def get_query_status(self, show_progress: bool = False) -> QueryStatus:
+    def _load_query_status(self) -> QueryStatus:
         byte_results = self._get_results()
 
         if not byte_results:
             raise QueryNotFoundError(f"Query {self.query_id} not found for team {self.team_id}")
 
-        query_status = QueryStatus(**json.loads(byte_results))
+        return QueryStatus(**json.loads(byte_results))
+
+    @staticmethod
+    def _looks_like_worker_lost(exception: object | None) -> bool:
+        if exception is None:
+            return False
+        return exception.__class__.__name__ == "WorkerLostError" or "WorkerLostError" in str(exception)
+
+    def _task_failure_message_and_reason(self, state: str, exception: object | None) -> tuple[str, str]:
+        if state == celery_states.REVOKED:
+            return ASYNC_QUERY_TASK_REVOKED_ERROR_MESSAGE, "revoked"
+        if self._looks_like_worker_lost(exception):
+            return ASYNC_QUERY_WORKER_LOST_ERROR_MESSAGE, "worker_lost"
+        return ASYNC_QUERY_TASK_FAILED_ERROR_MESSAGE, "task_failed"
+
+    def mark_query_status_failed(
+        self, query_status: QueryStatus, *, error_message: str, reason: str, task_id: str | None = None
+    ) -> QueryStatus:
+        if query_status.complete:
+            return query_status
+
+        query_status.complete = True
+        query_status.error = True
+        query_status.error_message = error_message
+        query_status.results = None
+        query_status.end_time = datetime.datetime.now(datetime.UTC)
+        self.store_query_status(query_status)
+
+        QUERY_ASYNC_TASK_FAILURE_TOTAL.labels(reason=reason).inc()
+        logger.warning(
+            "async_query_status_marked_failed",
+            team_id=self.team_id,
+            query_id=self.query_id,
+            task_id=task_id or query_status.task_id,
+            reason=reason,
+        )
+        return query_status
+
+    def _fail_if_task_finished_unsuccessfully(self, query_status: QueryStatus) -> QueryStatus:
+        if query_status.complete or not query_status.task_id:
+            return query_status
+
+        try:
+            task_result = celery.app.AsyncResult(query_status.task_id)
+            task_state = task_result.state
+        except Exception as err:
+            logger.warning(
+                "async_query_task_state_check_failed",
+                team_id=self.team_id,
+                query_id=self.query_id,
+                task_id=query_status.task_id,
+                error=str(err),
+            )
+            return query_status
+
+        if task_state not in (celery_states.FAILURE, celery_states.REVOKED):
+            return query_status
+
+        exception = getattr(task_result, "result", None)
+        error_message, reason = self._task_failure_message_and_reason(task_state, exception)
+        return self.mark_query_status_failed(
+            query_status,
+            error_message=error_message,
+            reason=reason,
+            task_id=query_status.task_id,
+        )
+
+    def get_query_status(self, show_progress: bool = False, check_task_state: bool = True) -> QueryStatus:
+        query_status = self._load_query_status()
+
+        if check_task_state:
+            query_status = self._fail_if_task_finished_unsuccessfully(query_status)
 
         if show_progress and not query_status.complete:
             query_status.query_progress = self.get_clickhouse_progresses()
@@ -172,6 +258,25 @@ class QueryStatusManager:
     def unregister_cache_key_mapping(self, cache_key: str) -> None:
         """Unregister a query that's no longer running."""
         self.redis_client.hdel(self.running_queries_key, cache_key)
+
+
+def mark_process_query_task_failed(
+    *, team_id: int, query_id: str, task_id: str | None, exception: object | None, state: str = celery_states.FAILURE
+) -> None:
+    manager = QueryStatusManager(query_id, team_id)
+    try:
+        query_status = manager.get_query_status(check_task_state=False)
+    except QueryNotFoundError:
+        logger.info(
+            "async_query_status_missing_for_failed_task",
+            team_id=team_id,
+            query_id=query_id,
+            task_id=task_id,
+        )
+        return
+
+    error_message, reason = manager._task_failure_message_and_reason(state, exception)
+    manager.mark_query_status_failed(query_status, error_message=error_message, reason=reason, task_id=task_id)
 
 
 def execute_process_query(

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -19,7 +19,12 @@ from posthog.clickhouse.client import (
     sync_execute,
 )
 from posthog.clickhouse.client.async_task_chain import task_chain_context
-from posthog.clickhouse.client.execute_async import QueryNotFoundError, QueryStatusManager, execute_process_query
+from posthog.clickhouse.client.execute_async import (
+    ASYNC_QUERY_WORKER_LOST_ERROR_MESSAGE,
+    QueryNotFoundError,
+    QueryStatusManager,
+    execute_process_query,
+)
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries
 from posthog.models import Organization, Team
@@ -101,6 +106,30 @@ class TestQueryStatusManager(SimpleTestCase):
 
         self.query_status.expiration_time = None  # We don't care about expiration time in this test
         self.assertEqual(self.manager.get_query_status(show_progress=True), self.query_status)
+
+    @patch("posthog.clickhouse.client.execute_async.celery.app.AsyncResult")
+    def test_get_query_status_marks_worker_lost_task_failed(self, async_result_mock):
+        class WorkerLostError(Exception):
+            pass
+
+        task_result = MagicMock()
+        task_result.state = "FAILURE"
+        task_result.result = WorkerLostError()
+        async_result_mock.return_value = task_result
+
+        self.query_status.task_id = "celery-task-id"
+        self.manager.store_query_status(self.query_status)
+
+        result = self.manager.get_query_status()
+
+        self.assertTrue(result.complete)
+        self.assertTrue(result.error)
+        self.assertEqual(result.error_message, ASYNC_QUERY_WORKER_LOST_ERROR_MESSAGE)
+
+        stored_status = QueryStatus(**json.loads(get_client().get(self.manager.results_key)))
+        self.assertTrue(stored_status.complete)
+        self.assertTrue(stored_status.error)
+        self.assertEqual(stored_status.error_message, ASYNC_QUERY_WORKER_LOST_ERROR_MESSAGE)
 
 
 class TestExecuteProcessQuery(TestCase):

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -94,6 +94,7 @@ def redis_heartbeat() -> None:
     max_retries=10,
     expires=60 * 10,  # Do not run queries that got stuck for more than this
     reject_on_worker_lost=True,
+    store_errors_even_if_ignored=True,
     track_started=True,
 )
 @limit_concurrency(150, limit_name="global")  # Do not go above what CH can handle (max_concurrent_queries)

--- a/posthog/test/test_celery.py
+++ b/posthog/test/test_celery.py
@@ -1,6 +1,9 @@
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+from celery import states as celery_states
+
+from posthog.celery import PROCESS_QUERY_TASK_NAME, _mark_process_query_task_failed_from_signal
 from posthog.tasks.tasks import clickhouse_errors_count
 
 
@@ -20,3 +23,20 @@ class TestCeleryMetrics(TestCase):
                 labels={"name": "NO_ZOOKEEPER", "replica": "ch1", "shard": "1"},
             ),
         )
+
+    @patch("posthog.clickhouse.client.execute_async.mark_process_query_task_failed")
+    def test_process_query_task_failure_signal_marks_query_failed(self, mark_process_query_task_failed_mock):
+        sender = Mock()
+        sender.name = PROCESS_QUERY_TASK_NAME
+
+        _mark_process_query_task_failed_from_signal(
+            sender,
+            {"task_id": "celery-task-id", "args": (123, None, "query-id"), "exception": RuntimeError("boom")},
+            state=celery_states.FAILURE,
+        )
+
+        mark_process_query_task_failed_mock.assert_called_once()
+        self.assertEqual(mark_process_query_task_failed_mock.call_args.kwargs["team_id"], 123)
+        self.assertEqual(mark_process_query_task_failed_mock.call_args.kwargs["query_id"], "query-id")
+        self.assertEqual(mark_process_query_task_failed_mock.call_args.kwargs["task_id"], "celery-task-id")
+        self.assertEqual(mark_process_query_task_failed_mock.call_args.kwargs["state"], celery_states.FAILURE)


### PR DESCRIPTION
## Problem

Async experiment metric queries can stay in a loading state when the Celery worker handling `process_query_task` exits before writing a terminal `QueryStatus` back to Redis. The query API keeps returning `202` for that incomplete status, so the frontend waits until its poll timeout.

## Changes

- Mark async query statuses as failed when Celery reports `process_query_task` failure or revocation.
- Store failed Celery task metadata for `process_query_task` even though successful results are ignored.
- Have the query status endpoint notice terminal Celery `FAILURE` or `REVOKED` states and return a terminal query error instead of continuing to wait.
- Add a Prometheus counter for async query task failures by low-cardinality reason.
- Add backend tests for the worker-lost status path and Celery signal extraction.

Frontend telemetry/error-code classification is intentionally split into the stacked branch `fix/experiment-async-query-task-error-codes`.

## How did you test this code?

- `ruff check posthog/api/query.py posthog/clickhouse/client/execute_async.py posthog/celery.py posthog/tasks/tasks.py posthog/clickhouse/client/test/test_execute_async.py posthog/api/test/test_query.py`
- `pytest posthog/test/test_celery.py posthog/clickhouse/client/test/test_execute_async.py::TestQueryStatusManager posthog/api/test/test_query.py::TestQueryRetrieve`
- Manual deterministic local check comparing this branch against `master`: `master` returned `202` with `complete=false`; this branch returned `500` with `complete=true`, `error=true`, and the worker-lost message.

## Publish to changelog?

do not publish to changelog

## Docs update

No docs update required.

## 🤖 LLM context

Authored by an LLM agent in this repository. The investigation traced async experiment metric polling through the generic query API, `QueryStatusManager`, Celery `process_query_task`, and query API status retrieval. This PR is intentionally scoped to backend behavior for Celery-visible terminal task failures; frontend telemetry classification is split into a stacked follow-up branch. A full pod disappearance that never records a Celery terminal state may still need separate heartbeat or stale-status detection.