### PR TITLE
fix(dashboards): ignore breakdown override for trends insights with dwh series

### DIFF
--- a/frontend/src/lib/components/Alerts/insightAlertsLogic.ts
+++ b/frontend/src/lib/components/Alerts/insightAlertsLogic.ts
@@ -6,7 +6,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
 import { AlertConditionType, BreakdownFilter, GoalLine, InsightThresholdType } from '~/queries/schema/schema-general'
-import { isInsightVizNode, isTrendsQuery, isValidBreakdown } from '~/queries/utils'
+import { isInsightVizNode, isTrendsQuery, hasBreakdownFilter } from '~/queries/utils'
 import { InsightLogicProps } from '~/types'
 
 import type { insightAlertsLogicType } from './insightAlertsLogicType'
@@ -155,7 +155,7 @@ export const insightAlertsLogic = kea<insightAlertsLogicType>([
                     return []
                 }
 
-                const hasBreakdown = isValidBreakdown(breakdownFilter)
+                const hasBreakdown = hasBreakdownFilter(breakdownFilter)
 
                 // Derive from all firing checks of each detector-based alert.
                 // Each check typically has 0-1 triggered points, so we aggregate

--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
@@ -24,7 +24,7 @@ import { Link } from 'lib/lemon-ui/Link'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { capitalizeFirstLetter, dateFilterToText } from 'lib/utils'
 import { BreakdownTag } from 'scenes/insights/filters/BreakdownFilter/BreakdownTag'
-import { humanizePathsEventTypes, containsNonDataWarehouseBreakdown } from 'scenes/insights/utils'
+import { humanizePathsEventTypes, hasUnsupportedBreakdownForDataWarehouseTrends } from 'scenes/insights/utils'
 import { QUERY_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
 import { MathCategory, apiValueToMathType, mathsLogic } from 'scenes/trends/mathsLogic'
 import { urls } from 'scenes/urls'
@@ -498,8 +498,8 @@ export const InsightDetails = React.memo(
         const hasIgnoredBreakdownOverrides =
             isInsightVizNode(query) &&
             isTrendsQuery(query.source) &&
-            (containsNonDataWarehouseBreakdown(filtersOverride) ||
-                containsNonDataWarehouseBreakdown(tileFiltersOverride))
+            (hasUnsupportedBreakdownForDataWarehouseTrends(filtersOverride) ||
+                hasUnsupportedBreakdownForDataWarehouseTrends(tileFiltersOverride))
 
         return (
             <div className="InsightDetails space-y-2" ref={ref}>

--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
@@ -496,7 +496,10 @@ export const InsightDetails = React.memo(
     ): JSX.Element {
         const hasPropertyOverrides = !!filtersOverride?.properties?.length || !!tileFiltersOverride?.properties?.length
         const hasIgnoredBreakdownOverrides =
-            containsNonDataWarehouseBreakdown(filtersOverride) || containsNonDataWarehouseBreakdown(tileFiltersOverride)
+            isInsightVizNode(query) &&
+            isTrendsQuery(query.source) &&
+            (containsNonDataWarehouseBreakdown(filtersOverride) ||
+                containsNonDataWarehouseBreakdown(tileFiltersOverride))
 
         return (
             <div className="InsightDetails space-y-2" ref={ref}>

--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
@@ -24,7 +24,7 @@ import { Link } from 'lib/lemon-ui/Link'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { capitalizeFirstLetter, dateFilterToText } from 'lib/utils'
 import { BreakdownTag } from 'scenes/insights/filters/BreakdownFilter/BreakdownTag'
-import { humanizePathsEventTypes } from 'scenes/insights/utils'
+import { humanizePathsEventTypes, containsNonDataWarehouseBreakdown } from 'scenes/insights/utils'
 import { QUERY_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
 import { MathCategory, apiValueToMathType, mathsLogic } from 'scenes/trends/mathsLogic'
 import { urls } from 'scenes/urls'
@@ -361,6 +361,18 @@ export function PropertiesIgnoredWarning(): JSX.Element {
     )
 }
 
+export function BreakdownIgnoredWarning(): JSX.Element {
+    return (
+        <InsightDetailSectionDisplay icon={<IconSort />} label="Breakdown by">
+            <Tooltip title="Breakdown overrides are not applied. Insights with a data warehouse series only support a single data warehouse property breakdown.">
+                <div className="flex items-center gap-1 text-warning italic">
+                    <IconWarning /> Breakdown overrides ignored (data warehouse series).
+                </div>
+            </Tooltip>
+        </InsightDetailSectionDisplay>
+    )
+}
+
 export function VariablesSummary({
     variables,
     variablesOverride,
@@ -483,6 +495,8 @@ export const InsightDetails = React.memo(
         ref
     ): JSX.Element {
         const hasPropertyOverrides = !!filtersOverride?.properties?.length || !!tileFiltersOverride?.properties?.length
+        const hasIgnoredBreakdownOverrides =
+            containsNonDataWarehouseBreakdown(filtersOverride) || containsNonDataWarehouseBreakdown(tileFiltersOverride)
 
         return (
             <div className="InsightDetails space-y-2" ref={ref}>
@@ -506,7 +520,11 @@ export const InsightDetails = React.memo(
                                 }
                             />
                         )}
-                        <InsightBreakdownSummary query={query.source} />
+                        {hasDataWarehouseSeries && hasIgnoredBreakdownOverrides ? (
+                            <BreakdownIgnoredWarning />
+                        ) : (
+                            <InsightBreakdownSummary query={query.source} />
+                        )}
                     </>
                 )}
                 {footerInfo && (

--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
@@ -62,7 +62,7 @@ import {
     isPathsQuery,
     isRetentionQuery,
     isTrendsQuery,
-    isValidBreakdown,
+    hasBreakdownFilter,
 } from '~/queries/utils'
 import { AnyPropertyFilter, BaseMathType, FilterLogicalOperator, PropertyGroupFilter, UserBasicType } from '~/types'
 
@@ -123,7 +123,7 @@ function SeriesDisplay({
     const { mathDefinitions } = useValues(mathsLogic)
     const series = query.series[seriesIndex]
 
-    const hasBreakdown = isInsightQueryWithBreakdown(query) && isValidBreakdown(query.breakdownFilter)
+    const hasBreakdown = isInsightQueryWithBreakdown(query) && hasBreakdownFilter(query.breakdownFilter)
 
     const mathKey = isLifecycleQuery(query)
         ? BaseMathType.UniqueUsers
@@ -408,7 +408,7 @@ export function VariablesSummary({
 }
 
 export function InsightBreakdownSummary({ query }: { query: InsightQueryNode | HogQLQuery }): JSX.Element | null {
-    if (!isInsightQueryWithBreakdown(query) || !isValidBreakdown(query.breakdownFilter)) {
+    if (!isInsightQueryWithBreakdown(query) || !hasBreakdownFilter(query.breakdownFilter)) {
         return null
     }
 
@@ -420,7 +420,7 @@ export function BreakdownSummary({
 }: {
     breakdownFilter: BreakdownFilter | null | undefined
 }): JSX.Element | null {
-    if (!isValidBreakdown(breakdownFilter)) {
+    if (!hasBreakdownFilter(breakdownFilter)) {
         return null
     }
 

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -43,7 +43,7 @@ import { PathStepPicker } from 'scenes/insights/views/Paths/PathStepPicker'
 import { RetentionBreakdownFilter } from 'scenes/retention/RetentionBreakdownFilter'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 
-import { isValidBreakdown, isWebAnalyticsInsightQuery } from '~/queries/utils'
+import { hasBreakdownFilter, isWebAnalyticsInsightQuery } from '~/queries/utils'
 import { isTrendsQuery } from '~/queries/utils'
 import { ChartDisplayType } from '~/types'
 
@@ -94,7 +94,7 @@ export function InsightDisplayConfig(): JSX.Element {
         ((isTrends || isStickiness) && !(display && NON_TIME_SERIES_DISPLAY_TYPES.includes(display)))
     const showSmoothing =
         isTrends &&
-        !isValidBreakdown(breakdownFilter) &&
+        !hasBreakdownFilter(breakdownFilter) &&
         (!display || display === ChartDisplayType.ActionsLineGraph || display === ChartDisplayType.ActionsAreaGraph)
     const showMultipleYAxesConfig = (isTrends || isStickiness) && !isNonTimeSeriesDisplay
     const showAlertThresholdLinesConfig = isTrends && !isNonTimeSeriesDisplay
@@ -346,7 +346,7 @@ export function InsightDisplayConfig(): JSX.Element {
                 {!!isRetention && (
                     <ConfigFilter>
                         <RetentionDatePicker />
-                        {isValidBreakdown(breakdownFilter) && <RetentionBreakdownFilter />}
+                        {hasBreakdownFilter(breakdownFilter) && <RetentionBreakdownFilter />}
                     </ConfigFilter>
                 )}
 

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -867,15 +867,16 @@ export function hogql(strings: TemplateStringsArray, ...values: any[]): HogQLQue
 hogql.identifier = hogQLIdentifier
 hogql.raw = hogQLRaw
 
-/**
- * Wether we have a valid `breakdownFilter` or not.
- */
-export function isValidBreakdown(breakdownFilter?: BreakdownFilter | null): breakdownFilter is BreakdownFilter {
-    return !!(
-        breakdownFilter &&
-        ((breakdownFilter.breakdown && breakdownFilter.breakdown_type) ||
-            (breakdownFilter.breakdowns && breakdownFilter.breakdowns.length > 0))
-    )
+export function hasSingleBreakdown(breakdownFilter?: BreakdownFilter | null): boolean {
+    return breakdownFilter?.breakdown != null
+}
+
+export function hasMultiBreakdown(breakdownFilter?: BreakdownFilter | null): boolean {
+    return (breakdownFilter?.breakdowns?.length ?? 0) > 0
+}
+
+export function hasBreakdownFilter(breakdownFilter?: BreakdownFilter | null): boolean {
+    return hasSingleBreakdown(breakdownFilter) || hasMultiBreakdown(breakdownFilter)
 }
 
 export function isValidQueryForExperiment(query: Node): boolean {

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -867,15 +867,27 @@ export function hogql(strings: TemplateStringsArray, ...values: any[]): HogQLQue
 hogql.identifier = hogQLIdentifier
 hogql.raw = hogQLRaw
 
-export function hasSingleBreakdown(breakdownFilter?: BreakdownFilter | null): boolean {
+type SingleBreakdownFilter = BreakdownFilter & {
+    breakdown: NonNullable<BreakdownFilter['breakdown']>
+}
+
+type MultiBreakdownFilter = BreakdownFilter & {
+    breakdowns: NonNullable<BreakdownFilter['breakdowns']>
+}
+
+type PopulatedBreakdownFilter = SingleBreakdownFilter | MultiBreakdownFilter
+
+export function hasSingleBreakdown(breakdownFilter?: BreakdownFilter | null): breakdownFilter is SingleBreakdownFilter {
     return breakdownFilter?.breakdown != null
 }
 
-export function hasMultiBreakdown(breakdownFilter?: BreakdownFilter | null): boolean {
+export function hasMultiBreakdown(breakdownFilter?: BreakdownFilter | null): breakdownFilter is MultiBreakdownFilter {
     return (breakdownFilter?.breakdowns?.length ?? 0) > 0
 }
 
-export function hasBreakdownFilter(breakdownFilter?: BreakdownFilter | null): boolean {
+export function hasBreakdownFilter(
+    breakdownFilter?: BreakdownFilter | null
+): breakdownFilter is PopulatedBreakdownFilter {
     return hasSingleBreakdown(breakdownFilter) || hasMultiBreakdown(breakdownFilter)
 }
 

--- a/frontend/src/scenes/funnels/funnelUtils.tsx
+++ b/frontend/src/scenes/funnels/funnelUtils.tsx
@@ -181,7 +181,7 @@ export function isBreakdownFunnelResults(results: FunnelResultType): results is 
 }
 
 /** Breakdown parameter could be a string (property breakdown) or object/number (list of cohort ids). */
-export function isValidBreakdownParameter(
+export function hasBreakdownFilterParameter(
     breakdown: BreakdownKeyType | undefined,
     breakdowns: Breakdown[] | undefined
 ): boolean {

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -828,7 +828,9 @@ export const getOverrideWarningPropsForButton = (
         : {}
 }
 
-export const containsNonDataWarehouseBreakdown = (
+/** Checks for breakdown features that are unsupported by trend insights with a
+ * data warehouse series. */
+export const hasUnsupportedBreakdownForDataWarehouseTrends = (
     filtersOverride: DashboardFilter | TileFilters | null | undefined
 ): boolean => {
     const breakdownFilter = filtersOverride?.breakdown_filter

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -33,6 +33,7 @@ import {
     ResultCustomizationBy,
     ResultCustomizationByPosition,
     ResultCustomizationByValue,
+    TileFilters,
 } from '~/queries/schema/schema-general'
 import {
     containsHogQLQuery,
@@ -825,4 +826,21 @@ export const getOverrideWarningPropsForButton = (
               tooltip: `This insight is being viewed with dashboard ${overrideType}. These will be discarded on edit.`,
           }
         : {}
+}
+
+export const containsNonDataWarehouseBreakdown = (
+    filtersOverride: DashboardFilter | TileFilters | null | undefined
+): boolean => {
+    const breakdownFilter = filtersOverride?.breakdown_filter
+
+    if (!breakdownFilter) {
+        return false
+    }
+
+    return !!(
+        breakdownFilter.breakdowns?.length ||
+        breakdownFilter.breakdown_type !== 'data_warehouse' ||
+        !breakdownFilter.breakdown ||
+        Array.isArray(breakdownFilter.breakdown)
+    )
 }

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -17,7 +17,7 @@ import { IndexedTrendResult } from 'scenes/trends/types'
 import { cohortsModel } from '~/models/cohortsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { extractDisplayLabel } from '~/queries/nodes/DataTable/utils'
-import { isValidBreakdown } from '~/queries/utils'
+import { hasBreakdownFilter } from '~/queries/utils'
 import { ChartDisplayType, TrendsFilterType } from '~/types'
 
 import { entityFilterLogic } from '../../filters/ActionFilter/entityFilterLogic'
@@ -135,10 +135,10 @@ export function InsightsTable({
     // info into the first column and skip the separate "Breakdown" column.
     const isSingleSeriesWithBreakdown =
         isSingleSeriesDefinition &&
-        isValidBreakdown(breakdownFilter) &&
+        hasBreakdownFilter(breakdownFilter) &&
         !(breakdownFilter.breakdowns && breakdownFilter.breakdowns.length > 1)
 
-    const formatItemBreakdownLabel = isValidBreakdown(breakdownFilter)
+    const formatItemBreakdownLabel = hasBreakdownFilter(breakdownFilter)
         ? (item: IndexedTrendResult): string =>
               formatBreakdownLabel(
                   Array.isArray(item.breakdown_value) ? item.breakdown_value[0] : item.breakdown_value,
@@ -191,7 +191,7 @@ export function InsightsTable({
                     seriesNameTooltip={seriesNameTooltip}
                     handleEditClick={handleSeriesEditClick}
                     hasMultipleSeries={!isSingleSeriesDefinition}
-                    hasBreakdown={isValidBreakdown(breakdownFilter)}
+                    hasBreakdown={hasBreakdownFilter(breakdownFilter)}
                     hideCompare={isCompareTable}
                 />
             )
@@ -226,7 +226,7 @@ export function InsightsTable({
         },
     })
 
-    if (isValidBreakdown(breakdownFilter) && breakdownFilter.breakdown) {
+    if (hasBreakdownFilter(breakdownFilter) && breakdownFilter.breakdown) {
         if (!isSingleSeriesWithBreakdown) {
             columns.push({
                 title: (

--- a/frontend/src/scenes/retention/retentionLogic.ts
+++ b/frontend/src/scenes/retention/retentionLogic.ts
@@ -12,7 +12,7 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import { cohortsModel } from '~/models/cohortsModel'
 import { RetentionFilter, RetentionResult } from '~/queries/schema/schema-general'
-import { isRetentionQuery, isValidBreakdown } from '~/queries/utils'
+import { isRetentionQuery, hasBreakdownFilter } from '~/queries/utils'
 import { BreakdownKeyType, CohortType, DateMappingOption, InsightLogicProps, RetentionPeriod } from '~/types'
 
 import type { retentionLogicType } from './retentionLogicType'
@@ -145,7 +145,7 @@ export const retentionLogic = kea<retentionLogicType>([
         ],
     }),
     selectors({
-        hasValidBreakdown: [(s) => [s.breakdownFilter], (breakdownFilter) => isValidBreakdown(breakdownFilter)],
+        hasValidBreakdown: [(s) => [s.breakdownFilter], (breakdownFilter) => hasBreakdownFilter(breakdownFilter)],
         isPropertyValueAggregation: [
             (s) => [s.retentionFilter],
             (retentionFilter: RetentionFilter | undefined) =>

--- a/frontend/src/scenes/saved-insights/activityDescriptions.tsx
+++ b/frontend/src/scenes/saved-insights/activityDescriptions.tsx
@@ -27,7 +27,7 @@ import { urls } from 'scenes/urls'
 import { filtersToQueryNode } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
 import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 import { InsightQueryNode, QuerySchema, TrendsQuery } from '~/queries/schema/schema-general'
-import { isInsightQueryNode, isValidBreakdown } from '~/queries/utils'
+import { isInsightQueryNode, hasBreakdownFilter } from '~/queries/utils'
 import { FilterType, InsightModel, InsightShortId } from '~/types'
 
 const nameOrLinkToInsight = (short_id?: InsightShortId | null, name?: string | null): string | JSX.Element => {
@@ -256,7 +256,7 @@ function summarizeChanges(filtersAfter: Partial<FilterType>): ChangeMapping | nu
             <div className="ActivityDescription">
                 <SeriesSummary query={query} />
                 <PropertiesSummary properties={query.properties} />
-                {isValidBreakdown(trendsQuery?.breakdownFilter) && <InsightBreakdownSummary query={query} />}
+                {hasBreakdownFilter(trendsQuery?.breakdownFilter) && <InsightBreakdownSummary query={query} />}
             </div>
         ),
     }

--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -29,7 +29,7 @@ import {
     TrendsFilter,
     TrendsQuery,
 } from '~/queries/schema/schema-general'
-import { isValidBreakdown } from '~/queries/utils'
+import { hasBreakdownFilter } from '~/queries/utils'
 import {
     ChartDisplayType,
     CountPerActorMathType,
@@ -188,7 +188,7 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
 
         isBreakdownValid: [
             (s) => [s.breakdownFilter],
-            (breakdownFilter: BreakdownFilter | null) => isValidBreakdown(breakdownFilter),
+            (breakdownFilter: BreakdownFilter | null) => hasBreakdownFilter(breakdownFilter),
         ],
 
         indexedResults: [

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -30,10 +30,7 @@ from posthog.hogql_queries.insights.funnels.funnel_validation_rules import (
 )
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
-from posthog.hogql_queries.validation.rules import (
-    DisallowUnsupportedDataWarehouseSettings,
-    ValidateDataWarehouseBreakdown,
-)
+from posthog.hogql_queries.validation.rules import DisallowUnsupportedDataWarehouseSettings
 from posthog.hogql_queries.validation.validation import QueryValidationRule
 from posthog.models import Team
 from posthog.models.filters.mixins.utils import cached_property
@@ -67,7 +64,6 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
             ValidateFunnelExclusions(),
             ValidateOptionalFunnelSteps(),
             DisallowUnsupportedDataWarehouseSettings(),
-            ValidateDataWarehouseBreakdown(),
         )
 
     def _refresh_frequency(self):

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -30,7 +30,10 @@ from posthog.hogql_queries.insights.funnels.funnel_validation_rules import (
 )
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
-from posthog.hogql_queries.validation.rules import DisallowUnsupportedDataWarehouseSettings
+from posthog.hogql_queries.validation.rules import (
+    DisallowUnsupportedDataWarehouseSettings,
+    ValidateDataWarehouseBreakdown,
+)
 from posthog.hogql_queries.validation.validation import QueryValidationRule
 from posthog.models import Team
 from posthog.models.filters.mixins.utils import cached_property
@@ -64,6 +67,7 @@ class FunnelsQueryRunner(AnalyticsQueryRunner[FunnelsQueryResponse]):
             ValidateFunnelExclusions(),
             ValidateOptionalFunnelSteps(),
             DisallowUnsupportedDataWarehouseSettings(),
+            ValidateDataWarehouseBreakdown(),
         )
 
     def _refresh_frequency(self):

--- a/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
@@ -33,11 +33,7 @@ from posthog.hogql_queries.insights.lifecycle.lifecycle_validation_rules import 
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange, compare_interval_length
 from posthog.hogql_queries.utils.timestamp_utils import format_label_date, get_earliest_timestamp_from_series
-from posthog.hogql_queries.validation.rules import (
-    DisallowUnsupportedDataWarehouseSettings,
-    RequireAtLeastOneSeries,
-    ValidateDataWarehouseBreakdown,
-)
+from posthog.hogql_queries.validation.rules import DisallowUnsupportedDataWarehouseSettings, RequireAtLeastOneSeries
 from posthog.hogql_queries.validation.validation import QueryValidationRule
 from posthog.models import Action
 from posthog.models.filters.mixins.utils import cached_property
@@ -52,7 +48,6 @@ class LifecycleQueryRunner(AnalyticsQueryRunner[LifecycleQueryResponse]):
             RequireAtLeastOneSeries(),
             RequireLifecycleDataWarehouseSeriesForCustomAggregationTarget(),
             DisallowUnsupportedDataWarehouseSettings(),
-            ValidateDataWarehouseBreakdown(),
         )
 
     def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:

--- a/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
@@ -33,7 +33,11 @@ from posthog.hogql_queries.insights.lifecycle.lifecycle_validation_rules import 
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange, compare_interval_length
 from posthog.hogql_queries.utils.timestamp_utils import format_label_date, get_earliest_timestamp_from_series
-from posthog.hogql_queries.validation.rules import DisallowUnsupportedDataWarehouseSettings, RequireAtLeastOneSeries
+from posthog.hogql_queries.validation.rules import (
+    DisallowUnsupportedDataWarehouseSettings,
+    RequireAtLeastOneSeries,
+    ValidateDataWarehouseBreakdown,
+)
 from posthog.hogql_queries.validation.validation import QueryValidationRule
 from posthog.models import Action
 from posthog.models.filters.mixins.utils import cached_property
@@ -48,6 +52,7 @@ class LifecycleQueryRunner(AnalyticsQueryRunner[LifecycleQueryResponse]):
             RequireAtLeastOneSeries(),
             RequireLifecycleDataWarehouseSeriesForCustomAggregationTarget(),
             DisallowUnsupportedDataWarehouseSettings(),
+            ValidateDataWarehouseBreakdown(),
         )
 
     def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -38,6 +38,7 @@ from posthog.hogql.timings import HogQLTimings
 from posthog.caching.insights_api import BASE_MINIMUM_INSIGHT_REFRESH_INTERVAL, REDUCED_MINIMUM_INSIGHT_REFRESH_INTERVAL
 from posthog.constants import TREND_FILTER_TYPE_EVENTS
 from posthog.hogql_queries.insights.trends.breakdown import BREAKDOWN_OTHER_STRING_LABEL
+from posthog.hogql_queries.insights.utils.breakdowns import has_breakdown_filter, has_single_breakdown
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRangeWithIntervals
 from posthog.models import Team
@@ -247,7 +248,8 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         return global_event_filters
 
     def convert_single_breakdown_to_multiple_breakdowns(self):
-        if self.query.breakdownFilter and self.query.breakdownFilter.breakdown:
+        if has_single_breakdown(self.query.breakdownFilter):
+            assert self.query.breakdownFilter is not None  # type checking
             if self.query.breakdownFilter.breakdown_type == "cohort":
                 # Ensure breakdown is always a list for cohorts
                 breakdown_values = self.query.breakdownFilter.breakdown
@@ -282,10 +284,7 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
 
     @cached_property
     def breakdowns_in_query(self) -> bool:
-        return self.query.breakdownFilter is not None and (
-            self.query.breakdownFilter.breakdown is not None
-            or (self.query.breakdownFilter.breakdowns is not None and len(self.query.breakdownFilter.breakdowns) > 0)
-        )
+        return has_breakdown_filter(self.query.breakdownFilter)
 
     @cached_property
     def events_timestamp_filter(self) -> ast.Expr:

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -253,6 +253,7 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
             if self.query.breakdownFilter.breakdown_type == "cohort":
                 # Ensure breakdown is always a list for cohorts
                 breakdown_values = self.query.breakdownFilter.breakdown
+                assert breakdown_values is not None  # type checking
                 if not isinstance(breakdown_values, list):
                     breakdown_values = [breakdown_values]
 

--- a/posthog/hogql_queries/insights/stickiness/stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/stickiness/stickiness_query_runner.py
@@ -30,7 +30,11 @@ from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_compare_to_date_range import QueryCompareToDateRange
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.hogql_queries.utils.query_previous_period_date_range import QueryPreviousPeriodDateRange
-from posthog.hogql_queries.validation.rules import DisallowUnsupportedDataWarehouseSettings, RequireAtLeastOneSeries
+from posthog.hogql_queries.validation.rules import (
+    DisallowUnsupportedDataWarehouseSettings,
+    RequireAtLeastOneSeries,
+    ValidateDataWarehouseBreakdown,
+)
 from posthog.hogql_queries.validation.validation import QueryValidationRule
 from posthog.models import Team
 from posthog.models.action.action import Action
@@ -77,6 +81,7 @@ class StickinessQueryRunner(AnalyticsQueryRunner[StickinessQueryResponse]):
         return (
             RequireAtLeastOneSeries(),
             DisallowUnsupportedDataWarehouseSettings(),
+            ValidateDataWarehouseBreakdown(),
         )
 
     def update_hogql_modifiers(self) -> None:

--- a/posthog/hogql_queries/insights/stickiness/stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/stickiness/stickiness_query_runner.py
@@ -30,11 +30,7 @@ from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_compare_to_date_range import QueryCompareToDateRange
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.hogql_queries.utils.query_previous_period_date_range import QueryPreviousPeriodDateRange
-from posthog.hogql_queries.validation.rules import (
-    DisallowUnsupportedDataWarehouseSettings,
-    RequireAtLeastOneSeries,
-    ValidateDataWarehouseBreakdown,
-)
+from posthog.hogql_queries.validation.rules import DisallowUnsupportedDataWarehouseSettings, RequireAtLeastOneSeries
 from posthog.hogql_queries.validation.validation import QueryValidationRule
 from posthog.models import Team
 from posthog.models.action.action import Action
@@ -81,7 +77,6 @@ class StickinessQueryRunner(AnalyticsQueryRunner[StickinessQueryResponse]):
         return (
             RequireAtLeastOneSeries(),
             DisallowUnsupportedDataWarehouseSettings(),
-            ValidateDataWarehouseBreakdown(),
         )
 
     def update_hogql_modifiers(self) -> None:

--- a/posthog/hogql_queries/insights/trends/breakdown.py
+++ b/posthog/hogql_queries/insights/trends/breakdown.py
@@ -23,6 +23,7 @@ from posthog.hogql.timings import HogQLTimings
 
 from posthog.hogql_queries.insights.trends.display import TrendsDisplay
 from posthog.hogql_queries.insights.trends.utils import get_properties_chain
+from posthog.hogql_queries.insights.utils.breakdowns import has_breakdown_filter, has_multi_breakdown
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.team.team import Team
@@ -67,10 +68,7 @@ class Breakdown:
 
     @property
     def enabled(self) -> bool:
-        return self.query.breakdownFilter is not None and (
-            self.query.breakdownFilter.breakdown is not None
-            or (self.query.breakdownFilter.breakdowns is not None and len(self.query.breakdownFilter.breakdowns) > 0)
-        )
+        return has_breakdown_filter(self.query.breakdownFilter)
 
     @cached_property
     def is_histogram_breakdown(self) -> bool:
@@ -89,10 +87,7 @@ class Breakdown:
 
     @property
     def is_multiple_breakdown(self) -> bool:
-        if self.enabled:
-            breakdown_filter = self._breakdown_filter
-            return breakdown_filter.breakdowns is not None
-        return False
+        return has_multi_breakdown(self.query.breakdownFilter)
 
     @cached_property
     def field_exprs(self) -> list[ast.Field]:

--- a/posthog/hogql_queries/insights/trends/test/test_trend_validation_rules.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trend_validation_rules.py
@@ -1,0 +1,108 @@
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock
+
+from parameterized import parameterized
+from rest_framework.exceptions import ValidationError
+
+from posthog.schema import Breakdown, BreakdownFilter, BreakdownType, DataWarehouseNode, EventsNode, TrendsQuery
+
+from posthog.hogql_queries.insights.trends.trend_validation_rules import ValidateDataWarehouseBreakdown
+from posthog.hogql_queries.validation.validation import QueryValidationContext
+
+
+class TestValidateDataWarehouseBreakdown(BaseTest):
+    def _context(self, query: TrendsQuery) -> QueryValidationContext[TrendsQuery]:
+        runner = MagicMock(query=query, team=self.team, user=None)
+        return QueryValidationContext(query=query, team=self.team, user=None, runner=runner)
+
+    def _data_warehouse_series(self) -> list[DataWarehouseNode]:
+        return [
+            DataWarehouseNode(
+                id="messages",
+                table_name="messages",
+                timestamp_field="sent_at",
+                id_field="message_id",
+                distinct_id_field="person_id",
+            )
+        ]
+
+    def test_allows_queries_without_data_warehouse_series(self) -> None:
+        query = TrendsQuery(
+            series=[EventsNode(event="$pageview")],
+            breakdownFilter=BreakdownFilter(breakdown="$browser"),
+        )
+
+        ValidateDataWarehouseBreakdown().validate(self._context(query))
+
+    def test_allows_data_warehouse_series_without_breakdown(self) -> None:
+        query = TrendsQuery(series=self._data_warehouse_series())
+
+        ValidateDataWarehouseBreakdown().validate(self._context(query))
+
+    def test_allows_data_warehouse_single_breakdown(self) -> None:
+        query = TrendsQuery(
+            series=self._data_warehouse_series(),
+            breakdownFilter=BreakdownFilter(
+                breakdown="plan",
+                breakdown_type=BreakdownType.DATA_WAREHOUSE,
+            ),
+        )
+
+        ValidateDataWarehouseBreakdown().validate(self._context(query))
+
+    @parameterized.expand(
+        [
+            (
+                "default_event_breakdown",
+                BreakdownFilter(breakdown="$browser"),
+            ),
+            (
+                "explicit_event_breakdown",
+                BreakdownFilter(breakdown="$browser", breakdown_type=BreakdownType.EVENT),
+            ),
+            (
+                "person_breakdown",
+                BreakdownFilter(breakdown="$geoip_country_code", breakdown_type=BreakdownType.PERSON),
+            ),
+        ]
+    )
+    def test_disallows_unsupported_single_breakdowns(self, _name: str, breakdown_filter: BreakdownFilter) -> None:
+        query = TrendsQuery(
+            series=self._data_warehouse_series(),
+            breakdownFilter=breakdown_filter,
+        )
+
+        with self.assertRaises(ValidationError) as context:
+            ValidateDataWarehouseBreakdown().validate(self._context(query))
+
+        self.assertIn(
+            "Event based breakdowns are not supported for trends insights with a data warehouse series.",
+            str(context.exception),
+        )
+        self.assertEqual(
+            context.exception.get_codes(),
+            ["data_warehouse_series_unsupported_breakdown"],
+        )
+
+    def test_disallows_multi_breakdowns_for_data_warehouse_series(self) -> None:
+        query = TrendsQuery(
+            series=self._data_warehouse_series(),
+            breakdownFilter=BreakdownFilter(
+                breakdowns=[
+                    Breakdown(property="$browser", type=BreakdownType.EVENT),
+                    Breakdown(property="$geoip_country_code", type=BreakdownType.PERSON),
+                ]
+            ),
+        )
+
+        with self.assertRaises(ValidationError) as context:
+            ValidateDataWarehouseBreakdown().validate(self._context(query))
+
+        self.assertIn(
+            "Multi-breakdowns not supported for trends insights with a data warehouse series.",
+            str(context.exception),
+        )
+        self.assertEqual(
+            context.exception.get_codes(),
+            ["data_warehouse_series_unsupported_breakdown"],
+        )

--- a/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
@@ -7,6 +7,7 @@ from parameterized import parameterized
 from posthog.schema import (
     ActionsNode,
     BreakdownFilter,
+    BreakdownType,
     CompareFilter,
     DashboardFilter,
     DataWarehouseNode,
@@ -26,8 +27,20 @@ from posthog.hogql.constants import LimitContext
 
 from posthog.hogql_queries.insights.trends.trends_query_runner import TrendsQueryRunner
 
+from products.data_warehouse.backend.models import DataWarehouseCredential, DataWarehouseTable
+
 
 class TestTrendsDashboardFilters(BaseTest):
+    def _create_data_warehouse_table(self, columns: dict[str, dict[str, str]]) -> None:
+        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="key", access_secret="secret")
+        DataWarehouseTable.objects.create(
+            team=self.team,
+            name="warehouse_orders",
+            columns=columns,
+            credential=credential,
+            url_pattern="https://bucket.s3/data/*",
+        )
+
     def _create_query_runner(
         self,
         date_from: str,
@@ -502,4 +515,67 @@ class TestTrendsDashboardFilters(BaseTest):
         assert query_runner.query.properties is None
 
         # validations pass
+        query_runner.validate()
+
+    def test_dashboard_breakdown_filter_is_ignored_for_incompatible_data_warehouse_series(self):
+        query_runner = self._create_query_runner(
+            "2020-01-09",
+            "2020-01-20",
+            IntervalType.DAY,
+            [
+                DataWarehouseNode(
+                    id="warehouse_orders",
+                    table_name="warehouse_orders",
+                    name="Orders",
+                    timestamp_field="created_at",
+                    id_field="order_id",
+                    distinct_id_field="customer_id",
+                )
+            ],
+            breakdown=BreakdownFilter(breakdown="status", breakdown_type=BreakdownType.DATA_WAREHOUSE),
+        )
+
+        query_runner.apply_dashboard_filters(
+            DashboardFilter(breakdown_filter=BreakdownFilter(breakdown="$browser", breakdown_type=BreakdownType.EVENT))
+        )
+
+        assert query_runner.query.breakdownFilter == BreakdownFilter(
+            breakdown="status", breakdown_type=BreakdownType.DATA_WAREHOUSE
+        )
+
+    def test_dashboard_breakdown_filter_updates_data_warehouse_series_when_valid(self):
+        self._create_data_warehouse_table(
+            {
+                "order_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                "customer_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                "created_at": {"clickhouse": "DateTime64(3, 'UTC')", "hogql": "DateTimeDatabaseField"},
+                "status": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+            }
+        )
+
+        query_runner = self._create_query_runner(
+            "2020-01-09",
+            "2020-01-20",
+            IntervalType.DAY,
+            [
+                DataWarehouseNode(
+                    id="warehouse_orders",
+                    table_name="warehouse_orders",
+                    name="Orders",
+                    timestamp_field="created_at",
+                    id_field="order_id",
+                    distinct_id_field="customer_id",
+                )
+            ],
+        )
+
+        query_runner.apply_dashboard_filters(
+            DashboardFilter(
+                breakdown_filter=BreakdownFilter(breakdown="status", breakdown_type=BreakdownType.DATA_WAREHOUSE)
+            )
+        )
+
+        assert query_runner.query.breakdownFilter == BreakdownFilter(
+            breakdown="status", breakdown_type=BreakdownType.DATA_WAREHOUSE
+        )
         query_runner.validate()

--- a/posthog/hogql_queries/insights/trends/trend_validation_rules.py
+++ b/posthog/hogql_queries/insights/trends/trend_validation_rules.py
@@ -1,0 +1,40 @@
+from rest_framework.exceptions import ValidationError
+
+from posthog.schema import BreakdownType, TrendsQuery
+
+from posthog.hogql_queries.insights.utils.breakdowns import (
+    has_breakdown_filter,
+    has_multi_breakdown,
+    has_single_breakdown,
+)
+from posthog.hogql_queries.insights.utils.entities import has_data_warehouse_node
+from posthog.hogql_queries.validation.utils import get_query_insight_name
+from posthog.hogql_queries.validation.validation import QueryValidationContext
+
+
+class ValidateDataWarehouseBreakdown:
+    """Multi-property breakdowns and event based breakdown types can't be used together with data warehouse series."""
+
+    code = "data_warehouse_series_unsupported_breakdown"
+
+    def validate(self, context: QueryValidationContext[TrendsQuery]) -> None:
+        if not has_data_warehouse_node(context.query.series):
+            return
+
+        if not has_breakdown_filter(context.query.breakdownFilter):
+            return
+
+        assert context.query.breakdownFilter is not None  # type checking
+        breakdown_filter = context.query.breakdownFilter
+
+        if has_multi_breakdown(breakdown_filter):
+            raise ValidationError(
+                f"Multi-breakdowns not supported for {get_query_insight_name(context.query).lower()} with a data warehouse series.",
+                code=self.code,
+            )
+
+        if has_single_breakdown(breakdown_filter) and breakdown_filter.breakdown_type != BreakdownType.DATA_WAREHOUSE:
+            raise ValidationError(
+                f"Event based breakdowns are not supported for {get_query_insight_name(context.query).lower()} with a data warehouse series.",
+                code=self.code,
+            )

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -64,6 +64,7 @@ from posthog.hogql_queries.insights.trends.display import TrendsDisplay
 from posthog.hogql_queries.insights.trends.series_with_extras import SeriesWithExtras
 from posthog.hogql_queries.insights.trends.trends_actors_query_builder import TrendsActorsQueryBuilder
 from posthog.hogql_queries.insights.trends.trends_query_builder import TrendsQueryBuilder
+from posthog.hogql_queries.insights.utils.breakdowns import has_breakdown_filter
 from posthog.hogql_queries.insights.utils.utils import get_response_hogql
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.formula_ast import FormulaAST
@@ -265,10 +266,8 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
             ]
 
         # Breakdowns
-        if self.query.breakdownFilter is not None and (
-            self.query.breakdownFilter.breakdown is not None
-            or (self.query.breakdownFilter.breakdowns is not None and len(self.query.breakdownFilter.breakdowns) > 0)
-        ):
+        if has_breakdown_filter(self.query.breakdownFilter):
+            assert self.query.breakdownFilter is not None  # type checking
             if self.query.breakdownFilter.breakdown_type == "cohort":
                 assert isinstance(self.query.breakdownFilter.breakdown, list)
 
@@ -1216,10 +1215,7 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
 
     @cached_property
     def breakdown_enabled(self):
-        return self.query.breakdownFilter is not None and (
-            self.query.breakdownFilter.breakdown is not None
-            or (self.query.breakdownFilter.breakdowns is not None and len(self.query.breakdownFilter.breakdowns) > 0)
-        )
+        return has_breakdown_filter(self.query.breakdownFilter)
 
     def _get_breakdown_items(
         self,

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -71,7 +71,11 @@ from posthog.hogql_queries.utils.query_compare_to_date_range import QueryCompare
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.hogql_queries.utils.query_previous_period_date_range import QueryPreviousPeriodDateRange
 from posthog.hogql_queries.utils.timestamp_utils import format_label_date, get_earliest_timestamp_from_series
-from posthog.hogql_queries.validation.rules import DisallowUnsupportedDataWarehouseSettings, RequireAtLeastOneSeries
+from posthog.hogql_queries.validation.rules import (
+    DisallowUnsupportedDataWarehouseSettings,
+    RequireAtLeastOneSeries,
+    ValidateDataWarehouseBreakdown,
+)
 from posthog.hogql_queries.validation.validation import QueryValidationRule
 from posthog.models import Team
 from posthog.models.action.action import Action
@@ -129,6 +133,7 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
         return (
             RequireAtLeastOneSeries(),
             DisallowUnsupportedDataWarehouseSettings(),
+            ValidateDataWarehouseBreakdown(),
         )
 
     def _refresh_frequency(self):

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -62,6 +62,7 @@ from posthog.hogql_queries.insights.trends.breakdown import (
 )
 from posthog.hogql_queries.insights.trends.display import TrendsDisplay
 from posthog.hogql_queries.insights.trends.series_with_extras import SeriesWithExtras
+from posthog.hogql_queries.insights.trends.trend_validation_rules import ValidateDataWarehouseBreakdown
 from posthog.hogql_queries.insights.trends.trends_actors_query_builder import TrendsActorsQueryBuilder
 from posthog.hogql_queries.insights.trends.trends_query_builder import TrendsQueryBuilder
 from posthog.hogql_queries.insights.utils.breakdowns import has_breakdown_filter
@@ -72,11 +73,7 @@ from posthog.hogql_queries.utils.query_compare_to_date_range import QueryCompare
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.hogql_queries.utils.query_previous_period_date_range import QueryPreviousPeriodDateRange
 from posthog.hogql_queries.utils.timestamp_utils import format_label_date, get_earliest_timestamp_from_series
-from posthog.hogql_queries.validation.rules import (
-    DisallowUnsupportedDataWarehouseSettings,
-    RequireAtLeastOneSeries,
-    ValidateDataWarehouseBreakdown,
-)
+from posthog.hogql_queries.validation.rules import DisallowUnsupportedDataWarehouseSettings, RequireAtLeastOneSeries
 from posthog.hogql_queries.validation.validation import QueryValidationRule
 from posthog.models import Team
 from posthog.models.action.action import Action

--- a/posthog/hogql_queries/insights/utils/breakdowns.py
+++ b/posthog/hogql_queries/insights/utils/breakdowns.py
@@ -1,0 +1,20 @@
+from posthog.schema import BreakdownFilter
+
+
+def has_single_breakdown(breakdown_filter: BreakdownFilter | None) -> bool:
+    """Return whether the single-field `breakdown` representation is populated."""
+    return breakdown_filter is not None and breakdown_filter.breakdown is not None
+
+
+def has_multi_breakdown(breakdown_filter: BreakdownFilter | None) -> bool:
+    """Return whether the multi-field `breakdowns` representation is populated."""
+    return (
+        breakdown_filter is not None
+        and breakdown_filter.breakdowns is not None
+        and len(breakdown_filter.breakdowns) > 0
+    )
+
+
+def has_breakdown_filter(breakdown_filter: BreakdownFilter | None) -> bool:
+    """Return whether a breakdown is configured via either supported representation."""
+    return has_single_breakdown(breakdown_filter) or has_multi_breakdown(breakdown_filter)

--- a/posthog/hogql_queries/insights/utils/test/test_breakdowns.py
+++ b/posthog/hogql_queries/insights/utils/test/test_breakdowns.py
@@ -1,0 +1,46 @@
+import pytest
+
+from posthog.schema import Breakdown, BreakdownFilter, BreakdownType
+
+from posthog.hogql_queries.insights.utils.breakdowns import (
+    has_breakdown_filter,
+    has_multi_breakdown,
+    has_single_breakdown,
+)
+
+
+@pytest.mark.parametrize(
+    "breakdown_filter, expected_has_breakdown, expected_has_single, expected_has_multi",
+    [
+        (None, False, False, False),
+        (BreakdownFilter(), False, False, False),
+        (BreakdownFilter(breakdown="$browser"), True, True, False),
+        (BreakdownFilter(breakdown=[1, 2], breakdown_type=BreakdownType.COHORT), True, True, False),
+        (
+            BreakdownFilter(
+                breakdowns=[Breakdown(property="$browser", type=BreakdownType.EVENT)],
+            ),
+            True,
+            False,
+            True,
+        ),
+        (
+            BreakdownFilter(
+                breakdown="$browser",
+                breakdowns=[Breakdown(property="$os", type=BreakdownType.EVENT)],
+            ),
+            True,
+            True,
+            True,
+        ),
+    ],
+)
+def test_breakdown_presence_helpers(
+    breakdown_filter: BreakdownFilter | None,
+    expected_has_breakdown: bool,
+    expected_has_single: bool,
+    expected_has_multi: bool,
+) -> None:
+    assert has_breakdown_filter(breakdown_filter) is expected_has_breakdown
+    assert has_single_breakdown(breakdown_filter) is expected_has_single
+    assert has_multi_breakdown(breakdown_filter) is expected_has_multi

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -100,6 +100,7 @@ from posthog.hogql_queries.query_cache_base import QueryCacheManagerBase
 from posthog.hogql_queries.query_cache_factory import get_query_cache_manager
 from posthog.hogql_queries.query_metadata import extract_query_metadata
 from posthog.hogql_queries.utils.event_usage import log_event_usage_from_query_metadata
+from posthog.hogql_queries.validation.rules import get_data_warehouse_breakdown_error
 from posthog.hogql_queries.validation.validation import (
     QueryValidationContext,
     QueryValidationRule,
@@ -1877,7 +1878,19 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
 
         if dashboard_filter.breakdown_filter:
             if hasattr(self.query, "breakdownFilter"):
-                self.query.breakdownFilter = dashboard_filter.breakdown_filter
+                should_ignore_dashboard_breakdown = (
+                    hasattr(self.query, "series")
+                    and isinstance(self.query.series, list)
+                    and get_data_warehouse_breakdown_error(
+                        team=self.team,
+                        series=self.query.series,
+                        breakdown_filter=dashboard_filter.breakdown_filter,
+                    )
+                    is not None
+                )
+
+                if not should_ignore_dashboard_breakdown:
+                    self.query.breakdownFilter = dashboard_filter.breakdown_filter
             else:
                 capture_exception(
                     NotImplementedError(

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, ConfigDict
 from posthog.schema import (
     ActorsPropertyTaxonomyQuery,
     ActorsQuery,
+    BreakdownType,
     CacheMissResponse,
     CalendarHeatmapQuery,
     ChartDisplayType,
@@ -100,7 +101,7 @@ from posthog.hogql_queries.query_cache_base import QueryCacheManagerBase
 from posthog.hogql_queries.query_cache_factory import get_query_cache_manager
 from posthog.hogql_queries.query_metadata import extract_query_metadata
 from posthog.hogql_queries.utils.event_usage import log_event_usage_from_query_metadata
-from posthog.hogql_queries.validation.rules import get_data_warehouse_breakdown_error
+from posthog.hogql_queries.validation.rules import has_multi_breakdown, has_single_breakdown
 from posthog.hogql_queries.validation.validation import (
     QueryValidationContext,
     QueryValidationRule,
@@ -1830,16 +1831,21 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             )
             return
 
-        # The default logic below applies to all insights and a lot of other queries
-        # Notable exception: `HogQLQuery`, which has `properties` and `dateRange` within `HogQLFilters`
-        should_ignore_dashboard_properties = (
-            dashboard_filter.properties
-            and hasattr(self.query, "series")
+        has_data_warehouse_series = (
+            hasattr(self.query, "series")
             and isinstance(self.query.series, list)
             and has_data_warehouse_node(self.query.series)
         )
 
-        if dashboard_filter.properties and not should_ignore_dashboard_properties:
+        should_ignore_dashboard_breakdown = has_data_warehouse_series and (
+            has_multi_breakdown(dashboard_filter.breakdown_filter)
+            or (
+                has_single_breakdown(dashboard_filter.breakdown_filter)
+                and dashboard_filter.breakdown_filter.breakdown_type != BreakdownType.DATA_WAREHOUSE
+            )
+        )
+
+        if dashboard_filter.properties and not has_data_warehouse_series:
             if self.query.properties and has_any_property_filters(self.query.properties):
                 # Check if query expects only a list (e.g. WebOverviewQuery) vs union with PropertyGroupFilter
                 properties_field = self.query.__class__.model_fields.get("properties")
@@ -1876,21 +1882,9 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             if dashboard_filter.explicitDate is not None:
                 date_range.explicitDate = dashboard_filter.explicitDate
 
-        if dashboard_filter.breakdown_filter:
+        if dashboard_filter.breakdown_filter and not should_ignore_dashboard_breakdown:
             if hasattr(self.query, "breakdownFilter"):
-                should_ignore_dashboard_breakdown = (
-                    hasattr(self.query, "series")
-                    and isinstance(self.query.series, list)
-                    and get_data_warehouse_breakdown_error(
-                        team=self.team,
-                        series=self.query.series,
-                        breakdown_filter=dashboard_filter.breakdown_filter,
-                    )
-                    is not None
-                )
-
-                if not should_ignore_dashboard_breakdown:
-                    self.query.breakdownFilter = dashboard_filter.breakdown_filter
+                self.query.breakdownFilter = dashboard_filter.breakdown_filter
             else:
                 capture_exception(
                     NotImplementedError(

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1837,14 +1837,17 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             and has_data_warehouse_node(self.query.series)
         )
 
+        dashboard_breakdown_filter = dashboard_filter.breakdown_filter
+
         should_ignore_dashboard_breakdown = (
             isinstance(self.query, TrendsQuery)
             and has_data_warehouse_series
             and (
-                has_multi_breakdown(dashboard_filter.breakdown_filter)
+                has_multi_breakdown(dashboard_breakdown_filter)
                 or (
-                    has_single_breakdown(dashboard_filter.breakdown_filter)
-                    and dashboard_filter.breakdown_filter.breakdown_type != BreakdownType.DATA_WAREHOUSE
+                    dashboard_breakdown_filter is not None
+                    and has_single_breakdown(dashboard_breakdown_filter)
+                    and dashboard_breakdown_filter.breakdown_type != BreakdownType.DATA_WAREHOUSE
                 )
             )
         )

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1845,8 +1845,8 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             and (
                 has_multi_breakdown(dashboard_breakdown_filter)
                 or (
-                    dashboard_breakdown_filter is not None
-                    and has_single_breakdown(dashboard_breakdown_filter)
+                    has_single_breakdown(dashboard_breakdown_filter)
+                    and dashboard_breakdown_filter is not None
                     and dashboard_breakdown_filter.breakdown_type != BreakdownType.DATA_WAREHOUSE
                 )
             )

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -94,6 +94,7 @@ from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries
 from posthog.errors import classify_query_error, clickhouse_error_type
 from posthog.event_usage import AnalyticsProps, groups, report_user_or_team_action
 from posthog.exceptions_capture import capture_exception
+from posthog.hogql_queries.insights.utils.breakdowns import has_multi_breakdown, has_single_breakdown
 from posthog.hogql_queries.insights.utils.entities import has_data_warehouse_node
 from posthog.hogql_queries.insights.utils.properties import has_any_property_filters
 from posthog.hogql_queries.query_cache import count_query_cache_hit
@@ -101,7 +102,6 @@ from posthog.hogql_queries.query_cache_base import QueryCacheManagerBase
 from posthog.hogql_queries.query_cache_factory import get_query_cache_manager
 from posthog.hogql_queries.query_metadata import extract_query_metadata
 from posthog.hogql_queries.utils.event_usage import log_event_usage_from_query_metadata
-from posthog.hogql_queries.validation.rules import has_multi_breakdown, has_single_breakdown
 from posthog.hogql_queries.validation.validation import (
     QueryValidationContext,
     QueryValidationRule,
@@ -1837,11 +1837,15 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             and has_data_warehouse_node(self.query.series)
         )
 
-        should_ignore_dashboard_breakdown = has_data_warehouse_series and (
-            has_multi_breakdown(dashboard_filter.breakdown_filter)
-            or (
-                has_single_breakdown(dashboard_filter.breakdown_filter)
-                and dashboard_filter.breakdown_filter.breakdown_type != BreakdownType.DATA_WAREHOUSE
+        should_ignore_dashboard_breakdown = (
+            isinstance(self.query, TrendsQuery)
+            and has_data_warehouse_series
+            and (
+                has_multi_breakdown(dashboard_filter.breakdown_filter)
+                or (
+                    has_single_breakdown(dashboard_filter.breakdown_filter)
+                    and dashboard_filter.breakdown_filter.breakdown_type != BreakdownType.DATA_WAREHOUSE
+                )
             )
         )
 

--- a/posthog/hogql_queries/validation/rules.py
+++ b/posthog/hogql_queries/validation/rules.py
@@ -1,21 +1,18 @@
-from collections.abc import Sequence
-from typing import Any, cast
-
 from rest_framework.exceptions import ValidationError
 
-from posthog.schema import BreakdownFilter, BreakdownType, FunnelsQuery, LifecycleQuery, StickinessQuery, TrendsQuery
+from posthog.schema import BreakdownType, FunnelsQuery, LifecycleQuery, StickinessQuery, TrendsQuery
 
 from posthog.hogql import ast
-from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import Database
-from posthog.hogql.errors import QueryError
-from posthog.hogql.resolver import resolve_types_from_table
 
-from posthog.hogql_queries.insights.utils.entities import has_data_warehouse_node, is_data_warehouse_node
+from posthog.hogql_queries.insights.utils.breakdowns import (
+    has_breakdown_filter,
+    has_multi_breakdown,
+    has_single_breakdown,
+)
+from posthog.hogql_queries.insights.utils.entities import has_data_warehouse_node
 from posthog.hogql_queries.insights.utils.properties import has_any_property_filters
 from posthog.hogql_queries.validation.utils import get_query_insight_name
 from posthog.hogql_queries.validation.validation import QueryValidationContext
-from posthog.models import Team
 
 
 class RequireAtLeastOneSeries:
@@ -70,59 +67,6 @@ VALID_DATA_WAREHOUSE_BREAKDOWN_CONSTANT_TYPES = (
 )
 
 
-def get_data_warehouse_breakdown_error(
-    team: Team,
-    series: Sequence[Any] | None,
-    breakdown_filter: BreakdownFilter | None,
-) -> str | None:
-    if not series or not breakdown_filter:
-        return None
-
-    data_warehouse_series = [node for node in series if is_data_warehouse_node(node)]
-    if not data_warehouse_series:
-        return None
-
-    has_non_data_warehouse_series = len(data_warehouse_series) != len(series)
-
-    if has_non_data_warehouse_series and breakdown_filter.breakdown_type != BreakdownType.DATA_WAREHOUSE:
-        return None
-
-    if breakdown_filter.breakdowns:
-        return "Insights with a data warehouse series can only be broken down by a single data warehouse property."
-
-    breakdown_value = breakdown_filter.breakdown
-    if isinstance(breakdown_value, list):
-        if len(breakdown_value) != 1 or not isinstance(breakdown_value[0], str):
-            return "Insights with a data warehouse series can only be broken down by a single data warehouse property."
-        breakdown_value = breakdown_value[0]
-
-    if breakdown_filter.breakdown_type != BreakdownType.DATA_WAREHOUSE or not isinstance(breakdown_value, str):
-        return "Insights with a data warehouse series can only be broken down by a single data warehouse property."
-
-    breakdown_field = breakdown_value
-    database = Database.create_for(team=team)
-    context = HogQLContext(team_id=team.pk, team=team, database=database)
-
-    breakdown_field_chain = cast(list[str | int], breakdown_field.split("."))
-
-    for node in data_warehouse_series:
-        try:
-            resolved_expr = resolve_types_from_table(
-                ast.Field(chain=breakdown_field_chain),
-                [node.table_name],
-                context,
-                "hogql",
-            )
-        except QueryError:
-            return f'"{breakdown_field}" is not a valid data warehouse property for breakdowns.'
-
-        resolved_type = resolved_expr.type.resolve_constant_type(context) if resolved_expr.type is not None else None
-        if type(resolved_type) not in VALID_DATA_WAREHOUSE_BREAKDOWN_CONSTANT_TYPES:
-            return f'"{breakdown_field}" is not a valid data warehouse property for breakdowns.'
-
-    return None
-
-
 class ValidateDataWarehouseBreakdown:
     """Multi-property breakdowns and event based breakdown types can't be used together with data warehouse series."""
 
@@ -132,37 +76,20 @@ class ValidateDataWarehouseBreakdown:
         if not has_data_warehouse_node(context.query.series):
             return
 
-        if not context.query.breakdownFilter:
+        if not has_breakdown_filter(context.query.breakdownFilter):
             return
 
-        context.query.breakdownFilter
+        assert context.query.breakdownFilter is not None  # type checking
+        breakdown_filter = context.query.breakdownFilter
 
-    #     class BreakdownFilter(BaseModel):
-    # model_config = ConfigDict(
-    #     extra="forbid",
-    # )
-    # breakdown: str | list[str | int] | int | None = None
-    # breakdown_group_type_index: int | None = None
-    # breakdown_hide_other_aggregation: bool | None = None
-    # breakdown_histogram_bin_count: int | None = None
-    # breakdown_limit: int | None = None
-    # breakdown_normalize_url: bool | None = None
-    # breakdown_path_cleaning: bool | None = None
-    # breakdown_type: BreakdownType | None = BreakdownType.EVENT
-    # breakdowns: list[Breakdown] | None = Field(default=None, max_length=3)
+        if has_multi_breakdown(breakdown_filter):
+            raise ValidationError(
+                f"Multi-breakdowns not supported for {get_query_insight_name(context.query).lower()} with a data warehouse series.",
+                code=self.code,
+            )
 
-    # unsupported_settings: list[str] = []
-    # if has_any_property_filters(context.query.properties):
-    #     unsupported_settings.append("filters")
-    # if context.query.filterTestAccounts:
-    #     unsupported_settings.append("test account filters")
-    # if context.query.samplingFactor is not None:
-    #     unsupported_settings.append("sampling")
-
-    # if unsupported_settings:
-    #     settings = " and ".join(unsupported_settings)
-    #     verb = "is" if unsupported_settings == ["sampling"] else "are"
-    #     raise ValidationError(
-    #         f"{settings.capitalize()} {verb} not supported for {get_query_insight_name(context.query).lower()} with a data warehouse series.",
-    #         code=self.code,
-    #     )
+        if has_single_breakdown(breakdown_filter) and breakdown_filter.breakdown_type != BreakdownType.DATA_WAREHOUSE:
+            raise ValidationError(
+                f"Event based breakdowns are not supported for {get_query_insight_name(context.query).lower()} with a data warehouse series.",
+                code=self.code,
+            )

--- a/posthog/hogql_queries/validation/rules.py
+++ b/posthog/hogql_queries/validation/rules.py
@@ -124,7 +124,7 @@ def get_data_warehouse_breakdown_error(
 
 
 class ValidateDataWarehouseBreakdown:
-    """Multi-propert breakdowns and event based breakdown types can't be used together with data warehouse series."""
+    """Multi-property breakdowns and event based breakdown types can't be used together with data warehouse series."""
 
     code = "data_warehouse_series_unsupported_breakdown"
 

--- a/posthog/hogql_queries/validation/rules.py
+++ b/posthog/hogql_queries/validation/rules.py
@@ -1,11 +1,21 @@
+from collections.abc import Sequence
+from typing import Any, cast
+
 from rest_framework.exceptions import ValidationError
 
-from posthog.schema import FunnelsQuery, LifecycleQuery, StickinessQuery, TrendsQuery
+from posthog.schema import BreakdownFilter, BreakdownType, FunnelsQuery, LifecycleQuery, StickinessQuery, TrendsQuery
 
-from posthog.hogql_queries.insights.utils.entities import has_data_warehouse_node
+from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.database import Database
+from posthog.hogql.errors import QueryError
+from posthog.hogql.resolver import resolve_types_from_table
+
+from posthog.hogql_queries.insights.utils.entities import has_data_warehouse_node, is_data_warehouse_node
 from posthog.hogql_queries.insights.utils.properties import has_any_property_filters
 from posthog.hogql_queries.validation.utils import get_query_insight_name
 from posthog.hogql_queries.validation.validation import QueryValidationContext
+from posthog.models import Team
 
 
 class RequireAtLeastOneSeries:
@@ -47,3 +57,112 @@ class DisallowUnsupportedDataWarehouseSettings:
                 f"{settings.capitalize()} {verb} not supported for {get_query_insight_name(context.query).lower()} with a data warehouse series.",
                 code=self.code,
             )
+
+
+VALID_DATA_WAREHOUSE_BREAKDOWN_CONSTANT_TYPES = (
+    ast.BooleanType,
+    ast.DateType,
+    ast.DateTimeType,
+    ast.DecimalType,
+    ast.FloatType,
+    ast.IntegerType,
+    ast.StringType,
+)
+
+
+def get_data_warehouse_breakdown_error(
+    team: Team,
+    series: Sequence[Any] | None,
+    breakdown_filter: BreakdownFilter | None,
+) -> str | None:
+    if not series or not breakdown_filter:
+        return None
+
+    data_warehouse_series = [node for node in series if is_data_warehouse_node(node)]
+    if not data_warehouse_series:
+        return None
+
+    has_non_data_warehouse_series = len(data_warehouse_series) != len(series)
+
+    if has_non_data_warehouse_series and breakdown_filter.breakdown_type != BreakdownType.DATA_WAREHOUSE:
+        return None
+
+    if breakdown_filter.breakdowns:
+        return "Insights with a data warehouse series can only be broken down by a single data warehouse property."
+
+    breakdown_value = breakdown_filter.breakdown
+    if isinstance(breakdown_value, list):
+        if len(breakdown_value) != 1 or not isinstance(breakdown_value[0], str):
+            return "Insights with a data warehouse series can only be broken down by a single data warehouse property."
+        breakdown_value = breakdown_value[0]
+
+    if breakdown_filter.breakdown_type != BreakdownType.DATA_WAREHOUSE or not isinstance(breakdown_value, str):
+        return "Insights with a data warehouse series can only be broken down by a single data warehouse property."
+
+    breakdown_field = breakdown_value
+    database = Database.create_for(team=team)
+    context = HogQLContext(team_id=team.pk, team=team, database=database)
+
+    breakdown_field_chain = cast(list[str | int], breakdown_field.split("."))
+
+    for node in data_warehouse_series:
+        try:
+            resolved_expr = resolve_types_from_table(
+                ast.Field(chain=breakdown_field_chain),
+                [node.table_name],
+                context,
+                "hogql",
+            )
+        except QueryError:
+            return f'"{breakdown_field}" is not a valid data warehouse property for breakdowns.'
+
+        resolved_type = resolved_expr.type.resolve_constant_type(context) if resolved_expr.type is not None else None
+        if type(resolved_type) not in VALID_DATA_WAREHOUSE_BREAKDOWN_CONSTANT_TYPES:
+            return f'"{breakdown_field}" is not a valid data warehouse property for breakdowns.'
+
+    return None
+
+
+class ValidateDataWarehouseBreakdown:
+    """Multi-propert breakdowns and event based breakdown types can't be used together with data warehouse series."""
+
+    code = "data_warehouse_series_unsupported_breakdown"
+
+    def validate(self, context: QueryValidationContext[TrendsQuery | FunnelsQuery]) -> None:
+        if not has_data_warehouse_node(context.query.series):
+            return
+
+        if not context.query.breakdownFilter:
+            return
+
+        context.query.breakdownFilter
+
+    #     class BreakdownFilter(BaseModel):
+    # model_config = ConfigDict(
+    #     extra="forbid",
+    # )
+    # breakdown: str | list[str | int] | int | None = None
+    # breakdown_group_type_index: int | None = None
+    # breakdown_hide_other_aggregation: bool | None = None
+    # breakdown_histogram_bin_count: int | None = None
+    # breakdown_limit: int | None = None
+    # breakdown_normalize_url: bool | None = None
+    # breakdown_path_cleaning: bool | None = None
+    # breakdown_type: BreakdownType | None = BreakdownType.EVENT
+    # breakdowns: list[Breakdown] | None = Field(default=None, max_length=3)
+
+    # unsupported_settings: list[str] = []
+    # if has_any_property_filters(context.query.properties):
+    #     unsupported_settings.append("filters")
+    # if context.query.filterTestAccounts:
+    #     unsupported_settings.append("test account filters")
+    # if context.query.samplingFactor is not None:
+    #     unsupported_settings.append("sampling")
+
+    # if unsupported_settings:
+    #     settings = " and ".join(unsupported_settings)
+    #     verb = "is" if unsupported_settings == ["sampling"] else "are"
+    #     raise ValidationError(
+    #         f"{settings.capitalize()} {verb} not supported for {get_query_insight_name(context.query).lower()} with a data warehouse series.",
+    #         code=self.code,
+    #     )

--- a/posthog/hogql_queries/validation/rules.py
+++ b/posthog/hogql_queries/validation/rules.py
@@ -1,14 +1,7 @@
 from rest_framework.exceptions import ValidationError
 
-from posthog.schema import BreakdownType, FunnelsQuery, LifecycleQuery, StickinessQuery, TrendsQuery
+from posthog.schema import FunnelsQuery, LifecycleQuery, StickinessQuery, TrendsQuery
 
-from posthog.hogql import ast
-
-from posthog.hogql_queries.insights.utils.breakdowns import (
-    has_breakdown_filter,
-    has_multi_breakdown,
-    has_single_breakdown,
-)
 from posthog.hogql_queries.insights.utils.entities import has_data_warehouse_node
 from posthog.hogql_queries.insights.utils.properties import has_any_property_filters
 from posthog.hogql_queries.validation.utils import get_query_insight_name
@@ -52,44 +45,5 @@ class DisallowUnsupportedDataWarehouseSettings:
             verb = "is" if unsupported_settings == ["sampling"] else "are"
             raise ValidationError(
                 f"{settings.capitalize()} {verb} not supported for {get_query_insight_name(context.query).lower()} with a data warehouse series.",
-                code=self.code,
-            )
-
-
-VALID_DATA_WAREHOUSE_BREAKDOWN_CONSTANT_TYPES = (
-    ast.BooleanType,
-    ast.DateType,
-    ast.DateTimeType,
-    ast.DecimalType,
-    ast.FloatType,
-    ast.IntegerType,
-    ast.StringType,
-)
-
-
-class ValidateDataWarehouseBreakdown:
-    """Multi-property breakdowns and event based breakdown types can't be used together with data warehouse series."""
-
-    code = "data_warehouse_series_unsupported_breakdown"
-
-    def validate(self, context: QueryValidationContext[TrendsQuery | FunnelsQuery]) -> None:
-        if not has_data_warehouse_node(context.query.series):
-            return
-
-        if not has_breakdown_filter(context.query.breakdownFilter):
-            return
-
-        assert context.query.breakdownFilter is not None  # type checking
-        breakdown_filter = context.query.breakdownFilter
-
-        if has_multi_breakdown(breakdown_filter):
-            raise ValidationError(
-                f"Multi-breakdowns not supported for {get_query_insight_name(context.query).lower()} with a data warehouse series.",
-                code=self.code,
-            )
-
-        if has_single_breakdown(breakdown_filter) and breakdown_filter.breakdown_type != BreakdownType.DATA_WAREHOUSE:
-            raise ValidationError(
-                f"Event based breakdowns are not supported for {get_query_insight_name(context.query).lower()} with a data warehouse series.",
                 code=self.code,
             )

--- a/posthog/hogql_queries/validation/test_rules.py
+++ b/posthog/hogql_queries/validation/test_rules.py
@@ -5,27 +5,16 @@ from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
 from posthog.schema import (
-    BreakdownFilter,
-    BreakdownType,
-    DataWarehouseNode,
-    DateRange,
     EventsNode,
     FilterLogicalOperator,
     LifecycleDataWarehouseNode,
     LifecycleQuery,
     PropertyGroupFilter,
     PropertyGroupFilterValue,
-    TrendsQuery,
 )
 
-from posthog.hogql_queries.validation.rules import (
-    DisallowUnsupportedDataWarehouseSettings,
-    RequireAtLeastOneSeries,
-    ValidateDataWarehouseBreakdown,
-)
+from posthog.hogql_queries.validation.rules import DisallowUnsupportedDataWarehouseSettings, RequireAtLeastOneSeries
 from posthog.hogql_queries.validation.validation import QueryValidationContext
-
-from products.data_warehouse.backend.models import DataWarehouseCredential, DataWarehouseTable
 
 
 class TestRequireAtLeastOneSeries(BaseTest):
@@ -124,138 +113,3 @@ class TestDisallowUnsupportedDataWarehouseSettings(BaseTest):
         )
 
         DisallowUnsupportedDataWarehouseSettings().validate(self._context(query))
-
-
-class TestValidateDataWarehouseBreakdown(BaseTest):
-    def _context(self, query: TrendsQuery) -> QueryValidationContext:
-        runner = MagicMock(query=query, team=self.team, user=None)
-        return QueryValidationContext(query=query, team=self.team, user=None, runner=runner)
-
-    def _create_data_warehouse_table(self, columns: dict[str, dict[str, str]]) -> str:
-        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="key", access_secret="secret")
-        table = DataWarehouseTable.objects.create(
-            team=self.team,
-            name="warehouse_orders",
-            columns=columns,
-            credential=credential,
-            url_pattern="https://bucket.s3/data/*",
-        )
-        return table.name
-
-    def _query(self, breakdown_filter: BreakdownFilter) -> TrendsQuery:
-        return TrendsQuery(
-            dateRange=DateRange(date_from="-7d"),
-            series=[
-                DataWarehouseNode(
-                    id="warehouse_orders",
-                    table_name="warehouse_orders",
-                    timestamp_field="created_at",
-                    id_field="order_id",
-                    distinct_id_field="customer_id",
-                )
-            ],
-            breakdownFilter=breakdown_filter,
-        )
-
-    def _mixed_query(self, breakdown_filter: BreakdownFilter) -> TrendsQuery:
-        return TrendsQuery(
-            dateRange=DateRange(date_from="-7d"),
-            series=[
-                EventsNode(event="$pageview"),
-                DataWarehouseNode(
-                    id="warehouse_orders",
-                    table_name="warehouse_orders",
-                    timestamp_field="created_at",
-                    id_field="order_id",
-                    distinct_id_field="customer_id",
-                ),
-            ],
-            breakdownFilter=breakdown_filter,
-        )
-
-    @parameterized.expand(
-        [
-            (
-                "non_data_warehouse_breakdown_type",
-                BreakdownFilter(breakdown="$browser", breakdown_type=BreakdownType.EVENT),
-                None,
-                "single data warehouse property",
-            ),
-            (
-                "non_scalar_data_warehouse_breakdown_field",
-                BreakdownFilter(breakdown="metadata", breakdown_type=BreakdownType.DATA_WAREHOUSE),
-                {
-                    "order_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
-                    "customer_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
-                    "created_at": {"clickhouse": "DateTime64(3, 'UTC')", "hogql": "DateTimeDatabaseField"},
-                    "metadata": {"clickhouse": "String", "hogql": "StringJSONDatabaseField"},
-                },
-                '"metadata" is not a valid data warehouse property for breakdowns.',
-            ),
-            (
-                "scalar_data_warehouse_breakdown_field",
-                BreakdownFilter(breakdown="status", breakdown_type=BreakdownType.DATA_WAREHOUSE),
-                {
-                    "order_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
-                    "customer_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
-                    "created_at": {"clickhouse": "DateTime64(3, 'UTC')", "hogql": "DateTimeDatabaseField"},
-                    "status": {"clickhouse": "String", "hogql": "StringDatabaseField"},
-                },
-                None,
-            ),
-        ]
-    )
-    def test_validates_data_warehouse_breakdown(self, _name, breakdown_filter, columns, expected_error):
-        if columns is not None:
-            self._create_data_warehouse_table(columns)
-
-        query = self._query(breakdown_filter)
-
-        if expected_error is None:
-            ValidateDataWarehouseBreakdown().validate(self._context(query))
-            return
-
-        with self.assertRaises(ValidationError) as context:
-            ValidateDataWarehouseBreakdown().validate(self._context(query))
-
-        self.assertIn(expected_error, str(context.exception))
-        self.assertEqual(context.exception.get_codes(), ["invalid_data_warehouse_breakdown"])
-
-    def test_allows_single_item_data_warehouse_breakdown_list(self):
-        self._create_data_warehouse_table(
-            {
-                "order_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
-                "customer_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
-                "created_at": {"clickhouse": "DateTime64(3, 'UTC')", "hogql": "DateTimeDatabaseField"},
-                "status": {"clickhouse": "String", "hogql": "StringDatabaseField"},
-            }
-        )
-
-        query = self._query(BreakdownFilter(breakdown=["status"], breakdown_type=BreakdownType.DATA_WAREHOUSE))
-
-        ValidateDataWarehouseBreakdown().validate(self._context(query))
-
-    @parameterized.expand(
-        [
-            ("event", BreakdownFilter(breakdown=["$browser"], breakdown_type=BreakdownType.EVENT)),
-            ("person", BreakdownFilter(breakdown=["email"], breakdown_type=BreakdownType.PERSON)),
-        ]
-    )
-    def test_allows_mixed_series_non_data_warehouse_breakdowns(self, _name, breakdown_filter):
-        query = self._mixed_query(breakdown_filter)
-
-        ValidateDataWarehouseBreakdown().validate(self._context(query))
-
-    def test_allows_mixed_series_data_warehouse_breakdown(self):
-        self._create_data_warehouse_table(
-            {
-                "order_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
-                "customer_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
-                "created_at": {"clickhouse": "DateTime64(3, 'UTC')", "hogql": "DateTimeDatabaseField"},
-                "status": {"clickhouse": "String", "hogql": "StringDatabaseField"},
-            }
-        )
-
-        query = self._mixed_query(BreakdownFilter(breakdown=["status"], breakdown_type=BreakdownType.DATA_WAREHOUSE))
-
-        ValidateDataWarehouseBreakdown().validate(self._context(query))

--- a/posthog/hogql_queries/validation/test_rules.py
+++ b/posthog/hogql_queries/validation/test_rules.py
@@ -5,16 +5,27 @@ from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
 from posthog.schema import (
+    BreakdownFilter,
+    BreakdownType,
+    DataWarehouseNode,
+    DateRange,
     EventsNode,
     FilterLogicalOperator,
     LifecycleDataWarehouseNode,
     LifecycleQuery,
     PropertyGroupFilter,
     PropertyGroupFilterValue,
+    TrendsQuery,
 )
 
-from posthog.hogql_queries.validation.rules import DisallowUnsupportedDataWarehouseSettings, RequireAtLeastOneSeries
+from posthog.hogql_queries.validation.rules import (
+    DisallowUnsupportedDataWarehouseSettings,
+    RequireAtLeastOneSeries,
+    ValidateDataWarehouseBreakdown,
+)
 from posthog.hogql_queries.validation.validation import QueryValidationContext
+
+from products.data_warehouse.backend.models import DataWarehouseCredential, DataWarehouseTable
 
 
 class TestRequireAtLeastOneSeries(BaseTest):
@@ -113,3 +124,138 @@ class TestDisallowUnsupportedDataWarehouseSettings(BaseTest):
         )
 
         DisallowUnsupportedDataWarehouseSettings().validate(self._context(query))
+
+
+class TestValidateDataWarehouseBreakdown(BaseTest):
+    def _context(self, query: TrendsQuery) -> QueryValidationContext:
+        runner = MagicMock(query=query, team=self.team, user=None)
+        return QueryValidationContext(query=query, team=self.team, user=None, runner=runner)
+
+    def _create_data_warehouse_table(self, columns: dict[str, dict[str, str]]) -> str:
+        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="key", access_secret="secret")
+        table = DataWarehouseTable.objects.create(
+            team=self.team,
+            name="warehouse_orders",
+            columns=columns,
+            credential=credential,
+            url_pattern="https://bucket.s3/data/*",
+        )
+        return table.name
+
+    def _query(self, breakdown_filter: BreakdownFilter) -> TrendsQuery:
+        return TrendsQuery(
+            dateRange=DateRange(date_from="-7d"),
+            series=[
+                DataWarehouseNode(
+                    id="warehouse_orders",
+                    table_name="warehouse_orders",
+                    timestamp_field="created_at",
+                    id_field="order_id",
+                    distinct_id_field="customer_id",
+                )
+            ],
+            breakdownFilter=breakdown_filter,
+        )
+
+    def _mixed_query(self, breakdown_filter: BreakdownFilter) -> TrendsQuery:
+        return TrendsQuery(
+            dateRange=DateRange(date_from="-7d"),
+            series=[
+                EventsNode(event="$pageview"),
+                DataWarehouseNode(
+                    id="warehouse_orders",
+                    table_name="warehouse_orders",
+                    timestamp_field="created_at",
+                    id_field="order_id",
+                    distinct_id_field="customer_id",
+                ),
+            ],
+            breakdownFilter=breakdown_filter,
+        )
+
+    @parameterized.expand(
+        [
+            (
+                "non_data_warehouse_breakdown_type",
+                BreakdownFilter(breakdown="$browser", breakdown_type=BreakdownType.EVENT),
+                None,
+                "single data warehouse property",
+            ),
+            (
+                "non_scalar_data_warehouse_breakdown_field",
+                BreakdownFilter(breakdown="metadata", breakdown_type=BreakdownType.DATA_WAREHOUSE),
+                {
+                    "order_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                    "customer_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                    "created_at": {"clickhouse": "DateTime64(3, 'UTC')", "hogql": "DateTimeDatabaseField"},
+                    "metadata": {"clickhouse": "String", "hogql": "StringJSONDatabaseField"},
+                },
+                '"metadata" is not a valid data warehouse property for breakdowns.',
+            ),
+            (
+                "scalar_data_warehouse_breakdown_field",
+                BreakdownFilter(breakdown="status", breakdown_type=BreakdownType.DATA_WAREHOUSE),
+                {
+                    "order_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                    "customer_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                    "created_at": {"clickhouse": "DateTime64(3, 'UTC')", "hogql": "DateTimeDatabaseField"},
+                    "status": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                },
+                None,
+            ),
+        ]
+    )
+    def test_validates_data_warehouse_breakdown(self, _name, breakdown_filter, columns, expected_error):
+        if columns is not None:
+            self._create_data_warehouse_table(columns)
+
+        query = self._query(breakdown_filter)
+
+        if expected_error is None:
+            ValidateDataWarehouseBreakdown().validate(self._context(query))
+            return
+
+        with self.assertRaises(ValidationError) as context:
+            ValidateDataWarehouseBreakdown().validate(self._context(query))
+
+        self.assertIn(expected_error, str(context.exception))
+        self.assertEqual(context.exception.get_codes(), ["invalid_data_warehouse_breakdown"])
+
+    def test_allows_single_item_data_warehouse_breakdown_list(self):
+        self._create_data_warehouse_table(
+            {
+                "order_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                "customer_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                "created_at": {"clickhouse": "DateTime64(3, 'UTC')", "hogql": "DateTimeDatabaseField"},
+                "status": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+            }
+        )
+
+        query = self._query(BreakdownFilter(breakdown=["status"], breakdown_type=BreakdownType.DATA_WAREHOUSE))
+
+        ValidateDataWarehouseBreakdown().validate(self._context(query))
+
+    @parameterized.expand(
+        [
+            ("event", BreakdownFilter(breakdown=["$browser"], breakdown_type=BreakdownType.EVENT)),
+            ("person", BreakdownFilter(breakdown=["email"], breakdown_type=BreakdownType.PERSON)),
+        ]
+    )
+    def test_allows_mixed_series_non_data_warehouse_breakdowns(self, _name, breakdown_filter):
+        query = self._mixed_query(breakdown_filter)
+
+        ValidateDataWarehouseBreakdown().validate(self._context(query))
+
+    def test_allows_mixed_series_data_warehouse_breakdown(self):
+        self._create_data_warehouse_table(
+            {
+                "order_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                "customer_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                "created_at": {"clickhouse": "DateTime64(3, 'UTC')", "hogql": "DateTimeDatabaseField"},
+                "status": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+            }
+        )
+
+        query = self._mixed_query(BreakdownFilter(breakdown=["status"], breakdown_type=BreakdownType.DATA_WAREHOUSE))
+
+        ValidateDataWarehouseBreakdown().validate(self._context(query))

--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -17,6 +17,7 @@ from posthog.api.services.query import ExecutionMode
 from posthog.caching.calculate_results import calculate_for_query_based_insight
 from posthog.caching.fetch_from_cache import InsightResult
 from posthog.event_usage import EventSource
+from posthog.hogql_queries.insights.utils.breakdowns import has_breakdown_filter
 from posthog.models import AlertConfiguration, Insight
 from posthog.tasks.alerts.utils import NON_TIME_SERIES_DISPLAY_TYPES, AlertEvaluationResult
 
@@ -402,13 +403,7 @@ def _drop_incomplete_current_interval(
 
 
 def _has_breakdown(query: TrendsQuery) -> bool:
-    return bool(
-        query.breakdownFilter
-        and (
-            (query.breakdownFilter.breakdown and query.breakdownFilter.breakdown_type)
-            or query.breakdownFilter.breakdowns
-        )
-    )
+    return has_breakdown_filter(query.breakdownFilter)
 
 
 def _date_range_override_for_intervals(query: TrendsQuery, last_x_intervals: int = 1) -> Optional[dict]:


### PR DESCRIPTION
## Problem

Trends insights with a data warehouse series on dashboards would break when there is a breakdown override.

## Changes

Gracefully handles this case:
- Added helpers `has_single_breakdown`, `has_multi_breakdown` and `has_breakdown_filter`
- Does not apply the override for trends insights that don't support it
- Shows a warning frontend side
<img width="435" height="461" alt="Screenshot 2026-04-22 at 10 00 44" src="https://github.com/user-attachments/assets/b74048f0-1e98-479a-830e-902314a7af91" />

## How did you test this code?

Added test cases and manual testing