### PR TITLE
feat(logs): add beta alert banner to LogsAlertingSection

### DIFF
--- a/products/logs/frontend/components/LogsAlerting/LogsAlertingSection.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertingSection.tsx
@@ -2,7 +2,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 
 import { IconTestTube } from '@posthog/icons'
-import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, Link } from '@posthog/lemon-ui'
 
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
 
@@ -34,6 +34,18 @@ function LogsAlertingSectionInner(): JSX.Element {
 
     return (
         <>
+            <LemonBanner
+                type="info"
+                dismissKey="logs-alerts-beta-banner"
+                className="mb-3"
+                action={{ children: 'Send feedback', id: 'logs-alerts-feedback-button' }}
+            >
+                Logs alerting is in beta — alerts are checked every 5 minutes. Read the{' '}
+                <Link to="https://posthog.com/docs/logs/alerts" target="_blank">
+                    docs
+                </Link>{' '}
+                or share feedback with what you'd like to see.
+            </LemonBanner>
             <LogsAlertList />
             <LemonModal
                 isOpen={isModalOpen}


### PR DESCRIPTION
## Problem

Users trying out logs alerting need context about the feature's current beta status, including how frequently alerts are checked, where to find documentation, and how to provide feedback.

## Changes

Adds an info banner to the Logs Alerting section that:

- Communicates that logs alerting is in beta and alerts are checked every 5 minutes
- Links to the logs alerts documentation
- Includes a "Send feedback" action button
- Is dismissible (keyed to `logs-alerts-beta-banner`)

## How did you test this code?

local dev

## Publish to changelog?

No

## Docs update

Docs not live yet until rolling out to testers