### PR TITLE
fix(dashboards): do not apply properties to insights with dwh series

### DIFF
--- a/posthog/hogql_queries/insights/lifecycle/test/test_lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle/test/test_lifecycle_query_runner.py
@@ -2207,10 +2207,16 @@ class TestLifecycleQueryRunner(ClickhouseTestMixin, APIBaseTest):
             )
         )
 
+        # date range is overriden
         assert query_runner.query.dateRange is not None
         assert query_runner.query.dateRange.date_from == "2024-07-07"
         assert query_runner.query.dateRange.date_to == "2024-07-14"
-        assert query_runner.query.properties is None
+
+        # but properties are not
+        assert query_runner.query.properties == []
+
+        # validations pass
+        query_runner.validate()
 
     @parameterized.expand(
         [

--- a/posthog/hogql_queries/insights/lifecycle/test/test_lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle/test/test_lifecycle_query_runner.py
@@ -23,6 +23,7 @@ from posthog.schema import (
     EventsNode,
     HogQLPropertyFilter,
     IntervalType,
+    LifecycleDataWarehouseNode,
     LifecycleQuery,
     PersonPropertyFilter,
     PropertyOperator,
@@ -2179,6 +2180,37 @@ class TestLifecycleQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         assert not hasattr(query_runner.query, "breakdownFilter")
+
+    def test_dashboard_property_filters_are_ignored_for_data_warehouse_series(self):
+        query_runner = LifecycleQueryRunner(
+            team=self.team,
+            query=LifecycleQuery(
+                dateRange=DateRange(date_from="2020-01-09", date_to="2020-01-20"),
+                interval=IntervalType.DAY,
+                series=[
+                    LifecycleDataWarehouseNode(
+                        id="messages",
+                        table_name="messages",
+                        timestamp_field="sent_at",
+                        aggregation_target_field="person_id",
+                        created_at_field="created_at",
+                    )
+                ],
+            ),
+        )
+
+        query_runner.apply_dashboard_filters(
+            DashboardFilter(
+                date_from="2024-07-07",
+                date_to="2024-07-14",
+                properties=[EventPropertyFilter(key="dashboard", value="filter", operator="exact")],
+            )
+        )
+
+        assert query_runner.query.dateRange is not None
+        assert query_runner.query.dateRange.date_from == "2024-07-07"
+        assert query_runner.query.dateRange.date_to == "2024-07-14"
+        assert query_runner.query.properties is None
 
     @parameterized.expand(
         [

--- a/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
@@ -33,7 +33,7 @@ class TestTrendsDashboardFilters(BaseTest):
         date_from: str,
         date_to: Optional[str],
         interval: IntervalType,
-        series: Optional[list[EventsNode | ActionsNode]],
+        series: Optional[list[EventsNode | ActionsNode | DataWarehouseNode]],
         properties: Optional[list[EventPropertyFilter] | PropertyGroupFilter] = None,
         trends_filters: Optional[TrendsFilter] = None,
         breakdown: Optional[BreakdownFilter] = None,
@@ -43,7 +43,9 @@ class TestTrendsDashboardFilters(BaseTest):
         explicit_date: Optional[bool] = None,
         compare_filters: Optional[CompareFilter] = None,
     ) -> TrendsQueryRunner:
-        query_series: list[EventsNode | ActionsNode] = [EventsNode(event="$pageview")] if series is None else series
+        query_series: list[EventsNode | ActionsNode | DataWarehouseNode] = (
+            [EventsNode(event="$pageview")] if series is None else series
+        )
         query = TrendsQuery(
             dateRange=DateRange(date_from=date_from, date_to=date_to, explicitDate=explicit_date),
             interval=interval,
@@ -491,7 +493,13 @@ class TestTrendsDashboardFilters(BaseTest):
             )
         )
 
+        # date range is overriden
         assert query_runner.query.dateRange is not None
         assert query_runner.query.dateRange.date_from == "2024-07-07"
         assert query_runner.query.dateRange.date_to == "2024-07-14"
-        assert query_runner.query.properties is None
+
+        # but properties are not
+        assert query_runner.query.properties == []
+
+        # validations pass
+        query_runner.validate()

--- a/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
@@ -9,6 +9,7 @@ from posthog.schema import (
     BreakdownFilter,
     CompareFilter,
     DashboardFilter,
+    DataWarehouseNode,
     DateRange,
     EventPropertyFilter,
     EventsNode,
@@ -464,3 +465,33 @@ class TestTrendsDashboardFilters(BaseTest):
         assert query_runner.query.compareFilter == CompareFilter(
             compare=False
         )  # There's no previous period for the "all time" date range
+
+    def test_dashboard_property_filters_are_ignored_for_data_warehouse_series(self):
+        query_runner = self._create_query_runner(
+            "2020-01-09",
+            "2020-01-20",
+            IntervalType.DAY,
+            [
+                DataWarehouseNode(
+                    id="warehouse_orders",
+                    table_name="warehouse_orders",
+                    name="Orders",
+                    timestamp_field="created_at",
+                    id_field="order_id",
+                    distinct_id_field="customer_id",
+                )
+            ],
+        )
+
+        query_runner.apply_dashboard_filters(
+            DashboardFilter(
+                date_from="2024-07-07",
+                date_to="2024-07-14",
+                properties=[EventPropertyFilter(key="dashboard", value="filter", operator="exact")],
+            )
+        )
+
+        assert query_runner.query.dateRange is not None
+        assert query_runner.query.dateRange.date_from == "2024-07-07"
+        assert query_runner.query.dateRange.date_to == "2024-07-14"
+        assert query_runner.query.properties is None

--- a/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
@@ -499,7 +499,7 @@ class TestTrendsDashboardFilters(BaseTest):
         assert query_runner.query.dateRange.date_to == "2024-07-14"
 
         # but properties are not
-        assert query_runner.query.properties == []
+        assert query_runner.query.properties is None
 
         # validations pass
         query_runner.validate()

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -93,6 +93,7 @@ from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries
 from posthog.errors import classify_query_error, clickhouse_error_type
 from posthog.event_usage import AnalyticsProps, groups, report_user_or_team_action
 from posthog.exceptions_capture import capture_exception
+from posthog.hogql_queries.insights.utils.entities import has_data_warehouse_node
 from posthog.hogql_queries.insights.utils.properties import has_any_property_filters
 from posthog.hogql_queries.query_cache import count_query_cache_hit
 from posthog.hogql_queries.query_cache_base import QueryCacheManagerBase
@@ -1830,7 +1831,14 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
 
         # The default logic below applies to all insights and a lot of other queries
         # Notable exception: `HogQLQuery`, which has `properties` and `dateRange` within `HogQLFilters`
-        if dashboard_filter.properties:
+        should_ignore_dashboard_properties = (
+            dashboard_filter.properties
+            and hasattr(self.query, "series")
+            and isinstance(self.query.series, list)
+            and has_data_warehouse_node(self.query.series)
+        )
+
+        if dashboard_filter.properties and not should_ignore_dashboard_properties:
             if self.query.properties and has_any_property_filters(self.query.properties):
                 # Check if query expects only a list (e.g. WebOverviewQuery) vs union with PropertyGroupFilter
                 properties_field = self.query.__class__.model_fields.get("properties")

--- a/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
+++ b/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
@@ -1071,15 +1071,7 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.person_id,
-               events.`mat_$browser`,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-13'), lessOrEquals(toDate(events.timestamp), '2024-01-17'))) AS events
+     FROM events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Pacific/Auckland')), max(toTimeZone(raw_sessions.max_timestamp, 'Pacific/Auckland'))), 10)))) AS `$is_bounce`,
@@ -1096,7 +1088,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Pacific/Auckland'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Pacific/Auckland'))), lessOrEquals(toTimeZone(events.timestamp, 'Pacific/Auckland'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Pacific/Auckland')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Pacific/Auckland'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Pacific/Auckland'))), lessOrEquals(toTimeZone(events.timestamp, 'Pacific/Auckland'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Pacific/Auckland')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`


### PR DESCRIPTION
## Problem

We added validations that correctly forbid insights with a data warehouse series from having properties. The case where the properties are passed down as override from a dashboard was not accounted for.

## Changes

Let's not pass down the properties, if an insight has a data warehouse series. I'm working on displaying this in a proper manner separately.

## How did you test this code?

Manual testing