### PR TITLE
fix(data-warehouse): propagate contextvars into source iterator thread

### DIFF
--- a/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
+++ b/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
@@ -997,15 +997,7 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.person_id,
-               events.`mat_$browser`,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-13'), lessOrEquals(toDate(events.timestamp), '2024-01-17'))) AS events
+     FROM events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Australia/Sydney')), max(toTimeZone(raw_sessions.max_timestamp, 'Australia/Sydney'))), 10)))) AS `$is_bounce`,
@@ -1022,7 +1014,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Australia/Sydney'))), lessOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Australia/Sydney')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Australia/Sydney'))), lessOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Australia/Sydney')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -110,7 +110,14 @@ async def async_iterate(iterable: Iterable[T] | AsyncIterable[T]) -> AsyncIterat
 
             yield item
     finally:
-        await loop.run_in_executor(_SOURCE_ITERATOR_EXECUTOR, ctx.run, _close)
+        # Use a fresh context snapshot for cleanup. Reusing `ctx` would fail
+        # with RuntimeError if the activity is cancelled mid-_next: the
+        # in-flight _next may still be inside `ctx` on an executor thread,
+        # and Context.run raises when re-entered. A failed _close would skip
+        # iterator.close() and leave DB cursors / connections / tunnels held
+        # open until garbage collection.
+        cleanup_ctx = contextvars.copy_context()
+        await loop.run_in_executor(_SOURCE_ITERATOR_EXECUTOR, cleanup_ctx.run, _close)
 
 
 class PipelineNonDLT(Generic[ResumableData]):

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -2,6 +2,7 @@ import sys
 import time
 import asyncio
 import threading
+import contextvars
 from collections.abc import AsyncIterable, AsyncIterator, Iterable
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Generic, Literal, TypeVar
@@ -83,6 +84,11 @@ async def async_iterate(iterable: Iterable[T] | AsyncIterable[T]) -> AsyncIterat
     iterator = iter(iterable)
     lock = threading.Lock()
     loop = asyncio.get_running_loop()
+    # loop.run_in_executor does not propagate contextvars across the thread
+    # boundary (unlike asyncio.to_thread). Snapshot them once so logs emitted
+    # from inside the source generator keep team_id / workflow_* and reach the
+    # log_entries table via LogMessagesRenderer's produce path.
+    ctx = contextvars.copy_context()
 
     def _next() -> tuple[bool, T | None]:
         with lock:
@@ -98,13 +104,13 @@ async def async_iterate(iterable: Iterable[T] | AsyncIterable[T]) -> AsyncIterat
 
     try:
         while True:
-            has_value, item = await loop.run_in_executor(_SOURCE_ITERATOR_EXECUTOR, _next)  # type: ignore
+            has_value, item = await loop.run_in_executor(_SOURCE_ITERATOR_EXECUTOR, ctx.run, _next)  # type: ignore
             if not has_value:
                 break
 
             yield item
     finally:
-        await loop.run_in_executor(_SOURCE_ITERATOR_EXECUTOR, _close)
+        await loop.run_in_executor(_SOURCE_ITERATOR_EXECUTOR, ctx.run, _close)
 
 
 class PipelineNonDLT(Generic[ResumableData]):

--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline.py
@@ -1,3 +1,6 @@
+import time
+import asyncio
+import threading
 import contextvars
 
 import pytest
@@ -36,3 +39,56 @@ async def test_async_iterate_context_snapshot_is_isolated_from_generator_mutatio
     assert seen == ["inner"]
     # Caller's context is unaffected by mutations inside the generator.
     assert _probe.get() == "outer"
+
+
+@pytest.mark.asyncio
+async def test_async_iterate_context_mutation_persists_across_iterations():
+    # The same context snapshot is reused for every iteration, so writes to
+    # ContextVars inside one _next() persist into the next. Intentional:
+    # matches pre-#46962 single-thread iteration semantics. Pinned here so
+    # a future switch to per-iteration copy (e.g. asyncio.to_thread style)
+    # becomes a loud test failure rather than a silent behavior change.
+    _probe.set("outer")
+
+    def sync_gen():
+        _probe.set("inner")
+        yield _probe.get()
+        yield _probe.get()
+
+    seen = [item async for item in async_iterate(sync_gen())]
+
+    assert seen == ["inner", "inner"]
+    assert _probe.get() == "outer"
+
+
+@pytest.mark.asyncio
+async def test_async_iterate_close_runs_when_cancelled_mid_iteration():
+    # Regression: reusing the iteration ctx for the finally-block _close
+    # caused RuntimeError on cancellation (ctx still entered by the
+    # in-flight _next), which skipped iterator.close() and leaked DB /
+    # network resources. Using a fresh cleanup_ctx prevents that.
+    closed_flag = threading.Event()
+
+    class SlowIterator:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            time.sleep(0.5)  # blocks long enough for cancellation to fire
+            return 1
+
+        def close(self):
+            closed_flag.set()
+
+    async def consume():
+        async for _ in async_iterate(SlowIterator()):
+            pass
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)  # let the first _next actually enter ctx.run
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # close() must have run despite cancellation mid-iteration.
+    assert closed_flag.wait(timeout=3.0), "iterator.close() was not called"

--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline.py
@@ -1,0 +1,38 @@
+import contextvars
+
+import pytest
+
+from posthog.temporal.data_imports.pipelines.pipeline.pipeline import async_iterate
+
+_probe: contextvars.ContextVar[str | None] = contextvars.ContextVar("probe", default=None)
+
+
+@pytest.mark.asyncio
+async def test_async_iterate_propagates_contextvars_to_source_thread():
+    # Regression: loop.run_in_executor does not propagate contextvars, so
+    # logs emitted from inside a source's streaming generator used to lose
+    # team_id / workflow_* and get silently dropped from the produce path.
+    _probe.set("bound-value")
+
+    def sync_gen():
+        yield _probe.get()
+        yield _probe.get()
+
+    seen = [item async for item in async_iterate(sync_gen())]
+
+    assert seen == ["bound-value", "bound-value"]
+
+
+@pytest.mark.asyncio
+async def test_async_iterate_context_snapshot_is_isolated_from_generator_mutations():
+    _probe.set("outer")
+
+    def sync_gen():
+        _probe.set("inner")
+        yield _probe.get()
+
+    seen = [item async for item in async_iterate(sync_gen())]
+
+    assert seen == ["inner"]
+    # Caller's context is unaffected by mutations inside the generator.
+    assert _probe.get() == "outer"


### PR DESCRIPTION
## Problem

Debug (and other) logs emitted from inside a source's streaming generator — e.g. `Running EXPLAIN on: ...` in `mysql.py`, `MySQL query: ...`, `Postgres query: ...` — stopped reaching the ClickHouse `log_entries` table on 2026-02-10.

Cause: #46962 (`feat(data-warehouse): make import_data_activity_sync fully async`) introduced `async_iterate` and a dedicated `_SOURCE_ITERATOR_EXECUTOR` so sync source generators no longer block the activity's event loop. The generator is pumped via `loop.run_in_executor(_SOURCE_ITERATOR_EXECUTOR, _next)` — which, unlike `asyncio.to_thread` or `asgiref.SyncToAsync`, does **not** propagate contextvars across the thread boundary.

`LogMessagesRenderer` in `posthog/temporal/common/logger.py` requires four identity keys in the log event dict to build the Kafka produce message: `workflow_type`, `workflow_id`, `workflow_run_id`, `team_id`. Those keys are populated by two processors (`merge_temporal_context`, `structlog.contextvars.merge_contextvars`) that read from ContextVars set at activity entry. Without those ContextVars the four keys are missing, `LogMessagesRenderer` hits its `except KeyError: pass` branch, and the log is silently dropped from the produce path. Stdout still gets it, which is why the regression went unnoticed — workers running in a TTY locally always hit the `WriteOnlyLogger` path and never exercise the produce path.

Evidence from prod ClickHouse (`log_entries`, 90-day retention):

- `message LIKE 'MySQL query:%'`: 225,250 rows, 150 teams, last seen 2026-02-09 — consistent with the 2026-02-10 merge cutting it off.
- `message LIKE 'Postgres query:%'` (same pattern, same scope in `get_rows` closure): expected to follow the same cliff.
- `message LIKE 'Running EXPLAIN%' / 'EXPLAIN result:%'`: still present — but those are all from Postgres *metadata* helpers invoked from `postgres_source()`'s outer block (which runs on `SyncToAsync`'s thread and is unaffected).

## Changes

`posthog/temporal/data_imports/pipelines/pipeline/pipeline.py` — in `async_iterate`:

- `contextvars.copy_context()` once, right before the first executor submission. Captures `team_id`, `workflow_*`, and anything else the caller's context holds.
- Wrap both `run_in_executor` calls (`_next`, `_close`) with `ctx.run`, so the source generator and its close hook execute inside the snapshotted context regardless of which executor thread picks them up.

This is the same pattern `asyncio.to_thread` (CPython stdlib) and `asgiref.SyncToAsync` (every `database_sync_to_async` call in the codebase) already use. We can't use `asyncio.to_thread` directly because it hardcodes the default executor; we need the dedicated `_SOURCE_ITERATOR_EXECUTOR` that #46962 introduced to isolate slow source I/O.

Scope of fix: restores pre-#46962 logging behavior for every source (MySQL, Postgres, Stripe, BigQuery, MongoDB, Snowflake, Redshift, MSSQL, etc.) that logs from inside its yielding loop.

## How did you test this code?

mysql syncs still work locally - will test logs being saved correctly in prod

Added `posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline.py` with two regression tests that exercise `async_iterate` directly:

1. Set a `ContextVar` in the caller, iterate a sync generator that reads the var, assert the caller's value is visible inside the iterator thread. Fails without the fix, passes with it.
2. Mutate the var inside the generator, assert the caller's context is unaffected (isolation — `copy_context` returns an independent snapshot).

Full pipeline test suite (112 tests) still passes.

End-to-end verification requires prod deploy — locally the logger is a `WriteOnlyLogger` (TTY mode) so the produce path is unreachable. Post-deploy check:

```sql
SELECT count(), min(timestamp), max(timestamp)
FROM log_entries
WHERE log_source = 'external_data_jobs'
  AND (message LIKE 'MySQL query:%' OR message LIKE 'Running EXPLAIN on%' OR message LIKE 'EXPLAIN result:%')
  AND timestamp > now() - INTERVAL 1 DAY
```

Should show non-zero rows for any MySQL sync run after rollout of `temporal-worker-data-warehouse`.

## Publish to changelog?

no

## 🤖 LLM context

Co-authored-by: Claude <noreply@anthropic.com>

Diagnosed while investigating why the EXPLAIN logs added in #55134 weren't visible in customer logs. The EXPLAIN calls sit inside the `_stream_with_optional_force_index` closure in `mysql.py`, which is pumped through `async_iterate`. The pre-existing `logger.debug(f"MySQL query: ...")` immediately above the EXPLAIN calls has been in the same scope since Feb 2025 and is similarly missing from `log_entries` after Feb 2026 — same bug, same fix. The regressor is #46962; the fix is a three-line context snapshot that aligns `async_iterate` with every other async→sync bridge in the codebase.