### PR TITLE
fix(data-warehouse): revert statement_timeout via libpq options

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1369,7 +1369,6 @@ def postgres_source(
                 sslrootcert="/tmp/no.txt",
                 sslcert="/tmp/no.txt",
                 sslkey="/tmp/no.txt",
-                options=f"-c statement_timeout={SYNC_STATEMENT_TIMEOUT_MS}",
             )
         except psycopg.OperationalError as e:
             if require_ssl and "SSL" in str(e):
@@ -1518,7 +1517,6 @@ def postgres_source(
                         sslcert="/tmp/no.txt",
                         sslkey="/tmp/no.txt",
                         cursor_factory=cursor_factory,
-                        options=f"-c statement_timeout={SYNC_STATEMENT_TIMEOUT_MS}",
                     )
                 except psycopg.OperationalError as e:
                     if require_ssl and "SSL" in str(e):
@@ -1536,13 +1534,19 @@ def postgres_source(
                 connection.adapters.register_loader("tstzrange", RangeAsStringLoader)
                 connection.adapters.register_loader("daterange", RangeAsStringLoader)
                 connection.adapters.register_loader("date", SafeDateLoader)
-                # Use psycopg.Cursor directly to bypass cursor_factory (which may be ServerCursor
-                # and requires a `name` arg).
-                with psycopg.Cursor(connection) as check_cursor:
-                    check_cursor.execute("SHOW statement_timeout")
-                    row = check_cursor.fetchone()
-                    timeout_val = str(row[0]) if row else "unknown"  # type: ignore[index]
-                    logger.info(f"Effective statement_timeout on sync connection: {timeout_val}")
+                # Bump statement_timeout for the streaming connection. A server
+                # cursor FETCH inherits the session statement_timeout, and on
+                # wide/partitioned scans the source's default (often 30-60s)
+                # kills the fetch before rows come back.
+                try:
+                    with connection.cursor() as setup_cursor:
+                        setup_cursor.execute(
+                            sql.SQL("SET statement_timeout = {timeout}").format(
+                                timeout=sql.Literal(SYNC_STATEMENT_TIMEOUT_MS)
+                            )
+                        )
+                except Exception as e:
+                    logger.debug(f"Failed to set statement_timeout on sync connection: {e}")
                 return connection
 
             def offset_chunking(offset: int, chunk_size: int):


### PR DESCRIPTION
## Problem

PR #54922 added `options=f"-c statement_timeout=..."` to psycopg connection kwargs. Many managed Postgres proxies (pgbouncer, Supabase pooled, Neon, RDS Proxy) reject the `options` startup parameter, causing connection failures for ~55 teams since the deploy on 2026-04-16 17:29 UTC.

The error manifests as:
- `FATAL: unsupported startup parameter: options` (Supabase/pgbouncer)
- `FATAL: unsupported startup parameter in options: statement_timeout` (Neon)
- `connection is insecure (try using sslmode=require)` (psycopg fallback after startup rejection)

~2,000+ exceptions/hour since deploy, still ongoing.

## Changes

Reverts #54922 — removes the `options` kwarg from both connection paths and restores the post-connect `SET statement_timeout` approach which is proxy-safe.

## How did you test this code?

This is a clean `git revert` of fe6edbf36f6. The restored code was the working state prior to 2026-04-16.

## 🤖 LLM context

Agent-authored revert. Root cause analysis traced the "connection is insecure" error spike to this PR via deploy timestamp correlation in the charts repo.

no