### PR TITLE
fix(subscriptions): scrub non-finite floats from content_snapshot

### DIFF
--- a/posthog/temporal/subscriptions/insight_snapshot.py
+++ b/posthog/temporal/subscriptions/insight_snapshot.py
@@ -14,6 +14,7 @@ lives here only:
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 import structlog
@@ -34,6 +35,17 @@ logger = structlog.get_logger(__name__)
 def _json_safe_value(val: Any) -> Any:
     """Coerce to JSONField-safe Python (dict/list/scalars); unknown types use fallback, not pass-through."""
     return to_jsonable_python(val, fallback=lambda x: str(x))
+
+
+def _scrub_non_finite_floats(value: Any) -> Any:
+    """Recursively coerce NaN / ±Inf to ``None`` — Postgres JSONB rejects those tokens."""
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, dict):
+        return {k: _scrub_non_finite_floats(v) for k, v in value.items()}
+    if isinstance(value, list | tuple):
+        return [_scrub_non_finite_floats(v) for v in value]
+    return value
 
 
 def build_initial_content_snapshot(subscription: Subscription) -> dict[str, Any]:
@@ -65,17 +77,21 @@ def build_initial_content_snapshot(subscription: Subscription) -> dict[str, Any]
 
 
 def _serialize_insight_result(result: InsightResult) -> dict[str, Any]:
-    return {
-        "result": result.result,
-        "columns": result.columns,
-        "types": result.types,
-        "resolved_date_range": _json_safe_value(result.resolved_date_range),
-        "last_refresh": result.last_refresh.isoformat() if result.last_refresh else None,
-        "is_cached": result.is_cached,
-        "timezone": result.timezone,
-        "has_more": result.has_more,
-        "query_status": _json_safe_value(result.query_status),
-    }
+    # Scrub at the return boundary so every field is protected uniformly — both raw
+    # `result` payloads and pydantic-coerced fields like `query_status` can contain NaN.
+    return _scrub_non_finite_floats(
+        {
+            "result": result.result,
+            "columns": result.columns,
+            "types": result.types,
+            "resolved_date_range": _json_safe_value(result.resolved_date_range),
+            "last_refresh": result.last_refresh.isoformat() if result.last_refresh else None,
+            "is_cached": result.is_cached,
+            "timezone": result.timezone,
+            "has_more": result.has_more,
+            "query_status": _json_safe_value(result.query_status),
+        }
+    )
 
 
 def _insight_snapshot_base_metadata(*, insight: Insight, tile: DashboardTile | None) -> dict[str, Any]:

--- a/posthog/temporal/subscriptions/insight_snapshot.py
+++ b/posthog/temporal/subscriptions/insight_snapshot.py
@@ -14,9 +14,9 @@ lives here only:
 
 from __future__ import annotations
 
-import math
 from typing import Any
 
+import orjson
 import structlog
 from pydantic_core import to_jsonable_python
 
@@ -35,17 +35,6 @@ logger = structlog.get_logger(__name__)
 def _json_safe_value(val: Any) -> Any:
     """Coerce to JSONField-safe Python (dict/list/scalars); unknown types use fallback, not pass-through."""
     return to_jsonable_python(val, fallback=lambda x: str(x))
-
-
-def _scrub_non_finite_floats(value: Any) -> Any:
-    """Recursively coerce NaN / ±Inf to ``None`` — Postgres JSONB rejects those tokens."""
-    if isinstance(value, float):
-        return value if math.isfinite(value) else None
-    if isinstance(value, dict):
-        return {k: _scrub_non_finite_floats(v) for k, v in value.items()}
-    if isinstance(value, list | tuple):
-        return [_scrub_non_finite_floats(v) for v in value]
-    return value
 
 
 def build_initial_content_snapshot(subscription: Subscription) -> dict[str, Any]:
@@ -77,20 +66,25 @@ def build_initial_content_snapshot(subscription: Subscription) -> dict[str, Any]
 
 
 def _serialize_insight_result(result: InsightResult) -> dict[str, Any]:
-    # Scrub at the return boundary so every field is protected uniformly — both raw
-    # `result` payloads and pydantic-coerced fields like `query_status` can contain NaN.
-    return _scrub_non_finite_floats(
-        {
-            "result": result.result,
-            "columns": result.columns,
-            "types": result.types,
-            "resolved_date_range": _json_safe_value(result.resolved_date_range),
-            "last_refresh": result.last_refresh.isoformat() if result.last_refresh else None,
-            "is_cached": result.is_cached,
-            "timezone": result.timezone,
-            "has_more": result.has_more,
-            "query_status": _json_safe_value(result.query_status),
-        }
+    # Coerce NaN / ±Inf to null via orjson — Postgres JSONB rejects the bare tokens that stdlib
+    # json.dumps (Django JSONField's default encoder) emits for non-finite floats.
+    # `default=str` covers types orjson doesn't serialize natively (notably Decimal) the way
+    # DjangoJSONEncoder would have, so switching encoders is a no-op for non-finite-float payloads.
+    return orjson.loads(
+        orjson.dumps(
+            {
+                "result": result.result,
+                "columns": result.columns,
+                "types": result.types,
+                "resolved_date_range": _json_safe_value(result.resolved_date_range),
+                "last_refresh": result.last_refresh.isoformat() if result.last_refresh else None,
+                "is_cached": result.is_cached,
+                "timezone": result.timezone,
+                "has_more": result.has_more,
+                "query_status": _json_safe_value(result.query_status),
+            },
+            default=str,
+        )
     )
 
 

--- a/posthog/temporal/subscriptions/test_insight_snapshot.py
+++ b/posthog/temporal/subscriptions/test_insight_snapshot.py
@@ -1,14 +1,31 @@
 import json
 import datetime as dt
+from decimal import Decimal
 
 import pytest
 
 from posthog.caching.fetch_from_cache import InsightResult
-from posthog.temporal.subscriptions.insight_snapshot import (
-    _has_comparison_enabled,
-    _scrub_non_finite_floats,
-    _serialize_insight_result,
-)
+from posthog.temporal.subscriptions.insight_snapshot import _has_comparison_enabled, _serialize_insight_result
+
+
+def _build_insight_result(**overrides) -> InsightResult:
+    base: dict = {
+        "result": [],
+        "columns": [],
+        "types": [],
+        "last_refresh": dt.datetime(2026, 4, 20, tzinfo=dt.UTC),
+        "is_cached": False,
+        "timezone": "UTC",
+        "has_more": False,
+        "resolved_date_range": None,
+        "query_status": None,
+        "cache_key": None,
+        "cache_target_age": None,
+        "next_allowed_client_refresh": None,
+        "hogql": None,
+    }
+    base.update(overrides)
+    return InsightResult(**base)
 
 
 @pytest.mark.parametrize(
@@ -34,52 +51,36 @@ def test_has_comparison_enabled(query_json, expected):
     assert _has_comparison_enabled(query_json) is expected
 
 
-@pytest.mark.parametrize(
-    "value,expected",
-    [
-        # finite scalars pass through unchanged (int, bool, None, str)
-        (1.5, 1.5),
-        (1, 1),
-        (True, True),
-        (None, None),
-        ("nan", "nan"),
-        # non-finite scalars become None
-        (float("nan"), None),
-        (float("inf"), None),
-        (float("-inf"), None),
-        # tuple → list coercion (JSON has no tuples)
-        ((float("nan"), 2.0), [None, 2.0]),
-        # the real prod shape: funnel row with 0/0 conversion rate
-        (
-            [["Final: prayer_screen_viewed", 0, 0.0, float("nan")]],
-            [["Final: prayer_screen_viewed", 0, 0.0, None]],
-        ),
-        # nested dict + list mix
-        ({"a": float("nan"), "b": [float("inf"), 1]}, {"a": None, "b": [None, 1]}),
-    ],
-)
-def test_scrub_non_finite_floats(value, expected):
-    assert _scrub_non_finite_floats(value) == expected
-
-
-def test_serialize_insight_result_nan_round_trips_through_json():
-    result = InsightResult(
-        result=[[float("nan"), 1.0, float("inf")]],
-        columns=["a", "b", "c"],
-        types=["float", "float", "float"],
-        last_refresh=dt.datetime(2026, 4, 20, tzinfo=dt.UTC),
-        is_cached=False,
-        timezone="UTC",
-        has_more=False,
-        resolved_date_range=None,
-        query_status=None,
-        cache_key=None,
-        cache_target_age=None,
-        next_allowed_client_refresh=None,
-        hogql=None,
+def test_serialize_insight_result_non_finite_floats_become_null():
+    result = _build_insight_result(
+        result=[
+            [float("nan"), 1.0, float("inf")],
+            ["Final: prayer_screen_viewed", 0, 0.0, float("nan")],
+        ],
+        columns=["a", "b", "c", "d"],
+        types=["float", "float", "float", "float"],
     )
 
     serialized = _serialize_insight_result(result)
 
     reparsed = json.loads(json.dumps(serialized))
-    assert reparsed["result"] == [[None, 1.0, None]]
+    assert reparsed["result"] == [
+        [None, 1.0, None],
+        ["Final: prayer_screen_viewed", 0, 0.0, None],
+    ]
+
+
+def test_serialize_insight_result_handles_decimal_and_date():
+    # Regression witness: orjson raises on Decimal without a default= hook, and stdlib json
+    # raises on bare date. Both used to live on the ClickHouse result path for revenue /
+    # analytics queries.
+    result = _build_insight_result(
+        result=[[Decimal("1.5"), dt.date(2026, 4, 20)]],
+        columns=["revenue", "day"],
+        types=["Decimal(10,2)", "Date"],
+    )
+
+    serialized = _serialize_insight_result(result)
+
+    reparsed = json.loads(json.dumps(serialized))
+    assert reparsed["result"] == [["1.5", "2026-04-20"]]

--- a/posthog/temporal/subscriptions/test_insight_snapshot.py
+++ b/posthog/temporal/subscriptions/test_insight_snapshot.py
@@ -55,7 +55,7 @@ def test_serialize_insight_result_non_finite_floats_become_null():
     result = _build_insight_result(
         result=[
             [float("nan"), 1.0, float("inf")],
-            ["Final: prayer_screen_viewed", 0, 0.0, float("nan")],
+            ["Final: $pageview", 0, 0.0, float("nan")],
         ],
         columns=["a", "b", "c", "d"],
         types=["float", "float", "float", "float"],
@@ -66,7 +66,7 @@ def test_serialize_insight_result_non_finite_floats_become_null():
     reparsed = json.loads(json.dumps(serialized))
     assert reparsed["result"] == [
         [None, 1.0, None],
-        ["Final: prayer_screen_viewed", 0, 0.0, None],
+        ["Final: $pageview", 0, 0.0, None],
     ]
 
 

--- a/posthog/temporal/subscriptions/test_insight_snapshot.py
+++ b/posthog/temporal/subscriptions/test_insight_snapshot.py
@@ -1,6 +1,14 @@
+import json
+import datetime as dt
+
 import pytest
 
-from posthog.temporal.subscriptions.insight_snapshot import _has_comparison_enabled
+from posthog.caching.fetch_from_cache import InsightResult
+from posthog.temporal.subscriptions.insight_snapshot import (
+    _has_comparison_enabled,
+    _scrub_non_finite_floats,
+    _serialize_insight_result,
+)
 
 
 @pytest.mark.parametrize(
@@ -24,3 +32,54 @@ from posthog.temporal.subscriptions.insight_snapshot import _has_comparison_enab
 )
 def test_has_comparison_enabled(query_json, expected):
     assert _has_comparison_enabled(query_json) is expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        # finite scalars pass through unchanged (int, bool, None, str)
+        (1.5, 1.5),
+        (1, 1),
+        (True, True),
+        (None, None),
+        ("nan", "nan"),
+        # non-finite scalars become None
+        (float("nan"), None),
+        (float("inf"), None),
+        (float("-inf"), None),
+        # tuple → list coercion (JSON has no tuples)
+        ((float("nan"), 2.0), [None, 2.0]),
+        # the real prod shape: funnel row with 0/0 conversion rate
+        (
+            [["Final: prayer_screen_viewed", 0, 0.0, float("nan")]],
+            [["Final: prayer_screen_viewed", 0, 0.0, None]],
+        ),
+        # nested dict + list mix
+        ({"a": float("nan"), "b": [float("inf"), 1]}, {"a": None, "b": [None, 1]}),
+    ],
+)
+def test_scrub_non_finite_floats(value, expected):
+    assert _scrub_non_finite_floats(value) == expected
+
+
+def test_serialize_insight_result_nan_round_trips_through_json():
+    result = InsightResult(
+        result=[[float("nan"), 1.0, float("inf")]],
+        columns=["a", "b", "c"],
+        types=["float", "float", "float"],
+        last_refresh=dt.datetime(2026, 4, 20, tzinfo=dt.UTC),
+        is_cached=False,
+        timezone="UTC",
+        has_more=False,
+        resolved_date_range=None,
+        query_status=None,
+        cache_key=None,
+        cache_target_age=None,
+        next_allowed_client_refresh=None,
+        hogql=None,
+    )
+
+    serialized = _serialize_insight_result(result)
+
+    reparsed = json.loads(json.dumps(serialized))
+    assert reparsed["result"] == [[None, 1.0, None]]


### PR DESCRIPTION
## Problem

Subscription deliveries with insights whose query results contain `NaN` or `±Inf` — most commonly funnel steps with zero entries, which produce a `0/0` conversion rate — fail to persist. Postgres JSONB rejects the INSERT on `SubscriptionDelivery.content_snapshot` because Python's `json.dumps` (Django `JSONField`'s default encoder) emits bare `NaN` / `Infinity` tokens, which aren't valid JSON.

The subscription workflow retries the activity to exhaustion before giving up, so every affected delivery burns its full retry budget and surfaces as a `DataError` on the `subscription_delivery` SLO.

### Why this only surfaces now

The HTTP read path has had no such problem since [#16911](https://github.com/PostHog/posthog/pull/16911) (Aug 2023): `SafeJSONRenderer` in `posthog/renderers.py` uses `orjson.dumps`, which silently coerces non-finite floats to `null`. Every API consumer of insight results has implicitly relied on that behaviour for ~2.5 years.

[#54684](https://github.com/PostHog/posthog/pull/54684) (2026-04-15, "Add SubscriptionDelivery history") introduced `_serialize_insight_result`, the first code path that persists insight results through Django's `JSONField` rather than the HTTP renderer. Because Django uses stdlib `json.dumps` under the hood, the orjson safety net stopped being invoked — and the latent NaN payloads immediately started hitting Postgres.

## Changes

Round-trip the serialized payload through `orjson` at the return boundary of `_serialize_insight_result`:

```python
return orjson.loads(
    orjson.dumps({...}, default=str),
)
```

- `orjson.dumps` emits JSON with `NaN` / `±Inf` coerced to `null` — matching the HTTP read path byte-for-byte.
- `default=str` falls back to string representation for types orjson doesn't serialize natively (notably `Decimal`). Preserves `DjangoJSONEncoder`'s prior behaviour so the encoder swap is a no-op for payloads that weren't already affected by the NaN bug.
- As a side effect this also resolves a separate `TypeError: Object of type date is not JSON serializable` that stdlib `json.dumps` raises on (orjson handles `date` natively).

## How did you test this code?

- Integration test builds an `InsightResult` containing `NaN`, `±Inf`, plus the real prod-failure row shape (funnel step with `0/0` conversion rate), calls `_serialize_insight_result`, and asserts the output round-trips through stdlib `json.dumps` / `json.loads` with `null` substituted in.
- Regression test builds an `InsightResult` with `Decimal` and `date` values, asserts the serializer now produces JSON-safe strings rather than raising.
- Full `posthog/temporal/subscriptions/test_insight_snapshot.py` suite passes (14 tests).

I'm an agent; manual testing was limited to the code-level unit/integration tests above. No end-to-end subscription delivery was exercised locally.

## Publish to changelog?

No.

## 🤖 LLM context

Authored with Claude Code following a production SLO triage. The failing operation / error type (`subscription_delivery` / `DataError`) was surfaced by a daily SLO failures report; root cause was confirmed via the Postgres error message and stack trace and pinned to `_serialize_insight_result` passing `result.result` through unchanged.

Initial attempt was a hand-rolled recursive NaN scrubber. A follow-up review surfaced that orjson already handles exactly this case (verified empirically) and that using orjson directly aligned with the HTTP read path's 2.5-year precedent. A second review iteration caught that a naive orjson swap would regress `Decimal` handling vs `DjangoJSONEncoder`; `default=str` restores it while preserving all the orjson wins.