### PR TITLE
feat(mcp): expose subscription test delivery and delivery history tools

### DIFF
--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -613,7 +613,22 @@ tools:
         enabled: false
     subscriptions-test-delivery-create:
         operation: subscriptions_test_delivery_create
-        enabled: false
+        enabled: true
+        scopes:
+            - subscription:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: false
+        title: Send test delivery
+        description: >
+            Trigger an immediate test delivery of a subscription to its configured target(s)
+            (email, Slack, or webhook). Runs the same pipeline as a scheduled delivery but
+            with trigger_type=manual, so it produces a real SubscriptionDelivery row you can
+            inspect. Returns 202 Accepted once the delivery workflow is queued; poll
+            subscriptions-deliveries-list (newest first) or subscriptions-deliveries-retrieve
+            for the outcome and per-recipient results. Returns 409 if a test delivery for the
+            same subscription is already in flight.
     users-github-login-retrieve:
         operation: users_github_login_retrieve
         enabled: false
@@ -622,7 +637,42 @@ tools:
         enabled: false
     subscriptions-deliveries-list:
         operation: subscriptions_deliveries_list
-        enabled: false
+        enabled: true
+        scopes:
+            - subscription:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List subscription deliveries
+        description: >
+            List delivery history for a subscription — one row per send attempt. Each entry
+            includes status (starting, completed, failed, skipped), trigger_type (scheduled,
+            manual, target_change), timestamps (created_at, finished_at), per-recipient results,
+            and any error payload. Filter with status=failed to quickly surface failed deliveries.
+            Results are cursor-paginated newest first. The full content_snapshot can be very
+            large, so it is excluded here — use subscriptions-deliveries-retrieve to fetch it
+            for a single delivery when needed.
+        response:
+            exclude:
+                - content_snapshot
     subscriptions-deliveries-retrieve:
         operation: subscriptions_deliveries_retrieve
-        enabled: false
+        enabled: true
+        scopes:
+            - subscription:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get subscription delivery
+        description: >
+            Fetch a single subscription delivery attempt by id. Returns the delivery row
+            including status, trigger_type, timestamps, per-recipient results, and any
+            top-level error payload. The content_snapshot (frozen dashboard/insight metadata
+            and query results) is excluded by default to avoid leaking PII from historical
+            insight results; fetch it through a separate path only when explicitly needed.
+        response:
+            exclude:
+                - content_snapshot

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -649,14 +649,16 @@ tools:
         description: >
             List delivery history for a subscription — one row per send attempt. Each entry
             includes status (starting, completed, failed, skipped), trigger_type (scheduled,
-            manual, target_change), timestamps (created_at, finished_at), per-recipient results,
-            and any error payload. Filter with status=failed to quickly surface failed deliveries.
-            Results are cursor-paginated newest first. The full content_snapshot can be very
-            large, so it is excluded here — use subscriptions-deliveries-retrieve to fetch it
-            for a single delivery when needed.
+            manual, target_change), and timestamps (created_at, finished_at). Filter with
+            status=failed to quickly surface failed deliveries. Results are cursor-paginated
+            newest first. content_snapshot, recipient_results, and error are excluded to
+            match what the web UI exposes and to avoid leaking recipient identifiers or
+            upstream response bodies that may contain tokens / PII.
         response:
             exclude:
                 - content_snapshot
+                - recipient_results
+                - error
     subscriptions-deliveries-retrieve:
         operation: subscriptions_deliveries_retrieve
         enabled: true
@@ -668,11 +670,15 @@ tools:
             idempotent: true
         title: Get subscription delivery
         description: >
-            Fetch a single subscription delivery attempt by id. Returns the delivery row
-            including status, trigger_type, timestamps, per-recipient results, and any
-            top-level error payload. The content_snapshot (frozen dashboard/insight metadata
-            and query results) is excluded by default to avoid leaking PII from historical
-            insight results; fetch it through a separate path only when explicitly needed.
+            Fetch a single subscription delivery attempt by id. Returns status,
+            trigger_type, target_type, target_value, timestamps, workflow/idempotency
+            metadata, and exported_asset_ids. content_snapshot (the frozen dashboard/insight
+            state at send time) is not returned — use the insight/dashboard tools for
+            current state. recipient_results and error are also excluded to match what the
+            web UI exposes and to avoid leaking recipient identifiers or upstream response
+            bodies that may contain tokens / PII.
         response:
             exclude:
                 - content_snapshot
+                - recipient_results
+                - error

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -624,11 +624,11 @@ tools:
         description: >
             Trigger an immediate test delivery of a subscription to its configured target(s)
             (email, Slack, or webhook). Runs the same pipeline as a scheduled delivery but
-            with trigger_type=manual, so it produces a real SubscriptionDelivery row you can
-            inspect. Returns 202 Accepted once the delivery workflow is queued; poll
-            subscriptions-deliveries-list (newest first) or subscriptions-deliveries-retrieve
-            for the outcome and per-recipient results. Returns 409 if a test delivery for the
-            same subscription is already in flight.
+            with trigger_type=manual, producing a real delivery record you can inspect via
+            subscriptions-deliveries-list / subscriptions-deliveries-retrieve. Returns 202
+            Accepted once the delivery workflow is queued; poll subscriptions-deliveries-list
+            (newest first) or subscriptions-deliveries-retrieve for the outcome. Returns 409
+            if a test delivery for the same subscription is already in flight.
     users-github-login-retrieve:
         operation: users_github_login_retrieve
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -570,7 +570,7 @@
         }
     },
     "subscriptions-test-delivery-create": {
-        "description": "Trigger an immediate test delivery of a subscription to its configured target(s) (email, Slack, or webhook). Runs the same pipeline as a scheduled delivery but with trigger_type=manual, so it produces a real SubscriptionDelivery row you can inspect. Returns 202 Accepted once the delivery workflow is queued; poll subscriptions-deliveries-list (newest first) or subscriptions-deliveries-retrieve for the outcome and per-recipient results. Returns 409 if a test delivery for the same subscription is already in flight.",
+        "description": "Trigger an immediate test delivery of a subscription to its configured target(s) (email, Slack, or webhook). Runs the same pipeline as a scheduled delivery but with trigger_type=manual, producing a real delivery record you can inspect via subscriptions-deliveries-list / subscriptions-deliveries-retrieve. Returns 202 Accepted once the delivery workflow is queued; poll subscriptions-deliveries-list (newest first) or subscriptions-deliveries-retrieve for the outcome. Returns 409 if a test delivery for the same subscription is already in flight.",
         "category": "Core",
         "feature": "core",
         "summary": "Send test delivery",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -569,6 +569,51 @@
             "readOnlyHint": false
         }
     },
+    "subscriptions-test-delivery-create": {
+        "description": "Trigger an immediate test delivery of a subscription to its configured target(s) (email, Slack, or webhook). Runs the same pipeline as a scheduled delivery but with trigger_type=manual, so it produces a real SubscriptionDelivery row you can inspect. Returns 202 Accepted once the delivery workflow is queued; poll subscriptions-deliveries-list (newest first) or subscriptions-deliveries-retrieve for the outcome and per-recipient results. Returns 409 if a test delivery for the same subscription is already in flight.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "Send test delivery",
+        "title": "Send test delivery",
+        "required_scopes": ["subscription:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "subscriptions-deliveries-list": {
+        "description": "List delivery history for a subscription — one row per send attempt. Each entry includes status (starting, completed, failed, skipped), trigger_type (scheduled, manual, target_change), and timestamps (created_at, finished_at). Filter with status=failed to quickly surface failed deliveries. Results are cursor-paginated newest first. content_snapshot, recipient_results, and error are excluded to match what the web UI exposes and to avoid leaking recipient identifiers or upstream response bodies that may contain tokens / PII.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "List subscription deliveries",
+        "title": "List subscription deliveries",
+        "required_scopes": ["subscription:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "subscriptions-deliveries-retrieve": {
+        "description": "Fetch a single subscription delivery attempt by id. Returns status, trigger_type, target_type, target_value, timestamps, workflow/idempotency metadata, and exported_asset_ids. content_snapshot (the frozen dashboard/insight state at send time) is not returned — use the insight/dashboard tools for current state. recipient_results and error are also excluded to match what the web UI exposes and to avoid leaking recipient identifiers or upstream response bodies that may contain tokens / PII.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "Get subscription delivery",
+        "title": "Get subscription delivery",
+        "required_scopes": ["subscription:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "dashboards-get-all": {
         "description": "Get all dashboards in the project with optional filtering by pinned status or search term. Returns name, description, pinned status, tags, and creation metadata. Tiles and insights are not included — use dashboard-get to fetch a dashboard's tiles, then dashboard-insights-run to fetch the actual data for each insight.",
         "category": "Dashboards",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1049,7 +1049,7 @@
         }
     },
     "subscriptions-test-delivery-create": {
-        "description": "Trigger an immediate test delivery of a subscription to its configured target(s) (email, Slack, or webhook). Runs the same pipeline as a scheduled delivery but with trigger_type=manual, so it produces a real SubscriptionDelivery row you can inspect. Returns 202 Accepted once the delivery workflow is queued; poll subscriptions-deliveries-list (newest first) or subscriptions-deliveries-retrieve for the outcome and per-recipient results. Returns 409 if a test delivery for the same subscription is already in flight.",
+        "description": "Trigger an immediate test delivery of a subscription to its configured target(s) (email, Slack, or webhook). Runs the same pipeline as a scheduled delivery but with trigger_type=manual, producing a real delivery record you can inspect via subscriptions-deliveries-list / subscriptions-deliveries-retrieve. Returns 202 Accepted once the delivery workflow is queued; poll subscriptions-deliveries-list (newest first) or subscriptions-deliveries-retrieve for the outcome. Returns 409 if a test delivery for the same subscription is already in flight.",
         "category": "Core",
         "feature": "core",
         "summary": "Send test delivery",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1048,6 +1048,51 @@
             "readOnlyHint": false
         }
     },
+    "subscriptions-test-delivery-create": {
+        "description": "Trigger an immediate test delivery of a subscription to its configured target(s) (email, Slack, or webhook). Runs the same pipeline as a scheduled delivery but with trigger_type=manual, so it produces a real SubscriptionDelivery row you can inspect. Returns 202 Accepted once the delivery workflow is queued; poll subscriptions-deliveries-list (newest first) or subscriptions-deliveries-retrieve for the outcome and per-recipient results. Returns 409 if a test delivery for the same subscription is already in flight.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "Send test delivery",
+        "title": "Send test delivery",
+        "required_scopes": ["subscription:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "subscriptions-deliveries-list": {
+        "description": "List delivery history for a subscription — one row per send attempt. Each entry includes status (starting, completed, failed, skipped), trigger_type (scheduled, manual, target_change), and timestamps (created_at, finished_at). Filter with status=failed to quickly surface failed deliveries. Results are cursor-paginated newest first. content_snapshot, recipient_results, and error are excluded to match what the web UI exposes and to avoid leaking recipient identifiers or upstream response bodies that may contain tokens / PII.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "List subscription deliveries",
+        "title": "List subscription deliveries",
+        "required_scopes": ["subscription:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "subscriptions-deliveries-retrieve": {
+        "description": "Fetch a single subscription delivery attempt by id. Returns status, trigger_type, target_type, target_value, timestamps, workflow/idempotency metadata, and exported_asset_ids. content_snapshot (the frozen dashboard/insight state at send time) is not returned — use the insight/dashboard tools for current state. recipient_results and error are also excluded to match what the web UI exposes and to avoid leaking recipient identifiers or upstream response bodies that may contain tokens / PII.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "Get subscription delivery",
+        "title": "Get subscription delivery",
+        "required_scopes": ["subscription:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "dashboards-get-all": {
         "description": "Get all dashboards in the project with optional filtering by pinned status or search term. Returns name, description, pinned status, tags, and creation metadata. Tiles and insights are not included — use dashboard-get to fetch a dashboard's tiles, then dashboard-insights-run to fetch the actual data for each insight.",
         "category": "Dashboards",

--- a/services/mcp/src/generated/core/api.ts
+++ b/services/mcp/src/generated/core/api.ts
@@ -3,10 +3,45 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 4 enabled ops
+ * PostHog API - MCP 7 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
+
+/**
+ * Paginated delivery history for a subscription. Requires premium subscriptions.
+ * @summary List subscription deliveries
+ */
+export const SubscriptionsDeliveriesListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+    subscription_id: zod.number(),
+})
+
+export const SubscriptionsDeliveriesListQueryParams = /* @__PURE__ */ zod.object({
+    cursor: zod.string().optional().describe('The pagination cursor value.'),
+    status: zod
+        .enum(['completed', 'failed', 'skipped', 'starting'])
+        .optional()
+        .describe('Return only deliveries in this run status (starting, completed, failed, or skipped).'),
+})
+
+/**
+ * Fetch one delivery row by id.
+ * @summary Retrieve subscription delivery
+ */
+export const SubscriptionsDeliveriesRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this subscription delivery.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+    subscription_id: zod.number(),
+})
 
 export const SubscriptionsListParams = /* @__PURE__ */ zod.object({
     project_id: zod
@@ -262,3 +297,12 @@ export const SubscriptionsPartialUpdateBody = /* @__PURE__ */ zod
         summary_prompt_guide: zod.string().max(subscriptionsPartialUpdateBodySummaryPromptGuideMax).optional(),
     })
     .describe('Standard Subscription serializer.')
+
+export const SubscriptionsTestDeliveryCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.number().describe('A unique integer value identifying this subscription.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})

--- a/services/mcp/src/tools/generated/core.ts
+++ b/services/mcp/src/tools/generated/core.ts
@@ -4,12 +4,16 @@ import { z } from 'zod'
 import type { Schemas } from '@/api/generated'
 import {
     SubscriptionsCreateBody,
+    SubscriptionsDeliveriesListParams,
+    SubscriptionsDeliveriesListQueryParams,
+    SubscriptionsDeliveriesRetrieveParams,
     SubscriptionsListQueryParams,
     SubscriptionsPartialUpdateBody,
     SubscriptionsPartialUpdateParams,
     SubscriptionsRetrieveParams,
+    SubscriptionsTestDeliveryCreateParams,
 } from '@/generated/core/api'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const SubscriptionsListSchema = SubscriptionsListQueryParams
@@ -200,9 +204,76 @@ const subscriptionsPartialUpdate = (): ToolBase<typeof SubscriptionsPartialUpdat
     },
 })
 
+const SubscriptionsTestDeliveryCreateSchema = SubscriptionsTestDeliveryCreateParams.omit({ project_id: true })
+
+const subscriptionsTestDeliveryCreate = (): ToolBase<typeof SubscriptionsTestDeliveryCreateSchema, unknown> => ({
+    name: 'subscriptions-test-delivery-create',
+    schema: SubscriptionsTestDeliveryCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof SubscriptionsTestDeliveryCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<unknown>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/subscriptions/${encodeURIComponent(String(params.id))}/test-delivery/`,
+        })
+        return result
+    },
+})
+
+const SubscriptionsDeliveriesListSchema = SubscriptionsDeliveriesListParams.omit({ project_id: true }).extend(
+    SubscriptionsDeliveriesListQueryParams.shape
+)
+
+const subscriptionsDeliveriesList = (): ToolBase<
+    typeof SubscriptionsDeliveriesListSchema,
+    WithPostHogUrl<Schemas.PaginatedSubscriptionDeliveryList>
+> => ({
+    name: 'subscriptions-deliveries-list',
+    schema: SubscriptionsDeliveriesListSchema,
+    handler: async (context: Context, params: z.infer<typeof SubscriptionsDeliveriesListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedSubscriptionDeliveryList>({
+            method: 'GET',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/subscriptions/${encodeURIComponent(String(params.subscription_id))}/deliveries/`,
+            query: {
+                cursor: params.cursor,
+                status: params.status,
+            },
+        })
+        const filtered = {
+            ...result,
+            results: (result.results ?? []).map((item: any) =>
+                omitResponseFields(item, ['content_snapshot', 'recipient_results', 'error'])
+            ),
+        } as typeof result
+        return await withPostHogUrl(context, filtered, '/')
+    },
+})
+
+const SubscriptionsDeliveriesRetrieveSchema = SubscriptionsDeliveriesRetrieveParams.omit({ project_id: true })
+
+const subscriptionsDeliveriesRetrieve = (): ToolBase<
+    typeof SubscriptionsDeliveriesRetrieveSchema,
+    Schemas.SubscriptionDelivery
+> => ({
+    name: 'subscriptions-deliveries-retrieve',
+    schema: SubscriptionsDeliveriesRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof SubscriptionsDeliveriesRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.SubscriptionDelivery>({
+            method: 'GET',
+            path: `/api/environments/${encodeURIComponent(String(projectId))}/subscriptions/${encodeURIComponent(String(params.subscription_id))}/deliveries/${encodeURIComponent(String(params.id))}/`,
+        })
+        const filtered = omitResponseFields(result, ['content_snapshot', 'recipient_results', 'error']) as typeof result
+        return filtered
+    },
+})
+
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'subscriptions-list': subscriptionsList,
     'subscriptions-create': subscriptionsCreate,
     'subscriptions-retrieve': subscriptionsRetrieve,
     'subscriptions-partial-update': subscriptionsPartialUpdate,
+    'subscriptions-test-delivery-create': subscriptionsTestDeliveryCreate,
+    'subscriptions-deliveries-list': subscriptionsDeliveriesList,
+    'subscriptions-deliveries-retrieve': subscriptionsDeliveriesRetrieve,
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/subscriptions-deliveries-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/subscriptions-deliveries-list.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "cursor": {
+            "description": "The pagination cursor value.",
+            "type": "string"
+        },
+        "status": {
+            "description": "Return only deliveries in this run status (starting, completed, failed, or skipped).",
+            "enum": ["completed", "failed", "skipped", "starting"],
+            "type": "string"
+        },
+        "subscription_id": {
+            "type": "number"
+        }
+    },
+    "required": ["subscription_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/subscriptions-deliveries-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/subscriptions-deliveries-retrieve.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A UUID string identifying this subscription delivery.",
+            "type": "string"
+        },
+        "subscription_id": {
+            "type": "number"
+        }
+    },
+    "required": ["id", "subscription_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/subscriptions-test-delivery-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/subscriptions-test-delivery-create.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "A unique integer value identifying this subscription.",
+            "type": "number"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}


### PR DESCRIPTION
i was using the MCP we added for subscriptions
and then i couldn't ask about previous deliveries or test the delivery

so

🤖 