### PR TITLE
feat(logs): add sparkline activity column and snooze UI to alert list

### DIFF
--- a/products/logs/backend/alerts_api.py
+++ b/products/logs/backend/alerts_api.py
@@ -1,10 +1,10 @@
 import datetime as dt
 from datetime import UTC, datetime
-from typing import Final, cast
+from typing import Final, TypedDict, cast
 from zoneinfo import ZoneInfo
 
 from django.db import transaction
-from django.db.models import F, OuterRef, Q, QuerySet, Subquery
+from django.db.models import F, OuterRef, Prefetch, Q, QuerySet, Subquery
 
 from drf_spectacular.utils import extend_schema, extend_schema_field
 from loginas.utils import is_impersonated_session
@@ -50,12 +50,30 @@ ALLOWED_WINDOW_MINUTES = {5, 10, 15, 30, 60}
 MAX_ALERTS_PER_TEAM = 20
 MAX_SIMULATE_LOOKBACK_DAYS = 30
 MAX_SIMULATE_BUCKETS = 15_000
+SPARKLINE_LOOKBACK_HOURS = 24
 _SENTINEL: Final = object()
 _NOT_ANNOTATED: Final = object()
 
 
 def _any_field_changed(instance: LogsAlertConfiguration, validated_data: dict, fields: set[str]) -> bool:
     return any(f in validated_data and validated_data[f] != getattr(instance, f) for f in fields)
+
+
+class LogsAlertSparklineBucketSerializer(serializers.Serializer):
+    timestamp = serializers.DateTimeField(help_text="Bucket start timestamp (UTC, hourly).")
+    breached = serializers.IntegerField(help_text="Count of breached checks in this hour.")
+    errored = serializers.IntegerField(help_text="Count of errored checks in this hour.")
+
+
+class SparklineBucket(TypedDict):
+    timestamp: datetime
+    breached: int
+    errored: int
+
+
+def _sparkline_window_start() -> datetime:
+    current_hour = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
+    return current_hour - dt.timedelta(hours=SPARKLINE_LOOKBACK_HOURS - 1)
 
 
 class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
@@ -156,6 +174,67 @@ class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
         allow_null=True,
         help_text="When the alert was last modified.",
     )
+    sparkline = serializers.SerializerMethodField(
+        help_text=(
+            f"{SPARKLINE_LOOKBACK_HOURS} hourly buckets of breached + errored check counts "
+            "for the last 24h, ordered oldest-first. Drives the activity column on the "
+            "alert list — empty sparkline = healthy alert. Ok checks are not included: "
+            "retention caps OK rows at MAX_EVALUATION_PERIODS (~50min at 5-min cadence), "
+            "so only events that survive the prune (breached + errored) are meaningful "
+            "over a 24h window."
+        ),
+    )
+
+    @extend_schema_field(LogsAlertSparklineBucketSerializer(many=True))
+    def get_sparkline(self, obj: LogsAlertConfiguration) -> list[SparklineBucket]:
+        start = self.context.get("sparkline_start") or _sparkline_window_start()
+
+        buckets: list[SparklineBucket] = [
+            {
+                "timestamp": start + dt.timedelta(hours=i),
+                "breached": 0,
+                "errored": 0,
+            }
+            for i in range(SPARKLINE_LOOKBACK_HOURS)
+        ]
+
+        events = getattr(obj, "recent_checks", None)
+        if events is None:
+            events = LogsAlertEvent.objects.filter(
+                alert=obj,
+                kind=LogsAlertEvent.Kind.CHECK,
+                created_at__gte=start,
+            )
+
+        for event in events:
+            hour_offset = int((event.created_at - start).total_seconds() // 3600)
+            if 0 <= hour_offset < SPARKLINE_LOOKBACK_HOURS:
+                if event.error_message:
+                    buckets[hour_offset]["errored"] += 1
+                elif event.threshold_breached:
+                    buckets[hour_offset]["breached"] += 1
+
+        return buckets
+
+    @extend_schema_field(serializers.CharField(allow_null=True))
+    def get_last_error_message(self, obj: LogsAlertConfiguration) -> str | None:
+        # The viewset annotates `_latest_error_message` via Subquery to avoid N+1 on list.
+        # Fallback direct query covers callers that construct this serializer outside the
+        # viewset (tests, admin actions).
+        annotated = getattr(obj, "_latest_error_message", _NOT_ANNOTATED)
+        if annotated is not _NOT_ANNOTATED:
+            # Subquery annotation yields either the error_message string or None.
+            return cast(str | None, annotated)
+        return (
+            LogsAlertEvent.objects.filter(
+                alert=obj,
+                kind=LogsAlertEvent.Kind.CHECK,
+                error_message__isnull=False,
+            )
+            .order_by("-created_at")
+            .values_list("error_message", flat=True)
+            .first()
+        )
 
     class Meta:
         model = LogsAlertConfiguration
@@ -178,6 +257,7 @@ class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
             "last_checked_at",
             "consecutive_failures",
             "last_error_message",
+            "sparkline",
             "created_at",
             "created_by",
             "updated_at",
@@ -191,30 +271,11 @@ class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
             "last_checked_at",
             "consecutive_failures",
             "last_error_message",
+            "sparkline",
             "created_at",
             "created_by",
             "updated_at",
         ]
-
-    @extend_schema_field(serializers.CharField(allow_null=True))
-    def get_last_error_message(self, obj: LogsAlertConfiguration) -> str | None:
-        # The viewset annotates `_latest_error_message` via Subquery to avoid N+1 on list.
-        # Fallback direct query covers callers that construct this serializer outside the
-        # viewset (tests, admin actions).
-        annotated = getattr(obj, "_latest_error_message", _NOT_ANNOTATED)
-        if annotated is not _NOT_ANNOTATED:
-            # Subquery annotation yields either the error_message string or None.
-            return cast(str | None, annotated)
-        return (
-            LogsAlertEvent.objects.filter(
-                alert=obj,
-                kind=LogsAlertEvent.Kind.CHECK,
-                error_message__isnull=False,
-            )
-            .order_by("-created_at")
-            .values_list("error_message", flat=True)
-            .first()
-        )
 
     def validate(self, attrs: dict) -> dict:
         filters = attrs.get("filters", getattr(self.instance, "filters", None) or {})
@@ -564,7 +625,23 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             .order_by("-created_at")
             .values("error_message")[:1]
         )
-        return queryset.filter(team_id=self.team_id).annotate(_latest_error_message=Subquery(latest_error))
+        # Anchor the prefetch window and the serializer's bucket grid to the same
+        # instant so they can't drift across an hour-boundary rollover mid-request.
+        self._sparkline_start = _sparkline_window_start()
+        sparkline_events = LogsAlertEvent.objects.filter(
+            kind=LogsAlertEvent.Kind.CHECK,
+            created_at__gte=self._sparkline_start,
+        ).order_by("created_at")
+        return (
+            queryset.filter(team_id=self.team_id)
+            .annotate(_latest_error_message=Subquery(latest_error))
+            .prefetch_related(Prefetch("events", queryset=sparkline_events, to_attr="recent_checks"))
+        )
+
+    def get_serializer_context(self) -> dict:
+        context = super().get_serializer_context()
+        context["sparkline_start"] = getattr(self, "_sparkline_start", None) or _sparkline_window_start()
+        return context
 
     @extend_schema(
         request=LogsAlertCreateDestinationSerializer,

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -1030,6 +1030,101 @@ class TestLogsAlertAPI(APIBaseTest):
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+    # --- Sparkline ---
+
+    @freeze_time("2025-12-16T10:30:00Z")
+    def test_sparkline_has_24_hourly_buckets_on_empty_alert(self):
+        created = self._create_via_api()
+
+        response = self.client.get(f"{self.base_url}{created['id']}/")
+
+        assert response.status_code == status.HTTP_200_OK
+        sparkline = response.json()["sparkline"]
+        assert len(sparkline) == 24
+        assert all(bucket["breached"] == 0 and bucket["errored"] == 0 for bucket in sparkline)
+        # Buckets are ordered oldest-first, hourly-aligned.
+        timestamps = [bucket["timestamp"] for bucket in sparkline]
+        assert timestamps == sorted(timestamps)
+
+    def _make_event_at(self, alert_id: str, when: datetime, **fields) -> LogsAlertEvent:
+        """Create a LogsAlertEvent at a specific timestamp (works around auto_now_add)."""
+        defaults = {
+            "kind": LogsAlertEvent.Kind.CHECK,
+            "threshold_breached": False,
+            "state_before": "not_firing",
+            "state_after": "not_firing",
+        }
+        defaults.update(fields)
+        event = LogsAlertEvent.objects.create(alert_id=alert_id, **defaults)
+        LogsAlertEvent.objects.filter(pk=event.pk).update(created_at=when)
+        event.refresh_from_db()
+        return event
+
+    @freeze_time("2025-12-16T10:30:00Z")
+    def test_sparkline_buckets_breached_and_errored_events(self):
+        created = self._create_via_api()
+        alert_id = created["id"]
+        self._make_event_at(
+            alert_id,
+            datetime(2025, 12, 16, 7, 15, tzinfo=UTC),
+            threshold_breached=True,
+            state_before="not_firing",
+            state_after="firing",
+        )
+        self._make_event_at(
+            alert_id,
+            datetime(2025, 12, 16, 9, 10, tzinfo=UTC),
+            state_before="firing",
+            state_after="errored",
+            error_message="Query timeout",
+        )
+        self._make_event_at(
+            alert_id,
+            datetime(2025, 12, 16, 9, 45, tzinfo=UTC),
+            threshold_breached=True,
+            state_before="not_firing",
+            state_after="firing",
+        )
+
+        response = self.client.get(f"{self.base_url}{alert_id}/")
+
+        assert response.status_code == status.HTTP_200_OK
+        sparkline = response.json()["sparkline"]
+        total_breached = sum(b["breached"] for b in sparkline)
+        total_errored = sum(b["errored"] for b in sparkline)
+        assert total_breached == 2
+        assert total_errored == 1
+
+    @parameterized.expand([(k.value, k) for k in LogsAlertEvent.Kind if k != LogsAlertEvent.Kind.CHECK])
+    @freeze_time("2025-12-16T10:30:00Z")
+    def test_sparkline_excludes_control_plane_row(self, _name: str, kind: LogsAlertEvent.Kind):
+        created = self._create_via_api()
+        alert_id = created["id"]
+        self._make_event_at(alert_id, datetime(2025, 12, 16, 9, 0, tzinfo=UTC), kind=kind)
+
+        response = self.client.get(f"{self.base_url}{alert_id}/")
+
+        sparkline = response.json()["sparkline"]
+        assert all(b["breached"] == 0 and b["errored"] == 0 for b in sparkline)
+
+    @freeze_time("2025-12-16T10:30:00Z")
+    def test_sparkline_excludes_events_older_than_24h(self):
+        created = self._create_via_api()
+        alert_id = created["id"]
+        # 26h before frozen time — outside the lookback window.
+        self._make_event_at(
+            alert_id,
+            datetime(2025, 12, 15, 8, 0, tzinfo=UTC),
+            threshold_breached=True,
+            state_before="not_firing",
+            state_after="firing",
+        )
+
+        response = self.client.get(f"{self.base_url}{alert_id}/")
+
+        sparkline = response.json()["sparkline"]
+        assert all(b["breached"] == 0 and b["errored"] == 0 for b in sparkline)
+
     # --- Simulate ---
 
     def _simulate_url(self) -> str:

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
@@ -2,13 +2,18 @@ import { useActions, useValues } from 'kea'
 
 import { LemonButton, LemonDialog, LemonSwitch, LemonTable, LemonTableColumns, SpinnerOverlay } from '@posthog/lemon-ui'
 
+import { Sparkline, SparklineTimeSeries } from 'lib/components/Sparkline'
 import { TZLabel } from 'lib/components/TZLabel'
+import { dayjs } from 'lib/dayjs'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { shortTimeZone } from 'lib/utils'
 
 import {
     LogsAlertConfigurationApi,
     LogsAlertConfigurationStateEnumApi,
+    LogsAlertSparklineBucketApi,
     ThresholdOperatorEnumApi,
 } from 'products/logs/frontend/generated/api.schemas'
 
@@ -20,10 +25,62 @@ function formatThreshold(alert: LogsAlertConfigurationApi): string {
     return `${operator} ${alert.threshold_count} in ${alert.window_minutes}m`
 }
 
+const SNOOZE_DURATIONS = [
+    { label: '30 minutes', minutes: 30 },
+    { label: '1 hour', minutes: 60 },
+    { label: '4 hours', minutes: 240 },
+    { label: '24 hours', minutes: 1440 },
+]
+
+function alertSparklineData(sparkline: readonly LogsAlertSparklineBucketApi[] | undefined): SparklineTimeSeries[] {
+    if (!sparkline || sparkline.length === 0) {
+        return []
+    }
+    return [
+        {
+            name: 'Breached',
+            values: sparkline.map((b) => b.breached),
+            color: 'danger',
+        },
+        {
+            name: 'Errored',
+            values: sparkline.map((b) => b.errored),
+            color: 'warning',
+        },
+        {
+            name: 'Quiet',
+            values: sparkline.map((b) => (b.breached === 0 && b.errored === 0 ? 1 : 0)),
+            color: 'border',
+        },
+    ]
+}
+
+function alertSparklineLabels(sparkline: readonly LogsAlertSparklineBucketApi[] | undefined): string[] {
+    if (!sparkline) {
+        return []
+    }
+    const tz = shortTimeZone()
+    const tzSuffix = tz ? ` ${tz}` : ''
+    return sparkline.map((b) => {
+        const startUtc = dayjs.utc(b.timestamp)
+        const start = startUtc.local()
+        const end = startUtc.add(1, 'hour').local()
+        return `${start.format('MMM D, HH:mm')} – ${end.format('HH:mm')}${tzSuffix}`
+    })
+}
+
 export function LogsAlertList(): JSX.Element {
     const { alerts, alertsLoading, resettingAlertIds } = useValues(logsAlertingLogic)
-    const { setEditingAlert, setIsCreating, deleteAlert, toggleAlertEnabled, resetAlert, setViewingHistoryAlert } =
-        useActions(logsAlertingLogic)
+    const {
+        setEditingAlert,
+        setIsCreating,
+        deleteAlert,
+        toggleAlertEnabled,
+        resetAlert,
+        setViewingHistoryAlert,
+        snoozeAlert,
+        unsnoozeAlert,
+    } = useActions(logsAlertingLogic)
 
     const columns: LemonTableColumns<LogsAlertConfigurationApi> = [
         {
@@ -39,7 +96,11 @@ export function LogsAlertList(): JSX.Element {
             title: 'Status',
             dataIndex: 'state',
             render: (_, alert) => (
-                <LogsAlertStateIndicator state={alert.state} lastErrorMessage={alert.last_error_message} />
+                <LogsAlertStateIndicator
+                    state={alert.state}
+                    lastErrorMessage={alert.last_error_message}
+                    snoozeUntil={alert.snooze_until}
+                />
             ),
         },
         {
@@ -55,6 +116,23 @@ export function LogsAlertList(): JSX.Element {
                 ) : (
                     <span className="text-muted text-xs">Never</span>
                 ),
+        },
+        {
+            title: (
+                <Tooltip title="Breached (red) and errored (yellow) checks over the last 24 hours. Grey bars mark quiet hours.">
+                    <span className="cursor-help">Last 24h</span>
+                </Tooltip>
+            ),
+            render: (_, alert) => (
+                <Sparkline
+                    data={alertSparklineData(alert.sparkline)}
+                    labels={alertSparklineLabels(alert.sparkline)}
+                    className="h-6 w-20"
+                    type="bar"
+                    maximumIndicator={false}
+                    hideZerosInTooltip
+                />
+            ),
         },
         {
             title: 'Enabled',
@@ -86,6 +164,18 @@ export function LogsAlertList(): JSX.Element {
                                     label: 'View history',
                                     onClick: () => setViewingHistoryAlert(alert),
                                 },
+                                alert.state === LogsAlertConfigurationStateEnumApi.Snoozed
+                                    ? {
+                                          label: 'Unsnooze',
+                                          onClick: () => unsnoozeAlert(alert.id),
+                                      }
+                                    : {
+                                          label: 'Snooze',
+                                          items: SNOOZE_DURATIONS.map((d) => ({
+                                              label: d.label,
+                                              onClick: () => snoozeAlert(alert.id, d.minutes),
+                                          })),
+                                      },
                                 ...(alert.state === LogsAlertConfigurationStateEnumApi.Broken
                                     ? [
                                           {

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertStateIndicator.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertStateIndicator.tsx
@@ -1,5 +1,6 @@
 import { LemonTag, LemonTagType } from '@posthog/lemon-ui'
 
+import { TZLabel } from 'lib/components/TZLabel'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
 import { LogsAlertConfigurationStateEnumApi } from 'products/logs/frontend/generated/api.schemas'
@@ -21,14 +22,29 @@ const STATES_WITH_ERROR_TOOLTIP = new Set<LogsAlertConfigurationStateEnumApi>([
 export function LogsAlertStateIndicator({
     state,
     lastErrorMessage,
+    snoozeUntil,
 }: {
     state: LogsAlertConfigurationStateEnumApi
     lastErrorMessage?: string | null
+    snoozeUntil?: string | null
 }): JSX.Element {
     const config = STATE_CONFIG[state] ?? { label: state, type: 'default' as LemonTagType }
     const tag = <LemonTag type={config.type}>{config.label}</LemonTag>
     if (lastErrorMessage && STATES_WITH_ERROR_TOOLTIP.has(state)) {
         return <Tooltip title={lastErrorMessage}>{tag}</Tooltip>
+    }
+    if (state === LogsAlertConfigurationStateEnumApi.Snoozed && snoozeUntil) {
+        return (
+            <Tooltip
+                title={
+                    <>
+                        Until <TZLabel time={snoozeUntil} />
+                    </>
+                }
+            >
+                {tag}
+            </Tooltip>
+        )
     }
     return tag
 }

--- a/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertFormLogic.test.ts
+++ b/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertFormLogic.test.ts
@@ -53,6 +53,7 @@ const MOCK_ALERT: LogsAlertConfigurationApi = {
     last_checked_at: null,
     consecutive_failures: 0,
     last_error_message: null,
+    sparkline: [],
     created_at: '2024-01-01T00:00:00Z',
     created_by: {
         id: 1,

--- a/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
@@ -4,6 +4,7 @@ import { router } from 'kea-router'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
+import { dayjs } from 'lib/dayjs'
 import { teamLogic } from 'scenes/teamLogic'
 
 import {
@@ -33,6 +34,8 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
         resetAlert: (id: string) => ({ id }),
         setResettingAlertId: (id: string, resetting: boolean) => ({ id, resetting }),
         setViewingHistoryAlert: (alert: LogsAlertConfigurationApi | null) => ({ alert }),
+        snoozeAlert: (alertId: string, durationMinutes: number) => ({ alertId, durationMinutes }),
+        unsnoozeAlert: (alertId: string) => ({ alertId }),
     }),
 
     reducers({
@@ -128,6 +131,27 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
                 lemonToast.error('Failed to reset alert')
             } finally {
                 actions.setResettingAlertId(id, false)
+            }
+        },
+        snoozeAlert: async ({ alertId, durationMinutes }) => {
+            const projectId = String(values.currentTeamId)
+            const snoozeUntil = dayjs().add(durationMinutes, 'minute').toISOString()
+            try {
+                await logsAlertsPartialUpdate(projectId, alertId, { snooze_until: snoozeUntil })
+                lemonToast.success('Alert snoozed')
+                actions.loadAlerts()
+            } catch {
+                lemonToast.error('Failed to snooze alert')
+            }
+        },
+        unsnoozeAlert: async ({ alertId }) => {
+            const projectId = String(values.currentTeamId)
+            try {
+                await logsAlertsPartialUpdate(projectId, alertId, { snooze_until: null })
+                lemonToast.success('Alert unsnoozed')
+                actions.loadAlerts()
+            } catch {
+                lemonToast.error('Failed to unsnooze alert')
             }
         },
     })),

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -153,6 +153,15 @@ export const LogsAlertConfigurationStateEnumApi = {
     Broken: 'broken',
 } as const
 
+export interface LogsAlertSparklineBucketApi {
+    /** Bucket start timestamp (UTC, hourly). */
+    timestamp: string
+    /** Count of breached checks in this hour. */
+    breached: number
+    /** Count of errored checks in this hour. */
+    errored: number
+}
+
 export interface LogsAlertConfigurationApi {
     /** Unique identifier for this alert. */
     readonly id: string
@@ -232,6 +241,8 @@ export interface LogsAlertConfigurationApi {
      * @nullable
      */
     readonly last_error_message: string | null
+    /** 24 hourly buckets of breached + errored check counts for the last 24h, ordered oldest-first. Drives the activity column on the alert list — empty sparkline = healthy alert. Ok checks are not included: retention caps OK rows at MAX_EVALUATION_PERIODS (~50min at 5-min cadence), so only events that survive the prune (breached + errored) are meaningful over a 24h window. */
+    readonly sparkline: readonly LogsAlertSparklineBucketApi[]
     /** When the alert was created. */
     readonly created_at: string
     readonly created_by: UserBasicApi
@@ -330,6 +341,8 @@ export interface PatchedLogsAlertConfigurationApi {
      * @nullable
      */
     readonly last_error_message?: string | null
+    /** 24 hourly buckets of breached + errored check counts for the last 24h, ordered oldest-first. Drives the activity column on the alert list — empty sparkline = healthy alert. Ok checks are not included: retention caps OK rows at MAX_EVALUATION_PERIODS (~50min at 5-min cadence), so only events that survive the prune (breached + errored) are meaningful over a 24h window. */
+    readonly sparkline?: readonly LogsAlertSparklineBucketApi[]
     /** When the alert was created. */
     readonly created_at?: string
     readonly created_by?: UserBasicApi

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -19945,6 +19945,15 @@ export namespace Schemas {
       Broken: 'broken',
     } as const;
 
+    export interface LogsAlertSparklineBucket {
+      /** Bucket start timestamp (UTC, hourly). */
+      timestamp: string;
+      /** Count of breached checks in this hour. */
+      breached: number;
+      /** Count of errored checks in this hour. */
+      errored: number;
+    }
+
     export interface LogsAlertConfiguration {
       /** Unique identifier for this alert. */
       readonly id: string;
@@ -20024,6 +20033,8 @@ export namespace Schemas {
        * @nullable
        */
       readonly last_error_message: string | null;
+      /** 24 hourly buckets of breached + errored check counts for the last 24h, ordered oldest-first. Drives the activity column on the alert list — empty sparkline = healthy alert. Ok checks are not included: retention caps OK rows at MAX_EVALUATION_PERIODS (~50min at 5-min cadence), so only events that survive the prune (breached + errored) are meaningful over a 24h window. */
+      readonly sparkline: readonly LogsAlertSparklineBucket[];
       /** When the alert was created. */
       readonly created_at: string;
       readonly created_by: UserBasic;
@@ -26165,6 +26176,8 @@ export namespace Schemas {
        * @nullable
        */
       readonly last_error_message?: string | null;
+      /** 24 hourly buckets of breached + errored check counts for the last 24h, ordered oldest-first. Drives the activity column on the alert list — empty sparkline = healthy alert. Ok checks are not included: retention caps OK rows at MAX_EVALUATION_PERIODS (~50min at 5-min cadence), so only events that survive the prune (breached + errored) are meaningful over a 24h window. */
+      readonly sparkline?: readonly LogsAlertSparklineBucket[];
       /** When the alert was created. */
       readonly created_at?: string;
       readonly created_by?: UserBasic;


### PR DESCRIPTION
## Problem

Users viewing the logs alert list had no quick way to assess recent alert health at a glance. The activity column was missing, making it hard to distinguish a healthy alert from one that has been repeatedly breaching or erroring over the past day.

## Changes

(Has changes for both snoozing UI, and sparkline UI - would have split these into two PRs, but I'm moving quick)

**Backend**

- Added a `sparkline` field to `LogsAlertConfigurationSerializer` that returns 24 hourly buckets (oldest-first) covering the last 24 hours. Each bucket contains counts of `breached` and `errored` CHECK events for that hour.
- The list endpoint prefetches recent CHECK events via `Prefetch` (filtered to the sparkline window) and attaches them as `recent_checks` on each alert instance, avoiding N+1 queries. Individual detail requests fall back to a direct queryset.
- Only CHECK-kind events are included; RESET, SNOOZE, and THRESHOLD_CHANGE control-plane rows are excluded. OK checks are intentionally omitted because retention prunes them quickly, making only breached and errored events meaningful over a 24h window.

**Frontend**

- Added a **Last 24h** sparkline column to the alert list table using the existing `Sparkline` component. Red bars represent breached checks, yellow bars represent errored checks, and grey bars mark quiet hours.
- Added snooze/unsnooze actions to the alert row menu, with preset durations (30 min, 1 h, 4 h, 24 h). Snoozing calls `logsAlertsPartialUpdate` with a computed `snooze_until` ISO timestamp; unsnoozing clears it.
- The `LogsAlertStateIndicator` now accepts a `snoozeUntil` prop and shows a tooltip with the snooze expiry time when the alert is in the `Snoozed` state.

## How did you test this code?

Four new API tests cover the sparkline behaviour:

- Empty alert produces 24 all-zero buckets ordered oldest-first.
- Breached and errored events are counted into the correct hourly buckets.
- Control-plane event kinds (RESET, SNOOZE, THRESHOLD_CHANGE) do not appear in the sparkline.
- Events older than 24 hours are excluded from the sparkline window.

## Publish to changelog?

No