### PR TITLE
chore(llma): add exploring-llm-costs skill

### DIFF
--- a/products/llm_analytics/skills/README.md
+++ b/products/llm_analytics/skills/README.md
@@ -10,6 +10,9 @@ Also available to Claude Code / Codex via `hogli sync:skill`.
   Covers the `$ai_*` event schema, content detail levels, and step-by-step debugging workflows.
 - **exploring-llm-clusters** — how to investigate LLM analytics clustering results,
   compare cluster behavior, compute metrics, and drill into individual traces.
+- **exploring-llm-costs** — how to investigate LLM spend: total cost, breakdowns
+  by model/provider/user/trace/custom dimension, token and cache economics,
+  cost regressions, and materializing cost insights, dashboards, and alerts.
 - **exploring-llm-evaluations** — how to manage and investigate LLM analytics
   evaluations (both `hog` and `llm_judge` types), run them on specific generations,
   query individual results, and generate AI-powered summaries of pass/fail/N/A patterns.

--- a/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
+++ b/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
@@ -39,19 +39,35 @@ All costs are USD, recorded per event at ingestion. PostHog derives them from th
 model+provider and token counts — you cannot set them manually and trust them to
 survive. Costs live on `$ai_generation` and `$ai_embedding` only.
 
-| Property                          | Where                 | Meaning                                         |
-| --------------------------------- | --------------------- | ----------------------------------------------- |
-| `$ai_total_cost_usd`              | generation, embedding | Total cost for the call                         |
-| `$ai_input_cost_usd`              | generation            | Cost attributable to input tokens               |
-| `$ai_output_cost_usd`             | generation            | Cost attributable to output tokens              |
-| `$ai_input_tokens`                | generation, embedding | Tokens sent to the model                        |
-| `$ai_output_tokens`               | generation            | Tokens returned by the model                    |
-| `$ai_cache_read_input_tokens`     | generation            | Input tokens served from provider prompt cache  |
-| `$ai_cache_creation_input_tokens` | generation            | Input tokens written into provider prompt cache |
-| `$ai_model`                       | generation, embedding | Primary breakdown dimension for cost            |
-| `$ai_provider`                    | generation, embedding | Secondary breakdown (openai, anthropic, …)      |
-| `$ai_is_error`                    | generation            | Exclude/include failed calls in cost totals     |
-| `$ai_trace_id`                    | all `$ai_*` events    | Roll costs up to trace level                    |
+| Property                          | Where                 | Meaning                                                                 |
+| --------------------------------- | --------------------- | ----------------------------------------------------------------------- |
+| `$ai_total_cost_usd`              | generation, embedding | Total cost for the call — **authoritative total**, use this for rollups |
+| `$ai_input_cost_usd`              | generation, embedding | Cost attributable to input tokens                                       |
+| `$ai_output_cost_usd`             | generation, embedding | Cost attributable to output tokens                                      |
+| `$ai_request_cost_usd`            | generation, embedding | Per-request flat cost (e.g. Anthropic per-request fee); often `0`       |
+| `$ai_web_search_cost_usd`         | generation, embedding | Cost of web-search tool calls inside the generation; often `0`          |
+| `$ai_audio_cost_usd`              | generation            | Audio-modality cost when the model charges a separate rate; often `0`   |
+| `$ai_image_cost_usd`              | generation            | Image-modality cost; often `0`                                          |
+| `$ai_video_cost_usd`              | generation            | Video-modality cost; often `0`                                          |
+| `$ai_input_tokens`                | generation, embedding | Tokens sent to the model (total across modalities)                      |
+| `$ai_output_tokens`               | generation            | Tokens returned by the model (total across modalities)                  |
+| `$ai_total_tokens`                | generation, embedding | Input + output tokens                                                   |
+| `$ai_cache_read_input_tokens`     | generation            | Input tokens served from provider prompt cache                          |
+| `$ai_cache_creation_input_tokens` | generation            | Input tokens written into provider prompt cache                         |
+| `$ai_reasoning_tokens`            | generation            | Reasoning-model thinking tokens (charged as output)                     |
+| `$ai_model`                       | generation, embedding | Primary breakdown dimension for cost                                    |
+| `$ai_provider`                    | generation, embedding | Secondary breakdown (openai, anthropic, …)                              |
+| `$ai_is_error`                    | generation            | Exclude/include failed calls in cost totals                             |
+| `$ai_trace_id`                    | all `$ai_*` events    | Roll costs up to trace level                                            |
+
+**Always sum `$ai_total_cost_usd`, not the components.** Ingestion sets
+`$ai_total_cost_usd = input + output + request + web_search` (plus any
+modality costs) in `nodejs/src/ingestion/ai/costs/index.ts`. Summing only
+`$ai_input_cost_usd + $ai_output_cost_usd` silently drops request and
+web-search fees — real and non-zero for Anthropic request fees and any
+tool-augmented generation. The UI's cost cells and both the
+`traces_query_runner` and `trace_query_runner` sum `$ai_total_cost_usd`
+over `event IN ('$ai_generation', '$ai_embedding')`; mirror that.
 
 Note: `$ai_trace` and `$ai_span` events do **not** carry cost. To get a trace's
 total cost, sum `$ai_total_cost_usd` across its `$ai_generation` and
@@ -229,6 +245,9 @@ SELECT
     properties.$ai_model AS model,
     round(sum(toFloat(properties.$ai_input_cost_usd)), 4) AS input_cost,
     round(sum(toFloat(properties.$ai_output_cost_usd)), 4) AS output_cost,
+    round(sum(toFloat(properties.$ai_request_cost_usd)), 4) AS request_cost,
+    round(sum(toFloat(properties.$ai_web_search_cost_usd)), 4) AS web_search_cost,
+    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS total_cost,
     sum(toInt(properties.$ai_input_tokens)) AS input_tokens,
     sum(toInt(properties.$ai_output_tokens)) AS output_tokens,
     sum(toInt(properties.$ai_cache_read_input_tokens)) AS cache_read_tokens,
@@ -241,8 +260,14 @@ FROM events
 WHERE event = '$ai_generation'
     AND timestamp >= now() - INTERVAL 30 DAY
 GROUP BY model
-ORDER BY input_cost + output_cost DESC
+ORDER BY total_cost DESC
 ```
+
+Rank and roll up on `total_cost` — summing only the input/output components
+drops request and web-search fees and can diverge from the `/llm-analytics`
+UI. If `request_cost` or `web_search_cost` are a meaningful share of
+`total_cost` for a model, that's a separate optimisation lever (e.g. chattier
+provider, tool-heavy generations).
 
 A low `cache_hit_rate` on a model that supports prompt caching is a lever —
 prompt structure changes can move cost materially.

--- a/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
+++ b/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
@@ -1,0 +1,390 @@
+---
+name: exploring-llm-costs
+description: >
+  Investigate LLM spend in PostHog — total cost over time, cost by model,
+  provider, user, trace, or custom dimension, token and cache-hit economics,
+  and cost regressions. Use when the user asks "how much are we spending on
+  LLMs?", "which model / user / feature is most expensive?", "why did cost
+  spike?", wants to build a cost dashboard or alert, or pastes a trace URL
+  and asks about its cost.
+---
+
+# Exploring LLM costs
+
+PostHog attaches per-call cost metadata to every `$ai_generation` and `$ai_embedding`
+event at ingestion time. Every cost question reduces to an aggregation over those
+two event types — the interesting variation is only in how you group, filter, and
+compare.
+
+This skill covers the common cost investigations: total spend, breakdowns
+(model, provider, user, trace, custom property), token and cache-hit analysis,
+regression debugging, and materializing results as insights, dashboards, or alerts.
+
+## Tools
+
+| Tool                                      | Purpose                                                             |
+| ----------------------------------------- | ------------------------------------------------------------------- |
+| `posthog:get-llm-total-costs-for-project` | One-shot: daily total cost broken down by model (last N days)       |
+| `posthog:execute-sql`                     | Ad-hoc HogQL for any cost aggregation — the workhorse of this skill |
+| `posthog:query-llm-traces-list`           | List traces with rolled-up cost, token, and error metrics           |
+| `posthog:query-llm-trace`                 | Cost breakdown of a single trace across all its events              |
+| `posthog:read-data-schema`                | Discover which custom properties exist for breakdowns               |
+| `posthog:insight-create`                  | Materialize a cost chart as a saved insight                         |
+| `posthog:dashboard-create`                | Bundle cost insights into a dashboard                               |
+| `posthog:alert-create`                    | Alert when cost crosses a threshold                                 |
+
+## Cost properties
+
+All costs are USD, recorded per event at ingestion. PostHog derives them from the
+model+provider and token counts — you cannot set them manually and trust them to
+survive. Costs live on `$ai_generation` and `$ai_embedding` only.
+
+| Property                          | Where                 | Meaning                                         |
+| --------------------------------- | --------------------- | ----------------------------------------------- |
+| `$ai_total_cost_usd`              | generation, embedding | Total cost for the call                         |
+| `$ai_input_cost_usd`              | generation            | Cost attributable to input tokens               |
+| `$ai_output_cost_usd`             | generation            | Cost attributable to output tokens              |
+| `$ai_input_tokens`                | generation, embedding | Tokens sent to the model                        |
+| `$ai_output_tokens`               | generation            | Tokens returned by the model                    |
+| `$ai_cache_read_input_tokens`     | generation            | Input tokens served from provider prompt cache  |
+| `$ai_cache_creation_input_tokens` | generation            | Input tokens written into provider prompt cache |
+| `$ai_model`                       | generation, embedding | Primary breakdown dimension for cost            |
+| `$ai_provider`                    | generation, embedding | Secondary breakdown (openai, anthropic, …)      |
+| `$ai_is_error`                    | generation            | Exclude/include failed calls in cost totals     |
+| `$ai_trace_id`                    | all `$ai_*` events    | Roll costs up to trace level                    |
+
+Note: `$ai_trace` and `$ai_span` events do **not** carry cost. To get a trace's
+total cost, sum `$ai_total_cost_usd` across its `$ai_generation` and
+`$ai_embedding` events (matched by `$ai_trace_id`).
+
+`distinct_id` is the canonical user dimension — customers typically set it in
+the SDK. Use person properties (e.g. `email`, `company_tier`) for richer
+per-user breakdowns; discover what exists with `read-data-schema`.
+
+## Workflow: answer "how much are we spending?"
+
+Default to the pre-built MCP tool when the user just wants the headline number:
+
+```json
+posthog:get-llm-total-costs-for-project
+{ "projectId": <id>, "days": 30 }
+```
+
+Returns a trends series of daily total cost broken down by model over the last
+N days (default 6). Links back to `/llm-observability` so the user can drill in.
+
+For anything beyond the default shape (different time range, different grouping,
+formula), drop to SQL — see the patterns below.
+
+## Workflow: breakdown patterns
+
+Every cost question is a variation of the same template. Always set a time range.
+Always include `$ai_embedding` alongside `$ai_generation` if the project uses
+embeddings — missing them silently under-counts.
+
+### Total cost in a window
+
+```sql
+posthog:execute-sql
+SELECT round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS total_cost_usd
+FROM events
+WHERE event IN ('$ai_generation', '$ai_embedding')
+    AND timestamp >= now() - INTERVAL 30 DAY
+```
+
+### Cost over time (daily)
+
+```sql
+posthog:execute-sql
+SELECT
+    toDate(timestamp) AS day,
+    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd,
+    sum(toInt(properties.$ai_input_tokens)) AS input_tokens,
+    sum(toInt(properties.$ai_output_tokens)) AS output_tokens,
+    count() AS calls
+FROM events
+WHERE event IN ('$ai_generation', '$ai_embedding')
+    AND timestamp >= now() - INTERVAL 30 DAY
+GROUP BY day
+ORDER BY day
+```
+
+### Cost by model
+
+```sql
+posthog:execute-sql
+SELECT
+    properties.$ai_model AS model,
+    properties.$ai_provider AS provider,
+    count() AS calls,
+    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd,
+    round(avg(toFloat(properties.$ai_total_cost_usd)), 6) AS avg_cost_per_call,
+    sum(toInt(properties.$ai_input_tokens)) AS input_tokens,
+    sum(toInt(properties.$ai_output_tokens)) AS output_tokens
+FROM events
+WHERE event IN ('$ai_generation', '$ai_embedding')
+    AND timestamp >= now() - INTERVAL 30 DAY
+GROUP BY model, provider
+ORDER BY cost_usd DESC
+```
+
+### Cost by user (top spenders)
+
+```sql
+posthog:execute-sql
+SELECT
+    distinct_id,
+    count() AS calls,
+    countDistinct(properties.$ai_trace_id) AS traces,
+    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd
+FROM events
+WHERE event IN ('$ai_generation', '$ai_embedding')
+    AND timestamp >= now() - INTERVAL 30 DAY
+    AND distinct_id != properties.$ai_trace_id  -- filter out traces used as distinct_id
+GROUP BY distinct_id
+ORDER BY cost_usd DESC
+LIMIT 25
+```
+
+For a richer per-user view with person properties, the `/llm-analytics/users`
+page uses the same shape — see `products/llm_analytics/frontend/tabs/llmAnalyticsUsersLogic.ts`.
+
+### Cost by trace (top expensive traces)
+
+```sql
+posthog:execute-sql
+SELECT
+    properties.$ai_trace_id AS trace_id,
+    count() AS llm_calls,
+    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd,
+    sum(toInt(properties.$ai_input_tokens)) AS input_tokens,
+    sum(toInt(properties.$ai_output_tokens)) AS output_tokens,
+    min(timestamp) AS started_at
+FROM events
+WHERE event IN ('$ai_generation', '$ai_embedding')
+    AND timestamp >= now() - INTERVAL 7 DAY
+    AND isNotNull(properties.$ai_trace_id)
+GROUP BY trace_id
+ORDER BY cost_usd DESC
+LIMIT 25
+```
+
+Then drill into the top traces with `posthog:query-llm-trace` to see which spans
+and generations are driving cost.
+
+### Cost by custom dimension
+
+Customers often attach their own dimensions (`feature`, `tenant_id`, `workflow_name`).
+Discover them first, then group:
+
+1. `posthog:read-data-schema` with `kind: "event_properties"` and
+   `event_name: "$ai_generation"` to find custom keys
+2. `posthog:read-data-schema` with `kind: "event_property_values"` to spot-check
+   that values look right
+3. Group by the discovered property:
+
+```sql
+posthog:execute-sql
+SELECT
+    properties.feature AS feature,
+    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd,
+    count() AS calls
+FROM events
+WHERE event IN ('$ai_generation', '$ai_embedding')
+    AND timestamp >= now() - INTERVAL 30 DAY
+    AND isNotNull(properties.feature)
+GROUP BY feature
+ORDER BY cost_usd DESC
+```
+
+Do not guess custom property names — they vary per project.
+
+### Cost per call (distribution)
+
+Totals hide skew. Use percentiles to see whether a few calls dominate:
+
+```sql
+posthog:execute-sql
+SELECT
+    properties.$ai_model AS model,
+    round(quantile(0.5)(toFloat(properties.$ai_total_cost_usd)), 6) AS p50_cost,
+    round(quantile(0.95)(toFloat(properties.$ai_total_cost_usd)), 6) AS p95_cost,
+    round(quantile(0.99)(toFloat(properties.$ai_total_cost_usd)), 6) AS p99_cost,
+    round(max(toFloat(properties.$ai_total_cost_usd)), 6) AS max_cost
+FROM events
+WHERE event = '$ai_generation'
+    AND timestamp >= now() - INTERVAL 7 DAY
+GROUP BY model
+ORDER BY p99_cost DESC
+```
+
+### Input vs output vs cache economics
+
+Output tokens usually cost 3–5× input tokens; cache reads cost ~10% of input.
+Split the spend to find optimisation targets:
+
+```sql
+posthog:execute-sql
+SELECT
+    properties.$ai_model AS model,
+    round(sum(toFloat(properties.$ai_input_cost_usd)), 4) AS input_cost,
+    round(sum(toFloat(properties.$ai_output_cost_usd)), 4) AS output_cost,
+    sum(toInt(properties.$ai_input_tokens)) AS input_tokens,
+    sum(toInt(properties.$ai_output_tokens)) AS output_tokens,
+    sum(toInt(properties.$ai_cache_read_input_tokens)) AS cache_read_tokens,
+    sum(toInt(properties.$ai_cache_creation_input_tokens)) AS cache_write_tokens,
+    round(
+        sum(toInt(properties.$ai_cache_read_input_tokens)) /
+        nullIf(sum(toInt(properties.$ai_input_tokens)), 0), 3
+    ) AS cache_hit_rate
+FROM events
+WHERE event = '$ai_generation'
+    AND timestamp >= now() - INTERVAL 30 DAY
+GROUP BY model
+ORDER BY input_cost + output_cost DESC
+```
+
+A low `cache_hit_rate` on a model that supports prompt caching is a lever —
+prompt structure changes can move cost materially.
+
+## Workflow: inspect a single trace's cost
+
+When the user pastes a trace URL and asks about its cost, fetch the trace and
+surface the per-event breakdown:
+
+```json
+posthog:query-llm-trace
+{ "traceId": "<trace_id>", "dateRange": {"date_from": "-30d"} }
+```
+
+Sum `$ai_total_cost_usd` across the returned events, grouped by span name or
+model, to show which step(s) drove the cost. The trace response already
+includes `totalCost` as a convenience.
+
+## Workflow: debug a cost regression
+
+"Our LLM bill jumped — why?" is almost always one of: more calls, bigger
+prompts, a new model, or a change in cache-hit rate. Work through them in order.
+
+### Step 1 — Confirm and scope the regression
+
+```sql
+posthog:execute-sql
+SELECT
+    toDate(timestamp) AS day,
+    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd,
+    count() AS calls,
+    round(sum(toFloat(properties.$ai_total_cost_usd)) / count(), 6) AS avg_cost_per_call
+FROM events
+WHERE event IN ('$ai_generation', '$ai_embedding')
+    AND timestamp >= now() - INTERVAL 60 DAY
+GROUP BY day
+ORDER BY day
+```
+
+Compare `calls` vs `avg_cost_per_call` before and after the jump. If calls
+doubled, it's volume; if cost-per-call rose, it's prompt size, model, or cache.
+
+### Step 2 — Look for a model mix shift
+
+Run the "cost by model" query (above) over two windows — the week before and
+the week after the jump — and diff. A new `$ai_model` value appearing, or an
+old one disappearing, is a strong signal.
+
+### Step 3 — Look for prompt bloat
+
+```sql
+posthog:execute-sql
+SELECT
+    toDate(timestamp) AS day,
+    properties.$ai_model AS model,
+    round(avg(toInt(properties.$ai_input_tokens)), 1) AS avg_input_tokens,
+    round(avg(toInt(properties.$ai_output_tokens)), 1) AS avg_output_tokens
+FROM events
+WHERE event = '$ai_generation'
+    AND timestamp >= now() - INTERVAL 30 DAY
+GROUP BY day, model
+ORDER BY day, model
+```
+
+### Step 4 — Look for cache degradation
+
+Rerun the "input vs output vs cache economics" query windowed by day and track
+`cache_hit_rate`. A drop often follows a system-prompt change that invalidated
+the cached prefix.
+
+### Step 5 — Isolate the feature
+
+Once you've identified the mechanism (more calls / bigger prompts / new model /
+worse cache), group by the custom property that separates features (e.g.
+`feature`, `workflow_name`) to find which surface is responsible. Then drill
+into a representative trace via `query-llm-trace`.
+
+## Workflow: materialize as an insight, dashboard, or alert
+
+### Save a cost-over-time insight
+
+```json
+posthog:insight-create
+{
+  "name": "Daily LLM cost",
+  "query": {
+    "kind": "TrendsQuery",
+    "dateRange": {"date_from": "-30d"},
+    "series": [{
+      "kind": "EventsNode",
+      "event": "$ai_generation",
+      "math": "sum",
+      "math_property": "$ai_total_cost_usd"
+    }],
+    "trendsFilter": {"aggregationAxisPrefix": "$", "decimalPlaces": 2}
+  }
+}
+```
+
+For "cost per user", add a second series with `math: "dau"` and a formula
+`A / B` in `trendsFilter`. For breakdowns, add `breakdownFilter` with
+`breakdown: "$ai_model"` or any other dimension.
+
+### Add to a dashboard
+
+After saving the insights, use `posthog:dashboard-create` (or `-update`) to
+bundle them. The default `/llm-analytics/dashboard` already includes Cost,
+Cost per user, and Cost by model tiles — mirror that structure when building
+a custom one.
+
+### Alert on a cost threshold
+
+```json
+posthog:alert-create
+{
+  "insight": "<insight_id>",
+  "name": "Daily LLM cost over $100",
+  "threshold": {"configuration": {"absoluteThreshold": {"upper": 100}}},
+  "condition": {"type": "absolute_value"}
+}
+```
+
+The insight must be a single-value trends query (e.g. bold-number daily cost).
+
+## Constructing UI links
+
+- **Dashboard**: `https://app.posthog.com/llm-analytics/dashboard`
+- **Traces list** (sort by cost): `https://app.posthog.com/llm-analytics/traces`
+- **Generations list**: `https://app.posthog.com/llm-analytics/generations`
+- **Users list** (per-user cost): `https://app.posthog.com/llm-analytics/users`
+- **Single trace**: `https://app.posthog.com/llm-analytics/traces/<trace_id>?timestamp=<url_encoded_iso>`
+
+Always surface a UI link so the user can verify visually.
+
+## Tips
+
+- Always set a time range — cost queries without one scan the full events table
+- Always include `$ai_embedding` alongside `$ai_generation` when summing cost; embeddings are cheap per-call but add up at scale
+- Costs are written at ingestion from the model+provider lookup — if `$ai_total_cost_usd` is missing or zero, the model wasn't recognised (unusual custom model, fine-tune). Grep for nulls: `countIf(properties.$ai_total_cost_usd IS NULL)` per model
+- Exclude errored calls from cost totals only when explicitly asked — providers still charge for many error modes, and including them gives the truthful bill
+- For per-user totals, exclude rows where `distinct_id = properties.$ai_trace_id` — some SDKs default distinct_id to the trace ID when no user is set
+- Cost is additive across `$ai_generation` + `$ai_embedding` events within a trace; summing on `$ai_span` or `$ai_trace` gives zero
+- When answering "why is X expensive?", show the cost **and** the token split — the user almost always wants to know whether to shrink prompts, shrink outputs, or switch models
+- Before building a custom dashboard, check whether the stock `/llm-analytics/dashboard` tiles already answer the question — re-creating them is churn
+- For large tenants, materialize common cost queries as insights and reuse via `insight-query`; ad-hoc SQL is fine for one-offs but re-running it on every dashboard load is expensive

--- a/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
+++ b/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
@@ -22,16 +22,15 @@ regression debugging, and materializing results as insights, dashboards, or aler
 
 ## Tools
 
-| Tool                                      | Purpose                                                             |
-| ----------------------------------------- | ------------------------------------------------------------------- |
-| `posthog:get-llm-total-costs-for-project` | One-shot: daily total cost broken down by model (last N days)       |
-| `posthog:execute-sql`                     | Ad-hoc HogQL for any cost aggregation — the workhorse of this skill |
-| `posthog:query-llm-traces-list`           | List traces with rolled-up cost, token, and error metrics           |
-| `posthog:query-llm-trace`                 | Cost breakdown of a single trace across all its events              |
-| `posthog:read-data-schema`                | Discover which custom properties exist for breakdowns               |
-| `posthog:insight-create`                  | Materialize a cost chart as a saved insight                         |
-| `posthog:dashboard-create`                | Bundle cost insights into a dashboard                               |
-| `posthog:alert-create`                    | Alert when cost crosses a threshold                                 |
+| Tool                            | Purpose                                                             |
+| ------------------------------- | ------------------------------------------------------------------- |
+| `posthog:execute-sql`           | Ad-hoc HogQL for any cost aggregation — the workhorse of this skill |
+| `posthog:query-llm-traces-list` | List traces with rolled-up cost, token, and error metrics           |
+| `posthog:query-llm-trace`       | Cost breakdown of a single trace across all its events              |
+| `posthog:read-data-schema`      | Discover which custom properties exist for breakdowns               |
+| `posthog:insight-create`        | Materialize a cost chart as a saved insight                         |
+| `posthog:dashboard-create`      | Bundle cost insights into a dashboard                               |
+| `posthog:alert-create`          | Alert when cost crosses a threshold                                 |
 
 ## Cost properties
 
@@ -161,21 +160,6 @@ WHERE event = '$ai_generation'
     AND timestamp >= now() - INTERVAL 30 DAY
 GROUP BY model, properties.$ai_cache_reporting_exclusive
 ```
-
-## Workflow: answer "how much are we spending?"
-
-Default to the pre-built MCP tool when the user just wants the headline number:
-
-```json
-posthog:get-llm-total-costs-for-project
-{ "projectId": <id>, "days": 30 }
-```
-
-Returns a trends series of daily total cost broken down by model over the last
-N days (default 6). Links back to `/llm-observability` so the user can drill in.
-
-For anything beyond the default shape (different time range, different grouping,
-formula), drop to SQL — see the patterns below.
 
 ## Workflow: breakdown patterns
 
@@ -485,14 +469,26 @@ a custom one.
 ```json
 posthog:alert-create
 {
-  "insight": "<insight_id>",
+  "insight": <insight_id>,
   "name": "Daily LLM cost over $100",
-  "threshold": {"configuration": {"absoluteThreshold": {"upper": 100}}},
-  "condition": {"type": "absolute_value"}
+  "subscribed_users": [<user_id>],
+  "threshold": {
+    "configuration": {
+      "bounds": {"upper": 100},
+      "type": "absolute"
+    }
+  },
+  "condition": {"type": "absolute_value"},
+  "config": {"series_index": 0},
+  "enabled": true
 }
 ```
 
 The insight must be a single-value trends query (e.g. bold-number daily cost).
+`subscribed_users` is required and must contain at least one user id from the
+same team. `threshold.configuration.type` is `"absolute"` or `"percentage"`;
+`condition.type` is `"absolute_value"`, `"relative_increase"`, or
+`"relative_decrease"` (see `services/mcp/src/generated/alerts/api.ts`).
 
 ## Constructing UI links
 

--- a/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
+++ b/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
@@ -331,19 +331,36 @@ posthog:insight-create
   "query": {
     "kind": "TrendsQuery",
     "dateRange": {"date_from": "-30d"},
-    "series": [{
-      "kind": "EventsNode",
-      "event": "$ai_generation",
-      "math": "sum",
-      "math_property": "$ai_total_cost_usd"
-    }],
-    "trendsFilter": {"aggregationAxisPrefix": "$", "decimalPlaces": 2}
+    "series": [
+      {
+        "kind": "EventsNode",
+        "event": "$ai_generation",
+        "math": "sum",
+        "math_property": "$ai_total_cost_usd"
+      },
+      {
+        "kind": "EventsNode",
+        "event": "$ai_embedding",
+        "math": "sum",
+        "math_property": "$ai_total_cost_usd"
+      }
+    ],
+    "trendsFilter": {
+      "formula": "A + B",
+      "aggregationAxisPrefix": "$",
+      "decimalPlaces": 2
+    }
   }
 }
 ```
 
-For "cost per user", add a second series with `math: "dau"` and a formula
-`A / B` in `trendsFilter`. For breakdowns, add `breakdownFilter` with
+Both series are required — omitting `$ai_embedding` silently drops embedding
+spend. If the project demonstrably does not use embeddings (`count()` of
+`$ai_embedding` is zero over the relevant window), you can drop series B and
+the formula for a simpler insight.
+
+For "cost per user", add a third series with `math: "dau"` and change the
+formula to `(A + B) / C`. For breakdowns, add `breakdownFilter` with
 `breakdown: "$ai_model"` or any other dimension.
 
 ### Add to a dashboard

--- a/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
+++ b/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
@@ -69,13 +69,98 @@ tool-augmented generation. The UI's cost cells and both the
 `traces_query_runner` and `trace_query_runner` sum `$ai_total_cost_usd`
 over `event IN ('$ai_generation', '$ai_embedding')`; mirror that.
 
-Note: `$ai_trace` and `$ai_span` events do **not** carry cost. To get a trace's
-total cost, sum `$ai_total_cost_usd` across its `$ai_generation` and
-`$ai_embedding` events (matched by `$ai_trace_id`).
+Note: `$ai_trace` and `$ai_span` events do **not** carry cost for rollup
+purposes. To get a trace's total cost, sum `$ai_total_cost_usd` across its
+`$ai_generation` and `$ai_embedding` events (matched by `$ai_trace_id`).
+Some framework wrappers (e.g. the Claude Agent SDK integration in
+`posthog-python`) duplicate `$ai_total_cost_usd` onto `$ai_trace` as a
+convenience, but the query runners still aggregate over
+`event IN ('$ai_generation', '$ai_embedding')` — don't mix event sets or
+you'll double-count.
 
 `distinct_id` is the canonical user dimension — customers typically set it in
 the SDK. Use person properties (e.g. `email`, `company_tier`) for richer
 per-user breakdowns; discover what exists with `read-data-schema`.
+
+## How costs get set: SDK, custom pricing, ingestion
+
+Costs can arrive on the event in three ways; ingestion applies them in this
+precedence (see `nodejs/src/ingestion/ai/costs/index.ts` and
+[the docs](https://posthog.com/docs/llm-analytics/calculating-costs)):
+
+1. **Pre-calculated** — the SDK / manual capture sets `$ai_input_cost_usd`,
+   `$ai_output_cost_usd`, `$ai_request_cost_usd`, `$ai_web_search_cost_usd`
+   directly. Ingestion preserves them and fills `$ai_total_cost_usd` as the
+   sum. Use when the caller already knows the cost.
+2. **Custom pricing** — the SDK sets `$ai_input_token_price` /
+   `$ai_output_token_price` (required pair) plus optionally
+   `$ai_cache_read_token_price`, `$ai_cache_write_token_price`,
+   `$ai_request_price`, `$ai_web_search_price`. Ingestion multiplies by the
+   token counts. Token prices are **per token**, not per million.
+3. **Automatic model matching** — ingestion looks up pricing by
+   `$ai_model` + `$ai_provider` (OpenRouter first, manual fallback).
+
+Three metadata properties tell you which path was taken — read them whenever
+a cost looks wrong:
+
+| Property                  | Meaning                                                                     |
+| ------------------------- | --------------------------------------------------------------------------- |
+| `$ai_model_cost_used`     | Canonical model id the pricing lookup matched (may differ from `$ai_model`) |
+| `$ai_cost_model_source`   | `openrouter` \| `manual` \| `custom` \| `passthrough`                       |
+| `$ai_cost_model_provider` | Provider the lookup used                                                    |
+
+When `$ai_total_cost_usd` is null or zero for a model, group by
+`$ai_cost_model_source` to distinguish an unmatched model (no source) from
+an explicitly-zero custom price:
+
+```sql
+posthog:execute-sql
+SELECT
+    properties.$ai_model AS model,
+    properties.$ai_cost_model_source AS source,
+    count() AS calls,
+    countIf(toFloat(properties.$ai_total_cost_usd) = 0 OR properties.$ai_total_cost_usd IS NULL) AS zero_cost_calls
+FROM events
+WHERE event = '$ai_generation'
+    AND timestamp >= now() - INTERVAL 7 DAY
+GROUP BY model, source
+ORDER BY zero_cost_calls DESC
+```
+
+## Cache token accounting (exclusive vs inclusive)
+
+Providers report cache tokens two ways, and the skill's cache-hit-rate math
+changes accordingly:
+
+- **Exclusive** (Anthropic / Claude) — `$ai_input_tokens` does **not**
+  include cache tokens. Total input volume is
+  `input_tokens + cache_read + cache_creation`.
+- **Inclusive** (OpenAI and most others) — `$ai_input_tokens` already
+  includes cache tokens.
+
+Ingestion auto-detects from `$ai_provider` / `$ai_model` and writes the
+resolved value to `$ai_cache_reporting_exclusive` (boolean) on the event
+(`nodejs/src/ingestion/ai/costs/input-costs.ts`). Callers can override with
+`$ai_cache_reporting_exclusive: true|false` when manually capturing. When
+computing a cache-hit rate, split by that flag:
+
+```sql
+posthog:execute-sql
+SELECT
+    properties.$ai_model AS model,
+    if(properties.$ai_cache_reporting_exclusive = 'true',
+       sum(toInt(properties.$ai_cache_read_input_tokens))
+         / nullIf(sum(toInt(properties.$ai_input_tokens))
+                + sum(toInt(properties.$ai_cache_read_input_tokens))
+                + sum(toInt(properties.$ai_cache_creation_input_tokens)), 0),
+       sum(toInt(properties.$ai_cache_read_input_tokens))
+         / nullIf(sum(toInt(properties.$ai_input_tokens)), 0)
+    ) AS cache_hit_rate
+FROM events
+WHERE event = '$ai_generation'
+    AND timestamp >= now() - INTERVAL 30 DAY
+GROUP BY model, properties.$ai_cache_reporting_exclusive
+```
 
 ## Workflow: answer "how much are we spending?"
 
@@ -423,10 +508,12 @@ Always surface a UI link so the user can verify visually.
 
 - Always set a time range — cost queries without one scan the full events table
 - Always include `$ai_embedding` alongside `$ai_generation` when summing cost; embeddings are cheap per-call but add up at scale
-- Costs are written at ingestion from the model+provider lookup — if `$ai_total_cost_usd` is missing or zero, the model wasn't recognised (unusual custom model, fine-tune). Grep for nulls: `countIf(properties.$ai_total_cost_usd IS NULL)` per model
+- Costs are written at ingestion (see [Calculating LLM costs](https://posthog.com/docs/llm-analytics/calculating-costs)) — if `$ai_total_cost_usd` is missing or zero, read `$ai_cost_model_source` first: `passthrough` means the SDK supplied costs; `custom` means custom token prices; `openrouter` / `manual` mean automatic lookup; missing means the model wasn't matched (unusual custom model, fine-tune). Grep: `countIf(properties.$ai_total_cost_usd IS NULL)` per `(model, source)`
+- Custom pricing uses **per-token** prices, not per-million — if a custom-priced model looks ~1M× too expensive or too cheap, that's almost always the bug
 - Exclude errored calls from cost totals only when explicitly asked — providers still charge for many error modes, and including them gives the truthful bill
 - For per-user totals, exclude rows where `distinct_id = properties.$ai_trace_id` — some SDKs default distinct_id to the trace ID when no user is set
-- Cost is additive across `$ai_generation` + `$ai_embedding` events within a trace; summing on `$ai_span` or `$ai_trace` gives zero
+- Cost is additive across `$ai_generation` + `$ai_embedding` events within a trace; summing on `$ai_span` gives zero. `$ai_trace` may carry `$ai_total_cost_usd` from some SDK wrappers (e.g. Claude Agent SDK) — don't include it in rollups or you'll double-count
+- Cache-hit rate depends on `$ai_cache_reporting_exclusive` — Anthropic reports exclusively, OpenAI inclusively. Use the split formula above, not a single divisor, when comparing across providers
 - When answering "why is X expensive?", show the cost **and** the token split — the user almost always wants to know whether to shrink prompts, shrink outputs, or switch models
 - Before building a custom dashboard, check whether the stock `/llm-analytics/dashboard` tiles already answer the question — re-creating them is churn
 - For large tenants, materialize common cost queries as insights and reuse via `insight-query`; ad-hoc SQL is fine for one-offs but re-running it on every dashboard load is expensive

--- a/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
+++ b/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
@@ -58,24 +58,42 @@ survive. Costs live on `$ai_generation` and `$ai_embedding` only.
 | `$ai_provider`                    | generation, embedding | Secondary breakdown (openai, anthropic, …)                              |
 | `$ai_is_error`                    | generation            | Exclude/include failed calls in cost totals                             |
 | `$ai_trace_id`                    | all `$ai_*` events    | Roll costs up to trace level                                            |
+| `$ai_session_id`                  | all `$ai_*` events    | Roll costs up to session level (group sequences of related traces)      |
 
-**Always sum `$ai_total_cost_usd`, not the components.** Ingestion sets
+**Always sum `$ai_total_cost_usd`, not the components.** At ingestion,
 `$ai_total_cost_usd = input + output + request + web_search` (plus any
-modality costs) in `nodejs/src/ingestion/ai/costs/index.ts`. Summing only
-`$ai_input_cost_usd + $ai_output_cost_usd` silently drops request and
-web-search fees — real and non-zero for Anthropic request fees and any
-tool-augmented generation. The UI's cost cells and both the
-`traces_query_runner` and `trace_query_runner` sum `$ai_total_cost_usd`
-over `event IN ('$ai_generation', '$ai_embedding')`; mirror that.
+modality costs). Summing only `$ai_input_cost_usd + $ai_output_cost_usd`
+silently drops request and web-search fees — real and non-zero for
+Anthropic request fees and any tool-augmented generation. The UI's cost
+cells sum `$ai_total_cost_usd` over `event IN ('$ai_generation',
+'$ai_embedding')`; mirror that. See [Calculating LLM costs](https://posthog.com/docs/llm-analytics/calculating-costs)
+for the full derivation.
+
+Note on cache costs: providers that report cache tokens exclusively of
+`$ai_input_tokens` (e.g. Anthropic) also surface cache-read/write spend
+outside `$ai_input_cost_usd`, so `$ai_input_cost_usd` understates the true
+input-side spend there; providers that report inclusively (e.g. OpenAI)
+bundle cache spend into `$ai_input_cost_usd`. This varies by SDK version
+as well — see the "Cache token accounting" section below for the
+provider-aware formula. `$ai_total_cost_usd` is always the authoritative
+total and already accounts for whichever style the event used.
 
 Note: `$ai_trace` and `$ai_span` events do **not** carry cost for rollup
 purposes. To get a trace's total cost, sum `$ai_total_cost_usd` across its
 `$ai_generation` and `$ai_embedding` events (matched by `$ai_trace_id`).
-Some framework wrappers (e.g. the Claude Agent SDK integration in
-`posthog-python`) duplicate `$ai_total_cost_usd` onto `$ai_trace` as a
-convenience, but the query runners still aggregate over
+Some SDK wrappers duplicate `$ai_total_cost_usd` onto `$ai_trace` as a
+convenience, but query runners still aggregate over
 `event IN ('$ai_generation', '$ai_embedding')` — don't mix event sets or
 you'll double-count.
+
+`$ai_evaluation` events also emit cost properties (ingestion treats them
+as costed alongside `$ai_generation` and `$ai_embedding`), but the stock
+`/llm-analytics` rollups and the query runners **do not** include them
+in cost totals. If the user wants "total spend including evaluations",
+add `$ai_evaluation` to the event filter explicitly (e.g.
+`event IN ('$ai_generation', '$ai_embedding', '$ai_evaluation')`) and
+call out that it's an expanded definition; otherwise stick to the
+generation + embedding set to match the UI.
 
 `distinct_id` is the canonical user dimension — customers typically set it in
 the SDK. Use person properties (e.g. `email`, `company_tier`) for richer
@@ -84,8 +102,8 @@ per-user breakdowns; discover what exists with `read-data-schema`.
 ## How costs get set: SDK, custom pricing, ingestion
 
 Costs can arrive on the event in three ways; ingestion applies them in this
-precedence (see `nodejs/src/ingestion/ai/costs/index.ts` and
-[the docs](https://posthog.com/docs/llm-analytics/calculating-costs)):
+precedence (see [Calculating LLM costs](https://posthog.com/docs/llm-analytics/calculating-costs)
+for the authoritative rules):
 
 1. **Pre-calculated** — the SDK / manual capture sets `$ai_input_cost_usd`,
    `$ai_output_cost_usd`, `$ai_request_cost_usd`, `$ai_web_search_cost_usd`
@@ -108,9 +126,14 @@ a cost looks wrong:
 | `$ai_cost_model_source`   | `openrouter` \| `manual` \| `custom` \| `passthrough`                       |
 | `$ai_cost_model_provider` | Provider the lookup used                                                    |
 
-When `$ai_total_cost_usd` is null or zero for a model, group by
-`$ai_cost_model_source` to distinguish an unmatched model (no source) from
-an explicitly-zero custom price:
+When `$ai_total_cost_usd` is null or zero for a model, group by model
+**and** `$ai_cost_model_source` so you can see, per model, how many of
+its zero-cost calls came from each ingestion path. A model that has only
+`source = NULL` rows means ingestion never matched a pricing entry (fix:
+add custom pricing or correct `$ai_model` / `$ai_provider`); a model
+with `source = 'custom'` and zero cost is an explicitly-zero custom
+price (usually a misconfigured `$ai_input_token_price` / `$ai_output_token_price`).
+Without the source grouping the two look the same.
 
 ```sql
 posthog:execute-sql
@@ -131,15 +154,17 @@ ORDER BY zero_cost_calls DESC
 Providers report cache tokens two ways, and the skill's cache-hit-rate math
 changes accordingly:
 
-- **Exclusive** (Anthropic / Claude) — `$ai_input_tokens` does **not**
-  include cache tokens. Total input volume is
-  `input_tokens + cache_read + cache_creation`.
-- **Inclusive** (OpenAI and most others) — `$ai_input_tokens` already
-  includes cache tokens.
+- **Exclusive** — `$ai_input_tokens` does **not** include cache tokens.
+  Total input volume is `input_tokens + cache_read + cache_creation`.
+  Anthropic currently reports this way on most SDKs.
+- **Inclusive** — `$ai_input_tokens` already includes cache tokens.
+  OpenAI and most others currently report this way.
 
-Ingestion auto-detects from `$ai_provider` / `$ai_model` and writes the
-resolved value to `$ai_cache_reporting_exclusive` (boolean) on the event
-(`nodejs/src/ingestion/ai/costs/input-costs.ts`). Callers can override with
+Don't hardcode provider behaviour — it varies by SDK and by SDK version,
+and providers can change their own reporting style over time. Instead,
+trust the per-event flag: ingestion auto-detects and writes the resolved
+value to `$ai_cache_reporting_exclusive` (boolean) on every
+`$ai_generation`. Callers can also override with
 `$ai_cache_reporting_exclusive: true|false` when manually capturing. When
 computing a cache-hit rate, split by that flag:
 
@@ -235,7 +260,7 @@ LIMIT 25
 ```
 
 For a richer per-user view with person properties, the `/llm-analytics/users`
-page uses the same shape — see `products/llm_analytics/frontend/tabs/llmAnalyticsUsersLogic.ts`.
+page uses the same shape — check there for inspiration before hand-rolling.
 
 ### Cost by trace (top expensive traces)
 
@@ -343,10 +368,11 @@ ORDER BY total_cost DESC
 ```
 
 The `cache_hit_rate` uses the provider-aware formula from the "Cache token
-accounting" section above — Anthropic reports cache tokens exclusively of
-`$ai_input_tokens`, so the denominator must include them. If a single model
-mixes both reporting styles (unusual), split by `$ai_cache_reporting_exclusive`
-in the GROUP BY instead.
+accounting" section above — it branches on `$ai_cache_reporting_exclusive`
+so the denominator is correct for both exclusive and inclusive providers
+without hardcoding any provider or model names. If a single model mixes
+both reporting styles across events (unusual), split by
+`$ai_cache_reporting_exclusive` in the GROUP BY instead of `any()`.
 
 Rank and roll up on `total_cost` — summing only the input/output components
 drops request and web-search fees and can diverge from the `/llm-analytics`
@@ -504,7 +530,9 @@ The insight must be a single-value trends query (e.g. bold-number daily cost).
 `subscribed_users` is required and must contain at least one user id from the
 same team. `threshold.configuration.type` is `"absolute"` or `"percentage"`;
 `condition.type` is `"absolute_value"`, `"relative_increase"`, or
-`"relative_decrease"` (see `services/mcp/src/generated/alerts/api.ts`).
+`"relative_decrease"`. If the MCP tool rejects the payload, run
+`posthog:docs-search` for "alerts" to pull the current schema — the
+accepted enum values can change with the alerting API.
 
 ## Constructing UI links
 
@@ -516,6 +544,26 @@ same team. `threshold.configuration.type` is `"absolute"` or `"percentage"`;
 
 Always surface a UI link so the user can verify visually.
 
+## Keeping this skill current
+
+Provider reporting behaviour (which tokens are inclusive vs exclusive,
+which costs show up where) shifts over time and can differ between SDK
+versions for the same provider. To avoid rot:
+
+- Branch on event-level flags (`$ai_cache_reporting_exclusive`,
+  `$ai_cost_model_source`) rather than hardcoded provider or model names.
+  Those flags are ingestion's resolved answer for the specific event and
+  are the right source of truth.
+- `$ai_total_cost_usd` is always authoritative for rollups — prefer it
+  over summing components, which can drift as new cost categories are
+  added.
+- For anything not covered here (new cost categories, changes to
+  pricing lookup, provider additions), run `posthog:docs-search` for
+  "calculating costs" or "llm analytics" first rather than trusting a
+  hardcoded rule in this file.
+- If you find this skill contradicting the UI, trust the UI and flag
+  the skill for an update.
+
 ## Tips
 
 - Always set a time range — cost queries without one scan the full events table
@@ -524,8 +572,8 @@ Always surface a UI link so the user can verify visually.
 - Custom pricing uses **per-token** prices, not per-million — if a custom-priced model looks ~1M× too expensive or too cheap, that's almost always the bug
 - Exclude errored calls from cost totals only when explicitly asked — providers still charge for many error modes, and including them gives the truthful bill
 - For per-user totals, exclude rows where `distinct_id = properties.$ai_trace_id` — some SDKs default distinct_id to the trace ID when no user is set
-- Cost is additive across `$ai_generation` + `$ai_embedding` events within a trace; summing on `$ai_span` gives zero. `$ai_trace` may carry `$ai_total_cost_usd` from some SDK wrappers (e.g. Claude Agent SDK) — don't include it in rollups or you'll double-count
-- Cache-hit rate depends on `$ai_cache_reporting_exclusive` — Anthropic reports exclusively, OpenAI inclusively. Use the split formula above, not a single divisor, when comparing across providers
+- Cost is additive across `$ai_generation` + `$ai_embedding` events within a trace; summing on `$ai_span` gives zero. `$ai_trace` may carry `$ai_total_cost_usd` from some SDK wrappers — don't include it in rollups or you'll double-count. `$ai_evaluation` events also carry cost but are not part of the stock UI rollups; include them only when the user explicitly wants evaluation spend in the total
+- Cache-hit rate depends on `$ai_cache_reporting_exclusive` — branch on the event-level flag rather than on provider or model name. Provider behaviour and SDK versions drift; the flag is ingestion's resolved answer for that specific event
 - When answering "why is X expensive?", show the cost **and** the token split — the user almost always wants to know whether to shrink prompts, shrink outputs, or switch models
 - Before building a custom dashboard, check whether the stock `/llm-analytics/dashboard` tiles already answer the question — re-creating them is churn
 - For large tenants, materialize common cost queries as insights and reuse via `insight-query`; ad-hoc SQL is fine for one-offs but re-running it on every dashboard load is expensive

--- a/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
+++ b/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
@@ -225,7 +225,10 @@ SELECT
 FROM events
 WHERE event IN ('$ai_generation', '$ai_embedding')
     AND timestamp >= now() - INTERVAL 30 DAY
-    AND distinct_id != properties.$ai_trace_id  -- filter out traces used as distinct_id
+    AND (
+        properties.$ai_trace_id IS NULL
+        OR distinct_id != properties.$ai_trace_id
+    )  -- filter out rows where distinct_id was defaulted to the trace id
 GROUP BY distinct_id
 ORDER BY cost_usd DESC
 LIMIT 25

--- a/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
+++ b/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
@@ -322,8 +322,15 @@ SELECT
     sum(toInt(properties.$ai_cache_read_input_tokens)) AS cache_read_tokens,
     sum(toInt(properties.$ai_cache_creation_input_tokens)) AS cache_write_tokens,
     round(
-        sum(toInt(properties.$ai_cache_read_input_tokens)) /
-        nullIf(sum(toInt(properties.$ai_input_tokens)), 0), 3
+        if(
+            any(properties.$ai_cache_reporting_exclusive) = 'true',
+            sum(toInt(properties.$ai_cache_read_input_tokens))
+                / nullIf(sum(toInt(properties.$ai_input_tokens))
+                       + sum(toInt(properties.$ai_cache_read_input_tokens))
+                       + sum(toInt(properties.$ai_cache_creation_input_tokens)), 0),
+            sum(toInt(properties.$ai_cache_read_input_tokens))
+                / nullIf(sum(toInt(properties.$ai_input_tokens)), 0)
+        ), 3
     ) AS cache_hit_rate
 FROM events
 WHERE event = '$ai_generation'
@@ -331,6 +338,12 @@ WHERE event = '$ai_generation'
 GROUP BY model
 ORDER BY total_cost DESC
 ```
+
+The `cache_hit_rate` uses the provider-aware formula from the "Cache token
+accounting" section above — Anthropic reports cache tokens exclusively of
+`$ai_input_tokens`, so the denominator must include them. If a single model
+mixes both reporting styles (unusual), split by `$ai_cache_reporting_exclusive`
+in the GROUP BY instead.
 
 Rank and roll up on `total_cost` — summing only the input/output components
 drops request and web-search fees and can diverge from the `/llm-analytics`

--- a/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
+++ b/products/llm_analytics/skills/exploring-llm-costs/SKILL.md
@@ -32,167 +32,37 @@ regression debugging, and materializing results as insights, dashboards, or aler
 | `posthog:dashboard-create`      | Bundle cost insights into a dashboard                               |
 | `posthog:alert-create`          | Alert when cost crosses a threshold                                 |
 
-## Cost properties
+## Core rules
 
-All costs are USD, recorded per event at ingestion. PostHog derives them from the
-model+provider and token counts — you cannot set them manually and trust them to
-survive. Costs live on `$ai_generation` and `$ai_embedding` only.
+Three rules cover most of what goes wrong:
 
-| Property                          | Where                 | Meaning                                                                 |
-| --------------------------------- | --------------------- | ----------------------------------------------------------------------- |
-| `$ai_total_cost_usd`              | generation, embedding | Total cost for the call — **authoritative total**, use this for rollups |
-| `$ai_input_cost_usd`              | generation, embedding | Cost attributable to input tokens                                       |
-| `$ai_output_cost_usd`             | generation, embedding | Cost attributable to output tokens                                      |
-| `$ai_request_cost_usd`            | generation, embedding | Per-request flat cost (e.g. Anthropic per-request fee); often `0`       |
-| `$ai_web_search_cost_usd`         | generation, embedding | Cost of web-search tool calls inside the generation; often `0`          |
-| `$ai_audio_cost_usd`              | generation            | Audio-modality cost when the model charges a separate rate; often `0`   |
-| `$ai_image_cost_usd`              | generation            | Image-modality cost; often `0`                                          |
-| `$ai_video_cost_usd`              | generation            | Video-modality cost; often `0`                                          |
-| `$ai_input_tokens`                | generation, embedding | Tokens sent to the model (total across modalities)                      |
-| `$ai_output_tokens`               | generation            | Tokens returned by the model (total across modalities)                  |
-| `$ai_total_tokens`                | generation, embedding | Input + output tokens                                                   |
-| `$ai_cache_read_input_tokens`     | generation            | Input tokens served from provider prompt cache                          |
-| `$ai_cache_creation_input_tokens` | generation            | Input tokens written into provider prompt cache                         |
-| `$ai_reasoning_tokens`            | generation            | Reasoning-model thinking tokens (charged as output)                     |
-| `$ai_model`                       | generation, embedding | Primary breakdown dimension for cost                                    |
-| `$ai_provider`                    | generation, embedding | Secondary breakdown (openai, anthropic, …)                              |
-| `$ai_is_error`                    | generation            | Exclude/include failed calls in cost totals                             |
-| `$ai_trace_id`                    | all `$ai_*` events    | Roll costs up to trace level                                            |
-| `$ai_session_id`                  | all `$ai_*` events    | Roll costs up to session level (group sequences of related traces)      |
+- **Sum `$ai_total_cost_usd` for rollups, never the components.** Components drop
+  request and web-search fees. The UI's cost cells sum `$ai_total_cost_usd`
+  over `event IN ('$ai_generation', '$ai_embedding')`; mirror that. Full
+  schema and rationale in [cost properties](./references/cost-properties.md).
+- **Always include both `$ai_generation` and `$ai_embedding`** in cost queries
+  unless the project demonstrably does not use embeddings — missing them silently
+  under-counts. `$ai_trace` and `$ai_span` carry no rollup cost; some SDK
+  wrappers duplicate `$ai_total_cost_usd` onto `$ai_trace` so don't include
+  it in rollups or you'll double-count.
+- **Always set a time range.** Cost queries without one scan the full events table.
 
-**Always sum `$ai_total_cost_usd`, not the components.** At ingestion,
-`$ai_total_cost_usd = input + output + request + web_search` (plus any
-modality costs). Summing only `$ai_input_cost_usd + $ai_output_cost_usd`
-silently drops request and web-search fees — real and non-zero for
-Anthropic request fees and any tool-augmented generation. The UI's cost
-cells sum `$ai_total_cost_usd` over `event IN ('$ai_generation',
-'$ai_embedding')`; mirror that. See [Calculating LLM costs](https://posthog.com/docs/llm-analytics/calculating-costs)
-for the full derivation.
+`$ai_total_cost_usd` is set at ingestion via one of three paths (passthrough,
+custom pricing, automatic lookup). When a cost looks wrong, read
+`$ai_cost_model_source` first — see [cost sources](./references/cost-sources.md)
+for the precedence rules and a diagnostic query.
 
-Note on cache costs: providers that report cache tokens exclusively of
-`$ai_input_tokens` (e.g. Anthropic) also surface cache-read/write spend
-outside `$ai_input_cost_usd`, so `$ai_input_cost_usd` understates the true
-input-side spend there; providers that report inclusively (e.g. OpenAI)
-bundle cache spend into `$ai_input_cost_usd`. This varies by SDK version
-as well — see the "Cache token accounting" section below for the
-provider-aware formula. `$ai_total_cost_usd` is always the authoritative
-total and already accounts for whichever style the event used.
+Cache-hit math depends on whether the provider reports cache tokens inclusively
+or exclusively of `$ai_input_tokens`. Always branch on the per-event
+`$ai_cache_reporting_exclusive` flag, never on provider name — see
+[cache accounting](./references/cache-accounting.md) for the exclusive-vs-inclusive
+formula.
 
-Note: `$ai_trace` and `$ai_span` events do **not** carry cost for rollup
-purposes. To get a trace's total cost, sum `$ai_total_cost_usd` across its
-`$ai_generation` and `$ai_embedding` events (matched by `$ai_trace_id`).
-Some SDK wrappers duplicate `$ai_total_cost_usd` onto `$ai_trace` as a
-convenience, but query runners still aggregate over
-`event IN ('$ai_generation', '$ai_embedding')` — don't mix event sets or
-you'll double-count.
+`distinct_id` is the canonical user dimension. Customers often attach custom
+properties (`feature`, `tenant_id`, `workflow_name`) — discover them with
+`posthog:read-data-schema` before grouping. Don't guess names.
 
-`$ai_evaluation` events also emit cost properties (ingestion treats them
-as costed alongside `$ai_generation` and `$ai_embedding`), but the stock
-`/llm-analytics` rollups and the query runners **do not** include them
-in cost totals. If the user wants "total spend including evaluations",
-add `$ai_evaluation` to the event filter explicitly (e.g.
-`event IN ('$ai_generation', '$ai_embedding', '$ai_evaluation')`) and
-call out that it's an expanded definition; otherwise stick to the
-generation + embedding set to match the UI.
-
-`distinct_id` is the canonical user dimension — customers typically set it in
-the SDK. Use person properties (e.g. `email`, `company_tier`) for richer
-per-user breakdowns; discover what exists with `read-data-schema`.
-
-## How costs get set: SDK, custom pricing, ingestion
-
-Costs can arrive on the event in three ways; ingestion applies them in this
-precedence (see [Calculating LLM costs](https://posthog.com/docs/llm-analytics/calculating-costs)
-for the authoritative rules):
-
-1. **Pre-calculated** — the SDK / manual capture sets `$ai_input_cost_usd`,
-   `$ai_output_cost_usd`, `$ai_request_cost_usd`, `$ai_web_search_cost_usd`
-   directly. Ingestion preserves them and fills `$ai_total_cost_usd` as the
-   sum. Use when the caller already knows the cost.
-2. **Custom pricing** — the SDK sets `$ai_input_token_price` /
-   `$ai_output_token_price` (required pair) plus optionally
-   `$ai_cache_read_token_price`, `$ai_cache_write_token_price`,
-   `$ai_request_price`, `$ai_web_search_price`. Ingestion multiplies by the
-   token counts. Token prices are **per token**, not per million.
-3. **Automatic model matching** — ingestion looks up pricing by
-   `$ai_model` + `$ai_provider` (OpenRouter first, manual fallback).
-
-Three metadata properties tell you which path was taken — read them whenever
-a cost looks wrong:
-
-| Property                  | Meaning                                                                     |
-| ------------------------- | --------------------------------------------------------------------------- |
-| `$ai_model_cost_used`     | Canonical model id the pricing lookup matched (may differ from `$ai_model`) |
-| `$ai_cost_model_source`   | `openrouter` \| `manual` \| `custom` \| `passthrough`                       |
-| `$ai_cost_model_provider` | Provider the lookup used                                                    |
-
-When `$ai_total_cost_usd` is null or zero for a model, group by model
-**and** `$ai_cost_model_source` so you can see, per model, how many of
-its zero-cost calls came from each ingestion path. A model that has only
-`source = NULL` rows means ingestion never matched a pricing entry (fix:
-add custom pricing or correct `$ai_model` / `$ai_provider`); a model
-with `source = 'custom'` and zero cost is an explicitly-zero custom
-price (usually a misconfigured `$ai_input_token_price` / `$ai_output_token_price`).
-Without the source grouping the two look the same.
-
-```sql
-posthog:execute-sql
-SELECT
-    properties.$ai_model AS model,
-    properties.$ai_cost_model_source AS source,
-    count() AS calls,
-    countIf(toFloat(properties.$ai_total_cost_usd) = 0 OR properties.$ai_total_cost_usd IS NULL) AS zero_cost_calls
-FROM events
-WHERE event = '$ai_generation'
-    AND timestamp >= now() - INTERVAL 7 DAY
-GROUP BY model, source
-ORDER BY zero_cost_calls DESC
-```
-
-## Cache token accounting (exclusive vs inclusive)
-
-Providers report cache tokens two ways, and the skill's cache-hit-rate math
-changes accordingly:
-
-- **Exclusive** — `$ai_input_tokens` does **not** include cache tokens.
-  Total input volume is `input_tokens + cache_read + cache_creation`.
-  Anthropic currently reports this way on most SDKs.
-- **Inclusive** — `$ai_input_tokens` already includes cache tokens.
-  OpenAI and most others currently report this way.
-
-Don't hardcode provider behaviour — it varies by SDK and by SDK version,
-and providers can change their own reporting style over time. Instead,
-trust the per-event flag: ingestion auto-detects and writes the resolved
-value to `$ai_cache_reporting_exclusive` (boolean) on every
-`$ai_generation`. Callers can also override with
-`$ai_cache_reporting_exclusive: true|false` when manually capturing. When
-computing a cache-hit rate, split by that flag:
-
-```sql
-posthog:execute-sql
-SELECT
-    properties.$ai_model AS model,
-    if(properties.$ai_cache_reporting_exclusive = 'true',
-       sum(toInt(properties.$ai_cache_read_input_tokens))
-         / nullIf(sum(toInt(properties.$ai_input_tokens))
-                + sum(toInt(properties.$ai_cache_read_input_tokens))
-                + sum(toInt(properties.$ai_cache_creation_input_tokens)), 0),
-       sum(toInt(properties.$ai_cache_read_input_tokens))
-         / nullIf(sum(toInt(properties.$ai_input_tokens)), 0)
-    ) AS cache_hit_rate
-FROM events
-WHERE event = '$ai_generation'
-    AND timestamp >= now() - INTERVAL 30 DAY
-GROUP BY model, properties.$ai_cache_reporting_exclusive
-```
-
-## Workflow: breakdown patterns
-
-Every cost question is a variation of the same template. Always set a time range.
-Always include `$ai_embedding` alongside `$ai_generation` if the project uses
-embeddings — missing them silently under-counts.
-
-### Total cost in a window
+## Workflow: total spend in a window
 
 ```sql
 posthog:execute-sql
@@ -202,186 +72,19 @@ WHERE event IN ('$ai_generation', '$ai_embedding')
     AND timestamp >= now() - INTERVAL 30 DAY
 ```
 
-### Cost over time (daily)
+## Workflow: cost breakdowns
 
-```sql
-posthog:execute-sql
-SELECT
-    toDate(timestamp) AS day,
-    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd,
-    sum(toInt(properties.$ai_input_tokens)) AS input_tokens,
-    sum(toInt(properties.$ai_output_tokens)) AS output_tokens,
-    count() AS calls
-FROM events
-WHERE event IN ('$ai_generation', '$ai_embedding')
-    AND timestamp >= now() - INTERVAL 30 DAY
-GROUP BY day
-ORDER BY day
-```
+Every cost question is a variation of the same template — group by a dimension,
+aggregate `$ai_total_cost_usd`. See [breakdown patterns](./references/breakdown-patterns.md)
+for ready-to-run recipes:
 
-### Cost by model
-
-```sql
-posthog:execute-sql
-SELECT
-    properties.$ai_model AS model,
-    properties.$ai_provider AS provider,
-    count() AS calls,
-    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd,
-    round(avg(toFloat(properties.$ai_total_cost_usd)), 6) AS avg_cost_per_call,
-    sum(toInt(properties.$ai_input_tokens)) AS input_tokens,
-    sum(toInt(properties.$ai_output_tokens)) AS output_tokens
-FROM events
-WHERE event IN ('$ai_generation', '$ai_embedding')
-    AND timestamp >= now() - INTERVAL 30 DAY
-GROUP BY model, provider
-ORDER BY cost_usd DESC
-```
-
-### Cost by user (top spenders)
-
-```sql
-posthog:execute-sql
-SELECT
-    distinct_id,
-    count() AS calls,
-    countDistinct(properties.$ai_trace_id) AS traces,
-    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd
-FROM events
-WHERE event IN ('$ai_generation', '$ai_embedding')
-    AND timestamp >= now() - INTERVAL 30 DAY
-    AND (
-        properties.$ai_trace_id IS NULL
-        OR distinct_id != properties.$ai_trace_id
-    )  -- filter out rows where distinct_id was defaulted to the trace id
-GROUP BY distinct_id
-ORDER BY cost_usd DESC
-LIMIT 25
-```
-
-For a richer per-user view with person properties, the `/llm-analytics/users`
-page uses the same shape — check there for inspiration before hand-rolling.
-
-### Cost by trace (top expensive traces)
-
-```sql
-posthog:execute-sql
-SELECT
-    properties.$ai_trace_id AS trace_id,
-    count() AS llm_calls,
-    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd,
-    sum(toInt(properties.$ai_input_tokens)) AS input_tokens,
-    sum(toInt(properties.$ai_output_tokens)) AS output_tokens,
-    min(timestamp) AS started_at
-FROM events
-WHERE event IN ('$ai_generation', '$ai_embedding')
-    AND timestamp >= now() - INTERVAL 7 DAY
-    AND isNotNull(properties.$ai_trace_id)
-GROUP BY trace_id
-ORDER BY cost_usd DESC
-LIMIT 25
-```
-
-Then drill into the top traces with `posthog:query-llm-trace` to see which spans
-and generations are driving cost.
-
-### Cost by custom dimension
-
-Customers often attach their own dimensions (`feature`, `tenant_id`, `workflow_name`).
-Discover them first, then group:
-
-1. `posthog:read-data-schema` with `kind: "event_properties"` and
-   `event_name: "$ai_generation"` to find custom keys
-2. `posthog:read-data-schema` with `kind: "event_property_values"` to spot-check
-   that values look right
-3. Group by the discovered property:
-
-```sql
-posthog:execute-sql
-SELECT
-    properties.feature AS feature,
-    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd,
-    count() AS calls
-FROM events
-WHERE event IN ('$ai_generation', '$ai_embedding')
-    AND timestamp >= now() - INTERVAL 30 DAY
-    AND isNotNull(properties.feature)
-GROUP BY feature
-ORDER BY cost_usd DESC
-```
-
-Do not guess custom property names — they vary per project.
-
-### Cost per call (distribution)
-
-Totals hide skew. Use percentiles to see whether a few calls dominate:
-
-```sql
-posthog:execute-sql
-SELECT
-    properties.$ai_model AS model,
-    round(quantile(0.5)(toFloat(properties.$ai_total_cost_usd)), 6) AS p50_cost,
-    round(quantile(0.95)(toFloat(properties.$ai_total_cost_usd)), 6) AS p95_cost,
-    round(quantile(0.99)(toFloat(properties.$ai_total_cost_usd)), 6) AS p99_cost,
-    round(max(toFloat(properties.$ai_total_cost_usd)), 6) AS max_cost
-FROM events
-WHERE event = '$ai_generation'
-    AND timestamp >= now() - INTERVAL 7 DAY
-GROUP BY model
-ORDER BY p99_cost DESC
-```
-
-### Input vs output vs cache economics
-
-Output tokens usually cost 3–5× input tokens; cache reads cost ~10% of input.
-Split the spend to find optimisation targets:
-
-```sql
-posthog:execute-sql
-SELECT
-    properties.$ai_model AS model,
-    round(sum(toFloat(properties.$ai_input_cost_usd)), 4) AS input_cost,
-    round(sum(toFloat(properties.$ai_output_cost_usd)), 4) AS output_cost,
-    round(sum(toFloat(properties.$ai_request_cost_usd)), 4) AS request_cost,
-    round(sum(toFloat(properties.$ai_web_search_cost_usd)), 4) AS web_search_cost,
-    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS total_cost,
-    sum(toInt(properties.$ai_input_tokens)) AS input_tokens,
-    sum(toInt(properties.$ai_output_tokens)) AS output_tokens,
-    sum(toInt(properties.$ai_cache_read_input_tokens)) AS cache_read_tokens,
-    sum(toInt(properties.$ai_cache_creation_input_tokens)) AS cache_write_tokens,
-    round(
-        if(
-            any(properties.$ai_cache_reporting_exclusive) = 'true',
-            sum(toInt(properties.$ai_cache_read_input_tokens))
-                / nullIf(sum(toInt(properties.$ai_input_tokens))
-                       + sum(toInt(properties.$ai_cache_read_input_tokens))
-                       + sum(toInt(properties.$ai_cache_creation_input_tokens)), 0),
-            sum(toInt(properties.$ai_cache_read_input_tokens))
-                / nullIf(sum(toInt(properties.$ai_input_tokens)), 0)
-        ), 3
-    ) AS cache_hit_rate
-FROM events
-WHERE event = '$ai_generation'
-    AND timestamp >= now() - INTERVAL 30 DAY
-GROUP BY model
-ORDER BY total_cost DESC
-```
-
-The `cache_hit_rate` uses the provider-aware formula from the "Cache token
-accounting" section above — it branches on `$ai_cache_reporting_exclusive`
-so the denominator is correct for both exclusive and inclusive providers
-without hardcoding any provider or model names. If a single model mixes
-both reporting styles across events (unusual), split by
-`$ai_cache_reporting_exclusive` in the GROUP BY instead of `any()`.
-
-Rank and roll up on `total_cost` — summing only the input/output components
-drops request and web-search fees and can diverge from the `/llm-analytics`
-UI. If `request_cost` or `web_search_cost` are a meaningful share of
-`total_cost` for a model, that's a separate optimisation lever (e.g. chattier
-provider, tool-heavy generations).
-
-A low `cache_hit_rate` on a model that supports prompt caching is a lever —
-prompt structure changes can move cost materially.
+- Cost over time (daily)
+- Cost by model
+- Cost by user (top spenders)
+- Cost by trace (top expensive traces)
+- Cost by custom dimension
+- Cost-per-call distribution
+- Input vs output vs cache economics
 
 ## Workflow: inspect a single trace's cost
 
@@ -400,139 +103,16 @@ includes `totalCost` as a convenience.
 ## Workflow: debug a cost regression
 
 "Our LLM bill jumped — why?" is almost always one of: more calls, bigger
-prompts, a new model, or a change in cache-hit rate. Work through them in order.
-
-### Step 1 — Confirm and scope the regression
-
-```sql
-posthog:execute-sql
-SELECT
-    toDate(timestamp) AS day,
-    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd,
-    count() AS calls,
-    round(sum(toFloat(properties.$ai_total_cost_usd)) / count(), 6) AS avg_cost_per_call
-FROM events
-WHERE event IN ('$ai_generation', '$ai_embedding')
-    AND timestamp >= now() - INTERVAL 60 DAY
-GROUP BY day
-ORDER BY day
-```
-
-Compare `calls` vs `avg_cost_per_call` before and after the jump. If calls
-doubled, it's volume; if cost-per-call rose, it's prompt size, model, or cache.
-
-### Step 2 — Look for a model mix shift
-
-Run the "cost by model" query (above) over two windows — the week before and
-the week after the jump — and diff. A new `$ai_model` value appearing, or an
-old one disappearing, is a strong signal.
-
-### Step 3 — Look for prompt bloat
-
-```sql
-posthog:execute-sql
-SELECT
-    toDate(timestamp) AS day,
-    properties.$ai_model AS model,
-    round(avg(toInt(properties.$ai_input_tokens)), 1) AS avg_input_tokens,
-    round(avg(toInt(properties.$ai_output_tokens)), 1) AS avg_output_tokens
-FROM events
-WHERE event = '$ai_generation'
-    AND timestamp >= now() - INTERVAL 30 DAY
-GROUP BY day, model
-ORDER BY day, model
-```
-
-### Step 4 — Look for cache degradation
-
-Rerun the "input vs output vs cache economics" query windowed by day and track
-`cache_hit_rate`. A drop often follows a system-prompt change that invalidated
-the cached prefix.
-
-### Step 5 — Isolate the feature
-
-Once you've identified the mechanism (more calls / bigger prompts / new model /
-worse cache), group by the custom property that separates features (e.g.
-`feature`, `workflow_name`) to find which surface is responsible. Then drill
-into a representative trace via `query-llm-trace`.
+prompts, a new model, or a change in cache-hit rate. Work through them in
+order — see [regression debugging](./references/regression-debugging.md) for
+the 5-step playbook.
 
 ## Workflow: materialize as an insight, dashboard, or alert
 
-### Save a cost-over-time insight
-
-```json
-posthog:insight-create
-{
-  "name": "Daily LLM cost",
-  "query": {
-    "kind": "TrendsQuery",
-    "dateRange": {"date_from": "-30d"},
-    "series": [
-      {
-        "kind": "EventsNode",
-        "event": "$ai_generation",
-        "math": "sum",
-        "math_property": "$ai_total_cost_usd"
-      },
-      {
-        "kind": "EventsNode",
-        "event": "$ai_embedding",
-        "math": "sum",
-        "math_property": "$ai_total_cost_usd"
-      }
-    ],
-    "trendsFilter": {
-      "formula": "A + B",
-      "aggregationAxisPrefix": "$",
-      "decimalPlaces": 2
-    }
-  }
-}
-```
-
-Both series are required — omitting `$ai_embedding` silently drops embedding
-spend. If the project demonstrably does not use embeddings (`count()` of
-`$ai_embedding` is zero over the relevant window), you can drop series B and
-the formula for a simpler insight.
-
-For "cost per user", add a third series with `math: "dau"` and change the
-formula to `(A + B) / C`. For breakdowns, add `breakdownFilter` with
-`breakdown: "$ai_model"` or any other dimension.
-
-### Add to a dashboard
-
-After saving the insights, use `posthog:dashboard-create` (or `-update`) to
-bundle them. The default `/llm-analytics/dashboard` already includes Cost,
-Cost per user, and Cost by model tiles — mirror that structure when building
-a custom one.
-
-### Alert on a cost threshold
-
-```json
-posthog:alert-create
-{
-  "insight": <insight_id>,
-  "name": "Daily LLM cost over $100",
-  "subscribed_users": [<user_id>],
-  "threshold": {
-    "configuration": {
-      "bounds": {"upper": 100},
-      "type": "absolute"
-    }
-  },
-  "condition": {"type": "absolute_value"},
-  "config": {"series_index": 0},
-  "enabled": true
-}
-```
-
-The insight must be a single-value trends query (e.g. bold-number daily cost).
-`subscribed_users` is required and must contain at least one user id from the
-same team. `threshold.configuration.type` is `"absolute"` or `"percentage"`;
-`condition.type` is `"absolute_value"`, `"relative_increase"`, or
-`"relative_decrease"`. If the MCP tool rejects the payload, run
-`posthog:docs-search` for "alerts" to pull the current schema — the
-accepted enum values can change with the alerting API.
+After ad-hoc queries answer the question, persist them as insights, bundle
+into a dashboard, or wire up alerts. See [materializing](./references/materializing.md)
+for ready-to-run JSON for `posthog:insight-create`, `posthog:dashboard-create`,
+and `posthog:alert-create`.
 
 ## Constructing UI links
 
@@ -546,7 +126,7 @@ Always surface a UI link so the user can verify visually.
 
 ## Keeping this skill current
 
-Provider reporting behaviour (which tokens are inclusive vs exclusive,
+Provider reporting behavior (which tokens are inclusive vs exclusive,
 which costs show up where) shifts over time and can differ between SDK
 versions for the same provider. To avoid rot:
 
@@ -573,7 +153,16 @@ versions for the same provider. To avoid rot:
 - Exclude errored calls from cost totals only when explicitly asked — providers still charge for many error modes, and including them gives the truthful bill
 - For per-user totals, exclude rows where `distinct_id = properties.$ai_trace_id` — some SDKs default distinct_id to the trace ID when no user is set
 - Cost is additive across `$ai_generation` + `$ai_embedding` events within a trace; summing on `$ai_span` gives zero. `$ai_trace` may carry `$ai_total_cost_usd` from some SDK wrappers — don't include it in rollups or you'll double-count. `$ai_evaluation` events also carry cost but are not part of the stock UI rollups; include them only when the user explicitly wants evaluation spend in the total
-- Cache-hit rate depends on `$ai_cache_reporting_exclusive` — branch on the event-level flag rather than on provider or model name. Provider behaviour and SDK versions drift; the flag is ingestion's resolved answer for that specific event
+- Cache-hit rate depends on `$ai_cache_reporting_exclusive` — branch on the event-level flag rather than on provider or model name. Provider behavior and SDK versions drift; the flag is ingestion's resolved answer for that specific event
 - When answering "why is X expensive?", show the cost **and** the token split — the user almost always wants to know whether to shrink prompts, shrink outputs, or switch models
 - Before building a custom dashboard, check whether the stock `/llm-analytics/dashboard` tiles already answer the question — re-creating them is churn
 - For large tenants, materialize common cost queries as insights and reuse via `insight-query`; ad-hoc SQL is fine for one-offs but re-running it on every dashboard load is expensive
+
+## References
+
+- [cost properties](./references/cost-properties.md) — full property schema, total-cost rationale, event-set rules
+- [cost sources](./references/cost-sources.md) — how costs get set at ingestion plus a diagnostic query
+- [cache accounting](./references/cache-accounting.md) — exclusive vs inclusive providers, cache-hit-rate formula
+- [breakdown patterns](./references/breakdown-patterns.md) — SQL recipes for every common breakdown
+- [regression debugging](./references/regression-debugging.md) — 5-step playbook for cost spikes
+- [materializing](./references/materializing.md) — insight, dashboard, and alert JSON

--- a/products/llm_analytics/skills/exploring-llm-costs/references/breakdown-patterns.md
+++ b/products/llm_analytics/skills/exploring-llm-costs/references/breakdown-patterns.md
@@ -1,0 +1,187 @@
+# Cost breakdown patterns
+
+Every cost question is a variation of the same template. Always set a time range.
+Always include `$ai_embedding` alongside `$ai_generation` if the project uses
+embeddings — missing them silently under-counts.
+
+## Cost over time (daily)
+
+```sql
+posthog:execute-sql
+SELECT
+    toDate(timestamp) AS day,
+    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd,
+    sum(toInt(properties.$ai_input_tokens)) AS input_tokens,
+    sum(toInt(properties.$ai_output_tokens)) AS output_tokens,
+    count() AS calls
+FROM events
+WHERE event IN ('$ai_generation', '$ai_embedding')
+    AND timestamp >= now() - INTERVAL 30 DAY
+GROUP BY day
+ORDER BY day
+```
+
+## Cost by model
+
+```sql
+posthog:execute-sql
+SELECT
+    properties.$ai_model AS model,
+    properties.$ai_provider AS provider,
+    count() AS calls,
+    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd,
+    round(avg(toFloat(properties.$ai_total_cost_usd)), 6) AS avg_cost_per_call,
+    sum(toInt(properties.$ai_input_tokens)) AS input_tokens,
+    sum(toInt(properties.$ai_output_tokens)) AS output_tokens
+FROM events
+WHERE event IN ('$ai_generation', '$ai_embedding')
+    AND timestamp >= now() - INTERVAL 30 DAY
+GROUP BY model, provider
+ORDER BY cost_usd DESC
+```
+
+## Cost by user (top spenders)
+
+```sql
+posthog:execute-sql
+SELECT
+    distinct_id,
+    count() AS calls,
+    countDistinct(properties.$ai_trace_id) AS traces,
+    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd
+FROM events
+WHERE event IN ('$ai_generation', '$ai_embedding')
+    AND timestamp >= now() - INTERVAL 30 DAY
+    AND (
+        properties.$ai_trace_id IS NULL
+        OR distinct_id != properties.$ai_trace_id
+    )  -- filter out rows where distinct_id was defaulted to the trace id
+GROUP BY distinct_id
+ORDER BY cost_usd DESC
+LIMIT 25
+```
+
+For a richer per-user view with person properties, the `/llm-analytics/users`
+page uses the same shape — check there for inspiration before hand-rolling.
+
+## Cost by trace (top expensive traces)
+
+```sql
+posthog:execute-sql
+SELECT
+    properties.$ai_trace_id AS trace_id,
+    count() AS llm_calls,
+    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd,
+    sum(toInt(properties.$ai_input_tokens)) AS input_tokens,
+    sum(toInt(properties.$ai_output_tokens)) AS output_tokens,
+    min(timestamp) AS started_at
+FROM events
+WHERE event IN ('$ai_generation', '$ai_embedding')
+    AND timestamp >= now() - INTERVAL 7 DAY
+    AND isNotNull(properties.$ai_trace_id)
+GROUP BY trace_id
+ORDER BY cost_usd DESC
+LIMIT 25
+```
+
+Then drill into the top traces with `posthog:query-llm-trace` to see which spans
+and generations are driving cost.
+
+## Cost by custom dimension
+
+Customers often attach their own dimensions (`feature`, `tenant_id`, `workflow_name`).
+Discover them first, then group:
+
+1. `posthog:read-data-schema` with `kind: "event_properties"` and
+   `event_name: "$ai_generation"` to find custom keys
+2. `posthog:read-data-schema` with `kind: "event_property_values"` to spot-check
+   that values look right
+3. Group by the discovered property:
+
+```sql
+posthog:execute-sql
+SELECT
+    properties.feature AS feature,
+    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd,
+    count() AS calls
+FROM events
+WHERE event IN ('$ai_generation', '$ai_embedding')
+    AND timestamp >= now() - INTERVAL 30 DAY
+    AND isNotNull(properties.feature)
+GROUP BY feature
+ORDER BY cost_usd DESC
+```
+
+Do not guess custom property names — they vary per project.
+
+## Cost per call (distribution)
+
+Totals hide skew. Use percentiles to see whether a few calls dominate:
+
+```sql
+posthog:execute-sql
+SELECT
+    properties.$ai_model AS model,
+    round(quantile(0.5)(toFloat(properties.$ai_total_cost_usd)), 6) AS p50_cost,
+    round(quantile(0.95)(toFloat(properties.$ai_total_cost_usd)), 6) AS p95_cost,
+    round(quantile(0.99)(toFloat(properties.$ai_total_cost_usd)), 6) AS p99_cost,
+    round(max(toFloat(properties.$ai_total_cost_usd)), 6) AS max_cost
+FROM events
+WHERE event = '$ai_generation'
+    AND timestamp >= now() - INTERVAL 7 DAY
+GROUP BY model
+ORDER BY p99_cost DESC
+```
+
+## Input vs output vs cache economics
+
+Output tokens usually cost 3–5× input tokens; cache reads cost ~10% of input.
+Split the spend to find optimization targets:
+
+```sql
+posthog:execute-sql
+SELECT
+    properties.$ai_model AS model,
+    round(sum(toFloat(properties.$ai_input_cost_usd)), 4) AS input_cost,
+    round(sum(toFloat(properties.$ai_output_cost_usd)), 4) AS output_cost,
+    round(sum(toFloat(properties.$ai_request_cost_usd)), 4) AS request_cost,
+    round(sum(toFloat(properties.$ai_web_search_cost_usd)), 4) AS web_search_cost,
+    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS total_cost,
+    sum(toInt(properties.$ai_input_tokens)) AS input_tokens,
+    sum(toInt(properties.$ai_output_tokens)) AS output_tokens,
+    sum(toInt(properties.$ai_cache_read_input_tokens)) AS cache_read_tokens,
+    sum(toInt(properties.$ai_cache_creation_input_tokens)) AS cache_write_tokens,
+    round(
+        if(
+            any(properties.$ai_cache_reporting_exclusive) = 'true',
+            sum(toInt(properties.$ai_cache_read_input_tokens))
+                / nullIf(sum(toInt(properties.$ai_input_tokens))
+                       + sum(toInt(properties.$ai_cache_read_input_tokens))
+                       + sum(toInt(properties.$ai_cache_creation_input_tokens)), 0),
+            sum(toInt(properties.$ai_cache_read_input_tokens))
+                / nullIf(sum(toInt(properties.$ai_input_tokens)), 0)
+        ), 3
+    ) AS cache_hit_rate
+FROM events
+WHERE event = '$ai_generation'
+    AND timestamp >= now() - INTERVAL 30 DAY
+GROUP BY model
+ORDER BY total_cost DESC
+```
+
+The `cache_hit_rate` uses the provider-aware formula from
+[cache accounting](./cache-accounting.md) — it branches on
+`$ai_cache_reporting_exclusive` so the denominator is correct for both
+exclusive and inclusive providers without hardcoding any provider or model
+names. If a single model mixes both reporting styles across events
+(unusual), split by `$ai_cache_reporting_exclusive` in the GROUP BY
+instead of `any()`.
+
+Rank and roll up on `total_cost` — summing only the input/output components
+drops request and web-search fees and can diverge from the `/llm-analytics`
+UI. If `request_cost` or `web_search_cost` are a meaningful share of
+`total_cost` for a model, that's a separate optimization lever (e.g. chattier
+provider, tool-heavy generations).
+
+A low `cache_hit_rate` on a model that supports prompt caching is a lever —
+prompt structure changes can move cost materially.

--- a/products/llm_analytics/skills/exploring-llm-costs/references/cache-accounting.md
+++ b/products/llm_analytics/skills/exploring-llm-costs/references/cache-accounting.md
@@ -1,0 +1,41 @@
+# Cache token accounting (exclusive vs inclusive)
+
+Providers report cache tokens two ways, and the cache-hit-rate math
+changes accordingly:
+
+- **Exclusive** — `$ai_input_tokens` does **not** include cache tokens.
+  Total input volume is `input_tokens + cache_read + cache_creation`.
+  Anthropic currently reports this way on most SDKs.
+- **Inclusive** — `$ai_input_tokens` already includes cache tokens.
+  OpenAI and most others currently report this way.
+
+Don't hardcode provider behavior — it varies by SDK and by SDK version,
+and providers can change their own reporting style over time. Instead,
+trust the per-event flag: ingestion auto-detects and writes the resolved
+value to `$ai_cache_reporting_exclusive` (boolean) on every
+`$ai_generation`. Callers can also override with
+`$ai_cache_reporting_exclusive: true|false` when manually capturing.
+
+## Cache-hit rate, branching on the per-event flag
+
+```sql
+posthog:execute-sql
+SELECT
+    properties.$ai_model AS model,
+    if(properties.$ai_cache_reporting_exclusive = 'true',
+       sum(toInt(properties.$ai_cache_read_input_tokens))
+         / nullIf(sum(toInt(properties.$ai_input_tokens))
+                + sum(toInt(properties.$ai_cache_read_input_tokens))
+                + sum(toInt(properties.$ai_cache_creation_input_tokens)), 0),
+       sum(toInt(properties.$ai_cache_read_input_tokens))
+         / nullIf(sum(toInt(properties.$ai_input_tokens)), 0)
+    ) AS cache_hit_rate
+FROM events
+WHERE event = '$ai_generation'
+    AND timestamp >= now() - INTERVAL 30 DAY
+GROUP BY model, properties.$ai_cache_reporting_exclusive
+```
+
+The same provider-aware `if(...)` formula is what powers `cache_hit_rate`
+in the [breakdown patterns](./breakdown-patterns.md) "input vs output vs
+cache economics" recipe.

--- a/products/llm_analytics/skills/exploring-llm-costs/references/cost-properties.md
+++ b/products/llm_analytics/skills/exploring-llm-costs/references/cost-properties.md
@@ -1,0 +1,73 @@
+# Cost properties
+
+All costs are USD, recorded per event at ingestion. PostHog derives them from the
+model+provider and token counts — you cannot set them manually and trust them to
+survive. Costs live on `$ai_generation` and `$ai_embedding` only.
+
+| Property                          | Where                 | Meaning                                                                 |
+| --------------------------------- | --------------------- | ----------------------------------------------------------------------- |
+| `$ai_total_cost_usd`              | generation, embedding | Total cost for the call — **authoritative total**, use this for rollups |
+| `$ai_input_cost_usd`              | generation, embedding | Cost attributable to input tokens                                       |
+| `$ai_output_cost_usd`             | generation, embedding | Cost attributable to output tokens                                      |
+| `$ai_request_cost_usd`            | generation, embedding | Per-request flat cost (e.g. Anthropic per-request fee); often `0`       |
+| `$ai_web_search_cost_usd`         | generation, embedding | Cost of web-search tool calls inside the generation; often `0`          |
+| `$ai_audio_cost_usd`              | generation            | Audio-modality cost when the model charges a separate rate; often `0`   |
+| `$ai_image_cost_usd`              | generation            | Image-modality cost; often `0`                                          |
+| `$ai_video_cost_usd`              | generation            | Video-modality cost; often `0`                                          |
+| `$ai_input_tokens`                | generation, embedding | Tokens sent to the model (total across modalities)                      |
+| `$ai_output_tokens`               | generation            | Tokens returned by the model (total across modalities)                  |
+| `$ai_total_tokens`                | generation, embedding | Input + output tokens                                                   |
+| `$ai_cache_read_input_tokens`     | generation            | Input tokens served from provider prompt cache                          |
+| `$ai_cache_creation_input_tokens` | generation            | Input tokens written into provider prompt cache                         |
+| `$ai_reasoning_tokens`            | generation            | Reasoning-model thinking tokens (charged as output)                     |
+| `$ai_model`                       | generation, embedding | Primary breakdown dimension for cost                                    |
+| `$ai_provider`                    | generation, embedding | Secondary breakdown (openai, anthropic, …)                              |
+| `$ai_is_error`                    | generation            | Exclude/include failed calls in cost totals                             |
+| `$ai_trace_id`                    | all `$ai_*` events    | Roll costs up to trace level                                            |
+| `$ai_session_id`                  | all `$ai_*` events    | Roll costs up to session level (group sequences of related traces)      |
+
+## Always sum `$ai_total_cost_usd`, not the components
+
+At ingestion, `$ai_total_cost_usd = input + output + request + web_search` (plus
+any modality costs). Summing only `$ai_input_cost_usd + $ai_output_cost_usd`
+silently drops request and web-search fees — real and non-zero for Anthropic
+request fees and any tool-augmented generation. The UI's cost cells sum
+`$ai_total_cost_usd` over `event IN ('$ai_generation', '$ai_embedding')`;
+mirror that. See [Calculating LLM costs](https://posthog.com/docs/llm-analytics/calculating-costs)
+for the full derivation.
+
+## Cache costs vary by provider reporting style
+
+Providers that report cache tokens exclusively of `$ai_input_tokens` (e.g.
+Anthropic) also surface cache-read/write spend outside `$ai_input_cost_usd`,
+so `$ai_input_cost_usd` understates the true input-side spend there;
+providers that report inclusively (e.g. OpenAI) bundle cache spend into
+`$ai_input_cost_usd`. This varies by SDK version as well — see
+[cache accounting](./cache-accounting.md) for the provider-aware formula.
+`$ai_total_cost_usd` is always the authoritative total and already accounts
+for whichever style the event used.
+
+## Event-set rules for trace and evaluation events
+
+`$ai_trace` and `$ai_span` events do **not** carry cost for rollup purposes.
+To get a trace's total cost, sum `$ai_total_cost_usd` across its
+`$ai_generation` and `$ai_embedding` events (matched by `$ai_trace_id`).
+Some SDK wrappers duplicate `$ai_total_cost_usd` onto `$ai_trace` as a
+convenience, but query runners still aggregate over
+`event IN ('$ai_generation', '$ai_embedding')` — don't mix event sets or
+you'll double-count.
+
+`$ai_evaluation` events also emit cost properties (ingestion treats them
+as costed alongside `$ai_generation` and `$ai_embedding`), but the stock
+`/llm-analytics` rollups and the query runners **do not** include them
+in cost totals. If the user wants "total spend including evaluations",
+add `$ai_evaluation` to the event filter explicitly (e.g.
+`event IN ('$ai_generation', '$ai_embedding', '$ai_evaluation')`) and
+call out that it's an expanded definition; otherwise stick to the
+generation + embedding set to match the UI.
+
+## User dimension
+
+`distinct_id` is the canonical user dimension — customers typically set it in
+the SDK. Use person properties (e.g. `email`, `company_tier`) for richer
+per-user breakdowns; discover what exists with `read-data-schema`.

--- a/products/llm_analytics/skills/exploring-llm-costs/references/cost-sources.md
+++ b/products/llm_analytics/skills/exploring-llm-costs/references/cost-sources.md
@@ -1,0 +1,51 @@
+# How costs get set: SDK, custom pricing, ingestion
+
+Costs can arrive on the event in three ways; ingestion applies them in this
+precedence (see [Calculating LLM costs](https://posthog.com/docs/llm-analytics/calculating-costs)
+for the authoritative rules):
+
+1. **Pre-calculated** — the SDK / manual capture sets `$ai_input_cost_usd`,
+   `$ai_output_cost_usd`, `$ai_request_cost_usd`, `$ai_web_search_cost_usd`
+   directly. Ingestion preserves them and fills `$ai_total_cost_usd` as the
+   sum. Use when the caller already knows the cost.
+2. **Custom pricing** — the SDK sets `$ai_input_token_price` /
+   `$ai_output_token_price` (required pair) plus optionally
+   `$ai_cache_read_token_price`, `$ai_cache_write_token_price`,
+   `$ai_request_price`, `$ai_web_search_price`. Ingestion multiplies by the
+   token counts. Token prices are **per token**, not per million.
+3. **Automatic model matching** — ingestion looks up pricing by
+   `$ai_model` + `$ai_provider` (OpenRouter first, manual fallback).
+
+Three metadata properties tell you which path was taken — read them whenever
+a cost looks wrong:
+
+| Property                  | Meaning                                                                     |
+| ------------------------- | --------------------------------------------------------------------------- |
+| `$ai_model_cost_used`     | Canonical model id the pricing lookup matched (may differ from `$ai_model`) |
+| `$ai_cost_model_source`   | `openrouter` \| `manual` \| `custom` \| `passthrough`                       |
+| `$ai_cost_model_provider` | Provider the lookup used                                                    |
+
+## Diagnostic: zero or null cost by model and source
+
+When `$ai_total_cost_usd` is null or zero for a model, group by model
+**and** `$ai_cost_model_source` so you can see, per model, how many of
+its zero-cost calls came from each ingestion path. A model that has only
+`source = NULL` rows means ingestion never matched a pricing entry (fix:
+add custom pricing or correct `$ai_model` / `$ai_provider`); a model
+with `source = 'custom'` and zero cost is an explicitly-zero custom
+price (usually a misconfigured `$ai_input_token_price` / `$ai_output_token_price`).
+Without the source grouping the two look the same.
+
+```sql
+posthog:execute-sql
+SELECT
+    properties.$ai_model AS model,
+    properties.$ai_cost_model_source AS source,
+    count() AS calls,
+    countIf(toFloat(properties.$ai_total_cost_usd) = 0 OR properties.$ai_total_cost_usd IS NULL) AS zero_cost_calls
+FROM events
+WHERE event = '$ai_generation'
+    AND timestamp >= now() - INTERVAL 7 DAY
+GROUP BY model, source
+ORDER BY zero_cost_calls DESC
+```

--- a/products/llm_analytics/skills/exploring-llm-costs/references/materializing.md
+++ b/products/llm_analytics/skills/exploring-llm-costs/references/materializing.md
@@ -1,0 +1,80 @@
+# Materializing cost queries as insights, dashboards, and alerts
+
+After ad-hoc queries answer the question, persist them as insights, bundle into
+a dashboard, or wire up alerts.
+
+## Save a cost-over-time insight
+
+```json
+posthog:insight-create
+{
+  "name": "Daily LLM cost",
+  "query": {
+    "kind": "TrendsQuery",
+    "dateRange": {"date_from": "-30d"},
+    "series": [
+      {
+        "kind": "EventsNode",
+        "event": "$ai_generation",
+        "math": "sum",
+        "math_property": "$ai_total_cost_usd"
+      },
+      {
+        "kind": "EventsNode",
+        "event": "$ai_embedding",
+        "math": "sum",
+        "math_property": "$ai_total_cost_usd"
+      }
+    ],
+    "trendsFilter": {
+      "formula": "A + B",
+      "aggregationAxisPrefix": "$",
+      "decimalPlaces": 2
+    }
+  }
+}
+```
+
+Both series are required — omitting `$ai_embedding` silently drops embedding
+spend. If the project demonstrably does not use embeddings (`count()` of
+`$ai_embedding` is zero over the relevant window), you can drop series B and
+the formula for a simpler insight.
+
+For "cost per user", add a third series with `math: "dau"` and change the
+formula to `(A + B) / C`. For breakdowns, add `breakdownFilter` with
+`breakdown: "$ai_model"` or any other dimension.
+
+## Add to a dashboard
+
+After saving the insights, use `posthog:dashboard-create` (or `-update`) to
+bundle them. The default `/llm-analytics/dashboard` already includes Cost,
+Cost per user, and Cost by model tiles — mirror that structure when building
+a custom one.
+
+## Alert on a cost threshold
+
+```json
+posthog:alert-create
+{
+  "insight": <insight_id>,
+  "name": "Daily LLM cost over $100",
+  "subscribed_users": [<user_id>],
+  "threshold": {
+    "configuration": {
+      "bounds": {"upper": 100},
+      "type": "absolute"
+    }
+  },
+  "condition": {"type": "absolute_value"},
+  "config": {"series_index": 0},
+  "enabled": true
+}
+```
+
+The insight must be a single-value trends query (e.g. bold-number daily cost).
+`subscribed_users` is required and must contain at least one user id from the
+same team. `threshold.configuration.type` is `"absolute"` or `"percentage"`;
+`condition.type` is `"absolute_value"`, `"relative_increase"`, or
+`"relative_decrease"`. If the MCP tool rejects the payload, run
+`posthog:docs-search` for "alerts" to pull the current schema — the
+accepted enum values can change with the alerting API.

--- a/products/llm_analytics/skills/exploring-llm-costs/references/regression-debugging.md
+++ b/products/llm_analytics/skills/exploring-llm-costs/references/regression-debugging.md
@@ -1,0 +1,59 @@
+# Debugging a cost regression
+
+"Our LLM bill jumped — why?" is almost always one of: more calls, bigger
+prompts, a new model, or a change in cache-hit rate. Work through them in order.
+
+## Step 1 — Confirm and scope the regression
+
+```sql
+posthog:execute-sql
+SELECT
+    toDate(timestamp) AS day,
+    round(sum(toFloat(properties.$ai_total_cost_usd)), 4) AS cost_usd,
+    count() AS calls,
+    round(sum(toFloat(properties.$ai_total_cost_usd)) / count(), 6) AS avg_cost_per_call
+FROM events
+WHERE event IN ('$ai_generation', '$ai_embedding')
+    AND timestamp >= now() - INTERVAL 60 DAY
+GROUP BY day
+ORDER BY day
+```
+
+Compare `calls` vs `avg_cost_per_call` before and after the jump. If calls
+doubled, it's volume; if cost-per-call rose, it's prompt size, model, or cache.
+
+## Step 2 — Look for a model mix shift
+
+Run the "cost by model" recipe in [breakdown patterns](./breakdown-patterns.md)
+over two windows — the week before and the week after the jump — and diff. A
+new `$ai_model` value appearing, or an old one disappearing, is a strong signal.
+
+## Step 3 — Look for prompt bloat
+
+```sql
+posthog:execute-sql
+SELECT
+    toDate(timestamp) AS day,
+    properties.$ai_model AS model,
+    round(avg(toInt(properties.$ai_input_tokens)), 1) AS avg_input_tokens,
+    round(avg(toInt(properties.$ai_output_tokens)), 1) AS avg_output_tokens
+FROM events
+WHERE event = '$ai_generation'
+    AND timestamp >= now() - INTERVAL 30 DAY
+GROUP BY day, model
+ORDER BY day, model
+```
+
+## Step 4 — Look for cache degradation
+
+Rerun the "input vs output vs cache economics" recipe in
+[breakdown patterns](./breakdown-patterns.md) windowed by day and track
+`cache_hit_rate`. A drop often follows a system-prompt change that invalidated
+the cached prefix.
+
+## Step 5 — Isolate the feature
+
+Once you've identified the mechanism (more calls / bigger prompts / new model /
+worse cache), group by the custom property that separates features (e.g.
+`feature`, `workflow_name`) to find which surface is responsible. Then drill
+into a representative trace via `posthog:query-llm-trace`.


### PR DESCRIPTION
## Problem

Cost exploration is one of the most common jobs-to-be-done in LLM analytics
(how much are we spending, on what, by whom, and why did it change?), but
there is no dedicated skill guiding an agent through the standard cost
investigations. Users and internal agents end up rebuilding the same HogQL
patterns from scratch.

## Changes

Adds a new `exploring-llm-costs` skill alongside `exploring-llm-traces`,
`exploring-llm-clusters`, and `exploring-llm-evaluations` under
`products/llm_analytics/skills/`.

The skill covers:

- Cost property reference (`$ai_*_cost_usd`, token and cache-token props,
  where they live, how to roll them up)
- Which MCP tools to reach for (`get-llm-total-costs-for-project` for the
  headline number, `execute-sql` for everything else, plus traces, schema
  discovery, and insight/dashboard/alert creation)
- Standard breakdown recipes: total, over time, by model, by user, by trace,
  by custom dimension, per-call distribution (percentiles), input/output/cache
  economics with `cache_hit_rate`
- Single-trace cost inspection
- Cost regression debugging playbook (volume vs avg-cost-per-call split, model
  mix shift, prompt bloat, cache degradation, feature isolation)
- Templates for materializing results as insights, dashboards, and alerts
- UI link conventions and common gotchas (embeddings, `distinct_id == trace_id`,
  `$ai_span` / `$ai_trace` don't carry cost)

Registers the new skill in `products/llm_analytics/skills/README.md`.

## How did you test this code?

Docs-only change — no tests. Reviewed against sibling skills for structural
consistency, cross-checked cost properties against
`products/llm_analytics/skills/exploring-llm-traces/references/events-and-properties.md`
and the `get-llm-total-costs-for-project` MCP tool implementation, and pulled
the HogQL patterns from the existing LLM analytics dashboard / users logic so
the recipes match what the product itself runs.

## Publish to changelog?

no

## Docs update

no