### PR TITLE
fix: add deeplinking to posthog code git intergration

### DIFF
--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -1,6 +1,6 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
-import { router, urlToAction } from 'kea-router'
+import { combineUrl, router, urlToAction } from 'kea-router'
 
 import { LemonDialog, lemonToast } from '@posthog/lemon-ui'
 
@@ -196,10 +196,17 @@ export const integrationsLogic = kea<integrationsLogicType>([
                         throw new Error('Invalid state token')
                     }
 
-                    await api.integrations.create({
+                    const integration = await api.integrations.create({
                         kind: 'github',
                         config: { installation_id, state: stateToken, code },
                     })
+
+                    // Forward the ids so the `next` landing page (e.g. the PostHog Code
+                    // deep link) knows which install was just completed.
+                    replaceUrl = combineUrl(replaceUrl, {
+                        installation_id: String(installation_id),
+                        integration_id: String(integration.id),
+                    }).url
 
                     actions.loadIntegrations()
                     lemonToast.success(`Integration successful.`)
@@ -212,6 +219,11 @@ export const integrationsLogic = kea<integrationsLogicType>([
                 }
             } catch (e) {
                 toastApiError(e)
+                const detail = e instanceof ApiError ? e.detail : null
+                replaceUrl = combineUrl(replaceUrl, {
+                    error: 'github_install_failed',
+                    error_message: detail || (e instanceof Error ? e.message : 'Unknown error'),
+                }).url
             } finally {
                 router.actions.replace(replaceUrl)
             }

--- a/frontend/src/scenes/authentication/AccountSocialConnected.tsx
+++ b/frontend/src/scenes/authentication/AccountSocialConnected.tsx
@@ -10,7 +10,7 @@ import { SceneExport } from 'scenes/sceneTypes'
 
 import type { SSOProvider } from '~/types'
 
-const POSTHOG_CODE_CALLBACK_URL = 'posthog-code://callback'
+const POSTHOG_CODE_DEEP_LINK = 'posthog-code://integration'
 
 function providerLabel(provider: string | undefined): string {
     if (!provider) {
@@ -19,29 +19,66 @@ function providerLabel(provider: string | undefined): string {
     return SSO_PROVIDER_NAMES[provider as SSOProvider] ?? provider
 }
 
+function buildDeepLinkUrl(searchParams: Record<string, unknown>): string {
+    const url = new URL(POSTHOG_CODE_DEEP_LINK)
+
+    const provider = typeof searchParams.provider === 'string' ? searchParams.provider : ''
+    if (provider) {
+        url.searchParams.set('provider', provider)
+    }
+
+    for (const key of ['project_id', 'installation_id'] as const) {
+        const value = searchParams[key]
+        if (value !== undefined && value !== null && value !== '') {
+            url.searchParams.set(key, String(value))
+        }
+    }
+
+    const errorCode = typeof searchParams.error === 'string' ? searchParams.error : ''
+    url.searchParams.set('status', errorCode ? 'error' : 'success')
+    if (errorCode) {
+        url.searchParams.set('error_code', errorCode)
+        const errorMessage = typeof searchParams.error_message === 'string' ? searchParams.error_message : ''
+        if (errorMessage) {
+            url.searchParams.set('error_message', errorMessage)
+        }
+    }
+
+    return url.toString()
+}
+
 export const scene: SceneExport = {
     component: AccountSocialConnected,
 }
 
 /**
- * After OAuth links a social provider from PostHog Code (`next` → /account/social-connected?provider=…).
- * Redirects to `posthog-code://callback` with a fallback link if the app does not open.
+ * Landing page after a PostHog Code flow completes on the web — social login linking
+ * (`next=/account/social-connected?provider=…&connect_from=posthog_code`) or GitHub App
+ * install (Twig sets `next` to this page via `connect_from=posthog_code`).
+ *
+ * Deep-links back to the Twig app via `posthog-code://integration?...`, forwarding the
+ * provider / project_id / installation_id and a status flag so Twig can close its
+ * pending flow without polling. Falls back to copy + manual switch-back if the protocol
+ * handler is not registered.
  */
 export function AccountSocialConnected(): JSX.Element {
     const { searchParams } = useValues(router)
     const provider = typeof searchParams.provider === 'string' ? searchParams.provider : undefined
     const label = providerLabel(provider)
+    const isError = typeof searchParams.error === 'string' && searchParams.error.length > 0
 
     useEffect(() => {
-        window.location.href = POSTHOG_CODE_CALLBACK_URL
-    }, [])
+        window.location.href = buildDeepLinkUrl(searchParams)
+    }, [searchParams])
 
     return (
         <BridgePage view="account-social-connected">
             <div className="flex flex-col items-center gap-4 text-center max-w-lg mx-auto">
                 <IconCheckCircle className="text-success text-5xl shrink-0" />
-                <h2 className="text-xl font-semibold m-0">{label} linked to account</h2>
-                <p className="text-muted mb-0">You can now log into PostHog using {label}.</p>
+                <h2 className="text-xl font-semibold m-0">
+                    {isError ? `${label} linking failed` : `${label} linked to account`}
+                </h2>
+                {!isError && <p className="text-muted mb-0">You can now log into PostHog using {label}.</p>}
                 <p className="text-muted mb-0">
                     <strong>Returning to PostHog Code…</strong>
                     <br />


### PR DESCRIPTION
## Problem

When a PostHog Code user completes a GitHub App installation or social login flow via the web, the app needs to know the outcome — including which installation was just completed and whether it succeeded or failed — so it can close the pending flow without polling.

Previously, the deep-link back to the app used a hardcoded `posthog-code://callback` URL with no contextual data, and errors were not forwarded at all.

## Changes

**GitHub integration callback:**

- After a successful GitHub App installation, `installation_id` and `integration_id` are now appended as query parameters to the `next` redirect URL, so the landing page can forward them to the app.
- On failure, `error` and `error_message` query parameters are appended to the redirect URL so the app receives a structured error.

**`AccountSocialConnected`** **landing page:**

- The deep-link scheme is updated from `posthog-code://callback` to `posthog-code://integration`.
- A `buildDeepLinkUrl` helper constructs the deep-link URL, forwarding `provider`, `project_id`, `installation_id`, a `status` flag (`success` or `error`), and optional `error_code` / `error_message` fields.
- The page now renders an error state heading (`{label} linking failed`) when an error is present, rather than always showing a success message.

## How did you test this code?

manually

## Publish to changelog?

No