### PR TITLE
chore(experiments): add mixed metrics case to summary eval

### DIFF
--- a/ee/hogai/eval/ci/max_tools/eval_experiment_summary.py
+++ b/ee/hogai/eval/ci/max_tools/eval_experiment_summary.py
@@ -61,6 +61,7 @@ Check:
 3. The agent must not declare a winner when results are not statistically significant.
 4. Variant names must match the tool output.
 5. When a metric's goal is "Decrease", a reduction in the metric is a positive outcome. The agent must frame lower values as good and not treat them as a regression.
+6. When multiple metrics are present (primary and secondary), the agent must mention results from both. It must not ignore a significant secondary metric that contradicts the primary.
 
 Choose: pass (all facts accurate, no hallucinations) or fail (any factual error, hallucinated number, or wrong conclusion)
 """.strip()
@@ -236,10 +237,68 @@ MOCK_BAYESIAN_GOAL_DECREASE = MaxExperimentSummaryContext(
 )
 
 
+# Mixed metrics: primary says ship (test wins on conversion), but a secondary
+# guardrail metric shows a significant regression (revenue per user dropped).
+# Checks that Claude surfaces both signals and doesn't cherry-pick the winner.
+MOCK_BAYESIAN_MIXED_METRICS = MaxExperimentSummaryContext(
+    experiment_id=0,  # replaced at runtime
+    experiment_name="Simplified Pricing Page Test",
+    description="Testing whether a simplified pricing page increases plan upgrades",
+    variants=["control", "test"],
+    exposures={"control": 5210.0, "test": 5185.0},
+    primary_metrics_results=[
+        MaxExperimentMetricResult(
+            name="1. Plan upgrade conversion",
+            goal=Goal.INCREASE,
+            variant_results=[
+                MaxExperimentVariantResultBayesian(
+                    key="control",
+                    chance_to_win=0.09,
+                    credible_interval=[-0.041, 0.008],
+                    delta=-0.0165,
+                    significant=False,
+                ),
+                MaxExperimentVariantResultBayesian(
+                    key="test",
+                    chance_to_win=0.91,
+                    credible_interval=[0.015, 0.058],
+                    delta=0.0365,
+                    significant=True,
+                ),
+            ],
+        ),
+    ],
+    secondary_metrics_results=[
+        MaxExperimentMetricResult(
+            name="1. Revenue per user",
+            goal=Goal.INCREASE,
+            variant_results=[
+                MaxExperimentVariantResultBayesian(
+                    key="control",
+                    chance_to_win=0.86,
+                    credible_interval=[0.012, 0.049],
+                    delta=0.0305,
+                    significant=True,
+                ),
+                MaxExperimentVariantResultBayesian(
+                    key="test",
+                    chance_to_win=0.14,
+                    credible_interval=[-0.049, -0.012],
+                    delta=-0.0305,
+                    significant=False,
+                ),
+            ],
+        ),
+    ],
+    stats_method=ExperimentStatsMethod.BAYESIAN,
+)
+
+
 MOCK_CONTEXTS: dict[str, MaxExperimentSummaryContext] = {
     "bayesian_significant": MOCK_BAYESIAN_SIGNIFICANT,
     "bayesian_non_significant": MOCK_BAYESIAN_NON_SIGNIFICANT,
     "bayesian_goal_decrease": MOCK_BAYESIAN_GOAL_DECREASE,
+    "bayesian_mixed_metrics": MOCK_BAYESIAN_MIXED_METRICS,
 }
 
 
@@ -370,6 +429,13 @@ async def eval_experiment_summary(call_agent_for_summary, pytestconfig):
                     mock_key="bayesian_goal_decrease",
                 ),
                 metadata={"test_type": "bayesian_goal_decrease"},
+            ),
+            EvalCase(
+                input=EvalInput(
+                    input="Summarize experiment {experiment_id}. What do the results show?",
+                    mock_key="bayesian_mixed_metrics",
+                ),
+                metadata={"test_type": "bayesian_mixed_metrics"},
             ),
         ],
         pytestconfig=pytestconfig,

--- a/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
+++ b/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
@@ -997,15 +997,7 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.person_id,
-               events.`mat_$browser`,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-13'), lessOrEquals(toDate(events.timestamp), '2024-01-17'))) AS events
+     FROM events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Australia/Sydney')), max(toTimeZone(raw_sessions.max_timestamp, 'Australia/Sydney'))), 10)))) AS `$is_bounce`,
@@ -1022,7 +1014,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Australia/Sydney'))), lessOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Australia/Sydney')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Australia/Sydney'))), lessOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Australia/Sydney')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
@@ -1079,7 +1071,15 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events
+     FROM
+       (SELECT events.`$session_id_uuid`,
+               events.distinct_id,
+               events.event,
+               events.person_id,
+               events.`mat_$browser`,
+               events.timestamp
+        FROM events
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-13'), lessOrEquals(toDate(events.timestamp), '2024-01-17'))) AS events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Pacific/Auckland')), max(toTimeZone(raw_sessions.max_timestamp, 'Pacific/Auckland'))), 10)))) AS `$is_bounce`,
@@ -1096,7 +1096,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Pacific/Auckland'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Pacific/Auckland'))), lessOrEquals(toTimeZone(events.timestamp, 'Pacific/Auckland'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Pacific/Auckland')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
+     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Pacific/Auckland'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Pacific/Auckland'))), lessOrEquals(toTimeZone(events.timestamp, 'Pacific/Auckland'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Pacific/Auckland')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`


### PR DESCRIPTION
## Problem

Existing eval cases all have a single metric. Real experiments often have primary and secondary metrics that tell different stories — e.g. conversion goes up but revenue per user goes down.

## Changes

Fourth eval case: primary metric (plan upgrade conversion) shows test winning significantly, but secondary metric (revenue per user) shows a significant regression. Checks that Claude surfaces both signals and doesn't just cherry-pick the winning metric.

Also added rule #6 to the scorer prompt for multi-metric coverage.

## How did you test this code?

All four cases pass at 100% locally.