### PR TITLE
fix: updated log default retention to a valid retention day (14,30,90)

### DIFF
--- a/nodejs/src/logs-ingestion/__snapshots__/logs-ingestion-consumer.test.ts.snap
+++ b/nodejs/src/logs-ingestion/__snapshots__/logs-ingestion-consumer.test.ts.snap
@@ -4,7 +4,7 @@ exports[`LogsIngestionConsumer general should process a valid log message 1`] = 
 [
   {
     "json-parse": "false",
-    "retention-days": "15",
+    "retention-days": "14",
     "team_id": "2",
     "token": "THIS IS NOT A TOKEN FOR TEAM 2",
   },
@@ -15,19 +15,19 @@ exports[`LogsIngestionConsumer general should process multiple log messages 1`] 
 [
   {
     "json-parse": "false",
-    "retention-days": "15",
+    "retention-days": "14",
     "team_id": "2",
     "token": "THIS IS NOT A TOKEN FOR TEAM 2",
   },
   {
     "json-parse": "false",
-    "retention-days": "15",
+    "retention-days": "14",
     "team_id": "2",
     "token": "THIS IS NOT A TOKEN FOR TEAM 2",
   },
   {
     "json-parse": "false",
-    "retention-days": "15",
+    "retention-days": "14",
     "team_id": "2",
     "token": "THIS IS NOT A TOKEN FOR TEAM 2",
   },
@@ -38,7 +38,7 @@ exports[`LogsIngestionConsumer message parsing and validation should overwrite e
 [
   {
     "json-parse": "false",
-    "retention-days": "15",
+    "retention-days": "14",
     "team_id": "2",
     "token": "THIS IS NOT A TOKEN FOR TEAM 2",
   },
@@ -50,7 +50,7 @@ exports[`LogsIngestionConsumer message parsing and validation should preserve ka
   {
     "json-parse": "false",
     "myHeader": "hello",
-    "retention-days": "15",
+    "retention-days": "14",
     "team_id": "2",
     "token": "THIS IS NOT A TOKEN FOR TEAM 2",
   },

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts
@@ -14,6 +14,7 @@ import { KAFKA_APP_METRICS_2 } from '../config/kafka-topics'
 import { parseJSON } from '../utils/json-parse'
 import { LogRecord, encodeLogRecords } from './log-record-avro'
 import {
+    DEFAULT_LOGS_RETENTION_DAYS,
     LogsIngestionConsumer,
     logMessageDlqCounter,
     logMessageDroppedCounter,
@@ -357,7 +358,7 @@ describe('LogsIngestionConsumer', () => {
                 token: team.api_token,
                 team_id: team.id.toString(),
                 'json-parse': 'false',
-                'retention-days': '15',
+                'retention-days': DEFAULT_LOGS_RETENTION_DAYS.toString(),
             })
         })
 
@@ -379,7 +380,7 @@ describe('LogsIngestionConsumer', () => {
                 token: team.api_token,
                 team_id: team.id.toString(),
                 'json-parse': 'false',
-                'retention-days': '15',
+                'retention-days': DEFAULT_LOGS_RETENTION_DAYS.toString(),
             })
         })
 

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -45,6 +45,9 @@ const DEFAULT_USAGE_STATS: UsageStats = {
 
 export type UsageStatsByTeam = Map<number, UsageStats>
 
+/** Ingestion default when `logs_settings.retention_days` is unset; must be in `TeamSerializer.VALID_RETENTION_DAYS`. */
+export const DEFAULT_LOGS_RETENTION_DAYS = 14
+
 export const logMessageDroppedCounter = new Counter({
     name: 'logs_ingestion_message_dropped_count',
     help: 'The number of logs ingestion messages dropped',
@@ -296,7 +299,7 @@ export class LogsIngestionConsumer {
 
                     // Extract settings with defaults
                     const jsonParse = logsSettings.json_parse_logs ?? false
-                    const retentionDays = logsSettings.retention_days ?? 14
+                    const retentionDays = logsSettings.retention_days ?? DEFAULT_LOGS_RETENTION_DAYS
 
                     // ignore empty messages
                     if (message.message.value === null) {

--- a/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs-ingestion/logs-ingestion-consumer.ts
@@ -296,7 +296,7 @@ export class LogsIngestionConsumer {
 
                     // Extract settings with defaults
                     const jsonParse = logsSettings.json_parse_logs ?? false
-                    const retentionDays = logsSettings.retention_days ?? 15
+                    const retentionDays = logsSettings.retention_days ?? 14
 
                     // ignore empty messages
                     if (message.message.value === null) {


### PR DESCRIPTION
## Problem

Logs ingestion defaulted `retention-days` to a value that did not match what teams can store via the API (`logs_settings.retention_days`). That made it easy for ingestion to emit headers inconsistent with settings users can PATCH.

## Changes

- Introduced `DEFAULT_LOGS_RETENTION_DAYS` (14) in `nodejs/src/logs-ingestion/logs-ingestion-consumer.ts` and use it when `team.logs_settings.retention_days` is unset.
- Updated `logs-ingestion-consumer` tests and Jest snapshots so default header expectations are 14.

**API contract:** `retention_days` in `logs_settings` is validated on the team API in `posthog/api/team.py` — `TeamSerializer.VALID_RETENTION_DAYS` is `{14, 30, 90}` (see `validate_logs_settings`). Ingestion’s default now matches the smallest allowed value so it stays API-valid if/when the team persists settings through that serializer.

## How did you test this code?

- Automated: `hogli test nodejs/src/logs-ingestion/logs-ingestion-consumer.test.ts` (or `pnpm exec jest` on that file from `nodejs/`) once the local Node + Postgres test DB match the repo’s expected setup.
- Not run in this session (environment-dependent: DB / native `node-rdkafka`).

## Publish to changelog?

no

## Docs update

no

## LLM context
