### PR TITLE
chore(modeling): change latency buckets for data-modeling temporal queue

### DIFF
--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -6,6 +6,8 @@ import collections.abc
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 
+from django.conf import settings
+
 from prometheus_client import REGISTRY
 from temporalio.contrib.opentelemetry import OpenTelemetryPlugin
 from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
@@ -18,6 +20,10 @@ from posthog.temporal.common.liveness_tracker import LivenessInterceptor
 from posthog.temporal.common.logger import get_write_only_logger
 from posthog.temporal.common.posthog_client import PostHogClientInterceptor
 from posthog.temporal.common.slo_interceptor import SloInterceptor
+from posthog.temporal.data_modeling.metrics import (
+    DATA_MODELING_LATENCY_HISTOGRAM_BUCKETS,
+    DATA_MODELING_LATENCY_HISTOGRAM_METRICS,
+)
 from posthog.temporal.llm_analytics.eval_reports.metrics import (
     EVAL_REPORTS_LATENCY_HISTOGRAM_BUCKETS,
     EVAL_REPORTS_LATENCY_HISTOGRAM_METRICS,
@@ -218,6 +224,41 @@ async def create_worker(
     else:
         plugins = ()
 
+    histogram_bucket_overrides: dict[str, list[float]] = (
+        dict(
+            zip(
+                BATCH_EXPORTS_LATENCY_HISTOGRAM_METRICS,
+                itertools.repeat(BATCH_EXPORTS_LATENCY_HISTOGRAM_BUCKETS),
+            )
+        )
+        | dict(zip(EVALS_LATENCY_HISTOGRAM_METRICS, itertools.repeat(EVALS_LATENCY_HISTOGRAM_BUCKETS)))
+        | dict(zip(SUMMARIZATION_LATENCY_HISTOGRAM_METRICS, itertools.repeat(SUMMARIZATION_LATENCY_HISTOGRAM_BUCKETS)))
+        | dict(zip(CLUSTERING_LATENCY_HISTOGRAM_METRICS, itertools.repeat(CLUSTERING_LATENCY_HISTOGRAM_BUCKETS)))
+        | dict(zip(TASKS_LATENCY_HISTOGRAM_METRICS, itertools.repeat(TASKS_LATENCY_HISTOGRAM_BUCKETS)))
+        | dict(zip(SENTIMENT_LATENCY_HISTOGRAM_METRICS, itertools.repeat(SENTIMENT_LATENCY_HISTOGRAM_BUCKETS)))
+        | dict(
+            zip(
+                EVAL_REPORTS_LATENCY_HISTOGRAM_METRICS,
+                itertools.repeat(EVAL_REPORTS_LATENCY_HISTOGRAM_BUCKETS),
+            )
+        )
+        | dict(
+            zip(
+                DELETE_RECORDINGS_LATENCY_HISTOGRAM_METRICS,
+                itertools.repeat(DELETE_RECORDINGS_LATENCY_HISTOGRAM_BUCKETS),
+            )
+        )
+        | dict(zip(LOGS_ALERTING_LATENCY_HISTOGRAM_METRICS, itertools.repeat(LOGS_ALERTING_LATENCY_HISTOGRAM_BUCKETS)))
+        | {"batch_exports_activity_attempt": [1.0, 5.0, 10.0, 100.0]}
+    )
+    if task_queue == settings.DATA_MODELING_TASK_QUEUE:
+        histogram_bucket_overrides |= dict(
+            zip(
+                DATA_MODELING_LATENCY_HISTOGRAM_METRICS,
+                itertools.repeat(DATA_MODELING_LATENCY_HISTOGRAM_BUCKETS),
+            )
+        )
+
     runtime = Runtime(
         telemetry=TelemetryConfig(
             metric_prefix=metric_prefix,
@@ -227,61 +268,7 @@ async def create_worker(
                 # Units are u64 milliseconds in sdk-core,
                 # given that the `duration_as_seconds` is `False`.
                 # But in Python we still need to pass floats due to type hints.
-                histogram_bucket_overrides=dict(
-                    zip(
-                        BATCH_EXPORTS_LATENCY_HISTOGRAM_METRICS,
-                        itertools.repeat(BATCH_EXPORTS_LATENCY_HISTOGRAM_BUCKETS),
-                    )
-                )
-                | dict(
-                    zip(
-                        EVALS_LATENCY_HISTOGRAM_METRICS,
-                        itertools.repeat(EVALS_LATENCY_HISTOGRAM_BUCKETS),
-                    )
-                )
-                | dict(
-                    zip(
-                        SUMMARIZATION_LATENCY_HISTOGRAM_METRICS,
-                        itertools.repeat(SUMMARIZATION_LATENCY_HISTOGRAM_BUCKETS),
-                    )
-                )
-                | dict(
-                    zip(
-                        CLUSTERING_LATENCY_HISTOGRAM_METRICS,
-                        itertools.repeat(CLUSTERING_LATENCY_HISTOGRAM_BUCKETS),
-                    )
-                )
-                | dict(
-                    zip(
-                        TASKS_LATENCY_HISTOGRAM_METRICS,
-                        itertools.repeat(TASKS_LATENCY_HISTOGRAM_BUCKETS),
-                    )
-                )
-                | dict(
-                    zip(
-                        SENTIMENT_LATENCY_HISTOGRAM_METRICS,
-                        itertools.repeat(SENTIMENT_LATENCY_HISTOGRAM_BUCKETS),
-                    )
-                )
-                | dict(
-                    zip(
-                        EVAL_REPORTS_LATENCY_HISTOGRAM_METRICS,
-                        itertools.repeat(EVAL_REPORTS_LATENCY_HISTOGRAM_BUCKETS),
-                    )
-                )
-                | dict(
-                    zip(
-                        DELETE_RECORDINGS_LATENCY_HISTOGRAM_METRICS,
-                        itertools.repeat(DELETE_RECORDINGS_LATENCY_HISTOGRAM_BUCKETS),
-                    )
-                )
-                | dict(
-                    zip(
-                        LOGS_ALERTING_LATENCY_HISTOGRAM_METRICS,
-                        itertools.repeat(LOGS_ALERTING_LATENCY_HISTOGRAM_BUCKETS),
-                    )
-                )
-                | {"batch_exports_activity_attempt": [1.0, 5.0, 10.0, 100.0]},
+                histogram_bucket_overrides=histogram_bucket_overrides,
             ),
         )
     )

--- a/posthog/temporal/data_modeling/metrics.py
+++ b/posthog/temporal/data_modeling/metrics.py
@@ -1,6 +1,32 @@
 from temporalio import workflow
 from temporalio.common import MetricCounter, MetricHistogramFloat
 
+# custom latency histogram buckets,
+# since we lose some important granularity with default max at 60s
+DATA_MODELING_LATENCY_HISTOGRAM_METRICS = (
+    "temporal_activity_execution_latency",
+    "temporal_activity_schedule_to_start_latency",
+    "temporal_workflow_task_execution_latency",
+    "temporal_workflow_task_schedule_to_start_latency",
+    "temporal_workflow_endtoend_latency",
+)
+DATA_MODELING_LATENCY_HISTOGRAM_BUCKETS = [
+    1.0,  # 1ms
+    10.0,  # 10ms
+    50.0,  # 50ms
+    100.0,  # 100ms
+    500.0,  # 500ms
+    1_000.0,  # 1s
+    5_000.0,  # 5s
+    30_000.0,  # 30s
+    60_000.0,  # 1m (old ceiling)
+    120_000.0,  # 2m
+    300_000.0,  # 5m
+    900_000.0,  # 15m
+    1_800_000.0,  # 30m
+    3_600_000.0,  # 1h (run_dag_activity start_to_close_timeout)
+]
+
 
 def get_data_modeling_finished_metric(status: str) -> MetricCounter:
     return (


### PR DESCRIPTION
## Problem

our metrics for the data-modeling-run workflow's schedule-to-start latency are a little off because of the default 1min max bucket

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

make the trend more granular just for the datamodeling task queue

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

ran the worker locally

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->