### PR TITLE
feat(signals): Inbox signal report ordering (actionable before not_actionable)

### DIFF
--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -229,8 +229,7 @@ class SignalReportSerializer(serializers.ModelSerializer):
         data = self._get_actionability_artefact_data(obj)
         if data is None:
             return None
-        # Support both agentic ("actionability") and legacy ("choice") field names
-        value = data.get("actionability") or data.get("choice")
+        value = data.get("actionability")
         return value if isinstance(value, str) else None
 
     def get_already_addressed(self, obj: SignalReport) -> bool | None:

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -122,6 +122,17 @@ class TestSignalReportListAPI(APIBaseTest):
             art.save()
         return art
 
+    def _actionability_artefact(self, report: SignalReport, *, actionability: str) -> SignalReportArtefact:
+        payload = {"explanation": "x", "actionability": actionability, "already_addressed": False}
+        art = SignalReportArtefact(
+            team=self.team,
+            report=report,
+            type=SignalReportArtefact.ArtefactType.ACTIONABILITY_JUDGMENT,
+            content=json.dumps(payload),
+        )
+        art.save()
+        return art
+
     # --- priority ---
 
     def test_list_includes_priority_from_priority_artefact(self):
@@ -282,3 +293,55 @@ class TestSignalReportListAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         ids = [r["id"] for r in response.json()["results"]]
         assert ids.index(str(high_candidate.id)) < ids.index(str(low_ready.id))
+
+    def test_priority_ordering_actionable_ready_before_not_actionable(self):
+        """Inbox-style ordering: actionable ready reports before not_actionable, then by priority."""
+        r_non_actionable = self._create_report(
+            title="Not actionable",
+            summary="s",
+            signal_count=1,
+            total_weight=1.0,
+        )
+        r_actionable = self._create_report(
+            title="Actionable",
+            summary="s",
+            signal_count=1,
+            total_weight=1.0,
+        )
+        self._priority_artefact(r_non_actionable, priority="P0")
+        self._priority_artefact(r_actionable, priority="P4")
+        self._actionability_artefact(r_non_actionable, actionability="not_actionable")
+        self._actionability_artefact(r_actionable, actionability="immediately_actionable")
+
+        response = self.client.get(
+            self._list_url(
+                status="ready",
+                ordering="status,actionability_ready_rank,-is_suggested_reviewer,priority",
+            )
+        )
+        assert response.status_code == status.HTTP_200_OK
+        ids = [r["id"] for r in response.json()["results"]]
+        assert ids.index(str(r_actionable.id)) < ids.index(str(r_non_actionable.id))
+
+    def test_is_suggested_reviewer_false_when_not_actionable_ready(self):
+        from social_django.models import UserSocialAuth
+
+        UserSocialAuth.objects.create(
+            user=self.user,
+            provider="github",
+            uid="github-test-not-actionable",
+            extra_data={"login": "suggestedgh"},
+        )
+        report = self._create_report()
+        self._actionability_artefact(report, actionability="not_actionable")
+        SignalReportArtefact.objects.create(
+            team=self.team,
+            report=report,
+            type=SignalReportArtefact.ArtefactType.SUGGESTED_REVIEWERS,
+            content=json.dumps([{"github_login": "suggestedgh"}]),
+        )
+
+        response = self.client.get(self._list_url(status="ready"))
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        assert row["is_suggested_reviewer"] is False

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 
 from parameterized import parameterized
 from rest_framework import status
+from social_django.models import UserSocialAuth
 
 from posthog.models.team.team import Team
 
@@ -132,6 +133,13 @@ class TestSignalReportListAPI(APIBaseTest):
         )
         art.save()
         return art
+
+    def _maybe_actionability_artefact(
+        self, report: SignalReport, actionability: str | None
+    ) -> SignalReportArtefact | None:
+        if actionability is None:
+            return None
+        return self._actionability_artefact(report, actionability=actionability)
 
     # --- priority ---
 
@@ -294,46 +302,43 @@ class TestSignalReportListAPI(APIBaseTest):
         ids = [r["id"] for r in response.json()["results"]]
         assert ids.index(str(high_candidate.id)) < ids.index(str(low_ready.id))
 
-    def test_priority_ordering_actionable_ready_before_not_actionable(self):
-        """Inbox-style ordering: actionable ready reports before not_actionable, then by priority."""
-        r_non_actionable = self._create_report(
-            title="Not actionable",
-            summary="s",
-            signal_count=1,
-            total_weight=1.0,
-        )
-        r_actionable = self._create_report(
-            title="Actionable",
-            summary="s",
-            signal_count=1,
-            total_weight=1.0,
-        )
-        self._priority_artefact(r_non_actionable, priority="P0")
-        self._priority_artefact(r_actionable, priority="P4")
-        self._actionability_artefact(r_non_actionable, actionability="not_actionable")
-        self._actionability_artefact(r_actionable, actionability="immediately_actionable")
+    @parameterized.expand(
+        [
+            ("immediately_actionable_before_not_actionable", "immediately_actionable", "not_actionable"),
+            ("requires_human_input_before_not_actionable", "requires_human_input", "not_actionable"),
+            ("no_judgment_before_not_actionable", None, "not_actionable"),
+        ]
+    )
+    def test_status_ordering_splits_ready_by_actionability(
+        self, _name, left_actionability: str | None, right_actionability: str
+    ):
+        """`ordering=status` maps to pipeline_status_rank: actionable ready before not_actionable."""
+        r_left = self._create_report(title="L", summary="s", signal_count=1, total_weight=1.0)
+        r_right = self._create_report(title="R", summary="s", signal_count=1, total_weight=1.0)
+        self._maybe_actionability_artefact(r_left, left_actionability)
+        self._actionability_artefact(r_right, actionability=right_actionability)
 
-        response = self.client.get(
-            self._list_url(
-                status="ready",
-                ordering="status,actionability_ready_rank,-is_suggested_reviewer,priority",
-            )
-        )
+        response = self.client.get(self._list_url(status="ready", ordering="status"))
         assert response.status_code == status.HTTP_200_OK
         ids = [r["id"] for r in response.json()["results"]]
-        assert ids.index(str(r_actionable.id)) < ids.index(str(r_non_actionable.id))
+        assert ids.index(str(r_left.id)) < ids.index(str(r_right.id))
 
-    def test_is_suggested_reviewer_false_when_not_actionable_ready(self):
-        from social_django.models import UserSocialAuth
-
+    @parameterized.expand(
+        [
+            ("not_actionable", "not_actionable", False),
+            ("immediately_actionable", "immediately_actionable", True),
+            ("requires_human_input", "requires_human_input", True),
+        ]
+    )
+    def test_is_suggested_reviewer_matches_actionability(self, _name, actionability: str, expected_suggested: bool):
         UserSocialAuth.objects.create(
             user=self.user,
             provider="github",
-            uid="github-test-not-actionable",
+            uid=f"github-test-suggested-{actionability}",
             extra_data={"login": "suggestedgh"},
         )
         report = self._create_report()
-        self._actionability_artefact(report, actionability="not_actionable")
+        self._actionability_artefact(report, actionability=actionability)
         SignalReportArtefact.objects.create(
             team=self.team,
             report=report,
@@ -344,4 +349,4 @@ class TestSignalReportListAPI(APIBaseTest):
         response = self.client.get(self._list_url(status="ready"))
         assert response.status_code == status.HTTP_200_OK
         row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
-        assert row["is_suggested_reviewer"] is False
+        assert row["is_suggested_reviewer"] is expected_suggested

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -6,6 +6,7 @@ from typing import cast
 from django.conf import settings
 from django.db import IntegrityError
 from django.db.models import (
+    BooleanField,
     Case,
     CharField,
     Count,
@@ -354,6 +355,8 @@ class SignalReportViewSet(
         "signal_count": "signal_count",
         "total_weight": "total_weight",
         "priority": "priority_rank",
+        # Ready + actionable before ready + not_actionable; see _annotate_actionability_ready_rank
+        "actionability_ready_rank": "actionability_ready_rank",
         "created_at": "created_at",
         "updated_at": "updated_at",
         "id": "id",
@@ -369,6 +372,8 @@ class SignalReportViewSet(
         qs = self._apply_signal_report_suggested_reviewer_filter(qs)
         qs = self._annotate_signal_report_status_rank(qs)
         qs = self._annotate_signal_report_priority(qs)
+        qs = self._annotate_latest_actionability_value(qs)
+        qs = self._annotate_actionability_ready_rank(qs)
         qs = self._prefetch_signal_report_priority_artefacts(qs)
         qs = self._annotate_is_suggested_reviewer(qs)
         return qs
@@ -492,6 +497,50 @@ class SignalReportViewSet(
             priority_rank=Coalesce(latest_priority, Value("~"), output_field=CharField()),
         )
 
+    def _annotate_latest_actionability_value(self, queryset):
+        # Latest actionability_judgment: coalesce json "actionability" and legacy "choice" (matches serializer).
+        latest_actionability = Subquery(
+            SignalReportArtefact.objects.filter(
+                report_id=OuterRef("id"),
+                type=SignalReportArtefact.ArtefactType.ACTIONABILITY_JUDGMENT,
+                content__startswith="{",
+            )
+            .order_by("-created_at")
+            .annotate(
+                _actionability_val=Coalesce(
+                    Func(
+                        Cast(F("content"), output_field=JSONField()),
+                        Value("actionability"),
+                        function="jsonb_extract_path_text",
+                        output_field=CharField(),
+                    ),
+                    Func(
+                        Cast(F("content"), output_field=JSONField()),
+                        Value("choice"),
+                        function="jsonb_extract_path_text",
+                        output_field=CharField(),
+                    ),
+                    output_field=CharField(),
+                ),
+            )
+            .values("_actionability_val")[:1],
+            output_field=CharField(),
+        )
+        return queryset.annotate(latest_actionability_value=latest_actionability)
+
+    def _annotate_actionability_ready_rank(self, queryset):
+        # Within status=ready, sort actionable (0) before not_actionable (1) for priority-style lists.
+        return queryset.annotate(
+            actionability_ready_rank=Case(
+                When(
+                    Q(status=SignalReport.Status.READY) & Q(latest_actionability_value="not_actionable"),
+                    then=Value(1),
+                ),
+                default=Value(0),
+                output_field=IntegerField(),
+            )
+        )
+
     def _prefetch_signal_report_priority_artefacts(self, queryset):
         return queryset.prefetch_related(
             Prefetch(
@@ -514,22 +563,31 @@ class SignalReportViewSet(
         # Annotate is_suggested_reviewer by resolving the current user's GitHub login
         # and checking jsonb containment on the artefact content list. This stays fresh
         # even when a user connects their GitHub account after the report was generated.
+        # Never true for ready + not_actionable — there is nothing actionable to review.
         github_login = self._get_github_login(self.request.user)
         if not github_login:
             return queryset.annotate(is_suggested_reviewer=Value(False))
 
         # github_login comes from our own UserSocialAuth DB, not user input.
-        return queryset.annotate(
-            is_suggested_reviewer=Exists(
-                # nosemgrep: python.django.security.audit.query-set-extra.avoid-query-set-extra (parameterized via params)
-                SignalReportArtefact.objects.filter(
-                    report_id=OuterRef("id"),
-                    type=SignalReportArtefact.ArtefactType.SUGGESTED_REVIEWERS,
-                ).extra(
-                    where=["content::jsonb @> %s::jsonb"],
-                    params=[json.dumps([{"github_login": github_login}])],
-                )
+        suggested_exists = Exists(
+            # nosemgrep: python.django.security.audit.query-set-extra.avoid-query-set-extra (parameterized via params)
+            SignalReportArtefact.objects.filter(
+                report_id=OuterRef("id"),
+                type=SignalReportArtefact.ArtefactType.SUGGESTED_REVIEWERS,
+            ).extra(
+                where=["content::jsonb @> %s::jsonb"],
+                params=[json.dumps([{"github_login": github_login}])],
             )
+        )
+        return queryset.annotate(
+            is_suggested_reviewer=Case(
+                When(
+                    Q(status=SignalReport.Status.READY) & Q(latest_actionability_value="not_actionable"),
+                    then=Value(False),
+                ),
+                default=suggested_exists,
+                output_field=BooleanField(),
+            ),
         )
 
     def filter_queryset(self, queryset):

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -355,8 +355,6 @@ class SignalReportViewSet(
         "signal_count": "signal_count",
         "total_weight": "total_weight",
         "priority": "priority_rank",
-        # Ready + actionable before ready + not_actionable; see _annotate_actionability_ready_rank
-        "actionability_ready_rank": "actionability_ready_rank",
         "created_at": "created_at",
         "updated_at": "updated_at",
         "id": "id",
@@ -370,10 +368,9 @@ class SignalReportViewSet(
         qs = self._apply_signal_report_search_filter(qs)
         qs = self._apply_signal_report_source_product_filter(qs)
         qs = self._apply_signal_report_suggested_reviewer_filter(qs)
+        qs = self._annotate_latest_actionability_value(qs)
         qs = self._annotate_signal_report_status_rank(qs)
         qs = self._annotate_signal_report_priority(qs)
-        qs = self._annotate_latest_actionability_value(qs)
-        qs = self._annotate_actionability_ready_rank(qs)
         qs = self._prefetch_signal_report_priority_artefacts(qs)
         qs = self._annotate_is_suggested_reviewer(qs)
         return qs
@@ -456,16 +453,22 @@ class SignalReportViewSet(
 
     def _annotate_signal_report_status_rank(self, queryset):
         # `ordering=status` uses semantic stage rank (annotation), not lexicographic `status` column order.
+        # `status=ready` splits into two virtual stages (requires `latest_actionability_value`):
+        # 0 = ready + actionable (or no judgment yet), 1 = ready + not_actionable; then other stages.
         return queryset.annotate(
             pipeline_status_rank=Case(
+                When(
+                    Q(status=SignalReport.Status.READY) & Q(latest_actionability_value="not_actionable"),
+                    then=Value(1),
+                ),
                 When(status=SignalReport.Status.READY, then=Value(0)),
-                When(status=SignalReport.Status.PENDING_INPUT, then=Value(1)),
-                When(status=SignalReport.Status.IN_PROGRESS, then=Value(2)),
-                When(status=SignalReport.Status.CANDIDATE, then=Value(3)),
-                When(status=SignalReport.Status.POTENTIAL, then=Value(4)),
-                When(status=SignalReport.Status.FAILED, then=Value(5)),
-                When(status=SignalReport.Status.SUPPRESSED, then=Value(6)),
-                When(status=SignalReport.Status.DELETED, then=Value(7)),
+                When(status=SignalReport.Status.PENDING_INPUT, then=Value(2)),
+                When(status=SignalReport.Status.IN_PROGRESS, then=Value(3)),
+                When(status=SignalReport.Status.CANDIDATE, then=Value(4)),
+                When(status=SignalReport.Status.POTENTIAL, then=Value(5)),
+                When(status=SignalReport.Status.FAILED, then=Value(6)),
+                When(status=SignalReport.Status.SUPPRESSED, then=Value(7)),
+                When(status=SignalReport.Status.DELETED, then=Value(8)),
                 default=Value(50),
                 output_field=IntegerField(),
             )
@@ -498,7 +501,7 @@ class SignalReportViewSet(
         )
 
     def _annotate_latest_actionability_value(self, queryset):
-        # Latest actionability_judgment: coalesce json "actionability" and legacy "choice" (matches serializer).
+        # Latest actionability_judgment: json "actionability" only (no legacy "choice").
         latest_actionability = Subquery(
             SignalReportArtefact.objects.filter(
                 report_id=OuterRef("id"),
@@ -507,19 +510,10 @@ class SignalReportViewSet(
             )
             .order_by("-created_at")
             .annotate(
-                _actionability_val=Coalesce(
-                    Func(
-                        Cast(F("content"), output_field=JSONField()),
-                        Value("actionability"),
-                        function="jsonb_extract_path_text",
-                        output_field=CharField(),
-                    ),
-                    Func(
-                        Cast(F("content"), output_field=JSONField()),
-                        Value("choice"),
-                        function="jsonb_extract_path_text",
-                        output_field=CharField(),
-                    ),
+                _actionability_val=Func(
+                    Cast(F("content"), output_field=JSONField()),
+                    Value("actionability"),
+                    function="jsonb_extract_path_text",
                     output_field=CharField(),
                 ),
             )
@@ -527,19 +521,6 @@ class SignalReportViewSet(
             output_field=CharField(),
         )
         return queryset.annotate(latest_actionability_value=latest_actionability)
-
-    def _annotate_actionability_ready_rank(self, queryset):
-        # Within status=ready, sort actionable (0) before not_actionable (1) for priority-style lists.
-        return queryset.annotate(
-            actionability_ready_rank=Case(
-                When(
-                    Q(status=SignalReport.Status.READY) & Q(latest_actionability_value="not_actionable"),
-                    then=Value(1),
-                ),
-                default=Value(0),
-                output_field=IntegerField(),
-            )
-        )
 
     def _prefetch_signal_report_priority_artefacts(self, queryset):
         return queryset.prefetch_related(


### PR DESCRIPTION
## Problem

Inbox “Priority” sorting could interleave ready-but-not-actionable reports with actually-actionable ones, and `is_suggested_reviewer` could still be true when there is nothing actionable to review, which didn't make sense, as was clear in demoing today.


<!-- Closes #ISSUE_ID -->

## Changes

Resolving actionability from the latest `actionability_judgment` artefact.
Sorting by the `status` column now automatically also sorts by that actionability within `ready`.

Setting `is_suggested_reviewer` to false when status is ready and actionability is `not_actionable`.


## How did you test this code?

Bunch of tests.