### PR TITLE
fix(homepage): Fix infinite loop when setting dashboard for default homepage

### DIFF
--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -11,7 +11,7 @@ import posthog from 'posthog-js'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { identifierToHuman } from 'lib/utils'
 import { addProjectIdIfMissing, removeProjectIdIfPresent } from 'lib/utils/router-utils'
-import { sceneLogic } from 'scenes/sceneLogic'
+import { getTabsSnapshotForHistory, sceneLogic } from 'scenes/sceneLogic'
 
 import { disposablesPlugin } from '~/kea-disposables'
 
@@ -86,11 +86,13 @@ export function initKea({
                 // This state is persisted into window.history
                 const logic = sceneLogic.findMounted()
                 if (logic) {
+                    // Strip sceneParams etc. — they are not JSON-safe and break structuredClone (cyclic/deep graphs)
+                    const tabs = getTabsSnapshotForHistory(logic.values.tabs)
                     if (typeof structuredClone !== 'undefined') {
-                        return { tabs: structuredClone(logic.values.tabs) }
+                        return { tabs: structuredClone(tabs) }
                     }
                     // structuredClone fails in jest for some reason, despite us being on the right versions
-                    return { tabs: JSON.parse(JSON.stringify(logic.values.tabs)) || [] }
+                    return { tabs: JSON.parse(JSON.stringify(tabs)) || [] }
                 }
                 return undefined
             },

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -75,35 +75,17 @@ const getStorageKey = (key: string): string => {
 const generateTabId = (): string => crypto?.randomUUID?.()?.split('-')?.pop() || `${Date.now()}-${Math.random()}`
 
 /**
- * Tab metadata we can safely JSON-serialize. `sceneParams` is omitted — it is derived from the URL when
- * scenes load and can contain deep or cyclic structures after routing (e.g. dashboard as homepage).
+ * Snapshot for JSON / structuredClone. Strips only `sceneParams` (deep/cyclic routing state); everything
+ * else on `SceneTab` is kept so new fields are not forgotten. If a future field holds non-plain data,
+ * omit it here explicitly.
  */
 const tabToPersistableSnapshot = (tab: SceneTab, overrides: Partial<SceneTab> = {}): SceneTab => {
-    const snapshot: SceneTab = {
+    const { sceneParams: _omitSceneParams, ...rest } = tab
+    return {
+        ...rest,
         id: tab.id || generateTabId(),
-        pathname: tab.pathname,
-        search: tab.search,
-        hash: tab.hash,
-        title: tab.title,
-        iconType: tab.iconType,
-        active: tab.active,
+        ...overrides,
     }
-    if (tab.customTitle !== undefined) {
-        snapshot.customTitle = tab.customTitle
-    }
-    if (tab.pinned !== undefined) {
-        snapshot.pinned = tab.pinned
-    }
-    if (tab.badge !== undefined) {
-        snapshot.badge = tab.badge
-    }
-    if (tab.sceneId !== undefined) {
-        snapshot.sceneId = tab.sceneId
-    }
-    if (tab.sceneKey !== undefined) {
-        snapshot.sceneKey = tab.sceneKey
-    }
-    return { ...snapshot, ...overrides }
 }
 
 /** Plain tab snapshots for browser history (`structuredClone` in initKea); excludes `sceneParams`. */
@@ -1461,15 +1443,12 @@ export const sceneLogic = kea<sceneLogicType>([
                 const targetSearch = homepage.search || ''
                 const targetHash = homepage.hash || ''
                 const loc = router.values.currentLocation
-                // If we're already at the homepage URL, skip replace. Otherwise replaceState re-runs this
-                // handler forever (e.g. homepage pathname equals project root `/project/:id`).
-                if (
+                // Already at homepage: skip replace or replaceState loops (e.g. homepage === project root).
+                const alreadyAtHomepage =
                     addProjectIdIfMissing(loc.pathname) === addProjectIdIfMissing(targetPathname) &&
                     (loc.search || '') === targetSearch &&
                     (loc.hash || '') === targetHash
-                ) {
-                    // Fall through to default `/` resolution below
-                } else {
+                if (!alreadyAtHomepage) {
                     router.actions.replace(targetPathname, targetSearch, targetHash)
                     return
                 }

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -74,8 +74,43 @@ const getStorageKey = (key: string): string => {
 
 const generateTabId = (): string => crypto?.randomUUID?.()?.split('-')?.pop() || `${Date.now()}-${Math.random()}`
 
+/**
+ * Tab metadata we can safely JSON-serialize. `sceneParams` is omitted — it is derived from the URL when
+ * scenes load and can contain deep or cyclic structures after routing (e.g. dashboard as homepage).
+ */
+const tabToPersistableSnapshot = (tab: SceneTab, overrides: Partial<SceneTab> = {}): SceneTab => {
+    const snapshot: SceneTab = {
+        id: tab.id || generateTabId(),
+        pathname: tab.pathname,
+        search: tab.search,
+        hash: tab.hash,
+        title: tab.title,
+        iconType: tab.iconType,
+        active: tab.active,
+    }
+    if (tab.customTitle !== undefined) {
+        snapshot.customTitle = tab.customTitle
+    }
+    if (tab.pinned !== undefined) {
+        snapshot.pinned = tab.pinned
+    }
+    if (tab.badge !== undefined) {
+        snapshot.badge = tab.badge
+    }
+    if (tab.sceneId !== undefined) {
+        snapshot.sceneId = tab.sceneId
+    }
+    if (tab.sceneKey !== undefined) {
+        snapshot.sceneKey = tab.sceneKey
+    }
+    return { ...snapshot, ...overrides }
+}
+
+/** Plain tab snapshots for browser history (`structuredClone` in initKea); excludes `sceneParams`. */
+export const getTabsSnapshotForHistory = (tabs: SceneTab[]): SceneTab[] => tabs.map((t) => tabToPersistableSnapshot(t))
+
 const persistSessionTabs = (tabs: SceneTab[]): void => {
-    sessionStorage.setItem(getStorageKey(TAB_STATE_KEY), JSON.stringify(tabs))
+    sessionStorage.setItem(getStorageKey(TAB_STATE_KEY), JSON.stringify(tabs.map((t) => tabToPersistableSnapshot(t))))
 }
 
 const getPersistedSessionTabs = (): SceneTab[] | null => {
@@ -91,13 +126,7 @@ const getPersistedSessionTabs = (): SceneTab[] | null => {
 }
 
 const sanitizeTabForPersistence = (tab: SceneTab): SceneTab => {
-    const { active, ...rest } = tab
-    return {
-        ...rest,
-        id: tab.id || generateTabId(),
-        pinned: true,
-        active: false,
-    }
+    return tabToPersistableSnapshot(tab, { pinned: true, active: false })
 }
 
 const persistPinnedTabs = (tabs: SceneTab[], homepage: SceneTab | null): void => {
@@ -1429,8 +1458,21 @@ export const sceneLogic = kea<sceneLogicType>([
                 if (targetPathname === '/') {
                     targetPathname = urls.projectHomepage()
                 }
-                router.actions.replace(targetPathname, homepage.search || '', homepage.hash || '')
-                return
+                const targetSearch = homepage.search || ''
+                const targetHash = homepage.hash || ''
+                const loc = router.values.currentLocation
+                // If we're already at the homepage URL, skip replace. Otherwise replaceState re-runs this
+                // handler forever (e.g. homepage pathname equals project root `/project/:id`).
+                if (
+                    addProjectIdIfMissing(loc.pathname) === addProjectIdIfMissing(targetPathname) &&
+                    (loc.search || '') === targetSearch &&
+                    (loc.hash || '') === targetHash
+                ) {
+                    // Fall through to default `/` resolution below
+                } else {
+                    router.actions.replace(targetPathname, targetSearch, targetHash)
+                    return
+                }
             }
 
             const isAIFirst = posthog.isFeatureEnabled(FEATURE_FLAGS.AI_FIRST)

--- a/products/endpoints/frontend/endpointSceneLogic.test.ts
+++ b/products/endpoints/frontend/endpointSceneLogic.test.ts
@@ -56,6 +56,7 @@ jest.mock('scenes/sceneLogic', () => ({
     get sceneLogic() {
         return mockSceneLogic
     },
+    getTabsSnapshotForHistory: (tabs: any[]) => tabs.map(({ sceneParams: _omit, ...rest }) => ({ ...rest })),
 }))
 
 describe('endpointSceneLogic', () => {


### PR DESCRIPTION
## Problem

User reported an issue that when setting a dashboard as their default home page (in the ai-first feature flag), it would crash their page.

I was able to replicate this by:
- navigating to the homepage settings
- setting the default view to be a dashboard, of a tab that I'm currently in
- trying to access the dashboard would result in an infinite loop causing out of memory.


## How did you test this code?

Locally.

## Publish to changelog?
No.