### PR TITLE
fix(linkedin-ads): retry transient SSL/network errors in client

### DIFF
--- a/posthog/temporal/data_imports/sources/linkedin_ads/client.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/client.py
@@ -2,7 +2,9 @@ import json
 from collections.abc import Generator
 from typing import Any, Optional
 
+import requests
 from linkedin_api.clients.restli.client import RestliClient
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from .schemas import (
     LINKEDIN_ADS_ENDPOINTS,
@@ -15,6 +17,10 @@ from .schemas import (
 LINKEDIN_SPONSORED_URN_PREFIX = "urn:li:sponsored"
 MAX_PAGE_SIZE = 1000
 API_VERSION = "202508"
+
+
+class LinkedinAdsRetryableError(Exception):
+    """Transient LinkedIn API error (5xx / 429) that should be retried."""
 
 
 class LinkedinAdsClient:
@@ -99,6 +105,37 @@ class LinkedinAdsClient:
             raise ValueError(f"No schema defined for resource: {resource}")
         return RESOURCE_SCHEMAS[resource]["field_names"]
 
+    @retry(
+        retry=retry_if_exception_type((LinkedinAdsRetryableError, requests.ConnectionError, requests.Timeout)),
+        stop=stop_after_attempt(5),
+        wait=wait_exponential_jitter(initial=1, max=30),
+        reraise=True,
+    )
+    def _call_finder(self, resource_path: str, finder: str, params: dict) -> Any:
+        """Call the Restli finder with bounded retries on transient transport and 5xx/429 errors.
+
+        LinkedIn's edge occasionally drops TLS connections mid-handshake (SSLEOFError) or
+        returns 504s; those surface here as `requests.ConnectionError` / `requests.Timeout`
+        from the underlying requests.Session, or as a non-2xx response we convert to
+        `LinkedinAdsRetryableError`. Non-retryable 4xx responses still raise immediately.
+        """
+        response = self.client.finder(
+            resource_path=resource_path,
+            finder_name=finder,
+            access_token=self.access_token,
+            query_params=params,
+            version_string=self.api_version,
+        )
+
+        if response.status_code == 429 or response.status_code >= 500:
+            raise LinkedinAdsRetryableError(
+                f"LinkedIn API error (retryable, {response.status_code}): {response.response.text}"
+            )
+        if response.status_code != 200:
+            raise Exception(f"LinkedIn API error ({response.status_code}): {response.response.text}")
+
+        return response
+
     def _make_request(
         self, endpoint: LinkedinAdsResource, finder: str, extra_params: dict | None = None, path: str | None = None
     ) -> list[dict[str, Any]]:
@@ -109,16 +146,7 @@ class LinkedinAdsClient:
 
         resource_path = path or f"/{LINKEDIN_ADS_ENDPOINTS[endpoint]}"
 
-        response = self.client.finder(
-            resource_path=resource_path,
-            finder_name=finder,
-            access_token=self.access_token,
-            query_params=params,
-            version_string=self.api_version,
-        )
-
-        if response.status_code != 200:
-            raise Exception(f"LinkedIn API error ({response.status_code}): {response.response.text}")
+        response = self._call_finder(resource_path=resource_path, finder=finder, params=params)
 
         return response.elements
 
@@ -134,16 +162,7 @@ class LinkedinAdsClient:
             if page_token:
                 params["pageToken"] = page_token
 
-            response = self.client.finder(
-                resource_path=path,
-                finder_name="search",
-                access_token=self.access_token,
-                query_params=params,
-                version_string=self.api_version,
-            )
-
-            if response.status_code != 200:
-                raise Exception(f"LinkedIn API error ({response.status_code}): {response.response.text}")
+            response = self._call_finder(resource_path=path, finder="search", params=params)
 
             if not response.elements:
                 break

--- a/posthog/temporal/data_imports/sources/linkedin_ads/client.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/client.py
@@ -111,7 +111,7 @@ class LinkedinAdsClient:
         wait=wait_exponential_jitter(initial=1, max=30),
         reraise=True,
     )
-    def _call_finder(self, resource_path: str, finder: str, params: dict) -> Any:
+    def _call_finder(self, resource_path: str, finder: str, params: dict[str, Any]) -> Any:
         """Call the Restli finder with bounded retries on transient transport and 5xx/429 errors.
 
         LinkedIn's edge occasionally drops TLS connections mid-handshake (SSLEOFError) or

--- a/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_client.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_client.py
@@ -1,9 +1,14 @@
 import json
 
 import pytest
+import requests
 from unittest import mock
 
-from posthog.temporal.data_imports.sources.linkedin_ads.client import LinkedinAdsClient, LinkedinAdsPivot
+from posthog.temporal.data_imports.sources.linkedin_ads.client import (
+    LinkedinAdsClient,
+    LinkedinAdsPivot,
+    LinkedinAdsRetryableError,
+)
 
 
 class TestLinkedinAdsClient:
@@ -110,3 +115,95 @@ class TestLinkedinAdsClient:
 
         expected = {"start": {"year": 2024, "month": 1, "day": 15}, "end": {"year": 2024, "month": 2, "day": 20}}
         assert result == expected
+
+    # Retry behavior: tenacity's exponential backoff sleeps are patched out to keep tests instant.
+
+    @mock.patch("tenacity.nap.time.sleep", return_value=None)
+    @mock.patch("posthog.temporal.data_imports.sources.linkedin_ads.client.RestliClient")
+    def test_retries_on_ssl_error_then_succeeds(self, mock_restli_client, _mock_sleep):
+        mock_success = mock.MagicMock()
+        mock_success.status_code = 200
+        mock_success.elements = [{"id": "123"}]
+
+        ssl_error = requests.exceptions.SSLError("UNEXPECTED_EOF_WHILE_READING")
+        mock_client_instance = mock_restli_client.return_value
+        mock_client_instance.finder.side_effect = [ssl_error, ssl_error, mock_success]
+
+        client = LinkedinAdsClient(self.access_token)
+        result = client.get_accounts()
+
+        assert result == [{"id": "123"}]
+        assert mock_client_instance.finder.call_count == 3
+
+    @mock.patch("tenacity.nap.time.sleep", return_value=None)
+    @mock.patch("posthog.temporal.data_imports.sources.linkedin_ads.client.RestliClient")
+    def test_retries_on_5xx_then_succeeds(self, mock_restli_client, _mock_sleep):
+        mock_504 = mock.MagicMock()
+        mock_504.status_code = 504
+        mock_504.response.text = "Gateway Timeout"
+
+        mock_success = mock.MagicMock()
+        mock_success.status_code = 200
+        mock_success.elements = [{"id": "456"}]
+
+        mock_client_instance = mock_restli_client.return_value
+        mock_client_instance.finder.side_effect = [mock_504, mock_success]
+
+        client = LinkedinAdsClient(self.access_token)
+        result = client.get_accounts()
+
+        assert result == [{"id": "456"}]
+        assert mock_client_instance.finder.call_count == 2
+
+    @mock.patch("tenacity.nap.time.sleep", return_value=None)
+    @mock.patch("posthog.temporal.data_imports.sources.linkedin_ads.client.RestliClient")
+    def test_retries_exhausted_reraises_last_error(self, mock_restli_client, _mock_sleep):
+        mock_client_instance = mock_restli_client.return_value
+        mock_client_instance.finder.side_effect = requests.exceptions.ConnectionError("boom")
+
+        client = LinkedinAdsClient(self.access_token)
+
+        with pytest.raises(requests.exceptions.ConnectionError, match="boom"):
+            client.get_accounts()
+
+        assert mock_client_instance.finder.call_count == 5
+
+    @mock.patch("tenacity.nap.time.sleep", return_value=None)
+    @mock.patch("posthog.temporal.data_imports.sources.linkedin_ads.client.RestliClient")
+    def test_no_retry_on_4xx(self, mock_restli_client, _mock_sleep):
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 401
+        mock_response.response.text = "Unauthorized"
+
+        mock_client_instance = mock_restli_client.return_value
+        mock_client_instance.finder.return_value = mock_response
+
+        client = LinkedinAdsClient(self.access_token)
+
+        with pytest.raises(Exception, match="LinkedIn API error \\(401\\): Unauthorized"):
+            client.get_accounts()
+
+        assert mock_client_instance.finder.call_count == 1
+
+    @mock.patch("tenacity.nap.time.sleep", return_value=None)
+    @mock.patch("posthog.temporal.data_imports.sources.linkedin_ads.client.RestliClient")
+    def test_429_is_retried(self, mock_restli_client, _mock_sleep):
+        mock_429 = mock.MagicMock()
+        mock_429.status_code = 429
+        mock_429.response.text = "Too Many Requests"
+
+        mock_success = mock.MagicMock()
+        mock_success.status_code = 200
+        mock_success.elements = []
+
+        mock_client_instance = mock_restli_client.return_value
+        mock_client_instance.finder.side_effect = [mock_429, mock_success]
+
+        client = LinkedinAdsClient(self.access_token)
+        result = client.get_accounts()
+
+        assert result == []
+        assert mock_client_instance.finder.call_count == 2
+
+    def test_retryable_error_is_exported(self):
+        assert issubclass(LinkedinAdsRetryableError, Exception)

--- a/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_client.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_client.py
@@ -1,8 +1,8 @@
 import json
+from unittest import mock
 
 import pytest
 import requests
-from unittest import mock
 
 from posthog.temporal.data_imports.sources.linkedin_ads.client import (
     LinkedinAdsClient,
@@ -118,42 +118,59 @@ class TestLinkedinAdsClient:
 
     # Retry behavior: tenacity's exponential backoff sleeps are patched out to keep tests instant.
 
+    @pytest.mark.parametrize(
+        "transient_factory,expected_calls",
+        [
+            pytest.param(
+                lambda: requests.exceptions.SSLError("UNEXPECTED_EOF_WHILE_READING"),
+                3,
+                id="ssl_error",
+            ),
+            pytest.param(
+                lambda: requests.exceptions.ConnectionError("RemoteDisconnected"),
+                3,
+                id="connection_error",
+            ),
+            pytest.param(
+                lambda: requests.exceptions.Timeout("read timed out"),
+                3,
+                id="timeout",
+            ),
+            pytest.param(
+                lambda: _status_response(504, "Gateway Timeout"),
+                2,
+                id="http_504",
+            ),
+            pytest.param(
+                lambda: _status_response(500, "Internal Server Error"),
+                2,
+                id="http_500",
+            ),
+            pytest.param(
+                lambda: _status_response(429, "Too Many Requests"),
+                2,
+                id="http_429",
+            ),
+        ],
+    )
     @mock.patch("tenacity.nap.time.sleep", return_value=None)
     @mock.patch("posthog.temporal.data_imports.sources.linkedin_ads.client.RestliClient")
-    def test_retries_on_ssl_error_then_succeeds(self, mock_restli_client, _mock_sleep):
+    def test_transient_errors_are_retried_then_succeed(
+        self, mock_restli_client, _mock_sleep, transient_factory, expected_calls
+    ):
         mock_success = mock.MagicMock()
         mock_success.status_code = 200
-        mock_success.elements = [{"id": "123"}]
+        mock_success.elements = [{"id": "ok"}]
 
-        ssl_error = requests.exceptions.SSLError("UNEXPECTED_EOF_WHILE_READING")
+        transient_failures = [transient_factory() for _ in range(expected_calls - 1)]
         mock_client_instance = mock_restli_client.return_value
-        mock_client_instance.finder.side_effect = [ssl_error, ssl_error, mock_success]
+        mock_client_instance.finder.side_effect = [*transient_failures, mock_success]
 
         client = LinkedinAdsClient(self.access_token)
         result = client.get_accounts()
 
-        assert result == [{"id": "123"}]
-        assert mock_client_instance.finder.call_count == 3
-
-    @mock.patch("tenacity.nap.time.sleep", return_value=None)
-    @mock.patch("posthog.temporal.data_imports.sources.linkedin_ads.client.RestliClient")
-    def test_retries_on_5xx_then_succeeds(self, mock_restli_client, _mock_sleep):
-        mock_504 = mock.MagicMock()
-        mock_504.status_code = 504
-        mock_504.response.text = "Gateway Timeout"
-
-        mock_success = mock.MagicMock()
-        mock_success.status_code = 200
-        mock_success.elements = [{"id": "456"}]
-
-        mock_client_instance = mock_restli_client.return_value
-        mock_client_instance.finder.side_effect = [mock_504, mock_success]
-
-        client = LinkedinAdsClient(self.access_token)
-        result = client.get_accounts()
-
-        assert result == [{"id": "456"}]
-        assert mock_client_instance.finder.call_count == 2
+        assert result == [{"id": "ok"}]
+        assert mock_client_instance.finder.call_count == expected_calls
 
     @mock.patch("tenacity.nap.time.sleep", return_value=None)
     @mock.patch("posthog.temporal.data_imports.sources.linkedin_ads.client.RestliClient")
@@ -185,25 +202,12 @@ class TestLinkedinAdsClient:
 
         assert mock_client_instance.finder.call_count == 1
 
-    @mock.patch("tenacity.nap.time.sleep", return_value=None)
-    @mock.patch("posthog.temporal.data_imports.sources.linkedin_ads.client.RestliClient")
-    def test_429_is_retried(self, mock_restli_client, _mock_sleep):
-        mock_429 = mock.MagicMock()
-        mock_429.status_code = 429
-        mock_429.response.text = "Too Many Requests"
-
-        mock_success = mock.MagicMock()
-        mock_success.status_code = 200
-        mock_success.elements = []
-
-        mock_client_instance = mock_restli_client.return_value
-        mock_client_instance.finder.side_effect = [mock_429, mock_success]
-
-        client = LinkedinAdsClient(self.access_token)
-        result = client.get_accounts()
-
-        assert result == []
-        assert mock_client_instance.finder.call_count == 2
-
     def test_retryable_error_is_exported(self):
         assert issubclass(LinkedinAdsRetryableError, Exception)
+
+
+def _status_response(status_code: int, text: str) -> mock.MagicMock:
+    response = mock.MagicMock()
+    response.status_code = status_code
+    response.response.text = text
+    return response

--- a/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_client.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_client.py
@@ -1,7 +1,8 @@
 import json
-from unittest import mock
 
 import pytest
+from unittest import mock
+
 import requests
 
 from posthog.temporal.data_imports.sources.linkedin_ads.client import (


### PR DESCRIPTION
## Problem

Two sibling error-tracking issues (`019d9fda-b295-...` and `019d9fda-c47d-...`) logged a burst of `SSLEOFError: UNEXPECTED_EOF_WHILE_READING` exceptions from the LinkedIn Ads data warehouse connector on 2026-04-18. Sibling transient-network errors against `api.linkedin.com` (504 Gateway Timeout, `RemoteDisconnected`, `ConnectionRefused`, `TimeoutError`) also appeared 9 times across Apr 1–15, suggesting recurring upstream instability.

The root cause is that `LinkedinAdsClient._make_request` / `_make_paginated_request` call `RestliClient.finder` with no per-request retry policy, so transient TLS drops bubble straight out of the Temporal activity as hard failures for the user's sync. The per-source `get_non_retryable_errors()` hook only covers auth-class errors.

## Changes

- Add `LinkedinAdsRetryableError` and a `_call_finder` helper in `linkedin_ads/client.py` decorated with `tenacity.retry` (5 attempts, `wait_exponential_jitter(initial=1, max=30)`, `reraise=True`).
- Retryable: `LinkedinAdsRetryableError`, `requests.ConnectionError` (covers `SSLError`, `RemoteDisconnected`, `ConnectionRefused`), `requests.Timeout`. 429 and 5xx responses are converted into `LinkedinAdsRetryableError`.
- 4xx responses (except 429) still fail fast without retrying, preserving existing auth-error behavior.
- Both `_make_request` and `_make_paginated_request` route through `_call_finder`, so pagination loops get per-request retries.

This matches the convention set by the existing `HubspotRetryableError`, `KlaviyoRetryableError`, and `LinearRetryableError` clients — same tenacity knobs and retryable-exception shape — so there's clear precedent.

Option A from the investigation (inline retry local to this connector) was chosen over Option B (shared HTTP session) to keep blast radius minimal. A shared session could be a follow-up once more sources need the same hardening.

## How did you test this code?

Added unit tests in `test_linkedin_client.py` covering:

- SSL error retry-and-recover
- 504 retry-and-recover
- Retry budget exhaustion (5 attempts then re-raise)
- 401 fast-fail (no retry)
- 429 retry
- `LinkedinAdsRetryableError` is exported

`tenacity.nap.time.sleep` is patched in tests so the exponential backoff runs instantly.

I'm an agent — I have not tested this manually against a real LinkedIn Ads sync, only via the unit tests added in this PR.

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored from an error-tracking signal flagging `SSLEOFError` from `linkedin_ads/client.py`. Option A from the investigation prompt was chosen (inline tenacity retry, local to this connector).