### PR TITLE
fix(ws): raise max.poll.interval.ms for v3 kafka consumer

### DIFF
--- a/posthog/management/commands/run_warehouse_sources_load.py
+++ b/posthog/management/commands/run_warehouse_sources_load.py
@@ -60,6 +60,16 @@ class Command(BaseCommand):
             default=KAFKA_WAREHOUSE_SOURCES_JOBS_DLQ,
             help="Kafka topic for dead-letter queue messages",
         )
+        parser.add_argument(
+            "--max-poll-interval-ms",
+            type=int,
+            default=900_000,
+            help=(
+                "Maximum time between consume() calls before librdkafka evicts this consumer "
+                "from the group (default: 900000 = 15 min). Post-load processing on final "
+                "batches can exceed the librdkafka default of 5 min."
+            ),
+        )
 
     def handle(self, *args, **options):
         health_port = options["health_port"]
@@ -69,6 +79,7 @@ class Command(BaseCommand):
         consumer_group = options["consumer_group"]
         health_timeout = options["health_timeout"]
         dlq_topic = options["dlq_topic"]
+        max_poll_interval_ms = options["max_poll_interval_ms"]
 
         logger.info(
             "warehouse_sources_load_starting",
@@ -79,6 +90,7 @@ class Command(BaseCommand):
             consumer_group=consumer_group,
             health_timeout=health_timeout,
             dlq_topic=dlq_topic,
+            max_poll_interval_ms=max_poll_interval_ms,
         )
 
         health_state = HealthState(timeout_seconds=health_timeout)
@@ -93,6 +105,7 @@ class Command(BaseCommand):
             batch_timeout_seconds=batch_timeout,
             health_port=health_port,
             health_timeout_seconds=health_timeout,
+            max_poll_interval_ms=max_poll_interval_ms,
         )
 
         consumer = KafkaConsumerService(

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py
@@ -103,6 +103,7 @@ class KafkaConsumerService:
             "enable.auto.commit": False,
             "security.protocol": self._kafka_security_protocol or _KafkaSecurityProtocol.PLAINTEXT,
             "partition.assignment.strategy": "cooperative-sticky",
+            "max.poll.interval.ms": self._config.max_poll_interval_ms,
         }
         consumer = ConfluentConsumer(config)
         consumer.subscribe(

--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/load/config.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/load/config.py
@@ -14,3 +14,4 @@ class ConsumerConfig:
     health_timeout_seconds: float = 60.0
     max_retries: int = 3
     retry_backoff_seconds: float = 1.0
+    max_poll_interval_ms: int = 900_000


### PR DESCRIPTION
## Problem

The `warehouse-sources-load` V3 Kafka consumer is being evicted from its consumer group with `KafkaError{_MAX_POLL_EXCEEDED}` errors. librdkafka's `max.poll.interval.ms` defaults to 300s, but a single message can legitimately take longer when it hits the finalize path

## Changes

  - `posthog/temporal/data_imports/pipelines/pipeline_v3/load/config.py` — added `max_poll_interval_ms: int = 900_000` to `ConsumerConfig`.
  - `posthog/temporal/data_imports/pipelines/pipeline_v3/kafka/consumer.py` — set `"max.poll.interval.ms": self._config.max_poll_interval_ms` on the confluent-kafka consumer config in `_create_consumer`.
  - `posthog/management/commands/run_warehouse_sources_load.py` — added a `--max-poll-interval-ms` CLI flag (default `900_000`), threaded it into `ConsumerConfig`, and logged the effective value on `warehouse_sources_load_starting`.

## How did you test this code?

Test pass

## Publish to changelog?

NO
