### PR TITLE
feat(workflows): reject malformed delay_duration in hog_flow API

### DIFF
--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -1,3 +1,4 @@
+import re
 import json
 import uuid as uuid_mod
 from datetime import timedelta
@@ -45,6 +46,10 @@ from products.workflows.backend.models.hog_flow_schedule import SCHEDULED_TRIGGE
 from products.workflows.backend.utils.rrule_utils import compute_next_occurrences, validate_rrule
 
 logger = structlog.get_logger(__name__)
+
+# Delay durations are strings like "30m", "2h", "1.5d". Must match the regex in the Node.js executor
+# (nodejs/src/cdp/services/hogflows/actions/delay.ts) that throws at runtime on mismatch.
+DELAY_DURATION_REGEX = re.compile(r"^\d*\.?\d+[dhm]$")
 
 
 class BlastRadiusRequestSerializer(serializers.Serializer):
@@ -175,6 +180,20 @@ class HogFlowActionSerializer(serializers.Serializer):
                         else:
                             serializer.is_valid(raise_exception=True)
                             condition["filters"] = serializer.validated_data
+
+        if data.get("type") == "delay":
+            delay_duration = data.get("config", {}).get("delay_duration")
+            if not isinstance(delay_duration, str) or not DELAY_DURATION_REGEX.match(delay_duration):
+                if not is_draft:
+                    raise serializers.ValidationError(
+                        {
+                            "config": (
+                                "delay_duration must be a string like '30m', '2h', or '1d'. "
+                                "If you are seeing this after importing or scripting a workflow, "
+                                "re-add each delay step in the UI so it writes the correct shape."
+                            )
+                        }
+                    )
 
         return data
 

--- a/posthog/api/test/test_hog_flow.py
+++ b/posthog/api/test/test_hog_flow.py
@@ -110,6 +110,82 @@ class TestHogFlowAPI(APIBaseTest):
         assert response.json()["actions"] == [trigger_action_expectation]
         assert response.json()["trigger"] == trigger_action_expectation["config"]
 
+    @parameterized.expand(
+        [
+            ("missing_delay_duration", {}),
+            ("null_delay_duration", {"delay_duration": None}),
+            ("numeric_delay_duration", {"delay_duration": 1800}),
+            ("seconds_as_input_shape", {"inputs": {"duration": {"value": 1800}}}),
+            ("iso_8601_duration", {"delay_duration": "P30D"}),
+            ("unit_and_duration_shape", {"unit": "days", "duration": 3}),
+            ("unsupported_unit", {"delay_duration": "30s"}),
+            ("empty_string", {"delay_duration": ""}),
+        ]
+    )
+    def test_hog_flow_delay_validation_rejects_malformed_config(self, _name, bad_config):
+        trigger_action = {
+            "id": "trigger_node",
+            "name": "trigger_1",
+            "type": "trigger",
+            "config": {
+                "type": "event",
+                "filters": {
+                    "events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0}],
+                },
+            },
+        }
+        delay_action = {"id": "d1", "name": "d1", "type": "delay", "config": bad_config}
+        hog_flow = {"name": "Test Flow", "status": "active", "actions": [trigger_action, delay_action]}
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert response.status_code == 400, response.json()
+        assert "delay_duration" in response.json()["detail"]
+
+    @parameterized.expand(
+        [
+            ("minutes", "30m"),
+            ("hours", "2h"),
+            ("days", "1d"),
+            ("fractional", "1.5h"),
+        ]
+    )
+    def test_hog_flow_delay_validation_accepts_canonical_config(self, _name, delay_duration):
+        trigger_action = {
+            "id": "trigger_node",
+            "name": "trigger_1",
+            "type": "trigger",
+            "config": {
+                "type": "event",
+                "filters": {
+                    "events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0}],
+                },
+            },
+        }
+        delay_action = {"id": "d1", "name": "d1", "type": "delay", "config": {"delay_duration": delay_duration}}
+        hog_flow = {"name": "Test Flow", "status": "active", "actions": [trigger_action, delay_action]}
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert response.status_code == 201, response.json()
+
+    def test_hog_flow_delay_validation_lenient_for_drafts(self):
+        trigger_action = {
+            "id": "trigger_node",
+            "name": "trigger_1",
+            "type": "trigger",
+            "config": {
+                "type": "event",
+                "filters": {
+                    "events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0}],
+                },
+            },
+        }
+        delay_action = {"id": "d1", "name": "d1", "type": "delay", "config": {"inputs": {"duration": {"value": 1800}}}}
+        # status defaults to draft; draft mode lets users save WIP with invalid configs
+        hog_flow = {"name": "Test Flow", "actions": [trigger_action, delay_action]}
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert response.status_code == 201, response.json()
+
     def test_hog_flow_function_validation(self):
         hog_flow, action = self._create_hog_flow_with_action(
             {


### PR DESCRIPTION
## Problem

A customer (ticket #56146) reported that clicking a delay step in the workflow editor crashes the editor. Root cause: the customer authored workflows via the API with a non-canonical delay config shape (`{"inputs": {"duration": {"value": 1800}}}`) — the frontend renders duration pickers from `config.delay_duration` string and crashed when it encountered the unexpected shape.

A prod scan (US only) turned up **39 malformed delay nodes across ~15 workflows in 2 teams**, in three distinct legacy shapes that were never rejected because `HogFlowActionSerializer.config` is a raw `JSONField` with no type-specific validation for delay actions.

## Changes

Add schema validation in `HogFlowActionSerializer.validate()` for delay actions: when `status == "active"`, reject any config whose `delay_duration` is not a string matching `^\d*\.?\d+[dhm]$` (the same regex enforced at executor time in `nodejs/src/cdp/services/hogflows/actions/delay.ts`). Draft saves stay lenient, matching the pattern used for trigger/function/condition validation so users can save WIP drafts.

The error message tells the caller to re-add the delay step via the UI (or via API with the correct shape) — targeted at customers who hit this through scripted workflow creation.

Follow-up not in this PR:
- One-time data migration to normalize the three legacy shapes in existing rows (scoping via Metabase first).
- Reach out to team 302,646 — their active workflows hit `throw new Error('Invalid duration: ...')` in the executor whenever they reach a delay step.

## How did you test this code?

Parameterized unit tests covering: missing, null, numeric, seconds-as-inputs, ISO-8601, `{unit, duration}`, unsupported unit, and empty-string configs for the reject path; `30m/2h/1d/1.5h` for the accept path; and draft-mode leniency.

```
13 passed, 48 deselected in 15.22s
```

## Publish to changelog?

no

## 🤖 LLM context

Root-caused with Claude Code. Prod impact scoped with a Metabase scan against `posthog_hogflow`; creation pathway confirmed by reading `posthog_activitylog` (all affected rows authored by a single user in rapid bursts — API-scripted, not UI). FE crash guard was drafted but dropped: existing malformed workflows can be fixed via API PATCH or workflow-list-page deletion, and backend validation prevents new ones.