### PR TITLE
feat(sql-editor): mixed area charts

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -64,6 +64,10 @@ const getGraphType = (chartType: ChartDisplayType, settings: AxisSeriesSettings 
     return GraphType.Line
 }
 
+const isAreaSeries = (chartType: ChartDisplayType, settings: AxisSeriesSettings | undefined): boolean => {
+    return chartType === ChartDisplayType.ActionsAreaGraph || settings?.display?.displayType === 'area'
+}
+
 const getYAxisSettings = (
     chartSettings: ChartSettings,
     settings: YAxisSettings | undefined,
@@ -177,7 +181,8 @@ export const LineGraph = ({
 
         return ySeriesData.map(({ data: seriesData, settings, ...rest }, index) => {
             const seriesColor = settings?.display?.color ?? getSeriesColor(index)
-            let backgroundColor = isAreaChart ? hexToRGBA(seriesColor, 0.5) : seriesColor
+            const hasAreaFill = isAreaSeries(visualizationType, settings)
+            let backgroundColor = hasAreaFill ? hexToRGBA(seriesColor, 0.5) : seriesColor
 
             // Dim non-hovered bars in stacked bar charts when shift is pressed
             if (isHighlightBarMode && hoveredDatasetIndex !== null && index !== hoveredDatasetIndex) {
@@ -213,7 +218,7 @@ export const LineGraph = ({
                 hoverBorderWidth: graphType === GraphType.Bar ? 0 : 2,
                 hoverBorderRadius: graphType === GraphType.Bar ? 0 : 2,
                 type: graphType,
-                fill: isAreaChart ? 'origin' : false,
+                fill: hasAreaFill ? 'origin' : false,
                 yAxisID,
                 ...(settings?.display?.trendLine && xData && yData && xData.data.length > 0 && seriesData.length > 0
                     ? {
@@ -231,7 +236,6 @@ export const LineGraph = ({
         ySeriesData,
         xData,
         yData,
-        isAreaChart,
         isHighlightBarMode,
         hoveredDatasetIndex,
         visualizationType,

--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.test.tsx
@@ -10,7 +10,7 @@ import { ChartDisplayType } from '~/types'
 
 import { dataNodeLogic } from '../../DataNode/dataNodeLogic'
 import { DataVisualizationLogicProps, dataVisualizationLogic } from '../dataVisualizationLogic'
-import { YSeriesFormattingTab } from './SeriesTab'
+import { YSeriesDisplayTab, YSeriesFormattingTab } from './SeriesTab'
 import { YSeriesLogicProps } from './ySeriesLogic'
 
 describe('SeriesTab', () => {
@@ -102,6 +102,96 @@ describe('SeriesTab', () => {
                                 }),
                             }),
                         ]),
+                    }),
+                })
+            )
+        )
+    })
+
+    it('persists area as a y-axis display type', async () => {
+        initKeaTests()
+
+        const setQuery = jest.fn()
+        const query: DataVisualizationNode = {
+            kind: NodeKind.DataVisualizationNode,
+            source: {
+                kind: NodeKind.HogQLQuery,
+                query: 'select day, value from numbers(2)',
+            },
+            display: ChartDisplayType.ActionsLineGraph,
+            chartSettings: {
+                yAxis: [
+                    {
+                        column: 'value',
+                        settings: {
+                            display: {
+                                displayType: 'auto',
+                            },
+                        },
+                    },
+                ],
+            },
+        }
+
+        const props: DataVisualizationLogicProps = {
+            key: 'series-display-tab-test',
+            query,
+            dataNodeCollectionId: 'series-display-tab-test',
+            setQuery: (setter) => setQuery(setter(query)),
+        }
+
+        dataVisualizationLogic(props).mount()
+        dataNodeLogic({
+            key: props.key,
+            query: query.source,
+            dataNodeCollectionId: props.dataNodeCollectionId,
+        }).mount()
+
+        const ySeriesLogicProps: YSeriesLogicProps = {
+            seriesIndex: 0,
+            dataVisualizationProps: props,
+            series: {
+                column: {
+                    name: 'value',
+                    label: 'value',
+                    dataIndex: 1,
+                    type: {
+                        name: 'FLOAT',
+                        isNumerical: true,
+                    },
+                },
+                data: [],
+                settings: {
+                    display: {
+                        displayType: 'auto',
+                    },
+                },
+            },
+        }
+
+        render(
+            <BindLogic logic={dataVisualizationLogic} props={props}>
+                <YSeriesDisplayTab ySeriesLogicProps={ySeriesLogicProps} />
+            </BindLogic>
+        )
+
+        const user = userEvent.setup()
+        await user.click(await screen.findByText('Area'))
+
+        await waitFor(() =>
+            expect(setQuery).toHaveBeenLastCalledWith(
+                expect.objectContaining({
+                    chartSettings: expect.objectContaining({
+                        yAxis: [
+                            expect.objectContaining({
+                                column: 'value',
+                                settings: expect.objectContaining({
+                                    display: expect.objectContaining({
+                                        displayType: 'area',
+                                    }),
+                                }),
+                            }),
+                        ],
                     }),
                 })
             )

--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -415,7 +415,7 @@ export const YSeriesFormattingTab = ({ ySeriesLogicProps }: { ySeriesLogicProps:
     )
 }
 
-const YSeriesDisplayTab = ({ ySeriesLogicProps }: { ySeriesLogicProps: YSeriesLogicProps }): JSX.Element => {
+export const YSeriesDisplayTab = ({ ySeriesLogicProps }: { ySeriesLogicProps: YSeriesLogicProps }): JSX.Element => {
     const { showTableSettings, dataVisualizationProps, effectiveVisualizationType } = useValues(dataVisualizationLogic)
     const { selectedSeriesBreakdownColumn } = useValues(seriesBreakdownLogic({ key: dataVisualizationProps.key }))
     const { updateSeriesIndex } = useActions(dataVisualizationLogic)
@@ -548,6 +548,10 @@ const YSeriesDisplayTab = ({ ySeriesLogicProps }: { ySeriesLogicProps: YSeriesLo
                                         label: 'Bar',
                                         value: 'bar',
                                     },
+                                    {
+                                        label: 'Area',
+                                        value: 'area',
+                                    },
                                 ]}
                                 onChange={(newValue) => {
                                     onChange(newValue)
@@ -556,7 +560,7 @@ const YSeriesDisplayTab = ({ ySeriesLogicProps }: { ySeriesLogicProps: YSeriesLo
                                         ySeriesLogicProps.series.column.name,
                                         {
                                             display: {
-                                                displayType: newValue as 'auto' | 'line' | 'bar',
+                                                displayType: newValue as 'auto' | 'line' | 'bar' | 'area',
                                             },
                                         }
                                     )

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -10098,7 +10098,7 @@
                     "type": "string"
                 },
                 "displayType": {
-                    "enum": ["auto", "line", "bar"],
+                    "enum": ["auto", "line", "bar", "area"],
                     "type": "string"
                 },
                 "label": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1092,7 +1092,7 @@ export interface ChartSettingsDisplay {
     label?: string
     trendLine?: boolean
     yAxisPosition?: 'left' | 'right'
-    displayType?: 'auto' | 'line' | 'bar'
+    displayType?: 'auto' | 'line' | 'bar' | 'area'
 }
 
 export interface HeatmapGradientStop {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -948,6 +948,7 @@ class DisplayType(StrEnum):
     AUTO = "auto"
     LINE = "line"
     BAR = "bar"
+    AREA = "area"
 
 
 class YAxisPosition(StrEnum):

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -9205,6 +9205,7 @@ export const DisplayTypeApi = {
     Auto: 'auto',
     Line: 'line',
     Bar: 'bar',
+    Area: 'area',
 } as const
 
 export type YAxisPositionApi = (typeof YAxisPositionApi)[keyof typeof YAxisPositionApi]

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7393,6 +7393,7 @@ export namespace Schemas {
       Auto: 'auto',
       Line: 'line',
       Bar: 'bar',
+      Area: 'area',
     } as const;
 
     export type YAxisPosition = typeof YAxisPosition[keyof typeof YAxisPosition];


### PR DESCRIPTION
## Problem

In the SQL editor you can specify the type of chart per each axis. Unfortunately "Area" was missing from the list.

## Changes

Add "area" here:

<img width="965" height="1038" alt="2026-04-21 13 43 54" src="https://github.com/user-attachments/assets/cb19eec6-aaa0-4edb-a2de-dc7b66ec9a4b" />


## How did you test this code?

👀 

## Publish to changelog?

no

## Docs update

no