### PR TITLE
feat(signals): rasterize session problem moments as GIF previews

### DIFF
--- a/posthog/temporal/session_replay/session_summary/activities/a6a_emit_session_problem_signals.py
+++ b/posthog/temporal/session_replay/session_summary/activities/a6a_emit_session_problem_signals.py
@@ -4,15 +4,27 @@ Emit signals for consolidated segments that indicate user problems.
 
 Runs after consolidation, emitting problem-indicating segments directly as signals
 instead of relying on the batch clustering pipeline.
+
+Also rasterizes a short GIF preview of each problematic moment (minimum 30s)
+for quick inline display in the desktop app.
 """
+
+import uuid
+from datetime import timedelta
+
+from django.conf import settings
+from django.utils.timezone import now
 
 import structlog
 import temporalio
+from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.team.team import Team
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
 from posthog.sync import database_sync_to_async
+from posthog.temporal.common.client import async_connect
+from posthog.temporal.session_replay.rasterize_recording.types import RasterizeRecordingInputs
 from posthog.temporal.session_replay.session_summary.types.video import (
     ConsolidatedVideoAnalysis,
     ConsolidatedVideoSegment,
@@ -24,6 +36,87 @@ from products.signals.backend.api import emit_signal
 from ee.hogai.session_summaries.constants import FULL_VIDEO_EXPORT_FORMAT
 
 logger = structlog.get_logger(__name__)
+
+# Minimum duration for the moment preview GIF (seconds)
+MIN_MOMENT_PREVIEW_DURATION_S = 30
+# Preview GIF export format
+MOMENT_PREVIEW_EXPORT_FORMAT = "image/gif"
+# How long to keep moment preview GIFs
+MOMENT_PREVIEW_EXPIRES_DAYS = 90
+
+
+def _parse_timestamp_to_seconds(ts: str) -> float:
+    """Parse MM:SS or HH:MM:SS timestamp to seconds."""
+    parts = ts.strip().split(":")
+    if len(parts) == 2:
+        return int(parts[0]) * 60 + float(parts[1])
+    elif len(parts) == 3:
+        return int(parts[0]) * 3600 + int(parts[1]) * 60 + float(parts[2])
+    return 0.0
+
+
+async def _rasterize_moment_preview(
+    team_id: int,
+    session_id: str,
+    start_time_s: float,
+    end_time_s: float,
+) -> int | None:
+    """Create a GIF preview of a session moment and return the ExportedAsset ID.
+
+    Expands the clip to at least MIN_MOMENT_PREVIEW_DURATION_S seconds where possible,
+    clamping start to 0 and compensating the end when near the recording start.
+    Returns None if rasterization fails.
+    """
+    duration = end_time_s - start_time_s
+    if duration < MIN_MOMENT_PREVIEW_DURATION_S:
+        # Expand symmetrically around the midpoint to reach the minimum
+        midpoint = (start_time_s + end_time_s) / 2
+        half = MIN_MOMENT_PREVIEW_DURATION_S / 2
+        start_time_s = max(0, midpoint - half)
+        end_time_s = midpoint + half
+        # When start was clamped to 0, extend end to compensate
+        if start_time_s == 0:
+            end_time_s = MIN_MOMENT_PREVIEW_DURATION_S
+
+    created_at = now()
+    expires_after = created_at + timedelta(days=MOMENT_PREVIEW_EXPIRES_DAYS)
+
+    exported_asset = await ExportedAsset.objects.acreate(
+        team_id=team_id,
+        export_format=MOMENT_PREVIEW_EXPORT_FORMAT,
+        export_context={
+            "session_recording_id": session_id,
+            "start_offset_s": start_time_s,
+            "end_offset_s": end_time_s,
+            "playback_speed": 1,
+            "show_metadata_footer": True,
+        },
+        created_at=created_at,
+        expires_after=expires_after,
+    )
+
+    try:
+        client = await async_connect()
+        await client.execute_workflow(
+            "rasterize-recording",
+            RasterizeRecordingInputs(exported_asset_id=exported_asset.id),
+            id=f"signal-moment-preview_{session_id}_{exported_asset.id}_{uuid.uuid4()}",
+            task_queue=settings.SESSION_REPLAY_TASK_QUEUE,
+            retry_policy=RetryPolicy(maximum_attempts=3),
+            id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+            execution_timeout=timedelta(minutes=10),
+        )
+        return exported_asset.id
+    except Exception:
+        logger.exception(
+            "Failed to rasterize moment preview",
+            session_id=session_id,
+            asset_id=exported_asset.id,
+            signals_type="session-summaries",
+        )
+        # Clean up the orphaned asset
+        await ExportedAsset.objects.filter(id=exported_asset.id).adelete()
+        return None
 
 
 @temporalio.activity.defn
@@ -67,6 +160,16 @@ async def emit_session_problem_signals_activity(
 
         source_id = f"{inputs.session_id}:{segment.start_time}:{segment.end_time}"
 
+        # Rasterize a GIF preview of the problematic moment
+        start_s = _parse_timestamp_to_seconds(segment.start_time)
+        end_s = _parse_timestamp_to_seconds(segment.end_time)
+        moment_preview_asset_id = await _rasterize_moment_preview(
+            team_id=inputs.team_id,
+            session_id=inputs.session_id,
+            start_time_s=start_s,
+            end_time_s=end_s,
+        )
+
         extra: dict = {
             "session_id": inputs.session_id,
             "segment_title": segment.title,
@@ -84,6 +187,9 @@ async def emit_session_problem_signals_activity(
         if exported_asset is not None:
             extra["exported_asset_id"] = exported_asset.id
 
+        if moment_preview_asset_id is not None:
+            extra["moment_preview_asset_id"] = moment_preview_asset_id
+
         try:
             await emit_signal(
                 team=team,
@@ -99,6 +205,7 @@ async def emit_session_problem_signals_activity(
                 f"Emitted session problem signal for {source_id}",
                 session_id=inputs.session_id,
                 problem_type=problem_type,
+                moment_preview_asset_id=moment_preview_asset_id,
                 signals_type="session-summaries",
             )
         except Exception:

--- a/posthog/temporal/tests/session_replay/session_summary/test_emit_session_problem_signals.py
+++ b/posthog/temporal/tests/session_replay/session_summary/test_emit_session_problem_signals.py
@@ -1,7 +1,11 @@
 import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from posthog.temporal.session_replay.session_summary.activities.a6a_emit_session_problem_signals import (
+    MIN_MOMENT_PREVIEW_DURATION_S,
     _classify_problem,
+    _parse_timestamp_to_seconds,
+    _rasterize_moment_preview,
 )
 from posthog.temporal.session_replay.session_summary.types.video import ConsolidatedVideoSegment
 
@@ -60,3 +64,106 @@ class TestClassifyProblem:
     )
     def test_priority_ordering(self, kwargs, expected):
         assert _classify_problem(_make_segment(**kwargs)) == expected
+
+
+class TestParseTimestampToSeconds:
+    @pytest.mark.parametrize(
+        "ts, expected",
+        [
+            ("00:00", 0.0),
+            ("01:30", 90.0),
+            ("10:05", 605.0),
+            ("1:00:00", 3600.0),
+            ("1:30:45", 5445.0),
+            ("0:00:30", 30.0),
+        ],
+        ids=["zero", "ninety_seconds", "ten_five", "one_hour", "ninety_min_45s", "thirty_seconds"],
+    )
+    def test_parses_correctly(self, ts, expected):
+        assert _parse_timestamp_to_seconds(ts) == expected
+
+
+_RASTERIZE_PATCH_OBJECTS = (
+    "posthog.temporal.session_replay.session_summary.activities.a6a_emit_session_problem_signals.ExportedAsset.objects"
+)
+_RASTERIZE_PATCH_CONNECT = (
+    "posthog.temporal.session_replay.session_summary.activities.a6a_emit_session_problem_signals.async_connect"
+)
+
+
+@pytest.mark.django_db
+class TestRasterizeMomentPreview:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "session_id, start_time_s, end_time_s, expected_start, expected_end",
+        [
+            # Segment already >= minimum duration — no expansion
+            ("sess-long", 60.0, 120.0, 60.0, 120.0),
+            # Short segment at midpoint — expand symmetrically (midpoint=55, half=15)
+            ("sess-short", 50.0, 60.0, 40.0, 70.0),
+            # Segment near start (5–10s) — start clamped to 0, end extended to minimum
+            ("sess-early", 5.0, 10.0, 0, MIN_MOMENT_PREVIEW_DURATION_S),
+        ],
+        ids=["no_expansion", "symmetric_expansion", "clamp_start_extend_end"],
+    )
+    async def test_export_context_offsets(
+        self,
+        session_id: str,
+        start_time_s: float,
+        end_time_s: float,
+        expected_start: float,
+        expected_end: float,
+    ):
+        mock_asset = MagicMock()
+        mock_asset.id = 42
+        mock_client = AsyncMock()
+        mock_client.execute_workflow = AsyncMock(return_value=None)
+
+        with (
+            patch(_RASTERIZE_PATCH_OBJECTS) as mock_objects,
+            patch(_RASTERIZE_PATCH_CONNECT, return_value=mock_client),
+        ):
+            mock_objects.acreate = AsyncMock(return_value=mock_asset)
+            result = await _rasterize_moment_preview(
+                team_id=1,
+                session_id=session_id,
+                start_time_s=start_time_s,
+                end_time_s=end_time_s,
+            )
+
+        assert result == 42
+        ctx = mock_objects.acreate.call_args[1]["export_context"]
+        assert ctx["session_recording_id"] == session_id
+        assert ctx["start_offset_s"] == expected_start
+        assert ctx["end_offset_s"] == expected_end
+        assert ctx["end_offset_s"] - ctx["start_offset_s"] >= MIN_MOMENT_PREVIEW_DURATION_S
+        assert ctx["playback_speed"] == 1
+        mock_client.execute_workflow.assert_called_once()
+        assert mock_client.execute_workflow.call_args[0][0] == "rasterize-recording"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_and_cleans_up_on_workflow_failure(self):
+        mock_asset = MagicMock()
+        mock_asset.id = 50
+        mock_client = AsyncMock()
+        mock_client.execute_workflow = AsyncMock(side_effect=RuntimeError("workflow failed"))
+        mock_filter = AsyncMock()
+
+        with (
+            patch(_RASTERIZE_PATCH_OBJECTS) as mock_objects,
+            patch(_RASTERIZE_PATCH_CONNECT, return_value=mock_client),
+        ):
+            mock_objects.acreate = AsyncMock(return_value=mock_asset)
+            mock_objects.filter = MagicMock(return_value=mock_filter)
+            mock_filter.adelete = AsyncMock(return_value=None)
+
+            result = await _rasterize_moment_preview(
+                team_id=1,
+                session_id="sess-fail",
+                start_time_s=0.0,
+                end_time_s=60.0,
+            )
+
+        assert result is None
+        mock_objects.filter.assert_called_once_with(id=50)
+        mock_filter.adelete.assert_called_once()

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -350,3 +350,97 @@ class TestSignalReportListAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
         assert row["is_suggested_reviewer"] is expected_suggested
+
+
+class TestEnrichSignalsWithMomentPreviewUrls(APIBaseTest):
+    def test_enriches_signals_with_preview_url(self):
+        from posthog.models.exported_asset import ExportedAsset
+
+        from products.signals.backend.views import _enrich_signals_with_moment_preview_urls
+
+        asset = ExportedAsset.objects.create(
+            team=self.team,
+            export_format="image/gif",
+            content=b"GIF89a\x01\x00",  # Minimal GIF content
+            export_context={"session_recording_id": "sess-1"},
+        )
+
+        signals_list = [
+            {
+                "signal_id": "sig-1",
+                "content": "Problem occurred",
+                "source_product": "session_replay",
+                "source_type": "session_problem",
+                "source_id": "sess-1:00:30:01:00",
+                "weight": 1.0,
+                "timestamp": "2024-01-01T00:00:00",
+                "extra": {
+                    "session_id": "sess-1",
+                    "problem_type": "confusion",
+                    "moment_preview_asset_id": asset.id,
+                },
+            },
+            {
+                "signal_id": "sig-2",
+                "content": "GitHub issue",
+                "source_product": "github",
+                "source_type": "issue",
+                "source_id": "org/repo#1",
+                "weight": 0.5,
+                "timestamp": "2024-01-01T00:00:00",
+                "extra": {"html_url": "https://github.com/org/repo/issues/1"},
+            },
+        ]
+
+        result = _enrich_signals_with_moment_preview_urls(signals_list, team_id=self.team.id)
+
+        # First signal should have a preview URL
+        assert "moment_preview_url" in result[0]["extra"]
+        assert "/exporter/" in result[0]["extra"]["moment_preview_url"]
+        assert "token=" in result[0]["extra"]["moment_preview_url"]
+
+        # Second signal should be unchanged
+        assert "moment_preview_url" not in result[1]["extra"]
+
+    def test_no_enrichment_when_no_preview_assets(self):
+        from products.signals.backend.views import _enrich_signals_with_moment_preview_urls
+
+        signals_list = [
+            {
+                "signal_id": "sig-1",
+                "content": "GitHub issue",
+                "source_product": "github",
+                "source_type": "issue",
+                "source_id": "org/repo#1",
+                "weight": 0.5,
+                "timestamp": "2024-01-01T00:00:00",
+                "extra": {"html_url": "https://github.com/org/repo/issues/1"},
+            },
+        ]
+
+        result = _enrich_signals_with_moment_preview_urls(signals_list, team_id=self.team.id)
+        assert result == signals_list
+
+    def test_handles_missing_asset_gracefully(self):
+        from products.signals.backend.views import _enrich_signals_with_moment_preview_urls
+
+        signals_list = [
+            {
+                "signal_id": "sig-1",
+                "content": "Problem",
+                "source_product": "session_replay",
+                "source_type": "session_problem",
+                "source_id": "sess-1:00:30:01:00",
+                "weight": 1.0,
+                "timestamp": "2024-01-01T00:00:00",
+                "extra": {
+                    "session_id": "sess-1",
+                    "problem_type": "confusion",
+                    "moment_preview_asset_id": 99999,  # Non-existent
+                },
+            },
+        ]
+
+        result = _enrich_signals_with_moment_preview_urls(signals_list, team_id=self.team.id)
+        # Should not add a URL for non-existent asset
+        assert "moment_preview_url" not in result[0]["extra"]

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from datetime import timedelta
-from typing import cast
+from typing import Any, cast
 
 from django.conf import settings
 from django.db import IntegrityError
@@ -43,6 +43,7 @@ from temporalio.service import RPCError, RPCStatusCode
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.auth import InternalAPIAuthentication, OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
 from posthog.models import Team
+from posthog.models.exported_asset import ExportedAsset
 from posthog.permissions import APIScopePermission
 from posthog.temporal.ai.video_segment_clustering.constants import clustering_workflow_id
 from posthog.temporal.ai.video_segment_clustering.models import ClusteringWorkflowInputs
@@ -89,6 +90,44 @@ from products.signals.backend.temporal.types import (
 )
 
 logger = structlog.get_logger(__name__)
+
+
+def _safe_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _enrich_signals_with_moment_preview_urls(signals_list: list[dict], team_id: int) -> list[dict]:
+    """Resolve moment_preview_asset_id in signal extras to public content URLs."""
+    asset_ids: list[int] = []
+    for signal in signals_list:
+        extra = signal.get("extra", {})
+        parsed = _safe_int(extra.get("moment_preview_asset_id"))
+        if parsed is not None:
+            asset_ids.append(parsed)
+
+    if not asset_ids:
+        return signals_list
+
+    # Batch-fetch all relevant assets and generate public URLs, scoped to this team
+    assets = ExportedAsset.objects.filter(id__in=asset_ids, team_id=team_id).only(
+        "id", "content", "content_location", "export_format", "created_at", "export_context"
+    )
+    asset_url_map: dict[int, str] = {}
+    for asset in assets:
+        if asset.has_content:
+            asset_url_map[asset.id] = asset.get_public_content_url()
+
+    # Inject the URL into each signal's extra
+    for signal in signals_list:
+        extra = signal.get("extra", {})
+        parsed = _safe_int(extra.get("moment_preview_asset_id"))
+        if parsed is not None and parsed in asset_url_map:
+            extra["moment_preview_url"] = asset_url_map[parsed]
+
+    return signals_list
 
 
 class EmitSignalSerializer(serializers.Serializer):
@@ -697,8 +736,9 @@ class SignalReportViewSet(
     def signals(self, request, pk=None, **kwargs):
         """Fetch all signals for a report from ClickHouse, including full metadata."""
         report = self.get_object()
-        report_data = SignalReportSerializer(report).data
+        report_data = SignalReportSerializer(report, context=self.get_serializer_context()).data
         signals_list = fetch_signals_for_report_sync(self.team, str(report.id))
+        signals_list = _enrich_signals_with_moment_preview_urls(signals_list, team_id=self.team.id)
         return Response({"report": report_data, "signals": signals_list})
 
     @extend_schema(exclude=True)


### PR DESCRIPTION
## Problem

When session problem signals are emitted from the video summarization pipeline, there's no quick visual preview of what happened. Reviewers in PostHog Code have to open the full session replay to understand the problem.

## Changes

- Modified `emit_session_problem_signals_activity` to rasterize a GIF preview of each problematic moment via the `rasterize-recording` Temporal workflow
- Ensures a minimum 30s clip by expanding short segments symmetrically around the midpoint
- Stores `moment_preview_asset_id` in the signal's `extra` dict
- Added `_enrich_signals_with_moment_preview_urls()` in the signals API to batch-resolve asset IDs to JWT-signed public URLs at read time
- Cleans up orphaned assets on rasterization failure

## How did you test this code?

- 20 unit tests for `_classify_problem`, `_parse_timestamp_to_seconds`, and `_rasterize_moment_preview` (happy path, short segment expansion, start clamping, failure cleanup)
- 3 integration tests for `_enrich_signals_with_moment_preview_urls` (URL resolution, no-op, missing asset)

## Publish to changelog?

No

## 🤖 LLM context

Co-authored with Claude Code.