### PR TITLE
chore(error-tracking): surface api errors in onboarding alerts submit

### DIFF
--- a/frontend/src/scenes/onboarding/error-tracking/onboardingErrorTrackingAlertsLogic.ts
+++ b/frontend/src/scenes/onboarding/error-tracking/onboardingErrorTrackingAlertsLogic.ts
@@ -2,6 +2,8 @@ import { actions, afterMount, connect, kea, path, reducers } from 'kea'
 import { forms } from 'kea-forms'
 import { router } from 'kea-router'
 
+import { lemonToast } from '@posthog/lemon-ui'
+
 import api from 'lib/api'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 
@@ -122,7 +124,14 @@ export const onboardingErrorTrackingAlertsLogic = kea<onboardingErrorTrackingAle
                     }
                 }
 
-                await api.hogFunctions.create(configuration)
+                try {
+                    await api.hogFunctions.create(configuration)
+                } catch (e: any) {
+                    // Without this, kea-forms swallows the API error and the "Next" button
+                    // appears to do nothing
+                    lemonToast.error(e?.detail || e?.message || 'Failed to create alert')
+                    throw e
+                }
                 actions.goToNextStep()
             },
         },


### PR DESCRIPTION
## Problem

The error-tracking onboarding alerts form has no error handling around the `api.hogFunctions.create()` call. `kea-forms` swallows API failures silently, so when the previous PR in this stack fixed the 400 the **Next** button had been producing, there was no UI feedback on any future backend failure either — no toast, no field error, no redirect. The user who reported the template-id bug had to open DevTools Network tab to see there was a problem at all, which is why the 10-month-old regression went unnoticed.

## Changes

Wrap the `hogFunctions.create` call in a `try/catch`, surface the API `detail` via `lemonToast.error`, and rethrow so `kea-forms` still resets its `submitting` flag.

No new dependencies, no state changes, no behaviour change on the happy path — only the failure path now notifies the user.

Optional follow-up (not in this PR): audit other kea-forms in `scenes/onboarding/` for the same silent-submit failure mode.

## How did you test this code?

- Reverted the template-id fix locally: onboarding submit now surfaces the exact backend validation detail as a toast instead of silently doing nothing
- With both PRs in the stack applied: happy path unchanged — toast never fires, `goToNextStep` runs as before
- No automated tests exist on this file; manual only

## Publish to changelog?

no

## Docs update

N/A

## 🤖 LLM context

Authored by Claude via Claude Code alongside the PR below it in the stack. The two changes are independently mergeable but tell one story: "here's the bug + here's why no one noticed for 10 months." Ship the fix first; ship the guard rail right after.
