### PR TITLE

feat(llma): Add AI-powered evaluation description generation endpoint

### DIFF
--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -72,6 +72,7 @@ from products.llm_analytics.backend.api import (
     LLMAnalyticsSummarizationViewSet,
     LLMAnalyticsTextReprViewSet,
     LLMAnalyticsTranslateViewSet,
+    LLMEvaluationDescriptionViewSet,
     LLMEvaluationSummaryViewSet,
     LLMModelsViewSet,
     LLMProviderKeyValidationViewSet,
@@ -1321,6 +1322,13 @@ environments_router.register(
     r"llm_analytics/evaluation_summary",
     LLMEvaluationSummaryViewSet,
     "environment_llm_analytics_evaluation_summary",
+    ["team_id"],
+)
+
+environments_router.register(
+    r"llm_analytics/evaluation_description",
+    LLMEvaluationDescriptionViewSet,
+    "environment_llm_analytics_evaluation_description",
     ["team_id"],
 )
 

--- a/products/llm_analytics/backend/api/__init__.py
+++ b/products/llm_analytics/backend/api/__init__.py
@@ -3,6 +3,7 @@ from .clustering_config import ClusteringConfigViewSet
 from .clustering_job import ClusteringJobViewSet
 from .datasets import DatasetItemViewSet, DatasetViewSet
 from .evaluation_config import EvaluationConfigViewSet
+from .evaluation_description import LLMEvaluationDescriptionViewSet
 from .evaluation_reports import EvaluationReportViewSet
 from .evaluation_runs import EvaluationRunViewSet
 from .evaluation_summary import LLMEvaluationSummaryViewSet
@@ -28,6 +29,7 @@ __all__ = [
     "LLMAnalyticsSummarizationViewSet",
     "LLMAnalyticsTranslateViewSet",
     "LLMEvaluationSummaryViewSet",
+    "LLMEvaluationDescriptionViewSet",
     "SUPPORTED_MODELS_WITH_THINKING",
     "DatasetViewSet",
     "DatasetItemViewSet",

--- a/products/llm_analytics/backend/api/evaluation_description.py
+++ b/products/llm_analytics/backend/api/evaluation_description.py
@@ -1,0 +1,256 @@
+"""
+Django REST API endpoint for generating LLM evaluation descriptions.
+
+This ViewSet provides AI-powered generation of a concise description for an
+LLM evaluation based on its current configuration (name, prompt or Hog source,
+evaluation type). It can be used both when creating a new evaluation (before
+an ID exists) and when updating an existing one.
+
+Endpoints:
+- POST /api/environments/:id/llm_analytics/evaluation_description/ - Generate description
+"""
+
+import time
+from typing import cast
+
+import structlog
+from asgiref.sync import async_to_sync
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiExample, extend_schema
+from rest_framework import exceptions, serializers, status, viewsets
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.api.monitoring import monitor
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.event_usage import report_user_action
+from posthog.models import User
+from posthog.permissions import AccessControlPermission
+from posthog.rate_limit import (
+    LLMAnalyticsSummarizationBurstThrottle,
+    LLMAnalyticsSummarizationDailyThrottle,
+    LLMAnalyticsSummarizationSustainedThrottle,
+)
+
+from products.llm_analytics.backend.api.metrics import llma_track_latency
+from products.llm_analytics.backend.summarization.llm.evaluation_description import generate_evaluation_description
+from products.llm_analytics.backend.summarization.models import OpenAIModel
+
+logger = structlog.get_logger(__name__)
+
+DESCRIPTION_MAX_LENGTH = 500
+PROMPT_MAX_LENGTH = 20000
+SOURCE_MAX_LENGTH = 20000
+
+
+class EvaluationDescriptionRequestSerializer(serializers.Serializer):
+    """Request serializer for evaluation description generation.
+
+    Accepts the current (possibly unsaved) evaluation configuration so the
+    feature works both for new evaluations and edits-in-progress.
+    """
+
+    evaluation_type = serializers.ChoiceField(
+        choices=["llm_judge", "hog"],
+        required=True,
+        help_text="The evaluation type ('llm_judge' or 'hog')",
+    )
+    name = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        max_length=400,
+        default="",
+        help_text="Current evaluation name (optional)",
+    )
+    prompt = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        max_length=PROMPT_MAX_LENGTH,
+        default="",
+        help_text="Current LLM judge prompt (required when evaluation_type is 'llm_judge')",
+    )
+    source = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        max_length=SOURCE_MAX_LENGTH,
+        default="",
+        help_text="Current Hog source code (required when evaluation_type is 'hog')",
+    )
+    allows_na = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="Whether the evaluation allows 'Not applicable' results",
+    )
+    existing_description = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        max_length=DESCRIPTION_MAX_LENGTH,
+        default="",
+        help_text="The current description, if any, to use as a hint",
+    )
+
+    def validate(self, attrs: dict) -> dict:
+        evaluation_type = attrs["evaluation_type"]
+        prompt = (attrs.get("prompt") or "").strip()
+        source = (attrs.get("source") or "").strip()
+        name = (attrs.get("name") or "").strip()
+
+        if evaluation_type == "llm_judge" and not prompt and not name:
+            raise serializers.ValidationError("Cannot generate description: add a name or a judge prompt first.")
+        if evaluation_type == "hog" and not source and not name:
+            raise serializers.ValidationError("Cannot generate description: add a name or Hog source code first.")
+        return attrs
+
+
+class EvaluationDescriptionResponseSerializer(serializers.Serializer):
+    description = serializers.CharField()
+
+
+class LLMEvaluationDescriptionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    """
+    ViewSet for generating LLM evaluation descriptions.
+
+    Produces a short, human-readable description based on the current
+    evaluation configuration. Works for both LLM judge and Hog code evaluations,
+    and for both new (unsaved) and existing evaluations.
+    """
+
+    scope_object = "llm_analytics"
+    permission_classes = [AccessControlPermission]
+
+    def get_throttles(self):
+        """Rate limit shared with other LLM-powered endpoints to control costs."""
+        return [
+            LLMAnalyticsSummarizationBurstThrottle(),
+            LLMAnalyticsSummarizationSustainedThrottle(),
+            LLMAnalyticsSummarizationDailyThrottle(),
+        ]
+
+    def _validate_feature_access(self, request: Request) -> None:
+        """Validate that the user is authenticated and AI data processing is approved."""
+        if not request.user.is_authenticated:
+            raise exceptions.NotAuthenticated()
+
+        if not self.organization.is_ai_data_processing_approved:
+            raise exceptions.PermissionDenied(
+                "AI data processing must be approved by your organization before using description generation"
+            )
+
+    @extend_schema(
+        request=EvaluationDescriptionRequestSerializer,
+        responses={
+            200: EvaluationDescriptionResponseSerializer,
+            400: OpenApiTypes.OBJECT,
+            403: OpenApiTypes.OBJECT,
+            500: OpenApiTypes.OBJECT,
+        },
+        examples=[
+            OpenApiExample(
+                "LLM Judge Description Request",
+                description="Generate a description for a new LLM judge evaluation",
+                value={
+                    "evaluation_type": "llm_judge",
+                    "name": "Helpfulness Check",
+                    "prompt": "Rate true if the assistant's response is helpful, actionable, and directly answers the user's question.",
+                    "allows_na": False,
+                },
+                request_only=True,
+            ),
+            OpenApiExample(
+                "Hog Description Request",
+                description="Generate a description for a Hog evaluation",
+                value={
+                    "evaluation_type": "hog",
+                    "name": "Output not empty",
+                    "source": "let result := length(output) > 0\nreturn result",
+                    "allows_na": False,
+                },
+                request_only=True,
+            ),
+            OpenApiExample(
+                "Success Response",
+                value={
+                    "description": "Checks whether the assistant's response directly addresses the user's question."
+                },
+                response_only=True,
+                status_codes=["200"],
+            ),
+        ],
+        description="""
+Generate an AI-powered description for an LLM evaluation based on its current configuration.
+
+Works for both LLM judge evaluations (prompt-based) and Hog code evaluations (code-based).
+Can be used before the evaluation is saved — no evaluation ID is required.
+        """,
+        tags=["LLM Analytics"],
+    )
+    @llma_track_latency("llma_evaluation_description")
+    @monitor(feature=None, endpoint="llma_evaluation_description", method="POST")
+    def create(self, request: Request, **kwargs) -> Response:
+        """
+        Generate a description for an evaluation.
+
+        POST /api/environments/:id/llm_analytics/evaluation_description/
+        """
+        self._validate_feature_access(request)
+
+        serializer = EvaluationDescriptionRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            data = serializer.validated_data
+            user = cast(User, self.request.user)
+            start_time = time.time()
+
+            generated = async_to_sync(generate_evaluation_description)(
+                team_id=self.team_id,
+                model=OpenAIModel.GPT_4_1_MINI,
+                evaluation_type=data["evaluation_type"],
+                evaluation_name=data.get("name", ""),
+                evaluation_prompt=data.get("prompt", ""),
+                evaluation_source=data.get("source", ""),
+                allows_na=data.get("allows_na", False),
+                existing_description=data.get("existing_description", ""),
+                user_distinct_id=user.distinct_id or "",
+            )
+            duration_seconds = time.time() - start_time
+
+            result = {"description": generated.description.strip()[:DESCRIPTION_MAX_LENGTH]}
+
+            logger.info(
+                "Generated evaluation description",
+                team_id=self.team_id,
+                evaluation_type=data["evaluation_type"],
+                duration_seconds=duration_seconds,
+            )
+
+            report_user_action(
+                user,
+                "llma evaluation description generated",
+                {
+                    "evaluation_type": data["evaluation_type"],
+                    "has_existing_description": bool(data.get("existing_description", "").strip()),
+                    "duration_seconds": duration_seconds,
+                },
+                team=self.team,
+                request=self.request,
+            )
+
+            return Response(result, status=status.HTTP_200_OK)
+
+        except exceptions.ValidationError:
+            raise
+        except Exception as e:
+            logger.exception(
+                "Failed to generate evaluation description",
+                team_id=self.team_id,
+                error=str(e),
+            )
+            return Response(
+                {
+                    "error": "Failed to generate description",
+                    "detail": "An error occurred while generating the description",
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )

--- a/products/llm_analytics/backend/api/evaluation_description.py
+++ b/products/llm_analytics/backend/api/evaluation_description.py
@@ -39,6 +39,10 @@ from products.llm_analytics.backend.summarization.models import OpenAIModel
 logger = structlog.get_logger(__name__)
 
 DESCRIPTION_MAX_LENGTH = 500
+# The Evaluation.description field is an unbounded TextField and may legitimately
+# exceed the UI cap for legacy or API-set values. Accept a longer hint so
+# regeneration requests for those records aren't hard-rejected.
+EXISTING_DESCRIPTION_MAX_LENGTH = 20000
 PROMPT_MAX_LENGTH = 20000
 SOURCE_MAX_LENGTH = 20000
 
@@ -84,7 +88,7 @@ class EvaluationDescriptionRequestSerializer(serializers.Serializer):
     existing_description = serializers.CharField(
         required=False,
         allow_blank=True,
-        max_length=DESCRIPTION_MAX_LENGTH,
+        max_length=EXISTING_DESCRIPTION_MAX_LENGTH,
         default="",
         help_text="The current description, if any, to use as a hint",
     )

--- a/products/llm_analytics/backend/api/test/test_evaluation_description.py
+++ b/products/llm_analytics/backend/api/test/test_evaluation_description.py
@@ -1,0 +1,201 @@
+"""
+Tests for evaluation description generation API endpoint.
+"""
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from rest_framework import status
+
+from products.llm_analytics.backend.summarization.llm.description_schema import EvaluationDescriptionResponse
+
+
+class TestEvaluationDescriptionAPI(APIBaseTest):
+    """Test the evaluation description generation endpoint."""
+
+    URL = "/api/environments/{team_id}/llm_analytics/evaluation_description/"
+
+    def _url(self) -> str:
+        return self.URL.format(team_id=self.team.id)
+
+    def _approve_ai(self) -> None:
+        self.organization.is_ai_data_processing_approved = True
+        self.organization.save()
+
+    def test_unauthenticated_user_cannot_access_endpoint(self):
+        self.client.logout()
+        response = self.client.post(self._url())
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_ai_consent_required(self):
+        self.organization.is_ai_data_processing_approved = False
+        self.organization.save()
+
+        response = self.client.post(
+            self._url(),
+            {
+                "evaluation_type": "llm_judge",
+                "name": "Helpfulness",
+                "prompt": "Is this helpful?",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "AI data processing must be approved" in response.data["detail"]
+
+    def test_missing_evaluation_type(self):
+        self._approve_ai()
+
+        response = self.client.post(self._url(), {}, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "evaluation_type" in response.data
+
+    def test_invalid_evaluation_type(self):
+        self._approve_ai()
+
+        response = self.client.post(
+            self._url(),
+            {"evaluation_type": "python", "prompt": "..."},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_llm_judge_requires_name_or_prompt(self):
+        self._approve_ai()
+
+        response = self.client.post(
+            self._url(),
+            {"evaluation_type": "llm_judge", "name": "", "prompt": ""},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_hog_requires_name_or_source(self):
+        self._approve_ai()
+
+        response = self.client.post(
+            self._url(),
+            {"evaluation_type": "hog", "name": "", "source": ""},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @patch("products.llm_analytics.backend.api.evaluation_description.async_to_sync")
+    def test_successful_generation_llm_judge(self, mock_async_to_sync):
+        self._approve_ai()
+
+        mock_async_to_sync.return_value = lambda **kwargs: EvaluationDescriptionResponse(
+            description="Checks whether the assistant's response directly answers the user's question."
+        )
+
+        response = self.client.post(
+            self._url(),
+            {
+                "evaluation_type": "llm_judge",
+                "name": "Helpfulness",
+                "prompt": "Is the response helpful and accurate?",
+                "allows_na": False,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["description"] == (
+            "Checks whether the assistant's response directly answers the user's question."
+        )
+
+    @patch("products.llm_analytics.backend.api.evaluation_description.async_to_sync")
+    def test_successful_generation_hog(self, mock_async_to_sync):
+        self._approve_ai()
+
+        mock_async_to_sync.return_value = lambda **kwargs: EvaluationDescriptionResponse(
+            description="Verifies the response is non-empty."
+        )
+
+        response = self.client.post(
+            self._url(),
+            {
+                "evaluation_type": "hog",
+                "name": "Non-empty output",
+                "source": "return length(output) > 0",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["description"] == "Verifies the response is non-empty."
+
+    @patch("products.llm_analytics.backend.api.evaluation_description.async_to_sync")
+    def test_passes_existing_description(self, mock_async_to_sync):
+        self._approve_ai()
+
+        captured_kwargs: dict = {}
+
+        def _call(**kwargs):
+            captured_kwargs.update(kwargs)
+            return EvaluationDescriptionResponse(description="Updated description.")
+
+        mock_async_to_sync.return_value = _call
+
+        response = self.client.post(
+            self._url(),
+            {
+                "evaluation_type": "llm_judge",
+                "name": "Helpfulness",
+                "prompt": "Is the response helpful?",
+                "existing_description": "Old description that's outdated.",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert captured_kwargs["existing_description"] == "Old description that's outdated."
+        assert captured_kwargs["evaluation_type"] == "llm_judge"
+        assert captured_kwargs["evaluation_prompt"] == "Is the response helpful?"
+
+    @patch("products.llm_analytics.backend.api.evaluation_description.async_to_sync")
+    def test_truncates_long_description(self, mock_async_to_sync):
+        self._approve_ai()
+
+        long_description = "x" * 1000
+        mock_async_to_sync.return_value = lambda **kwargs: EvaluationDescriptionResponse(description=long_description)
+
+        response = self.client.post(
+            self._url(),
+            {
+                "evaluation_type": "llm_judge",
+                "name": "Test",
+                "prompt": "Check this",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        # Enforced max of 500 chars on the response
+        assert len(response.data["description"]) == 500
+
+    @patch("products.llm_analytics.backend.api.evaluation_description.async_to_sync")
+    def test_generation_error_returns_500(self, mock_async_to_sync):
+        self._approve_ai()
+
+        def _raise(**kwargs):
+            raise RuntimeError("LLM exploded")
+
+        mock_async_to_sync.return_value = _raise
+
+        response = self.client.post(
+            self._url(),
+            {
+                "evaluation_type": "llm_judge",
+                "name": "Test",
+                "prompt": "Check this",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/products/llm_analytics/backend/api/test/test_evaluation_description.py
+++ b/products/llm_analytics/backend/api/test/test_evaluation_description.py
@@ -5,6 +5,7 @@ Tests for evaluation description generation API endpoint.
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from parameterized import parameterized
 from rest_framework import status
 
 from products.llm_analytics.backend.summarization.llm.description_schema import EvaluationDescriptionResponse
@@ -63,72 +64,54 @@ class TestEvaluationDescriptionAPI(APIBaseTest):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_llm_judge_requires_name_or_prompt(self):
+    @parameterized.expand(
+        [
+            ("llm_judge", {"evaluation_type": "llm_judge", "name": "", "prompt": ""}),
+            ("hog", {"evaluation_type": "hog", "name": "", "source": ""}),
+        ]
+    )
+    def test_requires_name_or_config(self, _label, payload):
         self._approve_ai()
 
-        response = self.client.post(
-            self._url(),
-            {"evaluation_type": "llm_judge", "name": "", "prompt": ""},
-            format="json",
-        )
+        response = self.client.post(self._url(), payload, format="json")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_hog_requires_name_or_source(self):
-        self._approve_ai()
-
-        response = self.client.post(
-            self._url(),
-            {"evaluation_type": "hog", "name": "", "source": ""},
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-
+    @parameterized.expand(
+        [
+            (
+                "llm_judge",
+                {
+                    "evaluation_type": "llm_judge",
+                    "name": "Helpfulness",
+                    "prompt": "Is the response helpful and accurate?",
+                    "allows_na": False,
+                },
+                "Checks whether the assistant's response directly answers the user's question.",
+            ),
+            (
+                "hog",
+                {
+                    "evaluation_type": "hog",
+                    "name": "Non-empty output",
+                    "source": "return length(output) > 0",
+                },
+                "Verifies the response is non-empty.",
+            ),
+        ]
+    )
     @patch("products.llm_analytics.backend.api.evaluation_description.async_to_sync")
-    def test_successful_generation_llm_judge(self, mock_async_to_sync):
+    def test_successful_generation(self, _label, payload, generated_description, mock_async_to_sync):
         self._approve_ai()
 
         mock_async_to_sync.return_value = lambda **kwargs: EvaluationDescriptionResponse(
-            description="Checks whether the assistant's response directly answers the user's question."
+            description=generated_description
         )
 
-        response = self.client.post(
-            self._url(),
-            {
-                "evaluation_type": "llm_judge",
-                "name": "Helpfulness",
-                "prompt": "Is the response helpful and accurate?",
-                "allows_na": False,
-            },
-            format="json",
-        )
+        response = self.client.post(self._url(), payload, format="json")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data["description"] == (
-            "Checks whether the assistant's response directly answers the user's question."
-        )
-
-    @patch("products.llm_analytics.backend.api.evaluation_description.async_to_sync")
-    def test_successful_generation_hog(self, mock_async_to_sync):
-        self._approve_ai()
-
-        mock_async_to_sync.return_value = lambda **kwargs: EvaluationDescriptionResponse(
-            description="Verifies the response is non-empty."
-        )
-
-        response = self.client.post(
-            self._url(),
-            {
-                "evaluation_type": "hog",
-                "name": "Non-empty output",
-                "source": "return length(output) > 0",
-            },
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data["description"] == "Verifies the response is non-empty."
+        assert response.data["description"] == generated_description
 
     @patch("products.llm_analytics.backend.api.evaluation_description.async_to_sync")
     def test_passes_existing_description(self, mock_async_to_sync):
@@ -157,6 +140,27 @@ class TestEvaluationDescriptionAPI(APIBaseTest):
         assert captured_kwargs["existing_description"] == "Old description that's outdated."
         assert captured_kwargs["evaluation_type"] == "llm_judge"
         assert captured_kwargs["evaluation_prompt"] == "Is the response helpful?"
+
+    @patch("products.llm_analytics.backend.api.evaluation_description.async_to_sync")
+    def test_accepts_long_existing_description(self, mock_async_to_sync):
+        self._approve_ai()
+
+        mock_async_to_sync.return_value = lambda **kwargs: EvaluationDescriptionResponse(description="Updated.")
+
+        # Simulates a legacy record whose description exceeds the UI cap of 500 chars.
+        long_existing = "x" * 4000
+        response = self.client.post(
+            self._url(),
+            {
+                "evaluation_type": "llm_judge",
+                "name": "Helpfulness",
+                "prompt": "Is the response helpful?",
+                "existing_description": long_existing,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
 
     @patch("products.llm_analytics.backend.api.evaluation_description.async_to_sync")
     def test_truncates_long_description(self, mock_async_to_sync):

--- a/products/llm_analytics/backend/summarization/llm/description_schema.py
+++ b/products/llm_analytics/backend/summarization/llm/description_schema.py
@@ -1,0 +1,15 @@
+"""
+Pydantic schema for structured LLM evaluation description generation outputs.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class EvaluationDescriptionResponse(BaseModel):
+    """Structured response from LLM evaluation description generation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    description: str = Field(
+        description="A concise, 1-3 sentence description of what the evaluation checks for, in plain English.",
+    )

--- a/products/llm_analytics/backend/summarization/llm/evaluation_description.py
+++ b/products/llm_analytics/backend/summarization/llm/evaluation_description.py
@@ -1,0 +1,128 @@
+"""LLM gateway-based evaluation description generation."""
+
+from typing import Any, cast
+
+import structlog
+from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletionMessageParam
+from rest_framework import exceptions
+
+from posthog.llm.gateway_client import get_llm_client
+
+from ..constants import SUMMARIZATION_TIMEOUT
+from ..models import OpenAIModel
+from ..utils import load_summarization_template
+from .description_schema import EvaluationDescriptionResponse
+
+logger = structlog.get_logger(__name__)
+
+
+EVALUATION_TYPE_LABELS = {
+    "llm_judge": "LLM judge (uses an LLM to grade each generation against a natural-language prompt)",
+    "hog": "Hog code (runs deterministic code against each generation)",
+}
+
+
+async def generate_evaluation_description(
+    team_id: int,
+    model: OpenAIModel,
+    evaluation_type: str,
+    evaluation_name: str = "",
+    evaluation_prompt: str = "",
+    evaluation_source: str = "",
+    allows_na: bool = False,
+    existing_description: str = "",
+    user_distinct_id: str = "",
+) -> EvaluationDescriptionResponse:
+    """
+    Generate a concise description for an evaluation using LLM gateway with structured outputs.
+
+    Args:
+        team_id: Team ID for logging and tracking
+        model: OpenAI model to use
+        evaluation_type: "llm_judge" or "hog"
+        evaluation_name: Current name of the evaluation
+        evaluation_prompt: Judge prompt (for llm_judge type)
+        evaluation_source: Hog source code (for hog type)
+        allows_na: Whether the evaluation allows "Not applicable" results
+        existing_description: The current description (used as a hint; may be rewritten)
+        user_distinct_id: Distinct ID of the user for analytics tracking
+
+    Returns:
+        Structured description response
+    """
+    if evaluation_type not in EVALUATION_TYPE_LABELS:
+        raise exceptions.ValidationError(f"Unknown evaluation type: {evaluation_type}")
+
+    has_config = bool(evaluation_prompt.strip()) if evaluation_type == "llm_judge" else bool(evaluation_source.strip())
+    if not has_config and not evaluation_name.strip():
+        raise exceptions.ValidationError(
+            "Cannot generate a description: evaluation has no name, prompt, or source code yet."
+        )
+
+    system_prompt = load_summarization_template(
+        "prompts/evaluation_description.djt",
+        {
+            "evaluation_type": evaluation_type,
+            "evaluation_type_label": EVALUATION_TYPE_LABELS[evaluation_type],
+            "evaluation_name": evaluation_name,
+            "evaluation_prompt": evaluation_prompt,
+            "evaluation_source": evaluation_source,
+            "allows_na": allows_na,
+            "existing_description": existing_description,
+        },
+    )
+
+    user_prompt = "Generate a concise description for this evaluation."
+
+    sync_client = get_llm_client("llma_eval_description")
+    client = AsyncOpenAI(
+        base_url=sync_client.base_url,
+        api_key=sync_client.api_key,
+        timeout=SUMMARIZATION_TIMEOUT,
+    )
+
+    messages: list[ChatCompletionMessageParam] = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt},
+    ]
+
+    try:
+        response = await client.chat.completions.create(
+            model=str(model),
+            messages=messages,
+            user=user_distinct_id or "llma-evaluation-description",
+            response_format=cast(
+                Any,
+                {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "evaluation_description",
+                        "strict": True,
+                        "schema": EvaluationDescriptionResponse.model_json_schema(),
+                    },
+                },
+            ),
+        )
+
+        content = response.choices[0].message.content
+        if not content:
+            logger.error(
+                "evaluation_description_empty_response",
+                team_id=team_id,
+                model=str(model),
+            )
+            raise exceptions.APIException("Failed to generate evaluation description: empty response")
+
+        return EvaluationDescriptionResponse.model_validate_json(content)
+
+    except exceptions.APIException:
+        raise
+    except Exception as e:
+        logger.exception(
+            "evaluation_description_failed",
+            team_id=team_id,
+            model=str(model),
+            error=str(e),
+        )
+        raise exceptions.APIException("Failed to generate evaluation description") from e

--- a/products/llm_analytics/backend/summarization/llm/evaluation_description.py
+++ b/products/llm_analytics/backend/summarization/llm/evaluation_description.py
@@ -3,11 +3,10 @@
 from typing import Any, cast
 
 import structlog
-from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletionMessageParam
 from rest_framework import exceptions
 
-from posthog.llm.gateway_client import get_llm_client
+from posthog.llm.gateway_client import get_async_llm_client
 
 from ..constants import SUMMARIZATION_TIMEOUT
 from ..models import OpenAIModel
@@ -75,12 +74,10 @@ async def generate_evaluation_description(
 
     user_prompt = "Generate a concise description for this evaluation."
 
-    sync_client = get_llm_client("llma_eval_description")
-    client = AsyncOpenAI(
-        base_url=sync_client.base_url,
-        api_key=sync_client.api_key,
-        timeout=SUMMARIZATION_TIMEOUT,
-    )
+    # Reuse the registered "llma_eval_summary" product slug — this endpoint is semantically
+    # part of the same feature. Adding a new slug requires a coordinated change in
+    # services/llm-gateway/src/llm_gateway/products/config.py.
+    client = get_async_llm_client("llma_eval_summary").with_options(timeout=SUMMARIZATION_TIMEOUT)
 
     messages: list[ChatCompletionMessageParam] = [
         {"role": "system", "content": system_prompt},

--- a/products/llm_analytics/backend/summarization/prompts/evaluation_description.djt
+++ b/products/llm_analytics/backend/summarization/prompts/evaluation_description.djt
@@ -1,0 +1,43 @@
+You are an expert at writing concise, clear descriptions for LLM evaluations. Your task is to write a short description (1-3 sentences) that explains what an evaluation checks for, based on its configuration.
+
+## Evaluation Context
+
+{% if evaluation_name %}**Name:** {{ evaluation_name }}
+{% endif %}
+**Type:** {{ evaluation_type_label }}
+
+{% if allows_na %}This evaluation may return "Not applicable" when the criteria doesn't apply to a given generation.
+{% endif %}
+{% if evaluation_type == "llm_judge" %}
+**Judge Prompt (used by the LLM judge to decide pass/fail):**
+```
+{{ evaluation_prompt }}
+```
+{% elif evaluation_type == "hog" %}
+**Hog Source Code (deterministic code run against each generation):**
+```
+{{ evaluation_source }}
+```
+{% endif %}
+
+{% if existing_description %}
+**Current Description (may be outdated or incomplete; rewrite to reflect the current configuration):**
+```
+{{ existing_description }}
+```
+{% endif %}
+
+## Guidelines
+
+- Write 1-3 sentences, plain English, no jargon
+- Focus on WHAT the evaluation checks for, not HOW it does it
+- Do not mention "LLM judge" or "Hog code" in the description — users already know the evaluation type from context
+- Do not start with "This evaluation..." — be direct
+- Do not include Markdown, quotes, or code blocks
+- Keep under 400 characters
+- If the configuration is empty or nonsensical, return a short placeholder like "Checks quality of LLM responses."
+
+Return JSON matching this schema:
+{
+  "description": "A concise description of what the evaluation checks for."
+}

--- a/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
+++ b/products/llm_analytics/frontend/evaluations/LLMAnalyticsEvaluation.tsx
@@ -3,7 +3,7 @@ import { Field, Form } from 'kea-forms'
 import { combineUrl, router } from 'kea-router'
 import { useRef } from 'react'
 
-import { IconArrowLeft, IconInfo, IconPlay, IconTrends, IconWarning } from '@posthog/icons'
+import { IconArrowLeft, IconInfo, IconPlay, IconSparkles, IconTrends, IconWarning } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
@@ -57,6 +57,8 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
         activeTab,
         canEnable,
         canEnableReason,
+        generatedDescriptionLoading,
+        canGenerateDescription,
     } = useValues(llmEvaluationLogic)
     const { user } = useValues(userLogic)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -71,6 +73,7 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
         setEvaluationType,
         setSignalEmission,
         setActiveTab,
+        generateEvaluationDescription,
     } = useActions(llmEvaluationLogic)
     const { push } = useActions(router)
     const triggersRef = useRef<HTMLDivElement>(null)
@@ -385,13 +388,48 @@ export function LLMAnalyticsEvaluation(): JSX.Element {
                                                 )}
                                             </p>
 
-                                            <Field name="description" label="Description (optional)">
+                                            <Field
+                                                name="description"
+                                                label={
+                                                    <div className="flex items-center justify-between w-full gap-2">
+                                                        <span>Description (optional)</span>
+                                                        <Tooltip
+                                                            title={
+                                                                canGenerateDescription
+                                                                    ? evaluation.description
+                                                                        ? 'Rewrite the description based on the current configuration'
+                                                                        : 'Generate a description based on the current configuration'
+                                                                    : isHog
+                                                                      ? 'Add a name or Hog code first to generate a description'
+                                                                      : 'Add a name or judge prompt first to generate a description'
+                                                            }
+                                                        >
+                                                            <span>
+                                                                <LemonButton
+                                                                    type="secondary"
+                                                                    size="xsmall"
+                                                                    icon={<IconSparkles />}
+                                                                    onClick={generateEvaluationDescription}
+                                                                    loading={generatedDescriptionLoading}
+                                                                    disabled={!canGenerateDescription}
+                                                                    data-attr="llma-evaluation-generate-description"
+                                                                >
+                                                                    {evaluation.description
+                                                                        ? 'Regenerate with AI'
+                                                                        : 'Generate with AI'}
+                                                                </LemonButton>
+                                                            </span>
+                                                        </Tooltip>
+                                                    </div>
+                                                }
+                                            >
                                                 <LemonTextArea
                                                     value={evaluation.description || ''}
                                                     onChange={setEvaluationDescription}
-                                                    placeholder="Describe what this evaluation checks for..."
+                                                    placeholder="Describe what this evaluation checks for, or click 'Generate with AI' to fill it in automatically."
                                                     rows={2}
                                                     maxLength={500}
+                                                    disabled={generatedDescriptionLoading}
                                                 />
                                             </Field>
 

--- a/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/llm_analytics/frontend/evaluations/llmEvaluationLogic.ts
@@ -119,6 +119,9 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
         toggleSummaryExpanded: true,
         regenerateEvaluationSummary: true,
         trackSummarizeClicked: true,
+
+        // Description generation actions
+        generateEvaluationDescription: true,
     }),
 
     loaders(({ props, values }) => ({
@@ -173,6 +176,40 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                         evaluationId: props.evaluationId,
                         forceRefresh: values.isForceRefresh,
                     })
+                },
+            },
+        ],
+        generatedDescription: [
+            null as string | null,
+            {
+                runGenerateEvaluationDescription: async (_, breakpoint): Promise<string | null> => {
+                    const teamId = teamLogic.values.currentTeamId
+                    if (!teamId) {
+                        return null
+                    }
+                    const evaluation = values.evaluation
+                    if (!evaluation) {
+                        return null
+                    }
+
+                    const body: Record<string, unknown> = {
+                        evaluation_type: evaluation.evaluation_type,
+                        name: evaluation.name,
+                        allows_na: evaluation.output_config?.allows_na ?? false,
+                        existing_description: evaluation.description || '',
+                    }
+                    if (evaluation.evaluation_type === 'hog') {
+                        body.source = evaluation.evaluation_config.source || ''
+                    } else {
+                        body.prompt = evaluation.evaluation_config.prompt || ''
+                    }
+
+                    const response = await api.create(
+                        `/api/environments/${teamId}/llm_analytics/evaluation_description/`,
+                        body
+                    )
+                    breakpoint()
+                    return typeof response?.description === 'string' ? response.description : null
                 },
             },
         ],
@@ -433,6 +470,29 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
             actions.generateEvaluationSummary({ forceRefresh: true })
         },
 
+        generateEvaluationDescription: () => {
+            const evaluation = values.evaluation
+            if (!evaluation) {
+                return
+            }
+            posthog.capture('llma evaluation description generate clicked', {
+                evaluation_type: evaluation.evaluation_type,
+                has_existing_description: !!(evaluation.description || '').trim(),
+            })
+            actions.runGenerateEvaluationDescription()
+        },
+
+        runGenerateEvaluationDescriptionSuccess: ({ generatedDescription }) => {
+            if (generatedDescription && typeof generatedDescription === 'string') {
+                actions.setEvaluationDescription(generatedDescription)
+            }
+        },
+
+        runGenerateEvaluationDescriptionFailure: ({ errorObject }) => {
+            const message = evaluationErrorMessage(errorObject, 'Failed to generate description')
+            lemonToast.error(message)
+        },
+
         trackSummarizeClicked: () => {
             posthog.capture('llma evaluation summarize clicked', {
                 filter: values.evaluationSummaryFilter,
@@ -589,6 +649,21 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
 
     selectors({
         isNewEvaluation: [(_, props) => [props.evaluationId], (evaluationId: string) => evaluationId === 'new'],
+
+        canGenerateDescription: [
+            (s) => [s.evaluation],
+            (evaluation: EvaluationConfig | null): boolean => {
+                if (!evaluation) {
+                    return false
+                }
+                const hasName = evaluation.name.trim().length > 0
+                const hasConfig =
+                    evaluation.evaluation_type === 'hog'
+                        ? (evaluation.evaluation_config.source || '').trim().length > 0
+                        : (evaluation.evaluation_config.prompt || '').trim().length > 0
+                return hasName || hasConfig
+            },
+        ],
 
         signalEmissionEnabled: [
             (s, props) => [s.signalEmissionOptimistic, s.sourceConfigs, props.evaluationId],

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -41,9 +41,10 @@ export const NullEnumApi = {} as const
  * * `llm_judge` - LLM as a judge
  * `hog` - Hog
  */
-export type EvaluationTypeEnumApi = (typeof EvaluationTypeEnumApi)[keyof typeof EvaluationTypeEnumApi]
+export type EvaluationEvaluationTypeEnumApi =
+    (typeof EvaluationEvaluationTypeEnumApi)[keyof typeof EvaluationEvaluationTypeEnumApi]
 
-export const EvaluationTypeEnumApi = {
+export const EvaluationEvaluationTypeEnumApi = {
     LlmJudge: 'llm_judge',
     Hog: 'hog',
 } as const
@@ -150,7 +151,7 @@ export interface EvaluationApi {
     enabled?: boolean
     readonly status: EvaluationStatusEnumApi
     readonly status_reason: StatusReasonEnumApi | NullEnumApi | null
-    evaluation_type: EvaluationTypeEnumApi
+    evaluation_type: EvaluationEvaluationTypeEnumApi
     evaluation_config?: unknown
     output_type: OutputTypeEnumApi
     output_config?: unknown
@@ -345,6 +346,58 @@ export interface ClusteringRunRequestApi {
      * @nullable
      */
     clustering_job_id?: string | null
+}
+
+/**
+ * * `llm_judge` - llm_judge
+ * `hog` - hog
+ */
+export type EvaluationDescriptionRequestEvaluationTypeEnumApi =
+    (typeof EvaluationDescriptionRequestEvaluationTypeEnumApi)[keyof typeof EvaluationDescriptionRequestEvaluationTypeEnumApi]
+
+export const EvaluationDescriptionRequestEvaluationTypeEnumApi = {
+    LlmJudge: 'llm_judge',
+    Hog: 'hog',
+} as const
+
+/**
+ * Request serializer for evaluation description generation.
+
+Accepts the current (possibly unsaved) evaluation configuration so the
+feature works both for new evaluations and edits-in-progress.
+ */
+export interface EvaluationDescriptionRequestApi {
+    /** The evaluation type ('llm_judge' or 'hog')
+
+* `llm_judge` - llm_judge
+* `hog` - hog */
+    evaluation_type: EvaluationDescriptionRequestEvaluationTypeEnumApi
+    /**
+     * Current evaluation name (optional)
+     * @maxLength 400
+     */
+    name?: string
+    /**
+     * Current LLM judge prompt (required when evaluation_type is 'llm_judge')
+     * @maxLength 20000
+     */
+    prompt?: string
+    /**
+     * Current Hog source code (required when evaluation_type is 'hog')
+     * @maxLength 20000
+     */
+    source?: string
+    /** Whether the evaluation allows 'Not applicable' results */
+    allows_na?: boolean
+    /**
+     * The current description, if any, to use as a hint
+     * @maxLength 500
+     */
+    existing_description?: string
+}
+
+export interface EvaluationDescriptionResponseApi {
+    description: string
 }
 
 /**
@@ -1475,6 +1528,12 @@ export type LlmAnalyticsClusteringJobsListParams = {
      */
     offset?: number
 }
+
+export type LlmAnalyticsEvaluationDescriptionCreate400 = { [key: string]: unknown }
+
+export type LlmAnalyticsEvaluationDescriptionCreate403 = { [key: string]: unknown }
+
+export type LlmAnalyticsEvaluationDescriptionCreate500 = { [key: string]: unknown }
 
 export type LlmAnalyticsEvaluationReportsListParams = {
     /**

--- a/products/llm_analytics/frontend/generated/api.ts
+++ b/products/llm_analytics/frontend/generated/api.ts
@@ -18,6 +18,8 @@ import type {
     DatasetItemsListParams,
     DatasetsListParams,
     EvaluationApi,
+    EvaluationDescriptionRequestApi,
+    EvaluationDescriptionResponseApi,
     EvaluationReportApi,
     EvaluationSummaryRequestApi,
     EvaluationSummaryResponseApi,
@@ -388,6 +390,31 @@ export const llmAnalyticsEvaluationConfigSetActiveKeyCreate = async (
     return apiMutator<void>(getLlmAnalyticsEvaluationConfigSetActiveKeyCreateUrl(projectId), {
         ...options,
         method: 'POST',
+    })
+}
+
+/**
+ * 
+Generate an AI-powered description for an LLM evaluation based on its current configuration.
+
+Works for both LLM judge evaluations (prompt-based) and Hog code evaluations (code-based).
+Can be used before the evaluation is saved — no evaluation ID is required.
+        
+ */
+export const getLlmAnalyticsEvaluationDescriptionCreateUrl = (projectId: string) => {
+    return `/api/environments/${projectId}/llm_analytics/evaluation_description/`
+}
+
+export const llmAnalyticsEvaluationDescriptionCreate = async (
+    projectId: string,
+    evaluationDescriptionRequestApi: EvaluationDescriptionRequestApi,
+    options?: RequestInit
+): Promise<EvaluationDescriptionResponseApi> => {
+    return apiMutator<EvaluationDescriptionResponseApi>(getLlmAnalyticsEvaluationDescriptionCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(evaluationDescriptionRequestApi),
     })
 }
 

--- a/products/llm_analytics/mcp/tools.yaml
+++ b/products/llm_analytics/mcp/tools.yaml
@@ -315,3 +315,6 @@ tools:
     llm-analytics-evaluation-reports-runs-list:
         operation: llm_analytics_evaluation_reports_runs_list
         enabled: false
+    llm-analytics-evaluation-description-create:
+        operation: llm_analytics_evaluation_description_create
+        enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14864,10 +14864,10 @@ export namespace Schemas {
      * * `llm_judge` - LLM as a judge
     * `hog` - Hog
      */
-    export type EvaluationTypeEnum = typeof EvaluationTypeEnum[keyof typeof EvaluationTypeEnum];
+    export type EvaluationEvaluationTypeEnum = typeof EvaluationEvaluationTypeEnum[keyof typeof EvaluationEvaluationTypeEnum];
 
 
-    export const EvaluationTypeEnum = {
+    export const EvaluationEvaluationTypeEnum = {
       LlmJudge: 'llm_judge',
       Hog: 'hog',
     } as const;
@@ -14921,7 +14921,7 @@ export namespace Schemas {
       enabled?: boolean;
       readonly status: EvaluationStatusEnum;
       readonly status_reason: StatusReasonEnum | NullEnum | null;
-      evaluation_type: EvaluationTypeEnum;
+      evaluation_type: EvaluationEvaluationTypeEnum;
       evaluation_config?: unknown;
       output_type: OutputTypeEnum;
       output_config?: unknown;
@@ -14931,6 +14931,58 @@ export namespace Schemas {
       readonly updated_at: string;
       readonly created_by: UserBasic;
       deleted?: boolean;
+    }
+
+    /**
+     * * `llm_judge` - llm_judge
+    * `hog` - hog
+     */
+    export type EvaluationDescriptionRequestEvaluationTypeEnum = typeof EvaluationDescriptionRequestEvaluationTypeEnum[keyof typeof EvaluationDescriptionRequestEvaluationTypeEnum];
+
+
+    export const EvaluationDescriptionRequestEvaluationTypeEnum = {
+      LlmJudge: 'llm_judge',
+      Hog: 'hog',
+    } as const;
+
+    /**
+     * Request serializer for evaluation description generation.
+
+    Accepts the current (possibly unsaved) evaluation configuration so the
+    feature works both for new evaluations and edits-in-progress.
+     */
+    export interface EvaluationDescriptionRequest {
+      /** The evaluation type ('llm_judge' or 'hog')
+
+    * `llm_judge` - llm_judge
+    * `hog` - hog */
+      evaluation_type: EvaluationDescriptionRequestEvaluationTypeEnum;
+      /**
+       * Current evaluation name (optional)
+       * @maxLength 400
+       */
+      name?: string;
+      /**
+       * Current LLM judge prompt (required when evaluation_type is 'llm_judge')
+       * @maxLength 20000
+       */
+      prompt?: string;
+      /**
+       * Current Hog source code (required when evaluation_type is 'hog')
+       * @maxLength 20000
+       */
+      source?: string;
+      /** Whether the evaluation allows 'Not applicable' results */
+      allows_na?: boolean;
+      /**
+       * The current description, if any, to use as a hint
+       * @maxLength 500
+       */
+      existing_description?: string;
+    }
+
+    export interface EvaluationDescriptionResponse {
+      description: string;
     }
 
     export interface EvaluationPattern {
@@ -24886,7 +24938,7 @@ export namespace Schemas {
       enabled?: boolean;
       readonly status?: EvaluationStatusEnum;
       readonly status_reason?: StatusReasonEnum | NullEnum | null;
-      evaluation_type?: EvaluationTypeEnum;
+      evaluation_type?: EvaluationEvaluationTypeEnum;
       evaluation_config?: unknown;
       output_type?: OutputTypeEnum;
       output_config?: unknown;
@@ -34859,6 +34911,12 @@ export namespace Schemas {
      */
     offset?: number;
     };
+
+    export type LlmAnalyticsEvaluationDescriptionCreate400 = {[key: string]: unknown};
+
+    export type LlmAnalyticsEvaluationDescriptionCreate403 = {[key: string]: unknown};
+
+    export type LlmAnalyticsEvaluationDescriptionCreate500 = {[key: string]: unknown};
 
     export type LlmAnalyticsEvaluationReportsListParams = {
     /**


### PR DESCRIPTION
## Problem

Users creating or editing LLM evaluations need help writing clear, concise descriptions of what their evaluations check for. Currently, descriptions must be written manually, which is time-consuming and inconsistent. This feature provides an AI-powered endpoint to automatically generate descriptions based on the evaluation's configuration (name, prompt for LLM judges, or Hog source code).

## Changes

### Backend
- **New API endpoint** (`POST /api/environments/:id/llm_analytics/evaluation_description/`): Generates AI-powered descriptions for evaluations
  - Accepts evaluation configuration (type, name, prompt/source, allows_na flag, existing description)
  - Works for both LLM judge and Hog code evaluations
  - Works before evaluation is saved (no ID required)
  - Rate-limited using shared LLM Analytics throttles
  - Requires AI data processing approval from organization

- **New LLM integration** (`evaluation_description.py`): Async function that calls OpenAI with structured output schema
  - Uses GPT-4 mini model via LLM gateway
  - Validates evaluation configuration before generation
  - Returns structured `EvaluationDescriptionResponse` with description field

- **Request/response serializers**: Validates input (evaluation type, name, prompt/source, allows_na, existing description) and enforces max lengths

- **Prompt template** (`evaluation_description.djt`): Django template that provides context to the LLM about the evaluation configuration and guidelines for generating concise, plain-English descriptions

- **Comprehensive test suite**: 10 tests covering authentication, authorization, validation, successful generation for both evaluation types, description truncation, and error handling

### Frontend
- **New logic actions** in `llmEvaluationLogic`:
  - `generateEvaluationDescription`: Triggers description generation with analytics tracking
  - `runGenerateEvaluationDescription`: Async loader that calls the API endpoint
  - `canGenerateDescription` selector: Determines if generation is possible (requires name or prompt/source)

- **UI updates** in `LLMAnalyticsEvaluation.tsx`:
  - Added sparkles icon button next to description field
  - Button is disabled until evaluation has name or prompt/source
  - Tooltip explains what's needed to enable generation
  - Integrates with existing description field to auto-populate generated text
  - Shows loading state during generation
  - Displays error toast on failure

## How did you test this code?

- **Automated tests**: Added 10 comprehensive unit tests covering:
  - Authentication and authorization (unauthenticated users, AI consent requirement)
  - Input validation (missing/invalid evaluation type, missing name/prompt/source)
  - Successful generation for both LLM judge and Hog evaluation types
  - Passing existing description as hint to the LLM
  - Description truncation to max length (500 chars)
  - Error handling (500 response on generation failure)

- **Code-based validation**: 
  - Serializers validate all input constraints (max lengths, required fields)
  - Backend validates evaluation configuration before calling LLM
  - Frontend selector prevents generation when configuration is incomplete
  - Rate limiting applied via existing LLM Analytics throttles

All tests pass and cover the main happy path and error scenarios.

## Publish to changelog?

Yes - this is a new user-facing feature for LLM Analytics evaluations.

https://claude.ai/code/session_01HckRmtakbHRWpahwKzKnnK