### PR TITLE
fix(scopes): sort API key scopes alphabetically by label

### DIFF
--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -126,6 +126,7 @@ export const API_SCOPES: APIScope[] = [
     { key: 'warehouse_view', objectName: 'Warehouse view', objectPlural: 'warehouse views' },
     { key: 'warehouse_table', objectName: 'Warehouse table', objectPlural: 'warehouse tables' },
 ]
+API_SCOPES.sort((a, b) => a.objectName.localeCompare(b.objectName))
 
 export const PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION = ['endpoint:read']
 


### PR DESCRIPTION
## Problem

"Shared metric" and several other entries appear out of alphabetical order in the Personal API Keys scope picker (Settings → User → Personal API keys) and the CLI authorize flow.

The `API_SCOPES` array in `frontend/src/lib/scopes.tsx` is rendered in source order, but new entries have been inserted by scope key rather than display label. So "Shared metric" (key `experiment_saved_metric`) lands next to "Experiment", and "Workflow" (key `hog_flow`) lands next to "Heatmap". In total, 8 entries are misplaced: `access_control`, `error_tracking` vs `event_definition`, `experiment_saved_metric`, `export` vs `external_data_source`, `hog_flow`, `customer_profile_config`, `task` vs `ticket`, and `warehouse_view` / `warehouse_table` vs `webhook`.

Reported by a user.

## Changes

Sort `API_SCOPES` once at module load by `objectName` using `localeCompare`. One line added.

This fixes all 8 current misplacements and prevents future regressions, regardless of where new scopes get inserted in the source array. The sort also applies to the CLI authorize flow (`frontend/src/scenes/authentication/CLIAuthorize.tsx`), which reads `API_SCOPES` directly.

Note: the sort is done as an in-place mutation after the `APIScope[]` literal, rather than chained. Sorting inside the literal triggers TypeScript's array literal type widening, which breaks the `APIScope[]` annotation (the `key` field widens from the narrow `APIScopeObject` union to `string`).

Before:
<img width="1072" height="478" alt="image" src="https://github.com/user-attachments/assets/27f2ea1e-3888-4d09-abca-c55e2b72b9aa" />

After:
<img width="1382" height="494" alt="CleanShot 2026-04-21 at 14 53 52@2x" src="https://github.com/user-attachments/assets/f8d757e5-877e-47c5-84e3-3870ff474bf1" />


## How did you test this code?

- TypeScript check passes on `scopes.tsx` (existing unrelated errors remain in `products/workflows/`)
- Frontend formatter (oxfmt + oxlint) passes
- Simulated the sort in Node and confirmed the output matches the expected alphabetical order: Access control, Action, Activity log, ..., Error tracking, Event definition, Experiment, Export, External data source, ..., Shared metric, ..., Task, Ticket, ..., Warehouse table, Warehouse view, Webhook, Workflow

Still need to finish testing in-browser

## Publish to changelog?

no

## 🤖 LLM context

Co-written with PostHog Code (Claude Opus 4.7)
---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
