### PR TITLE
feat(insights): add data warehouse source for retention

### DIFF
--- a/bin/find_affected_tests.py
+++ b/bin/find_affected_tests.py
@@ -93,6 +93,7 @@ GATE_ONLY_PATTERNS = (
     "bin/check_uv_python_compatibility.py",
     "bin/find_python_dependencies.py",
     "bin/granian_metrics.py",
+    "bin/ty.py",
     "bin/unit_metrics.py",
 )
 

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -32277,7 +32277,7 @@
             "type": "object"
         },
         "RetentionEntityKind": {
-            "enum": ["ActionsNode", "DataWarehouseNode", "EventsNode"],
+            "enum": ["ActionsNode", "EventsNode", "DataWarehouseNode"],
             "type": "string"
         },
         "RetentionFilter": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -32232,8 +32232,16 @@
                 "custom_name": {
                     "type": "string"
                 },
+                "distinct_id_field": {
+                    "description": "Data warehouse field used as the actor identifier (only used when kind is DataWarehouseNode)",
+                    "type": "string"
+                },
                 "id": {
                     "type": ["string", "number"]
+                },
+                "id_field": {
+                    "description": "Data warehouse row identifier field (only used when kind is DataWarehouseNode)",
+                    "type": "string"
                 },
                 "kind": {
                     "$ref": "#/definitions/RetentionEntityKind"
@@ -32251,6 +32259,14 @@
                     },
                     "type": "array"
                 },
+                "table_name": {
+                    "description": "Data warehouse table name (only used when kind is DataWarehouseNode)",
+                    "type": "string"
+                },
+                "timestamp_field": {
+                    "description": "Data warehouse timestamp field (only used when kind is DataWarehouseNode)",
+                    "type": "string"
+                },
                 "type": {
                     "$ref": "#/definitions/EntityType"
                 },
@@ -32261,7 +32277,7 @@
             "type": "object"
         },
         "RetentionEntityKind": {
-            "enum": ["ActionsNode", "EventsNode"],
+            "enum": ["ActionsNode", "DataWarehouseNode", "EventsNode"],
             "type": "string"
         },
         "RetentionFilter": {

--- a/frontend/src/scenes/insights/EditorFilters/RetentionCondition.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/RetentionCondition.tsx
@@ -19,8 +19,8 @@ import {
 } from 'scenes/retention/constants'
 import { MAX_BRACKETS, retentionLogic } from 'scenes/retention/retentionLogic'
 
-import { NodeKind } from '~/queries/schema/schema-general'
 import { groupsModel } from '~/models/groupsModel'
+import { NodeKind } from '~/queries/schema/schema-general'
 import { EditorFilterProps, EntityTypes, FilterType, RetentionPeriod, RetentionType } from '~/types'
 
 import { ActionFilter } from '../filters/ActionFilter/ActionFilter'
@@ -58,16 +58,14 @@ function readEntityFromFilters(newFilters: FilterType): Record<string, any> | un
 }
 
 function entityToActionFilter(entity: Record<string, any> | undefined): FilterType {
-    if (!entity) {
-        return { events: [entity] } as FilterType
+    const entities: Record<string, any>[] = entity ? [entity] : []
+    if (entity?.type === EntityTypes.DATA_WAREHOUSE) {
+        return { data_warehouse: entities } as FilterType
     }
-    if (entity.type === EntityTypes.DATA_WAREHOUSE) {
-        return { data_warehouse: [entity] } as FilterType
+    if (entity?.type === EntityTypes.ACTIONS) {
+        return { actions: entities } as FilterType
     }
-    if (entity.type === EntityTypes.ACTIONS) {
-        return { actions: [entity] } as FilterType
-    }
-    return { events: [entity] } as FilterType
+    return { events: entities } as FilterType
 }
 
 const MAX_RANGE = 1000

--- a/frontend/src/scenes/insights/EditorFilters/RetentionCondition.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/RetentionCondition.tsx
@@ -5,6 +5,7 @@ import { toast } from 'react-toastify'
 import { IconInfo, IconPlusSmall, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonInput, LemonSelect } from '@posthog/lemon-ui'
 
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { getOrdinalSuffix } from 'lib/utils'
 import { AggregationSelect } from 'scenes/insights/filters/AggregationSelect'
@@ -18,11 +19,56 @@ import {
 } from 'scenes/retention/constants'
 import { MAX_BRACKETS, retentionLogic } from 'scenes/retention/retentionLogic'
 
+import { NodeKind } from '~/queries/schema/schema-general'
 import { groupsModel } from '~/models/groupsModel'
-import { EditorFilterProps, FilterType, RetentionPeriod, RetentionType } from '~/types'
+import { EditorFilterProps, EntityTypes, FilterType, RetentionPeriod, RetentionType } from '~/types'
 
 import { ActionFilter } from '../filters/ActionFilter/ActionFilter'
 import { MathAvailability } from '../filters/ActionFilter/ActionFilterRow/ActionFilterRow'
+
+const RETENTION_ACTIONS_TAXONOMIC_GROUP_TYPES = [
+    TaxonomicFilterGroupType.Events,
+    TaxonomicFilterGroupType.Actions,
+    TaxonomicFilterGroupType.DataWarehouse,
+]
+
+const RETENTION_DATA_WAREHOUSE_POPOVER_FIELDS = [
+    { key: 'id_field', label: 'Unique ID' },
+    { key: 'timestamp_field', label: 'Timestamp' },
+    { key: 'distinct_id_field', label: 'Actor ID' },
+]
+
+function readEntityFromFilters(newFilters: FilterType): Record<string, any> | undefined {
+    if (newFilters.data_warehouse && newFilters.data_warehouse.length > 0) {
+        const source = newFilters.data_warehouse[0]
+        return {
+            ...source,
+            kind: NodeKind.DataWarehouseNode,
+            type: EntityTypes.DATA_WAREHOUSE,
+            table_name: source.table_name ?? source.id,
+        }
+    }
+    if (newFilters.events && newFilters.events.length > 0) {
+        return newFilters.events[0]
+    }
+    if (newFilters.actions && newFilters.actions.length > 0) {
+        return newFilters.actions[0]
+    }
+    return undefined
+}
+
+function entityToActionFilter(entity: Record<string, any> | undefined): FilterType {
+    if (!entity) {
+        return { events: [entity] } as FilterType
+    }
+    if (entity.type === EntityTypes.DATA_WAREHOUSE) {
+        return { data_warehouse: [entity] } as FilterType
+    }
+    if (entity.type === EntityTypes.ACTIONS) {
+        return { actions: [entity] } as FilterType
+    }
+    return { events: [entity] } as FilterType
+}
 
 const MAX_RANGE = 1000
 
@@ -147,18 +193,15 @@ export function RetentionCondition({ insightProps }: EditorFilterProps): JSX.Ele
                 entitiesLimit={1}
                 mathAvailability={MathAvailability.None}
                 hideRename
-                filters={{ events: [targetEntity] } as FilterType} // retention filters use target and returning entity instead of events
+                // retention filters use target and returning entity instead of events/actions/data_warehouse
+                filters={entityToActionFilter(targetEntity)}
                 setFilters={(newFilters: FilterType) => {
-                    if (newFilters.events && newFilters.events.length > 0) {
-                        updateInsightFilter({ targetEntity: newFilters.events[0] })
-                    } else if (newFilters.actions && newFilters.actions.length > 0) {
-                        updateInsightFilter({ targetEntity: newFilters.actions[0] })
-                    } else {
-                        updateInsightFilter({ targetEntity: undefined })
-                    }
+                    updateInsightFilter({ targetEntity: readEntityFromFilters(newFilters) })
                 }}
                 typeKey={`${keyForInsightLogicProps('new')(insightProps)}-targetEntity`}
                 propertiesTaxonomicGroupTypes={getRetentionPropertyFilterGroupTypes()}
+                actionsTaxonomicGroupTypes={RETENTION_ACTIONS_TAXONOMIC_GROUP_TYPES}
+                dataWarehousePopoverFields={RETENTION_DATA_WAREHOUSE_POPOVER_FIELDS}
             />
             <LemonSelect
                 options={Object.entries(retentionOptions).map(([key, value]) => ({
@@ -189,18 +232,14 @@ export function RetentionCondition({ insightProps }: EditorFilterProps): JSX.Ele
                 mathAvailability={MathAvailability.None}
                 hideRename
                 buttonCopy="Add graph series"
-                filters={{ events: [returningEntity] } as FilterType}
+                filters={entityToActionFilter(returningEntity)}
                 setFilters={(newFilters: FilterType) => {
-                    if (newFilters.events && newFilters.events.length > 0) {
-                        updateInsightFilter({ returningEntity: newFilters.events[0] })
-                    } else if (newFilters.actions && newFilters.actions.length > 0) {
-                        updateInsightFilter({ returningEntity: newFilters.actions[0] })
-                    } else {
-                        updateInsightFilter({ returningEntity: undefined })
-                    }
+                    updateInsightFilter({ returningEntity: readEntityFromFilters(newFilters) })
                 }}
                 typeKey={`${keyForInsightLogicProps('new')(insightProps)}-returningEntity`}
                 propertiesTaxonomicGroupTypes={getRetentionPropertyFilterGroupTypes()}
+                actionsTaxonomicGroupTypes={RETENTION_ACTIONS_TAXONOMIC_GROUP_TYPES}
+                dataWarehousePopoverFields={RETENTION_DATA_WAREHOUSE_POPOVER_FIELDS}
             />
             <div className="flex items-center gap-2">
                 {!retentionCustomBrackets ? (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2975,7 +2975,7 @@ export interface PathsFilterType extends FilterType {
     path_dropoff_key?: string // Paths People Dropoff Key
 }
 
-export type RetentionEntityKind = NodeKind.ActionsNode | NodeKind.EventsNode
+export type RetentionEntityKind = NodeKind.ActionsNode | NodeKind.EventsNode | NodeKind.DataWarehouseNode
 
 export interface RetentionEntity {
     id?: string | number // TODO: Fix weird typing issues
@@ -2988,6 +2988,14 @@ export interface RetentionEntity {
     custom_name?: string
     /** filters on the event */
     properties?: AnyPropertyFilter[]
+    /** Data warehouse table name (only used when kind is DataWarehouseNode) */
+    table_name?: string
+    /** Data warehouse timestamp field (only used when kind is DataWarehouseNode) */
+    timestamp_field?: string
+    /** Data warehouse field used as the actor identifier (only used when kind is DataWarehouseNode) */
+    distinct_id_field?: string
+    /** Data warehouse row identifier field (only used when kind is DataWarehouseNode) */
+    id_field?: string
 }
 
 export enum RetentionDashboardDisplayType {

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -155,9 +155,7 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         if self.group_type_index is not None:
             raise ValidationError("Group aggregation is not supported for data warehouse retention.")
         if retention_filter and retention_filter.aggregationType in (AggregationType.SUM, AggregationType.AVG):
-            raise ValidationError(
-                "Sum/avg aggregation is not yet supported for data warehouse retention."
-            )
+            raise ValidationError("Sum/avg aggregation is not yet supported for data warehouse retention.")
         if retention_filter and (retention_filter.minimumOccurrences or 1) > 1:
             raise ValidationError(
                 "Minimum occurrences greater than 1 is not yet supported for data warehouse retention."
@@ -180,23 +178,22 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
     @cached_property
     def _data_warehouse_table_name(self) -> str:
         assert self.is_data_warehouse_retention
-        table_name = self.start_event.table_name or self.return_event.table_name
-        assert table_name is not None
-        return table_name
+        # `_validate_data_warehouse_retention` has already enforced that both entities reference
+        # the same table/fields, so reading them off `start_event` is sufficient.
+        assert self.start_event.table_name is not None
+        return self.start_event.table_name
 
     @cached_property
     def _data_warehouse_timestamp_field(self) -> str:
         assert self.is_data_warehouse_retention
-        field = self.start_event.timestamp_field or self.return_event.timestamp_field
-        assert field is not None
-        return field
+        assert self.start_event.timestamp_field is not None
+        return self.start_event.timestamp_field
 
     @cached_property
     def _data_warehouse_distinct_id_field(self) -> str:
         assert self.is_data_warehouse_retention
-        field = self.start_event.distinct_id_field or self.return_event.distinct_id_field
-        assert field is not None
-        return field
+        assert self.start_event.distinct_id_field is not None
+        return self.start_event.distinct_id_field
 
     @cached_property
     def _source_table_chain(self) -> list[str | int]:
@@ -207,17 +204,13 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
     @cached_property
     def _source_timestamp_chain(self) -> list[str | int]:
         if self.is_data_warehouse_retention:
-            return cast(
-                list[str | int], [self._data_warehouse_table_name, self._data_warehouse_timestamp_field]
-            )
+            return cast(list[str | int], [self._data_warehouse_table_name, self._data_warehouse_timestamp_field])
         return cast(list[str | int], ["events", "timestamp"])
 
     @cached_property
     def _actor_id_chain(self) -> list[str | int]:
         if self.is_data_warehouse_retention:
-            return cast(
-                list[str | int], [self._data_warehouse_table_name, self._data_warehouse_distinct_id_field]
-            )
+            return cast(list[str | int], [self._data_warehouse_table_name, self._data_warehouse_distinct_id_field])
         return cast(list[str | int], ["events", self.target_field])
 
     def update_hogql_modifiers(self) -> None:

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -15,6 +15,7 @@ from posthog.schema import (
     InCohortVia,
     IntervalType,
     RetentionEntity,
+    RetentionEntityKind,
     RetentionQuery,
     RetentionQueryResponse,
     RetentionType,
@@ -109,6 +110,115 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             and self.query.retentionFilter.cumulative
         ):
             raise ValidationError("Cumulative retention is not supported for 24 hour windows.")
+
+        self._validate_data_warehouse_retention()
+
+    def _validate_data_warehouse_retention(self) -> None:
+        if not self.is_data_warehouse_retention:
+            return
+
+        start_is_dw = self._is_data_warehouse_entity(self.start_event)
+        return_is_dw = self._is_data_warehouse_entity(self.return_event)
+        if not (start_is_dw and return_is_dw):
+            raise ValidationError(
+                "Data warehouse retention requires both target and returning entities to be data warehouse nodes."
+            )
+
+        if not self.start_event.table_name or self.start_event.table_name != self.return_event.table_name:
+            raise ValidationError(
+                "Data warehouse retention requires both target and returning entities to reference the same table."
+            )
+        if not self.start_event.timestamp_field or not self.start_event.distinct_id_field:
+            raise ValidationError(
+                "Data warehouse retention requires timestamp_field and distinct_id_field on the target entity."
+            )
+        if self.return_event.timestamp_field != self.start_event.timestamp_field:
+            raise ValidationError(
+                "Data warehouse retention target and returning entities must use the same timestamp_field."
+            )
+        if self.return_event.distinct_id_field != self.start_event.distinct_id_field:
+            raise ValidationError(
+                "Data warehouse retention target and returning entities must use the same distinct_id_field."
+            )
+
+        retention_filter = self.query.retentionFilter
+        if self.is_24h_window_calculation:
+            raise ValidationError("24 hour windows are not yet supported for data warehouse retention.")
+        if self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence:
+            raise ValidationError(
+                "First-time and first-ever retention types are not yet supported for data warehouse retention."
+            )
+        if self.is_custom_bracket_retention:
+            raise ValidationError("Custom retention brackets are not yet supported for data warehouse retention.")
+        if self.breakdowns_in_query:
+            raise ValidationError("Breakdowns are not yet supported for data warehouse retention.")
+        if self.group_type_index is not None:
+            raise ValidationError("Group aggregation is not supported for data warehouse retention.")
+        if retention_filter and retention_filter.aggregationType in (AggregationType.SUM, AggregationType.AVG):
+            raise ValidationError(
+                "Sum/avg aggregation is not yet supported for data warehouse retention."
+            )
+        if retention_filter and (retention_filter.minimumOccurrences or 1) > 1:
+            raise ValidationError(
+                "Minimum occurrences greater than 1 is not yet supported for data warehouse retention."
+            )
+        if self.query.samplingFactor is not None:
+            raise ValidationError("Sampling is not supported for data warehouse retention.")
+        if self.query.filterTestAccounts:
+            raise ValidationError("Test account filters are not supported for data warehouse retention.")
+
+    @staticmethod
+    def _is_data_warehouse_entity(entity: RetentionEntity | None) -> bool:
+        if entity is None:
+            return False
+        return entity.kind == RetentionEntityKind.DATA_WAREHOUSE_NODE
+
+    @cached_property
+    def is_data_warehouse_retention(self) -> bool:
+        return self._is_data_warehouse_entity(self.start_event) or self._is_data_warehouse_entity(self.return_event)
+
+    @cached_property
+    def _data_warehouse_table_name(self) -> str:
+        assert self.is_data_warehouse_retention
+        table_name = self.start_event.table_name or self.return_event.table_name
+        assert table_name is not None
+        return table_name
+
+    @cached_property
+    def _data_warehouse_timestamp_field(self) -> str:
+        assert self.is_data_warehouse_retention
+        field = self.start_event.timestamp_field or self.return_event.timestamp_field
+        assert field is not None
+        return field
+
+    @cached_property
+    def _data_warehouse_distinct_id_field(self) -> str:
+        assert self.is_data_warehouse_retention
+        field = self.start_event.distinct_id_field or self.return_event.distinct_id_field
+        assert field is not None
+        return field
+
+    @cached_property
+    def _source_table_chain(self) -> list[str | int]:
+        if self.is_data_warehouse_retention:
+            return cast(list[str | int], [self._data_warehouse_table_name])
+        return cast(list[str | int], ["events"])
+
+    @cached_property
+    def _source_timestamp_chain(self) -> list[str | int]:
+        if self.is_data_warehouse_retention:
+            return cast(
+                list[str | int], [self._data_warehouse_table_name, self._data_warehouse_timestamp_field]
+            )
+        return cast(list[str | int], ["events", "timestamp"])
+
+    @cached_property
+    def _actor_id_chain(self) -> list[str | int]:
+        if self.is_data_warehouse_retention:
+            return cast(
+                list[str | int], [self._data_warehouse_table_name, self._data_warehouse_distinct_id_field]
+            )
+        return cast(list[str | int], ["events", self.target_field])
 
     def update_hogql_modifiers(self) -> None:
         """
@@ -208,11 +318,20 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
 
     @cached_property
     def start_entity_expr(self) -> ast.Expr:
-        return entity_to_expr(self.start_event, self.team)
+        return self._entity_to_expr(self.start_event)
 
     @cached_property
     def return_entity_expr(self) -> ast.Expr:
-        return entity_to_expr(self.return_event, self.team)
+        return self._entity_to_expr(self.return_event)
+
+    def _entity_to_expr(self, entity: RetentionEntity) -> ast.Expr:
+        # Data warehouse entities don't carry an event name — each row in the table represents
+        # an "event". Property filters still apply through the generic property path.
+        if self._is_data_warehouse_entity(entity):
+            if entity.properties is not None and entity.properties != []:
+                return property_to_expr(entity.properties, self.team)
+            return ast.Constant(value=True)
+        return entity_to_expr(entity, self.team)
 
     @cached_property
     def target_field(self) -> str:
@@ -227,10 +346,14 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         global_event_filters = self.events_where_clause(
             self.is_first_occurrence_matching_filters, self.is_first_ever_occurrence
         )
-        # Pre-filter events to only those we care about
-        is_relevant_event = ast.Or(exprs=[self.start_entity_expr, self.return_entity_expr])
-        if not self.is_first_ever_occurrence:
-            global_event_filters.append(is_relevant_event)
+        # Pre-filter events to only those we care about. For data warehouse retention,
+        # every row in the backing table is a candidate event and the start/return entity
+        # expressions only carry property filters (already applied via events_where_clause
+        # per-entity when they're non-trivial).
+        if not self.is_data_warehouse_retention:
+            is_relevant_event = ast.Or(exprs=[self.start_entity_expr, self.return_entity_expr])
+            if not self.is_first_ever_occurrence:
+                global_event_filters.append(is_relevant_event)
 
         if self.group_type_index is not None:
             global_event_filters.append(
@@ -292,7 +415,7 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         """
         Timestamp filter between date_from and date_to
         """
-        field_to_compare = ast.Field(chain=["events", "timestamp"])
+        field_to_compare = ast.Field(chain=self._source_timestamp_chain)
         return ast.And(
             exprs=[
                 ast.CompareOperation(
@@ -335,6 +458,10 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         )
 
     def get_events_for_entity(self, entity: RetentionEntity) -> list[str | None]:
+        if self._is_data_warehouse_entity(entity):
+            # Data warehouse entities don't have an event name column. Returning [None]
+            # signals "match all rows" and disables event-name pre-filtering.
+            return [None]
         if entity.type == EntityType.ACTIONS and entity.id:
             action = Action.objects.get(pk=int(entity.id), team__project_id=self.team.project_id)
             return action.get_step_events()
@@ -615,7 +742,7 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         selected_breakdown_value: str | list[str] | int | None = None,
     ) -> ast.SelectQuery:
         start_of_interval_sql = self.query_date_range.get_start_of_interval_hogql(
-            source=ast.Field(chain=["events", "timestamp"])
+            source=ast.Field(chain=self._source_timestamp_chain)
         )
 
         event_filters = self.global_event_filters.copy()
@@ -870,7 +997,7 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             )
 
         select_fields: list[ast.Expr] = [
-            ast.Alias(alias="actor_id", expr=ast.Field(chain=["events", self.target_field])),
+            ast.Alias(alias="actor_id", expr=ast.Field(chain=self._actor_id_chain)),
             # start events between date_from and date_to (represented by start of interval)
             # when TARGET_FIRST_TIME, also adds filter for start (target) event performed for first time
             ast.Alias(alias="start_event_timestamps", expr=start_event_timestamps),
@@ -945,7 +1072,7 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
 
         inner_query = ast.SelectQuery(
             select=select_fields,
-            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            select_from=ast.JoinExpr(table=ast.Field(chain=self._source_table_chain)),
             where=ast.And(exprs=event_filters),
             group_by=[ast.Field(chain=["actor_id"])],
             having=ast.And(

--- a/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
@@ -1,0 +1,194 @@
+import csv
+import tempfile
+from pathlib import Path
+
+from freezegun import freeze_time
+from parameterized import parameterized
+from rest_framework.exceptions import ValidationError
+
+from posthog.schema import (
+    DateRange,
+    RetentionEntity,
+    RetentionEntityKind,
+    RetentionFilter,
+    RetentionPeriod,
+    RetentionQuery,
+)
+
+from posthog.hogql_queries.insights.retention.retention_query_runner import RetentionQueryRunner
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+
+from products.data_warehouse.backend.test.utils import create_data_warehouse_table_from_csv
+
+TEST_BUCKET = "test_storage_bucket-posthog.hogql_queries.insights.retention.retention_data_warehouse"
+
+
+class TestRetentionDataWarehouse(ClickhouseTestMixin, APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.cleanup_fns = []
+        self.temp_dirs = []
+
+    def tearDown(self):
+        for cleanup in self.cleanup_fns:
+            cleanup()
+        for temp_dir in self.temp_dirs:
+            temp_dir.cleanup()
+        super().tearDown()
+
+    def _write_csv(self, filename: str, header: list[str], rows: list[list[object]]) -> Path:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dirs.append(temp_dir)
+        path = Path(temp_dir.name) / filename
+
+        with open(path, "w", newline="") as csv_file:
+            writer = csv.writer(csv_file)
+            writer.writerow(header)
+            writer.writerows(rows)
+
+        return path
+
+    def _setup_events_table(self) -> str:
+        # Four users over four days — classic retention shape:
+        # user-1: day 1, 2, 3, 4 — stays every day
+        # user-2: day 1, 3      — returns on day 3 only
+        # user-3: day 1         — never returns
+        # user-4: day 2, 3, 4   — cohorted on day 2
+        rows: list[list[object]] = [
+            ["user-1", "2025-11-04 08:00:00"],
+            ["user-1", "2025-11-05 08:00:00"],
+            ["user-1", "2025-11-06 08:00:00"],
+            ["user-1", "2025-11-07 08:00:00"],
+            ["user-2", "2025-11-04 08:00:00"],
+            ["user-2", "2025-11-06 08:00:00"],
+            ["user-3", "2025-11-04 08:00:00"],
+            ["user-4", "2025-11-05 08:00:00"],
+            ["user-4", "2025-11-06 08:00:00"],
+            ["user-4", "2025-11-07 08:00:00"],
+        ]
+
+        csv_path = self._write_csv(
+            "dw_events.csv",
+            ["user_id", "event_time"],
+            rows,
+        )
+
+        table, _source, _credential, _df, cleanup = create_data_warehouse_table_from_csv(
+            csv_path=csv_path,
+            table_name="dw_events",
+            table_columns={
+                "user_id": "String",
+                "event_time": "DateTime64(3, 'UTC')",
+            },
+            test_bucket=TEST_BUCKET,
+            team=self.team,
+        )
+        self.cleanup_fns.append(cleanup)
+        return table.name
+
+    def _dw_entity(self, table_name: str) -> RetentionEntity:
+        return RetentionEntity(
+            kind=RetentionEntityKind.DATA_WAREHOUSE_NODE,
+            id=table_name,
+            name=table_name,
+            type=None,
+            table_name=table_name,
+            timestamp_field="event_time",
+            distinct_id_field="user_id",
+            id_field="user_id",
+        )
+
+    def test_retention_data_warehouse_basic(self) -> None:
+        table_name = self._setup_events_table()
+
+        with freeze_time("2025-11-07T12:00:00Z"):
+            query = RetentionQuery(
+                dateRange=DateRange(date_from="2025-11-04", date_to="2025-11-07"),
+                retentionFilter=RetentionFilter(
+                    period=RetentionPeriod.DAY,
+                    totalIntervals=4,
+                    targetEntity=self._dw_entity(table_name),
+                    returningEntity=self._dw_entity(table_name),
+                ),
+            )
+
+            response = RetentionQueryRunner(team=self.team, query=query).calculate()
+
+        # Count users cohorted on the first day (2025-11-04): user-1, user-2, user-3 -> 3
+        day_0 = next(row for row in response.results if row["date"].strftime("%Y-%m-%d") == "2025-11-04")
+        self.assertEqual(day_0["values"][0]["count"], 3)  # day 0 cohort size
+        # Users from day 0 who returned on day 1 (2025-11-05): only user-1
+        self.assertEqual(day_0["values"][1]["count"], 1)
+        # Day 2 (2025-11-06) returners from day-0 cohort: user-1 and user-2
+        self.assertEqual(day_0["values"][2]["count"], 2)
+        # Day 3 (2025-11-07) returners from day-0 cohort: user-1
+        self.assertEqual(day_0["values"][3]["count"], 1)
+
+        day_1 = next(row for row in response.results if row["date"].strftime("%Y-%m-%d") == "2025-11-05")
+        # Cohort for 2025-11-05: user-1, user-4 -> 2
+        self.assertEqual(day_1["values"][0]["count"], 2)
+
+    @parameterized.expand(
+        [
+            ("24_hour_windows", {"timeWindowMode": "24_hour_windows"}, "24 hour windows"),
+            ("first_time", {"retentionType": "retention_first_time"}, "First-time"),
+            ("first_ever", {"retentionType": "retention_first_ever_occurrence"}, "First-time"),
+            ("custom_brackets", {"retentionCustomBrackets": [1, 2, 3]}, "Custom retention brackets"),
+            ("sum_aggregation", {"aggregationType": "sum", "aggregationProperty": "x"}, "Sum/avg"),
+        ]
+    )
+    def test_validation_rejects_unsupported(self, _name: str, extra: dict, expected_message_fragment: str) -> None:
+        with self.assertRaises(ValidationError) as cm:
+            RetentionQueryRunner(
+                team=self.team,
+                query=RetentionQuery(
+                    dateRange=DateRange(date_from="2025-11-04", date_to="2025-11-07"),
+                    retentionFilter=RetentionFilter(
+                        period=RetentionPeriod.DAY,
+                        totalIntervals=4,
+                        targetEntity=self._dw_entity("any_table"),
+                        returningEntity=self._dw_entity("any_table"),
+                        **extra,
+                    ),
+                ),
+            )
+
+        self.assertIn(expected_message_fragment, str(cm.exception))
+
+    def test_validation_rejects_mixed_entity_kinds(self) -> None:
+        with self.assertRaises(ValidationError) as cm:
+            RetentionQueryRunner(
+                team=self.team,
+                query=RetentionQuery(
+                    dateRange=DateRange(date_from="2025-11-04", date_to="2025-11-07"),
+                    retentionFilter=RetentionFilter(
+                        period=RetentionPeriod.DAY,
+                        totalIntervals=4,
+                        targetEntity=self._dw_entity("any_table"),
+                        returningEntity=RetentionEntity(
+                            kind=RetentionEntityKind.EVENTS_NODE,
+                            id="$pageview",
+                            type="events",
+                        ),
+                    ),
+                ),
+            )
+
+        self.assertIn("data warehouse nodes", str(cm.exception))
+
+    def test_validation_rejects_mismatched_tables(self) -> None:
+        with self.assertRaises(ValidationError) as cm:
+            RetentionQueryRunner(
+                team=self.team,
+                query=RetentionQuery(
+                    dateRange=DateRange(date_from="2025-11-04", date_to="2025-11-07"),
+                    retentionFilter=RetentionFilter(
+                        period=RetentionPeriod.DAY,
+                        totalIntervals=4,
+                        targetEntity=self._dw_entity("table_one"),
+                        returningEntity=self._dw_entity("table_two"),
+                    ),
+                ),
+            )
+
+        self.assertIn("same table", str(cm.exception))

--- a/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
@@ -113,10 +113,10 @@ class TestRetentionDataWarehouse(ClickhouseTestMixin, APIBaseTest):
                 ),
             )
 
-            response = RetentionQueryRunner(team=self.team, query=query).calculate()
+            results = RetentionQueryRunner(team=self.team, query=query).calculate().model_dump()["results"]
 
         # Count users cohorted on the first day (2025-11-04): user-1, user-2, user-3 -> 3
-        day_0 = next(row for row in response.results if row["date"].strftime("%Y-%m-%d") == "2025-11-04")
+        day_0 = next(row for row in results if row["date"].strftime("%Y-%m-%d") == "2025-11-04")
         self.assertEqual(day_0["values"][0]["count"], 3)  # day 0 cohort size
         # Users from day 0 who returned on day 1 (2025-11-05): only user-1
         self.assertEqual(day_0["values"][1]["count"], 1)
@@ -125,20 +125,35 @@ class TestRetentionDataWarehouse(ClickhouseTestMixin, APIBaseTest):
         # Day 3 (2025-11-07) returners from day-0 cohort: user-1
         self.assertEqual(day_0["values"][3]["count"], 1)
 
-        day_1 = next(row for row in response.results if row["date"].strftime("%Y-%m-%d") == "2025-11-05")
+        day_1 = next(row for row in results if row["date"].strftime("%Y-%m-%d") == "2025-11-05")
         # Cohort for 2025-11-05: user-1, user-4 -> 2
         self.assertEqual(day_1["values"][0]["count"], 2)
 
     @parameterized.expand(
         [
-            ("24_hour_windows", {"timeWindowMode": "24_hour_windows"}, "24 hour windows"),
-            ("first_time", {"retentionType": "retention_first_time"}, "First-time"),
-            ("first_ever", {"retentionType": "retention_first_ever_occurrence"}, "First-time"),
-            ("custom_brackets", {"retentionCustomBrackets": [1, 2, 3]}, "Custom retention brackets"),
-            ("sum_aggregation", {"aggregationType": "sum", "aggregationProperty": "x"}, "Sum/avg"),
+            ("24_hour_windows", {"timeWindowMode": "24_hour_windows"}, {}, "24 hour windows"),
+            ("first_time", {"retentionType": "retention_first_time"}, {}, "First-time"),
+            ("first_ever", {"retentionType": "retention_first_ever_occurrence"}, {}, "First-time"),
+            ("custom_brackets", {"retentionCustomBrackets": [1, 2, 3]}, {}, "Custom retention brackets"),
+            ("sum_aggregation", {"aggregationType": "sum", "aggregationProperty": "x"}, {}, "Sum/avg"),
+            ("minimum_occurrences", {"minimumOccurrences": 2}, {}, "Minimum occurrences"),
+            ("sampling_factor", {}, {"samplingFactor": 0.5}, "Sampling"),
+            ("test_account_filters", {}, {"filterTestAccounts": True}, "Test account"),
+            (
+                "breakdowns",
+                {},
+                {"breakdownFilter": {"breakdown": "browser", "breakdown_type": "event"}},
+                "Breakdowns",
+            ),
         ]
     )
-    def test_validation_rejects_unsupported(self, _name: str, extra: dict, expected_message_fragment: str) -> None:
+    def test_validation_rejects_unsupported(
+        self,
+        _name: str,
+        retention_extra: dict,
+        query_extra: dict,
+        expected_message_fragment: str,
+    ) -> None:
         with self.assertRaises(ValidationError) as cm:
             RetentionQueryRunner(
                 team=self.team,
@@ -149,8 +164,9 @@ class TestRetentionDataWarehouse(ClickhouseTestMixin, APIBaseTest):
                         totalIntervals=4,
                         targetEntity=self._dw_entity("any_table"),
                         returningEntity=self._dw_entity("any_table"),
-                        **extra,
+                        **retention_extra,
                     ),
+                    **query_extra,
                 ),
             )
 

--- a/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py
@@ -3,6 +3,8 @@ import tempfile
 from pathlib import Path
 
 from freezegun import freeze_time
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+
 from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
@@ -16,7 +18,6 @@ from posthog.schema import (
 )
 
 from posthog.hogql_queries.insights.retention.retention_query_runner import RetentionQueryRunner
-from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
 from products.data_warehouse.backend.test.utils import create_data_warehouse_table_from_csv
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4019,6 +4019,7 @@ class RetentionDashboardDisplayType(StrEnum):
 
 class RetentionEntityKind(StrEnum):
     ACTIONS_NODE = "ActionsNode"
+    DATA_WAREHOUSE_NODE = "DataWarehouseNode"
     EVENTS_NODE = "EventsNode"
 
 
@@ -17183,7 +17184,17 @@ class RetentionEntity(BaseModel):
         extra="forbid",
     )
     custom_name: str | None = None
+    distinct_id_field: str | None = Field(
+        default=None,
+        description=(
+            "Data warehouse field used as the actor identifier (only used when kind is DataWarehouseNode)"
+        ),
+    )
     id: str | float | None = None
+    id_field: str | None = Field(
+        default=None,
+        description="Data warehouse row identifier field (only used when kind is DataWarehouseNode)",
+    )
     kind: RetentionEntityKind | None = None
     name: str | None = None
     order: int | None = None
@@ -17212,6 +17223,14 @@ class RetentionEntity(BaseModel):
         ]
         | None
     ) = Field(default=None, description="filters on the event")
+    table_name: str | None = Field(
+        default=None,
+        description="Data warehouse table name (only used when kind is DataWarehouseNode)",
+    )
+    timestamp_field: str | None = Field(
+        default=None,
+        description="Data warehouse timestamp field (only used when kind is DataWarehouseNode)",
+    )
     type: EntityType | None = None
     uuid: str | None = None
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4019,8 +4019,8 @@ class RetentionDashboardDisplayType(StrEnum):
 
 class RetentionEntityKind(StrEnum):
     ACTIONS_NODE = "ActionsNode"
-    DATA_WAREHOUSE_NODE = "DataWarehouseNode"
     EVENTS_NODE = "EventsNode"
+    DATA_WAREHOUSE_NODE = "DataWarehouseNode"
 
 
 class RetentionPeriod(StrEnum):
@@ -17186,14 +17186,12 @@ class RetentionEntity(BaseModel):
     custom_name: str | None = None
     distinct_id_field: str | None = Field(
         default=None,
-        description=(
-            "Data warehouse field used as the actor identifier (only used when kind is DataWarehouseNode)"
-        ),
+        description=("Data warehouse field used as the actor identifier (only used when kind is DataWarehouseNode)"),
     )
     id: str | float | None = None
     id_field: str | None = Field(
         default=None,
-        description="Data warehouse row identifier field (only used when kind is DataWarehouseNode)",
+        description=("Data warehouse row identifier field (only used when kind is DataWarehouseNode)"),
     )
     kind: RetentionEntityKind | None = None
     name: str | None = None
@@ -17225,11 +17223,11 @@ class RetentionEntity(BaseModel):
     ) = Field(default=None, description="filters on the event")
     table_name: str | None = Field(
         default=None,
-        description="Data warehouse table name (only used when kind is DataWarehouseNode)",
+        description=("Data warehouse table name (only used when kind is DataWarehouseNode)"),
     )
     timestamp_field: str | None = Field(
         default=None,
-        description="Data warehouse timestamp field (only used when kind is DataWarehouseNode)",
+        description=("Data warehouse timestamp field (only used when kind is DataWarehouseNode)"),
     )
     type: EntityType | None = None
     uuid: str | None = None

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -2689,8 +2689,8 @@ export type RetentionEntityKindApi = (typeof RetentionEntityKindApi)[keyof typeo
 
 export const RetentionEntityKindApi = {
     ActionsNode: 'ActionsNode',
-    DataWarehouseNode: 'DataWarehouseNode',
     EventsNode: 'EventsNode',
+    DataWarehouseNode: 'DataWarehouseNode',
 } as const
 
 export type EntityTypeApi = (typeof EntityTypeApi)[keyof typeof EntityTypeApi]

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -2689,6 +2689,7 @@ export type RetentionEntityKindApi = (typeof RetentionEntityKindApi)[keyof typeo
 
 export const RetentionEntityKindApi = {
     ActionsNode: 'ActionsNode',
+    DataWarehouseNode: 'DataWarehouseNode',
     EventsNode: 'EventsNode',
 } as const
 
@@ -2705,7 +2706,17 @@ export const EntityTypeApi = {
 export interface RetentionEntityApi {
     /** @nullable */
     custom_name?: string | null
+    /**
+     * Data warehouse field used as the actor identifier (only used when kind is DataWarehouseNode)
+     * @nullable
+     */
+    distinct_id_field?: string | null
     id?: string | number | null
+    /**
+     * Data warehouse row identifier field (only used when kind is DataWarehouseNode)
+     * @nullable
+     */
+    id_field?: string | null
     kind?: RetentionEntityKindApi | null
     /** @nullable */
     name?: string | null
@@ -2739,6 +2750,16 @@ export interface RetentionEntityApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /**
+     * Data warehouse table name (only used when kind is DataWarehouseNode)
+     * @nullable
+     */
+    table_name?: string | null
+    /**
+     * Data warehouse timestamp field (only used when kind is DataWarehouseNode)
+     * @nullable
+     */
+    timestamp_field?: string | null
     type?: EntityTypeApi | null
     /** @nullable */
     uuid?: string | null

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -3017,6 +3017,7 @@ export namespace Schemas {
 
     export const RetentionEntityKind = {
       ActionsNode: 'ActionsNode',
+      DataWarehouseNode: 'DataWarehouseNode',
       EventsNode: 'EventsNode',
     } as const;
 
@@ -3034,7 +3035,17 @@ export namespace Schemas {
     export interface RetentionEntity {
       /** @nullable */
       custom_name?: string | null;
+      /**
+       * Data warehouse field used as the actor identifier (only used when kind is DataWarehouseNode)
+       * @nullable
+       */
+      distinct_id_field?: string | null;
       id?: string | number | null;
+      /**
+       * Data warehouse row identifier field (only used when kind is DataWarehouseNode)
+       * @nullable
+       */
+      id_field?: string | null;
       kind?: RetentionEntityKind | null;
       /** @nullable */
       name?: string | null;
@@ -3045,6 +3056,16 @@ export namespace Schemas {
        * @nullable
        */
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      /**
+       * Data warehouse table name (only used when kind is DataWarehouseNode)
+       * @nullable
+       */
+      table_name?: string | null;
+      /**
+       * Data warehouse timestamp field (only used when kind is DataWarehouseNode)
+       * @nullable
+       */
+      timestamp_field?: string | null;
       type?: EntityType | null;
       /** @nullable */
       uuid?: string | null;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -3017,8 +3017,8 @@ export namespace Schemas {
 
     export const RetentionEntityKind = {
       ActionsNode: 'ActionsNode',
-      DataWarehouseNode: 'DataWarehouseNode',
       EventsNode: 'EventsNode',
+      DataWarehouseNode: 'DataWarehouseNode',
     } as const;
 
     export type EntityType = typeof EntityType[keyof typeof EntityType];


### PR DESCRIPTION
## Problem

Retention insights today can only cohort/return on PostHog events (or actions). Teams with event-like data already modeled in the data warehouse (subscription activity, third-party product events, imported CRM pipelines, etc.) currently can't build retention curves on that data without re-emitting it as `$event`. This PR extends the retention query runner so a data warehouse table can drive the cohort and return series directly.

## Changes

### Schema

- `RetentionEntityKind` now includes `DataWarehouseNode` alongside `EventsNode`/`ActionsNode`.
- `RetentionEntity` gains optional `table_name`, `timestamp_field`, `distinct_id_field`, `id_field` — only populated when `kind === DataWarehouseNode`.
- `frontend/src/types.ts`, `frontend/src/queries/schema.json`, and `posthog/schema.py` are kept in sync.

### Backend (`posthog/hogql_queries/insights/retention/retention_query_runner.py`)

- New helpers — `_source_table_chain`, `_source_timestamp_chain`, `_actor_id_chain`, `_entity_to_expr`, plus `is_data_warehouse_retention` and table/field accessors — encapsulate the events-vs-DW switch.
- `events_timestamp_filter`, `global_event_filters`, `get_events_for_entity`, and the `actor_query_calendar` `FROM`/actor expressions now route through those helpers. The events path output is identical to before.
- `validate()` rejects DW retention combined with features that are not yet wired through: 24h windows, first-time / first-ever retention, custom brackets, breakdowns, group aggregation, sum/avg aggregation, `minimumOccurrences > 1`, sampling, test-account filters, mismatched tables/fields, and mixed DW + event entities. Each emits a distinct `ValidationError`.

### Frontend (`RetentionCondition.tsx`)

- Both retention entity pickers now expose `TaxonomicFilterGroupType.DataWarehouse` and a `dataWarehousePopoverFields` list for `id_field`, `timestamp_field`, `distinct_id_field`.
- Small helpers (`readEntityFromFilters`, `entityToActionFilter`) round-trip DW entities — ensuring `kind: NodeKind.DataWarehouseNode` is stamped on the entity going into `targetEntity`/`returningEntity`, and the entity is rehydrated into the correct `ActionFilter` bucket on re-render.

## How did you test this code?

I'm an agent and did **not** exercise the UI manually. Coverage added in this PR:

- `posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py` — happy-path recurring calendar retention against a CSV-backed data warehouse table, plus parameterized validation checks for each rejected combination and explicit mismatched-table / mixed-kind cases.
- Schema round-trip sanity-checked locally (`RetentionEntity` has the new fields, `RetentionEntityKind` includes `DataWarehouseNode`).

The sandbox I ran in lacked `uv`/`flox`, so the pytest suite itself wasn't executed — please run `hogli test posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse.py` before merging.

Out of scope for this PR (explicitly rejected by the new validator, future work):

- Breakdowns, aggregation modes, first-time / first-ever retention, 24-hour windows, group aggregation, cohort breakdowns, sampling, test account filters.
- The `to_events_query` drill-down still targets `events` — the actors modal's "view events" link on a DW retention insight will not render useful rows.

## Publish to changelog?

no — this is an initial cut; the public rollout will land once breakdowns and drill-down are wired up.

## 🤖 LLM context

Authored by an agent via the PostHog Code task harness. The agent reviewed existing DW implementations in lifecycle (`LifecycleQueryRunner`) and funnels (`FunnelEventQuery` / `FunnelsDataWarehouseNode`) before designing the retention variant, and prioritised keeping the events-based code path byte-identical so existing retention queries don't regress.