### PR TITLE
feat(experiments): link to experiment from slowest queries table

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -8,6 +8,7 @@ import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { Link } from 'lib/lemon-ui/Link'
 import { SceneExport } from 'scenes/sceneTypes'
 import { userLogic } from 'scenes/userLogic'
 
@@ -131,7 +132,23 @@ export function QueryPerformance(): JSX.Element {
         },
         {
             title: 'Experiment',
-            dataIndex: 'experiment_name',
+            render: function ExperimentCell(_, item) {
+                if (!item.experiment_name) {
+                    return <span className="text-muted">Unknown</span>
+                }
+                if (!item.experiment_id || !item.team_id) {
+                    return <span className="truncate max-w-60">{item.experiment_name}</span>
+                }
+                return (
+                    <Link
+                        to={`/project/${item.team_id}/experiments/${item.experiment_id}`}
+                        target="_blank"
+                        className="truncate max-w-60"
+                    >
+                        {item.experiment_name}
+                    </Link>
+                )
+            },
         },
         {
             title: 'Metric',

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -30,6 +30,7 @@ export interface SlowestQuery {
     experiment_metric_name: string
     experiment_execution_path: string
     experiment_metric_type: string
+    experiment_id: number | null
 }
 
 export const queryPerformanceLogic = kea<queryPerformanceLogicType>([

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -354,7 +354,8 @@ class DebugCHQueries(viewsets.ViewSet):
                 argMax(JSONExtractString(log_comment, 'experiment_name'), type) AS experiment_name,
                 argMax(JSONExtractString(log_comment, 'experiment_metric_name'), type) AS experiment_metric_name,
                 argMax(JSONExtractString(log_comment, 'experiment_execution_path'), type) AS experiment_execution_path,
-                argMax(JSONExtractString(log_comment, 'experiment_metric_type'), type) AS experiment_metric_type
+                argMax(JSONExtractString(log_comment, 'experiment_metric_type'), type) AS experiment_metric_type,
+                argMax(JSONExtractInt(log_comment, 'experiment_id'), type) AS experiment_id
             FROM (
                 SELECT
                     query_id, query, query_start_time, query_duration_ms, exception,
@@ -413,6 +414,7 @@ class DebugCHQueries(viewsets.ViewSet):
                     "experiment_metric_name": row[9],
                     "experiment_execution_path": row[10],
                     "experiment_metric_type": row[11],
+                    "experiment_id": row[12] or None,
                 }
                 for row in response
             ]


### PR DESCRIPTION
## Problem

No way to navigate to the experiment from the slowest queries table.

## Changes

Extract `experiment_id` from the ClickHouse log_comment and render the experiment name as a link (`/project/{team_id}/experiments/{experiment_id}`) that opens in a new browser tab. Name is clamped for long values. Falls back to plain text for older queries without `experiment_id`.

## How did you test this code?

Verified locally.

Do not publish to changelog.