### PR TITLE
fix(ci): restore accidentally deleted backend snapshot scripts

### DIFF
--- a/.github/scripts/count-snapshot-changes.sh
+++ b/.github/scripts/count-snapshot-changes.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -e
+
+# Count snapshot changes and optimize with OptiPNG
+#
+# Usage: count-snapshot-changes.sh <snapshot_directory>
+# Output: JSON with {added, modified, deleted, total, files: [{path, status, shard}]}
+#
+# This script:
+# 1. Counts git diff changes in snapshot directory
+# 2. Runs OptiPNG on new/modified snapshots
+# 3. Re-counts after optimization (OptiPNG may eliminate diffs)
+# 4. Outputs JSON for consumption by other scripts
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <snapshot_directory>" >&2
+    exit 1
+fi
+
+SNAPSHOT_DIR="$1"
+
+if [ ! -d "$SNAPSHOT_DIR" ]; then
+    echo "Error: Directory $SNAPSHOT_DIR does not exist" >&2
+    exit 1
+fi
+
+# Count changes before OptiPNG
+echo "Checking for changes in $SNAPSHOT_DIR..." >&2
+git diff --cached --name-status "$SNAPSHOT_DIR" > /tmp/snapshot-diff.txt || true
+
+ADDED=$(grep '^A' /tmp/snapshot-diff.txt | wc -l | xargs)
+MODIFIED=$(grep '^M' /tmp/snapshot-diff.txt | wc -l | xargs)
+DELETED=$(grep '^D' /tmp/snapshot-diff.txt | wc -l | xargs)
+
+# Track which file to read from for JSON building
+DIFF_FILE="/tmp/snapshot-diff.txt"
+
+# Run Oxipng if there are added or modified PNG files
+PNG_FILES=$(grep -E '^[AM].*\.png$' /tmp/snapshot-diff.txt | awk '{print $2}' | tr '\n' ' ' || true)
+if [ -n "$PNG_FILES" ]; then
+    echo "Running Oxipng optimization on PNG files..." >&2
+
+    echo "::group::Oxipng optimization" >&2
+    # Optimize changed PNGs using Oxipng via npx
+    # Oxipng auto-detects CPU cores and parallelizes internally
+    # --opt max for best compression, --strip safe for deterministic output
+    # --alpha to optimize transparent pixels, oxipng is deterministic by default
+    npx --yes oxipng@latest --opt max --strip safe --alpha $PNG_FILES
+    echo "::endgroup::" >&2
+
+    # Re-count after Oxipng (may have eliminated some diffs)
+    git diff --cached --name-status "$SNAPSHOT_DIR" > /tmp/snapshot-diff-after.txt || true
+    DIFF_FILE="/tmp/snapshot-diff-after.txt"
+    ADDED=$(grep '^A' /tmp/snapshot-diff-after.txt | wc -l | xargs)
+    MODIFIED=$(grep '^M' /tmp/snapshot-diff-after.txt | wc -l | xargs)
+    DELETED=$(grep '^D' /tmp/snapshot-diff-after.txt | wc -l | xargs)
+fi
+
+TOTAL=$((ADDED + MODIFIED + DELETED))
+
+# Build JSON array of changed files using jq for safe JSON construction
+FILES=$(while IFS= read -r line; do
+    if [ -z "$line" ]; then
+        continue
+    fi
+
+    status=$(echo "$line" | awk '{print $1}')
+    path=$(echo "$line" | awk '{print $2}')
+
+    # Extract shard number if present in filename (e.g., "shard-1-of-16")
+    shard=""
+    if [[ "$path" =~ shard-([0-9]+) ]]; then
+        shard="${BASH_REMATCH[1]}"
+    fi
+
+    # Use jq to safely construct JSON object
+    if [ -n "$shard" ]; then
+        jq -n --arg p "$path" --arg s "$status" --arg sh "$shard" '{path: $p, status: $s, shard: ($sh | tonumber)}'
+    else
+        jq -n --arg p "$path" --arg s "$status" '{path: $p, status: $s}'
+    fi
+done < "$DIFF_FILE" | jq -s '.')
+
+# Output JSON using jq with compact output
+jq -nc \
+    --argjson a "$ADDED" \
+    --argjson m "$MODIFIED" \
+    --argjson d "$DELETED" \
+    --argjson t "$TOTAL" \
+    --argjson f "$FILES" \
+    '{added: $a, modified: $m, deleted: $d, total: $t, files: $f}'

--- a/.github/scripts/post-snapshot-comment.js
+++ b/.github/scripts/post-snapshot-comment.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process')
+
+// Parse command-line arguments
+const [workflowType, mode, changesJson, prNumber, repo, commitSha, snapshotSha] = process.argv.slice(2)
+
+if (process.argv.length !== 8 && process.argv.length !== 9) {
+    console.error(
+        'Usage: post-snapshot-comment.js <workflow_type> <mode> <changes_json> <pr_number> <repo> <commit_sha> [snapshot_sha]'
+    )
+    process.exit(1)
+}
+
+// Parse changes JSON
+const changes = JSON.parse(changesJson)
+const { total, added, modified, deleted } = changes
+
+// Set workflow-specific labels
+const config =
+    workflowType === 'storybook'
+        ? {
+              label: 'Storybook',
+              type: 'UI snapshots',
+              filesFilter: 'frontend/__snapshots__/',
+              localCmd: '`pnpm storybook`',
+          }
+        : workflowType === 'backend'
+          ? {
+                label: 'Backend',
+                type: 'query snapshots',
+                filesFilter: '**/*.ambr',
+                localCmd: '`pytest <test_file> --snapshot-update`',
+            }
+          : {
+                label: 'Playwright E2E',
+                type: 'E2E screenshots',
+                filesFilter: 'playwright/',
+                localCmd: '`pnpm --filter=@posthog/playwright exec playwright test --ui`',
+            }
+
+// UPDATE mode: snapshots were updated
+if (mode !== 'update') {
+    console.error(`Error: Unknown mode: ${mode}`)
+    process.exit(1)
+}
+
+if (total === 0) {
+    console.error('No snapshot changes, skipping comment')
+    process.exit(0)
+}
+
+const headerPrefix = workflowType === 'backend' ? 'Query snapshots' : 'Visual regression'
+
+const whatThisMeans =
+    workflowType === 'backend'
+        ? `- Query snapshots have been automatically updated to match current output
+- These changes reflect modifications to database queries or schema`
+        : `- Snapshots have been automatically updated to match current rendering
+- Next CI run will switch to CHECK mode to verify stability
+- If snapshots change again, CHECK mode will fail (indicates flapping)`
+
+const nextSteps =
+    workflowType === 'backend'
+        ? `- Review the query changes to ensure they're intentional
+- If unexpected, investigate what caused the query to change`
+        : `- Review the changes to ensure they're intentional
+- Approve if changes match your expectations
+- If unexpected, investigate component rendering`
+
+const comment = `### ${headerPrefix}: ${config.label} ${config.type} updated
+
+**Changes:** ${total} snapshots (${modified} modified, ${added} added, ${deleted} deleted)
+
+**What this means:**
+${whatThisMeans}
+
+**Next steps:**
+${nextSteps}
+
+[Review snapshot changes →](https://github.com/${repo}/commit/${snapshotSha || commitSha})`
+
+// Post comment using gh CLI
+try {
+    execSync(`gh pr comment ${prNumber} --repo ${repo} --body-file -`, {
+        input: comment,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'inherit', 'inherit'],
+    })
+    console.error(`Posted comment to PR #${prNumber}`)
+} catch (error) {
+    console.error(`Failed to post comment: ${error.message}`)
+    process.exit(1)
+}


### PR DESCRIPTION
**Problem**

The VR switch PR (#54416) accidentally deleted `count-snapshot-changes.sh` and `post-snapshot-comment.js` alongside the storybook snapshot scripts. These are still used by the `commit-snapshots` action for backend API snapshots (ci-backend.yml) and MCP snapshots (ci-mcp.yml).

**Changes**

Restores both scripts from before the deletion (git restore from parent commit).

**How did you test this code?**

Verified the scripts are referenced in `.github/actions/commit-snapshots/action.yml` lines 132 and 172.

no