### PR TITLE
fix(tasks): Link SignalReportTask when creating signal report tasks via API

### DIFF
--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -13,6 +13,8 @@ from posthog.api.shared import UserBasicSerializer
 from posthog.models.integration import Integration
 from posthog.storage import object_storage
 
+from products.signals.backend.models import SignalReportTask
+
 from .constants import (
     ALL_INITIAL_PERMISSION_MODE_CHOICES,
     CODEX_INITIAL_PERMISSION_MODE_CHOICES,
@@ -42,6 +44,19 @@ class TaskSerializer(serializers.ModelSerializer):
     title = serializers.CharField(max_length=255, required=False, allow_blank=True)
     description = serializers.CharField(required=False, allow_blank=True)
     origin_product = serializers.ChoiceField(choices=Task.OriginProduct.choices, required=False)
+    # Write-only: which SignalReportTask row to create when linking a task to a report from the
+    # public task API (e.g. PostHog Code inbox). Only implementation is supported; research/repo
+    # selection links are created by server-side flows.
+    signal_report_task_relationship = serializers.ChoiceField(
+        choices=[
+            (
+                SignalReportTask.Relationship.IMPLEMENTATION.value,
+                SignalReportTask.Relationship.IMPLEMENTATION.label,
+            ),
+        ],
+        required=False,
+        write_only=True,
+    )
 
     class Meta:
         model = Task
@@ -56,6 +71,7 @@ class TaskSerializer(serializers.ModelSerializer):
             "repository",
             "github_integration",
             "signal_report",
+            "signal_report_task_relationship",
             "json_schema",
             "internal",
             "latest_run",
@@ -103,11 +119,29 @@ class TaskSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("Signal report must belong to the same team")
         return value
 
+    def validate(self, attrs: dict) -> dict:
+        rel = attrs.get("signal_report_task_relationship")
+        if rel is not None:
+            if not attrs.get("signal_report"):
+                raise serializers.ValidationError(
+                    {"signal_report_task_relationship": "Requires signal_report when set."}
+                )
+            if attrs.get("origin_product") != Task.OriginProduct.SIGNAL_REPORT:
+                raise serializers.ValidationError(
+                    {"signal_report_task_relationship": ("Requires origin_product signal_report when set.")}
+                )
+        return attrs
+
     def create(self, validated_data):
         validated_data["team"] = self.context["team"]
 
         if "request" in self.context and hasattr(self.context["request"], "user"):
             validated_data["created_by"] = self.context["request"].user
+
+        link_relationship = validated_data.pop(
+            "signal_report_task_relationship",
+            SignalReportTask.Relationship.IMPLEMENTATION,
+        )
 
         # Set default GitHub integration if not provided
         if not validated_data.get("github_integration"):
@@ -122,7 +156,20 @@ class TaskSerializer(serializers.ModelSerializer):
         elif title:
             validated_data.setdefault("title_manually_set", True)
 
-        return super().create(validated_data)
+        # Inbox / PostHog Code: tasks created via this API with a signal report use the same
+        # origin_product as server-side flows, but only those flows previously called
+        # SignalReportTask.objects.create. Link implementation tasks here so report task
+        # listings (e.g. getSignalReportTasks) match autostarted implementations.
+        with transaction.atomic():
+            task = super().create(validated_data)
+            if task.signal_report_id and task.origin_product == Task.OriginProduct.SIGNAL_REPORT:
+                SignalReportTask.objects.create(
+                    team_id=task.team_id,
+                    report_id=task.signal_report_id,
+                    task=task,
+                    relationship=link_relationship,
+                )
+            return task
 
     def update(self, instance, validated_data):
         if "title" in validated_data and "title_manually_set" not in validated_data:

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -257,7 +257,7 @@ class TestTaskAPI(BaseTaskAPITest):
         self.assertEqual(data["repository"], "posthog/posthog")
 
     def test_create_task_with_signal_report_same_team(self):
-        from products.signals.backend.models import SignalReport
+        from products.signals.backend.models import SignalReport, SignalReportTask
 
         report = SignalReport.objects.create(team=self.team)
         response = self.client.post(
@@ -267,11 +267,19 @@ class TestTaskAPI(BaseTaskAPITest):
                 "description": "From a signal report",
                 "origin_product": "signal_report",
                 "signal_report": str(report.id),
+                "signal_report_task_relationship": SignalReportTask.Relationship.IMPLEMENTATION.value,
             },
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.json()["signal_report"], str(report.id))
+        data = response.json()
+        self.assertEqual(data["signal_report"], str(report.id))
+        link = SignalReportTask.objects.get(
+            report=report,
+            relationship=SignalReportTask.Relationship.IMPLEMENTATION,
+        )
+        self.assertEqual(str(link.task_id), data["id"])
+        self.assertEqual(link.relationship, SignalReportTask.Relationship.IMPLEMENTATION)
 
     def test_create_task_with_signal_report_different_team_rejected(self):
         from products.signals.backend.models import SignalReport

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -279,7 +279,6 @@ class TestTaskAPI(BaseTaskAPITest):
             relationship=SignalReportTask.Relationship.IMPLEMENTATION,
         )
         self.assertEqual(str(link.task_id), data["id"])
-        self.assertEqual(link.relationship, SignalReportTask.Relationship.IMPLEMENTATION)
 
     def test_create_task_with_signal_report_different_team_rejected(self):
         from products.signals.backend.models import SignalReport

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -232,6 +232,16 @@ export const OriginProductEnumApi = {
     SignalReport: 'signal_report',
 } as const
 
+/**
+ * * `implementation` - Implementation
+ */
+export type SignalReportTaskRelationshipEnumApi =
+    (typeof SignalReportTaskRelationshipEnumApi)[keyof typeof SignalReportTaskRelationshipEnumApi]
+
+export const SignalReportTaskRelationshipEnumApi = {
+    Implementation: 'implementation',
+} as const
+
 export interface PatchedTaskApi {
     readonly id?: string
     /** @nullable */
@@ -254,6 +264,7 @@ export interface PatchedTaskApi {
     github_integration?: number | null
     /** @nullable */
     signal_report?: string | null
+    signal_report_task_relationship?: SignalReportTaskRelationshipEnumApi
     /** JSON schema for the task. This is used to validate the output of the task. */
     json_schema?: unknown | null
     /** If true, this task is for internal use and should not be exposed to end users. */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -27575,6 +27575,16 @@ export namespace Schemas {
      */
     export type PatchedTaskLatestRun = {[key: string]: unknown} | null | null;
 
+    /**
+     * * `implementation` - Implementation
+     */
+    export type SignalReportTaskRelationshipEnum = typeof SignalReportTaskRelationshipEnum[keyof typeof SignalReportTaskRelationshipEnum];
+
+
+    export const SignalReportTaskRelationshipEnum = {
+      Implementation: 'implementation',
+    } as const;
+
     export interface PatchedTask {
       readonly id?: string;
       /** @nullable */
@@ -27597,6 +27607,7 @@ export namespace Schemas {
       github_integration?: number | null;
       /** @nullable */
       signal_report?: string | null;
+      signal_report_task_relationship?: SignalReportTaskRelationshipEnum;
       /** JSON schema for the task. This is used to validate the output of the task. */
       json_schema?: unknown | null;
       /** If true, this task is for internal use and should not be exposed to end users. */


### PR DESCRIPTION
## Problem

Report implementation tasks kicked off manually from Code weren't being attributed to the report via `SignalReportTask`.

## Changes

When a task is created through the public Task API with `signal_report` and `origin_product: signal_report`, we now create a matching `SignalReportTask` row (implementation) in the same transaction. Keeps PH Code report task kickoff aligned with server-side autostart behavior.
