### PR TITLE
feat(web-analytics): port bot detection to real-time web analytics tab

### DIFF
--- a/frontend/src/lib/utils/botDetection.test.ts
+++ b/frontend/src/lib/utils/botDetection.test.ts
@@ -1,0 +1,75 @@
+import { detectBot, getBotName, isBot } from './botDetection'
+
+describe('botDetection', () => {
+    describe('detectBot', () => {
+        it.each([
+            [
+                'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; GPTBot/1.2; +https://openai.com/gptbot)',
+                'GPTBot',
+                'ai_crawler',
+            ],
+            ['ChatGPT-User/1.0; +https://openai.com/bot', 'ChatGPT', 'ai_assistant'],
+            ['Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)', 'Claude', 'ai_crawler'],
+            [
+                'Mozilla/5.0 (compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot)',
+                'Perplexity',
+                'ai_search',
+            ],
+            ['Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)', 'Googlebot', 'search_crawler'],
+            ['curl/8.5.0', 'curl', 'http_client'],
+            ['Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)', 'Bingbot', 'search_crawler'],
+            ['HeadlessChrome/120.0.6099.216', 'Headless Chrome', 'headless_browser'],
+        ])('detects bot from user agent: %s', (userAgent, expectedName, expectedCategory) => {
+            const bot = detectBot(userAgent)
+            expect(bot).not.toBeNull()
+            expect(bot?.name).toBe(expectedName)
+            expect(bot?.category).toBe(expectedCategory)
+        })
+
+        it('prefers Applebot-Extended over Applebot/ when the more specific pattern matches first', () => {
+            const bot = detectBot('Mozilla/5.0 (compatible; Applebot-Extended/1.0)')
+            expect(bot?.name).toBe('Apple AI')
+        })
+
+        it('classifies regular Applebot to the search crawler entry', () => {
+            const bot = detectBot('Mozilla/5.0 Applebot/0.1')
+            expect(bot?.name).toBe('Applebot')
+        })
+
+        it('returns null for regular browser user agents', () => {
+            expect(
+                detectBot(
+                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+                )
+            ).toBeNull()
+        })
+
+        it('treats empty or missing user agent as "No user agent"', () => {
+            expect(detectBot('')?.category).toBe('no_user_agent')
+            expect(detectBot(null)?.category).toBe('no_user_agent')
+            expect(detectBot(undefined)?.category).toBe('no_user_agent')
+        })
+    })
+
+    describe('getBotName', () => {
+        it('returns the bot name for a known bot', () => {
+            expect(getBotName('Googlebot/2.1')).toBe('Googlebot')
+        })
+        it('returns "" for regular traffic', () => {
+            expect(getBotName('Mozilla/5.0 Chrome/120.0.0.0')).toBe('')
+        })
+    })
+
+    describe('isBot', () => {
+        it('returns true for a known bot', () => {
+            expect(isBot('GPTBot/1.0')).toBe(true)
+        })
+        it('returns true for empty user agent (treated as automation)', () => {
+            expect(isBot('')).toBe(true)
+            expect(isBot(null)).toBe(true)
+        })
+        it('returns false for a regular browser', () => {
+            expect(isBot('Mozilla/5.0 Chrome/120.0.0.0 Safari/537.36')).toBe(false)
+        })
+    })
+})

--- a/frontend/src/lib/utils/botDetection.ts
+++ b/frontend/src/lib/utils/botDetection.ts
@@ -1,0 +1,388 @@
+/**
+ * Client-side bot detection — mirrors `posthog.hogql_queries.web_analytics.bot_definitions`
+ * and the `__preview_getBotName` / `__preview_isBot` / `__preview_getTrafficCategory`
+ * HogQL functions. Used by real-time dashboards where events arrive via the
+ * livestream SSE feed and therefore cannot be classified server-side.
+ *
+ * Keep this file in sync with `posthog/hogql_queries/web_analytics/bot_definitions.py`.
+ */
+
+export type BotTrafficType = 'AI Agent' | 'Bot' | 'Automation' | 'Regular'
+
+export type BotCategory =
+    | 'ai_crawler'
+    | 'ai_search'
+    | 'ai_assistant'
+    | 'search_crawler'
+    | 'seo_crawler'
+    | 'social_crawler'
+    | 'monitoring'
+    | 'http_client'
+    | 'headless_browser'
+    | 'no_user_agent'
+    | 'regular'
+
+export interface BotDefinition {
+    name: string
+    category: BotCategory
+    trafficType: BotTrafficType
+    operator: string
+}
+
+// Ordered by specificity — more specific patterns (e.g. `Applebot-Extended`)
+// must precede less specific patterns (`Applebot/`).
+export const BOT_DEFINITIONS: { pattern: string; definition: BotDefinition }[] = [
+    // AI Crawlers (training data collection)
+    {
+        pattern: 'GPTBot',
+        definition: { name: 'GPTBot', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'OpenAI' },
+    },
+    {
+        pattern: 'Google-CloudVertexBot',
+        definition: {
+            name: 'Google Cloud Vertex',
+            category: 'ai_crawler',
+            trafficType: 'AI Agent',
+            operator: 'Google',
+        },
+    },
+    {
+        pattern: 'Google-Extended',
+        definition: { name: 'Google AI', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'Google' },
+    },
+    {
+        pattern: 'GoogleOther',
+        definition: { name: 'GoogleOther', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'Google' },
+    },
+    {
+        pattern: 'Claude-SearchBot',
+        definition: { name: 'Claude Search', category: 'ai_search', trafficType: 'AI Agent', operator: 'Anthropic' },
+    },
+    {
+        pattern: 'Claude-User',
+        definition: { name: 'Claude User', category: 'ai_assistant', trafficType: 'AI Agent', operator: 'Anthropic' },
+    },
+    {
+        pattern: 'ClaudeBot',
+        definition: { name: 'Claude', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'Anthropic' },
+    },
+    {
+        pattern: 'Claude-Web',
+        definition: { name: 'Claude Web', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'Anthropic' },
+    },
+    {
+        pattern: 'anthropic-ai',
+        definition: { name: 'Anthropic', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'Anthropic' },
+    },
+    {
+        pattern: 'Perplexity-User',
+        definition: {
+            name: 'Perplexity User',
+            category: 'ai_assistant',
+            trafficType: 'AI Agent',
+            operator: 'Perplexity',
+        },
+    },
+    {
+        pattern: 'PerplexityBot',
+        definition: { name: 'Perplexity', category: 'ai_search', trafficType: 'AI Agent', operator: 'Perplexity' },
+    },
+    {
+        pattern: 'CCBot',
+        definition: { name: 'Common Crawl', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'Common Crawl' },
+    },
+    {
+        pattern: 'meta-externalagent',
+        definition: { name: 'Meta AI', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'Meta' },
+    },
+    {
+        pattern: 'Bytespider',
+        definition: { name: 'ByteDance', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'ByteDance' },
+    },
+    {
+        pattern: 'TikTokSpider',
+        definition: { name: 'TikTok AI', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'ByteDance' },
+    },
+    {
+        pattern: 'cohere-ai',
+        definition: { name: 'Cohere', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'Cohere' },
+    },
+    {
+        pattern: 'Diffbot',
+        definition: { name: 'Diffbot', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'Diffbot' },
+    },
+    {
+        pattern: 'omgili',
+        definition: { name: 'Webz.io', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'Webz.io' },
+    },
+    {
+        pattern: 'Webzio-Extended',
+        definition: { name: 'Webz.io Extended', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'Webz.io' },
+    },
+    {
+        pattern: 'Timpibot',
+        definition: { name: 'Timpi', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'Timpi' },
+    },
+    {
+        pattern: 'Amazonbot',
+        definition: { name: 'Amazon', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'Amazon' },
+    },
+    {
+        pattern: 'PetalBot',
+        definition: { name: 'Petal', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'Huawei' },
+    },
+    {
+        pattern: 'Brightbot',
+        definition: { name: 'Brightbot', category: 'ai_crawler', trafficType: 'AI Agent', operator: 'Bright Data' },
+    },
+    // AI Search (search result generation)
+    {
+        pattern: 'OAI-SearchBot',
+        definition: { name: 'OpenAI Search', category: 'ai_search', trafficType: 'AI Agent', operator: 'OpenAI' },
+    },
+    {
+        pattern: 'Applebot-Extended',
+        definition: { name: 'Apple AI', category: 'ai_search', trafficType: 'AI Agent', operator: 'Apple' },
+    },
+    // AI Assistants (real-time user-facing fetching)
+    {
+        pattern: 'ChatGPT-User',
+        definition: { name: 'ChatGPT', category: 'ai_assistant', trafficType: 'AI Agent', operator: 'OpenAI' },
+    },
+    {
+        pattern: 'Meta-ExternalFetcher',
+        definition: { name: 'Meta Fetcher', category: 'ai_assistant', trafficType: 'AI Agent', operator: 'Meta' },
+    },
+    {
+        pattern: 'DuckAssistBot',
+        definition: {
+            name: 'DuckDuckGo AI',
+            category: 'ai_assistant',
+            trafficType: 'AI Agent',
+            operator: 'DuckDuckGo',
+        },
+    },
+    {
+        pattern: 'MistralAI-User',
+        definition: { name: 'Mistral AI', category: 'ai_assistant', trafficType: 'AI Agent', operator: 'Mistral' },
+    },
+    // Search Crawlers (Applebot/ avoids matching Applebot-Extended)
+    {
+        pattern: 'Applebot/',
+        definition: { name: 'Applebot', category: 'ai_search', trafficType: 'AI Agent', operator: 'Apple' },
+    },
+    {
+        pattern: 'Googlebot',
+        definition: { name: 'Googlebot', category: 'search_crawler', trafficType: 'Bot', operator: 'Google' },
+    },
+    {
+        pattern: 'bingbot',
+        definition: { name: 'Bingbot', category: 'search_crawler', trafficType: 'Bot', operator: 'Microsoft' },
+    },
+    {
+        pattern: 'Bingbot',
+        definition: { name: 'Bingbot', category: 'search_crawler', trafficType: 'Bot', operator: 'Microsoft' },
+    },
+    {
+        pattern: 'YandexBot',
+        definition: { name: 'Yandex', category: 'search_crawler', trafficType: 'Bot', operator: 'Yandex' },
+    },
+    {
+        pattern: 'Baiduspider',
+        definition: { name: 'Baidu', category: 'search_crawler', trafficType: 'Bot', operator: 'Baidu' },
+    },
+    {
+        pattern: 'DuckDuckBot',
+        definition: { name: 'DuckDuckGo', category: 'search_crawler', trafficType: 'Bot', operator: 'DuckDuckGo' },
+    },
+    {
+        pattern: 'Slurp',
+        definition: { name: 'Yahoo', category: 'search_crawler', trafficType: 'Bot', operator: 'Yahoo' },
+    },
+    // SEO Tools
+    {
+        pattern: 'AhrefsBot',
+        definition: { name: 'Ahrefs', category: 'seo_crawler', trafficType: 'Bot', operator: 'Ahrefs' },
+    },
+    {
+        pattern: 'SemrushBot',
+        definition: { name: 'Semrush', category: 'seo_crawler', trafficType: 'Bot', operator: 'Semrush' },
+    },
+    {
+        pattern: 'MJ12bot',
+        definition: { name: 'Majestic', category: 'seo_crawler', trafficType: 'Bot', operator: 'Majestic' },
+    },
+    { pattern: 'DotBot', definition: { name: 'Moz', category: 'seo_crawler', trafficType: 'Bot', operator: 'Moz' } },
+    // Social Crawlers
+    {
+        pattern: 'FacebookBot',
+        definition: { name: 'Facebook Bot', category: 'social_crawler', trafficType: 'Bot', operator: 'Meta' },
+    },
+    {
+        pattern: 'facebookexternalhit',
+        definition: { name: 'Facebook', category: 'social_crawler', trafficType: 'Bot', operator: 'Meta' },
+    },
+    {
+        pattern: 'Twitterbot',
+        definition: { name: 'Twitter', category: 'social_crawler', trafficType: 'Bot', operator: 'X' },
+    },
+    {
+        pattern: 'LinkedInBot',
+        definition: { name: 'LinkedIn', category: 'social_crawler', trafficType: 'Bot', operator: 'LinkedIn' },
+    },
+    {
+        pattern: 'Pinterest',
+        definition: { name: 'Pinterest', category: 'social_crawler', trafficType: 'Bot', operator: 'Pinterest' },
+    },
+    {
+        pattern: 'Slackbot',
+        definition: { name: 'Slack', category: 'social_crawler', trafficType: 'Bot', operator: 'Salesforce' },
+    },
+    {
+        pattern: 'TelegramBot',
+        definition: { name: 'Telegram', category: 'social_crawler', trafficType: 'Bot', operator: 'Telegram' },
+    },
+    {
+        pattern: 'WhatsApp',
+        definition: { name: 'WhatsApp', category: 'social_crawler', trafficType: 'Bot', operator: 'Meta' },
+    },
+    // Monitoring
+    {
+        pattern: 'Pingdom',
+        definition: { name: 'Pingdom', category: 'monitoring', trafficType: 'Bot', operator: 'SolarWinds' },
+    },
+    {
+        pattern: 'UptimeRobot',
+        definition: { name: 'UptimeRobot', category: 'monitoring', trafficType: 'Bot', operator: 'UptimeRobot' },
+    },
+    {
+        pattern: 'Site24x7',
+        definition: { name: 'Site24x7', category: 'monitoring', trafficType: 'Bot', operator: 'Zoho' },
+    },
+    {
+        pattern: 'StatusCake',
+        definition: { name: 'StatusCake', category: 'monitoring', trafficType: 'Bot', operator: 'StatusCake' },
+    },
+    {
+        pattern: 'Datadog',
+        definition: { name: 'Datadog', category: 'monitoring', trafficType: 'Bot', operator: 'Datadog' },
+    },
+    // HTTP Clients
+    {
+        pattern: 'curl/',
+        definition: { name: 'curl', category: 'http_client', trafficType: 'Automation', operator: 'curl' },
+    },
+    {
+        pattern: 'Wget',
+        definition: { name: 'Wget', category: 'http_client', trafficType: 'Automation', operator: 'GNU' },
+    },
+    {
+        pattern: 'python-requests',
+        definition: { name: 'Python Requests', category: 'http_client', trafficType: 'Automation', operator: 'Python' },
+    },
+    {
+        pattern: 'axios',
+        definition: { name: 'Axios', category: 'http_client', trafficType: 'Automation', operator: 'axios' },
+    },
+    {
+        pattern: 'node-fetch',
+        definition: { name: 'Node Fetch', category: 'http_client', trafficType: 'Automation', operator: 'Node.js' },
+    },
+    {
+        pattern: 'Go-http-client',
+        definition: { name: 'Go HTTP', category: 'http_client', trafficType: 'Automation', operator: 'Go' },
+    },
+    {
+        pattern: 'okhttp',
+        definition: { name: 'OkHttp', category: 'http_client', trafficType: 'Automation', operator: 'Square' },
+    },
+    {
+        pattern: 'Apache-HttpClient',
+        definition: { name: 'Apache HTTP', category: 'http_client', trafficType: 'Automation', operator: 'Apache' },
+    },
+    {
+        pattern: 'libwww-perl',
+        definition: { name: 'LWP', category: 'http_client', trafficType: 'Automation', operator: 'Perl' },
+    },
+    {
+        pattern: 'Scrapy',
+        definition: { name: 'Scrapy', category: 'http_client', trafficType: 'Automation', operator: 'Scrapy' },
+    },
+    // Headless Browsers
+    {
+        pattern: 'HeadlessChrome',
+        definition: {
+            name: 'Headless Chrome',
+            category: 'headless_browser',
+            trafficType: 'Automation',
+            operator: 'Google',
+        },
+    },
+    {
+        pattern: 'PhantomJS',
+        definition: {
+            name: 'PhantomJS',
+            category: 'headless_browser',
+            trafficType: 'Automation',
+            operator: 'PhantomJS',
+        },
+    },
+    {
+        pattern: 'Puppeteer',
+        definition: { name: 'Puppeteer', category: 'headless_browser', trafficType: 'Automation', operator: 'Google' },
+    },
+    {
+        pattern: 'Playwright',
+        definition: {
+            name: 'Playwright',
+            category: 'headless_browser',
+            trafficType: 'Automation',
+            operator: 'Microsoft',
+        },
+    },
+    {
+        pattern: 'Selenium',
+        definition: { name: 'Selenium', category: 'headless_browser', trafficType: 'Automation', operator: 'Selenium' },
+    },
+]
+
+const NO_USER_AGENT_DEFINITION: BotDefinition = {
+    name: 'No user agent',
+    category: 'no_user_agent',
+    trafficType: 'Automation',
+    operator: 'Unknown',
+}
+
+export const CATEGORY_LABELS: Record<BotCategory, string> = {
+    ai_crawler: 'AI crawler',
+    ai_search: 'AI search',
+    ai_assistant: 'AI assistant',
+    search_crawler: 'Search crawler',
+    seo_crawler: 'SEO crawler',
+    social_crawler: 'Social crawler',
+    monitoring: 'Monitoring',
+    http_client: 'HTTP client',
+    headless_browser: 'Headless browser',
+    no_user_agent: 'No user agent',
+    regular: 'Regular',
+}
+
+export const detectBot = (userAgent: string | null | undefined): BotDefinition | null => {
+    if (userAgent == null || userAgent === '') {
+        return NO_USER_AGENT_DEFINITION
+    }
+    for (const { pattern, definition } of BOT_DEFINITIONS) {
+        if (userAgent.includes(pattern)) {
+            return definition
+        }
+    }
+    return null
+}
+
+export const getBotName = (userAgent: string | null | undefined): string => {
+    return detectBot(userAgent)?.name ?? ''
+}
+
+export const isBot = (userAgent: string | null | undefined): boolean => {
+    return detectBot(userAgent) !== null
+}

--- a/frontend/src/scenes/activity/live/LiveBotPanel.tsx
+++ b/frontend/src/scenes/activity/live/LiveBotPanel.tsx
@@ -1,0 +1,102 @@
+import { useMemo } from 'react'
+
+import { LemonTag, Tooltip } from '@posthog/lemon-ui'
+
+import { IconRobot } from 'lib/lemon-ui/icons'
+import { CATEGORY_LABELS, detectBot } from 'lib/utils/botDetection'
+
+import { LiveEvent } from '~/types'
+
+const TOP_BOT_LIMIT = 5
+
+interface BotTotals {
+    total: number
+    byName: Map<string, { name: string; category: string; count: number }>
+}
+
+const aggregateBots = (events: LiveEvent[]): BotTotals => {
+    const byName = new Map<string, { name: string; category: string; count: number }>()
+    let total = 0
+
+    for (const event of events) {
+        const userAgent = event.properties?.$raw_user_agent || event.properties?.$user_agent
+        const bot = detectBot(userAgent)
+        if (!bot) {
+            continue
+        }
+        total += 1
+        const existing = byName.get(bot.name)
+        if (existing) {
+            existing.count += 1
+        } else {
+            byName.set(bot.name, {
+                name: bot.name,
+                category: CATEGORY_LABELS[bot.category] ?? bot.category,
+                count: 1,
+            })
+        }
+    }
+
+    return { total, byName }
+}
+
+export interface LiveBotPanelProps {
+    events: LiveEvent[]
+    className?: string
+}
+
+export function LiveBotPanel({ events, className }: LiveBotPanelProps): JSX.Element | null {
+    const { total, byName } = useMemo(() => aggregateBots(events), [events])
+
+    if (events.length === 0) {
+        return null
+    }
+
+    const topBots = [...byName.values()].sort((a, b) => b.count - a.count).slice(0, TOP_BOT_LIMIT)
+    const regularCount = events.length - total
+    const botShare = events.length > 0 ? (total / events.length) * 100 : 0
+
+    return (
+        <div
+            className={`flex flex-wrap items-center gap-2 rounded-md border border-border bg-bg-light px-3 py-2 text-xs ${
+                className ?? ''
+            }`}
+        >
+            <Tooltip title="Bot detection is based on known user agent patterns for crawlers, AI agents, monitoring tools and automation frameworks.">
+                <span className="flex items-center gap-1 font-medium text-default">
+                    <IconRobot className="text-sm text-muted" />
+                    Bot traffic
+                </span>
+            </Tooltip>
+
+            <span className="tabular-nums text-muted">
+                <span className="font-medium text-default">{total.toLocaleString()}</span> bot events of{' '}
+                <span className="tabular-nums">{events.length.toLocaleString()}</span>
+                {` · `}
+                {botShare.toFixed(botShare < 10 ? 1 : 0)}%
+            </span>
+
+            {regularCount > 0 && (
+                <span className="text-muted hidden sm:inline">({regularCount.toLocaleString()} regular)</span>
+            )}
+
+            {topBots.length > 0 && (
+                <>
+                    <span className="text-muted">·</span>
+                    <div className="flex flex-wrap items-center gap-1">
+                        {topBots.map((bot) => (
+                            <Tooltip key={bot.name} title={`${bot.count.toLocaleString()} events · ${bot.category}`}>
+                                <LemonTag type="muted" size="small" className="text-[11px]">
+                                    {bot.name} · {bot.count.toLocaleString()}
+                                </LemonTag>
+                            </Tooltip>
+                        ))}
+                        {byName.size > TOP_BOT_LIMIT && (
+                            <span className="text-muted">+{byName.size - TOP_BOT_LIMIT} more</span>
+                        )}
+                    </div>
+                </>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/activity/live/LiveEventsTable.tsx
+++ b/frontend/src/scenes/activity/live/LiveEventsTable.tsx
@@ -22,6 +22,7 @@ import { ActivityTab, PropertyOperator } from '~/types'
 
 import { EventName } from 'products/actions/frontend/components/EventName'
 
+import { LiveBotPanel } from './LiveBotPanel'
 import { LiveEventsFeed } from './LiveEventsFeed'
 import { liveEventsLogic } from './liveEventsLogic'
 import { liveEventsTableSceneLogic } from './liveEventsTableSceneLogic'
@@ -110,6 +111,7 @@ export function LiveEventsTable(): JSX.Element {
                     </LemonButton>
                 </div>
             </div>
+            <LiveBotPanel events={events} className="mb-2" />
             <LiveEventsFeed events={events} streamPaused={streamPaused} />
         </SceneContent>
     )

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveBotTrafficCard.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveBotTrafficCard.tsx
@@ -1,0 +1,128 @@
+import clsx from 'clsx'
+import React, { useMemo } from 'react'
+
+import { LemonTag, Spinner, Tooltip } from '@posthog/lemon-ui'
+
+import { getSeriesColorPalette } from 'lib/colors'
+import { IconRobot } from 'lib/lemon-ui/icons'
+
+import { BotBreakdownItem } from './LiveWebAnalyticsMetricsTypes'
+
+interface LiveBotTrafficCardProps {
+    data: BotBreakdownItem[]
+    totalBotEvents: number
+    totalEvents: number
+    isLoading?: boolean
+}
+
+const LiveBotTrafficCardInner = ({
+    data,
+    totalBotEvents,
+    totalEvents,
+    isLoading,
+}: LiveBotTrafficCardProps): JSX.Element => {
+    const colors = useMemo(() => getSeriesColorPalette(), [])
+
+    const processedData = useMemo(() => {
+        if (data.length === 0) {
+            return []
+        }
+        return [...data]
+            .sort((a, b) => {
+                if (a.bot === 'Other') {
+                    return 1
+                }
+                if (b.bot === 'Other') {
+                    return -1
+                }
+                return b.count - a.count
+            })
+            .map((d, index) => ({ item: d, color: colors[index % colors.length] }))
+    }, [data, colors])
+
+    const hasData = data.some((d) => d.count > 0)
+    const botShare = totalEvents > 0 ? (totalBotEvents / totalEvents) * 100 : 0
+
+    return (
+        <div className="bg-bg-light rounded-lg border border-border p-4 h-full min-h-[340px] flex flex-col">
+            <div className="mb-4 flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-default flex items-center gap-2">
+                    <IconRobot className="text-base text-muted" />
+                    Bot traffic
+                </h3>
+                <Tooltip title="Based on PostHog's experimental user agent bot detection, matching search engines, AI crawlers, monitoring tools and more.">
+                    <span className="text-xs text-muted">Preview</span>
+                </Tooltip>
+            </div>
+
+            {isLoading ? (
+                <div className="flex-1 flex items-center justify-center">
+                    <Spinner className="text-2xl" />
+                </div>
+            ) : !hasData ? (
+                <div className="flex-1 flex items-center justify-center text-muted text-sm text-center px-4">
+                    No bots detected in the last 30 minutes. When crawlers like Googlebot, GPTBot or ClaudeBot hit your
+                    site, they'll appear here.
+                </div>
+            ) : (
+                <>
+                    <div className="text-center mb-4">
+                        <div className="text-3xl font-bold tabular-nums">{totalBotEvents.toLocaleString()}</div>
+                        <div className="text-xs text-muted">
+                            bot events · {botShare.toFixed(botShare < 10 ? 1 : 0)}% of total
+                        </div>
+                    </div>
+
+                    <div className="space-y-2">
+                        {processedData.map(({ item, color }, index) => {
+                            const isTop = index === 0
+                            return (
+                                <Tooltip
+                                    key={item.bot}
+                                    title={`${item.count.toLocaleString()} events · ${item.bot}${
+                                        item.category ? ` (${item.category})` : ''
+                                    }`}
+                                >
+                                    <div className="flex items-center gap-2 cursor-default">
+                                        <div
+                                            className={clsx(
+                                                'text-xs truncate w-20',
+                                                isTop ? 'text-default font-medium' : 'text-muted'
+                                            )}
+                                        >
+                                            {item.bot}
+                                        </div>
+                                        {item.category ? (
+                                            <LemonTag type="muted" size="small" className="shrink-0 text-[10px]">
+                                                {item.category}
+                                            </LemonTag>
+                                        ) : null}
+                                        <div className="flex-1 h-2 bg-border-light rounded-full overflow-hidden">
+                                            <div
+                                                className="h-full rounded-full transition-all duration-300 ease-out"
+                                                style={{
+                                                    width: `${item.percentage}%`,
+                                                    backgroundColor: color,
+                                                }}
+                                            />
+                                        </div>
+                                        <div
+                                            className={clsx(
+                                                'w-10 text-xs text-right tabular-nums',
+                                                isTop ? 'text-default font-medium' : 'text-muted'
+                                            )}
+                                        >
+                                            {item.percentage.toFixed(0)}%
+                                        </div>
+                                    </div>
+                                </Tooltip>
+                            )
+                        })}
+                    </div>
+                </>
+            )}
+        </div>
+    )
+}
+
+export const LiveBotTrafficCard = React.memo(LiveBotTrafficCardInner)

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.test.ts
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.test.ts
@@ -1012,4 +1012,71 @@ describe('LiveMetricsSlidingWindow', () => {
             expect(window.getTopReferrers(10)).toEqual([])
         })
     })
+
+    describe('bot tracking', () => {
+        it('tracks bot counts per name via addDataPoint', () => {
+            const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
+            const eventTs = toUnixSeconds(relativeTime(-5 * MINUTE))
+
+            window.addDataPoint(eventTs, 'bot-1', { bot: { name: 'Googlebot', category: 'Search crawler' } })
+            window.addDataPoint(eventTs, 'bot-2', { bot: { name: 'Googlebot', category: 'Search crawler' } })
+            window.addDataPoint(eventTs, 'bot-3', { bot: { name: 'GPTBot', category: 'AI crawler' } })
+
+            expect(window.getTotalBotEvents()).toBe(3)
+            expect(window.getBotBreakdown()).toEqual([
+                { bot: 'Googlebot', category: 'Search crawler', count: 2, percentage: (2 / 3) * 100 },
+                { bot: 'GPTBot', category: 'AI crawler', count: 1, percentage: (1 / 3) * 100 },
+            ])
+        })
+
+        it('rolls excess bots into the "Other" bucket when over the limit', () => {
+            const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
+            const eventTs = toUnixSeconds(relativeTime(-5 * MINUTE))
+
+            window.addDataPoint(eventTs, 'a', { bot: { name: 'Googlebot', category: 'Search crawler' } })
+            window.addDataPoint(eventTs, 'b', { bot: { name: 'GPTBot', category: 'AI crawler' } })
+            window.addDataPoint(eventTs, 'c', { bot: { name: 'Bingbot', category: 'Search crawler' } })
+
+            const breakdown = window.getBotBreakdown(2)
+            expect(breakdown.length).toBe(3)
+            expect(breakdown[2].bot).toBe('Other')
+            expect(breakdown[2].count).toBe(1)
+        })
+
+        it('decrements bot counts when buckets are pruned', () => {
+            const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
+            const oldTs = toUnixSeconds(relativeTime(-40 * MINUTE))
+            const recentTs = toUnixSeconds(relativeTime(-5 * MINUTE))
+
+            window.addDataPoint(oldTs, 'old-1', { bot: { name: 'ClaudeBot', category: 'AI crawler' } })
+            window.addDataPoint(recentTs, 'new-1', { bot: { name: 'Googlebot', category: 'Search crawler' } })
+
+            window.prune()
+
+            expect(window.getTotalBotEvents()).toBe(1)
+            expect(window.getBotBreakdown().map((b) => b.bot)).toEqual(['Googlebot'])
+        })
+
+        it('round-trips bot data through extendBucketData', () => {
+            const window = new LiveMetricsSlidingWindow(WINDOW_SIZE_MINUTES)
+            window.extendBucketData(toUnixSeconds(relativeTime(-5 * MINUTE)), {
+                pageviews: 0,
+                newUserCount: 0,
+                returningUserCount: 0,
+                devices: new Map(),
+                paths: new Map(),
+                referrers: new Map(),
+                browsers: new Map(),
+                uniqueUsers: new Set(),
+                countries: new Map(),
+                bots: new Map([
+                    ['Googlebot', { count: 4, category: 'Search crawler' }],
+                    ['GPTBot', { count: 2, category: 'AI crawler' }],
+                ]),
+            })
+
+            expect(window.getTotalBotEvents()).toBe(6)
+            expect(window.getBotBreakdown().map((b) => b.bot)).toEqual(['Googlebot', 'GPTBot'])
+        })
+    })
 })

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveMetricsSlidingWindow.tsx
@@ -1,4 +1,7 @@
+import { BotCategory, CATEGORY_LABELS } from 'lib/utils/botDetection'
+
 import {
+    BotBreakdownItem,
     BrowserBreakdownItem,
     CountryBreakdownItem,
     ReferrerItem,
@@ -19,6 +22,9 @@ export class LiveMetricsSlidingWindow {
     private _totalPageviews = 0
     private _globalPathCounts = new Map<string, number>()
     private _globalReferrerCounts = new Map<string, number>()
+    private _globalBotCounts = new Map<string, number>()
+    private _globalBotCategoryCounts = new Map<string, number>()
+    private _botNameToCategory = new Map<string, string>()
 
     constructor(windowSizeMinutes: number) {
         this.windowSizeSeconds = windowSizeMinutes * 60
@@ -33,6 +39,7 @@ export class LiveMetricsSlidingWindow {
             referringDomain?: string
             device?: { deviceId: string; deviceType: string }
             browser?: { deviceId: string; browserType: string }
+            bot?: { name: string; category: string }
         }
     ): void {
         const bucket = this.getOrCreateBucket(eventTs)
@@ -63,6 +70,10 @@ export class LiveMetricsSlidingWindow {
 
         if (data.browser) {
             this.addBrowserToBucket(bucket, data.browser.browserType, data.browser.deviceId)
+        }
+
+        if (data.bot) {
+            this.addBotToBucket(bucket, data.bot.name, data.bot.category)
         }
     }
 
@@ -125,6 +136,14 @@ export class LiveMetricsSlidingWindow {
                 }
             }
         }
+
+        if (data.bots) {
+            for (const [botName, entry] of data.bots) {
+                for (let i = 0; i < entry.count; i++) {
+                    this.addBotToBucket(bucket, botName, entry.category)
+                }
+            }
+        }
     }
 
     private addUserToBucket(bucket: SlidingWindowBucket, userId: string): void {
@@ -167,6 +186,18 @@ export class LiveMetricsSlidingWindow {
 
     private addBrowserToBucket(bucket: SlidingWindowBucket, browserType: string, deviceId: string): void {
         this.addItemToBucket(bucket.browsers, this.browserBucketCounts, browserType, deviceId)
+    }
+
+    private addBotToBucket(bucket: SlidingWindowBucket, botName: string, category: string): void {
+        if (!bucket.bots) {
+            bucket.bots = new Map<string, { count: number; category: string }>()
+        }
+        const existing = bucket.bots.get(botName)
+        bucket.bots.set(botName, { count: (existing?.count ?? 0) + 1, category })
+
+        this._globalBotCounts.set(botName, (this._globalBotCounts.get(botName) || 0) + 1)
+        this._globalBotCategoryCounts.set(category, (this._globalBotCategoryCounts.get(category) || 0) + 1)
+        this._botNameToCategory.set(botName, category)
     }
 
     private addCountryToBucket(bucket: SlidingWindowBucket, countryCode: string, distinctId: string): void {
@@ -264,8 +295,30 @@ export class LiveMetricsSlidingWindow {
                 this.removeCountriesFromTracking(bucket)
                 this.decrementGlobalCounts(bucket.paths, this._globalPathCounts)
                 this.decrementGlobalCounts(bucket.referrers, this._globalReferrerCounts)
+                if (bucket.bots) {
+                    this.decrementBotCounts(bucket.bots)
+                }
                 this._totalPageviews -= bucket.pageviews
                 this.buckets.delete(ts)
+            }
+        }
+    }
+
+    private decrementBotCounts(botMap: Map<string, { count: number; category: string }>): void {
+        for (const [botName, { count, category }] of botMap) {
+            const currentCount = this._globalBotCounts.get(botName) || 0
+            if (currentCount <= count) {
+                this._globalBotCounts.delete(botName)
+                this._botNameToCategory.delete(botName)
+            } else {
+                this._globalBotCounts.set(botName, currentCount - count)
+            }
+
+            const currentCategoryCount = this._globalBotCategoryCounts.get(category) || 0
+            if (currentCategoryCount <= count) {
+                this._globalBotCategoryCounts.delete(category)
+            } else {
+                this._globalBotCategoryCounts.set(category, currentCategoryCount - count)
             }
         }
     }
@@ -388,6 +441,59 @@ export class LiveMetricsSlidingWindow {
         return this.userBucketCounts.size
     }
 
+    getBotBreakdown(limit?: number): BotBreakdownItem[] {
+        let total = 0
+        for (const count of this._globalBotCounts.values()) {
+            total += count
+        }
+
+        if (total === 0) {
+            return []
+        }
+
+        const sorted: BotBreakdownItem[] = [...this._globalBotCounts.entries()]
+            .map(([bot, count]) => {
+                const categoryKey = (this._botNameToCategory.get(bot) ?? 'regular') as BotCategory
+                return {
+                    bot,
+                    category: CATEGORY_LABELS[categoryKey] ?? categoryKey,
+                    count,
+                    percentage: (count / total) * 100,
+                }
+            })
+            .sort((a, b) => b.count - a.count)
+
+        if (!limit || sorted.length <= limit) {
+            return sorted
+        }
+
+        const top = sorted.slice(0, limit)
+        const othersCount = sorted.slice(limit).reduce((sum, item) => sum + item.count, 0)
+
+        if (othersCount > 0) {
+            top.push({
+                bot: 'Other',
+                category: '',
+                count: othersCount,
+                percentage: (othersCount / total) * 100,
+            })
+        }
+
+        return top
+    }
+
+    getTotalBotEvents(): number {
+        let total = 0
+        for (const count of this._globalBotCounts.values()) {
+            total += count
+        }
+        return total
+    }
+
+    getBotCategoryCounts(): Map<string, number> {
+        return new Map(this._globalBotCategoryCounts)
+    }
+
     private getOrCreateBucket(eventTs: number): SlidingWindowBucket {
         const bucketTs = Math.floor(eventTs / 60) * 60
 
@@ -404,6 +510,7 @@ export class LiveMetricsSlidingWindow {
                 referrers: new Map<string, number>(),
                 uniqueUsers: new Set<string>(),
                 countries: new Map<string, Set<string>>(),
+                bots: new Map<string, { count: number; category: string }>(),
             }
             this.buckets.set(bucketTs, bucket)
         }

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetrics.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetrics.tsx
@@ -25,6 +25,7 @@ import { LiveEventsFeed, LiveEventsFeedColumn } from 'scenes/activity/live/LiveE
 import { WebAnalyticsDomainSelector } from '../WebAnalyticsFilters'
 import { BreakdownLiveCard } from './BreakdownLiveCard'
 import { getBrowserLogo } from './browserLogos'
+import { LiveBotTrafficCard } from './LiveBotTrafficCard'
 import { CONTENT_CARD_SPAN, LiveContentCardId, LiveStatCardId } from './liveCards'
 import { LiveChartCard } from './LiveChartCard'
 import { LiveStatCard, LiveStatDivider } from './LiveStatCard'
@@ -121,6 +122,8 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
         totalPageviews,
         totalUniqueVisitors,
         totalBrowsers,
+        botBreakdown,
+        totalBotEvents,
         liveUserCount,
         selectedHost,
         isLoading,
@@ -237,6 +240,15 @@ export const LiveWebAnalyticsMetrics = (): JSX.Element => {
                         renderIcon={renderCountryIcon}
                         emptyMessage="No country data"
                         statLabel="unique visitors"
+                        isLoading={isLoading}
+                    />
+                )
+            case 'bot_traffic':
+                return (
+                    <LiveBotTrafficCard
+                        data={botBreakdown}
+                        totalBotEvents={totalBotEvents}
+                        totalEvents={totalPageviews + totalBotEvents}
                         isLoading={isLoading}
                     />
                 )

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetricsTypes.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/LiveWebAnalyticsMetricsTypes.tsx
@@ -41,6 +41,16 @@ export interface SlidingWindowBucket {
     referrers: Map<string, number>
     uniqueUsers: Set<string>
     countries: Map<string, Set<string>>
+    // Optional so that existing tests and backfill helpers don't have to
+    // construct bot maps when they are not asserting on bot traffic.
+    bots?: Map<string, { count: number; category: string }>
+}
+
+export interface BotBreakdownItem {
+    bot: string
+    category: string
+    count: number
+    percentage: number
 }
 
 export interface CountryBreakdownItem {

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveCards.ts
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveCards.ts
@@ -7,6 +7,7 @@ export type LiveContentCardId =
     | 'devices'
     | 'browsers'
     | 'top_countries'
+    | 'bot_traffic'
     | 'countries'
     | 'live_events'
 
@@ -19,6 +20,7 @@ export const DEFAULT_CONTENT_ORDER: readonly LiveContentCardId[] = [
     'devices',
     'browsers',
     'top_countries',
+    'bot_traffic',
     'countries',
     'live_events',
 ]
@@ -30,6 +32,7 @@ export const CONTENT_CARD_SPAN: Record<LiveContentCardId, 'full' | 'half'> = {
     devices: 'half',
     browsers: 'half',
     top_countries: 'half',
+    bot_traffic: 'half',
     countries: 'full',
     live_events: 'full',
 }

--- a/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/LiveMetricsDashboard/liveWebAnalyticsMetricsLogic.tsx
@@ -9,6 +9,7 @@ import { dayjs } from 'lib/dayjs'
 import { FeatureFlagsSet, featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { hashCodeForString } from 'lib/utils'
 import { liveEventsHostOrigin } from 'lib/utils/apiHost'
+import { CATEGORY_LABELS, detectBot } from 'lib/utils/botDetection'
 import { deduplicateEvents } from 'scenes/activity/live/deduplicateEvents'
 import { teamLogic } from 'scenes/teamLogic'
 import { webAnalyticsFilterLogic } from 'scenes/web-analytics/webAnalyticsFilterLogic'
@@ -27,6 +28,7 @@ import { createStreamConnection } from './createStreamConnection'
 import { LiveMetricsSlidingWindow } from './LiveMetricsSlidingWindow'
 import type { liveWebAnalyticsMetricsLogicType } from './liveWebAnalyticsMetricsLogicType'
 import {
+    BotBreakdownItem,
     BrowserBreakdownItem,
     ChartDataPoint,
     CountryBreakdownItem,
@@ -125,12 +127,22 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                                       ? DIRECT_REFERRER
                                       : undefined
 
+                            const rawUserAgent = event.properties?.$raw_user_agent
+                            const fallbackUserAgent = event.properties?.$user_agent
+                            const botDefinition = detectBot(rawUserAgent || fallbackUserAgent)
+
                             window.addDataPoint(eventTs, event.distinct_id, {
                                 pageviews: isPageview ? 1 : 0,
                                 device: deviceType ? { deviceId: deviceKey, deviceType } : undefined,
                                 browser: browser ? { deviceId: deviceKey, browserType: browser } : undefined,
                                 pathname: isPageview ? pathname : undefined,
                                 referringDomain: normalizedReferrer,
+                                bot: botDefinition
+                                    ? {
+                                          name: botDefinition.name,
+                                          category: CATEGORY_LABELS[botDefinition.category] ?? botDefinition.category,
+                                      }
+                                    : undefined,
                             })
                         }
                     }
@@ -277,6 +289,15 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
             (s) => [s.slidingWindow, s.eventsVersion],
             (slidingWindow: LiveMetricsSlidingWindow): number => slidingWindow.getTotalBrowsers(),
         ],
+        botBreakdown: [
+            (s) => [s.slidingWindow, s.eventsVersion],
+            (slidingWindow: LiveMetricsSlidingWindow): BotBreakdownItem[] => slidingWindow.getBotBreakdown(6),
+            { resultEqualityCheck: equal },
+        ],
+        totalBotEvents: [
+            (s) => [s.slidingWindow, s.eventsVersion],
+            (slidingWindow: LiveMetricsSlidingWindow): number => slidingWindow.getTotalBotEvents(),
+        ],
         liveUserCount: [
             (s) => [s.recentUsersByLastSeen],
             (recentUsersByLastSeen: Map<string, number>): number => recentUsersByLastSeen.size,
@@ -337,6 +358,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                     referrerResponse,
                     geoResponse,
                     recentUsersResponse,
+                    botResponse,
                 ] = await loadQueryData(dateFrom, handoff, values.selectedHost)
 
                 const bucketMap = new Map<number, SlidingWindowBucket>()
@@ -347,6 +369,7 @@ export const liveWebAnalyticsMetricsLogic = kea<liveWebAnalyticsMetricsLogicType
                 addPathDataToBuckets(pathsResponse, bucketMap)
                 addReferrerDataToBuckets(referrerResponse, bucketMap)
                 addGeoDataToBuckets(geoResponse, bucketMap)
+                addBotDataToBuckets(botResponse, bucketMap)
 
                 actions.setInitialData(
                     [...bucketMap.entries()].map(([timestamp, bucket]) => ({ timestamp, bucket })),
@@ -547,6 +570,7 @@ const loadQueryData = async (
         HogQLQueryResponse,
         HogQLQueryResponse,
         HogQLQueryResponse | null,
+        HogQLQueryResponse,
     ]
 > => {
     const hostFilterClause = host ? `AND properties.$host = {host}` : ''
@@ -705,6 +729,29 @@ const loadQueryData = async (
         },
     }
 
+    const botQuery: HogQLQuery = {
+        kind: NodeKind.HogQLQuery,
+        query: `SELECT
+                    toStartOfMinute(timestamp) AS minute_bucket,
+                    \`$virt_bot_name\` AS bot_name,
+                    \`$virt_traffic_category\` AS bot_category,
+                    count() AS event_count
+                FROM events
+                WHERE
+                    timestamp >= toDateTime({dateFrom})
+                    AND timestamp <= toDateTime({dateTo})
+                    AND \`$virt_is_bot\` = true
+                    AND \`$virt_bot_name\` != ''
+                    ${hostFilterClause}
+                GROUP BY minute_bucket, bot_name, bot_category
+                ORDER BY minute_bucket ASC`,
+        values: {
+            dateFrom: dateFrom.toISOString(),
+            dateTo: dateTo.toISOString(),
+            ...hostValues,
+        },
+    }
+
     const recentUsersQuery: HogQLQuery | null = host
         ? {
               kind: NodeKind.HogQLQuery,
@@ -732,6 +779,7 @@ const loadQueryData = async (
         performQuery(referrerQuery),
         performQuery(geoQuery),
         recentUsersQuery ? performQuery(recentUsersQuery) : Promise.resolve(null),
+        performQuery(botQuery),
     ])
 }
 
@@ -837,6 +885,36 @@ const addGeoDataToBuckets = (geoResponse: HogQLQueryResponse, bucketMap: Map<num
     }
 }
 
+const addBotDataToBuckets = (botResponse: HogQLQueryResponse, bucketMap: Map<number, SlidingWindowBucket>): void => {
+    const results = botResponse.results as [string, string, string, number][]
+
+    for (const [timestampStr, botName, rawCategory, eventCount] of results) {
+        if (!botName) {
+            continue
+        }
+        const timestamp = Date.parse(timestampStr)
+        const bucket = getOrCreateBucket(bucketMap, timestamp)
+
+        const categoryLabel = translateCategoryLabel(rawCategory)
+        if (!bucket.bots) {
+            bucket.bots = new Map<string, { count: number; category: string }>()
+        }
+        const existing = bucket.bots.get(botName)
+        bucket.bots.set(botName, {
+            count: (existing?.count ?? 0) + eventCount,
+            category: categoryLabel,
+        })
+    }
+}
+
+const translateCategoryLabel = (rawCategory: string | null | undefined): string => {
+    if (!rawCategory) {
+        return CATEGORY_LABELS.regular
+    }
+    const known = (CATEGORY_LABELS as Record<string, string>)[rawCategory]
+    return known ?? rawCategory
+}
+
 const getOrCreateBucket = (map: Map<number, SlidingWindowBucket>, timestamp: number): SlidingWindowBucket => {
     if (!map.has(timestamp)) {
         map.set(timestamp, createEmptyBucket())
@@ -856,5 +934,6 @@ const createEmptyBucket = (): SlidingWindowBucket => {
         referrers: new Map<string, number>(),
         uniqueUsers: new Set<string>(),
         countries: new Map<string, Set<string>>(),
+        bots: new Map<string, { count: number; category: string }>(),
     }
 }


### PR DESCRIPTION
## Problem

Real-time web analytics dashboards receive events via livestream SSE feeds that cannot be classified server-side. We need client-side bot detection to identify and categorize bot traffic (AI crawlers, search engines, monitoring tools, etc.) in live metrics.

## Changes

This PR adds comprehensive client-side bot detection that mirrors the server-side implementation:

### Core Bot Detection (`lib/utils/botDetection.ts`)
- New utility module with 388 lines of bot definitions covering:
  - AI crawlers (GPTBot, Claude, Perplexity, etc.)
  - AI search agents (OAI-SearchBot, Applebot-Extended)
  - AI assistants (ChatGPT-User, Meta-ExternalFetcher)
  - Search crawlers (Googlebot, Bingbot, Yandex, Baidu)
  - SEO tools (Ahrefs, Semrush, Moz)
  - Social crawlers (Facebook, Twitter, LinkedIn, Pinterest)
  - Monitoring tools (Pingdom, UptimeRobot, Datadog)
  - HTTP clients (curl, wget, Python requests, axios)
  - Headless browsers (Chrome, Puppeteer, Playwright, Selenium)
- Exports: `detectBot()`, `getBotName()`, `isBot()` functions
- Comprehensive unit tests covering edge cases and pattern specificity

### Live Metrics Integration
- **LiveMetricsSlidingWindow**: Added bot tracking with per-name counts and categories
  - `addBotToBucket()` method to track bot events
  - `getBotBreakdown()` to retrieve sorted bot statistics with "Other" rollup
  - `getTotalBotEvents()` for aggregate bot event count
  - Proper cleanup when buckets are pruned from the sliding window
- **liveWebAnalyticsMetricsLogic**: Integrated bot detection into event processing pipeline
  - Detects bots from `$raw_user_agent` or `$user_agent` properties
  - Passes bot data to sliding window for aggregation
  - Exposes `botBreakdown` and `totalBotEvents` selectors

### UI Components
- **LiveBotTrafficCard**: New dashboard card displaying:
  - Total bot events and percentage of traffic
  - Breakdown by bot name with category tags
  - Color-coded percentage bars
  - Sorted by event count with "Other" bucket for overflow
  - Loading and empty states
- **LiveBotPanel**: Compact panel for live events feed showing:
  - Bot event count and percentage
  - Top 5 bots with category labels
  - Integrated into LiveEventsTable

### Supporting Changes
- Updated `LiveWebAnalyticsMetricsTypes` with `BotBreakdownItem` interface
- Added bot traffic card to live cards configuration
- Extended `SlidingWindowBucket` with optional `bots` map

## How did you test this code?

- Added comprehensive unit tests in `botDetection.test.ts` covering:
  - Bot detection from various user agent strings
  - Pattern specificity (e.g., Applebot-Extended vs Applebot/)
  - Regular browser detection (returns null)
  - Empty/missing user agent handling
  - `getBotName()` and `isBot()` helper functions
- Added integration tests in `LiveMetricsSlidingWindow.test.ts` covering:
  - Bot count tracking via `addDataPoint()`
  - "Other" bucket rollup when exceeding limit
  - Proper decrement when buckets are pruned
  - Round-trip through `extendBucketData()`
- All existing tests pass; no breaking changes to existing functionality

## Publish to changelog?

Yes - this adds bot traffic detection to real-time web analytics dashboards, a new feature for understanding automated traffic patterns.

https://claude.ai/code/session_014rK8Qf5svYoREN3b6MfRiW