### PR TITLE
fix(claude): avoid cross-worktree pollution in setup-flox cache

### DIFF
--- a/.claude/hooks/setup-flox.sh
+++ b/.claude/hooks/setup-flox.sh
@@ -5,33 +5,19 @@
 # CLAUDE_ENV_FILE is only available in SessionStart hooks:
 # https://code.claude.com/docs/en/hooks#sessionstart
 
-HOOK_LOG="${CLAUDE_PROJECT_DIR:-$(pwd)}/.claude/setup-flox.log"
-log_hook() {
-  printf '%s reason=%s remote=%q env_file=%s project=%q\n' \
-    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-    "$1" \
-    "${CLAUDE_CODE_REMOTE:-}" \
-    "${CLAUDE_ENV_FILE:+set}" \
-    "${CLAUDE_PROJECT_DIR:-}" \
-    >> "$HOOK_LOG" 2>/dev/null || true
-}
+# Records the hook's exit path as env vars so future sessions can inspect
+# what happened via `echo $POSTHOG_FLOX_HOOK_EXIT` — cheap breadcrumb for
+# diagnosing failures like the cross-worktree cache pollution we hit before.
 mark_exit() {
-  log_hook "$1"
   if [ -n "$CLAUDE_ENV_FILE" ]; then
     printf 'export POSTHOG_FLOX_HOOK_EXIT=%q\n' "$1" >> "$CLAUDE_ENV_FILE"
     printf 'export POSTHOG_FLOX_HOOK_STARTED=%q\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$CLAUDE_ENV_FILE"
   fi
 }
-log_hook started
 
-# Skip on Claude web (no flox there); distinguish from a missing CLAUDE_ENV_FILE
-# so the log tells us which branch fired.
-if [ "$CLAUDE_CODE_REMOTE" = "true" ]; then
-  log_hook remote
-  exit 0
-fi
-if [ -z "$CLAUDE_ENV_FILE" ]; then
-  log_hook no_env_file
+# Skip on Claude web (no flox there); skip if CLAUDE_ENV_FILE is unset since
+# we'd have nowhere to write the captured env anyway.
+if [ "$CLAUDE_CODE_REMOTE" = "true" ] || [ -z "$CLAUDE_ENV_FILE" ]; then
   exit 0
 fi
 

--- a/.claude/hooks/setup-flox.sh
+++ b/.claude/hooks/setup-flox.sh
@@ -56,11 +56,22 @@ if [ -f "$FLOX_MANIFEST" ]; then
   fi
 fi
 
+# Worktree-local env (VIRTUAL_ENV, PATH prepend) must NOT be cached — the
+# cache file is often hardlinked across worktrees for fast setup, so caching
+# these would pollute every linked worktree with one worktree's venv path.
+append_worktree_local_env() {
+  if [ -d "$VENV_DIR/bin" ]; then
+    printf 'export PATH="%s/bin:$PATH"\n' "${VENV_DIR}" >> "$CLAUDE_ENV_FILE"
+    printf 'export VIRTUAL_ENV="%s"\n' "${VENV_DIR}" >> "$CLAUDE_ENV_FILE"
+  fi
+}
+
 # Fast path: reuse cached env if manifest hash matches
 if [ -f "$CACHE_FILE" ] && [ -n "$MANIFEST_HASH" ]; then
   CACHED_HASH=$(head -1 "$CACHE_FILE" | sed 's/^# manifest-hash: //')
   if [ "$CACHED_HASH" = "$MANIFEST_HASH" ]; then
     tail -n +2 "$CACHE_FILE" >> "$CLAUDE_ENV_FILE"
+    append_worktree_local_env
     mark_exit cache_hit
     exit 0
   fi
@@ -80,14 +91,14 @@ while IFS='=' read -r key value; do
   ENV_CONTENT="${ENV_CONTENT}$(printf 'export %s=%q\n' "$key" "$value")"$'\n'
 done < <(echo "$FLOX_ENV_SNAPSHOT" | grep -E "^(PATH|FLOX_|UV_PROJECT_ENVIRONMENT|OPENSSL_|LDFLAGS|CPPFLAGS|RUST_|LIBRARY_PATH|MANPATH|DOTENV_FILE|DEBUG|POSTHOG_SKIP_MIGRATION_CHECKS|FLAGS_REDIS_URL|RUSTC_WRAPPER|SCCACHE_)=")
 
-if [ -d "$VENV_DIR/bin" ]; then
-  ENV_CONTENT="${ENV_CONTENT}export PATH=\"${VENV_DIR}/bin:\$PATH\""$'\n'
-  ENV_CONTENT="${ENV_CONTENT}export VIRTUAL_ENV=\"${VENV_DIR}\""$'\n'
-fi
-
+# ENV_CONTENT deliberately excludes $VENV_DIR-based values — those are
+# worktree-specific and are appended to $CLAUDE_ENV_FILE separately below so
+# the cache file stays worktree-agnostic (safe to hardlink across worktrees).
 mkdir -p "$(dirname "$CACHE_FILE")"
 printf '%s' "$ENV_CONTENT" >> "$CLAUDE_ENV_FILE"
 printf '# manifest-hash: %s\n%s' "$MANIFEST_HASH" "$ENV_CONTENT" > "$CACHE_FILE"
+
+append_worktree_local_env
 
 mark_exit fresh_snapshot
 exit 0

--- a/.claude/hooks/setup-flox.sh
+++ b/.claude/hooks/setup-flox.sh
@@ -5,13 +5,39 @@
 # CLAUDE_ENV_FILE is only available in SessionStart hooks:
 # https://code.claude.com/docs/en/hooks#sessionstart
 
-# Skip on Claude web (no flox there) or if CLAUDE_ENV_FILE isn't set
-if [ "$CLAUDE_CODE_REMOTE" = "true" ] || [ -z "$CLAUDE_ENV_FILE" ]; then
+HOOK_LOG="${CLAUDE_PROJECT_DIR:-$(pwd)}/.claude/setup-flox.log"
+log_hook() {
+  printf '%s reason=%s remote=%q env_file=%s project=%q\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    "$1" \
+    "${CLAUDE_CODE_REMOTE:-}" \
+    "${CLAUDE_ENV_FILE:+set}" \
+    "${CLAUDE_PROJECT_DIR:-}" \
+    >> "$HOOK_LOG" 2>/dev/null || true
+}
+mark_exit() {
+  log_hook "$1"
+  if [ -n "$CLAUDE_ENV_FILE" ]; then
+    printf 'export POSTHOG_FLOX_HOOK_EXIT=%q\n' "$1" >> "$CLAUDE_ENV_FILE"
+    printf 'export POSTHOG_FLOX_HOOK_STARTED=%q\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$CLAUDE_ENV_FILE"
+  fi
+}
+log_hook started
+
+# Skip on Claude web (no flox there); distinguish from a missing CLAUDE_ENV_FILE
+# so the log tells us which branch fired.
+if [ "$CLAUDE_CODE_REMOTE" = "true" ]; then
+  log_hook remote
+  exit 0
+fi
+if [ -z "$CLAUDE_ENV_FILE" ]; then
+  log_hook no_env_file
   exit 0
 fi
 
 # Skip if flox isn't installed
 if ! command -v flox &>/dev/null; then
+  mark_exit no_flox
   exit 0
 fi
 
@@ -35,6 +61,7 @@ if [ -f "$CACHE_FILE" ] && [ -n "$MANIFEST_HASH" ]; then
   CACHED_HASH=$(head -1 "$CACHE_FILE" | sed 's/^# manifest-hash: //')
   if [ "$CACHED_HASH" = "$MANIFEST_HASH" ]; then
     tail -n +2 "$CACHE_FILE" >> "$CLAUDE_ENV_FILE"
+    mark_exit cache_hit
     exit 0
   fi
 fi
@@ -44,6 +71,7 @@ FLOX_ENV_SNAPSHOT=$(flox activate --dir "$PROJECT_DIR" -- bash -c 'printenv' 2>/
 
 if [ $? -ne 0 ] || [ -z "$FLOX_ENV_SNAPSHOT" ]; then
   echo "Warning: flox activate failed, skipping env setup" >&2
+  mark_exit flox_failed
   exit 0
 fi
 
@@ -61,4 +89,5 @@ mkdir -p "$(dirname "$CACHE_FILE")"
 printf '%s' "$ENV_CONTENT" >> "$CLAUDE_ENV_FILE"
 printf '# manifest-hash: %s\n%s' "$MANIFEST_HASH" "$ENV_CONTENT" > "$CACHE_FILE"
 
+mark_exit fresh_snapshot
 exit 0

--- a/.claude/hooks/setup-flox.sh
+++ b/.claude/hooks/setup-flox.sh
@@ -5,25 +5,13 @@
 # CLAUDE_ENV_FILE is only available in SessionStart hooks:
 # https://code.claude.com/docs/en/hooks#sessionstart
 
-# Records the hook's exit path as env vars so future sessions can inspect
-# what happened via `echo $POSTHOG_FLOX_HOOK_EXIT` — cheap breadcrumb for
-# diagnosing failures like the cross-worktree cache pollution we hit before.
-mark_exit() {
-  if [ -n "$CLAUDE_ENV_FILE" ]; then
-    printf 'export POSTHOG_FLOX_HOOK_EXIT=%q\n' "$1" >> "$CLAUDE_ENV_FILE"
-    printf 'export POSTHOG_FLOX_HOOK_STARTED=%q\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$CLAUDE_ENV_FILE"
-  fi
-}
-
-# Skip on Claude web (no flox there); skip if CLAUDE_ENV_FILE is unset since
-# we'd have nowhere to write the captured env anyway.
+# Skip on Claude web (no flox there) or if CLAUDE_ENV_FILE isn't set
 if [ "$CLAUDE_CODE_REMOTE" = "true" ] || [ -z "$CLAUDE_ENV_FILE" ]; then
   exit 0
 fi
 
 # Skip if flox isn't installed
 if ! command -v flox &>/dev/null; then
-  mark_exit no_flox
   exit 0
 fi
 
@@ -58,7 +46,6 @@ if [ -f "$CACHE_FILE" ] && [ -n "$MANIFEST_HASH" ]; then
   if [ "$CACHED_HASH" = "$MANIFEST_HASH" ]; then
     tail -n +2 "$CACHE_FILE" >> "$CLAUDE_ENV_FILE"
     append_worktree_local_env
-    mark_exit cache_hit
     exit 0
   fi
 fi
@@ -68,7 +55,6 @@ FLOX_ENV_SNAPSHOT=$(flox activate --dir "$PROJECT_DIR" -- bash -c 'printenv' 2>/
 
 if [ $? -ne 0 ] || [ -z "$FLOX_ENV_SNAPSHOT" ]; then
   echo "Warning: flox activate failed, skipping env setup" >&2
-  mark_exit flox_failed
   exit 0
 fi
 
@@ -86,5 +72,4 @@ printf '# manifest-hash: %s\n%s' "$MANIFEST_HASH" "$ENV_CONTENT" > "$CACHE_FILE"
 
 append_worktree_local_env
 
-mark_exit fresh_snapshot
 exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,7 @@ posthog/management/commands/clear_demo_data.py
 .claude/settings.local.json
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+.claude/setup-flox.log
 
 # Ignore local mprocs configs
 bin/mprocs*.local.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -147,7 +147,6 @@ posthog/management/commands/clear_demo_data.py
 .claude/settings.local.json
 .claude/worktrees/
 .claude/scheduled_tasks.lock
-.claude/setup-flox.log
 
 # Ignore local mprocs configs
 bin/mprocs*.local.yaml


### PR DESCRIPTION
## Problem

PostHog Code (and any `git worktree`-based flow) provisions sibling worktrees by hardlinking `.flox/cache/` contents — great for startup speed since the prebuilt flox env and `venv/` directory are shared for free. However, `.claude/hooks/setup-flox.sh` was writing worktree-specific values (`VIRTUAL_ENV` and a `PATH` prepend pointing at `$PROJECT_DIR/.flox/cache/venv`) into a file that sits inside that same hardlinked directory: `$PROJECT_DIR/.flox/cache/claude-env-cache`. Because `> "$CACHE_FILE"` truncates the inode in place, whichever worktree's hook ran last overwrote the cache for every hardlinked sibling. Subsequent sessions in other worktrees then hit the `cache_hit` fast path and exported a sibling's venv path, which made shell tools fall back to running `flox activate -- bash -c "..."` wrappers to recover.

Symptom: sessions in worktree `A` showing `$VIRTUAL_ENV` pointing at worktree `B`'s `.flox/cache/venv`, despite the hook firing correctly.

## Changes

Keep the cache file content worktree-agnostic and append `$VENV_DIR`-derived `VIRTUAL_ENV` / `PATH` lines to `$CLAUDE_ENV_FILE` at session time from the current `$PROJECT_DIR`. The hardlink stays intact, so new worktrees continue to inherit a pre-populated cache and skip `flox activate` on first session — startup speed unchanged.

Net diff is small: a short `append_worktree_local_env` helper, called after the cached content is written into `$CLAUDE_ENV_FILE` on both the fast and slow paths, and removal of the two lines that previously baked those same exports into the cache file.

The branch includes some intermediate scaffolding commits (temporary file logging + marker env vars used during diagnosis) that were added and then removed within this PR. The net effect against `master` is just the fix.

## How did you test this code?

I'm an agent; manual testing was limited to running the hook end-to-end from within a session.

- Ran the hook directly (`cache_hit` path) — confirmed `$CLAUDE_ENV_FILE` gets worktree-local `VIRTUAL_ENV` / `PATH` appended after the cached content, and that the cache itself no longer contains those two lines.
- Invalidated the hardlinked cache in place (to bust the hash and force slow-path regen), re-ran the hook (`fresh_snapshot` path) — confirmed the regenerated cache contains zero worktree-specific `VIRTUAL_ENV` / `/venv/bin:$PATH` entries, inode preserved so sibling worktrees inherit the corrected content.
- Spun up a fresh PostHog Code session in a newly-provisioned worktree on this branch — confirmed `$VIRTUAL_ENV` resolves inside the fresh worktree's path, the first session regenerated the cache on the slow path, and subsequent sessions in the same worktree hit the fast path with correct worktree-local paths.

No automated tests — hook is a shell script invoked only by Claude Code's SessionStart.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs

## 🤖 LLM context

Authored by PostHog Code (Claude Opus 4.7). Diagnosis path was roughly:

1. User observed other sessions running `flox activate -- bash -c "..."` wrappers despite the SessionStart hook being in place; initially suspected `$CLAUDE_ENV_FILE` was unset.
2. Instrumented the hook temporarily (log file + marker env vars) to distinguish early-exit branches — `$CLAUDE_ENV_FILE` turned out to always be set.
3. Discovered via `stat -f "%i"` that `.flox/cache/claude-env-cache` shares an inode across sibling worktrees.
4. Fixed by factoring the worktree-specific lines out of the cache and appending them at session time. Preserves the hardlink speedup.
5. Verified in a fresh worktree, then removed the diagnostic scaffolding — final state of the branch is just the fix.

One cosmetic leak remains out of scope: `flox activate`'s snapshot inherits the invoking shell's `PATH`, which can contain a sibling worktree's venv entry when the parent shell has one leaked in. That entry gets baked into the cached `PATH`. It doesn't affect correctness because the worktree-local `PATH` prepend wins on tool resolution, but worth a follow-up.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*