### PR TITLE
feat(subscriptions): rate limit test_delivery action

### DIFF
--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -435,6 +435,7 @@ class SubscriptionViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.M
         detail=True,
         url_path="test-delivery",
         throttle_classes=[SubscriptionTestDeliveryThrottle],
+        required_scopes=["subscription:write"],
     )
     def test_delivery(self, request, **kwargs):
         subscription = self.get_object()

--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -30,6 +30,7 @@ from posthog.models import Insight
 from posthog.models.integration import Integration
 from posthog.models.subscription import Subscription, SubscriptionDelivery, unsubscribe_using_token
 from posthog.permissions import PremiumFeaturePermission
+from posthog.rate_limit import SubscriptionTestDeliveryThrottle
 from posthog.security.url_validation import is_url_allowed
 from posthog.temporal.common.client import sync_connect
 from posthog.temporal.subscriptions.types import ProcessSubscriptionWorkflowInputs, SubscriptionTriggerType
@@ -429,7 +430,12 @@ class SubscriptionViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.M
         request=None,
         responses={202: OpenApiResponse(description="Test delivery workflow started")},
     )
-    @action(methods=["POST"], detail=True, url_path="test-delivery")
+    @action(
+        methods=["POST"],
+        detail=True,
+        url_path="test-delivery",
+        throttle_classes=[SubscriptionTestDeliveryThrottle],
+    )
     def test_delivery(self, request, **kwargs):
         subscription = self.get_object()
         if subscription.deleted:

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -4,6 +4,8 @@ from uuid import uuid4
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from django.core.cache import cache
+
 from parameterized import parameterized
 from rest_framework import status
 from temporalio.exceptions import WorkflowAlreadyStartedError
@@ -12,7 +14,9 @@ from posthog.models import Team
 from posthog.models.filters.filter import Filter
 from posthog.models.insight import Insight
 from posthog.models.integration import Integration
+from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.subscription import Subscription, SubscriptionDelivery
+from posthog.models.utils import generate_random_token_personal, hash_key_value
 from posthog.temporal.subscriptions.types import ProcessSubscriptionWorkflowInputs, SubscriptionTriggerType
 
 from products.dashboards.backend.models.dashboard import Dashboard
@@ -540,6 +544,50 @@ class TestSubscriptionTemporal(APILicensedTest):
 
         response = self.client.post(f"/api/projects/{self.team.id}/subscriptions/{sub_id}/test-delivery/")
         assert response.status_code == status.HTTP_409_CONFLICT
+
+    @patch("posthog.rate_limit.SubscriptionTestDeliveryThrottle.rate", new="3/minute")
+    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
+    def test_test_delivery_throttled_per_team_across_subscriptions_and_keys(self, _rate_limit_enabled_mock):
+        mock_client = MagicMock()
+        mock_client.start_workflow = AsyncMock()
+        self.mock_sync.return_value = mock_client
+
+        throttle_key = f"throttle_subscription_test_delivery_team_{self.team.id}"
+        cache.delete(throttle_key)
+        self.addCleanup(cache.delete, throttle_key)
+
+        def fresh_api_key_headers() -> dict[str, str]:
+            raw_key = generate_random_token_personal()
+            PersonalAPIKey.objects.create(
+                label=f"throttle-test-{uuid4()}",
+                user=self.user,
+                secure_value=hash_key_value(raw_key),
+                scopes=["*"],
+            )
+            return {"authorization": f"Bearer {raw_key}"}
+
+        pat_a = fresh_api_key_headers()
+        pat_b = fresh_api_key_headers()
+
+        sub_a = self._create_subscription(invite_message=None).json()["id"]
+        sub_b = self._create_subscription(invite_message=None).json()["id"]
+        mock_client.start_workflow.reset_mock()
+
+        for sub_id, headers in [(sub_a, pat_a), (sub_b, pat_b), (sub_a, pat_b)]:
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/subscriptions/{sub_id}/test-delivery/",
+                headers=headers,
+            )
+            assert response.status_code == status.HTTP_202_ACCEPTED
+
+        for headers in (pat_a, pat_b):
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/subscriptions/{sub_b}/test-delivery/",
+                headers=headers,
+            )
+            assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+        assert mock_client.start_workflow.call_count == 3
 
     def test_backfill_picks_same_integration_as_delivery(self):
         """The data migration must assign the lowest-id Slack integration

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -587,6 +587,9 @@ class TestSubscriptionTemporal(APILicensedTest):
             )
             assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
 
+        session_response = self.client.post(f"/api/projects/{self.team.id}/subscriptions/{sub_a}/test-delivery/")
+        assert session_response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
         assert mock_client.start_workflow.call_count == 3
 
     def test_backfill_picks_same_integration_as_delivery(self):

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -559,7 +559,7 @@ class TestSubscriptionTemporal(APILicensedTest):
         def fresh_api_key_headers() -> dict[str, str]:
             raw_key = generate_random_token_personal()
             PersonalAPIKey.objects.create(
-                label=f"throttle-test-{uuid4()}",
+                label=f"throttle-{uuid4().hex[:8]}",
                 user=self.user,
                 secure_value=hash_key_value(raw_key),
                 scopes=["*"],

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -789,6 +789,36 @@ class MaterializationRateThrottle(PersonalApiKeyRateThrottle):
         return super().get_cache_key(request, view)
 
 
+class SubscriptionTestDeliveryThrottle(PersonalApiKeyRateThrottle):
+    # Rate limit manual test deliveries of subscriptions.
+    #
+    # The viewset already returns 409 for concurrent deliveries on the same
+    # subscription, but that per-subscription dedupe does not stop a caller
+    # rotating across many subscriptions to spam real email / Slack / webhook
+    # recipients, nor does it stop a caller minting extra personal API keys
+    # and splitting traffic across them.
+    #
+    # Keyed per team (not per personal API key, not per subscription) so
+    # neither rotating subscriptions nor rotating API keys bypasses the limit.
+    # Intentionally overrides get_cache_key — sibling throttles
+    # (RunSavedQueryRateThrottle, MaterializationRateThrottle) use "{team_id}_{pk}",
+    # but we want a single team-wide bucket, so we drop pk.
+    #
+    # Only applies to personal-API-key callers (inherited from
+    # PersonalApiKeyRateThrottle._allow_request_internal). Session-cookie UI
+    # users fall through unthrottled — matches sibling precedent and is
+    # defensible since the UI already gates with per-subscription 409 and
+    # human click cadence.
+    scope = "subscription_test_delivery"
+    rate = "10/minute"
+
+    def get_cache_key(self, request, view):
+        team_id = self.safely_get_team_id_from_view(view)
+        if team_id:
+            return self.cache_format % {"scope": self.scope, "ident": f"team_{team_id}"}
+        return super().get_cache_key(request, view)
+
+
 class ToolbarOAuthRefreshThrottle(IPThrottle):
     """Rate limit the unauthenticated toolbar OAuth refresh endpoint by IP."""
 

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -789,7 +789,7 @@ class MaterializationRateThrottle(PersonalApiKeyRateThrottle):
         return super().get_cache_key(request, view)
 
 
-class SubscriptionTestDeliveryThrottle(PersonalApiKeyRateThrottle):
+class SubscriptionTestDeliveryThrottle(PersonalApiKeyOrUserRateThrottle):
     # Rate limit manual test deliveries of subscriptions.
     #
     # The viewset already returns 409 for concurrent deliveries on the same
@@ -804,11 +804,13 @@ class SubscriptionTestDeliveryThrottle(PersonalApiKeyRateThrottle):
     # (RunSavedQueryRateThrottle, MaterializationRateThrottle) use "{team_id}_{pk}",
     # but we want a single team-wide bucket, so we drop pk.
     #
-    # Only applies to personal-API-key callers (inherited from
-    # PersonalApiKeyRateThrottle._allow_request_internal). Session-cookie UI
-    # users fall through unthrottled — matches sibling precedent and is
-    # defensible since the UI already gates with per-subscription 409 and
-    # human click cadence.
+    # Extends PersonalApiKeyOrUserRateThrottle (not PersonalApiKeyRateThrottle)
+    # so the limit applies to every authenticated caller — personal API keys,
+    # OAuth access tokens (the MCP OAuth flow forwards bearer tokens that are
+    # not personal API keys), and session-cookie UI users. The sibling
+    # throttles only target PATs because they gate expensive read work; for
+    # this endpoint the real-world side-effect blast radius means we want
+    # every auth method covered.
     scope = "subscription_test_delivery"
     rate = "10/minute"
 


### PR DESCRIPTION
## Problem

[PR #55345](https://github.com/PostHog/posthog/pull/55345) exposes the subscription `test_delivery` action via MCP. The existing viewset returns 409 when the same subscription has a workflow in flight, but that per-subscription dedupe doesn't stop a caller iterating across many subscriptions (or rotating across personal API keys or OAuth tokens) to spam real email / Slack / webhook recipients. Once this is agent-callable, that abuse shape needs a proper bound.

## Changes

- Add `SubscriptionTestDeliveryThrottle` in `posthog/rate_limit.py` — extends `PersonalApiKeyOrUserRateThrottle` (not the PAT-only `PersonalApiKeyRateThrottle` the sibling throttles use), rate `10/minute`.
- Key the throttle per `team_id` only (drop the `{team_id}_{pk}` the sibling throttles use), so rotating subscriptions *and* rotating API keys both share one team-wide bucket.
- Apply via `throttle_classes=[…]` on `SubscriptionViewSet.test_delivery`.
- Every authenticated caller is subject to the limit: personal API keys, OAuth access tokens (the MCP OAuth flow forwards bearer tokens that aren't PATs), and session-cookie UI users. The sibling throttles only target PATs because they gate expensive read work; this endpoint produces real external side effects so the narrower PAT-only base would leave OAuth callers unthrottled.

## How did you test this code?

Agent-authored — only code-based testing has been done, no manual QA.

- New test `test_test_delivery_throttled_per_team_across_subscriptions_and_keys` in `ee/api/test/test_subscription.py` that rotates across two subscriptions and two personal API keys on the same team to prove the throttle fires regardless of subscription or key rotation; asserts two consecutive 429s (sustained throttling, not a one-shot gate); asserts `mock_client.start_workflow.call_count == 3` (pins that throttling runs before the view handler so no workflow starts on 429); and finally asserts that a session-authenticated request to the same team is also throttled once the bucket is exhausted, pinning the contract that all auth methods share the same bucket.
- Cache is narrowed to just this throttle's key (`cache.delete("throttle_subscription_test_delivery_team_{team_id}")`) with `addCleanup` so the test doesn't pollute sibling tests.
- Postgres isn't available in the agent environment; the test passes `ruff check` and `ruff format` and will run in CI.

## Publish to changelog?

no

## Docs update

No docs impact.

## 🤖 LLM context

Authored by [PostHog Code](https://posthog.com/code). Stacked on #55345 (now merged); QA Swarm review of the parent PR flagged the abuse shape this PR closes. Subsequent QA Swarm on this PR converged on: tighten class comment wording, add explicit reasoning for dropping `pk` vs siblings, strengthen test assertions — addressed. A later human review flagged that the original `PersonalApiKeyRateThrottle` base left OAuth callers unthrottled (MCP OAuth forwards `pha_` bearer tokens that aren't PATs); fixed by switching to `PersonalApiKeyOrUserRateThrottle`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
