### PR TITLE
feat(logs-alerts): add Created by column to logs alerts table

### DIFF
--- a/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
@@ -135,6 +135,15 @@ export function LogsAlertList(): JSX.Element {
             ),
         },
         {
+            title: 'Created by',
+            dataIndex: 'created_by',
+            render: (_, alert) => (
+                <span className="text-muted text-xs">
+                    {alert.created_by?.first_name || alert.created_by?.email || '—'}
+                </span>
+            ),
+        },
+        {
             title: 'Enabled',
             dataIndex: 'enabled',
             render: (_, alert) => (


### PR DESCRIPTION
## Problem

Users viewing the Logs Alert List have no way to identify who created each alert, making it difficult to manage alerts in team environments where multiple people may be configuring them.

## Changes

Adds a "Created by" column to the Logs Alert List table that displays the creator's first name or email address. If neither is available, a dash (`—`) is shown as a fallback.

## How did you test this code?

local dev

## Publish to changelog?

No