### PR TITLE
feat(logs): anchor alert windows on ingestion checkpoint

### DIFF
--- a/products/logs/backend/alert_check_query.py
+++ b/products/logs/backend/alert_check_query.py
@@ -192,6 +192,46 @@ class AlertCheckQuery:
         )
 
 
+# Explicit per-partition `GROUP BY` is required on both the dev `MergeTree`
+# shard (no auto-merge at all) and the prod `AggregatingMergeTree` between
+# merges. A bare `min(max_observed_timestamp)` scans every raw insert and
+# returns the oldest value ever written.
+_LIVE_LOGS_CHECKPOINT_SQL = """
+    SELECT min(partition_checkpoint) FROM (
+        SELECT _topic, _partition, max(max_observed_timestamp) AS partition_checkpoint
+        FROM logs_kafka_metrics
+        GROUP BY _topic, _partition
+    )
+"""
+
+# Fall back to `now` when the checkpoint is older than this — a quiet partition
+# can pin `min(...)` hours behind while other partitions have fresh data.
+CHECKPOINT_MAX_STALENESS = dt.timedelta(minutes=5)
+
+
+def fetch_live_logs_checkpoint(team: Team) -> dt.datetime | None:
+    response = execute_hogql_query(
+        query_type="alert_check_checkpoint",
+        query=parse_select(_LIVE_LOGS_CHECKPOINT_SQL),
+        team=team,
+        workload=Workload.LOGS,
+        modifiers=HogQLQueryModifiers(convertToProjectTimezone=False),
+    )
+    if not response.results or response.results[0][0] is None:
+        return None
+    checkpoint = response.results[0][0]
+    if checkpoint.tzinfo is None:
+        checkpoint = checkpoint.replace(tzinfo=ZoneInfo("UTC"))
+    return checkpoint
+
+
+def resolve_alert_date_to(now: dt.datetime, checkpoint: dt.datetime | None) -> dt.datetime:
+    """Anchor `date_to` on the checkpoint when fresh, else fall back to `now`."""
+    if checkpoint is None or (now - checkpoint) > CHECKPOINT_MAX_STALENESS:
+        return now
+    return min(now, checkpoint)
+
+
 def is_projection_eligible(filters: dict) -> bool:
     """True when filters use only serviceNames + severityLevels (no filterGroup values).
 

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -14,7 +14,7 @@ import temporalio.activity
 from posthog.cdp.internal_events import InternalEventEvent, produce_internal_event
 from posthog.exceptions_capture import capture_exception
 
-from products.logs.backend.alert_check_query import AlertCheckQuery
+from products.logs.backend.alert_check_query import AlertCheckQuery, fetch_live_logs_checkpoint, resolve_alert_date_to
 from products.logs.backend.alert_error_classifier import (
     AlertErrorCode,
     classify as classify_alert_error,
@@ -37,6 +37,7 @@ from products.logs.backend.temporal.metrics import (
     increment_state_transition,
     record_alerts_active,
     record_check_duration,
+    record_checkpoint_lag,
     record_scheduler_lag,
 )
 
@@ -82,13 +83,25 @@ def _check_alerts_sync() -> CheckAlertsOutput:
     except Exception:
         logger.exception("Failed to record alerts_active gauge")
 
+    checkpoint: datetime | None = None
+    if all_alerts:
+        try:
+            checkpoint = fetch_live_logs_checkpoint(all_alerts[0].team)
+        except Exception:
+            logger.exception("Failed to fetch logs ingestion checkpoint; falling back to wall-clock")
+
+    try:
+        record_checkpoint_lag(now, checkpoint)
+    except Exception:
+        logger.exception("Failed to record checkpoint lag gauge")
+
     stats = {"checked": 0, "fired": 0, "resolved": 0, "errored": 0}
 
     # Sequential for now. TODO, stagger
     # or cap concurrency to avoid bursting all ClickHouse queries at :00 each minute.
     for alert in all_alerts:
         try:
-            _evaluate_single_alert(alert, now, stats)
+            _evaluate_single_alert(alert, now, stats, checkpoint=checkpoint)
         except Exception:
             logger.exception(
                 "Unexpected error evaluating alert",
@@ -116,13 +129,15 @@ def _evaluate_single_alert(
     alert: LogsAlertConfiguration,
     now: datetime,
     stats: dict[str, int],
+    *,
+    checkpoint: datetime | None = None,
 ) -> None:
     """Run the ClickHouse query, apply state machine, persist, and emit events for a single alert."""
     start_time = time.perf_counter()
     original_next_check_at = alert.next_check_at
 
-    date_to = now
-    date_from = now - timedelta(minutes=alert.window_minutes)
+    date_to = resolve_alert_date_to(now, checkpoint)
+    date_from = date_to - timedelta(minutes=alert.window_minutes)
 
     check_result: CheckResult
     error_category: AlertErrorCode | None = None

--- a/products/logs/backend/temporal/metrics.py
+++ b/products/logs/backend/temporal/metrics.py
@@ -118,6 +118,21 @@ def record_alerts_active(count: int) -> None:
     gauge.set(count)
 
 
+def record_checkpoint_lag(now: dt.datetime, checkpoint: dt.datetime | None) -> None:
+    # Emits -1 when checkpoint is None — dashboards/alerts must treat negative as
+    # "unavailable", not a real lag value.
+    meter = get_metric_meter()
+    gauge = meter.create_gauge(
+        "logs_alerting_ingestion_checkpoint_lag_seconds",
+        "Wall-clock age of the logs-ingestion checkpoint used to anchor alert windows",
+    )
+    if checkpoint is None:
+        gauge.set(-1)
+        return
+    lag_seconds = max(0, int((now - checkpoint).total_seconds()))
+    gauge.set(lag_seconds)
+
+
 def record_check_duration(duration_ms: int) -> None:
     _record_histogram("logs_alerting_check_duration_ms", "Per-alert evaluation duration", duration_ms)
 

--- a/products/logs/backend/test/test_alert_check_query.py
+++ b/products/logs/backend/test/test_alert_check_query.py
@@ -1,5 +1,6 @@
 import os
 import json
+import datetime as dt
 from datetime import UTC, datetime
 
 import unittest
@@ -12,10 +13,13 @@ from parameterized import parameterized
 from posthog.clickhouse.client import sync_execute
 
 from products.logs.backend.alert_check_query import (
+    CHECKPOINT_MAX_STALENESS,
     AlertCheckCountResult,
     AlertCheckQuery,
     BucketedCount,
+    fetch_live_logs_checkpoint,
     is_projection_eligible,
+    resolve_alert_date_to,
 )
 from products.logs.backend.models import LogsAlertConfiguration
 
@@ -325,3 +329,65 @@ class TestAlertCheckQuery(ClickhouseTestMixin, APIBaseTest):
         ):
             with self.assertRaisesRegex(Exception, "ClickHouse timeout"):
                 query.execute()
+
+
+class TestFetchLiveLogsCheckpoint(APIBaseTest):
+    @patch("products.logs.backend.alert_check_query.execute_hogql_query")
+    def test_returns_datetime_from_response(self, mock_execute):
+        mock_response = type("R", (), {"results": [[datetime(2025, 1, 1, 12, 34, 56, tzinfo=UTC)]]})()
+        mock_execute.return_value = mock_response
+
+        result = fetch_live_logs_checkpoint(self.team)
+
+        assert result == datetime(2025, 1, 1, 12, 34, 56, tzinfo=UTC)
+
+    @patch("products.logs.backend.alert_check_query.execute_hogql_query")
+    def test_returns_none_on_empty_table(self, mock_execute):
+        # min() over an empty set returns NULL.
+        mock_execute.return_value = type("R", (), {"results": [[None]]})()
+
+        assert fetch_live_logs_checkpoint(self.team) is None
+
+    @patch("products.logs.backend.alert_check_query.execute_hogql_query")
+    def test_returns_none_when_no_rows(self, mock_execute):
+        mock_execute.return_value = type("R", (), {"results": []})()
+
+        assert fetch_live_logs_checkpoint(self.team) is None
+
+    @patch("products.logs.backend.alert_check_query.execute_hogql_query")
+    def test_attaches_utc_to_naive_datetime(self, mock_execute):
+        # ClickHouse returns tz-naive datetimes for DateTime64 columns in some code paths.
+        mock_execute.return_value = type("R", (), {"results": [[datetime(2025, 1, 1, 12, 34, 56)]]})()
+
+        result = fetch_live_logs_checkpoint(self.team)
+
+        assert result == datetime(2025, 1, 1, 12, 34, 56, tzinfo=UTC)
+        assert result is not None and result.tzinfo is not None
+
+
+class TestResolveAlertDateTo(unittest.TestCase):
+    NOW = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+    def test_none_checkpoint_returns_now(self):
+        assert resolve_alert_date_to(self.NOW, None) == self.NOW
+
+    def test_fresh_checkpoint_in_past_is_used(self):
+        checkpoint = self.NOW - dt.timedelta(seconds=30)
+        assert resolve_alert_date_to(self.NOW, checkpoint) == checkpoint
+
+    def test_checkpoint_equal_to_now_is_used(self):
+        assert resolve_alert_date_to(self.NOW, self.NOW) == self.NOW
+
+    def test_future_checkpoint_is_clamped_to_now(self):
+        checkpoint = self.NOW + dt.timedelta(seconds=60)
+        assert resolve_alert_date_to(self.NOW, checkpoint) == self.NOW
+
+    def test_stale_checkpoint_beyond_threshold_falls_back_to_now(self):
+        # The "quiet partition pins min() backwards" case — must not strand spikes
+        # on active partitions in the past.
+        checkpoint = self.NOW - CHECKPOINT_MAX_STALENESS - dt.timedelta(seconds=1)
+        assert resolve_alert_date_to(self.NOW, checkpoint) == self.NOW
+
+    def test_checkpoint_exactly_at_threshold_is_still_used(self):
+        checkpoint = self.NOW - CHECKPOINT_MAX_STALENESS
+        assert resolve_alert_date_to(self.NOW, checkpoint) == checkpoint

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -1,3 +1,4 @@
+import datetime as dt
 from datetime import UTC, datetime
 
 from freezegun import freeze_time
@@ -21,6 +22,25 @@ def _make_stats() -> dict[str, int]:
 
 
 class TestCheckAlertsSync(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        # Stub the cycle-level CH queries and metric emitters so tests that aren't
+        # asserting on them don't hit a real ClickHouse or raise outside Temporal.
+        # fetch_live_logs_checkpoint must return None (not MagicMock) so the real
+        # date-resolution path can run with a well-typed sentinel.
+        checkpoint_patch = patch(
+            "products.logs.backend.temporal.activities.fetch_live_logs_checkpoint", return_value=None
+        )
+        checkpoint_patch.start()
+        self.addCleanup(checkpoint_patch.stop)
+        for target in (
+            "products.logs.backend.temporal.activities.record_checkpoint_lag",
+            "products.logs.backend.temporal.activities.record_alerts_active",
+        ):
+            p = patch(target)
+            p.start()
+            self.addCleanup(p.stop)
+
     def _make_alert(self, **kwargs) -> LogsAlertConfiguration:
         defaults = {
             "team": self.team,
@@ -134,6 +154,56 @@ class TestCheckAlertsSync(APIBaseTest):
         _check_alerts_sync()
 
         mock_record_gauge.assert_called_once_with(expected_count)
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.record_checkpoint_lag")
+    @patch("products.logs.backend.temporal.activities.fetch_live_logs_checkpoint")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    def test_fetches_checkpoint_once_and_passes_to_evaluator(
+        self, mock_query_cls, mock_fetch_checkpoint, mock_record_lag
+    ):
+        checkpoint = datetime(2025, 1, 1, 0, 0, 30, tzinfo=UTC)
+        mock_fetch_checkpoint.return_value = checkpoint
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        self._make_alert()
+        self._make_alert(name="Second")
+
+        _check_alerts_sync()
+
+        # One checkpoint fetch per cycle, regardless of alert count.
+        mock_fetch_checkpoint.assert_called_once()
+        mock_record_lag.assert_called_once()
+        (now_arg, checkpoint_arg), _ = mock_record_lag.call_args
+        assert checkpoint_arg == checkpoint
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.record_checkpoint_lag")
+    @patch("products.logs.backend.temporal.activities.fetch_live_logs_checkpoint")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    def test_skips_checkpoint_fetch_when_no_due_alerts(self, _mock_query_cls, mock_fetch_checkpoint, mock_record_lag):
+        _check_alerts_sync()
+
+        mock_fetch_checkpoint.assert_not_called()
+        # Still record the gauge with None so the sentinel fires (pipeline unavailable-ish).
+        mock_record_lag.assert_called_once()
+        _now, checkpoint_arg = mock_record_lag.call_args.args
+        assert checkpoint_arg is None
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.record_checkpoint_lag")
+    @patch("products.logs.backend.temporal.activities.fetch_live_logs_checkpoint", side_effect=RuntimeError("CH down"))
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    def test_checkpoint_fetch_failure_falls_back_to_wall_clock(self, mock_query_cls, _mock_fetch, mock_record_lag):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        self._make_alert()
+
+        result = _check_alerts_sync()
+
+        # Alert still evaluated — failed checkpoint fetch must not block alerting.
+        assert result.alerts_checked == 1
+        mock_record_lag.assert_called_once()
+        _now, checkpoint_arg = mock_record_lag.call_args.args
+        assert checkpoint_arg is None
 
 
 class TestEvaluateSingleAlert(APIBaseTest):
@@ -719,3 +789,66 @@ class TestEvaluateSingleAlert(APIBaseTest):
         )
 
         mock_check_errors.assert_not_called()
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_query_uses_checkpoint_as_date_to_when_in_past(self, _mock_produce, mock_query_cls):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        alert = self._make_alert(window_minutes=5)
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+        checkpoint = datetime(2025, 1, 1, 0, 0, 30, tzinfo=UTC)  # 30s behind now
+
+        _evaluate_single_alert(alert, now, _make_stats(), checkpoint=checkpoint)
+
+        kwargs = mock_query_cls.call_args.kwargs
+        assert kwargs["date_to"] == checkpoint
+        assert kwargs["date_from"] == checkpoint - dt.timedelta(minutes=5)
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_query_uses_now_when_checkpoint_is_in_future(self, _mock_produce, mock_query_cls):
+        # Defensive case: if clocks are skewed so checkpoint > now, don't query the future.
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        alert = self._make_alert(window_minutes=5)
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+        checkpoint = datetime(2025, 1, 1, 0, 2, 0, tzinfo=UTC)  # 60s ahead of now
+
+        _evaluate_single_alert(alert, now, _make_stats(), checkpoint=checkpoint)
+
+        kwargs = mock_query_cls.call_args.kwargs
+        assert kwargs["date_to"] == now
+        assert kwargs["date_from"] == now - dt.timedelta(minutes=5)
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_query_uses_now_when_checkpoint_is_none(self, _mock_produce, mock_query_cls):
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        alert = self._make_alert(window_minutes=5)
+        now = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+
+        _evaluate_single_alert(alert, now, _make_stats(), checkpoint=None)
+
+        kwargs = mock_query_cls.call_args.kwargs
+        assert kwargs["date_to"] == now
+        assert kwargs["date_from"] == now - dt.timedelta(minutes=5)
+
+    @freeze_time("2025-01-01T01:00:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_query_ignores_stale_checkpoint_quiet_partition_case(self, _mock_produce, mock_query_cls):
+        # Quiet partitions pin min(max_observed_timestamp) backwards. If that's older than
+        # CHECKPOINT_MAX_STALENESS we must ignore the checkpoint — otherwise a spike of
+        # errors on an active partition would never appear in the window.
+        mock_query_cls.return_value.execute.return_value = AlertCheckCountResult(count=5, query_duration_ms=100)
+        alert = self._make_alert(window_minutes=5)
+        now = datetime(2025, 1, 1, 1, 0, 0, tzinfo=UTC)
+        stale_checkpoint = datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)  # 1 hour behind now
+
+        _evaluate_single_alert(alert, now, _make_stats(), checkpoint=stale_checkpoint)
+
+        kwargs = mock_query_cls.call_args.kwargs
+        assert kwargs["date_to"] == now
+        assert kwargs["date_from"] == now - dt.timedelta(minutes=5)

--- a/products/logs/backend/test/test_logs_alerting_metrics.py
+++ b/products/logs/backend/test/test_logs_alerting_metrics.py
@@ -17,6 +17,7 @@ from products.logs.backend.temporal.metrics import (
     increment_state_transition,
     record_alerts_active,
     record_check_duration,
+    record_checkpoint_lag,
     record_schedule_to_start_latency,
     record_scheduler_lag,
 )
@@ -122,6 +123,43 @@ class TestRecordAlertsActive:
         (name, _description), _ = mock_meter.create_gauge.call_args
         assert name == "logs_alerting_alerts_active"
         mock_gauge.set.assert_called_once_with(count)
+
+
+class TestRecordCheckpointLag:
+    @pytest.mark.parametrize(
+        "lag_seconds,expected",
+        [
+            (0, 0),  # checkpoint == now
+            (15, 15),  # typical healthy lag
+            (300, 300),  # backlog starting
+            (-60, 0),  # checkpoint somehow ahead of now — clamped to 0
+        ],
+    )
+    @patch("products.logs.backend.temporal.metrics.get_metric_meter")
+    def test_records_positive_lag(self, mock_get_meter: MagicMock, lag_seconds: int, expected: int):
+        mock_meter = MagicMock()
+        mock_gauge = MagicMock()
+        mock_meter.create_gauge.return_value = mock_gauge
+        mock_get_meter.return_value = mock_meter
+
+        now = dt.datetime(2025, 1, 1, 0, 0, 0)
+        checkpoint = now - dt.timedelta(seconds=lag_seconds)
+        record_checkpoint_lag(now, checkpoint)
+
+        (name, _description), _ = mock_meter.create_gauge.call_args
+        assert name == "logs_alerting_ingestion_checkpoint_lag_seconds"
+        mock_gauge.set.assert_called_once_with(expected)
+
+    @patch("products.logs.backend.temporal.metrics.get_metric_meter")
+    def test_sentinel_when_checkpoint_none(self, mock_get_meter: MagicMock):
+        mock_meter = MagicMock()
+        mock_gauge = MagicMock()
+        mock_meter.create_gauge.return_value = mock_gauge
+        mock_get_meter.return_value = mock_meter
+
+        record_checkpoint_lag(dt.datetime(2025, 1, 1, 0, 0, 0), None)
+
+        mock_gauge.set.assert_called_once_with(-1)
 
 
 class TestRecordCheckDuration:


### PR DESCRIPTION
## Problem

Alert windows for logs alerting were anchored to wall-clock `now`, which means they could query ahead of what ClickHouse has actually ingested. On both the dev `MergeTree` shard and the prod `AggregatingMergeTree` between merges, a bare `min(max_observed_timestamp)` scans every raw insert and returns the oldest value ever written. This caused alert windows to potentially miss recent log data or include gaps where ingestion hadn't caught up yet.

Additionally, quiet partitions (those receiving no traffic) could pin `min(max_observed_timestamp)` hours behind active partitions, causing alert windows to be anchored far in the past and miss spikes on active partitions.

## Changes  
![image.png](https://app.graphite.com/user-attachments/assets/f2378df5-94c4-4668-98c6-5e0450dfef51.png)

- Adds `fetch_live_logs_checkpoint` which queries `logs_kafka_metrics` using a per-partition `GROUP BY` before taking the `min`, returning the true ingestion frontier.
- Adds `resolve_alert_date_to` which anchors `date_to` on the checkpoint when it is fresh (within 5 minutes), clamps future checkpoints to `now`, and falls back to `now` when the checkpoint is stale or unavailable.
- The checkpoint is fetched once per alerting cycle (not per alert) and passed down to each `_evaluate_single_alert` call, so `date_from` slides with `date_to` rather than being fixed to wall-clock `now`.
- Adds `record_checkpoint_lag` metric gauge (`logs_alerting_ingestion_checkpoint_lag_seconds`) that emits the age of the checkpoint in seconds, or `-1` as a sentinel when the checkpoint is unavailable.
- Checkpoint fetch failures are caught and logged; alerting continues using wall-clock `now` as a fallback so a ClickHouse outage does not block alert evaluation.

## How did you test this code?

Covered by tests:

- `TestFetchLiveLogsCheckpoint` — verifies correct datetime parsing, UTC attachment to naive datetimes, and `None` returns for empty/null results.
- `TestResolveAlertDateTo` — verifies fresh checkpoint is used, stale checkpoint falls back to `now`, future checkpoint is clamped to `now`, and the boundary at exactly `CHECKPOINT_MAX_STALENESS` is handled correctly.
- `TestCheckAlertsSync` — verifies the checkpoint is fetched once per cycle regardless of alert count, skipped when there are no due alerts, and that a fetch failure falls back gracefully without blocking alert evaluation.
- `TestEvaluateSingleAlert` — verifies `date_to`/`date_from` are set correctly for fresh checkpoints, future checkpoints, `None` checkpoints, and stale checkpoints from quiet partitions.
- `TestRecordCheckpointLag` — verifies positive lag values, clamping of negative lag to 0, and the `-1` sentinel when checkpoint is `None`.

## Publish to changelog?

No