### PR TITLE
feat(logs): add event history endpoint for alerts with pagination and filtering

### DIFF
--- a/products/alerts/mcp/tools.yaml
+++ b/products/alerts/mcp/tools.yaml
@@ -152,3 +152,6 @@ tools:
     logs-alerts-reset-create:
         operation: logs_alerts_reset_create
         enabled: false
+    logs-alerts-events-list:
+        operation: logs_alerts_events_list
+        enabled: false

--- a/products/logs/backend/alerts_api.py
+++ b/products/logs/backend/alerts_api.py
@@ -4,7 +4,7 @@ from typing import Final, cast
 from zoneinfo import ZoneInfo
 
 from django.db import transaction
-from django.db.models import OuterRef, QuerySet, Subquery
+from django.db.models import F, OuterRef, Q, QuerySet, Subquery
 
 from drf_spectacular.utils import extend_schema, extend_schema_field
 from loginas.utils import is_impersonated_session
@@ -247,6 +247,23 @@ def _validate_filters(filters: dict) -> None:
         raise ValidationError(
             {"filters": "At least one filter is required (severityLevels, serviceNames, or filterGroup)."}
         )
+
+
+class LogsAlertEventSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = LogsAlertEvent
+        fields = [
+            "id",
+            "created_at",
+            "kind",
+            "state_before",
+            "state_after",
+            "threshold_breached",
+            "result_count",
+            "error_message",
+            "query_duration_ms",
+        ]
+        read_only_fields = fields
 
 
 class LogsAlertSimulateBucketSerializer(serializers.Serializer):
@@ -560,6 +577,43 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         )
         serializer.is_valid(raise_exception=True)
         return serializer.save(team=team)
+
+    @extend_schema(
+        request=None,
+        responses={200: LogsAlertEventSerializer(many=True)},
+        description=(
+            "Paginated event history for this alert, newest first. Returns state transitions, "
+            "errored checks, and user-initiated control-plane rows (reset, enable/disable, "
+            "snooze/unsnooze, threshold change) — quiet no-op check rows (where state didn't "
+            "change and there was no error) are filtered out since only the last 10 are kept "
+            "and they carry no forensic value. Optional `?kind=...` narrows to a single kind."
+        ),
+    )
+    @action(detail=True, methods=["GET"], url_path="events")
+    def events(self, request: Request, *args: object, **kwargs: object) -> Response:
+        alert = self.get_object()
+        queryset = (
+            LogsAlertEvent.objects.filter(alert=alert)
+            .filter(
+                ~Q(kind=LogsAlertEvent.Kind.CHECK) | Q(error_message__isnull=False) | ~Q(state_before=F("state_after"))
+            )
+            .order_by("-created_at")
+        )
+
+        kind = request.query_params.get("kind")
+        if kind is not None:
+            valid_kinds = LogsAlertEvent.Kind.values
+            if kind not in valid_kinds:
+                raise ValidationError({"kind": f"Must be one of {sorted(valid_kinds)}."})
+            queryset = queryset.filter(kind=kind)
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = LogsAlertEventSerializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = LogsAlertEventSerializer(queryset, many=True)
+        return Response(serializer.data)
 
     @extend_schema(
         request=None,

--- a/products/logs/backend/migrations/0008_logsalertevent_logs_alert_event_alert_ts_idx.py
+++ b/products/logs/backend/migrations/0008_logsalertevent_logs_alert_event_alert_ts_idx.py
@@ -1,0 +1,17 @@
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False  # Required for CREATE INDEX CONCURRENTLY
+
+    dependencies = [
+        ("logs", "0007_backfill_check_interval_minutes"),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name="logsalertevent",
+            index=models.Index(fields=["alert", "-created_at"], name="logs_alert_event_alert_ts_idx"),
+        ),
+    ]

--- a/products/logs/backend/migrations/max_migration.txt
+++ b/products/logs/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0007_backfill_check_interval_minutes
+0008_logsalertevent_logs_alert_event_alert_ts_idx

--- a/products/logs/backend/models.py
+++ b/products/logs/backend/models.py
@@ -213,6 +213,9 @@ class LogsAlertEvent(UUIDModel):
 
     class Meta:
         db_table = "logs_logsalertevent"
+        indexes = [
+            models.Index(fields=["alert", "-created_at"], name="logs_alert_event_alert_ts_idx"),
+        ]
 
     def __str__(self) -> str:
         return f"LogsAlertEvent for {self.alert.name} at {self.created_at}"

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -905,6 +905,131 @@ class TestLogsAlertAPI(APIBaseTest):
 
         assert not LogsAlertEvent.objects.filter(alert_id=created["id"]).exists()
 
+    # --- Event history ---
+
+    def _events_url(self, alert_id: str) -> str:
+        return f"{self.base_url}{alert_id}/events/"
+
+    def test_events_returns_rows_newest_first(self):
+        created = self._create_via_api()
+        older_transition = LogsAlertEvent.objects.create(
+            alert_id=created["id"],
+            kind=LogsAlertEvent.Kind.CHECK,
+            threshold_breached=False,
+            state_before="firing",
+            state_after="not_firing",
+        )
+        newer_transition = LogsAlertEvent.objects.create(
+            alert_id=created["id"],
+            kind=LogsAlertEvent.Kind.CHECK,
+            threshold_breached=True,
+            state_before="not_firing",
+            state_after="firing",
+        )
+
+        response = self.client.get(self._events_url(created["id"]))
+
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json().get("results", response.json())
+        ids = [row["id"] for row in results]
+        assert ids.index(str(newer_transition.id)) < ids.index(str(older_transition.id))
+
+    def test_events_filters_out_quiet_check_rows(self):
+        # "Quiet" CHECK rows (state didn't change, no error) carry no forensic value and
+        # are kept inline at a cap of 10 per alert — surfacing them in the event history
+        # would bury the interesting transitions. Backend filter pins this contract.
+        created = self._create_via_api()
+        LogsAlertEvent.objects.create(
+            alert_id=created["id"],
+            kind=LogsAlertEvent.Kind.CHECK,
+            threshold_breached=False,
+            state_before="not_firing",
+            state_after="not_firing",
+        )
+        LogsAlertEvent.objects.create(
+            alert_id=created["id"],
+            kind=LogsAlertEvent.Kind.CHECK,
+            threshold_breached=True,
+            state_before="firing",
+            state_after="firing",
+        )
+        transition = LogsAlertEvent.objects.create(
+            alert_id=created["id"],
+            kind=LogsAlertEvent.Kind.CHECK,
+            threshold_breached=True,
+            state_before="not_firing",
+            state_after="firing",
+        )
+        errored = LogsAlertEvent.objects.create(
+            alert_id=created["id"],
+            kind=LogsAlertEvent.Kind.CHECK,
+            threshold_breached=False,
+            state_before="not_firing",
+            state_after="not_firing",
+            error_message="CH timeout",
+        )
+
+        response = self.client.get(self._events_url(created["id"]))
+
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json().get("results", response.json())
+        returned_ids = {row["id"] for row in results}
+        assert returned_ids == {str(transition.id), str(errored.id)}
+
+    @parameterized.expand([(kind,) for kind in LogsAlertEvent.Kind.values])
+    def test_events_filter_by_kind(self, kind):
+        created = self._create_via_api()
+        # CHECK rows need a real transition to survive the quiet-row filter; control-plane
+        # kinds are never quiet-filtered so any state pair is fine.
+        kept_before, kept_after = (
+            ("not_firing", "firing") if kind == LogsAlertEvent.Kind.CHECK else ("not_firing", "not_firing")
+        )
+        kept = LogsAlertEvent.objects.create(
+            alert_id=created["id"],
+            kind=kind,
+            threshold_breached=False,
+            state_before=kept_before,
+            state_after=kept_after,
+        )
+        # Noise row of a different kind with a state transition so it survives the quiet
+        # filter and would show up absent the ?kind= narrowing.
+        other_kind = next(k for k in LogsAlertEvent.Kind.values if k != kind)
+        LogsAlertEvent.objects.create(
+            alert_id=created["id"],
+            kind=other_kind,
+            threshold_breached=False,
+            state_before="firing",
+            state_after="not_firing",
+        )
+
+        response = self.client.get(self._events_url(created["id"]), {"kind": kind})
+
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json().get("results", response.json())
+        returned_ids = {row["id"] for row in results}
+        assert returned_ids == {str(kept.id)}
+
+    def test_events_rejects_unknown_kind(self):
+        created = self._create_via_api()
+
+        response = self.client.get(self._events_url(created["id"]), {"kind": "not_a_real_kind"})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["attr"] == "kind"
+
+    def test_events_scoped_to_alert_team(self):
+        other_team = Team.objects.create(organization=self.organization, name="Other")
+        other_alert = LogsAlertConfiguration.objects.create(
+            team=other_team,
+            name="Other team alert",
+            threshold_count=10,
+            filters={"severityLevels": ["error"]},
+        )
+
+        response = self.client.get(self._events_url(str(other_alert.id)))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
     # --- Simulate ---
 
     def _simulate_url(self) -> str:

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertEventHistory.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertEventHistory.tsx
@@ -1,0 +1,209 @@
+import { BindLogic, useActions, useValues } from 'kea'
+
+import { LemonButton, LemonModal, LemonTable, LemonTableColumns, LemonTag, LemonTagType } from '@posthog/lemon-ui'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import { truncate } from 'lib/utils'
+
+import {
+    LogsAlertConfigurationApi,
+    LogsAlertEventApi,
+    LogsAlertEventKindEnumApi,
+} from 'products/logs/frontend/generated/api.schemas'
+
+import { LogsAlertEventHistoryLogicProps, logsAlertEventHistoryLogic } from './logsAlertEventHistoryLogic'
+
+interface LogsAlertEventHistoryModalProps {
+    alert: LogsAlertConfigurationApi | null
+    onClose: () => void
+}
+
+export function LogsAlertEventHistoryModal({ alert, onClose }: LogsAlertEventHistoryModalProps): JSX.Element {
+    return (
+        <LemonModal isOpen={alert !== null} onClose={onClose} width={640} title="" simple>
+            {alert ? <LogsAlertEventHistoryContent alert={alert} /> : null}
+        </LemonModal>
+    )
+}
+
+function LogsAlertEventHistoryContent({ alert }: { alert: LogsAlertConfigurationApi }): JSX.Element {
+    const logicProps: LogsAlertEventHistoryLogicProps = { alertId: alert.id }
+
+    return (
+        <BindLogic logic={logsAlertEventHistoryLogic} props={logicProps}>
+            <LemonModal.Header>
+                <h3 className="flex items-center gap-2">
+                    Alert history
+                    <span className="text-muted text-sm font-normal">· {alert.name}</span>
+                </h3>
+                <p className="text-muted text-sm m-0">Transitions, errors, and user actions.</p>
+            </LemonModal.Header>
+            <LemonModal.Content>
+                <LogsAlertEventTimeline />
+            </LemonModal.Content>
+        </BindLogic>
+    )
+}
+
+function LogsAlertEventTimeline(): JSX.Element {
+    const { eventsPage, eventsPageLoading } = useValues(logsAlertEventHistoryLogic)
+    const { loadMore } = useActions(logsAlertEventHistoryLogic)
+
+    const columns: LemonTableColumns<LogsAlertEventApi> = [
+        {
+            title: 'Event',
+            render: (_, event) => {
+                const { label, type } = describeEvent(event)
+                return <LemonTag type={type}>{label}</LemonTag>
+            },
+        },
+        {
+            title: 'When',
+            render: (_, event) => <TZLabel time={event.created_at} formatDate="MMM D" formatTime="HH:mm:ss" />,
+        },
+        {
+            title: 'Detail',
+            render: (_, event) => {
+                const { detail } = describeEvent(event)
+                return detail ? <span className="text-muted text-xs">{detail}</span> : null
+            },
+        },
+    ]
+
+    const hasMore = eventsPage.next !== null
+    const shownOf =
+        eventsPage.count > eventsPage.results.length
+            ? ` · Showing ${eventsPage.results.length} of ${eventsPage.count}`
+            : ''
+
+    return (
+        <div className="space-y-3">
+            <LemonTable
+                columns={columns}
+                dataSource={eventsPage.results}
+                rowKey="id"
+                loading={eventsPageLoading}
+                emptyState="No events yet. Transitions and user actions will appear here."
+                size="small"
+                expandable={{
+                    rowExpandable: () => true,
+                    expandedRowRender: (event) => <LogsAlertEventDetails event={event} />,
+                }}
+            />
+            {hasMore ? (
+                <div className="flex justify-center">
+                    <LemonButton type="secondary" size="small" onClick={loadMore} loading={eventsPageLoading}>
+                        Load more{shownOf}
+                    </LemonButton>
+                </div>
+            ) : null}
+        </div>
+    )
+}
+
+interface EventDescription {
+    label: string
+    type: LemonTagType
+    detail: string | null
+}
+
+const CONTROL_PLANE_DESCRIPTIONS: Record<
+    Exclude<LogsAlertEventKindEnumApi, typeof LogsAlertEventKindEnumApi.Check>,
+    Pick<EventDescription, 'label' | 'type'>
+> = {
+    [LogsAlertEventKindEnumApi.Reset]: { label: 'Reset', type: 'primary' },
+    [LogsAlertEventKindEnumApi.Enable]: { label: 'Enabled', type: 'success' },
+    [LogsAlertEventKindEnumApi.Disable]: { label: 'Disabled', type: 'muted' },
+    [LogsAlertEventKindEnumApi.Snooze]: { label: 'Snoozed', type: 'highlight' },
+    [LogsAlertEventKindEnumApi.Unsnooze]: { label: 'Unsnoozed', type: 'highlight' },
+    [LogsAlertEventKindEnumApi.ThresholdChange]: { label: 'Threshold changed', type: 'completion' },
+}
+
+function describeEvent(event: LogsAlertEventApi): EventDescription {
+    if (event.kind !== LogsAlertEventKindEnumApi.Check) {
+        return { ...CONTROL_PLANE_DESCRIPTIONS[event.kind], detail: formatTransition(event) }
+    }
+
+    if (event.error_message && event.state_after === 'broken') {
+        return {
+            label: 'Auto-disabled',
+            type: 'caution',
+            detail: '5 consecutive errors',
+        }
+    }
+    if (event.error_message) {
+        return {
+            label: 'Errored',
+            type: 'warning',
+            detail: truncate(event.error_message, 80),
+        }
+    }
+    if (event.state_before !== 'firing' && event.state_after === 'firing') {
+        return {
+            label: 'Fired',
+            type: 'danger',
+            detail:
+                event.result_count !== null ? `${event.result_count} logs · threshold breached` : 'threshold breached',
+        }
+    }
+    if (event.state_before === 'firing' && event.state_after !== 'firing') {
+        return {
+            label: 'Resolved',
+            type: 'success',
+            detail: event.result_count !== null ? `${event.result_count} logs · back to normal` : 'back to normal',
+        }
+    }
+    return {
+        label: 'Check',
+        type: 'default',
+        detail: event.result_count !== null ? `${event.result_count} logs` : null,
+    }
+}
+
+function LogsAlertEventDetails({ event }: { event: LogsAlertEventApi }): JSX.Element {
+    return (
+        <dl className="px-3 py-2 text-xs grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
+            <dt className="text-muted">Kind</dt>
+            <dd className="font-mono">{event.kind}</dd>
+            <dt className="text-muted">State</dt>
+            <dd className="font-mono">
+                {event.state_before} → {event.state_after}
+            </dd>
+            {event.kind === LogsAlertEventKindEnumApi.Check ? (
+                <>
+                    <dt className="text-muted">Breached</dt>
+                    <dd className="font-mono">{event.threshold_breached ? 'yes' : 'no'}</dd>
+                </>
+            ) : null}
+            {event.result_count !== null ? (
+                <>
+                    <dt className="text-muted">Result count</dt>
+                    <dd className="font-mono">{event.result_count}</dd>
+                </>
+            ) : null}
+            {event.query_duration_ms !== null ? (
+                <>
+                    <dt className="text-muted">Query duration</dt>
+                    <dd className="font-mono">{event.query_duration_ms} ms</dd>
+                </>
+            ) : null}
+            {event.error_message ? (
+                <>
+                    <dt className="text-muted">Error</dt>
+                    <dd className="font-mono whitespace-pre-wrap break-words">{event.error_message}</dd>
+                </>
+            ) : null}
+            <dt className="text-muted">Timestamp</dt>
+            <dd className="font-mono">
+                <TZLabel time={event.created_at} />
+            </dd>
+        </dl>
+    )
+}
+
+function formatTransition(event: LogsAlertEventApi): string | null {
+    if (event.state_before === event.state_after) {
+        return null
+    }
+    return `${event.state_before} → ${event.state_after}`
+}

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
@@ -22,7 +22,7 @@ function formatThreshold(alert: LogsAlertConfigurationApi): string {
 
 export function LogsAlertList(): JSX.Element {
     const { alerts, alertsLoading, resettingAlertIds } = useValues(logsAlertingLogic)
-    const { setEditingAlert, setIsCreating, deleteAlert, toggleAlertEnabled, resetAlert } =
+    const { setEditingAlert, setIsCreating, deleteAlert, toggleAlertEnabled, resetAlert, setViewingHistoryAlert } =
         useActions(logsAlertingLogic)
 
     const columns: LemonTableColumns<LogsAlertConfigurationApi> = [
@@ -81,6 +81,10 @@ export function LogsAlertList(): JSX.Element {
                                 {
                                     label: 'Edit',
                                     onClick: () => setEditingAlert(alert),
+                                },
+                                {
+                                    label: 'View history',
+                                    onClick: () => setViewingHistoryAlert(alert),
                                 },
                                 ...(alert.state === LogsAlertConfigurationStateEnumApi.Broken
                                     ? [

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertingSection.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertingSection.tsx
@@ -11,6 +11,7 @@ import {
     LogsAlertConfigurationStateEnumApi,
 } from 'products/logs/frontend/generated/api.schemas'
 
+import { LogsAlertEventHistoryModal } from './LogsAlertEventHistory'
 import { LogsAlertForm } from './LogsAlertForm'
 import { logsAlertFormLogic } from './logsAlertFormLogic'
 import { logsAlertingLogic } from './logsAlertingLogic'
@@ -27,8 +28,8 @@ export function LogsAlertingSection(): JSX.Element {
 }
 
 function LogsAlertingSectionInner(): JSX.Element {
-    const { isCreating, editingAlert } = useValues(logsAlertingLogic)
-    const { setIsCreating, setEditingAlert } = useActions(logsAlertingLogic)
+    const { isCreating, editingAlert, viewingHistoryAlert } = useValues(logsAlertingLogic)
+    const { setIsCreating, setEditingAlert, setViewingHistoryAlert } = useActions(logsAlertingLogic)
 
     const isModalOpen = isCreating || editingAlert !== null
 
@@ -40,7 +41,7 @@ function LogsAlertingSectionInner(): JSX.Element {
                 className="mb-3"
                 action={{ children: 'Send feedback', id: 'logs-alerts-feedback-button' }}
             >
-                Logs alerting is in beta — alerts are checked every 5 minutes. Read the{' '}
+                Logs alerting is in beta. Alerts are checked every 5 minutes. Read the{' '}
                 <Link to="https://posthog.com/docs/logs/alerts" target="_blank">
                     docs
                 </Link>{' '}
@@ -59,6 +60,7 @@ function LogsAlertingSectionInner(): JSX.Element {
             >
                 {isModalOpen && <LogsAlertModalContent editingAlert={editingAlert} />}
             </LemonModal>
+            <LogsAlertEventHistoryModal alert={viewingHistoryAlert} onClose={() => setViewingHistoryAlert(null)} />
         </>
     )
 }

--- a/products/logs/frontend/components/LogsAlerting/logsAlertEventHistoryLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertEventHistoryLogic.ts
@@ -1,0 +1,74 @@
+import { actions, afterMount, connect, kea, key, path, props } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import { teamLogic } from 'scenes/teamLogic'
+
+import { logsAlertsEventsList } from 'products/logs/frontend/generated/api'
+import { LogsAlertEventApi } from 'products/logs/frontend/generated/api.schemas'
+
+import type { logsAlertEventHistoryLogicType } from './logsAlertEventHistoryLogicType'
+
+export interface LogsAlertEventHistoryLogicProps {
+    alertId: string
+}
+
+export interface EventsPage {
+    results: LogsAlertEventApi[]
+    next: string | null
+    count: number
+}
+
+export const logsAlertEventHistoryLogic = kea<logsAlertEventHistoryLogicType>([
+    path((key) => ['products', 'logs', 'frontend', 'components', 'LogsAlerting', 'logsAlertEventHistoryLogic', key]),
+    props({} as LogsAlertEventHistoryLogicProps),
+    key((props) => props.alertId),
+
+    connect({
+        values: [teamLogic, ['currentTeamId']],
+    }),
+
+    actions({
+        loadMore: true,
+    }),
+
+    loaders(({ props, values }) => ({
+        eventsPage: [
+            { results: [], next: null, count: 0 } as EventsPage,
+            {
+                loadEvents: async () => {
+                    const projectId = String(values.currentTeamId)
+                    const response = await logsAlertsEventsList(projectId, props.alertId)
+                    return {
+                        results: response.results ?? [],
+                        next: response.next ?? null,
+                        count: response.count ?? 0,
+                    }
+                },
+                loadMore: async () => {
+                    const nextUrl = values.eventsPage.next
+                    if (!nextUrl) {
+                        return values.eventsPage
+                    }
+                    const res = await fetch(nextUrl, { credentials: 'include' })
+                    if (!res.ok) {
+                        throw new Error(`Failed to load more events: ${res.status} ${res.statusText}`)
+                    }
+                    const data = (await res.json()) as {
+                        results?: LogsAlertEventApi[]
+                        next?: string | null
+                        count?: number
+                    }
+                    return {
+                        results: [...values.eventsPage.results, ...(data.results ?? [])],
+                        next: data.next ?? null,
+                        count: data.count ?? values.eventsPage.count,
+                    }
+                },
+            },
+        ],
+    })),
+
+    afterMount(({ actions }) => {
+        actions.loadEvents()
+    }),
+])

--- a/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
@@ -32,6 +32,7 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
         toggleAlertEnabled: (alert: LogsAlertConfigurationApi) => ({ alert }),
         resetAlert: (id: string) => ({ id }),
         setResettingAlertId: (id: string, resetting: boolean) => ({ id, resetting }),
+        setViewingHistoryAlert: (alert: LogsAlertConfigurationApi | null) => ({ alert }),
     }),
 
     reducers({
@@ -54,6 +55,12 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
             {
                 setResettingAlertId: (state, { id, resetting }) =>
                     resetting ? new Set([...state, id]) : new Set([...state].filter((x) => x !== id)),
+            },
+        ],
+        viewingHistoryAlert: [
+            null as LogsAlertConfigurationApi | null,
+            {
+                setViewingHistoryAlert: (_, { alert }) => alert,
             },
         ],
     }),
@@ -129,7 +136,7 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
         actions.loadAlerts()
         cache.disposables.add(() => {
             const intervalId = window.setInterval(() => {
-                if (!values.isCreating && values.editingAlert === null) {
+                if (!values.isCreating && values.editingAlert === null && values.viewingHistoryAlert === null) {
                     actions.loadAlerts()
                 }
             }, ALERT_POLL_INTERVAL_MS)

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -345,13 +345,6 @@ export const LogsAlertEventKindEnumApi = {
     ThresholdChange: 'threshold_change',
 } as const
 
-/**
- * Read-only serializer for LogsAlertEvent rows surfaced by the /events/ action.
-
-Mixes worker-produced CHECK rows (result_count, threshold_breached set) with
-control-plane rows (result_count=None, threshold_breached=False) — callers
-distinguish by `kind`.
- */
 export interface LogsAlertEventApi {
     readonly id: string
     readonly created_at: string

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -324,6 +324,58 @@ export interface LogsAlertDeleteDestinationApi {
     hog_function_ids: string[]
 }
 
+/**
+ * * `check` - Check
+ * `reset` - Reset
+ * `enable` - Enable
+ * `disable` - Disable
+ * `snooze` - Snooze
+ * `unsnooze` - Unsnooze
+ * `threshold_change` - Threshold change
+ */
+export type LogsAlertEventKindEnumApi = (typeof LogsAlertEventKindEnumApi)[keyof typeof LogsAlertEventKindEnumApi]
+
+export const LogsAlertEventKindEnumApi = {
+    Check: 'check',
+    Reset: 'reset',
+    Enable: 'enable',
+    Disable: 'disable',
+    Snooze: 'snooze',
+    Unsnooze: 'unsnooze',
+    ThresholdChange: 'threshold_change',
+} as const
+
+/**
+ * Read-only serializer for LogsAlertEvent rows surfaced by the /events/ action.
+
+Mixes worker-produced CHECK rows (result_count, threshold_breached set) with
+control-plane rows (result_count=None, threshold_breached=False) — callers
+distinguish by `kind`.
+ */
+export interface LogsAlertEventApi {
+    readonly id: string
+    readonly created_at: string
+    readonly kind: LogsAlertEventKindEnumApi
+    readonly state_before: string
+    readonly state_after: string
+    readonly threshold_breached: boolean
+    /** @nullable */
+    readonly result_count: number | null
+    /** @nullable */
+    readonly error_message: string | null
+    /** @nullable */
+    readonly query_duration_ms: number | null
+}
+
+export interface PaginatedLogsAlertEventListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: LogsAlertEventApi[]
+}
+
 export interface LogsAlertSimulateRequestApi {
     /** Filter criteria — same format as LogsAlertConfiguration.filters. */
     filters: unknown
@@ -634,6 +686,17 @@ export type LogsViewsListParams = {
 }
 
 export type LogsAlertsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
+export type LogsAlertsEventsListParams = {
     /**
      * Number of results to return per page.
      */

--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -16,12 +16,14 @@ import type {
     LogsAlertDestinationResponseApi,
     LogsAlertSimulateRequestApi,
     LogsAlertSimulateResponseApi,
+    LogsAlertsEventsListParams,
     LogsAlertsListParams,
     LogsAttributesRetrieveParams,
     LogsValuesRetrieveParams,
     LogsViewApi,
     LogsViewsListParams,
     PaginatedLogsAlertConfigurationListApi,
+    PaginatedLogsAlertEventListApi,
     PaginatedLogsViewListApi,
     PaginatedPluginLogEntryListApi,
     PatchedLogsAlertConfigurationApi,
@@ -336,6 +338,37 @@ export const logsAlertsDestinationsDeleteCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(logsAlertDeleteDestinationApi),
+    })
+}
+
+/**
+ * Paginated event history for this alert, newest first. Returns both worker-produced check rows (fires, resolves, errors, transitions) and user-initiated control-plane rows (reset, enable/disable, snooze/unsnooze, threshold changes) — distinguished by the `kind` field. Optional `?kind=...` query filter narrows to a single kind.
+ */
+export const getLogsAlertsEventsListUrl = (projectId: string, id: string, params?: LogsAlertsEventsListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/logs/alerts/${id}/events/?${stringifiedParams}`
+        : `/api/projects/${projectId}/logs/alerts/${id}/events/`
+}
+
+export const logsAlertsEventsList = async (
+    projectId: string,
+    id: string,
+    params?: LogsAlertsEventsListParams,
+    options?: RequestInit
+): Promise<PaginatedLogsAlertEventListApi> => {
+    return apiMutator<PaginatedLogsAlertEventListApi>(getLogsAlertsEventsListUrl(projectId, id, params), {
+        ...options,
+        method: 'GET',
     })
 }
 

--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -342,7 +342,7 @@ export const logsAlertsDestinationsDeleteCreate = async (
 }
 
 /**
- * Paginated event history for this alert, newest first. Returns both worker-produced check rows (fires, resolves, errors, transitions) and user-initiated control-plane rows (reset, enable/disable, snooze/unsnooze, threshold changes) — distinguished by the `kind` field. Optional `?kind=...` query filter narrows to a single kind.
+ * Paginated event history for this alert, newest first. Returns state transitions, errored checks, and user-initiated control-plane rows (reset, enable/disable, snooze/unsnooze, threshold change) — quiet no-op check rows (where state didn't change and there was no error) are filtered out since only the last 10 are kept and they carry no forensic value. Optional `?kind=...` narrows to a single kind.
  */
 export const getLogsAlertsEventsListUrl = (projectId: string, id: string, params?: LogsAlertsEventsListParams) => {
     const normalizedParams = new URLSearchParams()

--- a/products/logs/mcp/tools.yaml
+++ b/products/logs/mcp/tools.yaml
@@ -36,8 +36,8 @@ tools:
         description: >
             List available log attribute names for filtering. Defaults to attribute_type "log" (log-level attributes).
             To search resource-level attributes (e.g. k8s.pod.name, k8s.namespace.name), you MUST explicitly pass
-            attribute_type: "resource" — it will NOT return resource attributes unless you do.
-            Accepts optional serviceNames, dateRange, and filterGroup to narrow which logs are scanned.
+            attribute_type: "resource" — it will NOT return resource attributes unless you do. Accepts optional
+            serviceNames, dateRange, and filterGroup to narrow which logs are scanned.
         response:
             include:
                 - results
@@ -54,9 +54,9 @@ tools:
         title: List log attribute values
         description: >
             List values for a specific log attribute key. Use to discover what values exist before building filters.
-            Defaults to attribute_type "log" (log-level attributes). To get values for resource-level attributes
-            (e.g. service.name, k8s.pod.name), you MUST explicitly pass attribute_type: "resource".
-            Accepts optional serviceNames, dateRange, and filterGroup to narrow which logs are scanned.
+            Defaults to attribute_type "log" (log-level attributes). To get values for resource-level attributes (e.g.
+            service.name, k8s.pod.name), you MUST explicitly pass attribute_type: "resource". Accepts optional
+            serviceNames, dateRange, and filterGroup to narrow which logs are scanned.
         response:
             include:
                 - results
@@ -157,4 +157,7 @@ tools:
         enabled: false
     logs-alerts-reset-create:
         operation: logs_alerts_reset_create
+        enabled: false
+    logs-alerts-events-list:
+        operation: logs_alerts_events_list
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -19924,6 +19924,50 @@ export namespace Schemas {
       hog_function_ids: string[];
     }
 
+    /**
+     * * `check` - Check
+    * `reset` - Reset
+    * `enable` - Enable
+    * `disable` - Disable
+    * `snooze` - Snooze
+    * `unsnooze` - Unsnooze
+    * `threshold_change` - Threshold change
+     */
+    export type LogsAlertEventKindEnum = typeof LogsAlertEventKindEnum[keyof typeof LogsAlertEventKindEnum];
+
+
+    export const LogsAlertEventKindEnum = {
+      Check: 'check',
+      Reset: 'reset',
+      Enable: 'enable',
+      Disable: 'disable',
+      Snooze: 'snooze',
+      Unsnooze: 'unsnooze',
+      ThresholdChange: 'threshold_change',
+    } as const;
+
+    /**
+     * Read-only serializer for LogsAlertEvent rows surfaced by the /events/ action.
+
+    Mixes worker-produced CHECK rows (result_count, threshold_breached set) with
+    control-plane rows (result_count=None, threshold_breached=False) — callers
+    distinguish by `kind`.
+     */
+    export interface LogsAlertEvent {
+      readonly id: string;
+      readonly created_at: string;
+      readonly kind: LogsAlertEventKindEnum;
+      readonly state_before: string;
+      readonly state_after: string;
+      readonly threshold_breached: boolean;
+      /** @nullable */
+      readonly result_count: number | null;
+      /** @nullable */
+      readonly error_message: string | null;
+      /** @nullable */
+      readonly query_duration_ms: number | null;
+    }
+
     export interface LogsAlertSimulateBucket {
       /** Bucket start timestamp. */
       timestamp: string;
@@ -21666,6 +21710,15 @@ export namespace Schemas {
       /** @nullable */
       previous?: string | null;
       results: LogsAlertConfiguration[];
+    }
+
+    export interface PaginatedLogsAlertEventList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: LogsAlertEvent[];
     }
 
     export interface PaginatedLogsViewList {
@@ -34134,6 +34187,17 @@ export namespace Schemas {
     offset?: number;
     };
 
+    export type EnvironmentsLogsAlertsEventsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
+
     export type EnvironmentsLogsAttributesRetrieveParams = {
     /**
      * Type of attributes: "log" for log attributes, "resource" for resource attributes. Defaults to "log".
@@ -37783,6 +37847,17 @@ export namespace Schemas {
     };
 
     export type LogsAlertsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
+
+    export type LogsAlertsEventsListParams = {
     /**
      * Number of results to return per page.
      */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -19946,13 +19946,6 @@ export namespace Schemas {
       ThresholdChange: 'threshold_change',
     } as const;
 
-    /**
-     * Read-only serializer for LogsAlertEvent rows surfaced by the /events/ action.
-
-    Mixes worker-produced CHECK rows (result_count, threshold_breached set) with
-    control-plane rows (result_count=None, threshold_breached=False) — callers
-    distinguish by `kind`.
-     */
     export interface LogsAlertEvent {
       readonly id: string;
       readonly created_at: string;


### PR DESCRIPTION
## Problem

Users investigating a misfiring or silently-broken alert have no way to see what happened — when it fired, when it resolved, whether checks errored, or what user actions (reset, snooze, threshold change) were taken. This makes debugging and auditing logs alerts difficult.

## Changes  
![image.png](https://app.graphite.com/user-attachments/assets/2c9724b8-d97f-43d2-9b8b-a5fd05306725.png)

**Backend**

- Adds a `GET /api/projects/{projectId}/logs/alerts/{id}/events/` endpoint that returns paginated event history for an alert, newest first.
- Quiet no-op CHECK rows (state unchanged, no error) are filtered out at the query level - only transitions, errors, and control-plane actions are surfaced.
- Supports an optional `?kind=` query parameter to narrow results to a single event kind.
- Adds a `LogsAlertEventSerializer` exposing all forensically relevant fields (`kind`, `state_before`, `state_after`, `threshold_breached`, `result_count`, `error_message`, `query_duration_ms`).
- Adds a concurrent index on `(alert, -created_at)` to back the paginated query efficiently.

**Frontend**

- Adds a `logsAlertEventHistoryLogic` (keyed by `alertId`) that fetches the first page on mount and supports cursor-based "load more" via the DRF `next` URL.
- Adds a `LogsAlertEventHistoryModal` / `LogsAlertEventHistoryContent` component that renders events in a `LemonTable` with expandable detail rows showing all raw fields.
- Each event is described with a human-readable label and colour-coded `LemonTag` (e.g. "Fired" → danger, "Resolved" → success, "Errored" → warning, "Auto-disabled" → caution, control-plane actions → their own types).
- Adds a **View history** option to the alert list row menu.
- Pauses the background alert-list polling while the history modal is open.

## How did you test this code?

New tests

## Publish to changelog?

No