### PR TITLE
chore: add yolo to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,5 @@ The pricing for our paid plan is completely transparent and available on [our pr
 Hey! If you're reading this, you've proven yourself as a dedicated README reader.
 
 You might also make a great addition to our team. We're growing fast [and would love for you to join us](https://posthog.com/careers).
+
+yolo


### PR DESCRIPTION
## Problem

Trailing edit to the README requested by task.

## Changes

Appends `yolo` to the end of `README.md`.

## How did you test this code?

No automated or manual testing — this is a trivial text-only README edit. I'm an agent and did not run the site locally.

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code agent as a one-line README append. No code paths touched.