### PR TITLE
feat(logs-alerts): add emoji indicators to alert headers for better visibility

### DIFF
--- a/products/logs/backend/alert_destinations.py
+++ b/products/logs/backend/alert_destinations.py
@@ -37,7 +37,7 @@ _FIRE_RESOLVE_WEBHOOK_BODY: dict[str, str] = {
 EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
     "firing": EventKindSpec(
         event_id="$logs_alert_firing",
-        header="Log alert '{event.properties.alert_name}' is firing",
+        header="🔴 Log alert '{event.properties.alert_name}' is firing",
         body=(
             "*Threshold breached:* {event.properties.result_count} logs in "
             "{event.properties.window_minutes}m "
@@ -49,7 +49,7 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
     ),
     "resolved": EventKindSpec(
         event_id="$logs_alert_resolved",
-        header="Log alert '{event.properties.alert_name}' has resolved",
+        header="🟢 Log alert '{event.properties.alert_name}' has resolved",
         body=(
             "*Current count:* {event.properties.result_count} logs in "
             "{event.properties.window_minutes}m "
@@ -61,7 +61,7 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
     ),
     "broken": EventKindSpec(
         event_id="$logs_alert_auto_disabled",
-        header="Log alert '{event.properties.alert_name}' was auto-disabled",
+        header="⚠️ Log alert '{event.properties.alert_name}' was auto-disabled",
         body=(
             "*Reason:* {event.properties.consecutive_failures} consecutive check failures.\n"
             "*Last error:* {event.properties.last_error_message}"


### PR DESCRIPTION
## Problem

Alert notification headers for log alerts lack visual indicators to quickly distinguish between different alert states at a glance.

## Changes

Added emoji indicators to log alert notification headers to improve visual clarity:

- 🔴 for firing alerts
- 🟢 for resolved alerts
- ⚠️ for auto-disabled (broken) alerts

## How did you test this code?

local dev webhooks

## Publish to changelog?

No

## Docs update

No docs update required.