### PR TITLE
fix(insights): open test accounts filter settings in the side panel

### DIFF
--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -338,8 +338,9 @@ export const insightSceneLogic = kea<insightSceneLogicType>([
                           },
                           access_control_resource: 'insight',
                           access_control_resource_id: `${insight.id}`,
+                          settings_section: 'project-product-analytics',
                       }
-                    : null
+                    : { settings_section: 'project-product-analytics' }
             },
         ],
         maxContext: [


### PR DESCRIPTION
## Problem

Trying to configure the test accounts filter (using the cog icon) opens the side panel on the "info" tab and does not show the correct settings view.

https://posthoghelp.zendesk.com/agent/tickets/56327 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/57619)

## Changes

Seems like we've been refactoring the side panel logic (#53103), so just patching the test accounts filtering

## How did you test this code?

Manually

## Publish to changelog?

No