### PR TITLE
chore(skills): refine skill guidance and distribution docs

### DIFF
--- a/docs/published/handbook/engineering/ai/writing-skills.md
+++ b/docs/published/handbook/engineering/ai/writing-skills.md
@@ -196,6 +196,17 @@ see [`exploring-llm-traces/SKILL.md`](https://github.com/PostHog/posthog/blob/ma
   rather than listing generic instructions.
 - Uses progressive disclosure – details like the full event schema live in `references/`
   so the entry point stays focused.
+- Ships with **pre-written Python scripts** in `scripts/`
+  ([`print_summary.py`](https://github.com/PostHog/posthog/blob/master/products/llm_analytics/skills/exploring-llm-traces/scripts/print_summary.py),
+  [`print_timeline.py`](https://github.com/PostHog/posthog/blob/master/products/llm_analytics/skills/exploring-llm-traces/scripts/print_timeline.py),
+  [`extract_span.py`](https://github.com/PostHog/posthog/blob/master/products/llm_analytics/skills/exploring-llm-traces/scripts/extract_span.py),
+  [`extract_conversation.py`](https://github.com/PostHog/posthog/blob/master/products/llm_analytics/skills/exploring-llm-traces/scripts/extract_conversation.py),
+  [`search_traces.py`](https://github.com/PostHog/posthog/blob/master/products/llm_analytics/skills/exploring-llm-traces/scripts/search_traces.py),
+  [`show_structure.py`](https://github.com/PostHog/posthog/blob/master/products/llm_analytics/skills/exploring-llm-traces/scripts/show_structure.py))
+  that cover the common workflows.
+  The agent runs these instead of re-deriving the shape of the trace JSON,
+  slicing nested payloads by hand, or burning tokens on exploratory parsing –
+  which streamlines its trajectory and keeps the context window clean.
 
 The agent knows _which_ tools to use, _in what order_, and what a successful result looks like –
 which is exactly what separates a skill from a generic prompt.

--- a/docs/published/handbook/engineering/ai/writing-skills.md
+++ b/docs/published/handbook/engineering/ai/writing-skills.md
@@ -130,7 +130,7 @@ Use lowercase kebab-case. Prefer gerund form (verb + -ing):
 
 | Pattern                   | Examples                                                                  |
 | ------------------------- | ------------------------------------------------------------------------- |
-| Gerund form (preferred)   | `analyzing-llm-traces`, `writing-hogql-queries`, `managing-feature-flags` |
+| Gerund form (preferred)   | `exploring-llm-traces`, `writing-hogql-queries`, `managing-feature-flags` |
 | Noun phrases (acceptable) | `query-examples`, `error-tracking-guide`                                  |
 
 Skills **must not** be prefixed with `posthog-*`.
@@ -165,9 +165,11 @@ description: >
   experiments, surveys, data warehouse).
 
 description: >
-  Step-by-step guide for analyzing LLM traces in PostHog.
-  Use when inspecting AI generation latency, token usage,
-  human feedback, or trace hierarchies.
+  ABSOLUTE MUST to debug and inspect LLM/AI agent traces using PostHog's MCP tools.
+  Use when the user pastes a trace URL (e.g. /llm-observability/traces/<id>),
+  asks to debug a trace, figure out what went wrong, check if an agent used a tool correctly,
+  verify context/files were surfaced, inspect subagent behavior, investigate LLM decisions,
+  or analyze token usage and costs.
 ```
 
 **Bad descriptions:**
@@ -182,17 +184,21 @@ description: 'Everything about PostHog AI features'
 
 ## Good and bad skill examples
 
-### Good: `analyzing-llm-traces`
+### Good: `exploring-llm-traces`
 
-A focused skill that guides the agent through a specific workflow:
+A focused skill that guides the agent through a specific workflow –
+see [`exploring-llm-traces/SKILL.md`](https://github.com/PostHog/posthog/blob/master/products/llm_analytics/skills/exploring-llm-traces/SKILL.md):
 
-- Starts by verifying that `$ai_trace`, `$ai_generation`, `$ai_feedback` events exist.
-- Provides HogQL queries to retrieve trace data with the right properties.
-- Explains how to join generations to traces via `$ai_trace_id`.
-- Describes the desired outcome (latency analysis, feedback summary, cost breakdown).
+- Declares the exact MCP tools it relies on (`posthog:query-llm-traces-list`, `posthog:query-llm-trace`, `posthog:execute-sql`).
+- Explains the `$ai_trace` / `$ai_span` / `$ai_generation` / `$ai_embedding` event hierarchy
+  and how events link via `$ai_parent_id`.
+- Walks through concrete workflows (debugging a trace from a URL, cost analysis, tool-use verification)
+  rather than listing generic instructions.
+- Uses progressive disclosure – details like the full event schema live in `references/`
+  so the entry point stays focused.
 
-The agent knows what tools to use (execute-sql, read-data-schema),
-in what order, and what a successful result looks like.
+The agent knows _which_ tools to use, _in what order_, and what a successful result looks like –
+which is exactly what separates a skill from a generic prompt.
 
 ### Good: `query-examples`
 
@@ -327,15 +333,22 @@ and packaged into `dist/skills.zip` with deterministic timestamps for reproducib
 
 ## Distribution
 
-Distribution is automatic.
-Built skills are published through the [posthog/skills](https://github.com/PostHog/skills) repo
-and consumed via plugins for coding agents at [PostHog/ai-plugin](https://github.com/PostHog/ai-plugin).
+Distribution is automatic – once a skill lands on `master`,
+CI builds the `dist/skills.zip` artifact and publishes it to two downstream repositories:
 
-PostHog Code already consumes skills automatically.
-PostHog AI will consume the same set of skills.
+- [`PostHog/skills`](https://github.com/PostHog/skills) –
+  the canonical distribution repo.
+  Each built skill is pushed as a standalone directory so it can be synced directly into
+  any agent that follows Anthropic's skills layout (Claude Code, Claude Desktop, etc.).
+- [`PostHog/ai-plugin`](https://github.com/PostHog/ai-plugin) –
+  the plugin distribution used by coding agents that consume PostHog capabilities
+  (PostHog Code, PostHog AI). The plugin bundles the skills alongside the MCP tool definitions
+  so agents get the "how" and the "what" together.
 
-Product teams don't need to handle distribution –
-the pipeline and CI take care of it.
+PostHog Code already consumes skills automatically, and PostHog AI consumes the same set.
+Because both repositories are updated from the same `dist/skills.zip` on every merge to `master`,
+you don't need to handle distribution yourself –
+merge your skill and it shows up in both places on the next CI run.
 
 ## Testing
 

--- a/docs/published/handbook/engineering/ai/writing-skills.md
+++ b/docs/published/handbook/engineering/ai/writing-skills.md
@@ -165,7 +165,7 @@ description: >
   experiments, surveys, data warehouse).
 
 description: >
-  ABSOLUTE MUST to debug and inspect LLM/AI agent traces using PostHog's MCP tools.
+  Debug and inspect LLM/AI agent traces using PostHog's MCP tools.
   Use when the user pastes a trace URL (e.g. /llm-observability/traces/<id>),
   asks to debug a trace, figure out what went wrong, check if an agent used a tool correctly,
   verify context/files were surfaced, inspect subagent behavior, investigate LLM decisions,

--- a/docs/published/handbook/engineering/ai/writing-skills.md
+++ b/docs/published/handbook/engineering/ai/writing-skills.md
@@ -196,13 +196,8 @@ see [`exploring-llm-traces/SKILL.md`](https://github.com/PostHog/posthog/blob/ma
   rather than listing generic instructions.
 - Uses progressive disclosure – details like the full event schema live in `references/`
   so the entry point stays focused.
-- Ships with **pre-written Python scripts** in `scripts/`
-  ([`print_summary.py`](https://github.com/PostHog/posthog/blob/master/products/llm_analytics/skills/exploring-llm-traces/scripts/print_summary.py),
-  [`print_timeline.py`](https://github.com/PostHog/posthog/blob/master/products/llm_analytics/skills/exploring-llm-traces/scripts/print_timeline.py),
-  [`extract_span.py`](https://github.com/PostHog/posthog/blob/master/products/llm_analytics/skills/exploring-llm-traces/scripts/extract_span.py),
-  [`extract_conversation.py`](https://github.com/PostHog/posthog/blob/master/products/llm_analytics/skills/exploring-llm-traces/scripts/extract_conversation.py),
-  [`search_traces.py`](https://github.com/PostHog/posthog/blob/master/products/llm_analytics/skills/exploring-llm-traces/scripts/search_traces.py),
-  [`show_structure.py`](https://github.com/PostHog/posthog/blob/master/products/llm_analytics/skills/exploring-llm-traces/scripts/show_structure.py))
+- Ships with pre-written Python helpers in
+  [`scripts/`](https://github.com/PostHog/posthog/tree/master/products/llm_analytics/skills/exploring-llm-traces/scripts)
   that cover the common workflows.
   The agent runs these instead of re-deriving the shape of the trace JSON,
   slicing nested payloads by hand, or burning tokens on exploratory parsing –


### PR DESCRIPTION
## Problem

The handbook documentation for AI writing skills needed updates to:
1. Better reflect the actual skill implementation (`exploring-llm-traces` vs `analyzing-llm-traces`)
2. Provide clearer, more concrete guidance on what makes a good skill with specific examples
3. Clarify the distribution pipeline and how skills reach downstream consumers

## Changes

**Skill naming and description:**
- Updated the example skill name from `analyzing-llm-traces` to `exploring-llm-traces` to match actual implementation
- Rewrote the skill description to be more prescriptive and use-case focused, emphasizing when to use the skill (trace URL inspection, debugging, agent behavior verification, cost analysis)

**Good skill example section:**
- Expanded the `exploring-llm-traces` example with concrete implementation details
- Added reference to the actual `SKILL.md` file in the repository
- Clarified the skill structure: MCP tool declarations, event hierarchy explanation, concrete workflows, and progressive disclosure pattern
- Emphasized what separates a skill from a generic prompt (knowing which tools to use, in what order, and what success looks like)

**Distribution documentation:**
- Expanded the Distribution section with detailed explanation of the CI pipeline
- Clarified the role of both downstream repositories:
  - `PostHog/skills`: canonical distribution for Anthropic-compatible agent layouts
  - `PostHog/ai-plugin`: plugin distribution for PostHog-specific agents
- Explained how both repositories stay in sync via `dist/skills.zip` on every merge to `master`
- Removed the implication that distribution is "automatic" without context; now explains the actual mechanism

## How did you test this code?

Documentation-only changes. No automated tests needed. The changes clarify existing processes and update examples to match current implementation.

## Publish to changelog?

No – this is a documentation update to the engineering handbook, not a user-facing feature change.

## Docs update

This PR itself updates the handbook documentation, so no additional docs update needed.

https://claude.ai/code/session_017hVMWhmAEhRiozWW6ALHR6