### PR TITLE
chore(ws): prepare pipeline_v3 consumer for multi-consumer-per-pod scale-up

### DIFF
--- a/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
+++ b/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
@@ -997,15 +997,7 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.person_id,
-               events.`mat_$browser`,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-13'), lessOrEquals(toDate(events.timestamp), '2024-01-17'))) AS events
+     FROM events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Australia/Sydney')), max(toTimeZone(raw_sessions.max_timestamp, 'Australia/Sydney'))), 10)))) AS `$is_bounce`,
@@ -1022,7 +1014,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Australia/Sydney'))), lessOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Australia/Sydney')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Australia/Sydney'))), lessOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Australia/Sydney')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py
@@ -23,6 +23,7 @@ from posthog.temporal.data_imports.pipelines.pipeline_v3.kafka.metrics import (
     BATCH_RETRY_EXHAUSTED_TOTAL,
     BATCH_RETRY_TOTAL,
     BATCH_SIZE,
+    BATCH_UTILIZATION,
     DLQ_MESSAGES_TOTAL,
     MESSAGES_PROCESSED_TOTAL,
     OFFSET_COMMITS_TOTAL,
@@ -108,6 +109,7 @@ class KafkaConsumerService:
             [self._config.input_topic],
             on_assign=self._on_assign,
             on_revoke=self._on_revoke,
+            on_lost=self._on_lost,
         )
         return consumer
 
@@ -121,13 +123,19 @@ class KafkaConsumerService:
             )
 
     def _on_revoke(self, consumer: ConfluentConsumer, partitions: list) -> None:
-        for p in partitions:
-            logger.info(
-                "partition_revoked",
-                topic=p.topic,
-                partition=p.partition,
-                offset=p.offset,
-            )
+        """Graceful revoke during a cooperative-sticky rebalance.
+
+        With cooperative-sticky the callback fires only for the partitions
+        actually being revoked; other assignments stay put. The synchronous
+        consume loop calls back here *between* batches, so there's no
+        in-flight processing to drain at this point. Commit stored offsets
+        so the next owner picks up from where we stopped.
+        """
+        logger.info(
+            "partition_revocation_starting",
+            revoked_partition_count=len(partitions),
+            revoked_partitions=[{"topic": p.topic, "partition": p.partition} for p in partitions],
+        )
         try:
             consumer.commit(asynchronous=False)
         except KafkaException as e:
@@ -138,6 +146,20 @@ class KafkaConsumerService:
                 logger.warning("failed_to_commit_on_revoke", error=str(e))
         except Exception as e:
             logger.warning("failed_to_commit_on_revoke", error=str(e))
+        logger.info("partition_revocation_complete", revoked_partition_count=len(partitions))
+
+    def _on_lost(self, consumer: ConfluentConsumer, partitions: list) -> None:
+        """Involuntary partition loss (session timeout, network blip, etc.).
+
+        Do NOT commit: another consumer may already own these partitions,
+        and committing here could cause the new owner to skip messages we
+        never finished processing.
+        """
+        logger.warning(
+            "partitions_lost",
+            lost_partition_count=len(partitions),
+            lost_partitions=[{"topic": p.topic, "partition": p.partition} for p in partitions],
+        )
 
     def _get_dlq_producer(self) -> _KafkaProducer:
         if self._dlq_producer is None:
@@ -213,6 +235,10 @@ class KafkaConsumerService:
                 raw_messages = self._consumer.consume(
                     num_messages=self._config.batch_size,
                     timeout=self._config.batch_timeout_seconds,
+                )
+
+                BATCH_UTILIZATION.labels(group_id=self._config.consumer_group).set(
+                    len(raw_messages) / self._config.batch_size
                 )
 
                 messages: list[tuple[Any, dict]] = []

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/metrics.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/metrics.py
@@ -1,4 +1,4 @@
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Gauge, Histogram
 
 MESSAGES_PROCESSED_TOTAL = Counter(
     "warehouse_consumer_messages_processed_total",
@@ -41,4 +41,11 @@ BATCH_SIZE = Histogram(
     "warehouse_consumer_batch_size",
     "Number of messages in each consumed batch",
     buckets=(1, 5, 10, 25, 50, 100, 250, 500, 1000),
+)
+
+BATCH_UTILIZATION = Gauge(
+    "warehouse_consumer_batch_utilization",
+    "Ratio of messages returned per consume call to configured batch size (0.0-1.0). Leading signal for autoscaling — sustained high values mean the consumer is saturating.",
+    labelnames=["group_id"],
+    multiprocess_mode="liveall",
 )

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/test_consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/test_consumer.py
@@ -61,6 +61,7 @@ class TestKafkaConsumerServiceConfig:
                 ["test-topic"],
                 on_assign=service._on_assign,
                 on_revoke=service._on_revoke,
+                on_lost=service._on_lost,
             )
 
 
@@ -113,15 +114,45 @@ class TestKafkaConsumerServiceCallbacks:
             mock_consumer = MagicMock()
             service._on_revoke(mock_consumer, partitions)
 
-            assert mock_logger.info.call_count == len(partition_data)
-            for topic, partition, offset in partition_data:
-                mock_logger.info.assert_any_call(
-                    "partition_revoked",
-                    topic=topic,
-                    partition=partition,
-                    offset=offset,
-                )
+            expected_partitions = [{"topic": t, "partition": p} for t, p, _ in partition_data]
+            mock_logger.info.assert_any_call(
+                "partition_revocation_starting",
+                revoked_partition_count=len(partition_data),
+                revoked_partitions=expected_partitions,
+            )
+            mock_logger.info.assert_any_call(
+                "partition_revocation_complete",
+                revoked_partition_count=len(partition_data),
+            )
             mock_consumer.commit.assert_called_once_with(asynchronous=False)
+
+    @parameterized.expand(
+        [
+            ("single_partition", [("test-topic", 0, 42)]),
+            ("multiple_partitions", [("test-topic", 0, 10), ("test-topic", 1, 20)]),
+        ]
+    )
+    def test_on_lost_logs_warning_and_does_not_commit(self, _name, partition_data):
+        service = _make_service()
+        partitions = []
+        for topic, partition, offset in partition_data:
+            p = MagicMock()
+            p.topic = topic
+            p.partition = partition
+            p.offset = offset
+            partitions.append(p)
+
+        with patch("posthog.temporal.data_imports.pipelines.pipeline_v3.kafka.consumer.logger") as mock_logger:
+            mock_consumer = MagicMock()
+            service._on_lost(mock_consumer, partitions)
+
+            expected_partitions = [{"topic": t, "partition": p} for t, p, _ in partition_data]
+            mock_logger.warning.assert_called_once_with(
+                "partitions_lost",
+                lost_partition_count=len(partition_data),
+                lost_partitions=expected_partitions,
+            )
+            mock_consumer.commit.assert_not_called()
 
     def test_on_revoke_logs_warning_on_commit_failure(self):
         service = _make_service()

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/health.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/health.py
@@ -1,10 +1,11 @@
+import os
 import time
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Optional
 
 import structlog
-from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest, multiprocess
 
 logger = structlog.get_logger(__name__)
 
@@ -73,7 +74,15 @@ class HealthCheckHandler(BaseHTTPRequestHandler):
         self.wfile.write(b"OK")
 
     def _handle_metrics(self) -> None:
-        output = generate_latest()
+        # When multiple consumer processes share a pod, each writes its metrics
+        # to PROMETHEUS_MULTIPROC_DIR; MultiProcessCollector aggregates them so
+        # a single scrape endpoint reflects the whole pod.
+        if os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+            registry = CollectorRegistry()
+            multiprocess.MultiProcessCollector(registry)
+            output = generate_latest(registry)
+        else:
+            output = generate_latest()
         self.send_response(200)
         self.send_header("Content-Type", CONTENT_TYPE_LATEST)
         self.end_headers()


### PR DESCRIPTION
## Problem

The warehouse sources load consumer currently runs one process per pod, but it will consume several consumer per pod. To absorb the produced volume without over-provisioning very large pods, we want to run multiple consumer processes inside one pod while scaling the underlying Kafka topic out to many more partitions.

## Changes

  - `posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py` -> emit `batch_utilization` after each consume, split `_on_revoke` (commits) from `_on_lost` (does not commit).
  - `posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/metrics.py` -> add `BATCH_UTILIZATION` gauge with `multiprocess_mode="liveall"` so each live consumer contributes its own sample.
  - `posthog/temporal/data_imports/pipelines/pipeline_v3/load/health.py` -> `/_metrics` uses `MultiProcessCollector` when `PROMETHEUS_MULTIPROC_DIR` is set so one scrape covers every consumer in the pod.
  - `posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/test_consumer.py` -> tests for `_on_lost` and the new `_on_revoke` log shape.

## How did you test this code?

- Test pass
- Local run

## Publish to changelog?

NO
