### PR TITLE
feat(data-warehouse): make meta ads source resumable

### DIFF
--- a/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
@@ -9,6 +9,7 @@ import requests
 from posthog.models.integration import ERROR_TOKEN_REFRESH_FAILED, Integration, MetaAdsIntegration
 from posthog.temporal.data_imports.naming_convention import NamingConvention
 from posthog.temporal.data_imports.pipelines.pipeline.typings import PartitionFormat, PartitionMode, SourceResponse
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.generated_configs import MetaAdsSourceConfig
 from posthog.temporal.data_imports.sources.meta_ads.schemas import RESOURCE_SCHEMAS
 
@@ -17,6 +18,32 @@ from products.data_warehouse.backend.types import IncrementalFieldType
 # Meta Ads API only supports data from the last 3 years
 META_ADS_MAX_HISTORY_DAYS = 3 * 365
 DEFAULT_SYNC_LOOKBACK_DAYS = 90
+
+
+@dataclass
+class MetaAdsResumeConfig:
+    """Resume state for a Meta Ads sync.
+
+    Two shapes are encoded here:
+
+    - Simple pagination (non-stats endpoints, no time range): only ``next_url``
+      is set. It is a ``paging.next`` URL returned by the Graph API and already
+      has query params (including the access token) embedded, so it is fetched
+      as-is on resume.
+    - Time-range pagination (stats endpoints): ``end_date`` acts as the
+      discriminator. ``chunk_since`` and ``chunk_size_days`` describe where to
+      restart the outer chunk loop. ``chunk_next_url`` is set when the crash
+      happened mid-chunk — on resume we fetch that URL directly, skipping the
+      initial chunk request. When the chunk was complete at save time,
+      ``chunk_next_url`` is None and we issue a fresh initial request for
+      ``chunk_since``.
+    """
+
+    next_url: str | None = None
+    end_date: str | None = None
+    chunk_since: str | None = None
+    chunk_size_days: int | None = None
+    chunk_next_url: str | None = None
 
 
 def _clean_account_id(s: str | None) -> str | None:
@@ -114,48 +141,23 @@ def _is_timeout_error(response: requests.Response) -> bool:
         return False
 
 
-def _fetch_time_range_chunk(
-    url: str,
+def _iter_simple_pagination(
+    initial_url: str,
     params: dict,
-    chunk_start: dt.datetime,
-    chunk_end: dt.datetime,
-    chunk_size_days: int,
+    resume_config: MetaAdsResumeConfig | None,
+    resumable_source_manager: ResumableSourceManager[MetaAdsResumeConfig],
 ) -> collections.abc.Generator[list[dict], None, None]:
-    """Fetch data for a single time range chunk, with adaptive fallback to smaller chunks on timeout.
+    """Iterate a non-time-range Graph API request via ``paging.next`` URLs.
 
-    Fallback only happens on the initial request for a chunk (before any data is yielded).
-    If a timeout occurs during pagination (after data has been yielded), the error is raised
-    to avoid duplicate data.
+    On resume, the saved ``next_url`` is re-issued as-is (params and token are
+    already embedded by Meta), so the initial request is skipped.
     """
-    chunk_time_range = {
-        "since": chunk_start.strftime("%Y-%m-%d"),
-        "until": chunk_end.strftime("%Y-%m-%d"),
-    }
+    if resume_config is not None and resume_config.next_url and resume_config.end_date is None:
+        response = requests.get(resume_config.next_url)
+    else:
+        response = requests.get(initial_url, params=params)
 
-    chunk_params = params.copy()
-    chunk_params["time_range"] = json.dumps(chunk_time_range)
-
-    # Make the initial request for this chunk
-    response = requests.get(url, params=chunk_params)
-
-    if response.status_code != 200:
-        # Only attempt fallback on the initial request (before any data is yielded)
-        if _is_timeout_error(response) and chunk_size_days in TIME_RANGE_CHUNK_SIZES:
-            current_index = TIME_RANGE_CHUNK_SIZES.index(chunk_size_days)
-            if current_index < len(TIME_RANGE_CHUNK_SIZES) - 1:
-                smaller_chunk_size = TIME_RANGE_CHUNK_SIZES[current_index + 1]
-                yield from _fetch_with_chunk_size(url, params, chunk_start, chunk_end, smaller_chunk_size)
-                return
-        raise Exception(f"Meta API request failed: {response.status_code} - {response.text}")
-
-    response_payload = response.json()
-    yield response_payload.get("data", [])
-
-    # Handle pagination for remaining pages (no fallback here to avoid duplicates)
-    next_url = response_payload.get("paging", {}).get("next")
-    while next_url:
-        response = requests.get(next_url)
-
+    while True:
         if response.status_code != 200:
             raise Exception(f"Meta API request failed: {response.status_code} - {response.text}")
 
@@ -163,28 +165,103 @@ def _fetch_time_range_chunk(
         yield response_payload.get("data", [])
 
         next_url = response_payload.get("paging", {}).get("next")
+        if not next_url:
+            return
+
+        # Saved state points at the NEXT page. On resume we re-fetch from there;
+        # the already-yielded page is not re-emitted (primary keys would dedupe it anyway).
+        resumable_source_manager.save_state(MetaAdsResumeConfig(next_url=next_url))
+        response = requests.get(next_url)
 
 
-def _fetch_with_chunk_size(
+def _iter_time_range_pagination(
     url: str,
     params: dict,
-    start_date: dt.datetime,
-    end_date: dt.datetime,
-    chunk_size_days: int,
+    time_range: dict,
+    resume_config: MetaAdsResumeConfig | None,
+    resumable_source_manager: ResumableSourceManager[MetaAdsResumeConfig],
 ) -> collections.abc.Generator[list[dict], None, None]:
-    """Fetch data by breaking the date range into chunks of the specified size."""
-    current_start = start_date
-    while current_start <= end_date:
-        current_end = current_start + dt.timedelta(days=chunk_size_days - 1)
-        current_end = min(current_end, end_date)
+    """Iterate an insights-style request by chunked date ranges.
 
-        yield from _fetch_time_range_chunk(url, params, current_start, current_end, chunk_size_days)
+    The outer loop walks adaptive date chunks (30/7/1 days). The inner loop
+    follows ``paging.next`` within each chunk. Resume state captures both
+    levels: ``chunk_since`` + ``chunk_size_days`` for the outer loop, and
+    ``chunk_next_url`` when the crash happened mid-chunk.
+    """
+    start_date = dt.datetime.strptime(time_range["since"], "%Y-%m-%d")
+    end_date = dt.datetime.strptime(time_range["until"], "%Y-%m-%d")
+
+    chunk_size_days = TIME_RANGE_CHUNK_SIZES[0]
+    current_start = start_date
+    pending_next_url: str | None = None
+
+    if resume_config is not None and resume_config.end_date is not None and resume_config.chunk_since is not None:
+        current_start = dt.datetime.strptime(resume_config.chunk_since, "%Y-%m-%d")
+        chunk_size_days = resume_config.chunk_size_days or TIME_RANGE_CHUNK_SIZES[0]
+        pending_next_url = resume_config.chunk_next_url
+
+    end_date_iso = end_date.strftime("%Y-%m-%d")
+
+    def _save(since: dt.datetime, size_days: int, next_url_in_chunk: str | None) -> None:
+        resumable_source_manager.save_state(
+            MetaAdsResumeConfig(
+                end_date=end_date_iso,
+                chunk_since=since.strftime("%Y-%m-%d"),
+                chunk_size_days=size_days,
+                chunk_next_url=next_url_in_chunk,
+            )
+        )
+
+    while current_start <= end_date:
+        current_end = min(current_start + dt.timedelta(days=chunk_size_days - 1), end_date)
+
+        if pending_next_url:
+            # Mid-chunk resume: the saved next_url already has params embedded.
+            response = requests.get(pending_next_url)
+            pending_next_url = None
+        else:
+            chunk_time_range = {
+                "since": current_start.strftime("%Y-%m-%d"),
+                "until": current_end.strftime("%Y-%m-%d"),
+            }
+            chunk_params = {**params, "time_range": json.dumps(chunk_time_range)}
+            response = requests.get(url, params=chunk_params)
+
+            if response.status_code != 200:
+                # Fallback only happens on the initial chunk request (before any data is yielded).
+                if _is_timeout_error(response) and chunk_size_days in TIME_RANGE_CHUNK_SIZES:
+                    current_index = TIME_RANGE_CHUNK_SIZES.index(chunk_size_days)
+                    if current_index < len(TIME_RANGE_CHUNK_SIZES) - 1:
+                        chunk_size_days = TIME_RANGE_CHUNK_SIZES[current_index + 1]
+                        continue
+                raise Exception(f"Meta API request failed: {response.status_code} - {response.text}")
+
+        while True:
+            if response.status_code != 200:
+                raise Exception(f"Meta API request failed: {response.status_code} - {response.text}")
+
+            response_payload = response.json()
+            yield response_payload.get("data", [])
+
+            next_url = response_payload.get("paging", {}).get("next")
+            if not next_url:
+                break
+
+            _save(current_start, chunk_size_days, next_url)
+            response = requests.get(next_url)
 
         current_start = current_end + dt.timedelta(days=1)
+        # Mark the chunk as complete so a resume starts fresh at the next chunk.
+        if current_start <= end_date:
+            _save(current_start, chunk_size_days, None)
 
 
 def _make_paginated_api_request(
-    url: str, params: dict, access_token: str, time_range: dict | None = None
+    url: str,
+    params: dict,
+    access_token: str,
+    time_range: dict | None,
+    resumable_source_manager: ResumableSourceManager[MetaAdsResumeConfig],
 ) -> collections.abc.Generator[list[dict], None, None]:
     """Make paginated requests to the Meta Graph API.
     This function handles two types of pagination:
@@ -192,37 +269,20 @@ def _make_paginated_api_request(
     2. Time-range pagination: Breaks large date ranges into chunks, with adaptive fallback
        to smaller chunks (30-day -> 7-day -> 1-day) if the API times out
     """
-    params["access_token"] = access_token
+    params = {**params, "access_token": access_token}
+    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
 
     if time_range is None:
-        # Original pagination logic for non-time-range requests
-        next_url = url
-        while next_url:
-            if next_url == url:
-                response = requests.get(next_url, params=params)
-            else:
-                response = requests.get(next_url)
-
-            if response.status_code != 200:
-                raise Exception(f"Meta API request failed: {response.status_code} - {response.text}")
-
-            response_payload = response.json()
-            yield response_payload.get("data", [])
-
-            paging = response_payload.get("paging", {})
-            next_url = paging.get("next")
+        yield from _iter_simple_pagination(url, params, resume_config, resumable_source_manager)
     else:
-        start_date = dt.datetime.strptime(time_range["since"], "%Y-%m-%d")
-        end_date = dt.datetime.strptime(time_range["until"], "%Y-%m-%d")
-
-        # Start with the largest chunk size and adaptively fall back to smaller ones on timeout
-        yield from _fetch_with_chunk_size(url, params, start_date, end_date, TIME_RANGE_CHUNK_SIZES[0])
+        yield from _iter_time_range_pagination(url, params, time_range, resume_config, resumable_source_manager)
 
 
 def meta_ads_source(
     resource_name: str,
     config: MetaAdsSourceConfig,
     team_id: int,
+    resumable_source_manager: ResumableSourceManager[MetaAdsResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: typing.Any = None,
     incremental_field: str | None = None,
@@ -278,7 +338,9 @@ def meta_ads_source(
             **schema.extra_params,
         }
 
-        yield from _make_paginated_api_request(formatted_url, params, access_token, time_range)
+        yield from _make_paginated_api_request(
+            formatted_url, params, access_token, time_range, resumable_source_manager
+        )
 
     return SourceResponse(
         name=name,

--- a/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
@@ -3,6 +3,7 @@ import typing
 import datetime as dt
 import collections.abc
 from dataclasses import dataclass
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import requests
 
@@ -27,16 +28,17 @@ class MetaAdsResumeConfig:
     Two shapes are encoded here:
 
     - Simple pagination (non-stats endpoints, no time range): only ``next_url``
-      is set. It is a ``paging.next`` URL returned by the Graph API and already
-      has query params (including the access token) embedded, so it is fetched
-      as-is on resume.
+      is set. It is a ``paging.next`` URL returned by the Graph API with its
+      ``access_token`` query param stripped (see ``_strip_access_token``); the
+      token is re-attached from the integration config at request time on
+      resume.
     - Time-range pagination (stats endpoints): ``end_date`` acts as the
       discriminator. ``chunk_since`` and ``chunk_size_days`` describe where to
       restart the outer chunk loop. ``chunk_next_url`` is set when the crash
       happened mid-chunk — on resume we fetch that URL directly, skipping the
       initial chunk request. When the chunk was complete at save time,
       ``chunk_next_url`` is None and we issue a fresh initial request for
-      ``chunk_since``.
+      ``chunk_since``. Saved URLs have ``access_token`` stripped.
     """
 
     next_url: str | None = None
@@ -44,6 +46,29 @@ class MetaAdsResumeConfig:
     chunk_since: str | None = None
     chunk_size_days: int | None = None
     chunk_next_url: str | None = None
+
+
+def _strip_access_token(url: str) -> str:
+    """Remove the ``access_token`` query parameter from a URL.
+
+    Meta's ``paging.next`` URLs embed the caller's access token as a query
+    param. We never want that token at rest in Redis or in logs — we re-attach
+    a fresh one from the integration config at request time.
+    """
+    parts = urlsplit(url)
+    if not parts.query:
+        return url
+    filtered = [(k, v) for k, v in parse_qsl(parts.query, keep_blank_values=True) if k != "access_token"]
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(filtered), parts.fragment))
+
+
+def _fetch_paging_url(url: str, access_token: str) -> requests.Response:
+    """Fetch a Meta ``paging.next``-style URL with a freshly injected access token.
+
+    Saved URLs have ``access_token`` stripped; we pass it via ``params`` at
+    request time so the token never persists in Redis or debug logs.
+    """
+    return requests.get(url, params={"access_token": access_token})
 
 
 def _clean_account_id(s: str | None) -> str | None:
@@ -149,11 +174,12 @@ def _iter_simple_pagination(
 ) -> collections.abc.Generator[list[dict], None, None]:
     """Iterate a non-time-range Graph API request via ``paging.next`` URLs.
 
-    On resume, the saved ``next_url`` is re-issued as-is (params and token are
-    already embedded by Meta), so the initial request is skipped.
+    On resume, the saved ``next_url`` is re-issued with a fresh ``access_token``
+    injected at request time, so the initial request is skipped.
     """
+    access_token = params["access_token"]
     if resume_config is not None and resume_config.next_url and resume_config.end_date is None:
-        response = requests.get(resume_config.next_url)
+        response = _fetch_paging_url(resume_config.next_url, access_token)
     else:
         response = requests.get(initial_url, params=params)
 
@@ -170,8 +196,9 @@ def _iter_simple_pagination(
 
         # Saved state points at the NEXT page. On resume we re-fetch from there;
         # the already-yielded page is not re-emitted (primary keys would dedupe it anyway).
-        resumable_source_manager.save_state(MetaAdsResumeConfig(next_url=next_url))
-        response = requests.get(next_url)
+        # We strip the access_token before saving so it never sits at rest in Redis or in logs.
+        resumable_source_manager.save_state(MetaAdsResumeConfig(next_url=_strip_access_token(next_url)))
+        response = _fetch_paging_url(next_url, access_token)
 
 
 def _iter_time_range_pagination(
@@ -188,6 +215,7 @@ def _iter_time_range_pagination(
     levels: ``chunk_since`` + ``chunk_size_days`` for the outer loop, and
     ``chunk_next_url`` when the crash happened mid-chunk.
     """
+    access_token = params["access_token"]
     start_date = dt.datetime.strptime(time_range["since"], "%Y-%m-%d")
     end_date = dt.datetime.strptime(time_range["until"], "%Y-%m-%d")
 
@@ -203,12 +231,15 @@ def _iter_time_range_pagination(
     end_date_iso = end_date.strftime("%Y-%m-%d")
 
     def _save(since: dt.datetime, size_days: int, next_url_in_chunk: str | None) -> None:
+        # Saved URLs have the access_token stripped so the token never sits
+        # at rest in Redis or appears in debug logs.
+        sanitised = _strip_access_token(next_url_in_chunk) if next_url_in_chunk else None
         resumable_source_manager.save_state(
             MetaAdsResumeConfig(
                 end_date=end_date_iso,
                 chunk_since=since.strftime("%Y-%m-%d"),
                 chunk_size_days=size_days,
-                chunk_next_url=next_url_in_chunk,
+                chunk_next_url=sanitised,
             )
         )
 
@@ -216,8 +247,8 @@ def _iter_time_range_pagination(
         current_end = min(current_start + dt.timedelta(days=chunk_size_days - 1), end_date)
 
         if pending_next_url:
-            # Mid-chunk resume: the saved next_url already has params embedded.
-            response = requests.get(pending_next_url)
+            # Mid-chunk resume: re-attach a fresh access_token at request time.
+            response = _fetch_paging_url(pending_next_url, access_token)
             pending_next_url = None
         else:
             chunk_time_range = {
@@ -248,12 +279,15 @@ def _iter_time_range_pagination(
                 break
 
             _save(current_start, chunk_size_days, next_url)
-            response = requests.get(next_url)
+            response = _fetch_paging_url(next_url, access_token)
 
         current_start = current_end + dt.timedelta(days=1)
-        # Mark the chunk as complete so a resume starts fresh at the next chunk.
-        if current_start <= end_date:
-            _save(current_start, chunk_size_days, None)
+        # Always save the chunk-boundary state, even when we've advanced past
+        # end_date. This clears any stale mid-chunk next_url from the previous
+        # iteration (so a resume doesn't redo already-completed pagination)
+        # and guarantees a crash right after the final chunk finds the loop
+        # already satisfied on restart.
+        _save(current_start, chunk_size_days, None)
 
 
 def _make_paginated_api_request(

--- a/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/meta_ads.py
@@ -196,9 +196,11 @@ def _iter_simple_pagination(
 
         # Saved state points at the NEXT page. On resume we re-fetch from there;
         # the already-yielded page is not re-emitted (primary keys would dedupe it anyway).
-        # We strip the access_token before saving so it never sits at rest in Redis or in logs.
-        resumable_source_manager.save_state(MetaAdsResumeConfig(next_url=_strip_access_token(next_url)))
-        response = _fetch_paging_url(next_url, access_token)
+        # Strip access_token from the URL before using it so we don't end up with a
+        # duplicated `access_token` query param (requests merges `params=...` into the URL).
+        stripped_next_url = _strip_access_token(next_url)
+        resumable_source_manager.save_state(MetaAdsResumeConfig(next_url=stripped_next_url))
+        response = _fetch_paging_url(stripped_next_url, access_token)
 
 
 def _iter_time_range_pagination(
@@ -278,8 +280,12 @@ def _iter_time_range_pagination(
             if not next_url:
                 break
 
-            _save(current_start, chunk_size_days, next_url)
-            response = _fetch_paging_url(next_url, access_token)
+            # Strip the token once and use the same URL for both save and fetch,
+            # otherwise `requests.get(url_with_token, params={access_token: ...})`
+            # would send two `access_token` query params.
+            stripped_next_url = _strip_access_token(next_url)
+            _save(current_start, chunk_size_days, stripped_next_url)
+            response = _fetch_paging_url(stripped_next_url, access_token)
 
         current_start = current_end + dt.timedelta(days=1)
         # Always save the chunk-boundary state, even when we've advanced past

--- a/posthog/temporal/data_imports/sources/meta_ads/source.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/source.py
@@ -13,19 +13,20 @@ from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInput
 from posthog.temporal.data_imports.sources.common.base import (
     MARKETING_ANALYTICS_SUGGESTED_TABLE_TOOLTIP,
     FieldType,
-    SimpleSource,
+    ResumableSource,
 )
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import MetaAdsSourceConfig
-from posthog.temporal.data_imports.sources.meta_ads.meta_ads import meta_ads_source
+from posthog.temporal.data_imports.sources.meta_ads.meta_ads import MetaAdsResumeConfig, meta_ads_source
 from posthog.temporal.data_imports.sources.meta_ads.schemas import ENDPOINTS, INCREMENTAL_FIELDS
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class MetaAdsSource(SimpleSource[MetaAdsSourceConfig]):
+class MetaAdsSource(ResumableSource[MetaAdsSourceConfig, MetaAdsResumeConfig]):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.METAADS
@@ -56,11 +57,20 @@ class MetaAdsSource(SimpleSource[MetaAdsSourceConfig]):
 
         return schemas
 
-    def source_for_pipeline(self, config: MetaAdsSourceConfig, inputs: SourceInputs) -> SourceResponse:
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[MetaAdsResumeConfig]:
+        return ResumableSourceManager[MetaAdsResumeConfig](inputs, MetaAdsResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: MetaAdsSourceConfig,
+        resumable_source_manager: ResumableSourceManager[MetaAdsResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
         return meta_ads_source(
             resource_name=inputs.schema_name,
             config=config,
             team_id=inputs.team_id,
+            resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             incremental_field=inputs.incremental_field if inputs.should_use_incremental_field else None,
             incremental_field_type=inputs.incremental_field_type if inputs.should_use_incremental_field else None,

--- a/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -273,7 +273,7 @@ class TestTimeRangePagination:
                 _iter_time_range_pagination(
                     self.URL,
                     self.PARAMS,
-                    {"since": "2026-03-01", "until": "2026-04-30"},
+                    {"since": "2026-03-01", "until": "2026-04-29"},
                     None,
                     manager,
                 )

--- a/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -1,0 +1,315 @@
+from typing import Any
+
+from unittest import mock
+
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.meta_ads.meta_ads import (
+    MetaAdsResumeConfig,
+    _iter_simple_pagination,
+    _iter_time_range_pagination,
+)
+
+
+def _mock_response(status: int, body: dict) -> mock.MagicMock:
+    response = mock.MagicMock()
+    response.status_code = status
+    response.json.return_value = body
+    response.text = ""
+    return response
+
+
+def _build_manager(*, can_resume: bool = False, state: MetaAdsResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock(spec=ResumableSourceManager)
+    manager.can_resume.return_value = can_resume
+    manager.load_state.return_value = state
+    return manager
+
+
+class TestSimplePagination:
+    def test_fresh_run_fetches_initial_and_saves_next_url(self) -> None:
+        manager = _build_manager()
+
+        responses = [
+            _mock_response(
+                200,
+                {
+                    "data": [{"id": "1"}, {"id": "2"}],
+                    "paging": {"next": "https://graph.facebook.com/v20/next?cursor=abc"},
+                },
+            ),
+            _mock_response(200, {"data": [{"id": "3"}], "paging": {}}),
+        ]
+
+        with mock.patch("requests.get", side_effect=responses) as mock_get:
+            batches = list(
+                _iter_simple_pagination(
+                    "https://graph.facebook.com/v20/act_123/campaigns",
+                    {"fields": "id,name", "access_token": "tok"},
+                    None,
+                    manager,
+                )
+            )
+
+        assert batches == [[{"id": "1"}, {"id": "2"}], [{"id": "3"}]]
+        # First call: initial URL + params. Second call: paging.next URL only.
+        assert mock_get.call_args_list[0].args[0] == "https://graph.facebook.com/v20/act_123/campaigns"
+        assert mock_get.call_args_list[0].kwargs["params"] == {"fields": "id,name", "access_token": "tok"}
+        assert mock_get.call_args_list[1].args[0] == "https://graph.facebook.com/v20/next?cursor=abc"
+        assert "params" not in mock_get.call_args_list[1].kwargs
+
+        manager.save_state.assert_called_once_with(
+            MetaAdsResumeConfig(next_url="https://graph.facebook.com/v20/next?cursor=abc")
+        )
+
+    def test_resume_skips_initial_request(self) -> None:
+        saved_url = "https://graph.facebook.com/v20/next?cursor=xyz"
+        manager = _build_manager(can_resume=True, state=MetaAdsResumeConfig(next_url=saved_url))
+
+        responses = [
+            _mock_response(200, {"data": [{"id": "5"}], "paging": {}}),
+        ]
+
+        with mock.patch("requests.get", side_effect=responses) as mock_get:
+            batches = list(
+                _iter_simple_pagination(
+                    "https://graph.facebook.com/v20/act_123/campaigns",
+                    {"fields": "id,name", "access_token": "tok"},
+                    MetaAdsResumeConfig(next_url=saved_url),
+                    manager,
+                )
+            )
+
+        assert batches == [[{"id": "5"}]]
+        assert mock_get.call_count == 1
+        assert mock_get.call_args_list[0].args[0] == saved_url
+        assert "params" not in mock_get.call_args_list[0].kwargs
+        # No more pages, no save call needed.
+        manager.save_state.assert_not_called()
+
+    def test_single_page_does_not_save_state(self) -> None:
+        manager = _build_manager()
+
+        responses = [
+            _mock_response(200, {"data": [{"id": "1"}], "paging": {}}),
+        ]
+
+        with mock.patch("requests.get", side_effect=responses):
+            batches = list(
+                _iter_simple_pagination(
+                    "https://graph.facebook.com/v20/act_123/campaigns",
+                    {"access_token": "tok"},
+                    None,
+                    manager,
+                )
+            )
+
+        assert batches == [[{"id": "1"}]]
+        manager.save_state.assert_not_called()
+
+    def test_ignores_resume_state_when_time_range_mode(self) -> None:
+        # A time-range-mode state (end_date set) should NOT be consumed by simple pagination.
+        manager = _build_manager()
+        stale_state = MetaAdsResumeConfig(
+            next_url="https://example/ignored",
+            end_date="2026-01-01",
+            chunk_since="2025-12-15",
+            chunk_size_days=30,
+        )
+
+        responses = [_mock_response(200, {"data": [], "paging": {}})]
+
+        with mock.patch("requests.get", side_effect=responses) as mock_get:
+            list(
+                _iter_simple_pagination(
+                    "https://graph.facebook.com/v20/act_123/campaigns",
+                    {"access_token": "tok"},
+                    stale_state,
+                    manager,
+                )
+            )
+
+        # Initial request should be the original URL with params, not the stale next_url.
+        assert mock_get.call_args_list[0].args[0] == "https://graph.facebook.com/v20/act_123/campaigns"
+        assert mock_get.call_args_list[0].kwargs["params"] == {"access_token": "tok"}
+
+
+class TestTimeRangePagination:
+    URL = "https://graph.facebook.com/v20/act_1/insights"
+    PARAMS: dict[str, Any] = {"fields": "ad_id", "limit": 500, "level": "ad", "access_token": "tok"}
+
+    def test_fresh_run_saves_chunk_state_after_first_page(self) -> None:
+        manager = _build_manager()
+        # One 1-day window (since == until), one page with a paging.next, then done.
+        responses = [
+            _mock_response(
+                200,
+                {
+                    "data": [{"ad_id": "a"}],
+                    "paging": {"next": "https://graph.facebook.com/v20/act_1/insights?after=abc"},
+                },
+            ),
+            _mock_response(200, {"data": [{"ad_id": "b"}], "paging": {}}),
+        ]
+
+        with mock.patch("requests.get", side_effect=responses) as mock_get:
+            batches = list(
+                _iter_time_range_pagination(
+                    self.URL,
+                    self.PARAMS,
+                    {"since": "2026-04-21", "until": "2026-04-21"},
+                    None,
+                    manager,
+                )
+            )
+
+        assert batches == [[{"ad_id": "a"}], [{"ad_id": "b"}]]
+        # Two pages in one chunk => one save pointing at the mid-chunk next_url.
+        assert manager.save_state.call_count == 1
+        saved: MetaAdsResumeConfig = manager.save_state.call_args_list[0].args[0]
+        assert saved.end_date == "2026-04-21"
+        assert saved.chunk_since == "2026-04-21"
+        assert saved.chunk_size_days == 30
+        assert saved.chunk_next_url == "https://graph.facebook.com/v20/act_1/insights?after=abc"
+
+        # Second request used the saved next_url with no params.
+        assert mock_get.call_args_list[1].args[0] == "https://graph.facebook.com/v20/act_1/insights?after=abc"
+        assert "params" not in mock_get.call_args_list[1].kwargs
+
+    def test_fresh_run_saves_chunk_boundary_between_chunks(self) -> None:
+        manager = _build_manager()
+        # Two 30-day chunks back to back, each with one page.
+        responses = [
+            _mock_response(200, {"data": [{"ad_id": "a"}], "paging": {}}),
+            _mock_response(200, {"data": [{"ad_id": "b"}], "paging": {}}),
+        ]
+
+        with mock.patch("requests.get", side_effect=responses):
+            batches = list(
+                _iter_time_range_pagination(
+                    self.URL,
+                    self.PARAMS,
+                    {"since": "2026-03-01", "until": "2026-04-29"},
+                    None,
+                    manager,
+                )
+            )
+
+        assert batches == [[{"ad_id": "a"}], [{"ad_id": "b"}]]
+        # After chunk 1 finishes we save a chunk-boundary state pointing at chunk 2.
+        assert manager.save_state.call_count == 1
+        saved: MetaAdsResumeConfig = manager.save_state.call_args_list[0].args[0]
+        assert saved.end_date == "2026-04-29"
+        assert saved.chunk_since == "2026-03-31"  # chunk 1 covered 2026-03-01..2026-03-30 (30 days)
+        assert saved.chunk_size_days == 30
+        assert saved.chunk_next_url is None
+
+    def test_resume_mid_chunk_skips_initial_request(self) -> None:
+        saved_next = "https://graph.facebook.com/v20/act_1/insights?after=xyz"
+        # End date matches the end of the resumed chunk so no further chunks are fetched.
+        state = MetaAdsResumeConfig(
+            end_date="2026-04-16",
+            chunk_since="2026-04-10",
+            chunk_size_days=7,
+            chunk_next_url=saved_next,
+        )
+        manager = _build_manager(can_resume=True, state=state)
+
+        responses = [_mock_response(200, {"data": [{"ad_id": "c"}], "paging": {}})]
+
+        with mock.patch("requests.get", side_effect=responses) as mock_get:
+            batches = list(
+                _iter_time_range_pagination(
+                    self.URL, self.PARAMS, {"since": "2026-01-01", "until": "2026-04-16"}, state, manager
+                )
+            )
+
+        assert batches == [[{"ad_id": "c"}]]
+        # The single request goes straight to the saved next_url.
+        assert mock_get.call_count == 1
+        assert mock_get.call_args_list[0].args[0] == saved_next
+        assert "params" not in mock_get.call_args_list[0].kwargs
+
+    def test_resume_at_chunk_boundary_issues_fresh_initial_request(self) -> None:
+        state = MetaAdsResumeConfig(
+            end_date="2026-04-21",
+            chunk_since="2026-04-10",
+            chunk_size_days=7,
+            chunk_next_url=None,
+        )
+        manager = _build_manager(can_resume=True, state=state)
+
+        responses = [
+            _mock_response(200, {"data": [{"ad_id": "d"}], "paging": {}}),
+            _mock_response(200, {"data": [], "paging": {}}),
+        ]
+
+        with mock.patch("requests.get", side_effect=responses) as mock_get:
+            list(
+                _iter_time_range_pagination(
+                    self.URL, self.PARAMS, {"since": "2026-01-01", "until": "2026-04-21"}, state, manager
+                )
+            )
+
+        # First request must be a fresh initial with params embedding the chunk time_range.
+        first_call = mock_get.call_args_list[0]
+        assert first_call.args[0] == self.URL
+        sent_params = first_call.kwargs["params"]
+        assert sent_params["access_token"] == "tok"
+        # time_range should be JSON-encoded and cover 2026-04-10..2026-04-16 (7 days).
+        import json as _json
+
+        tr = _json.loads(sent_params["time_range"])
+        assert tr == {"since": "2026-04-10", "until": "2026-04-16"}
+
+    def test_empty_chunk_still_iterates_to_next(self) -> None:
+        manager = _build_manager()
+        responses = [
+            _mock_response(200, {"data": [], "paging": {}}),
+            _mock_response(200, {"data": [{"ad_id": "x"}], "paging": {}}),
+        ]
+
+        with mock.patch("requests.get", side_effect=responses):
+            batches = list(
+                _iter_time_range_pagination(
+                    self.URL,
+                    self.PARAMS,
+                    {"since": "2026-03-01", "until": "2026-04-30"},
+                    None,
+                    manager,
+                )
+            )
+
+        assert batches == [[], [{"ad_id": "x"}]]
+
+    def test_timeout_fallback_shrinks_chunk_size(self) -> None:
+        manager = _build_manager()
+        timeout_body = {"error": {"error_subcode": 1504018, "message": "timeout"}}
+        # 30-day chunk times out, then 7-day chunks succeed.
+        # 2026-03-01..2026-03-30 is one 30-day attempt that fails.
+        # After fallback: 7-day chunks: 03-01..03-07, 03-08..03-14, 03-15..03-21, 03-22..03-28, 03-29..03-30.
+        responses = [
+            _mock_response(500, timeout_body),
+            _mock_response(200, {"data": [{"ad_id": "1"}], "paging": {}}),
+            _mock_response(200, {"data": [{"ad_id": "2"}], "paging": {}}),
+            _mock_response(200, {"data": [{"ad_id": "3"}], "paging": {}}),
+            _mock_response(200, {"data": [{"ad_id": "4"}], "paging": {}}),
+            _mock_response(200, {"data": [{"ad_id": "5"}], "paging": {}}),
+        ]
+
+        with mock.patch("requests.get", side_effect=responses) as mock_get:
+            batches = list(
+                _iter_time_range_pagination(
+                    self.URL, self.PARAMS, {"since": "2026-03-01", "until": "2026-03-30"}, None, manager
+                )
+            )
+
+        assert [b[0]["ad_id"] for b in batches] == ["1", "2", "3", "4", "5"]
+        # Subsequent saves should all record chunk_size_days=7.
+        for call in manager.save_state.call_args_list:
+            saved: MetaAdsResumeConfig = call.args[0]
+            assert saved.chunk_size_days == 7
+        # The first successful request was for a 7-day chunk.
+        import json as _json
+
+        tr = _json.loads(mock_get.call_args_list[1].kwargs["params"]["time_range"])
+        assert tr == {"since": "2026-03-01", "until": "2026-03-07"}

--- a/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -1,5 +1,7 @@
+import json
 from typing import Any
 
+import pytest
 from unittest import mock
 
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
@@ -7,6 +9,7 @@ from posthog.temporal.data_imports.sources.meta_ads.meta_ads import (
     MetaAdsResumeConfig,
     _iter_simple_pagination,
     _iter_time_range_pagination,
+    _strip_access_token,
 )
 
 
@@ -25,7 +28,45 @@ def _build_manager(*, can_resume: bool = False, state: MetaAdsResumeConfig | Non
     return manager
 
 
+class TestStripAccessToken:
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            (
+                "https://graph.facebook.com/v20/next?access_token=secret&cursor=abc",
+                "https://graph.facebook.com/v20/next?cursor=abc",
+            ),
+            (
+                "https://graph.facebook.com/v20/next?cursor=abc&access_token=secret",
+                "https://graph.facebook.com/v20/next?cursor=abc",
+            ),
+            (
+                "https://graph.facebook.com/v20/next?access_token=secret",
+                "https://graph.facebook.com/v20/next",
+            ),
+            (
+                "https://graph.facebook.com/v20/next?cursor=abc",
+                "https://graph.facebook.com/v20/next?cursor=abc",
+            ),
+            (
+                "https://graph.facebook.com/v20/next",
+                "https://graph.facebook.com/v20/next",
+            ),
+            (
+                # Multiple access_token params (pathological) — all removed.
+                "https://example/path?access_token=a&foo=1&access_token=b",
+                "https://example/path?foo=1",
+            ),
+        ],
+    )
+    def test_strips(self, url: str, expected: str) -> None:
+        assert _strip_access_token(url) == expected
+
+
 class TestSimplePagination:
+    INITIAL_URL = "https://graph.facebook.com/v20/act_123/campaigns"
+    INITIAL_PARAMS: dict[str, Any] = {"fields": "id,name", "access_token": "tok"}
+
     def test_fresh_run_fetches_initial_and_saves_next_url(self) -> None:
         manager = _build_manager()
 
@@ -34,7 +75,7 @@ class TestSimplePagination:
                 200,
                 {
                     "data": [{"id": "1"}, {"id": "2"}],
-                    "paging": {"next": "https://graph.facebook.com/v20/next?cursor=abc"},
+                    "paging": {"next": "https://graph.facebook.com/v20/next?access_token=tok&cursor=abc"},
                 },
             ),
             _mock_response(200, {"data": [{"id": "3"}], "paging": {}}),
@@ -43,25 +84,28 @@ class TestSimplePagination:
         with mock.patch("requests.get", side_effect=responses) as mock_get:
             batches = list(
                 _iter_simple_pagination(
-                    "https://graph.facebook.com/v20/act_123/campaigns",
-                    {"fields": "id,name", "access_token": "tok"},
+                    self.INITIAL_URL,
+                    self.INITIAL_PARAMS,
                     None,
                     manager,
                 )
             )
 
         assert batches == [[{"id": "1"}, {"id": "2"}], [{"id": "3"}]]
-        # First call: initial URL + params. Second call: paging.next URL only.
-        assert mock_get.call_args_list[0].args[0] == "https://graph.facebook.com/v20/act_123/campaigns"
-        assert mock_get.call_args_list[0].kwargs["params"] == {"fields": "id,name", "access_token": "tok"}
-        assert mock_get.call_args_list[1].args[0] == "https://graph.facebook.com/v20/next?cursor=abc"
-        assert "params" not in mock_get.call_args_list[1].kwargs
+        # First call: initial URL + params.
+        assert mock_get.call_args_list[0].args[0] == self.INITIAL_URL
+        assert mock_get.call_args_list[0].kwargs["params"] == self.INITIAL_PARAMS
+        # Second call: paging.next URL, with access_token injected via params (not baked into URL).
+        assert mock_get.call_args_list[1].args[0] == "https://graph.facebook.com/v20/next?access_token=tok&cursor=abc"
+        assert mock_get.call_args_list[1].kwargs["params"] == {"access_token": "tok"}
 
+        # Saved state: access_token stripped from the saved URL.
         manager.save_state.assert_called_once_with(
             MetaAdsResumeConfig(next_url="https://graph.facebook.com/v20/next?cursor=abc")
         )
 
     def test_resume_skips_initial_request(self) -> None:
+        # Saved URL has access_token stripped; we re-inject a fresh one at request time.
         saved_url = "https://graph.facebook.com/v20/next?cursor=xyz"
         manager = _build_manager(can_resume=True, state=MetaAdsResumeConfig(next_url=saved_url))
 
@@ -72,8 +116,8 @@ class TestSimplePagination:
         with mock.patch("requests.get", side_effect=responses) as mock_get:
             batches = list(
                 _iter_simple_pagination(
-                    "https://graph.facebook.com/v20/act_123/campaigns",
-                    {"fields": "id,name", "access_token": "tok"},
+                    self.INITIAL_URL,
+                    self.INITIAL_PARAMS,
                     MetaAdsResumeConfig(next_url=saved_url),
                     manager,
                 )
@@ -82,7 +126,8 @@ class TestSimplePagination:
         assert batches == [[{"id": "5"}]]
         assert mock_get.call_count == 1
         assert mock_get.call_args_list[0].args[0] == saved_url
-        assert "params" not in mock_get.call_args_list[0].kwargs
+        # access_token is supplied via params (from config), NOT embedded in the saved URL.
+        assert mock_get.call_args_list[0].kwargs["params"] == {"access_token": "tok"}
         # No more pages, no save call needed.
         manager.save_state.assert_not_called()
 
@@ -96,7 +141,7 @@ class TestSimplePagination:
         with mock.patch("requests.get", side_effect=responses):
             batches = list(
                 _iter_simple_pagination(
-                    "https://graph.facebook.com/v20/act_123/campaigns",
+                    self.INITIAL_URL,
                     {"access_token": "tok"},
                     None,
                     manager,
@@ -121,7 +166,7 @@ class TestSimplePagination:
         with mock.patch("requests.get", side_effect=responses) as mock_get:
             list(
                 _iter_simple_pagination(
-                    "https://graph.facebook.com/v20/act_123/campaigns",
+                    self.INITIAL_URL,
                     {"access_token": "tok"},
                     stale_state,
                     manager,
@@ -129,7 +174,7 @@ class TestSimplePagination:
             )
 
         # Initial request should be the original URL with params, not the stale next_url.
-        assert mock_get.call_args_list[0].args[0] == "https://graph.facebook.com/v20/act_123/campaigns"
+        assert mock_get.call_args_list[0].args[0] == self.INITIAL_URL
         assert mock_get.call_args_list[0].kwargs["params"] == {"access_token": "tok"}
 
 
@@ -145,7 +190,7 @@ class TestTimeRangePagination:
                 200,
                 {
                     "data": [{"ad_id": "a"}],
-                    "paging": {"next": "https://graph.facebook.com/v20/act_1/insights?after=abc"},
+                    "paging": {"next": "https://graph.facebook.com/v20/act_1/insights?access_token=tok&after=abc"},
                 },
             ),
             _mock_response(200, {"data": [{"ad_id": "b"}], "paging": {}}),
@@ -163,17 +208,24 @@ class TestTimeRangePagination:
             )
 
         assert batches == [[{"ad_id": "a"}], [{"ad_id": "b"}]]
-        # Two pages in one chunk => one save pointing at the mid-chunk next_url.
-        assert manager.save_state.call_count == 1
-        saved: MetaAdsResumeConfig = manager.save_state.call_args_list[0].args[0]
-        assert saved.end_date == "2026-04-21"
-        assert saved.chunk_since == "2026-04-21"
-        assert saved.chunk_size_days == 30
-        assert saved.chunk_next_url == "https://graph.facebook.com/v20/act_1/insights?after=abc"
+        # Two saves: mid-chunk next_url, then the chunk-boundary (past end_date) save.
+        assert manager.save_state.call_count == 2
+        mid_chunk: MetaAdsResumeConfig = manager.save_state.call_args_list[0].args[0]
+        assert mid_chunk.end_date == "2026-04-21"
+        assert mid_chunk.chunk_since == "2026-04-21"
+        assert mid_chunk.chunk_size_days == 30
+        # Saved URL has access_token stripped.
+        assert mid_chunk.chunk_next_url == "https://graph.facebook.com/v20/act_1/insights?after=abc"
 
-        # Second request used the saved next_url with no params.
-        assert mock_get.call_args_list[1].args[0] == "https://graph.facebook.com/v20/act_1/insights?after=abc"
-        assert "params" not in mock_get.call_args_list[1].kwargs
+        final: MetaAdsResumeConfig = manager.save_state.call_args_list[1].args[0]
+        assert final.chunk_since == "2026-04-22"
+        assert final.chunk_next_url is None
+
+        # Second request used the saved next_url with access_token injected via params.
+        assert mock_get.call_args_list[1].args[0] == (
+            "https://graph.facebook.com/v20/act_1/insights?access_token=tok&after=abc"
+        )
+        assert mock_get.call_args_list[1].kwargs["params"] == {"access_token": "tok"}
 
     def test_fresh_run_saves_chunk_boundary_between_chunks(self) -> None:
         manager = _build_manager()
@@ -195,13 +247,59 @@ class TestTimeRangePagination:
             )
 
         assert batches == [[{"ad_id": "a"}], [{"ad_id": "b"}]]
-        # After chunk 1 finishes we save a chunk-boundary state pointing at chunk 2.
+        # After chunk 1 we save pointing at chunk 2; after chunk 2 we save the past-end cursor.
+        assert manager.save_state.call_count == 2
+        first: MetaAdsResumeConfig = manager.save_state.call_args_list[0].args[0]
+        assert first.end_date == "2026-04-29"
+        assert first.chunk_since == "2026-03-31"  # chunk 1 covered 2026-03-01..2026-03-30 (30 days)
+        assert first.chunk_size_days == 30
+        assert first.chunk_next_url is None
+
+        final: MetaAdsResumeConfig = manager.save_state.call_args_list[1].args[0]
+        assert final.chunk_since == "2026-04-30"  # one past end_date
+        assert final.chunk_next_url is None
+
+    def test_past_end_date_chunk_saved_after_final_chunk(self) -> None:
+        """After the final chunk completes, we must save a chunk-boundary cursor
+        with ``chunk_since > end_date`` — otherwise a stale mid-chunk next_url
+        from an earlier iteration (or no state at all) could cause a resume to
+        re-process pages that were already yielded."""
+        manager = _build_manager()
+        responses = [_mock_response(200, {"data": [{"ad_id": "only"}], "paging": {}})]
+
+        with mock.patch("requests.get", side_effect=responses):
+            list(
+                _iter_time_range_pagination(
+                    self.URL, self.PARAMS, {"since": "2026-04-21", "until": "2026-04-21"}, None, manager
+                )
+            )
+
         assert manager.save_state.call_count == 1
         saved: MetaAdsResumeConfig = manager.save_state.call_args_list[0].args[0]
-        assert saved.end_date == "2026-04-29"
-        assert saved.chunk_since == "2026-03-31"  # chunk 1 covered 2026-03-01..2026-03-30 (30 days)
-        assert saved.chunk_size_days == 30
+        assert saved.chunk_since == "2026-04-22"
         assert saved.chunk_next_url is None
+
+    def test_resume_past_end_date_cursor_is_noop(self) -> None:
+        """If resume state already says ``chunk_since > end_date``, the generator
+        must finish without issuing any HTTP request (the sync already ran to
+        completion before the crash)."""
+        state = MetaAdsResumeConfig(
+            end_date="2026-04-21",
+            chunk_since="2026-04-22",
+            chunk_size_days=30,
+            chunk_next_url=None,
+        )
+        manager = _build_manager(can_resume=True, state=state)
+
+        with mock.patch("requests.get") as mock_get:
+            batches = list(
+                _iter_time_range_pagination(
+                    self.URL, self.PARAMS, {"since": "2026-04-10", "until": "2026-04-21"}, state, manager
+                )
+            )
+
+        assert batches == []
+        mock_get.assert_not_called()
 
     def test_resume_mid_chunk_skips_initial_request(self) -> None:
         saved_next = "https://graph.facebook.com/v20/act_1/insights?after=xyz"
@@ -224,10 +322,12 @@ class TestTimeRangePagination:
             )
 
         assert batches == [[{"ad_id": "c"}]]
-        # The single request goes straight to the saved next_url.
+        # Two requests: the resumed mid-chunk URL, then nothing more to fetch within this chunk.
+        # (There is a final "past end_date" save_state, but no additional HTTP call is made.)
         assert mock_get.call_count == 1
         assert mock_get.call_args_list[0].args[0] == saved_next
-        assert "params" not in mock_get.call_args_list[0].kwargs
+        # access_token is injected fresh — never served from the saved URL.
+        assert mock_get.call_args_list[0].kwargs["params"] == {"access_token": "tok"}
 
     def test_resume_at_chunk_boundary_issues_fresh_initial_request(self) -> None:
         state = MetaAdsResumeConfig(
@@ -256,9 +356,7 @@ class TestTimeRangePagination:
         sent_params = first_call.kwargs["params"]
         assert sent_params["access_token"] == "tok"
         # time_range should be JSON-encoded and cover 2026-04-10..2026-04-16 (7 days).
-        import json as _json
-
-        tr = _json.loads(sent_params["time_range"])
+        tr = json.loads(sent_params["time_range"])
         assert tr == {"since": "2026-04-10", "until": "2026-04-16"}
 
     def test_empty_chunk_still_iterates_to_next(self) -> None:
@@ -309,7 +407,5 @@ class TestTimeRangePagination:
             saved: MetaAdsResumeConfig = call.args[0]
             assert saved.chunk_size_days == 7
         # The first successful request was for a 7-day chunk.
-        import json as _json
-
-        tr = _json.loads(mock_get.call_args_list[1].kwargs["params"]["time_range"])
+        tr = json.loads(mock_get.call_args_list[1].kwargs["params"]["time_range"])
         assert tr == {"since": "2026-03-01", "until": "2026-03-07"}

--- a/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -95,8 +95,10 @@ class TestSimplePagination:
         # First call: initial URL + params.
         assert mock_get.call_args_list[0].args[0] == self.INITIAL_URL
         assert mock_get.call_args_list[0].kwargs["params"] == self.INITIAL_PARAMS
-        # Second call: paging.next URL, with access_token injected via params (not baked into URL).
-        assert mock_get.call_args_list[1].args[0] == "https://graph.facebook.com/v20/next?access_token=tok&cursor=abc"
+        # Second call: the saved (token-stripped) URL plus access_token supplied via params.
+        # Using the stripped URL for the fetch too prevents `requests` from sending duplicate
+        # `access_token` query parameters.
+        assert mock_get.call_args_list[1].args[0] == "https://graph.facebook.com/v20/next?cursor=abc"
         assert mock_get.call_args_list[1].kwargs["params"] == {"access_token": "tok"}
 
         # Saved state: access_token stripped from the saved URL.
@@ -221,10 +223,8 @@ class TestTimeRangePagination:
         assert final.chunk_since == "2026-04-22"
         assert final.chunk_next_url is None
 
-        # Second request used the saved next_url with access_token injected via params.
-        assert mock_get.call_args_list[1].args[0] == (
-            "https://graph.facebook.com/v20/act_1/insights?access_token=tok&after=abc"
-        )
+        # Second request uses the stripped URL plus access_token via params (no duplicate token).
+        assert mock_get.call_args_list[1].args[0] == "https://graph.facebook.com/v20/act_1/insights?after=abc"
         assert mock_get.call_args_list[1].kwargs["params"] == {"access_token": "tok"}
 
     def test_fresh_run_saves_chunk_boundary_between_chunks(self) -> None:


### PR DESCRIPTION
## Problem

`MetaAdsSource` currently inherits from `SimpleSource`, so if a worker is restarted during a long full-refresh run (especially for stats endpoints that walk the past 90 days in chunked Graph API calls) the sync starts over. For customers with wide date ranges or slow-to-paginate responses this can mean never completing.

## Changes

- Swap `MetaAdsSource` from `SimpleSource` to `ResumableSource[..., MetaAdsResumeConfig]` and implement `get_resumable_source_manager`.
- Introduce `MetaAdsResumeConfig` with fields to re-enter both pagination modes used by the Meta Graph API:
  - **Simple pagination** (non-stats endpoints): a saved `next_url` is re-issued directly (params and token are already embedded).
  - **Time-range pagination** (stats/insights endpoints): outer-loop state (`chunk_since`, `chunk_size_days`, `end_date`) plus optional mid-chunk `chunk_next_url` so a crash mid-chunk resumes at page granularity rather than re-fetching up to 30 days of data.
- Split the fetch loop into `_iter_simple_pagination` and `_iter_time_range_pagination` helpers that save state after each yielded batch. The existing 30/7/1-day adaptive timeout fallback is preserved.
- No changes to public config, schemas, primary keys, validation, or partitioning — this is strictly a restart-safety change.

## How did you test this code?

- New unit tests in `test_meta_ads.py` cover both pagination modes: fresh run saves the expected `MetaAdsResumeConfig`; resume (mocked `can_resume=True` + `load_state`) skips the initial request and fetches the saved cursor; chunk-boundary resume issues a fresh `time_range` request; mid-chunk resume uses the saved `paging.next`; 30->7 day timeout fallback is preserved.
- `ruff check` and `ruff format --check` clean on the touched directory.
- I am an AI agent and have not manually run the sync against Meta's API - verification is via the unit tests above and will be validated further by CI.

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code (agent). Followed the pattern established by `klaviyo` (saved `paging.next` URL) and `temporalio` (mid-iteration cursor) ResumableSource conversions. Primary keys on the `SourceResponse` already handle duplicate rows on resume.