### PR TITLE
feat(provisioning): support cimd urls in provisioning auth

### DIFF
--- a/ee/api/agentic_provisioning/authentication.py
+++ b/ee/api/agentic_provisioning/authentication.py
@@ -13,7 +13,13 @@ from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
 
-from posthog.api.oauth.cimd import get_application_by_client_id
+from posthog.api.oauth.cimd import (
+    CIMDFetchError,
+    CIMDValidationError,
+    get_application_by_client_id,
+    get_or_create_cimd_provisioning_application,
+    is_cimd_client_id,
+)
 from posthog.models.oauth import OAuthApplication, find_oauth_access_token
 
 from .signature import _compute_hmac, _get_raw_body, _parse_signature_header
@@ -130,6 +136,17 @@ class ProvisioningAuthentication(BaseAuthentication):
         return app if app.provisioning_active else None
 
     def _identify_pkce_partner(self, client_id: str) -> OAuthApplication | None:
+        # CIMD URLs: fetch metadata and auto-register the partner on first use, so
+        # a new partner hosting a valid metadata document can provision without
+        # any manual admin setup.
+        if is_cimd_client_id(client_id):
+            try:
+                app = get_or_create_cimd_provisioning_application(client_id)
+            except (CIMDFetchError, CIMDValidationError) as e:
+                logger.warning("provisioning_cimd_resolution_failed", client_id=client_id, error=str(e))
+                return None
+            return app if app.provisioning_active else None
+
         try:
             app = get_application_by_client_id(client_id)
             if not app.is_provisioning_partner or not app.provisioning_active:

--- a/ee/api/agentic_provisioning/authentication.py
+++ b/ee/api/agentic_provisioning/authentication.py
@@ -14,11 +14,12 @@ from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
 
 from posthog.api.oauth.cimd import (
-    CIMDFetchError,
-    CIMDValidationError,
+    CIMD_PROVISIONING_DEFAULTS,
     get_application_by_client_id,
-    get_or_create_cimd_provisioning_application,
     is_cimd_client_id,
+    is_cimd_registration_in_progress,
+    is_cimd_url_blocked,
+    register_cimd_provisioning_application_task,
 )
 from posthog.exceptions_capture import capture_exception
 from posthog.models.oauth import OAuthApplication, find_oauth_access_token
@@ -44,6 +45,8 @@ class ProvisioningAuthentication(BaseAuthentication):
     client_id param) and dispatched to the matching auth strategy. Returns None
     if no partner is identified, allowing Stripe Projects HMAC auth to handle the request.
     """
+
+    cimd_registration_pending: bool = False
 
     def authenticate(self, request: Request):
         app = self._identify_partner(request)
@@ -137,29 +140,33 @@ class ProvisioningAuthentication(BaseAuthentication):
         return app if app.provisioning_active else None
 
     def _identify_pkce_partner(self, client_id: str) -> OAuthApplication | None:
-        # CIMD URLs: fetch metadata and auto-register the partner on first use, so
-        # a new partner hosting a valid metadata document can provision without
-        # any manual admin setup.
         if is_cimd_client_id(client_id):
-            try:
-                app = get_or_create_cimd_provisioning_application(client_id)
-            except (CIMDFetchError, CIMDValidationError) as e:
-                logger.warning("provisioning_cimd_resolution_failed", client_id=client_id, error=str(e))
+            if is_cimd_url_blocked(client_id):
                 return None
-            except Exception as e:
-                # Any other failure (transient DB error during backfill, etc.) must
-                # degrade to unauthenticated rather than 500 — this is a public endpoint.
-                logger.warning(
-                    "provisioning_cimd_resolution_unexpected_error",
-                    client_id=client_id,
-                    error=str(e),
-                    error_type=type(e).__name__,
-                )
-                capture_exception(e)
-                return None
-            if app is None:
-                return None
-            return app if app.provisioning_active else None
+
+            app = OAuthApplication.objects.filter(cimd_metadata_url=client_id).first()
+            if app is not None:
+                try:
+                    if not app.is_provisioning_partner:
+                        for field, value in CIMD_PROVISIONING_DEFAULTS.items():
+                            setattr(app, field, value)
+                        app.save(update_fields=list(CIMD_PROVISIONING_DEFAULTS.keys()))
+                except Exception as e:
+                    logger.warning(
+                        "provisioning_cimd_backfill_error",
+                        client_id=client_id,
+                        error=str(e),
+                        error_type=type(e).__name__,
+                    )
+                    capture_exception(e)
+                    app.refresh_from_db()
+                return app if app.provisioning_active else None
+
+            # New CIMD URL: kick off background registration, don't block the worker
+            if not is_cimd_registration_in_progress(client_id):
+                register_cimd_provisioning_application_task.delay(client_id)
+            self.cimd_registration_pending = True
+            return None
 
         try:
             app = get_application_by_client_id(client_id)

--- a/ee/api/agentic_provisioning/authentication.py
+++ b/ee/api/agentic_provisioning/authentication.py
@@ -159,7 +159,10 @@ class ProvisioningAuthentication(BaseAuthentication):
                         error_type=type(e).__name__,
                     )
                     capture_exception(e)
-                    app.refresh_from_db()
+                    try:
+                        app.refresh_from_db()
+                    except Exception:
+                        return None
                 return app if app.provisioning_active else None
 
             # New CIMD URL: kick off background registration, don't block the worker

--- a/ee/api/agentic_provisioning/authentication.py
+++ b/ee/api/agentic_provisioning/authentication.py
@@ -157,6 +157,8 @@ class ProvisioningAuthentication(BaseAuthentication):
                 )
                 capture_exception(e)
                 return None
+            if app is None:
+                return None
             return app if app.provisioning_active else None
 
         try:

--- a/ee/api/agentic_provisioning/authentication.py
+++ b/ee/api/agentic_provisioning/authentication.py
@@ -20,6 +20,7 @@ from posthog.api.oauth.cimd import (
     get_or_create_cimd_provisioning_application,
     is_cimd_client_id,
 )
+from posthog.exceptions_capture import capture_exception
 from posthog.models.oauth import OAuthApplication, find_oauth_access_token
 
 from .signature import _compute_hmac, _get_raw_body, _parse_signature_header
@@ -144,6 +145,17 @@ class ProvisioningAuthentication(BaseAuthentication):
                 app = get_or_create_cimd_provisioning_application(client_id)
             except (CIMDFetchError, CIMDValidationError) as e:
                 logger.warning("provisioning_cimd_resolution_failed", client_id=client_id, error=str(e))
+                return None
+            except Exception as e:
+                # Any other failure (transient DB error during backfill, etc.) must
+                # degrade to unauthenticated rather than 500 — this is a public endpoint.
+                logger.warning(
+                    "provisioning_cimd_resolution_unexpected_error",
+                    client_id=client_id,
+                    error=str(e),
+                    error_type=type(e).__name__,
+                )
+                capture_exception(e)
                 return None
             return app if app.provisioning_active else None
 

--- a/ee/api/agentic_provisioning/test/test_provisioning_auth.py
+++ b/ee/api/agentic_provisioning/test/test_provisioning_auth.py
@@ -798,7 +798,7 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
         assert res.status_code == 429
         assert res.json()["error"]["code"] == "rate_limited"
 
-    @patch("posthog.api.oauth.cimd.CIMD_THROTTLES", new=[])
+    @patch("posthog.api.oauth.cimd.CIMD_THROTTLE_CLASSES", new=[])
     @patch("posthog.api.oauth.cimd.requests.get")
     def test_cimd_domain_rate_limit_blocks_excessive_registrations(self, mock_get, _url_mock):
         from ee.api.agentic_provisioning.views import CIMD_DOMAIN_RATE_LIMIT_MAX
@@ -841,7 +841,7 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
         assert res.status_code == 429
         assert res.json()["error"]["code"] == "rate_limited"
 
-    @patch("posthog.api.oauth.cimd.CIMD_THROTTLES", new=[])
+    @patch("posthog.api.oauth.cimd.CIMD_THROTTLE_CLASSES", new=[])
     @patch("posthog.api.oauth.cimd.requests.get")
     def test_cimd_domain_rate_limit_does_not_block_different_domains(self, mock_get, _url_mock):
         from ee.api.agentic_provisioning.views import CIMD_DOMAIN_RATE_LIMIT_MAX
@@ -865,7 +865,7 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
             )
             assert res.status_code == 200, f"Request {i} for domain-{i} failed: {res.json()}"
 
-    @patch("posthog.api.oauth.cimd.CIMD_THROTTLES", new=[])
+    @patch("posthog.api.oauth.cimd.CIMD_THROTTLE_CLASSES", new=[])
     @patch("posthog.api.oauth.cimd.requests.get")
     def test_cimd_domain_rate_limit_skipped_for_existing_apps(self, mock_get, _url_mock):
         from ee.api.agentic_provisioning.views import CIMD_DOMAIN_RATE_LIMIT_MAX

--- a/ee/api/agentic_provisioning/test/test_provisioning_auth.py
+++ b/ee/api/agentic_provisioning/test/test_provisioning_auth.py
@@ -7,10 +7,13 @@ from urllib.parse import urlencode
 
 import pytest
 from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock, patch
 
 from django.conf import settings
+from django.core.cache import cache as real_cache
 from django.test import override_settings
 
+import requests as requests_lib
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from rest_framework.test import APIClient
@@ -614,3 +617,154 @@ class TestProvisioningAuthentication(APIBaseTest):
         )
         assert res.status_code == 400
         assert "S256" in res.json()["error"]["message"]
+
+
+CIMD_PROV_URL = "https://partner.example.com/.well-known/oauth-client-metadata.json"
+
+
+def _make_cimd_metadata(url: str = CIMD_PROV_URL, **overrides) -> dict:
+    metadata = {
+        "client_id": url,
+        "client_name": "Partner App",
+        "redirect_uris": ["http://127.0.0.1:3000/callback"],
+        "grant_types": ["authorization_code"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+    }
+    metadata.update(overrides)
+    return metadata
+
+
+def _cimd_mock_response(metadata: dict | None, status_code: int = 200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = {}
+    resp.is_redirect = False
+    resp.is_permanent_redirect = False
+    resp.close = MagicMock()
+    body = json.dumps(metadata).encode() if metadata is not None else b""
+    resp.iter_content = MagicMock(return_value=iter([body]))
+    return resp
+
+
+@pytest.mark.requires_secrets
+@patch("posthog.api.oauth.cimd.is_url_allowed", return_value=(True, None))
+@override_settings(
+    STRIPE_APP_SECRET_KEY=HMAC_SECRET,
+    STRIPE_POSTHOG_OAUTH_CLIENT_ID=TEST_STRIPE_OAUTH_CLIENT_ID,
+    STRIPE_ORCHESTRATOR_CALLBACK_URL="https://stripe.com/callback",
+    OIDC_RSA_PRIVATE_KEY=_RSA_KEY,
+    OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, "OIDC_RSA_PRIVATE_KEY": _RSA_KEY},
+)
+class TestCimdProvisioningAutoRegistration(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        OAuthApplication.objects.filter(cimd_metadata_url=CIMD_PROV_URL).delete()
+        real_cache.clear()
+
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_new_cimd_partner_auto_registers_on_account_request(self, mock_get, _url_mock):
+        mock_get.return_value = _cimd_mock_response(_make_cimd_metadata())
+
+        _, challenge = _pkce_pair()
+        res = self.client.post(
+            "/api/agentic/provisioning/account_requests",
+            data={
+                "id": "req_cimd_auto",
+                "email": "cimd-auto@example.com",
+                "client_id": CIMD_PROV_URL,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+            content_type="application/json",
+            HTTP_API_VERSION="0.1d",
+        )
+
+        assert res.status_code == 200, res.json()
+        assert res.json()["type"] == "oauth"
+
+        app = OAuthApplication.objects.get(cimd_metadata_url=CIMD_PROV_URL)
+        assert app.is_cimd_client
+        assert app.provisioning_auth_method == "pkce"
+        assert app.provisioning_active
+        assert app.provisioning_can_create_accounts
+        assert app.provisioning_can_provision_resources
+
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_existing_cimd_app_gets_provisioning_backfilled(self, mock_get, _url_mock):
+        OAuthApplication.objects.create(
+            name="Pre-existing CIMD",
+            client_secret="",
+            client_type=OAuthApplication.CLIENT_PUBLIC,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="http://127.0.0.1:3000/callback",
+            algorithm="RS256",
+            is_cimd_client=True,
+            cimd_metadata_url=CIMD_PROV_URL,
+        )
+        mock_get.return_value = _cimd_mock_response(_make_cimd_metadata())
+
+        _, challenge = _pkce_pair()
+        res = self.client.post(
+            "/api/agentic/provisioning/account_requests",
+            data={
+                "id": "req_cimd_backfill",
+                "email": "cimd-backfill@example.com",
+                "client_id": CIMD_PROV_URL,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+            content_type="application/json",
+            HTTP_API_VERSION="0.1d",
+        )
+        assert res.status_code == 200
+
+        app = OAuthApplication.objects.get(cimd_metadata_url=CIMD_PROV_URL)
+        assert app.provisioning_auth_method == "pkce"
+        assert app.provisioning_active
+
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_cimd_fetch_failure_returns_unauthorized(self, mock_get, _url_mock):
+        mock_get.side_effect = requests_lib.ConnectionError("DNS resolution failed")
+
+        _, challenge = _pkce_pair()
+        res = self.client.post(
+            "/api/agentic/provisioning/account_requests",
+            data={
+                "id": "req_cimd_fail",
+                "email": "cimd-fail@example.com",
+                "client_id": CIMD_PROV_URL,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+            content_type="application/json",
+            HTTP_API_VERSION="0.1d",
+        )
+        assert res.status_code == 401
+        assert not OAuthApplication.objects.filter(cimd_metadata_url=CIMD_PROV_URL).exists()
+
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_self_serve_org_named_after_client_name(self, mock_get, _url_mock):
+        from posthog.models.user import User
+
+        mock_get.return_value = _cimd_mock_response(_make_cimd_metadata(client_name="Partner App"))
+
+        email = "cimd-org-name@example.com"
+        _, challenge = _pkce_pair()
+        self.client.post(
+            "/api/agentic/provisioning/account_requests",
+            data={
+                "id": "req_cimd_org",
+                "email": email,
+                "client_id": CIMD_PROV_URL,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+            content_type="application/json",
+            HTTP_API_VERSION="0.1d",
+        )
+
+        user = User.objects.get(email=email)
+        org = user.organization_memberships.first().organization
+        assert org.name == f"Partner App ({email})"

--- a/ee/api/agentic_provisioning/test/test_provisioning_auth.py
+++ b/ee/api/agentic_provisioning/test/test_provisioning_auth.py
@@ -724,6 +724,26 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
         assert app.provisioning_auth_method == "pkce"
         assert app.provisioning_active
 
+    def test_cimd_backfill_db_error_degrades_to_unauthorized(self, _url_mock):
+        with patch(
+            "ee.api.agentic_provisioning.authentication.get_or_create_cimd_provisioning_application",
+            side_effect=RuntimeError("simulated DB error"),
+        ):
+            _, challenge = _pkce_pair()
+            res = self.client.post(
+                "/api/agentic/provisioning/account_requests",
+                data={
+                    "id": "req_cimd_db_err",
+                    "email": "cimd-db-err@example.com",
+                    "client_id": CIMD_PROV_URL,
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                },
+                content_type="application/json",
+                HTTP_API_VERSION="0.1d",
+            )
+        assert res.status_code == 401
+
     @patch("posthog.api.oauth.cimd.requests.get")
     def test_cimd_fetch_failure_returns_unauthorized(self, mock_get, _url_mock):
         mock_get.side_effect = requests_lib.ConnectionError("DNS resolution failed")

--- a/ee/api/agentic_provisioning/test/test_provisioning_auth.py
+++ b/ee/api/agentic_provisioning/test/test_provisioning_auth.py
@@ -13,7 +13,6 @@ from django.conf import settings
 from django.core.cache import cache as real_cache
 from django.test import override_settings
 
-import requests as requests_lib
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from rest_framework.test import APIClient
@@ -665,10 +664,8 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
         OAuthApplication.objects.filter(cimd_metadata_url=CIMD_PROV_URL).delete()
         real_cache.clear()
 
-    @patch("posthog.api.oauth.cimd.requests.get")
-    def test_new_cimd_partner_auto_registers_on_account_request(self, mock_get, _url_mock):
-        mock_get.return_value = _cimd_mock_response(_make_cimd_metadata())
-
+    @patch("ee.api.agentic_provisioning.authentication.register_cimd_provisioning_application_task")
+    def test_new_cimd_partner_returns_202_and_kicks_off_registration(self, mock_task, _url_mock):
         _, challenge = _pkce_pair()
         res = self.client.post(
             "/api/agentic/provisioning/account_requests",
@@ -683,8 +680,18 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
             HTTP_API_VERSION="0.1d",
         )
 
-        assert res.status_code == 200, res.json()
-        assert res.json()["type"] == "oauth"
+        assert res.status_code == 202
+        assert res.json()["type"] == "registering"
+        assert res.json()["retry_after"] == 5
+        mock_task.delay.assert_called_once_with(CIMD_PROV_URL)
+
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_new_cimd_partner_succeeds_after_background_registration(self, mock_get, _url_mock):
+        mock_get.return_value = _cimd_mock_response(_make_cimd_metadata())
+
+        from posthog.api.oauth.cimd import register_cimd_provisioning_application_task
+
+        register_cimd_provisioning_application_task(CIMD_PROV_URL)
 
         app = OAuthApplication.objects.get(cimd_metadata_url=CIMD_PROV_URL)
         assert app.is_cimd_client
@@ -693,8 +700,24 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
         assert app.provisioning_can_create_accounts
         assert app.provisioning_can_provision_resources
 
-    @patch("posthog.api.oauth.cimd.requests.get")
-    def test_existing_cimd_app_gets_provisioning_backfilled(self, mock_get, _url_mock):
+        _, challenge = _pkce_pair()
+        res = self.client.post(
+            "/api/agentic/provisioning/account_requests",
+            data={
+                "id": "req_cimd_auto",
+                "email": "cimd-auto@example.com",
+                "client_id": CIMD_PROV_URL,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+            content_type="application/json",
+            HTTP_API_VERSION="0.1d",
+        )
+        assert res.status_code == 200
+        assert res.json()["type"] == "oauth"
+
+    @patch("posthog.api.oauth.cimd.refresh_cimd_metadata_task")
+    def test_existing_cimd_app_gets_provisioning_backfilled(self, mock_refresh, _url_mock):
         OAuthApplication.objects.create(
             name="Pre-existing CIMD",
             client_secret="",
@@ -705,7 +728,6 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
             is_cimd_client=True,
             cimd_metadata_url=CIMD_PROV_URL,
         )
-        mock_get.return_value = _cimd_mock_response(_make_cimd_metadata())
 
         _, challenge = _pkce_pair()
         res = self.client.post(
@@ -727,9 +749,22 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
         assert app.provisioning_active
 
     def test_cimd_backfill_db_error_degrades_to_unauthorized(self, _url_mock):
+        OAuthApplication.objects.create(
+            name="CIMD DB Error App",
+            client_secret="",
+            client_type=OAuthApplication.CLIENT_PUBLIC,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="http://127.0.0.1:3000/callback",
+            algorithm="RS256",
+            is_cimd_client=True,
+            cimd_metadata_url=CIMD_PROV_URL,
+        )
         with patch(
-            "ee.api.agentic_provisioning.authentication.get_or_create_cimd_provisioning_application",
-            side_effect=RuntimeError("simulated DB error"),
+            "ee.api.agentic_provisioning.authentication.CIMD_PROVISIONING_DEFAULTS",
+            new_callable=lambda: MagicMock(
+                items=MagicMock(side_effect=RuntimeError("simulated DB error")),
+                keys=MagicMock(return_value=[]),
+            ),
         ):
             _, challenge = _pkce_pair()
             res = self.client.post(
@@ -746,10 +781,8 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
             )
         assert res.status_code == 401
 
-    @patch("posthog.api.oauth.cimd.requests.get")
-    def test_cimd_fetch_failure_returns_unauthorized(self, mock_get, _url_mock):
-        mock_get.side_effect = requests_lib.ConnectionError("DNS resolution failed")
-
+    @patch("ee.api.agentic_provisioning.authentication.register_cimd_provisioning_application_task")
+    def test_new_cimd_url_returns_202_not_401(self, mock_task, _url_mock):
         _, challenge = _pkce_pair()
         res = self.client.post(
             "/api/agentic/provisioning/account_requests",
@@ -763,12 +796,27 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
             content_type="application/json",
             HTTP_API_VERSION="0.1d",
         )
-        assert res.status_code == 401
-        assert not OAuthApplication.objects.filter(cimd_metadata_url=CIMD_PROV_URL).exists()
+        assert res.status_code == 202
+        assert res.json()["type"] == "registering"
+        mock_task.delay.assert_called_once()
 
-    @patch("posthog.api.oauth.cimd.requests.get")
-    def test_partner_rate_limit_enforced_after_threshold(self, mock_get, _url_mock):
-        mock_get.return_value = _cimd_mock_response(_make_cimd_metadata())
+    @patch("posthog.api.oauth.cimd.refresh_cimd_metadata_task")
+    def test_partner_rate_limit_enforced_after_threshold(self, mock_refresh, _url_mock):
+        OAuthApplication.objects.create(
+            name="Rate Limit Test CIMD",
+            client_secret="",
+            client_type=OAuthApplication.CLIENT_PUBLIC,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="http://127.0.0.1:3000/callback",
+            algorithm="RS256",
+            is_cimd_client=True,
+            cimd_metadata_url=CIMD_PROV_URL,
+            provisioning_auth_method="pkce",
+            provisioning_active=True,
+            provisioning_can_create_accounts=True,
+            provisioning_can_provision_resources=True,
+            provisioning_rate_limit_account_requests=10,
+        )
 
         _, challenge = _pkce_pair()
 
@@ -786,7 +834,6 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
                 HTTP_API_VERSION="0.1d",
             )
 
-        # First request auto-registers the CIMD partner with a low default limit (10/hr).
         assert post_account_request("ratelimit-1@example.com").status_code == 200
 
         partner = OAuthApplication.objects.get(cimd_metadata_url=CIMD_PROV_URL)
@@ -799,8 +846,8 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
         assert res.json()["error"]["code"] == "rate_limited"
 
     @patch("posthog.api.oauth.cimd.CIMD_THROTTLE_CLASSES", new=[])
-    @patch("posthog.api.oauth.cimd.requests.get")
-    def test_cimd_domain_rate_limit_blocks_excessive_registrations(self, mock_get, _url_mock):
+    @patch("ee.api.agentic_provisioning.authentication.register_cimd_provisioning_application_task")
+    def test_cimd_domain_rate_limit_blocks_excessive_registrations(self, mock_task, _url_mock):
         from ee.api.agentic_provisioning.views import CIMD_DOMAIN_RATE_LIMIT_MAX
 
         base_domain = "evil.example.com"
@@ -808,7 +855,6 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
 
         for i in range(CIMD_DOMAIN_RATE_LIMIT_MAX):
             url = f"https://{base_domain}/path-{i}/metadata.json"
-            mock_get.return_value = _cimd_mock_response(_make_cimd_metadata(url))
             res = self.client.post(
                 "/api/agentic/provisioning/account_requests",
                 data={
@@ -821,11 +867,9 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
                 content_type="application/json",
                 HTTP_API_VERSION="0.1d",
             )
-            assert res.status_code == 200, f"Request {i} failed: {res.json()}"
+            assert res.status_code == 202, f"Request {i} failed: {res.json()}"
 
-        # Next registration from the same domain should be blocked
         url = f"https://{base_domain}/path-blocked/metadata.json"
-        mock_get.return_value = _cimd_mock_response(_make_cimd_metadata(url))
         res = self.client.post(
             "/api/agentic/provisioning/account_requests",
             data={
@@ -842,15 +886,14 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
         assert res.json()["error"]["code"] == "rate_limited"
 
     @patch("posthog.api.oauth.cimd.CIMD_THROTTLE_CLASSES", new=[])
-    @patch("posthog.api.oauth.cimd.requests.get")
-    def test_cimd_domain_rate_limit_does_not_block_different_domains(self, mock_get, _url_mock):
+    @patch("ee.api.agentic_provisioning.authentication.register_cimd_provisioning_application_task")
+    def test_cimd_domain_rate_limit_does_not_block_different_domains(self, mock_task, _url_mock):
         from ee.api.agentic_provisioning.views import CIMD_DOMAIN_RATE_LIMIT_MAX
 
         _, challenge = _pkce_pair()
 
         for i in range(CIMD_DOMAIN_RATE_LIMIT_MAX + 2):
             url = f"https://domain-{i}.example.com/.well-known/metadata.json"
-            mock_get.return_value = _cimd_mock_response(_make_cimd_metadata(url))
             res = self.client.post(
                 "/api/agentic/provisioning/account_requests",
                 data={
@@ -863,17 +906,16 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
                 content_type="application/json",
                 HTTP_API_VERSION="0.1d",
             )
-            assert res.status_code == 200, f"Request {i} for domain-{i} failed: {res.json()}"
+            assert res.status_code == 202, f"Request {i} for domain-{i} failed: {res.json()}"
 
     @patch("posthog.api.oauth.cimd.CIMD_THROTTLE_CLASSES", new=[])
-    @patch("posthog.api.oauth.cimd.requests.get")
-    def test_cimd_domain_rate_limit_skipped_for_existing_apps(self, mock_get, _url_mock):
+    @patch("posthog.api.oauth.cimd.refresh_cimd_metadata_task")
+    def test_cimd_domain_rate_limit_skipped_for_existing_apps(self, mock_refresh, _url_mock):
         from ee.api.agentic_provisioning.views import CIMD_DOMAIN_RATE_LIMIT_MAX
 
         base_domain = "existing.example.com"
         _, challenge = _pkce_pair()
 
-        # Pre-create apps exceeding the domain limit
         for i in range(CIMD_DOMAIN_RATE_LIMIT_MAX + 1):
             url = f"https://{base_domain}/path-{i}/metadata.json"
             OAuthApplication.objects.create(
@@ -891,9 +933,7 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
                 provisioning_can_provision_resources=True,
             )
 
-        # Requests for existing apps should bypass the domain rate limit
         url = f"https://{base_domain}/path-0/metadata.json"
-        mock_get.return_value = _cimd_mock_response(_make_cimd_metadata(url))
         res = self.client.post(
             "/api/agentic/provisioning/account_requests",
             data={
@@ -908,11 +948,24 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
         )
         assert res.status_code == 200
 
-    @patch("posthog.api.oauth.cimd.requests.get")
-    def test_self_serve_org_named_after_client_name(self, mock_get, _url_mock):
+    @patch("posthog.api.oauth.cimd.refresh_cimd_metadata_task")
+    def test_self_serve_org_named_after_client_name(self, mock_refresh, _url_mock):
         from posthog.models.user import User
 
-        mock_get.return_value = _cimd_mock_response(_make_cimd_metadata(client_name="Partner App"))
+        OAuthApplication.objects.create(
+            name="Partner App",
+            client_secret="",
+            client_type=OAuthApplication.CLIENT_PUBLIC,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="http://127.0.0.1:3000/callback",
+            algorithm="RS256",
+            is_cimd_client=True,
+            cimd_metadata_url=CIMD_PROV_URL,
+            provisioning_auth_method="pkce",
+            provisioning_active=True,
+            provisioning_can_create_accounts=True,
+            provisioning_can_provision_resources=True,
+        )
 
         email = "cimd-org-name@example.com"
         _, challenge = _pkce_pair()
@@ -932,3 +985,58 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
         user = User.objects.get(email=email)
         org = user.organization_memberships.first().organization
         assert org.name == f"Partner App ({email})"
+
+    def test_blocked_cimd_url_returns_unauthorized(self, _url_mock):
+        from posthog.api.oauth.cimd import block_cimd_url
+
+        block_cimd_url(CIMD_PROV_URL)
+
+        _, challenge = _pkce_pair()
+        res = self.client.post(
+            "/api/agentic/provisioning/account_requests",
+            data={
+                "id": "req_blocked",
+                "email": "blocked@example.com",
+                "client_id": CIMD_PROV_URL,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+            content_type="application/json",
+            HTTP_API_VERSION="0.1d",
+        )
+        assert res.status_code == 401
+
+    @patch("posthog.api.oauth.cimd.refresh_cimd_metadata_task")
+    def test_blocked_cimd_url_with_existing_app_returns_unauthorized(self, mock_refresh, _url_mock):
+        from posthog.api.oauth.cimd import block_cimd_url
+
+        OAuthApplication.objects.create(
+            name="Blocked CIMD App",
+            client_secret="",
+            client_type=OAuthApplication.CLIENT_PUBLIC,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="http://127.0.0.1:3000/callback",
+            algorithm="RS256",
+            is_cimd_client=True,
+            cimd_metadata_url=CIMD_PROV_URL,
+            provisioning_auth_method="pkce",
+            provisioning_active=True,
+            provisioning_can_create_accounts=True,
+            provisioning_can_provision_resources=True,
+        )
+        block_cimd_url(CIMD_PROV_URL)
+
+        _, challenge = _pkce_pair()
+        res = self.client.post(
+            "/api/agentic/provisioning/account_requests",
+            data={
+                "id": "req_blocked_existing",
+                "email": "blocked-existing@example.com",
+                "client_id": CIMD_PROV_URL,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+            content_type="application/json",
+            HTTP_API_VERSION="0.1d",
+        )
+        assert res.status_code == 401

--- a/ee/api/agentic_provisioning/test/test_provisioning_auth.py
+++ b/ee/api/agentic_provisioning/test/test_provisioning_auth.py
@@ -530,7 +530,8 @@ class TestProvisioningAuthentication(APIBaseTest):
 
     # --- CIMD URL-based PKCE identification ---
 
-    def test_pkce_partner_identified_by_cimd_url(self):
+    @patch("posthog.api.oauth.cimd.refresh_cimd_metadata_task")
+    def test_pkce_partner_identified_by_cimd_url(self, mock_refresh):
         cimd_url = "https://example.com/api/oauth/wizard/client-metadata"
         cimd_app = OAuthApplication.objects.create(
             name="CIMD Wizard",
@@ -566,7 +567,8 @@ class TestProvisioningAuthentication(APIBaseTest):
 
         cimd_app.delete()
 
-    def test_cimd_url_inactive_partner_rejected(self):
+    @patch("posthog.api.oauth.cimd.refresh_cimd_metadata_task")
+    def test_cimd_url_inactive_partner_rejected(self, mock_refresh):
         cimd_url = "https://example.com/api/oauth/wizard/client-metadata-inactive"
         cimd_app = OAuthApplication.objects.create(
             name="Inactive CIMD Wizard",

--- a/ee/api/agentic_provisioning/test/test_provisioning_auth.py
+++ b/ee/api/agentic_provisioning/test/test_provisioning_auth.py
@@ -745,6 +745,38 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
         assert not OAuthApplication.objects.filter(cimd_metadata_url=CIMD_PROV_URL).exists()
 
     @patch("posthog.api.oauth.cimd.requests.get")
+    def test_partner_rate_limit_enforced_after_threshold(self, mock_get, _url_mock):
+        mock_get.return_value = _cimd_mock_response(_make_cimd_metadata())
+
+        _, challenge = _pkce_pair()
+
+        def post_account_request(email: str):
+            return self.client.post(
+                "/api/agentic/provisioning/account_requests",
+                data={
+                    "id": f"req_{email}",
+                    "email": email,
+                    "client_id": CIMD_PROV_URL,
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                },
+                content_type="application/json",
+                HTTP_API_VERSION="0.1d",
+            )
+
+        # First request auto-registers the CIMD partner with a low default limit (10/hr).
+        assert post_account_request("ratelimit-1@example.com").status_code == 200
+
+        partner = OAuthApplication.objects.get(cimd_metadata_url=CIMD_PROV_URL)
+        partner.provisioning_rate_limit_account_requests = 2
+        partner.save(update_fields=["provisioning_rate_limit_account_requests"])
+
+        assert post_account_request("ratelimit-2@example.com").status_code == 200
+        res = post_account_request("ratelimit-3@example.com")
+        assert res.status_code == 429
+        assert res.json()["error"]["code"] == "rate_limited"
+
+    @patch("posthog.api.oauth.cimd.requests.get")
     def test_self_serve_org_named_after_client_name(self, mock_get, _url_mock):
         from posthog.models.user import User
 

--- a/ee/api/agentic_provisioning/test/test_provisioning_auth.py
+++ b/ee/api/agentic_provisioning/test/test_provisioning_auth.py
@@ -798,6 +798,116 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
         assert res.status_code == 429
         assert res.json()["error"]["code"] == "rate_limited"
 
+    @patch("posthog.api.oauth.cimd.CIMD_THROTTLES", new=[])
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_cimd_domain_rate_limit_blocks_excessive_registrations(self, mock_get, _url_mock):
+        from ee.api.agentic_provisioning.views import CIMD_DOMAIN_RATE_LIMIT_MAX
+
+        base_domain = "evil.example.com"
+        _, challenge = _pkce_pair()
+
+        for i in range(CIMD_DOMAIN_RATE_LIMIT_MAX):
+            url = f"https://{base_domain}/path-{i}/metadata.json"
+            mock_get.return_value = _cimd_mock_response(_make_cimd_metadata(url))
+            res = self.client.post(
+                "/api/agentic/provisioning/account_requests",
+                data={
+                    "id": f"req_domain_rl_{i}",
+                    "email": f"domain-rl-{i}@example.com",
+                    "client_id": url,
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                },
+                content_type="application/json",
+                HTTP_API_VERSION="0.1d",
+            )
+            assert res.status_code == 200, f"Request {i} failed: {res.json()}"
+
+        # Next registration from the same domain should be blocked
+        url = f"https://{base_domain}/path-blocked/metadata.json"
+        mock_get.return_value = _cimd_mock_response(_make_cimd_metadata(url))
+        res = self.client.post(
+            "/api/agentic/provisioning/account_requests",
+            data={
+                "id": "req_domain_rl_blocked",
+                "email": "domain-rl-blocked@example.com",
+                "client_id": url,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+            content_type="application/json",
+            HTTP_API_VERSION="0.1d",
+        )
+        assert res.status_code == 429
+        assert res.json()["error"]["code"] == "rate_limited"
+
+    @patch("posthog.api.oauth.cimd.CIMD_THROTTLES", new=[])
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_cimd_domain_rate_limit_does_not_block_different_domains(self, mock_get, _url_mock):
+        from ee.api.agentic_provisioning.views import CIMD_DOMAIN_RATE_LIMIT_MAX
+
+        _, challenge = _pkce_pair()
+
+        for i in range(CIMD_DOMAIN_RATE_LIMIT_MAX + 2):
+            url = f"https://domain-{i}.example.com/.well-known/metadata.json"
+            mock_get.return_value = _cimd_mock_response(_make_cimd_metadata(url))
+            res = self.client.post(
+                "/api/agentic/provisioning/account_requests",
+                data={
+                    "id": f"req_diff_domain_{i}",
+                    "email": f"diff-domain-{i}@example.com",
+                    "client_id": url,
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                },
+                content_type="application/json",
+                HTTP_API_VERSION="0.1d",
+            )
+            assert res.status_code == 200, f"Request {i} for domain-{i} failed: {res.json()}"
+
+    @patch("posthog.api.oauth.cimd.CIMD_THROTTLES", new=[])
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_cimd_domain_rate_limit_skipped_for_existing_apps(self, mock_get, _url_mock):
+        from ee.api.agentic_provisioning.views import CIMD_DOMAIN_RATE_LIMIT_MAX
+
+        base_domain = "existing.example.com"
+        _, challenge = _pkce_pair()
+
+        # Pre-create apps exceeding the domain limit
+        for i in range(CIMD_DOMAIN_RATE_LIMIT_MAX + 1):
+            url = f"https://{base_domain}/path-{i}/metadata.json"
+            OAuthApplication.objects.create(
+                name=f"Existing CIMD {i}",
+                client_secret="",
+                client_type=OAuthApplication.CLIENT_PUBLIC,
+                authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+                redirect_uris="http://127.0.0.1:3000/callback",
+                algorithm="RS256",
+                is_cimd_client=True,
+                cimd_metadata_url=url,
+                provisioning_auth_method="pkce",
+                provisioning_active=True,
+                provisioning_can_create_accounts=True,
+                provisioning_can_provision_resources=True,
+            )
+
+        # Requests for existing apps should bypass the domain rate limit
+        url = f"https://{base_domain}/path-0/metadata.json"
+        mock_get.return_value = _cimd_mock_response(_make_cimd_metadata(url))
+        res = self.client.post(
+            "/api/agentic/provisioning/account_requests",
+            data={
+                "id": "req_existing_domain",
+                "email": "existing-domain@example.com",
+                "client_id": url,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+            content_type="application/json",
+            HTTP_API_VERSION="0.1d",
+        )
+        assert res.status_code == 200
+
     @patch("posthog.api.oauth.cimd.requests.get")
     def test_self_serve_org_named_after_client_name(self, mock_get, _url_mock):
         from posthog.models.user import User

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -261,6 +261,9 @@ def account_requests(request: Request) -> Response:
     if error := verify_api_version(request):
         return error
 
+    if error := _enforce_cimd_registration_throttle(request):
+        return error
+
     # --- Identify partner ---
     auth = ProvisioningAuthentication()
     partner = None
@@ -482,9 +485,7 @@ def _handle_new_user(
     if not isinstance(configuration, dict):
         configuration = {}
 
-    partner_label = (
-        partner.provisioning_partner_type.capitalize() if partner and partner.provisioning_partner_type else "Stripe"
-    )
+    partner_label = _partner_label(partner)
     org_name = configuration.get("organization_name") or f"{partner_label} ({email})"
 
     try:
@@ -1585,6 +1586,42 @@ def deep_links(request: Request) -> Response:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _partner_label(partner: OAuthApplication | None) -> str:
+    if not partner:
+        return "Stripe"
+    if partner.provisioning_partner_type:
+        return partner.provisioning_partner_type.capitalize()
+    if partner.name:
+        return partner.name
+    return "Stripe"
+
+
+def _enforce_cimd_registration_throttle(request: Request) -> Response | None:
+    """Rate-limit first-time CIMD app registration by IP to match /authorize protections."""
+    from posthog.api.oauth.cimd import CIMD_THROTTLES, is_cimd_client_id
+
+    client_id = request.data.get("client_id") or request.query_params.get("client_id")
+    if not is_cimd_client_id(client_id):
+        return None
+    if OAuthApplication.objects.filter(cimd_metadata_url=client_id).exists():
+        return None
+
+    for throttle in CIMD_THROTTLES:
+        if not throttle.allow_request(request, view=None):
+            logger.warning("cimd_rate_limited", client_id=client_id, scope=throttle.scope, wait=throttle.wait())
+            return Response(
+                {
+                    "type": "error",
+                    "error": {
+                        "code": "rate_limited",
+                        "message": "Too many new client registrations. Try again later.",
+                    },
+                },
+                status=429,
+            )
+    return None
 
 
 def _verify_hmac_if_present(request: Request) -> Response | None:

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -68,6 +68,9 @@ DEEP_LINK_RATE_LIMIT_PREFIX = "agentic_login_rate:"
 DEEP_LINK_RATE_LIMIT_MAX_ATTEMPTS = 10
 DEEP_LINK_RATE_LIMIT_WINDOW_SECONDS = 300
 
+ACCOUNT_REQUEST_PARTNER_RATE_LIMIT_PREFIX = "agentic_provisioning_account_requests_partner_rate:"
+ACCOUNT_REQUEST_PARTNER_RATE_LIMIT_WINDOW_SECONDS = 3600
+
 _SAFE_STATE_RE = re.compile(r"^[A-Za-z0-9_\-]{1,256}$")
 
 STRIPE_APP_NAME = "PostHog Stripe App"
@@ -276,6 +279,9 @@ def account_requests(request: Request) -> Response:
             {"type": "error", "error": {"code": "unauthorized", "message": "Authentication failed"}},
             status=401,
         )
+
+    if partner and (error := _enforce_partner_account_request_rate_limit(partner)):
+        return error
 
     # --- Parse request ---
     data = request.data
@@ -1596,6 +1602,41 @@ def _partner_label(partner: OAuthApplication | None) -> str:
     if partner.name:
         return partner.name
     return "Stripe"
+
+
+def _enforce_partner_account_request_rate_limit(partner: OAuthApplication) -> Response | None:
+    """Enforce the partner's per-hour account_requests limit if one is configured.
+
+    Uses a fixed-window counter keyed on partner id + hour-of-epoch. Self-serve
+    CIMD partners get a low default on first registration; admins can raise it.
+    """
+    limit = partner.provisioning_rate_limit_account_requests
+    if not limit or limit <= 0:
+        return None
+
+    window_index = int(time.time()) // ACCOUNT_REQUEST_PARTNER_RATE_LIMIT_WINDOW_SECONDS
+    key = f"{ACCOUNT_REQUEST_PARTNER_RATE_LIMIT_PREFIX}{partner.id}:{window_index}"
+    try:
+        count = cache.incr(key)
+    except ValueError:
+        cache.set(key, 1, timeout=ACCOUNT_REQUEST_PARTNER_RATE_LIMIT_WINDOW_SECONDS)
+        count = 1
+
+    if count > limit:
+        _capture_provisioning_event(
+            "account_request", "rate_limited", partner_id=str(partner.id), limit=limit, count=count
+        )
+        return Response(
+            {
+                "type": "error",
+                "error": {
+                    "code": "rate_limited",
+                    "message": "Account request rate limit exceeded for this partner. Try again later.",
+                },
+            },
+            status=429,
+        )
+    return None
 
 
 def _enforce_cimd_registration_throttle(request: Request) -> Response | None:

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -1619,8 +1619,9 @@ def _enforce_partner_account_request_rate_limit(partner: OAuthApplication) -> Re
     try:
         count = cache.incr(key)
     except ValueError:
-        cache.set(key, 1, timeout=ACCOUNT_REQUEST_PARTNER_RATE_LIMIT_WINDOW_SECONDS)
-        count = 1
+        # cache.add is atomic set-if-not-exists; safe under concurrent initialization.
+        cache.add(key, 0, timeout=ACCOUNT_REQUEST_PARTNER_RATE_LIMIT_WINDOW_SECONDS)
+        count = cache.incr(key)
 
     if count > limit:
         _capture_provisioning_event(

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -1646,7 +1646,7 @@ def _enforce_partner_account_request_rate_limit(partner: OAuthApplication) -> Re
 
 def _enforce_cimd_registration_throttle(request: Request) -> Response | None:
     """Rate-limit first-time CIMD app registration by IP and domain to match /authorize protections."""
-    from posthog.api.oauth.cimd import CIMD_THROTTLES, is_cimd_client_id
+    from posthog.api.oauth.cimd import CIMD_THROTTLE_CLASSES, is_cimd_client_id
 
     client_id = request.data.get("client_id") or request.query_params.get("client_id")
     if not is_cimd_client_id(client_id):
@@ -1654,7 +1654,8 @@ def _enforce_cimd_registration_throttle(request: Request) -> Response | None:
     if OAuthApplication.objects.filter(cimd_metadata_url=client_id).exists():
         return None
 
-    for throttle in CIMD_THROTTLES:
+    for throttle_cls in CIMD_THROTTLE_CLASSES:
+        throttle = throttle_cls()
         if not throttle.allow_request(request, view=None):  # type: ignore[arg-type]
             logger.warning("cimd_rate_limited", client_id=client_id, scope=throttle.scope, wait=throttle.wait())
             return Response(

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -284,6 +284,12 @@ def account_requests(request: Request) -> Response:
             status=401,
         )
 
+    if partner is None and auth.cimd_registration_pending:
+        return Response(
+            {"type": "registering", "retry_after": 5},
+            status=202,
+        )
+
     if partner and (error := _enforce_partner_account_request_rate_limit(partner)):
         return error
 

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -71,6 +71,10 @@ DEEP_LINK_RATE_LIMIT_WINDOW_SECONDS = 300
 ACCOUNT_REQUEST_PARTNER_RATE_LIMIT_PREFIX = "agentic_provisioning_account_requests_partner_rate:"
 ACCOUNT_REQUEST_PARTNER_RATE_LIMIT_WINDOW_SECONDS = 3600
 
+CIMD_DOMAIN_RATE_LIMIT_PREFIX = "cimd_registration_domain_rate:"
+CIMD_DOMAIN_RATE_LIMIT_MAX = 5
+CIMD_DOMAIN_RATE_LIMIT_WINDOW_SECONDS = 3600
+
 _SAFE_STATE_RE = re.compile(r"^[A-Za-z0-9_\-]{1,256}$")
 
 STRIPE_APP_NAME = "PostHog Stripe App"
@@ -1641,7 +1645,7 @@ def _enforce_partner_account_request_rate_limit(partner: OAuthApplication) -> Re
 
 
 def _enforce_cimd_registration_throttle(request: Request) -> Response | None:
-    """Rate-limit first-time CIMD app registration by IP to match /authorize protections."""
+    """Rate-limit first-time CIMD app registration by IP and domain to match /authorize protections."""
     from posthog.api.oauth.cimd import CIMD_THROTTLES, is_cimd_client_id
 
     client_id = request.data.get("client_id") or request.query_params.get("client_id")
@@ -1651,8 +1655,6 @@ def _enforce_cimd_registration_throttle(request: Request) -> Response | None:
         return None
 
     for throttle in CIMD_THROTTLES:
-        # CIMD throttles key on IP (CIMDBurstThrottle, CIMDSustainedThrottle) or a
-        # fixed global ident (CIMDGlobalThrottle) — none of them use the view argument.
         if not throttle.allow_request(request, view=None):  # type: ignore[arg-type]
             logger.warning("cimd_rate_limited", client_id=client_id, scope=throttle.scope, wait=throttle.wait())
             return Response(
@@ -1665,6 +1667,42 @@ def _enforce_cimd_registration_throttle(request: Request) -> Response | None:
                 },
                 status=429,
             )
+
+    if error := _enforce_cimd_domain_rate_limit(client_id):
+        return error
+
+    return None
+
+
+def _enforce_cimd_domain_rate_limit(client_id: str) -> Response | None:
+    """Prevent a single domain from registering unlimited CIMD apps via different URL paths."""
+    from urllib.parse import urlparse
+
+    domain = urlparse(client_id).hostname
+    if not domain:
+        return None
+
+    window_index = int(time.time()) // CIMD_DOMAIN_RATE_LIMIT_WINDOW_SECONDS
+    key = f"{CIMD_DOMAIN_RATE_LIMIT_PREFIX}{domain}:{window_index}"
+    try:
+        count = cache.incr(key)
+    except ValueError:
+        cache.add(key, 0, timeout=CIMD_DOMAIN_RATE_LIMIT_WINDOW_SECONDS)
+        count = cache.incr(key)
+
+    if count > CIMD_DOMAIN_RATE_LIMIT_MAX:
+        logger.warning("cimd_domain_rate_limited", client_id=client_id, domain=domain, count=count)
+        _capture_provisioning_event("account_request", "cimd_domain_rate_limited", domain=domain, count=count)
+        return Response(
+            {
+                "type": "error",
+                "error": {
+                    "code": "rate_limited",
+                    "message": "Too many new client registrations from this domain. Try again later.",
+                },
+            },
+            status=429,
+        )
     return None
 
 

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -1668,7 +1668,7 @@ def _enforce_cimd_registration_throttle(request: Request) -> Response | None:
                 status=429,
             )
 
-    if error := _enforce_cimd_domain_rate_limit(client_id):
+    if error := _enforce_cimd_domain_rate_limit(cast(str, client_id)):
         return error
 
     return None

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -1650,7 +1650,9 @@ def _enforce_cimd_registration_throttle(request: Request) -> Response | None:
         return None
 
     for throttle in CIMD_THROTTLES:
-        if not throttle.allow_request(request, view=None):
+        # CIMD throttles key on IP (CIMDBurstThrottle, CIMDSustainedThrottle) or a
+        # fixed global ident (CIMDGlobalThrottle) — none of them use the view argument.
+        if not throttle.allow_request(request, view=None):  # type: ignore[arg-type]
             logger.warning("cimd_rate_limited", client_id=client_id, scope=throttle.scope, wait=throttle.wait())
             return Response(
                 {

--- a/posthog/api/oauth/cimd.py
+++ b/posthog/api/oauth/cimd.py
@@ -138,13 +138,33 @@ def is_cimd_client_id(client_id: str | None) -> bool:
 
 
 def _cache_key(url: str) -> str:
-    hash = hashlib.sha256(url.encode()).hexdigest()
-    return f"cimd:metadata:{hash}"
+    url_hash = hashlib.sha256(url.encode()).hexdigest()
+    return f"cimd:metadata:{url_hash}"
 
 
 def _fetch_lock_key(url: str) -> str:
-    hash = hashlib.sha256(url.encode()).hexdigest()
-    return f"cimd:fetching:{hash}"
+    url_hash = hashlib.sha256(url.encode()).hexdigest()
+    return f"cimd:fetching:{url_hash}"
+
+
+def _blocked_key(url: str) -> str:
+    url_hash = hashlib.sha256(url.encode()).hexdigest()
+    return f"cimd:blocked:{url_hash}"
+
+
+def block_cimd_url(url: str, ttl: int = 86400 * 365) -> None:
+    """Add a CIMD URL to the blocklist. Used by admin to prevent re-registration after deletion."""
+    cache.set(_blocked_key(url), True, timeout=ttl)
+
+
+def unblock_cimd_url(url: str) -> None:
+    """Remove a CIMD URL from the blocklist."""
+    cache.delete(_blocked_key(url))
+
+
+def is_cimd_url_blocked(url: str) -> bool:
+    """Check if a CIMD URL has been blocklisted."""
+    return bool(cache.get(_blocked_key(url)))
 
 
 def _parse_cache_ttl(response: requests.Response) -> int:
@@ -338,6 +358,10 @@ def fetch_and_upsert_cimd_application(url: str, capture_ph_event=posthoganalytic
 
     Used by both synchronous (new client) and asynchronous (stale refresh) paths.
     """
+    if is_cimd_url_blocked(url):
+        logger.warning("cimd_blocked_url_fetch_attempt", url=url)
+        return None
+
     fetch_lock = _fetch_lock_key(url)
     if not cache.add(fetch_lock, True, timeout=CIMD_FETCH_TIMEOUT_SECONDS * 3):
         return None
@@ -455,7 +479,7 @@ CIMD_PROVISIONING_DEFAULTS = {
 }
 
 
-def get_or_create_cimd_provisioning_application(url: str) -> OAuthApplication:
+def get_or_create_cimd_provisioning_application(url: str) -> OAuthApplication | None:
     """
     Resolve a CIMD URL to an OAuthApplication configured as a provisioning partner.
 
@@ -463,8 +487,13 @@ def get_or_create_cimd_provisioning_application(url: str) -> OAuthApplication:
     then backfills provisioning defaults if they haven't been set. Existing apps
     that already have provisioning fields configured (e.g. via admin) are left alone.
 
+    Returns None if the URL is blocklisted.
     Raises CIMDFetchError / CIMDValidationError on fetch failures.
     """
+    if is_cimd_url_blocked(url):
+        logger.warning("cimd_blocked_url", url=url)
+        return None
+
     app = get_or_create_cimd_application(url)
     if not app.is_provisioning_partner:
         for field, value in CIMD_PROVISIONING_DEFAULTS.items():

--- a/posthog/api/oauth/cimd.py
+++ b/posthog/api/oauth/cimd.py
@@ -442,11 +442,16 @@ def get_application_by_client_id(client_id: str) -> OAuthApplication:
 # Defaults applied when a CIMD app is first used for provisioning. A self-serve
 # partner can hit /account_requests immediately without manual admin setup; the
 # app is opted into provisioning at the same trust level as other PKCE partners.
+# The account-request rate limit is set to a conservative floor so a single
+# self-serve partner cannot burn through bulk user-onboarding calls — admin can
+# raise it per-partner once a partner demonstrates legitimate volume.
+CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT = 10  # per hour
 CIMD_PROVISIONING_DEFAULTS = {
     "provisioning_auth_method": "pkce",
     "provisioning_active": True,
     "provisioning_can_create_accounts": True,
     "provisioning_can_provision_resources": True,
+    "provisioning_rate_limit_account_requests": CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT,
 }
 
 
@@ -465,4 +470,14 @@ def get_or_create_cimd_provisioning_application(url: str) -> OAuthApplication:
         for field, value in CIMD_PROVISIONING_DEFAULTS.items():
             setattr(app, field, value)
         app.save(update_fields=list(CIMD_PROVISIONING_DEFAULTS.keys()))
+        posthoganalytics.capture(
+            distinct_id=url,
+            event="cimd_provisioning_partner_registered",
+            properties={
+                "cimd_url": url,
+                "client_name": app.name,
+                "app_id": str(app.pk),
+                "account_requests_rate_limit": CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT,
+            },
+        )
     return app

--- a/posthog/api/oauth/cimd.py
+++ b/posthog/api/oauth/cimd.py
@@ -437,3 +437,32 @@ def get_application_by_client_id(client_id: str) -> OAuthApplication:
     if is_cimd_client_id(client_id):
         return OAuthApplication.objects.get(cimd_metadata_url=client_id)
     return OAuthApplication.objects.get(client_id=client_id)
+
+
+# Defaults applied when a CIMD app is first used for provisioning. A self-serve
+# partner can hit /account_requests immediately without manual admin setup; the
+# app is opted into provisioning at the same trust level as other PKCE partners.
+CIMD_PROVISIONING_DEFAULTS = {
+    "provisioning_auth_method": "pkce",
+    "provisioning_active": True,
+    "provisioning_can_create_accounts": True,
+    "provisioning_can_provision_resources": True,
+}
+
+
+def get_or_create_cimd_provisioning_application(url: str) -> OAuthApplication:
+    """
+    Resolve a CIMD URL to an OAuthApplication configured as a provisioning partner.
+
+    Creates the CIMD app via the normal fetch+upsert path if it doesn't exist,
+    then backfills provisioning defaults if they haven't been set. Existing apps
+    that already have provisioning fields configured (e.g. via admin) are left alone.
+
+    Raises CIMDFetchError / CIMDValidationError on fetch failures.
+    """
+    app = get_or_create_cimd_application(url)
+    if not app.is_provisioning_partner:
+        for field, value in CIMD_PROVISIONING_DEFAULTS.items():
+            setattr(app, field, value)
+        app.save(update_fields=list(CIMD_PROVISIONING_DEFAULTS.keys()))
+    return app

--- a/posthog/api/oauth/cimd.py
+++ b/posthog/api/oauth/cimd.py
@@ -416,11 +416,43 @@ def fetch_and_upsert_cimd_application(url: str, capture_ph_event=posthoganalytic
 def refresh_cimd_metadata_task(url: str) -> None:
     """Celery task wrapper: refresh CIMD metadata in the background."""
     try:
-        with ph_scoped_capture() as capture_ph_event:  # This runs inside Celery, needs this to capture event
+        with ph_scoped_capture() as capture_ph_event:
             fetch_and_upsert_cimd_application(url, capture_ph_event=capture_ph_event)
     except (CIMDFetchError, CIMDValidationError) as e:
         logger.warning("cimd_background_refresh_failed", url=url, error=str(e))
         capture_exception(e)
+
+
+@shared_task(ignore_result=True, time_limit=30)
+def register_cimd_provisioning_application_task(url: str) -> None:
+    """Celery task: fetch CIMD metadata, create the app, and backfill provisioning defaults."""
+    try:
+        with ph_scoped_capture() as capture_ph_event:
+            app = fetch_and_upsert_cimd_application(url, capture_ph_event=capture_ph_event)
+            if app is None:
+                return
+            if not app.is_provisioning_partner:
+                for field, value in CIMD_PROVISIONING_DEFAULTS.items():
+                    setattr(app, field, value)
+                app.save(update_fields=list(CIMD_PROVISIONING_DEFAULTS.keys()))
+                capture_ph_event(
+                    distinct_id=url,
+                    event="cimd_provisioning_partner_registered",
+                    properties={
+                        "cimd_url": url,
+                        "client_name": app.name,
+                        "app_id": str(app.pk),
+                        "account_requests_rate_limit": CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT,
+                    },
+                )
+    except (CIMDFetchError, CIMDValidationError) as e:
+        logger.warning("cimd_background_registration_failed", url=url, error=str(e))
+        capture_exception(e)
+
+
+def is_cimd_registration_in_progress(url: str) -> bool:
+    """Check if a fetch/registration is currently in progress for this CIMD URL."""
+    return bool(cache.get(_fetch_lock_key(url)))
 
 
 def get_or_create_cimd_application(url: str) -> OAuthApplication:

--- a/posthog/api/oauth/cimd.py
+++ b/posthog/api/oauth/cimd.py
@@ -85,7 +85,7 @@ class CIMDGlobalThrottle(SimpleRateThrottle):
         return self.cache_format % {"scope": self.scope, "ident": "global"}
 
 
-CIMD_THROTTLES = [CIMDBurstThrottle(), CIMDSustainedThrottle(), CIMDGlobalThrottle()]
+CIMD_THROTTLE_CLASSES: list[type[SimpleRateThrottle]] = [CIMDBurstThrottle, CIMDSustainedThrottle, CIMDGlobalThrottle]
 
 
 class CIMDMetadataDocument(TypedDict, total=False):

--- a/posthog/api/oauth/test_cimd.py
+++ b/posthog/api/oauth/test_cimd.py
@@ -17,6 +17,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from rest_framework.test import APIClient
 
 from posthog.api.oauth.cimd import (
+    CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT,
     CIMDBurstThrottle,
     CIMDFetchError,
     CIMDValidationError,
@@ -458,6 +459,32 @@ class TestGetOrCreateCimdProvisioningApplication(APIBaseTest):
         self.assertTrue(app.provisioning_active)
         self.assertTrue(app.provisioning_can_create_accounts)
         self.assertTrue(app.provisioning_can_provision_resources)
+        self.assertEqual(
+            app.provisioning_rate_limit_account_requests,
+            CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT,
+        )
+
+    @patch("posthog.api.oauth.cimd.posthoganalytics.capture")
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_emits_registration_event_on_provisioning_upgrade(self, mock_get, mock_capture, _url_mock):
+        mock_get.return_value = _mock_response(_make_metadata(), headers={})
+
+        get_or_create_cimd_provisioning_application(VALID_CIMD_URL)
+
+        events = [call.kwargs.get("event") for call in mock_capture.call_args_list]
+        self.assertIn("cimd_provisioning_partner_registered", events)
+
+    @patch("posthog.api.oauth.cimd.posthoganalytics.capture")
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_no_event_when_provisioning_already_configured(self, mock_get, mock_capture, _url_mock):
+        mock_get.return_value = _mock_response(_make_metadata(), headers={})
+        get_or_create_cimd_provisioning_application(VALID_CIMD_URL)
+        mock_capture.reset_mock()
+
+        get_or_create_cimd_provisioning_application(VALID_CIMD_URL)
+
+        events = [call.kwargs.get("event") for call in mock_capture.call_args_list]
+        self.assertNotIn("cimd_provisioning_partner_registered", events)
 
     @patch("posthog.api.oauth.cimd.requests.get")
     def test_backfills_provisioning_defaults_on_existing_cimd_app(self, mock_get, _url_mock):

--- a/posthog/api/oauth/test_cimd.py
+++ b/posthog/api/oauth/test_cimd.py
@@ -18,7 +18,6 @@ from rest_framework.test import APIClient
 
 from posthog.api.oauth.cimd import (
     CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT,
-    CIMDBurstThrottle,
     CIMDFetchError,
     CIMDValidationError,
     _fetch_lock_key,
@@ -629,12 +628,14 @@ class TestCIMDAuthorizeIntegration(APIBaseTest):
         metadata = _make_metadata()
         mock_get.return_value = _mock_response(metadata)
 
-        throttle = CIMDBurstThrottle()
-        with patch("posthog.api.oauth.views.CIMD_THROTTLES", new=[throttle]):
-            with patch.object(throttle, "allow_request", return_value=False):
-                with patch.object(throttle, "wait", return_value=30):
-                    url = self._authorize_url("https://new-client.example.com/.well-known/oauth-client-metadata.json")
-                    response = self.client.get(url)
+        mock_throttle = MagicMock()
+        mock_throttle.allow_request.return_value = False
+        mock_throttle.wait.return_value = 30
+        mock_throttle.scope = "cimd_burst"
+        mock_throttle_cls = MagicMock(return_value=mock_throttle)
+        with patch("posthog.api.oauth.views.CIMD_THROTTLE_CLASSES", new=[mock_throttle_cls]):
+            url = self._authorize_url("https://new-client.example.com/.well-known/oauth-client-metadata.json")
+            response = self.client.get(url)
 
         self.assertEqual(response.status_code, 400)
         mock_get.assert_not_called()

--- a/posthog/api/oauth/test_cimd.py
+++ b/posthog/api/oauth/test_cimd.py
@@ -25,6 +25,7 @@ from posthog.api.oauth.cimd import (
     fetch_cimd_metadata,
     get_application_by_client_id,
     get_or_create_cimd_application,
+    get_or_create_cimd_provisioning_application,
     is_cimd_client_id,
     refresh_cimd_metadata_task,
     validate_cimd_url,
@@ -435,6 +436,67 @@ class TestGetApplicationByClientId(APIBaseTest):
     def test_cimd_url_not_found(self):
         with self.assertRaises(OAuthApplication.DoesNotExist):
             get_application_by_client_id("https://unknown.example.com/.well-known/oauth-client-metadata.json")
+
+
+@patch("posthog.api.oauth.cimd.is_url_allowed", return_value=(True, None))
+@override_settings(
+    OAUTH2_PROVIDER={
+        **settings.OAUTH2_PROVIDER,
+        "OIDC_RSA_PRIVATE_KEY": generate_rsa_key(),
+    }
+)
+class TestGetOrCreateCimdProvisioningApplication(APIBaseTest):
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_creates_new_app_with_provisioning_defaults(self, mock_get, _url_mock):
+        mock_get.return_value = _mock_response(_make_metadata(), headers={})
+
+        app = get_or_create_cimd_provisioning_application(VALID_CIMD_URL)
+
+        self.assertTrue(app.is_cimd_client)
+        self.assertEqual(app.cimd_metadata_url, VALID_CIMD_URL)
+        self.assertEqual(app.provisioning_auth_method, "pkce")
+        self.assertTrue(app.provisioning_active)
+        self.assertTrue(app.provisioning_can_create_accounts)
+        self.assertTrue(app.provisioning_can_provision_resources)
+
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_backfills_provisioning_defaults_on_existing_cimd_app(self, mock_get, _url_mock):
+        mock_get.return_value = _mock_response(_make_metadata(), headers={})
+        existing = fetch_and_upsert_cimd_application(VALID_CIMD_URL)
+        assert existing is not None
+        self.assertFalse(existing.is_provisioning_partner)
+
+        app = get_or_create_cimd_provisioning_application(VALID_CIMD_URL)
+
+        self.assertEqual(app.pk, existing.pk)
+        self.assertEqual(app.provisioning_auth_method, "pkce")
+        self.assertTrue(app.provisioning_active)
+        self.assertTrue(app.provisioning_can_create_accounts)
+        self.assertTrue(app.provisioning_can_provision_resources)
+
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_preserves_existing_provisioning_config(self, mock_get, _url_mock):
+        mock_get.return_value = _mock_response(_make_metadata(), headers={})
+        existing = fetch_and_upsert_cimd_application(VALID_CIMD_URL)
+        assert existing is not None
+        existing.provisioning_auth_method = "hmac"
+        existing.provisioning_active = False
+        existing.provisioning_can_create_accounts = False
+        existing.save(
+            update_fields=["provisioning_auth_method", "provisioning_active", "provisioning_can_create_accounts"]
+        )
+
+        app = get_or_create_cimd_provisioning_application(VALID_CIMD_URL)
+
+        self.assertEqual(app.provisioning_auth_method, "hmac")
+        self.assertFalse(app.provisioning_active)
+        self.assertFalse(app.provisioning_can_create_accounts)
+
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_fetch_failure_raises(self, mock_get, _url_mock):
+        mock_get.side_effect = requests.ConnectionError("DNS resolution failed")
+        with self.assertRaises(CIMDFetchError):
+            get_or_create_cimd_provisioning_application(VALID_CIMD_URL)
 
 
 @override_settings(

--- a/posthog/api/oauth/test_cimd.py
+++ b/posthog/api/oauth/test_cimd.py
@@ -451,6 +451,7 @@ class TestGetOrCreateCimdProvisioningApplication(APIBaseTest):
         mock_get.return_value = _mock_response(_make_metadata(), headers={})
 
         app = get_or_create_cimd_provisioning_application(VALID_CIMD_URL)
+        assert app is not None
 
         self.assertTrue(app.is_cimd_client)
         self.assertEqual(app.cimd_metadata_url, VALID_CIMD_URL)
@@ -493,6 +494,7 @@ class TestGetOrCreateCimdProvisioningApplication(APIBaseTest):
         self.assertFalse(existing.is_provisioning_partner)
 
         app = get_or_create_cimd_provisioning_application(VALID_CIMD_URL)
+        assert app is not None
 
         self.assertEqual(app.pk, existing.pk)
         self.assertEqual(app.provisioning_auth_method, "pkce")
@@ -513,6 +515,7 @@ class TestGetOrCreateCimdProvisioningApplication(APIBaseTest):
         )
 
         app = get_or_create_cimd_provisioning_application(VALID_CIMD_URL)
+        assert app is not None
 
         self.assertEqual(app.provisioning_auth_method, "hmac")
         self.assertFalse(app.provisioning_active)

--- a/posthog/api/oauth/test_cimd.py
+++ b/posthog/api/oauth/test_cimd.py
@@ -524,6 +524,26 @@ class TestGetOrCreateCimdProvisioningApplication(APIBaseTest):
         with self.assertRaises(CIMDFetchError):
             get_or_create_cimd_provisioning_application(VALID_CIMD_URL)
 
+    def test_blocked_url_returns_none(self, _url_mock):
+        from posthog.api.oauth.cimd import block_cimd_url, unblock_cimd_url
+
+        block_cimd_url(VALID_CIMD_URL)
+        result = get_or_create_cimd_provisioning_application(VALID_CIMD_URL)
+        self.assertIsNone(result)
+
+        unblock_cimd_url(VALID_CIMD_URL)
+
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_blocked_url_prevents_fetch(self, mock_get, _url_mock):
+        from posthog.api.oauth.cimd import block_cimd_url, unblock_cimd_url
+
+        block_cimd_url(VALID_CIMD_URL)
+        result = fetch_and_upsert_cimd_application(VALID_CIMD_URL)
+        self.assertIsNone(result)
+        mock_get.assert_not_called()
+
+        unblock_cimd_url(VALID_CIMD_URL)
+
 
 @override_settings(
     OAUTH2_PROVIDER={

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -36,7 +36,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from posthog.api.oauth.cimd import (
-    CIMD_THROTTLES,
+    CIMD_THROTTLE_CLASSES,
     CIMDFetchError,
     CIMDValidationError,
     get_application_by_client_id,
@@ -449,7 +449,8 @@ class OAuthAuthorizationView(OAuthLibMixin, APIView):
         # only receives an oauthlib Request which lacks request.META for IP extraction.
         client_id = request.query_params.get("client_id")
         if is_cimd_client_id(client_id) and not OAuthApplication.objects.filter(cimd_metadata_url=client_id).exists():
-            for throttle in CIMD_THROTTLES:
+            for throttle_cls in CIMD_THROTTLE_CLASSES:
+                throttle = throttle_cls()
                 if not throttle.allow_request(request, view=self):
                     logger.warning("cimd_rate_limited", client_id=client_id, scope=throttle.scope, wait=throttle.wait())
                     return Response(

--- a/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
+++ b/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
@@ -923,7 +923,15 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events
+     FROM
+       (SELECT events.`$session_id_uuid`,
+               events.distinct_id,
+               events.event,
+               events.person_id,
+               events.`mat_$browser`,
+               events.timestamp
+        FROM events
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-13'), lessOrEquals(toDate(events.timestamp), '2024-01-17'))) AS events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Asia/Tokyo')), max(toTimeZone(raw_sessions.max_timestamp, 'Asia/Tokyo'))), 10)))) AS `$is_bounce`,
@@ -940,7 +948,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Tokyo'))), lessOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Tokyo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
+     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Tokyo'))), lessOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Tokyo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`

--- a/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
+++ b/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
@@ -923,15 +923,7 @@
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.person_id,
-               events.`mat_$browser`,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2024-01-13'), lessOrEquals(toDate(events.timestamp), '2024-01-17'))) AS events
+     FROM events
      LEFT JOIN
        (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Asia/Tokyo')), max(toTimeZone(raw_sessions.max_timestamp, 'Asia/Tokyo'))), 10)))) AS `$is_bounce`,
@@ -948,7 +940,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Tokyo'))), lessOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Tokyo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Tokyo'))), lessOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Tokyo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
      GROUP BY session_id,
               breakdown_value)
   GROUP BY `context.columns.breakdown_value`

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -2,6 +2,7 @@
 # name: TestAllTasksRegistered.test_all_posthog_tasks_registered_snapshot
   list([
     'posthog.api.oauth.cimd.refresh_cimd_metadata_task',
+    'posthog.api.oauth.cimd.register_cimd_provisioning_application_task',
     'posthog.approvals.tasks.expire_old_change_requests',
     'posthog.approvals.tasks.validate_pending_change_requests',
     'posthog.caching.warming.schedule_warming_for_teams_task',


### PR DESCRIPTION
## Problem

**A CIMD URL cannot currently be used to provision PostHog accounts.** A partner hosting a CIMD metadata document can complete the OAuth `/authorize` flow, but `POST /account_requests` rejects their CIMD URL — the provisioning auth path only looks up existing `OAuthApplication`s and won't auto-create from a metadata URL, and even if the app already exists (e.g. from a prior OAuth sign-in) it has no provisioning fields set.

Result today: every new self-serve partner (Replit, Lovable, Rork, v0, ...) is blocked on a manual Django admin setup to get `provisioning_*` fields configured before they can onboard their first user.

Closes #55286. Implements Slice 2 of the [self-serve agentic provisioning RFC](https://github.com/PostHog/requests-for-comments-internal/pull/1077).

## Changes

**Headline:** A partner who publishes a valid CIMD metadata document can now `POST /api/agentic/provisioning/account_requests` with `client_id=<their-metadata-url>` and:
- The `OAuthApplication` is auto-created from the metadata doc (same fetch/validation path used by OAuth `/authorize`).
- Provisioning fields are filled in with a tight default profile: `auth_method="pkce"`, `active=True`, `can_create_accounts=True`, `can_provision_resources=True`, `rate_limit_account_requests=10/hr`.
- The partner can immediately onboard users via the usual `/account_requests` → `/oauth/token` → `/resources` flow.
- Existing apps with admin-configured provisioning fields are **never** overwritten.

### Implementation

- **`posthog/api/oauth/cimd.py`** — new `get_or_create_cimd_provisioning_application(url)` that wraps the existing fetch/upsert flow and backfills `CIMD_PROVISIONING_DEFAULTS` only when the app has no provisioning config. Emits `cimd_provisioning_partner_registered` analytics event on upgrade so we can watch the first month for abuse patterns.
- **`ee/api/agentic_provisioning/authentication.py`** — `_identify_pkce_partner` routes CIMD URLs through the new helper. Fetch/validation errors are swallowed and the request is treated as unauthenticated (401).
- **`ee/api/agentic_provisioning/views.py`**
  - Applies the same `CIMD_THROTTLES` as `/authorize` to first-time CIMD registration on `/account_requests` (per-IP + global caps on new client creation).
  - Wires up the previously-unused `provisioning_rate_limit_account_requests` field via a fixed-window cache counter, enforced per-partner after identification.
  - `_partner_label` falls back to `partner.name` when `provisioning_partner_type` is blank, so self-serve orgs get a sensible name like `Partner App (email)` instead of `Stripe (email)`.

### Trust model (for reviewer input)

Per the [RFC](https://github.com/PostHog/requests-for-comments-internal/pull/1077): CIMD partners provision by default, with abuse bounded by tight rate limits rather than manual approval. The capability granted is effectively **bulk invite users via API** — created users still receive a password-reset email from PostHog and have to click through to log in; the partner never gets the user's identity. Two layers of rate limits: `/authorize`-style throttles on first-time registration (5/min burst, 10/hr sustained per-IP, 100/hr global) plus the per-partner 10/hr account-creation default. Admin can tighten or lift per-partner once abuse signals exist.

CIMD draft-01 and RFC 7591 defer trust policy to the authorization server, so this is a product call rather than a spec conformance question. Flagging for any team-growth reviewer who wants to push back on the default being "on".

## How did you test this code?

**Automated:**
- `pytest ee/api/agentic_provisioning/test/test_provisioning_auth.py posthog/api/oauth/test_cimd.py` - 82 passed
- `ruff check` + `ruff format --check` - clean

**End-to-end against a live CIMD document** (sandbox on this branch, CIMD doc hosted as a public [GitHub gist](https://gist.github.com/MattBro/473fd167bf07975d2526cdb719ffdba8)):

```text
Step 1: POST /account_requests with client_id=<gist CIMD URL>
  → 200  {"type": "oauth", "oauth": {"code": "9FGWGizFTF1dwfV9pNlutM82l0yZPKdIzQ7FkjaHDZU"}}

Step 2: POST /oauth/token (PKCE code exchange)
  → 200  token_type=bearer, access_token=pha_u9CzhKD..., refresh_token issued
  → account: {id: "019dab7d-e9cc-0000-be52-9eb0a30b4689",
     org_name: "Test CIMD Provisioning Partner (e2e-2a9b7df5@test.posthog.com)"}

Step 3: POST /provisioning/resources with bearer token
  → 200  {"status": "complete", "id": "7", "service_id": "analytics",
           "complete": {"access_configuration": {
             "api_key": "phc_zrQ7uURKRvqBBFW8yibb7KtdDd7x2Memd4JCDwSZNStm",
             "host": "https://us.posthog.com",
             "personal_api_key": "phx_KUyBqYaagugPXRbC2LGLNW2kTDVD5xkcwyq4qoomPkq43XoT"}}}
```

OAuthApplication state after the flow - confirmed auto-creation with tight defaults:

```text
name:                                      Test CIMD Provisioning Partner
client_id:                                 UbjZ1EyXRr76lZ4M6WF3GP47RBRPB8RfKALJX818
cimd_metadata_url:                         https://gist.githubusercontent.com/MattBro/...
is_cimd_client:                            True
provisioning_auth_method:                  pkce
provisioning_can_create_accounts:          True
provisioning_can_provision_resources:      True
provisioning_rate_limit_account_requests:  10
```

No manual admin setup was performed between sandbox boot and the partner's first successful resource provision.

## Publish to changelog?

No - internal API surface for partner provisioning.

## LLM context

Authored by Claude (Opus 4.6) in a Claude Code session. Slice 2 of the self-serve provisioning RFC; Slice 1 (#53452) shipped the generic provisioning auth layer. Scoped to the three gaps in #55286 plus two hardening items (per-partner rate limit, registration analytics event) added after an online OAuth-spec review raised concerns about auto-granting account-creation capability. End-to-end validated in a sandbox on this branch against a publicly-hosted CIMD metadata document.