### PR TITLE
fix: clickhouse migration 0237, drop redundant 0222

### DIFF
--- a/posthog/clickhouse/migrations/0222_add_session_id_uuid_minmax_index.py
+++ b/posthog/clickhouse/migrations/0222_add_session_id_uuid_minmax_index.py
@@ -1,18 +1,3 @@
-from posthog.clickhouse.client.connection import NodeRole
-from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+# migration has been removed and reapplied as 0237
 
-ADD_MINMAX_INDEX_SHARDED_EVENTS = """
-ALTER TABLE sharded_events
-ADD INDEX IF NOT EXISTS `minmax_$session_id_uuid` `$session_id_uuid`
-TYPE minmax
-GRANULARITY 1
-"""
-
-operations = [
-    run_sql_with_exceptions(
-        ADD_MINMAX_INDEX_SHARDED_EVENTS,
-        node_roles=[NodeRole.DATA],
-        sharded=True,
-        is_alter_on_replicated_table=True,
-    ),
-]
+operations = []  # type: ignore

--- a/posthog/clickhouse/migrations/0237_readd_session_id_uuid_minmax_index.py
+++ b/posthog/clickhouse/migrations/0237_readd_session_id_uuid_minmax_index.py
@@ -17,6 +17,6 @@ operations = [
     run_sql_with_exceptions(
         ADD_MINMAX_INDEX_SHARDED_EVENTS,
         sharded=True,
-        is_alter_on_replicated_table=False,
+        is_alter_on_replicated_table=True,
     ),
 ]


### PR DESCRIPTION
## Problem

applying migration to all replicas fail

## Changes

apply to only one node per table replica

