### PR TITLE
SUPPORT SUPERDAY: feat(support): add GitHub bug-report link to support menu

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/support/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/support/SidePanelSupport.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import React from 'react'
 
-import { IconFeatures, IconHelmet, IconMap, IconWarning } from '@posthog/icons'
+import { IconBug, IconFeatures, IconHelmet, IconMap, IconWarning } from '@posthog/icons'
 import { LemonButton, Link } from '@posthog/lemon-ui'
 
 import { incidentStatusLogic } from 'lib/components/HealthMenu/incidentStatusLogic'
@@ -472,6 +472,17 @@ export function SidePanelSupport(): JSX.Element {
                                             targetBlank
                                         >
                                             Request a feature
+                                        </LemonButton>
+                                    </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
+                                            to="https://github.com/PostHog/posthog/issues/new?&labels=bug&template=bug_report.yml"
+                                            icon={<IconBug />}
+                                            targetBlank
+                                        >
+                                            Report a bug
                                         </LemonButton>
                                     </li>
                                 </ul>


### PR DESCRIPTION
## Problem

The in-app support side panel has a "Request a feature" button but no equivalent shortcut for reporting a bug, so users have to leave the product to find the right GitHub issue template.

## Changes

Adds a "Report a bug" `LemonButton` to the "Share feedback" section of the support side panel, placed directly below "Request a feature". The button opens the pre-filled GitHub bug-report form in a new tab using the existing `bug_report.yml` template and `bug` label.

- New sibling `<li>` in `SidePanelSupport.tsx`, mirrors the adjacent feature-request button's props (`type="secondary"`, `status="alt"`, `targetBlank`) so styling stays consistent
- Uses `IconBug` from `@posthog/icons`
- Links to `https://github.com/PostHog/posthog/issues/new?&labels=bug&template=bug_report.yml`

## How did you test this code?

- Ran `tsc --noEmit` locally against the frontend workspace — no TypeScript errors attributed to this change. The two `implicit-any` errors that do appear in `SidePanelSupport.tsx` are at lines 113 and 116, which are pre-existing kea-driven code untouched by this PR
- Confirmed `.github/ISSUE_TEMPLATE/bug_report.yml` declares `labels: ['bug']`, matching the `labels=bug` URL query string
- Loaded the target URL in a browser to verify GitHub serves the pre-filled bug-report form
- Verified the new button mirrors the adjacent feature-request button exactly (props, structure, placement), so render parity is expected
- No unit tests added — this is a JSX link-only change with no logic to cover
- App not run locally; relying on the PR preview deploy for visual verification

## Publish to changelog?

No — small UX addition, not a headline feature.

## Docs update

Not required.

## 🤖 LLM context

SUPPORT SUPERDAY submission. Co-authored with Claude Code (Opus 4.7). Single-file JSX addition, no refactor, no new tests, no new Storybook story. cc @abigailbramble.