### PR TITLE
feat(alerts): add checks, snooze, and toggle MCP tools

### DIFF
--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -563,6 +563,30 @@ class BreakdownSimulationResultSerializer(serializers.Serializer):
     )
 
 
+class AlertSnoozeSerializer(serializers.Serializer):
+    duration = serializers.CharField(
+        help_text="Relative duration to snooze for (e.g. '2h', '1d', '1w'). Alert resumes when the duration elapses.",
+    )
+
+    def validate_duration(self, value):
+        if not value:
+            raise ValidationError("duration is required.")
+        try:
+            relative_date_parse(value, ZoneInfo("UTC"), increase=True, always_truncate=True)
+        except Exception:
+            raise ValidationError("Invalid duration. Use a relative duration like '2h', '1d', or '1w'.")
+        return value
+
+
+class AlertToggleSerializer(serializers.Serializer):
+    enabled = serializers.BooleanField(help_text="Enable or disable the alert.")
+
+
+class AlertCheckListResponseSerializer(serializers.Serializer):
+    count = serializers.IntegerField(help_text="Total checks matching the filters.")
+    results = AlertCheckSerializer(many=True)  # type: ignore[assignment]
+
+
 class AlertSimulateResponseSerializer(serializers.Serializer):
     data = serializers.ListField(child=serializers.FloatField(), help_text="Data values for each point.")  # type: ignore[assignment]
     dates = serializers.ListField(child=serializers.CharField(), help_text="Date labels for each point.")
@@ -747,6 +771,151 @@ class AlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         response_serializer = AlertSimulateResponseSerializer(result)
         return Response(response_serializer.data)
+
+    CHECKS_LIST_DEFAULT_LIMIT = 50
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="date_from",
+                type=str,
+                required=False,
+                description="Relative date string for the start of the check history window (e.g. '-24h', '-7d'). Max retention is 14 days.",
+            ),
+            OpenApiParameter(
+                name="date_to",
+                type=str,
+                required=False,
+                description="Relative date string for the end of the check history window (e.g. '-1h'). Defaults to now if not specified.",
+            ),
+            OpenApiParameter(
+                name="limit",
+                type=int,
+                required=False,
+                description="Maximum number of check results to return (default 50, max 500).",
+            ),
+            OpenApiParameter(
+                name="offset",
+                type=int,
+                required=False,
+                description="Number of newest checks to skip (0-based). Default 0.",
+            ),
+            OpenApiParameter(
+                name="state",
+                type=str,
+                required=False,
+                description="Filter by check state: Firing, Not firing, Errored, or Snoozed.",
+            ),
+        ],
+        responses={200: AlertCheckListResponseSerializer},
+        description="List historical checks for an alert without returning the full alert record.",
+    )
+    @action(detail=True, methods=["GET"], url_path="checks", required_scopes=["alert:read"])
+    def checks(self, request, *args, **kwargs):
+        instance = self.get_object()
+        checks_qs = instance.alertcheck_set.all().order_by("-created_at")
+
+        date_from = request.query_params.get("date_from")
+        if date_from:
+            checks_qs = checks_qs.filter(created_at__gte=relative_date_parse(date_from, ZoneInfo("UTC")))
+
+        date_to = request.query_params.get("date_to")
+        if date_to:
+            checks_qs = checks_qs.filter(created_at__lte=relative_date_parse(date_to, ZoneInfo("UTC")))
+
+        state = request.query_params.get("state")
+        if state:
+            checks_qs = checks_qs.filter(state=state)
+
+        raw_limit = request.query_params.get("limit")
+        if raw_limit is not None:
+            try:
+                limit = max(1, min(int(raw_limit), self.CHECKS_MAX_LIMIT))
+            except (ValueError, TypeError):
+                limit = self.CHECKS_LIST_DEFAULT_LIMIT
+        else:
+            limit = self.CHECKS_LIST_DEFAULT_LIMIT
+
+        raw_offset = request.query_params.get("offset")
+        if raw_offset is not None:
+            try:
+                offset = max(0, int(raw_offset))
+            except (ValueError, TypeError):
+                offset = 0
+        else:
+            offset = 0
+
+        count = checks_qs.count()
+        offset = min(offset, count)
+        results = list(checks_qs[offset : offset + limit])
+
+        return Response(
+            {
+                "count": count,
+                "results": AlertCheckSerializer(results, many=True).data,
+            }
+        )
+
+    @extend_schema(
+        request=AlertSnoozeSerializer,
+        responses={200: AlertSerializer},
+        description="Snooze an alert for a relative duration. Creates a snoozed AlertCheck record.",
+    )
+    @action(detail=True, methods=["POST"], url_path="snooze", required_scopes=["alert:write"])
+    def snooze(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = AlertSnoozeSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        duration = serializer.validated_data["duration"]
+
+        snoozed_until = relative_date_parse(duration, ZoneInfo("UTC"), increase=True, always_truncate=True)
+        instance.state = AlertState.SNOOZED
+        instance.snoozed_until = snoozed_until
+        instance.save(update_fields=["state", "snoozed_until"])
+
+        AlertCheck.objects.create(
+            alert_configuration=instance,
+            calculated_value=None,
+            condition=instance.condition,
+            targets_notified={},
+            state=instance.state,
+            error=None,
+        )
+
+        instance.report_updated(
+            request.user,
+            analytics_props=get_request_analytics_properties(request),
+        )
+        instance.checks = list(instance.alertcheck_set.all().order_by("-created_at")[: self.CHECKS_DEFAULT_LIMIT])
+        return Response(self.get_serializer(instance).data)
+
+    @extend_schema(
+        request=AlertToggleSerializer,
+        responses={200: AlertSerializer},
+        description="Enable or disable an alert. Re-enabling schedules a fresh check.",
+    )
+    @action(detail=True, methods=["POST"], url_path="toggle", required_scopes=["alert:write"])
+    def toggle(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = AlertToggleSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        enabled = serializer.validated_data["enabled"]
+
+        if instance.enabled != enabled:
+            was_disabled = not instance.enabled
+            instance.enabled = enabled
+            update_fields = ["enabled"]
+            if enabled and was_disabled:
+                update_fields.extend(instance.mark_for_recheck(reset_state=False))
+            instance.save(update_fields=update_fields)
+
+            instance.report_updated(
+                request.user,
+                analytics_props=get_request_analytics_properties(request),
+            )
+
+        instance.checks = list(instance.alertcheck_set.all().order_by("-created_at")[: self.CHECKS_DEFAULT_LIMIT])
+        return Response(self.get_serializer(instance).data)
 
 
 class ThresholdWithAlertSerializer(ThresholdSerializer):

--- a/posthog/api/test/test_alert.py
+++ b/posthog/api/test/test_alert.py
@@ -435,6 +435,153 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         check = AlertCheck.objects.filter(alert_configuration=firing_alert.id).latest("created_at")
         assert check.state == AlertState.SNOOZED
 
+    def _create_alert(self, **overrides) -> dict:
+        creation_request = {
+            "insight": self.insight["id"],
+            "subscribed_users": [self.user.id],
+            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
+            "config": {"type": "TrendsAlertConfig", "series_index": 0},
+            "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
+            "name": "test alert",
+            **overrides,
+        }
+        return self.client.post(f"/api/projects/{self.team.id}/alerts", creation_request).json()
+
+    def test_checks_action_returns_paginated_history(self) -> None:
+        alert = self._create_alert(name="checks action test")
+        alert_obj = AlertConfiguration.objects.get(id=alert["id"])
+        now = datetime.now(UTC)
+        for i in range(6):
+            check = AlertCheck.objects.create(
+                alert_configuration=alert_obj,
+                calculated_value=float(i),
+                state=AlertState.NOT_FIRING,
+            )
+            AlertCheck.objects.filter(id=check.id).update(created_at=now - timedelta(seconds=6 - i))
+
+        response = self.client.get(f"/api/projects/{self.team.id}/alerts/{alert['id']}/checks")
+        assert response.status_code == status.HTTP_200_OK, response.content
+        body = response.json()
+        assert body["count"] == 6
+        assert [c["calculated_value"] for c in body["results"]] == [5.0, 4.0, 3.0, 2.0, 1.0, 0.0]
+
+        response = self.client.get(f"/api/projects/{self.team.id}/alerts/{alert['id']}/checks?limit=2&offset=2")
+        body = response.json()
+        assert body["count"] == 6
+        assert [c["calculated_value"] for c in body["results"]] == [3.0, 2.0]
+
+    def test_checks_action_filters_by_date_and_state(self) -> None:
+        alert = self._create_alert(name="checks filter test")
+        alert_obj = AlertConfiguration.objects.get(id=alert["id"])
+        now = datetime.now(UTC)
+
+        old_firing = AlertCheck.objects.create(
+            alert_configuration=alert_obj, calculated_value=1.0, state=AlertState.FIRING
+        )
+        AlertCheck.objects.filter(id=old_firing.id).update(created_at=now - timedelta(hours=48))
+        AlertCheck.objects.create(alert_configuration=alert_obj, calculated_value=2.0, state=AlertState.FIRING)
+        AlertCheck.objects.create(alert_configuration=alert_obj, calculated_value=3.0, state=AlertState.NOT_FIRING)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/alerts/{alert['id']}/checks?date_from=-24h")
+        body = response.json()
+        assert body["count"] == 2
+        assert {c["calculated_value"] for c in body["results"]} == {2.0, 3.0}
+
+        response = self.client.get(f"/api/projects/{self.team.id}/alerts/{alert['id']}/checks?state=Firing")
+        body = response.json()
+        assert body["count"] == 2
+        assert {c["calculated_value"] for c in body["results"]} == {1.0, 2.0}
+
+    def test_checks_action_scoped_to_team(self) -> None:
+        alert = self._create_alert(name="scoping test")
+        other_team = Team.objects.create(organization=self.organization, api_token=self.CONFIG_API_TOKEN + "2")
+        response = self.client.get(f"/api/projects/{other_team.id}/alerts/{alert['id']}/checks")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_snooze_action(self) -> None:
+        alert = self._create_alert(name="snooze action test")
+        alert_obj = AlertConfiguration.objects.get(id=alert["id"])
+        alert_obj.state = AlertState.FIRING
+        alert_obj.save()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/alerts/{alert['id']}/snooze",
+            {"duration": "2h"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+        body = response.json()
+        assert body["state"] == AlertState.SNOOZED
+        assert body["snoozed_until"] is not None
+
+        alert_obj.refresh_from_db()
+        assert alert_obj.state == AlertState.SNOOZED
+        assert alert_obj.snoozed_until is not None
+        assert alert_obj.snoozed_until > datetime.now(UTC)
+
+        check = AlertCheck.objects.filter(alert_configuration=alert_obj).latest("created_at")
+        assert check.state == AlertState.SNOOZED
+        assert check.calculated_value is None
+
+    def test_snooze_action_rejects_invalid_duration(self) -> None:
+        alert = self._create_alert(name="snooze validation test")
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/alerts/{alert['id']}/snooze",
+            {"duration": "not a duration"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/alerts/{alert['id']}/snooze",
+            {},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @parameterized.expand(
+        [
+            ("disable_an_enabled_alert", True, False),
+            ("enable_a_disabled_alert", False, True),
+            ("toggle_is_idempotent", True, True),
+        ]
+    )
+    def test_toggle_action(self, _label: str, initial_enabled: bool, target_enabled: bool) -> None:
+        alert = self._create_alert(name=f"toggle test {_label}")
+        alert_obj = AlertConfiguration.objects.get(id=alert["id"])
+        if alert_obj.enabled != initial_enabled:
+            alert_obj.enabled = initial_enabled
+            alert_obj.save()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/alerts/{alert['id']}/toggle",
+            {"enabled": target_enabled},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert response.json()["enabled"] == target_enabled
+
+        alert_obj.refresh_from_db()
+        assert alert_obj.enabled == target_enabled
+
+    def test_toggle_reenable_marks_for_recheck(self) -> None:
+        alert = self._create_alert(name="toggle reenable test")
+        alert_obj = AlertConfiguration.objects.get(id=alert["id"])
+        alert_obj.enabled = False
+        alert_obj.next_check_at = datetime.now(UTC) + timedelta(days=1)
+        alert_obj.save()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/alerts/{alert['id']}/toggle",
+            {"enabled": True},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        alert_obj.refresh_from_db()
+        assert alert_obj.enabled is True
+        assert alert_obj.next_check_at is None
+
     @parameterized.expand(
         [
             (

--- a/products/alerts/frontend/generated/api.schemas.ts
+++ b/products/alerts/frontend/generated/api.schemas.ts
@@ -693,6 +693,22 @@ export interface PatchedAlertApi {
     readonly last_value?: number | null
 }
 
+export interface AlertCheckListResponseApi {
+    /** Total checks matching the filters. */
+    count: number
+    results: AlertCheckApi[]
+}
+
+export interface AlertSnoozeApi {
+    /** Relative duration to snooze for (e.g. '2h', '1d', '1w'). Alert resumes when the duration elapses. */
+    duration: string
+}
+
+export interface AlertToggleApi {
+    /** Enable or disable the alert. */
+    enabled: boolean
+}
+
 export interface AlertSimulateApi {
     /** Insight ID to simulate the detector on. */
     insight: number
@@ -786,4 +802,27 @@ export type AlertsRetrieveParams = {
      * Number of newest checks to skip (0-based). Use with checks_limit for pagination. Default 0.
      */
     checks_offset?: number
+}
+
+export type AlertsChecksRetrieveParams = {
+    /**
+     * Relative date string for the start of the check history window (e.g. '-24h', '-7d'). Max retention is 14 days.
+     */
+    date_from?: string
+    /**
+     * Relative date string for the end of the check history window (e.g. '-1h'). Defaults to now if not specified.
+     */
+    date_to?: string
+    /**
+     * Maximum number of check results to return (default 50, max 500).
+     */
+    limit?: number
+    /**
+     * Number of newest checks to skip (0-based). Default 0.
+     */
+    offset?: number
+    /**
+     * Filter by check state: Firing, Not firing, Errored, or Snoozed.
+     */
+    state?: string
 }

--- a/products/alerts/frontend/generated/api.ts
+++ b/products/alerts/frontend/generated/api.ts
@@ -10,8 +10,12 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  */
 import type {
     AlertApi,
+    AlertCheckListResponseApi,
     AlertSimulateApi,
     AlertSimulateResponseApi,
+    AlertSnoozeApi,
+    AlertToggleApi,
+    AlertsChecksRetrieveParams,
     AlertsListParams,
     AlertsRetrieveParams,
     PaginatedAlertListApi,
@@ -151,6 +155,79 @@ export const alertsDestroy = async (projectId: string, id: string, options?: Req
     return apiMutator<void>(getAlertsDestroyUrl(projectId, id), {
         ...options,
         method: 'DELETE',
+    })
+}
+
+/**
+ * List historical checks for an alert without returning the full alert record.
+ */
+export const getAlertsChecksRetrieveUrl = (projectId: string, id: string, params?: AlertsChecksRetrieveParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/alerts/${id}/checks/?${stringifiedParams}`
+        : `/api/projects/${projectId}/alerts/${id}/checks/`
+}
+
+export const alertsChecksRetrieve = async (
+    projectId: string,
+    id: string,
+    params?: AlertsChecksRetrieveParams,
+    options?: RequestInit
+): Promise<AlertCheckListResponseApi> => {
+    return apiMutator<AlertCheckListResponseApi>(getAlertsChecksRetrieveUrl(projectId, id, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+/**
+ * Snooze an alert for a relative duration. Creates a snoozed AlertCheck record.
+ */
+export const getAlertsSnoozeCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/alerts/${id}/snooze/`
+}
+
+export const alertsSnoozeCreate = async (
+    projectId: string,
+    id: string,
+    alertSnoozeApi: AlertSnoozeApi,
+    options?: RequestInit
+): Promise<AlertApi> => {
+    return apiMutator<AlertApi>(getAlertsSnoozeCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(alertSnoozeApi),
+    })
+}
+
+/**
+ * Enable or disable an alert. Re-enabling schedules a fresh check.
+ */
+export const getAlertsToggleCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/alerts/${id}/toggle/`
+}
+
+export const alertsToggleCreate = async (
+    projectId: string,
+    id: string,
+    alertToggleApi: AlertToggleApi,
+    options?: RequestInit
+): Promise<AlertApi> => {
+    return apiMutator<AlertApi>(getAlertsToggleCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(alertToggleApi),
     })
 }
 

--- a/products/alerts/mcp/tools.yaml
+++ b/products/alerts/mcp/tools.yaml
@@ -119,6 +119,50 @@ tools:
             lof, ocsvm, pca, or ensemble). Optionally specify date_from (e.g. '-48h', '-30d') to control how far back to
             simulate, and series_index to pick which series to analyze. Returns data values, anomaly scores per point,
             triggered indices and dates, and for ensemble detectors, per-sub-detector score breakdowns.
+    alert-checks-list:
+        operation: alerts_checks_retrieve
+        enabled: true
+        scopes:
+            - alert:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List alert checks
+        description: >
+            List historical checks for a specific alert without returning the full alert record. Each check includes
+            calculated_value, state (Firing, Not firing, Errored, Snoozed), triggered_points, triggered_dates, and
+            anomaly_scores for detector-based alerts. Use date_from and date_to (e.g. '-24h', '-7d') to scope the
+            window; retention is 14 days. Filter by state to surface only firing or errored checks. Prefer this over
+            alert-get when you only need check history.
+    alert-snooze:
+        operation: alerts_snooze_create
+        enabled: true
+        scopes:
+            - alert:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Snooze alert
+        description: >
+            Pause an alert for a relative duration (e.g. '2h', '1d', '1w'). The alert resumes evaluation automatically
+            when the duration elapses and a snoozed AlertCheck record is written. To unsnooze early, use alert-update
+            with snoozed_until set to null.
+    alert-toggle:
+        operation: alerts_toggle_create
+        enabled: true
+        scopes:
+            - alert:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Enable or disable alert
+        description: >
+            Turn an alert's evaluation on or off. Re-enabling schedules a fresh check. Prefer this over alert-update
+            when the only change is the enabled flag so the intent reads clearly in activity logs.
     logs-alerts-list:
         operation: logs_alerts_list
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -164,6 +164,51 @@
             "readOnlyHint": true
         }
     },
+    "alert-checks-list": {
+        "description": "List historical checks for a specific alert without returning the full alert record. Each check includes calculated_value, state (Firing, Not firing, Errored, Snoozed), triggered_points, triggered_dates, and anomaly_scores for detector-based alerts. Use date_from and date_to (e.g. '-24h', '-7d') to scope the window; retention is 14 days. Filter by state to surface only firing or errored checks. Prefer this over alert-get when you only need check history.",
+        "category": "Alerts",
+        "feature": "alerts",
+        "summary": "List alert checks",
+        "title": "List alert checks",
+        "required_scopes": ["alert:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "alert-snooze": {
+        "description": "Pause an alert for a relative duration (e.g. '2h', '1d', '1w'). The alert resumes evaluation automatically when the duration elapses and a snoozed AlertCheck record is written. To unsnooze early, use alert-update with snoozed_until set to null.",
+        "category": "Alerts",
+        "feature": "alerts",
+        "summary": "Snooze alert",
+        "title": "Snooze alert",
+        "required_scopes": ["alert:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "alert-toggle": {
+        "description": "Turn an alert's evaluation on or off. Re-enabling schedules a fresh check. Prefer this over alert-update when the only change is the enabled flag so the intent reads clearly in activity logs.",
+        "category": "Alerts",
+        "feature": "alerts",
+        "summary": "Enable or disable alert",
+        "title": "Enable or disable alert",
+        "required_scopes": ["alert:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "annotations-list": {
         "description": "List annotations in the current project, newest first. Use this to review existing deployment markers and analysis notes before adding new annotations.",
         "category": "Annotations",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -643,6 +643,51 @@
             "readOnlyHint": true
         }
     },
+    "alert-checks-list": {
+        "description": "List historical checks for a specific alert without returning the full alert record. Each check includes calculated_value, state (Firing, Not firing, Errored, Snoozed), triggered_points, triggered_dates, and anomaly_scores for detector-based alerts. Use date_from and date_to (e.g. '-24h', '-7d') to scope the window; retention is 14 days. Filter by state to surface only firing or errored checks. Prefer this over alert-get when you only need check history.",
+        "category": "Alerts",
+        "feature": "alerts",
+        "summary": "List alert checks",
+        "title": "List alert checks",
+        "required_scopes": ["alert:read"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "alert-snooze": {
+        "description": "Pause an alert for a relative duration (e.g. '2h', '1d', '1w'). The alert resumes evaluation automatically when the duration elapses and a snoozed AlertCheck record is written. To unsnooze early, use alert-update with snoozed_until set to null.",
+        "category": "Alerts",
+        "feature": "alerts",
+        "summary": "Snooze alert",
+        "title": "Snooze alert",
+        "required_scopes": ["alert:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "alert-toggle": {
+        "description": "Turn an alert's evaluation on or off. Re-enabling schedules a fresh check. Prefer this over alert-update when the only change is the enabled flag so the intent reads clearly in activity logs.",
+        "category": "Alerts",
+        "feature": "alerts",
+        "summary": "Enable or disable alert",
+        "title": "Enable or disable alert",
+        "required_scopes": ["alert:write"],
+        "new_mcp": true,
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "annotations-list": {
         "description": "List annotations in the current project, newest first. Use this to review existing deployment markers and analysis notes before adding new annotations.",
         "category": "Annotations",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -5491,6 +5491,12 @@ export namespace Schemas {
       readonly last_value: number | null;
     }
 
+    export interface AlertCheckListResponse {
+      /** Total checks matching the filters. */
+      count: number;
+      results: AlertCheck[];
+    }
+
     export interface AlertSimulate {
       /** Insight ID to simulate the detector on. */
       insight: number;
@@ -5554,6 +5560,16 @@ export namespace Schemas {
       sub_detector_scores?: AlertSimulateResponseSubDetectorScoresItem[];
       /** Per-breakdown-value simulation results. Present only when the insight has breakdowns (up to 25 values). */
       breakdown_results?: BreakdownSimulationResult[];
+    }
+
+    export interface AlertSnooze {
+      /** Relative duration to snooze for (e.g. '2h', '1d', '1w'). Alert resumes when the duration elapses. */
+      duration: string;
+    }
+
+    export interface AlertToggle {
+      /** Enable or disable the alert. */
+      enabled: boolean;
     }
 
     /**
@@ -33298,6 +33314,29 @@ export namespace Schemas {
     checks_offset?: number;
     };
 
+    export type EnvironmentsAlertsChecksRetrieveParams = {
+    /**
+     * Relative date string for the start of the check history window (e.g. '-24h', '-7d'). Max retention is 14 days.
+     */
+    date_from?: string;
+    /**
+     * Relative date string for the end of the check history window (e.g. '-1h'). Defaults to now if not specified.
+     */
+    date_to?: string;
+    /**
+     * Maximum number of check results to return (default 50, max 500).
+     */
+    limit?: number;
+    /**
+     * Number of newest checks to skip (0-based). Default 0.
+     */
+    offset?: number;
+    /**
+     * Filter by check state: Firing, Not firing, Errored, or Snoozed.
+     */
+    state?: string;
+    };
+
     export type EnvironmentsBatchExportsListParams = {
     /**
      * Number of results to return per page.
@@ -36932,6 +36971,29 @@ export namespace Schemas {
      * Number of newest checks to skip (0-based). Use with checks_limit for pagination. Default 0.
      */
     checks_offset?: number;
+    };
+
+    export type AlertsChecksRetrieveParams = {
+    /**
+     * Relative date string for the start of the check history window (e.g. '-24h', '-7d'). Max retention is 14 days.
+     */
+    date_from?: string;
+    /**
+     * Relative date string for the end of the check history window (e.g. '-1h'). Defaults to now if not specified.
+     */
+    date_to?: string;
+    /**
+     * Maximum number of check results to return (default 50, max 500).
+     */
+    limit?: number;
+    /**
+     * Number of newest checks to skip (0-based). Default 0.
+     */
+    offset?: number;
+    /**
+     * Filter by check state: Firing, Not firing, Errored, or Snoozed.
+     */
+    state?: string;
     };
 
     export type AnnotationsListParams = {

--- a/services/mcp/src/generated/alerts/api.ts
+++ b/services/mcp/src/generated/alerts/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 6 enabled ops
+ * PostHog API - MCP 9 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -1958,6 +1958,70 @@ export const AlertsDestroyParams = /* @__PURE__ */ zod.object({
         .describe(
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
         ),
+})
+
+/**
+ * List historical checks for an alert without returning the full alert record.
+ */
+export const AlertsChecksRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this alert configuration.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const AlertsChecksRetrieveQueryParams = /* @__PURE__ */ zod.object({
+    date_from: zod
+        .string()
+        .optional()
+        .describe(
+            "Relative date string for the start of the check history window (e.g. '-24h', '-7d'). Max retention is 14 days."
+        ),
+    date_to: zod
+        .string()
+        .optional()
+        .describe(
+            "Relative date string for the end of the check history window (e.g. '-1h'). Defaults to now if not specified."
+        ),
+    limit: zod.number().optional().describe('Maximum number of check results to return (default 50, max 500).'),
+    offset: zod.number().optional().describe('Number of newest checks to skip (0-based). Default 0.'),
+    state: zod.string().optional().describe('Filter by check state: Firing, Not firing, Errored, or Snoozed.'),
+})
+
+/**
+ * Snooze an alert for a relative duration. Creates a snoozed AlertCheck record.
+ */
+export const AlertsSnoozeCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this alert configuration.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const AlertsSnoozeCreateBody = /* @__PURE__ */ zod.object({
+    duration: zod
+        .string()
+        .describe("Relative duration to snooze for (e.g. '2h', '1d', '1w'). Alert resumes when the duration elapses."),
+})
+
+/**
+ * Enable or disable an alert. Re-enabling schedules a fresh check.
+ */
+export const AlertsToggleCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this alert configuration.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const AlertsToggleCreateBody = /* @__PURE__ */ zod.object({
+    enabled: zod.boolean().describe('Enable or disable the alert.'),
 })
 
 /**

--- a/services/mcp/src/tools/generated/alerts.ts
+++ b/services/mcp/src/tools/generated/alerts.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 
 import type { Schemas } from '@/api/generated'
 import {
+    AlertsChecksRetrieveParams,
+    AlertsChecksRetrieveQueryParams,
     AlertsCreateBody,
     AlertsDestroyParams,
     AlertsListQueryParams,
@@ -11,6 +13,10 @@ import {
     AlertsRetrieveParams,
     AlertsRetrieveQueryParams,
     AlertsSimulateCreateBody,
+    AlertsSnoozeCreateBody,
+    AlertsSnoozeCreateParams,
+    AlertsToggleCreateBody,
+    AlertsToggleCreateParams,
 } from '@/generated/alerts/api'
 import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
@@ -205,6 +211,70 @@ const alertSimulate = (): ToolBase<typeof AlertSimulateSchema, Schemas.AlertSimu
     },
 })
 
+const AlertChecksListSchema = AlertsChecksRetrieveParams.omit({ project_id: true }).extend(
+    AlertsChecksRetrieveQueryParams.shape
+)
+
+const alertChecksList = (): ToolBase<typeof AlertChecksListSchema, WithPostHogUrl<Schemas.AlertCheckListResponse>> => ({
+    name: 'alert-checks-list',
+    schema: AlertChecksListSchema,
+    handler: async (context: Context, params: z.infer<typeof AlertChecksListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.AlertCheckListResponse>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/alerts/${encodeURIComponent(String(params.id))}/checks/`,
+            query: {
+                date_from: params.date_from,
+                date_to: params.date_to,
+                limit: params.limit,
+                offset: params.offset,
+                state: params.state,
+            },
+        })
+        return await withPostHogUrl(context, result, '/insights?tab=alerts')
+    },
+})
+
+const AlertSnoozeSchema = AlertsSnoozeCreateParams.omit({ project_id: true }).extend(AlertsSnoozeCreateBody.shape)
+
+const alertSnooze = (): ToolBase<typeof AlertSnoozeSchema, Schemas.Alert> => ({
+    name: 'alert-snooze',
+    schema: AlertSnoozeSchema,
+    handler: async (context: Context, params: z.infer<typeof AlertSnoozeSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.duration !== undefined) {
+            body['duration'] = params.duration
+        }
+        const result = await context.api.request<Schemas.Alert>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/alerts/${encodeURIComponent(String(params.id))}/snooze/`,
+            body,
+        })
+        return result
+    },
+})
+
+const AlertToggleSchema = AlertsToggleCreateParams.omit({ project_id: true }).extend(AlertsToggleCreateBody.shape)
+
+const alertToggle = (): ToolBase<typeof AlertToggleSchema, Schemas.Alert> => ({
+    name: 'alert-toggle',
+    schema: AlertToggleSchema,
+    handler: async (context: Context, params: z.infer<typeof AlertToggleSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.enabled !== undefined) {
+            body['enabled'] = params.enabled
+        }
+        const result = await context.api.request<Schemas.Alert>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/alerts/${encodeURIComponent(String(params.id))}/toggle/`,
+            body,
+        })
+        return result
+    },
+})
+
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'alerts-list': alertsList,
     'alert-get': alertGet,
@@ -212,4 +282,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'alert-update': alertUpdate,
     'alert-delete': alertDelete,
     'alert-simulate': alertSimulate,
+    'alert-checks-list': alertChecksList,
+    'alert-snooze': alertSnooze,
+    'alert-toggle': alertToggle,
 }


### PR DESCRIPTION
## Problem

Alerts already expose 6 MCP tools, but three lifecycle operations are either awkward or missing:

- Querying `AlertCheck` history requires fetching the full alert record (config + insight + subscriptions) just to read the `checks` field on `alert-get`.
- Snoozing is only reachable via `alert-update` with `snoozed_until: "2h"`, which isn't obvious from the tool schema.
- Enabling/disabling goes through the generic `alert-update` path, so activity logs read as generic edits rather than lifecycle events.

## Changes

Three new MCP tools, each backed by a new `@action` on `AlertViewSet`:

- `alert-checks-list` — `GET /alerts/{id}/checks/` with `date_from`, `date_to`, `limit`, `offset`, `state` query params. Returns `{count, results}` with the same `AlertCheckSerializer` shape as the nested field.
- `alert-snooze` — `POST /alerts/{id}/snooze/` taking a relative `duration`. Sets state to Snoozed and writes an `AlertCheck` record, mirroring the existing snooze-via-update flow.
- `alert-toggle` — `POST /alerts/{id}/toggle/` taking `enabled`. Re-enabling calls `mark_for_recheck(reset_state=False)` so a fresh check is scheduled.

All three go through `instance.save()` so `ModelActivityMixin` emits activity signals automatically. No schema changes to `AlertConfiguration`.

Operation IDs (`alerts_checks_retrieve`, `alerts_snooze_create`, `alerts_toggle_create`) in `products/alerts/mcp/tools.yaml` follow the drf-spectacular pattern and were picked to match what `hogli build:openapi` will generate — if CI's scaffold sync flags drift, they'll need a one-line tweak.

## How did you test this code?

- Added unit tests in `posthog/api/test/test_alert.py` covering happy paths, date/state filters, team scoping, invalid-duration validation, and toggle idempotency.
- Agent-authored — no manual testing beyond what lands in the test suite. Generated MCP handler (`services/mcp/src/tools/generated/alerts.ts`) is regenerated by CI; not hand-edited here.

## Publish to changelog?

no

## Docs update

<!-- Add the skip-inkeep-docs label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 LLM context

Authored by PostHog Code as Task-Id `f61d7f0b-4023-4d56-9026-b77fafe3309b`. Scope intentionally narrow: no UI apps, no touching of the disabled `logs-alerts-*` family, no `Threshold` or `AlertSubscription` viewsets.