### PR TITLE
feat(cohorts): route cohortpeople membership reads through personhog

### DIFF
--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -27,7 +27,7 @@ from posthog.models.file_system.file_system_representation import FileSystemRepr
 from posthog.models.filters.filter import Filter
 from posthog.models.person import Person, PersonDistinctId
 from posthog.models.person.person import READ_DB_FOR_PERSONS
-from posthog.models.person.util import get_person_by_uuid, get_persons_by_distinct_ids
+from posthog.models.person.util import get_person_by_uuid, get_persons_by_distinct_ids, is_person_in_cohort
 from posthog.models.property import Property, PropertyGroup
 from posthog.models.utils import RootTeamManager, RootTeamMixin, sane_repr
 from posthog.person_db_router import PERSONS_DB_FOR_WRITE
@@ -794,16 +794,16 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
             if person is None:
                 raise Person.DoesNotExist
 
-            # Check if person is in the cohort in PostgreSQL
-            cohort_person = CohortPeople.objects.filter(
-                cohort_id=self.id,
-                person_id=person.id,
-            ).first()
+            # Check if person is in the cohort — routed through personhog when enabled,
+            # falling back to the persons-DB ORM query otherwise.
+            is_member = is_person_in_cohort(team_id=team_id, person_id=person.id, cohort_id=self.id)
 
             # Delete from PostgreSQL first (source of truth), then ClickHouse.
             # This order ensures if PG delete fails, we don't create inverse inconsistency.
-            if cohort_person:
-                cohort_person.delete()
+            # The delete itself still goes through the ORM — no personhog RPC exists yet
+            # for removing a cohort member.
+            if is_member:
+                CohortPeople.objects.filter(cohort_id=self.id, person_id=person.id).delete()
             else:
                 # Person not in PG - this is expected when handling CH/PG sync issues
                 logger.info(

--- a/posthog/models/cohort/test/test_cohort_personhog.py
+++ b/posthog/models/cohort/test/test_cohort_personhog.py
@@ -250,6 +250,46 @@ class TestCheckCohortMembership(PersonhogTestMixin, BaseTest):
 
         assert result == {c1.id: True, c2.id: False, c3.id: True}
 
+    def test_isolates_cross_team_cohort(self):
+        """Cohorts belonging to other teams must not leak into results, regardless
+        of which path (personhog vs ORM) runs. Tenant scoping happens in the
+        public wrapper before dispatch, so the RPC is never called for
+        out-of-team cohort_ids."""
+        from posthog.models.person.util import check_cohort_membership
+
+        other_team = Team.objects.create(organization=self.organization)
+        person = self._seed_person(team=self.team, distinct_ids=["d1"])
+        other_team_cohort = Cohort.objects.create(team=other_team, groups=[], is_static=True, name="other")
+        # Plant a real CohortPeople row (ORM-path leak canary) and a fake
+        # membership (personhog-path leak canary). If scoping were missing on
+        # either path the assertion would flip to True.
+        CohortPeople.objects.create(cohort=other_team_cohort, person=person)
+        self._seed_cohort_membership(person_id=person.id, cohort_id=other_team_cohort.id, is_member=True)
+
+        result = check_cohort_membership(self.team.id, person.id, [other_team_cohort.id])
+
+        assert result == {other_team_cohort.id: False}
+        self._assert_personhog_not_called("check_cohort_membership")
+
+    def test_isolates_cross_team_cohort_mixed_with_in_team(self):
+        """When a mix of in-team and out-of-team cohort_ids is passed, only the
+        in-team ones reach downstream; the caller still gets a dict keyed by
+        every requested id with out-of-team ones reported as non-member."""
+        from posthog.models.person.util import check_cohort_membership
+
+        other_team = Team.objects.create(organization=self.organization)
+        person = self._seed_person(team=self.team, distinct_ids=["d1"])
+        in_team_cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="in")
+        other_team_cohort = Cohort.objects.create(team=other_team, groups=[], is_static=True, name="out")
+        CohortPeople.objects.create(cohort=in_team_cohort, person=person)
+        CohortPeople.objects.create(cohort=other_team_cohort, person=person)
+        self._seed_cohort_membership(person_id=person.id, cohort_id=in_team_cohort.id, is_member=True)
+        self._seed_cohort_membership(person_id=person.id, cohort_id=other_team_cohort.id, is_member=True)
+
+        result = check_cohort_membership(self.team.id, person.id, [in_team_cohort.id, other_team_cohort.id])
+
+        assert result == {in_team_cohort.id: True, other_team_cohort.id: False}
+
 
 class TestCheckCohortMembershipFallback(BaseTest):
     """Routing test: verifies ORM fallback when the personhog gate is disabled."""
@@ -264,41 +304,6 @@ class TestCheckCohortMembershipFallback(BaseTest):
         with fake_personhog_client(gate_enabled=False) as fake:
             assert is_person_in_cohort(team_id=self.team.id, person_id=person.id, cohort_id=cohort.id) is True
 
-        fake.assert_not_called("check_cohort_membership")
-
-    def test_orm_path_isolates_by_team(self):
-        """ORM fallback must not return membership for a cohort belonging to a
-        different team, even if the cohort_id is passed explicitly."""
-        from posthog.models.person.util import check_cohort_membership
-
-        other_team = Team.objects.create(organization=self.organization)
-        person = Person.objects.create(team=self.team, distinct_ids=["d1"])
-        other_team_cohort = Cohort.objects.create(team=other_team, groups=[], is_static=True, name="other")
-        CohortPeople.objects.create(cohort=other_team_cohort, person=person)
-
-        with fake_personhog_client(gate_enabled=False):
-            result = check_cohort_membership(self.team.id, person.id, [other_team_cohort.id])
-
-        assert result == {other_team_cohort.id: False}
-
-    def test_personhog_path_isolates_by_team(self):
-        """Personhog path must not forward cross-team cohort_ids to the RPC.
-        Tenant scoping happens in the public wrapper before dispatch."""
-        from posthog.models.person.util import check_cohort_membership
-
-        other_team = Team.objects.create(organization=self.organization)
-        person = Person.objects.create(team=self.team, distinct_ids=["d1"])
-        other_team_cohort = Cohort.objects.create(team=other_team, groups=[], is_static=True, name="other")
-
-        with fake_personhog_client() as fake:
-            # Seed a fake "true" membership so we can detect a leak: if the
-            # scoping didn't happen, the RPC would see this and report True.
-            fake.add_cohort_membership(person_id=person.id, cohort_id=other_team_cohort.id, is_member=True)
-
-            result = check_cohort_membership(self.team.id, person.id, [other_team_cohort.id])
-
-        assert result == {other_team_cohort.id: False}
-        # The RPC should not have been called at all — no in-team cohort_ids remained.
         fake.assert_not_called("check_cohort_membership")
 
 

--- a/posthog/models/cohort/test/test_cohort_personhog.py
+++ b/posthog/models/cohort/test/test_cohort_personhog.py
@@ -147,6 +147,26 @@ class TestRemoveUserByUuid(PersonhogTestMixin, BaseTest):
         mock_remove_ch.assert_not_called()
 
     @patch("posthog.models.cohort.util.remove_person_from_static_cohort")
+    @patch("posthog.models.cohort.util.get_static_cohort_size", return_value=0)
+    def test_does_not_delete_when_cohort_belongs_to_other_team(self, mock_get_size, mock_remove_ch):
+        """Calling remove_user_by_uuid with a team_id that does not own the
+        cohort must not touch CohortPeople rows for that cohort."""
+        other_team = Team.objects.create(organization=self.organization)
+        person = self._seed_person(team=other_team, distinct_ids=["d1"])
+        # Cohort lives on other_team; caller claims to be self.team.
+        other_team_cohort = Cohort.objects.create(team=other_team, groups=[], is_static=True, name="other")
+        CohortPeople.objects.create(cohort=other_team_cohort, person=person)
+        self._seed_cohort_membership(person_id=person.id, cohort_id=other_team_cohort.id, is_member=True)
+
+        result = other_team_cohort.remove_user_by_uuid(str(person.uuid), team_id=self.team.id)
+
+        # Person isn't resolvable under self.team → removal is a no-op (returns False)
+        # and the CohortPeople row for the other team's cohort stays put.
+        assert result is False
+        assert CohortPeople.objects.filter(cohort=other_team_cohort, person=person).exists()
+        mock_remove_ch.assert_not_called()
+
+    @patch("posthog.models.cohort.util.remove_person_from_static_cohort")
     @patch("posthog.models.cohort.util.get_static_cohort_size", return_value=5)
     def test_updates_cohort_count_after_removal(self, mock_get_size, mock_remove_ch):
         person = self._seed_person(team=self.team, distinct_ids=["d1"])
@@ -246,6 +266,41 @@ class TestCheckCohortMembershipFallback(BaseTest):
 
         fake.assert_not_called("check_cohort_membership")
 
+    def test_orm_path_isolates_by_team(self):
+        """ORM fallback must not return membership for a cohort belonging to a
+        different team, even if the cohort_id is passed explicitly."""
+        from posthog.models.person.util import check_cohort_membership
+
+        other_team = Team.objects.create(organization=self.organization)
+        person = Person.objects.create(team=self.team, distinct_ids=["d1"])
+        other_team_cohort = Cohort.objects.create(team=other_team, groups=[], is_static=True, name="other")
+        CohortPeople.objects.create(cohort=other_team_cohort, person=person)
+
+        with fake_personhog_client(gate_enabled=False):
+            result = check_cohort_membership(self.team.id, person.id, [other_team_cohort.id])
+
+        assert result == {other_team_cohort.id: False}
+
+    def test_personhog_path_isolates_by_team(self):
+        """Personhog path must not forward cross-team cohort_ids to the RPC.
+        Tenant scoping happens in the public wrapper before dispatch."""
+        from posthog.models.person.util import check_cohort_membership
+
+        other_team = Team.objects.create(organization=self.organization)
+        person = Person.objects.create(team=self.team, distinct_ids=["d1"])
+        other_team_cohort = Cohort.objects.create(team=other_team, groups=[], is_static=True, name="other")
+
+        with fake_personhog_client() as fake:
+            # Seed a fake "true" membership so we can detect a leak: if the
+            # scoping didn't happen, the RPC would see this and report True.
+            fake.add_cohort_membership(person_id=person.id, cohort_id=other_team_cohort.id, is_member=True)
+
+            result = check_cohort_membership(self.team.id, person.id, [other_team_cohort.id])
+
+        assert result == {other_team_cohort.id: False}
+        # The RPC should not have been called at all — no in-team cohort_ids remained.
+        fake.assert_not_called("check_cohort_membership")
+
 
 @parameterized_class(("personhog",), [(False,), (True,)])
 class TestPropertyToQStaticCohortShortCircuit(PersonhogTestMixin, BaseTest):
@@ -304,3 +359,26 @@ class TestPropertyToQStaticCohortShortCircuit(PersonhogTestMixin, BaseTest):
         assert q != Q(pk__isnull=True)
         # The Exists subquery path never calls the RPC
         self._assert_personhog_not_called("check_cohort_membership")
+
+    def test_isolates_cohort_by_team_id(self):
+        """A cohort owned by a different team (even within the same project)
+        must resolve to Q(pk__isnull=True), regardless of any CohortPeople
+        rows or fake memberships set up for it."""
+        from posthog.queries.base import property_to_Q
+
+        other_team = self.organization.teams.create(name="other", project=self.team.project)
+        person = self._seed_person(team=self.team, distinct_ids=["d1"])
+        other_team_cohort = Cohort.objects.create(team=other_team, groups=[], is_static=True, name="other")
+        # Plant a CohortPeople row and (in the personhog run) a fake membership
+        # so that a missing team scope would show up as a false positive.
+        CohortPeople.objects.create(cohort=other_team_cohort, person=person)
+        self._seed_cohort_membership(person_id=person.id, cohort_id=other_team_cohort.id, is_member=True)
+
+        q = property_to_Q(
+            self.team.project_id,
+            self._make_cohort_property(other_team_cohort.id),
+            person_id=person.id,
+            team_id=self.team.id,
+        )
+
+        assert q == Q(pk__isnull=True)

--- a/posthog/models/cohort/test/test_cohort_personhog.py
+++ b/posthog/models/cohort/test/test_cohort_personhog.py
@@ -433,6 +433,20 @@ class TestListCohortMemberIds(PersonhogTestMixin, BaseTest):
 
         assert result == [p1.id]
 
+    def test_isolates_cross_team_cohort(self):
+        from posthog.models.person.util import list_cohort_member_ids
+
+        other_team = Team.objects.create(organization=self.organization)
+        person = self._seed_person(team=other_team, distinct_ids=["d1"])
+        other_team_cohort = Cohort.objects.create(team=other_team, groups=[], is_static=True, name="other")
+        CohortPeople.objects.create(cohort=other_team_cohort, person=person)
+        self._seed_cohort_membership(person_id=person.id, cohort_id=other_team_cohort.id, is_member=True)
+
+        result = list_cohort_member_ids(team_id=self.team.id, cohort_id=other_team_cohort.id)
+
+        assert result == []
+        self._assert_personhog_not_called("list_cohort_member_ids")
+
 
 class TestListCohortMemberIdsFallback(BaseTest):
     def test_falls_back_to_orm_when_personhog_disabled(self):

--- a/posthog/models/cohort/test/test_cohort_personhog.py
+++ b/posthog/models/cohort/test/test_cohort_personhog.py
@@ -4,6 +4,8 @@ via the ORM and personhog paths."""
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.db.models import Q
+
 from parameterized import parameterized_class
 
 from posthog.models import Cohort, Person, Team
@@ -101,6 +103,7 @@ class TestRemoveUserByUuid(PersonhogTestMixin, BaseTest):
         person = self._seed_person(team=self.team, distinct_ids=["d1"])
         cohort = self._create_static_cohort()
         CohortPeople.objects.create(cohort=cohort, person=person)
+        self._seed_cohort_membership(person_id=person.id, cohort_id=cohort.id, is_member=True)
 
         result = cohort.remove_user_by_uuid(str(person.uuid), team_id=self.team.id)
 
@@ -111,6 +114,7 @@ class TestRemoveUserByUuid(PersonhogTestMixin, BaseTest):
         assert call_args[0][0] == person.uuid
         assert call_args[0][1] == cohort.pk
         assert call_args[1]["team_id"] == self.team.id
+        self._assert_personhog_called("check_cohort_membership")
 
     @patch("posthog.models.cohort.util.remove_person_from_static_cohort")
     @patch("posthog.models.cohort.util.get_static_cohort_size", return_value=0)
@@ -148,6 +152,7 @@ class TestRemoveUserByUuid(PersonhogTestMixin, BaseTest):
         person = self._seed_person(team=self.team, distinct_ids=["d1"])
         cohort = self._create_static_cohort()
         CohortPeople.objects.create(cohort=cohort, person=person)
+        self._seed_cohort_membership(person_id=person.id, cohort_id=cohort.id, is_member=True)
 
         cohort.remove_user_by_uuid(str(person.uuid), team_id=self.team.id)
 
@@ -160,6 +165,7 @@ class TestRemoveUserByUuid(PersonhogTestMixin, BaseTest):
         person = self._seed_person(team=self.team, distinct_ids=["d1"])
         cohort = self._create_static_cohort()
         CohortPeople.objects.create(cohort=cohort, person=person)
+        self._seed_cohort_membership(person_id=person.id, cohort_id=cohort.id, is_member=True)
 
         result = cohort.remove_user_by_uuid(str(person.uuid), team_id=self.team.id)
 
@@ -176,3 +182,125 @@ class TestRemoveUserByUuid(PersonhogTestMixin, BaseTest):
         cohort.remove_user_by_uuid(str(person.uuid), team_id=self.team.id)
 
         self._assert_personhog_called("get_person_by_uuid")
+
+
+@parameterized_class(("personhog",), [(False,), (True,)])
+class TestCheckCohortMembership(PersonhogTestMixin, BaseTest):
+    def test_returns_true_for_member(self):
+        from posthog.models.person.util import check_cohort_membership, is_person_in_cohort
+
+        person = self._seed_person(team=self.team, distinct_ids=["d1"])
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c1")
+        CohortPeople.objects.create(cohort=cohort, person=person)
+        self._seed_cohort_membership(person_id=person.id, cohort_id=cohort.id, is_member=True)
+
+        assert is_person_in_cohort(team_id=self.team.id, person_id=person.id, cohort_id=cohort.id) is True
+        assert check_cohort_membership(self.team.id, person.id, [cohort.id]) == {cohort.id: True}
+        self._assert_personhog_called("check_cohort_membership")
+
+    def test_returns_false_for_non_member(self):
+        from posthog.models.person.util import is_person_in_cohort
+
+        person = self._seed_person(team=self.team, distinct_ids=["d1"])
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c1")
+
+        assert is_person_in_cohort(team_id=self.team.id, person_id=person.id, cohort_id=cohort.id) is False
+
+    def test_returns_empty_dict_for_empty_cohort_ids(self):
+        from posthog.models.person.util import check_cohort_membership
+
+        person = self._seed_person(team=self.team, distinct_ids=["d1"])
+
+        assert check_cohort_membership(self.team.id, person.id, []) == {}
+        self._assert_personhog_not_called("check_cohort_membership")
+
+    def test_mixed_membership(self):
+        from posthog.models.person.util import check_cohort_membership
+
+        person = self._seed_person(team=self.team, distinct_ids=["d1"])
+        c1 = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c1")
+        c2 = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c2")
+        c3 = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c3")
+        CohortPeople.objects.create(cohort=c1, person=person)
+        CohortPeople.objects.create(cohort=c3, person=person)
+        self._seed_cohort_membership(person_id=person.id, cohort_id=c1.id, is_member=True)
+        self._seed_cohort_membership(person_id=person.id, cohort_id=c3.id, is_member=True)
+
+        result = check_cohort_membership(self.team.id, person.id, [c1.id, c2.id, c3.id])
+
+        assert result == {c1.id: True, c2.id: False, c3.id: True}
+
+
+class TestCheckCohortMembershipFallback(BaseTest):
+    """Routing test: verifies ORM fallback when the personhog gate is disabled."""
+
+    def test_falls_back_to_orm_when_personhog_disabled(self):
+        from posthog.models.person.util import is_person_in_cohort
+
+        person = Person.objects.create(team=self.team, distinct_ids=["d1"])
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c1")
+        CohortPeople.objects.create(cohort=cohort, person=person)
+
+        with fake_personhog_client(gate_enabled=False) as fake:
+            assert is_person_in_cohort(team_id=self.team.id, person_id=person.id, cohort_id=cohort.id) is True
+
+        fake.assert_not_called("check_cohort_membership")
+
+
+@parameterized_class(("personhog",), [(False,), (True,)])
+class TestPropertyToQStaticCohortShortCircuit(PersonhogTestMixin, BaseTest):
+    """property_to_Q short-circuits the Exists(CohortPeople) subquery when
+    caller passes person_id + team_id for a static cohort."""
+
+    def _make_cohort_property(self, cohort_id: int):
+        from posthog.models.property import Property
+
+        return Property(key="id", value=cohort_id, type="cohort")
+
+    def test_returns_match_all_q_when_person_is_member(self):
+        from posthog.queries.base import property_to_Q
+
+        person = self._seed_person(team=self.team, distinct_ids=["d1"])
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c1")
+        CohortPeople.objects.create(cohort=cohort, person=person)
+        self._seed_cohort_membership(person_id=person.id, cohort_id=cohort.id, is_member=True)
+
+        q = property_to_Q(
+            self.team.project_id,
+            self._make_cohort_property(cohort.id),
+            person_id=person.id,
+            team_id=self.team.id,
+        )
+
+        assert q == Q(pk__isnull=False)
+        self._assert_personhog_called("check_cohort_membership")
+
+    def test_returns_no_match_q_when_person_is_not_member(self):
+        from posthog.queries.base import property_to_Q
+
+        person = self._seed_person(team=self.team, distinct_ids=["d1"])
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c1")
+
+        q = property_to_Q(
+            self.team.project_id,
+            self._make_cohort_property(cohort.id),
+            person_id=person.id,
+            team_id=self.team.id,
+        )
+
+        assert q == Q(pk__isnull=True)
+
+    def test_falls_back_to_exists_without_person_id(self):
+        from posthog.queries.base import property_to_Q
+
+        person = self._seed_person(team=self.team, distinct_ids=["d1"])
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c1")
+        CohortPeople.objects.create(cohort=cohort, person=person)
+
+        q = property_to_Q(self.team.project_id, self._make_cohort_property(cohort.id))
+
+        # Not a short-circuit Q — it's an Exists() wrapped in Q
+        assert q != Q(pk__isnull=False)
+        assert q != Q(pk__isnull=True)
+        # The Exists subquery path never calls the RPC
+        self._assert_personhog_not_called("check_cohort_membership")

--- a/posthog/models/cohort/test/test_cohort_personhog.py
+++ b/posthog/models/cohort/test/test_cohort_personhog.py
@@ -350,7 +350,7 @@ class TestPropertyToQStaticCohortShortCircuit(PersonhogTestMixin, BaseTest):
 
         assert q == Q(pk__isnull=True)
 
-    def test_falls_back_to_exists_without_person_id(self):
+    def test_falls_back_to_exists_without_person_id_or_team_id(self):
         from posthog.queries.base import property_to_Q
 
         person = self._seed_person(team=self.team, distinct_ids=["d1"])
@@ -362,8 +362,9 @@ class TestPropertyToQStaticCohortShortCircuit(PersonhogTestMixin, BaseTest):
         # Not a short-circuit Q — it's an Exists() wrapped in Q
         assert q != Q(pk__isnull=False)
         assert q != Q(pk__isnull=True)
-        # The Exists subquery path never calls the RPC
+        # The Exists subquery path never calls either RPC
         self._assert_personhog_not_called("check_cohort_membership")
+        self._assert_personhog_not_called("list_cohort_member_ids")
 
     def test_isolates_cohort_by_team_id(self):
         """A cohort owned by a different team (even within the same project)
@@ -387,3 +388,127 @@ class TestPropertyToQStaticCohortShortCircuit(PersonhogTestMixin, BaseTest):
         )
 
         assert q == Q(pk__isnull=True)
+
+
+@parameterized_class(("personhog",), [(False,), (True,)])
+class TestListCohortMemberIds(PersonhogTestMixin, BaseTest):
+    def test_returns_member_ids(self):
+        from posthog.models.person.util import list_cohort_member_ids
+
+        p1 = self._seed_person(team=self.team, distinct_ids=["d1"])
+        p2 = self._seed_person(team=self.team, distinct_ids=["d2"])
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c1")
+        CohortPeople.objects.create(cohort=cohort, person=p1)
+        CohortPeople.objects.create(cohort=cohort, person=p2)
+        self._seed_cohort_membership(person_id=p1.id, cohort_id=cohort.id, is_member=True)
+        self._seed_cohort_membership(person_id=p2.id, cohort_id=cohort.id, is_member=True)
+
+        result = list_cohort_member_ids(team_id=self.team.id, cohort_id=cohort.id)
+
+        assert sorted(result) == sorted([p1.id, p2.id])
+        self._assert_personhog_called("list_cohort_member_ids")
+
+    def test_returns_empty_for_empty_cohort(self):
+        from posthog.models.person.util import list_cohort_member_ids
+
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c1")
+
+        result = list_cohort_member_ids(team_id=self.team.id, cohort_id=cohort.id)
+
+        assert result == []
+
+    def test_excludes_non_members(self):
+        from posthog.models.person.util import list_cohort_member_ids
+
+        p1 = self._seed_person(team=self.team, distinct_ids=["d1"])
+        p2 = self._seed_person(team=self.team, distinct_ids=["d2"])
+        c1 = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c1")
+        c2 = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c2")
+        CohortPeople.objects.create(cohort=c1, person=p1)
+        CohortPeople.objects.create(cohort=c2, person=p2)
+        self._seed_cohort_membership(person_id=p1.id, cohort_id=c1.id, is_member=True)
+        self._seed_cohort_membership(person_id=p2.id, cohort_id=c2.id, is_member=True)
+
+        result = list_cohort_member_ids(team_id=self.team.id, cohort_id=c1.id)
+
+        assert result == [p1.id]
+
+
+class TestListCohortMemberIdsFallback(BaseTest):
+    def test_falls_back_to_orm_when_personhog_disabled(self):
+        from posthog.models.person.util import list_cohort_member_ids
+
+        person = Person.objects.create(team=self.team, distinct_ids=["d1"])
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c1")
+        CohortPeople.objects.create(cohort=cohort, person=person)
+
+        with fake_personhog_client(gate_enabled=False) as fake:
+            result = list_cohort_member_ids(team_id=self.team.id, cohort_id=cohort.id)
+
+        assert result == [person.id]
+        fake.assert_not_called("list_cohort_member_ids")
+
+
+@parameterized_class(("personhog",), [(False,), (True,)])
+class TestPropertyToQStaticCohortMemberList(PersonhogTestMixin, BaseTest):
+    """property_to_Q uses list_cohort_member_ids to produce Q(id__in=…) when
+    team_id is provided but person_id is not (queryset-wide filtering)."""
+
+    def _make_cohort_property(self, cohort_id: int):
+        from posthog.models.property import Property
+
+        return Property(key="id", value=cohort_id, type="cohort")
+
+    def test_returns_id_in_q_with_team_id_and_no_person_id(self):
+        from posthog.queries.base import property_to_Q
+
+        p1 = self._seed_person(team=self.team, distinct_ids=["d1"])
+        p2 = self._seed_person(team=self.team, distinct_ids=["d2"])
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c1")
+        CohortPeople.objects.create(cohort=cohort, person=p1)
+        CohortPeople.objects.create(cohort=cohort, person=p2)
+        self._seed_cohort_membership(person_id=p1.id, cohort_id=cohort.id, is_member=True)
+        self._seed_cohort_membership(person_id=p2.id, cohort_id=cohort.id, is_member=True)
+
+        q = property_to_Q(
+            self.team.project_id,
+            self._make_cohort_property(cohort.id),
+            team_id=self.team.id,
+        )
+
+        matched = Person.objects.filter(team_id=self.team.id).filter(q)
+        assert sorted(matched.values_list("id", flat=True)) == sorted([p1.id, p2.id])
+        self._assert_personhog_called("list_cohort_member_ids")
+
+    def test_returns_no_match_for_empty_cohort(self):
+        from posthog.queries.base import property_to_Q
+
+        self._seed_person(team=self.team, distinct_ids=["d1"])
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c1")
+
+        q = property_to_Q(
+            self.team.project_id,
+            self._make_cohort_property(cohort.id),
+            team_id=self.team.id,
+        )
+
+        assert q == Q(pk__isnull=True)
+
+    def test_filters_correctly_with_queryset(self):
+        from posthog.queries.base import property_to_Q
+
+        member = self._seed_person(team=self.team, distinct_ids=["member"])
+        non_member = self._seed_person(team=self.team, distinct_ids=["outsider"])
+        cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True, name="c1")
+        CohortPeople.objects.create(cohort=cohort, person=member)
+        self._seed_cohort_membership(person_id=member.id, cohort_id=cohort.id, is_member=True)
+
+        q = property_to_Q(
+            self.team.project_id,
+            self._make_cohort_property(cohort.id),
+            team_id=self.team.id,
+        )
+
+        matched = set(Person.objects.filter(team_id=self.team.id).filter(q).values_list("id", flat=True))
+        assert member.id in matched
+        assert non_member.id not in matched

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -45,6 +45,7 @@ from posthog.personhog_client.proto import (
     GetPersonRequest,
     GetPersonsByDistinctIdsInTeamRequest,
     GetPersonsByUuidsRequest,
+    ListCohortMemberIdsRequest,
 )
 from posthog.settings import TEST
 
@@ -625,6 +626,52 @@ def check_cohort_membership(team_id: int, person_id: int, cohort_ids: list[int])
 def is_person_in_cohort(team_id: int, person_id: int, cohort_id: int) -> bool:
     """Convenience single-cohort variant of ``check_cohort_membership``."""
     return check_cohort_membership(team_id, person_id, [cohort_id]).get(cohort_id, False)
+
+
+_LIST_COHORT_MEMBER_IDS_PAGE_SIZE = 10_000
+
+
+def _list_cohort_member_ids_via_personhog(cohort_id: int) -> list[int]:
+    from posthog.personhog_client.client import get_personhog_client
+
+    client = get_personhog_client()
+    if client is None:
+        raise RuntimeError("personhog client not configured")
+
+    all_ids: list[int] = []
+    cursor = 0
+    while True:
+        resp = client.list_cohort_member_ids(
+            ListCohortMemberIdsRequest(cohort_id=cohort_id, cursor=cursor, limit=_LIST_COHORT_MEMBER_IDS_PAGE_SIZE)
+        )
+        all_ids.extend(resp.person_ids)
+        if resp.next_cursor == 0:
+            break
+        cursor = resp.next_cursor
+    return all_ids
+
+
+def list_cohort_member_ids(team_id: int, cohort_id: int) -> list[int]:
+    """Return all person IDs belonging to a static cohort.
+
+    Routes through personhog when the gate is enabled, falling back to a Django
+    ORM query against ``posthog_cohortpeople`` (on the persons DB) otherwise.
+    """
+    from posthog.models.cohort.cohort import CohortPeople
+
+    def orm_fn() -> list[int]:
+        return list(
+            CohortPeople.objects.db_manager(READ_DB_FOR_PERSONS)
+            .filter(cohort_id=cohort_id)
+            .values_list("person_id", flat=True)
+        )
+
+    return _personhog_routed(
+        "list_cohort_member_ids",
+        lambda: _list_cohort_member_ids_via_personhog(cohort_id),
+        orm_fn,
+        team_id=team_id,
+    )
 
 
 def get_person_by_pk_or_uuid(team_id: int, key: str) -> Optional[Person]:

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -566,7 +566,7 @@ def get_person_by_distinct_id(team_id: int, distinct_id: str) -> Optional[Person
     )
 
 
-def _check_cohort_membership_via_personhog(team_id: int, person_id: int, cohort_ids: list[int]) -> dict[int, bool]:
+def _check_cohort_membership_via_personhog(person_id: int, cohort_ids: list[int]) -> dict[int, bool]:
     from posthog.personhog_client.client import get_personhog_client
 
     client = get_personhog_client()
@@ -589,23 +589,37 @@ def check_cohort_membership(team_id: int, person_id: int, cohort_ids: list[int])
     if not cohort_ids:
         return {}
 
-    def orm_fn() -> dict[int, bool]:
-        # Local import to avoid circulars (cohort → person via CohortPeople FK).
-        from posthog.models.cohort.cohort import CohortPeople
+    # Local import to avoid circulars (cohort → person via CohortPeople FK).
+    from posthog.models.cohort.cohort import Cohort, CohortPeople
 
+    # Scope cohort_ids to the team via Cohort on the default DB before querying
+    # either the personhog RPC or the persons-DB CohortPeople table. Neither
+    # downstream path enforces team ownership (posthog_cohortpeople has no
+    # team_id column; the RPC just filters by person_id + cohort_id), so the
+    # tenant boundary has to be applied here. Cohorts belonging to a different
+    # team are reported as ``False`` rather than looked up. Same pattern as
+    # `posthog.models.team.util.delete_bulky_postgres_data`.
+    scoped_cohort_ids = list(Cohort.objects.filter(id__in=cohort_ids, team_id=team_id).values_list("id", flat=True))
+    if not scoped_cohort_ids:
+        return dict.fromkeys(cohort_ids, False)
+
+    def orm_fn() -> dict[int, bool]:
         member_ids = set(
             CohortPeople.objects.db_manager(READ_DB_FOR_PERSONS)
-            .filter(person_id=person_id, cohort_id__in=cohort_ids)
+            .filter(person_id=person_id, cohort_id__in=scoped_cohort_ids)
             .values_list("cohort_id", flat=True)
         )
-        return {cohort_id: cohort_id in member_ids for cohort_id in cohort_ids}
+        return {cohort_id: cohort_id in member_ids for cohort_id in scoped_cohort_ids}
 
-    return _personhog_routed(
+    scoped_result = _personhog_routed(
         "check_cohort_membership",
-        lambda: _check_cohort_membership_via_personhog(team_id, person_id, cohort_ids),
+        lambda: _check_cohort_membership_via_personhog(person_id, scoped_cohort_ids),
         orm_fn,
         team_id=team_id,
     )
+    # Expand back to the caller's original cohort_ids; cohorts that were scoped
+    # out (not owned by this team) register as non-member.
+    return {cohort_id: scoped_result.get(cohort_id, False) for cohort_id in cohort_ids}
 
 
 def is_person_in_cohort(team_id: int, person_id: int, cohort_id: int) -> bool:

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -657,7 +657,14 @@ def list_cohort_member_ids(team_id: int, cohort_id: int) -> list[int]:
     Routes through personhog when the gate is enabled, falling back to a Django
     ORM query against ``posthog_cohortpeople`` (on the persons DB) otherwise.
     """
-    from posthog.models.cohort.cohort import CohortPeople
+    from posthog.models.cohort.cohort import Cohort, CohortPeople
+
+    # Validate cohort ownership on the default DB before querying the persons DB
+    # or the personhog RPC — neither downstream path enforces team isolation
+    # (posthog_cohortpeople has no team_id column; the proto has no team_id field).
+    # Same pattern as check_cohort_membership / delete_bulky_postgres_data.
+    if not Cohort.objects.filter(id=cohort_id, team_id=team_id).exists():
+        return []
 
     def orm_fn() -> list[int]:
         return list(

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -36,6 +36,7 @@ from posthog.personhog_client.metrics import (
     get_client_name,
 )
 from posthog.personhog_client.proto import (
+    CheckCohortMembershipRequest,
     DeletePersonsRequest,
     GetDistinctIdsForPersonRequest,
     GetDistinctIdsForPersonsRequest,
@@ -563,6 +564,53 @@ def get_person_by_distinct_id(team_id: int, distinct_id: str) -> Optional[Person
         .first(),
         team_id=team_id,
     )
+
+
+def _check_cohort_membership_via_personhog(team_id: int, person_id: int, cohort_ids: list[int]) -> dict[int, bool]:
+    from posthog.personhog_client.client import get_personhog_client
+
+    client = get_personhog_client()
+    if client is None:
+        raise RuntimeError("personhog client not configured")
+
+    resp = client.check_cohort_membership(CheckCohortMembershipRequest(person_id=person_id, cohort_ids=cohort_ids))
+    membership_by_cohort: dict[int, bool] = {m.cohort_id: m.is_member for m in resp.memberships}
+    return {cohort_id: membership_by_cohort.get(cohort_id, False) for cohort_id in cohort_ids}
+
+
+def check_cohort_membership(team_id: int, person_id: int, cohort_ids: list[int]) -> dict[int, bool]:
+    """Return ``{cohort_id: is_member}`` for the given person.
+
+    Routes through personhog when the gate is enabled, falling back to a Django
+    ORM query against ``posthog_cohortpeople`` (on the persons DB) otherwise.
+    Membership for cohorts the person is not in is returned as ``False`` rather
+    than being omitted, so callers can index directly by cohort_id.
+    """
+    if not cohort_ids:
+        return {}
+
+    def orm_fn() -> dict[int, bool]:
+        # Local import to avoid circulars (cohort → person via CohortPeople FK).
+        from posthog.models.cohort.cohort import CohortPeople
+
+        member_ids = set(
+            CohortPeople.objects.db_manager(READ_DB_FOR_PERSONS)
+            .filter(person_id=person_id, cohort_id__in=cohort_ids)
+            .values_list("cohort_id", flat=True)
+        )
+        return {cohort_id: cohort_id in member_ids for cohort_id in cohort_ids}
+
+    return _personhog_routed(
+        "check_cohort_membership",
+        lambda: _check_cohort_membership_via_personhog(team_id, person_id, cohort_ids),
+        orm_fn,
+        team_id=team_id,
+    )
+
+
+def is_person_in_cohort(team_id: int, person_id: int, cohort_id: int) -> bool:
+    """Convenience single-cohort variant of ``check_cohort_membership``."""
+    return check_cohort_membership(team_id, person_id, [cohort_id]).get(cohort_id, False)
 
 
 def get_person_by_pk_or_uuid(team_id: int, key: str) -> Optional[Person]:

--- a/posthog/personhog_client/test_helpers.py
+++ b/posthog/personhog_client/test_helpers.py
@@ -97,6 +97,17 @@ class PersonhogTestMixin:
             )
         return person
 
+    def _seed_cohort_membership(self, *, person_id: int, cohort_id: int, is_member: bool = True) -> None:
+        """Seed a cohort membership in the fake personhog client.  No-op on the ORM path.
+
+        Mirrors the pattern of ``_seed_person``: callers still create real
+        ``CohortPeople`` DB rows (needed for the ORM fallback and any secondary
+        queries).  This helper additionally registers the membership in the
+        fake client when personhog routing is active.
+        """
+        if self._fake_client is not None:
+            self._fake_client.add_cohort_membership(person_id=person_id, cohort_id=cohort_id, is_member=is_member)
+
     def _assert_personhog_called(self, method: str, *, times: int | None = None) -> list[Any]:
         """Assert a personhog method was called.  No-op on the ORM path.
 

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -356,6 +356,19 @@ def property_to_Q(
                     return Q(pk__isnull=False)
                 return Q(pk__isnull=True)
 
+            # When team_id is available, list all member IDs and filter with
+            # Q(id__in=…) — routes through personhog when the gate is on,
+            # falling back to the CohortPeople table otherwise. This avoids
+            # the Exists(CohortPeople) subquery so the persons DB is not
+            # required on the personhog path.
+            if team_id is not None:
+                from posthog.models.person.util import list_cohort_member_ids
+
+                member_ids = list_cohort_member_ids(team_id=team_id, cohort_id=cohort_id)
+                if not member_ids:
+                    return Q(pk__isnull=True)
+                return Q(id__in=member_ids)
+
             return Q(
                 Exists(
                     CohortPeople.objects.db_manager(using_database)

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -309,6 +309,9 @@ def property_to_Q(
     override_property_values: Optional[dict[str, Any]] = None,
     cohorts_cache: Optional[dict[int, CohortOrEmpty]] = None,
     using_database: str = "default",
+    *,
+    person_id: Optional[int] = None,
+    team_id: Optional[int] = None,
 ) -> Q:
     if override_property_values is None:
         override_property_values = {}
@@ -342,6 +345,17 @@ def property_to_Q(
             return Q(pk__isnull=True)
 
         if cohort.is_static:
+            # When a concrete person is in scope, short-circuit the Exists subquery
+            # with a direct membership check — routes through personhog when enabled,
+            # falling back to the persons-DB ORM otherwise. Mirrors the override
+            # short-circuit below (returning Q(pk__isnull=False|True)).
+            if person_id is not None and team_id is not None:
+                from posthog.models.person.util import is_person_in_cohort
+
+                if is_person_in_cohort(team_id=team_id, person_id=person_id, cohort_id=cohort_id):
+                    return Q(pk__isnull=False)
+                return Q(pk__isnull=True)
+
             return Q(
                 Exists(
                     CohortPeople.objects.db_manager(using_database)
@@ -362,6 +376,8 @@ def property_to_Q(
                 override_property_values,
                 cohorts_cache,
                 using_database,
+                person_id=person_id,
+                team_id=team_id,
             )
 
     # short circuit query if key exists in override_property_values
@@ -432,6 +448,9 @@ def property_group_to_Q(
     override_property_values: Optional[dict[str, Any]] = None,
     cohorts_cache: Optional[dict[int, CohortOrEmpty]] = None,
     using_database: str = "default",
+    *,
+    person_id: Optional[int] = None,
+    team_id: Optional[int] = None,
 ) -> Q:
     if override_property_values is None:
         override_property_values = {}
@@ -448,6 +467,8 @@ def property_group_to_Q(
                 override_property_values,
                 cohorts_cache,
                 using_database,
+                person_id=person_id,
+                team_id=team_id,
             )
             if property_group.type == PropertyOperatorType.OR:
                 filters |= group_filter
@@ -457,7 +478,13 @@ def property_group_to_Q(
         for property in property_group.values:
             property = cast(Property, property)
             property_filter = property_to_Q(
-                project_id, property, override_property_values, cohorts_cache, using_database
+                project_id,
+                property,
+                override_property_values,
+                cohorts_cache,
+                using_database,
+                person_id=person_id,
+                team_id=team_id,
             )
             if property_group.type == PropertyOperatorType.OR:
                 if property.negation:
@@ -479,10 +506,18 @@ def properties_to_Q(
     override_property_values: Optional[dict[str, Any]] = None,
     cohorts_cache: Optional[dict[int, CohortOrEmpty]] = None,
     using_database: str = "default",
+    *,
+    person_id: Optional[int] = None,
+    team_id: Optional[int] = None,
 ) -> Q:
     """
     Converts a filter to Q, for use in Django ORM .filter()
     If you're filtering a Person/Group QuerySet, use is_direct_query to avoid doing an unnecessary nested loop
+
+    When ``person_id`` and ``team_id`` are both provided, static-cohort
+    membership checks short-circuit through ``is_person_in_cohort`` (routed via
+    personhog when enabled) instead of emitting an ``Exists(CohortPeople)``
+    subquery — useful for per-person evaluation paths.
     """
     if override_property_values is None:
         override_property_values = {}
@@ -497,6 +532,8 @@ def properties_to_Q(
         override_property_values,
         cohorts_cache,
         using_database,
+        person_id=person_id,
+        team_id=team_id,
     )
 
 


### PR DESCRIPTION
## Problem

Django currently has many DB connections to the persons database to service CohortPeople data access. We are migrating django to use personhog service, so these need to be shifted to start going through that service.

## Changes

- **Cohort membership checks**: Modified `Cohort.remove_user_by_uuid()` to use `is_person_in_cohort()` helper instead of direct ORM queries for checking if a person belongs to a cohort
- **New utility functions**: Added `is_person_in_cohort()` and `check_cohort_membership()` in `posthog/models/person/util.py` that:
  - Route through personhog RPC when the feature is enabled
  - Fall back to ORM queries when personhog is disabled or unavailable
  - Support single and batch membership checks
- **Test coverage**: Added comprehensive tests in `test_cohort_personhog.py` including:
  - Tests for single membership checks (true/false cases)
  - Batch membership checks with mixed results
  - Empty cohort ID handling
  - Fallback behavior when personhog is disabled
  - Parameterized tests for both ORM and personhog routing paths
- **Deletion logic**: Deletion still uses ORM (no personhog RPC exists yet), but membership check is now routed appropriately

## How did you test this code?

This is an agent-authored PR. Code-based tests are included in the diff:
- Unit tests verify membership checking returns correct boolean values
- Parameterized tests validate both ORM and personhog code paths
- Fallback tests confirm correct behavior when personhog is disabled
- Tests verify personhog RPC is called appropriately and not called when disabled

Manual integration testing with the personhog service would be required to fully validate the RPC routing in a live environment.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*