### PR TITLE
fix: Parse Logs only once on ingestion if any flag is on that needs parsing

### DIFF
--- a/nodejs/src/logs-ingestion/log-body-parse.test.ts
+++ b/nodejs/src/logs-ingestion/log-body-parse.test.ts
@@ -1,0 +1,33 @@
+import { parseLogBodyForIngestion } from './log-body-parse'
+
+describe('log-body-parse', () => {
+    it('returns empty for null body', () => {
+        expect(parseLogBodyForIngestion(null)).toEqual({ kind: 'empty' })
+    })
+
+    it('classifies JSON object', () => {
+        const body = JSON.stringify({ a: 1 })
+        const r = parseLogBodyForIngestion(body)
+        expect(r).toEqual({ kind: 'json_object_or_array', value: { a: 1 } })
+    })
+
+    it('classifies JSON array', () => {
+        const r = parseLogBodyForIngestion('[1,2]')
+        expect(r).toEqual({ kind: 'json_object_or_array', value: [1, 2] })
+    })
+
+    it('classifies JSON string primitive', () => {
+        const r = parseLogBodyForIngestion('"hi"')
+        expect(r).toEqual({ kind: 'json_string', value: 'hi' })
+    })
+
+    it('classifies JSON number primitive', () => {
+        const r = parseLogBodyForIngestion('42')
+        expect(r).toEqual({ kind: 'json_primitive', parsed: 42 })
+    })
+
+    it('returns invalid_json on parse failure', () => {
+        const raw = 'not json {'
+        expect(parseLogBodyForIngestion(raw)).toEqual({ kind: 'invalid_json', raw })
+    })
+})

--- a/nodejs/src/logs-ingestion/log-body-parse.ts
+++ b/nodejs/src/logs-ingestion/log-body-parse.ts
@@ -1,0 +1,30 @@
+import { parseJSON } from '../utils/json-parse'
+
+/**
+ * Single `parseJSON(record.body)` outcome for logs ingestion.
+ * Branches match `extractJsonAttributesFromBody` and `scrubBodyField` so one parse can feed both.
+ */
+export type LogBodyParseResult =
+    | { kind: 'empty' }
+    | { kind: 'invalid_json'; raw: string }
+    | { kind: 'json_object_or_array'; value: object }
+    | { kind: 'json_string'; value: string }
+    | { kind: 'json_primitive'; parsed: number | boolean | null }
+
+export function parseLogBodyForIngestion(body: string | null): LogBodyParseResult {
+    if (body === null) {
+        return { kind: 'empty' }
+    }
+    try {
+        const parsed = parseJSON(body)
+        if (parsed !== null && typeof parsed === 'object') {
+            return { kind: 'json_object_or_array', value: parsed as object }
+        }
+        if (typeof parsed === 'string') {
+            return { kind: 'json_string', value: parsed }
+        }
+        return { kind: 'json_primitive', parsed: parsed as number | boolean | null }
+    } catch {
+        return { kind: 'invalid_json', raw: body }
+    }
+}

--- a/nodejs/src/logs-ingestion/log-pii-scrub.ts
+++ b/nodejs/src/logs-ingestion/log-pii-scrub.ts
@@ -12,6 +12,7 @@
  */
 import { parseJSON } from '../utils/json-parse'
 import { createTrackedRE2 } from '../utils/tracked-re2'
+import type { LogBodyParseResult } from './log-body-parse'
 import type { LogRecord } from './log-record-avro'
 
 export const PII_REDACTED = '{{REDACTED}}'
@@ -119,11 +120,30 @@ function scrubJsonValue(value: unknown): unknown {
 }
 
 /** If body is JSON object/array, scrub nested strings and re-serialize; if invalid JSON, scrub as plain text. */
-function scrubBodyField(record: LogRecord): void {
+function scrubBodyField(record: LogRecord, bodyParse?: LogBodyParseResult): void {
     if (record.body == null) {
         return
     }
     const body = record.body
+
+    if (bodyParse) {
+        switch (bodyParse.kind) {
+            case 'empty':
+                return
+            case 'invalid_json':
+                record.body = scrubPlainString(bodyParse.raw)
+                return
+            case 'json_object_or_array':
+                record.body = JSON.stringify(scrubJsonValue(bodyParse.value))
+                return
+            case 'json_string':
+                record.body = JSON.stringify(scrubPlainString(bodyParse.value))
+                return
+            case 'json_primitive':
+                return
+        }
+    }
+
     try {
         const parsed = parseJSON(body)
         if (parsed !== null && typeof parsed === 'object') {
@@ -157,9 +177,14 @@ function scrubStringMap(map: Record<string, string> | null): Record<string, stri
     return out
 }
 
+export type ScrubLogRecordOptions = {
+    /** When set, body scrubbing reuses this parse so callers can parse `record.body` once (e.g. with JSON enrich). */
+    bodyParse?: LogBodyParseResult
+}
+
 /** Mutate record in place: body, attributes, resource_attributes, and common string metadata fields. */
-export function scrubLogRecord(record: LogRecord): void {
-    scrubBodyField(record)
+export function scrubLogRecord(record: LogRecord, options?: ScrubLogRecordOptions): void {
+    scrubBodyField(record, options?.bodyParse)
     record.attributes = scrubStringMap(record.attributes)
     record.resource_attributes = scrubStringMap(record.resource_attributes)
     if (record.service_name) {

--- a/nodejs/src/logs-ingestion/log-record-avro.test.ts
+++ b/nodejs/src/logs-ingestion/log-record-avro.test.ts
@@ -1,6 +1,7 @@
 import avro from 'avsc'
 
 import { parseJSON } from '../utils/json-parse'
+import * as logBodyParse from './log-body-parse'
 import { PII_REDACTED, encodeAttributeCell } from './log-pii-scrub'
 import {
     LogRecord,
@@ -543,6 +544,53 @@ describe('log-record-avro', () => {
                 message: encodeAttributeCell(PII_REDACTED),
                 note: encodeAttributeCell(PII_REDACTED),
             })
+        })
+
+        it('calls parseLogBodyForIngestion once per record when both JSON parse and PII scrub are on', async () => {
+            const spy = jest.spyOn(logBodyParse, 'parseLogBodyForIngestion')
+            const records: LogRecord[] = [
+                {
+                    uuid: 'test-uuid',
+                    trace_id: null,
+                    span_id: null,
+                    trace_flags: null,
+                    timestamp: null,
+                    observed_timestamp: null,
+                    body: JSON.stringify({ level: 'info', message: 'once@parse.test' }),
+                    severity_text: null,
+                    severity_number: null,
+                    service_name: null,
+                    resource_attributes: null,
+                    instrumentation_scope: null,
+                    event_name: null,
+                    attributes: null,
+                },
+                {
+                    uuid: 'test-uuid-2',
+                    trace_id: null,
+                    span_id: null,
+                    trace_flags: null,
+                    timestamp: null,
+                    observed_timestamp: null,
+                    body: JSON.stringify({ level: 'warn', message: 'two@parse.test' }),
+                    severity_text: null,
+                    severity_number: null,
+                    service_name: null,
+                    resource_attributes: null,
+                    instrumentation_scope: null,
+                    event_name: null,
+                    attributes: null,
+                },
+            ]
+
+            const inputBuffer = await encodeLogRecords(LOG_RECORD_SCHEMA, 'zstandard', records)
+            await processLogMessageBuffer(inputBuffer, {
+                json_parse_logs: true,
+                pii_scrub_logs: true,
+            })
+
+            expect(spy).toHaveBeenCalledTimes(2)
+            spy.mockRestore()
         })
 
         it('flattens nested JSON keys then scrubs sensitive flattened attribute keys when both flags are on', async () => {

--- a/nodejs/src/logs-ingestion/log-record-avro.ts
+++ b/nodejs/src/logs-ingestion/log-record-avro.ts
@@ -4,7 +4,7 @@ import { Histogram } from 'prom-client'
 import { Readable } from 'stream'
 
 import type { LogsSettings } from '../types'
-import { parseJSON } from '../utils/json-parse'
+import { type LogBodyParseResult, parseLogBodyForIngestion } from './log-body-parse'
 import { scrubLogRecord } from './log-pii-scrub'
 
 const MAX_JSON_ATTRIBUTES = 50
@@ -159,27 +159,12 @@ export function flattenJson(obj: unknown, prefix = '', result: Record<string, an
     return result
 }
 
-/**
- * Parses the log body as JSON (if valid) and extracts flattened attributes.
- * Returns up to MAX_JSON_ATTRIBUTES attributes, without overwriting existing attributes.
- */
-export function extractJsonAttributesFromBody(body: string | null): Record<string, string> {
-    if (!body) {
+function jsonAttributesFromBodyParse(bodyParse: LogBodyParseResult): Record<string, string> {
+    if (bodyParse.kind !== 'json_object_or_array') {
         return {}
     }
 
-    let parsed: unknown
-    try {
-        parsed = parseJSON(body)
-    } catch {
-        return {}
-    }
-
-    if (typeof parsed !== 'object' || parsed === null) {
-        return {}
-    }
-
-    const flattened = flattenJson(parsed)
+    const flattened = flattenJson(bodyParse.value)
     const newAttributes: Record<string, string> = {}
     let count = 0
 
@@ -195,16 +180,28 @@ export function extractJsonAttributesFromBody(body: string | null): Record<strin
 }
 
 /**
+ * Parses the log body as JSON (if valid) and extracts flattened attributes.
+ * Returns up to MAX_JSON_ATTRIBUTES attributes, without overwriting existing attributes.
+ */
+export function extractJsonAttributesFromBody(body: string | null): Record<string, string> {
+    return jsonAttributesFromBodyParse(parseLogBodyForIngestion(body))
+}
+
+/**
  * Processes a LogRecord by parsing its body as JSON and adding flattened attributes.
  * Modifies the record in place and returns it.
+ *
+ * When `bodyParse` is omitted, parses once internally. When provided (e.g. from `processLogMessageBuffer`),
+ * avoids a second parse of the same body string.
  */
-export function enrichLogRecordWithJsonAttributes(record: LogRecord): LogRecord {
+export function enrichLogRecordWithJsonAttributes(record: LogRecord, bodyParse?: LogBodyParseResult): LogRecord {
     if (!record.body) {
         return record
     }
 
+    const parse = bodyParse ?? parseLogBodyForIngestion(record.body)
     const existingAttributes = record.attributes || {}
-    const jsonAttributes = extractJsonAttributesFromBody(record.body)
+    const jsonAttributes = jsonAttributesFromBodyParse(parse)
 
     if (Object.keys(jsonAttributes).length > 0) {
         record.attributes = {
@@ -240,15 +237,13 @@ export async function processLogMessageBuffer(buffer: Buffer, settings: LogsSett
             throw new Error('avro schema metadata not found')
         }
 
-        if (jsonParse) {
-            for (const record of records) {
-                enrichLogRecordWithJsonAttributes(record)
+        for (const record of records) {
+            const bodyParse = parseLogBodyForIngestion(record.body)
+            if (jsonParse) {
+                enrichLogRecordWithJsonAttributes(record, bodyParse)
             }
-        }
-
-        if (piiScrub) {
-            for (const record of records) {
-                scrubLogRecord(record)
+            if (piiScrub) {
+                scrubLogRecord(record, { bodyParse })
             }
         }
 


### PR DESCRIPTION
## Problem

When both **JSON parse logs** and **PII scrub logs** are enabled, the logs ingestion path parsed each log **body** twice (`parseJSON` in JSON attribute extraction and again in PII body scrubbing). That doubles CPU and allocation on large JSON bodies for no behavioral gain.

## Changes

- Add [`nodejs/src/logs-ingestion/log-body-parse.ts`](nodejs/src/logs-ingestion/log-body-parse.ts) with `parseLogBodyForIngestion` and a `LogBodyParseResult` discriminated union aligned with existing enrich + scrub body semantics.
- [`processLogMessageBuffer`](nodejs/src/logs-ingestion/log-record-avro.ts): one parse per record, then optional enrich and optional scrub, then encode (Avro decode/encode count unchanged).
- [`enrichLogRecordWithJsonAttributes`](nodejs/src/logs-ingestion/log-record-avro.ts): optional second argument to reuse a precomputed parse; [`extractJsonAttributesFromBody`](nodejs/src/logs-ingestion/log-record-avro.ts) stays a thin wrapper for callers/tests.
- [`scrubLogRecord`](nodejs/src/logs-ingestion/log-pii-scrub.ts): optional `bodyParse` on options; [`scrubBodyField`](nodejs/src/logs-ingestion/log-pii-scrub.ts) uses it when provided, otherwise keeps the previous internal parse path for direct callers.
- Tests: [`log-body-parse.test.ts`](nodejs/src/logs-ingestion/log-body-parse.test.ts) for parse classification; spy in [`log-record-avro.test.ts`](nodejs/src/logs-ingestion/log-record-avro.test.ts) asserting `parseLogBodyForIngestion` is called once per record when both flags are on.

## How did you test this code?

- Ran Jest (non-watchman) on `log-body-parse.test.ts`, `log-record-avro.test.ts`, and `log-pii-scrub.test.ts` — all passing.
- No manual OTLP / dev stack verification from this agent.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

skip-inkeep-docs
