### PR TITLE
feat(comments): show full text inline in data management list

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -3547,9 +3547,13 @@ snapshots:
     scenes-app-data-management-actions--screen-action--light:
         hash: v1.k794b7964.d8bf73932b4afa31b9f38a86a55d96c1e4c12f6970168badd52faccbae7b890f.b6EHh73OZeepK8-PbH0_B-xwdwe_loNTxYBXcCb_95s
     scenes-app-data-management-comments--comments--dark:
-        hash: v1.k794b7964.f92f6adf84258a051a53309111d82ddf1716fda3e936e7a99e156ef463d94398.sEZd0u4LuriA2sJ3yRJMLMyBDKKq6YzHHCPsmNjI5UI
+        hash: v1.k794b7964.4718fab57e9c454d3f9fec825cda6dd0ef9eb2e9e6fe3a61453df043dca2e251.BT46ByXB1FNK-bIuw2rzM81XA3V6pi4NzIkmW1nDPTw
     scenes-app-data-management-comments--comments--light:
-        hash: v1.k794b7964.139627df6d1c67f48f415ca84d6ee071b3fda3f84cc46b2ce7b049c767920963.7KfE_3ucLeSKjH7p130nGbjftIDLW5Ari3URSA9MZzs
+        hash: v1.k794b7964.a90a254fb0fda5a4053b1b5d966a1dd5a52dbbad69d4a6bacdcc8d0dadf8422f.oXtSQ_Vv4RU1Eyw120Q_m-jF4c63rd5ck5ShCnQd3Ck
+    scenes-app-data-management-comments--long-content--dark:
+        hash: v1.k794b7964.4dd3aa5aa87124df2bfd7b43ba0c918a3c822bcd13bd9ef0caf4258e028ede38.Fqcb1ozn9DqcPxCf9sUotPw9NOBxblWu5IjqzyLjVqs
+    scenes-app-data-management-comments--long-content--light:
+        hash: v1.k794b7964.4198d7931a0c423c93d1fd8f5024c23d923ef8b25e1e016f26adf24cb45750b9.N8kMJ6McV90YxBhB292YEU3XSIIUTPsZB4ZJyRPxGZM
     scenes-app-data-management-event-definitions--default--dark:
         hash: v1.k794b7964.8abd2bae0fcc4c0e2c987577a452c624fa1da6bec82e38496ebbe0d5e36a1e78.VqAaVrKlhQfXUM8cYv325-g5ZbkUmY-fiDC4sqLXuzE
     scenes-app-data-management-event-definitions--default--light:

--- a/frontend/src/scenes/data-management/comments/Comments.stories.tsx
+++ b/frontend/src/scenes/data-management/comments/Comments.stories.tsx
@@ -5,6 +5,7 @@ import { urls } from 'scenes/urls'
 
 import { mswDecorator } from '~/mocks/browser'
 
+import commentsLongJson from './__mocks__/comments-long.json'
 import commentsJson from './__mocks__/comments.json'
 
 const meta: Meta = {
@@ -28,3 +29,13 @@ export default meta
 
 type Story = StoryObj<{}>
 export const Comments: Story = {}
+
+export const LongContent: Story = {
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/projects/:team_id/comments/': commentsLongJson,
+            },
+        }),
+    ],
+}

--- a/frontend/src/scenes/data-management/comments/Comments.tsx
+++ b/frontend/src/scenes/data-management/comments/Comments.tsx
@@ -45,7 +45,7 @@ export function Comments(): JSX.Element {
             render: function RenderComment(_, comment: CommentType): JSX.Element {
                 return (
                     <div
-                        className="font-semibold whitespace-pre-wrap break-words max-h-64 overflow-y-auto"
+                        className="whitespace-pre-wrap break-words max-h-64 overflow-y-auto"
                         data-attr="comment-scene-comment-title-rendered-content"
                     >
                         {getText(comment)}

--- a/frontend/src/scenes/data-management/comments/Comments.tsx
+++ b/frontend/src/scenes/data-management/comments/Comments.tsx
@@ -13,7 +13,6 @@ import { IconOpenInApp } from 'lib/lemon-ui/icons'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
-import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { getText } from 'scenes/comments/Comment'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
@@ -42,27 +41,16 @@ export function Comments(): JSX.Element {
         {
             title: 'Comment',
             key: 'content',
-            width: '30%',
+            width: '45%',
             render: function RenderComment(_, comment: CommentType): JSX.Element {
-                const textContent = getText(comment)
-                let renderedContent = <>{textContent}</>
-                if (textContent.length > 50) {
-                    renderedContent = (
-                        <Tooltip
-                            title={
-                                <div
-                                    className="whitespace-pre-wrap break-words"
-                                    data-attr="comment-scene-comment-title-rendered-content"
-                                >
-                                    {textContent}
-                                </div>
-                            }
-                        >
-                            {textContent.slice(0, 47) + '...'}
-                        </Tooltip>
-                    )
-                }
-                return <div className="font-semibold">{renderedContent}</div>
+                return (
+                    <div
+                        className="font-semibold whitespace-pre-wrap break-words"
+                        data-attr="comment-scene-comment-title-rendered-content"
+                    >
+                        {getText(comment)}
+                    </div>
+                )
             },
         },
         {

--- a/frontend/src/scenes/data-management/comments/Comments.tsx
+++ b/frontend/src/scenes/data-management/comments/Comments.tsx
@@ -45,7 +45,7 @@ export function Comments(): JSX.Element {
             render: function RenderComment(_, comment: CommentType): JSX.Element {
                 return (
                     <div
-                        className="font-semibold whitespace-pre-wrap break-words"
+                        className="font-semibold whitespace-pre-wrap break-words max-h-64 overflow-y-auto"
                         data-attr="comment-scene-comment-title-rendered-content"
                     >
                         {getText(comment)}

--- a/frontend/src/scenes/data-management/comments/__mocks__/comments-long.json
+++ b/frontend/src/scenes/data-management/comments/__mocks__/comments-long.json
@@ -3,6 +3,31 @@
     "previous": null,
     "results": [
         {
+            "id": "01984696-0000-0000-0000-0000000000ee",
+            "created_by": {
+                "id": 2,
+                "uuid": "019838c5-64ac-0000-9f43-aaaaaaaaaaaa",
+                "distinct_id": "aaaaAAAAbbbbBBBBccccCCCCddddDDDDeeeeEEEEffff",
+                "first_name": "Mira",
+                "last_name": "Sato",
+                "email": "mira@example.com",
+                "is_email_verified": true,
+                "hedgehog_config": null,
+                "role_at_organization": "engineering"
+            },
+            "deleted": false,
+            "content": "Full-session write-up from today's moderated research call with the Acme Growth team. This is the longest comment on purpose — it should exercise the max-h-64 overflow cap and show a scrollbar inside the cell rather than blowing the row height out.\n\nContext\n-------\nMira drove, two PMs observed. Goal: understand why Acme's weekly \"Monday metrics\" ritual is taking ~40 minutes instead of the ~10 minutes we thought it would. Recording starts at 00:03:12 (real session start) and the decision moments are timestamped below so future-us can jump straight there.\n\nTimeline\n--------\n- 00:05:14 — user opens the dashboard, immediately flinches at the load time. First thought out loud: \"is this broken?\" It isn't — the dashboard is slow because four of the tiles are funnels filtered to last-90-days with breakdown-by-browser, which we all know is a pathological query for the current query engine. Note for self: we should either cache these or push a warning when a user configures a funnel that is going to take >5s.\n- 00:09:41 — user tries to filter one of the tiles by cohort. Clicks the filter icon, gets the property filter instead. This is the UX bug we already have a ticket for (#48217) but today confirmed the cost: it took the user ~45 seconds to realise the filter they applied wasn't the cohort filter, and they only noticed when the numbers didn't match what they expected.\n- 00:17:03 — user reaches for export, lands in the overflow menu, struggles for ~40s before finding the CSV option. This is the same issue as #51902 — export is hidden behind the ⋯ menu and the affordance is weak. Low-hanging fix.\n- 00:26:48 — user tries to save the dashboard as a \"shared view\" so their team can look at the same thing. Confused by the difference between \"pin\", \"share\", and \"save as template\". In their words: \"there are too many save buttons.\" Their mental model is one action — \"give this to my team\" — and our UI fragments that across three features.\n- 00:38:22 — user gives up on the built-in PDF export and pastes a screenshot into Notion. This is signal worth paying attention to: when the official escape hatch is too slow or too hidden, the unofficial one wins, and we lose telemetry about who is reading the report.\n\nFollow-ups\n----------\n1. Short term — promote CSV export out of the overflow menu on trends, funnels, and retention (same fix as #51902).\n2. Short term — add a preflight warning when a funnel breakdown is likely to be slow (>5s p50 for the selected date range). The warning should suggest materializing the funnel or reducing the breakdown cardinality.\n3. Medium term — consolidate the \"save / pin / share\" triumvirate. A single \"share with team\" entry point would collapse the decision tree from three options to one.\n4. Medium term — fix #48217 so the filter icon opens the cohort filter, not the property filter. We have been sitting on this for a quarter and it is still the #1 source of \"wrong number\" tickets.\n5. Longer term — instrument the PDF/CSV export pipeline so we can see how often users fall back to manual screenshots. If we can measure it we can fix it; right now we are guessing.\n\nQuotes worth saving\n-------------------\n> \"There are too many save buttons.\"\n> \"I don't trust the numbers when the page takes this long to load.\"\n> \"Just let me send this to Slack.\"\n\nNext step: schedule a 30 min with the growth platform team to sequence the short-term fixes. Mira to write up a one-pager by end of week; link will live in this thread when it exists.",
+            "rich_content": null,
+            "version": 0,
+            "created_at": "2025-07-26T12:10:00.000000Z",
+            "item_id": "019838c8-8f12-7dfa-b651-abf957639b4b",
+            "item_context": {
+                "time_in_recording": "2025-07-23T19:45:00.000Z"
+            },
+            "scope": "recording",
+            "source_comment": null
+        },
+        {
             "id": "01984696-0000-0000-0000-00000000bbbb",
             "created_by": {
                 "id": 1,

--- a/frontend/src/scenes/data-management/comments/__mocks__/comments-long.json
+++ b/frontend/src/scenes/data-management/comments/__mocks__/comments-long.json
@@ -1,0 +1,81 @@
+{
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": "01984696-0000-0000-0000-00000000bbbb",
+            "created_by": {
+                "id": 1,
+                "uuid": "019838c5-64ac-0000-9f43-17f1bf64f508",
+                "distinct_id": "xugZUZjVMSe5Ceo67Y1KX85kiQqB4Gp5OSdC02cjsWl",
+                "first_name": "fasda",
+                "last_name": "",
+                "email": "paul@posthog.com",
+                "is_email_verified": false,
+                "hedgehog_config": null,
+                "role_at_organization": "other"
+            },
+            "deleted": false,
+            "content": "User struggled to find the export button — it's hidden behind the overflow menu and they spent about 40 seconds hovering over the top-right area before giving up.\n\nFollow-ups:\n- Promote the export action out of the overflow menu on the trends view\n- Check whether the same issue shows up for funnels and retention\n- Write a short loom walking through what the user tried",
+            "rich_content": null,
+            "version": 0,
+            "created_at": "2025-07-26T12:05:00.000000Z",
+            "item_id": "019838c8-8f12-7dfa-b651-abf957639b4b",
+            "item_context": {
+                "time_in_recording": "2025-07-23T19:35:47.216Z"
+            },
+            "scope": "recording",
+            "source_comment": null
+        },
+        {
+            "id": "01984696-0000-0000-0000-00000000cccc",
+            "created_by": {
+                "id": 1,
+                "uuid": "019838c5-64ac-0000-9f43-17f1bf64f508",
+                "distinct_id": "xugZUZjVMSe5Ceo67Y1KX85kiQqB4Gp5OSdC02cjsWl",
+                "first_name": "David",
+                "last_name": "",
+                "email": "david@posthog.com",
+                "is_email_verified": false,
+                "hedgehog_config": null,
+                "role_at_organization": "other"
+            },
+            "deleted": false,
+            "content": "Repro: open the session, click the timeline scrubber, drag past the 3-minute mark. The page briefly shows a 'connection lost' toast even though the network tab is quiet. Seems related to the websocket reconnect logic we changed last week. Needs a real repro in Playwright before we can triage.",
+            "rich_content": null,
+            "version": 0,
+            "created_at": "2025-07-26T12:03:00.000000Z",
+            "item_id": "019838c8-8f12-7dfa-b651-abf957639b4b",
+            "item_context": {
+                "time_in_recording": "2025-07-23T19:38:12.010Z"
+            },
+            "scope": "recording",
+            "source_comment": null
+        },
+        {
+            "id": "01984696-0000-0000-0000-00000000dddd",
+            "created_by": {
+                "id": 1,
+                "uuid": "019838c5-64ac-0000-9f43-17f1bf64f508",
+                "distinct_id": "xugZUZjVMSe5Ceo67Y1KX85kiQqB4Gp5OSdC02cjsWl",
+                "first_name": "fasda",
+                "last_name": "",
+                "email": "paul@posthog.com",
+                "is_email_verified": false,
+                "hedgehog_config": null,
+                "role_at_organization": "other"
+            },
+            "deleted": false,
+            "content": "quick fix",
+            "rich_content": null,
+            "version": 0,
+            "created_at": "2025-07-26T12:01:00.000000Z",
+            "item_id": "019838c8-8f12-7dfa-b651-abf957639b4b",
+            "item_context": {
+                "time_in_recording": "2025-07-23T19:40:00.000Z"
+            },
+            "scope": "recording",
+            "source_comment": null
+        }
+    ]
+}

--- a/frontend/src/scenes/data-management/comments/__mocks__/comments.json
+++ b/frontend/src/scenes/data-management/comments/__mocks__/comments.json
@@ -3,31 +3,6 @@
     "previous": null,
     "results": [
         {
-            "id": "01984696-0000-0000-0000-00000000aaaa",
-            "created_by": {
-                "id": 1,
-                "uuid": "019838c5-64ac-0000-9f43-17f1bf64f508",
-                "distinct_id": "xugZUZjVMSe5Ceo67Y1KX85kiQqB4Gp5OSdC02cjsWl",
-                "first_name": "fasda",
-                "last_name": "",
-                "email": "paul@posthog.com",
-                "is_email_verified": false,
-                "hedgehog_config": null,
-                "role_at_organization": "other"
-            },
-            "deleted": false,
-            "content": "User struggled to find the export button — it's hidden behind the overflow menu and they spent about 40 seconds hovering over the top-right area before giving up.\n\nFollow-ups:\n- Promote the export action out of the overflow menu on the trends view\n- Check whether the same issue shows up for funnels and retention\n- Write a short loom walking through what the user tried",
-            "rich_content": null,
-            "version": 0,
-            "created_at": "2025-07-26T12:00:00.000000Z",
-            "item_id": "019838c8-8f12-7dfa-b651-abf957639b4b",
-            "item_context": {
-                "time_in_recording": "2025-07-23T19:35:47.216Z"
-            },
-            "scope": "recording",
-            "source_comment": null
-        },
-        {
             "id": "01984695-c93f-0000-a115-d4fa40b8a1e5",
             "created_by": {
                 "id": 1,

--- a/frontend/src/scenes/data-management/comments/__mocks__/comments.json
+++ b/frontend/src/scenes/data-management/comments/__mocks__/comments.json
@@ -3,6 +3,31 @@
     "previous": null,
     "results": [
         {
+            "id": "01984696-0000-0000-0000-00000000aaaa",
+            "created_by": {
+                "id": 1,
+                "uuid": "019838c5-64ac-0000-9f43-17f1bf64f508",
+                "distinct_id": "xugZUZjVMSe5Ceo67Y1KX85kiQqB4Gp5OSdC02cjsWl",
+                "first_name": "fasda",
+                "last_name": "",
+                "email": "paul@posthog.com",
+                "is_email_verified": false,
+                "hedgehog_config": null,
+                "role_at_organization": "other"
+            },
+            "deleted": false,
+            "content": "User struggled to find the export button — it's hidden behind the overflow menu and they spent about 40 seconds hovering over the top-right area before giving up.\n\nFollow-ups:\n- Promote the export action out of the overflow menu on the trends view\n- Check whether the same issue shows up for funnels and retention\n- Write a short loom walking through what the user tried",
+            "rich_content": null,
+            "version": 0,
+            "created_at": "2025-07-26T12:00:00.000000Z",
+            "item_id": "019838c8-8f12-7dfa-b651-abf957639b4b",
+            "item_context": {
+                "time_in_recording": "2025-07-23T19:35:47.216Z"
+            },
+            "scope": "recording",
+            "source_comment": null
+        },
+        {
             "id": "01984695-c93f-0000-a115-d4fa40b8a1e5",
             "created_by": {
                 "id": 1,


### PR DESCRIPTION
## Problem

Zendesk 56218: a paying customer uses session recording comments as a
timestamped app-improvement log. On `/data-management/comments` the
Comment column truncates to 47 chars + `...` and reveals the full text
only on hover, so they can't scan their notes and end up opening every
recording individually.

## Changes

- `Comments.tsx` — dropped the 47-char truncation and the `Tooltip`
  fallback; the Comment cell now renders the full text inline with
  `whitespace-pre-wrap break-words`. Widened the Comment column from
  30% to 45% so multi-line notes are readable without overlapping the
  other columns.
- `Comments.stories.tsx` — kept the default story; added a
  `LongContent` story backed by a new `comments-long.json` fixture so
  the un-truncated layout is covered by visual regression.
- Mock fixtures updated accordingly.

The replay-with-timestamp deep link is untouched and still opens the
recording at the correct time.

Explicitly out of scope (follow-up):
- `is_resolved` field on the `Comment` model + toggle action — needs
  product scoping and a Django migration.

## How did you test this code?

I'm an agent and haven't exercised this in a running browser. Verified:

- `pnpm --filter=@posthog/frontend typescript:check` reports no new
  errors in the touched files (pre-existing kea type-gen errors in
  `commentsLogic.ts` and unrelated errors in `products/workflows/**`
  remain).
- `pnpm --filter=@posthog/frontend format` runs clean.
- The new `LongContent` Storybook story should produce a Chromatic diff
  showing the un-truncated layout — please eyeball before merging.

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code (Opus 4.7). Task ID
`4a9f13d4-806a-4e29-83ef-eafc17cebfb9`. Human should review the widened
column width (45%) and the long-content fixture prose before merge.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*