### PR TITLE
fix(query): reap async queries orphaned by worker pod deaths

### DIFF
--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -1,5 +1,6 @@
 import uuid
 import datetime
+import threading
 from typing import TYPE_CHECKING, Optional
 
 import orjson as json
@@ -55,8 +56,11 @@ class QueryStatusManager:
     DEDUP_TTL_SECONDS = 60 * 20  # 20 minutes
     POLL_INTERVAL_SECONDS = 20
     HEARTBEAT_TTL_SECONDS = POLL_INTERVAL_SECONDS * 3
+    WORKER_HEARTBEAT_INTERVAL_SECONDS = 15
+    REAPER_GRACE_SECONDS = 90
     KEY_PREFIX_ASYNC_RESULTS = "query_async"
     KEY_PREFIX_RUNNING_QUERIES = "running_queries"
+    IN_PROGRESS_INDEX_KEY = "query_async:in_progress"
 
     def __init__(self, query_id: str, team_id: int):
         self.redis_client = redis.get_client()
@@ -173,6 +177,55 @@ class QueryStatusManager:
         """Unregister a query that's no longer running."""
         self.redis_client.hdel(self.running_queries_key, cache_key)
 
+    @property
+    def in_progress_index_member(self) -> str:
+        return f"{self.team_id}:{self.query_id}"
+
+    def add_to_in_progress_index(self, pickup_timestamp: float) -> None:
+        self.redis_client.zadd(self.IN_PROGRESS_INDEX_KEY, {self.in_progress_index_member: pickup_timestamp})
+
+    def remove_from_in_progress_index(self) -> None:
+        self.redis_client.zrem(self.IN_PROGRESS_INDEX_KEY, self.in_progress_index_member)
+
+    def write_worker_heartbeat(self) -> None:
+        self.redis_client.set(self.heartbeat_key, "1", ex=self.HEARTBEAT_TTL_SECONDS)
+
+    def is_worker_alive(self) -> bool:
+        return self.redis_client.exists(self.heartbeat_key) == 1
+
+
+class _WorkerHeartbeatThread:
+    """Daemon thread that writes a heartbeat key to Redis while a query task executes.
+
+    The heartbeat expires after HEARTBEAT_TTL_SECONDS. If the worker dies (e.g. OOMKilled),
+    the thread dies with it, the key expires, and the reaper picks up the orphan.
+    """
+
+    def __init__(self, manager: QueryStatusManager):
+        self._manager = manager
+        self._stop_event = threading.Event()
+        self._thread = threading.Thread(target=self._run, name=f"query-heartbeat-{manager.query_id}", daemon=True)
+
+    def _run(self) -> None:
+        # Write immediately so the key exists before the first interval elapses.
+        self._safe_write_heartbeat()
+        while not self._stop_event.wait(self._manager.WORKER_HEARTBEAT_INTERVAL_SECONDS):
+            self._safe_write_heartbeat()
+
+    def _safe_write_heartbeat(self) -> None:
+        try:
+            self._manager.write_worker_heartbeat()
+        except Exception as e:
+            logger.warning("Failed to write query worker heartbeat", error=str(e), query_id=self._manager.query_id)
+
+    def __enter__(self) -> "_WorkerHeartbeatThread":
+        self._thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self._stop_event.set()
+        self._thread.join(timeout=5)
+
 
 def execute_process_query(
     team_id: int,
@@ -205,6 +258,7 @@ def execute_process_query(
 
     query_status.pickup_time = datetime.datetime.now(datetime.UTC)
     manager.store_query_status(query_status)
+    manager.add_to_in_progress_index(query_status.pickup_time.timestamp())
 
     query_status.error = True  # Assume error in case nothing below ends up working
     query_status.complete = True
@@ -218,44 +272,47 @@ def execute_process_query(
         QUERY_WAIT_TIME.labels(team=team_id, mode=trigger).observe(wait_duration)
 
     try:
-        results = process_query_dict(
-            team=team,
-            query_json=query_json,
-            limit_context=limit_context,
-            execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
-            insight_id=query_status.insight_id,
-            dashboard_id=query_status.dashboard_id,
-            user=user,
-            is_query_service=is_query_service,
-            analytics_props=analytics_props,
-        )
-        if isinstance(results, BaseModel):
-            results = results.model_dump(by_alias=True)
-        logger.info("Got results for team %s query %s", team_id, query_id)
-        query_status.error = False
-        query_status.results = results
-        process_duration = (datetime.datetime.now(datetime.UTC) - query_status.pickup_time) / datetime.timedelta(
-            seconds=1
-        )
-        QUERY_PROCESS_TIME.labels(team=team_id).observe(process_duration)
-    except CHQueryErrorTooManySimultaneousQueries:
-        raise
-    except Exception as err:
-        from posthog.rbac.user_access_control import UserAccessControlError
+        with _WorkerHeartbeatThread(manager):
+            try:
+                results = process_query_dict(
+                    team=team,
+                    query_json=query_json,
+                    limit_context=limit_context,
+                    execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
+                    insight_id=query_status.insight_id,
+                    dashboard_id=query_status.dashboard_id,
+                    user=user,
+                    is_query_service=is_query_service,
+                    analytics_props=analytics_props,
+                )
+                if isinstance(results, BaseModel):
+                    results = results.model_dump(by_alias=True)
+                logger.info("Got results for team %s query %s", team_id, query_id)
+                query_status.error = False
+                query_status.results = results
+                process_duration = (
+                    datetime.datetime.now(datetime.UTC) - query_status.pickup_time
+                ) / datetime.timedelta(seconds=1)
+                QUERY_PROCESS_TIME.labels(team=team_id).observe(process_duration)
+            except CHQueryErrorTooManySimultaneousQueries:
+                raise
+            except Exception as err:
+                from posthog.rbac.user_access_control import UserAccessControlError
 
-        query_status.results = None  # Clear results in case they are faulty
-        if (
-            isinstance(err, APIException | ExposedHogQLError | ExposedCHQueryError | UserAccessControlError)
-            or is_staff_user
-        ):
-            # We can only expose the error message if it's a known safe error OR if the user is PostHog staff
-            query_status.error_message = str(err)
-        logger.exception("Error processing query async", team_id=team_id, query_id=query_id, exc_info=True)
-        capture_exception(err)
-        # Do not raise here, the task itself did its job and we cannot recover
+                query_status.results = None  # Clear results in case they are faulty
+                if (
+                    isinstance(err, APIException | ExposedHogQLError | ExposedCHQueryError | UserAccessControlError)
+                    or is_staff_user
+                ):
+                    # We can only expose the error message if it's a known safe error OR if the user is PostHog staff
+                    query_status.error_message = str(err)
+                logger.exception("Error processing query async", team_id=team_id, query_id=query_id, exc_info=True)
+                capture_exception(err)
+                # Do not raise here, the task itself did its job and we cannot recover
     finally:
         query_status.end_time = datetime.datetime.now(datetime.UTC)
         manager.store_query_status(query_status)
+        manager.remove_from_in_progress_index()
         cache_key = None
         try:
             if query_status.results:
@@ -402,5 +459,6 @@ def cancel_query(team_id: int, query_id: str, dequeue_only: bool = False) -> str
         message = "Cancelled query on clickhouse"
 
     manager.delete_query_status()
+    manager.remove_from_in_progress_index()
 
     return message

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -1,4 +1,5 @@
 import json
+import time
 import uuid
 from typing import Any
 
@@ -19,7 +20,12 @@ from posthog.clickhouse.client import (
     sync_execute,
 )
 from posthog.clickhouse.client.async_task_chain import task_chain_context
-from posthog.clickhouse.client.execute_async import QueryNotFoundError, QueryStatusManager, execute_process_query
+from posthog.clickhouse.client.execute_async import (
+    QueryNotFoundError,
+    QueryStatusManager,
+    _WorkerHeartbeatThread,
+    execute_process_query,
+)
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries
 from posthog.models import Organization, Team
@@ -130,10 +136,13 @@ class TestExecuteProcessQuery(TestCase):
         mock_redis_client.assert_called_once()
         mock_process_query_dict.assert_called_once()
 
-        # Assert that Redis set method was called with the correct arguments
-        self.assertEqual(mock_redis.set.call_count, 2)  # Once on pickup, once on completion
-        args, kwargs = mock_redis.set.call_args
-        args_loaded = json.loads(args[1])
+        # store_query_status is called on pickup and on completion. The heartbeat thread also calls `set`
+        # during task execution, so we filter to just the store_query_status calls by their key prefix.
+        results_key = f"query_async:{self.team.id}:{self.query_id}"
+        store_calls = [call for call in mock_redis.set.call_args_list if call.args and call.args[0] == results_key]
+        self.assertEqual(len(store_calls), 2)  # Once on pickup, once on completion
+        final_call_args = store_calls[-1].args
+        args_loaded = json.loads(final_call_args[1])
         self.assertEqual(args_loaded["results"], [None, None, None, 1.0, "👍"])
 
 
@@ -549,3 +558,132 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
         assert not new_status.complete
         # Stale mapping was replaced with the new query's mapping
         assert expired_manager.get_running_query_by_cache_key(cache_key) == new_status.id
+
+
+class TestInProgressIndex(TestCase):
+    def setUp(self):
+        self.user = User.objects.create(email="test@posthog.com")
+        self.organization = Organization.objects.create(name="test")
+        self.team = Team.objects.create(organization=self.organization)
+        self.query_id = "in_progress_index_test_query"
+        self.query_json = {}
+        self.manager = QueryStatusManager(self.query_id, self.team.id)
+        get_client().flushall()
+
+    def _index_members(self) -> list[str]:
+        raw = get_client().zrange(QueryStatusManager.IN_PROGRESS_INDEX_KEY, 0, -1)
+        return [m.decode("utf-8") if isinstance(m, bytes) else m for m in raw]
+
+    def _seed_initial_status(self) -> None:
+        self.manager.store_query_status(QueryStatus(id=self.query_id, team_id=self.team.id))
+
+    @patch("posthog.api.services.query.process_query_dict")
+    def test_adds_to_index_on_pickup_and_removes_in_finally_on_success(self, mock_process_query_dict):
+        mock_process_query_dict.return_value = {"results": [[2]]}
+        self._seed_initial_status()
+
+        execute_process_query(self.team.id, self.user.id, self.query_id, self.query_json, None)
+
+        assert self._index_members() == []
+        assert self.manager.get_query_status().complete is True
+        assert self.manager.get_query_status().error is False
+
+    @patch("posthog.api.services.query.process_query_dict", side_effect=RuntimeError("boom"))
+    def test_adds_to_index_on_pickup_and_removes_in_finally_on_handled_exception(self, mock_process_query_dict):
+        self._seed_initial_status()
+
+        execute_process_query(self.team.id, self.user.id, self.query_id, self.query_json, None)
+
+        assert self._index_members() == []
+        final_status = self.manager.get_query_status()
+        assert final_status.complete is True
+        assert final_status.error is True
+
+    @patch(
+        "posthog.api.services.query.process_query_dict",
+        side_effect=CHQueryErrorTooManySimultaneousQueries("throttled"),
+    )
+    def test_removes_from_index_even_when_exception_is_reraised(self, mock_process_query_dict):
+        self._seed_initial_status()
+
+        with self.assertRaises(CHQueryErrorTooManySimultaneousQueries):
+            execute_process_query(self.team.id, self.user.id, self.query_id, self.query_json, None)
+
+        assert self._index_members() == []
+
+    @patch("posthog.api.services.query.process_query_dict")
+    def test_in_progress_entry_scored_by_pickup_time(self, mock_process_query_dict):
+        # Arrange for execute to start but hang inside process_query_dict so we can observe the mid-execution state.
+        pickup_observed = {}
+
+        def _slow(*args, **kwargs):
+            pickup_observed["members_with_scores"] = get_client().zrange(
+                QueryStatusManager.IN_PROGRESS_INDEX_KEY, 0, -1, withscores=True
+            )
+            return {"results": []}
+
+        mock_process_query_dict.side_effect = _slow
+        self._seed_initial_status()
+        execute_process_query(self.team.id, self.user.id, self.query_id, self.query_json, None)
+
+        members = pickup_observed["members_with_scores"]
+        assert len(members) == 1
+        member_bytes, score = members[0]
+        member = member_bytes.decode("utf-8") if isinstance(member_bytes, bytes) else member_bytes
+        assert member == f"{self.team.id}:{self.query_id}"
+        # Score is a unix timestamp — sanity-check it's in the last few seconds.
+        assert abs(score - time.time()) < 10
+
+
+class TestWorkerHeartbeatThread(SimpleTestCase):
+    def setUp(self):
+        get_client().flushall()
+        self.query_id = "heartbeat-test"
+        self.team_id = 7777
+        self.manager = QueryStatusManager(self.query_id, self.team_id)
+
+    def test_writes_heartbeat_immediately_and_on_interval(self):
+        with patch.object(QueryStatusManager, "WORKER_HEARTBEAT_INTERVAL_SECONDS", 0.05):
+            with _WorkerHeartbeatThread(self.manager):
+                # Immediate write happens before the first sleep — verify without racing on the interval.
+                deadline = time.time() + 0.5
+                while time.time() < deadline:
+                    if get_client().exists(self.manager.heartbeat_key):
+                        break
+                    time.sleep(0.01)
+                assert self.manager.is_worker_alive()
+
+                # Let at least one periodic iteration run, then confirm the key is still being refreshed.
+                time.sleep(0.15)
+                assert self.manager.is_worker_alive()
+
+    def test_thread_stops_writing_after_context_exit(self):
+        with patch.object(QueryStatusManager, "WORKER_HEARTBEAT_INTERVAL_SECONDS", 0.05):
+            with _WorkerHeartbeatThread(self.manager):
+                time.sleep(0.1)
+
+        # After exit, delete the key and confirm no further writes refresh it.
+        get_client().delete(self.manager.heartbeat_key)
+        time.sleep(0.15)
+        assert not self.manager.is_worker_alive()
+
+    def test_heartbeat_write_errors_do_not_kill_thread(self):
+        call_count = {"n": 0}
+
+        def _flaky_write():
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("transient redis failure")
+            self.manager.redis_client.set(self.manager.heartbeat_key, "1", ex=self.manager.HEARTBEAT_TTL_SECONDS)
+
+        with patch.object(QueryStatusManager, "WORKER_HEARTBEAT_INTERVAL_SECONDS", 0.05):
+            with patch.object(self.manager, "write_worker_heartbeat", side_effect=_flaky_write):
+                with _WorkerHeartbeatThread(self.manager):
+                    deadline = time.time() + 1.0
+                    while time.time() < deadline:
+                        if call_count["n"] >= 2:
+                            break
+                        time.sleep(0.02)
+
+        # Thread survived the first failure and made at least one successful write
+        assert call_count["n"] >= 2

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -58,6 +58,7 @@ from posthog.tasks.tasks import (
     pg_row_count,
     pg_table_cache_hit_rate,
     process_scheduled_changes,
+    reap_orphaned_query_statuses,
     redis_celery_queue_depth,
     redis_heartbeat,
     refresh_activity_log_fields_cache,
@@ -170,6 +171,12 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         QueryStatusManager.POLL_INTERVAL_SECONDS,
         start_poll_query_performance.s(),
         name="query performance heartbeat",
+    )
+
+    sender.add_periodic_task(
+        30,
+        reap_orphaned_query_statuses.s(),
+        name="reap orphaned async query statuses",
     )
 
     sender.add_periodic_task(

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -53,6 +53,16 @@ COHORT_DELETION_RUN_FAILURE_COUNTER = Counter(
     "Times cohort deletion run failed",
 )
 
+QUERY_ASYNC_ORPHANED_REAPED_COUNTER = Counter(
+    "query_async_orphaned_reaped_total",
+    "Async query statuses marked as errored because their worker heartbeat expired",
+)
+
+QUERY_ASYNC_IN_PROGRESS_INDEX_SIZE_GAUGE = Gauge(
+    "query_async_in_progress_index_size",
+    "Number of async queries currently tracked in the in-progress index",
+)
+
 
 @shared_task(ignore_result=True)
 def delete_expired_exported_assets() -> None:
@@ -134,6 +144,92 @@ def process_query_task(
         is_query_service=is_query_service,
         analytics_props=analytics_props,
     )
+
+
+@shared_task(
+    ignore_result=True,
+    # Runs on DEFAULT — must NOT be ANALYTICS_QUERIES, since workers on that queue are what we're reaping for.
+    queue=CeleryQueue.DEFAULT.value,
+    expires=60,
+)
+def reap_orphaned_query_statuses() -> None:
+    """Find async query statuses whose worker died uncatchably (OOMKilled/SIGKILL) and mark them as errored.
+
+    A task-level heartbeat key with a short TTL is written by a daemon thread while the worker executes
+    the query. When the worker dies, the thread dies with it and the key expires. This sweep catches the
+    orphan and flips the status to complete+error so polling clients stop hanging until the 20-minute
+    status TTL expires.
+    """
+    import datetime as _dt
+
+    from posthog.clickhouse.client.execute_async import QueryNotFoundError, QueryStatusManager
+
+    redis_client = get_client()
+
+    lock_acquired = redis_client.set("query_async:reaper_lock", "1", nx=True, ex=60)
+    if not lock_acquired:
+        return
+
+    now = _dt.datetime.now(_dt.UTC)
+    stale_cutoff = now.timestamp() - QueryStatusManager.REAPER_GRACE_SECONDS
+
+    index_size = redis_client.zcard(QueryStatusManager.IN_PROGRESS_INDEX_KEY)
+    QUERY_ASYNC_IN_PROGRESS_INDEX_SIZE_GAUGE.set(index_size)
+
+    stale_members = redis_client.zrangebyscore(QueryStatusManager.IN_PROGRESS_INDEX_KEY, 0, stale_cutoff)
+
+    for raw_member in stale_members:
+        member = raw_member.decode("utf-8") if isinstance(raw_member, bytes) else raw_member
+        try:
+            team_id_str, query_id = member.split(":", 1)
+            team_id = int(team_id_str)
+        except ValueError:
+            logger.warning("Skipping malformed in-progress index member", member=member)
+            redis_client.zrem(QueryStatusManager.IN_PROGRESS_INDEX_KEY, raw_member)
+            continue
+
+        manager = QueryStatusManager(query_id, team_id)
+
+        if manager.is_worker_alive():
+            continue
+
+        try:
+            query_status = manager.get_query_status()
+        except QueryNotFoundError:
+            # Status TTL already expired (20 minutes). Nothing to mark — just clean up the index entry.
+            manager.remove_from_in_progress_index()
+            continue
+        except Exception as e:
+            logger.exception("Failed to read query status during reap", query_id=query_id, team_id=team_id, error=e)
+            continue
+
+        if query_status.complete:
+            manager.remove_from_in_progress_index()
+            continue
+
+        query_status.complete = True
+        query_status.error = True
+        query_status.error_message = (
+            "Query worker terminated unexpectedly (likely OOMKilled or pod eviction). Please retry."
+        )
+        query_status.end_time = now
+
+        try:
+            manager.store_query_status(query_status)
+            if query_status.results:
+                cache_key = query_status.results.get("cache_key")
+                if cache_key:
+                    manager.unregister_cache_key_mapping(cache_key)
+        finally:
+            manager.remove_from_in_progress_index()
+
+        QUERY_ASYNC_ORPHANED_REAPED_COUNTER.inc()
+        logger.warning(
+            "Reaped orphaned async query status",
+            query_id=query_id,
+            team_id=team_id,
+            pickup_time=query_status.pickup_time.isoformat() if query_status.pickup_time else None,
+        )
 
 
 @shared_task(ignore_result=True)

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -118,6 +118,7 @@
     'posthog.tasks.tasks.poll_query_performance',
     'posthog.tasks.tasks.process_query_task',
     'posthog.tasks.tasks.process_scheduled_changes',
+    'posthog.tasks.tasks.reap_orphaned_query_statuses',
     'posthog.tasks.tasks.redis_celery_queue_depth',
     'posthog.tasks.tasks.redis_heartbeat',
     'posthog.tasks.tasks.refresh_activity_log_fields_cache',

--- a/posthog/tasks/test/test_reap_orphaned_query_statuses.py
+++ b/posthog/tasks/test/test_reap_orphaned_query_statuses.py
@@ -1,0 +1,136 @@
+import datetime
+
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from posthog.schema import QueryStatus
+
+from posthog.clickhouse.client.execute_async import QueryStatusManager
+from posthog.redis import get_client
+from posthog.tasks.tasks import reap_orphaned_query_statuses
+
+
+class TestReapOrphanedQueryStatuses(SimpleTestCase):
+    def setUp(self) -> None:
+        get_client().flushall()
+        self.team_id = 4242
+        self.query_id = "reaper-test-query"
+        self.manager = QueryStatusManager(self.query_id, self.team_id)
+
+    def _seed_in_progress(self, *, pickup_offset_seconds: float, complete: bool = False) -> None:
+        pickup_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=pickup_offset_seconds)
+        self.manager.store_query_status(
+            QueryStatus(
+                id=self.query_id,
+                team_id=self.team_id,
+                complete=complete,
+                error=False,
+                pickup_time=pickup_time,
+            )
+        )
+        self.manager.add_to_in_progress_index(pickup_time.timestamp())
+
+    def _index_members(self) -> list[str]:
+        raw = get_client().zrange(QueryStatusManager.IN_PROGRESS_INDEX_KEY, 0, -1)
+        return [m.decode("utf-8") if isinstance(m, bytes) else m for m in raw]
+
+    def test_reaps_stale_entry_with_no_heartbeat(self) -> None:
+        self._seed_in_progress(pickup_offset_seconds=120)
+
+        reap_orphaned_query_statuses()
+
+        status = self.manager.get_query_status()
+        assert status.complete is True
+        assert status.error is True
+        assert status.error_message is not None
+        assert "Query worker terminated unexpectedly" in status.error_message
+        assert status.end_time is not None
+        assert self._index_members() == []
+
+    def test_does_not_reap_when_heartbeat_present(self) -> None:
+        self._seed_in_progress(pickup_offset_seconds=120)
+        self.manager.write_worker_heartbeat()
+
+        reap_orphaned_query_statuses()
+
+        status = self.manager.get_query_status()
+        assert status.complete is False
+        assert status.error is False
+        assert self._index_members() == [f"{self.team_id}:{self.query_id}"]
+
+    def test_does_not_reap_recent_entry_within_grace_period(self) -> None:
+        self._seed_in_progress(pickup_offset_seconds=10)
+
+        reap_orphaned_query_statuses()
+
+        status = self.manager.get_query_status()
+        assert status.complete is False
+        assert status.error is False
+        assert self._index_members() == [f"{self.team_id}:{self.query_id}"]
+
+    def test_removes_stale_index_entry_when_status_already_complete(self) -> None:
+        self._seed_in_progress(pickup_offset_seconds=120, complete=True)
+
+        reap_orphaned_query_statuses()
+
+        # Status is untouched — the reaper only cleans up the dangling index entry.
+        status = self.manager.get_query_status()
+        assert status.complete is True
+        assert status.error is False
+        assert self._index_members() == []
+
+    def test_removes_index_entry_when_status_ttl_already_expired(self) -> None:
+        pickup_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=120)
+        # Add to the index but do NOT store a status — simulates the 20-minute status TTL having expired.
+        self.manager.add_to_in_progress_index(pickup_time.timestamp())
+
+        reap_orphaned_query_statuses()
+
+        assert self._index_members() == []
+
+    def test_reaper_lock_prevents_concurrent_runs(self) -> None:
+        self._seed_in_progress(pickup_offset_seconds=120)
+
+        # Simulate another reaper holding the lock
+        get_client().set("query_async:reaper_lock", "1", nx=True, ex=60)
+
+        reap_orphaned_query_statuses()
+
+        # Status was not updated because this reaper bailed out on the lock
+        status = self.manager.get_query_status()
+        assert status.complete is False
+        assert status.error is False
+        assert self._index_members() == [f"{self.team_id}:{self.query_id}"]
+
+    def test_malformed_index_member_is_cleaned_up(self) -> None:
+        # Deliberately insert an invalid member with a stale score so the reaper looks at it.
+        get_client().zadd(
+            QueryStatusManager.IN_PROGRESS_INDEX_KEY,
+            {"not-a-valid-format": datetime.datetime.now(datetime.UTC).timestamp() - 300},
+        )
+
+        reap_orphaned_query_statuses()
+
+        assert self._index_members() == []
+
+    def test_unregisters_cache_key_mapping_on_reap(self) -> None:
+        self._seed_in_progress(pickup_offset_seconds=120)
+        cache_key = "test-cache-key"
+        # Pre-populate results with a cache_key so the reaper tries to unregister the mapping
+        status = self.manager.get_query_status()
+        status.results = {"cache_key": cache_key, "results": []}
+        self.manager.store_query_status(status)
+        self.manager.register_cache_key_mapping(cache_key)
+
+        reap_orphaned_query_statuses()
+
+        assert self.manager.get_running_query_by_cache_key(cache_key) is None
+
+    def test_reaper_increments_prometheus_counter(self) -> None:
+        self._seed_in_progress(pickup_offset_seconds=120)
+
+        with patch("posthog.tasks.tasks.QUERY_ASYNC_ORPHANED_REAPED_COUNTER") as mock_counter:
+            reap_orphaned_query_statuses()
+
+        mock_counter.inc.assert_called_once()


### PR DESCRIPTION
## Problem

When a celery worker pod dies uncatchably (OOMKilled, SIGKILL, node eviction), the async query task it was executing leaves its Redis status stuck at `complete=false` until the 20-minute TTL expires. Polling clients (e.g. the experiments page on async queries) hang until their own deadline, with no actionable error surfaced.

Celery's `acks_late=True` + `reject_on_worker_lost=True` doesn't help here: the Redis broker has no heartbeat mechanism (unlike RabbitMQ), so the broker never detects the worker's disappearance. The `finally` block in `execute_process_query` doesn't run on SIGKILL either.

## Changes

Three pieces:

1. **Worker self-heartbeat.** `execute_process_query` spawns a daemon thread that writes a Redis key every 15s with a 60s TTL while the task is in-flight. If the worker dies, the thread dies with it and the key expires naturally.
2. **In-progress index.** A Redis sorted set (`query_async:in_progress`) tracks currently-executing queries, keyed by `{team_id}:{query_id}` and scored by pickup time. Added on pickup, removed in the `finally` block and on `cancel_query`.
3. **Periodic reaper.** A new `reap_orphaned_query_statuses` task runs every 30s on the `DEFAULT` queue (crucial — it must not run on `analytics_queries`, since those are exactly the workers that might be dead). It scans the sorted set for entries older than 90s, and for any whose heartbeat key is missing, flips the status to `complete=true, error=true, error_message=\"Query worker terminated unexpectedly...\"` and cleans up the cache-key mapping.

Detection latency is ~90s grace + ≤30s scheduling = under 2 minutes end-to-end.

## How did you test this code?

**Automated (unit tests):**
- 9 new tests in `test_reap_orphaned_query_statuses.py` covering: stale+no-heartbeat reaped, stale+heartbeat not reaped, recent not reaped, already-complete cleaned, TTL-expired cleaned, malformed member cleaned, cache-key unregistered, lock prevents concurrent runs, Prometheus counter incremented.
- 7 new tests in `test_execute_async.py` covering: in-progress index add/remove on pickup/finally (success, handled exception, re-raised exception), index scored by pickup time, heartbeat thread writes immediately and on interval, stops on context exit, survives transient Redis failures.
- Updated the existing `test_execute_process_query` to account for the heartbeat thread's Redis writes.
- Task registration snapshot updated.

**Manual SIGKILL simulation:** not yet performed — I'm an agent and haven't run the end-to-end test against a live dev stack. The plan file documents a verification procedure (submit a long async query → `kill -9` the worker → observe the reaper flip the status within ~2 min) for the reviewer or author to run before merging.

## Publish to changelog?

do not publish to changelog

## Docs update

No docs changes needed.

## 🤖 LLM context

Authored with Claude Opus 4.7 in plan mode. Plan file: `/Users/andehen/.claude/plans/when-celery-worker-pods-concurrent-pillow.md` — covers alternatives considered (Celery events consumer, k8s pod-death signal, signal.alarm) and why the self-heartbeat + sorted-set + sweeper design was chosen (smallest surface area, works on self-hosted, doesn't require new deployments or celery.events subscription).