### PR TITLE
chore(devex): Add bin/ty.py to find_affected_tests gate paterns

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -105,7 +105,6 @@ jobs:
                         - bin/check_uv_python_compatibility.py
                         - bin/find_python_dependencies.py
                         - bin/granian_metrics.py
-                        - bin/ty.py
                         - bin/unit_metrics.py
                         - pyproject.toml
                         - uv.lock
@@ -152,7 +151,6 @@ jobs:
                         - bin/check_uv_python_compatibility.py
                         - bin/find_python_dependencies.py
                         - bin/granian_metrics.py
-                        - bin/ty.py
                         - bin/unit_metrics.py
                         - pyproject.toml
                         - uv.lock

--- a/.github/workflows/ci-blacksmith-shadow.yml
+++ b/.github/workflows/ci-blacksmith-shadow.yml
@@ -84,7 +84,6 @@ jobs:
                         - bin/check_uv_python_compatibility.py
                         - bin/find_python_dependencies.py
                         - bin/granian_metrics.py
-                        - bin/ty.py
                         - bin/unit_metrics.py
                         - pyproject.toml
                         - uv.lock

--- a/bin/find_affected_tests.py
+++ b/bin/find_affected_tests.py
@@ -94,7 +94,6 @@ GATE_ONLY_PATTERNS = (
     "bin/find_python_dependencies.py",
     "bin/granian_metrics.py",
     "bin/unit_metrics.py",
-    "bin/ty.py",
 )
 
 # Max changed files before we give up and run everything

--- a/bin/find_affected_tests.py
+++ b/bin/find_affected_tests.py
@@ -94,6 +94,7 @@ GATE_ONLY_PATTERNS = (
     "bin/find_python_dependencies.py",
     "bin/granian_metrics.py",
     "bin/unit_metrics.py",
+    "bin/ty.py",
 )
 
 # Max changed files before we give up and run everything


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

```
posthog ❯ uv run bin/find_affected_tests.py --check-sync 
ERROR: dorny backend patterns not covered by find_affected_tests.py:
  - bin/ty.py

Add each pattern to FULL_RUN_PATTERNS (forces full test run) or
GATE_ONLY_PATTERNS (dorny gate only, no test impact) in bin/find_affected_tests.py
```

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

posthog ❯ uv run bin/find_affected_tests.py --check-sync                        
OK: all 37 dorny backend patterns are covered

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

no

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

skip-inkeep-docs

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
