### PR TITLE
fix(mcp): guard trends-actors ActorsQuery against invalid sources

### DIFF
--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -910,6 +910,24 @@ export class ApiClient {
                 hasMore: boolean
                 offset: number
             }> => {
+                // The hardcoded select/orderBy below reference `actor_id` and `event_count`,
+                // aliases that only exist on the output of TrendsActorsQueryBuilder. Forwarding
+                // any other source lets those names fall through to the persons table and
+                // ClickHouse rejects the query with a confusing `Unknown column: *` error.
+                if (query.kind !== 'InsightActorsQuery') {
+                    throw new Error(
+                        `trendsActors expected an InsightActorsQuery, got kind=${JSON.stringify(query.kind)}`
+                    )
+                }
+                const source = query.source
+                if (!source || typeof source !== 'object' || (source as { kind?: unknown }).kind !== 'TrendsQuery') {
+                    throw new Error(
+                        `trendsActors only supports TrendsQuery sources, got source.kind=${JSON.stringify(
+                            (source as { kind?: unknown } | null | undefined)?.kind
+                        )}`
+                    )
+                }
+
                 const wrappedQuery = {
                     kind: 'ActorsQuery',
                     source: normalizeQuery(query),

--- a/services/mcp/tests/unit/api-client.test.ts
+++ b/services/mcp/tests/unit/api-client.test.ts
@@ -87,46 +87,20 @@ describe('ApiClient', () => {
             })
         }
 
-        it('rejects queries whose kind is not InsightActorsQuery', async () => {
+        it.each([
+            ['wrong outer kind', { kind: 'ActorsQuery', source: { kind: 'TrendsQuery' } }, /InsightActorsQuery/],
+            [
+                'non-trends inner source',
+                { kind: 'InsightActorsQuery', source: { kind: 'FunnelsQuery' } },
+                /TrendsQuery/,
+            ],
+            ['missing source', { kind: 'InsightActorsQuery' }, /TrendsQuery/],
+        ] as const)('rejects %s before any network call', async (_label, query, expectedError) => {
             const mockFetch = vi.fn()
             vi.stubGlobal('fetch', mockFetch)
 
             const client = createClient()
-            await expect(
-                client.query({ projectId: '1' }).trendsActors({
-                    query: { kind: 'ActorsQuery', source: { kind: 'TrendsQuery' } },
-                })
-            ).rejects.toThrow(/InsightActorsQuery/)
-            expect(mockFetch).not.toHaveBeenCalled()
-
-            vi.unstubAllGlobals()
-        })
-
-        it('rejects InsightActorsQuery whose source is not a TrendsQuery', async () => {
-            const mockFetch = vi.fn()
-            vi.stubGlobal('fetch', mockFetch)
-
-            const client = createClient()
-            await expect(
-                client.query({ projectId: '1' }).trendsActors({
-                    query: { kind: 'InsightActorsQuery', source: { kind: 'FunnelsQuery' } },
-                })
-            ).rejects.toThrow(/TrendsQuery/)
-            expect(mockFetch).not.toHaveBeenCalled()
-
-            vi.unstubAllGlobals()
-        })
-
-        it('rejects InsightActorsQuery with a missing source', async () => {
-            const mockFetch = vi.fn()
-            vi.stubGlobal('fetch', mockFetch)
-
-            const client = createClient()
-            await expect(
-                client.query({ projectId: '1' }).trendsActors({
-                    query: { kind: 'InsightActorsQuery' },
-                })
-            ).rejects.toThrow(/TrendsQuery/)
+            await expect(client.query({ projectId: '1' }).trendsActors({ query })).rejects.toThrow(expectedError)
             expect(mockFetch).not.toHaveBeenCalled()
 
             vi.unstubAllGlobals()

--- a/services/mcp/tests/unit/api-client.test.ts
+++ b/services/mcp/tests/unit/api-client.test.ts
@@ -78,4 +78,58 @@ describe('ApiClient', () => {
 
         vi.unstubAllGlobals()
     })
+
+    describe('query().trendsActors', () => {
+        function createClient(): ApiClient {
+            return new ApiClient({
+                apiToken: 'test-token',
+                baseUrl: 'https://example.com',
+            })
+        }
+
+        it('rejects queries whose kind is not InsightActorsQuery', async () => {
+            const mockFetch = vi.fn()
+            vi.stubGlobal('fetch', mockFetch)
+
+            const client = createClient()
+            await expect(
+                client.query({ projectId: '1' }).trendsActors({
+                    query: { kind: 'ActorsQuery', source: { kind: 'TrendsQuery' } },
+                })
+            ).rejects.toThrow(/InsightActorsQuery/)
+            expect(mockFetch).not.toHaveBeenCalled()
+
+            vi.unstubAllGlobals()
+        })
+
+        it('rejects InsightActorsQuery whose source is not a TrendsQuery', async () => {
+            const mockFetch = vi.fn()
+            vi.stubGlobal('fetch', mockFetch)
+
+            const client = createClient()
+            await expect(
+                client.query({ projectId: '1' }).trendsActors({
+                    query: { kind: 'InsightActorsQuery', source: { kind: 'FunnelsQuery' } },
+                })
+            ).rejects.toThrow(/TrendsQuery/)
+            expect(mockFetch).not.toHaveBeenCalled()
+
+            vi.unstubAllGlobals()
+        })
+
+        it('rejects InsightActorsQuery with a missing source', async () => {
+            const mockFetch = vi.fn()
+            vi.stubGlobal('fetch', mockFetch)
+
+            const client = createClient()
+            await expect(
+                client.query({ projectId: '1' }).trendsActors({
+                    query: { kind: 'InsightActorsQuery' },
+                })
+            ).rejects.toThrow(/TrendsQuery/)
+            expect(mockFetch).not.toHaveBeenCalled()
+
+            vi.unstubAllGlobals()
+        })
+    })
 })


### PR DESCRIPTION
## Problem

The MCP `query-trends-actors` tool emits a malformed `ActorsQuery` whenever the LLM supplies a source that is not a `TrendsQuery`, surfacing as the opaque ClickHouse error `DB::Exception: Unknown column: *, there are only columns id, properties___$initial_...` (the materialised persons-table schema).

Root cause: `ApiClient.query().trendsActors` hardcodes `select: ['actor', 'event_count']` and `orderBy: ['event_count DESC', 'actor_id DESC']`. Those aliases only exist on the output of `TrendsActorsQueryBuilder.build_actors_query` (`posthog/hogql_queries/insights/trends/trends_actors_query_builder.py:181-192`). When the wrapped source isn't a trends actors source, `ActorsQueryRunner.determine_strategy` (`posthog/hogql_queries/actors_query_runner.py:102-109`) falls through to `PersonStrategy` and `parse_expr` resolves those strings against the persons table, which ClickHouse rejects.

Surface area: the existing Zod schema declares `source: AssistantTrendsQuery`, but `query-wrapper-factory.ts` routes anything whose `kind` ends with `ActorsQuery` through `trendsActors`, so any future ActorsQuery wrapper or unexpected runtime shape hits the same trap.

Seen once in production on 2026-04-18, one day after `edcbdec854` (feat(mcp): initial trends actors query) landed.

## Changes

- `services/mcp/src/api/client.ts`: add runtime guards at the top of `trendsActors` that reject the call with a clear, MCP-level error whenever `query.kind !== 'InsightActorsQuery'` or `query.source?.kind !== 'TrendsQuery'`, before any request is sent. A comment documents why those aliases can't leak to other sources.
- `services/mcp/tests/unit/api-client.test.ts`: three unit tests covering the new guard — wrong outer kind, non-trends inner source, and missing source. Each also asserts that no network call is made.

## How did you test this code?

- Ran `pnpm exec vitest run tests/unit/` from `services/mcp/` — 606 tests pass, including the 3 new ones.
- Ran `pnpm exec tsc --noEmit` on the touched files — no new typecheck errors.
- I am an agent and have not manually exercised the MCP tool end-to-end; verification is limited to the automated unit tests above.

## Publish to changelog?

no

## Docs update

No docs changes.

## 🤖 LLM context

Authored by the PostHog Code agent. Investigation traced the `Unknown column: *` error through `posthog/clickhouse/client/execute.py` → `posthog/hogql/query.py` → `posthog/hogql_queries/actors_query_runner.py:188` and confirmed the column list returned by ClickHouse matches the materialised persons table, ruling out a strategy-selection bug in the Python layer. Considered Option B (detect unresolved columns inside `actors_query_runner.to_query`) but deferred it — the fix here is proportionate to a single-occurrence signal and keeps the broader HogQL ergonomics change for a separate PR.