### PR TITLE
fix(experiments): Harden metric validation especially for agent-driven requests

### DIFF
--- a/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
+++ b/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
@@ -923,15 +923,7 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.person_id,
-               events.`mat_$browser`,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-13'), lessOrEquals(toDate(events.timestamp), '2024-01-17'))) AS events
+     FROM events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Asia/Tokyo')), max(toTimeZone(raw_sessions.max_timestamp, 'Asia/Tokyo'))), 10)))) AS `$is_bounce`,
@@ -948,7 +940,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Tokyo'))), lessOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Tokyo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Tokyo'))), lessOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Tokyo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -171,10 +171,13 @@ class ExperimentService:
                     # ExperimentMetric is a RootModel wrapping a union, so access .root to get the actual type
                     actual_metric = validated_metric.root
                     if isinstance(actual_metric, ExperimentFunnelMetric):
-                        if len(actual_metric.series) < 2:
+                        # The experiment exposure event is prepended as step_0 at query time,
+                        # so series must contain at least one user-supplied step for the funnel
+                        # to yield a meaningful conversion metric.
+                        if not actual_metric.series:
                             raise ValidationError(
-                                f"Invalid metric at index {i}: funnel metrics require at least 2 steps. "
-                                "For tracking a single event, use 'mean' metric type instead."
+                                f"Invalid metric at index {i}: funnel metrics require at least one step. "
+                                "The experiment exposure event is added as the initial step automatically."
                             )
                         # Additional validation for funnel metrics with DW steps
                         FunnelDWValidator.validate_funnel_metric(actual_metric)

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -168,10 +168,15 @@ class ExperimentService:
                 try:
                     validated_metric = ExperimentMetric.model_validate(metric)
 
-                    # Additional validation for funnel metrics with DW steps
                     # ExperimentMetric is a RootModel wrapping a union, so access .root to get the actual type
                     actual_metric = validated_metric.root
                     if isinstance(actual_metric, ExperimentFunnelMetric):
+                        if len(actual_metric.series) < 2:
+                            raise ValidationError(
+                                f"Invalid metric at index {i}: funnel metrics require at least 2 steps. "
+                                "For tracking a single event, use 'mean' metric type instead."
+                            )
+                        # Additional validation for funnel metrics with DW steps
                         FunnelDWValidator.validate_funnel_metric(actual_metric)
 
                 except pydantic.ValidationError as e:
@@ -1260,13 +1265,21 @@ class ExperimentService:
         if "saved_metrics_ids" in update_data:
             self.validate_saved_metrics_ids(update_data["saved_metrics_ids"], self.team.id)
         if "metrics" in update_data:
+            self.validate_experiment_metrics(update_data["metrics"])
             self.validate_metric_action_ids(update_data["metrics"], self.team.id)
             if not allow_unknown_events:
                 self.validate_metric_event_names(update_data["metrics"])
+            for metric in update_data["metrics"] or []:
+                if not metric.get("uuid"):
+                    metric["uuid"] = str(uuid4())
         if "metrics_secondary" in update_data:
+            self.validate_experiment_metrics(update_data["metrics_secondary"])
             self.validate_metric_action_ids(update_data["metrics_secondary"], self.team.id)
             if not allow_unknown_events:
                 self.validate_metric_event_names(update_data["metrics_secondary"])
+            for metric in update_data["metrics_secondary"] or []:
+                if not metric.get("uuid"):
+                    metric["uuid"] = str(uuid4())
 
         context = serializer_context or self._build_serializer_context()
         feature_flag = experiment.feature_flag

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -3159,20 +3159,26 @@ class TestExperimentService(APIBaseTest):
             )
         assert "at least 2 steps" in str(ctx.exception)
 
-    def test_update_experiment_rejects_single_step_funnel(self):
+    @parameterized.expand(
+        [
+            ("primary_single_step", "metrics", [{"kind": "EventsNode", "event": "$pageview"}]),
+            ("primary_empty", "metrics", []),
+            ("secondary_single_step", "metrics_secondary", [{"kind": "EventsNode", "event": "$pageview"}]),
+            ("secondary_empty", "metrics_secondary", []),
+        ]
+    )
+    def test_update_experiment_rejects_insufficient_funnel(self, _name, field, series):
         experiment = self._create_draft_experiment()
         service = self._service()
         with self.assertRaises(ValidationError):
             service.update_experiment(
                 experiment,
                 {
-                    "metrics": [
+                    field: [
                         {
                             "kind": "ExperimentMetric",
                             "metric_type": "funnel",
-                            "series": [
-                                {"kind": "EventsNode", "event": "$pageview"},
-                            ],
+                            "series": series,
                         }
                     ],
                 },

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -3136,38 +3136,32 @@ class TestExperimentService(APIBaseTest):
         )
         assert experiment.metrics is not None and len(experiment.metrics) == 1
 
-    @parameterized.expand(
-        [
-            ("single_step", [{"kind": "EventsNode", "event": "$pageview"}]),
-            ("empty_series", []),
-        ]
-    )
-    def test_funnel_metric_insufficient_series_raises(self, name, series):
+    def test_funnel_metric_with_empty_series_raises(self):
+        # The experiment exposure event is prepended as step_0 at query time, so an
+        # empty series would produce a degenerate single-step funnel with no conversion event.
         service = self._service()
         with self.assertRaises(ValidationError) as ctx:
             service.create_experiment(
-                name=f"Insufficient Funnel {name}",
-                feature_flag_key=f"insufficient-funnel-flag-{name.replace('_', '-')}",
+                name="Empty Funnel",
+                feature_flag_key="empty-funnel-flag",
                 allow_unknown_events=True,
                 metrics=[
                     {
                         "kind": "ExperimentMetric",
                         "metric_type": "funnel",
-                        "series": series,
+                        "series": [],
                     },
                 ],
             )
-        assert "at least 2 steps" in str(ctx.exception)
+        assert "at least one step" in str(ctx.exception)
 
     @parameterized.expand(
         [
-            ("primary_single_step", "metrics", [{"kind": "EventsNode", "event": "$pageview"}]),
-            ("primary_empty", "metrics", []),
-            ("secondary_single_step", "metrics_secondary", [{"kind": "EventsNode", "event": "$pageview"}]),
-            ("secondary_empty", "metrics_secondary", []),
+            ("primary", "metrics"),
+            ("secondary", "metrics_secondary"),
         ]
     )
-    def test_update_experiment_rejects_insufficient_funnel(self, _name, field, series):
+    def test_update_experiment_rejects_empty_funnel_series(self, _name, field):
         experiment = self._create_draft_experiment()
         service = self._service()
         with self.assertRaises(ValidationError):
@@ -3178,28 +3172,43 @@ class TestExperimentService(APIBaseTest):
                         {
                             "kind": "ExperimentMetric",
                             "metric_type": "funnel",
-                            "series": series,
+                            "series": [],
                         }
                     ],
                 },
                 allow_unknown_events=True,
             )
 
-    def test_funnel_metric_with_two_steps_succeeds(self):
-        self._create_flag(key="valid-funnel-flag")
+    @parameterized.expand(
+        [
+            (
+                "single_step",
+                [{"kind": "EventsNode", "event": "$pageview"}],
+            ),
+            (
+                "two_steps",
+                [
+                    {"kind": "EventsNode", "event": "$pageview"},
+                    {"kind": "EventsNode", "event": "$pageleave"},
+                ],
+            ),
+        ]
+    )
+    def test_funnel_metric_with_valid_series_succeeds(self, name, series):
+        # Single-step series is valid: the exposure event is prepended as step_0 at query
+        # time, yielding a standard conversion-rate funnel (exposure → event).
+        flag_key = f"valid-funnel-flag-{name.replace('_', '-')}"
+        self._create_flag(key=flag_key)
         service = self._service()
         experiment = service.create_experiment(
-            name="Valid Funnel",
-            feature_flag_key="valid-funnel-flag",
+            name=f"Valid Funnel {name}",
+            feature_flag_key=flag_key,
             allow_unknown_events=True,
             metrics=[
                 {
                     "kind": "ExperimentMetric",
                     "metric_type": "funnel",
-                    "series": [
-                        {"kind": "EventsNode", "event": "$pageview"},
-                        {"kind": "EventsNode", "event": "$pageleave"},
-                    ],
+                    "series": series,
                 },
             ],
         )

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -980,10 +980,21 @@ class TestExperimentService(APIBaseTest):
             experiment,
             {
                 "metrics": [
-                    {"kind": "ExperimentMetric", "metric_type": "count", "uuid": "m1", "event": "$pageview"},
-                    {"kind": "ExperimentMetric", "metric_type": "count", "uuid": "m2", "event": "$pageleave"},
+                    {
+                        "kind": "ExperimentMetric",
+                        "metric_type": "mean",
+                        "uuid": "m1",
+                        "source": {"kind": "EventsNode", "event": "$pageview"},
+                    },
+                    {
+                        "kind": "ExperimentMetric",
+                        "metric_type": "mean",
+                        "uuid": "m2",
+                        "source": {"kind": "EventsNode", "event": "$pageleave"},
+                    },
                 ],
             },
+            allow_unknown_events=True,
         )
 
         assert updated.primary_metrics_ordered_uuids is not None
@@ -1030,6 +1041,65 @@ class TestExperimentService(APIBaseTest):
         )
 
         assert updated.primary_metrics_ordered_uuids == ["m1"]
+
+    @parameterized.expand(
+        [
+            ("primary", "metrics", "primary_metrics_ordered_uuids"),
+            ("secondary", "metrics_secondary", "secondary_metrics_ordered_uuids"),
+        ]
+    )
+    def test_update_experiment_auto_generates_uuids(self, _name, field, ordering_attr):
+        experiment = self._create_draft_experiment()
+        service = self._service()
+
+        updated = service.update_experiment(
+            experiment,
+            {
+                field: [
+                    {
+                        "kind": "ExperimentMetric",
+                        "metric_type": "mean",
+                        "source": {"kind": "EventsNode", "event": "$pageview"},
+                    }
+                ],
+            },
+            allow_unknown_events=True,
+        )
+
+        metrics = getattr(updated, field)
+        assert len(metrics) == 1
+        generated_uuid = metrics[0].get("uuid")
+        assert generated_uuid, "UUID should be auto-generated for metrics without one"
+        assert getattr(updated, ordering_attr) == [generated_uuid]
+
+    @parameterized.expand(
+        [
+            ("primary", "metrics", "primary_metrics_ordered_uuids"),
+            ("secondary", "metrics_secondary", "secondary_metrics_ordered_uuids"),
+        ]
+    )
+    def test_update_experiment_preserves_provided_metric_uuids(self, _name, field, ordering_attr):
+        experiment = self._create_draft_experiment()
+        service = self._service()
+
+        updated = service.update_experiment(
+            experiment,
+            {
+                field: [
+                    {
+                        "kind": "ExperimentMetric",
+                        "metric_type": "mean",
+                        "uuid": "explicit-uuid",
+                        "source": {"kind": "EventsNode", "event": "$pageview"},
+                    }
+                ],
+            },
+            allow_unknown_events=True,
+        )
+
+        metrics = getattr(updated, field)
+        assert metrics[0]["uuid"] == "explicit-uuid"
+        assert "explicit-uuid" in (getattr(updated, ordering_attr) or [])
 
     def test_update_experiment_replaces_saved_metrics(self):
         experiment = self._create_draft_experiment()
@@ -3065,6 +3135,70 @@ class TestExperimentService(APIBaseTest):
             ],
         )
         assert experiment.metrics is not None and len(experiment.metrics) == 1
+
+    @parameterized.expand(
+        [
+            ("single_step", [{"kind": "EventsNode", "event": "$pageview"}]),
+            ("empty_series", []),
+        ]
+    )
+    def test_funnel_metric_insufficient_series_raises(self, name, series):
+        service = self._service()
+        with self.assertRaises(ValidationError) as ctx:
+            service.create_experiment(
+                name=f"Insufficient Funnel {name}",
+                feature_flag_key=f"insufficient-funnel-flag-{name.replace('_', '-')}",
+                allow_unknown_events=True,
+                metrics=[
+                    {
+                        "kind": "ExperimentMetric",
+                        "metric_type": "funnel",
+                        "series": series,
+                    },
+                ],
+            )
+        assert "at least 2 steps" in str(ctx.exception)
+
+    def test_update_experiment_rejects_single_step_funnel(self):
+        experiment = self._create_draft_experiment()
+        service = self._service()
+        with self.assertRaises(ValidationError):
+            service.update_experiment(
+                experiment,
+                {
+                    "metrics": [
+                        {
+                            "kind": "ExperimentMetric",
+                            "metric_type": "funnel",
+                            "series": [
+                                {"kind": "EventsNode", "event": "$pageview"},
+                            ],
+                        }
+                    ],
+                },
+                allow_unknown_events=True,
+            )
+
+    def test_funnel_metric_with_two_steps_succeeds(self):
+        self._create_flag(key="valid-funnel-flag")
+        service = self._service()
+        experiment = service.create_experiment(
+            name="Valid Funnel",
+            feature_flag_key="valid-funnel-flag",
+            allow_unknown_events=True,
+            metrics=[
+                {
+                    "kind": "ExperimentMetric",
+                    "metric_type": "funnel",
+                    "series": [
+                        {"kind": "EventsNode", "event": "$pageview"},
+                        {"kind": "EventsNode", "event": "$pageleave"},
+                    ],
+                },
+            ],
+        )
+        assert len(experiment.metrics) == 1
+        assert experiment.metrics[0]["metric_type"] == "funnel"
 
     def test_funnel_metric_with_nonexistent_action_in_series_raises(self):
         action = Action.objects.create(team=self.team, name="real action")

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -3197,7 +3197,7 @@ class TestExperimentService(APIBaseTest):
                 },
             ],
         )
-        assert len(experiment.metrics) == 1
+        assert experiment.metrics is not None and len(experiment.metrics) == 1
         assert experiment.metrics[0]["metric_type"] == "funnel"
 
     def test_funnel_metric_with_nonexistent_action_in_series_raises(self):

--- a/services/mcp/tests/tools/experiments.integration.test.ts
+++ b/services/mcp/tests/tools/experiments.integration.test.ts
@@ -753,6 +753,8 @@ describe('Experiments', { concurrent: false }, () => {
         })
 
         it('should handle funnel with single step', async () => {
+            // A single-step series is valid for experiments: the exposure event is
+            // prepended at query time, yielding a conversion-rate funnel from exposure to event.
             const flagKey = generateUniqueKey('exp-single-funnel-flag')
 
             const params = {


### PR DESCRIPTION
## Problem

Agents calling `experiment-update` to add metrics were hitting two silent failure modes:

1. Metrics without `uuid` were accepted but not shown in UI. This was a gap between `create_experiment` (which auto-generates UUIDs) and `update_experiment` 

2. Single-step funnel metrics were accepted in both actions

## Changes

- Fix these two issues
- Note: existing test `test_update_experiment_syncs_ordering_on_metric_add` used an invalid metric shape (`metric_type: "count"` doesn't exist). It only worked because update didn't validate. Fixed to use valid `mean` metrics.

## How did you test this code?

- Test automation: New test cases + existing pass
- Manually: Add only one step in UI works (in addition to implicit exposure) - i.e. not testing the validation, but that the common use case through UI works

## Publish to changelog?

no
