### PR TITLE
fix(signals): Simplify output contract of the multi-turn-session demo

### DIFF
--- a/products/tasks/backend/management/commands/demo_mts_example.py
+++ b/products/tasks/backend/management/commands/demo_mts_example.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import time
 import asyncio
 import traceback
@@ -12,6 +11,7 @@ from django.core.management.base import BaseCommand, CommandError
 from posthog.models.team.team import Team
 from posthog.models.user import User
 
+from products.signals.backend.report_generation.research import ReportResearchOutput
 from products.tasks.backend.services.custom_prompt_runner import CustomPromptSandboxContext
 from products.tasks.backend.services.mts_example import run_cursed_identifier_research
 
@@ -61,7 +61,7 @@ class Command(BaseCommand):
         self.stdout.write("")
 
         try:
-            findings, actionability, priority, presentation = asyncio.run(
+            result = asyncio.run(
                 run_cursed_identifier_research(
                     context,
                     branch=BRANCH,
@@ -74,31 +74,32 @@ class Command(BaseCommand):
             self.stdout.write(traceback.format_exc())
             raise
 
-        self._print_result(findings, actionability, priority, presentation)
-        self._write_json(findings, actionability, priority, presentation)
+        self._print_result(result)
+        self._write_json(result)
 
     def _flushing_write(self, msg: str) -> None:
         self.stdout.write(msg)
         self.stdout.flush()
 
-    def _print_result(self, findings, actionability, priority, presentation) -> None:
+    def _print_result(self, result: ReportResearchOutput) -> None:
         self.stdout.write("")
         self.stdout.write(self.style.SUCCESS("=" * 60))
-        self.stdout.write(self.style.SUCCESS(f"Title:   {presentation.title}"))
-        self.stdout.write(f"Summary: {presentation.summary}")
+        self.stdout.write(self.style.SUCCESS(f"Title:   {result.title}"))
+        self.stdout.write(f"Summary: {result.summary}")
         self.stdout.write("")
         self.stdout.write(
-            f"Actionability: {actionability.actionability.value} (already_addressed={actionability.already_addressed})"
+            f"Actionability: {result.actionability.actionability.value} "
+            f"(already_addressed={result.actionability.already_addressed})"
         )
-        self.stdout.write(f"  Reason: {actionability.explanation}")
-        if priority:
-            self.stdout.write(f"Priority: {priority.priority.value}")
-            self.stdout.write(f"  Reason: {priority.explanation}")
+        self.stdout.write(f"  Reason: {result.actionability.explanation}")
+        if result.priority:
+            self.stdout.write(f"Priority: {result.priority.priority.value}")
+            self.stdout.write(f"  Reason: {result.priority.explanation}")
         else:
             self.stdout.write("Priority: N/A (not actionable)")
         self.stdout.write("")
-        for i, finding in enumerate(findings, start=1):
-            self.stdout.write(self.style.WARNING(f"--- Finding {i}/{len(findings)} ({finding.signal_id}) ---"))
+        for i, finding in enumerate(result.findings, start=1):
+            self.stdout.write(self.style.WARNING(f"--- Finding {i}/{len(result.findings)} ({finding.signal_id}) ---"))
             self.stdout.write(f"  Paths: {', '.join(finding.relevant_code_paths) or '(none)'}")
             self.stdout.write(f"  Verified: {finding.verified}")
             for sha, reason in finding.relevant_commit_hashes.items():
@@ -106,13 +107,7 @@ class Command(BaseCommand):
             self.stdout.write(f"  MCP/data: {finding.data_queried}")
             self.stdout.write("")
 
-    def _write_json(self, findings, actionability, priority, presentation) -> None:
-        payload = {
-            "findings": [f.model_dump(mode="json") for f in findings],
-            "actionability": actionability.model_dump(mode="json"),
-            "priority": priority.model_dump(mode="json") if priority else None,
-            "presentation": presentation.model_dump(mode="json"),
-        }
+    def _write_json(self, result: ReportResearchOutput) -> None:
         path = Path(f"mts_example_{int(time.time())}.json")
-        path.write_text(json.dumps(payload, indent=2, default=str))
+        path.write_text(result.model_dump_json(indent=2))
         self.stdout.write(self.style.SUCCESS(f"Saved: {path}"))

--- a/products/tasks/backend/services/mts_example/README.md
+++ b/products/tasks/backend/services/mts_example/README.md
@@ -18,11 +18,7 @@ discovery → research ×N (up to 10) → actionability → priority? → presen
 
 ## Output shape
 
-4-tuple, types imported from Signals:
-
-```python
-(list[SignalFinding], ActionabilityAssessment, PriorityAssessment | None, ReportPresentationOutput)
-```
+Returns `ReportResearchOutput` from `products.signals.backend.report_generation.research` — consumed as-is by the Signals pipeline.
 
 ## Run it
 

--- a/products/tasks/backend/services/mts_example/__init__.py
+++ b/products/tasks/backend/services/mts_example/__init__.py
@@ -1,9 +1,8 @@
-from products.tasks.backend.services.mts_example.runner import CursedResearchResult, run_cursed_identifier_research
+from products.tasks.backend.services.mts_example.runner import run_cursed_identifier_research
 from products.tasks.backend.services.mts_example.schemas import CursedItem, CursedItemCandidates
 
 __all__ = [
     "CursedItem",
     "CursedItemCandidates",
-    "CursedResearchResult",
     "run_cursed_identifier_research",
 ]

--- a/products/tasks/backend/services/mts_example/runner.py
+++ b/products/tasks/backend/services/mts_example/runner.py
@@ -8,6 +8,7 @@ from products.signals.backend.report_generation.research import (
     ActionabilityChoice,
     PriorityAssessment,
     ReportPresentationOutput,
+    ReportResearchOutput,
     SignalFinding,
 )
 from products.tasks.backend.services.custom_prompt_multi_turn_runner import MultiTurnSession
@@ -25,14 +26,6 @@ logger = logging.getLogger(__name__)
 
 MAX_CURSED_ITEMS = 10
 
-# Shape mirrors what Signals consumes: findings + actionability + (priority | None) + presentation.
-CursedResearchResult = tuple[
-    list[SignalFinding],
-    ActionabilityAssessment,
-    PriorityAssessment | None,
-    ReportPresentationOutput,
-]
-
 
 async def run_cursed_identifier_research(
     context: CustomPromptSandboxContext,
@@ -40,7 +33,7 @@ async def run_cursed_identifier_research(
     branch: str = "master",
     verbose: bool = False,
     output_fn: OutputFn = None,
-) -> CursedResearchResult:
+) -> ReportResearchOutput:
     """Demo multi-turn session whose output shape matches the Signals pipeline.
 
     Turn flow: discovery → N research (one per discovered item) → actionability
@@ -119,4 +112,10 @@ async def run_cursed_identifier_research(
 
     await session.end()
     logger.info("mts_example: completed with %d finding(s)", len(findings))
-    return findings, actionability, priority, presentation
+    return ReportResearchOutput(
+        title=presentation.title,
+        summary=presentation.summary,
+        findings=findings,
+        actionability=actionability,
+        priority=priority,
+    )


### PR DESCRIPTION
## Problem
- 4-sized-tuple output is cryptic

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Use proper `ReportResearchOutput` class

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
