### PR TITLE
feat: store activity sessions column configs

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTableExport.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTableExport.tsx
@@ -28,6 +28,7 @@ import {
     isMarketingAnalyticsTableQuery,
     isNonIntegratedConversionsTableQuery,
     isPersonsNode,
+    isSessionsQuery,
 } from '~/queries/utils'
 import { ExportContext, ExporterFormat } from '~/types'
 
@@ -67,7 +68,10 @@ export async function startDownload(
 
     if (onlySelectedColumns) {
         let columns = (
-            (isEventsQuery(query.source) || isActorsQuery(query.source) || isGroupsQuery(query.source)
+            (isEventsQuery(query.source) ||
+            isActorsQuery(query.source) ||
+            isGroupsQuery(query.source) ||
+            isSessionsQuery(query.source)
                 ? query.source.select
                 : null) ??
             query.columns ??

--- a/frontend/src/scenes/activity/explore/defaults.ts
+++ b/frontend/src/scenes/activity/explore/defaults.ts
@@ -46,5 +46,5 @@ export const getDefaultSessionsSceneQuery = (properties?: AnyPropertyFilter[]): 
     propertiesViaUrl: true,
     showSavedQueries: true,
     showPersistentColumnConfigurator: true,
-    contextKey: 'sessions',
+    contextKey: 'activity-sessions',
 })

--- a/frontend/src/scenes/activity/explore/defaults.ts
+++ b/frontend/src/scenes/activity/explore/defaults.ts
@@ -46,4 +46,5 @@ export const getDefaultSessionsSceneQuery = (properties?: AnyPropertyFilter[]): 
     propertiesViaUrl: true,
     showSavedQueries: true,
     showPersistentColumnConfigurator: true,
+    contextKey: 'sessions',
 })


### PR DESCRIPTION
## Problem

Two related problems here

### Configure Columns

In Activity -> Sessions, if you configure columns they do not persist, and actually (can) cause a problem for the Events view because we're contaminating the columns for the Events view (the default).

https://github.com/user-attachments/assets/2523baa8-b018-4f86-be6f-54f6ffc14d16

### Exporting data columns

From Activity -> Sessions, if you export to CSV or XLSX, it falls back to default columns because we don't recognise it's a sessions export.

## Changes

Provide a unique context key to store session columns in a `ColumnConfiguration` object. And, validate using `isSessionQuery` that the query we're making can use the non-default column to export with.

## How did you test this code?

Manually in development

## Publish to changelog?

no.

## 🤖 LLM context 

Claude led the charge on the investigation.