### PR TITLE
Removed PI scrubbing call, just doing avro decoding/encoding to bench…

### DIFF
--- a/nodejs/src/logs-ingestion/log-record-avro.test.ts
+++ b/nodejs/src/logs-ingestion/log-record-avro.test.ts
@@ -478,7 +478,8 @@ describe('log-record-avro', () => {
             expect(outputBuffer).toBe(inputBuffer)
         })
 
-        it('decodes and scrubs only when PII scrub is on without JSON parse', async () => {
+        // TEMP: skipped while pii_scrub_logs repurposes Avro round-trip only (no scrubLogRecord). Re-enable when scrub is wired back.
+        it.skip('decodes and scrubs only when PII scrub is on without JSON parse', async () => {
             const records: LogRecord[] = [
                 {
                     uuid: 'test-uuid',
@@ -512,7 +513,8 @@ describe('log-record-avro', () => {
             expect(body.message).toContain('{{REDACTED}}')
         })
 
-        it('enriches then scrubs when both JSON parse and PII scrub are on', async () => {
+        // TEMP: same as decodes-and-scrubs test above.
+        it.skip('enriches then scrubs when both JSON parse and PII scrub are on', async () => {
             const records: LogRecord[] = [
                 {
                     uuid: 'test-uuid',
@@ -545,7 +547,8 @@ describe('log-record-avro', () => {
             })
         })
 
-        it('flattens nested JSON keys then scrubs sensitive flattened attribute keys when both flags are on', async () => {
+        // TEMP: same as decodes-and-scrubs test above.
+        it.skip('flattens nested JSON keys then scrubs sensitive flattened attribute keys when both flags are on', async () => {
             const records: LogRecord[] = [
                 {
                     uuid: 'test-uuid',

--- a/nodejs/src/logs-ingestion/log-record-avro.ts
+++ b/nodejs/src/logs-ingestion/log-record-avro.ts
@@ -5,13 +5,14 @@ import { Readable } from 'stream'
 
 import type { LogsSettings } from '../types'
 import { parseJSON } from '../utils/json-parse'
-import { scrubLogRecord } from './log-pii-scrub'
 
 const MAX_JSON_ATTRIBUTES = 50
 
+// Histogram: `pii_scrub_enabled` reflects team `pii_scrub_logs` (TEMP: repurposed as “enter Avro decode/encode path”
+// for benchmark, not “PII scrub ran”). Revert label semantics when scrub is reattached below.
 const logProcessingDurationHistogram = new Histogram({
     name: 'logs_ingestion_processing_duration_seconds',
-    help: 'Time spent processing log messages (AVRO decode/encode cycle)',
+    help: 'Time spent processing log messages (AVRO decode/encode cycle). Label pii_scrub_enabled mirrors logs_settings.pii_scrub_logs (TEMP: gates Avro path only, scrub disabled).',
     labelNames: ['json_parse_enabled', 'pii_scrub_enabled', 'compression_codec'],
     buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1],
 })
@@ -219,7 +220,9 @@ export function enrichLogRecordWithJsonAttributes(record: LogRecord): LogRecord 
 /**
  * Processes an AVRO-encoded log message buffer containing multiple records.
  * Passthrough (no decode) when both json_parse_logs and pii_scrub_logs are off.
- * Otherwise: decode → optional JSON enrich → optional PII scrub → encode.
+ *
+ * TEMP (Avro benchmark): `pii_scrub_logs` only forces decode → encode (Avro round-trip). It does **not** run PII scrub.
+ * Revert: restore `scrubLogRecord` loop when `piiScrub`, un-skip tests in log-record-avro.test.ts, restore UI meaning.
  */
 export async function processLogMessageBuffer(buffer: Buffer, settings: LogsSettings): Promise<Buffer> {
     const jsonParse = settings.json_parse_logs ?? false
@@ -246,11 +249,7 @@ export async function processLogMessageBuffer(buffer: Buffer, settings: LogsSett
             }
         }
 
-        if (piiScrub) {
-            for (const record of records) {
-                scrubLogRecord(record)
-            }
-        }
+        // TEMP: pii_scrub_logs gates Avro decode/encode path only (benchmark). scrubLogRecord not called — see file docstring.
 
         const resultBuffer = await encodeLogRecords(logRecordType, codec, records)
         return resultBuffer


### PR DESCRIPTION
## Problem

We need to isolate how much CPU/lag comes from **Avro decode/encode** on the logs ingestion path, separate from JSON body parsing and PII scrubbing. Today processing only runs when `json_parse_logs` or `pii_scrub_logs` is set, and there was no way to stress **decode → encode** alone for benchmarking.

## Changes

- **Temporary benchmark behavior:** `logs_settings.pii_scrub_logs` still forces messages through `processLogMessageBuffer` (Avro decode → encode), but **`scrubLogRecord` is not called** so we can measure Avro round-trip cost without scrub work.
- **`json_parse_logs`** unchanged: when enabled, JSON flatten/enrich still runs after decode.
- Prometheus histogram `logs_ingestion_processing_duration_seconds`: documented that label `pii_scrub_enabled` reflects the team setting but during this branch does **not** mean “PII scrub ran.”
- **Tests:** three `processLogMessageBuffer` integration tests that assert PII scrubbing are **`it.skip`** with TEMP comments until scrub is reattached.

**Revert before shipping real PII:** restore the `scrubLogRecord` loop, docstrings, histogram help text, and un-skip tests. Teams with “Scrub PII” on would otherwise get **no** redaction while this branch is deployed.

## How did you test this code?

- `pnpm --filter=@posthog/nodejs exec jest --no-watchman nodejs/src/logs-ingestion/log-record-avro.test.ts` (passing; 3 skipped as above).
- OTLP probe script can still be used to generate load; **verify in dev** with `pii_scrub_logs` on / `json_parse_logs` off for Avro-only path and compare `logs_ingestion_processing_duration_seconds` and worker CPU/lag vs both flags off.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## LLM context
