### PR TITLE
fix(data-warehouse): handle network failures in loadSources loader

### DIFF
--- a/products/data_warehouse/frontend/shared/logics/sourcesDataLogic.ts
+++ b/products/data_warehouse/frontend/shared/logics/sourcesDataLogic.ts
@@ -34,7 +34,16 @@ export const sourcesDataLogic = kea<sourcesDataLogicType>([
                         return res
                     } catch (error: any) {
                         // On 403, return empty result instead of failing - user doesn't have access
-                        if (error.status === 403) {
+                        if (error?.status === 403) {
+                            cache.abortController = null
+                            return { results: [], count: 0, next: null, previous: null }
+                        }
+                        // Transient failures (offline, DNS, CORS, aborted mid-flight) surface as
+                        // either a DOMException AbortError or an ApiError with no HTTP status.
+                        // Swallow these so the UI degrades gracefully instead of reporting an exception.
+                        const isAbort = error?.name === 'AbortError'
+                        const isNetworkError = error?.status === undefined
+                        if (isAbort || isNetworkError) {
                             cache.abortController = null
                             return { results: [], count: 0, next: null, previous: null }
                         }

--- a/products/data_warehouse/frontend/shared/logics/sourcesDataLogic.ts
+++ b/products/data_warehouse/frontend/shared/logics/sourcesDataLogic.ts
@@ -1,7 +1,7 @@
 import { actions, kea, listeners, path, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 
-import api, { ApiMethodOptions, PaginatedResponse } from 'lib/api'
+import api, { ApiError, ApiMethodOptions, PaginatedResponse } from 'lib/api'
 
 import { ExternalDataSource, ExternalDataSourceRevenueAnalyticsConfig } from '~/types'
 
@@ -33,21 +33,24 @@ export const sourcesDataLogic = kea<sourcesDataLogicType>([
 
                         return res
                     } catch (error: any) {
-                        // On 403, return empty result instead of failing - user doesn't have access
-                        if (error?.status === 403) {
-                            cache.abortController = null
-                            return { results: [], count: 0, next: null, previous: null }
+                        // Transient failures shouldn't surface as exceptions:
+                        //   - 403: the user has no access to the endpoint
+                        //   - AbortError: abortAnyRunningQuery cancelled this request mid-flight
+                        //   - ApiError with no HTTP status: handleFetch wraps native fetch
+                        //     failures (offline, DNS, CORS) as ApiError(err, undefined)
+                        // Anything else (including kea's BreakPointException) propagates.
+                        const isTransient =
+                            error?.status === 403 ||
+                            error?.name === 'AbortError' ||
+                            (error instanceof ApiError && error.status === undefined)
+                        if (!isTransient) {
+                            throw error
                         }
-                        // Transient failures (offline, DNS, CORS, aborted mid-flight) surface as
-                        // either a DOMException AbortError or an ApiError with no HTTP status.
-                        // Swallow these so the UI degrades gracefully instead of reporting an exception.
-                        const isAbort = error?.name === 'AbortError'
-                        const isNetworkError = error?.status === undefined
-                        if (isAbort || isNetworkError) {
-                            cache.abortController = null
-                            return { results: [], count: 0, next: null, previous: null }
-                        }
-                        throw error
+                        // Bail out if a newer loadSources has superseded this one so we don't
+                        // clobber its state with an empty result.
+                        breakpoint()
+                        cache.abortController = null
+                        return { results: [], count: 0, next: null, previous: null }
                     }
                 },
                 updateSource: async (source: ExternalDataSource) => {

--- a/products/data_warehouse/frontend/shared/logics/tests/sourcesDataLogic.test.ts
+++ b/products/data_warehouse/frontend/shared/logics/tests/sourcesDataLogic.test.ts
@@ -7,7 +7,24 @@ import { AccessControlLevel, DataWarehouseSyncInterval, ExternalDataJobStatus, E
 
 import { sourcesDataLogic } from '../sourcesDataLogic'
 
-jest.mock('lib/api')
+// Stub the default `api` export but keep the real ApiError class so both the
+// test fixtures and the loader reference the same constructor — the loader's
+// `error instanceof ApiError` guard would otherwise never match an auto-mocked
+// ApiError instance.
+jest.mock('lib/api', () => {
+    const actual = jest.requireActual('lib/api')
+    return {
+        __esModule: true,
+        ...actual,
+        default: {
+            externalDataSources: {
+                list: jest.fn(),
+                update: jest.fn(),
+                updateRevenueAnalyticsConfig: jest.fn(),
+            },
+        },
+    }
+})
 
 const emptyResponse: PaginatedResponse<ExternalDataSource> = {
     results: [],

--- a/products/data_warehouse/frontend/shared/logics/tests/sourcesDataLogic.test.ts
+++ b/products/data_warehouse/frontend/shared/logics/tests/sourcesDataLogic.test.ts
@@ -1,6 +1,6 @@
 import { expectLogic } from 'kea-test-utils'
 
-import api, { PaginatedResponse } from 'lib/api'
+import api, { ApiError, PaginatedResponse } from 'lib/api'
 
 import { initKeaTests } from '~/test/init'
 import { AccessControlLevel, DataWarehouseSyncInterval, ExternalDataJobStatus, ExternalDataSource } from '~/types'
@@ -8,6 +8,13 @@ import { AccessControlLevel, DataWarehouseSyncInterval, ExternalDataJobStatus, E
 import { sourcesDataLogic } from '../sourcesDataLogic'
 
 jest.mock('lib/api')
+
+const emptyResponse: PaginatedResponse<ExternalDataSource> = {
+    results: [],
+    count: 0,
+    next: null,
+    previous: null,
+} as PaginatedResponse<ExternalDataSource>
 
 describe('sourcesDataLogic', () => {
     let logic: ReturnType<typeof sourcesDataLogic.build>
@@ -61,5 +68,25 @@ describe('sourcesDataLogic', () => {
             })
 
         expect(api.externalDataSources.list).toHaveBeenCalledWith({ signal: expect.any(AbortSignal) })
+    })
+
+    it.each([
+        ['403 access denied', new ApiError('forbidden', 403)],
+        ['network failure (no HTTP status)', new ApiError('TypeError: Failed to fetch', undefined)],
+        ['aborted request', Object.assign(new Error('aborted'), { name: 'AbortError' })],
+    ])('returns an empty paginated result on %s without surfacing loader failure', async (_label, error) => {
+        jest.spyOn(api.externalDataSources, 'list').mockRejectedValue(error)
+
+        logic.mount()
+
+        await expectLogic(logic, () => {
+            logic.actions.loadSources()
+        })
+            .toDispatchActions(['loadSources', 'loadSourcesSuccess'])
+            .toNotHaveDispatchedActions(['loadSourcesFailure'])
+            .toMatchValues({
+                dataWarehouseSources: emptyResponse,
+                dataWarehouseSourcesLoading: false,
+            })
     })
 })


### PR DESCRIPTION
## Problem

Four first-occurrence `TypeError: Failed to fetch` exceptions surfaced from the data warehouse sources loader across consecutive deploys, pointing at a gap in error handling rather than a user-visible regression. The stack trace was consistent on each build: `loadSources → externalDataSources.list → ApiRequest.get → handleFetch`.

The error is a native browser `TypeError` with no HTTP status, meaning `fetch` never reached the server. The `loadSources` loader in `sourcesDataLogic.ts` only swallowed `error.status === 403` and rethrew everything else, so transient network failures (offline, DNS, CORS) and `AbortController` cancellations racing with the response bubbled up as uncaught loader failures and got captured as exceptions.

## Changes

Broaden the `loadSources` catch block to treat two additional transient cases the same way as 403:

- `error.name === 'AbortError'` — the `DOMException` raised when `abortAnyRunningQuery` fires mid-flight
- `error.status === undefined` — `ApiError` wrapped around a native fetch failure in `handleFetch`

Both resolve to an empty paginated result so the UI degrades gracefully and the next navigation or poll retries. The existing `loadSourcesSuccess` / `loadSourcesFailure` loading-state reducer (keyed on `cache.abortController !== null`) keeps working unchanged.

## How did you test this code?

I'm an agent — only automated testing was performed, no manual browser verification.

- Added parameterized Jest cases in `sourcesDataLogic.test.ts` for 403, network failure (no HTTP status), and `AbortError`, asserting `loadSourcesSuccess` fires (not `loadSourcesFailure`) and `dataWarehouseSources` becomes the empty paginated result.
- `pnpm --filter=@posthog/frontend exec jest products/data_warehouse/frontend/shared/logics/tests/sourcesDataLogic.test.ts` — all 4 tests pass.
- Ran `pnpm --filter=@posthog/frontend exec tsc --noEmit` scoped to the modified file — no new type errors introduced.

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code (Claude) in response to an error-tracking signal surfacing four first-occurrence `TypeError: Failed to fetch` issues across consecutive deploys (same stack, different bundle chunk hashes). The investigation traced the thrown exception to the narrow 403-only try/catch added in the original data-warehouse access control PR (#39277). Task ID: `364fc587-73a9-4022-a440-0f53e15e6b5e`.