### PR TITLE
fix(ci): reset scheduled branches to workflow HEAD

### DIFF
--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -155,15 +155,25 @@ jobs:
                     echo "Closed stale PR #$existing_pr and deleted branch"
                   fi
 
-            - name: Ensure branch exists
+            - name: Reset branch to checked-out SHA
+              # Force-reset the branch to the SHA this job was pinned to so each run is
+              # independent of any unmerged commits from prior runs. Using `github.sha`
+              # (instead of looking up master's current tip) guarantees the branch tip
+              # matches workspace HEAD — otherwise a merge to master during the run could
+              # leave ghcommit-action with a parent mismatch and the same
+              # "Expected branch to point to X but it did not" failure mode.
               if: steps.check-changes.outputs.changed == 'true' && github.event_name != 'pull_request'
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  TARGET_SHA: ${{ github.sha }}
               run: |
-                  if ! gh api repos/${{ github.repository }}/git/ref/heads/chore/update-test-timings 2>/dev/null; then
-                    master_sha=$(gh api repos/${{ github.repository }}/git/ref/heads/master --jq '.object.sha')
-                    gh api repos/${{ github.repository }}/git/refs -f ref=refs/heads/chore/update-test-timings -f sha="$master_sha"
-                    echo "Created branch from master at $master_sha"
+                  if gh api repos/${{ github.repository }}/git/ref/heads/chore/update-test-timings >/dev/null 2>&1; then
+                    gh api -X PATCH repos/${{ github.repository }}/git/refs/heads/chore/update-test-timings \
+                      -f sha="$TARGET_SHA" -F force=true
+                    echo "Force-reset branch to $TARGET_SHA (superseding any prior unmerged commits)"
+                  else
+                    gh api repos/${{ github.repository }}/git/refs -f ref=refs/heads/chore/update-test-timings -f sha="$TARGET_SHA"
+                    echo "Created branch at $TARGET_SHA"
                   fi
 
             # On schedule/dispatch: commit to a branch and create a PR

--- a/.github/workflows/update-bot-ips.yml
+++ b/.github/workflows/update-bot-ips.yml
@@ -54,15 +54,25 @@ jobs:
                     echo "Closed stale PR #$existing_pr and deleted branch"
                   fi
 
-            - name: Ensure branch exists
+            - name: Reset branch to checked-out SHA
+              # Force-reset the branch to the SHA this job was pinned to so each run is
+              # independent of any unmerged commits from prior runs. Using `github.sha`
+              # (instead of looking up master's current tip) guarantees the branch tip
+              # matches workspace HEAD — otherwise a merge to master during the run could
+              # leave ghcommit-action with a parent mismatch and the same
+              # "Expected branch to point to X but it did not" failure mode.
               if: steps.check-changes.outputs.changes == 'true'
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  TARGET_SHA: ${{ github.sha }}
               run: |
-                  if ! gh api repos/${{ github.repository }}/git/ref/heads/chore/update-bot-ips 2>/dev/null; then
-                    master_sha=$(gh api repos/${{ github.repository }}/git/ref/heads/master --jq '.object.sha')
-                    gh api repos/${{ github.repository }}/git/refs -f ref=refs/heads/chore/update-bot-ips -f sha="$master_sha"
-                    echo "Created branch from master at $master_sha"
+                  if gh api repos/${{ github.repository }}/git/ref/heads/chore/update-bot-ips >/dev/null 2>&1; then
+                    gh api -X PATCH repos/${{ github.repository }}/git/refs/heads/chore/update-bot-ips \
+                      -f sha="$TARGET_SHA" -F force=true
+                    echo "Force-reset branch to $TARGET_SHA (superseding any prior unmerged commits)"
+                  else
+                    gh api repos/${{ github.repository }}/git/refs -f ref=refs/heads/chore/update-bot-ips -f sha="$TARGET_SHA"
+                    echo "Created branch at $TARGET_SHA"
                   fi
 
             - name: Commit via GitHub API (signed)


### PR DESCRIPTION
## Problem

Two scheduled workflows — `update-bot-ips.yml` (daily 02:00 UTC) and `ci-backend-update-test-timing.yml` (Sunday 03:00 UTC) — use the create-if-missing branch pattern introduced in #54264. When the target chore branch already exists from an unmerged prior run, the branch tip no longer matches the workspace HEAD the action was pinned to, and `planetscale/ghcommit-action` aborts.

**Observed failure signature** on `Update Bot IPs` (25 of the last 30 runs failed):

- Run [24646474208](https://github.com/PostHog/posthog/actions/runs/24646474208) (2026-04-20):
  `Expected branch to point to "f55d8340b44b9f815a1c0555ebb71a1d40d57d75" but it did not. Pull and try again.`
- Run [24619641667](https://github.com/PostHog/posthog/actions/runs/24619641667) (2026-04-19):
  `Expected branch to point to "dccb9dcdc87200e9a07911472f17a685defdb67b" but it did not. Pull and try again.`

In each case the SHA quoted by the action equals that run's `github.sha` (the workspace HEAD the job was pinned to) — so the action's precondition check was: "branch tip must equal workspace HEAD; it doesn't; abort." The `Ensure branch exists` step only *creates* the branch if absent; it never *resets* an existing stale branch, so the precondition fails every run after a failed-but-unmerged prior run.

`Backend CI - Update test timing` has the same pattern but is latent — its weekly cadence gives the "Clean up stale branch" step time to garbage-collect before the next run.

Fix already proven on `update-ai-costs.yml` (#55251). This ports it.

## Changes

Replace the "Ensure branch exists" step in both workflows with "Reset branch to checked-out SHA":

- Force-reset the branch ref to `${{ github.sha }}` via `PATCH /git/refs/heads/...` with `force=true` when the branch exists
- Create the branch at `${{ github.sha }}` when it doesn't
- Using `github.sha` (the job's pinned SHA) rather than master's current tip guarantees the branch tip matches workspace HEAD, even if master moves during the run

`update-ai-costs.yml` is already on this pattern and is unchanged.

## How did you test this code?

Agent-authored — no manual runtime testing. Validated:

- Both workflow files parse as valid YAML
- Diff is a near-verbatim copy of the `update-ai-costs.yml` pattern (already in production), with only branch names swapped
- Observed failure SHAs in recent logs match `github.sha` — confirms the root-cause hypothesis the fix addresses

Next scheduled firing (or a `workflow_dispatch` on this branch) will validate end-to-end.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Code (Opus 4.7). 