### PR TITLE
fix(replay): guard node.attributes before 'in' check in extension stripping

### DIFF
--- a/common/replay-shared/src/snapshot-processing/chrome-extension-stripping.test.ts
+++ b/common/replay-shared/src/snapshot-processing/chrome-extension-stripping.test.ts
@@ -1,0 +1,145 @@
+import { NodeType, serializedNodeWithId } from '@posthog/rrweb-types'
+
+import { CHROME_EXTENSION_DENY_LIST, stripChromeExtensionDataFromNode } from './chrome-extension-stripping'
+
+describe('stripChromeExtensionDataFromNode', () => {
+    const needles = Object.keys(CHROME_EXTENSION_DENY_LIST)
+
+    it.each([
+        ['attributes is undefined', undefined],
+        ['attributes is null', null],
+    ])('does not throw when %s', (_label, attributes) => {
+        const node = {
+            type: NodeType.Element,
+            tagName: 'div',
+            attributes,
+            childNodes: [],
+            id: 1,
+        } as unknown as serializedNodeWithId
+
+        const matched = new Set<string>()
+        expect(() => stripChromeExtensionDataFromNode(node, needles, matched)).not.toThrow()
+        expect(matched.size).toBe(0)
+    })
+
+    it('does not throw or match when attributes object lacks relevant keys', () => {
+        const node: serializedNodeWithId = {
+            type: NodeType.Element,
+            tagName: 'div',
+            attributes: { 'data-safe': 'yes' },
+            childNodes: [],
+            id: 1,
+        }
+
+        const matched = new Set<string>()
+        expect(stripChromeExtensionDataFromNode(node, needles, matched)).toBe(false)
+        expect(matched.size).toBe(0)
+    })
+
+    it('strips children when id attribute matches a needle', () => {
+        const node: serializedNodeWithId = {
+            type: NodeType.Element,
+            tagName: 'div',
+            attributes: { id: 'dji-sru-root' },
+            childNodes: [
+                {
+                    type: NodeType.Text,
+                    textContent: 'sensitive',
+                    id: 2,
+                },
+            ],
+            id: 1,
+        }
+
+        const matched = new Set<string>()
+        expect(stripChromeExtensionDataFromNode(node, needles, matched)).toBe(true)
+        expect((node as { childNodes: serializedNodeWithId[] }).childNodes).toEqual([])
+        expect(matched.has('snap and read')).toBe(true)
+    })
+
+    it('removes the needle from a matching class attribute on a DIV', () => {
+        const node: serializedNodeWithId = {
+            type: NodeType.Element,
+            tagName: 'DIV',
+            attributes: { class: 'wrapper aitopia inner' },
+            childNodes: [],
+            id: 1,
+        }
+
+        const matched = new Set<string>()
+        expect(stripChromeExtensionDataFromNode(node, needles, matched)).toBe(true)
+        expect((node as { attributes: Record<string, string> }).attributes.class).not.toContain('aitopia')
+        expect(matched.has('aitopia')).toBe(true)
+    })
+
+    it('strips children when tagName includes a needle', () => {
+        const node: serializedNodeWithId = {
+            type: NodeType.Element,
+            tagName: 'sublime-root-widget',
+            attributes: {},
+            childNodes: [
+                {
+                    type: NodeType.Text,
+                    textContent: 'overlay',
+                    id: 2,
+                },
+            ],
+            id: 1,
+        }
+
+        const matched = new Set<string>()
+        expect(stripChromeExtensionDataFromNode(node, needles, matched)).toBe(true)
+        expect((node as { childNodes: serializedNodeWithId[] }).childNodes).toEqual([])
+        expect(matched.has('sublime pop-up')).toBe(true)
+    })
+
+    it('recurses into children and strips nested matches', () => {
+        const node: serializedNodeWithId = {
+            type: NodeType.Element,
+            tagName: 'body',
+            attributes: {},
+            childNodes: [
+                {
+                    type: NodeType.Element,
+                    tagName: 'DIV',
+                    attributes: { class: 'aitopia' },
+                    childNodes: [
+                        {
+                            type: NodeType.Text,
+                            textContent: 'ad',
+                            id: 3,
+                        },
+                    ],
+                    id: 2,
+                },
+            ],
+            id: 1,
+        }
+
+        const matched = new Set<string>()
+        expect(stripChromeExtensionDataFromNode(node, needles, matched)).toBe(true)
+        expect(matched.has('aitopia')).toBe(true)
+    })
+
+    it('does not throw when a nested child has undefined attributes', () => {
+        const node = {
+            type: NodeType.Element,
+            tagName: 'body',
+            attributes: {},
+            childNodes: [
+                {
+                    type: NodeType.Element,
+                    tagName: 'div',
+                    attributes: undefined,
+                    childNodes: [],
+                    id: 2,
+                },
+            ],
+            id: 1,
+        } as unknown as serializedNodeWithId
+
+        const matched = new Set<string>()
+        expect(() => stripChromeExtensionDataFromNode(node, needles, matched)).not.toThrow()
+        expect(matched.size).toBe(0)
+    })
+})

--- a/common/replay-shared/src/snapshot-processing/chrome-extension-stripping.ts
+++ b/common/replay-shared/src/snapshot-processing/chrome-extension-stripping.ts
@@ -20,13 +20,21 @@ interface IsStrippable {
     childNodes: serializedNodeWithId[]
 }
 
+function hasAttribute(
+    node: serializedNodeWithId,
+    attribute: string
+): node is serializedNodeWithId & { attributes: Record<string, unknown> } {
+    const attributes = (node as { attributes?: unknown }).attributes
+    return !!attributes && typeof attributes === 'object' && attribute in attributes
+}
+
 function safelyCheckCSSAttribute(
     node: serializedNodeWithId,
     attribute: string,
     needles: string[],
     matchedExtensions: Set<string>
 ): node is IsStrippable & serializedNodeWithId {
-    const hasAttributes = 'attributes' in node && attribute in node.attributes && !!node.attributes[attribute]
+    const hasAttributes = hasAttribute(node, attribute) && !!node.attributes[attribute]
     if (!hasAttributes) {
         return false
     }
@@ -51,7 +59,7 @@ function safelyCheckClassAttribute(
     needle: string,
     matchedExtensions: Set<string>
 ): node is IsStrippable & serializedNodeWithId {
-    const hasAttributes = 'attributes' in node && 'class' in node.attributes && !!node.attributes['class']
+    const hasAttributes = hasAttribute(node, 'class') && !!node.attributes['class']
     if (!hasAttributes) {
         return false
     }
@@ -108,7 +116,7 @@ function safelyCheckIDAttribute(
     needles: string[],
     matchedExtensions: Set<string>
 ): node is IsStrippable & serializedNodeWithId {
-    const hasID = 'attributes' in node && 'id' in node.attributes && !!node.attributes['id']
+    const hasID = hasAttribute(node, 'id') && !!node.attributes['id']
     if (!hasID) {
         return false
     }


### PR DESCRIPTION
## Problem

Session-replay playback was crashing for recordings whose root or nested DOM nodes were serialized with `attributes: undefined`. The exception surfaced as a new error-tracking issue:

```
TypeError: right-hand side of 'in' should be an object, got undefined
```

The deminified stack maps through `loadSnapshotsForSourceSuccess` → `processSnapshotsAsync` → `processAllSnapshots` → `stripChromeExtensionDataFromNode`. When the helper throws, the kea listener aborts and `processedSnapshots` is never set, so the affected recording fails to render.

## Changes

In `common/replay-shared/src/snapshot-processing/chrome-extension-stripping.ts`, three helpers (`safelyCheckCSSAttribute`, `safelyCheckClassAttribute`, `safelyCheckIDAttribute`) all used the same guard:

```ts
'attributes' in node && attribute in node.attributes && !!node.attributes[attribute]
```

JavaScript's `in` returns `true` when a property key exists even if its value is `undefined` or `null`, so the first check passed and the second `in` threw on the `undefined` value.

Replaced the three copies with a single shared `hasAttribute` type predicate that also confirms `node.attributes` is a real object. Added `chrome-extension-stripping.test.ts` with regression coverage for:

- `attributes: undefined` and `attributes: null` (parameterized — both previously threw)
- `attributes` present but missing the target key
- nested children with `attributes: undefined`
- the existing happy paths (id match, class match on DIV, tagName match, recursion) so the refactor doesn't regress.

## How did you test this code?

I am an AI agent — I only verified this with automated tests. I have not tested this manually in the browser.

- Ran `hogli test common/replay-shared/src/snapshot-processing/chrome-extension-stripping.test.ts` — all 8 tests pass, including the undefined/null regression cases that reproduce the original crash.
- Typechecked `common/replay-shared` — only pre-existing unrelated errors in `canvas-plugin.test.ts` remain.

Reviewers should confirm the error-tracking issue `019d9fc8-6d33-7441-8950-30ea88253f98` stops firing after rollout.

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code (Claude Opus 4.7) based on a signal from the error-tracking issue above. The agent identified the root cause, proposed a fix that also removes three copies of the same pattern (OnceAndOnlyOnce), and added parameterized regression tests before opening this PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*