### PR TITLE
feat(mcp): progressive tool disclosure via ?progressive=true

### DIFF
--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -458,5 +458,19 @@
             "openWorldHint": false,
             "readOnlyHint": true
         }
+    },
+    "toolsets": {
+        "description": "Manage which PostHog MCP toolsets are active in this session. Call with action='list' to see all available toolsets, action='describe' with a name to see which tools a toolset contains, action='enable' with a name to activate a toolset (its tools become callable), and action='disable' with a name to turn one off. Use this when the user asks about a PostHog surface (dashboards, feature flags, experiments, surveys, error tracking, LLM analytics, etc.) whose tools aren't yet available.",
+        "category": "Meta",
+        "feature": "meta",
+        "summary": "List, describe, enable, or disable progressive-disclosure toolsets.",
+        "title": "Manage toolsets",
+        "required_scopes": [],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": false,
+            "readOnlyHint": false
+        }
     }
 }

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -19,6 +19,21 @@
             },
             "required": ["query"]
         },
+        "ToolsetsInputSchema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list", "describe", "enable", "disable"],
+                    "description": "What to do: 'list' returns all available toolsets and which ones are currently enabled; 'describe' returns the tools inside one toolset; 'enable' activates a toolset so its tools become callable; 'disable' turns one off."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Toolset id — required for 'describe', 'enable', and 'disable'. Get valid ids from 'list'."
+                }
+            },
+            "required": ["action"]
+        },
         "EntitySearchSchema": {
             "type": "object",
             "properties": {

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -19,21 +19,6 @@
             },
             "required": ["query"]
         },
-        "ToolsetsInputSchema": {
-            "type": "object",
-            "properties": {
-                "action": {
-                    "type": "string",
-                    "enum": ["list", "describe", "enable", "disable"],
-                    "description": "What to do: 'list' returns all available toolsets and which ones are currently enabled; 'describe' returns the tools inside one toolset; 'enable' activates a toolset so its tools become callable; 'disable' turns one off."
-                },
-                "name": {
-                    "type": "string",
-                    "description": "Toolset id — required for 'describe', 'enable', and 'disable'. Get valid ids from 'list'."
-                }
-            },
-            "required": ["action"]
-        },
         "EntitySearchSchema": {
             "type": "object",
             "properties": {
@@ -2718,6 +2703,21 @@
         "SurveyResponseCountsSchema": {
             "type": "object",
             "properties": {}
+        },
+        "ToolsetsInputSchema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list", "describe", "enable", "disable"],
+                    "description": "What to do: 'list' returns all available toolsets and which ones are currently enabled; 'describe' returns the tools inside one toolset; 'enable' activates a toolset so its tools become callable; 'disable' turns one off."
+                },
+                "name": {
+                    "description": "Toolset id — required for 'describe', 'enable', and 'disable'. Get valid ids from 'list'.",
+                    "type": "string"
+                }
+            },
+            "required": ["action"]
         }
     }
 }

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -272,6 +272,30 @@ const handleRequest = async (
     const toolsetsParam = url.searchParams.get('toolsets')
     const initialToolsets = toolsetsParam ? toolsetsParam.split(',').filter(Boolean) : undefined
 
+    // Peek at initialize request body to capture clientInfo.name early. We do this here
+    // rather than reading via the SDK's `getInitializeRequest()` in the DO because that
+    // hasn't persisted reliably in our testing; parsing the body is deterministic.
+    let earlyClientName: string | undefined
+    if (progressive && request.method === 'POST') {
+        try {
+            const cloned = request.clone()
+            const bodyText = await cloned.text()
+            if (bodyText) {
+                const parsed = JSON.parse(bodyText)
+                const messages = Array.isArray(parsed) ? parsed : [parsed]
+                for (const msg of messages) {
+                    if (msg?.method === 'initialize') {
+                        const name = msg?.params?.clientInfo?.name
+                        if (typeof name === 'string') earlyClientName = name
+                        break
+                    }
+                }
+            }
+        } catch {
+            // ignore — body may not be parseable
+        }
+    }
+
     const extraContextProps = {
         features,
         tools,
@@ -280,6 +304,7 @@ const handleRequest = async (
         readOnly,
         progressive,
         initialToolsets,
+        ...(earlyClientName ? { earlyClientName } : {}),
     }
     Object.assign(ctx.props, extraContextProps)
     log.extend(extraContextProps)

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -264,7 +264,23 @@ const handleRequest = async (
     const readOnlyRaw = request.headers.get('x-posthog-readonly') || url.searchParams.get('readonly')
     const readOnly = readOnlyRaw === 'true' || readOnlyRaw === '1' || undefined
 
-    const extraContextProps = { features, tools, region: regionParam, version, readOnly }
+    // Progressive disclosure: ?progressive=true exposes only bootstrap tools + the toolsets
+    // meta-tool. ?toolsets=a,b pre-enables specific toolsets on connect (used by the reconnect
+    // fallback for clients that don't support notifications/tools/list_changed).
+    const progressiveParam = request.headers.get('x-posthog-progressive') || url.searchParams.get('progressive')
+    const progressive = progressiveParam === 'true' || progressiveParam === '1' || undefined
+    const toolsetsParam = url.searchParams.get('toolsets')
+    const initialToolsets = toolsetsParam ? toolsetsParam.split(',').filter(Boolean) : undefined
+
+    const extraContextProps = {
+        features,
+        tools,
+        region: regionParam,
+        version,
+        readOnly,
+        progressive,
+        initialToolsets,
+    }
     Object.assign(ctx.props, extraContextProps)
     log.extend(extraContextProps)
 

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -287,7 +287,7 @@ const handleRequest = async (
                     if (msg?.method === 'initialize') {
                         const name = msg?.params?.clientInfo?.name
                         if (typeof name === 'string') {
-                            earlyClientName = name
+                            earlyClientName = sanitizeHeaderValue(name)
                         }
                         break
                     }

--- a/services/mcp/src/index.ts
+++ b/services/mcp/src/index.ts
@@ -286,7 +286,9 @@ const handleRequest = async (
                 for (const msg of messages) {
                     if (msg?.method === 'initialize') {
                         const name = msg?.params?.clientInfo?.name
-                        if (typeof name === 'string') earlyClientName = name
+                        if (typeof name === 'string') {
+                            earlyClientName = name
+                        }
                         break
                     }
                 }

--- a/services/mcp/src/lib/clientCapabilities.ts
+++ b/services/mcp/src/lib/clientCapabilities.ts
@@ -1,0 +1,24 @@
+/**
+ * MCP clients known NOT to refresh their tool list on `notifications/tools/list_changed`.
+ *
+ * When `toolsets(action='enable'|'disable')` runs in progressive mode for one of these
+ * clients, we fall back to instructing the model (via appended text) to ask the user to
+ * reconnect with `?toolsets=<ids>`, which re-initializes the session with those toolsets
+ * already active.
+ *
+ * Maintained conservatively: when in doubt, assume the client DOES support list_changed
+ * and rely on the notification. The `note` field in the tool response already tells the
+ * model how to recover, so this secondary hint is belt-and-suspenders for clients where
+ * we've empirically confirmed the auto-refresh is broken.
+ *
+ * Last audited: 2026-04 against https://modelcontextprotocol.io/clients
+ */
+const KNOWN_UNSUPPORTED_CLIENTS: readonly string[] = ['cursor', 'codeium', 'windsurf']
+
+export function clientSupportsListChanged(clientName?: string): boolean {
+    if (!clientName) {
+        return true
+    }
+    const normalized = clientName.trim().toLowerCase()
+    return !KNOWN_UNSUPPORTED_CLIENTS.some((n) => normalized.includes(n))
+}

--- a/services/mcp/src/lib/clientCapabilities.ts
+++ b/services/mcp/src/lib/clientCapabilities.ts
@@ -20,7 +20,16 @@
  *
  * Last audited: 2026-04 against https://modelcontextprotocol.io/clients + local tests.
  */
-const KNOWN_UNSUPPORTED_CLIENTS: readonly string[] = ['cursor', 'codeium', 'windsurf', 'claude-code']
+const KNOWN_UNSUPPORTED_CLIENTS: readonly string[] = [
+    'cursor',
+    'codeium',
+    'windsurf',
+    'claude-code',
+    // OpenAI Codex CLI sends clientInfo.name='codex-mcp-client'. Verified empirically
+    // 2026-04: after toolsets(enable), Codex tries the new tool, gets no match, and gives
+    // up without surfacing the reconnect path.
+    'codex',
+]
 
 export function clientSupportsListChanged(clientName?: string): boolean {
     if (!clientName) {

--- a/services/mcp/src/lib/clientCapabilities.ts
+++ b/services/mcp/src/lib/clientCapabilities.ts
@@ -1,19 +1,26 @@
 /**
- * MCP clients known NOT to refresh their tool list on `notifications/tools/list_changed`.
+ * MCP clients known NOT to make newly-enabled tools callable after
+ * `notifications/tools/list_changed`.
  *
- * When `toolsets(action='enable'|'disable')` runs in progressive mode for one of these
- * clients, we fall back to instructing the model (via appended text) to ask the user to
- * reconnect with `?toolsets=<ids>`, which re-initializes the session with those toolsets
- * already active.
+ * "Unsupported" here is a practical behavioral test: does a tool that wasn't in the
+ * initial `tools/list` become callable mid-session once the server emits `list_changed`?
+ * The raw MCP SDK does handle this, but some clients wrap the SDK with their own
+ * deferred/cached tool layer that doesn't re-scan on notifications.
  *
- * Maintained conservatively: when in doubt, assume the client DOES support list_changed
- * and rely on the notification. The `note` field in the tool response already tells the
- * model how to recover, so this secondary hint is belt-and-suspenders for clients where
- * we've empirically confirmed the auto-refresh is broken.
+ * For these clients we surface a `_reconnectHint` on toolset enable/disable so the model
+ * can ask the user to reconnect with `?toolsets=<ids>` pre-enabled — the session
+ * re-initializes and the tools appear in the catalog up front.
  *
- * Last audited: 2026-04 against https://modelcontextprotocol.io/clients
+ * Findings (2026-04):
+ * - **claude-code**: defers non-bootstrap tools at init, doesn't re-scan on list_changed.
+ *   Verified empirically — `No such tool available` on post-enable invocation across
+ *   Opus/Sonnet/Haiku.
+ * - **cursor**, **codeium**, **windsurf**: documented in the MCP client compatibility
+ *   matrix as not honoring list_changed.
+ *
+ * Last audited: 2026-04 against https://modelcontextprotocol.io/clients + local tests.
  */
-const KNOWN_UNSUPPORTED_CLIENTS: readonly string[] = ['cursor', 'codeium', 'windsurf']
+const KNOWN_UNSUPPORTED_CLIENTS: readonly string[] = ['cursor', 'codeium', 'windsurf', 'claude-code']
 
 export function clientSupportsListChanged(clientName?: string): boolean {
     if (!clientName) {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -15,6 +15,7 @@ import {
     type MCPAnalyticsContext,
 } from '@/lib/analytics'
 import { DurableObjectCache } from '@/lib/cache/DurableObjectCache'
+import { clientSupportsListChanged } from '@/lib/clientCapabilities'
 import {
     CUSTOM_API_BASE_URL,
     POSTHOG_EU_BASE_URL,
@@ -34,6 +35,7 @@ import { registerResources } from '@/resources'
 import { registerUiAppResources } from '@/resources/ui-apps'
 import INSTRUCTIONS_TEMPLATE_V1 from '@/templates/instructions-v1.md'
 import INSTRUCTIONS_TEMPLATE_V2 from '@/templates/instructions-v2.md'
+import { ENABLED_TOOLSETS_KEY } from '@/tools/toolsets/manage'
 import {
     POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY,
     POSTHOG_META_KEY,
@@ -58,6 +60,10 @@ export type RequestProperties = {
     readOnly?: boolean
     transport?: 'streamable-http' | 'sse'
     requestStartTime?: number
+    /** When true, only expose bootstrap tools + toolsets(action='enable',...)'d tools. */
+    progressive?: boolean
+    /** Toolset ids to pre-enable on connect (from ?toolsets=a,b URL param). */
+    initialToolsets?: string[]
 }
 
 export class MCP extends McpAgent<Env> {
@@ -70,6 +76,9 @@ export class MCP extends McpAgent<Env> {
         region: undefined,
         apiKey: undefined,
         clientName: undefined,
+        aiConsentGiven: undefined,
+        aiConsentFetchedAt: undefined,
+        enabledToolsets: undefined,
     }
 
     _cache: DurableObjectCache<State> | undefined
@@ -459,6 +468,22 @@ export class MCP extends McpAgent<Env> {
         )
     }
 
+    /**
+     * Fire a `notifications/tools/list_changed` MCP notification so compatible clients
+     * re-request `tools/list`. Best-effort: swallow errors since the transport may not
+     * support notifications at all.
+     */
+    notifyToolListChanged(): void {
+        try {
+            const underlying = (this.server as any)?.server
+            if (underlying && typeof underlying.sendToolListChanged === 'function') {
+                underlying.sendToolListChanged()
+            }
+        } catch {
+            // best-effort
+        }
+    }
+
     async getContext(): Promise<Context> {
         const api = await this.api()
         return {
@@ -471,7 +496,16 @@ export class MCP extends McpAgent<Env> {
     }
 
     async init(): Promise<void> {
-        const { features, tools, version: clientVersion, organizationId, projectId, readOnly } = this.requestProperties
+        const {
+            features,
+            tools,
+            version: clientVersion,
+            organizationId,
+            projectId,
+            readOnly,
+            progressive,
+            initialToolsets,
+        } = this.requestProperties
 
         // Start feature flag resolution in parallel with cache seeding
         const flagPromise = this.resolveVersionFlag()
@@ -535,6 +569,8 @@ export class MCP extends McpAgent<Env> {
             excludeTools,
             readOnly,
             featureFlags: toolFeatureFlags,
+            progressive,
+            enabledToolsets: initialToolsets,
         })
 
         // OAuth introspection has now run (triggered by getToolsFromContext → getApiKey),
@@ -546,7 +582,29 @@ export class MCP extends McpAgent<Env> {
 
         for (const tool of allTools) {
             const typedTool = tool as Tool<z.ZodObject>
-            this.registerTool(typedTool, async (params) => typedTool.handler(context, params))
+            if (progressive && typedTool.name === 'toolsets') {
+                // Wrap the toolsets meta-tool so enable/disable calls fire
+                // notifications/tools/list_changed and (for known-unsupported clients)
+                // include a reconnect hint in the response.
+                this.registerTool(typedTool, async (params: any) => {
+                    const result = (await typedTool.handler(context, params)) as Record<string, unknown>
+                    if (params?.action === 'enable' || params?.action === 'disable') {
+                        this.notifyToolListChanged()
+                        await this.resolveClientInfo()
+                        if (!clientSupportsListChanged(this._mcpClientName)) {
+                            const enabled = ((await context.cache.get(ENABLED_TOOLSETS_KEY as any)) ?? []) as string[]
+                            const reconnectQuery = `?progressive=true${enabled.length ? `&toolsets=${enabled.join(',')}` : ''}`
+                            return {
+                                ...result,
+                                _reconnectHint: `Your MCP client may not auto-refresh the tool list. If new tools aren't visible next turn, ask the user to reconnect with: ${reconnectQuery}`,
+                            }
+                        }
+                    }
+                    return result
+                })
+            } else {
+                this.registerTool(typedTool, async (params) => typedTool.handler(context, params))
+            }
         }
 
         await initMcpCatObservability(this.server, {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -36,7 +36,7 @@ import { registerUiAppResources } from '@/resources/ui-apps'
 import INSTRUCTIONS_TEMPLATE_V1 from '@/templates/instructions-v1.md'
 import INSTRUCTIONS_TEMPLATE_V2 from '@/templates/instructions-v2.md'
 import { ENABLED_TOOLSETS_KEY } from '@/tools/toolsets/manage'
-import { toolsetIdForFeature } from '@/tools/toolsets/taxonomy'
+import { expandToolsetToFeatures, isBootstrapTool, resolveEnabledFeatures } from '@/tools/toolsets/taxonomy'
 import {
     POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY,
     POSTHOG_META_KEY,
@@ -484,24 +484,34 @@ export class MCP extends McpAgent<Env> {
     }
 
     /**
-     * Flip `_toolRegistrations` enabled state for every tool whose feature maps to `toolsetId`.
+     * Flip `_toolRegistrations` enabled state for every tool whose feature is covered by
+     * `toolsetId` (either a base toolset = 1 feature, or a composite = many features).
      * The SDK auto-fires `notifications/tools/list_changed` on each `.enable()`/`.disable()`,
      * so compatible MCP clients re-request `tools/list` and see the updated catalog.
      */
     applyToolsetToRegistrations(
         toolsetId: string | undefined,
         action: 'enable' | 'disable',
-        toolDefs: Record<string, { feature: string }>
+        toolDefs: Record<string, { feature: string }>,
+        version?: number
     ): void {
         if (!toolsetId) {
             return
         }
+        const features = new Set(expandToolsetToFeatures(toolsetId, version))
+        if (features.size === 0) {
+            return
+        }
         for (const [name, registered] of this._toolRegistrations.entries()) {
+            // Bootstrap tools are always visible regardless of toolset state. Never flip them.
+            if (isBootstrapTool(name)) {
+                continue
+            }
             const def = toolDefs[name]
             if (!def) {
                 continue
             }
-            if (toolsetIdForFeature(def.feature) !== toolsetId) {
+            if (!features.has(def.feature)) {
                 continue
             }
             if (action === 'enable') {
@@ -634,10 +644,6 @@ export class MCP extends McpAgent<Env> {
             excludeTools,
             readOnly,
             featureFlags: toolFeatureFlags,
-            // Fetch catalog unfiltered by progressive state; we handle enable/disable on
-            // the registered tool refs below so tools/list_changed just works.
-            progressive: progressive ? true : undefined,
-            enabledToolsets: undefined,
         })
 
         // OAuth introspection has now run (triggered by getToolsFromContext → getApiKey),
@@ -647,25 +653,47 @@ export class MCP extends McpAgent<Env> {
             this._api.config.oauthClientName = oauthClientName
         }
 
-        const { isBootstrapTool } = await import('@/tools/toolsets/taxonomy')
         const { getToolDefinitions } = await import('@/tools/toolDefinitions')
         const toolDefs = getToolDefinitions(version)
 
-        // Resolve initial enabled toolsets: merge session cache with ?toolsets=<ids>
+        // Resolve the set of FEATURES that should be active at init time: merge session
+        // cache with any ?toolsets=<ids> query-param pre-enables, then expand composites.
         const sessionEnabled = ((await this.cache.get(ENABLED_TOOLSETS_KEY as any)) ?? []) as string[]
-        const enabledToolsets = new Set<string>([...sessionEnabled, ...(initialToolsets ?? [])])
+        const initialEnabledToolsets = Array.from(new Set([...sessionEnabled, ...(initialToolsets ?? [])]))
+        const initialEnabledFeatures = resolveEnabledFeatures(initialEnabledToolsets, version)
 
         for (const tool of allTools) {
             const typedTool = tool as Tool<z.ZodObject>
-            let registered: { enable: () => void; disable: () => void }
-            if (progressive && typedTool.name === 'toolsets') {
-                // Wrap the toolsets meta-tool so enable/disable calls flip individual tool
-                // registrations. The SDK's `.enable()` / `.disable()` auto-fires
-                // notifications/tools/list_changed, so compatible clients auto-refresh.
-                registered = this.registerTool(typedTool, async (params: any) => {
-                    const result = (await typedTool.handler(context, params)) as Record<string, unknown>
+            const registered = this.registerTool(typedTool, async (params) => typedTool.handler(context, params))
+
+            // In progressive mode, disable everything that isn't bootstrap and whose feature
+            // isn't already active (via session cache or ?toolsets= pre-enable). Keep the
+            // registration so `toolsets(action='enable')` can `.enable()` it later without
+            // needing a full re-init.
+            if (progressive) {
+                if (isBootstrapTool(typedTool.name)) {
+                    continue
+                }
+                const def = toolDefs[typedTool.name]
+                const feature = def?.feature
+                if (!feature || !initialEnabledFeatures.has(feature)) {
+                    registered.disable()
+                }
+            }
+        }
+
+        // Register the `toolsets` meta-tool explicitly in progressive mode. It isn't returned
+        // by getToolsFromContext (always excluded there so the default tool surface is
+        // unchanged), so we construct it from TOOL_MAP + toolDefs here.
+        if (progressive) {
+            const { TOOL_MAP, buildTool } = await import('@/tools')
+            const toolsetsFactory = TOOL_MAP.toolsets
+            if (toolsetsFactory) {
+                const toolsetsTool = buildTool(toolsetsFactory(), version) as Tool<z.ZodObject>
+                this.registerTool(toolsetsTool, async (params: any) => {
+                    const result = (await toolsetsTool.handler(context, params)) as Record<string, unknown>
                     if (params?.action === 'enable' || params?.action === 'disable') {
-                        this.applyToolsetToRegistrations(params.name, params.action, toolDefs)
+                        this.applyToolsetToRegistrations(params.name, params.action, toolDefs, version)
                         await this.resolveClientInfo()
                         if (!clientSupportsListChanged(this._mcpClientName)) {
                             const enabled = ((await context.cache.get(ENABLED_TOOLSETS_KEY as any)) ?? []) as string[]
@@ -678,22 +706,6 @@ export class MCP extends McpAgent<Env> {
                     }
                     return result
                 })
-            } else {
-                registered = this.registerTool(typedTool, async (params) => typedTool.handler(context, params))
-            }
-
-            // In progressive mode, disable everything that isn't bootstrap or in an
-            // already-enabled toolset. Keep the registration so the toolsets meta-tool
-            // can `.enable()` it later without needing a full re-init.
-            if (progressive) {
-                if (isBootstrapTool(typedTool.name)) {
-                    continue
-                }
-                const def = toolDefs[typedTool.name]
-                const toolsetId = def ? toolsetIdForFeature(def.feature) : undefined
-                if (!toolsetId || !enabledToolsets.has(toolsetId)) {
-                    registered.disable()
-                }
             }
         }
 

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -493,13 +493,22 @@ export class MCP extends McpAgent<Env> {
         action: 'enable' | 'disable',
         toolDefs: Record<string, { feature: string }>
     ): void {
-        if (!toolsetId) return
+        if (!toolsetId) {
+            return
+        }
         for (const [name, registered] of this._toolRegistrations.entries()) {
             const def = toolDefs[name]
-            if (!def) continue
-            if (toolsetIdForFeature(def.feature) !== toolsetId) continue
-            if (action === 'enable') registered.enable()
-            else registered.disable()
+            if (!def) {
+                continue
+            }
+            if (toolsetIdForFeature(def.feature) !== toolsetId) {
+                continue
+            }
+            if (action === 'enable') {
+                registered.enable()
+            } else {
+                registered.disable()
+            }
         }
     }
 
@@ -677,7 +686,9 @@ export class MCP extends McpAgent<Env> {
             // already-enabled toolset. Keep the registration so the toolsets meta-tool
             // can `.enable()` it later without needing a full re-init.
             if (progressive) {
-                if (isBootstrapTool(typedTool.name)) continue
+                if (isBootstrapTool(typedTool.name)) {
+                    continue
+                }
                 const def = toolDefs[typedTool.name]
                 const toolsetId = def ? toolsetIdForFeature(def.feature) : undefined
                 if (!toolsetId || !enabledToolsets.has(toolsetId)) {

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -703,9 +703,13 @@ export class MCP extends McpAgent<Env> {
                         if (!clientSupportsListChanged(this._mcpClientName)) {
                             const enabled = ((await context.cache.get(ENABLED_TOOLSETS_KEY as any)) ?? []) as string[]
                             const reconnectQuery = `?progressive=true${enabled.length ? `&toolsets=${enabled.join(',')}` : ''}`
+                            const symptom =
+                                params.action === 'enable'
+                                    ? "newly enabled tools aren't visible"
+                                    : 'disabled tools are still visible'
                             return {
                                 ...result,
-                                _reconnectHint: `Your MCP client may not auto-refresh the tool list. If new tools aren't visible next turn, ask the user to reconnect with: ${reconnectQuery}`,
+                                _reconnectHint: `Your MCP client may not auto-refresh the tool list. If ${symptom} next turn, ask the user to reconnect with: ${reconnectQuery}`,
                             }
                         }
                     }

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -36,6 +36,7 @@ import { registerUiAppResources } from '@/resources/ui-apps'
 import INSTRUCTIONS_TEMPLATE_V1 from '@/templates/instructions-v1.md'
 import INSTRUCTIONS_TEMPLATE_V2 from '@/templates/instructions-v2.md'
 import { ENABLED_TOOLSETS_KEY } from '@/tools/toolsets/manage'
+import { toolsetIdForFeature } from '@/tools/toolsets/taxonomy'
 import {
     POSTHOG_FORMATTED_RESULTS_OVERRIDE_KEY,
     POSTHOG_META_KEY,
@@ -64,6 +65,11 @@ export type RequestProperties = {
     progressive?: boolean
     /** Toolset ids to pre-enable on connect (from ?toolsets=a,b URL param). */
     initialToolsets?: string[]
+    /**
+     * MCP clientInfo.name parsed from the initialize request body in the worker fetch
+     * handler — more reliable than `getInitializeRequest()` from inside the DO.
+     */
+    earlyClientName?: string
 }
 
 export class MCP extends McpAgent<Env> {
@@ -352,10 +358,17 @@ export class MCP extends McpAgent<Env> {
         )
     }
 
+    /**
+     * Map of tool-name → RegisteredTool returned by `McpServer.registerTool()`. Used by the
+     * `toolsets` meta-tool to flip individual tools `.enable()`/`.disable()` at runtime, which
+     * the SDK surfaces via `tools/list` filtering + auto-fired `notifications/tools/list_changed`.
+     */
+    _toolRegistrations: Map<string, { enable: () => void; disable: () => void }> = new Map()
+
     registerTool<TSchema extends z.ZodObject>(
         tool: Tool<TSchema>,
         handler: (params: z.infer<TSchema>) => Promise<any>
-    ): void {
+    ): { enable: () => void; disable: () => void } {
         const wrappedHandler = async (params: z.infer<TSchema>): Promise<any> => {
             const validation = tool.schema.safeParse(params)
 
@@ -455,7 +468,7 @@ export class MCP extends McpAgent<Env> {
             }
         }
 
-        this.server.registerTool(
+        const registered = this.server.registerTool(
             tool.name,
             {
                 title: tool.title,
@@ -465,7 +478,29 @@ export class MCP extends McpAgent<Env> {
                 ...(normalizedMeta ? { _meta: normalizedMeta } : {}),
             },
             wrappedHandler as unknown as ToolCallback<TSchema['shape']>
-        )
+        ) as unknown as { enable: () => void; disable: () => void }
+        this._toolRegistrations.set(tool.name, registered)
+        return registered
+    }
+
+    /**
+     * Flip `_toolRegistrations` enabled state for every tool whose feature maps to `toolsetId`.
+     * The SDK auto-fires `notifications/tools/list_changed` on each `.enable()`/`.disable()`,
+     * so compatible MCP clients re-request `tools/list` and see the updated catalog.
+     */
+    applyToolsetToRegistrations(
+        toolsetId: string | undefined,
+        action: 'enable' | 'disable',
+        toolDefs: Record<string, { feature: string }>
+    ): void {
+        if (!toolsetId) return
+        for (const [name, registered] of this._toolRegistrations.entries()) {
+            const def = toolDefs[name]
+            if (!def) continue
+            if (toolsetIdForFeature(def.feature) !== toolsetId) continue
+            if (action === 'enable') registered.enable()
+            else registered.disable()
+        }
     }
 
     /**
@@ -505,7 +540,26 @@ export class MCP extends McpAgent<Env> {
             readOnly,
             progressive,
             initialToolsets,
+            earlyClientName,
         } = this.requestProperties
+
+        // Stash clientInfo captured from the initialize body so progressive-mode tool calls
+        // can detect known-unsupported clients even across requests in the same session.
+        // Bypassing the State type here because the cache union is already crowded with
+        // per-feature prefix-keys; mcpClientName is a simple string lookup.
+        const cacheUntyped = this.cache as unknown as {
+            get: (k: string) => Promise<unknown>
+            set: (k: string, v: unknown) => Promise<void>
+        }
+        if (earlyClientName) {
+            this._mcpClientName = earlyClientName
+            await cacheUntyped.set('mcpClientName', earlyClientName)
+        } else {
+            const cached = await cacheUntyped.get('mcpClientName')
+            if (typeof cached === 'string') {
+                this._mcpClientName = cached
+            }
+        }
 
         // Start feature flag resolution in parallel with cache seeding
         const flagPromise = this.resolveVersionFlag()
@@ -560,7 +614,9 @@ export class MCP extends McpAgent<Env> {
             registerUiAppResources(this.server, context),
         ])
 
-        // Register tools
+        // Register tools. In progressive mode we still fetch the full catalog (so we can
+        // dynamically `.enable()` tools on demand without needing to re-init the session),
+        // then disable non-bootstrap, non-enabled ones below.
         const { getToolsFromContext } = await import('@/tools')
         const allTools = await getToolsFromContext(context, {
             features,
@@ -569,8 +625,10 @@ export class MCP extends McpAgent<Env> {
             excludeTools,
             readOnly,
             featureFlags: toolFeatureFlags,
-            progressive,
-            enabledToolsets: initialToolsets,
+            // Fetch catalog unfiltered by progressive state; we handle enable/disable on
+            // the registered tool refs below so tools/list_changed just works.
+            progressive: progressive ? true : undefined,
+            enabledToolsets: undefined,
         })
 
         // OAuth introspection has now run (triggered by getToolsFromContext → getApiKey),
@@ -580,16 +638,25 @@ export class MCP extends McpAgent<Env> {
             this._api.config.oauthClientName = oauthClientName
         }
 
+        const { isBootstrapTool } = await import('@/tools/toolsets/taxonomy')
+        const { getToolDefinitions } = await import('@/tools/toolDefinitions')
+        const toolDefs = getToolDefinitions(version)
+
+        // Resolve initial enabled toolsets: merge session cache with ?toolsets=<ids>
+        const sessionEnabled = ((await this.cache.get(ENABLED_TOOLSETS_KEY as any)) ?? []) as string[]
+        const enabledToolsets = new Set<string>([...sessionEnabled, ...(initialToolsets ?? [])])
+
         for (const tool of allTools) {
             const typedTool = tool as Tool<z.ZodObject>
+            let registered: { enable: () => void; disable: () => void }
             if (progressive && typedTool.name === 'toolsets') {
-                // Wrap the toolsets meta-tool so enable/disable calls fire
-                // notifications/tools/list_changed and (for known-unsupported clients)
-                // include a reconnect hint in the response.
-                this.registerTool(typedTool, async (params: any) => {
+                // Wrap the toolsets meta-tool so enable/disable calls flip individual tool
+                // registrations. The SDK's `.enable()` / `.disable()` auto-fires
+                // notifications/tools/list_changed, so compatible clients auto-refresh.
+                registered = this.registerTool(typedTool, async (params: any) => {
                     const result = (await typedTool.handler(context, params)) as Record<string, unknown>
                     if (params?.action === 'enable' || params?.action === 'disable') {
-                        this.notifyToolListChanged()
+                        this.applyToolsetToRegistrations(params.name, params.action, toolDefs)
                         await this.resolveClientInfo()
                         if (!clientSupportsListChanged(this._mcpClientName)) {
                             const enabled = ((await context.cache.get(ENABLED_TOOLSETS_KEY as any)) ?? []) as string[]
@@ -603,7 +670,19 @@ export class MCP extends McpAgent<Env> {
                     return result
                 })
             } else {
-                this.registerTool(typedTool, async (params) => typedTool.handler(context, params))
+                registered = this.registerTool(typedTool, async (params) => typedTool.handler(context, params))
+            }
+
+            // In progressive mode, disable everything that isn't bootstrap or in an
+            // already-enabled toolset. Keep the registration so the toolsets meta-tool
+            // can `.enable()` it later without needing a full re-init.
+            if (progressive) {
+                if (isBootstrapTool(typedTool.name)) continue
+                const def = toolDefs[typedTool.name]
+                const toolsetId = def ? toolsetIdForFeature(def.feature) : undefined
+                if (!toolsetId || !enabledToolsets.has(toolsetId)) {
+                    registered.disable()
+                }
             }
         }
 

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -662,6 +662,11 @@ export class MCP extends McpAgent<Env> {
         const initialEnabledToolsets = Array.from(new Set([...sessionEnabled, ...(initialToolsets ?? [])]))
         const initialEnabledFeatures = resolveEnabledFeatures(initialEnabledToolsets, version)
 
+        // Persist ?toolsets= pre-enables so a subsequent toolsets(action='list') reflects reality.
+        if (initialEnabledToolsets.length !== sessionEnabled.length) {
+            await this.cache.set(ENABLED_TOOLSETS_KEY as any, initialEnabledToolsets as any)
+        }
+
         for (const tool of allTools) {
             const typedTool = tool as Tool<z.ZodObject>
             const registered = this.registerTool(typedTool, async (params) => typedTool.handler(context, params))

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -72,6 +72,18 @@ export const DocumentationSearchSchema = z.object({
     query: z.string(),
 })
 
+export const ToolsetsInputSchema = z.object({
+    action: z
+        .enum(['list', 'describe', 'enable', 'disable'])
+        .describe(
+            "What to do: 'list' returns all available toolsets and which ones are currently enabled; 'describe' returns the tools inside one toolset; 'enable' activates a toolset so its tools become callable; 'disable' turns one off."
+        ),
+    name: z
+        .string()
+        .optional()
+        .describe("Toolset id — required for 'describe', 'enable', and 'disable'. Get valid ids from 'list'."),
+})
+
 export const ExperimentResultsGetSchema = z.object({
     experimentId: z.number().describe('The ID of the experiment to get comprehensive results for'),
     refresh: z.boolean().describe('Force refresh of results instead of using cached values'),

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -102,10 +102,9 @@ export const getToolsFromContext = async (
         ...(aiConsentGiven !== undefined ? { aiConsentGiven } : {}),
     }
     const effectiveMap = { ...TOOL_MAP, ...GENERATED_TOOL_MAP }
-    // The toolsets meta-tool only exists in progressive mode — skip it in default mode so
-    // the default tool surface is unchanged.
-    const baseExcludes = options?.excludeTools ?? []
-    const excludeTools = options?.progressive ? baseExcludes : [...baseExcludes, 'toolsets']
+    // The `toolsets` meta-tool is always excluded from this path — callers that want it
+    // (mcp.ts progressive mode) register it explicitly from TOOL_MAP themselves.
+    const excludeTools = [...(options?.excludeTools ?? []), 'toolsets']
     const allowedToolNames = getFilteredToolNames(effectiveOptions).filter((name) => !excludeTools.includes(name))
     const toolBases: ToolBase<ZodObjectAny>[] = []
 
@@ -125,19 +124,26 @@ export const getToolsFromContext = async (
     const effectiveVersion = options?.version ?? 1
     const filteredBases = toolBases.filter((tb) => tb.mcpVersion === undefined || tb.mcpVersion === effectiveVersion)
 
-    const tools: Tool<ZodObjectAny>[] = filteredBases.map((toolBase) => {
-        const definition = getToolDefinition(toolBase.name, options?.version)
-        return {
-            ...toolBase,
-            title: definition.title,
-            description: definition.description,
-            scopes: definition.required_scopes ?? [],
-            annotations: definition.annotations,
-        }
-    })
+    const tools: Tool<ZodObjectAny>[] = filteredBases.map((toolBase) => buildTool(toolBase, options?.version))
 
     const apiKey = await context.stateManager.getApiKey()
     const scopes = apiKey?.scopes ?? []
 
     return tools.filter((tool) => hasScopes(scopes, tool.scopes))
+}
+
+/**
+ * Shape a ToolBase (factory output) into a fully-decorated Tool by merging in
+ * title/description/scopes/annotations from the tool-definitions catalog. Exposed so the
+ * progressive-disclosure meta-tool in mcp.ts can be assembled the same way.
+ */
+export function buildTool(toolBase: ToolBase<ZodObjectAny>, version?: number): Tool<ZodObjectAny> {
+    const definition = getToolDefinition(toolBase.name, version)
+    return {
+        ...toolBase,
+        title: definition.title,
+        description: definition.description,
+        scopes: definition.required_scopes ?? [],
+        annotations: definition.annotations,
+    }
 }

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -97,19 +97,9 @@ export const getToolsFromContext = async (
     // Check org AI consent to gate tools that use LLMs internally (cached in StateManager)
     const aiConsentGiven = await context.stateManager.getAiConsentGiven()
 
-    // Progressive disclosure: merge session-enabled toolsets from cache with
-    // any toolsets pre-enabled via the ?toolsets=a,b query param.
-    let enabledToolsetsForFilter: string[] | undefined
-    if (options?.progressive) {
-        const sessionEnabled = ((await context.cache.get('enabledToolsets' as any)) ?? []) as string[]
-        const fromQuery = options?.enabledToolsets ?? []
-        enabledToolsetsForFilter = Array.from(new Set([...sessionEnabled, ...fromQuery]))
-    }
-
     const effectiveOptions: ToolFilterOptions = {
         ...options,
         ...(aiConsentGiven !== undefined ? { aiConsentGiven } : {}),
-        ...(enabledToolsetsForFilter !== undefined ? { enabledToolsets: enabledToolsetsForFilter } : {}),
     }
     const effectiveMap = { ...TOOL_MAP, ...GENERATED_TOOL_MAP }
     // The toolsets meta-tool only exists in progressive mode — skip it in default mode so

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -39,6 +39,8 @@ import {
     getToolsForFeatures as getFilteredToolNames,
     getToolDefinition,
 } from './toolDefinitions'
+// Toolsets (progressive disclosure meta-tool)
+import toolsetsMetaTool from './toolsets/manage'
 import type { Context, Tool, ToolBase, ZodObjectAny } from './types'
 
 // Map of tool names to tool factory functions
@@ -83,6 +85,9 @@ export const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
     // Data warehouse (custom handlers for non-standard request shapes)
     'external-data-sources-db-schema': externalDataSourcesDbSchema,
     'external-data-sources-jobs': externalDataSourcesJobs,
+
+    // Meta (progressive disclosure)
+    toolsets: toolsetsMetaTool,
 }
 
 export const getToolsFromContext = async (
@@ -91,9 +96,26 @@ export const getToolsFromContext = async (
 ): Promise<Tool<ZodObjectAny>[]> => {
     // Check org AI consent to gate tools that use LLMs internally (cached in StateManager)
     const aiConsentGiven = await context.stateManager.getAiConsentGiven()
-    const effectiveOptions = aiConsentGiven !== undefined ? { ...options, aiConsentGiven } : options
+
+    // Progressive disclosure: merge session-enabled toolsets from cache with
+    // any toolsets pre-enabled via the ?toolsets=a,b query param.
+    let enabledToolsetsForFilter: string[] | undefined
+    if (options?.progressive) {
+        const sessionEnabled = ((await context.cache.get('enabledToolsets' as any)) ?? []) as string[]
+        const fromQuery = options?.enabledToolsets ?? []
+        enabledToolsetsForFilter = Array.from(new Set([...sessionEnabled, ...fromQuery]))
+    }
+
+    const effectiveOptions: ToolFilterOptions = {
+        ...options,
+        ...(aiConsentGiven !== undefined ? { aiConsentGiven } : {}),
+        ...(enabledToolsetsForFilter !== undefined ? { enabledToolsets: enabledToolsetsForFilter } : {}),
+    }
     const effectiveMap = { ...TOOL_MAP, ...GENERATED_TOOL_MAP }
-    const excludeTools = options?.excludeTools ?? []
+    // The toolsets meta-tool only exists in progressive mode — skip it in default mode so
+    // the default tool surface is unchanged.
+    const baseExcludes = options?.excludeTools ?? []
+    const excludeTools = options?.progressive ? baseExcludes : [...baseExcludes, 'toolsets']
     const allowedToolNames = getFilteredToolNames(effectiveOptions).filter((name) => !excludeTools.includes(name))
     const toolBases: ToolBase<ZodObjectAny>[] = []
 

--- a/services/mcp/src/tools/toolDefinitions.ts
+++ b/services/mcp/src/tools/toolDefinitions.ts
@@ -183,8 +183,13 @@ export function getToolsForFeatures(options?: ToolFilterOptions): string[] {
         })
     }
 
-    if (progressive) {
-        const enabled = new Set(enabledToolsets ?? [])
+    // Progressive-disclosure filter: only applied when the caller explicitly provides
+    // `enabledToolsets` (an array — can be empty for "bootstrap only"). When the caller sets
+    // `progressive: true` but leaves `enabledToolsets` undefined, the full catalog is returned
+    // (registration happens upfront so the toolsets meta-tool can `.enable()` tools dynamically
+    // without a session re-init).
+    if (progressive && enabledToolsets !== undefined) {
+        const enabled = new Set(enabledToolsets)
         entries = entries.filter(([toolName, definition]) => {
             if (isBootstrapTool(toolName)) {
                 return true

--- a/services/mcp/src/tools/toolDefinitions.ts
+++ b/services/mcp/src/tools/toolDefinitions.ts
@@ -3,6 +3,7 @@ import z from 'zod'
 import generatedToolDefinitionsJson from '../../schema/generated-tool-definitions.json'
 import toolDefinitionsV2Json from '../../schema/tool-definitions-v2.json'
 import toolDefinitionsJson from '../../schema/tool-definitions.json'
+import { isBootstrapTool, toolsetIdForFeature } from './toolsets/taxonomy'
 
 export const ToolDefinitionSchema = z.object({
     description: z.string(),
@@ -84,6 +85,16 @@ export interface ToolFilterOptions {
      * Used to gate tools that declare `feature_flag` in their YAML config.
      */
     featureFlags?: Record<string, boolean> | undefined
+    /**
+     * When true, only return bootstrap tools + tools whose toolset is in `enabledToolsets`.
+     * See docs/published/handbook/engineering/ai/mcp-progressive-disclosure.md for the RFC.
+     */
+    progressive?: boolean | undefined
+    /**
+     * Toolset ids to surface in progressive mode — merged with session-enabled toolsets
+     * from the DurableObjectCache.
+     */
+    enabledToolsets?: string[] | undefined
 }
 
 /**
@@ -106,7 +117,8 @@ function normalizeFeatureName(name: string): string {
 }
 
 export function getToolsForFeatures(options?: ToolFilterOptions): string[] {
-    const { features, tools, version, readOnly, aiConsentGiven, featureFlags } = options || {}
+    const { features, tools, version, readOnly, aiConsentGiven, featureFlags, progressive, enabledToolsets } =
+        options || {}
     const toolDefinitions = getToolDefinitions(version)
 
     let entries = Object.entries(toolDefinitions)
@@ -168,6 +180,20 @@ export function getToolsForFeatures(options?: ToolFilterOptions): string[] {
                 return true
             }
             return (definition.feature_flag_behavior ?? 'enable') === 'disable'
+        })
+    }
+
+    if (progressive) {
+        const enabled = new Set(enabledToolsets ?? [])
+        entries = entries.filter(([toolName, definition]) => {
+            if (isBootstrapTool(toolName)) {
+                return true
+            }
+            const toolsetId = toolsetIdForFeature(definition.feature)
+            if (!toolsetId) {
+                return false
+            }
+            return enabled.has(toolsetId)
         })
     }
 

--- a/services/mcp/src/tools/toolDefinitions.ts
+++ b/services/mcp/src/tools/toolDefinitions.ts
@@ -3,7 +3,6 @@ import z from 'zod'
 import generatedToolDefinitionsJson from '../../schema/generated-tool-definitions.json'
 import toolDefinitionsV2Json from '../../schema/tool-definitions-v2.json'
 import toolDefinitionsJson from '../../schema/tool-definitions.json'
-import { isBootstrapTool, toolsetIdForFeature } from './toolsets/taxonomy'
 
 export const ToolDefinitionSchema = z.object({
     description: z.string(),
@@ -85,16 +84,6 @@ export interface ToolFilterOptions {
      * Used to gate tools that declare `feature_flag` in their YAML config.
      */
     featureFlags?: Record<string, boolean> | undefined
-    /**
-     * When true, only return bootstrap tools + tools whose toolset is in `enabledToolsets`.
-     * See docs/published/handbook/engineering/ai/mcp-progressive-disclosure.md for the RFC.
-     */
-    progressive?: boolean | undefined
-    /**
-     * Toolset ids to surface in progressive mode — merged with session-enabled toolsets
-     * from the DurableObjectCache.
-     */
-    enabledToolsets?: string[] | undefined
 }
 
 /**
@@ -117,8 +106,7 @@ function normalizeFeatureName(name: string): string {
 }
 
 export function getToolsForFeatures(options?: ToolFilterOptions): string[] {
-    const { features, tools, version, readOnly, aiConsentGiven, featureFlags, progressive, enabledToolsets } =
-        options || {}
+    const { features, tools, version, readOnly, aiConsentGiven, featureFlags } = options || {}
     const toolDefinitions = getToolDefinitions(version)
 
     let entries = Object.entries(toolDefinitions)
@@ -180,25 +168,6 @@ export function getToolsForFeatures(options?: ToolFilterOptions): string[] {
                 return true
             }
             return (definition.feature_flag_behavior ?? 'enable') === 'disable'
-        })
-    }
-
-    // Progressive-disclosure filter: only applied when the caller explicitly provides
-    // `enabledToolsets` (an array — can be empty for "bootstrap only"). When the caller sets
-    // `progressive: true` but leaves `enabledToolsets` undefined, the full catalog is returned
-    // (registration happens upfront so the toolsets meta-tool can `.enable()` tools dynamically
-    // without a session re-init).
-    if (progressive && enabledToolsets !== undefined) {
-        const enabled = new Set(enabledToolsets)
-        entries = entries.filter(([toolName, definition]) => {
-            if (isBootstrapTool(toolName)) {
-                return true
-            }
-            const toolsetId = toolsetIdForFeature(definition.feature)
-            if (!toolsetId) {
-                return false
-            }
-            return enabled.has(toolsetId)
         })
     }
 

--- a/services/mcp/src/tools/toolsets/manage.ts
+++ b/services/mcp/src/tools/toolsets/manage.ts
@@ -3,33 +3,38 @@ import type { z } from 'zod'
 import { ToolsetsInputSchema } from '@/schema/tool-inputs'
 import { getToolDefinitions } from '@/tools/toolDefinitions'
 import {
-    TOOLSETS,
-    type ToolsetId,
+    COMPOSITE_TOOLSETS,
+    expandToolsetToFeatures,
+    getAllToolsets,
     getToolsetById,
     isValidToolsetId,
-    toolsetIdForFeature,
 } from '@/tools/toolsets/taxonomy'
 import type { Context, ToolBase } from '@/tools/types'
 
 const schema = ToolsetsInputSchema
 type Params = z.infer<typeof schema>
 
+/**
+ * DO cache key for the set of enabled toolset IDs (base or composite). Stored as-is;
+ * expansion to features happens at filter/registration time via resolveEnabledFeatures.
+ */
 export const ENABLED_TOOLSETS_KEY = 'enabledToolsets' as const
 
-async function readEnabled(context: Context): Promise<ToolsetId[]> {
-    const raw = (await context.cache.get(ENABLED_TOOLSETS_KEY as any)) as ToolsetId[] | undefined
+async function readEnabled(context: Context): Promise<string[]> {
+    const raw = (await context.cache.get(ENABLED_TOOLSETS_KEY as any)) as string[] | undefined
     return raw ?? []
 }
 
-async function writeEnabled(context: Context, ids: ToolsetId[]): Promise<void> {
+async function writeEnabled(context: Context, ids: string[]): Promise<void> {
     const dedup = Array.from(new Set(ids))
     await context.cache.set(ENABLED_TOOLSETS_KEY as any, dedup as any)
 }
 
-function toolsInToolset(toolsetId: ToolsetId, version?: number): { name: string; description: string }[] {
+function toolsForFeatures(features: string[], version?: number): { name: string; description: string }[] {
     const defs = getToolDefinitions(version)
+    const featureSet = new Set(features)
     return Object.entries(defs)
-        .filter(([_, meta]) => toolsetIdForFeature(meta.feature) === toolsetId)
+        .filter(([_, meta]) => featureSet.has(meta.feature))
         .map(([name, meta]) => ({ name, description: meta.summary }))
 }
 
@@ -38,15 +43,28 @@ export const toolsetsHandler = async (context: Context, params: Params): Promise
 
     if (action === 'list') {
         const enabled = await readEnabled(context)
+        const all = getAllToolsets()
+        // Group base vs composite in the response so the model sees the two layers clearly.
+        const base = all.filter((ts) => ts.isBase)
+        const composites = all.filter((ts) => !ts.isBase)
         return {
-            toolsets: TOOLSETS.map((ts) => ({
+            composites: composites.map((ts) => ({
+                id: ts.id,
+                title: ts.title,
+                description: ts.description,
+                bundles: ts.features,
+                enabled: enabled.includes(ts.id),
+            })),
+            base: base.map((ts) => ({
                 id: ts.id,
                 title: ts.title,
                 description: ts.description,
                 enabled: enabled.includes(ts.id),
             })),
             enabled,
-            usage: "Call toolsets(action='enable', name='<id>') to activate a toolset.",
+            usage:
+                "Call toolsets(action='enable', name='<id>') to activate a toolset. Composites bundle " +
+                'multiple base toolsets; base toolsets map 1:1 to a PostHog product area.',
         }
     }
 
@@ -67,11 +85,14 @@ export const toolsetsHandler = async (context: Context, params: Params): Promise
         if (!toolset) {
             return { error: `Unknown toolset '${name}'.` }
         }
+        const features = expandToolsetToFeatures(name)
         return {
             id: toolset.id,
             title: toolset.title,
             description: toolset.description,
-            tools: toolsInToolset(name),
+            composite: !toolset.isBase,
+            bundles: toolset.isBase ? undefined : features,
+            tools: toolsForFeatures(features),
         }
     }
 
@@ -81,10 +102,12 @@ export const toolsetsHandler = async (context: Context, params: Params): Promise
             enabled.push(name)
             await writeEnabled(context, enabled)
         }
-        const toolNames = toolsInToolset(name).map((t) => t.name)
+        const features = expandToolsetToFeatures(name)
+        const toolNames = toolsForFeatures(features).map((t) => t.name)
         return {
             enabled: name,
             enabledNow: enabled,
+            expandedFeatures: features,
             newlyAvailableTools: toolNames,
             note: `Tools in this toolset are now callable. If your MCP client supports tools/list_changed, they will appear automatically. If not, ask the user to reconnect with ?progressive=true&toolsets=${enabled.join(',')}`,
         }
@@ -102,6 +125,9 @@ export const toolsetsHandler = async (context: Context, params: Params): Promise
 
     return { error: `Unknown action '${action}'.` }
 }
+
+// Re-export for callers that need the composites table
+export { COMPOSITE_TOOLSETS }
 
 const tool = (): ToolBase<typeof schema> => ({
     name: 'toolsets',

--- a/services/mcp/src/tools/toolsets/manage.ts
+++ b/services/mcp/src/tools/toolsets/manage.ts
@@ -104,12 +104,16 @@ export const toolsetsHandler = async (context: Context, params: Params): Promise
         }
         const features = expandToolsetToFeatures(name)
         const toolNames = toolsForFeatures(features).map((t) => t.name)
+        const reconnectQuery = `?progressive=true&toolsets=${enabled.join(',')}`
         return {
             enabled: name,
             enabledNow: enabled,
             expandedFeatures: features,
             newlyAvailableTools: toolNames,
-            note: `Tools in this toolset are now callable. If your MCP client supports tools/list_changed, they will appear automatically. If not, ask the user to reconnect with ?progressive=true&toolsets=${enabled.join(',')}`,
+            // Keep this terse and action-first. Empirically, wordy notes get Sonnet-class
+            // models to retry-and-thrash before surfacing the reconnect. Leading with the
+            // concrete instruction reduces wasted turns.
+            nextStep: `If calling a newly-available tool returns "No such tool available", ask the user to reconnect the MCP with: ${reconnectQuery}`,
         }
     }
 

--- a/services/mcp/src/tools/toolsets/manage.ts
+++ b/services/mcp/src/tools/toolsets/manage.ts
@@ -1,0 +1,112 @@
+import type { z } from 'zod'
+
+import { ToolsetsInputSchema } from '@/schema/tool-inputs'
+import { getToolDefinitions } from '@/tools/toolDefinitions'
+import {
+    TOOLSETS,
+    type ToolsetId,
+    getToolsetById,
+    isValidToolsetId,
+    toolsetIdForFeature,
+} from '@/tools/toolsets/taxonomy'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = ToolsetsInputSchema
+type Params = z.infer<typeof schema>
+
+export const ENABLED_TOOLSETS_KEY = 'enabledToolsets' as const
+
+async function readEnabled(context: Context): Promise<ToolsetId[]> {
+    const raw = (await context.cache.get(ENABLED_TOOLSETS_KEY as any)) as ToolsetId[] | undefined
+    return raw ?? []
+}
+
+async function writeEnabled(context: Context, ids: ToolsetId[]): Promise<void> {
+    const dedup = Array.from(new Set(ids))
+    await context.cache.set(ENABLED_TOOLSETS_KEY as any, dedup as any)
+}
+
+function toolsInToolset(toolsetId: ToolsetId, version?: number): { name: string; description: string }[] {
+    const defs = getToolDefinitions(version)
+    return Object.entries(defs)
+        .filter(([_, meta]) => toolsetIdForFeature(meta.feature) === toolsetId)
+        .map(([name, meta]) => ({ name, description: meta.summary }))
+}
+
+export const toolsetsHandler = async (context: Context, params: Params): Promise<unknown> => {
+    const { action, name } = params
+
+    if (action === 'list') {
+        const enabled = await readEnabled(context)
+        return {
+            toolsets: TOOLSETS.map((ts) => ({
+                id: ts.id,
+                title: ts.title,
+                description: ts.description,
+                enabled: enabled.includes(ts.id),
+            })),
+            enabled,
+            usage: "Call toolsets(action='enable', name='<id>') to activate a toolset.",
+        }
+    }
+
+    if (!name) {
+        return {
+            error: `Action '${action}' requires a 'name' parameter. Call toolsets(action='list') to see valid ids.`,
+        }
+    }
+
+    if (!isValidToolsetId(name)) {
+        return {
+            error: `Unknown toolset '${name}'. Call toolsets(action='list') to see valid ids.`,
+        }
+    }
+
+    if (action === 'describe') {
+        const toolset = getToolsetById(name)
+        if (!toolset) {
+            return { error: `Unknown toolset '${name}'.` }
+        }
+        return {
+            id: toolset.id,
+            title: toolset.title,
+            description: toolset.description,
+            tools: toolsInToolset(name),
+        }
+    }
+
+    if (action === 'enable') {
+        const enabled = await readEnabled(context)
+        if (!enabled.includes(name)) {
+            enabled.push(name)
+            await writeEnabled(context, enabled)
+        }
+        const toolNames = toolsInToolset(name).map((t) => t.name)
+        return {
+            enabled: name,
+            enabledNow: enabled,
+            newlyAvailableTools: toolNames,
+            note: `Tools in this toolset are now callable. If your MCP client supports tools/list_changed, they will appear automatically. If not, ask the user to reconnect with ?progressive=true&toolsets=${enabled.join(',')}`,
+        }
+    }
+
+    if (action === 'disable') {
+        const enabled = await readEnabled(context)
+        const next = enabled.filter((id) => id !== name)
+        await writeEnabled(context, next)
+        return {
+            disabled: name,
+            enabledNow: next,
+        }
+    }
+
+    return { error: `Unknown action '${action}'.` }
+}
+
+const tool = (): ToolBase<typeof schema> => ({
+    name: 'toolsets',
+    schema,
+    handler: toolsetsHandler,
+})
+
+export default tool

--- a/services/mcp/src/tools/toolsets/taxonomy.ts
+++ b/services/mcp/src/tools/toolsets/taxonomy.ts
@@ -1,0 +1,159 @@
+/**
+ * Progressive disclosure taxonomy: groups the MCP's ~200+ tools into a small set of
+ * product-shaped toolsets. In progressive mode (`?progressive=true`), only the bootstrap
+ * tools are surfaced initially; the rest activate when a model calls
+ * `toolsets(action='enable', name='<id>')`.
+ *
+ * Product-shaped rather than workflow-shaped so the groups align with how the underlying
+ * features ship — a new `notebooks` agentic feature can split out of `content` without
+ * breaking skills that declared `required_toolsets: ['analytics']`.
+ */
+
+export type ToolsetId =
+    | 'analytics'
+    | 'content'
+    | 'flags'
+    | 'experiments'
+    | 'surveys'
+    | 'error_tracking'
+    | 'llm_analytics'
+    | 'workspace'
+    | 'data_warehouse'
+    | 'replay'
+    | 'hog_functions'
+    | 'logs'
+    | 'workflows'
+    | 'reverse_proxy'
+
+export type ToolsetDefinition = {
+    id: ToolsetId
+    title: string
+    description: string
+    /** Tool-definition `feature` values that belong to this toolset. */
+    features: string[]
+}
+
+/**
+ * Tools always available in progressive mode regardless of which toolsets are enabled.
+ * Kept small (goal: ≤5 from the RFC) so idle token cost stays near the 5K target.
+ */
+export const BOOTSTRAP_TOOL_NAMES = ['query-run', 'docs-search', 'entity-search', 'toolsets'] as const
+
+export const TOOLSETS: ToolsetDefinition[] = [
+    {
+        id: 'analytics',
+        title: 'Analytics',
+        description:
+            'Events, insights, cohorts, actions, persons, and product analytics. Enable for trends, funnels, retention, HogQL, insight CRUD, and event/property discovery.',
+        features: ['insights', 'events', 'product_analytics', 'cohorts', 'actions', 'persons'],
+    },
+    {
+        id: 'content',
+        title: 'Dashboards, notebooks, annotations',
+        description:
+            'Dashboards, notebooks, and annotations. Enable for dashboard CRUD, notebook reads/writes, and annotating charts.',
+        features: ['dashboards', 'notebooks', 'annotations'],
+    },
+    {
+        id: 'flags',
+        title: 'Feature flags',
+        description:
+            'Feature flag CRUD + early access features. Enable for flag definitions, rollout changes, and release gating.',
+        features: ['flags', 'early_access_features'],
+    },
+    {
+        id: 'experiments',
+        title: 'Experiments',
+        description: 'A/B experiments and results. Enable for experiment CRUD and result reads.',
+        features: ['experiments'],
+    },
+    {
+        id: 'surveys',
+        title: 'Surveys',
+        description: 'Survey CRUD and stats. Enable for survey management and response analytics.',
+        features: ['surveys'],
+    },
+    {
+        id: 'error_tracking',
+        title: 'Error tracking',
+        description: 'Exceptions and error issues. Enable for exception triage and error investigation.',
+        features: ['error_tracking'],
+    },
+    {
+        id: 'llm_analytics',
+        title: 'LLM analytics',
+        description:
+            'LLM traces, prompts, evaluations, conversations, and cost. Enable when the user asks about LLM spend, prompt versioning, or tracing.',
+        features: ['llm_analytics', 'prompts', 'conversations'],
+    },
+    {
+        id: 'workspace',
+        title: 'Workspace',
+        description:
+            'Orgs, projects, platform admin, integrations, alerts, roles. Enable first if the model cannot tell which project to query or needs admin primitives.',
+        features: ['workspace', 'core', 'platform_features', 'integrations', 'alerts'],
+    },
+    {
+        id: 'data_warehouse',
+        title: 'Data warehouse + endpoints',
+        description:
+            'Warehouse views, endpoints, SQL, and data schema. Enable for warehouse queries, query endpoints, and exploring the schema.',
+        features: ['data_warehouse', 'endpoints', 'data_schema', 'sql'],
+    },
+    {
+        id: 'replay',
+        title: 'Session replay',
+        description: 'Recordings and playlists. Enable for session recording reads and playlist management.',
+        features: ['replay'],
+    },
+    {
+        id: 'hog_functions',
+        title: 'Destinations / Hog functions',
+        description: 'CDP destinations, sources, transformations, and Hog function templates.',
+        features: ['hog_functions', 'hog_function_templates'],
+    },
+    {
+        id: 'logs',
+        title: 'Logs',
+        description: 'Log queries and log attribute discovery.',
+        features: ['logs'],
+    },
+    {
+        id: 'workflows',
+        title: 'Workflows',
+        description: 'Workflow CRUD. Enable when the user asks about automation workflows.',
+        features: ['workflows'],
+    },
+    {
+        id: 'reverse_proxy',
+        title: 'Managed reverse proxy',
+        description: 'PostHog managed reverse proxy CRUD.',
+        features: ['reverse_proxy'],
+    },
+]
+
+const FEATURE_TO_TOOLSET: Record<string, ToolsetId> = (() => {
+    const out: Record<string, ToolsetId> = {}
+    for (const ts of TOOLSETS) {
+        for (const feature of ts.features) {
+            out[feature] = ts.id
+        }
+    }
+    return out
+})()
+
+export function toolsetIdForFeature(feature: string): ToolsetId | undefined {
+    return FEATURE_TO_TOOLSET[feature]
+}
+
+export function getToolsetById(id: string): ToolsetDefinition | undefined {
+    return TOOLSETS.find((ts) => ts.id === id)
+}
+
+export function isBootstrapTool(name: string): boolean {
+    return (BOOTSTRAP_TOOL_NAMES as readonly string[]).includes(name)
+}
+
+export function isValidToolsetId(id: string): id is ToolsetId {
+    return TOOLSETS.some((ts) => ts.id === id)
+}

--- a/services/mcp/src/tools/toolsets/taxonomy.ts
+++ b/services/mcp/src/tools/toolsets/taxonomy.ts
@@ -1,159 +1,144 @@
 /**
- * Progressive disclosure taxonomy: groups the MCP's ~200+ tools into a small set of
- * product-shaped toolsets. In progressive mode (`?progressive=true`), only the bootstrap
- * tools are surfaced initially; the rest activate when a model calls
- * `toolsets(action='enable', name='<id>')`.
+ * Progressive disclosure taxonomy.
  *
- * Product-shaped rather than workflow-shaped so the groups align with how the underlying
- * features ship — a new `notebooks` agentic feature can split out of `content` without
- * breaking skills that declared `required_toolsets: ['analytics']`.
+ * **Base toolsets** are auto-derived from the `feature` field on every tool definition
+ * (which comes from `products/<name>/mcp/tools.yaml` via codegen). No hand-edits needed
+ * when a new product ships MCP tools — adding a new `feature` value in a YAML automatically
+ * creates a new base toolset with the product's category as its title.
+ *
+ * **Composite toolsets** are a small, hand-curated editorial layer that bundles related
+ * base toolsets into convenience groupings (e.g., `analytics` = insights + events + cohorts
+ * + actions + persons + product_analytics). Enabling a composite is equivalent to enabling
+ * every base toolset it contains. Composites are optional — the model can always enable
+ * base toolsets directly.
+ *
+ * **Excluded features** are either bootstrap (`docs`, `search`), internal (`debug`,
+ * `skills`, `meta`), or otherwise never surfaced as a standalone toolset.
  */
 
-export type ToolsetId =
-    | 'analytics'
-    | 'content'
-    | 'flags'
-    | 'experiments'
-    | 'surveys'
-    | 'error_tracking'
-    | 'llm_analytics'
-    | 'workspace'
-    | 'data_warehouse'
-    | 'replay'
-    | 'hog_functions'
-    | 'logs'
-    | 'workflows'
-    | 'reverse_proxy'
+import { getToolDefinitions } from '@/tools/toolDefinitions'
+
+/** Tools always available in progressive mode regardless of enabled toolsets. */
+export const BOOTSTRAP_TOOL_NAMES = ['query-run', 'docs-search', 'entity-search', 'toolsets'] as const
+
+/**
+ * Features that should NOT appear as base toolsets. Either their tools are bootstrap
+ * (docs, search), or they're internal/meta and not user-addressable.
+ */
+const EXCLUDED_FEATURES = new Set(['docs', 'search', 'debug', 'skills', 'meta'])
+
+/**
+ * Optional composite toolsets. Each bundles multiple base features into one enable/disable
+ * action for convenience. This is the only hand-curated part of the taxonomy — decisions
+ * about what belongs together are editorial, not mechanical.
+ *
+ * Keep the set small (≤10) and focused on workflows a single prompt might touch. When in
+ * doubt, leave it out and let the model enable base toolsets directly.
+ */
+export const COMPOSITE_TOOLSETS: Record<string, { title: string; description: string; features: string[] }> = {
+    analytics: {
+        title: 'Analytics (bundle)',
+        description:
+            'Insights, events, cohorts, actions, persons, and product analytics — everything needed for trends, funnels, retention, and event/property discovery.',
+        features: ['insights', 'events', 'cohorts', 'actions', 'persons', 'product_analytics'],
+    },
+    content: {
+        title: 'Dashboards, notebooks, annotations (bundle)',
+        description:
+            'Dashboards, notebooks, and annotations — for building and annotating the artifacts that get shared.',
+        features: ['dashboards', 'notebooks', 'annotations'],
+    },
+    admin: {
+        title: 'Admin / workspace (bundle)',
+        description:
+            'Orgs, projects, platform admin, integrations, alerts — the primitives needed to manage a PostHog instance. Enable this first if the model cannot tell which project/org to operate on.',
+        features: ['workspace', 'core', 'platform_features', 'integrations', 'alerts'],
+    },
+}
 
 export type ToolsetDefinition = {
-    id: ToolsetId
+    id: string
     title: string
     description: string
-    /** Tool-definition `feature` values that belong to this toolset. */
+    /** Feature IDs this toolset covers (1 element for base, multiple for composites). */
     features: string[]
+    /** True when derived directly from a tool `feature` value; false for composites. */
+    isBase: boolean
 }
 
 /**
- * Tools always available in progressive mode regardless of which toolsets are enabled.
- * Kept small (goal: ≤5 from the RFC) so idle token cost stays near the 5K target.
+ * Build the full toolset list for a given MCP version. Base toolsets come from the tool
+ * catalog's distinct `feature` values; composites come from COMPOSITE_TOOLSETS above.
  */
-export const BOOTSTRAP_TOOL_NAMES = ['query-run', 'docs-search', 'entity-search', 'toolsets'] as const
+export function getAllToolsets(version?: number): ToolsetDefinition[] {
+    const defs = getToolDefinitions(version)
+    const base: Record<string, { category: string; toolCount: number }> = {}
 
-export const TOOLSETS: ToolsetDefinition[] = [
-    {
-        id: 'analytics',
-        title: 'Analytics',
-        description:
-            'Events, insights, cohorts, actions, persons, and product analytics. Enable for trends, funnels, retention, HogQL, insight CRUD, and event/property discovery.',
-        features: ['insights', 'events', 'product_analytics', 'cohorts', 'actions', 'persons'],
-    },
-    {
-        id: 'content',
-        title: 'Dashboards, notebooks, annotations',
-        description:
-            'Dashboards, notebooks, and annotations. Enable for dashboard CRUD, notebook reads/writes, and annotating charts.',
-        features: ['dashboards', 'notebooks', 'annotations'],
-    },
-    {
-        id: 'flags',
-        title: 'Feature flags',
-        description:
-            'Feature flag CRUD + early access features. Enable for flag definitions, rollout changes, and release gating.',
-        features: ['flags', 'early_access_features'],
-    },
-    {
-        id: 'experiments',
-        title: 'Experiments',
-        description: 'A/B experiments and results. Enable for experiment CRUD and result reads.',
-        features: ['experiments'],
-    },
-    {
-        id: 'surveys',
-        title: 'Surveys',
-        description: 'Survey CRUD and stats. Enable for survey management and response analytics.',
-        features: ['surveys'],
-    },
-    {
-        id: 'error_tracking',
-        title: 'Error tracking',
-        description: 'Exceptions and error issues. Enable for exception triage and error investigation.',
-        features: ['error_tracking'],
-    },
-    {
-        id: 'llm_analytics',
-        title: 'LLM analytics',
-        description:
-            'LLM traces, prompts, evaluations, conversations, and cost. Enable when the user asks about LLM spend, prompt versioning, or tracing.',
-        features: ['llm_analytics', 'prompts', 'conversations'],
-    },
-    {
-        id: 'workspace',
-        title: 'Workspace',
-        description:
-            'Orgs, projects, platform admin, integrations, alerts, roles. Enable first if the model cannot tell which project to query or needs admin primitives.',
-        features: ['workspace', 'core', 'platform_features', 'integrations', 'alerts'],
-    },
-    {
-        id: 'data_warehouse',
-        title: 'Data warehouse + endpoints',
-        description:
-            'Warehouse views, endpoints, SQL, and data schema. Enable for warehouse queries, query endpoints, and exploring the schema.',
-        features: ['data_warehouse', 'endpoints', 'data_schema', 'sql'],
-    },
-    {
-        id: 'replay',
-        title: 'Session replay',
-        description: 'Recordings and playlists. Enable for session recording reads and playlist management.',
-        features: ['replay'],
-    },
-    {
-        id: 'hog_functions',
-        title: 'Destinations / Hog functions',
-        description: 'CDP destinations, sources, transformations, and Hog function templates.',
-        features: ['hog_functions', 'hog_function_templates'],
-    },
-    {
-        id: 'logs',
-        title: 'Logs',
-        description: 'Log queries and log attribute discovery.',
-        features: ['logs'],
-    },
-    {
-        id: 'workflows',
-        title: 'Workflows',
-        description: 'Workflow CRUD. Enable when the user asks about automation workflows.',
-        features: ['workflows'],
-    },
-    {
-        id: 'reverse_proxy',
-        title: 'Managed reverse proxy',
-        description: 'PostHog managed reverse proxy CRUD.',
-        features: ['reverse_proxy'],
-    },
-]
-
-const FEATURE_TO_TOOLSET: Record<string, ToolsetId> = (() => {
-    const out: Record<string, ToolsetId> = {}
-    for (const ts of TOOLSETS) {
-        for (const feature of ts.features) {
-            out[feature] = ts.id
+    for (const meta of Object.values(defs)) {
+        const feature = meta.feature
+        if (!feature || EXCLUDED_FEATURES.has(feature)) {
+            continue
         }
+        if (!base[feature]) {
+            base[feature] = { category: meta.category, toolCount: 0 }
+        }
+        base[feature].toolCount++
     }
-    return out
-})()
 
-export function toolsetIdForFeature(feature: string): ToolsetId | undefined {
-    return FEATURE_TO_TOOLSET[feature]
+    const baseToolsets: ToolsetDefinition[] = Object.entries(base)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([id, { category, toolCount }]) => ({
+            id,
+            title: category,
+            description: `${category} tools (${toolCount}).`,
+            features: [id],
+            isBase: true,
+        }))
+
+    const compositeToolsets: ToolsetDefinition[] = Object.entries(COMPOSITE_TOOLSETS).map(
+        ([id, { title, description, features }]) => ({
+            id,
+            title,
+            description,
+            features,
+            isBase: false,
+        })
+    )
+
+    return [...baseToolsets, ...compositeToolsets]
 }
 
-export function getToolsetById(id: string): ToolsetDefinition | undefined {
-    return TOOLSETS.find((ts) => ts.id === id)
+export function getToolsetById(id: string, version?: number): ToolsetDefinition | undefined {
+    return getAllToolsets(version).find((ts) => ts.id === id)
+}
+
+export function isValidToolsetId(id: string, version?: number): boolean {
+    return getAllToolsets(version).some((ts) => ts.id === id)
 }
 
 export function isBootstrapTool(name: string): boolean {
     return (BOOTSTRAP_TOOL_NAMES as readonly string[]).includes(name)
 }
 
-export function isValidToolsetId(id: string): id is ToolsetId {
-    return TOOLSETS.some((ts) => ts.id === id)
+/**
+ * Expand a toolset id to the concrete set of feature IDs it unlocks. For base toolsets
+ * this is [id]; for composites it's the feature list.
+ */
+export function expandToolsetToFeatures(id: string, version?: number): string[] {
+    const ts = getToolsetById(id, version)
+    return ts ? ts.features : []
+}
+
+/**
+ * Given a set of enabled toolset ids (mixed base/composite), return the flat set of
+ * feature ids that should be surfaced. Unknown ids are silently ignored.
+ */
+export function resolveEnabledFeatures(enabledToolsets: readonly string[], version?: number): Set<string> {
+    const out = new Set<string>()
+    for (const id of enabledToolsets) {
+        for (const feature of expandToolsetToFeatures(id, version)) {
+            out.add(feature)
+        }
+    }
+    return out
 }

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -25,6 +25,10 @@ export type State = {
     region: CloudRegion | undefined
     apiKey: ApiRedactedPersonalApiKey | undefined
     clientName: string | undefined
+    aiConsentGiven: boolean | undefined
+    aiConsentFetchedAt: number | undefined
+    /** Toolset ids activated via toolsets(action='enable') in progressive mode. */
+    enabledToolsets: string[] | undefined
 } & Record<PrefixedString<'session'>, SessionState> &
     Record<PrefixedString<'groupTypes'>, GroupType[] | undefined> &
     Record<PrefixedString<'groupTypesFetchedAt'>, number | undefined> &

--- a/services/mcp/tests/unit/progressive-disclosure.test.ts
+++ b/services/mcp/tests/unit/progressive-disclosure.test.ts
@@ -263,6 +263,8 @@ describe('Client capability detection', () => {
         // Claude Code defers non-bootstrap tools at init and doesn't re-scan on list_changed,
         // so the reconnect path is needed. Verified empirically 2026-04.
         ['claude-code', false],
+        // OpenAI Codex CLI sends 'codex-mcp-client' in clientInfo.name. Matches via substring.
+        ['codex-mcp-client', false],
     ])('clientSupportsListChanged(%s) === %s', (clientName, expected) => {
         expect(clientSupportsListChanged(clientName as string | undefined)).toBe(expected)
     })

--- a/services/mcp/tests/unit/progressive-disclosure.test.ts
+++ b/services/mcp/tests/unit/progressive-disclosure.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest'
+
+import { clientSupportsListChanged } from '@/lib/clientCapabilities'
+import { SessionManager } from '@/lib/SessionManager'
+import { getToolsFromContext } from '@/tools'
+import { getToolsForFeatures } from '@/tools/toolDefinitions'
+import { ENABLED_TOOLSETS_KEY, toolsetsHandler } from '@/tools/toolsets/manage'
+import { BOOTSTRAP_TOOL_NAMES, TOOLSETS } from '@/tools/toolsets/taxonomy'
+import type { Context } from '@/tools/types'
+
+function createMockContext(scopes: string[] = ['*'], initialCache: Record<string, any> = {}): Context {
+    const store: Record<string, any> = { ...initialCache }
+    const cache: any = {
+        get: async (key: string) => store[key],
+        set: async (key: string, value: any) => {
+            store[key] = value
+        },
+        delete: async (key: string) => {
+            delete store[key]
+        },
+        clear: async () => {
+            for (const k of Object.keys(store)) {
+                delete store[k]
+            }
+        },
+    }
+    return {
+        api: {} as any,
+        cache,
+        env: {
+            INKEEP_API_KEY: undefined,
+            POSTHOG_API_BASE_URL: undefined,
+            MCP_APPS_BASE_URL: undefined,
+            POSTHOG_MCP_APPS_ANALYTICS_BASE_URL: undefined,
+            POSTHOG_UI_APPS_TOKEN: undefined,
+            POSTHOG_ANALYTICS_API_KEY: undefined,
+            POSTHOG_ANALYTICS_HOST: undefined,
+        },
+        stateManager: {
+            getApiKey: async () => ({ scopes }),
+            getAiConsentGiven: async () => true,
+        } as any,
+        sessionManager: new SessionManager(cache),
+    }
+}
+
+describe('Progressive disclosure — tool-name filtering', () => {
+    it('progressive mode without enabled toolsets exposes only bootstrap tools', () => {
+        const names = getToolsForFeatures({ progressive: true })
+        const set = new Set(names)
+        for (const bt of BOOTSTRAP_TOOL_NAMES) {
+            expect(set.has(bt), `bootstrap tool missing: ${bt}`).toBe(true)
+        }
+        // Non-bootstrap tools should be gone
+        expect(set.has('feature-flag-get-all')).toBe(false)
+        expect(set.has('experiment-get-all')).toBe(false)
+    })
+
+    it('progressive mode with ?toolsets=flags surfaces flag tools', () => {
+        const names = getToolsForFeatures({
+            progressive: true,
+            enabledToolsets: ['flags'],
+        })
+        expect(names).toContain('feature-flag-get-all')
+        expect(names).toContain('create-feature-flag')
+        // Flag tools yes, dashboard tools no
+        expect(names).not.toContain('dashboard-create')
+    })
+
+    it('progressive mode honours multiple enabled toolsets', () => {
+        const names = getToolsForFeatures({
+            progressive: true,
+            enabledToolsets: ['flags', 'experiments'],
+        })
+        expect(names).toContain('feature-flag-get-all')
+        expect(names).toContain('experiment-get-all')
+        expect(names).not.toContain('dashboard-create')
+    })
+
+    it('unknown toolset ids in enabledToolsets are ignored gracefully', () => {
+        const names = getToolsForFeatures({
+            progressive: true,
+            enabledToolsets: ['analytics', 'not-a-real-toolset'],
+        })
+        // Analytics tools are there; nothing about the unknown id caused an error.
+        expect(names).toContain('query-run')
+    })
+
+    it('default mode (no progressive) omits the toolsets meta-tool from the tool surface', async () => {
+        const context = createMockContext(['*'])
+        const tools = await getToolsFromContext(context, {})
+        const names = tools.map((t) => t.name)
+        expect(names).not.toContain('toolsets')
+        // The catalog itself (getToolsForFeatures) does include 'toolsets' — the exclusion
+        // is applied in getToolsFromContext.
+    })
+})
+
+describe('Progressive disclosure — toolsets meta-tool', () => {
+    it("list returns all toolsets with enabled=false when nothing's activated", async () => {
+        const context = createMockContext()
+        const body = (await toolsetsHandler(context, { action: 'list' })) as any
+        expect(body.toolsets).toHaveLength(TOOLSETS.length)
+        expect(body.enabled).toEqual([])
+        for (const ts of body.toolsets) {
+            expect(ts.enabled).toBe(false)
+        }
+    })
+
+    it('enable persists the toolset into the cache', async () => {
+        const context = createMockContext()
+        const body = (await toolsetsHandler(context, { action: 'enable', name: 'flags' })) as any
+        expect(body.enabled).toBe('flags')
+        expect(body.enabledNow).toEqual(['flags'])
+        expect(await context.cache.get(ENABLED_TOOLSETS_KEY as any)).toEqual(['flags'])
+    })
+
+    it('enable is idempotent', async () => {
+        const context = createMockContext()
+        await toolsetsHandler(context, { action: 'enable', name: 'flags' })
+        const body = (await toolsetsHandler(context, { action: 'enable', name: 'flags' })) as any
+        expect(body.enabledNow).toEqual(['flags'])
+    })
+
+    it('disable removes the toolset', async () => {
+        const context = createMockContext()
+        await toolsetsHandler(context, { action: 'enable', name: 'flags' })
+        await toolsetsHandler(context, { action: 'enable', name: 'experiments' })
+        const body = (await toolsetsHandler(context, { action: 'disable', name: 'flags' })) as any
+        expect(body.disabled).toBe('flags')
+        expect(body.enabledNow).toEqual(['experiments'])
+    })
+
+    it('describe returns tools inside the toolset', async () => {
+        const context = createMockContext()
+        const body = (await toolsetsHandler(context, { action: 'describe', name: 'flags' })) as any
+        expect(body.id).toBe('flags')
+        const names = body.tools.map((t: any) => t.name)
+        expect(names).toContain('feature-flag-get-all')
+    })
+
+    it('rejects unknown toolset ids', async () => {
+        const context = createMockContext()
+        const body = (await toolsetsHandler(context, { action: 'enable', name: 'does-not-exist' })) as any
+        expect(body.error).toMatch(/Unknown toolset/)
+    })
+
+    it('prompts for name when needed', async () => {
+        const context = createMockContext()
+        const body = (await toolsetsHandler(context, { action: 'enable' } as any)) as any
+        expect(body.error).toMatch(/requires a 'name'/)
+    })
+
+    it('enabling then filtering surfaces the toolset', async () => {
+        const context = createMockContext()
+        const before = await getToolsFromContext(context, { progressive: true })
+        expect(before.map((t) => t.name)).not.toContain('feature-flag-get-all')
+        await toolsetsHandler(context, { action: 'enable', name: 'flags' })
+        const after = await getToolsFromContext(context, { progressive: true })
+        const names = after.map((t) => t.name)
+        expect(names).toContain('feature-flag-get-all')
+        expect(names).toContain('toolsets')
+    })
+})
+
+describe('Client capability detection', () => {
+    it('assumes list_changed supported when client name is missing', () => {
+        expect(clientSupportsListChanged(undefined)).toBe(true)
+        expect(clientSupportsListChanged('')).toBe(true)
+    })
+
+    it('assumes supported for uncataloged clients', () => {
+        expect(clientSupportsListChanged('claude-ai')).toBe(true)
+        expect(clientSupportsListChanged('claude-code')).toBe(true)
+        expect(clientSupportsListChanged('some-new-client')).toBe(true)
+    })
+
+    it('flags known-unsupported clients', () => {
+        expect(clientSupportsListChanged('Cursor')).toBe(false)
+        expect(clientSupportsListChanged('cursor-vscode')).toBe(false)
+        expect(clientSupportsListChanged('Windsurf')).toBe(false)
+    })
+})
+
+describe('Toolset taxonomy', () => {
+    it('every tool with a feature either lives in a toolset or is intentionally excluded', async () => {
+        const { getToolDefinitions } = await import('@/tools/toolDefinitions')
+        const { toolsetIdForFeature } = await import('@/tools/toolsets/taxonomy')
+        const defs = getToolDefinitions()
+        const allowedUngrouped = new Set(['docs', 'search', 'debug', 'skills', 'meta'])
+
+        const ungrouped: string[] = []
+        for (const [name, def] of Object.entries(defs)) {
+            if (allowedUngrouped.has(def.feature)) {
+                continue
+            }
+            if (!toolsetIdForFeature(def.feature)) {
+                ungrouped.push(`${name} (feature=${def.feature})`)
+            }
+        }
+        expect(ungrouped, `tools missing from toolsets: ${ungrouped.join(', ')}`).toEqual([])
+    })
+
+    it('bootstrap tool names are declared', () => {
+        expect(BOOTSTRAP_TOOL_NAMES).toContain('query-run')
+        expect(BOOTSTRAP_TOOL_NAMES).toContain('toolsets')
+        expect(BOOTSTRAP_TOOL_NAMES).toContain('docs-search')
+    })
+})

--- a/services/mcp/tests/unit/progressive-disclosure.test.ts
+++ b/services/mcp/tests/unit/progressive-disclosure.test.ts
@@ -45,29 +45,36 @@ function createMockContext(scopes: string[] = ['*'], initialCache: Record<string
 }
 
 describe('Progressive disclosure — tool-name filtering', () => {
-    it('progressive mode without enabled toolsets exposes only bootstrap tools', () => {
-        const names = getToolsForFeatures({ progressive: true })
+    it('progressive mode with empty enabledToolsets[] exposes only bootstrap tools', () => {
+        // Note: `progressive: true` alone doesn't filter — you have to pass `enabledToolsets: []`
+        // to opt into bootstrap-only. This lets mcp.ts register the full catalog at init and
+        // dynamically `.enable()` tools without needing to re-init the session.
+        const names = getToolsForFeatures({ progressive: true, enabledToolsets: [] })
         const set = new Set(names)
         for (const bt of BOOTSTRAP_TOOL_NAMES) {
             expect(set.has(bt), `bootstrap tool missing: ${bt}`).toBe(true)
         }
-        // Non-bootstrap tools should be gone
         expect(set.has('feature-flag-get-all')).toBe(false)
         expect(set.has('experiment-get-all')).toBe(false)
     })
 
-    it('progressive mode with ?toolsets=flags surfaces flag tools', () => {
+    it('progressive mode with enabledToolsets=undefined returns the full catalog (for register-all init path)', () => {
+        const names = getToolsForFeatures({ progressive: true })
+        expect(names).toContain('feature-flag-get-all')
+        expect(names).toContain('experiment-get-all')
+    })
+
+    it('progressive mode + enabledToolsets=[flags] surfaces flag tools only', () => {
         const names = getToolsForFeatures({
             progressive: true,
             enabledToolsets: ['flags'],
         })
         expect(names).toContain('feature-flag-get-all')
         expect(names).toContain('create-feature-flag')
-        // Flag tools yes, dashboard tools no
         expect(names).not.toContain('dashboard-create')
     })
 
-    it('progressive mode honours multiple enabled toolsets', () => {
+    it('progressive mode + enabledToolsets=[flags,experiments] surfaces both', () => {
         const names = getToolsForFeatures({
             progressive: true,
             enabledToolsets: ['flags', 'experiments'],
@@ -82,7 +89,6 @@ describe('Progressive disclosure — tool-name filtering', () => {
             progressive: true,
             enabledToolsets: ['analytics', 'not-a-real-toolset'],
         })
-        // Analytics tools are there; nothing about the unknown id caused an error.
         expect(names).toContain('query-run')
     })
 
@@ -151,13 +157,13 @@ describe('Progressive disclosure — toolsets meta-tool', () => {
         expect(body.error).toMatch(/requires a 'name'/)
     })
 
-    it('enabling then filtering surfaces the toolset', async () => {
+    it('enabling a toolset then filtering via getToolsForFeatures surfaces its tools', async () => {
         const context = createMockContext()
-        const before = await getToolsFromContext(context, { progressive: true })
-        expect(before.map((t) => t.name)).not.toContain('feature-flag-get-all')
         await toolsetsHandler(context, { action: 'enable', name: 'flags' })
-        const after = await getToolsFromContext(context, { progressive: true })
-        const names = after.map((t) => t.name)
+        const enabled = ((await context.cache.get('enabledToolsets' as any)) ?? []) as string[]
+        expect(enabled).toEqual(['flags'])
+        // Simulate the mcp.ts filter: progressive + explicitly-passed enabled ids
+        const names = getToolsForFeatures({ progressive: true, enabledToolsets: enabled })
         expect(names).toContain('feature-flag-get-all')
         expect(names).toContain('toolsets')
     })

--- a/services/mcp/tests/unit/progressive-disclosure.test.ts
+++ b/services/mcp/tests/unit/progressive-disclosure.test.ts
@@ -2,10 +2,18 @@ import { describe, expect, it } from 'vitest'
 
 import { clientSupportsListChanged } from '@/lib/clientCapabilities'
 import { SessionManager } from '@/lib/SessionManager'
-import { getToolsFromContext } from '@/tools'
-import { getToolsForFeatures } from '@/tools/toolDefinitions'
+import { getToolDefinitions } from '@/tools/toolDefinitions'
 import { ENABLED_TOOLSETS_KEY, toolsetsHandler } from '@/tools/toolsets/manage'
-import { BOOTSTRAP_TOOL_NAMES, TOOLSETS } from '@/tools/toolsets/taxonomy'
+import {
+    BOOTSTRAP_TOOL_NAMES,
+    COMPOSITE_TOOLSETS,
+    expandToolsetToFeatures,
+    getAllToolsets,
+    getToolsetById,
+    isBootstrapTool,
+    isValidToolsetId,
+    resolveEnabledFeatures,
+} from '@/tools/toolsets/taxonomy'
 import type { Context } from '@/tools/types'
 
 function createMockContext(scopes: string[] = ['*'], initialCache: Record<string, any> = {}): Context {
@@ -44,81 +52,121 @@ function createMockContext(scopes: string[] = ['*'], initialCache: Record<string
     }
 }
 
-describe('Progressive disclosure — tool-name filtering', () => {
-    it('progressive mode with empty enabledToolsets[] exposes only bootstrap tools', () => {
-        // Note: `progressive: true` alone doesn't filter — you have to pass `enabledToolsets: []`
-        // to opt into bootstrap-only. This lets mcp.ts register the full catalog at init and
-        // dynamically `.enable()` tools without needing to re-init the session.
-        const names = getToolsForFeatures({ progressive: true, enabledToolsets: [] })
-        const set = new Set(names)
-        for (const bt of BOOTSTRAP_TOOL_NAMES) {
-            expect(set.has(bt), `bootstrap tool missing: ${bt}`).toBe(true)
+describe('Taxonomy — base toolsets auto-derived from tool definitions', () => {
+    it('returns at least one base toolset per product area present in the catalog', () => {
+        const all = getAllToolsets()
+        const base = all.filter((ts) => ts.isBase)
+        // Sanity: we expect base toolsets for core product surfaces.
+        const baseIds = new Set(base.map((ts) => ts.id))
+        for (const expected of ['flags', 'experiments', 'surveys', 'insights', 'dashboards']) {
+            expect(baseIds, `missing base toolset for '${expected}'`).toContain(expected)
         }
-        expect(set.has('feature-flag-get-all')).toBe(false)
-        expect(set.has('experiment-get-all')).toBe(false)
     })
 
-    it('progressive mode with enabledToolsets=undefined returns the full catalog (for register-all init path)', () => {
-        const names = getToolsForFeatures({ progressive: true })
-        expect(names).toContain('feature-flag-get-all')
-        expect(names).toContain('experiment-get-all')
+    it('excludes bootstrap/internal features (docs, search, debug, skills, meta)', () => {
+        const ids = new Set(getAllToolsets().map((ts) => ts.id))
+        for (const excluded of ['docs', 'search', 'debug', 'skills', 'meta']) {
+            expect(ids, `excluded feature '${excluded}' leaked into toolsets`).not.toContain(excluded)
+        }
     })
 
-    it('progressive mode + enabledToolsets=[flags] surfaces flag tools only', () => {
-        const names = getToolsForFeatures({
-            progressive: true,
-            enabledToolsets: ['flags'],
-        })
-        expect(names).toContain('feature-flag-get-all')
-        expect(names).toContain('create-feature-flag')
-        expect(names).not.toContain('dashboard-create')
+    it('every non-excluded feature in the catalog appears as a base toolset (no gaps)', () => {
+        const defs = getToolDefinitions()
+        const excluded = new Set(['docs', 'search', 'debug', 'skills', 'meta'])
+        const catalogFeatures = new Set(
+            Object.values(defs)
+                .map((d) => d.feature)
+                .filter((f) => f && !excluded.has(f))
+        )
+        const baseIds = new Set(
+            getAllToolsets()
+                .filter((ts) => ts.isBase)
+                .map((ts) => ts.id)
+        )
+        const missing = [...catalogFeatures].filter((f) => !baseIds.has(f))
+        expect(missing, `features without a base toolset: ${missing.join(', ')}`).toEqual([])
     })
 
-    it('progressive mode + enabledToolsets=[flags,experiments] surfaces both', () => {
-        const names = getToolsForFeatures({
-            progressive: true,
-            enabledToolsets: ['flags', 'experiments'],
-        })
-        expect(names).toContain('feature-flag-get-all')
-        expect(names).toContain('experiment-get-all')
-        expect(names).not.toContain('dashboard-create')
-    })
-
-    it('unknown toolset ids in enabledToolsets are ignored gracefully', () => {
-        const names = getToolsForFeatures({
-            progressive: true,
-            enabledToolsets: ['analytics', 'not-a-real-toolset'],
-        })
-        expect(names).toContain('query-run')
-    })
-
-    it('default mode (no progressive) omits the toolsets meta-tool from the tool surface', async () => {
-        const context = createMockContext(['*'])
-        const tools = await getToolsFromContext(context, {})
-        const names = tools.map((t) => t.name)
-        expect(names).not.toContain('toolsets')
-        // The catalog itself (getToolsForFeatures) does include 'toolsets' — the exclusion
-        // is applied in getToolsFromContext.
+    it('base toolset titles use the tool-definition category (human-readable)', () => {
+        const flagsToolset = getToolsetById('flags')
+        expect(flagsToolset?.title).toBe('Feature flags')
+        const replayToolset = getToolsetById('replay')
+        expect(replayToolset?.title).toBe('Session replays')
     })
 })
 
-describe('Progressive disclosure — toolsets meta-tool', () => {
-    it("list returns all toolsets with enabled=false when nothing's activated", async () => {
-        const context = createMockContext()
-        const body = (await toolsetsHandler(context, { action: 'list' })) as any
-        expect(body.toolsets).toHaveLength(TOOLSETS.length)
-        expect(body.enabled).toEqual([])
-        for (const ts of body.toolsets) {
-            expect(ts.enabled).toBe(false)
+describe('Taxonomy — composites', () => {
+    it('every composite references real base features', () => {
+        const baseIds = new Set(
+            getAllToolsets()
+                .filter((ts) => ts.isBase)
+                .map((ts) => ts.id)
+        )
+        for (const [compositeId, { features }] of Object.entries(COMPOSITE_TOOLSETS)) {
+            for (const feature of features) {
+                expect(baseIds, `composite '${compositeId}' references missing feature '${feature}'`).toContain(feature)
+            }
         }
     })
 
-    it('enable persists the toolset into the cache', async () => {
+    it('expanding a composite returns its feature list', () => {
+        const analyticsFeatures = expandToolsetToFeatures('analytics')
+        expect(analyticsFeatures).toContain('insights')
+        expect(analyticsFeatures).toContain('events')
+        expect(analyticsFeatures).toContain('cohorts')
+    })
+
+    it('expanding a base toolset returns just its own feature id', () => {
+        expect(expandToolsetToFeatures('flags')).toEqual(['flags'])
+    })
+
+    it('expanding an unknown id returns []', () => {
+        expect(expandToolsetToFeatures('not-a-real-toolset')).toEqual([])
+    })
+})
+
+describe('Taxonomy — resolveEnabledFeatures', () => {
+    it('flattens a mix of composites and base ids into the union of features', () => {
+        const features = resolveEnabledFeatures(['analytics', 'flags'])
+        expect(features.has('insights')).toBe(true)
+        expect(features.has('events')).toBe(true)
+        expect(features.has('flags')).toBe(true)
+    })
+
+    it('ignores unknown ids silently', () => {
+        const features = resolveEnabledFeatures(['flags', 'not-real'])
+        expect(features.has('flags')).toBe(true)
+        expect(features.size).toBe(1)
+    })
+})
+
+describe('toolsets meta-tool', () => {
+    it('list returns composites + base, all disabled initially', async () => {
+        const context = createMockContext()
+        const body = (await toolsetsHandler(context, { action: 'list' })) as any
+        expect(Array.isArray(body.composites)).toBe(true)
+        expect(Array.isArray(body.base)).toBe(true)
+        expect(body.enabled).toEqual([])
+        expect(body.composites.find((c: any) => c.id === 'analytics').enabled).toBe(false)
+        expect(body.base.find((b: any) => b.id === 'flags').enabled).toBe(false)
+    })
+
+    it('enable on a base toolset persists the id', async () => {
         const context = createMockContext()
         const body = (await toolsetsHandler(context, { action: 'enable', name: 'flags' })) as any
         expect(body.enabled).toBe('flags')
         expect(body.enabledNow).toEqual(['flags'])
+        expect(body.expandedFeatures).toEqual(['flags'])
         expect(await context.cache.get(ENABLED_TOOLSETS_KEY as any)).toEqual(['flags'])
+    })
+
+    it('enable on a composite expands to its features', async () => {
+        const context = createMockContext()
+        const body = (await toolsetsHandler(context, { action: 'enable', name: 'analytics' })) as any
+        expect(body.enabled).toBe('analytics')
+        expect(body.enabledNow).toEqual(['analytics'])
+        expect(body.expandedFeatures).toContain('insights')
+        expect(body.expandedFeatures).toContain('events')
     })
 
     it('enable is idempotent', async () => {
@@ -128,7 +176,28 @@ describe('Progressive disclosure — toolsets meta-tool', () => {
         expect(body.enabledNow).toEqual(['flags'])
     })
 
-    it('disable removes the toolset', async () => {
+    it('describe on a base toolset lists the tools', async () => {
+        const context = createMockContext()
+        const body = (await toolsetsHandler(context, { action: 'describe', name: 'flags' })) as any
+        expect(body.id).toBe('flags')
+        expect(body.composite).toBe(false)
+        const names = body.tools.map((t: any) => t.name)
+        expect(names).toContain('feature-flag-get-all')
+    })
+
+    it('describe on a composite shows its bundled features + tools from all of them', async () => {
+        const context = createMockContext()
+        const body = (await toolsetsHandler(context, { action: 'describe', name: 'analytics' })) as any
+        expect(body.id).toBe('analytics')
+        expect(body.composite).toBe(true)
+        expect(body.bundles).toContain('insights')
+        const names = body.tools.map((t: any) => t.name)
+        // Analytics includes insights + events + cohorts + actions + persons + product_analytics.
+        expect(names.some((n: string) => n.includes('insight'))).toBe(true)
+        expect(names.some((n: string) => n.includes('cohort'))).toBe(true)
+    })
+
+    it('disable removes the id', async () => {
         const context = createMockContext()
         await toolsetsHandler(context, { action: 'enable', name: 'flags' })
         await toolsetsHandler(context, { action: 'enable', name: 'experiments' })
@@ -137,79 +206,63 @@ describe('Progressive disclosure — toolsets meta-tool', () => {
         expect(body.enabledNow).toEqual(['experiments'])
     })
 
-    it('describe returns tools inside the toolset', async () => {
-        const context = createMockContext()
-        const body = (await toolsetsHandler(context, { action: 'describe', name: 'flags' })) as any
-        expect(body.id).toBe('flags')
-        const names = body.tools.map((t: any) => t.name)
-        expect(names).toContain('feature-flag-get-all')
-    })
-
     it('rejects unknown toolset ids', async () => {
         const context = createMockContext()
         const body = (await toolsetsHandler(context, { action: 'enable', name: 'does-not-exist' })) as any
         expect(body.error).toMatch(/Unknown toolset/)
     })
 
-    it('prompts for name when needed', async () => {
+    it('prompts for name when action needs one', async () => {
         const context = createMockContext()
         const body = (await toolsetsHandler(context, { action: 'enable' } as any)) as any
         expect(body.error).toMatch(/requires a 'name'/)
     })
+})
 
-    it('enabling a toolset then filtering via getToolsForFeatures surfaces its tools', async () => {
-        const context = createMockContext()
-        await toolsetsHandler(context, { action: 'enable', name: 'flags' })
-        const enabled = ((await context.cache.get('enabledToolsets' as any)) ?? []) as string[]
-        expect(enabled).toEqual(['flags'])
-        // Simulate the mcp.ts filter: progressive + explicitly-passed enabled ids
-        const names = getToolsForFeatures({ progressive: true, enabledToolsets: enabled })
-        expect(names).toContain('feature-flag-get-all')
-        expect(names).toContain('toolsets')
+describe('isValidToolsetId / isBootstrapTool', () => {
+    it('isValidToolsetId accepts both base and composite ids', () => {
+        expect(isValidToolsetId('flags')).toBe(true)
+        expect(isValidToolsetId('analytics')).toBe(true)
+        expect(isValidToolsetId('definitely-not-real')).toBe(false)
+    })
+
+    it('isBootstrapTool recognizes bootstrap tools', () => {
+        expect(isBootstrapTool('query-run')).toBe(true)
+        expect(isBootstrapTool('docs-search')).toBe(true)
+        expect(isBootstrapTool('toolsets')).toBe(true)
+        expect(isBootstrapTool('entity-search')).toBe(true)
+        expect(isBootstrapTool('feature-flag-get-all')).toBe(false)
+    })
+
+    it('BOOTSTRAP_TOOL_NAMES is the declared source of truth', () => {
+        expect(BOOTSTRAP_TOOL_NAMES.length).toBe(4)
+    })
+})
+
+describe('Bootstrap immunity', () => {
+    it('query-run has feature "insights" — used to catch the regression where disabling the "analytics" composite (which includes "insights") would disable query-run', () => {
+        const defs = getToolDefinitions()
+        // Reality check: query-run is classified under the insights feature in the catalog,
+        // and the analytics composite includes insights. So any toolset operation on analytics
+        // will attempt to flip query-run too — the mcp.ts loop must exempt bootstrap tools.
+        expect(defs['query-run']?.feature).toBe('insights')
+        expect(expandToolsetToFeatures('analytics')).toContain('insights')
+        expect(isBootstrapTool('query-run')).toBe(true)
     })
 })
 
 describe('Client capability detection', () => {
-    it('assumes list_changed supported when client name is missing', () => {
+    it('treats unknown clients as supporting list_changed', () => {
         expect(clientSupportsListChanged(undefined)).toBe(true)
         expect(clientSupportsListChanged('')).toBe(true)
-    })
-
-    it('assumes supported for uncataloged clients', () => {
-        expect(clientSupportsListChanged('claude-ai')).toBe(true)
         expect(clientSupportsListChanged('claude-code')).toBe(true)
-        expect(clientSupportsListChanged('some-new-client')).toBe(true)
+        expect(clientSupportsListChanged('claude-ai')).toBe(true)
     })
 
     it('flags known-unsupported clients', () => {
         expect(clientSupportsListChanged('Cursor')).toBe(false)
         expect(clientSupportsListChanged('cursor-vscode')).toBe(false)
         expect(clientSupportsListChanged('Windsurf')).toBe(false)
-    })
-})
-
-describe('Toolset taxonomy', () => {
-    it('every tool with a feature either lives in a toolset or is intentionally excluded', async () => {
-        const { getToolDefinitions } = await import('@/tools/toolDefinitions')
-        const { toolsetIdForFeature } = await import('@/tools/toolsets/taxonomy')
-        const defs = getToolDefinitions()
-        const allowedUngrouped = new Set(['docs', 'search', 'debug', 'skills', 'meta'])
-
-        const ungrouped: string[] = []
-        for (const [name, def] of Object.entries(defs)) {
-            if (allowedUngrouped.has(def.feature)) {
-                continue
-            }
-            if (!toolsetIdForFeature(def.feature)) {
-                ungrouped.push(`${name} (feature=${def.feature})`)
-            }
-        }
-        expect(ungrouped, `tools missing from toolsets: ${ungrouped.join(', ')}`).toEqual([])
-    })
-
-    it('bootstrap tool names are declared', () => {
-        expect(BOOTSTRAP_TOOL_NAMES).toContain('query-run')
-        expect(BOOTSTRAP_TOOL_NAMES).toContain('toolsets')
-        expect(BOOTSTRAP_TOOL_NAMES).toContain('docs-search')
+        expect(clientSupportsListChanged('codeium')).toBe(false)
     })
 })

--- a/services/mcp/tests/unit/progressive-disclosure.test.ts
+++ b/services/mcp/tests/unit/progressive-disclosure.test.ts
@@ -255,12 +255,14 @@ describe('Client capability detection', () => {
     it.each([
         [undefined, true],
         ['', true],
-        ['claude-code', true],
         ['claude-ai', true],
         ['Cursor', false],
         ['cursor-vscode', false],
         ['Windsurf', false],
         ['codeium', false],
+        // Claude Code defers non-bootstrap tools at init and doesn't re-scan on list_changed,
+        // so the reconnect path is needed. Verified empirically 2026-04.
+        ['claude-code', false],
     ])('clientSupportsListChanged(%s) === %s', (clientName, expected) => {
         expect(clientSupportsListChanged(clientName as string | undefined)).toBe(expected)
     })

--- a/services/mcp/tests/unit/progressive-disclosure.test.ts
+++ b/services/mcp/tests/unit/progressive-disclosure.test.ts
@@ -252,17 +252,16 @@ describe('Bootstrap immunity', () => {
 })
 
 describe('Client capability detection', () => {
-    it('treats unknown clients as supporting list_changed', () => {
-        expect(clientSupportsListChanged(undefined)).toBe(true)
-        expect(clientSupportsListChanged('')).toBe(true)
-        expect(clientSupportsListChanged('claude-code')).toBe(true)
-        expect(clientSupportsListChanged('claude-ai')).toBe(true)
-    })
-
-    it('flags known-unsupported clients', () => {
-        expect(clientSupportsListChanged('Cursor')).toBe(false)
-        expect(clientSupportsListChanged('cursor-vscode')).toBe(false)
-        expect(clientSupportsListChanged('Windsurf')).toBe(false)
-        expect(clientSupportsListChanged('codeium')).toBe(false)
+    it.each([
+        [undefined, true],
+        ['', true],
+        ['claude-code', true],
+        ['claude-ai', true],
+        ['Cursor', false],
+        ['cursor-vscode', false],
+        ['Windsurf', false],
+        ['codeium', false],
+    ])('clientSupportsListChanged(%s) === %s', (clientName, expected) => {
+        expect(clientSupportsListChanged(clientName as string | undefined)).toBe(expected)
     })
 })


### PR DESCRIPTION
## Problem

PostHog's MCP ships with ~200+ enabled tools that consume **~213K tokens** at idle (measured via `/context`). This is breaking things:

- **Replit Agent auto-disabled us** for exceeding their 195-tool platform limit
- **YC founders are complaining directly** — Codex users especially, since Codex has no client-side tool-search
- **Haiku subagents in Claude Code don't work** with the MCP enabled — the tool defs fill the context before any task starts

Tool growth is ~52 PRs/month and the problem gets worse, not better. Full context in the RFC: PostHog/requests-for-comments-internal#1079.

## Changes

Implements the "GitHub MCP dynamic-toolsets" pattern from the RFC as an **opt-in** query param (`?progressive=true`). Default behavior is untouched.

**Flow when `?progressive=true`:**

1. `tools/list` returns four bootstrap tools: `query-run`, `docs-search`, `entity-search`, and a new meta-tool `toolsets`.
2. Model calls `toolsets(action='list')` to see available product-shaped toolsets + composite bundles.
3. Model calls `toolsets(action='enable', name='flags')` (or `disable`). The tool writes the enabled set into the DurableObjectCache and fires `notifications/tools/list_changed`.
4. Compatible clients (SDK-native, Claude.ai) pick up the new tools mid-session.
5. Clients that cache their tool catalog (Claude Code, Codex, Cursor <2.0, Codeium, Windsurf — detected via `clientInfo.name`) get a `_reconnectHint` in the enable response with `?progressive=true&toolsets=<ids>`. The model relays this to the user, who reconnects once.

**Toolset taxonomy** lives in `src/tools/toolsets/taxonomy.ts`, two layers:

- **Base toolsets** (30, auto-derived) come from the distinct `feature` values in the tool catalog — which come from each `products/*/mcp/tools.yaml` via codegen. Title comes from the tool's `category`. No hand-edit when a new product ships MCP tools.
- **Composite toolsets** (3: `analytics`, `content`, `admin`) are a small hand-curated table of convenience bundles. Enabling a composite enables all its member features. This is the only hand-edited surface — and only for editorial "these ship together" decisions, not mechanical feature-assignment.

**Files touched:**

- `src/tools/toolsets/{taxonomy,manage}.ts` — toolset definitions + meta-tool handler
- `src/lib/clientCapabilities.ts` — known-broken-client list
- `src/tools/index.ts`, `src/tools/toolDefinitions.ts` — always exclude the `toolsets` meta-tool from `getToolsFromContext`; mcp.ts registers it separately
- `src/mcp.ts`, `src/index.ts` — query-param parsing; full catalog registered + non-enabled `.disable()`'d at init; `toolsets` handler flips registrations on enable/disable and injects `_reconnectHint` for known-broken clients
- `schema/tool-definitions.json`, `schema/tool-inputs.json`, `src/schema/tool-inputs.ts` — `toolsets` tool definition + input schema

## How did you test this code?

Four layers of validation, from synthetic up to a real model against real data.

### 1. Unit (664 total, 32 new)

In `progressive-disclosure.test.ts`: taxonomy auto-derivation from catalog, composite expansion, meta-tool actions (list/describe/enable/disable), bootstrap-immunity regression (disabling `analytics` composite must not touch `query-run` which has feature=`insights`), client capability classification.

### 2. Raw MCP SDK client (`@modelcontextprotocol/sdk@1.26.0`, streamable-HTTP)

Against `wrangler dev` pointed at a local `manage.py runserver`:

- Default mode: 206 tools (unchanged)
- Progressive bootstrap: 4 tools
- `toolsets(enable, 'flags')` → `list_changed` fires → `listTools()` returns 20 tools; `feature-flag-get-all` dispatches successfully
- `toolsets(enable, 'analytics')` (composite) → expands to 6 features → 31 tools
- `toolsets(disable, 'analytics')` → back to 4 (bootstrap preserved)

### 3. Token-cost measurement (`gpt-tokenizer`, cl100k_base — close proxy for Claude)

Measured the `tools` array of `tools/list` responses from wrangler dev:

| Mode | Tools | Tokens |
|---|---:|---:|
| Default (today's prod) | 217 | **142,309** |
| Progressive bootstrap only | 4 | **4,138** ✅ |
| Progressive + `flags` | 20 | 12,485 |
| Progressive + `analytics` composite | 32 | 19,838 |
| Progressive + 4 base toolsets | 51 | 57,444 |

Bootstrap mode hits the RFC's <5K idle target. Adam's prior 213K measurement via `/context` includes prompts/resources/UI-apps in addition to the tools array; the ~35× reduction in the tools array alone dominates.

### 4. Real-model cross-client suite

Cold prompts (no hints about the meta-tool) via `claude -p --strict-mcp-config` and `codex exec --json` against local PostHog with 4 seeded feature flags.

**Claude Code (Opus, Sonnet, Haiku)** — "List my feature flags":

| Model | Tool calls | Outcome |
|---|---:|---|
| Opus | 7 | Enabled `flags` correctly, hit Claude Code's defer-block, surfaced reconnect cleanly |
| Sonnet | 6 | Same (was 14 before the `nextStep` sharpening) |
| Haiku | 7 | Same |

**Claude Code (Sonnet) ambiguous / cohort**:
- "How many events last 7 days?" → **4 calls, zero `toolsets` calls** — bootstrap's `query-run` handled it
- "Create a cohort of pricing visitors" → 9 calls (down from 33 before the `nextStep` rewrite), correctly picked `cohorts` base toolset

**Codex** (GPT-5, `clientInfo.name='codex-mcp-client'`) — "List my feature flags":
- **Cold progressive**: 218K input tokens, enabled `flags` correctly, hit defer-block, ended with reconnect instruction
- **Pre-enabled (`?toolsets=flags`)**: 1 tool call, 95K input tokens, listed all 4 real flags ✅

**Reconnect path (Sonnet with `?toolsets=flags` pre-enabled)**: 2 calls, clean, listed real flags. Progressive mode's "opt into a specific slice up front" path works perfectly.

## Client compatibility finding

During validation I discovered that **Claude Code and Codex both cache their tool catalog at init and don't re-scan on `notifications/tools/list_changed`** (Claude Code upstream: [anthropics/claude-code#50515](https://github.com/anthropics/claude-code/issues/50515)). After `toolsets(action='enable')`, the newly-registered tools are unreachable from the function-calling layer even though the MCP SDK transport has them correctly.

So for these clients the flow is:

1. Model calls `toolsets(enable, name='<id>')` → server registers + fires `list_changed`
2. Server response includes `_reconnectHint` with `?progressive=true&toolsets=<id>`
3. Model relays the reconnect instruction to the user
4. User reconnects once → tools are in the initial catalog this time → callable directly

This matches the behavior already documented for Cursor, Codeium, Windsurf. Raw SDK clients and Claude.ai don't need the reconnect — `list_changed` works natively.

One earlier iteration had the reconnect field named `note` with softer phrasing. Sonnet-class models retry-and-thrashed (33 calls on the cohort task, 14 on flags) before giving up. Leading with the concrete action (`nextStep: "If calling a newly-available tool returns ..., ask the user to reconnect with: ?progressive=true&toolsets=..."`) short-circuits that loop. All models now consistently surface the reconnect instruction in their final text.

## Known gaps before flipping the default

Progressive mode is opt-in via `?progressive=true`, so this PR carries zero risk for existing users. Before flipping the default I'd want:

1. **Formal eval suite** — hook into PostHog AI's existing eval infrastructure (`products/posthog_ai/`). The cold-prompt signal above is N≈6 total runs; need the full suite to say tool-use accuracy is uncharmed on non-flag tasks.
2. **Idle-token measurement in real clients against a real account** — reproduce Adam's 213K `/context` measurement in Claude Code and Codex with progressive on against a PostHog account with actual data.
3. **Internal dogfood** — post `?progressive=true` in `#posthog-replit` / `#mcp`, let a few folks live with it for a week, collect complaints.
4. **Wider model coverage** — I only tested Anthropic (via Claude Code) and OpenAI (via Codex). Gemini and Cursor's model layer unknown.
5. **Verify the Claude Code deferred-tool refresh behavior** with the Anthropic MCP team — the fix is upstream. If they do honor `list_changed` mid-session for deferred tools, we can remove `claude-code` from `KNOWN_UNSUPPORTED_CLIENTS`.

All five are in scope for a follow-up PR that flips the default. This PR gets the mechanism in place and validated on synthetic + local-real flows.

## Publish to changelog?

No — behind a query-param flag. Will publish when the default flips.

RFC: https://github.com/PostHog/requests-for-comments-internal/pull/1079
