### PR TITLE
fix(llma): allow personal API keys on evaluation report runs/generate

### DIFF
--- a/products/llm_analytics/backend/api/evaluation_reports.py
+++ b/products/llm_analytics/backend/api/evaluation_reports.py
@@ -332,7 +332,7 @@ class EvaluationReportViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewse
             )
 
     @extend_schema(responses=EvaluationReportRunSerializer(many=True))
-    @action(detail=True, methods=["get"], url_path="runs")
+    @action(detail=True, methods=["get"], url_path="runs", required_scopes=["llm_analytics:read"])
     @llma_track_latency("llma_evaluation_report_runs_list")
     def runs(self, request: Request, **kwargs) -> Response:
         """List report runs (history) for this report."""
@@ -346,7 +346,7 @@ class EvaluationReportViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewse
         return Response(serializer.data)
 
     @extend_schema(request=None, responses={202: None})
-    @action(detail=True, methods=["post"], url_path="generate")
+    @action(detail=True, methods=["post"], url_path="generate", required_scopes=["llm_analytics:write"])
     @llma_track_latency("llma_evaluation_report_generate")
     def generate(self, request: Request, **kwargs) -> Response:
         """Trigger immediate report generation."""

--- a/products/llm_analytics/backend/api/test/test_evaluation_reports.py
+++ b/products/llm_analytics/backend/api/test/test_evaluation_reports.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from django.utils import timezone
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models.integration import Integration
@@ -288,24 +289,47 @@ class TestEvaluationReportApi(APIBaseTest):
         self.assertEqual(body["count"], 1)
         self.assertEqual(len(body["results"]), 1)
 
-    def test_runs_action_allows_personal_api_key_with_read_scope(self):
-        # The /runs/ custom @action has to declare required_scopes explicitly; without
-        # it the default scope resolver returns None for non-CRUD action names and PAK
-        # requests are rejected with "This action does not support Personal API Key access".
+    # The /runs/ and /generate/ custom @actions have to declare required_scopes explicitly;
+    # without them the default scope resolver returns None for non-CRUD action names and PAK
+    # requests are rejected with "This action does not support Personal API Key access".
+    @parameterized.expand(
+        [
+            ("read_scope_allowed", ["llm_analytics:read"], status.HTTP_200_OK),
+            ("wrong_scope_denied", ["insight:read"], status.HTTP_403_FORBIDDEN),
+        ]
+    )
+    def test_runs_action_pak_scope(self, _name: str, scopes: list[str], expected_status: int) -> None:
         report = self._create_report()
-        api_key = self.create_personal_api_key_with_scopes(["llm_analytics:read"])
+        api_key = self.create_personal_api_key_with_scopes(scopes)
         self.client.logout()
         self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {api_key}")
         response = self.client.get(f"{self.base_url}{report.id}/runs/")
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        self.assertEqual(response.status_code, expected_status)
 
-    def test_runs_action_denies_personal_api_key_missing_scope(self):
+    @parameterized.expand(
+        [
+            ("write_scope_allowed", ["llm_analytics:write"], status.HTTP_202_ACCEPTED),
+            ("wrong_scope_denied", ["llm_analytics:read"], status.HTTP_403_FORBIDDEN),
+        ]
+    )
+    @patch("products.llm_analytics.backend.api.evaluation_reports.async_to_sync")
+    @patch("posthog.temporal.common.client.sync_connect")
+    def test_generate_action_pak_scope(
+        self,
+        _name: str,
+        scopes: list[str],
+        expected_status: int,
+        mock_sync_connect: MagicMock,
+        mock_async_to_sync: MagicMock,
+    ) -> None:
+        mock_sync_connect.return_value = MagicMock()
+        mock_async_to_sync.return_value = MagicMock()
         report = self._create_report()
-        api_key = self.create_personal_api_key_with_scopes(["insight:read"])
+        api_key = self.create_personal_api_key_with_scopes(scopes)
         self.client.logout()
         self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {api_key}")
-        response = self.client.get(f"{self.base_url}{report.id}/runs/")
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        response = self.client.post(f"{self.base_url}{report.id}/generate/")
+        self.assertEqual(response.status_code, expected_status)
 
     @patch("products.llm_analytics.backend.api.evaluation_reports.report_user_action")
     def test_create_reports_user_action(self, mock_report: MagicMock) -> None:

--- a/products/llm_analytics/backend/api/test/test_evaluation_reports.py
+++ b/products/llm_analytics/backend/api/test/test_evaluation_reports.py
@@ -288,6 +288,25 @@ class TestEvaluationReportApi(APIBaseTest):
         self.assertEqual(body["count"], 1)
         self.assertEqual(len(body["results"]), 1)
 
+    def test_runs_action_allows_personal_api_key_with_read_scope(self):
+        # The /runs/ custom @action has to declare required_scopes explicitly; without
+        # it the default scope resolver returns None for non-CRUD action names and PAK
+        # requests are rejected with "This action does not support Personal API Key access".
+        report = self._create_report()
+        api_key = self.create_personal_api_key_with_scopes(["llm_analytics:read"])
+        self.client.logout()
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {api_key}")
+        response = self.client.get(f"{self.base_url}{report.id}/runs/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+
+    def test_runs_action_denies_personal_api_key_missing_scope(self):
+        report = self._create_report()
+        api_key = self.create_personal_api_key_with_scopes(["insight:read"])
+        self.client.logout()
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {api_key}")
+        response = self.client.get(f"{self.base_url}{report.id}/runs/")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
     @patch("products.llm_analytics.backend.api.evaluation_reports.report_user_action")
     def test_create_reports_user_action(self, mock_report: MagicMock) -> None:
         response = self.client.post(self.base_url, self._scheduled_payload(), format="json")


### PR DESCRIPTION
## Problem

The nested `runs` and `generate` endpoints on `EvaluationReportViewSet` rejected personal API key requests with `This action does not support Personal API Key access`. Hit while dogfooding evaluation reports through the PostHog MCP — `evaluation-report-get` worked, but `evaluation-report-runs-list` returned 403.

Root cause: DRF's default scope resolver in `APIScopePermission` only maps standard CRUD action names (`list`, `retrieve`, `create`, etc.) onto `<scope_object>:<read|write>`. Custom `@action` names like `runs` and `generate` fall through; `_get_required_scopes` returns `None`, which the permission class treats as an explicit PAK deny.

## Changes

- `products/llm_analytics/backend/api/evaluation_reports.py` — declare `required_scopes=["llm_analytics:read"]` on the `runs` `@action` and `required_scopes=["llm_analytics:write"]` on the `generate` `@action`.
- `products/llm_analytics/backend/api/test/test_evaluation_reports.py` — add two regression tests covering the PAK path: a read-scoped key hitting `/runs/` (expects 200) and a wrong-scope key (`insight:read`) on the same endpoint (expects 403).

## How did you test this code?

Automated tests only — I'm an agent, no manual testing beyond running the tests.

- `hogli test products/llm_analytics/backend/api/test/test_evaluation_reports.py::TestEvaluationReportApi::test_runs_action_allows_personal_api_key_with_read_scope` — pass
- `hogli test products/llm_analytics/backend/api/test/test_evaluation_reports.py::TestEvaluationReportApi::test_runs_action_denies_personal_api_key_missing_scope` — pass
- The existing `test_runs_action_returns_paginated_shape` still passes (session auth path unaffected).

## Publish to changelog?

no

## Docs update

No docs change.

## 🤖 LLM context

Authored by Claude Code (Opus 4.7). Found while using the PostHog MCP to inspect evaluation reports — the MCP tool hit the same 403 an external PAK user would. Fix adds the scope declarations DRF needs and tests lock in the behavior so the next custom action on this viewset doesn't silently regress.