### PR TITLE
feat(replay): add matchtype indication to mobile settings tab

### DIFF
--- a/frontend/src/lib/components/IngestionControls/TriggerMatchChoice.tsx
+++ b/frontend/src/lib/components/IngestionControls/TriggerMatchChoice.tsx
@@ -10,13 +10,20 @@ import { SelectOption } from '~/queries/nodes/InsightViz/PropertyGroupFilters/An
 import { RestrictionScope, useRestrictedArea } from '../RestrictedArea'
 import { ingestionControlsLogic } from './ingestionControlsLogic'
 
-export function MatchTypeSelect(): JSX.Element {
+interface MatchTypeSelectProps {
+    lockedToAllReason?: string
+}
+
+export function MatchTypeSelect({ lockedToAllReason }: MatchTypeSelectProps = {}): JSX.Element {
     const { matchType } = useValues(ingestionControlsLogic)
     const { onChangeMatchType } = useActions(ingestionControlsLogic)
     const restrictedReason = useRestrictedArea({
         scope: RestrictionScope.Project,
         minimumAccessLevel: TeamMembershipLevel.Admin,
     })
+
+    const displayedValue = lockedToAllReason ? 'all' : matchType
+    const disabledReason = lockedToAllReason ?? restrictedReason
 
     return (
         <div className="flex flex-col gap-y-1">
@@ -35,7 +42,7 @@ export function MatchTypeSelect(): JSX.Element {
                                     title="All"
                                     description="Every trigger must match"
                                     value="all"
-                                    selectedValue={matchType}
+                                    selectedValue={displayedValue}
                                 />
                             ),
                         },
@@ -47,7 +54,7 @@ export function MatchTypeSelect(): JSX.Element {
                                     title="Any"
                                     description="One or more triggers must match"
                                     value="any"
-                                    selectedValue={matchType}
+                                    selectedValue={displayedValue}
                                 />
                             ),
                         },
@@ -55,8 +62,8 @@ export function MatchTypeSelect(): JSX.Element {
                     dropdownMatchSelectWidth={false}
                     data-attr="trigger-match-choice"
                     onChange={onChangeMatchType}
-                    value={matchType}
-                    disabledReason={restrictedReason}
+                    value={displayedValue}
+                    disabledReason={disabledReason}
                 />
 
                 <div>triggers below match</div>

--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -496,6 +496,7 @@ export function ReplayTriggers(): JSX.Element {
                     {currentTeam && (
                         <RecordingTriggersSummary currentTeam={currentTeam} selectedPlatform={selectedPlatform} />
                     )}
+                    <IngestionControls.MatchTypeSelect lockedToAllReason="Mobile only supports trigger matching of type 'all'." />
                     <LinkedFlagSelector />
                     <MobileSampling />
                     <MobileMinimumDuration />


### PR DESCRIPTION
## Problem

this is the current behavior but its DEFINITELY not indicated anywhere in the UI rn

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

make it clear mobile is always "all" type

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

![Screenshot 2026-04-20 at 11.32.28 AM.png](https://app.graphite.com/user-attachments/assets/8fecb020-f13e-40fd-a068-d3079c7d4e77.png)



<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->