### PR TITLE
feat(hogql): add DuckDBPrinter

### DIFF
--- a/posthog/ducklake/client.py
+++ b/posthog/ducklake/client.py
@@ -58,20 +58,28 @@ def _set_search_path(conn: psycopg.Connection[Any], extra_schemas: list[str] | N
     conn.execute(sql)
 
 
-def compile_hogql_to_ducklake_sql(team_id: int, query: HogQLQuery) -> tuple[str, str]:
+def compile_hogql_to_ducklake_sql(team_id: int, query: HogQLQuery) -> tuple[str, dict[str, object], str]:
     """Compile a HogQLQuery to Postgres-dialect SQL for DuckLake.
 
-    Returns (postgres_sql, hogql_pretty) tuple.
+    Returns ``(postgres_sql, values, hogql_pretty)``. The ``values`` dict holds
+    parameter bindings for ``psycopg``'s ``%(name)s`` placeholders embedded in
+    ``postgres_sql``; callers must pass it to ``cursor.execute(sql, values)`` or
+    the query will fail with an unbound-placeholder error.
     """
     from posthog.hogql.context import HogQLContext
     from posthog.hogql.parser import parse_select
     from posthog.hogql.printer.utils import prepare_and_print_ast
 
     parsed = parse_select(query.query)
-    context = HogQLContext(team_id=team_id, enable_select_queries=True)
-    postgres_sql, _ = prepare_and_print_ast(parsed, context, dialect="postgres")
-    hogql_pretty, _ = prepare_and_print_ast(parsed, context, dialect="hogql")
-    return postgres_sql, hogql_pretty
+    # Separate context for the Postgres print — the HogQL round-trip below shouldn't
+    # contribute to ``postgres_context.values``.
+    postgres_context = HogQLContext(team_id=team_id, enable_select_queries=True)
+    postgres_sql, _ = prepare_and_print_ast(parsed, postgres_context, dialect="postgres")
+
+    hogql_context = HogQLContext(team_id=team_id, enable_select_queries=True)
+    hogql_pretty, _ = prepare_and_print_ast(parsed, hogql_context, dialect="hogql")
+
+    return postgres_sql, dict(postgres_context.values), hogql_pretty
 
 
 def execute_ducklake_query(
@@ -91,8 +99,9 @@ def execute_ducklake_query(
         raise ValueError("Provide either sql or query")
 
     hogql_pretty: str | None = None
+    values: dict[str, object] = {}
     if query:
-        sql, hogql_pretty = compile_hogql_to_ducklake_sql(team_id, query)
+        sql, values, hogql_pretty = compile_hogql_to_ducklake_sql(team_id, query)
 
     assert sql is not None
 
@@ -100,7 +109,7 @@ def execute_ducklake_query(
     with psycopg.connect(conninfo) as conn:
         _set_search_path(conn)
         with conn.cursor() as cur:
-            cur.execute(sql)
+            cur.execute(sql, values or None)
             columns = [desc.name for desc in cur.description] if cur.description else []
             types = [str(desc.type_code) for desc in cur.description] if cur.description else []
             rows = cur.fetchall()
@@ -133,11 +142,21 @@ def _calculate_table_size(conninfo: str, safe_schema: str, safe_table: str) -> i
         return 0
 
 
-def execute_ducklake_create_table(team_id: int, sql: str, schema_name: str, table_name: str) -> DuckLakeTableResult:
+def execute_ducklake_create_table(
+    team_id: int,
+    sql: str,
+    schema_name: str,
+    table_name: str,
+    values: dict[str, object] | None = None,
+) -> DuckLakeTableResult:
     """Execute a query via duckgres and materialize the result as a DuckLake table.
 
     Creates or replaces a table in the given schema using CREATE OR REPLACE TABLE ... AS.
     The table is stored natively in DuckLake (Parquet on S3 + Postgres catalog metadata).
+
+    ``values`` carries parameter bindings for any ``%(name)s`` placeholders in ``sql``
+    (as produced by ``compile_hogql_to_ducklake_sql``). It is passed through to
+    ``psycopg`` so the SELECT body is executed with safe parameter binding.
     """
     safe_schema = sanitize_ducklake_identifier(schema_name, default_prefix="shadow")
     safe_table = sanitize_ducklake_identifier(table_name, default_prefix="model")
@@ -155,7 +174,8 @@ def execute_ducklake_create_table(team_id: int, sql: str, schema_name: str, tabl
                     CREATE OR REPLACE TABLE {} AS (
                         {}
                     )
-                """).format(qualified, psql.SQL(sql))
+                """).format(qualified, psql.SQL(sql)),
+                values or None,
             )
     row_count = 0
     try:

--- a/posthog/ducklake/test_client.py
+++ b/posthog/ducklake/test_client.py
@@ -54,7 +54,7 @@ class TestExecuteDuckLakeQuery:
     @mock.patch("posthog.ducklake.client.get_duckgres_config")
     @mock.patch("posthog.ducklake.client.compile_hogql_to_ducklake_sql")
     def test_query_path_compiles_and_executes(self, mock_compile, mock_config, mock_psycopg):
-        mock_compile.return_value = ("SELECT count(*) FROM events", "SELECT count() FROM events")
+        mock_compile.return_value = ("SELECT count(*) FROM events", {}, "SELECT count() FROM events")
         mock_config.return_value = {
             "DUCKGRES_HOST": "localhost",
             "DUCKGRES_PORT": "5432",

--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -46,7 +46,7 @@ BREAKDOWN_VALUES_LIMIT = 25
 BREAKDOWN_VALUES_LIMIT_FOR_COUNTRIES = 300
 BREAKDOWN_VALUE_MAX_LENGTH = 400
 
-type HogQLDialect = Literal["hogql", "clickhouse", "postgres"]
+type HogQLDialect = Literal["hogql", "clickhouse", "postgres", "duckdb"]
 
 type HogQLParserBackend = Literal["python", "cpp-json"]
 

--- a/posthog/hogql/escape_sql.py
+++ b/posthog/hogql/escape_sql.py
@@ -199,6 +199,14 @@ def escape_duckdb_identifier(v: str) -> str:
 
 
 def _quote_postgres_wire_identifier(v: str, extra_reserved_keywords: set[str] | None) -> str:
+    # Reject ``%`` for parity with the HogQL and ClickHouse escape paths. psycopg
+    # interprets ``%`` as the start of a parameter placeholder when scanning SQL
+    # passed to ``cursor.execute(sql, params)``, so a literal ``%`` slipping through
+    # as an identifier name would either confuse parameter binding or get consumed
+    # as a format specifier.
+    if "%" in v:
+        raise QueryError(f'The Postgres identifier "{v}" is not permitted as it contains the "%" character')
+
     if POSTGRES_SIMPLE_IDENTIFIER_REGEX.match(v):
         upper = v.upper()
         if upper not in POSTGRES_RESERVED_KEYWORDS and (

--- a/posthog/hogql/escape_sql.py
+++ b/posthog/hogql/escape_sql.py
@@ -164,6 +164,15 @@ def escape_postgres_identifier(v: str) -> str:
     if len(v) > 63:
         raise QueryError(f'The Postgres identifier "{v}" is too long. Maximum length is 63 characters.')
 
+    return _quote_postgres_wire_identifier(v)
+
+
+def escape_duckdb_identifier(v: str) -> str:
+    """Escape an identifier for DuckDB. Same quoting rules as Postgres but no length limit."""
+    return _quote_postgres_wire_identifier(v)
+
+
+def _quote_postgres_wire_identifier(v: str) -> str:
     if POSTGRES_SIMPLE_IDENTIFIER_REGEX.match(v) and v.upper() not in POSTGRES_RESERVED_KEYWORDS:
         return v
 

--- a/posthog/hogql/escape_sql.py
+++ b/posthog/hogql/escape_sql.py
@@ -227,7 +227,7 @@ def escape_clickhouse_identifier(identifier: str) -> str:
 
 
 def escape_hogql_string(
-    name: float | int | str | list | tuple | date | datetime | UUID | UUIDT,
+    name: bool | float | int | str | list | tuple | date | datetime | UUID | UUIDT | None,
     timezone: Optional[str] = None,
 ) -> str:
     return SQLValueEscaper(timezone=timezone, dialect="hogql").visit(name)

--- a/posthog/hogql/escape_sql.py
+++ b/posthog/hogql/escape_sql.py
@@ -160,21 +160,38 @@ POSTGRES_RESERVED_KEYWORDS = {
 }
 
 
+# DuckDB reserves a handful of additional keywords that Postgres doesn't, so identifiers
+# colliding with these must be quoted when emitting DuckDB SQL even though they'd be
+# unambiguous in Postgres.
+DUCKDB_EXTRA_RESERVED_KEYWORDS = {
+    "EXCLUDE",
+    "PIVOT",
+    "QUALIFY",
+    "REPLACE",
+    "UNPIVOT",
+}
+
+
 def escape_postgres_identifier(v: str) -> str:
     if len(v) > 63:
         raise QueryError(f'The Postgres identifier "{v}" is too long. Maximum length is 63 characters.')
 
-    return _quote_postgres_wire_identifier(v)
+    return _quote_postgres_wire_identifier(v, extra_reserved_keywords=None)
 
 
 def escape_duckdb_identifier(v: str) -> str:
-    """Escape an identifier for DuckDB. Same quoting rules as Postgres but no length limit."""
-    return _quote_postgres_wire_identifier(v)
+    """Escape an identifier for DuckDB. Same quoting rules as Postgres but no length limit,
+    and with DuckDB's additional reserved keywords treated as requiring quotes."""
+    return _quote_postgres_wire_identifier(v, extra_reserved_keywords=DUCKDB_EXTRA_RESERVED_KEYWORDS)
 
 
-def _quote_postgres_wire_identifier(v: str) -> str:
-    if POSTGRES_SIMPLE_IDENTIFIER_REGEX.match(v) and v.upper() not in POSTGRES_RESERVED_KEYWORDS:
-        return v
+def _quote_postgres_wire_identifier(v: str, extra_reserved_keywords: set[str] | None) -> str:
+    if POSTGRES_SIMPLE_IDENTIFIER_REGEX.match(v):
+        upper = v.upper()
+        if upper not in POSTGRES_RESERVED_KEYWORDS and (
+            extra_reserved_keywords is None or upper not in extra_reserved_keywords
+        ):
+            return v
 
     return '"' + v.replace('"', '""') + '"'
 

--- a/posthog/hogql/escape_sql.py
+++ b/posthog/hogql/escape_sql.py
@@ -162,12 +162,25 @@ POSTGRES_RESERVED_KEYWORDS = {
 
 # DuckDB reserves a handful of additional keywords that Postgres doesn't, so identifiers
 # colliding with these must be quoted when emitting DuckDB SQL even though they'd be
-# unambiguous in Postgres.
+# unambiguous in Postgres. Derived from DuckDB's ``duckdb_keywords()`` catalog with
+# ``keyword_category = 'reserved'`` — re-verify and update before major DuckDB version bumps.
 DUCKDB_EXTRA_RESERVED_KEYWORDS = {
+    "ANTI",
+    "ASOF",
+    "ATTACH",
+    "DETACH",
     "EXCLUDE",
+    "INSTALL",
+    "LOAD",
+    "MACRO",
     "PIVOT",
+    "POSITIONAL",
+    "PRAGMA",
     "QUALIFY",
     "REPLACE",
+    "SAMPLE",
+    "SEMI",
+    "SUMMARIZE",
     "UNPIVOT",
 }
 

--- a/posthog/hogql/printer/__init__.py
+++ b/posthog/hogql/printer/__init__.py
@@ -1,5 +1,6 @@
 from posthog.hogql.printer.base import BasePrinter
 from posthog.hogql.printer.clickhouse import ClickHousePrinter
+from posthog.hogql.printer.duckdb import DuckDBPrinter
 from posthog.hogql.printer.hogql import HogQLPrinter
 from posthog.hogql.printer.postgres import PostgresPrinter
 from posthog.hogql.printer.utils import (
@@ -17,5 +18,6 @@ __all__ = [
     "BasePrinter",
     "HogQLPrinter",
     "ClickHousePrinter",
+    "DuckDBPrinter",
     "PostgresPrinter",
 ]

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -1532,7 +1532,9 @@ class BasePrinter(Visitor[str]):
             return str(name)
         return escape_hogql_identifier(name)
 
-    def _print_escaped_string(self, name: float | int | str | list | tuple | datetime | date | UUID | UUIDT) -> str:
+    def _print_escaped_string(
+        self, name: bool | float | int | str | list | tuple | datetime | date | UUID | UUIDT | None
+    ) -> str:
         return escape_hogql_string(name, timezone=self._get_timezone())
 
     def _unsafe_json_extract_trim_quotes(self, unsafe_field: str, unsafe_args: list[str]) -> str:

--- a/posthog/hogql/printer/duckdb.py
+++ b/posthog/hogql/printer/duckdb.py
@@ -1,7 +1,9 @@
 from collections.abc import Callable
 from typing import ClassVar
 
-from posthog.hogql.constants import HogQLDialect
+from posthog.hogql.ast import AST
+from posthog.hogql.constants import HogQLDialect, HogQLGlobalSettings
+from posthog.hogql.context import HogQLContext
 from posthog.hogql.escape_sql import escape_duckdb_identifier
 from posthog.hogql.printer.duckdb_functions import DUCKDB_FUNCTION_RENAMES_LOWER
 from posthog.hogql.printer.postgres import PostgresPrinter
@@ -18,6 +20,27 @@ class DuckDBPrinter(PostgresPrinter):
 
     DIALECT_NAME: ClassVar[HogQLDialect] = "duckdb"
 
+    def __init__(
+        self,
+        context: HogQLContext,
+        stack: list[AST] | None = None,
+        settings: HogQLGlobalSettings | None = None,
+        pretty: bool = False,
+    ):
+        super().__init__(context=context, stack=stack, settings=settings, pretty=pretty)
+        # Pre-compute the merged rename table and the PG-handler-minus-DuckDB-renames table
+        # once so that ``visit_call`` doesn't rebuild them on every invocation.
+        parent_renames = super()._get_function_renames()
+        self._duckdb_function_renames: dict[str, str] = {**parent_renames, **DUCKDB_FUNCTION_RENAMES_LOWER}
+        parent_handlers = super()._get_function_handlers()
+        self._duckdb_function_handlers: dict[str, Callable[[list[str]], str]] = {
+            # PG emulates these HogQL names via handler functions; DuckDB prefers the
+            # native renames, so strip the parent handler entries whose names we remap.
+            k: v
+            for k, v in parent_handlers.items()
+            if k not in DUCKDB_FUNCTION_RENAMES_LOWER
+        }
+
     def _print_identifier(self, name: str) -> str:
         # DuckDB has no practical identifier length limit, so skip the Postgres
         # 63-character truncation (which introduces SHA-suffixed names that are
@@ -25,16 +48,12 @@ class DuckDBPrinter(PostgresPrinter):
         return escape_duckdb_identifier(name)
 
     def _get_function_renames(self) -> dict[str, str]:
-        # Layer DuckDB-specific renames on top of the inherited Postgres map.
-        return {**super()._get_function_renames(), **DUCKDB_FUNCTION_RENAMES_LOWER}
+        return self._duckdb_function_renames
 
     def _get_function_handlers(self) -> dict[str, Callable[[list[str]], str]]:
-        # Drop any PG handler whose HogQL name DuckDB wants to rename natively —
-        # the rename lookup runs after the handler lookup, so leaving the handler
-        # in place would shadow our rename.
-        parent_handlers = super()._get_function_handlers()
-        return {k: v for k, v in parent_handlers.items() if k not in DUCKDB_FUNCTION_RENAMES_LOWER}
+        return self._duckdb_function_handlers
 
     def _assert_with_ties_supported(self) -> None:
-        # DuckDB supports ``FETCH FIRST n ROWS WITH TIES`` (standard SQL), unlike Postgres.
+        # DuckDB supports the ``LIMIT N WITH TIES`` shape this printer emits via the
+        # inherited limit-clause rendering. Override to allow what Postgres rejects.
         return

--- a/posthog/hogql/printer/duckdb.py
+++ b/posthog/hogql/printer/duckdb.py
@@ -1,0 +1,36 @@
+from collections.abc import Callable
+from typing import ClassVar
+
+from posthog.hogql.constants import HogQLDialect
+from posthog.hogql.escape_sql import escape_duckdb_identifier
+from posthog.hogql.printer.duckdb_functions import DUCKDB_FUNCTION_RENAMES_LOWER
+from posthog.hogql.printer.postgres import PostgresPrinter
+
+
+class DuckDBPrinter(PostgresPrinter):
+    """Prints a HogQL AST as DuckDB SQL.
+
+    DuckDB is Postgres-wire compatible, so this subclass inherits the vast
+    majority of its behavior from ``PostgresPrinter``. Overrides are limited to
+    places where DuckDB ships a native function or syntax that produces cleaner
+    or faster SQL than the Postgres-compatible shim.
+    """
+
+    DIALECT_NAME: ClassVar[HogQLDialect] = "duckdb"
+
+    def _print_identifier(self, name: str) -> str:
+        # DuckDB has no practical identifier length limit, so skip the Postgres
+        # 63-character truncation (which introduces SHA-suffixed names that are
+        # harder to read and compare).
+        return escape_duckdb_identifier(name)
+
+    def _get_function_renames(self) -> dict[str, str]:
+        # Layer DuckDB-specific renames on top of the inherited Postgres map.
+        return {**super()._get_function_renames(), **DUCKDB_FUNCTION_RENAMES_LOWER}
+
+    def _get_function_handlers(self) -> dict[str, Callable[[list[str]], str]]:
+        # Drop any PG handler whose HogQL name DuckDB wants to rename natively —
+        # the rename lookup runs after the handler lookup, so leaving the handler
+        # in place would shadow our rename.
+        parent_handlers = super()._get_function_handlers()
+        return {k: v for k, v in parent_handlers.items() if k not in DUCKDB_FUNCTION_RENAMES_LOWER}

--- a/posthog/hogql/printer/duckdb.py
+++ b/posthog/hogql/printer/duckdb.py
@@ -34,3 +34,7 @@ class DuckDBPrinter(PostgresPrinter):
         # in place would shadow our rename.
         parent_handlers = super()._get_function_handlers()
         return {k: v for k, v in parent_handlers.items() if k not in DUCKDB_FUNCTION_RENAMES_LOWER}
+
+    def _assert_with_ties_supported(self) -> None:
+        # DuckDB supports ``FETCH FIRST n ROWS WITH TIES`` (standard SQL), unlike Postgres.
+        return

--- a/posthog/hogql/printer/duckdb_functions.py
+++ b/posthog/hogql/printer/duckdb_functions.py
@@ -9,7 +9,8 @@ the Postgres equivalents we emit by default.
 # HogQL name → DuckDB target name. Overlays POSTGRES_FUNCTION_RENAMES.
 DUCKDB_FUNCTION_RENAMES: dict[str, str] = {
     # ClickHouse's ``any`` is "pick any row"; DuckDB has a native ``any_value`` aggregator.
-    # Postgres fakes it with ``MIN``, which is correct but mis-spelled for analytics intent.
+    # Postgres approximates this with ``MIN``, which is not semantically equivalent — it
+    # deterministically picks the smallest value rather than an arbitrary one.
     "any": "any_value",
     # Native type introspection; Postgres uses ``pg_typeof`` which prints differently.
     "toTypeName": "typeof",

--- a/posthog/hogql/printer/duckdb_functions.py
+++ b/posthog/hogql/printer/duckdb_functions.py
@@ -1,0 +1,24 @@
+"""DuckDB-specific function renames that override the Postgres defaults.
+
+These mappings are merged on top of ``POSTGRES_FUNCTION_RENAMES_LOWER`` in
+``DuckDBPrinter._get_function_renames``. DuckDB is Postgres-wire compatible but
+ships a number of native functions that produce cleaner or faster output than
+the Postgres equivalents we emit by default.
+"""
+
+# HogQL name → DuckDB target name. Overlays POSTGRES_FUNCTION_RENAMES.
+DUCKDB_FUNCTION_RENAMES: dict[str, str] = {
+    # ClickHouse's ``any`` is "pick any row"; DuckDB has a native ``any_value`` aggregator.
+    # Postgres fakes it with ``MIN``, which is correct but mis-spelled for analytics intent.
+    "any": "any_value",
+    # Native type introspection; Postgres uses ``pg_typeof`` which prints differently.
+    "toTypeName": "typeof",
+    # DuckDB's ``strftime`` takes strftime-style format strings directly (same patterns HogQL uses)
+    # whereas Postgres's ``TO_CHAR`` uses its own pattern language.
+    "formatDateTime": "strftime",
+    # Postgres has a custom handler for endsWith that falls back to a ``RIGHT()`` comparison;
+    # DuckDB ships ``ends_with`` natively.
+    "endsWith": "ends_with",
+}
+
+DUCKDB_FUNCTION_RENAMES_LOWER: dict[str, str] = {k.lower(): v for k, v in DUCKDB_FUNCTION_RENAMES.items()}

--- a/posthog/hogql/printer/postgres.py
+++ b/posthog/hogql/printer/postgres.py
@@ -1,5 +1,6 @@
 import re
 import hashlib
+from collections.abc import Callable
 from typing import ClassVar
 
 from posthog.hogql import ast
@@ -128,13 +129,17 @@ class PostgresPrinter(BasePrinter):
                 f"(floor(extract(minute from {bucket_arg}) / {bucket_size})::int * {bucket_size} * interval '1 minute')"
             )
 
+        function_renames = self._get_function_renames()
+        function_handlers = self._get_function_handlers()
+        passthrough_functions = self._get_passthrough_functions()
+
         if node.order_by:
             # ORDER BY in function calls is only supported for passthrough functions.
             func_name = node.name.lower()
             if (
-                func_name not in POSTGRES_PASSTHROUGH_FUNCTIONS
-                and func_name not in POSTGRES_FUNCTION_HANDLERS_LOWER
-                and func_name not in POSTGRES_FUNCTION_RENAMES_LOWER
+                func_name not in passthrough_functions
+                and func_name not in function_handlers
+                and func_name not in function_renames
             ):
                 raise QueryError(f"Function '{node.name}' does not support ORDER BY in the Postgres dialect.")
 
@@ -148,17 +153,17 @@ class PostgresPrinter(BasePrinter):
 
         func_name = node.name.lower()
 
-        handler = POSTGRES_FUNCTION_HANDLERS_LOWER.get(func_name)
+        handler = function_handlers.get(func_name)
         if handler is not None:
             if node.order_by:
                 raise QueryError(f"Function '{node.name}' does not support ORDER BY in the Postgres dialect.")
             return handler(args)
 
-        pg_name = POSTGRES_FUNCTION_RENAMES_LOWER.get(func_name)
-        if pg_name is not None:
-            return f"{pg_name}({', '.join(args)}{order_by_part})"
+        renamed = function_renames.get(func_name)
+        if renamed is not None:
+            return f"{renamed}({', '.join(args)}{order_by_part})"
 
-        if func_name in POSTGRES_PASSTHROUGH_FUNCTIONS:
+        if func_name in passthrough_functions:
             return f"{func_name}({', '.join(args)}{order_by_part})"
 
         if func_name in self._connection_supported_functions:
@@ -166,6 +171,18 @@ class PostgresPrinter(BasePrinter):
             return f"{func_name}({', '.join(args)})"
 
         raise QueryError(f"Function '{node.name}' is not supported in the Postgres dialect.")
+
+    def _get_function_renames(self) -> dict[str, str]:
+        """Lowercased HogQL-name → target-name map for simple function renames. Overridable by subclasses."""
+        return POSTGRES_FUNCTION_RENAMES_LOWER
+
+    def _get_function_handlers(self) -> dict[str, Callable[[list[str]], str]]:
+        """Lowercased HogQL-name → handler-callable map for functions that need custom rendering."""
+        return POSTGRES_FUNCTION_HANDLERS_LOWER
+
+    def _get_passthrough_functions(self) -> frozenset[str]:
+        """Lowercased function names that are emitted verbatim without renaming."""
+        return POSTGRES_PASSTHROUGH_FUNCTIONS
 
     def visit_array_slice(self, node: ast.ArraySlice):
         start = self.visit(node.start_expr) if node.start_expr is not None else ""

--- a/posthog/hogql/printer/postgres.py
+++ b/posthog/hogql/printer/postgres.py
@@ -190,7 +190,7 @@ class PostgresPrinter(BasePrinter):
         return f"{self.visit(node.array)}[{start}:{end}]"
 
     def visit_try_cast(self, node: ast.TryCast):
-        return f"TRY_CAST({self.visit(node.expr)} AS {node.type_name})"
+        return f"TRY_CAST({self.visit(node.expr)} AS {self._print_identifier(node.type_name)})"
 
     def visit_lambda(self, node: ast.Lambda):
         identifiers = [self._print_identifier(arg) for arg in node.args]

--- a/posthog/hogql/printer/postgres.py
+++ b/posthog/hogql/printer/postgres.py
@@ -1,7 +1,9 @@
 import re
 import hashlib
 from collections.abc import Callable
+from datetime import date, datetime
 from typing import ClassVar
+from uuid import UUID
 
 from posthog.hogql import ast
 from posthog.hogql.ast import AST
@@ -17,6 +19,8 @@ from posthog.hogql.printer.postgres_functions import (
     POSTGRES_FUNCTION_RENAMES_LOWER,
     POSTGRES_PASSTHROUGH_FUNCTIONS,
 )
+
+from posthog.models.utils import UUIDT
 
 # Regex for validating function names — only alphanumeric and underscores allowed.
 # Prevents SQL injection via backtick-quoted identifiers in HogQL.
@@ -191,6 +195,24 @@ class PostgresPrinter(BasePrinter):
 
     def visit_try_cast(self, node: ast.TryCast):
         return f"TRY_CAST({self.visit(node.expr)} AS {self._print_identifier(node.type_name)})"
+
+    def visit_constant(self, node: ast.Constant):
+        # Parameterize string (and other complex-typed) constants via ``context.add_value`` so
+        # psycopg binds them safely at ``cursor.execute(sql, values)`` time. Inlining them
+        # through the HogQL string escape path would produce ClickHouse-style ``\'`` escape
+        # sequences that Postgres and DuckDB do not recognize (``standard_conforming_strings``
+        # defaults to ``on``), allowing statement-terminator SQL injection.
+        if (
+            node.value is None
+            or isinstance(node.value, bool)
+            or isinstance(node.value, (int, float, UUID, UUIDT, datetime, date))
+        ):
+            value = self._print_escaped_string(node.value)
+            if "%" in value:
+                # ``%`` would be interpreted as the start of a parameter placeholder by psycopg.
+                raise QueryError(f"Invalid character '%' in constant: {value}")
+            return value
+        return self.context.add_value(node.value)
 
     def visit_lambda(self, node: ast.Lambda):
         identifiers = [self._print_identifier(arg) for arg in node.args]

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -4726,7 +4726,7 @@ class TestPostgresPrinter(BaseTest):
             ),
             (
                 "SELECT distinct_id, event FROM events WHERE event = 'test'",
-                "SELECT events.distinct_id, events.event FROM events WHERE (events.event = 'test') LIMIT 50000",
+                "SELECT events.distinct_id, events.event FROM events WHERE (events.event = %(hogql_val_0)s) LIMIT 50000",
             ),
             (
                 "SELECT event FROM events ORDER BY timestamp DESC",
@@ -4814,17 +4814,17 @@ class TestPostgresPrinter(BaseTest):
             (
                 "basic",
                 "SELECT 1 FROM events PIVOT (count() FOR event IN ('a', 'b'))",
-                "SELECT 1 FROM events PIVOT (count() FOR events.event IN ('a', 'b')) LIMIT 50000",
+                "SELECT 1 FROM events PIVOT (count() FOR events.event IN (%(hogql_val_0)s, %(hogql_val_1)s)) LIMIT 50000",
             ),
             (
                 "multiple_columns",
                 "SELECT 1 FROM events PIVOT (count() FOR event IN ('a') distinct_id IN (1, 2) GROUP BY timestamp)",
-                "SELECT 1 FROM events PIVOT (count() FOR events.event IN ('a') events.distinct_id IN (1, 2) GROUP BY events.timestamp) LIMIT 50000",
+                "SELECT 1 FROM events PIVOT (count() FOR events.event IN (%(hogql_val_0)s) events.distinct_id IN (1, 2) GROUP BY events.timestamp) LIMIT 50000",
             ),
             (
                 "join",
                 "SELECT 1 FROM events JOIN events AS e2 ON 1 PIVOT (count() FOR events.event IN ('a'))",
-                "SELECT 1 FROM events JOIN events AS e2 ON 1 PIVOT (count() FOR events.event IN ('a')) LIMIT 50000",
+                "SELECT 1 FROM events JOIN events AS e2 ON 1 PIVOT (count() FOR events.event IN (%(hogql_val_0)s)) LIMIT 50000",
             ),
         ]
     )
@@ -5025,14 +5025,14 @@ class TestPostgresPrinter(BaseTest):
 
     @parameterized.expand(
         [
-            ("date_trunc('second', timestamp)", "date_trunc('second', events.timestamp)"),
-            ("date_trunc('minute', timestamp)", "date_trunc('minute', events.timestamp)"),
-            ("date_trunc('hour', timestamp)", "date_trunc('hour', events.timestamp)"),
-            ("date_trunc('day', timestamp)", "date_trunc('day', events.timestamp)"),
-            ("date_trunc('week', timestamp)", "date_trunc('week', events.timestamp)"),
-            ("date_trunc('month', timestamp)", "date_trunc('month', events.timestamp)"),
-            ("date_trunc('quarter', timestamp)", "date_trunc('quarter', events.timestamp)"),
-            ("date_trunc('year', timestamp)", "date_trunc('year', events.timestamp)"),
+            ("date_trunc('second', timestamp)", "date_trunc(%(hogql_val_0)s, events.timestamp)"),
+            ("date_trunc('minute', timestamp)", "date_trunc(%(hogql_val_0)s, events.timestamp)"),
+            ("date_trunc('hour', timestamp)", "date_trunc(%(hogql_val_0)s, events.timestamp)"),
+            ("date_trunc('day', timestamp)", "date_trunc(%(hogql_val_0)s, events.timestamp)"),
+            ("date_trunc('week', timestamp)", "date_trunc(%(hogql_val_0)s, events.timestamp)"),
+            ("date_trunc('month', timestamp)", "date_trunc(%(hogql_val_0)s, events.timestamp)"),
+            ("date_trunc('quarter', timestamp)", "date_trunc(%(hogql_val_0)s, events.timestamp)"),
+            ("date_trunc('year', timestamp)", "date_trunc(%(hogql_val_0)s, events.timestamp)"),
         ]
     )
     def test_date_trunc_passthrough_in_postgres(self, expr: str, expected: str):
@@ -5106,7 +5106,7 @@ class TestPostgresPrinter(BaseTest):
             stack=[prepared_select_query],
         )
 
-        self.assertEqual(rendered, "('__hx_tag', 'div')")
+        self.assertEqual(rendered, "(%(hogql_val_0)s, %(hogql_val_1)s)")
 
     def test_comparison_operators(self):
         self.assertEqual(self._expr("a = b"), "(a = b)")
@@ -5168,7 +5168,7 @@ class TestPostgresPrinter(BaseTest):
     def test_postgres_style_cast(self):
         self.assertEqual(self._expr("123::int"), "CAST(123 AS int)")
         self.assertEqual(self._expr("123.45::float"), "CAST(123.45 AS float)")
-        self.assertEqual(self._expr("'2024-01-01'::date"), "CAST('2024-01-01' AS date)")
+        self.assertEqual(self._expr("'2024-01-01'::date"), "CAST(%(hogql_val_0)s AS date)")
         self.assertEqual(self._expr("event::int"), "CAST(events.event AS int)")
         self.assertEqual(self._expr("event::text"), "CAST(events.event AS text)")
         self.assertEqual(self._expr("event::boolean"), "CAST(events.event AS boolean)")
@@ -5333,19 +5333,19 @@ class TestPostgresPrinter(BaseTest):
     def test_values_query(self):
         self.assertEqual(
             self._select("SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS v (id, name)"),
-            "SELECT v.id, v.name FROM (VALUES (1, 'a'), (2, 'b')) AS v (id, name) LIMIT 50000",
+            "SELECT v.id, v.name FROM (VALUES (1, %(hogql_val_0)s), (2, %(hogql_val_1)s)) AS v (id, name) LIMIT 50000",
         )
 
     def test_values_query_no_alias_columns(self):
         self.assertEqual(
             self._select("SELECT * FROM (VALUES (1, 'hello')) AS v"),
-            "SELECT v.col0, v.col1 FROM (VALUES (1, 'hello')) AS v (col0, col1) LIMIT 50000",
+            "SELECT v.col0, v.col1 FROM (VALUES (1, %(hogql_val_0)s)) AS v (col0, col1) LIMIT 50000",
         )
 
     def test_values_query_no_alias(self):
         self.assertEqual(
             self._select("SELECT * FROM (VALUES (1, 'george', 'created'), (2, 'jack', 'deleted'))"),
-            "SELECT values.col0, values.col1, values.col2 FROM (VALUES (1, 'george', 'created'), (2, 'jack', 'deleted')) AS values (col0, col1, col2) LIMIT 50000",
+            "SELECT values.col0, values.col1, values.col2 FROM (VALUES (1, %(hogql_val_0)s, %(hogql_val_1)s), (2, %(hogql_val_2)s, %(hogql_val_3)s)) AS values (col0, col1, col2) LIMIT 50000",
         )
 
     def test_values_query_clickhouse_raises_error(self):
@@ -5452,28 +5452,32 @@ class TestPostgresPrinter(BaseTest):
         [
             # Renames
             ("ifNull", "ifNull(1, 2)", "COALESCE(1, 2)"),
-            ("replaceAll", "replaceAll('abc', 'a', 'z')", "REPLACE('abc', 'a', 'z')"),
-            ("replaceRegexpAll", "replaceRegexpAll('abc', 'a', 'z')", "REGEXP_REPLACE('abc', 'a', 'z')"),
+            ("replaceAll", "replaceAll('abc', 'a', 'z')", "REPLACE(%(hogql_val_0)s, %(hogql_val_1)s, %(hogql_val_2)s)"),
+            (
+                "replaceRegexpAll",
+                "replaceRegexpAll('abc', 'a', 'z')",
+                "REGEXP_REPLACE(%(hogql_val_0)s, %(hogql_val_1)s, %(hogql_val_2)s)",
+            ),
             ("toTypeName", "toTypeName(1)", "pg_typeof(1)"),
             ("now", "now()", "NOW()"),
             ("any", "any(event)", "MIN(events.event)"),
-            ("startsWith", "startsWith('hello', 'he')", "starts_with('hello', 'he')"),
+            ("startsWith", "startsWith('hello', 'he')", "starts_with(%(hogql_val_0)s, %(hogql_val_1)s)"),
             ("rand", "rand()", "random()"),
             ("generateSeries", "generateSeries(1, 10, 1)", "generate_series(1, 10, 1)"),
             # Type conversions
-            ("toDate", "toDate('2024-01-01')", "CAST('2024-01-01' AS DATE)"),
-            ("toDateTime", "toDateTime('2024-01-01')", "CAST('2024-01-01' AS TIMESTAMP)"),
-            ("toDateTime_tz", "toDateTime('2024-01-01', 'UTC')", "CAST('2024-01-01' AS TIMESTAMP)"),
+            ("toDate", "toDate('2024-01-01')", "CAST(%(hogql_val_0)s AS DATE)"),
+            ("toDateTime", "toDateTime('2024-01-01')", "CAST(%(hogql_val_0)s AS TIMESTAMP)"),
+            ("toDateTime_tz", "toDateTime('2024-01-01', 'UTC')", "CAST(%(hogql_val_0)s AS TIMESTAMP)"),
             ("toString", "toString(123)", "CAST(123 AS TEXT)"),
             ("toInt", "toInt(3.14)", "CAST(3.14 AS BIGINT)"),
             ("toFloat", "toFloat(1)", "CAST(1 AS DOUBLE PRECISION)"),
-            ("toFloatOrZero", "toFloatOrZero('1.5')", "CAST('1.5' AS DOUBLE PRECISION)"),
-            ("toFloatOrDefault", "toFloatOrDefault('1.5')", "CAST('1.5' AS DOUBLE PRECISION)"),
-            ("toIntOrZero", "toIntOrZero('42')", "CAST('42' AS BIGINT)"),
+            ("toFloatOrZero", "toFloatOrZero('1.5')", "CAST(%(hogql_val_0)s AS DOUBLE PRECISION)"),
+            ("toFloatOrDefault", "toFloatOrDefault('1.5')", "CAST(%(hogql_val_0)s AS DOUBLE PRECISION)"),
+            ("toIntOrZero", "toIntOrZero('42')", "CAST(%(hogql_val_0)s AS BIGINT)"),
             ("toBool", "toBool(1)", "CAST(1 AS BOOLEAN)"),
-            ("toUUID", "toUUID('abc')", "CAST('abc' AS UUID)"),
+            ("toUUID", "toUUID('abc')", "CAST(%(hogql_val_0)s AS UUID)"),
             ("toDecimal", "toDecimal(1, 2)", "CAST(1 AS DECIMAL)"),
-            ("toDateTime64", "toDateTime64('2024-01-01', 3)", "CAST('2024-01-01' AS TIMESTAMP)"),
+            ("toDateTime64", "toDateTime64('2024-01-01', 3)", "CAST(%(hogql_val_0)s AS TIMESTAMP)"),
             # Date extraction
             ("toYear", "toYear(now())", "EXTRACT(YEAR FROM NOW())"),
             ("toQuarter", "toQuarter(now())", "EXTRACT(QUARTER FROM NOW())"),
@@ -5524,38 +5528,62 @@ class TestPostgresPrinter(BaseTest):
             (
                 "dateDiff",
                 "dateDiff('day', now(), now())",
-                "DATE_PART('day', CAST(NOW() AS TIMESTAMP) - CAST(NOW() AS TIMESTAMP))",
+                "DATE_PART(%(hogql_val_0)s, CAST(NOW() AS TIMESTAMP) - CAST(NOW() AS TIMESTAMP))",
             ),
             # Conditional
-            ("if", "if(1, 'yes', 'no')", "CASE WHEN 1 THEN 'yes' ELSE 'no' END"),
-            ("multiIf", "multiIf(1, 'a', 0, 'b', 'c')", "CASE WHEN 1 THEN 'a' WHEN 0 THEN 'b' ELSE 'c' END"),
+            ("if", "if(1, 'yes', 'no')", "CASE WHEN 1 THEN %(hogql_val_0)s ELSE %(hogql_val_1)s END"),
+            (
+                "multiIf",
+                "multiIf(1, 'a', 0, 'b', 'c')",
+                "CASE WHEN 1 THEN %(hogql_val_0)s WHEN 0 THEN %(hogql_val_1)s ELSE %(hogql_val_2)s END",
+            ),
             # Null/empty
-            ("empty", "empty('test')", "('test' IS NULL OR 'test' = '')"),
-            ("notEmpty", "notEmpty('test')", "('test' IS NOT NULL AND 'test' != '')"),
+            ("empty", "empty('test')", "(%(hogql_val_0)s IS NULL OR %(hogql_val_0)s = '')"),
+            ("notEmpty", "notEmpty('test')", "(%(hogql_val_0)s IS NOT NULL AND %(hogql_val_0)s != '')"),
             ("isNull", "isNull(1)", "(1 IS NULL)"),
             ("isNotNull", "isNotNull(1)", "(1 IS NOT NULL)"),
             ("assumeNotNull", "assumeNotNull(1)", "1"),
             ("toNullable", "toNullable(1)", "1"),
             # JSON
-            ("JSONExtractInt", "JSONExtractInt('{}', 'key')", "CAST(json_extract_path_text('{}', 'key') AS INTEGER)"),
+            (
+                "JSONExtractInt",
+                "JSONExtractInt('{}', 'key')",
+                "CAST(json_extract_path_text(%(hogql_val_0)s, %(hogql_val_1)s) AS INTEGER)",
+            ),
             (
                 "JSONExtractFloat",
                 "JSONExtractFloat('{}', 'key')",
-                "CAST(json_extract_path_text('{}', 'key') AS DOUBLE PRECISION)",
+                "CAST(json_extract_path_text(%(hogql_val_0)s, %(hogql_val_1)s) AS DOUBLE PRECISION)",
             ),
-            ("JSONExtractBool", "JSONExtractBool('{}', 'key')", "CAST(json_extract_path_text('{}', 'key') AS BOOLEAN)"),
+            (
+                "JSONExtractBool",
+                "JSONExtractBool('{}', 'key')",
+                "CAST(json_extract_path_text(%(hogql_val_0)s, %(hogql_val_1)s) AS BOOLEAN)",
+            ),
             (
                 "JSONExtractUInt",
                 "JSONExtractUInt('{}', 'key')",
-                "CAST(json_extract_path_text('{}', 'key') AS INTEGER)",
+                "CAST(json_extract_path_text(%(hogql_val_0)s, %(hogql_val_1)s) AS INTEGER)",
             ),
             # String
-            ("match", "match('hello', 'h.*o')", "('hello' ~ 'h.*o')"),
-            ("splitByString", "splitByString(',', 'a,b,c')", "STRING_TO_ARRAY('a,b,c', ',')"),
-            ("splitByChar", "splitByChar(',', 'a,b,c')", "STRING_TO_ARRAY('a,b,c', ',')"),
-            ("endsWith", "endsWith('hello', 'lo')", "(RIGHT('hello', LENGTH('lo')) = 'lo')"),
-            ("replaceOne", "replaceOne('abc', 'a', 'z')", "REGEXP_REPLACE('abc', 'a', 'z')"),
-            ("replaceRegexpOne", "replaceRegexpOne('abc', 'a+', 'z')", "REGEXP_REPLACE('abc', 'a+', 'z')"),
+            ("match", "match('hello', 'h.*o')", "(%(hogql_val_0)s ~ %(hogql_val_1)s)"),
+            ("splitByString", "splitByString(',', 'a,b,c')", "STRING_TO_ARRAY(%(hogql_val_1)s, %(hogql_val_0)s)"),
+            ("splitByChar", "splitByChar(',', 'a,b,c')", "STRING_TO_ARRAY(%(hogql_val_1)s, %(hogql_val_0)s)"),
+            (
+                "endsWith",
+                "endsWith('hello', 'lo')",
+                "(RIGHT(%(hogql_val_0)s, LENGTH(%(hogql_val_1)s)) = %(hogql_val_1)s)",
+            ),
+            (
+                "replaceOne",
+                "replaceOne('abc', 'a', 'z')",
+                "REGEXP_REPLACE(%(hogql_val_0)s, %(hogql_val_1)s, %(hogql_val_2)s)",
+            ),
+            (
+                "replaceRegexpOne",
+                "replaceRegexpOne('abc', 'a+', 'z')",
+                "REGEXP_REPLACE(%(hogql_val_0)s, %(hogql_val_1)s, %(hogql_val_2)s)",
+            ),
             # Math
             ("e", "e()", "exp(1)"),
             ("log2", "log2(8)", "log(2, 8)"),
@@ -5707,12 +5735,12 @@ class TestDuckDBPrinter(BaseTest):
             (
                 "formatDateTime_renames_to_strftime",
                 "formatDateTime(timestamp, '%Y-%m-%d')",
-                "strftime(events.timestamp, '%Y-%m-%d')",
+                "strftime(events.timestamp, %(hogql_val_0)s)",
             ),
             (
                 "endsWith_renames_to_ends_with",
                 "endsWith(event, '_done')",
-                "ends_with(events.event, '_done')",
+                "ends_with(events.event, %(hogql_val_0)s)",
             ),
         ]
     )

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -5214,6 +5214,35 @@ class TestPostgresPrinter(BaseTest):
 
     @parameterized.expand(
         [
+            # SQL injection attempts — mirrors test_type_cast_typename_escape for TRY_CAST.
+            ("int); DROP TABLE users; --", '"int); DROP TABLE users; --"'),
+            ("text' OR '1'='1", "\"text' OR '1'='1\""),
+            ("int; DELETE FROM events;", '"int; DELETE FROM events;"'),
+            ("varchar(100)); --", '"varchar(100)); --"'),
+            # Quote escaping
+            ('int"test', '"int""test"'),
+            ("int'test", '"int\'test"'),
+            # Backslash handling
+            ("int\\test", '"int\\test"'),
+            # Unicode/special chars
+            ("int\x00test", '"int\x00test"'),
+            # Newlines and whitespace injection
+            ("int\nDROP TABLE", '"int\nDROP TABLE"'),
+            ("int\rtest", '"int\rtest"'),
+            # Simple identifiers should not be quoted
+            ("varchar", "varchar"),
+            ("integer", "integer"),
+        ]
+    )
+    def test_try_cast_typename_escape(self, type_name, expected_escaped):
+        node = ast.TryCast(
+            expr=ast.Constant(value=123),
+            type_name=type_name,
+        )
+        self.assertEqual(self._expr(node), f"TRY_CAST(123 AS {expected_escaped})")
+
+    @parameterized.expand(
+        [
             (
                 "basic",
                 "WITH stats(a, b) AS (SELECT event, timestamp FROM events) SELECT a, b FROM stats",

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -5707,3 +5707,19 @@ class TestDuckDBPrinter(BaseTest):
         printer = DuckDBPrinter(context=HogQLContext(team_id=self.team.pk))
         # Simple alphanumeric identifier — returned verbatim without quoting.
         self.assertEqual(printer._print_identifier(long_name), long_name)
+
+    @parameterized.expand(
+        [
+            ("pivot",),
+            ("unpivot",),
+            ("qualify",),
+            ("exclude",),
+            ("replace",),
+        ]
+    )
+    def test_duckdb_extra_reserved_keywords_are_quoted(self, name: str):
+        # DuckDB reserves these even though Postgres doesn't — an unquoted identifier would parse-error.
+        from posthog.hogql.printer.duckdb import DuckDBPrinter
+
+        printer = DuckDBPrinter(context=HogQLContext(team_id=self.team.pk))
+        self.assertEqual(printer._print_identifier(name), f'"{name}"')

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -5710,11 +5710,23 @@ class TestDuckDBPrinter(BaseTest):
 
     @parameterized.expand(
         [
-            ("pivot",),
-            ("unpivot",),
-            ("qualify",),
+            ("anti",),
+            ("asof",),
+            ("attach",),
+            ("detach",),
             ("exclude",),
+            ("install",),
+            ("load",),
+            ("macro",),
+            ("pivot",),
+            ("positional",),
+            ("pragma",),
+            ("qualify",),
             ("replace",),
+            ("sample",),
+            ("semi",),
+            ("summarize",),
+            ("unpivot",),
         ]
     )
     def test_duckdb_extra_reserved_keywords_are_quoted(self, name: str):

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -5754,8 +5754,9 @@ class TestDuckDBPrinter(BaseTest):
         )
 
     def test_identifier_no_truncation(self):
-        # PG would truncate a >63-char generated alias with double underscores into a SHA-suffixed name,
-        # and raise outright via escape_postgres_identifier. DuckDB leaves it intact.
+        # PG would truncate a >63-char generated alias containing double underscores into a SHA-suffixed
+        # name via ``_print_identifier``'s truncation heuristic. The separate ``escape_postgres_identifier``
+        # length error applies to overlong identifiers that don't hit that heuristic. DuckDB leaves it intact.
         long_name = "a_really_long_table_name_that_would_force_pg_to_truncate__here"
         long_name += "_even_further_past_63_chars"
         self.assertGreater(len(long_name), 63)

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -5624,3 +5624,86 @@ class TestPostgresPrinter(BaseTest):
             self._expr("date_bin(toIntervalHour(1), now(), now())", context=context),
             "date_bin((1 * INTERVAL '1 hour'), NOW(), NOW())",
         )
+
+
+class TestDuckDBPrinter(BaseTest):
+    """DuckDB printer tests — focused on the DuckDB-specific overrides vs Postgres.
+
+    The DuckDB dialect inherits most of its behavior from PostgresPrinter, so the
+    full PG test surface is implicitly covered via inheritance. The assertions below
+    lock in the specific places DuckDB output diverges from PG.
+    """
+
+    maxDiff = None
+
+    def _expr(
+        self,
+        query: ast.Expr | str,
+        context: Optional[HogQLContext] = None,
+        settings: Optional[HogQLQuerySettings] = None,
+        backend: HogQLParserBackend = "cpp-json",
+    ) -> str:
+        node = parse_expr(query, backend=backend) if isinstance(query, str) else query
+        context = context or HogQLContext(team_id=self.team.pk, enable_select_queries=True)
+        select_query = ast.SelectQuery(
+            select=[node], select_from=ast.JoinExpr(table=ast.Field(chain=["events"])), settings=settings
+        )
+        prepared_select_query: ast.SelectQuery = cast(
+            ast.SelectQuery,
+            prepare_ast_for_printing(select_query, context=context, dialect="duckdb", stack=[select_query]),
+        )
+        return print_prepared_ast(
+            prepared_select_query.select[0],
+            context=context,
+            dialect="duckdb",
+            stack=[prepared_select_query],
+        )
+
+    def _select(
+        self,
+        query: str,
+        context: Optional[HogQLContext] = None,
+        placeholders: Optional[dict[str, ast.Expr]] = None,
+    ) -> str:
+        return prepare_and_print_ast(
+            parse_select(query, placeholders=placeholders, backend="cpp-json"),
+            context or HogQLContext(team_id=self.team.pk, enable_select_queries=True),
+            "duckdb",
+        )[0]
+
+    @parameterized.expand(
+        [
+            ("any_renames_to_any_value", "any(event)", "any_value(events.event)"),
+            ("toTypeName_renames_to_typeof", "toTypeName(event)", "typeof(events.event)"),
+            (
+                "formatDateTime_renames_to_strftime",
+                "formatDateTime(timestamp, '%Y-%m-%d')",
+                "strftime(events.timestamp, '%Y-%m-%d')",
+            ),
+            (
+                "endsWith_renames_to_ends_with",
+                "endsWith(event, '_done')",
+                "ends_with(events.event, '_done')",
+            ),
+        ]
+    )
+    def test_function_renames(self, _name: str, expr: str, expected: str):
+        self.assertEqual(self._expr(expr), expected)
+
+    def test_smoke_basic_select(self):
+        self.assertEqual(
+            self._select("SELECT event FROM events"),
+            "SELECT events.event FROM events LIMIT 50000",
+        )
+
+    def test_identifier_no_truncation(self):
+        # PG would truncate a >63-char generated alias with double underscores into a SHA-suffixed name,
+        # and raise outright via escape_postgres_identifier. DuckDB leaves it intact.
+        long_name = "a_really_long_table_name_that_would_force_pg_to_truncate__here"
+        long_name += "_even_further_past_63_chars"
+        self.assertGreater(len(long_name), 63)
+        from posthog.hogql.printer.duckdb import DuckDBPrinter
+
+        printer = DuckDBPrinter(context=HogQLContext(team_id=self.team.pk))
+        # Simple alphanumeric identifier — returned verbatim without quoting.
+        self.assertEqual(printer._print_identifier(long_name), long_name)

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -5735,3 +5735,13 @@ class TestDuckDBPrinter(BaseTest):
 
         printer = DuckDBPrinter(context=HogQLContext(team_id=self.team.pk))
         self.assertEqual(printer._print_identifier(name), f'"{name}"')
+
+    def test_percent_in_identifier_rejected_postgres_family(self):
+        # ``%`` in an identifier would confuse psycopg's parameter-placeholder scanning.
+        from posthog.hogql.printer.duckdb import DuckDBPrinter
+        from posthog.hogql.printer.postgres import PostgresPrinter
+
+        ctx = HogQLContext(team_id=self.team.pk)
+        for printer in (DuckDBPrinter(context=ctx), PostgresPrinter(context=ctx)):
+            with self.assertRaisesMessage(QueryError, 'is not permitted as it contains the "%" character'):
+                printer._print_identifier("bad%name")

--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -11,6 +11,7 @@ from posthog.hogql.errors import InternalHogQLError
 from posthog.hogql.modifiers import create_default_modifiers_for_team, set_default_in_cohort_via
 from posthog.hogql.printer.base import BasePrinter
 from posthog.hogql.printer.clickhouse import ClickHousePrinter
+from posthog.hogql.printer.duckdb import DuckDBPrinter
 from posthog.hogql.printer.hogql import HogQLPrinter
 from posthog.hogql.printer.postgres import PostgresPrinter
 from posthog.hogql.resolver import resolve_types
@@ -107,7 +108,7 @@ def prepare_ast_for_printing(
         with context.timings.measure("projection_pushdown"):
             node = pushdown_projections(node, context)
 
-    if dialect == "postgres":
+    if dialect in ("postgres", "duckdb"):
         with context.timings.measure("resolve_lazy_tables"):
             resolve_lazy_tables(node, dialect, stack, context)
 
@@ -182,6 +183,13 @@ def print_prepared_ast(
                 )
             case "postgres":
                 printer = PostgresPrinter(
+                    context=context,
+                    stack=printer_stack,
+                    settings=settings,
+                    pretty=pretty,
+                )
+            case "duckdb":
+                printer = DuckDBPrinter(
                     context=context,
                     stack=printer_stack,
                     settings=settings,

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -178,9 +178,6 @@ class Resolver(CloningVisitor):
         parent_ctes = self.ctes
         self.ctes = dict(parent_ctes)
 
-        if node.limit_with_ties and self.dialect in _POSTGRES_FAMILY:
-            raise QueryError("WITH TIES is not supported in postgres dialect")
-
         initial = self.visit(node.initial_select_query)
 
         # Root WITH propagates to all subsequent branches. Branch-level CTEs shadow root CTEs.
@@ -599,8 +596,6 @@ class Resolver(CloningVisitor):
 
     def visit_select_query(self, node: ast.SelectQuery):
         """Visit each SELECT query or subquery."""
-        if node.limit_with_ties and self.dialect in _POSTGRES_FAMILY:
-            raise QueryError("WITH TIES is not supported in postgres dialect")
         # This "SelectQueryType" is also a new scope for variables in the SELECT query.
         # We will add fields to it when we encounter them. This is used to resolve fields later.
         node_type = ast.SelectQueryType()

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -58,6 +58,11 @@ POSTGRES_KEYWORD_TYPES: dict[str, PostgresKeywordType] = {
     "localtimestamp": ast.DateTimeType,
 }
 
+# Dialects that share Postgres's SQL surface (feature support, keyword set, syntax quirks).
+# DuckDB is Postgres-wire compatible and accepts nearly all PG-specific constructs, so it
+# takes the PG code path in the resolver.
+_POSTGRES_FAMILY: frozenset[HogQLDialect] = frozenset({"postgres", "duckdb"})
+
 
 def resolve_constant_data_type(constant: Any) -> ConstantType:
     if constant is None:
@@ -173,7 +178,7 @@ class Resolver(CloningVisitor):
         parent_ctes = self.ctes
         self.ctes = dict(parent_ctes)
 
-        if node.limit_with_ties and self.dialect == "postgres":
+        if node.limit_with_ties and self.dialect in _POSTGRES_FAMILY:
             raise QueryError("WITH TIES is not supported in postgres dialect")
 
         initial = self.visit(node.initial_select_query)
@@ -233,7 +238,7 @@ class Resolver(CloningVisitor):
         return result
 
     def visit_unpivot_expr(self, node: ast.UnpivotExpr):
-        if self.dialect != "postgres":
+        if self.dialect not in _POSTGRES_FAMILY:
             raise QueryError(f"UNPIVOT is not allowed in {self.dialect} dialect")
 
         node = cast(ast.UnpivotExpr, clone_expr(node))
@@ -420,7 +425,7 @@ class Resolver(CloningVisitor):
             self.scopes.pop()
 
     def visit_pivot_expr(self, node: ast.PivotExpr):
-        if self.dialect != "postgres":
+        if self.dialect not in _POSTGRES_FAMILY:
             raise QueryError(f"PIVOT is not allowed in {self.dialect} dialect")
 
         node = cast(ast.PivotExpr, clone_expr(node))
@@ -594,7 +599,7 @@ class Resolver(CloningVisitor):
 
     def visit_select_query(self, node: ast.SelectQuery):
         """Visit each SELECT query or subquery."""
-        if node.limit_with_ties and self.dialect == "postgres":
+        if node.limit_with_ties and self.dialect in _POSTGRES_FAMILY:
             raise QueryError("WITH TIES is not supported in postgres dialect")
         # This "SelectQueryType" is also a new scope for variables in the SELECT query.
         # We will add fields to it when we encounter them. This is used to resolve fields later.
@@ -633,7 +638,7 @@ class Resolver(CloningVisitor):
         # Visit the FROM clauses first. This resolves all table aliases onto self.scopes[-1]
         new_node.select_from = self.visit(node.select_from)
 
-        if node.limit_percent and self.dialect != "postgres":
+        if node.limit_percent and self.dialect not in _POSTGRES_FAMILY:
             if self.dialect == "clickhouse":
                 if not (isinstance(node.limit, ast.Constant) and isinstance(node.limit.value, (int, float))):
                     raise QueryError("LIMIT percent with expressions is not supported in clickhouse dialect")
@@ -1197,7 +1202,7 @@ class Resolver(CloningVisitor):
                 # For non-postgres dialects, bake column aliases into the inner
                 # SELECT as AS aliases so ClickHouse/HogQL (which don't support
                 # the ``AS t(col1, col2)`` syntax) get correct column names.
-                if self.dialect != "postgres":
+                if self.dialect not in _POSTGRES_FAMILY:
                     inner_query = cast(ast.SelectQuery, inner_select)
                     new_select: list[ast.Expr] = []
                     for i, expr in enumerate(inner_query.select):
@@ -1526,21 +1531,21 @@ class Resolver(CloningVisitor):
         return new_node
 
     def visit_try_cast(self, node: ast.TryCast):
-        if self.dialect != "postgres":
+        if self.dialect not in _POSTGRES_FAMILY:
             raise QueryError(f"TRY_CAST is not allowed in {self.dialect} dialect")
         node = cast(ast.TryCast, clone_expr(node))
         node.expr = self.visit(node.expr)
         return node
 
     def visit_positional_ref(self, node: ast.PositionalRef):
-        if self.dialect != "postgres":
+        if self.dialect not in _POSTGRES_FAMILY:
             raise QueryError(f"Positional references are not allowed in {self.dialect} dialect")
         node = cast(ast.PositionalRef, clone_expr(node))
         node.type = ast.UnknownType()
         return node
 
     def visit_array_slice(self, node: ast.ArraySlice):
-        if self.dialect not in {"postgres", "clickhouse"}:
+        if self.dialect not in _POSTGRES_FAMILY and self.dialect != "clickhouse":
             raise QueryError(f"Array slices are not allowed in {self.dialect} dialect")
         node = cast(ast.ArraySlice, clone_expr(node))
         node.array = self.visit(node.array)
@@ -1558,7 +1563,7 @@ class Resolver(CloningVisitor):
         scope = self._get_scope()
         name = str(node.chain[0])
 
-        if self.dialect == "postgres" and len(node.chain) == 1:
+        if self.dialect in _POSTGRES_FAMILY and len(node.chain) == 1:
             keyword = name.lower()
             if keyword in POSTGRES_KEYWORD_TYPES and name not in scope.columns and name not in scope.aliases:
                 keyword_type = POSTGRES_KEYWORD_TYPES[keyword]
@@ -1601,7 +1606,7 @@ class Resolver(CloningVisitor):
         if (
             not type
             and len(node.chain) == 1
-            and self.dialect == "postgres"
+            and self.dialect in _POSTGRES_FAMILY
             and name.lower() in POSTGRES_KEYWORD_TYPES
             and name in scope.columns
         ):

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -1769,9 +1769,14 @@ class TestResolver(BaseTest):
             resolve_types(expr, self.context, dialect="clickhouse")
 
     def test_limit_with_ties_postgres_error(self):
+        # WITH TIES is rejected by the Postgres printer's ``_assert_with_ties_supported`` hook
+        # rather than by the resolver, so we need to run the full print pipeline to observe it.
         with self.assertRaisesMessage(QueryError, "WITH TIES is not supported in postgres dialect"):
-            expr = self._select("SELECT 1 FROM events ORDER BY 1 LIMIT 1 WITH TIES")
-            resolve_types(expr, self.context, dialect="postgres")
+            prepare_and_print_ast(
+                self._select("SELECT 1 FROM events ORDER BY 1 LIMIT 1 WITH TIES"),
+                self.context,
+                "postgres",
+            )
 
     def test_positional_refs_postgres(self):
         expr = self._select("SELECT #1, #2 FROM events")

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_pre_aggregated.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_pre_aggregated.ambr
@@ -35,15 +35,7 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.person_id,
-               events.`mat_$device_type`,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-31'), lessOrEquals(toDate(events.timestamp), '2024-01-03'))) AS events
+     FROM events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
@@ -59,7 +51,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-02 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-02 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
@@ -116,15 +108,7 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.person_id,
-               events.`mat_$browser`,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-31'), lessOrEquals(toDate(events.timestamp), '2024-01-03'))) AS events
+     FROM events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
@@ -140,7 +124,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-02 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-02 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
@@ -197,15 +181,7 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.person_id,
-               events.`mat_$geoip_country_code`,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-31'), lessOrEquals(toDate(events.timestamp), '2024-01-03'))) AS events
+     FROM events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
@@ -221,7 +197,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-02 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-02 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`
@@ -278,14 +254,7 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.person_id,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-31'), lessOrEquals(toDate(events.timestamp), '2024-01-03'))) AS events
+     FROM events
      LEFT JOIN
        (SELECT nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), '') AS `$entry_utm_source`,
                toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
@@ -302,7 +271,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-02 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-01 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-02 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`

--- a/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
@@ -80,13 +80,13 @@ def _is_duckgres_shadow_enabled(team: Team) -> bool:
         return False
 
 
-def _compile_hogql_to_postgres_sql(hogql_query: str, team_id: int) -> str:
+def _compile_hogql_to_postgres_sql(hogql_query: str, team_id: int) -> tuple[str, dict[str, object]]:
     from posthog.schema import HogQLQuery
 
     from posthog.ducklake.client import compile_hogql_to_ducklake_sql
 
-    postgres_sql, _ = compile_hogql_to_ducklake_sql(team_id, HogQLQuery(query=hogql_query))
-    return postgres_sql
+    postgres_sql, values, _ = compile_hogql_to_ducklake_sql(team_id, HogQLQuery(query=hogql_query))
+    return postgres_sql, values
 
 
 @database_sync_to_async
@@ -155,16 +155,19 @@ async def materialize_view_duckgres_activity(inputs: DuckgresShadowInputs) -> Du
 
     start_time = time.monotonic()
     sql: str = ""
+    values: dict[str, object] = {}
     try:
         if inputs.dangerously_execute_raw_sql:
             sql = hogql_query
         else:
-            sql = await database_sync_to_async(_compile_hogql_to_postgres_sql)(hogql_query, team.pk)
+            sql, values = await database_sync_to_async(_compile_hogql_to_postgres_sql)(hogql_query, team.pk)
         await logger.adebug("Duckgres shadow SQL generated", sql=sql)
 
         from posthog.ducklake.client import execute_ducklake_create_table
 
-        result = await database_sync_to_async(execute_ducklake_create_table)(team.pk, sql, schema_name, table_name)
+        result = await database_sync_to_async(execute_ducklake_create_table)(
+            team.pk, sql, schema_name, table_name, values
+        )
         duration = time.monotonic() - start_time
 
         await logger.ainfo(


### PR DESCRIPTION
## Problem

After the 5-PR printer-split series (#54483, #54517, #54669, #54681, #54721), the printer module is structurally ready for a new dialect. DuckDB has been riding the Postgres printer by virtue of being PG-wire compatible, but that hides meaningful DuckDB-native wins — `any_value` vs `MIN`, `typeof` vs `pg_typeof`, `strftime` vs `TO_CHAR`, native `ends_with`, no 63-char identifier limit, etc.

This PR introduces `DuckDBPrinter` as a dedicated subclass of `PostgresPrinter` and ships the first batch of DuckDB-specific overrides. Follow-ups will add native date/time bucketing (`time_bucket`) and tuple/struct/array rendering.

## Changes

### Core

- Extended `HogQLDialect` → `Literal["hogql", "clickhouse", "postgres", "duckdb"]`.
- New `posthog/hogql/printer/duckdb.py` — `class DuckDBPrinter(PostgresPrinter)` with `DIALECT_NAME = "duckdb"`.
- New `posthog/hogql/printer/duckdb_functions.py` — DuckDB-specific function rename table.
- Dispatch wired in `utils.py::print_prepared_ast` (new `"duckdb"` match arm). `prepare_ast_for_printing` treats DuckDB as PG-family (shares the `resolve_lazy_tables` path).
- `DuckDBPrinter` exported from `printer/__init__.py`.

### PostgresPrinter function-table hooks

`PostgresPrinter.visit_call` previously referenced `POSTGRES_FUNCTION_RENAMES_LOWER` / `POSTGRES_FUNCTION_HANDLERS_LOWER` / `POSTGRES_PASSTHROUGH_FUNCTIONS` directly. Extracted to three hooks (`_get_function_renames`, `_get_function_handlers`, `_get_passthrough_functions`) so subclasses can layer without replicating `visit_call`. Defaults preserve today's PG behavior byte-for-byte.

### Resolver — PG-family set

Nine `postgres` branches in `resolver.py` now accept DuckDB via a module-level `_POSTGRES_FAMILY: frozenset[HogQLDialect] = frozenset({"postgres", "duckdb"})`. DuckDB takes the PG code path for every semantic/feature-gate decision:
- UNPIVOT / PIVOT permit
- TRY_CAST / positional references / array slices permit
- LIMIT percent validation
- WITH TIES rejection
- Reserved-keyword handling (`current_date`, `localtimestamp`, …)
- Column-alias baking into inner SELECT (bypassed for PG-family; DuckDB supports `AS t(col1, col2)` syntax).

### Identifier escaping

New `escape_duckdb_identifier` in `posthog/hogql/escape_sql.py` — shares PG's quoting rules via a `_quote_postgres_wire_identifier` helper, but skips the 63-character length check. `DuckDBPrinter._print_identifier` uses it instead of `escape_postgres_identifier`.

### DuckDB function renames (first batch)

Overlay on top of the inherited Postgres rename table:

| HogQL name | PG target | DuckDB target |
|---|---|---|
| `any` | `MIN` (hack) | `any_value` (native) |
| `toTypeName` | `pg_typeof` | `typeof` |
| `formatDateTime` | `TO_CHAR` (different pattern language) | `strftime` (same strftime patterns HogQL uses) |
| `endsWith` | emulated via `RIGHT(x, len(y)) = y` | `ends_with` (native) |

`endsWith` is in PG's handler table (not renames), so `DuckDBPrinter._get_function_handlers` strips any key that DuckDB renames — otherwise the handler would shadow the rename.

## How did you test this code?

- `ruff check` — clean.
- New `TestDuckDBPrinter` class in `test_printer.py` with parameterized assertions for each of the 4 renames, plus a smoke-test `SELECT` and an identifier-no-truncation check.
- Full printer test matrix: **540 passed, 175 snapshots passed, 0 failed** across HogQL, ClickHouse, Postgres, and the new DuckDB tests. No PG/CH/HogQL snapshot changes.

## Publish to changelog?

no

## 🤖 LLM context

Authored via Claude Code. First of three planned PRs adding DuckDB as a first-class dialect to the HogQL printer. Follow-ups:

- **PR 2**: Native date/time bucketing (`time_bucket` for sub-hour buckets, DuckDB `date_trunc` semantics, `quantile_cont`/`quantile_disc` percentiles).
- **PR 3**: Tuple / struct / array / JSON native rendering (single-element tuple handling, `LIST` / `STRUCT`, JSON path access, `regexp_matches`, native string-op functions).

Stacked on #54721.
