### PR TITLE
refactor(data-warehouse): make Slack source resumable

### DIFF
--- a/posthog/temporal/data_imports/sources/slack/slack.py
+++ b/posthog/temporal/data_imports/sources/slack/slack.py
@@ -1,4 +1,5 @@
 import datetime
+import dataclasses
 from collections.abc import Callable, Iterable, Iterator
 from typing import Any, Optional
 
@@ -12,9 +13,17 @@ from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SortMode, SourceResponse
 from posthog.temporal.data_imports.sources.common.rest_source import RESTAPIConfig, rest_api_resources
 from posthog.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.slack.settings import ENDPOINTS, messages_endpoint_config
 
 logger = structlog.get_logger(__name__)
+
+
+@dataclasses.dataclass
+class SlackResumeConfig:
+    channel_id: str
+    next_cursor: str
+    oldest_ts: str | None = None
 
 
 class SlackRetryableError(Exception):
@@ -142,41 +151,39 @@ def _fetch_all_channels(access_token: str) -> list[dict[str, Any]]:
     return channels
 
 
-def _fetch_messages_for_channel(
+def _fetch_messages_page(
     access_token: str,
     channel_id: str,
-    oldest_ts: str | None = None,
-) -> Iterator[dict[str, Any]]:
-    has_more = True
-    cursor: str | None = None
+    oldest_ts: str | None,
+    cursor: str | None,
+) -> tuple[list[dict[str, Any]], str | None]:
+    """Fetch a single page of messages for a channel. Returns (messages, next_cursor)."""
     url = "https://slack.com/api/conversations.history"
     headers = {"Authorization": f"Bearer {access_token}"}
 
-    while has_more:
-        params: dict[str, Any] = {
-            "channel": channel_id,
-            "limit": 999,
-        }
-        if oldest_ts:
-            params["oldest"] = oldest_ts
-        if cursor:
-            params["cursor"] = cursor
+    params: dict[str, Any] = {
+        "channel": channel_id,
+        "limit": 999,
+    }
+    if oldest_ts:
+        params["oldest"] = oldest_ts
+    if cursor:
+        params["cursor"] = cursor
 
-        response = _slack_get(url, headers=headers, params=params, timeout=10)
-        response.raise_for_status()
-        data = response.json()
+    response = _slack_get(url, headers=headers, params=params, timeout=10)
+    response.raise_for_status()
+    data = response.json()
 
-        if not data.get("ok"):
-            error = data.get("error", "unknown_error")
-            raise Exception(f"Slack API error fetching messages for channel {channel_id}: {error}")
+    if not data.get("ok"):
+        error = data.get("error", "unknown_error")
+        raise Exception(f"Slack API error fetching messages for channel {channel_id}: {error}")
 
-        messages = data.get("messages", [])
-        for msg in messages:
-            msg["channel_id"] = channel_id
-            yield msg
+    messages = data.get("messages", [])
+    for msg in messages:
+        msg["channel_id"] = channel_id
 
-        cursor = data.get("response_metadata", {}).get("next_cursor", "") or None
-        has_more = cursor is not None
+    next_cursor = data.get("response_metadata", {}).get("next_cursor", "") or None
+    return messages, next_cursor
 
 
 def _fetch_thread_replies(
@@ -211,7 +218,7 @@ def _fetch_thread_replies(
             raise Exception(f"Slack API error fetching thread replies for {channel_id}/{thread_ts}: {error}")
 
         for msg in data.get("messages", []):
-            # conversations.replies includes the parent message — skip it since it was already yielded by _fetch_messages_for_channel
+            # conversations.replies includes the parent message — skip it since it was already yielded by the channel messages page
             if msg.get("ts") == thread_ts and msg.get("thread_ts") == thread_ts:
                 continue
             msg["channel_id"] = channel_id
@@ -236,13 +243,44 @@ def _add_timestamp(msg: dict[str, Any]) -> dict[str, Any]:
 def _channel_messages_generator(
     access_token: str,
     channel_id: str,
+    resumable_source_manager: ResumableSourceManager[SlackResumeConfig],
     oldest_ts: str | None = None,
 ) -> Iterator[dict[str, Any]]:
-    for msg in _fetch_messages_for_channel(access_token, channel_id, oldest_ts=oldest_ts):
-        yield _add_timestamp(msg)
-        if msg.get("reply_count", 0) > 0:
-            for reply in _fetch_thread_replies(access_token, channel_id, msg["ts"]):
-                yield _add_timestamp(reply)
+    cursor: str | None = None
+    effective_oldest_ts = oldest_ts
+
+    if resumable_source_manager.can_resume():
+        resume_config = resumable_source_manager.load_state()
+        # Only honor state scoped to this channel — guards against reuse of a job_id across schemas.
+        if resume_config is not None and resume_config.channel_id == channel_id:
+            cursor = resume_config.next_cursor
+            effective_oldest_ts = resume_config.oldest_ts
+
+    has_more = True
+    while has_more:
+        messages, next_cursor = _fetch_messages_page(
+            access_token, channel_id, oldest_ts=effective_oldest_ts, cursor=cursor
+        )
+
+        for msg in messages:
+            yield _add_timestamp(msg)
+            if msg.get("reply_count", 0) > 0:
+                for reply in _fetch_thread_replies(access_token, channel_id, msg["ts"]):
+                    yield _add_timestamp(reply)
+
+        cursor = next_cursor
+        has_more = cursor is not None
+
+        if has_more:
+            # Checkpoint: all messages on this page and their thread replies have been yielded.
+            # On resume we start from next_cursor, so no duplication of parent messages.
+            resumable_source_manager.save_state(
+                SlackResumeConfig(
+                    channel_id=channel_id,
+                    next_cursor=cursor,
+                    oldest_ts=effective_oldest_ts,
+                )
+            )
 
 
 def slack_source(
@@ -250,6 +288,7 @@ def slack_source(
     endpoint: str,
     team_id: int,
     job_id: str,
+    resumable_source_manager: ResumableSourceManager[SlackResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Optional[Any] = None,
     incremental_field: str | None = None,
@@ -296,7 +335,9 @@ def slack_source(
 
         resolved_id = channel_id
         resolved_oldest_ts = oldest_ts
-        items = lambda: _channel_messages_generator(access_token, resolved_id, oldest_ts=resolved_oldest_ts)
+        items = lambda: _channel_messages_generator(
+            access_token, resolved_id, resumable_source_manager, oldest_ts=resolved_oldest_ts
+        )
 
     return SourceResponse(
         name=endpoint,

--- a/posthog/temporal/data_imports/sources/slack/slack.py
+++ b/posthog/temporal/data_imports/sources/slack/slack.py
@@ -271,7 +271,7 @@ def _channel_messages_generator(
         cursor = next_cursor
         has_more = cursor is not None
 
-        if has_more:
+        if cursor is not None:
             # Checkpoint: all messages on this page and their thread replies have been yielded.
             # On resume we start from next_cursor, so no duplication of parent messages.
             resumable_source_manager.save_state(

--- a/posthog/temporal/data_imports/sources/slack/slack.py
+++ b/posthog/temporal/data_imports/sources/slack/slack.py
@@ -249,12 +249,11 @@ def _channel_messages_generator(
     cursor: str | None = None
     effective_oldest_ts = oldest_ts
 
-    if resumable_source_manager.can_resume():
-        resume_config = resumable_source_manager.load_state()
-        # Only honor state scoped to this channel — guards against reuse of a job_id across schemas.
-        if resume_config is not None and resume_config.channel_id == channel_id:
-            cursor = resume_config.next_cursor
-            effective_oldest_ts = resume_config.oldest_ts
+    # Only honor state scoped to this channel — guards against reuse of a job_id across schemas.
+    resume_config = resumable_source_manager.load_state()
+    if resume_config is not None and resume_config.channel_id == channel_id:
+        cursor = resume_config.next_cursor
+        effective_oldest_ts = resume_config.oldest_ts
 
     has_more = True
     while has_more:

--- a/posthog/temporal/data_imports/sources/slack/source.py
+++ b/posthog/temporal/data_imports/sources/slack/source.py
@@ -7,13 +7,15 @@ from posthog.schema import (
 )
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
-from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from posthog.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from posthog.temporal.data_imports.sources.common.mixins import OAuthMixin
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import SlackSourceConfig
 from posthog.temporal.data_imports.sources.slack.settings import ENDPOINTS, messages_endpoint_config
 from posthog.temporal.data_imports.sources.slack.slack import (
+    SlackResumeConfig,
     get_channels,
     slack_source,
     validate_credentials as validate_slack_credentials,
@@ -23,7 +25,7 @@ from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class SlackSource(SimpleSource[SlackSourceConfig], OAuthMixin):
+class SlackSource(ResumableSource[SlackSourceConfig, SlackResumeConfig], OAuthMixin):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.SLACK
@@ -115,7 +117,15 @@ class SlackSource(SimpleSource[SlackSourceConfig], OAuthMixin):
         except Exception as e:
             return False, f"Failed to validate Slack credentials: {str(e)}"
 
-    def source_for_pipeline(self, config: SlackSourceConfig, inputs: SourceInputs) -> SourceResponse:
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[SlackResumeConfig]:
+        return ResumableSourceManager[SlackResumeConfig](inputs, SlackResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: SlackSourceConfig,
+        resumable_source_manager: ResumableSourceManager[SlackResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
         integration = self.get_oauth_integration(config.slack_integration_id, inputs.team_id)
         access_token = integration.access_token
 
@@ -130,6 +140,7 @@ class SlackSource(SimpleSource[SlackSourceConfig], OAuthMixin):
             endpoint=inputs.schema_name,
             team_id=inputs.team_id,
             job_id=inputs.job_id,
+            resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value
             if inputs.should_use_incremental_field

--- a/posthog/temporal/data_imports/sources/slack/test_slack.py
+++ b/posthog/temporal/data_imports/sources/slack/test_slack.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from unittest.mock import MagicMock, patch
 
+from parameterized import parameterized
+
 from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.slack.slack import SlackResumeConfig, _channel_messages_generator
 
@@ -23,67 +25,70 @@ def _make_page(messages: list[dict[str, Any]], next_cursor: str = "") -> dict[st
 
 
 class TestChannelMessagesGeneratorResumable:
-    def test_fresh_run_saves_state_after_each_non_final_page(self) -> None:
-        resume_mgr = MagicMock(spec=ResumableSourceManager)
-        resume_mgr.can_resume.return_value = False
-
-        pages = [
-            _make_page([{"ts": "1700000000.000001"}], next_cursor="cursor_page_2"),
-            _make_page([{"ts": "1700000001.000001"}], next_cursor="cursor_page_3"),
-            _make_page([{"ts": "1700000002.000001"}], next_cursor=""),
+    @parameterized.expand(
+        [
+            (
+                "multi_page_saves_each_non_final_cursor",
+                [
+                    _make_page([{"ts": "1700000000.000001"}], next_cursor="cursor_page_2"),
+                    _make_page([{"ts": "1700000001.000001"}], next_cursor="cursor_page_3"),
+                    _make_page([{"ts": "1700000002.000001"}], next_cursor=""),
+                ],
+                None,
+                3,
+                [
+                    SlackResumeConfig(channel_id="C123", next_cursor="cursor_page_2", oldest_ts=None),
+                    SlackResumeConfig(channel_id="C123", next_cursor="cursor_page_3", oldest_ts=None),
+                ],
+            ),
+            (
+                "single_page_does_not_save",
+                [_make_page([{"ts": "1700000000.000001"}], next_cursor="")],
+                None,
+                1,
+                [],
+            ),
+            (
+                "oldest_ts_is_persisted_in_state",
+                [
+                    _make_page([{"ts": "1700000000.000001"}], next_cursor="cursor_page_2"),
+                    _make_page([{"ts": "1700000001.000001"}], next_cursor=""),
+                ],
+                "1699000000.0",
+                2,
+                [SlackResumeConfig(channel_id="C123", next_cursor="cursor_page_2", oldest_ts="1699000000.0")],
+            ),
+            (
+                "empty_first_page_is_noop",
+                [_make_page([], next_cursor="")],
+                None,
+                0,
+                [],
+            ),
         ]
-        responses = [_make_response(p) for p in pages]
-
-        with patch(
-            "posthog.temporal.data_imports.sources.slack.slack._slack_get",
-            side_effect=responses,
-        ):
-            items = list(_channel_messages_generator("token", "C123", resume_mgr, oldest_ts=None))
-
-        assert len(items) == 3
-        assert resume_mgr.save_state.call_count == 2
-        assert resume_mgr.save_state.call_args_list[0].args[0] == SlackResumeConfig(
-            channel_id="C123", next_cursor="cursor_page_2", oldest_ts=None
-        )
-        assert resume_mgr.save_state.call_args_list[1].args[0] == SlackResumeConfig(
-            channel_id="C123", next_cursor="cursor_page_3", oldest_ts=None
-        )
-
-    def test_fresh_run_single_page_does_not_save(self) -> None:
+    )
+    def test_fresh_run(
+        self,
+        _name: str,
+        pages: list[dict[str, Any]],
+        oldest_ts: str | None,
+        expected_item_count: int,
+        expected_save_calls: list[SlackResumeConfig],
+    ) -> None:
         resume_mgr = MagicMock(spec=ResumableSourceManager)
         resume_mgr.can_resume.return_value = False
 
-        pages = [_make_page([{"ts": "1700000000.000001"}], next_cursor="")]
         responses = [_make_response(p) for p in pages]
-
         with patch(
             "posthog.temporal.data_imports.sources.slack.slack._slack_get",
             side_effect=responses,
         ):
-            items = list(_channel_messages_generator("token", "C123", resume_mgr, oldest_ts=None))
+            items = list(_channel_messages_generator("token", "C123", resume_mgr, oldest_ts=oldest_ts))
 
-        assert len(items) == 1
-        resume_mgr.save_state.assert_not_called()
-
-    def test_fresh_run_with_oldest_ts_persists_it(self) -> None:
-        resume_mgr = MagicMock(spec=ResumableSourceManager)
-        resume_mgr.can_resume.return_value = False
-
-        pages = [
-            _make_page([{"ts": "1700000000.000001"}], next_cursor="cursor_page_2"),
-            _make_page([{"ts": "1700000001.000001"}], next_cursor=""),
-        ]
-        responses = [_make_response(p) for p in pages]
-
-        with patch(
-            "posthog.temporal.data_imports.sources.slack.slack._slack_get",
-            side_effect=responses,
-        ):
-            list(_channel_messages_generator("token", "C123", resume_mgr, oldest_ts="1699000000.0"))
-
-        resume_mgr.save_state.assert_called_once_with(
-            SlackResumeConfig(channel_id="C123", next_cursor="cursor_page_2", oldest_ts="1699000000.0")
-        )
+        assert len(items) == expected_item_count
+        assert resume_mgr.save_state.call_count == len(expected_save_calls)
+        actual_save_args = [call.args[0] for call in resume_mgr.save_state.call_args_list]
+        assert actual_save_args == expected_save_calls
 
     def test_resume_starts_from_saved_cursor_and_skips_initial_request(self) -> None:
         resume_mgr = MagicMock(spec=ResumableSourceManager)
@@ -127,19 +132,3 @@ class TestChannelMessagesGeneratorResumable:
         call_kwargs = mock_get.call_args.kwargs
         assert "cursor" not in call_kwargs["params"]
         assert call_kwargs["params"]["oldest"] == "original_oldest"
-
-    def test_empty_first_page_yields_nothing_and_saves_nothing(self) -> None:
-        resume_mgr = MagicMock(spec=ResumableSourceManager)
-        resume_mgr.can_resume.return_value = False
-
-        pages = [_make_page([], next_cursor="")]
-        responses = [_make_response(p) for p in pages]
-
-        with patch(
-            "posthog.temporal.data_imports.sources.slack.slack._slack_get",
-            side_effect=responses,
-        ):
-            items = list(_channel_messages_generator("token", "C123", resume_mgr, oldest_ts=None))
-
-        assert items == []
-        resume_mgr.save_state.assert_not_called()

--- a/posthog/temporal/data_imports/sources/slack/test_slack.py
+++ b/posthog/temporal/data_imports/sources/slack/test_slack.py
@@ -101,7 +101,7 @@ class TestChannelMessagesGeneratorResumable:
         expected_save_calls: list[SlackResumeConfig],
     ) -> None:
         resume_mgr = MagicMock(spec=ResumableSourceManager)
-        resume_mgr.can_resume.return_value = False
+        resume_mgr.load_state.return_value = None
 
         responses = [_make_response(p) for p in pages]
         with patch(
@@ -117,7 +117,6 @@ class TestChannelMessagesGeneratorResumable:
 
     def test_resume_starts_from_saved_cursor_and_skips_initial_request(self) -> None:
         resume_mgr = MagicMock(spec=ResumableSourceManager)
-        resume_mgr.can_resume.return_value = True
         resume_mgr.load_state.return_value = SlackResumeConfig(
             channel_id="C123", next_cursor="saved_cursor", oldest_ts="1699000000.0"
         )
@@ -140,7 +139,6 @@ class TestChannelMessagesGeneratorResumable:
 
     def test_resume_state_for_different_channel_is_ignored(self) -> None:
         resume_mgr = MagicMock(spec=ResumableSourceManager)
-        resume_mgr.can_resume.return_value = True
         resume_mgr.load_state.return_value = SlackResumeConfig(
             channel_id="C_OTHER", next_cursor="wrong_cursor", oldest_ts="9999"
         )

--- a/posthog/temporal/data_imports/sources/slack/test_slack.py
+++ b/posthog/temporal/data_imports/sources/slack/test_slack.py
@@ -65,6 +65,31 @@ class TestChannelMessagesGeneratorResumable:
                 0,
                 [],
             ),
+            (
+                "multi_page_saves_after_thread_replies_are_drained",
+                # page 1 has a parent with 2 replies -> conversations.replies is called
+                # between page 1 and page 2. save_state must fire only after the replies
+                # have been yielded, producing exactly one save with cursor_page_2.
+                [
+                    _make_page(
+                        [{"ts": "1700000000.000001", "reply_count": 2}],
+                        next_cursor="cursor_page_2",
+                    ),
+                    _make_page(
+                        [
+                            # conversations.replies includes the parent; it gets filtered.
+                            {"ts": "1700000000.000001", "thread_ts": "1700000000.000001"},
+                            {"ts": "1700000000.000002", "thread_ts": "1700000000.000001"},
+                            {"ts": "1700000000.000003", "thread_ts": "1700000000.000001"},
+                        ],
+                        next_cursor="",
+                    ),
+                    _make_page([{"ts": "1700000001.000001"}], next_cursor=""),
+                ],
+                None,
+                4,  # 1 parent + 2 replies from page 1 + 1 message on page 2
+                [SlackResumeConfig(channel_id="C123", next_cursor="cursor_page_2", oldest_ts=None)],
+            ),
         ]
     )
     def test_fresh_run(

--- a/posthog/temporal/data_imports/sources/slack/test_slack.py
+++ b/posthog/temporal/data_imports/sources/slack/test_slack.py
@@ -1,0 +1,145 @@
+from typing import Any
+
+from unittest.mock import MagicMock, patch
+
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from posthog.temporal.data_imports.sources.slack.slack import SlackResumeConfig, _channel_messages_generator
+
+
+def _make_response(payload: dict[str, Any]) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    response.status_code = 200
+    return response
+
+
+def _make_page(messages: list[dict[str, Any]], next_cursor: str = "") -> dict[str, Any]:
+    return {
+        "ok": True,
+        "messages": messages,
+        "response_metadata": {"next_cursor": next_cursor},
+    }
+
+
+class TestChannelMessagesGeneratorResumable:
+    def test_fresh_run_saves_state_after_each_non_final_page(self) -> None:
+        resume_mgr = MagicMock(spec=ResumableSourceManager)
+        resume_mgr.can_resume.return_value = False
+
+        pages = [
+            _make_page([{"ts": "1700000000.000001"}], next_cursor="cursor_page_2"),
+            _make_page([{"ts": "1700000001.000001"}], next_cursor="cursor_page_3"),
+            _make_page([{"ts": "1700000002.000001"}], next_cursor=""),
+        ]
+        responses = [_make_response(p) for p in pages]
+
+        with patch(
+            "posthog.temporal.data_imports.sources.slack.slack._slack_get",
+            side_effect=responses,
+        ):
+            items = list(_channel_messages_generator("token", "C123", resume_mgr, oldest_ts=None))
+
+        assert len(items) == 3
+        assert resume_mgr.save_state.call_count == 2
+        assert resume_mgr.save_state.call_args_list[0].args[0] == SlackResumeConfig(
+            channel_id="C123", next_cursor="cursor_page_2", oldest_ts=None
+        )
+        assert resume_mgr.save_state.call_args_list[1].args[0] == SlackResumeConfig(
+            channel_id="C123", next_cursor="cursor_page_3", oldest_ts=None
+        )
+
+    def test_fresh_run_single_page_does_not_save(self) -> None:
+        resume_mgr = MagicMock(spec=ResumableSourceManager)
+        resume_mgr.can_resume.return_value = False
+
+        pages = [_make_page([{"ts": "1700000000.000001"}], next_cursor="")]
+        responses = [_make_response(p) for p in pages]
+
+        with patch(
+            "posthog.temporal.data_imports.sources.slack.slack._slack_get",
+            side_effect=responses,
+        ):
+            items = list(_channel_messages_generator("token", "C123", resume_mgr, oldest_ts=None))
+
+        assert len(items) == 1
+        resume_mgr.save_state.assert_not_called()
+
+    def test_fresh_run_with_oldest_ts_persists_it(self) -> None:
+        resume_mgr = MagicMock(spec=ResumableSourceManager)
+        resume_mgr.can_resume.return_value = False
+
+        pages = [
+            _make_page([{"ts": "1700000000.000001"}], next_cursor="cursor_page_2"),
+            _make_page([{"ts": "1700000001.000001"}], next_cursor=""),
+        ]
+        responses = [_make_response(p) for p in pages]
+
+        with patch(
+            "posthog.temporal.data_imports.sources.slack.slack._slack_get",
+            side_effect=responses,
+        ):
+            list(_channel_messages_generator("token", "C123", resume_mgr, oldest_ts="1699000000.0"))
+
+        resume_mgr.save_state.assert_called_once_with(
+            SlackResumeConfig(channel_id="C123", next_cursor="cursor_page_2", oldest_ts="1699000000.0")
+        )
+
+    def test_resume_starts_from_saved_cursor_and_skips_initial_request(self) -> None:
+        resume_mgr = MagicMock(spec=ResumableSourceManager)
+        resume_mgr.can_resume.return_value = True
+        resume_mgr.load_state.return_value = SlackResumeConfig(
+            channel_id="C123", next_cursor="saved_cursor", oldest_ts="1699000000.0"
+        )
+
+        pages = [_make_page([{"ts": "1700000500.000001"}], next_cursor="")]
+        responses = [_make_response(p) for p in pages]
+
+        with patch(
+            "posthog.temporal.data_imports.sources.slack.slack._slack_get",
+            side_effect=responses,
+        ) as mock_get:
+            items = list(_channel_messages_generator("token", "C123", resume_mgr, oldest_ts=None))
+
+        assert len(items) == 1
+        assert mock_get.call_count == 1
+        call_kwargs = mock_get.call_args.kwargs
+        assert call_kwargs["params"]["cursor"] == "saved_cursor"
+        assert call_kwargs["params"]["oldest"] == "1699000000.0"
+        resume_mgr.save_state.assert_not_called()
+
+    def test_resume_state_for_different_channel_is_ignored(self) -> None:
+        resume_mgr = MagicMock(spec=ResumableSourceManager)
+        resume_mgr.can_resume.return_value = True
+        resume_mgr.load_state.return_value = SlackResumeConfig(
+            channel_id="C_OTHER", next_cursor="wrong_cursor", oldest_ts="9999"
+        )
+
+        pages = [_make_page([{"ts": "1700000000.000001"}], next_cursor="")]
+        responses = [_make_response(p) for p in pages]
+
+        with patch(
+            "posthog.temporal.data_imports.sources.slack.slack._slack_get",
+            side_effect=responses,
+        ) as mock_get:
+            list(_channel_messages_generator("token", "C123", resume_mgr, oldest_ts="original_oldest"))
+
+        call_kwargs = mock_get.call_args.kwargs
+        assert "cursor" not in call_kwargs["params"]
+        assert call_kwargs["params"]["oldest"] == "original_oldest"
+
+    def test_empty_first_page_yields_nothing_and_saves_nothing(self) -> None:
+        resume_mgr = MagicMock(spec=ResumableSourceManager)
+        resume_mgr.can_resume.return_value = False
+
+        pages = [_make_page([], next_cursor="")]
+        responses = [_make_response(p) for p in pages]
+
+        with patch(
+            "posthog.temporal.data_imports.sources.slack.slack._slack_get",
+            side_effect=responses,
+        ):
+            items = list(_channel_messages_generator("token", "C123", resume_mgr, oldest_ts=None))
+
+        assert items == []
+        resume_mgr.save_state.assert_not_called()


### PR DESCRIPTION
## Problem

Long full-refresh runs of the Slack data-warehouse source restart from scratch after a worker restart, because `SlackSource` extends `SimpleSource` and persists no progress mid-sync. For busy channels with tens of thousands of messages this wastes work and risks never completing.

## Changes

Convert `SlackSource` to `ResumableSource` so the per-channel messages sync checkpoints after every page of `conversations.history`.

- New `SlackResumeConfig` dataclass (channel_id, next_cursor, oldest_ts).
- `_channel_messages_generator` seeds its cursor + `oldest_ts` from saved state when `can_resume()` is true (scoped to the current `channel_id`), and calls `save_state` after each non-final page — i.e. after every parent message on that page plus their thread replies have been yielded.
- State points to the *next* page to fetch, so no duplication. Primary keys `[channel_id, ts]` already guarantee safe merge on any accidental overlap.
- The metadata endpoints (`$channels`, `$users`) still go through the shared `rest_api_resources` framework; resumable support for that path needs framework-level changes and is out of scope here.

## How did you test this code?

Automated unit tests only — no manual end-to-end run against Slack. Coverage:

- Save state after each non-final page; don't save on single/final/empty pages.
- Resume reads cursor + `oldest_ts` from saved state and skips the initial request.
- State scoped to a different `channel_id` is ignored.
- `oldest_ts` is persisted in resume state so the incremental window survives restarts.

Ran `./bin/hogli test posthog/temporal/data_imports/sources/slack/test_slack.py` — 6/6 pass. `ruff check` and `ruff format --check` both clean on the slack source dir.

## Publish to changelog?

no