### PR TITLE
fix(cohorts): enable count assertion in static cohort insertion test

### DIFF
--- a/posthog/test/test_cohort_model.py
+++ b/posthog/test/test_cohort_model.py
@@ -338,8 +338,7 @@ class TestCohort(BaseTest):
 
         # Fetch all persons in the cohort
         cohort.refresh_from_db()
-        # TODO: THIS NEXT ASSERT FAILS AND I DON'T KNOW WHY. WILL FIGURE OUT LATER - @haacked
-        # assert cohort.count == 11
+        assert cohort.count == 11
         assert cohort.people.count() == 11
         cohort_person_uuids = {str(p.uuid) for p in cohort.people.all()}
         assert cohort_person_uuids == set(uuids)


### PR DESCRIPTION
## Problem

`test_insert_users_list_by_uuid` had a commented-out assertion (`cohort.count == 11`) with a stale TODO from PR #33888 (June 2025) — at that time, `cohort.count` was not being updated after `insert_users_list_by_uuid`. PR #38138 (Sept 2025, "fix(cohort): static cohort count based on postgres") added count tracking via `_insert_users_list_with_batching`'s `finally` block, making the commented assertion valid.

cc @sortafreel I'm assuming you're done using this in your demos so it's fine for me to fix. But if you want to keep it in the code, I'm fine canceling this PR. 😆 

## Changes

- Remove the stale TODO comment
- Enable `assert cohort.count == 11`

This only affects a unit test.

## How did you test this code?

Ran `hogli test posthog/test/test_cohort_model.py::TestCohort::test_insert_users_list_by_uuid` locally. It passes.

## Publish to changelog?

no