### PR TITLE
fix: SDK Doctor parsing for unprefixed GitHub release tags

### DIFF
--- a/products/growth/dags/github_sdk_versions.py
+++ b/products/growth/dags/github_sdk_versions.py
@@ -19,6 +19,7 @@ logger = structlog.get_logger(__name__)
 
 MAX_REQUEST_RETRIES = 3
 INITIAL_RETRIES_BACKOFF = 1  # in seconds
+UNPREFIXED_SEMVER_TAG = re.compile(r"[0-9]")
 
 
 SdkTypes = Literal[
@@ -74,6 +75,11 @@ def fetch_github_data_for_sdk(lib_name: str) -> Optional[dict[str, Any]]:
     if fetch_fn:
         return fetch_fn()
     return None
+
+
+def prefixed_or_unprefixed_semver_tags(*prefixes: str) -> list[str | re.Pattern]:
+    """Match semver-style release tags with optional string prefixes."""
+    return [*prefixes, UNPREFIXED_SEMVER_TAG]
 
 
 def fetch_sdk_data_from_releases(repo: str, tag_prefixes: list[str | re.Pattern] | None = None) -> dict[str, Any]:
@@ -195,7 +201,7 @@ def fetch_web_sdk_data() -> dict[str, Any]:
 
 def fetch_python_sdk_data() -> dict[str, Any]:
     """Fetch Python SDK data from GitHub releases API"""
-    return fetch_sdk_data_from_releases("PostHog/posthog-python", tag_prefixes=["v"])
+    return fetch_sdk_data_from_releases("PostHog/posthog-python", tag_prefixes=prefixed_or_unprefixed_semver_tags("v"))
 
 
 def fetch_node_sdk_data() -> dict[str, Any]:
@@ -255,12 +261,14 @@ def fetch_ios_sdk_data() -> dict[str, Any]:
 
 def fetch_android_sdk_data() -> dict[str, Any]:
     """Fetch Android SDK data from GitHub releases API"""
-    return fetch_sdk_data_from_releases("PostHog/posthog-android", tag_prefixes=["android-v", re.compile(r"[0-9]")])
+    return fetch_sdk_data_from_releases(
+        "PostHog/posthog-android", tag_prefixes=prefixed_or_unprefixed_semver_tags("android-v")
+    )
 
 
 def fetch_go_sdk_data() -> dict[str, Any]:
     """Fetch Go SDK data from GitHub releases API"""
-    return fetch_sdk_data_from_releases("PostHog/posthog-go", tag_prefixes=["v"])
+    return fetch_sdk_data_from_releases("PostHog/posthog-go", tag_prefixes=prefixed_or_unprefixed_semver_tags("v"))
 
 
 def fetch_php_sdk_data() -> dict[str, Any]:
@@ -275,12 +283,12 @@ def fetch_ruby_sdk_data() -> dict[str, Any]:
 
 def fetch_elixir_sdk_data() -> dict[str, Any]:
     """Fetch Elixir SDK data from CHANGELOG.md with release dates"""
-    return fetch_sdk_data_from_releases("PostHog/posthog-elixir", tag_prefixes=["v"])
+    return fetch_sdk_data_from_releases("PostHog/posthog-elixir", tag_prefixes=prefixed_or_unprefixed_semver_tags("v"))
 
 
 def fetch_dotnet_sdk_data() -> dict[str, Any]:
     """Fetch .NET SDK data from GitHub releases API"""
-    return fetch_sdk_data_from_releases("PostHog/posthog-dotnet", tag_prefixes=["v"])
+    return fetch_sdk_data_from_releases("PostHog/posthog-dotnet", tag_prefixes=prefixed_or_unprefixed_semver_tags("v"))
 
 
 # ---- Dagster defs

--- a/products/growth/dags/github_sdk_versions.py
+++ b/products/growth/dags/github_sdk_versions.py
@@ -19,7 +19,7 @@ logger = structlog.get_logger(__name__)
 
 MAX_REQUEST_RETRIES = 3
 INITIAL_RETRIES_BACKOFF = 1  # in seconds
-UNPREFIXED_SEMVER_TAG = re.compile(r"[0-9]")
+UNPREFIXED_SEMVER_TAG = re.compile(r"\d+\.\d+(?:\.\d+)*$")
 
 
 SdkTypes = Literal[

--- a/products/growth/dags/tests/test_github_sdk_versions.py
+++ b/products/growth/dags/tests/test_github_sdk_versions.py
@@ -129,6 +129,22 @@ class TestFetchPythonSdkData(TestFetchSdkDataBase):
         assert result["releaseDates"]["7.0.1"] == "2025-11-15T12:43:55Z"
         assert mock_get.call_count == 2  # Assert that it attempted to paginate
 
+    @patch("products.growth.dags.github_sdk_versions.requests.get")
+    def test_fetch_python_sdk_data_supports_unprefixed_release_tags(self, mock_get):
+        self.setup_ok_json_mock(
+            mock_get,
+            [
+                {"tag_name": "7.0.2", "draft": False, "prerelease": False, "created_at": "2025-11-16T12:43:55Z"},
+                {"tag_name": "v7.0.1", "draft": False, "prerelease": False, "created_at": "2025-11-15T12:43:55Z"},
+            ],
+        )
+
+        result = fetch_python_sdk_data()
+
+        assert result["latestVersion"] == "7.0.2"
+        assert result["releaseDates"]["7.0.2"] == "2025-11-16T12:43:55Z"
+        assert result["releaseDates"]["7.0.1"] == "2025-11-15T12:43:55Z"
+
 
 class TestFetchNodeSdkData(TestFetchSdkDataBase):
     @patch("products.growth.dags.github_sdk_versions.requests.get")
@@ -234,6 +250,22 @@ class TestFetchGoSdkData(TestFetchSdkDataBase):
         assert result["releaseDates"]["1.6.13"] == "2025-11-21T21:58:29Z"
         assert mock_get.call_count == 2  # Assert that it attempted to paginate
 
+    @patch("products.growth.dags.github_sdk_versions.requests.get")
+    def test_fetch_go_sdk_data_supports_unprefixed_release_tags(self, mock_get):
+        self.setup_ok_json_mock(
+            mock_get,
+            [
+                {"tag_name": "1.6.14", "draft": False, "prerelease": False, "created_at": "2025-11-22T21:58:29Z"},
+                {"tag_name": "v1.6.13", "draft": False, "prerelease": False, "created_at": "2025-11-21T21:58:29Z"},
+            ],
+        )
+
+        result = fetch_go_sdk_data()
+
+        assert result["latestVersion"] == "1.6.14"
+        assert result["releaseDates"]["1.6.14"] == "2025-11-22T21:58:29Z"
+        assert result["releaseDates"]["1.6.13"] == "2025-11-21T21:58:29Z"
+
 
 class TestFetchPhpSdkData(TestFetchSdkDataBase):
     @patch("products.growth.dags.github_sdk_versions.requests.get")
@@ -282,6 +314,22 @@ class TestFetchElixirSdkData(TestFetchSdkDataBase):
         assert result["releaseDates"]["2.1.0"] == "2025-11-25T18:54:57Z"
         assert mock_get.call_count == 2  # Assert that it attempted to paginate
 
+    @patch("products.growth.dags.github_sdk_versions.requests.get")
+    def test_fetch_elixir_sdk_data_supports_unprefixed_release_tags(self, mock_get):
+        self.setup_ok_json_mock(
+            mock_get,
+            [
+                {"tag_name": "2.1.1", "draft": False, "prerelease": False, "created_at": "2025-11-26T18:54:57Z"},
+                {"tag_name": "v2.1.0", "draft": False, "prerelease": False, "created_at": "2025-11-25T18:54:57Z"},
+            ],
+        )
+
+        result = fetch_elixir_sdk_data()
+
+        assert result["latestVersion"] == "2.1.1"
+        assert result["releaseDates"]["2.1.1"] == "2025-11-26T18:54:57Z"
+        assert result["releaseDates"]["2.1.0"] == "2025-11-25T18:54:57Z"
+
 
 class TestFetchDotnetSdkData(TestFetchSdkDataBase):
     @patch("products.growth.dags.github_sdk_versions.requests.get")
@@ -297,3 +345,19 @@ class TestFetchDotnetSdkData(TestFetchSdkDataBase):
         assert "2.2.2" in result["releaseDates"]
         assert result["releaseDates"]["2.2.2"] == "2025-11-21T17:27:02Z"
         assert mock_get.call_count == 2  # Assert that it attempted to paginate
+
+    @patch("products.growth.dags.github_sdk_versions.requests.get")
+    def test_fetch_dotnet_sdk_data_supports_unprefixed_release_tags(self, mock_get):
+        self.setup_ok_json_mock(
+            mock_get,
+            [
+                {"tag_name": "2.2.3", "draft": False, "prerelease": False, "created_at": "2025-11-22T17:27:02Z"},
+                {"tag_name": "v2.2.2", "draft": False, "prerelease": False, "created_at": "2025-11-21T17:27:02Z"},
+            ],
+        )
+
+        result = fetch_dotnet_sdk_data()
+
+        assert result["latestVersion"] == "2.2.3"
+        assert result["releaseDates"]["2.2.3"] == "2025-11-22T17:27:02Z"
+        assert result["releaseDates"]["2.2.2"] == "2025-11-21T17:27:02Z"

--- a/products/growth/dags/tests/test_github_sdk_versions.py
+++ b/products/growth/dags/tests/test_github_sdk_versions.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import pytest
 from unittest.mock import MagicMock, patch
 
 from products.growth.dags.github_sdk_versions import (
@@ -129,22 +130,6 @@ class TestFetchPythonSdkData(TestFetchSdkDataBase):
         assert result["releaseDates"]["7.0.1"] == "2025-11-15T12:43:55Z"
         assert mock_get.call_count == 2  # Assert that it attempted to paginate
 
-    @patch("products.growth.dags.github_sdk_versions.requests.get")
-    def test_fetch_python_sdk_data_supports_unprefixed_release_tags(self, mock_get):
-        self.setup_ok_json_mock(
-            mock_get,
-            [
-                {"tag_name": "7.0.2", "draft": False, "prerelease": False, "created_at": "2025-11-16T12:43:55Z"},
-                {"tag_name": "v7.0.1", "draft": False, "prerelease": False, "created_at": "2025-11-15T12:43:55Z"},
-            ],
-        )
-
-        result = fetch_python_sdk_data()
-
-        assert result["latestVersion"] == "7.0.2"
-        assert result["releaseDates"]["7.0.2"] == "2025-11-16T12:43:55Z"
-        assert result["releaseDates"]["7.0.1"] == "2025-11-15T12:43:55Z"
-
 
 class TestFetchNodeSdkData(TestFetchSdkDataBase):
     @patch("products.growth.dags.github_sdk_versions.requests.get")
@@ -250,22 +235,6 @@ class TestFetchGoSdkData(TestFetchSdkDataBase):
         assert result["releaseDates"]["1.6.13"] == "2025-11-21T21:58:29Z"
         assert mock_get.call_count == 2  # Assert that it attempted to paginate
 
-    @patch("products.growth.dags.github_sdk_versions.requests.get")
-    def test_fetch_go_sdk_data_supports_unprefixed_release_tags(self, mock_get):
-        self.setup_ok_json_mock(
-            mock_get,
-            [
-                {"tag_name": "1.6.14", "draft": False, "prerelease": False, "created_at": "2025-11-22T21:58:29Z"},
-                {"tag_name": "v1.6.13", "draft": False, "prerelease": False, "created_at": "2025-11-21T21:58:29Z"},
-            ],
-        )
-
-        result = fetch_go_sdk_data()
-
-        assert result["latestVersion"] == "1.6.14"
-        assert result["releaseDates"]["1.6.14"] == "2025-11-22T21:58:29Z"
-        assert result["releaseDates"]["1.6.13"] == "2025-11-21T21:58:29Z"
-
 
 class TestFetchPhpSdkData(TestFetchSdkDataBase):
     @patch("products.growth.dags.github_sdk_versions.requests.get")
@@ -314,22 +283,6 @@ class TestFetchElixirSdkData(TestFetchSdkDataBase):
         assert result["releaseDates"]["2.1.0"] == "2025-11-25T18:54:57Z"
         assert mock_get.call_count == 2  # Assert that it attempted to paginate
 
-    @patch("products.growth.dags.github_sdk_versions.requests.get")
-    def test_fetch_elixir_sdk_data_supports_unprefixed_release_tags(self, mock_get):
-        self.setup_ok_json_mock(
-            mock_get,
-            [
-                {"tag_name": "2.1.1", "draft": False, "prerelease": False, "created_at": "2025-11-26T18:54:57Z"},
-                {"tag_name": "v2.1.0", "draft": False, "prerelease": False, "created_at": "2025-11-25T18:54:57Z"},
-            ],
-        )
-
-        result = fetch_elixir_sdk_data()
-
-        assert result["latestVersion"] == "2.1.1"
-        assert result["releaseDates"]["2.1.1"] == "2025-11-26T18:54:57Z"
-        assert result["releaseDates"]["2.1.0"] == "2025-11-25T18:54:57Z"
-
 
 class TestFetchDotnetSdkData(TestFetchSdkDataBase):
     @patch("products.growth.dags.github_sdk_versions.requests.get")
@@ -346,18 +299,49 @@ class TestFetchDotnetSdkData(TestFetchSdkDataBase):
         assert result["releaseDates"]["2.2.2"] == "2025-11-21T17:27:02Z"
         assert mock_get.call_count == 2  # Assert that it attempted to paginate
 
-    @patch("products.growth.dags.github_sdk_versions.requests.get")
-    def test_fetch_dotnet_sdk_data_supports_unprefixed_release_tags(self, mock_get):
-        self.setup_ok_json_mock(
-            mock_get,
-            [
-                {"tag_name": "2.2.3", "draft": False, "prerelease": False, "created_at": "2025-11-22T17:27:02Z"},
-                {"tag_name": "v2.2.2", "draft": False, "prerelease": False, "created_at": "2025-11-21T17:27:02Z"},
-            ],
-        )
 
-        result = fetch_dotnet_sdk_data()
+class TestSupportsUnprefixedReleaseTags(TestFetchSdkDataBase):
+    @pytest.mark.parametrize(
+        "fetch_fn,latest_tag,previous_tag,previous_version,latest_created_at,previous_created_at",
+        [
+            (fetch_python_sdk_data, "7.0.2", "v7.0.1", "7.0.1", "2025-11-16T12:43:55Z", "2025-11-15T12:43:55Z"),
+            (fetch_go_sdk_data, "1.6.14", "v1.6.13", "1.6.13", "2025-11-22T21:58:29Z", "2025-11-21T21:58:29Z"),
+            (fetch_elixir_sdk_data, "2.1.1", "v2.1.0", "2.1.0", "2025-11-26T18:54:57Z", "2025-11-25T18:54:57Z"),
+            (fetch_dotnet_sdk_data, "2.2.3", "v2.2.2", "2.2.2", "2025-11-22T17:27:02Z", "2025-11-21T17:27:02Z"),
+            (
+                fetch_android_sdk_data,
+                "3.27.0",
+                "android-v3.26.0",
+                "3.26.0",
+                "2025-11-06T20:29:02Z",
+                "2025-11-05T20:29:02Z",
+            ),
+        ],
+    )
+    def test_supports_unprefixed_release_tags(
+        self, fetch_fn, latest_tag, previous_tag, previous_version, latest_created_at, previous_created_at
+    ):
+        with patch("products.growth.dags.github_sdk_versions.requests.get") as mock_get:
+            self.setup_ok_json_mock(
+                mock_get,
+                [
+                    {
+                        "tag_name": latest_tag,
+                        "draft": False,
+                        "prerelease": False,
+                        "created_at": latest_created_at,
+                    },
+                    {
+                        "tag_name": previous_tag,
+                        "draft": False,
+                        "prerelease": False,
+                        "created_at": previous_created_at,
+                    },
+                ],
+            )
 
-        assert result["latestVersion"] == "2.2.3"
-        assert result["releaseDates"]["2.2.3"] == "2025-11-22T17:27:02Z"
-        assert result["releaseDates"]["2.2.2"] == "2025-11-21T17:27:02Z"
+            result = fetch_fn()
+
+        assert result["latestVersion"] == latest_tag
+        assert result["releaseDates"][latest_tag] == latest_created_at
+        assert result["releaseDates"][previous_version] == previous_created_at


### PR DESCRIPTION
## Problem

SDK Doctor determines the latest SDK versions by reading GitHub release tag names for each SDK repo.

Some SDK repos have started removing the `v` prefix from GitHub tags and releases. Without updating the parser in the main PostHog repo, SDK Doctor would ignore those new releases and continue reporting the older `v`-prefixed version as latest.

## Changes

- added a shared helper in `products/growth/dags/github_sdk_versions.py` to normalize semver-style release tags with or without a prefix
- updated SDK Doctor GitHub release parsing to accept both prefixed and unprefixed tags for Python, Go, Elixir, .NET, and Android
- added test coverage for mixed tag histories where a new unprefixed release follows older `v`-prefixed releases

## How did you test this code?

- ran `.venv/bin/pytest --noconftest -q products/growth/dags/tests/test_github_sdk_versions.py`
- verified `17 passed`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

No docs update needed.
