### PR TITLE
feat(cloud-agent): gate posthog-code slack integration

### DIFF
--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -10,6 +10,7 @@ from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.utils import timezone
 
+import posthoganalytics
 from drf_spectacular.utils import extend_schema
 from rest_framework import mixins, serializers, viewsets
 from rest_framework.exceptions import ValidationError
@@ -45,8 +46,10 @@ from posthog.models.integration import (
     StripeIntegration,
     TwilioIntegration,
 )
+from posthog.models.user import User
 from posthog.permissions import TeamMemberStrictManagementPermission
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
+from posthog.utils import get_instance_region
 
 
 class NativeEmailIntegrationSerializer(serializers.Serializer):
@@ -344,6 +347,14 @@ class IntegrationViewSet(
         kind = request.GET.get("kind")
         next = request.GET.get("next", "")
         token = os.urandom(33).hex()
+
+        if kind == "slack-posthog-code" and not posthoganalytics.feature_enabled(
+            "posthog_code_slack_availability",
+            str(cast(User, request.user).distinct_id),
+            groups={"organization": str(self.team.organization_id)},
+            person_properties={"region": get_instance_region() or "unknown"},
+        ):
+            raise ValidationError("PostHog Code Slack app not available for this organization")
 
         if kind in OauthIntegration.supported_kinds:
             try:

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -1366,3 +1366,51 @@ class TestGitHubBranches:
         assert first == "develop"
         assert second == "develop"
         assert mock_get.call_count == 1
+
+
+class TestIntegrationAuthorizePostHogCodeSlackFlag:
+    @pytest.fixture(autouse=True)
+    def setup_integration(self, db, settings):
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.user = User.objects.create_and_join(self.organization, "test@posthog.com", "test")
+        settings.SLACK_POSTHOG_CODE_CLIENT_ID = "client_id"
+        settings.SLACK_POSTHOG_CODE_CLIENT_SECRET = "client_secret"
+
+    @patch("posthog.api.integration.posthoganalytics.feature_enabled", return_value=True)
+    def test_authorize_allowed_when_flag_on(self, mock_flag, client: HttpClient):
+        client.force_login(self.user)
+
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/authorize/?kind=slack-posthog-code",
+        )
+
+        assert response.status_code == status.HTTP_302_FOUND
+        assert "slack.com/oauth/v2/authorize" in response["Location"]
+        mock_flag.assert_called_once()
+        assert mock_flag.call_args.args[0] == "posthog_code_slack_availability"
+        assert mock_flag.call_args.kwargs["groups"] == {"organization": str(self.team.organization_id)}
+
+    @patch("posthog.api.integration.posthoganalytics.feature_enabled", return_value=False)
+    def test_authorize_rejected_when_flag_off(self, mock_flag, client: HttpClient):
+        client.force_login(self.user)
+
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/authorize/?kind=slack-posthog-code",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "not available" in str(response.json())
+
+    @patch("posthog.api.integration.posthoganalytics.feature_enabled", return_value=False)
+    def test_authorize_flag_does_not_gate_other_kinds(self, mock_flag, client: HttpClient, settings):
+        settings.HUBSPOT_APP_CLIENT_ID = "hubspot_id"
+        settings.HUBSPOT_APP_CLIENT_SECRET = "hubspot_secret"
+        client.force_login(self.user)
+
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/authorize/?kind=hubspot",
+        )
+
+        assert response.status_code == status.HTTP_302_FOUND
+        mock_flag.assert_not_called()

--- a/posthog/api/test/test_preflight.py
+++ b/posthog/api/test/test_preflight.py
@@ -327,3 +327,46 @@ class TestPreflight(APIBaseTest, QueryMatchingTest):
             assert response.status_code == status.HTTP_200_OK
             assert response.json()["realm"] == "hosted-clickhouse"
             assert response.json()["cloud"] is False
+
+    @patch("posthog.views.posthoganalytics.feature_enabled", return_value=True)
+    def test_posthog_code_slack_service_available_when_flag_on(self, mock_flag):
+        with self.settings(
+            SLACK_POSTHOG_CODE_CLIENT_ID="client_id",
+            SLACK_POSTHOG_CODE_CLIENT_SECRET="client_secret",
+            SLACK_POSTHOG_CODE_SIGNING_SECRET="signing_secret",
+        ):
+            response = self.client.get("/_preflight/")
+            assert response.status_code == status.HTTP_200_OK
+            assert response.json()["posthog_code_slack_service"] == {
+                "available": True,
+                "client_id": "client_id",
+            }
+            mock_flag.assert_called_once()
+            assert mock_flag.call_args.args[0] == "posthog_code_slack_availability"
+
+    @patch("posthog.views.posthoganalytics.feature_enabled", return_value=False)
+    def test_posthog_code_slack_service_hidden_when_flag_off(self, mock_flag):
+        with self.settings(
+            SLACK_POSTHOG_CODE_CLIENT_ID="client_id",
+            SLACK_POSTHOG_CODE_CLIENT_SECRET="client_secret",
+            SLACK_POSTHOG_CODE_SIGNING_SECRET="signing_secret",
+        ):
+            response = self.client.get("/_preflight/")
+            assert response.status_code == status.HTTP_200_OK
+            assert response.json()["posthog_code_slack_service"] == {
+                "available": False,
+                "client_id": "client_id",
+            }
+
+    @patch("posthog.views.posthoganalytics.feature_enabled")
+    def test_posthog_code_slack_service_hidden_for_anonymous_preflight(self, mock_flag):
+        self.client.logout()
+        with self.settings(
+            SLACK_POSTHOG_CODE_CLIENT_ID="client_id",
+            SLACK_POSTHOG_CODE_CLIENT_SECRET="client_secret",
+            SLACK_POSTHOG_CODE_SIGNING_SECRET="signing_secret",
+        ):
+            response = self.client.get("/_preflight/")
+            assert response.status_code == status.HTTP_200_OK
+            assert response.json()["posthog_code_slack_service"]["available"] is False
+            mock_flag.assert_not_called()

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -23,6 +23,7 @@ from django.views.decorators.csrf import csrf_exempt, csrf_protect
 from django.views.decorators.http import require_http_methods
 
 import structlog
+import posthoganalytics
 
 from posthog.auth import AUTH_BRAND_COOKIE, apply_auth_brand_cookie, normalize_auth_brand
 from posthog.cloud_utils import is_cloud
@@ -168,6 +169,26 @@ def render_query(request: HttpRequest) -> HttpResponse:
     return render_template("render_query.html", request, context={"render_query_payload": payload})
 
 
+POSTHOG_CODE_SLACK_AVAILABILITY_FLAG = "posthog_code_slack_availability"
+
+
+def _posthog_code_slack_available_for_user(request: HttpRequest) -> bool:
+    user = getattr(request, "user", None)
+    if not user or not getattr(user, "is_authenticated", False):
+        return False
+    org = getattr(user, "current_organization", None)
+    region = get_instance_region() or "unknown"
+    groups = {"organization": str(org.id)} if org else {}
+    return bool(
+        posthoganalytics.feature_enabled(
+            POSTHOG_CODE_SLACK_AVAILABILITY_FLAG,
+            str(user.distinct_id),
+            groups=groups,
+            person_properties={"region": region},
+        )
+    )
+
+
 @never_cache
 def preflight_check(request: HttpRequest) -> JsonResponse:
     slack_client_id = SlackIntegration.slack_config().get("SLACK_APP_CLIENT_ID")
@@ -198,7 +219,8 @@ def preflight_check(request: HttpRequest) -> JsonResponse:
             "client_id": slack_client_id or None,
         },
         "posthog_code_slack_service": {
-            "available": bool(posthog_code_slack_client_id)
+            "available": _posthog_code_slack_available_for_user(request)
+            and bool(posthog_code_slack_client_id)
             and bool(posthog_code_slack_signing_secret)
             and bool(posthog_code_slack_config.get("SLACK_POSTHOG_CODE_CLIENT_SECRET")),
             "client_id": posthog_code_slack_client_id or None,


### PR DESCRIPTION
## Problem

We're preparing to promote the PostHog Code Slack integration from the standalone alpha app to production, by repointing the approved PostHog Slack app at the posthog-code event/interactivity handlers.

Will update app manifest as well.