### PR TITLE
feat(cloud-agent): render cloud run attachments in task sessions

### DIFF
--- a/products/tasks/frontend/components/TaskDetailPage.tsx
+++ b/products/tasks/frontend/components/TaskDetailPage.tsx
@@ -187,6 +187,7 @@ export function TaskDetailPage({ taskId }: TaskDetailPageProps): JSX.Element {
                         streamEntries={streamEntries}
                         isPolling={shouldPoll}
                         isStreaming={isStreaming}
+                        initialPrompt={task.description}
                         run={selectedRun}
                     />
                 </div>

--- a/products/tasks/frontend/components/TaskSessionView.test.ts
+++ b/products/tasks/frontend/components/TaskSessionView.test.ts
@@ -1,74 +1,134 @@
 import { LogEntry } from '../lib/parse-logs'
 import { filterDuplicateInitialPromptEntry, mergeDuplicateUserPromptEntries } from './TaskSessionView'
 
+const createEntry = (overrides: Partial<LogEntry>): LogEntry => ({
+    id: 'entry-1',
+    type: 'user',
+    message: 'Hello from the initial prompt',
+    ...overrides,
+})
+
 describe('filterDuplicateInitialPromptEntry', () => {
-    const createEntry = (overrides: Partial<LogEntry>): LogEntry => ({
-        id: 'entry-1',
-        type: 'user',
-        message: 'Hello from the initial prompt',
-        ...overrides,
-    })
-
-    it('drops the first user entry when it matches the initial prompt', () => {
-        const entries = [
-            createEntry({ id: 'entry-1' }),
-            createEntry({ id: 'entry-2', type: 'agent', message: 'I read the file' }),
-        ]
-
-        expect(filterDuplicateInitialPromptEntry(entries, 'Hello from the initial prompt')).toEqual([entries[1]])
-    })
-
-    it('keeps the first user entry when it does not match the initial prompt', () => {
-        const entries = [
-            createEntry({ id: 'entry-1', message: 'A different prompt' }),
-            createEntry({ id: 'entry-2', type: 'agent', message: 'I read the file' }),
-        ]
-
-        expect(filterDuplicateInitialPromptEntry(entries, 'Hello from the initial prompt')).toEqual(entries)
-    })
-
-    it('keeps non-user leading entries even when the prompt text matches later', () => {
-        const entries = [
-            createEntry({ id: 'entry-1', type: 'system', message: 'Run started' }),
-            createEntry({ id: 'entry-2' }),
-        ]
-
-        expect(filterDuplicateInitialPromptEntry(entries, 'Hello from the initial prompt')).toEqual(entries)
+    it.each([
+        {
+            name: 'drops matching plain first entry',
+            entries: [
+                createEntry({ id: 'entry-1' }),
+                createEntry({ id: 'entry-2', type: 'agent', message: 'I read the file' }),
+            ],
+            prompt: 'Hello from the initial prompt',
+            expected: (entries: LogEntry[]) => [entries[1]],
+        },
+        {
+            name: 'keeps first entry when message differs',
+            entries: [
+                createEntry({ id: 'entry-1', message: 'A different prompt' }),
+                createEntry({ id: 'entry-2', type: 'agent', message: 'I read the file' }),
+            ],
+            prompt: 'Hello from the initial prompt',
+            expected: (entries: LogEntry[]) => entries,
+        },
+        {
+            name: 'keeps first entry when non-user leads',
+            entries: [
+                createEntry({ id: 'entry-1', type: 'system', message: 'Run started' }),
+                createEntry({ id: 'entry-2' }),
+            ],
+            prompt: 'Hello from the initial prompt',
+            expected: (entries: LogEntry[]) => entries,
+        },
+        {
+            name: 'keeps matching first entry when it has attachments',
+            entries: [
+                createEntry({
+                    id: 'entry-1',
+                    attachments: [{ id: 'attachment-1', label: 'file.pdf' }],
+                }),
+                createEntry({ id: 'entry-2', type: 'agent', message: 'ok' }),
+            ],
+            prompt: 'Hello from the initial prompt',
+            expected: (entries: LogEntry[]) => entries,
+        },
+    ])('$name', ({ entries, prompt, expected }) => {
+        expect(filterDuplicateInitialPromptEntry(entries, prompt)).toEqual(expected(entries))
     })
 })
 
 describe('mergeDuplicateUserPromptEntries', () => {
-    const createEntry = (overrides: Partial<LogEntry>): LogEntry => ({
-        id: 'entry-1',
-        type: 'user',
-        message: 'Please inspect the attached file',
-        ...overrides,
-    })
-
-    it('keeps the attachment-bearing user entry when the next entry duplicates its text', () => {
-        const attachmentEntry = createEntry({
-            id: 'entry-1',
-            attachments: [{ id: 'attachment-1', label: 'Receipt-2264-0277.pdf' }],
-        })
-        const duplicateTextEntry = createEntry({ id: 'entry-2' })
-
-        expect(mergeDuplicateUserPromptEntries([attachmentEntry, duplicateTextEntry])).toEqual([attachmentEntry])
-    })
-
-    it('replaces a plain user entry with a later attachment-bearing duplicate', () => {
-        const plainEntry = createEntry({ id: 'entry-1' })
-        const attachmentEntry = createEntry({
-            id: 'entry-2',
-            attachments: [{ id: 'attachment-1', label: 'Receipt-2264-0277.pdf' }],
-        })
-
-        expect(mergeDuplicateUserPromptEntries([plainEntry, attachmentEntry])).toEqual([attachmentEntry])
-    })
-
-    it('keeps distinct user entries untouched', () => {
-        const firstEntry = createEntry({ id: 'entry-1', message: 'First prompt' })
-        const secondEntry = createEntry({ id: 'entry-2', message: 'Second prompt' })
-
-        expect(mergeDuplicateUserPromptEntries([firstEntry, secondEntry])).toEqual([firstEntry, secondEntry])
+    it.each([
+        {
+            name: 'keeps the attachment-bearing first entry when followed by plain duplicate text',
+            entries: [
+                createEntry({
+                    id: 'entry-1',
+                    message: 'Please inspect the attached file',
+                    attachments: [{ id: 'attachment-1', label: 'Receipt-2264-0277.pdf' }],
+                }),
+                createEntry({ id: 'entry-2', message: 'Please inspect the attached file' }),
+            ],
+            expected: [
+                createEntry({
+                    id: 'entry-1',
+                    message: 'Please inspect the attached file',
+                    attachments: [{ id: 'attachment-1', label: 'Receipt-2264-0277.pdf' }],
+                }),
+            ],
+        },
+        {
+            name: 'replaces a plain user entry with a later attachment-bearing duplicate',
+            entries: [
+                createEntry({ id: 'entry-1', message: 'Please inspect the attached file' }),
+                createEntry({
+                    id: 'entry-2',
+                    message: 'Please inspect the attached file',
+                    attachments: [{ id: 'attachment-1', label: 'Receipt-2264-0277.pdf' }],
+                }),
+            ],
+            expected: [
+                createEntry({
+                    id: 'entry-2',
+                    message: 'Please inspect the attached file',
+                    attachments: [{ id: 'attachment-1', label: 'Receipt-2264-0277.pdf' }],
+                }),
+            ],
+        },
+        {
+            name: 'merges attachments when both duplicate entries have them',
+            entries: [
+                createEntry({
+                    id: 'entry-1',
+                    message: 'Please inspect the attached file',
+                    attachments: [{ id: 'attachment-1', label: 'Receipt-2264-0277.pdf' }],
+                }),
+                createEntry({
+                    id: 'entry-2',
+                    message: 'Please inspect the attached file',
+                    attachments: [{ id: 'attachment-2', label: 'New Project.png' }],
+                }),
+            ],
+            expected: [
+                createEntry({
+                    id: 'entry-1',
+                    message: 'Please inspect the attached file',
+                    attachments: [
+                        { id: 'attachment-1', label: 'Receipt-2264-0277.pdf' },
+                        { id: 'attachment-2', label: 'New Project.png' },
+                    ],
+                }),
+            ],
+        },
+        {
+            name: 'keeps distinct user entries untouched',
+            entries: [
+                createEntry({ id: 'entry-1', message: 'First prompt' }),
+                createEntry({ id: 'entry-2', message: 'Second prompt' }),
+            ],
+            expected: [
+                createEntry({ id: 'entry-1', message: 'First prompt' }),
+                createEntry({ id: 'entry-2', message: 'Second prompt' }),
+            ],
+        },
+    ])('$name', ({ entries, expected }) => {
+        expect(mergeDuplicateUserPromptEntries(entries)).toEqual(expected)
     })
 })

--- a/products/tasks/frontend/components/TaskSessionView.test.ts
+++ b/products/tasks/frontend/components/TaskSessionView.test.ts
@@ -1,0 +1,74 @@
+import { LogEntry } from '../lib/parse-logs'
+import { filterDuplicateInitialPromptEntry, mergeDuplicateUserPromptEntries } from './TaskSessionView'
+
+describe('filterDuplicateInitialPromptEntry', () => {
+    const createEntry = (overrides: Partial<LogEntry>): LogEntry => ({
+        id: 'entry-1',
+        type: 'user',
+        message: 'Hello from the initial prompt',
+        ...overrides,
+    })
+
+    it('drops the first user entry when it matches the initial prompt', () => {
+        const entries = [
+            createEntry({ id: 'entry-1' }),
+            createEntry({ id: 'entry-2', type: 'agent', message: 'I read the file' }),
+        ]
+
+        expect(filterDuplicateInitialPromptEntry(entries, 'Hello from the initial prompt')).toEqual([entries[1]])
+    })
+
+    it('keeps the first user entry when it does not match the initial prompt', () => {
+        const entries = [
+            createEntry({ id: 'entry-1', message: 'A different prompt' }),
+            createEntry({ id: 'entry-2', type: 'agent', message: 'I read the file' }),
+        ]
+
+        expect(filterDuplicateInitialPromptEntry(entries, 'Hello from the initial prompt')).toEqual(entries)
+    })
+
+    it('keeps non-user leading entries even when the prompt text matches later', () => {
+        const entries = [
+            createEntry({ id: 'entry-1', type: 'system', message: 'Run started' }),
+            createEntry({ id: 'entry-2' }),
+        ]
+
+        expect(filterDuplicateInitialPromptEntry(entries, 'Hello from the initial prompt')).toEqual(entries)
+    })
+})
+
+describe('mergeDuplicateUserPromptEntries', () => {
+    const createEntry = (overrides: Partial<LogEntry>): LogEntry => ({
+        id: 'entry-1',
+        type: 'user',
+        message: 'Please inspect the attached file',
+        ...overrides,
+    })
+
+    it('keeps the attachment-bearing user entry when the next entry duplicates its text', () => {
+        const attachmentEntry = createEntry({
+            id: 'entry-1',
+            attachments: [{ id: 'attachment-1', label: 'Receipt-2264-0277.pdf' }],
+        })
+        const duplicateTextEntry = createEntry({ id: 'entry-2' })
+
+        expect(mergeDuplicateUserPromptEntries([attachmentEntry, duplicateTextEntry])).toEqual([attachmentEntry])
+    })
+
+    it('replaces a plain user entry with a later attachment-bearing duplicate', () => {
+        const plainEntry = createEntry({ id: 'entry-1' })
+        const attachmentEntry = createEntry({
+            id: 'entry-2',
+            attachments: [{ id: 'attachment-1', label: 'Receipt-2264-0277.pdf' }],
+        })
+
+        expect(mergeDuplicateUserPromptEntries([plainEntry, attachmentEntry])).toEqual([attachmentEntry])
+    })
+
+    it('keeps distinct user entries untouched', () => {
+        const firstEntry = createEntry({ id: 'entry-1', message: 'First prompt' })
+        const secondEntry = createEntry({ id: 'entry-2', message: 'Second prompt' })
+
+        expect(mergeDuplicateUserPromptEntries([firstEntry, secondEntry])).toEqual([firstEntry, secondEntry])
+    })
+})

--- a/products/tasks/frontend/components/TaskSessionView.tsx
+++ b/products/tasks/frontend/components/TaskSessionView.tsx
@@ -67,7 +67,11 @@ export function filterDuplicateInitialPromptEntry(entries: LogEntry[], initialPr
     }
 
     const [firstEntry, ...restEntries] = entries
-    if (firstEntry.type !== 'user' || firstEntry.message?.trim() !== normalizedPrompt) {
+    if (
+        firstEntry.type !== 'user' ||
+        firstEntry.message?.trim() !== normalizedPrompt ||
+        (firstEntry.attachments?.length ?? 0) > 0
+    ) {
         return entries
     }
 
@@ -88,6 +92,11 @@ export function mergeDuplicateUserPromptEntries(entries: LogEntry[]): LogEntry[]
 
             if (!previousHasAttachments && currentHasAttachments) {
                 mergedEntries[mergedEntries.length - 1] = entry
+            } else if (previousHasAttachments && currentHasAttachments) {
+                mergedEntries[mergedEntries.length - 1] = {
+                    ...previousEntry,
+                    attachments: [...(previousEntry.attachments ?? []), ...(entry.attachments ?? [])],
+                }
             }
 
             return mergedEntries

--- a/products/tasks/frontend/components/TaskSessionView.tsx
+++ b/products/tasks/frontend/components/TaskSessionView.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { TextMorph } from 'torph/react'
 
 import { IconCopy } from '@posthog/icons'
-import { LemonButton, Spinner } from '@posthog/lemon-ui'
+import { LemonButton, LemonTag, Spinner } from '@posthog/lemon-ui'
 
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 
@@ -56,7 +56,46 @@ interface TaskSessionViewProps {
     streamEntries: LogEntry[]
     isPolling: boolean
     isStreaming: boolean
+    initialPrompt?: string | null
     run: TaskRun | null
+}
+
+export function filterDuplicateInitialPromptEntry(entries: LogEntry[], initialPrompt?: string | null): LogEntry[] {
+    const normalizedPrompt = initialPrompt?.trim()
+    if (!normalizedPrompt || entries.length === 0) {
+        return entries
+    }
+
+    const [firstEntry, ...restEntries] = entries
+    if (firstEntry.type !== 'user' || firstEntry.message?.trim() !== normalizedPrompt) {
+        return entries
+    }
+
+    return restEntries
+}
+
+export function mergeDuplicateUserPromptEntries(entries: LogEntry[]): LogEntry[] {
+    return entries.reduce<LogEntry[]>((mergedEntries, entry) => {
+        const previousEntry = mergedEntries[mergedEntries.length - 1]
+
+        if (
+            previousEntry?.type === 'user' &&
+            entry.type === 'user' &&
+            previousEntry.message?.trim() === entry.message?.trim()
+        ) {
+            const previousHasAttachments = Boolean(previousEntry.attachments?.length)
+            const currentHasAttachments = Boolean(entry.attachments?.length)
+
+            if (!previousHasAttachments && currentHasAttachments) {
+                mergedEntries[mergedEntries.length - 1] = entry
+            }
+
+            return mergedEntries
+        }
+
+        mergedEntries.push(entry)
+        return mergedEntries
+    }, [])
 }
 
 function LogEntryRenderer({ entry }: { entry: LogEntry }): JSX.Element | null {
@@ -92,6 +131,15 @@ function LogEntryRenderer({ entry }: { entry: LogEntry }): JSX.Element | null {
                         <CollapsibleContent gradientColor="--bg-3000">
                             <div className="text-sm whitespace-pre-wrap">{entry.message}</div>
                         </CollapsibleContent>
+                        {entry.attachments && entry.attachments.length > 0 ? (
+                            <div className="mt-2 flex flex-wrap justify-end gap-2">
+                                {entry.attachments.map((attachment) => (
+                                    <LemonTag key={attachment.id} type="completion" size="small">
+                                        {attachment.label}
+                                    </LemonTag>
+                                ))}
+                            </div>
+                        ) : null}
                     </div>
                 </div>
             )
@@ -146,11 +194,15 @@ export function TaskSessionView({
     streamEntries,
     isPolling,
     isStreaming,
+    initialPrompt,
     run,
 }: TaskSessionViewProps): JSX.Element {
     const parsedLogs = useMemo(() => parseLogs(logs), [logs])
     // Use stream entries when available (real-time), otherwise fall back to parsed S3 logs
-    const entries = streamEntries.length > 0 ? streamEntries : parsedLogs
+    const entries = useMemo(() => {
+        const sourceEntries = streamEntries.length > 0 ? streamEntries : parsedLogs
+        return filterDuplicateInitialPromptEntry(mergeDuplicateUserPromptEntries(sourceEntries), initialPrompt)
+    }, [initialPrompt, parsedLogs, streamEntries])
 
     const handleCopyLogs = (): void => {
         navigator.clipboard.writeText(logs).then(

--- a/products/tasks/frontend/lib/parse-logs.ts
+++ b/products/tasks/frontend/lib/parse-logs.ts
@@ -2,12 +2,18 @@ export type LogEntryType = 'console' | 'agent' | 'tool' | 'user' | 'raw' | 'syst
 export type LogLevel = 'info' | 'warn' | 'error' | 'debug'
 export type ToolStatus = 'pending' | 'running' | 'completed' | 'error'
 
+export interface LogEntryAttachment {
+    id: string
+    label: string
+}
+
 export interface LogEntry {
     id: string
     type: LogEntryType
     timestamp?: string
     level?: LogLevel
     message?: string
+    attachments?: LogEntryAttachment[]
     toolName?: string
     toolCallId?: string
     toolStatus?: ToolStatus
@@ -86,6 +92,23 @@ interface ACPNotification {
     }
 }
 
+interface SessionPromptParams {
+    prompt?: PromptBlock[]
+}
+
+interface PromptTextBlock {
+    type: 'text'
+    text?: string
+}
+
+interface PromptResourceLinkBlock {
+    type: 'resource_link'
+    uri?: string
+    name?: string
+}
+
+type PromptBlock = PromptTextBlock | PromptResourceLinkBlock | { type: string; [key: string]: unknown }
+
 interface SessionUpdateParams {
     sessionId?: string
     update?: {
@@ -108,6 +131,55 @@ function isACPNotification(parsed: unknown): parsed is ACPNotification {
         (parsed as ACPNotification).type === 'notification' &&
         'notification' in parsed
     )
+}
+
+function getAttachmentLabel(block: PromptResourceLinkBlock): string | null {
+    if (block.name?.trim()) {
+        return block.name.trim()
+    }
+
+    if (!block.uri) {
+        return null
+    }
+
+    try {
+        const pathname = new URL(block.uri).pathname
+        const segments = pathname.split('/').filter(Boolean)
+        return segments.at(-1) ?? block.uri
+    } catch {
+        const segments = block.uri.split('/').filter(Boolean)
+        return segments.at(-1) ?? block.uri
+    }
+}
+
+function parsePromptBlocks(prompt: PromptBlock[], id: string): Pick<LogEntry, 'message' | 'attachments'> | null {
+    const textParts: string[] = []
+    const attachments: LogEntryAttachment[] = []
+
+    prompt.forEach((block, index) => {
+        if (block.type === 'text' && block.text) {
+            textParts.push(block.text)
+        }
+
+        if (block.type === 'resource_link') {
+            const label = getAttachmentLabel(block)
+            if (label) {
+                attachments.push({
+                    id: `${id}-attachment-${index}`,
+                    label,
+                })
+            }
+        }
+    })
+
+    if (textParts.length === 0 && attachments.length === 0) {
+        return null
+    }
+
+    return {
+        message: textParts.join(''),
+        attachments: attachments.length > 0 ? attachments : undefined,
+    }
 }
 
 function parseACPNotification(
@@ -225,6 +297,26 @@ function parseACPNotification(
 
             default:
                 return null
+        }
+    }
+
+    if (method === 'session/prompt') {
+        const params = notification.params as SessionPromptParams | undefined
+        if (!params?.prompt) {
+            return null
+        }
+
+        const parsedPrompt = parsePromptBlocks(params.prompt, id)
+        if (!parsedPrompt) {
+            return null
+        }
+
+        return {
+            id,
+            type: 'user',
+            timestamp,
+            message: parsedPrompt.message,
+            attachments: parsedPrompt.attachments,
         }
     }
 

--- a/products/tasks/frontend/lib/parse-logs.ts
+++ b/products/tasks/frontend/lib/parse-logs.ts
@@ -152,16 +152,24 @@ function getAttachmentLabel(block: PromptResourceLinkBlock): string | null {
     }
 }
 
+function isPromptTextBlock(block: PromptBlock): block is PromptTextBlock {
+    return block.type === 'text'
+}
+
+function isPromptResourceLinkBlock(block: PromptBlock): block is PromptResourceLinkBlock {
+    return block.type === 'resource_link'
+}
+
 function parsePromptBlocks(prompt: PromptBlock[], id: string): Pick<LogEntry, 'message' | 'attachments'> | null {
     const textParts: string[] = []
     const attachments: LogEntryAttachment[] = []
 
     prompt.forEach((block, index) => {
-        if (block.type === 'text' && block.text) {
+        if (isPromptTextBlock(block) && block.text) {
             textParts.push(block.text)
         }
 
-        if (block.type === 'resource_link') {
+        if (isPromptResourceLinkBlock(block)) {
             const label = getAttachmentLabel(block)
             if (label) {
                 attachments.push({

--- a/products/tasks/frontend/types.ts
+++ b/products/tasks/frontend/types.ts
@@ -23,8 +23,10 @@ export enum TaskRunEnvironment {
 }
 
 export interface TaskRunArtifact {
+    id?: string
     name: string
     type: string
+    source?: string
     size?: number
     content_type?: string
     storage_path: string


### PR DESCRIPTION
## Problem

The tasks UI needs to show cloud-run attachment prompts the same way it shows local task prompts.

https://github.com/user-attachments/assets/535243cb-e761-45b8-8bf1-298031ab7fb1

## Changes

- parse cloud prompt resource links from task run logs
- render attachment chips in the task session view and cover the new parsing path with tests