### PR TITLE
fix(llma): include reasoning tokens in cost for gemini 3 models

### DIFF
--- a/nodejs/src/ingestion/ai/costs/output-costs.test.ts
+++ b/nodejs/src/ingestion/ai/costs/output-costs.test.ts
@@ -172,6 +172,43 @@ describe('calculateOutputCost()', () => {
         })
     })
 
+    describe('gemini 3 models - reasoning token handling', () => {
+        const gemini3FlashModel = createModel('gemini-3-flash-preview', 'google', 0.0000003, 0.0000025)
+        const gemini31ProModel = createModel('gemini-3.1-pro-preview', 'google', 0.00000125, 0.00001)
+
+        it.each([
+            {
+                modelName: 'gemini-3-flash-preview',
+                modelRow: gemini3FlashModel,
+                outputTokens: 2,
+                reasoningTokens: 77,
+                // (2 + 77) * 0.0000025 = 0.0001975
+                expectedCost: 0.0001975,
+                description: 'includes reasoning tokens for gemini-3-flash-preview (issue #3160)',
+            },
+            {
+                modelName: 'gemini-3.1-pro-preview',
+                modelRow: gemini31ProModel,
+                outputTokens: 100,
+                reasoningTokens: 200,
+                // (100 + 200) * 0.00001 = 0.003
+                expectedCost: 0.003,
+                description: 'includes reasoning tokens for gemini-3.1-pro-preview',
+            },
+        ])('$description', ({ modelName, modelRow, outputTokens, reasoningTokens, expectedCost }) => {
+            const event = createAIEvent({
+                $ai_provider: 'google',
+                $ai_model: modelName,
+                $ai_output_tokens: outputTokens,
+                $ai_reasoning_tokens: reasoningTokens,
+            })
+
+            const result = calculateOutputCost(event, modelRow)
+
+            expectCost(result, expectedCost, 7)
+        })
+    })
+
     describe('gemini 2.0 models - no reasoning token handling', () => {
         const gemini20FlashModel = createModel('gemini-2.0-flash', 'google', 1e-7, 4e-7)
 

--- a/nodejs/src/ingestion/ai/costs/output-costs.test.ts
+++ b/nodejs/src/ingestion/ai/costs/output-costs.test.ts
@@ -173,8 +173,9 @@ describe('calculateOutputCost()', () => {
     })
 
     describe('gemini 3 models - reasoning token handling', () => {
-        const gemini3FlashModel = createModel('gemini-3-flash-preview', 'google', 0.0000003, 0.0000025)
-        const gemini31ProModel = createModel('gemini-3.1-pro-preview', 'google', 0.00000125, 0.00001)
+        // Real rates from llm-costs.json
+        const gemini3FlashModel = createModel('gemini-3-flash-preview', 'google', 5e-7, 3e-6)
+        const gemini31ProModel = createModel('gemini-3.1-pro-preview', 'google', 2e-6, 1.2e-5)
 
         it.each([
             {
@@ -182,8 +183,8 @@ describe('calculateOutputCost()', () => {
                 modelRow: gemini3FlashModel,
                 outputTokens: 2,
                 reasoningTokens: 77,
-                // (2 + 77) * 0.0000025 = 0.0001975
-                expectedCost: 0.0001975,
+                // (2 + 77) * 3e-6 = 0.000237
+                expectedCost: 0.000237,
                 description: 'includes reasoning tokens for gemini-3-flash-preview (issue #3160)',
             },
             {
@@ -191,8 +192,8 @@ describe('calculateOutputCost()', () => {
                 modelRow: gemini31ProModel,
                 outputTokens: 100,
                 reasoningTokens: 200,
-                // (100 + 200) * 0.00001 = 0.003
-                expectedCost: 0.003,
+                // (100 + 200) * 1.2e-5 = 0.0036
+                expectedCost: 0.0036,
                 description: 'includes reasoning tokens for gemini-3.1-pro-preview',
             },
         ])('$description', ({ modelName, modelRow, outputTokens, reasoningTokens, expectedCost }) => {
@@ -205,7 +206,7 @@ describe('calculateOutputCost()', () => {
 
             const result = calculateOutputCost(event, modelRow)
 
-            expectCost(result, expectedCost, 7)
+            expectCost(result, expectedCost)
         })
     })
 
@@ -380,6 +381,27 @@ describe('calculateOutputCost()', () => {
             // Text tokens with reasoning: 10 + 200 = 210
             // Expected: (210 * 0.0000025) + (1290 * 0.00003) = 0.000525 + 0.0387 = 0.039225
             expectCost(result, 0.039225, 6)
+        })
+
+        it('handles image output with reasoning tokens for gemini-3', () => {
+            // Gemini 3 Pro Image Preview pricing (from llm-costs.json):
+            // Text output: $12/1M tokens ($1.2e-5/token)
+            // Image output: $120/1M tokens ($1.2e-4/token)
+            const gemini3ImageModel = createModel('gemini-3-pro-image-preview', 'google', 2e-6, 1.2e-5, 1.2e-4)
+            const event = createAIEvent({
+                $ai_provider: 'google',
+                $ai_model: 'gemini-3-pro-image-preview',
+                $ai_output_tokens: 1500,
+                $ai_image_output_tokens: 1290,
+                $ai_text_output_tokens: 10,
+                $ai_reasoning_tokens: 200,
+            })
+
+            const result = calculateOutputCost(event, gemini3ImageModel)
+
+            // Text tokens with reasoning: 10 + 200 = 210
+            // Expected: (210 * 1.2e-5) + (1290 * 1.2e-4) = 0.00252 + 0.1548 = 0.15732
+            expectCost(result, 0.15732, 5)
         })
 
         it('handles zero image tokens with image pricing (text only)', () => {

--- a/nodejs/src/ingestion/ai/costs/output-costs.ts
+++ b/nodejs/src/ingestion/ai/costs/output-costs.ts
@@ -44,7 +44,7 @@ export const calculateOutputCost = (event: PluginEvent, cost: ResolvedModelCost)
             textOutputTokens = Math.max(0, Number(totalOutputTokens) - imageOutputTokens)
         }
 
-        // Add reasoning tokens to text tokens for Gemini 2.5 models
+        // Add reasoning tokens to text tokens for Gemini models that report them separately
         if (
             event.properties['$ai_reasoning_tokens'] &&
             event.properties['$ai_model'] &&

--- a/nodejs/src/ingestion/ai/costs/output-costs.ts
+++ b/nodejs/src/ingestion/ai/costs/output-costs.ts
@@ -4,7 +4,7 @@ import { PluginEvent } from '~/plugin-scaffold'
 
 import { ResolvedModelCost } from './providers/types'
 
-const REASONING_COST_MODELS = [/^gemini-2.5-/]
+const REASONING_COST_MODELS = [/^gemini-2\.5-/, /^gemini-3(\.\d+)?-/]
 
 const mustAddReasoningCost = (model: string): boolean => {
     return REASONING_COST_MODELS.some((candidate) => candidate.test(model.toLowerCase()))


### PR DESCRIPTION
## Problem

Events for Gemini 3.x models report `$ai_reasoning_tokens` separately from `$ai_output_tokens` (unlike OpenAI o-series and Anthropic thinking, where reasoning tokens are already inside output tokens). The server-side cost calculator was only adding reasoning tokens to the output cost for Gemini 2.5, so Gemini 3 reports came out undercounted by the reasoning-token multiplier.

Reported in https://github.com/PostHog/posthog-js/issues/3160 with a `gemini-3-flash-preview` event that had 2 output tokens and 77 reasoning tokens — the 77 reasoning tokens were silently dropped from `$ai_output_cost_usd`. The fix lives here because cost calculation runs in the Node.js ingestion pipeline, not in the SDK.

Closes PostHog/posthog-js#3160

## Changes

- `nodejs/src/ingestion/ai/costs/output-costs.ts`: extend `REASONING_COST_MODELS` from `/^gemini-2.5-/` to `[/^gemini-2\.5-/, /^gemini-3(\.\d+)?-/]`. Covers all 6 Gemini 3.x variants currently present in `llm-costs.json` (`gemini-3-flash-preview`, `gemini-3-pro-image-preview`, `gemini-3.1-flash-image-preview`, `gemini-3.1-flash-lite-preview`, `gemini-3.1-pro-preview`, `gemini-3.1-pro-preview-customtools`). Also escaped the dot in the existing 2.5 pattern.
- `nodejs/src/ingestion/ai/costs/output-costs.test.ts`: parameterized regression tests for `gemini-3-flash-preview` (explicitly referencing the issue) and `gemini-3.1-pro-preview`.

Non-goal: the same file has an `internal_reasoning` rate on the Perplexity `sonar-deep-research` model that's still unused by the calculator — separate issue, not touched here.

## How did you test this code?

Agent-authored PR — tested only via the unit test suite (`nodejs/src/ingestion/ai/costs/output-costs.test.ts`, all 34 tests pass, including the 2 new Gemini 3 cases). No manual reproduction against a live Gemini 3 model.

## Publish to changelog?

no

## Docs update

No docs change needed.

## 🤖 LLM context

Authored by PostHog Code agent. Verified the fix path by tracing the reported event through `costs/index.ts`: `$ai_cost_model_source: "openrouter"` in the reporter's trace confirms `setCostsOnEvent` → `calculateOutputCost` ran server-side rather than passing through SDK-computed values, so the Node-side fix is the right place. Numerical check on the reported trace: completion rate 3e-6/token → current `2 × 3e-6 = 0.000006` (matches reported `$ai_output_cost_usd`); after fix `(2 + 77) × 3e-6 = 0.000237`. Also confirmed OpenAI/Anthropic/DeepSeek reasoning models have no `internal_reasoning` pricing entry (because their reasoning tokens are already inside output tokens), so the Gemini-scoped whitelist remains correct to avoid double-counting.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*