### PR TITLE
fix(exports): truncate error envelope to fit Temporal's 2 MiB payload

### DIFF
--- a/posthog/temporal/common/errors.py
+++ b/posthog/temporal/common/errors.py
@@ -9,7 +9,6 @@ MAX_ERROR_TRACE_CHARS = 32_000
 
 
 def truncate_for_temporal_payload(value: str, limit: int) -> str:
-    """Trim ``value`` to ``limit`` chars plus a ~40-char marker (max output ~``limit + 40``)."""
     if len(value) <= limit:
         return value
     return f"{value[:limit]}… (truncated, original {len(value)} chars)"

--- a/posthog/temporal/common/errors.py
+++ b/posthog/temporal/common/errors.py
@@ -2,22 +2,14 @@ import traceback
 
 from temporalio.exceptions import ActivityError, ApplicationError
 
-# Temporal's gRPC payload hard limit is 2 MiB. Cap error strings well under that so
-# message, trace, envelope framing, and any activity-return metadata all fit together
-# even when an upstream exception (ClickHouse 5xx body, Playwright HTML dump) stuffs
-# a multi-MB string into str(e).
+# Bound error strings so a multi-MB str(e) (ClickHouse 5xx body, Playwright HTML dump)
+# can't blow out Temporal's 2 MiB payload limit.
 MAX_ERROR_MESSAGE_CHARS = 8_000
 MAX_ERROR_TRACE_CHARS = 32_000
 
 
 def truncate_for_temporal_payload(value: str, limit: int) -> str:
-    """Trim ``value`` so it can ride inside a Temporal payload.
-
-    When truncation is needed the first ``limit`` chars are kept and a short
-    diagnostic marker (``… (truncated, original N chars)``, ~40 chars) is appended —
-    so the returned string is at most ``limit + ~40`` chars, not strictly ``limit``.
-    Limits are chosen with the marker overhead in mind at call sites.
-    """
+    """Trim ``value`` to ``limit`` chars plus a ~40-char marker (max output ~``limit + 40``)."""
     if len(value) <= limit:
         return value
     return f"{value[:limit]}… (truncated, original {len(value)} chars)"

--- a/posthog/temporal/common/errors.py
+++ b/posthog/temporal/common/errors.py
@@ -11,7 +11,13 @@ MAX_ERROR_TRACE_CHARS = 32_000
 
 
 def truncate_for_temporal_payload(value: str, limit: int) -> str:
-    """Cap ``value`` at ``limit`` chars so it can ride inside a Temporal payload."""
+    """Trim ``value`` so it can ride inside a Temporal payload.
+
+    When truncation is needed the first ``limit`` chars are kept and a short
+    diagnostic marker (``… (truncated, original N chars)``, ~40 chars) is appended —
+    so the returned string is at most ``limit + ~40`` chars, not strictly ``limit``.
+    Limits are chosen with the marker overhead in mind at call sites.
+    """
     if len(value) <= limit:
         return value
     return f"{value[:limit]}… (truncated, original {len(value)} chars)"

--- a/posthog/temporal/common/errors.py
+++ b/posthog/temporal/common/errors.py
@@ -2,6 +2,20 @@ import traceback
 
 from temporalio.exceptions import ActivityError, ApplicationError
 
+# Temporal's gRPC payload hard limit is 2 MiB. Cap error strings well under that so
+# message, trace, envelope framing, and any activity-return metadata all fit together
+# even when an upstream exception (ClickHouse 5xx body, Playwright HTML dump) stuffs
+# a multi-MB string into str(e).
+MAX_ERROR_MESSAGE_CHARS = 8_000
+MAX_ERROR_TRACE_CHARS = 32_000
+
+
+def truncate_for_temporal_payload(value: str, limit: int) -> str:
+    """Cap ``value`` at ``limit`` chars so it can ride inside a Temporal payload."""
+    if len(value) <= limit:
+        return value
+    return f"{value[:limit]}… (truncated, original {len(value)} chars)"
+
 
 def unwrap_temporal_cause(exc: BaseException) -> ApplicationError | None:
     if isinstance(exc, ActivityError) and isinstance(exc.cause, ApplicationError):
@@ -17,5 +31,5 @@ def resolve_exception_class(exc: BaseException) -> str:
 def resolve_error_trace(exc: BaseException) -> str:
     cause = unwrap_temporal_cause(exc)
     if cause is not None and cause.details and isinstance(cause.details[0], str):
-        return cause.details[0]
-    return "".join(traceback.format_exception(exc, limit=5))
+        return truncate_for_temporal_payload(cause.details[0], MAX_ERROR_TRACE_CHARS)
+    return truncate_for_temporal_payload("".join(traceback.format_exception(exc, limit=5)), MAX_ERROR_TRACE_CHARS)

--- a/posthog/temporal/common/slo_interceptor.py
+++ b/posthog/temporal/common/slo_interceptor.py
@@ -12,7 +12,13 @@ from temporalio.worker import (
 
 from posthog.slo.events import emit_slo_completed, emit_slo_started
 from posthog.slo.types import SloCompletedProperties, SloConfig, SloOutcome, SloStartedProperties
-from posthog.temporal.common.errors import resolve_error_trace, resolve_exception_class, unwrap_temporal_cause
+from posthog.temporal.common.errors import (
+    MAX_ERROR_MESSAGE_CHARS,
+    resolve_error_trace,
+    resolve_exception_class,
+    truncate_for_temporal_payload,
+    unwrap_temporal_cause,
+)
 
 
 class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
@@ -56,7 +62,10 @@ class _SloWorkflowInterceptor(WorkflowInboundInterceptor):
             outcome = slo.outcome if slo.outcome is not None else SloOutcome.FAILURE
             # setdefault lets workflows pre-populate completion_properties to override any of these.
             slo.completion_properties.setdefault("error_type", resolve_exception_class(exc))
-            slo.completion_properties.setdefault("error_message", str(unwrap_temporal_cause(exc) or exc))
+            slo.completion_properties.setdefault(
+                "error_message",
+                truncate_for_temporal_payload(str(unwrap_temporal_cause(exc) or exc), MAX_ERROR_MESSAGE_CHARS),
+            )
             slo.completion_properties.setdefault("error_trace", resolve_error_trace(exc))
             raise
         finally:

--- a/posthog/temporal/common/test_errors.py
+++ b/posthog/temporal/common/test_errors.py
@@ -21,8 +21,6 @@ def test_truncate_for_temporal_payload(value, limit, expected):
 
 
 def test_default_limits_fit_under_temporal_payload_limit():
-    # Temporal's hard gRPC payload limit is 2 MiB. UTF-8 uses up to 4 bytes per codepoint,
-    # so bound the worst case (multi-byte Unicode payload) under the limit — keeps metadata
-    # and framing room even if every char turns out to be astral.
+    # UTF-8 is up to 4 bytes/char; assert the worst case stays under Temporal's 2 MiB limit.
     worst_case_bytes = (MAX_ERROR_MESSAGE_CHARS + MAX_ERROR_TRACE_CHARS) * 4
     assert worst_case_bytes < 2 * 1024 * 1024

--- a/posthog/temporal/common/test_errors.py
+++ b/posthog/temporal/common/test_errors.py
@@ -1,0 +1,26 @@
+import pytest
+
+from posthog.temporal.common.errors import MAX_ERROR_MESSAGE_CHARS, MAX_ERROR_TRACE_CHARS, truncate_for_temporal_payload
+
+
+@pytest.mark.parametrize(
+    "value,limit,expected",
+    [
+        # Short values pass through unchanged
+        ("", 10, ""),
+        ("short", 10, "short"),
+        ("exactly10!", 10, "exactly10!"),
+        # Long values are truncated with a diagnostic marker
+        ("a" * 20, 10, "aaaaaaaaaa… (truncated, original 20 chars)"),
+        # Limit of 0 is treated as "no content"
+        ("anything", 0, "… (truncated, original 8 chars)"),
+    ],
+)
+def test_truncate_for_temporal_payload(value, limit, expected):
+    assert truncate_for_temporal_payload(value, limit) == expected
+
+
+def test_default_limits_fit_under_temporal_payload_limit():
+    # Temporal's hard gRPC payload limit is 2 MiB; keep message + trace well under
+    # so metadata and framing still fit.
+    assert MAX_ERROR_MESSAGE_CHARS + MAX_ERROR_TRACE_CHARS < 2 * 1024 * 1024

--- a/posthog/temporal/common/test_errors.py
+++ b/posthog/temporal/common/test_errors.py
@@ -21,6 +21,8 @@ def test_truncate_for_temporal_payload(value, limit, expected):
 
 
 def test_default_limits_fit_under_temporal_payload_limit():
-    # UTF-8 is up to 4 bytes/char; assert the worst case stays under Temporal's 2 MiB limit.
-    worst_case_bytes = (MAX_ERROR_MESSAGE_CHARS + MAX_ERROR_TRACE_CHARS) * 4
-    assert worst_case_bytes < 2 * 1024 * 1024
+    # Temporal's hard limit is 2 MiB for the whole payload — activity metadata, input ref,
+    # envelope framing, and our error strings all share that budget. Assert our error strings
+    # fit inside 1 MiB (worst-case UTF-8: 4 bytes/char) to leave headroom for everything else.
+    worst_case_error_bytes = (MAX_ERROR_MESSAGE_CHARS + MAX_ERROR_TRACE_CHARS) * 4
+    assert worst_case_error_bytes < 1 * 1024 * 1024

--- a/posthog/temporal/common/test_errors.py
+++ b/posthog/temporal/common/test_errors.py
@@ -21,6 +21,8 @@ def test_truncate_for_temporal_payload(value, limit, expected):
 
 
 def test_default_limits_fit_under_temporal_payload_limit():
-    # Temporal's hard gRPC payload limit is 2 MiB; keep message + trace well under
-    # so metadata and framing still fit.
-    assert MAX_ERROR_MESSAGE_CHARS + MAX_ERROR_TRACE_CHARS < 2 * 1024 * 1024
+    # Temporal's hard gRPC payload limit is 2 MiB. UTF-8 uses up to 4 bytes per codepoint,
+    # so bound the worst case (multi-byte Unicode payload) under the limit — keeps metadata
+    # and framing room even if every char turns out to be astral.
+    worst_case_bytes = (MAX_ERROR_MESSAGE_CHARS + MAX_ERROR_TRACE_CHARS) * 4
+    assert worst_case_bytes < 2 * 1024 * 1024

--- a/posthog/temporal/exports/activities.py
+++ b/posthog/temporal/exports/activities.py
@@ -49,14 +49,11 @@ async def export_asset_activity(inputs: ExportAssetActivityInputs) -> ExportAsse
                 exception_class=exception_class,
                 error=str(e),
             )
-            # Wrap in ApplicationError to propagate failure metadata as details
-            # while preserving the exception class name for retry policy matching.
-            # Only known transient errors (CH/network) are worth retrying — unknown
-            # errors like Chrome crashes or programming errors should fail fast.
-            # exception_class is on .type; details carry [error_trace]
-            # See: posthog.temporal.exports.types.extract_error_details
-            # Truncate to keep the failure envelope under Temporal's 2 MiB payload limit;
-            # upstream exceptions (CH 5xx bodies, Playwright HTML dumps) can exceed it alone.
+            # Wrap in ApplicationError to propagate failure metadata as details while
+            # preserving the exception class for retry-policy matching (transient CH/network
+            # errors retry; programming errors and Chrome crashes fail fast). See
+            # posthog.temporal.exports.types.extract_error_details. Strings are truncated so
+            # an upstream exception can't blow out the 2 MiB payload envelope.
             raise ApplicationError(
                 truncate_for_temporal_payload(str(e), MAX_ERROR_MESSAGE_CHARS),
                 truncate_for_temporal_payload(error_trace, MAX_ERROR_TRACE_CHARS),

--- a/posthog/temporal/exports/activities.py
+++ b/posthog/temporal/exports/activities.py
@@ -9,6 +9,7 @@ from posthog.models.exported_asset import ExportedAsset
 from posthog.sync import database_sync_to_async
 from posthog.tasks import exporter
 from posthog.tasks.exports.failure_handler import SYSTEM_ERROR_NAMES
+from posthog.temporal.common.errors import MAX_ERROR_MESSAGE_CHARS, MAX_ERROR_TRACE_CHARS, truncate_for_temporal_payload
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.exports.types import ExportAssetActivityInputs, ExportAssetResult
 
@@ -54,9 +55,11 @@ async def export_asset_activity(inputs: ExportAssetActivityInputs) -> ExportAsse
             # errors like Chrome crashes or programming errors should fail fast.
             # exception_class is on .type; details carry [error_trace]
             # See: posthog.temporal.exports.types.extract_error_details
+            # Truncate to keep the failure envelope under Temporal's 2 MiB payload limit;
+            # upstream exceptions (CH 5xx bodies, Playwright HTML dumps) can exceed it alone.
             raise ApplicationError(
-                str(e),
-                error_trace,
+                truncate_for_temporal_payload(str(e), MAX_ERROR_MESSAGE_CHARS),
+                truncate_for_temporal_payload(error_trace, MAX_ERROR_TRACE_CHARS),
                 type=exception_class,
                 non_retryable=exception_class not in SYSTEM_ERROR_NAMES,
             ) from e


### PR DESCRIPTION
## Problem

Export activity failures raise `ApplicationError(str(e), error_trace, ...)`. When the upstream exception has a multi-MB `str()` — a ClickHouse 5xx with a verbose error body or a Playwright timeout embedding rendered HTML — the envelope exceeds Temporal's 2 MiB gRPC payload limit. Temporal rejects the activity with `PayloadSizeError` (`TMPRL1103`), the workflow burns its retry budget, and the subscription delivery times out. ~30 failures / ~10 teams over 72h in prod.

## Changes

Adds `truncate_for_temporal_payload(value, limit)` in `posthog/temporal/common/errors.py` with defaults `MAX_ERROR_MESSAGE_CHARS = 8_000` and `MAX_ERROR_TRACE_CHARS = 32_000`.

Applied at three sites:
- `posthog/temporal/exports/activities.py` — the `ApplicationError` raise in `export_asset_activity`.
- `posthog/temporal/common/errors.py:resolve_error_trace` — defense in depth on the read side.
- `posthog/temporal/common/slo_interceptor.py` — the workflow interceptor was lifting unbounded `str(exc)` into `completion_properties["error_message"]`; the trace was already bounded via `resolve_error_trace` but the message was not. Fixing the asymmetry closes the same failure mode for every other workflow, not just exports.

Marker appended on truncation: `… (truncated, original N chars)` — keeps post-hoc "how much got cut" debuggable.

### Sizing

| Limit | Value | Worst-case bytes |
|---|---|---|
| Message | 8 KB | 32 KB (all 4-byte UTF-8) |
| Trace | 32 KB | 128 KB |
| **Combined ceiling per envelope** | **40 KB** | **160 KB** |
| Temporal hard limit | 2 MiB | |
| Ceiling as % of hard limit | **~2%** (realistic) / ~8% (worst-case UTF-8) | |

At ~30 failures / 72h that's at most ~5 MB of error data in that window — negligible against PostHog's event volume. Full ClickHouse 5xx messages (300–800 chars) and 5-frame Python tracebacks (~1–2.5 KB) stay intact; only pathological payloads get trimmed.

## How did you test this code?

- Parametrized unit tests on `truncate_for_temporal_payload` (empty, under-limit, boundary, over-limit, `limit=0`).
- Invariant test asserting `(MAX_ERROR_MESSAGE_CHARS + MAX_ERROR_TRACE_CHARS) * 4 < 2 MiB` so UTF-8 worst-case still fits under the hard limit.
- Existing `test_export_activities.py` tests pass — they exercise the `ApplicationError` raise path and confirm the exception class is preserved for retry-policy matching.

Agent-authored; no live Temporal worker exercised. Hand-testing limited to unit tests.

## Publish to changelog?

No.

## 🤖 LLM context

Authored with Claude Code following a production SLO triage. `PayloadSizeError` flagged as P0 in the daily report. Root cause pinned via read-only investigation: `export_asset_activity` is the only export-path site that raises `ApplicationError` with exception content in `details[0]`; both `str(e)` and the formatted traceback carry the upstream exception verbatim.

Local review surfaced an asymmetric unbound in `slo_interceptor.py` (trace bounded, message unbounded) — fixed here. Second pass from bot reviewers surfaced (1) docstring was imprecise about the marker overhead and (2) the char-count-vs-byte-count test invariant — both fixed.