### PR TITLE
refactor(data-warehouse): make Linear source resumable

### DIFF
--- a/posthog/temporal/data_imports/sources/linear/linear.py
+++ b/posthog/temporal/data_imports/sources/linear/linear.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Any
 
 import requests
@@ -5,6 +6,7 @@ from structlog.types import FilteringBoundLogger
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.linear.queries import QUERIES, VIEWER_QUERY
 from posthog.temporal.data_imports.sources.linear.settings import (
     LINEAR_API_URL,
@@ -17,10 +19,16 @@ class LinearRetryableError(Exception):
     pass
 
 
+@dataclasses.dataclass
+class LinearResumeConfig:
+    cursor: str
+
+
 def _make_paginated_request(
     access_token: str,
     endpoint_name: str,
     logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[LinearResumeConfig],
     updated_at_gte: str | None = None,
 ):
     endpoint_config = LINEAR_ENDPOINTS.get(endpoint_name)
@@ -82,6 +90,11 @@ def _make_paginated_request(
     if updated_at_gte:
         variables["filter"] = {"updatedAt": {"gt": updated_at_gte}}
 
+    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    if resume_config is not None:
+        variables["cursor"] = resume_config.cursor
+        logger.debug(f"Linear: resuming {endpoint_name} from saved cursor")
+
     try:
         has_next_page = True
         while has_next_page:
@@ -95,6 +108,9 @@ def _make_paginated_request(
             has_next_page = page_info["hasNextPage"]
             if has_next_page:
                 variables["cursor"] = page_info["endCursor"]
+                # Checkpoint points at the next page to fetch; duplicates on resume
+                # are dedup'd via the endpoint's primary_key.
+                resumable_source_manager.save_state(LinearResumeConfig(cursor=page_info["endCursor"]))
     finally:
         sess.close()
 
@@ -103,6 +119,7 @@ def linear_source(
     access_token: str,
     endpoint_name: str,
     logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[LinearResumeConfig],
     should_use_incremental_field: bool = False,
     db_incremental_field_last_value: Any | None = None,
 ) -> SourceResponse:
@@ -120,6 +137,7 @@ def linear_source(
             access_token=access_token,
             endpoint_name=endpoint_name,
             logger=logger,
+            resumable_source_manager=resumable_source_manager,
             updated_at_gte=updated_at_gte,
         )
 

--- a/posthog/temporal/data_imports/sources/linear/source.py
+++ b/posthog/temporal/data_imports/sources/linear/source.py
@@ -8,12 +8,14 @@ from posthog.schema import (
 
 from posthog.models.integration import OauthIntegration
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
-from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from posthog.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from posthog.temporal.data_imports.sources.common.mixins import OAuthMixin
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import LinearSourceConfig
 from posthog.temporal.data_imports.sources.linear.linear import (
+    LinearResumeConfig,
     linear_source,
     validate_credentials as validate_linear_credentials,
 )
@@ -23,7 +25,7 @@ from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class LinearSource(SimpleSource[LinearSourceConfig], OAuthMixin):
+class LinearSource(ResumableSource[LinearSourceConfig, LinearResumeConfig], OAuthMixin):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.LINEAR
@@ -92,13 +94,22 @@ class LinearSource(SimpleSource[LinearSourceConfig], OAuthMixin):
         except Exception as e:
             return False, str(e)
 
-    def source_for_pipeline(self, config: LinearSourceConfig, inputs: SourceInputs) -> SourceResponse:
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[LinearResumeConfig]:
+        return ResumableSourceManager[LinearResumeConfig](inputs, LinearResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: LinearSourceConfig,
+        resumable_source_manager: ResumableSourceManager[LinearResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
         access_token = self._get_access_token(config, inputs.team_id)
 
         return linear_source(
             access_token=access_token,
             endpoint_name=inputs.schema_name,
             logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value
             if inputs.should_use_incremental_field

--- a/posthog/temporal/data_imports/sources/linear/test_linear.py
+++ b/posthog/temporal/data_imports/sources/linear/test_linear.py
@@ -1,0 +1,207 @@
+import copy
+from typing import Any
+
+from unittest.mock import MagicMock, patch
+
+from posthog.temporal.data_imports.sources.linear.linear import (
+    LinearResumeConfig,
+    _make_paginated_request,
+    linear_source,
+)
+
+
+def _make_response(nodes: list[dict[str, Any]], has_next_page: bool, end_cursor: str | None) -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.ok = True
+    response.json.return_value = {
+        "data": {
+            "issues": {
+                "nodes": nodes,
+                "pageInfo": {"hasNextPage": has_next_page, "endCursor": end_cursor},
+            }
+        }
+    }
+    return response
+
+
+def _capture_post_calls(session: MagicMock, responses: list[MagicMock]) -> list[dict[str, Any]]:
+    """Configure session.post to record a deep-copied snapshot of variables at each call.
+
+    The paginator mutates a single `variables` dict across pages, so recorded calls all
+    reference the same object. Snapshotting here gives us a per-call view for assertions.
+    """
+    snapshots: list[dict[str, Any]] = []
+    response_iter = iter(responses)
+
+    def side_effect(*_args: object, **kwargs: object) -> MagicMock:
+        json_payload = kwargs.get("json")
+        variables = json_payload.get("variables") if isinstance(json_payload, dict) else None
+        snapshots.append(copy.deepcopy(variables) if variables is not None else {})
+        return next(response_iter)
+
+    session.post.side_effect = side_effect
+    return snapshots
+
+
+def _make_resumable_manager(*, can_resume: bool = False, saved: LinearResumeConfig | None = None) -> MagicMock:
+    manager = MagicMock()
+    manager.can_resume.return_value = can_resume
+    manager.load_state.return_value = saved
+    return manager
+
+
+class TestMakePaginatedRequest:
+    @patch("posthog.temporal.data_imports.sources.linear.linear.requests.Session")
+    def test_fresh_run_saves_cursor_after_each_page_with_next(self, mock_session_cls: MagicMock) -> None:
+        session = MagicMock()
+        snapshots = _capture_post_calls(
+            session,
+            [
+                _make_response([{"id": "1"}], True, "cursor-1"),
+                _make_response([{"id": "2"}], True, "cursor-2"),
+                _make_response([{"id": "3"}], False, None),
+            ],
+        )
+        mock_session_cls.return_value = session
+
+        manager = _make_resumable_manager(can_resume=False)
+        logger = MagicMock()
+
+        pages = list(
+            _make_paginated_request(
+                access_token="tok",
+                endpoint_name="issues",
+                logger=logger,
+                resumable_source_manager=manager,
+            )
+        )
+
+        assert pages == [[{"id": "1"}], [{"id": "2"}], [{"id": "3"}]]
+        manager.load_state.assert_not_called()
+        # Saved after page 1 and page 2 (both had hasNextPage=True), not after the final page.
+        assert manager.save_state.call_args_list == [
+            ((LinearResumeConfig(cursor="cursor-1"),),),
+            ((LinearResumeConfig(cursor="cursor-2"),),),
+        ]
+        # First request must NOT carry a cursor; subsequent ones do.
+        assert "cursor" not in snapshots[0]
+        assert snapshots[1]["cursor"] == "cursor-1"
+        assert snapshots[2]["cursor"] == "cursor-2"
+
+    @patch("posthog.temporal.data_imports.sources.linear.linear.requests.Session")
+    def test_resume_seeds_cursor_from_saved_state(self, mock_session_cls: MagicMock) -> None:
+        session = MagicMock()
+        snapshots = _capture_post_calls(
+            session,
+            [_make_response([{"id": "42"}], False, None)],
+        )
+        mock_session_cls.return_value = session
+
+        manager = _make_resumable_manager(can_resume=True, saved=LinearResumeConfig(cursor="saved-cursor"))
+        logger = MagicMock()
+
+        pages = list(
+            _make_paginated_request(
+                access_token="tok",
+                endpoint_name="issues",
+                logger=logger,
+                resumable_source_manager=manager,
+            )
+        )
+
+        assert pages == [[{"id": "42"}]]
+        manager.load_state.assert_called_once()
+        # The very first request should carry the resumed cursor, not start over.
+        assert snapshots[0]["cursor"] == "saved-cursor"
+        # Final page — no save on a page that has no next.
+        manager.save_state.assert_not_called()
+
+    @patch("posthog.temporal.data_imports.sources.linear.linear.requests.Session")
+    def test_empty_single_page_does_not_save_state(self, mock_session_cls: MagicMock) -> None:
+        session = MagicMock()
+        session.post.return_value = _make_response([], False, None)
+        mock_session_cls.return_value = session
+
+        manager = _make_resumable_manager(can_resume=False)
+        logger = MagicMock()
+
+        pages = list(
+            _make_paginated_request(
+                access_token="tok",
+                endpoint_name="issues",
+                logger=logger,
+                resumable_source_manager=manager,
+            )
+        )
+
+        assert pages == [[]]
+        manager.save_state.assert_not_called()
+
+    @patch("posthog.temporal.data_imports.sources.linear.linear.requests.Session")
+    def test_incremental_filter_preserved_across_pages(self, mock_session_cls: MagicMock) -> None:
+        session = MagicMock()
+        snapshots = _capture_post_calls(
+            session,
+            [
+                _make_response([{"id": "1"}], True, "cursor-1"),
+                _make_response([{"id": "2"}], False, None),
+            ],
+        )
+        mock_session_cls.return_value = session
+
+        manager = _make_resumable_manager(can_resume=False)
+        logger = MagicMock()
+
+        list(
+            _make_paginated_request(
+                access_token="tok",
+                endpoint_name="issues",
+                logger=logger,
+                resumable_source_manager=manager,
+                updated_at_gte="2026-01-01T00:00:00Z",
+            )
+        )
+
+        for variables in snapshots:
+            assert variables["filter"] == {"updatedAt": {"gt": "2026-01-01T00:00:00Z"}}
+
+
+class TestLinearSource:
+    def test_source_response_wires_primary_key_and_items(self) -> None:
+        manager = _make_resumable_manager(can_resume=False)
+        logger = MagicMock()
+
+        response = linear_source(
+            access_token="tok",
+            endpoint_name="issues",
+            logger=logger,
+            resumable_source_manager=manager,
+        )
+
+        assert response.name == "issues"
+        assert response.primary_keys == ["id"]
+        assert callable(response.items)
+
+    @patch("posthog.temporal.data_imports.sources.linear.linear.requests.Session")
+    def test_get_rows_threads_manager_through(self, mock_session_cls: MagicMock) -> None:
+        session = MagicMock()
+        session.post.side_effect = [
+            _make_response([{"id": "a"}], True, "cursor-a"),
+            _make_response([{"id": "b"}], False, None),
+        ]
+        mock_session_cls.return_value = session
+
+        manager = _make_resumable_manager(can_resume=False)
+        logger = MagicMock()
+
+        response = linear_source(
+            access_token="tok",
+            endpoint_name="issues",
+            logger=logger,
+            resumable_source_manager=manager,
+        )
+        pages = list(response.items())
+
+        assert pages == [[{"id": "a"}], [{"id": "b"}]]
+        manager.save_state.assert_called_once_with(LinearResumeConfig(cursor="cursor-a"))

--- a/posthog/temporal/data_imports/sources/linear/test_linear.py
+++ b/posthog/temporal/data_imports/sources/linear/test_linear.py
@@ -1,7 +1,10 @@
 import copy
-from typing import Any
+from collections.abc import Iterable
+from typing import Any, cast
 
 from unittest.mock import MagicMock, patch
+
+from parameterized import parameterized
 
 from posthog.temporal.data_imports.sources.linear.linear import (
     LinearResumeConfig,
@@ -51,106 +54,50 @@ def _make_resumable_manager(*, can_resume: bool = False, saved: LinearResumeConf
     return manager
 
 
+# (has_next, end_cursor) per page. Nodes are synthetic; only pagination matters.
+PageSpec = tuple[bool, str | None]
+
+
 class TestMakePaginatedRequest:
-    @patch("posthog.temporal.data_imports.sources.linear.linear.requests.Session")
-    def test_fresh_run_saves_cursor_after_each_page_with_next(self, mock_session_cls: MagicMock) -> None:
-        session = MagicMock()
-        snapshots = _capture_post_calls(
-            session,
-            [
-                _make_response([{"id": "1"}], True, "cursor-1"),
-                _make_response([{"id": "2"}], True, "cursor-2"),
-                _make_response([{"id": "3"}], False, None),
-            ],
-        )
-        mock_session_cls.return_value = session
-
-        manager = _make_resumable_manager(can_resume=False)
-        logger = MagicMock()
-
-        pages = list(
-            _make_paginated_request(
-                access_token="tok",
-                endpoint_name="issues",
-                logger=logger,
-                resumable_source_manager=manager,
-            )
-        )
-
-        assert pages == [[{"id": "1"}], [{"id": "2"}], [{"id": "3"}]]
-        manager.load_state.assert_not_called()
-        # Saved after page 1 and page 2 (both had hasNextPage=True), not after the final page.
-        assert manager.save_state.call_args_list == [
-            ((LinearResumeConfig(cursor="cursor-1"),),),
-            ((LinearResumeConfig(cursor="cursor-2"),),),
+    @parameterized.expand(
+        [
+            # Fresh runs
+            ("fresh_multi_page", False, None, [(True, "c1"), (True, "c2"), (False, None)], None, ["c1", "c2"], False),
+            ("fresh_single_empty", False, None, [(False, None)], None, [], False),
+            ("fresh_with_filter", False, None, [(True, "c1"), (False, None)], "2026-01-01T00:00:00Z", ["c1"], False),
+            # Resume runs
+            ("resume_final_page_only", True, "saved-c", [(False, None)], None, [], True),
+            ("resume_then_more_pages", True, "saved-c", [(True, "c1"), (False, None)], None, ["c1"], True),
+            (
+                "resume_with_filter",
+                True,
+                "saved-c",
+                [(True, "c1"), (False, None)],
+                "2026-01-01T00:00:00Z",
+                ["c1"],
+                True,
+            ),
         ]
-        # First request must NOT carry a cursor; subsequent ones do.
-        assert "cursor" not in snapshots[0]
-        assert snapshots[1]["cursor"] == "cursor-1"
-        assert snapshots[2]["cursor"] == "cursor-2"
-
+    )
     @patch("posthog.temporal.data_imports.sources.linear.linear.requests.Session")
-    def test_resume_seeds_cursor_from_saved_state(self, mock_session_cls: MagicMock) -> None:
+    def test_pagination_state(
+        self,
+        _name: str,
+        can_resume: bool,
+        saved_cursor: str | None,
+        page_specs: list[PageSpec],
+        filter_gte: str | None,
+        expected_save_cursors: list[str],
+        first_request_has_cursor: bool,
+        mock_session_cls: MagicMock,
+    ) -> None:
         session = MagicMock()
-        snapshots = _capture_post_calls(
-            session,
-            [_make_response([{"id": "42"}], False, None)],
-        )
+        responses = [_make_response([{"id": f"{i}"}], has_next, end) for i, (has_next, end) in enumerate(page_specs)]
+        snapshots = _capture_post_calls(session, responses)
         mock_session_cls.return_value = session
 
-        manager = _make_resumable_manager(can_resume=True, saved=LinearResumeConfig(cursor="saved-cursor"))
-        logger = MagicMock()
-
-        pages = list(
-            _make_paginated_request(
-                access_token="tok",
-                endpoint_name="issues",
-                logger=logger,
-                resumable_source_manager=manager,
-            )
-        )
-
-        assert pages == [[{"id": "42"}]]
-        manager.load_state.assert_called_once()
-        # The very first request should carry the resumed cursor, not start over.
-        assert snapshots[0]["cursor"] == "saved-cursor"
-        # Final page — no save on a page that has no next.
-        manager.save_state.assert_not_called()
-
-    @patch("posthog.temporal.data_imports.sources.linear.linear.requests.Session")
-    def test_empty_single_page_does_not_save_state(self, mock_session_cls: MagicMock) -> None:
-        session = MagicMock()
-        session.post.return_value = _make_response([], False, None)
-        mock_session_cls.return_value = session
-
-        manager = _make_resumable_manager(can_resume=False)
-        logger = MagicMock()
-
-        pages = list(
-            _make_paginated_request(
-                access_token="tok",
-                endpoint_name="issues",
-                logger=logger,
-                resumable_source_manager=manager,
-            )
-        )
-
-        assert pages == [[]]
-        manager.save_state.assert_not_called()
-
-    @patch("posthog.temporal.data_imports.sources.linear.linear.requests.Session")
-    def test_incremental_filter_preserved_across_pages(self, mock_session_cls: MagicMock) -> None:
-        session = MagicMock()
-        snapshots = _capture_post_calls(
-            session,
-            [
-                _make_response([{"id": "1"}], True, "cursor-1"),
-                _make_response([{"id": "2"}], False, None),
-            ],
-        )
-        mock_session_cls.return_value = session
-
-        manager = _make_resumable_manager(can_resume=False)
+        saved_config = LinearResumeConfig(cursor=saved_cursor) if saved_cursor is not None else None
+        manager = _make_resumable_manager(can_resume=can_resume, saved=saved_config)
         logger = MagicMock()
 
         list(
@@ -159,12 +106,23 @@ class TestMakePaginatedRequest:
                 endpoint_name="issues",
                 logger=logger,
                 resumable_source_manager=manager,
-                updated_at_gte="2026-01-01T00:00:00Z",
+                updated_at_gte=filter_gte,
             )
         )
 
-        for variables in snapshots:
-            assert variables["filter"] == {"updatedAt": {"gt": "2026-01-01T00:00:00Z"}}
+        # Resume path: first request carries the saved cursor; fresh path: no cursor on first request.
+        if first_request_has_cursor:
+            assert snapshots[0]["cursor"] == saved_cursor
+        else:
+            assert "cursor" not in snapshots[0]
+
+        # Each non-final page checkpoints the cursor of the next page.
+        assert manager.save_state.call_args_list == [((LinearResumeConfig(cursor=c),),) for c in expected_save_cursors]
+
+        # The updated_at filter, if any, must be applied on every page including the resumed first request.
+        if filter_gte is not None:
+            for variables in snapshots:
+                assert variables["filter"] == {"updatedAt": {"gt": filter_gte}}
 
 
 class TestLinearSource:
@@ -201,7 +159,7 @@ class TestLinearSource:
             logger=logger,
             resumable_source_manager=manager,
         )
-        pages = list(response.items())
+        pages = list(cast(Iterable[Any], response.items()))
 
         assert pages == [[{"id": "a"}], [{"id": "b"}]]
         manager.save_state.assert_called_once_with(LinearResumeConfig(cursor="cursor-a"))


### PR DESCRIPTION
## Problem

Full-refresh syncs of the Linear data-warehouse source restart from page 1 when a worker is restarted mid-sync. For workspaces with many issues/comments, this means re-fetching hundreds of pages and can prevent the sync from ever finishing within its time budget.

## Changes

Convert `LinearSource` from `SimpleSource` to `ResumableSource`:

- Add `LinearResumeConfig(cursor: str)` dataclass holding the GraphQL `endCursor` to resume from.
- Thread `ResumableSourceManager[LinearResumeConfig]` through `_make_paginated_request`. On entry it seeds `variables["cursor"]` from saved state if `can_resume()` is True; otherwise it starts from scratch (and re-applies `updated_at_gte` from `db_incremental_field_last_value` for incremental syncs as before).
- After yielding each page with `hasNextPage=True`, save the new cursor. Duplicates on the resumed page are dedup'd via the endpoint's `primary_key` on the `SourceResponse`.
- No changes to public config, schemas, credential validation, primary keys, or partitioning.

## How did you test this code?

I'm an agent and have not tested this manually. Added unit tests under `posthog/temporal/data_imports/sources/linear/test_linear.py` covering:

- Fresh run saves cursor after each non-final page; first request carries no cursor, subsequent ones carry the saved one.
- Resume run seeds the first request from saved state and does not re-issue the initial (un-cursored) request.
- Single/empty page saves no state.
- Incremental updatedAt filter is preserved across pages.
- SourceResponse wiring (name, primary_keys, items callable) is unchanged.

## Publish to changelog?

no

## 🤖 LLM context

Authored by an agent as a focused conversion mirroring the klaviyo/temporalio resumable patterns. Scope is strictly limited to linear/.