### PR TITLE
feat(logs): enhance alert metrics tracking

### DIFF
--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -15,7 +15,10 @@ from posthog.cdp.internal_events import InternalEventEvent, produce_internal_eve
 from posthog.exceptions_capture import capture_exception
 
 from products.logs.backend.alert_check_query import AlertCheckQuery
-from products.logs.backend.alert_error_classifier import classify as classify_alert_error
+from products.logs.backend.alert_error_classifier import (
+    AlertErrorCode,
+    classify as classify_alert_error,
+)
 from products.logs.backend.alert_state_machine import (
     AlertCheckOutcome,
     AlertState,
@@ -27,7 +30,15 @@ from products.logs.backend.alert_state_machine import (
 from products.logs.backend.alert_utils import advance_next_check_at
 from products.logs.backend.logs_url_params import build_logs_url_params
 from products.logs.backend.models import MAX_EVALUATION_PERIODS, LogsAlertConfiguration, LogsAlertEvent
-from products.logs.backend.temporal.metrics import increment_checks_total, record_check_duration, record_scheduler_lag
+from products.logs.backend.temporal.metrics import (
+    increment_check_errors,
+    increment_checks_total,
+    increment_notification_failures,
+    increment_state_transition,
+    record_alerts_active,
+    record_check_duration,
+    record_scheduler_lag,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -65,6 +76,11 @@ def _check_alerts_sync() -> CheckAlertsOutput:
         .exclude(state=LogsAlertConfiguration.State.SNOOZED, snooze_until__gt=now)
         .exclude(state=LogsAlertConfiguration.State.BROKEN)
     )
+
+    try:
+        record_alerts_active(len(all_alerts))
+    except Exception:
+        logger.exception("Failed to record alerts_active gauge")
 
     stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
 
@@ -109,6 +125,7 @@ def _evaluate_single_alert(
     date_from = now - timedelta(minutes=alert.window_minutes)
 
     check_result: CheckResult
+    error_category: AlertErrorCode | None = None
     try:
         query_result = AlertCheckQuery(
             team=alert.team,
@@ -128,6 +145,7 @@ def _evaluate_single_alert(
         )
     except Exception as e:
         classified = classify_alert_error(e)
+        error_category = classified.code
         capture_exception(e, {"alert_id": str(alert.id), "classification": classified.code})
         logger.warning(
             "Alert check query failed",
@@ -281,6 +299,16 @@ def _evaluate_single_alert(
             increment_checks_total("resolved")
         else:
             increment_checks_total("ok")
+
+        if error_category is not None:
+            increment_check_errors(error_category)
+
+        if notification_failed:
+            increment_notification_failures(outcome.notification)
+
+        state_before_enum = AlertState(state_before)
+        if committed_state != state_before_enum:
+            increment_state_transition(state_before_enum, committed_state)
     except Exception:
         logger.exception("Failed to record alert check metrics", alert_id=str(alert.id))
 

--- a/products/logs/backend/temporal/metrics.py
+++ b/products/logs/backend/temporal/metrics.py
@@ -12,7 +12,15 @@ from temporalio.worker import ActivityInboundInterceptor, ExecuteActivityInput, 
 
 from posthog.temporal.common.logger import get_write_only_logger
 
+from products.logs.backend.alert_error_classifier import AlertErrorCode
+from products.logs.backend.alert_state_machine import AlertState, NotificationAction
+
 logger = get_write_only_logger(__name__)
+
+_NOTIFICATION_FAILURE_LABELS: dict[NotificationAction, str] = {
+    NotificationAction.FIRE: "firing",
+    NotificationAction.RESOLVE: "resolved",
+}
 
 ALERTING_ACTIVITY_TYPES = frozenset(
     {
@@ -71,6 +79,43 @@ def increment_checks_total(outcome: AlertOutcome) -> None:
     meter = get_metric_meter({"outcome": outcome})
     counter = meter.create_counter("logs_alerting_checks_total", "Number of individual alert checks by outcome")
     counter.add(1)
+
+
+def increment_check_errors(category: AlertErrorCode) -> None:
+    meter = get_metric_meter({"category": category})
+    counter = meter.create_counter(
+        "logs_alerting_check_errors_total",
+        "Errored alert checks broken down by classifier category",
+    )
+    counter.add(1)
+
+
+def increment_notification_failures(action: NotificationAction) -> None:
+    label = _NOTIFICATION_FAILURE_LABELS[action]
+    meter = get_metric_meter({"event": label})
+    counter = meter.create_counter(
+        "logs_alerting_notification_failures_total",
+        "Kafka produce failures for firing/resolved notifications",
+    )
+    counter.add(1)
+
+
+def increment_state_transition(from_state: AlertState, to_state: AlertState) -> None:
+    meter = get_metric_meter({"from": from_state.value, "to": to_state.value})
+    counter = meter.create_counter(
+        "logs_alerting_state_transitions_total",
+        "Alert state transitions by from/to state (worker-committed)",
+    )
+    counter.add(1)
+
+
+def record_alerts_active(count: int) -> None:
+    meter = get_metric_meter()
+    gauge = meter.create_gauge(
+        "logs_alerting_alerts_active",
+        "Number of due alerts evaluated this cycle",
+    )
+    gauge.set(count)
 
 
 def record_check_duration(duration_ms: int) -> None:

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -11,6 +11,7 @@ from parameterized import parameterized
 from posthog.errors import QueryErrorCategory
 
 from products.logs.backend.alert_check_query import AlertCheckCountResult
+from products.logs.backend.alert_state_machine import AlertState, NotificationAction
 from products.logs.backend.models import MAX_EVALUATION_PERIODS, LogsAlertConfiguration, LogsAlertEvent
 from products.logs.backend.temporal.activities import CheckAlertsOutput, _check_alerts_sync, _evaluate_single_alert
 
@@ -108,8 +109,49 @@ class TestCheckAlertsSync(APIBaseTest):
         assert result.alerts_errored == 1
         assert result.alerts_checked == 0
 
+    @parameterized.expand(
+        [
+            ("with_due_alerts", True, 2),
+            ("none_due", False, 0),
+        ]
+    )
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.record_alerts_active")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    def test_records_alerts_active_gauge(self, _name, seed_alerts, expected_count, mock_query_cls, mock_record_gauge):
+        if seed_alerts:
+            mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+            self._make_alert()
+            self._make_alert(name="Second")
+            # Disabled and snoozed alerts should not count toward the gauge.
+            self._make_alert(name="Disabled", enabled=False)
+            self._make_alert(
+                name="Snoozed",
+                state=LogsAlertConfiguration.State.SNOOZED,
+                snooze_until=datetime(2025, 1, 2, 0, 0, 0, tzinfo=UTC),
+            )
+
+        _check_alerts_sync()
+
+        mock_record_gauge.assert_called_once_with(expected_count)
+
 
 class TestEvaluateSingleAlert(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        # Silence the per-alert metric helpers at class level — they raise outside
+        # Temporal context and the try/except in activities.py swallows the first raise,
+        # skipping later helpers that individual tests want to assert on.
+        for target in (
+            "products.logs.backend.temporal.activities.record_check_duration",
+            "products.logs.backend.temporal.activities.record_scheduler_lag",
+            "products.logs.backend.temporal.activities.increment_checks_total",
+            "products.logs.backend.temporal.activities.increment_check_errors",
+        ):
+            p = patch(target)
+            p.start()
+            self.addCleanup(p.stop)
+
     def _make_alert(self, **kwargs) -> LogsAlertConfiguration:
         defaults = {
             "team": self.team,
@@ -558,3 +600,122 @@ class TestEvaluateSingleAlert(APIBaseTest):
             # Auto-disabled event surfaces the classified user message, never the raw CH exception.
             assert props["last_error_message"] == "Query is too expensive. Try narrower filters or a shorter window."
             assert "DB::Exception" not in props["last_error_message"]
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.increment_state_transition")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_state_transition_counter_fires_on_state_change(self, _mock_produce, mock_query_cls, mock_transition):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        alert = self._make_alert()
+
+        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
+
+        mock_transition.assert_called_once_with(AlertState.NOT_FIRING, AlertState.FIRING)
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.increment_state_transition")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_state_transition_counter_silent_when_state_unchanged(self, _mock_produce, mock_query_cls, mock_transition):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        self._make_alert()
+
+        _evaluate_single_alert(
+            LogsAlertConfiguration.objects.get(), datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats()
+        )
+
+        mock_transition.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("fire", 50, LogsAlertConfiguration.State.NOT_FIRING),
+            ("resolve", 0, LogsAlertConfiguration.State.FIRING),
+        ]
+    )
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.increment_notification_failures")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event", side_effect=Exception("Kafka down"))
+    @patch("products.logs.backend.temporal.activities.capture_exception")
+    def test_notification_failures_counter(
+        self,
+        expected_action_name,
+        result_count,
+        initial_state,
+        _mock_capture,
+        _mock_produce,
+        mock_query_cls,
+        mock_notif_failures,
+    ):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(
+            count=result_count, query_duration_ms=100
+        )
+        self._make_alert(state=initial_state)
+
+        _evaluate_single_alert(
+            LogsAlertConfiguration.objects.get(), datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats()
+        )
+
+        mock_notif_failures.assert_called_once_with(NotificationAction(expected_action_name))
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.increment_notification_failures")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_notification_failures_silent_on_success(self, _mock_produce, mock_query_cls, mock_notif_failures):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=50, query_duration_ms=100)
+        self._make_alert()
+
+        _evaluate_single_alert(
+            LogsAlertConfiguration.objects.get(), datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats()
+        )
+
+        mock_notif_failures.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("server_busy", QueryErrorCategory.RATE_LIMITED),
+            ("query_performance", QueryErrorCategory.QUERY_PERFORMANCE_ERROR),
+            ("cancelled", QueryErrorCategory.CANCELLED),
+            ("unknown", QueryErrorCategory.ERROR),
+        ]
+    )
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.increment_check_errors")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_check_errors_counter_labelled_by_classifier(
+        self,
+        expected_category,
+        classifier_category,
+        _mock_produce,
+        mock_query_cls,
+        mock_check_errors,
+    ):
+        mock_query_cls.return_value.execute.side_effect = Exception("boom")
+        self._make_alert()
+
+        with patch(
+            "products.logs.backend.alert_error_classifier.classify_query_error",
+            return_value=classifier_category,
+        ):
+            _evaluate_single_alert(
+                LogsAlertConfiguration.objects.get(), datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats()
+            )
+
+        mock_check_errors.assert_called_once_with(expected_category)
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.increment_check_errors")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_check_errors_counter_silent_on_success(self, _mock_produce, mock_query_cls, mock_check_errors):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        self._make_alert()
+
+        _evaluate_single_alert(
+            LogsAlertConfiguration.objects.get(), datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats()
+        )
+
+        mock_check_errors.assert_not_called()

--- a/products/logs/backend/test/test_logs_alerting_metrics.py
+++ b/products/logs/backend/test/test_logs_alerting_metrics.py
@@ -5,12 +5,17 @@ from unittest.mock import MagicMock, patch
 
 from django.conf import settings
 
+from products.logs.backend.alert_state_machine import AlertState, NotificationAction
 from products.logs.backend.temporal.metrics import (
     ALERTING_ACTIVITY_TYPES,
     AlertOutcome,
     ExecutionTimeRecorder,
     LogsAlertingMetricsInterceptor,
+    increment_check_errors,
     increment_checks_total,
+    increment_notification_failures,
+    increment_state_transition,
+    record_alerts_active,
     record_check_duration,
     record_schedule_to_start_latency,
     record_scheduler_lag,
@@ -46,6 +51,77 @@ class TestIncrementChecksTotal:
 
         mock_get_meter.assert_called_once_with({"outcome": outcome})
         mock_counter.add.assert_called_once_with(1)
+
+
+class TestIncrementCheckErrors:
+    @pytest.mark.parametrize("category", ["server_busy", "query_performance", "invalid_query", "cancelled", "unknown"])
+    @patch("products.logs.backend.temporal.metrics.get_metric_meter")
+    def test_increments_counter_with_category(self, mock_get_meter: MagicMock, category):
+        mock_meter = MagicMock()
+        mock_counter = MagicMock()
+        mock_meter.create_counter.return_value = mock_counter
+        mock_get_meter.return_value = mock_meter
+
+        increment_check_errors(category)
+
+        mock_get_meter.assert_called_once_with({"category": category})
+        (name, _description), _ = mock_meter.create_counter.call_args
+        assert name == "logs_alerting_check_errors_total"
+        mock_counter.add.assert_called_once_with(1)
+
+
+class TestIncrementNotificationFailures:
+    @pytest.mark.parametrize(
+        "action,expected_label",
+        [(NotificationAction.FIRE, "firing"), (NotificationAction.RESOLVE, "resolved")],
+    )
+    @patch("products.logs.backend.temporal.metrics.get_metric_meter")
+    def test_increments_counter_with_event(self, mock_get_meter: MagicMock, action, expected_label):
+        mock_meter = MagicMock()
+        mock_counter = MagicMock()
+        mock_meter.create_counter.return_value = mock_counter
+        mock_get_meter.return_value = mock_meter
+
+        increment_notification_failures(action)
+
+        mock_get_meter.assert_called_once_with({"event": expected_label})
+        mock_meter.create_counter.assert_called_once()
+        (name, _description), _ = mock_meter.create_counter.call_args
+        assert name == "logs_alerting_notification_failures_total"
+        mock_counter.add.assert_called_once_with(1)
+
+
+class TestIncrementStateTransition:
+    @patch("products.logs.backend.temporal.metrics.get_metric_meter")
+    def test_increments_counter_with_from_and_to(self, mock_get_meter: MagicMock):
+        mock_meter = MagicMock()
+        mock_counter = MagicMock()
+        mock_meter.create_counter.return_value = mock_counter
+        mock_get_meter.return_value = mock_meter
+
+        increment_state_transition(AlertState.NOT_FIRING, AlertState.FIRING)
+
+        mock_get_meter.assert_called_once_with({"from": "not_firing", "to": "firing"})
+        (name, _description), _ = mock_meter.create_counter.call_args
+        assert name == "logs_alerting_state_transitions_total"
+        mock_counter.add.assert_called_once_with(1)
+
+
+class TestRecordAlertsActive:
+    @pytest.mark.parametrize("count", [17, 0])
+    @patch("products.logs.backend.temporal.metrics.get_metric_meter")
+    def test_sets_gauge_with_count(self, mock_get_meter: MagicMock, count: int):
+        mock_meter = MagicMock()
+        mock_gauge = MagicMock()
+        mock_meter.create_gauge.return_value = mock_gauge
+        mock_get_meter.return_value = mock_meter
+
+        record_alerts_active(count)
+
+        mock_get_meter.assert_called_once_with()
+        (name, _description), _ = mock_meter.create_gauge.call_args
+        assert name == "logs_alerting_alerts_active"
+        mock_gauge.set.assert_called_once_with(count)
 
 
 class TestRecordCheckDuration:


### PR DESCRIPTION
## Problem

The logs alerting system lacked sufficient observability into its runtime behaviour. There was no way to track how many alerts were active per evaluation cycle, which error categories were causing check failures, whether Kafka notifications were failing to produce, or how frequently alerts were transitioning between states.

## Changes

Four new metrics have been added to the logs alerting system:

- **`logs_alerting_alerts_active`** **(gauge)** — records the number of due alerts evaluated each cycle, set once per `_check_alerts_sync` invocation.
- **`logs_alerting_check_errors_total`** **(counter)** — incremented on query failures, labelled by the classifier error category (e.g. `server_busy`, `query_performance`, `cancelled`, `unknown`).
- **`logs_alerting_notification_failures_total`** **(counter)** — incremented when a Kafka produce call fails for a `fire` or `resolve` notification, labelled by event type (`firing` / `resolved`).
- **`logs_alerting_state_transitions_total`** **(counter)** — incremented whenever an alert's committed state changes, labelled with `from` and `to` state values.

The `error_category` is now captured at the point of classification and passed through to the metrics block, and `AlertErrorCode` is re-exported from the classifier module for use in activities.

## How did you test this code?

New tests & passing existing tests

## Publish to changelog?

No