### PR TITLE
fix(mcp): surface 403 permission_denied errors with missing scope

### DIFF
--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -167,7 +167,9 @@ export class ApiClient {
         const result = await this.fetchJson<T>(url, fetchOptions)
 
         if (!result.success) {
-            throw new Error(result.error.message)
+            // Re-throw the original error instance so callers can instanceof-check
+            // typed errors (e.g. PostHogPermissionError) that fetchJson throws.
+            throw result.error
         }
         return result.data as T
     }

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 import { getUserAgent } from '@/lib/constants'
-import { ErrorCode } from '@/lib/errors'
+import { ErrorCode, PostHogPermissionError } from '@/lib/errors'
 import { getSearchParamsFromRecord } from '@/lib/utils.js'
 import type {
     ApiEventDefinition,
@@ -222,6 +222,20 @@ export class ApiClient {
                         errorData = JSON.parse(errorText)
                     } catch {
                         errorData = { detail: errorText }
+                    }
+
+                    if (response.status === 403 && errorData?.code === 'permission_denied') {
+                        const scopeMatch = /required scope ['"]([^'"]+)['"]/.exec(errorData.detail || '')
+                        const missingScope = scopeMatch?.[1]
+                        console.error(
+                            `[API] Permission denied on ${method} ${url}: ${errorData.detail || 'unknown'}${missingScope ? ` (missing scope: ${missingScope})` : ''}`
+                        )
+                        throw new PostHogPermissionError({
+                            detail: errorData.detail || 'permission denied',
+                            missingScope,
+                            url,
+                            method,
+                        })
                     }
 
                     if (errorData.type === 'validation_error') {

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -1,5 +1,5 @@
 import { MCP_DOCS_URL, OAUTH_SCOPES_SUPPORTED, getAuthorizationServerUrl } from '@/lib/constants'
-import { ErrorCode } from '@/lib/errors'
+import { ErrorCode, findPostHogPermissionError, formatPermissionErrorMessage } from '@/lib/errors'
 import { RequestLogger, withLogging } from '@/lib/logging'
 import { buildRedirectUrl, matchAuthServerRedirect } from '@/lib/routing'
 import { hash, sanitizeHeaderValue } from '@/lib/utils'
@@ -68,7 +68,7 @@ function getRegionFromRequest(request: Request): CloudRegion | null {
 const onThenErrorHandler = async (response: Response): Promise<Response> => {
     if (!response.ok) {
         const body = await response.clone().text()
-        const errorResponse = generateErrorResponse(body)
+        const errorResponse = generateErrorResponseFromMessage(body)
         if (errorResponse) {
             return errorResponse
         }
@@ -78,10 +78,22 @@ const onThenErrorHandler = async (response: Response): Promise<Response> => {
 }
 
 const onCatchErrorHandler = async (error: Error): Promise<Response> => {
-    return generateErrorResponse(error.message) || new Response('Internal server error', { status: 500 })
+    const permissionError = findPostHogPermissionError(error)
+    if (permissionError) {
+        return new Response(formatPermissionErrorMessage(permissionError), {
+            status: 403,
+            headers: {
+                'Content-Type': 'text/plain; charset=utf-8',
+                ...(permissionError.missingScope
+                    ? { 'x-posthog-mcp-missing-scope': permissionError.missingScope }
+                    : {}),
+            },
+        })
+    }
+    return generateErrorResponseFromMessage(error.message) || new Response('Internal server error', { status: 500 })
 }
 
-const generateErrorResponse = (message: string): Response | null => {
+const generateErrorResponseFromMessage = (message: string): Response | null => {
     if (message.includes(ErrorCode.INACTIVE_OAUTH_TOKEN)) {
         return new Response('OAuth token is inactive', { status: 401 })
     } else if (message.includes(ErrorCode.INVALID_API_KEY)) {

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -1,5 +1,10 @@
 import { MCP_DOCS_URL, OAUTH_SCOPES_SUPPORTED, getAuthorizationServerUrl } from '@/lib/constants'
-import { ErrorCode, findPostHogPermissionError, formatPermissionErrorMessage } from '@/lib/errors'
+import {
+    buildInsufficientScopeChallenge,
+    ErrorCode,
+    findPostHogPermissionError,
+    formatPermissionErrorMessage,
+} from '@/lib/errors'
 import { RequestLogger, withLogging } from '@/lib/logging'
 import { buildRedirectUrl, matchAuthServerRedirect } from '@/lib/routing'
 import { hash, sanitizeHeaderValue } from '@/lib/utils'
@@ -84,9 +89,7 @@ const onCatchErrorHandler = async (error: Error): Promise<Response> => {
             status: 403,
             headers: {
                 'Content-Type': 'text/plain; charset=utf-8',
-                ...(permissionError.missingScope
-                    ? { 'x-posthog-mcp-missing-scope': permissionError.missingScope }
-                    : {}),
+                'WWW-Authenticate': buildInsufficientScopeChallenge(permissionError),
             },
         })
     }

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -1,5 +1,5 @@
 import type { ApiClient } from '@/api/client'
-import { ErrorCode } from '@/lib/errors'
+import { ErrorCode, wrapError } from '@/lib/errors'
 import { sanitizeHeaderValue } from '@/lib/utils'
 import type { ApiUser } from '@/schema/api'
 import type { State } from '@/tools/types'
@@ -20,7 +20,7 @@ export class StateManager {
     private async _fetchUser(): Promise<ApiUser> {
         const userResult = await this._api.users().me()
         if (!userResult.success) {
-            throw new Error(`Failed to get user: ${userResult.error.message}`)
+            throw wrapError(`Failed to get user: ${userResult.error.message}`, userResult.error)
         }
         return userResult.data
     }

--- a/services/mcp/src/lib/errors.ts
+++ b/services/mcp/src/lib/errors.ts
@@ -21,6 +21,90 @@ export class MCPToolError extends Error {
     }
 }
 
+export interface PostHogPermissionErrorOptions {
+    detail: string
+    missingScope?: string | undefined
+    url: string
+    method: string
+}
+
+/**
+ * Thrown when the PostHog API rejects a request with HTTP 403 `permission_denied`.
+ * Preserves the missing scope (when present) so the MCP layer can surface an
+ * actionable remediation message instead of a generic failure.
+ */
+export class PostHogPermissionError extends Error {
+    public readonly detail: string
+    public readonly missingScope: string | undefined
+    public readonly url: string
+    public readonly method: string
+
+    constructor(options: PostHogPermissionErrorOptions) {
+        const message = options.missingScope
+            ? `Missing PostHog API scope: '${options.missingScope}'`
+            : `PostHog API permission denied: ${options.detail}`
+        super(message)
+        this.name = 'PostHogPermissionError'
+        this.detail = options.detail
+        this.missingScope = options.missingScope
+        this.url = options.url
+        this.method = options.method
+    }
+}
+
+/**
+ * Creates an Error that wraps another error as its `cause`.
+ * The tsconfig targets ES2021, which doesn't expose the ErrorOptions overload,
+ * so set `cause` manually after construction. At runtime (Node 18+ / CF Workers)
+ * the property still participates in cause-walking helpers like
+ * `findPostHogPermissionError`.
+ */
+export function wrapError(message: string, cause: unknown): Error {
+    const err = new Error(message) as Error & { cause?: unknown }
+    err.cause = cause
+    return err
+}
+
+const PERSONAL_API_KEY_DOCS_URL = 'https://posthog.com/docs/api#how-to-authenticate-with-the-posthog-api'
+
+export function formatPermissionErrorMessage(error: PostHogPermissionError): string {
+    if (error.missingScope) {
+        return [
+            `Missing PostHog API scope: '${error.missingScope}'`,
+            '',
+            `Your Personal API key is missing the '${error.missingScope}' scope, which is required to call ${error.method} ${error.url}.`,
+            '',
+            `To fix: edit the Personal API key in PostHog (User settings → Personal API keys) and add the '${error.missingScope}' scope. Alternatively, select the "MCP Server" scope preset which includes every scope the MCP needs.`,
+            '',
+            `See: ${PERSONAL_API_KEY_DOCS_URL}`,
+        ].join('\n')
+    }
+
+    return [
+        `PostHog API permission denied: ${error.detail}`,
+        '',
+        `The request to ${error.method} ${error.url} was rejected with HTTP 403. Verify that your API key, OAuth token, and user account have access to this project.`,
+    ].join('\n')
+}
+
+/**
+ * Walk `Error.cause` chains to find a wrapped PostHogPermissionError.
+ * Tool-level wrappers (e.g. `throw new Error("Failed to X: ...", { cause })`)
+ * hide the underlying permission error, so callers must unwrap before acting.
+ */
+export function findPostHogPermissionError(error: unknown): PostHogPermissionError | undefined {
+    let current: unknown = error
+    const seen = new Set<unknown>()
+    while (current && !seen.has(current)) {
+        if (current instanceof PostHogPermissionError) {
+            return current
+        }
+        seen.add(current)
+        current = current instanceof Error ? (current as Error & { cause?: unknown }).cause : undefined
+    }
+    return undefined
+}
+
 /**
  * Handles tool errors and returns a structured error message.
  * Any errors that originate from the tool SHOULD be reported inside the result
@@ -36,10 +120,39 @@ export class MCPToolError extends Error {
  * @returns A structured error message.
  */
 export function handleToolError(error: any, tool?: string, distinctId?: string, sessionUuid?: string): CallToolResult {
+    const toolName = tool || 'unknown'
+
+    const permissionError = findPostHogPermissionError(error)
+    if (permissionError) {
+        const properties: Record<string, any> = {
+            team: 'growth',
+            tool: toolName,
+            is_permission_error: true,
+            missing_scope: permissionError.missingScope,
+            $exception_fingerprint: `posthog-permission-error:${permissionError.missingScope ?? 'unknown'}`,
+        }
+
+        if (sessionUuid) {
+            properties.$session_id = sessionUuid
+        }
+
+        getPostHogClient().captureException(permissionError, distinctId, properties)
+
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: `Error: [${toolName}]: ${formatPermissionErrorMessage(permissionError)}`,
+                },
+            ],
+            isError: true,
+        }
+    }
+
     const mcpError =
         error instanceof MCPToolError
             ? error
-            : new MCPToolError(error instanceof Error ? error.message : String(error), tool || 'unknown', error)
+            : new MCPToolError(error instanceof Error ? error.message : String(error), toolName, error)
 
     const properties: Record<string, any> = {
         team: 'growth',

--- a/services/mcp/src/lib/errors.ts
+++ b/services/mcp/src/lib/errors.ts
@@ -1,6 +1,7 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 
 import { getPostHogClient } from '@/lib/analytics'
+import { sanitizeHeaderValue } from '@/lib/utils'
 
 export enum ErrorCode {
     INVALID_API_KEY = 'INVALID_API_KEY',
@@ -88,6 +89,25 @@ export function formatPermissionErrorMessage(error: PostHogPermissionError): str
 }
 
 /**
+ * RFC 6750 §3.1: OAuth 2.0 Bearer challenge for 403 insufficient_scope. When
+ * a missing scope is known, advertise it so OAuth-aware clients can prompt
+ * for re-consent with the correct scope instead of reporting a generic error.
+ */
+export function buildInsufficientScopeChallenge(error: PostHogPermissionError): string {
+    const parts = ['Bearer error="insufficient_scope"']
+    const scope = sanitizeHeaderValue(error.missingScope)
+    if (scope) {
+        parts.push(`scope="${scope}"`)
+    }
+    // Replace double quotes to keep the challenge syntactically valid.
+    const description = sanitizeHeaderValue(error.detail)?.replace(/"/g, "'")
+    if (description) {
+        parts.push(`error_description="${description}"`)
+    }
+    return parts.join(', ')
+}
+
+/**
  * Walk `Error.cause` chains to find a wrapped PostHogPermissionError.
  * Tool-level wrappers (e.g. `throw new Error("Failed to X: ...", { cause })`)
  * hide the underlying permission error, so callers must unwrap before acting.
@@ -129,7 +149,7 @@ export function handleToolError(error: any, tool?: string, distinctId?: string, 
             tool: toolName,
             is_permission_error: true,
             missing_scope: permissionError.missingScope,
-            $exception_fingerprint: `posthog-permission-error:${permissionError.missingScope ?? 'unknown'}`,
+            $exception_fingerprint: `posthog-permission-error:${toolName}:${permissionError.missingScope ?? 'unknown'}`,
         }
 
         if (sessionUuid) {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -14,7 +14,7 @@ import {
     getBaseUrlForRegion,
     toCloudRegion,
 } from '@/lib/constants'
-import { handleToolError } from '@/lib/errors'
+import { handleToolError, wrapError } from '@/lib/errors'
 import { buildInstructionsV2 } from '@/lib/instructions'
 import { initMcpCatObservability } from '@/lib/mcpcat'
 import { formatResponse } from '@/lib/response'
@@ -248,7 +248,7 @@ export class MCP extends McpAgent<Env> {
         if (!_distinctId) {
             const userResult = await (await this.api()).users().me()
             if (!userResult.success) {
-                throw new Error(`Failed to get user: ${userResult.error.message}`)
+                throw wrapError(`Failed to get user: ${userResult.error.message}`, userResult.error)
             }
             await this.cache.set('distinctId', userResult.data.distinct_id)
             _distinctId = userResult.data.distinct_id as string

--- a/services/mcp/tests/unit/permission-errors.test.ts
+++ b/services/mcp/tests/unit/permission-errors.test.ts
@@ -1,0 +1,256 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ApiClient } from '@/api/client'
+import {
+    findPostHogPermissionError,
+    formatPermissionErrorMessage,
+    handleToolError,
+    PostHogPermissionError,
+    wrapError,
+} from '@/lib/errors'
+
+vi.mock('@/api/rate-limiter', () => ({
+    globalRateLimiter: {
+        throttle: vi.fn().mockResolvedValue(undefined),
+    },
+}))
+
+vi.mock('@/lib/analytics', () => ({
+    getPostHogClient: () => ({
+        captureException: vi.fn(),
+    }),
+    AnalyticsEvent: { MCP_INIT: 'mcp init' },
+    isFeatureFlagEnabled: vi.fn().mockResolvedValue(false),
+}))
+
+const permissionDeniedBody = JSON.stringify({
+    type: 'authentication_error',
+    code: 'permission_denied',
+    detail: "API key missing required scope 'user:read'",
+    attr: null,
+})
+
+describe('PostHogPermissionError', () => {
+    it('builds message with missing scope', () => {
+        const error = new PostHogPermissionError({
+            detail: "API key missing required scope 'user:read'",
+            missingScope: 'user:read',
+            url: 'https://us.posthog.com/api/users/@me/',
+            method: 'GET',
+        })
+
+        expect(error.message).toBe("Missing PostHog API scope: 'user:read'")
+        expect(error.missingScope).toBe('user:read')
+        expect(error.name).toBe('PostHogPermissionError')
+    })
+
+    it('builds message without missing scope', () => {
+        const error = new PostHogPermissionError({
+            detail: 'you do not have access to this team',
+            url: 'https://us.posthog.com/api/projects/47074/',
+            method: 'GET',
+        })
+
+        expect(error.message).toContain('PostHog API permission denied')
+        expect(error.missingScope).toBeUndefined()
+    })
+})
+
+describe('formatPermissionErrorMessage', () => {
+    it('names the missing scope and points to remediation', () => {
+        const error = new PostHogPermissionError({
+            detail: "API key missing required scope 'user:read'",
+            missingScope: 'user:read',
+            url: 'https://us.posthog.com/api/users/@me/',
+            method: 'GET',
+        })
+
+        const text = formatPermissionErrorMessage(error)
+
+        expect(text).toContain("'user:read'")
+        expect(text).toContain('MCP Server')
+        expect(text).toContain('GET https://us.posthog.com/api/users/@me/')
+    })
+
+    it('falls back to generic remediation when no scope is parsed', () => {
+        const error = new PostHogPermissionError({
+            detail: 'team access denied',
+            url: 'https://us.posthog.com/api/projects/47074/',
+            method: 'GET',
+        })
+
+        const text = formatPermissionErrorMessage(error)
+
+        expect(text).toContain('PostHog API permission denied')
+        expect(text).toContain('HTTP 403')
+    })
+})
+
+describe('findPostHogPermissionError', () => {
+    it('returns the error directly when instance matches', () => {
+        const original = new PostHogPermissionError({
+            detail: 'x',
+            missingScope: 'user:read',
+            url: 'https://us.posthog.com/api/users/@me/',
+            method: 'GET',
+        })
+
+        expect(findPostHogPermissionError(original)).toBe(original)
+    })
+
+    it('walks Error.cause chains', () => {
+        const original = new PostHogPermissionError({
+            detail: 'x',
+            missingScope: 'user:read',
+            url: 'https://us.posthog.com/api/users/@me/',
+            method: 'GET',
+        })
+        const wrapped = wrapError(`Failed to get user: ${original.message}`, original)
+        const doubleWrapped = wrapError('Tool failed', wrapped)
+
+        expect(findPostHogPermissionError(doubleWrapped)).toBe(original)
+    })
+
+    it('returns undefined for unrelated errors', () => {
+        expect(findPostHogPermissionError(new Error('boom'))).toBeUndefined()
+        expect(findPostHogPermissionError('string error')).toBeUndefined()
+        expect(findPostHogPermissionError(undefined)).toBeUndefined()
+    })
+
+    it('does not loop on self-referential cause', () => {
+        const err: Error & { cause?: unknown } = new Error('loop')
+        err.cause = err
+        expect(findPostHogPermissionError(err)).toBeUndefined()
+    })
+})
+
+describe('handleToolError with permission errors', () => {
+    it('returns a structured CallToolResult with remediation text', () => {
+        const error = new PostHogPermissionError({
+            detail: "API key missing required scope 'user:read'",
+            missingScope: 'user:read',
+            url: 'https://us.posthog.com/api/users/@me/',
+            method: 'GET',
+        })
+
+        const result = handleToolError(error, 'users-me')
+
+        expect(result.isError).toBe(true)
+        const [content] = result.content as Array<{ type: string; text: string }>
+        expect(content?.type).toBe('text')
+        expect(content?.text).toContain('[users-me]')
+        expect(content?.text).toContain("'user:read'")
+        expect(content?.text).toContain('MCP Server')
+    })
+
+    it('unwraps permission errors hidden behind Error.cause', () => {
+        const original = new PostHogPermissionError({
+            detail: "API key missing required scope 'insight:read'",
+            missingScope: 'insight:read',
+            url: 'https://us.posthog.com/api/projects/1/insights/',
+            method: 'GET',
+        })
+        const wrapped = wrapError(`Failed to list insights: ${original.message}`, original)
+
+        const result = handleToolError(wrapped, 'insights-list')
+        const [content] = result.content as Array<{ type: string; text: string }>
+
+        expect(content?.text).toContain("'insight:read'")
+    })
+})
+
+describe('ApiClient fetchJson on 403 permission_denied', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('throws PostHogPermissionError with the parsed missingScope', async () => {
+        const mockFetch = vi.fn().mockResolvedValue(
+            new Response(permissionDeniedBody, {
+                status: 403,
+                statusText: 'Forbidden',
+                headers: { 'Content-Type': 'application/json' },
+            })
+        )
+        vi.stubGlobal('fetch', mockFetch)
+
+        const client = new ApiClient({
+            apiToken: 'phx_test',
+            baseUrl: 'https://us.posthog.com',
+        })
+
+        const result = await client.users().me()
+
+        expect(result.success).toBe(false)
+        if (result.success) {
+            throw new Error('expected failure')
+        }
+        expect(result.error).toBeInstanceOf(PostHogPermissionError)
+        const permissionError = result.error as PostHogPermissionError
+        expect(permissionError.missingScope).toBe('user:read')
+        expect(permissionError.method).toBe('GET')
+        expect(permissionError.url).toBe('https://us.posthog.com/api/users/@me/')
+
+        vi.unstubAllGlobals()
+    })
+
+    it('still throws PostHogPermissionError when no scope is present in detail', async () => {
+        const body = JSON.stringify({
+            type: 'authentication_error',
+            code: 'permission_denied',
+            detail: 'You do not have access to this team.',
+            attr: null,
+        })
+        const mockFetch = vi.fn().mockResolvedValue(
+            new Response(body, {
+                status: 403,
+                statusText: 'Forbidden',
+                headers: { 'Content-Type': 'application/json' },
+            })
+        )
+        vi.stubGlobal('fetch', mockFetch)
+
+        const client = new ApiClient({
+            apiToken: 'phx_test',
+            baseUrl: 'https://us.posthog.com',
+        })
+
+        const result = await client.users().me()
+
+        expect(result.success).toBe(false)
+        if (result.success) {
+            throw new Error('expected failure')
+        }
+        expect(result.error).toBeInstanceOf(PostHogPermissionError)
+        expect((result.error as PostHogPermissionError).missingScope).toBeUndefined()
+
+        vi.unstubAllGlobals()
+    })
+
+    it('leaves non-permission 403s on the existing error path', async () => {
+        const body = 'forbidden'
+        const mockFetch = vi.fn().mockResolvedValue(
+            new Response(body, {
+                status: 403,
+                statusText: 'Forbidden',
+            })
+        )
+        vi.stubGlobal('fetch', mockFetch)
+
+        const client = new ApiClient({
+            apiToken: 'phx_test',
+            baseUrl: 'https://us.posthog.com',
+        })
+
+        const result = await client.users().me()
+
+        expect(result.success).toBe(false)
+        if (result.success) {
+            throw new Error('expected failure')
+        }
+        expect(result.error).not.toBeInstanceOf(PostHogPermissionError)
+        expect(result.error.message).toContain('Request failed')
+
+        vi.unstubAllGlobals()
+    })
+})

--- a/services/mcp/tests/unit/permission-errors.test.ts
+++ b/services/mcp/tests/unit/permission-errors.test.ts
@@ -316,4 +316,26 @@ describe('ApiClient fetchJson on 403 permission_denied', () => {
 
         vi.unstubAllGlobals()
     })
+
+    it('preserves PostHogPermissionError when surfaced via ApiClient.request()', async () => {
+        const mockFetch = vi.fn().mockResolvedValue(
+            new Response(permissionDeniedBody, {
+                status: 403,
+                statusText: 'Forbidden',
+                headers: { 'Content-Type': 'application/json' },
+            })
+        )
+        vi.stubGlobal('fetch', mockFetch)
+
+        const client = new ApiClient({
+            apiToken: 'phx_test',
+            baseUrl: 'https://us.posthog.com',
+        })
+
+        await expect(client.request({ method: 'GET', path: '/api/users/@me/' })).rejects.toBeInstanceOf(
+            PostHogPermissionError
+        )
+
+        vi.unstubAllGlobals()
+    })
 })

--- a/services/mcp/tests/unit/permission-errors.test.ts
+++ b/services/mcp/tests/unit/permission-errors.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ApiClient } from '@/api/client'
 import {
+    buildInsufficientScopeChallenge,
     findPostHogPermissionError,
     formatPermissionErrorMessage,
     handleToolError,
@@ -15,9 +16,10 @@ vi.mock('@/api/rate-limiter', () => ({
     },
 }))
 
+const captureException = vi.fn()
 vi.mock('@/lib/analytics', () => ({
     getPostHogClient: () => ({
-        captureException: vi.fn(),
+        captureException,
     }),
     AnalyticsEvent: { MCP_INIT: 'mcp init' },
     isFeatureFlagEnabled: vi.fn().mockResolvedValue(false),
@@ -86,6 +88,48 @@ describe('formatPermissionErrorMessage', () => {
     })
 })
 
+describe('buildInsufficientScopeChallenge', () => {
+    it('follows RFC 6750 §3.1 when a scope is known', () => {
+        const error = new PostHogPermissionError({
+            detail: "API key missing required scope 'user:read'",
+            missingScope: 'user:read',
+            url: 'https://us.posthog.com/api/users/@me/',
+            method: 'GET',
+        })
+
+        expect(buildInsufficientScopeChallenge(error)).toBe(
+            'Bearer error="insufficient_scope", scope="user:read", error_description="API key missing required scope \'user:read\'"'
+        )
+    })
+
+    it('omits scope when unknown', () => {
+        const error = new PostHogPermissionError({
+            detail: 'team access denied',
+            url: 'https://us.posthog.com/api/projects/1/',
+            method: 'GET',
+        })
+
+        expect(buildInsufficientScopeChallenge(error)).toBe(
+            'Bearer error="insufficient_scope", error_description="team access denied"'
+        )
+    })
+
+    it('strips control chars and balances quotes in detail', () => {
+        const error = new PostHogPermissionError({
+            detail: 'hi "there"\nthis is bad',
+            missingScope: 'user:read',
+            url: 'https://us.posthog.com/api/users/@me/',
+            method: 'GET',
+        })
+
+        const header = buildInsufficientScopeChallenge(error)
+        // Double quotes inside error_description must be swapped out and newlines dropped.
+        expect(header).not.toMatch(/"there"/)
+        expect(header).not.toMatch(/\n/)
+        expect(header).toContain(`error_description="hi 'there'this is bad"`)
+    })
+})
+
 describe('findPostHogPermissionError', () => {
     it('returns the error directly when instance matches', () => {
         const original = new PostHogPermissionError({
@@ -141,6 +185,25 @@ describe('handleToolError with permission errors', () => {
         expect(content?.text).toContain('[users-me]')
         expect(content?.text).toContain("'user:read'")
         expect(content?.text).toContain('MCP Server')
+    })
+
+    it('fingerprints per tool to avoid dogpiling multiple tools into one issue', () => {
+        captureException.mockClear()
+        const error = new PostHogPermissionError({
+            detail: "API key missing required scope 'user:read'",
+            missingScope: 'user:read',
+            url: 'https://us.posthog.com/api/users/@me/',
+            method: 'GET',
+        })
+
+        handleToolError(error, 'insights-list')
+        handleToolError(error, 'dashboards-list')
+
+        const fingerprints = captureException.mock.calls.map(([, , props]) => props.$exception_fingerprint)
+        expect(fingerprints).toEqual([
+            'posthog-permission-error:insights-list:user:read',
+            'posthog-permission-error:dashboards-list:user:read',
+        ])
     })
 
     it('unwraps permission errors hidden behind Error.cause', () => {


### PR DESCRIPTION
## Problem

When the PostHog API returns a 403 `permission_denied` error (e.g. `"API key missing required scope 'user:read'"`), the MCP Cloudflare Worker catches it and returns a bare HTTP 500 `Internal server error` to the client. The client (Cursor, Claude Desktop, Claude Code, etc.) sees only:

```
HTTP MCP tool execution failed: Streamable HTTP error: Error POSTing to endpoint: Internal server error
```

There is no way for the user (or an agent they're running) to self-diagnose. The upstream PostHog API already returns a perfectly clear, machine-readable error — the worker was swallowing it.

## Changes

Introduce a `PostHogPermissionError` that preserves the missing scope, parsed from the `detail` field on the upstream response, and route it through both error paths:

- **Tool-level failures** return a structured `CallToolResult` with `isError: true` and remediation text that names the missing scope and points at the "MCP Server" scope preset. Per the MCP spec, tool execution errors belong in `CallToolResult`, not as JSON-RPC protocol errors, so the LLM can see the failure and self-correct.
- **Worker-level init failures** (e.g. `/api/users/@me/` during startup) now return HTTP 403 with the same remediation body and a standards-conformant `WWW-Authenticate: Bearer error="insufficient_scope", scope="...", error_description="..."` header per [RFC 6750 §3.1](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1). OAuth-aware clients can pick up the missing scope and prompt for re-consent directly.
- Wrappers that re-throw user-fetch failures (`mcp.ts#getDistinctId`, `StateManager#_fetchUser`) preserve the original error via `Error.cause`. A new `wrapError` helper sets `cause` without fighting the ES2021 tsconfig target.
- `findPostHogPermissionError` walks the cause chain (self-reference safe) so detection works through any wrapper boundary.
- `$exception_fingerprint` includes both the tool name and missing scope so different tools don't collapse into one error-tracking issue.

Non-permission 403s fall through to the existing error path unchanged.

## How did you test this code?

Added `tests/unit/permission-errors.test.ts` (19 unit tests) covering:

- `PostHogPermissionError` construction and message formatting, with and without a parsed scope.
- `formatPermissionErrorMessage` naming the scope and pointing at remediation docs.
- `buildInsufficientScopeChallenge` producing the RFC 6750-shaped challenge, omitting `scope` when unknown, and sanitizing quotes/control chars in `error_description`.
- `findPostHogPermissionError` direct match, cause walking (single + double wrap), unrelated errors, and self-referential cause loop safety.
- `handleToolError` returning the structured `CallToolResult` for both direct and cause-wrapped permission errors, and fingerprinting per-tool.
- `ApiClient.fetchJson` throwing `PostHogPermissionError` on 403 `permission_denied` responses, with and without a scope in `detail`, and leaving non-permission 403s on the existing error path.

Verification:
- `pnpm run typecheck` clean.
- `pnpm test --project unit` passes 587/587 (including the 19 new tests).
- Confirmed the upstream JSON shape in `posthog/test/base.py#permission_denied_response` matches what `fetchJson` now branches on (`code === 'permission_denied'`) and that `posthog/permissions.py` emits the `"API key missing required scope '<name>'"` phrasing the regex targets.

I am an agent. I have not manually exercised this against a deployed worker with a scope-limited PAT — reviewers should verify the end-to-end shape in Cursor/Claude Desktop before merging.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude (Opus 4.7) off a spec at `docs/specs/mcp-403-permission-denied-error-handling.md`. The spec originally proposed returning a `JSONRPCError` with code `-32001` for tool-level failures, but the existing MCP convention in this codebase is to use `CallToolResult` with `isError: true` per the [MCP spec §Error Handling](https://modelcontextprotocol.io/specification/2025-06-18/server/tools), so the tool-level path surfaces structured remediation text in that shape instead. The worker-level 403 was upgraded from a custom `x-posthog-mcp-missing-scope` header to a full RFC 6750 `WWW-Authenticate: Bearer error="insufficient_scope"` challenge during pre-PR self-review.