### PR TITLE
feat(data-deletion): add Dagster pickup sensor for approved requests

### DIFF
--- a/posthog/dags/data_deletion_requests.py
+++ b/posthog/dags/data_deletion_requests.py
@@ -554,19 +554,21 @@ def data_deletion_request_pickup_sensor(context: dagster.SensorEvaluationContext
     Operator enables this sensor manually from the Dagster UI when ready to
     process approved requests.
     """
-    active_runs = context.instance.get_run_records(
-        dagster.RunsFilter(
-            job_name__in=_DELETION_JOB_NAMES,
-            statuses=[
-                dagster.DagsterRunStatus.QUEUED,
-                dagster.DagsterRunStatus.NOT_STARTED,
-                dagster.DagsterRunStatus.STARTING,
-                dagster.DagsterRunStatus.STARTED,
-            ],
-        ),
-    )
-    if len(active_runs) > 0:
-        return dagster.SkipReason(f"A deletion job is already running ({len(active_runs)} active). Waiting.")
+    active_statuses = [
+        dagster.DagsterRunStatus.QUEUED,
+        dagster.DagsterRunStatus.NOT_STARTED,
+        dagster.DagsterRunStatus.STARTING,
+        dagster.DagsterRunStatus.STARTED,
+    ]
+    active_count = 0
+    for job_name in _DELETION_JOB_NAMES:
+        active_count += len(
+            context.instance.get_run_records(
+                dagster.RunsFilter(job_name=job_name, statuses=active_statuses),
+            )
+        )
+    if active_count > 0:
+        return dagster.SkipReason(f"A deletion job is already running ({active_count} active). Waiting.")
 
     next_request = DataDeletionRequest.objects.filter(status=RequestStatus.APPROVED).order_by("approved_at").first()
     if next_request is None:
@@ -575,9 +577,11 @@ def data_deletion_request_pickup_sensor(context: dagster.SensorEvaluationContext
     if next_request.request_type == RequestType.EVENT_REMOVAL:
         job = data_deletion_request_event_removal
         load_op = "load_deletion_request"
-    else:
+    elif next_request.request_type == RequestType.PROPERTY_REMOVAL:
         job = data_deletion_request_property_removal
         load_op = "load_property_removal_request"
+    else:
+        return dagster.SkipReason(f"Unknown request_type for request {next_request.pk}: {next_request.request_type}")
 
     context.log.info(
         f"Launching {job.name} for request {next_request.pk} "

--- a/posthog/dags/data_deletion_requests.py
+++ b/posthog/dags/data_deletion_requests.py
@@ -531,3 +531,68 @@ def data_deletion_request_property_removal():
     request = delete_original_events(request)
     request = cleanup_temp_tables(request)
     mark_deletion_complete(request)
+
+
+# ---------------------------------------------------------------------------
+# Pickup sensor: scans for APPROVED requests and launches jobs (max 1 at a time)
+# ---------------------------------------------------------------------------
+
+_DELETION_JOB_NAMES = [
+    data_deletion_request_event_removal.name,
+    data_deletion_request_property_removal.name,
+]
+
+
+@dagster.sensor(
+    jobs=[data_deletion_request_event_removal, data_deletion_request_property_removal],
+    minimum_interval_seconds=60,
+    default_status=dagster.DefaultSensorStatus.STOPPED,
+)
+def data_deletion_request_pickup_sensor(context: dagster.SensorEvaluationContext):
+    """Poll for APPROVED DataDeletionRequests and launch jobs (max 1 active at a time).
+
+    Operator enables this sensor manually from the Dagster UI when ready to
+    process approved requests.
+    """
+    active_runs = context.instance.get_run_records(
+        dagster.RunsFilter(
+            job_name__in=_DELETION_JOB_NAMES,
+            statuses=[
+                dagster.DagsterRunStatus.QUEUED,
+                dagster.DagsterRunStatus.NOT_STARTED,
+                dagster.DagsterRunStatus.STARTING,
+                dagster.DagsterRunStatus.STARTED,
+            ],
+        ),
+    )
+    if len(active_runs) > 0:
+        return dagster.SkipReason(f"A deletion job is already running ({len(active_runs)} active). Waiting.")
+
+    next_request = DataDeletionRequest.objects.filter(status=RequestStatus.APPROVED).order_by("approved_at").first()
+    if next_request is None:
+        return dagster.SkipReason("No approved deletion requests to process.")
+
+    if next_request.request_type == RequestType.EVENT_REMOVAL:
+        job = data_deletion_request_event_removal
+        load_op = "load_deletion_request"
+    else:
+        job = data_deletion_request_property_removal
+        load_op = "load_property_removal_request"
+
+    context.log.info(
+        f"Launching {job.name} for request {next_request.pk} "
+        f"(team_id={next_request.team_id}, type={next_request.request_type})"
+    )
+
+    return dagster.RunRequest(
+        run_key=str(next_request.pk),
+        job_name=job.name,
+        run_config={
+            "ops": {
+                load_op: {
+                    "config": {"request_id": str(next_request.pk)},
+                },
+            },
+        },
+        tags={"team_id": str(next_request.team_id), "deletion_request_id": str(next_request.pk)},
+    )

--- a/posthog/dags/data_deletion_requests.py
+++ b/posthog/dags/data_deletion_requests.py
@@ -545,7 +545,7 @@ _DELETION_JOB_NAMES = [
 
 @dagster.sensor(
     jobs=[data_deletion_request_event_removal, data_deletion_request_property_removal],
-    minimum_interval_seconds=60,
+    minimum_interval_seconds=600,
     default_status=dagster.DefaultSensorStatus.STOPPED,
 )
 def data_deletion_request_pickup_sensor(context: dagster.SensorEvaluationContext):

--- a/posthog/dags/locations/clickhouse.py
+++ b/posthog/dags/locations/clickhouse.py
@@ -62,6 +62,7 @@ defs = dagster.Definitions(
     ],
     sensors=[
         deletes.run_deletes_after_squash,
+        data_deletion_requests.data_deletion_request_pickup_sensor,
     ],
     resources=resources,
 )

--- a/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
+++ b/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
@@ -997,15 +997,7 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.person_id,
-               events.`mat_$browser`,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-13'), lessOrEquals(toDate(events.timestamp), '2024-01-17'))) AS events
+     FROM events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Australia/Sydney')), max(toTimeZone(raw_sessions.max_timestamp, 'Australia/Sydney'))), 10)))) AS `$is_bounce`,
@@ -1022,7 +1014,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Australia/Sydney'))), lessOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Australia/Sydney')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Australia/Sydney'))), lessOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Australia/Sydney')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`


### PR DESCRIPTION
## Problem

Approved `DataDeletionRequest`s currently require an operator to
manually launch `data_deletion_request_event_removal` or
`data_deletion_request_property_removal` from the Dagster UI each
time. That manual step is easy to miss and slows down processing.

## Changes

- New `data_deletion_request_pickup_sensor` in
  `posthog/dags/data_deletion_requests.py` — polls every 60s for
  `DataDeletionRequest` rows in `APPROVED` status (oldest
  `approved_at` first) and launches the matching removal job.
- Caps concurrency to one active run across both jobs; skips with a
  `SkipReason` while anything is queued/starting/running.
- Ships `default_status=DefaultSensorStatus.STOPPED` so operators
  enable it deliberately. Manual launches keep working unchanged.
- Registers the sensor in `posthog/dags/locations/clickhouse.py`
  alongside the existing `deletes.run_deletes_after_squash`.

## How did you test this code?

- Loaded the `clickhouse` Dagster code location locally and
  confirmed the sensor appears under sensors, off by default.
- Enabled the sensor, created an APPROVED request, and watched it
  launch the correct job with the expected `request_id` run config.
- Verified the concurrency cap by approving a second request while
  a job was running — it was skipped with the expected reason and
  picked up after the first finished.
- `ruff check` passes on both edited files.

## Publish to changelog?

no