### PR TITLE
fix(marketing-analytics): correct goals count and has_compare telemetry

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -63,13 +63,20 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
     def _capture_query_event(self, event: str, start: float, error: Optional[BaseException] = None) -> None:
         try:
             duration_ms = (time.perf_counter() - start) * 1000
+            team_goals = self.team.marketing_analytics_config.conversion_goals or []
+            draft_goal = getattr(self.query, "draftConversionGoal", None)
+            conversion_goals_count = len(team_goals) + (1 if draft_goal else 0)
+
+            compare_filter = getattr(self.query, "compareFilter", None)
+            has_compare = bool(compare_filter and getattr(compare_filter, "compare", False))
+
             props: dict = {
                 "query_kind": getattr(self.query, "kind", None),
                 "duration_ms": round(duration_ms, 2),
                 "drill_down_level": getattr(self.config, "drill_down_level", None),
                 "attribution_mode": getattr(self.query, "attributionMode", None),
-                "conversion_goals_count": len(getattr(self.query, "conversionGoals", None) or []),
-                "has_compare": getattr(self.query, "compareFilter", None) is not None,
+                "conversion_goals_count": conversion_goals_count,
+                "has_compare": has_compare,
                 "team_id": self.team.pk,
             }
             if error is None:

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -49,6 +49,7 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
         super().__init__(*args, **kwargs)
         self.config = MarketingAnalyticsConfig()
         self._conversion_goal_warnings: list[str] = []
+        self._valid_conversion_goals_count: Optional[int] = None
 
     def calculate(self) -> ResponseType:
         start = time.perf_counter()
@@ -63,12 +64,23 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
     def _capture_query_event(self, event: str, start: float, error: Optional[BaseException] = None) -> None:
         try:
             duration_ms = (time.perf_counter() - start) * 1000
-            team_goals = self.team.marketing_analytics_config.conversion_goals or []
-            draft_goal = getattr(self.query, "draftConversionGoal", None)
-            conversion_goals_count = len(team_goals) + (1 if draft_goal else 0)
+            if self._valid_conversion_goals_count is not None:
+                conversion_goals_count = self._valid_conversion_goals_count
+            else:
+                team_goals = self.team.marketing_analytics_config.conversion_goals or []
+                draft_goal = getattr(self.query, "draftConversionGoal", None)
+                conversion_goals_count = len(team_goals) + (1 if draft_goal else 0)
 
+            # Compare mode is entered via either compareFilter.compare (previous period)
+            # or compareFilter.compare_to (specific period) — see query_compare_to_date_range.
             compare_filter = getattr(self.query, "compareFilter", None)
-            has_compare = bool(compare_filter and getattr(compare_filter, "compare", False))
+            has_compare = bool(
+                compare_filter
+                and (
+                    getattr(compare_filter, "compare", False)
+                    or isinstance(getattr(compare_filter, "compare_to", None), str)
+                )
+            )
 
             props: dict = {
                 "query_kind": getattr(self.query, "kind", None),
@@ -553,6 +565,7 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             valid_conversion_goals, self._conversion_goal_warnings = self._filter_invalid_conversion_goals(
                 conversion_goals
             )
+            self._valid_conversion_goals_count = len(valid_conversion_goals)
 
             # Create processors only for valid conversion goals
             processors = (


### PR DESCRIPTION
## Problem

The marketing analytics query telemetry added in #54527 emits two properties that are effectively useless for analysis:

- `conversion_goals_count` is read from `self.query.conversionGoals`, which is always empty — goals live on the team config, not on the query object. In the last 30 days of production telemetry **every single event reports 0 goals**, regardless of the actual team setup.
- `has_compare` checks `self.query.compareFilter is not None`, but the compare filter object exists even when compare mode is off — the actual toggle is `compareFilter.compare`. As a result `has_compare` is **always `True`** in production.

This matters beyond cosmetics. These are the two dimensions we need to measure the impact of upcoming optimizations:

- We want to track how query latency scales with the number of conversion goals configured for a team. This becomes the primary metric to validate the lazy precompute work in #55005 — the whole point of precompute is to flatten the per-goal cost, and we can't see that flattening if the breakdown is always `0`.
- We want to separate the cost of compare mode (which renders two periods) from normal renders, so we can tell whether compare-mode-specific work (like the parallelisation in #54989, once it's useful) actually helps.

Without this fix, any insight built on top of these properties is meaningless, and we can't tell whether precompute or parallelisation move the needle for teams with many goals or compare enabled.

## Changes

- Read the goals count from `team.marketing_analytics_config.conversion_goals` (the same source the runner itself uses in `_get_team_conversion_goals`), plus `+1` when `draftConversionGoal` is set on the query.
- Evaluate `has_compare` via `compareFilter.compare`, matching how the runner itself branches into compare mode in `calculate_with_compare`.

Both fixes are inside the existing `try/except` in `_capture_query_event`, so telemetry still cannot break a query.

## How did you test this code?

- Confirmed the bugs against production telemetry (`us.posthog.com` project 2): across the last 30 days, 100% of `marketing analytics query performed` events have `conversion_goals_count = 0` and `has_compare = true`, which is not plausible given the team mix we see in `conversion_goals` configs.
- Verified the new code paths mirror the sources of truth used elsewhere in `MarketingAnalyticsBaseQueryRunner` (`_get_team_conversion_goals` for goals, `calculate_with_compare` for the compare toggle).
- Did not add new automated tests in this PR — the existing `test_marketing_analytics_telemetry.py` suite is a good place to extend coverage in a follow-up, since the current suite asserts on the full property payload and will catch any regression once the assertions are updated.

## Publish to changelog?

no