### PR TITLE
refactor(auth): Consolidate GitHub App OAuth settings

### DIFF
--- a/ee/models/session_summaries.py
+++ b/ee/models/session_summaries.py
@@ -11,9 +11,8 @@ from posthog.models.team import Team
 from posthog.models.user import User
 from posthog.models.utils import CreatedMetaFields, UUIDModel
 
-from ee.hogai.session_summaries.session.output_data import SessionSummarySerializer
-
 if TYPE_CHECKING:
+    from ee.hogai.session_summaries.session.output_data import SessionSummarySerializer
     from ee.hogai.videos.session_moments import SessionMomentOutput
 
 
@@ -100,7 +99,7 @@ class SingleSessionSummaryManager(models.Manager["SingleSessionSummary"]):
         self,
         team_id: int,
         session_id: str,
-        summary: SessionSummarySerializer,
+        summary: "SessionSummarySerializer",
         exception_event_ids: list[str],
         *,
         extra_summary_context: ExtraSummaryContext | None = None,

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2004,6 +2004,18 @@ class GitHubCommitAuthor:
 GITHUB_DEFAULT_BRANCH_CACHE_TTL_SECONDS = 60 * 60 * 6
 
 
+@dataclass(frozen=True)
+class GitHubUserAuthorization:
+    """Outcome of a successful GitHub App user authorization code exchange."""
+
+    gh_id: int
+    gh_login: str
+    access_token: str
+    refresh_token: str | None
+    access_token_expires_in: int | None
+    refresh_token_expires_in: int | None
+
+
 class GitHubIntegration:
     integration: Integration
 
@@ -2085,9 +2097,16 @@ class GitHubIntegration:
 
     @classmethod
     def github_login_from_code(cls, code: str) -> str | None:
-        """Exchange an OAuth authorization code from the GitHub App user authorization flow for the user's login.
+        result = cls.github_user_from_code(code)
+        return result.gh_login if result else None
 
-        Returns the GitHub username or None if the exchange fails.
+    @classmethod
+    def github_user_from_code(cls, code: str) -> "GitHubUserAuthorization | None":
+        """Exchange an OAuth code from the GitHub App user authorization flow.
+
+        Returns a :class:`GitHubUserAuthorization` with the user's id/login plus the
+        user-to-server access/refresh tokens and their expirations, or ``None`` if
+        the exchange fails or the response lacks an id/login.
         """
         client_id = settings.GITHUB_APP_CLIENT_ID
         client_secret = settings.GITHUB_APP_CLIENT_SECRET
@@ -2110,7 +2129,11 @@ class GitHubIntegration:
             access_token = token_data.get("access_token")
             if not access_token:
                 logger.warning(
-                    "GitHubIntegration: code exchange returned no access_token", error=token_data.get("error")
+                    "GitHubIntegration: code exchange returned no access_token",
+                    status_code=token_response.status_code,
+                    error=token_data.get("error"),
+                    error_description=token_data.get("error_description"),
+                    error_uri=token_data.get("error_uri"),
                 )
                 return None
 
@@ -2127,9 +2150,23 @@ class GitHubIntegration:
                 logger.warning("GitHubIntegration: /user request failed", status_code=user_response.status_code)
                 return None
 
-            return user_response.json().get("login")
+            payload = user_response.json()
+            gh_id = payload.get("id")
+            gh_login = payload.get("login")
+            if gh_id is None or not gh_login:
+                return None
+            access_expires_in = token_data.get("expires_in")
+            refresh_expires_in = token_data.get("refresh_token_expires_in")
+            return GitHubUserAuthorization(
+                gh_id=int(gh_id),
+                gh_login=str(gh_login),
+                access_token=str(access_token),
+                refresh_token=token_data.get("refresh_token") or None,
+                access_token_expires_in=int(access_expires_in) if access_expires_in is not None else None,
+                refresh_token_expires_in=int(refresh_expires_in) if refresh_expires_in is not None else None,
+            )
         except Exception:
-            logger.warning("GitHubIntegration: failed to exchange code for github login", exc_info=True)
+            logger.warning("GitHubIntegration: failed to exchange code for github user", exc_info=True)
             return None
 
     @classmethod

--- a/posthog/settings/integrations.py
+++ b/posthog/settings/integrations.py
@@ -35,7 +35,10 @@ LINEAR_APP_CLIENT_SECRET = get_from_env("LINEAR_APP_CLIENT_SECRET", "")
 
 GITHUB_APP_CLIENT_ID = get_from_env("GITHUB_APP_CLIENT_ID", "")
 GITHUB_APP_PRIVATE_KEY = get_from_env("GITHUB_APP_PRIVATE_KEY", "")
-# The GH client secret is only available with "Request user authorization during installation" enabled, it's for OAuth
+# OAuth *secret* for the same GitHub App as above - generated in the App's settings
+# when "Request user authorization during installation" is enabled.
+# Used with GITHUB_APP_CLIENT_ID to exchange an authorization code for a user access token,
+# which is separate from the private key used for App-as-App JWT signing.
 GITHUB_APP_CLIENT_SECRET = get_from_env("GITHUB_APP_CLIENT_SECRET", "")
 
 ZENDESK_ADMIN_EMAIL = get_from_env("ZENDESK_ADMIN_EMAIL", "")


### PR DESCRIPTION
## Problem

SSO-enforced users (e.g. Google SSO) can't link a GitHub account, as the GitHub OAuth flow runs fully through the `social-auth` pipeline. So features that need a GitHub identity mapping – report attribution in PostHog Code, or error tracking assignments – just don't work for SSO-enforced users. For non SSO-enforced users they do work, but require GitHub to be allowed for login, which is a little off.

Separately, user-authored PostHog Code runs required every caller to ship a short-lived `github_user_token` in the request body. That forced clients (the UI) to manage GitHub tokens themselves, broke on long-running or resumed runs, and meant user-authored runs couldn't be kicked off from anywhere but the desktop app.

There was also no UI for users to see or manage their OAuth connections.

This is the first PR in a 4-part stack addressing all of the above. It lays the groundwork by consolidating settings and enriching the code exchange return type.

## Changes

- Rename `GITHUB_APP_OAUTH_CLIENT_ID` → reuse `GITHUB_APP_CLIENT_ID` and `GITHUB_APP_OAUTH_CLIENT_SECRET` → `GITHUB_APP_CLIENT_SECRET`, since they're credentials for the same GitHub App.
- Refactor `github_login_from_code` → `github_user_from_code` returning a `GitHubUserAuthorization` dataclass (id, login, access_token, refresh_token, expirations) instead of just the login string. The old method stays as a thin wrapper.
- Fix a circular import in `session_summaries.py` (move import behind `TYPE_CHECKING`).

**Stack:** 1/4 — followed by #55303 → #55304 → #55305

## How did you test this code?

Refactoring only — existing behavior preserved. `github_login_from_code` delegates to the new method, so callers are unaffected.

`GitHubIntegration.github_user_from_code` is covered in #55304: full-bundle return shape, bad code → `None`, OAuth not configured → `None`.

## Publish to changelog?

No — covered by #55304's changelog entry.

## Docs update

No docs changes needed.

## 🤖 LLM context

Split from #55190 into a reviewable Graphite stack with Claude Code.