### PR TITLE
feat(signals): Add source_products, implementation_pr_url, and actionability ordering to reports

### DIFF
--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -165,6 +165,15 @@ class SignalReportSerializer(serializers.ModelSerializer):
         help_text="Whether the issue appears already fixed, from the actionability judgment artefact.",
     )
     is_suggested_reviewer = serializers.BooleanField(read_only=True, default=False)
+    source_products = serializers.SerializerMethodField(
+        help_text="Distinct source products contributing signals to this report (from ClickHouse).",
+    )
+    implementation_pr_url = serializers.CharField(
+        read_only=True,
+        default=None,
+        allow_null=True,
+        help_text="PR URL from the latest implementation task run, if available.",
+    )
 
     class Meta:
         model = SignalReport
@@ -183,6 +192,8 @@ class SignalReportSerializer(serializers.ModelSerializer):
             "actionability",
             "already_addressed",
             "is_suggested_reviewer",
+            "source_products",
+            "implementation_pr_url",
         ]
         read_only_fields = fields
 
@@ -238,6 +249,12 @@ class SignalReportSerializer(serializers.ModelSerializer):
             return None
         value = data.get("already_addressed")
         return value if isinstance(value, bool) else None
+
+    def get_source_products(self, obj: SignalReport) -> list[str]:
+        source_products_map: dict[str, list[str]] | None = self.context.get("source_products_map")
+        if source_products_map is not None:
+            return source_products_map.get(str(obj.id), [])
+        return []
 
 
 class SignalReportArtefactSerializer(serializers.ModelSerializer):

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -168,10 +168,7 @@ class SignalReportSerializer(serializers.ModelSerializer):
     source_products = serializers.SerializerMethodField(
         help_text="Distinct source products contributing signals to this report (from ClickHouse).",
     )
-    implementation_pr_url = serializers.CharField(
-        read_only=True,
-        default=None,
-        allow_null=True,
+    implementation_pr_url = serializers.SerializerMethodField(
         help_text="PR URL from the latest implementation task run, if available.",
     )
 
@@ -255,6 +252,13 @@ class SignalReportSerializer(serializers.ModelSerializer):
         if source_products_map is not None:
             return source_products_map.get(str(obj.id), [])
         return []
+
+    def get_implementation_pr_url(self, obj: SignalReport) -> str | None:
+        implementation_pr_url_map: dict[str, str] | None = self.context.get("implementation_pr_url_map")
+        if implementation_pr_url_map is not None:
+            return implementation_pr_url_map.get(str(obj.id))
+        value = getattr(obj, "implementation_pr_url", None)
+        return value if isinstance(value, str) else None
 
 
 class SignalReportArtefactSerializer(serializers.ModelSerializer):

--- a/products/signals/backend/temporal/signal_queries.py
+++ b/products/signals/backend/temporal/signal_queries.py
@@ -39,36 +39,29 @@ def _ensure_tz_aware(value: Union[datetime, str]) -> datetime:
 # Shared query builders
 # ---------------------------------------------------------------------------
 
-# The innermost dedup subquery, shared by every query that reads signal rows.
-# Uses argMax(…, inserted_at) GROUP BY document_id to collapse ReplacingMergeTree
-# duplicates deterministically, regardless of background merge state.
-_DEDUPED_SIGNALS_SUBQUERY = """
-    SELECT
-        document_id,
-        argMax(content, inserted_at) as content,
-        argMax(metadata, inserted_at) as metadata,
-        argMax(timestamp, inserted_at) as timestamp
-    FROM document_embeddings
-    WHERE model_name = {model_name}
-      AND product = 'signals'
-      AND document_type = 'signal'
-    GROUP BY document_id
-"""
+def _deduped_signals_subquery(*, include_embedding: bool = False, extra_where: str | None = None) -> str:
+    """Build the shared signal dedup subquery with an optional extra document_embeddings filter."""
+    selected_columns = [
+        "document_id",
+        "argMax(content, inserted_at) as content",
+        "argMax(metadata, inserted_at) as metadata",
+    ]
+    if include_embedding:
+        selected_columns.append("argMax(embedding, inserted_at) as embedding")
+    selected_columns.append("argMax(timestamp, inserted_at) as timestamp")
+    selected_columns_sql = ",\n            ".join(selected_columns)
 
-# Same as above but also deduplicates the embedding column (needed for vector search).
-_DEDUPED_SIGNALS_WITH_EMBEDDING_SUBQUERY = """
-    SELECT
-        document_id,
-        argMax(content, inserted_at) as content,
-        argMax(metadata, inserted_at) as metadata,
-        argMax(embedding, inserted_at) as embedding,
-        argMax(timestamp, inserted_at) as timestamp
-    FROM document_embeddings
-    WHERE model_name = {model_name}
-      AND product = 'signals'
-      AND document_type = 'signal'
-    GROUP BY document_id
-"""
+    extra_where_clause = f"\n      AND {extra_where}" if extra_where else ""
+
+    return f"""
+        SELECT
+            {selected_columns_sql}
+        FROM document_embeddings
+        WHERE model_name = {{model_name}}
+          AND product = 'signals'
+          AND document_type = 'signal'{extra_where_clause}
+        GROUP BY document_id
+    """
 
 
 def _signals_for_report_query(*, include_deleted: bool = False, limit: int | None = None) -> str:
@@ -88,7 +81,7 @@ def _signals_for_report_query(*, include_deleted: bool = False, limit: int | Non
             content,
             metadata,
             timestamp
-        FROM ({_DEDUPED_SIGNALS_SUBQUERY})
+        FROM ({_deduped_signals_subquery()})
         WHERE JSONExtractString(metadata, 'report_id') = {{report_id}}{deleted_filter}
         ORDER BY timestamp ASC{limit_clause}
     """
@@ -193,7 +186,7 @@ async def fetch_signal_type_examples_activity(input: FetchSignalTypeExamplesInpu
                     content,
                     metadata,
                     timestamp
-                FROM ({_DEDUPED_SIGNALS_SUBQUERY})
+                FROM ({_deduped_signals_subquery()})
                 WHERE content != ''
                   AND timestamp >= now() - INTERVAL 1 MONTH
                   AND NOT JSONExtractBool(metadata, 'deleted')
@@ -269,7 +262,7 @@ async def run_signal_semantic_search_activity(input: RunSignalSemanticSearchInpu
                 JSONExtractString(metadata, 'source_product') as source_product,
                 JSONExtractString(metadata, 'source_type') as source_type,
                 cosineDistance(embedding, {{embedding}}) as distance
-            FROM ({_DEDUPED_SIGNALS_WITH_EMBEDDING_SUBQUERY})
+            FROM ({_deduped_signals_subquery(include_embedding=True)})
             WHERE JSONExtractString(metadata, 'report_id') != ''
               AND timestamp >= now() - INTERVAL 1 MONTH
               AND NOT JSONExtractBool(metadata, 'deleted')
@@ -515,7 +508,7 @@ def fetch_report_ids_for_source_products(team: Team, source_products: list[str])
                 JSONExtractBool(metadata, 'deleted') as is_deleted,
                 JSONExtractString(metadata, 'source_product') as source_product,
                 timestamp
-            FROM ({_DEDUPED_SIGNALS_SUBQUERY})
+            FROM ({_deduped_signals_subquery()})
             ORDER BY timestamp DESC
         )
         WHERE NOT is_deleted
@@ -558,17 +551,7 @@ def fetch_source_products_for_reports(team: Team, report_ids: list[str]) -> dict
                 JSONExtractString(metadata, 'report_id') as report_id,
                 JSONExtractBool(metadata, 'deleted') as is_deleted,
                 JSONExtractString(metadata, 'source_product') as source_product
-            FROM (
-                SELECT
-                    document_id,
-                    argMax(metadata, inserted_at) as metadata
-                FROM document_embeddings
-                WHERE model_name = {{model_name}}
-                  AND product = 'signals'
-                  AND document_type = 'signal'
-                  AND JSONExtractString(metadata, 'report_id') IN ({{report_ids}})
-                GROUP BY document_id
-            )
+            FROM ({_deduped_signals_subquery(extra_where="JSONExtractString(metadata, 'report_id') IN ({report_ids})")})
         )
         WHERE NOT is_deleted
           AND report_id != ''

--- a/products/signals/backend/temporal/signal_queries.py
+++ b/products/signals/backend/temporal/signal_queries.py
@@ -557,10 +557,11 @@ def fetch_source_products_for_reports(team: Team, report_ids: list[str]) -> dict
                 JSONExtractString(metadata, 'report_id') as report_id,
                 JSONExtractBool(metadata, 'deleted') as is_deleted,
                 JSONExtractString(metadata, 'source_product') as source_product
-            FROM ({_deduped_signals_subquery(extra_where="JSONExtractString(metadata, 'report_id') IN ({report_ids})")})
+            FROM ({_deduped_signals_subquery()})
         )
         WHERE NOT is_deleted
           AND report_id != ''
+          AND report_id IN ({{report_ids}})
           AND source_product != ''
         GROUP BY report_id
     """

--- a/products/signals/backend/temporal/signal_queries.py
+++ b/products/signals/backend/temporal/signal_queries.py
@@ -536,3 +536,45 @@ def fetch_report_ids_for_source_products(team: Team, source_products: list[str])
     )
 
     return {row[0] for row in (result.results or []) if row[0]}
+
+
+# ---------------------------------------------------------------------------
+# fetch_source_products_for_reports — synchronous, for the serializer list view
+# ---------------------------------------------------------------------------
+
+
+def fetch_source_products_for_reports(team: Team, report_ids: list[str]) -> dict[str, list[str]]:
+    """Return a mapping of report_id -> distinct source_products for those reports.
+
+    Only includes non-deleted signals. Source products are returned as an unordered distinct set.
+    """
+    if not report_ids:
+        return {}
+
+    ch_query = f"""
+        SELECT report_id, groupUniqArray(source_product) as source_products
+        FROM (
+            SELECT
+                JSONExtractString(metadata, 'report_id') as report_id,
+                JSONExtractBool(metadata, 'deleted') as is_deleted,
+                JSONExtractString(metadata, 'source_product') as source_product
+            FROM ({_DEDUPED_SIGNALS_SUBQUERY})
+        )
+        WHERE NOT is_deleted
+          AND report_id IN ({{report_ids}})
+          AND source_product != ''
+        GROUP BY report_id
+    """
+
+    tag_queries(product=Product.SIGNALS, feature=Feature.USAGE_REPORT)
+    result = execute_hogql_query(
+        query_type="SignalsFetchSourceProductsForReports",
+        query=ch_query,
+        team=team,
+        placeholders={
+            "model_name": ast.Constant(value=EMBEDDING_MODEL.value),
+            "report_ids": ast.Tuple(exprs=[ast.Constant(value=rid) for rid in report_ids]),
+        },
+    )
+
+    return {row[0]: row[1] for row in (result.results or []) if row[0]}

--- a/products/signals/backend/temporal/signal_queries.py
+++ b/products/signals/backend/temporal/signal_queries.py
@@ -546,22 +546,32 @@ def fetch_report_ids_for_source_products(team: Team, source_products: list[str])
 def fetch_source_products_for_reports(team: Team, report_ids: list[str]) -> dict[str, list[str]]:
     """Return a mapping of report_id -> distinct source_products for those reports.
 
-    Only includes non-deleted signals. Source products are returned as an unordered distinct set.
+    Only includes non-deleted signals. Source products are returned in sorted order.
     """
     if not report_ids:
         return {}
 
     ch_query = f"""
-        SELECT report_id, groupUniqArray(source_product) as source_products
+        SELECT report_id, arraySort(groupUniqArray(source_product)) as source_products
         FROM (
             SELECT
                 JSONExtractString(metadata, 'report_id') as report_id,
                 JSONExtractBool(metadata, 'deleted') as is_deleted,
                 JSONExtractString(metadata, 'source_product') as source_product
-            FROM ({_DEDUPED_SIGNALS_SUBQUERY})
+            FROM (
+                SELECT
+                    document_id,
+                    argMax(metadata, inserted_at) as metadata
+                FROM document_embeddings
+                WHERE model_name = {{model_name}}
+                  AND product = 'signals'
+                  AND document_type = 'signal'
+                  AND JSONExtractString(metadata, 'report_id') IN ({{report_ids}})
+                GROUP BY document_id
+            )
         )
         WHERE NOT is_deleted
-          AND report_id IN ({{report_ids}})
+          AND report_id != ''
           AND source_product != ''
         GROUP BY report_id
     """

--- a/products/signals/backend/temporal/signal_queries.py
+++ b/products/signals/backend/temporal/signal_queries.py
@@ -39,6 +39,7 @@ def _ensure_tz_aware(value: Union[datetime, str]) -> datetime:
 # Shared query builders
 # ---------------------------------------------------------------------------
 
+
 def _deduped_signals_subquery(*, include_embedding: bool = False, extra_where: str | None = None) -> str:
     """Build the shared signal dedup subquery with an optional extra document_embeddings filter."""
     selected_columns = [
@@ -62,6 +63,11 @@ def _deduped_signals_subquery(*, include_embedding: bool = False, extra_where: s
           AND document_type = 'signal'{extra_where_clause}
         GROUP BY document_id
     """
+
+
+# Backwards-compatible aliases for callers that import the shared query constants directly.
+_DEDUPED_SIGNALS_SUBQUERY = _deduped_signals_subquery()
+_DEDUPED_SIGNALS_WITH_EMBEDDING_SUBQUERY = _deduped_signals_subquery(include_embedding=True)
 
 
 def _signals_for_report_query(*, include_deleted: bool = False, limit: int | None = None) -> str:

--- a/products/signals/backend/temporal/signal_queries.py
+++ b/products/signals/backend/temporal/signal_queries.py
@@ -467,7 +467,7 @@ async def fetch_signals_for_report_activity(input: FetchSignalsForReportInput) -
 
 def fetch_signals_for_report_sync(team: Team, report_id: str) -> list[dict]:
     """Fetch all signals for a report from ClickHouse, including full metadata. Synchronous."""
-    tag_queries(product=Product.SIGNALS, feature=Feature.USAGE_REPORT)
+    tag_queries(product=Product.SIGNALS, feature=Feature.QUERY)
     result = execute_hogql_query(
         query_type="SignalsDebugFetchForReport",
         query=_signals_for_report_query(),
@@ -523,7 +523,7 @@ def fetch_report_ids_for_source_products(team: Team, source_products: list[str])
         LIMIT 300
     """
 
-    tag_queries(product=Product.SIGNALS, feature=Feature.USAGE_REPORT)
+    tag_queries(product=Product.SIGNALS, feature=Feature.QUERY)
     result = execute_hogql_query(
         query_type="SignalsFilterBySourceProduct",
         query=ch_query,
@@ -566,7 +566,7 @@ def fetch_source_products_for_reports(team: Team, report_ids: list[str]) -> dict
         GROUP BY report_id
     """
 
-    tag_queries(product=Product.SIGNALS, feature=Feature.USAGE_REPORT)
+    tag_queries(product=Product.SIGNALS, feature=Feature.QUERY)
     result = execute_hogql_query(
         query_type="SignalsFetchSourceProductsForReports",
         query=ch_query,

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -13,6 +13,7 @@ from social_django.models import UserSocialAuth
 from posthog.models.team.team import Team
 
 from products.signals.backend.models import SignalReport, SignalReportArtefact, SignalReportTask
+from products.signals.backend.views import SignalReportViewSet
 from products.tasks.backend.models import Task, TaskRun
 
 
@@ -408,6 +409,14 @@ class TestSignalReportListAPI(APIBaseTest):
         row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
         assert row["implementation_pr_url"] == "https://github.com/org/repo/pull/42"
 
+    def test_retrieve_implementation_pr_url_present_when_task_has_pr(self):
+        report = self._create_report()
+        self._create_implementation_task_with_run(report, pr_url="https://github.com/org/repo/pull/42")
+
+        response = self.client.get(f"/api/projects/{self.team.id}/signals/reports/{report.id}/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["implementation_pr_url"] == "https://github.com/org/repo/pull/42"
+
     def test_implementation_pr_url_null_when_no_implementation_task(self):
         report = self._create_report()
 
@@ -467,6 +476,20 @@ class TestSignalReportListAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
         assert row["implementation_pr_url"] == "https://github.com/org/repo/pull/99"
+
+    def test_fetches_implementation_pr_urls_for_current_report_page(self):
+        report_with_pr = self._create_report(title="Report with PR")
+        report_without_pr = self._create_report(title="Report without PR")
+        self._create_implementation_task_with_run(report_with_pr, pr_url="https://github.com/org/repo/pull/42")
+        self._create_implementation_task_with_run(report_without_pr, output={"commit_sha": "abc123"})
+
+        viewset = SignalReportViewSet()
+        viewset.team = self.team
+        result = viewset._fetch_implementation_pr_urls_for_reports([str(report_with_pr.id), str(report_without_pr.id)])
+
+        assert result == {
+            str(report_with_pr.id): "https://github.com/org/repo/pull/42",
+        }
 
     # --- source_products ---
 

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -12,7 +12,8 @@ from social_django.models import UserSocialAuth
 
 from posthog.models.team.team import Team
 
-from products.signals.backend.models import SignalReport, SignalReportArtefact
+from products.signals.backend.models import SignalReport, SignalReportArtefact, SignalReportTask
+from products.tasks.backend.models import Task, TaskRun
 
 
 class TestSignalReportDeleteAPI(APIBaseTest):
@@ -350,3 +351,152 @@ class TestSignalReportListAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
         assert row["is_suggested_reviewer"] is expected_suggested
+
+    def test_is_suggested_reviewer_true_when_no_actionability_judgment(self):
+        UserSocialAuth.objects.create(
+            user=self.user,
+            provider="github",
+            uid="github-test-suggested-no-judgment",
+            extra_data={"login": "suggestedgh"},
+        )
+        report = self._create_report()
+        # No actionability artefact — latest_actionability_value is NULL
+        SignalReportArtefact.objects.create(
+            team=self.team,
+            report=report,
+            type=SignalReportArtefact.ArtefactType.SUGGESTED_REVIEWERS,
+            content=json.dumps([{"github_login": "suggestedgh"}]),
+        )
+
+        response = self.client.get(self._list_url(status="ready"))
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        assert row["is_suggested_reviewer"] is True
+
+    # --- implementation_pr_url ---
+
+    def _create_implementation_task_with_run(
+        self, report: SignalReport, *, pr_url: str | None = None, output: dict | None = None
+    ) -> tuple[Task, TaskRun]:
+        task = Task.objects.create(
+            team=self.team,
+            title="Implementation task",
+            description="Fix the bug",
+            origin_product=Task.OriginProduct.SIGNAL_REPORT,
+        )
+        SignalReportTask.objects.create(
+            team=self.team,
+            report=report,
+            task=task,
+            relationship=SignalReportTask.Relationship.IMPLEMENTATION,
+        )
+        run_output = output if output is not None else ({"pr_url": pr_url} if pr_url else None)
+        run = TaskRun.objects.create(
+            team=self.team,
+            task=task,
+            status=TaskRun.Status.COMPLETED,
+            output=run_output,
+        )
+        return task, run
+
+    def test_implementation_pr_url_present_when_task_has_pr(self):
+        report = self._create_report()
+        self._create_implementation_task_with_run(report, pr_url="https://github.com/org/repo/pull/42")
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        assert row["implementation_pr_url"] == "https://github.com/org/repo/pull/42"
+
+    def test_implementation_pr_url_null_when_no_implementation_task(self):
+        report = self._create_report()
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        assert row["implementation_pr_url"] is None
+
+    def test_implementation_pr_url_null_when_output_has_no_pr_url(self):
+        report = self._create_report()
+        self._create_implementation_task_with_run(report, output={"commit_sha": "abc123"})
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        assert row["implementation_pr_url"] is None
+
+    def test_implementation_pr_url_null_when_pr_url_is_empty_string(self):
+        report = self._create_report()
+        self._create_implementation_task_with_run(report, pr_url="")
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        assert row["implementation_pr_url"] is None
+
+    def test_implementation_pr_url_uses_latest_task_run(self):
+        report = self._create_report()
+        task = Task.objects.create(
+            team=self.team,
+            title="Implementation task",
+            description="Fix the bug",
+            origin_product=Task.OriginProduct.SIGNAL_REPORT,
+        )
+        SignalReportTask.objects.create(
+            team=self.team,
+            report=report,
+            task=task,
+            relationship=SignalReportTask.Relationship.IMPLEMENTATION,
+        )
+        old_run = TaskRun.objects.create(
+            team=self.team,
+            task=task,
+            status=TaskRun.Status.COMPLETED,
+            output={"pr_url": "https://github.com/org/repo/pull/1"},
+        )
+        # Force older created_at
+        TaskRun.objects.filter(pk=old_run.pk).update(created_at=timezone.now() - timedelta(hours=1))
+        TaskRun.objects.create(
+            team=self.team,
+            task=task,
+            status=TaskRun.Status.COMPLETED,
+            output={"pr_url": "https://github.com/org/repo/pull/99"},
+        )
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        assert row["implementation_pr_url"] == "https://github.com/org/repo/pull/99"
+
+    # --- source_products ---
+
+    def test_source_products_defaults_to_empty_list(self):
+        report = self._create_report()
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        assert row["source_products"] == []
+
+    def test_source_products_empty_on_retrieve(self):
+        report = self._create_report()
+
+        response = self.client.get(f"/api/projects/{self.team.id}/signals/reports/{report.id}/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["source_products"] == []
+
+    # --- legacy choice removal ---
+
+    def test_actionability_null_for_legacy_choice_artefact(self):
+        report = self._create_report()
+        SignalReportArtefact.objects.create(
+            team=self.team,
+            report=report,
+            type=SignalReportArtefact.ArtefactType.ACTIONABILITY_JUDGMENT,
+            content=json.dumps({"choice": "immediately_actionable", "explanation": "x"}),
+        )
+
+        response = self.client.get(self._list_url())
+        assert response.status_code == status.HTTP_200_OK
+        row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
+        assert row["actionability"] is None

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -416,6 +416,7 @@ class TestSignalReportListAPI(APIBaseTest):
         response = self.client.get(f"/api/projects/{self.team.id}/signals/reports/{report.id}/")
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["implementation_pr_url"] == "https://github.com/org/repo/pull/42"
+        assert response.json()["implementation_pr_url"] == response.json()["implementation_pr_url"].strip('"')
 
     def test_implementation_pr_url_null_when_no_implementation_task(self):
         report = self._create_report()

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -592,6 +592,7 @@ class SignalReportViewSet(
         if not report_ids:
             return {}
 
+        # Batch this after pagination so the hot list queryset avoids a per-row correlated TaskRun subquery.
         latest_runs = (
             TaskRun.objects.filter(
                 task__signal_report_tasks__report_id__in=report_ids,

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -82,6 +82,7 @@ from products.signals.backend.temporal.reingestion import SignalReportReingestio
 from products.signals.backend.temporal.signal_queries import (
     fetch_report_ids_for_source_products,
     fetch_signals_for_report_sync,
+    fetch_source_products_for_reports,
 )
 from products.signals.backend.temporal.types import (
     SignalReportDeletionWorkflowInputs,
@@ -348,6 +349,9 @@ class SignalReportViewSet(
     permission_classes = [IsAuthenticated, APIScopePermission]
     scope_object = "task"
     queryset = SignalReport.objects.all()
+    # Shared Q for "ready but not actionable" — used in status ranking and suggested-reviewer suppression.
+    # Requires `latest_actionability_value` annotation to be applied first.
+    _Q_READY_NOT_ACTIONABLE = Q(status=SignalReport.Status.READY) & Q(latest_actionability_value="not_actionable")
     _DEFAULT_SIGNAL_REPORT_ORDERING = "-is_suggested_reviewer,status,-updated_at"
     _SIGNAL_REPORT_ORDERING_FIELDS: dict[str, str] = {
         "status": "pipeline_status_rank",
@@ -373,6 +377,7 @@ class SignalReportViewSet(
         qs = self._annotate_signal_report_priority(qs)
         qs = self._prefetch_signal_report_priority_artefacts(qs)
         qs = self._annotate_is_suggested_reviewer(qs)
+        qs = self._annotate_implementation_pr_url(qs)
         return qs
 
     def _scope_signal_report_queryset(self, queryset):
@@ -457,10 +462,7 @@ class SignalReportViewSet(
         # 0 = ready + actionable (or no judgment yet), 1 = ready + not_actionable; then other stages.
         return queryset.annotate(
             pipeline_status_rank=Case(
-                When(
-                    Q(status=SignalReport.Status.READY) & Q(latest_actionability_value="not_actionable"),
-                    then=Value(1),
-                ),
+                When(self._Q_READY_NOT_ACTIONABLE, then=Value(1)),
                 When(status=SignalReport.Status.READY, then=Value(0)),
                 When(status=SignalReport.Status.PENDING_INPUT, then=Value(2)),
                 When(status=SignalReport.Status.IN_PROGRESS, then=Value(3)),
@@ -501,7 +503,7 @@ class SignalReportViewSet(
         )
 
     def _annotate_latest_actionability_value(self, queryset):
-        # Latest actionability_judgment: json "actionability" only (no legacy "choice").
+        # Extract the "actionability" value from the latest actionability_judgment artefact.
         latest_actionability = Subquery(
             SignalReportArtefact.objects.filter(
                 report_id=OuterRef("id"),
@@ -562,14 +564,37 @@ class SignalReportViewSet(
         )
         return queryset.annotate(
             is_suggested_reviewer=Case(
-                When(
-                    Q(status=SignalReport.Status.READY) & Q(latest_actionability_value="not_actionable"),
-                    then=Value(False),
-                ),
+                When(self._Q_READY_NOT_ACTIONABLE, then=Value(False)),
                 default=suggested_exists,
                 output_field=BooleanField(),
             ),
         )
+
+    def _annotate_implementation_pr_url(self, queryset):
+        from products.tasks.backend.models import TaskRun
+
+        # Find the latest TaskRun output->pr_url for the implementation task linked to each report.
+        # Path: SignalReportTask(relationship=implementation) -> Task -> TaskRun(latest) -> output->'pr_url'
+        latest_impl_pr_url = Subquery(
+            TaskRun.objects.filter(
+                task__signal_report_tasks__report_id=OuterRef("id"),
+                task__signal_report_tasks__relationship=SignalReportTask.Relationship.IMPLEMENTATION,
+                output__pr_url__isnull=False,
+            )
+            .exclude(output__pr_url="")
+            .order_by("-created_at")
+            .annotate(
+                _pr_url=Func(
+                    Cast(F("output"), output_field=JSONField()),
+                    Value("pr_url"),
+                    function="jsonb_extract_path_text",
+                    output_field=CharField(),
+                ),
+            )
+            .values("_pr_url")[:1],
+            output_field=CharField(),
+        )
+        return queryset.annotate(implementation_pr_url=latest_impl_pr_url)
 
     def filter_queryset(self, queryset):
         queryset = super().filter_queryset(queryset)
@@ -613,6 +638,22 @@ class SignalReportViewSet(
 
     def get_serializer_context(self):
         return {**super().get_serializer_context(), "team": self.team}
+
+    @extend_schema(exclude=True)
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        reports = list(page if page is not None else queryset)
+
+        report_ids = [str(r.id) for r in reports]
+        source_products_map = fetch_source_products_for_reports(self.team, report_ids) if report_ids else {}
+
+        context = {**self.get_serializer_context(), "source_products_map": source_products_map}
+        serializer = self.get_serializer(reports, many=True, context=context)
+
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
 
     @extend_schema(exclude=True)
     @action(detail=False, methods=["get"], url_path="available_reviewers", required_scopes=["task:read"])

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -88,6 +88,7 @@ from products.signals.backend.temporal.types import (
     SignalReportDeletionWorkflowInputs,
     SignalReportReingestionWorkflowInputs,
 )
+from products.tasks.backend.models import TaskRun
 
 logger = structlog.get_logger(__name__)
 
@@ -377,7 +378,8 @@ class SignalReportViewSet(
         qs = self._annotate_signal_report_priority(qs)
         qs = self._prefetch_signal_report_priority_artefacts(qs)
         qs = self._annotate_is_suggested_reviewer(qs)
-        qs = self._annotate_implementation_pr_url(qs)
+        if self.action != "list":
+            qs = self._annotate_implementation_pr_url(qs)
         return qs
 
     def _scope_signal_report_queryset(self, queryset):
@@ -571,8 +573,6 @@ class SignalReportViewSet(
         )
 
     def _annotate_implementation_pr_url(self, queryset):
-        from products.tasks.backend.models import TaskRun
-
         # Find the latest TaskRun output->pr_url for the implementation task linked to each report.
         # Path: SignalReportTask(relationship=implementation) -> Task -> TaskRun(latest) -> output->'pr_url'
         latest_impl_pr_url = Subquery(
@@ -583,18 +583,32 @@ class SignalReportViewSet(
             )
             .exclude(output__pr_url="")
             .order_by("-created_at")
-            .annotate(
-                _pr_url=Func(
-                    Cast(F("output"), output_field=JSONField()),
-                    Value("pr_url"),
-                    function="jsonb_extract_path_text",
-                    output_field=CharField(),
-                ),
-            )
-            .values("_pr_url")[:1],
+            .values("output__pr_url")[:1],
             output_field=CharField(),
         )
         return queryset.annotate(implementation_pr_url=latest_impl_pr_url)
+
+    def _fetch_implementation_pr_urls_for_reports(self, report_ids: list[str]) -> dict[str, str]:
+        if not report_ids:
+            return {}
+
+        latest_runs = (
+            TaskRun.objects.filter(
+                task__signal_report_tasks__report_id__in=report_ids,
+                task__signal_report_tasks__relationship=SignalReportTask.Relationship.IMPLEMENTATION,
+                output__pr_url__isnull=False,
+            )
+            .exclude(output__pr_url="")
+            .order_by("task__signal_report_tasks__report_id", "-created_at", "-id")
+            .values("task__signal_report_tasks__report_id", "output__pr_url")
+            .distinct("task__signal_report_tasks__report_id")
+        )
+
+        return {
+            str(row["task__signal_report_tasks__report_id"]): row["output__pr_url"]
+            for row in latest_runs
+            if row["task__signal_report_tasks__report_id"] and row["output__pr_url"]
+        }
 
     def filter_queryset(self, queryset):
         queryset = super().filter_queryset(queryset)
@@ -647,8 +661,13 @@ class SignalReportViewSet(
 
         report_ids = [str(r.id) for r in reports]
         source_products_map = fetch_source_products_for_reports(self.team, report_ids) if report_ids else {}
+        implementation_pr_url_map = self._fetch_implementation_pr_urls_for_reports(report_ids)
 
-        context = {**self.get_serializer_context(), "source_products_map": source_products_map}
+        context = {
+            **self.get_serializer_context(),
+            "source_products_map": source_products_map,
+            "implementation_pr_url_map": implementation_pr_url_map,
+        }
         serializer = self.get_serializer(reports, many=True, context=context)
 
         if page is not None:

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -22,6 +22,7 @@ from django.db.models import (
     Value,
     When,
 )
+from django.db.models.fields.json import KeyTextTransform
 from django.db.models.functions import Cast, Coalesce
 
 import structlog
@@ -583,7 +584,8 @@ class SignalReportViewSet(
             )
             .exclude(output__pr_url="")
             .order_by("-created_at")
-            .values("output__pr_url")[:1],
+            .annotate(output_pr_url_text=KeyTextTransform("pr_url", "output"))
+            .values("output_pr_url_text")[:1],
             output_field=CharField(),
         )
         return queryset.annotate(implementation_pr_url=latest_impl_pr_url)
@@ -601,14 +603,15 @@ class SignalReportViewSet(
             )
             .exclude(output__pr_url="")
             .order_by("task__signal_report_tasks__report_id", "-created_at", "-id")
-            .values("task__signal_report_tasks__report_id", "output__pr_url")
+            .annotate(output_pr_url_text=KeyTextTransform("pr_url", "output"))
+            .values("task__signal_report_tasks__report_id", "output_pr_url_text")
             .distinct("task__signal_report_tasks__report_id")
         )
 
         return {
-            str(row["task__signal_report_tasks__report_id"]): row["output__pr_url"]
+            str(row["task__signal_report_tasks__report_id"]): row["output_pr_url_text"]
             for row in latest_runs
-            if row["task__signal_report_tasks__report_id"] and row["output__pr_url"]
+            if row["task__signal_report_tasks__report_id"] and row["output_pr_url_text"]
         }
 
     def filter_queryset(self, queryset):


### PR DESCRIPTION
## Problem

The signal reports API lacks metadata needed by PostHog Code to show source product icons and PR badges in the inbox list, and the inbox ordering doesn't distinguish between actionable and not-actionable ready reports.

## Changes

As summarized by Claude:

- Added `source_products` field to `SignalReportSerializer` — batch-fetched from ClickHouse per page via `fetch_source_products_for_reports()`
- Added `implementation_pr_url` field — annotated via correlated subquery through `SignalReportTask` → `Task` → `TaskRun` → `output->'pr_url'`
- Split ready status ordering by actionability: rank 0 = actionable (or no judgment), rank 1 = not_actionable
- Suppressed `is_suggested_reviewer` for not_actionable reports
- Extracted `_Q_READY_NOT_ACTIONABLE` shared constant to avoid duplicate Q expressions
- Dropped legacy `choice` fallback in serializer (only `actionability` key is read now)
- Passed serializer context in the `signals` detail action

See what this looks like in the Code app in the companion PR: https://github.com/PostHog/code/pull/1755


## How did you test this code?

Bunch of tests.

## Publish to changelog?

No