### PR TITLE
fix(error-tracking): onboarding sends parent template ids

### DIFF
--- a/frontend/src/scenes/onboarding/error-tracking/onboardingErrorTrackingAlertsLogic.ts
+++ b/frontend/src/scenes/onboarding/error-tracking/onboardingErrorTrackingAlertsLogic.ts
@@ -101,7 +101,7 @@ export const onboardingErrorTrackingAlertsLogic = kea<onboardingErrorTrackingAle
             submit: async (formValues) => {
                 const configuration = {
                     ...DEFAULT_HOG_FUNCTION_CONFIGURATION,
-                    template_id: `template-${values.integration}-error-tracking-issue-created`,
+                    template_id: `template-${values.integration}`,
                 }
 
                 if (values.integration === 'microsoft-teams') {


### PR DESCRIPTION
## Problem

Migration `0766_fix_sub_template_ids_to_template_ids` (merged 2025-06-12 in #33584) collapsed sub-template ids like `template-slack-error-tracking-issue-created` into their parent templates (`template-slack`, `template-discord`, `template-microsoft-teams`). The error-tracking onboarding step kept building the retired sub-template id, so `POST /hog_functions/` has been returning 400 since then with:

```
{
  "type": "validation_error",
  "code": "invalid_input",
  "detail": "No template found for id 'template-slack-error-tracking-issue-created'",
  "attr": "template_id"
}
```

Users hit the onboarding "Configure alerts" screen, pick Slack / Discord / Microsoft Teams, click **Next**, and the button silently does nothing. The PR on top of this in the stack addresses the silent-failure UX.

## Changes

Swap the onboarding's hardcoded sub-template id for the parent template id. The "alert flavor" is preserved by `filters.events` (already set to `$error_tracking_issue_created` in `DEFAULT_HOG_FUNCTION_CONFIGURATION` at the top of the file).

The parent templates accept every input key this form sends (`slack_workspace`, `channel`, `icon_emoji`, `blocks`, `text`, `username` for Slack; `webhookUrl` for Discord / MS Teams), so the configuration is wire-compatible. Listings, the coverage-recommendation card, and the edit flow all identify error-tracking alerts off `filters.events` rather than `template_id`, so there is no observable change for existing alerts or new ones created through this path.

## How did you test this code?

- Reproduced the 400 locally by POSTing the original payload from DevTools for all three integrations
- Verified the parent template ids resolve via `HogFunctionTemplate.get_template(...)` for each of Slack / Discord / Microsoft Teams
- Cross-checked that the `AlertWizard` (`frontend/src/scenes/hog-functions/AlertWizard/alertWizardLogic.ts`) uses the same parent ids + `filters.events` approach today and renders existing records correctly
- No automated tests exist on this file; manual only

## Publish to changelog?

no

## Docs update

N/A — internal onboarding bug fix

## 🤖 LLM context

Authored by Claude via Claude Code. Root-cause analysis traced the 400 to migration 0766 plus a lingering caller that wasn't updated. The PR stacked on top adds error-toast handling so the next such drift surfaces to users immediately rather than hiding behind a silent submit button.
