### PR TITLE
fix(logs): fix the default for json parse logs being wrong in the UI

### DIFF
--- a/frontend/src/scenes/settings/environment/LogsCaptureSettings.tsx
+++ b/frontend/src/scenes/settings/environment/LogsCaptureSettings.tsx
@@ -48,7 +48,7 @@ export function LogsJsonParseSettings(): JSX.Element {
         minimumAccessLevel: TeamMembershipLevel.Admin,
     })
 
-    const isJsonParseLogs = currentTeam?.logs_settings?.json_parse_logs ?? true
+    const isJsonParseLogs = currentTeam?.logs_settings?.json_parse_logs ?? false
 
     return (
         <>


### PR DESCRIPTION
## Problem

The UI default for the JSON parse toggle switch was set to true, but the default behaviour was false. So it looked like json parse was enabled when it wasn't

## Changes

Align UI default with behaviour default
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
n/a
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
