### PR TITLE
feat(tasks): Resolve GitHub tokens from UserIntegration

### DIFF
--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -119,6 +119,7 @@ from .temporal.process_task.utils import (
     cache_github_user_token,
     get_provider_for_runtime_adapter,
     get_reasoning_effort_error,
+    get_user_github_integration,
     parse_run_state,
 )
 
@@ -613,9 +614,29 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 status=400,
             )
 
-        # Only require a user token when the task has a repo (no-repo cloud runs skip GitHub operations)
+        # User-authored cloud runs need *some* GitHub credential: either the caller
+        # ships its own token in ``github_user_token`` (backward-compat for PostHog Code),
+        # or the task creator has linked GitHub from Settings so the server has stored
+        # user-to-server tokens. No-repo runs skip this gate since they never touch GitHub.
         if pr_authorship_mode == PrAuthorshipMode.USER and task.repository and not github_user_token:
-            return Response({"detail": "github_user_token is required for user-authored cloud runs"}, status=400)
+            user_github_integration = get_user_github_integration(task.created_by)
+            if (
+                user_github_integration is None
+                or user_github_integration.refresh_token_expired()
+                or not user_github_integration.refresh_token
+            ):
+                return Response(
+                    {
+                        "type": "validation_error",
+                        "code": "github_authorization_required",
+                        "detail": (
+                            "Provide github_user_token, or have the task creator link a GitHub account "
+                            "with repo access from Settings → Linked accounts before running user-authored tasks."
+                        ),
+                        "attr": "pr_authorship_mode",
+                    },
+                    status=400,
+                )
 
         if sandbox_environment_id is not None:
             sandbox_environment = SandboxEnvironment.get_accessible_for_task(

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -619,9 +619,20 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         # or the task creator has linked GitHub from Settings so the server has stored
         # user-to-server tokens. No-repo runs skip this gate since they never touch GitHub.
         if pr_authorship_mode == PrAuthorshipMode.USER and task.repository and not github_user_token:
+            if task.created_by_id != getattr(request.user, "id", None):
+                return Response(
+                    {
+                        "type": "validation_error",
+                        "code": "github_authorization_required",
+                        "detail": "User-authored runs must be started by the task creator, or provide github_user_token.",
+                        "attr": "pr_authorship_mode",
+                    },
+                    status=400,
+                )
             user_github_integration = get_user_github_integration(task.created_by)
             if (
                 user_github_integration is None
+                or not user_github_integration.user_access_token
                 or user_github_integration.user_refresh_token_expired()
                 or not user_github_integration.user_refresh_token
             ):

--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -622,8 +622,8 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             user_github_integration = get_user_github_integration(task.created_by)
             if (
                 user_github_integration is None
-                or user_github_integration.refresh_token_expired()
-                or not user_github_integration.refresh_token
+                or user_github_integration.user_refresh_token_expired()
+                or not user_github_integration.user_refresh_token
             ):
                 return Response(
                     {

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -918,7 +918,11 @@ class TaskRunCreateRequestSerializer(serializers.Serializer):
         default=None,
         allow_blank=False,
         write_only=True,
-        help_text="Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests.",
+        help_text=(
+            "Optional GitHub user token from PostHog Code for user-authored cloud pull requests. "
+            "Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; "
+            "this field remains supported for callers that still manage their own tokens."
+        ),
     )
     initial_permission_mode = serializers.ChoiceField(
         choices=ALL_INITIAL_PERMISSION_MODE_CHOICES,
@@ -1232,7 +1236,11 @@ class TaskRunResumeRequestSchemaSerializer(serializers.Serializer):
         default=None,
         allow_blank=False,
         write_only=True,
-        help_text="Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests.",
+        help_text=(
+            "Optional GitHub user token from PostHog Code for user-authored cloud pull requests. "
+            "Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; "
+            "this field remains supported for callers that still manage their own tokens."
+        ),
     )
 
 

--- a/products/tasks/backend/temporal/process_task/activities/create_sandbox_from_snapshot.py
+++ b/products/tasks/backend/temporal/process_task/activities/create_sandbox_from_snapshot.py
@@ -76,6 +76,7 @@ def create_sandbox_from_snapshot(input: CreateSandboxFromSnapshotInput) -> Creat
                         ctx.github_integration_id,
                         run_id=ctx.run_id,
                         state=ctx.state,
+                        created_by=task.created_by,
                     )
                     or ""
                 )

--- a/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
@@ -144,6 +144,7 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
                         github_integration_id,
                         run_id=ctx.run_id,
                         state=ctx.state,
+                        created_by=task.created_by,
                     )
                     or ""
                 )

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -235,6 +235,7 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
                         ctx.github_integration_id,
                         run_id=ctx.run_id,
                         state=ctx.state,
+                        created_by=task.created_by,
                     )
                     or ""
                 )

--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -331,23 +331,58 @@ class TestGetGitIdentityEnvVars(TestCase):
 
 
 class TestGetSandboxGitHubToken(TestCase):
-    @patch("products.tasks.backend.temporal.process_task.utils.get_github_token")
     @patch("products.tasks.backend.temporal.process_task.utils.get_cached_github_user_token")
-    def test_user_authorship_uses_cached_user_token(self, mock_cached_token, mock_get_github_token) -> None:
-        mock_cached_token.return_value = "ghu_user"
+    @patch("products.tasks.backend.temporal.process_task.utils.get_user_github_integration")
+    @patch("products.tasks.backend.temporal.process_task.utils.get_github_token")
+    def test_user_authorship_prefers_cached_token_over_identity(
+        self, mock_get_github_token, mock_get_identity, mock_cached
+    ) -> None:
+        """Back-compat: a caller-supplied token (cached per-run) wins over the stored identity."""
+        mock_cached.return_value = "ghu_cached"
+        identity = MagicMock()
+        mock_get_identity.return_value = identity
 
-        result = get_sandbox_github_token(123, run_id="run-1", state={"pr_authorship_mode": "user"})
+        result = get_sandbox_github_token(
+            123, run_id="run-1", state={"pr_authorship_mode": "user"}, created_by=MagicMock()
+        )
 
-        assert result == "ghu_user"
-        mock_cached_token.assert_called_once_with("run-1")
+        assert result == "ghu_cached"
+        mock_cached.assert_called_once_with("run-1")
+        mock_get_identity.assert_not_called()
+        identity.get_usable_access_token.assert_not_called()
         mock_get_github_token.assert_not_called()
 
     @patch("products.tasks.backend.temporal.process_task.utils.get_cached_github_user_token")
-    def test_user_authorship_requires_cached_user_token(self, mock_cached_token) -> None:
-        mock_cached_token.return_value = None
+    @patch("products.tasks.backend.temporal.process_task.utils.get_user_github_integration")
+    @patch("products.tasks.backend.temporal.process_task.utils.get_github_token")
+    def test_user_authorship_falls_back_to_user_identity(
+        self, mock_get_github_token, mock_get_identity, mock_cached
+    ) -> None:
+        mock_cached.return_value = None
+        creator = MagicMock(name="creator")
+        identity = MagicMock()
+        identity.get_usable_access_token.return_value = "ghu_user"
+        mock_get_identity.return_value = identity
 
-        with self.assertRaises(ValueError):
-            get_sandbox_github_token(123, run_id="run-1", state={"pr_authorship_mode": "user"})
+        result = get_sandbox_github_token(123, run_id="run-1", state={"pr_authorship_mode": "user"}, created_by=creator)
+
+        assert result == "ghu_user"
+        mock_get_identity.assert_called_once_with(creator)
+        identity.get_usable_access_token.assert_called_once()
+        mock_get_github_token.assert_not_called()
+
+    @patch("products.tasks.backend.temporal.process_task.utils.get_cached_github_user_token")
+    @patch("products.tasks.backend.temporal.process_task.utils.get_user_github_integration")
+    def test_user_authorship_raises_when_neither_cached_token_nor_identity(
+        self, mock_get_identity, mock_cached
+    ) -> None:
+        from posthog.models.user_social_identity import ReauthorizationRequired
+
+        mock_cached.return_value = None
+        mock_get_identity.return_value = None
+
+        with self.assertRaises(ReauthorizationRequired):
+            get_sandbox_github_token(123, run_id="run-1", state={"pr_authorship_mode": "user"}, created_by=MagicMock())
 
     @patch("products.tasks.backend.temporal.process_task.utils.get_github_token")
     def test_bot_authorship_uses_installation_token(self, mock_get_github_token) -> None:

--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -349,7 +349,7 @@ class TestGetSandboxGitHubToken(TestCase):
         assert result == "ghu_cached"
         mock_cached.assert_called_once_with("run-1")
         mock_get_identity.assert_not_called()
-        identity.get_usable_access_token.assert_not_called()
+        identity.get_usable_user_access_token.assert_not_called()
         mock_get_github_token.assert_not_called()
 
     @patch("products.tasks.backend.temporal.process_task.utils.get_cached_github_user_token")
@@ -361,14 +361,14 @@ class TestGetSandboxGitHubToken(TestCase):
         mock_cached.return_value = None
         creator = MagicMock(name="creator")
         identity = MagicMock()
-        identity.get_usable_access_token.return_value = "ghu_user"
+        identity.get_usable_user_access_token.return_value = "ghu_user"
         mock_get_identity.return_value = identity
 
         result = get_sandbox_github_token(123, run_id="run-1", state={"pr_authorship_mode": "user"}, created_by=creator)
 
         assert result == "ghu_user"
         mock_get_identity.assert_called_once_with(creator)
-        identity.get_usable_access_token.assert_called_once()
+        identity.get_usable_user_access_token.assert_called_once()
         mock_get_github_token.assert_not_called()
 
     @patch("products.tasks.backend.temporal.process_task.utils.get_cached_github_user_token")
@@ -376,7 +376,7 @@ class TestGetSandboxGitHubToken(TestCase):
     def test_user_authorship_raises_when_neither_cached_token_nor_identity(
         self, mock_get_identity, mock_cached
     ) -> None:
-        from posthog.models.user_social_identity import ReauthorizationRequired
+        from posthog.models.user_integration import ReauthorizationRequired
 
         mock_cached.return_value = None
         mock_get_identity.return_value = None

--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -331,58 +331,66 @@ class TestGetGitIdentityEnvVars(TestCase):
 
 
 class TestGetSandboxGitHubToken(TestCase):
+    @parameterized.expand(
+        [
+            ("cached_token_wins", "ghu_cached", True, "ghu_user", None, "ghu_cached"),
+            ("identity_token", None, True, "ghu_user", None, "ghu_user"),
+            ("missing_identity", None, False, None, "missing", None),
+            ("identity_requires_reauthorization", None, True, None, "reauthorization", None),
+        ]
+    )
     @patch("products.tasks.backend.temporal.process_task.utils.get_cached_github_user_token")
     @patch("products.tasks.backend.temporal.process_task.utils.get_user_github_integration")
     @patch("products.tasks.backend.temporal.process_task.utils.get_github_token")
-    def test_user_authorship_prefers_cached_token_over_identity(
-        self, mock_get_github_token, mock_get_identity, mock_cached
-    ) -> None:
-        """Back-compat: a caller-supplied token (cached per-run) wins over the stored identity."""
-        mock_cached.return_value = "ghu_cached"
-        identity = MagicMock()
-        mock_get_identity.return_value = identity
-
-        result = get_sandbox_github_token(
-            123, run_id="run-1", state={"pr_authorship_mode": "user"}, created_by=MagicMock()
-        )
-
-        assert result == "ghu_cached"
-        mock_cached.assert_called_once_with("run-1")
-        mock_get_identity.assert_not_called()
-        identity.get_usable_user_access_token.assert_not_called()
-        mock_get_github_token.assert_not_called()
-
-    @patch("products.tasks.backend.temporal.process_task.utils.get_cached_github_user_token")
-    @patch("products.tasks.backend.temporal.process_task.utils.get_user_github_integration")
-    @patch("products.tasks.backend.temporal.process_task.utils.get_github_token")
-    def test_user_authorship_falls_back_to_user_identity(
-        self, mock_get_github_token, mock_get_identity, mock_cached
-    ) -> None:
-        mock_cached.return_value = None
-        creator = MagicMock(name="creator")
-        identity = MagicMock()
-        identity.get_usable_user_access_token.return_value = "ghu_user"
-        mock_get_identity.return_value = identity
-
-        result = get_sandbox_github_token(123, run_id="run-1", state={"pr_authorship_mode": "user"}, created_by=creator)
-
-        assert result == "ghu_user"
-        mock_get_identity.assert_called_once_with(creator)
-        identity.get_usable_user_access_token.assert_called_once()
-        mock_get_github_token.assert_not_called()
-
-    @patch("products.tasks.backend.temporal.process_task.utils.get_cached_github_user_token")
-    @patch("products.tasks.backend.temporal.process_task.utils.get_user_github_integration")
-    def test_user_authorship_raises_when_neither_cached_token_nor_identity(
-        self, mock_get_identity, mock_cached
+    def test_user_authorship_token_resolution(
+        self,
+        _case_name: str,
+        cached_token: str | None,
+        has_identity: bool,
+        identity_token: str | None,
+        error_case: str | None,
+        expected_token: str | None,
+        mock_get_github_token: MagicMock,
+        mock_get_identity: MagicMock,
+        mock_cached: MagicMock,
     ) -> None:
         from posthog.models.user_integration import ReauthorizationRequired
 
-        mock_cached.return_value = None
-        mock_get_identity.return_value = None
+        mock_cached.return_value = cached_token
+        creator = MagicMock(name="creator")
+        identity = MagicMock()
+        if error_case == "reauthorization":
+            identity.get_usable_user_access_token.side_effect = ReauthorizationRequired("reauthorize GitHub")
+        else:
+            identity.get_usable_user_access_token.return_value = identity_token
+        mock_get_identity.return_value = identity if has_identity else None
 
-        with self.assertRaises(ReauthorizationRequired):
-            get_sandbox_github_token(123, run_id="run-1", state={"pr_authorship_mode": "user"}, created_by=MagicMock())
+        if error_case:
+            with self.assertRaises(ReauthorizationRequired):
+                get_sandbox_github_token(
+                    123,
+                    run_id="run-1",
+                    state={"pr_authorship_mode": "user"},
+                    created_by=creator,
+                )
+        else:
+            result = get_sandbox_github_token(
+                123,
+                run_id="run-1",
+                state={"pr_authorship_mode": "user"},
+                created_by=creator,
+            )
+            assert result == expected_token
+
+        mock_cached.assert_called_once_with("run-1")
+        if cached_token:
+            mock_get_identity.assert_not_called()
+            identity.get_usable_user_access_token.assert_not_called()
+        else:
+            mock_get_identity.assert_called_once_with(creator)
+            if has_identity:
+                identity.get_usable_user_access_token.assert_called_once()
+        mock_get_github_token.assert_not_called()
 
     @patch("products.tasks.backend.temporal.process_task.utils.get_github_token")
     def test_bot_authorship_uses_installation_token(self, mock_get_github_token) -> None:

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -12,11 +12,19 @@ from pydantic import BaseModel
 
 from posthog.models.integration import GitHubIntegration, Integration
 from posthog.temporal.oauth import TOKEN_EXPIRATION_SECONDS, PosthogMcpScopes, has_write_scopes
+from posthog.models.user_social_identity import (
+    GITHUB_PROVIDER,
+    ReauthorizationRequired,
+    UserGitHubIntegration,
+    UserSocialIdentity,
+)
 
 from products.mcp_store.backend.facade.api import get_active_installations
 from products.tasks.backend.constants import InitialPermissionMode
 
 if TYPE_CHECKING:
+    from posthog.models.user import User
+
     from products.tasks.backend.models import Task
 
 
@@ -329,6 +337,22 @@ def get_github_token(github_integration_id: int) -> Optional[str]:
     return github_integration.integration.access_token or None
 
 
+def get_user_github_integration(user: User | None) -> UserGitHubIntegration | None:
+    """Return the requesting user's GitHub integration wrapper, if linked."""
+    if user is None:
+        return None
+    identity = UserSocialIdentity.objects.filter(user=user, provider=GITHUB_PROVIDER).first()
+    if identity is None:
+        return None
+    return UserGitHubIntegration(identity)
+
+
+# TTL for the per-run GitHub user token cache. Kept for backward-compat with callers
+# (notably the PostHog Code CLI) that still pass ``github_user_token`` on the run request.
+# The server-side identity flow should be preferred going forward.
+GITHUB_USER_TOKEN_CACHE_TTL_SECONDS = 6 * 60 * 60
+
+
 def _github_user_token_cache_key(run_id: str) -> str:
     return f"task-run-github-user-token:{run_id}"
 
@@ -343,17 +367,33 @@ def get_cached_github_user_token(run_id: str) -> str | None:
 
 
 def get_sandbox_github_token(
-    github_integration_id: int | None, *, run_id: str, state: dict[str, Any] | None = None
+    github_integration_id: int | None,
+    *,
+    run_id: str,
+    state: dict[str, Any] | None = None,
+    created_by: User | None = None,
 ) -> str | None:
+    """Resolve the GitHub token used inside a task sandbox.
+
+    Resolution order for ``USER`` authorship:
+
+    1. Caller-supplied token cached at run-create time (backward compat for the
+       PostHog Code CLI — wins when present so self-managed tokens still work).
+    2. Server-side ``UserSocialIdentity`` for the task creator, refreshing on demand.
+
+    ``BOT`` authorship falls through to the team's ``Integration`` installation token.
+    """
     run_state = parse_run_state(state)
     if run_state.pr_authorship_mode == PrAuthorshipMode.USER:
-        github_user_token = get_cached_github_user_token(run_id)
-        if not github_user_token:
-            raise ValueError(
-                f"Missing GitHub user token for user-authored run {run_id} "
-                f"(token may have expired after {GITHUB_USER_TOKEN_CACHE_TTL_SECONDS // 3600}h TTL)"
+        cached = get_cached_github_user_token(run_id)
+        if cached:
+            return cached
+        user_github_integration = get_user_github_integration(created_by)
+        if user_github_integration is None:
+            raise ReauthorizationRequired(
+                f"User-authored run {run_id} requires a linked GitHub account with repo access."
             )
-        return github_user_token
+        return user_github_integration.get_usable_access_token()
 
     if github_integration_id is None:
         return None

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -11,13 +11,8 @@ from django.core.cache import cache
 from pydantic import BaseModel
 
 from posthog.models.integration import GitHubIntegration, Integration
+from posthog.models.user_integration import ReauthorizationRequired, UserGitHubIntegration, UserIntegration
 from posthog.temporal.oauth import TOKEN_EXPIRATION_SECONDS, PosthogMcpScopes, has_write_scopes
-from posthog.models.user_social_identity import (
-    GITHUB_PROVIDER,
-    ReauthorizationRequired,
-    UserGitHubIntegration,
-    UserSocialIdentity,
-)
 
 from products.mcp_store.backend.facade.api import get_active_installations
 from products.tasks.backend.constants import InitialPermissionMode
@@ -341,10 +336,10 @@ def get_user_github_integration(user: User | None) -> UserGitHubIntegration | No
     """Return the requesting user's GitHub integration wrapper, if linked."""
     if user is None:
         return None
-    identity = UserSocialIdentity.objects.filter(user=user, provider=GITHUB_PROVIDER).first()
-    if identity is None:
+    integration = UserIntegration.objects.filter(user=user, kind="github").first()
+    if integration is None:
         return None
-    return UserGitHubIntegration(identity)
+    return UserGitHubIntegration(integration)
 
 
 # TTL for the per-run GitHub user token cache. Kept for backward-compat with callers
@@ -379,7 +374,7 @@ def get_sandbox_github_token(
 
     1. Caller-supplied token cached at run-create time (backward compat for the
        PostHog Code CLI — wins when present so self-managed tokens still work).
-    2. Server-side ``UserSocialIdentity`` for the task creator, refreshing on demand.
+    2. Server-side ``UserIntegration`` for the task creator, refreshing on demand.
 
     ``BOT`` authorship falls through to the team's ``Integration`` installation token.
     """
@@ -393,7 +388,7 @@ def get_sandbox_github_token(
             raise ReauthorizationRequired(
                 f"User-authored run {run_id} requires a linked GitHub account with repo access."
             )
-        return user_github_integration.get_usable_access_token()
+        return user_github_integration.get_usable_user_access_token()
 
     if github_integration_id is None:
         return None

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1070,6 +1070,59 @@ class TestTaskAPI(BaseTaskAPITest):
         assert response.json()["code"] == "github_authorization_required"
         mock_workflow.assert_not_called()
 
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_rejects_user_authorship_when_requester_is_not_creator(self, mock_workflow: MagicMock) -> None:
+        task = self.create_task(created_by=self.user)
+        task.repository = "posthog/posthog"
+        task.save(update_fields=["repository"])
+        _grant_user_github_access(self.user)
+        requester = self.create_organization_user()
+        self.client.force_authenticate(requester)
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {
+                "mode": "interactive",
+                "pr_authorship_mode": "user",
+                "run_source": "manual",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            "type": "validation_error",
+            "code": "github_authorization_required",
+            "detail": "User-authored runs must be started by the task creator, or provide github_user_token.",
+            "attr": "pr_authorship_mode",
+        }
+        mock_workflow.assert_not_called()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_rejects_user_authorship_when_access_token_missing(self, mock_workflow: MagicMock) -> None:
+        task = self.create_task(created_by=self.user)
+        task.repository = "posthog/posthog"
+        task.save(update_fields=["repository"])
+        integration = _grant_user_github_access(self.user)
+        sensitive_config = dict(integration.sensitive_config)
+        sensitive_config.pop("user_access_token")
+        integration.sensitive_config = sensitive_config
+        integration.save(update_fields=["sensitive_config"])
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {
+                "mode": "interactive",
+                "pr_authorship_mode": "user",
+                "run_source": "manual",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["code"] == "github_authorization_required"
+        mock_workflow.assert_not_called()
+
     @parameterized.expand(
         [
             ("missing_runtime_adapter", {"model": "gpt-5.3-codex"}, "runtime_adapter"),

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -22,7 +22,7 @@ from rest_framework.test import APIClient
 
 from posthog.models import Integration, Organization, OrganizationMembership, PersonalAPIKey, Team, User
 from posthog.models.personal_api_key import hash_key_value
-from posthog.models.user_social_identity import GITHUB_PROVIDER, UserSocialIdentity
+from posthog.models.user_integration import UserIntegration
 from posthog.models.utils import generate_random_token_personal
 from posthog.storage import object_storage
 
@@ -54,20 +54,28 @@ from products.tasks.backend.stream.redis_stream import (
 from products.tasks.backend.temporal.process_task.utils import get_cached_github_user_token
 
 
-def _grant_user_github_access(user: User, *, refresh_ttl_seconds: int = 15897600) -> UserSocialIdentity:
+def _grant_user_github_access(user: User, *, refresh_ttl_seconds: int = 15897600) -> UserIntegration:
     now = int(time.time())
-    return UserSocialIdentity.objects.create(
+    return UserIntegration.objects.create(
         user=user,
-        provider=GITHUB_PROVIDER,
-        uid="99",
-        extra_data={
-            "login": "octocat",
-            "id": 99,
+        kind="github",
+        integration_id="12345",
+        config={
+            "installation_id": "12345",
+            "expires_in": 3600,
             "refreshed_at": now,
-            "access_token_expires_at": now + 28800,
-            "refresh_token_expires_at": now + refresh_ttl_seconds,
+            "repository_selection": "selected",
+            "account": {"type": "User", "name": "octocat"},
+            "github_user": {"login": "octocat", "id": 99},
+            "user_token_refreshed_at": now,
+            "user_access_token_expires_at": now + 28800,
+            "user_refresh_token_expires_at": now + refresh_ttl_seconds,
         },
-        sensitive_config={"access_token": "gho_access", "refresh_token": "ghr_refresh"},
+        sensitive_config={
+            "access_token": "ghs_install",
+            "user_access_token": "gho_access",
+            "user_refresh_token": "ghr_refresh",
+        },
     )
 
 
@@ -1044,9 +1052,9 @@ class TestTaskAPI(BaseTaskAPITest):
         task.repository = "posthog/posthog"
         task.created_by = self.user
         task.save(update_fields=["repository", "created_by"])
-        identity = _grant_user_github_access(self.user)
-        identity.extra_data["refresh_token_expires_at"] = int(time.time()) - 1
-        identity.save(update_fields=["extra_data"])
+        integration = _grant_user_github_access(self.user)
+        integration.config["user_refresh_token_expires_at"] = int(time.time()) - 1
+        integration.save(update_fields=["config"])
 
         response = self.client.post(
             f"/api/projects/@current/tasks/{task.id}/run/",

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -22,6 +22,7 @@ from rest_framework.test import APIClient
 
 from posthog.models import Integration, Organization, OrganizationMembership, PersonalAPIKey, Team, User
 from posthog.models.personal_api_key import hash_key_value
+from posthog.models.user_social_identity import GITHUB_PROVIDER, UserSocialIdentity
 from posthog.models.utils import generate_random_token_personal
 from posthog.storage import object_storage
 
@@ -51,6 +52,24 @@ from products.tasks.backend.stream.redis_stream import (
     publish_task_run_stream_event,
 )
 from products.tasks.backend.temporal.process_task.utils import get_cached_github_user_token
+
+
+def _grant_user_github_access(user: User, *, refresh_ttl_seconds: int = 15897600) -> UserSocialIdentity:
+    now = int(time.time())
+    return UserSocialIdentity.objects.create(
+        user=user,
+        provider=GITHUB_PROVIDER,
+        uid="99",
+        extra_data={
+            "login": "octocat",
+            "id": 99,
+            "refreshed_at": now,
+            "access_token_expires_at": now + 28800,
+            "refresh_token_expires_at": now + refresh_ttl_seconds,
+        },
+        sensitive_config={"access_token": "gho_access", "refresh_token": "ghr_refresh"},
+    )
+
 
 # Test RSA private key for JWT tests (RS256)
 TEST_RSA_PRIVATE_KEY = """-----BEGIN PRIVATE KEY-----
@@ -824,6 +843,35 @@ class TestTaskAPI(BaseTaskAPITest):
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
     def test_run_endpoint_persists_pr_authorship_metadata(self, mock_workflow):
         task = self.create_task()
+        task.repository = "posthog/posthog"
+        task.created_by = self.user
+        task.save(update_fields=["repository", "created_by"])
+        _grant_user_github_access(self.user)
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {
+                "mode": "interactive",
+                "branch": "main",
+                "pr_authorship_mode": "user",
+                "run_source": "manual",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        task_run = TaskRun.objects.get(id=response.json()["latest_run"]["id"])
+        assert task_run.state["pr_authorship_mode"] == "user"
+        assert task_run.state["run_source"] == "manual"
+        assert task_run.state["pr_base_branch"] == "main"
+        mock_workflow.assert_called_once()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_caches_github_user_token_backcompat(self, mock_workflow):
+        """Backward-compat: callers that ship ``github_user_token`` have it cached per-run."""
+        task = self.create_task()
+        task.repository = "posthog/posthog"
+        task.save(update_fields=["repository"])
         github_user_token = "ghu_test_token"
 
         response = self.client.post(
@@ -840,10 +888,28 @@ class TestTaskAPI(BaseTaskAPITest):
 
         assert response.status_code == status.HTTP_200_OK
         task_run = TaskRun.objects.get(id=response.json()["latest_run"]["id"])
-        assert task_run.state["pr_authorship_mode"] == "user"
-        assert task_run.state["run_source"] == "manual"
-        assert task_run.state["pr_base_branch"] == "main"
         assert get_cached_github_user_token(str(task_run.id)) == github_user_token
+        mock_workflow.assert_called_once()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_accepts_token_even_without_linked_identity(self, mock_workflow):
+        """A caller-supplied token satisfies the preflight on its own (no identity required)."""
+        task = self.create_task()
+        task.repository = "posthog/posthog"
+        task.save(update_fields=["repository"])
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {
+                "mode": "interactive",
+                "pr_authorship_mode": "user",
+                "run_source": "manual",
+                "github_user_token": "ghu_manual_token",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
         mock_workflow.assert_called_once()
 
     @parameterized.expand(
@@ -953,7 +1019,7 @@ class TestTaskAPI(BaseTaskAPITest):
         mock_workflow.assert_not_called()
 
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
-    def test_run_endpoint_rejects_user_authorship_without_github_user_token(self, mock_workflow):
+    def test_run_endpoint_rejects_user_authorship_without_github_identity(self, mock_workflow):
         task = self.create_task()
         task.repository = "posthog/posthog"
         task.save(update_fields=["repository"])
@@ -969,7 +1035,31 @@ class TestTaskAPI(BaseTaskAPITest):
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json()["detail"] == "github_user_token is required for user-authored cloud runs"
+        assert response.json()["code"] == "github_authorization_required"
+        mock_workflow.assert_not_called()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_run_endpoint_rejects_user_authorship_when_refresh_token_expired(self, mock_workflow):
+        task = self.create_task()
+        task.repository = "posthog/posthog"
+        task.created_by = self.user
+        task.save(update_fields=["repository", "created_by"])
+        identity = _grant_user_github_access(self.user)
+        identity.extra_data["refresh_token_expires_at"] = int(time.time()) - 1
+        identity.save(update_fields=["extra_data"])
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {
+                "mode": "interactive",
+                "pr_authorship_mode": "user",
+                "run_source": "manual",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["code"] == "github_authorization_required"
         mock_workflow.assert_not_called()
 
     @parameterized.expand(
@@ -1089,7 +1179,6 @@ class TestTaskAPI(BaseTaskAPITest):
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
     def test_run_endpoint_resume_carries_forward_pr_authorship_metadata(self, mock_workflow):
         task = self.create_task()
-        github_user_token = "ghu_resume_token"
         previous_run = TaskRun.objects.create(
             task=task,
             team=self.team,
@@ -1112,7 +1201,7 @@ class TestTaskAPI(BaseTaskAPITest):
                 "mode": "interactive",
                 "resume_from_run_id": str(previous_run.id),
                 "pending_user_message": "Please continue",
-                "github_user_token": github_user_token,
+                "github_user_token": "ghu_resume_token",
             },
             format="json",
         )
@@ -1128,7 +1217,7 @@ class TestTaskAPI(BaseTaskAPITest):
         assert task_run.state["provider"] == "openai"
         assert task_run.state["model"] == "gpt-5.3-codex"
         assert task_run.state["reasoning_effort"] == "medium"
-        # Token not cached for bot-authored runs even if the client sends one
+        # Token passed on a BOT resume must not be cached — only USER mode runs use it.
         assert get_cached_github_user_token(str(task_run.id)) is None
 
     @patch("products.tasks.backend.api.execute_task_processing_workflow")

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -448,7 +448,7 @@ export interface ClaudeTaskRunCreateSchemaApi {
 * `xhigh` - xhigh
 * `max` - max */
     reasoning_effort?: ReasoningEffortEnumApi
-    /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
+    /** Optional GitHub user token from PostHog Code for user-authored cloud pull requests. Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; this field remains supported for callers that still manage their own tokens. */
     github_user_token?: string
     /** Initial permission mode for Claude runtimes.
 
@@ -532,7 +532,7 @@ export interface CodexTaskRunCreateSchemaApi {
 * `xhigh` - xhigh
 * `max` - max */
     reasoning_effort?: ReasoningEffortEnumApi
-    /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
+    /** Optional GitHub user token from PostHog Code for user-authored cloud pull requests. Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; this field remains supported for callers that still manage their own tokens. */
     github_user_token?: string
     /** Initial permission mode for Codex runtimes.
 
@@ -572,7 +572,7 @@ export interface TaskRunResumeRequestSchemaApi {
     run_source?: RunSourceEnumApi
     /** Optional signal report identifier when this run was started from Inbox. */
     signal_report_id?: string
-    /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
+    /** Optional GitHub user token from PostHog Code for user-authored cloud pull requests. Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; this field remains supported for callers that still manage their own tokens. */
     github_user_token?: string
 }
 

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -292,7 +292,9 @@ export const TasksRunCreateBody = /* @__PURE__ */ zod.union([
             github_user_token: zod
                 .string()
                 .optional()
-                .describe('Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests.'),
+                .describe(
+                    'Optional GitHub user token from PostHog Code for user-authored cloud pull requests. Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; this field remains supported for callers that still manage their own tokens.'
+                ),
             initial_permission_mode: zod
                 .enum(['default', 'acceptEdits', 'plan', 'bypassPermissions', 'auto'])
                 .describe(
@@ -369,7 +371,9 @@ export const TasksRunCreateBody = /* @__PURE__ */ zod.union([
             github_user_token: zod
                 .string()
                 .optional()
-                .describe('Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests.'),
+                .describe(
+                    'Optional GitHub user token from PostHog Code for user-authored cloud pull requests. Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; this field remains supported for callers that still manage their own tokens.'
+                ),
             initial_permission_mode: zod
                 .enum(['auto', 'read-only', 'full-access'])
                 .describe('* `auto` - auto\n* `read-only` - read-only\n* `full-access` - full-access')
@@ -425,7 +429,9 @@ export const TasksRunCreateBody = /* @__PURE__ */ zod.union([
         github_user_token: zod
             .string()
             .optional()
-            .describe('Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests.'),
+            .describe(
+                'Optional GitHub user token from PostHog Code for user-authored cloud pull requests. Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; this field remains supported for callers that still manage their own tokens.'
+            ),
     }),
 ])
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7856,7 +7856,7 @@ export namespace Schemas {
     * `xhigh` - xhigh
     * `max` - max */
       reasoning_effort?: ReasoningEffortEnum;
-      /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
+      /** Optional GitHub user token from PostHog Code for user-authored cloud pull requests. Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; this field remains supported for callers that still manage their own tokens. */
       github_user_token?: string;
       /** Initial permission mode for Claude runtimes.
 
@@ -8171,7 +8171,7 @@ export namespace Schemas {
     * `xhigh` - xhigh
     * `max` - max */
       reasoning_effort?: ReasoningEffortEnum;
-      /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
+      /** Optional GitHub user token from PostHog Code for user-authored cloud pull requests. Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; this field remains supported for callers that still manage their own tokens. */
       github_user_token?: string;
       /** Initial permission mode for Codex runtimes.
 
@@ -36800,7 +36800,7 @@ export namespace Schemas {
       run_source?: RunSourceEnum;
       /** Optional signal report identifier when this run was started from Inbox. */
       signal_report_id?: string;
-      /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
+      /** Optional GitHub user token from PostHog Code for user-authored cloud pull requests. Prefer linking GitHub from Settings → Linked accounts so the server can manage tokens; this field remains supported for callers that still manage their own tokens. */
       github_user_token?: string;
     }
 


### PR DESCRIPTION
## Problem

User-authored PostHog Code runs required every caller to ship a `github_user_token` in the request body. That forced clients (like PH Code) to manage GitHub tokens themselves, broke on long-running/resumed runs, and meant user-authored runs couldn't be kicked off from Slack. Fortunately the `UserIntegration` from #55304 already stores user-to-server tokens server-side.

## Changes

This PR uses `UserIntegration`in the cloud run pipeline so callers no longer need to ship tokens.

### Token resolution

`get_sandbox_github_token()` now resolves tokens for `USER` authorship in order:

1. Caller-supplied token cached at run-create time (backward compat for PostHog Code CLI)
2. Server-side `UserIntegration` for the task creator, refreshing on demand via `UserGitHubIntegration` (all sandbox activities pass `created_by=task.created_by` for token resolution)

`BOT` authorship still uses the team `Integration` installation token.

## How did you test this code?

`products/tasks/backend/tests/test_api.py` and`products/tasks/backend/temporal/process_task/tests/test_utils.py`

## Publish to changelog?

Nope.

## Docs update

No docs changes needed.