### PR TITLE
chore(llma): make update-ai-costs workflow recover from stale PRs

### DIFF
--- a/.github/workflows/update-ai-costs.yml
+++ b/.github/workflows/update-ai-costs.yml
@@ -80,13 +80,21 @@ jobs:
                     echo "Closed stale PR #$existing_pr and deleted branch"
                   fi
 
-            - name: Ensure branch exists
+            - name: Reset branch to master
+              # Force-reset the branch to master's current SHA so each run is independent of
+              # any unmerged commits from prior runs. Without this, ghcommit-action fails with
+              # "Expected branch to point to X but it did not" whenever a previous auto-PR is
+              # still open, and every subsequent run stays broken until someone intervenes.
               if: steps.check-changes.outputs.changes == 'true'
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
-                  if ! gh api repos/${{ github.repository }}/git/ref/heads/chore/llma-update-ai-costs 2>/dev/null; then
-                    master_sha=$(gh api repos/${{ github.repository }}/git/ref/heads/master --jq '.object.sha')
+                  master_sha=$(gh api repos/${{ github.repository }}/git/ref/heads/master --jq '.object.sha')
+                  if gh api repos/${{ github.repository }}/git/ref/heads/chore/llma-update-ai-costs >/dev/null 2>&1; then
+                    gh api -X PATCH repos/${{ github.repository }}/git/refs/heads/chore/llma-update-ai-costs \
+                      -f sha="$master_sha" -F force=true
+                    echo "Force-reset branch to master at $master_sha (superseding any prior unmerged commits)"
+                  else
                     gh api repos/${{ github.repository }}/git/refs -f ref=refs/heads/chore/llma-update-ai-costs -f sha="$master_sha"
                     echo "Created branch from master at $master_sha"
                   fi

--- a/.github/workflows/update-ai-costs.yml
+++ b/.github/workflows/update-ai-costs.yml
@@ -80,23 +80,25 @@ jobs:
                     echo "Closed stale PR #$existing_pr and deleted branch"
                   fi
 
-            - name: Reset branch to master
-              # Force-reset the branch to master's current SHA so each run is independent of
-              # any unmerged commits from prior runs. Without this, ghcommit-action fails with
-              # "Expected branch to point to X but it did not" whenever a previous auto-PR is
-              # still open, and every subsequent run stays broken until someone intervenes.
+            - name: Reset branch to checked-out SHA
+              # Force-reset the branch to the SHA this job was pinned to so each run is
+              # independent of any unmerged commits from prior runs. Using `github.sha`
+              # (instead of looking up master's current tip) guarantees the branch tip
+              # matches workspace HEAD — otherwise a merge to master during the run could
+              # leave ghcommit-action with a parent mismatch and the same
+              # "Expected branch to point to X but it did not" failure mode.
               if: steps.check-changes.outputs.changes == 'true'
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  TARGET_SHA: ${{ github.sha }}
               run: |
-                  master_sha=$(gh api repos/${{ github.repository }}/git/ref/heads/master --jq '.object.sha')
                   if gh api repos/${{ github.repository }}/git/ref/heads/chore/llma-update-ai-costs >/dev/null 2>&1; then
                     gh api -X PATCH repos/${{ github.repository }}/git/refs/heads/chore/llma-update-ai-costs \
-                      -f sha="$master_sha" -F force=true
-                    echo "Force-reset branch to master at $master_sha (superseding any prior unmerged commits)"
+                      -f sha="$TARGET_SHA" -F force=true
+                    echo "Force-reset branch to $TARGET_SHA (superseding any prior unmerged commits)"
                   else
-                    gh api repos/${{ github.repository }}/git/refs -f ref=refs/heads/chore/llma-update-ai-costs -f sha="$master_sha"
-                    echo "Created branch from master at $master_sha"
+                    gh api repos/${{ github.repository }}/git/refs -f ref=refs/heads/chore/llma-update-ai-costs -f sha="$TARGET_SHA"
+                    echo "Created branch at $TARGET_SHA"
                   fi
 
             - name: Commit via GitHub API (signed)


### PR DESCRIPTION
## Problem

The `Update AI Costs` workflow has been failing on every run since 2026-04-14 (8 consecutive failures). Root cause:

1. Auto-generated PR [#54332](https://github.com/PostHog/posthog/pull/54332) was opened 2026-04-13 and never merged, so the branch `chore/llma-update-ai-costs` sits one commit ahead of `master`.
2. The workflow's `Ensure branch exists` step only created the branch from master when missing — it had no path to recover when the branch already existed with stale commits.
3. `planetscale/ghcommit-action` then refused to commit because the remote branch tip (#54332's commit) wasn't an ancestor of the workspace HEAD (master), erroring with `Expected branch to point to X but it did not. Pull and try again.`

Net result: `llm-costs.json` on master has been stale for a few days.

## Changes

Renamed `Ensure branch exists` → `Reset branch to master`. Each run now force-resets `chore/llma-update-ai-costs` to master's current SHA before committing (creates the branch if missing, force-updates the ref if it exists). This makes every run independent of prior unmerged state — any open auto-PR is superseded in place with the latest cost data.

## How did you test this code?

I'm an agent and have not run the workflow end-to-end. Validation is code-review only:

- `gh api -X PATCH .../git/refs/heads/<branch> -F force=true` is the standard force-update ref call.
- The workspace is on `master` (from `actions/checkout@v6`), so after the reset the branch tip equals workspace HEAD, which is exactly what `ghcommit-action` requires.
- The existing `Clean up stale branch` step (when `changes=false`) is unchanged and still closes stale PRs.

Reviewer: please scan the diff for the force-update logic and confirm the `gh api` PATCH call syntax matches what we use elsewhere.

## Publish to changelog?

no