### PR TITLE
Add trends eval cases for sandboxed coding agent

### DIFF
--- a/ee/hogai/eval/sandboxed/product_analytics/eval_retention.py
+++ b/ee/hogai/eval/sandboxed/product_analytics/eval_retention.py
@@ -18,20 +18,12 @@ from posthog.schema import AssistantRetentionEventsNode, AssistantRetentionFilte
 
 from ee.hogai.eval.sandboxed.base import SandboxedPublicEval
 from ee.hogai.eval.sandboxed.config import SandboxedEvalCase
-from ee.hogai.eval.sandboxed.product_analytics.scorers import RetentionSchemaAlignment, RetentionTimeRangeRelevancy
-from ee.hogai.eval.sandboxed.scorers import ExitCodeZero, NoToolCall
-
-# PostHog MCP tools that persist saved-insight state. The sandbox is disposable
-# but these tools still hit real rows, so any successful call is a bug in the
-# agent's behaviour for a "just run the query" prompt.
-INSIGHT_WRITE_TOOLS = frozenset(
-    {
-        "insight-create",
-        "insight-update",
-        "insight-partial-update",
-        "insight-destroy",
-    }
+from ee.hogai.eval.sandboxed.product_analytics.scorers import (
+    INSIGHT_WRITE_TOOLS,
+    RetentionSchemaAlignment,
+    RetentionTimeRangeRelevancy,
 )
+from ee.hogai.eval.sandboxed.scorers import ExitCodeZero, NoToolCall
 
 
 def _retention_case(

--- a/ee/hogai/eval/sandboxed/product_analytics/eval_trends.py
+++ b/ee/hogai/eval/sandboxed/product_analytics/eval_trends.py
@@ -1,0 +1,324 @@
+"""Product analytics trends eval cases for the sandboxed coding agent.
+
+Intent mirrors ``ee/hogai/eval/ci/eval_trends.py`` — the CI version asserts
+on the exact ``AssistantTrendsQuery`` Max produces, this version exercises
+the same intents end-to-end through the sandboxed agent + PostHog MCP tools
+and judges the trends query the agent ran via the ``query-trends`` MCP tool.
+
+To run:
+    pytest ee/hogai/eval/sandboxed/product_analytics/eval_trends.py
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from posthog.schema import (
+    AssistantEventMultipleBreakdownFilterType,
+    AssistantGenericMultipleBreakdownFilter,
+    AssistantTrendsBreakdownFilter,
+    AssistantTrendsEventsNode,
+    AssistantTrendsFilter,
+    AssistantTrendsQuery,
+    TrendsFormulaNode,
+)
+
+from ee.hogai.eval.sandboxed.base import SandboxedPublicEval
+from ee.hogai.eval.sandboxed.config import SandboxedEvalCase
+from ee.hogai.eval.sandboxed.product_analytics.scorers import (
+    INSIGHT_WRITE_TOOLS,
+    TrendsSchemaAlignment,
+    TrendsTimeRangeRelevancy,
+)
+from ee.hogai.eval.sandboxed.scorers import ExitCodeZero, NoToolCall
+
+
+def _trends_case(
+    *,
+    name: str,
+    prompt: str,
+    query: AssistantTrendsQuery,
+) -> SandboxedEvalCase:
+    return SandboxedEvalCase(
+        name=name,
+        prompt=prompt,
+        expected={
+            "trends_query": query.model_dump(exclude_none=True),
+        },
+    )
+
+
+@pytest.mark.django_db
+async def eval_trends(sandboxed_demo_data, pytestconfig, posthog_client):
+    cases = [
+        _trends_case(
+            name="trends_pageview_default",
+            prompt="Show the $pageview trend",
+            query=AssistantTrendsQuery(
+                dateRange={"date_from": "-30d", "date_to": None},
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(
+                    display="ActionsLineGraph",
+                    showLegend=True,
+                ),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event="$pageview",
+                        math="total",
+                        properties=None,
+                    )
+                ],
+            ),
+        ),
+        _trends_case(
+            name="trends_mau",
+            prompt="What is our MAU?",
+            query=AssistantTrendsQuery(
+                dateRange={"date_from": "-30d", "date_to": None},
+                filterTestAccounts=True,
+                trendsFilter=AssistantTrendsFilter(
+                    display="BoldNumber",
+                    showLegend=True,
+                ),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event=None,
+                        math="dau",  # "dau" name is a legacy misnomer, it actually just means "unique users"
+                        properties=None,
+                    )
+                ],
+            ),
+        ),
+        _trends_case(
+            name="trends_chrome_vs_safari_upload",
+            prompt="can you compare how many Chrome vs Safari users uploaded a file in the last 30d?",
+            query=AssistantTrendsQuery(
+                dateRange={"date_from": "-30d", "date_to": None},
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(
+                    display="ActionsLineGraph",
+                    showLegend=True,
+                ),
+                breakdownFilter=AssistantTrendsBreakdownFilter(
+                    breakdowns=[
+                        AssistantGenericMultipleBreakdownFilter(
+                            property="$browser",
+                            type=AssistantEventMultipleBreakdownFilterType.EVENT,
+                        )
+                    ]
+                ),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event="uploaded_file",
+                        math="total",
+                        properties=[
+                            {
+                                "key": "$browser",
+                                "value": ["Chrome", "Safari"],
+                                "operator": "exact",
+                                "type": "event",
+                            },
+                        ],
+                    )
+                ],
+            ),
+        ),
+        _trends_case(
+            name="trends_identify_over_pageview_ratio",
+            prompt="i want to see a ratio of identify divided by page views",
+            query=AssistantTrendsQuery(
+                dateRange={"date_from": "-30d", "date_to": None},
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(
+                    display="ActionsLineGraph", showLegend=True, formulaNodes=[TrendsFormulaNode(formula="A/B")]
+                ),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event="$identify",
+                        math="total",
+                        properties=None,
+                    ),
+                    AssistantTrendsEventsNode(
+                        event="$pageview",
+                        math="total",
+                        properties=None,
+                    ),
+                ],
+            ),
+        ),
+        _trends_case(
+            name="trends_avg_session_duration",
+            prompt="what is our average session duration?",
+            query=AssistantTrendsQuery(
+                dateRange={"date_from": "-30d", "date_to": None},
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(
+                    display="ActionsLineGraph",
+                    showLegend=True,
+                ),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event="$all_events",
+                        math="avg",
+                        math_property="$session_duration",
+                        properties=None,
+                    )
+                ],
+            ),
+        ),
+        _trends_case(
+            name="trends_pageviews_unique_sessions",
+            prompt="how many $pageviews with unique sessions did we have?",
+            query=AssistantTrendsQuery(
+                dateRange={"date_from": "-30d", "date_to": None},
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(
+                    display="ActionsLineGraph",
+                    showLegend=True,
+                ),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event="$pageview",
+                        math="unique_session",
+                        properties=None,
+                    )
+                ],
+            ),
+        ),
+        _trends_case(
+            name="trends_pageview_this_january",
+            prompt="How often do users view the website in this January?",
+            query=AssistantTrendsQuery(
+                dateRange={
+                    "date_from": f"{datetime.now().year}-01-01",
+                    "date_to": f"{datetime.now().year}-01-31",
+                },
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(
+                    display="ActionsLineGraph",
+                    showLegend=True,
+                ),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event="$pageview",
+                        math="total",
+                        properties=None,
+                    )
+                ],
+            ),
+        ),
+        _trends_case(
+            name="trends_paid_bill_january_over_20usd",
+            prompt="How many paid bill events have occurred with amount more than 20 usd in this January?",
+            query=AssistantTrendsQuery(
+                dateRange={
+                    "date_from": f"{datetime.now().year}-01-01",
+                    "date_to": f"{datetime.now().year}-01-31",
+                },
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(
+                    display="ActionsLineGraph",
+                    showLegend=True,
+                ),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event="paid_bill",
+                        math="total",
+                        properties=[
+                            {
+                                "key": "amount_usd",
+                                "value": 20,
+                                "operator": "gt",
+                                "type": "event",
+                            },
+                        ],
+                    )
+                ],
+            ),
+        ),
+        _trends_case(
+            name="trends_hedgebox_mac_os_pct",
+            prompt="on hedgebox.net, what is the % of mac os x users",
+            query=AssistantTrendsQuery(
+                dateRange={"date_from": "-30d", "date_to": None},
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(
+                    display="BoldNumber", showLegend=True, formulaNodes=[TrendsFormulaNode(formula="B/A * 100")]
+                ),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event=None,
+                        math="dau",
+                        properties=[
+                            {
+                                "key": "$host",
+                                "value": "hedgebox.net",
+                                "operator": "icontains",
+                                "type": "event",
+                            },
+                        ],
+                    ),
+                    AssistantTrendsEventsNode(
+                        event=None,
+                        math="dau",
+                        properties=[
+                            {
+                                "key": "$host",
+                                "value": "hedgebox.net",
+                                "operator": "icontains",
+                                "type": "event",
+                            },
+                            {
+                                "key": "$os",
+                                "value": "Mac OS X",
+                                "operator": "exact",
+                                "type": "event",
+                            },
+                        ],
+                    ),
+                ],
+            ),
+        ),
+        # Specific, uppercase event to use, which doesn't exist in the actual data (but the user quotes it specifically anyway)
+        _trends_case(
+            name="trends_onboarding_completed_january_2025",
+            prompt="How many 'Onboarding Completed' events have we had in January 2025?",
+            query=AssistantTrendsQuery(
+                dateRange={"date_from": "2025-01-01", "date_to": "2025-01-31"},
+                filterTestAccounts=True,
+                interval="day",
+                trendsFilter=AssistantTrendsFilter(display="ActionsLineGraph"),
+                series=[
+                    AssistantTrendsEventsNode(
+                        event="Onboarding Completed",
+                        math="total",
+                        properties=None,
+                    )
+                ],
+            ),
+        ),
+    ]
+
+    await SandboxedPublicEval(
+        experiment_name="sandboxed-trends",
+        cases=cases,
+        scorers=[
+            ExitCodeZero(),
+            NoToolCall(forbidden=INSIGHT_WRITE_TOOLS, name="no_persistent_insight_save"),
+            TrendsSchemaAlignment(),
+            TrendsTimeRangeRelevancy(),
+        ],
+        pytestconfig=pytestconfig,
+        sandboxed_demo_data=sandboxed_demo_data,
+        posthog_client=posthog_client,
+    )

--- a/ee/hogai/eval/sandboxed/product_analytics/scorers.py
+++ b/ee/hogai/eval/sandboxed/product_analytics/scorers.py
@@ -1,7 +1,7 @@
-"""Retention scorers for the sandboxed product-analytics eval.
+"""Product-analytics scorers for the sandboxed eval.
 
-Both scorers extract the final ``query-retention`` MCP tool call the agent
-made, then grade it against an expected shape or against the user prompt.
+Each scorer extracts the final ``query-<insight>`` MCP tool call the agent
+made, then grades it against an expected shape or against the user prompt.
 Binary outputs only — the LLM is asked yes/no.
 """
 
@@ -15,6 +15,19 @@ from braintrust import Score
 from ee.hogai.eval.sandboxed.scorers import iter_successful_tool_calls, normalize_tool_name
 
 QUERY_RETENTION_TOOL_NAME = "query-retention"
+QUERY_TRENDS_TOOL_NAME = "query-trends"
+
+# PostHog MCP tools that persist saved-insight state. The sandbox is disposable
+# but these tools still hit real rows, so any successful call is a bug in the
+# agent's behaviour for a "just run the query" prompt.
+INSIGHT_WRITE_TOOLS = frozenset(
+    {
+        "insight-create",
+        "insight-update",
+        "insight-partial-update",
+        "insight-destroy",
+    }
+)
 
 BINARY_CHOICE_SCORES = {"yes": 1.0, "no": 0.0}
 
@@ -179,6 +192,176 @@ Evaluation rules:
 </actual_query>
 
 Is the time range / period in the actual query consistent with the user's prompt? Answer `yes` or `no`.
+""".strip(),
+            choice_scores=BINARY_CHOICE_SCORES,
+            model=_JUDGE_MODEL,
+            max_tokens=512,
+            **kwargs,
+        )
+
+
+def extract_last_query_trends_input(output: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return the input dict of the most recent successful ``query-trends`` call.
+
+    Returns ``None`` when the agent never ran the tool successfully — scorers
+    that depend on this should short-circuit with ``score=None`` in that case
+    rather than counting it as an incorrect trends query.
+    """
+    if not output:
+        return None
+    messages = output.get("messages")
+    if not messages:
+        return None
+
+    last_input: dict[str, Any] | None = None
+    for tool_use, _ in iter_successful_tool_calls(messages):
+        if normalize_tool_name(tool_use.get("name")) != QUERY_TRENDS_TOOL_NAME:
+            continue
+        tool_input = tool_use.get("input")
+        if isinstance(tool_input, dict):
+            last_input = tool_input
+    return last_input
+
+
+class TrendsSchemaAlignment(LLMClassifier):
+    """Binary yes/no: does the trends query the agent ran match the expected one?"""
+
+    async def _run_eval_async(self, output, expected=None, **kwargs):
+        return await self._judge_async(output, expected, **kwargs)
+
+    def _run_eval_sync(self, output, expected=None, **kwargs):
+        return self._judge_sync(output, expected, **kwargs)
+
+    async def _judge_async(self, output, expected, **kwargs):
+        prepared = self._prepare(output, expected)
+        if isinstance(prepared, Score):
+            return prepared
+        return await super()._run_eval_async(prepared["output"], prepared["expected"], **kwargs)
+
+    def _judge_sync(self, output, expected, **kwargs):
+        prepared = self._prepare(output, expected)
+        if isinstance(prepared, Score):
+            return prepared
+        return super()._run_eval_sync(prepared["output"], prepared["expected"], **kwargs)
+
+    def _prepare(self, output, expected) -> dict[str, Any] | Score:
+        actual = extract_last_query_trends_input(output)
+        if actual is None:
+            return Score(
+                name=self._name(),
+                score=None,
+                metadata={"reason": "Agent never ran query-trends successfully"},
+            )
+        expected_query = (expected or {}).get("trends_query") if isinstance(expected, dict) else None
+        if not isinstance(expected_query, dict):
+            return Score(
+                name=self._name(),
+                score=None,
+                metadata={"reason": "No expected.trends_query provided"},
+            )
+        return {
+            "output": {"trends_query": actual},
+            "expected": {"trends_query": expected_query},
+        }
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            name="trends_schema_alignment",
+            prompt_template="""
+You are comparing two trends query specs. The ACTUAL spec was produced by an agent via PostHog's `query-trends` MCP tool. The EXPECTED spec is the correct answer we want.
+
+Treat these fields as material:
+- `kind` (must be `TrendsQuery`).
+- `series[]` — each series must match on:
+    - `kind` (e.g. `EventsNode`, `ActionsNode`).
+    - `event` — event names are case-sensitive and must match exactly. `null` is the "All events" sentinel.
+    - `math` — e.g. `total`, `dau` (unique users, legacy name), `unique_session`, `avg`, `median`, `p95`, `sum`, etc.
+    - `math_property` — required when the math operation needs one (e.g. `avg` of `$session_duration`).
+    - `properties` — entity-level property filters; `key`, `operator`, `value`, and `type` must match. Multiple selected values may appear as arrays.
+- `dateRange.date_from` / `dateRange.date_to` — relative windows like `-14d`, `-3m`, `-1y` are acceptable when equivalent to the expected window. Absolute dates must match.
+- `interval` — `hour` / `day` / `week` / `month`.
+- `breakdownFilter.breakdowns[]` — each breakdown's `property` and `type` must match. If expected has no breakdown, actual shouldn't introduce one.
+- `trendsFilter.display` — only when it is non-default in the expected spec (e.g. `BoldNumber`, `ActionsBar`).
+- `trendsFilter.formulaNodes[]` — formulas must match semantically (e.g. `A/B` vs `B/A * 100`).
+
+Ignore `filterTestAccounts`, `samplingFactor`, `showLegend`, `showValuesOnSeries`, `smoothingIntervals`, `compareFilter`, and other cosmetic fields unless they were set explicitly in the expected spec.
+
+<expected_query>
+{{expected.trends_query}}
+</expected_query>
+
+<actual_query>
+{{output.trends_query}}
+</actual_query>
+
+Does the actual trends query match the expected trends query on the material fields above? Answer `yes` or `no`.
+""".strip(),
+            choice_scores=BINARY_CHOICE_SCORES,
+            model=_JUDGE_MODEL,
+            max_tokens=512,
+            **kwargs,
+        )
+
+
+class TrendsTimeRangeRelevancy(LLMClassifier):
+    """Binary yes/no: is the trends query's time range / interval consistent with the user prompt?"""
+
+    async def _run_eval_async(self, output, expected=None, **kwargs):
+        return await self._judge_async(output, expected, **kwargs)
+
+    def _run_eval_sync(self, output, expected=None, **kwargs):
+        return self._judge_sync(output, expected, **kwargs)
+
+    async def _judge_async(self, output, expected, **kwargs):
+        prepared = self._prepare(output, expected)
+        if isinstance(prepared, Score):
+            return prepared
+        return await super()._run_eval_async(prepared["output"], prepared["expected"], **kwargs)
+
+    def _judge_sync(self, output, expected, **kwargs):
+        prepared = self._prepare(output, expected)
+        if isinstance(prepared, Score):
+            return prepared
+        return super()._run_eval_sync(prepared["output"], prepared["expected"], **kwargs)
+
+    def _prepare(self, output, expected) -> dict[str, Any] | Score:
+        actual = extract_last_query_trends_input(output)
+        if actual is None:
+            return Score(
+                name=self._name(),
+                score=None,
+                metadata={"reason": "Agent never ran query-trends successfully"},
+            )
+        prompt = _extract_user_prompt(output)
+        return {
+            "output": {
+                "trends_query": actual,
+                "prompt": prompt,
+            },
+            "expected": expected or {},
+        }
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            name="trends_time_range_relevancy",
+            prompt_template="""
+Check the time range and interval granularity of a trends query against the user's prompt.
+
+Evaluation rules:
+1. Explicit time mentions (e.g. "last 14 days", "last 3 months", "this year", "January 2025") — `dateRange.date_from` must be consistent (`-14d`, `-3m`, an absolute `YYYY-MM-DD`, etc.). Absolute ranges must match month/year.
+2. Implicit granularity mentions — "daily" → `interval: "day"`, "weekly" → `week`, "monthly" → `month`, "hourly" → `hour`.
+3. If the prompt has no time component at all, a sensible default (last 30 days with `interval: "day"`) is acceptable.
+4. Ignore `filterTestAccounts`, display type, breakdowns, series math, and unrelated fields — they are not about time.
+
+<user_prompt>
+{{output.prompt}}
+</user_prompt>
+
+<actual_query>
+{{output.trends_query}}
+</actual_query>
+
+Is the time range / interval in the actual query consistent with the user's prompt? Answer `yes` or `no`.
 """.strip(),
             choice_scores=BINARY_CHOICE_SCORES,
             model=_JUDGE_MODEL,


### PR DESCRIPTION
## Problem

The sandboxed eval suite for the PostHog AI agent currently only covers retention insights. We need to extend coverage to trends queries, which are a core insight type that users frequently request.

## Changes

- **New file**: `ee/hogai/eval/sandboxed/product_analytics/eval_trends.py` — Adds 10 comprehensive eval cases for trends queries, mirroring the structure of the existing CI-based trends eval. Cases cover:
  - Basic event trends (pageviews, MAU)
  - Breakdowns (browser comparison)
  - Formulas (ratios, percentages)
  - Math operations (average, unique sessions)
  - Date ranges (relative windows, absolute dates, specific months)
  - Property filters (numeric comparisons, string matching)

- **Updated**: `ee/hogai/eval/sandboxed/product_analytics/scorers.py`
  - Extracted `INSIGHT_WRITE_TOOLS` constant to shared location (was previously duplicated in `eval_retention.py`)
  - Added `extract_last_query_trends_input()` helper to extract the final `query-trends` MCP tool call
  - Added `TrendsSchemaAlignment` scorer — validates that the agent's trends query matches expected schema on material fields (series, math operations, date ranges, breakdowns, formulas)
  - Added `TrendsTimeRangeRelevancy` scorer — validates that time range and interval granularity align with the user prompt
  - Updated module docstring to reflect broader product-analytics scope

- **Updated**: `ee/hogai/eval/sandboxed/product_analytics/eval_retention.py`
  - Moved `INSIGHT_WRITE_TOOLS` import from local definition to shared `scorers` module

## How did you test this code?

The eval cases are designed to run via pytest:
```bash
pytest ee/hogai/eval/sandboxed/product_analytics/eval_trends.py
```

The test suite exercises the sandboxed agent end-to-end with PostHog MCP tools and validates:
1. Agent successfully executes without errors (`ExitCodeZero`)
2. Agent doesn't persist insights to the database (`NoToolCall` on write tools)
3. Generated trends query matches expected schema (`TrendsSchemaAlignment`)
4. Time range and interval are relevant to the user prompt (`TrendsTimeRangeRelevancy`)

Existing retention eval tests continue to pass with the refactored `INSIGHT_WRITE_TOOLS` constant.

## Publish to changelog?

No — this is internal eval infrastructure, not a user-facing feature.

https://claude.ai/code/session_01QinzUY4vfgWR2f1rdtpta9