### PR TITLE
feat(sql-editor): unflag direct querying

### DIFF
--- a/frontend/src/layout/panel-layout/DatabaseTree/DatabaseTree.tsx
+++ b/frontend/src/layout/panel-layout/DatabaseTree/DatabaseTree.tsx
@@ -5,8 +5,6 @@ import { IconSidebarClose } from '@posthog/icons'
 
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { cn } from 'lib/utils/css-classes'
 import { ConnectionSelector } from 'scenes/data-warehouse/editor/ConnectionSelector'
@@ -26,16 +24,12 @@ export const DatabaseTree = memo(function DatabaseTree({
     const scrollContainerRef = useRef<HTMLDivElement | null>(null)
     const { databaseTreeWidth, databaseTreeResizerProps, isDatabaseTreeCollapsed, databaseTreeWillCollapse } =
         useValues(editorSizingLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
     const { selectedConnectionId, selectedDirectSource } = useValues(sqlEditorLogic)
     const { toggleDatabaseTreeCollapsed, setDatabaseTreeCollapsed } = useActions(editorSizingLogic)
-    const isDirectQueryEnabled = !!featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]
 
-    const searchPlaceholder = isDirectQueryEnabled
-        ? selectedConnectionId
-            ? `Search ${selectedDirectSource?.prefix ? selectedDirectSource.prefix : 'database'}`
-            : 'Search PostHog Warehouse'
-        : 'Search warehouse'
+    const searchPlaceholder = selectedConnectionId
+        ? `Search ${selectedDirectSource?.prefix ? selectedDirectSource.prefix : 'database'}`
+        : 'Search PostHog Warehouse'
 
     if (isDatabaseTreeCollapsed) {
         return null
@@ -65,13 +59,9 @@ export const DatabaseTree = memo(function DatabaseTree({
                     >
                         <IconSidebarClose className="size-4 text-tertiary rotate-180" />
                     </ButtonPrimitive>
-                    {isDirectQueryEnabled ? (
-                        <ConnectionSelector />
-                    ) : (
-                        <DatabaseSearchField placeholder={searchPlaceholder} />
-                    )}
+                    <ConnectionSelector />
                 </div>
-                {isDirectQueryEnabled ? <DatabaseSearchField placeholder={searchPlaceholder} /> : null}
+                <DatabaseSearchField placeholder={searchPlaceholder} />
             </div>
             <ScrollableShadows
                 scrollRef={scrollContainerRef}

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -273,7 +273,6 @@ export const FEATURE_FLAGS = {
     DWH_FREE_SYNCS: 'dwh-free-syncs', // owner: @Gilbert09  #team-warehouse-sources
     DWH_JOIN_TABLE_PREVIEW: 'dwh-join-table-preview', // owner: @arthurdedeus #team-customer-analytics
     DWH_POSTGRES_CDC: 'dwh-postgres-cdc', // owner: #team-warehouse-sources
-    DWH_POSTGRES_DIRECT_QUERY: 'dwh-postgres-direct-query', // owner: #team-data-tools
     DWH_SOURCE_METRICS: 'dwh-source-metrics', // owner: #team-warehouse-sources
     EDITOR_DRAFTS: 'editor-drafts', // owner: @EDsCODE #team-data-tools
     ENDPOINTS: 'embedded-analytics', // owner: @sakce #team-clickhouse

--- a/frontend/src/scenes/data-management/database/databaseTableListLogic.test.ts
+++ b/frontend/src/scenes/data-management/database/databaseTableListLogic.test.ts
@@ -1,5 +1,3 @@
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
 
 import { performQuery } from '~/queries/query'
@@ -14,7 +12,6 @@ describe('databaseTableListLogic', () => {
 
     beforeEach(() => {
         initKeaTests()
-        featureFlagLogic.mount()
         ;(performQuery as jest.Mock).mockResolvedValue({
             tables: {},
             joins: [],
@@ -28,9 +25,6 @@ describe('databaseTableListLogic', () => {
     })
 
     it('does not read sql editor connection hashes or auto-load on mount', () => {
-        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-            [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
-        })
         window.history.replaceState({}, '', `${urls.sqlEditor()}#c=conn-123`)
 
         logic = databaseTableListLogic()
@@ -41,9 +35,6 @@ describe('databaseTableListLogic', () => {
     })
 
     it('does not auto-load on mount without a connection hash', () => {
-        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-            [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
-        })
         window.history.replaceState({}, '', urls.sqlEditor())
 
         logic = databaseTableListLogic()
@@ -53,10 +44,6 @@ describe('databaseTableListLogic', () => {
     })
 
     it('deduplicates in-flight schema loads for the same connection', async () => {
-        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-            [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
-        })
-
         let resolveQuery: ((value: { tables: Record<string, never>; joins: never[] }) => void) | undefined
         ;(performQuery as jest.Mock).mockImplementation(
             () =>

--- a/frontend/src/scenes/data-management/database/databaseTableListLogic.test.ts
+++ b/frontend/src/scenes/data-management/database/databaseTableListLogic.test.ts
@@ -68,10 +68,6 @@ describe('databaseTableListLogic', () => {
     })
 
     it('does not let a stale schema response overwrite the selected connection schema', async () => {
-        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-            [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
-        })
-
         let resolvePosthogQuery:
             | ((value: { tables: Record<string, { name: string; type: 'posthog' }>; joins: never[] }) => void)
             | undefined

--- a/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
+++ b/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
@@ -1,8 +1,6 @@
-import { actions, connect, kea, path, reducers, selectors } from 'kea'
+import { actions, kea, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { objectsEqual } from 'lib/utils'
 
 import { performQuery } from '~/queries/query'
@@ -38,17 +36,11 @@ const toMapById = <T extends { id: string }>(items: T[]): Record<string, T> =>
         {} as Record<string, T>
     )
 
-const isDirectQueryEnabled = (): boolean =>
-    !!featureFlagLogic.values.featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]
-
 let inFlightDatabaseLoadKey: string | null = null
 let inFlightDatabaseLoadPromise: Promise<Required<DatabaseSchemaQueryResponse> | null> | null = null
 
 export const databaseTableListLogic = kea<databaseTableListLogicType>([
     path(['scenes', 'data-management', 'database', 'databaseTableListLogic']),
-    connect(() => ({
-        values: [featureFlagLogic, ['featureFlags']],
-    })),
     actions({
         setSearchTerm: (searchTerm: string) => ({ searchTerm }),
         setConnection: (connectionId: string | null) => ({ connectionId }),
@@ -58,7 +50,7 @@ export const databaseTableListLogic = kea<databaseTableListLogicType>([
             null as Required<DatabaseSchemaQueryResponse> | null,
             {
                 loadDatabase: async (): Promise<Required<DatabaseSchemaQueryResponse> | null> => {
-                    const requestConnectionId = isDirectQueryEnabled() ? (values.connectionId ?? undefined) : undefined
+                    const requestConnectionId = values.connectionId ?? undefined
                     const requestKey = requestConnectionId ?? '__posthog__'
 
                     if (inFlightDatabaseLoadKey === requestKey && inFlightDatabaseLoadPromise) {

--- a/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
+++ b/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
@@ -69,9 +69,7 @@ export const databaseTableListLogic = kea<databaseTableListLogicType>([
 
                     try {
                         const database = await request
-                        const currentConnectionId = isDirectQueryEnabled()
-                            ? (values.connectionId ?? undefined)
-                            : undefined
+                        const currentConnectionId = values.connectionId ?? undefined
 
                         if (currentConnectionId !== requestConnectionId) {
                             return values.database

--- a/frontend/src/scenes/data-warehouse/editor/ConnectionSelector.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/ConnectionSelector.tsx
@@ -21,7 +21,7 @@ const sourceIcon = (src: string): JSX.Element => (
 
 export function ConnectionSelector(): JSX.Element | null {
     const { sourceQuery, selectedConnectionId } = useValues(sqlEditorLogic)
-    const { connectionSelectOptions, connectionSelectorValue, isDirectQueryEnabled } = useValues(
+    const { connectionSelectOptions, connectionSelectorValue } = useValues(
         connectionSelectorLogic({ selectedConnectionId })
     )
     const { setSourceQuery, syncUrlWithQuery } = useActions(sqlEditorLogic)
@@ -30,10 +30,6 @@ export function ConnectionSelector(): JSX.Element | null {
         sourceQuery as typeof sourceQuery & {
             connectionId?: string
         }
-
-    if (!isDirectQueryEnabled) {
-        return null
-    }
 
     return (
         <LemonSelect

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -8,14 +8,12 @@ import { LemonDivider } from '@posthog/lemon-ui'
 
 import { AppShortcut } from 'lib/components/AppShortcuts/AppShortcut'
 import { keyBinds } from 'lib/components/AppShortcuts/shortcuts'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconCancel } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonMenu } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { userPreferencesLogic } from 'lib/logic/userPreferencesLogic'
 import { cn } from 'lib/utils/css-classes'
 import { SQLEditorMode } from 'scenes/data-warehouse/editor/sqlEditorModes'
@@ -81,11 +79,9 @@ export function QueryWindow({
     const { setSuggestedQueryInput, reportAIQueryPromptOpen } = useActions(sqlEditorLogic)
     const vimModeFeatureEnabled = useFeatureFlag('SQL_EDITOR_VIM_MODE')
     const { editorVimModeEnabled } = useValues(userPreferencesLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
     const { setEditorVimModeEnabled } = useActions(userPreferencesLogic)
     const { isDatabaseTreeCollapsed } = useValues(editorSizingLogic)
-    const isDirectQueryEnabled = !!featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]
-    const canSendRawQuery = isDirectQueryEnabled && !!selectedConnectionId
+    const canSendRawQuery = !!selectedConnectionId
     const sendRawQueryLabel = (
         <span className="inline-flex items-center gap-1">
             <span>Send raw query</span>
@@ -155,7 +151,7 @@ export function QueryWindow({
                             onShowDatabaseTree={onShowDatabaseTree}
                         />
                         <RunButton />
-                        <CollapsedConnectionSelector mode={mode} isDirectQueryEnabled={isDirectQueryEnabled} />
+                        <CollapsedConnectionSelector mode={mode} />
                         <LemonDivider vertical />
                         <QueryVariablesMenu
                             disabledReason={editingView ? 'Variables are not allowed in views.' : undefined}
@@ -386,16 +382,10 @@ const InternalQueryWindow = memo(function InternalQueryWindow({ tabId }: { tabId
     return <OutputPane tabId={tabId} />
 })
 
-function CollapsedConnectionSelector({
-    mode,
-    isDirectQueryEnabled,
-}: {
-    mode?: SQLEditorMode
-    isDirectQueryEnabled: boolean
-}): JSX.Element | null {
+function CollapsedConnectionSelector({ mode }: { mode?: SQLEditorMode }): JSX.Element | null {
     const { isDatabaseTreeCollapsed } = useValues(editorSizingLogic)
 
-    if (!isDirectQueryEnabled || !isDatabaseTreeCollapsed || (mode && mode !== SQLEditorMode.FullScene)) {
+    if (!isDatabaseTreeCollapsed || (mode && mode !== SQLEditorMode.FullScene)) {
         return null
     }
 

--- a/frontend/src/scenes/data-warehouse/editor/connectionSelectorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/connectionSelectorLogic.test.ts
@@ -1,8 +1,6 @@
 import { expectLogic } from 'kea-test-utils'
 
 import api from 'lib/api'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
 
 import { initKeaTests } from '~/test/init'
@@ -14,7 +12,6 @@ describe('connectionSelectorLogic', () => {
 
     beforeEach(() => {
         initKeaTests()
-        featureFlagLogic.mount()
         jest.spyOn(api.externalDataSources, 'connections').mockResolvedValue([
             {
                 id: 'conn-123',
@@ -29,11 +26,7 @@ describe('connectionSelectorLogic', () => {
         jest.restoreAllMocks()
     })
 
-    it('loads connection options on mount when direct query is enabled', async () => {
-        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-            [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
-        })
-
+    it('loads connection options on mount', async () => {
         logic = connectionSelectorLogic({ selectedConnectionId: undefined })
         logic.mount()
 

--- a/frontend/src/scenes/data-warehouse/editor/connectionSelectorLogic.ts
+++ b/frontend/src/scenes/data-warehouse/editor/connectionSelectorLogic.ts
@@ -2,8 +2,6 @@ import { afterMount, connect, kea, listeners, path, props, selectors } from 'kea
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
 
 import type { ExternalDataSourceConnectionOption } from '~/types'
@@ -45,7 +43,6 @@ export const connectionSelectorLogic = kea<connectionSelectorLogicType>([
     path(['scenes', 'data-warehouse', 'editor', 'connectionSelectorLogic']),
     props({ selectedConnectionId: undefined } as ConnectionSelectorLogicProps),
     connect(() => ({
-        values: [featureFlagLogic, ['featureFlags']],
         actions: [sourcesDataLogic, ['loadSourcesSuccess']],
     })),
     loaders(() => ({
@@ -67,10 +64,6 @@ export const connectionSelectorLogic = kea<connectionSelectorLogicType>([
         ],
     })),
     selectors({
-        isDirectQueryEnabled: [
-            (s) => [s.featureFlags],
-            (featureFlags): boolean => !!featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY],
-        ],
         connectionSelectOptions: [
             (s) => [s.connectionOptions, s.connectionOptionsLoading],
             (
@@ -133,15 +126,13 @@ export const connectionSelectorLogic = kea<connectionSelectorLogicType>([
         ],
     }),
     afterMount(({ actions, values }) => {
-        if (values.isDirectQueryEnabled && values.connectionOptions === null && !values.connectionOptionsLoading) {
+        if (values.connectionOptions === null && !values.connectionOptionsLoading) {
             actions.loadConnectionOptions()
         }
     }),
-    listeners(({ actions, values }) => ({
+    listeners(({ actions }) => ({
         loadSourcesSuccess: () => {
-            if (values.isDirectQueryEnabled) {
-                actions.loadConnectionOptions()
-            }
+            actions.loadConnectionOptions()
         },
     })),
 ])

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -1,8 +1,6 @@
 import { router } from 'kea-router'
 import { expectLogic, partial } from 'kea-test-utils'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { teamLogic } from 'scenes/teamLogic'
@@ -905,9 +903,6 @@ describe('sqlEditorLogic', () => {
                 editor: createMockEditor(),
             })
             logic.mount()
-            featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-                [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
-            })
 
             logic.actions.setSourceQuery({
                 kind: NodeKind.DataVisualizationNode,
@@ -929,9 +924,6 @@ describe('sqlEditorLogic', () => {
                 editor: createMockEditor(),
             })
             logic.mount()
-            featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-                [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
-            })
 
             router.actions.push(urls.sqlEditor(), undefined, { q: 'SELECT 1', c: 'conn-123' })
 
@@ -954,9 +946,6 @@ describe('sqlEditorLogic', () => {
                 editor: createMockEditor(),
             })
             logic.mount()
-            featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-                [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
-            })
 
             router.actions.push(urls.sqlEditor(), undefined, { q: 'SELECT 1', c: 'conn-123', raw: '1' })
 
@@ -981,9 +970,6 @@ describe('sqlEditorLogic', () => {
                 editor: createMockEditor(),
             })
             logic.mount()
-            featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-                [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
-            })
 
             router.actions.push(urls.sqlEditor(), undefined, { q: 'SELECT 1', raw: '1' })
 
@@ -1001,9 +987,6 @@ describe('sqlEditorLogic', () => {
                 editor: createMockEditor(),
             })
             logic.mount()
-            featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-                [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
-            })
 
             router.actions.push(urls.sqlEditor(), undefined, { q: 'SELECT 1', c: 'conn-123' })
 
@@ -1058,9 +1041,6 @@ describe('sqlEditorLogic', () => {
                 editor: createMockEditor(),
             })
             logic.mount()
-            featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-                [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
-            })
 
             router.actions.push(urls.sqlEditor(), undefined, { q: 'SELECT 1' })
 
@@ -1085,9 +1065,6 @@ describe('sqlEditorLogic', () => {
                 editor: createMockEditor(),
             })
             logic.mount()
-            featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-                [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
-            })
 
             router.actions.push(urls.sqlEditor(), undefined, { q: 'SELECT 1', c: 'conn-123' })
 
@@ -1105,10 +1082,6 @@ describe('sqlEditorLogic', () => {
             const performQuerySpy = jest
                 .spyOn(queryRunner, 'performQuery')
                 .mockResolvedValue({ tables: {}, joins: [] } as never)
-
-            featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-                [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
-            })
 
             databaseLogic.actions.setConnection('conn-123')
             await databaseLogic.asyncActions.loadDatabase()
@@ -1143,9 +1116,6 @@ describe('sqlEditorLogic', () => {
                 editor: createMockEditor(),
             })
             logic.mount()
-            featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-                [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
-            })
 
             router.actions.push(urls.sqlEditor(), undefined, { q: 'SELECT 1', c: 'conn-123' })
 
@@ -1189,9 +1159,6 @@ describe('sqlEditorLogic', () => {
                 editor: createMockEditor(),
             })
             logic.mount()
-            featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-                [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
-            })
 
             router.actions.push(urls.sqlEditor(), undefined, { q: 'SELECT 1' })
 

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -320,7 +320,7 @@ function getTabHash(values: sqlEditorLogicType['values']): Record<string, any> {
         output_tab: values.outputActiveTab,
     }
     const connectionId = values.sourceQuery?.source.connectionId
-    if (values.featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY] && connectionId) {
+    if (connectionId) {
         hash['c'] = connectionId
         if (values.sourceQuery?.source.sendRawQuery) {
             hash['raw'] = '1'
@@ -2106,11 +2106,8 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
             },
         ],
         selectedConnectionId: [
-            (s) => [s.sourceQuery, s.featureFlags],
-            (sourceQuery, featureFlags) => {
-                if (!featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]) {
-                    return undefined
-                }
+            (s) => [s.sourceQuery],
+            (sourceQuery) => {
                 return sourceQuery.source && 'connectionId' in sourceQuery.source
                     ? sourceQuery.source.connectionId
                     : undefined
@@ -2469,15 +2466,8 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
             }
 
             const connectionIdFromHash =
-                values.featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY] &&
-                typeof hashParams.c === 'string' &&
-                hashParams.c !== ''
-                    ? hashParams.c
-                    : undefined
-            const sendRawQueryFromHash =
-                connectionIdFromHash !== undefined &&
-                values.featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY] &&
-                String(hashParams.raw) === '1'
+                typeof hashParams.c === 'string' && hashParams.c !== '' ? hashParams.c : undefined
+            const sendRawQueryFromHash = connectionIdFromHash !== undefined && String(hashParams.raw) === '1'
             const currentConnectionId = values.sourceQuery.source.connectionId || undefined
             const currentSendRawQuery = values.sourceQuery.source.sendRawQuery ?? false
             const filtersForSourceQuery = applyFiltersFromUrl(values.sourceQuery).source.filters

--- a/frontend/src/scenes/data-warehouse/settings/DataWarehouseSourceScene.test.ts
+++ b/frontend/src/scenes/data-warehouse/settings/DataWarehouseSourceScene.test.ts
@@ -21,9 +21,8 @@ describe('DataWarehouseSourceScene', () => {
     })
 
     it('hides the syncs tab until the source is loaded and for direct query sources', () => {
-        expect(shouldShowManagedSourceSyncsTab(null, true)).toEqual(false)
-        expect(shouldShowManagedSourceSyncsTab({ access_method: 'direct' }, true)).toEqual(false)
-        expect(shouldShowManagedSourceSyncsTab({ access_method: 'warehouse' }, true)).toEqual(true)
-        expect(shouldShowManagedSourceSyncsTab({ access_method: 'direct' }, false)).toEqual(true)
+        expect(shouldShowManagedSourceSyncsTab(null)).toEqual(false)
+        expect(shouldShowManagedSourceSyncsTab({ access_method: 'direct' })).toEqual(false)
+        expect(shouldShowManagedSourceSyncsTab({ access_method: 'warehouse' })).toEqual(true)
     })
 })

--- a/frontend/src/scenes/debug/Modifiers.test.tsx
+++ b/frontend/src/scenes/debug/Modifiers.test.tsx
@@ -5,8 +5,6 @@ import userEvent from '@testing-library/user-event'
 import { Provider } from 'kea'
 
 import api from 'lib/api'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { NodeKind } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
@@ -77,9 +75,6 @@ describe('Modifiers', () => {
     beforeEach(() => {
         initKeaTests()
         sourcesDataLogic.mount()
-        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-            [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: false,
-        })
     })
 
     afterEach(() => {
@@ -88,10 +83,7 @@ describe('Modifiers', () => {
         cleanup()
     })
 
-    it('renders a connection selector for HogQL queries when direct query is enabled', async () => {
-        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-            [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
-        })
+    it('renders a connection selector for HogQL queries', async () => {
         jest.spyOn(api.externalDataSources, 'list').mockResolvedValue(mockSourcesResponse)
 
         const setQuery = jest.fn()
@@ -120,10 +112,6 @@ describe('Modifiers', () => {
     })
 
     it('does not render a connection selector for non-HogQL queries', () => {
-        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
-            [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: false,
-        })
-
         const setQuery = jest.fn()
 
         render(

--- a/frontend/src/scenes/debug/Modifiers.tsx
+++ b/frontend/src/scenes/debug/Modifiers.tsx
@@ -1,10 +1,8 @@
 import { useActions, useValues } from 'kea'
 import { useEffect, useMemo } from 'react'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { HogQLQueryModifiers, NodeKind } from '~/queries/schema/schema-general'
 
@@ -34,17 +32,15 @@ function ConnectionIdModifier<Q extends QueryWithModifiers>({
     query: Q
     setQuery: (query: Q) => void
 }): JSX.Element | null {
-    const { featureFlags } = useValues(featureFlagLogic)
     const { dataWarehouseSources, dataWarehouseSourcesLoading } = useValues(sourcesDataLogic)
     const { loadSources } = useActions(sourcesDataLogic)
-    const isDirectQueryEnabled = !!featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]
     const isHogQLQuery = query.kind === NodeKind.HogQLQuery
 
     useEffect(() => {
-        if (isHogQLQuery && isDirectQueryEnabled && !dataWarehouseSources) {
+        if (isHogQLQuery && !dataWarehouseSources) {
             loadSources()
         }
-    }, [dataWarehouseSources, isDirectQueryEnabled, isHogQLQuery, loadSources])
+    }, [dataWarehouseSources, isHogQLQuery, loadSources])
 
     const directPostgresSources = useMemo(
         () =>
@@ -54,7 +50,7 @@ function ConnectionIdModifier<Q extends QueryWithModifiers>({
         [dataWarehouseSources]
     )
 
-    if (!isHogQLQuery || !isDirectQueryEnabled) {
+    if (!isHogQLQuery) {
         return null
     }
 

--- a/playwright/e2e/sql-editor-direct-postgres.spec.ts
+++ b/playwright/e2e/sql-editor-direct-postgres.spec.ts
@@ -1,6 +1,5 @@
 import { execFileSync } from 'node:child_process'
 
-import { mockFeatureFlags } from '../utils/mockApi'
 import { expect, LOGIN_PASSWORD, LOGIN_USERNAME, test } from '../utils/playwright-test-core'
 
 test.describe('SQL Editor direct Postgres queries', () => {
@@ -23,11 +22,6 @@ test.describe('SQL Editor direct Postgres queries', () => {
                     INSERT INTO ${tableName} (id, label) VALUES (1, 'alpha'), (2, 'beta');
                 `,
             ])
-
-            await mockFeatureFlags(page, {
-                'dwh-postgres-direct-query': true,
-            })
-
             await page.goto('/login')
             await page.evaluate(
                 async ({ email, password }) => {

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
@@ -14,7 +14,6 @@ import {
 } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { useFloatingContainer } from 'lib/hooks/useFloatingContainerContext'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
@@ -130,7 +129,6 @@ function InternalSourcesWizard(props: NewSourcesWizardProps): JSX.Element {
         isSelfManagedSource,
         source,
         sourceConnectionDetails,
-        featureFlags,
     } = useValues(sourceWizardLogic)
     const { onBack, onSubmit, setInitialConnector, setSourceConnectionDetailsValue, updateSource } =
         useActions(sourceWizardLogic)
@@ -139,10 +137,7 @@ function InternalSourcesWizard(props: NewSourcesWizardProps): JSX.Element {
         sourceConnectionDetails?.access_method,
         source.access_method
     )
-    const showAccessMethodSelector =
-        currentStep === 2 &&
-        selectedConnector?.name === 'Postgres' &&
-        !!featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]
+    const showAccessMethodSelector = currentStep === 2 && selectedConnector?.name === 'Postgres'
     const { tableLoading: manualLinkIsLoading } = useValues(selfManagedSourceLogic)
 
     const mainContainer = useFloatingContainer()

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -8,7 +8,6 @@ import { LemonDialog, lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { Scene } from 'scenes/sceneTypes'
@@ -711,11 +710,9 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
         ],
         isManualLinkingSelected: [(s) => [s.selectedConnector], (selectedConnector): boolean => !selectedConnector],
         isDirectQueryMode: [
-            (s) => [s.source, s.selectedConnector, s.featureFlags],
-            (source, selectedConnector, featureFlags): boolean =>
-                source.access_method === 'direct' &&
-                selectedConnector?.name === 'Postgres' &&
-                !!featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY],
+            (s) => [s.source, s.selectedConnector],
+            (source, selectedConnector): boolean =>
+                source.access_method === 'direct' && selectedConnector?.name === 'Postgres',
         ],
         canGoBack: [
             (s) => [s.currentStep],
@@ -1490,9 +1487,7 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
             submit: async (sourceValues) => {
                 if (values.selectedConnector) {
                     const isDirectQueryMode =
-                        !!values.featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY] &&
-                        values.selectedConnector.name === 'Postgres' &&
-                        sourceValues.access_method === 'direct'
+                        values.selectedConnector.name === 'Postgres' && sourceValues.access_method === 'direct'
                     const payload: Record<string, any> = {
                         ...sourceValues,
                         access_method: isDirectQueryMode ? 'direct' : 'warehouse',

--- a/products/data_warehouse/frontend/scenes/SourceScene/SourceScene.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/SourceScene.tsx
@@ -56,10 +56,9 @@ export function isManagedSourceSceneId(id: string): boolean {
 }
 
 export function shouldShowManagedSourceSyncsTab(
-    source: Pick<ExternalDataSource, 'access_method'> | null | undefined,
-    isDirectQueryEnabled: boolean
+    source: Pick<ExternalDataSource, 'access_method'> | null | undefined
 ): boolean {
-    return !!source && !(isDirectQueryEnabled && source.access_method === 'direct')
+    return !!source && source.access_method !== 'direct'
 }
 
 export const sourceSceneLogic = kea<sourceSceneLogicType>([
@@ -222,10 +221,7 @@ function ManagedSourceTabs({
 
     useAttachedLogic(settingsLogic, attachTo)
 
-    const showSyncsTab = shouldShowManagedSourceSyncsTab(
-        source,
-        !!featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]
-    )
+    const showSyncsTab = shouldShowManagedSourceSyncsTab(source)
     const showWebhookTab = !!featureFlags[FEATURE_FLAGS.WAREHOUSE_SOURCE_WEBHOOKS] && !!source?.supports_webhooks
     const showMetricsTab = !!featureFlags[FEATURE_FLAGS.DWH_SOURCE_METRICS]
 

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
@@ -53,10 +53,8 @@ export function SchemasTab({ id }: SchemasTabProps): JSX.Element {
 
 function SchemasTabInner({ id }: { id: string }): JSX.Element {
     const { source } = useValues(sourceSettingsLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
-    const isDirectQuerySource =
-        !!featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY] && source?.access_method === 'direct'
+    const isDirectQuerySource = source?.access_method === 'direct'
 
     if (isDirectQuerySource) {
         return <DirectQuerySchemasTab id={id} />

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/dataWarehouseSourceSettingsLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/dataWarehouseSourceSettingsLogic.test.ts
@@ -154,7 +154,7 @@ describe('sourceSettingsLogic', () => {
 
         await expectLogic(logic).toFinishAllListeners()
 
-        expect(sceneLogicForTab.values.breadcrumbName).toEqual('Postgres')
+        expect(sceneLogicForTab.values.breadcrumbName).toEqual('warehouse')
 
         sceneLogicForTab.unmount()
     })

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
@@ -7,8 +7,6 @@ import posthog from 'posthog-js'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { objectsEqual } from 'lib/utils'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { urls } from 'scenes/urls'
@@ -582,10 +580,8 @@ export const sourceSettingsLogic = kea<sourceSettingsLogicType>([
                     }
                 }
 
-                const isDirectQueryEnabled =
-                    !!featureFlagLogic.values.featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]
                 const breadcrumbName =
-                    isDirectQueryEnabled && values.source?.access_method === 'direct'
+                    values.source?.access_method === 'direct'
                         ? values.source?.prefix || values.source?.source_type || 'Source'
                         : values.source?.source_type || 'Source'
 

--- a/products/data_warehouse/frontend/shared/components/SelfManagedSourcesTable.tsx
+++ b/products/data_warehouse/frontend/shared/components/SelfManagedSourcesTable.tsx
@@ -2,9 +2,7 @@ import { useActions, useValues } from 'kea'
 
 import { LemonButton, LemonDialog, LemonInput, LemonTable, Spinner } from '@posthog/lemon-ui'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
 
 import { DatabaseSchemaDataWarehouseTable } from '~/queries/schema/schema-general'
@@ -15,28 +13,24 @@ import { sourcesDataLogic } from '../logics/sourcesDataLogic'
 import { SourceIcon, mapUrlToProvider } from './SourceIcon'
 
 export function SelfManagedSourcesTable(): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
     const { filteredSelfManagedTables, searchTerm, sourceReloadingById } = useValues(sourceManagementLogic)
     const { deleteSelfManagedTable, refreshSelfManagedTableSchema, setSearchTerm, reloadSource, deleteSource } =
         useActions(sourceManagementLogic)
     const { dataWarehouseSources, dataWarehouseSourcesLoading } = useValues(sourcesDataLogic)
-    const isDirectQueryEnabled = !!featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]
 
-    const directSources = isDirectQueryEnabled
-        ? (dataWarehouseSources?.results ?? [])
-              .filter((source) => source.access_method?.toLowerCase() === 'direct')
-              .filter((source) => {
-                  if (!searchTerm?.trim()) {
-                      return true
-                  }
-                  const normalizedSearch = searchTerm.toLowerCase()
-                  return (
-                      source.source_type.toLowerCase().includes(normalizedSearch) ||
-                      source.prefix?.toLowerCase().includes(normalizedSearch) ||
-                      source.description?.toLowerCase().includes(normalizedSearch)
-                  )
-              })
-        : []
+    const directSources = (dataWarehouseSources?.results ?? [])
+        .filter((source) => source.access_method?.toLowerCase() === 'direct')
+        .filter((source) => {
+            if (!searchTerm?.trim()) {
+                return true
+            }
+            const normalizedSearch = searchTerm.toLowerCase()
+            return (
+                source.source_type.toLowerCase().includes(normalizedSearch) ||
+                source.prefix?.toLowerCase().includes(normalizedSearch) ||
+                source.description?.toLowerCase().includes(normalizedSearch)
+            )
+        })
 
     const rows: Array<
         { kind: 'direct'; source: ExternalDataSource } | { kind: 'table'; table: DatabaseSchemaDataWarehouseTable }
@@ -53,7 +47,7 @@ export function SelfManagedSourcesTable(): JSX.Element {
             <LemonTable
                 id="self-managed-sources"
                 dataSource={rows}
-                loading={isDirectQueryEnabled ? dataWarehouseSourcesLoading : undefined}
+                loading={dataWarehouseSourcesLoading}
                 pagination={{ pageSize: 10 }}
                 columns={[
                     {

--- a/products/data_warehouse/frontend/shared/components/forms/SourceForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SourceForm.tsx
@@ -624,10 +624,7 @@ export function SourceFormComponent({
     const [selectedAccessMethod, setSelectedAccessMethod] = React.useState<'warehouse' | 'direct'>(
         initialAccessMethod ?? 'warehouse'
     )
-    const isPostgresDirectQuery =
-        sourceConfig.name === 'Postgres' &&
-        !!featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY] &&
-        selectedAccessMethod === 'direct'
+    const isPostgresDirectQuery = sourceConfig.name === 'Postgres' && selectedAccessMethod === 'direct'
 
     useEffect(() => {
         if (initialAccessMethod) {
@@ -651,25 +648,22 @@ export function SourceFormComponent({
 
     return (
         <div className="space-y-4 ph-no-capture">
-            {!isUpdateMode &&
-                sourceConfig.name === 'Postgres' &&
-                showAccessMethodSelector &&
-                featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY] && (
-                    <>
-                        <LemonField name="access_method">
-                            {({ value, onChange }) => (
-                                <SourceAccessMethodSelector
-                                    value={(value as 'warehouse' | 'direct' | undefined) || selectedAccessMethod}
-                                    onChange={(nextValue) => {
-                                        setSelectedAccessMethod(nextValue)
-                                        onChange(nextValue)
-                                    }}
-                                />
-                            )}
-                        </LemonField>
-                        <LemonDivider />
-                    </>
-                )}
+            {!isUpdateMode && sourceConfig.name === 'Postgres' && showAccessMethodSelector && (
+                <>
+                    <LemonField name="access_method">
+                        {({ value, onChange }) => (
+                            <SourceAccessMethodSelector
+                                value={(value as 'warehouse' | 'direct' | undefined) || selectedAccessMethod}
+                                onChange={(nextValue) => {
+                                    setSelectedAccessMethod(nextValue)
+                                    onChange(nextValue)
+                                }}
+                            />
+                        )}
+                    </LemonField>
+                    <LemonDivider />
+                </>
+            )}
             {isPostgresDirectQuery && (
                 <LemonField
                     name="prefix"

--- a/products/data_warehouse/frontend/shared/logics/sourceManagementLogic.ts
+++ b/products/data_warehouse/frontend/shared/logics/sourceManagementLogic.ts
@@ -4,9 +4,7 @@ import { router, urlToAction } from 'kea-router'
 import posthog from 'posthog-js'
 
 import api from 'lib/api'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 
@@ -33,8 +31,6 @@ export const sourceManagementLogic = kea<sourceManagementLogicType>([
             ['database', 'dataWarehouseTables'],
             sourcesDataLogic,
             ['dataWarehouseSources', 'dataWarehouseSourcesLoading'],
-            featureFlagLogic,
-            ['featureFlags'],
         ],
         actions: [
             databaseTableListLogic,
@@ -145,13 +141,11 @@ export const sourceManagementLogic = kea<sourceManagementLogicType>([
             },
         ],
         filteredManagedSources: [
-            (s) => [s.dataWarehouseSources, s.managedSearchTerm, s.featureFlags],
-            (dataWarehouseSources, managedSearchTerm, featureFlags): ExternalDataSource[] => {
-                const sources = featureFlags[FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]
-                    ? (dataWarehouseSources?.results ?? []).filter(
-                          (source) => source.access_method?.toLowerCase() !== 'direct'
-                      )
-                    : (dataWarehouseSources?.results ?? [])
+            (s) => [s.dataWarehouseSources, s.managedSearchTerm],
+            (dataWarehouseSources, managedSearchTerm): ExternalDataSource[] => {
+                const sources = (dataWarehouseSources?.results ?? []).filter(
+                    (source) => source.access_method?.toLowerCase() !== 'direct'
+                )
                 if (!managedSearchTerm?.trim()) {
                     return sources
                 }


### PR DESCRIPTION
## Problem

We want to release postgres/duck/etc direct querying to users as part of our BI offering.

## Changes

Remove the flag.

We'll still want to gradually roll it out before merging this PR, but getting it ready nevertheless.

## How did you test this code?

This is a test.

## Publish to changelog?

yes

## Docs update

yes