### PR TITLE
fix(clickhouse): re-add minmax_$session_id_uuid index on missing shards

### DIFF
--- a/posthog/clickhouse/migrations/0237_readd_session_id_uuid_minmax_index.py
+++ b/posthog/clickhouse/migrations/0237_readd_session_id_uuid_minmax_index.py
@@ -1,0 +1,22 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+# Migration 0222 added this index but used is_alter_on_replicated_table=True, which routed
+# through map_one_host_per_shard. In prod-us only a subset of shards had the ALTER applied
+# (4 out of 10 shards ended up with the index). Re-run with sharded=True only, matching
+# the pattern used by migration 0109 for the underlying column — this runs on every DATA
+# node, and IF NOT EXISTS + ReplicatedMergeTree's ZooKeeper-backed ALTER dedup make it
+# safe to apply on shards that already have the index.
+ADD_MINMAX_INDEX_SHARDED_EVENTS = """
+ALTER TABLE sharded_events
+ADD INDEX IF NOT EXISTS `minmax_$session_id_uuid` `$session_id_uuid`
+TYPE minmax
+GRANULARITY 1
+"""
+
+operations = [
+    run_sql_with_exceptions(
+        ADD_MINMAX_INDEX_SHARDED_EVENTS,
+        sharded=True,
+        is_alter_on_replicated_table=False,
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0236_drop_property_values_table
+0237_readd_session_id_uuid_minmax_index


### PR DESCRIPTION
## Problem

Migration [0222](https://github.com/PostHog/posthog/blob/master/posthog/clickhouse/migrations/0222_add_session_id_uuid_minmax_index.py) added `minmax_$session_id_uuid` to `sharded_events` but used `is_alter_on_replicated_table=True` alongside `sharded=True`. That combination routes through `ClickhouseCluster.map_one_host_per_shard`, which depends on the cluster object having every shard in its topology.

In prod-us only 4 of 10 shards ended up with the index. Verified via:

```sql
SELECT
    hostName() AS host,
    countIf(name = 'minmax_$session_id_uuid') AS has_index
FROM clusterAllReplicas('posthog', system.data_skipping_indices)
WHERE database = currentDatabase()
  AND table = 'sharded_events'
GROUP BY host
ORDER BY host;
```

Shards 1, 3, 5, 10 have `has_index = 1` on all replicas; shards 2, 4, 6, 7, 8, 9 have `0`. ZooKeeper correctly propagated within each shard — the shards themselves were skipped.

## Changes

New migration `0235_readd_session_id_uuid_minmax_index.py` that re-runs the same `ADD INDEX IF NOT EXISTS` with `sharded=True` only (no `is_alter_on_replicated_table`). This matches the pattern used by migration [0109](https://github.com/PostHog/posthog/blob/master/posthog/clickhouse/migrations/0109_materialize_session_ids_uuid.py) for the underlying `$session_id_uuid` column, which did land on every shard.

Dropping `is_alter_on_replicated_table` makes the migration fall through to `map_hosts_by_roles` which iterates every DATA node. For `ReplicatedMergeTree` this is safe — duplicate `ADD INDEX IF NOT EXISTS` attempts are deduped via ZooKeeper.

Note: this migration only ensures the index **definition** exists on every shard. The existing parts still need to be materialized against it — that's a follow-up run of the `backfill_materialized_column` dagster job with `indexes=["minmax_$session_id_uuid"]` over the partition range.

## How did you test this code?

I'm an agent — I have not manually tested this migration against any environment. Verification plan:

- [ ] Agent-visible checks: `ruff` ran via lint-staged on commit, migration format matches adjacent migrations (0109, 0222)
- [ ] After merge + deploy to prod-us: re-run the `clusterAllReplicas(system.data_skipping_indices)` count-by-host query — every replica should return `has_index = 1`
- [ ] After confirming the definition is everywhere, trigger `backfill_materialized_column` to populate the index on existing parts

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude in an agent session. Root cause analysis traced the `sharded=True` + `is_alter_on_replicated_table=True` combination to `ClickhouseCluster.map_one_host_per_shard`, whose `self.__shards` can be incomplete if the migrations cluster doesn't include every data shard (see comment at `posthog/clickhouse/cluster.py:135`). The fix mirrors migration 0109's pattern which successfully added the column to every shard.