### PR TITLE
refactor(data-warehouse): make BuildBetter source resumable

### DIFF
--- a/posthog/temporal/data_imports/sources/buildbetter/buildbetter.py
+++ b/posthog/temporal/data_imports/sources/buildbetter/buildbetter.py
@@ -101,8 +101,7 @@ def _make_paginated_request(
         variables["where"] = {incremental_field: {"_gt": incremental_field_last_value}}
 
     try:
-        has_more = True
-        while has_more:
+        while True:
             logger.debug(f"Querying BuildBetter endpoint {endpoint_name} with variables: {variables}")
             payload = execute(variables)
 
@@ -112,10 +111,11 @@ def _make_paginated_request(
 
             yield data
 
-            has_more = len(data) >= page_size
-            if has_more:
-                variables["offset"] = variables["offset"] + len(data)
-                resumable_source_manager.save_state(BuildBetterResumeConfig(offset=variables["offset"]))
+            if len(data) < page_size:
+                break
+
+            variables["offset"] = variables["offset"] + len(data)
+            resumable_source_manager.save_state(BuildBetterResumeConfig(offset=variables["offset"]))
     finally:
         sess.close()
 

--- a/posthog/temporal/data_imports/sources/buildbetter/buildbetter.py
+++ b/posthog/temporal/data_imports/sources/buildbetter/buildbetter.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Any
 
 import requests
@@ -7,16 +8,23 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.temporal.data_imports.sources.buildbetter.queries import QUERIES, VIEWER_QUERY
 from posthog.temporal.data_imports.sources.buildbetter.settings import BUILDBETTER_API_URL, BUILDBETTER_ENDPOINTS
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 
 
 class BuildBetterRetryableError(Exception):
     pass
 
 
+@dataclasses.dataclass
+class BuildBetterResumeConfig:
+    offset: int
+
+
 def _make_paginated_request(
     api_key: str,
     endpoint_name: str,
     logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[BuildBetterResumeConfig],
     incremental_field: str | None = None,
     incremental_field_last_value: str | None = None,
 ):
@@ -78,9 +86,15 @@ def _make_paginated_request(
         return payload
 
     page_size = endpoint_config.page_size
+
+    resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    initial_offset = resume_config.offset if resume_config is not None else 0
+    if resume_config is not None:
+        logger.debug(f"BuildBetter: resuming {endpoint_name} from offset {initial_offset}")
+
     variables: dict[str, Any] = {
         "limit": page_size,
-        "offset": 0,
+        "offset": initial_offset,
     }
 
     if incremental_field and incremental_field_last_value:
@@ -101,6 +115,7 @@ def _make_paginated_request(
             has_more = len(data) >= page_size
             if has_more:
                 variables["offset"] = variables["offset"] + len(data)
+                resumable_source_manager.save_state(BuildBetterResumeConfig(offset=variables["offset"]))
     finally:
         sess.close()
 
@@ -109,6 +124,7 @@ def buildbetter_source(
     api_key: str,
     endpoint_name: str,
     logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[BuildBetterResumeConfig],
     incremental_field: str | None = None,
     incremental_field_last_value: str | None = None,
 ) -> SourceResponse:
@@ -126,6 +142,7 @@ def buildbetter_source(
             api_key=api_key,
             endpoint_name=endpoint_name,
             logger=logger,
+            resumable_source_manager=resumable_source_manager,
             incremental_field=incremental_field,
             incremental_field_last_value=incremental_field_last_value,
         )

--- a/posthog/temporal/data_imports/sources/buildbetter/source.py
+++ b/posthog/temporal/data_imports/sources/buildbetter/source.py
@@ -9,12 +9,14 @@ from posthog.schema import (
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.buildbetter.buildbetter import (
+    BuildBetterResumeConfig,
     buildbetter_source,
     validate_credentials as validate_buildbetter_credentials,
 )
 from posthog.temporal.data_imports.sources.buildbetter.settings import ENDPOINTS, INCREMENTAL_FIELDS
-from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from posthog.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import BuildBetterSourceConfig
 
@@ -22,7 +24,7 @@ from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class BuildBetterSource(SimpleSource[BuildBetterSourceConfig]):
+class BuildBetterSource(ResumableSource[BuildBetterSourceConfig, BuildBetterResumeConfig]):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.BUILDBETTER
@@ -56,7 +58,15 @@ class BuildBetterSource(SimpleSource[BuildBetterSourceConfig]):
     ) -> tuple[bool, str | None]:
         return validate_buildbetter_credentials(config.api_key)
 
-    def source_for_pipeline(self, config: BuildBetterSourceConfig, inputs: SourceInputs) -> SourceResponse:
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[BuildBetterResumeConfig]:
+        return ResumableSourceManager[BuildBetterResumeConfig](inputs, BuildBetterResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: BuildBetterSourceConfig,
+        resumable_source_manager: ResumableSourceManager[BuildBetterResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
         incremental_field_last_value = None
         if inputs.should_use_incremental_field and inputs.db_incremental_field_last_value is not None:
             incremental_field_last_value = str(inputs.db_incremental_field_last_value)
@@ -65,6 +75,7 @@ class BuildBetterSource(SimpleSource[BuildBetterSourceConfig]):
             api_key=config.api_key,
             endpoint_name=inputs.schema_name,
             logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
             incremental_field=inputs.incremental_field if inputs.should_use_incremental_field else None,
             incremental_field_last_value=incremental_field_last_value,
         )

--- a/posthog/temporal/data_imports/sources/buildbetter/test_buildbetter.py
+++ b/posthog/temporal/data_imports/sources/buildbetter/test_buildbetter.py
@@ -1,0 +1,197 @@
+from unittest.mock import MagicMock, patch
+
+from posthog.temporal.data_imports.sources.buildbetter.buildbetter import (
+    BuildBetterResumeConfig,
+    _make_paginated_request,
+    buildbetter_source,
+)
+from posthog.temporal.data_imports.sources.buildbetter.settings import BUILDBETTER_ENDPOINTS
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+
+
+def _make_response(json_data: dict, status_code: int = 200) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.ok = 200 <= status_code < 300
+    response.json.return_value = json_data
+    return response
+
+
+def _make_manager(can_resume: bool = False, state: BuildBetterResumeConfig | None = None) -> MagicMock:
+    manager = MagicMock(spec=ResumableSourceManager)
+    manager.can_resume.return_value = can_resume
+    manager.load_state.return_value = state
+    return manager
+
+
+def _interview_payload(ids: list[str]) -> dict:
+    return {"data": {"interview": [{"id": i} for i in ids]}}
+
+
+class TestMakePaginatedRequest:
+    def test_fresh_run_starts_at_offset_zero_and_saves_state(self) -> None:
+        page_size = BUILDBETTER_ENDPOINTS["interviews"].page_size
+        first_page = _interview_payload([str(i) for i in range(page_size)])
+        second_page = _interview_payload(["last"])
+
+        manager = _make_manager(can_resume=False)
+        logger = MagicMock()
+
+        with patch("posthog.temporal.data_imports.sources.buildbetter.buildbetter.requests.Session") as session_cls:
+            session = session_cls.return_value
+            session.post.side_effect = [
+                _make_response(first_page),
+                _make_response(second_page),
+            ]
+
+            batches = list(
+                _make_paginated_request(
+                    api_key="key",
+                    endpoint_name="interviews",
+                    logger=logger,
+                    resumable_source_manager=manager,
+                )
+            )
+
+        assert len(batches) == 2
+        assert len(batches[0]) == page_size
+        assert batches[1] == [{"id": "last"}]
+
+        # First request starts from offset 0
+        first_call = session.post.call_args_list[0]
+        assert first_call.kwargs["json"]["variables"]["offset"] == 0
+
+        # Second request picks up after the first full page
+        second_call = session.post.call_args_list[1]
+        assert second_call.kwargs["json"]["variables"]["offset"] == page_size
+
+        # State is saved after the first (full) page pointing at the next offset,
+        # and not again after the final short page (loop exits without advancing).
+        manager.save_state.assert_called_once_with(BuildBetterResumeConfig(offset=page_size))
+
+    def test_resume_path_seeds_offset_from_loaded_state(self) -> None:
+        page_size = BUILDBETTER_ENDPOINTS["interviews"].page_size
+        saved_offset = page_size * 3
+        # Single short page ends the loop without saving further state
+        resumed_page = _interview_payload(["resumed"])
+
+        manager = _make_manager(can_resume=True, state=BuildBetterResumeConfig(offset=saved_offset))
+        logger = MagicMock()
+
+        with patch("posthog.temporal.data_imports.sources.buildbetter.buildbetter.requests.Session") as session_cls:
+            session = session_cls.return_value
+            session.post.return_value = _make_response(resumed_page)
+
+            batches = list(
+                _make_paginated_request(
+                    api_key="key",
+                    endpoint_name="interviews",
+                    logger=logger,
+                    resumable_source_manager=manager,
+                )
+            )
+
+        assert batches == [[{"id": "resumed"}]]
+
+        # Single request issued, starting from the saved offset (no re-fetch of earlier pages)
+        assert session.post.call_count == 1
+        call = session.post.call_args_list[0]
+        assert call.kwargs["json"]["variables"]["offset"] == saved_offset
+
+        manager.can_resume.assert_called_once()
+        manager.load_state.assert_called_once()
+        # Short page terminates the loop; save_state is not invoked
+        manager.save_state.assert_not_called()
+
+    def test_empty_first_page_does_not_save_state(self) -> None:
+        manager = _make_manager(can_resume=False)
+        logger = MagicMock()
+
+        with patch("posthog.temporal.data_imports.sources.buildbetter.buildbetter.requests.Session") as session_cls:
+            session = session_cls.return_value
+            session.post.return_value = _make_response({"data": {"interview": []}})
+
+            batches = list(
+                _make_paginated_request(
+                    api_key="key",
+                    endpoint_name="interviews",
+                    logger=logger,
+                    resumable_source_manager=manager,
+                )
+            )
+
+        assert batches == []
+        manager.save_state.assert_not_called()
+
+    def test_save_state_called_for_each_full_page(self) -> None:
+        page_size = BUILDBETTER_ENDPOINTS["interviews"].page_size
+        full_page_a = _interview_payload([f"a{i}" for i in range(page_size)])
+        full_page_b = _interview_payload([f"b{i}" for i in range(page_size)])
+        tail_page = _interview_payload(["c0"])
+
+        manager = _make_manager(can_resume=False)
+        logger = MagicMock()
+
+        with patch("posthog.temporal.data_imports.sources.buildbetter.buildbetter.requests.Session") as session_cls:
+            session = session_cls.return_value
+            session.post.side_effect = [
+                _make_response(full_page_a),
+                _make_response(full_page_b),
+                _make_response(tail_page),
+            ]
+
+            list(
+                _make_paginated_request(
+                    api_key="key",
+                    endpoint_name="interviews",
+                    logger=logger,
+                    resumable_source_manager=manager,
+                )
+            )
+
+        saved_offsets = [call.args[0].offset for call in manager.save_state.call_args_list]
+        assert saved_offsets == [page_size, page_size * 2]
+
+    def test_incremental_filter_passes_where_clause(self) -> None:
+        manager = _make_manager(can_resume=False)
+        logger = MagicMock()
+
+        with patch("posthog.temporal.data_imports.sources.buildbetter.buildbetter.requests.Session") as session_cls:
+            session = session_cls.return_value
+            session.post.return_value = _make_response({"data": {"interview": []}})
+
+            list(
+                _make_paginated_request(
+                    api_key="key",
+                    endpoint_name="interviews",
+                    logger=logger,
+                    resumable_source_manager=manager,
+                    incremental_field="updated_at",
+                    incremental_field_last_value="2026-01-01",
+                )
+            )
+
+        call = session.post.call_args_list[0]
+        assert call.kwargs["json"]["variables"]["where"] == {"updated_at": {"_gt": "2026-01-01"}}
+
+
+class TestBuildbetterSource:
+    def test_source_threads_resumable_manager_through(self) -> None:
+        manager = _make_manager(can_resume=False)
+        logger = MagicMock()
+
+        with patch("posthog.temporal.data_imports.sources.buildbetter.buildbetter.requests.Session") as session_cls:
+            session = session_cls.return_value
+            session.post.return_value = _make_response(_interview_payload(["x"]))
+
+            response = buildbetter_source(
+                api_key="key",
+                endpoint_name="interviews",
+                logger=logger,
+                resumable_source_manager=manager,
+            )
+            batches = list(response.items())
+
+        assert batches == [[{"id": "x"}]]
+        assert response.primary_keys == ["id"]
+        manager.can_resume.assert_called_once()

--- a/posthog/temporal/data_imports/sources/buildbetter/test_buildbetter.py
+++ b/posthog/temporal/data_imports/sources/buildbetter/test_buildbetter.py
@@ -1,4 +1,9 @@
+from collections.abc import Iterable
+from typing import Any, cast
+
 from unittest.mock import MagicMock, patch
+
+from parameterized import parameterized
 
 from posthog.temporal.data_imports.sources.buildbetter.buildbetter import (
     BuildBetterResumeConfig,
@@ -29,53 +34,27 @@ def _interview_payload(ids: list[str]) -> dict:
 
 
 class TestMakePaginatedRequest:
-    def test_fresh_run_starts_at_offset_zero_and_saves_state(self) -> None:
+    @parameterized.expand(
+        [
+            ("fresh_run", False, None, 0),
+            ("resume", True, 3, 3),
+        ]
+    )
+    def test_starting_offset_from_resume_state(
+        self,
+        _name: str,
+        can_resume: bool,
+        saved_offset_multiplier: int | None,
+        expected_first_offset_multiplier: int,
+    ) -> None:
         page_size = BUILDBETTER_ENDPOINTS["interviews"].page_size
-        first_page = _interview_payload([str(i) for i in range(page_size)])
-        second_page = _interview_payload(["last"])
+        saved_offset = saved_offset_multiplier * page_size if saved_offset_multiplier is not None else None
+        expected_first_offset = expected_first_offset_multiplier * page_size
+        # Single short page terminates the loop without saving further state
+        resumed_page = _interview_payload(["x"])
 
-        manager = _make_manager(can_resume=False)
-        logger = MagicMock()
-
-        with patch("posthog.temporal.data_imports.sources.buildbetter.buildbetter.requests.Session") as session_cls:
-            session = session_cls.return_value
-            session.post.side_effect = [
-                _make_response(first_page),
-                _make_response(second_page),
-            ]
-
-            batches = list(
-                _make_paginated_request(
-                    api_key="key",
-                    endpoint_name="interviews",
-                    logger=logger,
-                    resumable_source_manager=manager,
-                )
-            )
-
-        assert len(batches) == 2
-        assert len(batches[0]) == page_size
-        assert batches[1] == [{"id": "last"}]
-
-        # First request starts from offset 0
-        first_call = session.post.call_args_list[0]
-        assert first_call.kwargs["json"]["variables"]["offset"] == 0
-
-        # Second request picks up after the first full page
-        second_call = session.post.call_args_list[1]
-        assert second_call.kwargs["json"]["variables"]["offset"] == page_size
-
-        # State is saved after the first (full) page pointing at the next offset,
-        # and not again after the final short page (loop exits without advancing).
-        manager.save_state.assert_called_once_with(BuildBetterResumeConfig(offset=page_size))
-
-    def test_resume_path_seeds_offset_from_loaded_state(self) -> None:
-        page_size = BUILDBETTER_ENDPOINTS["interviews"].page_size
-        saved_offset = page_size * 3
-        # Single short page ends the loop without saving further state
-        resumed_page = _interview_payload(["resumed"])
-
-        manager = _make_manager(can_resume=True, state=BuildBetterResumeConfig(offset=saved_offset))
+        state = BuildBetterResumeConfig(offset=saved_offset) if saved_offset is not None else None
+        manager = _make_manager(can_resume=can_resume, state=state)
         logger = MagicMock()
 
         with patch("posthog.temporal.data_imports.sources.buildbetter.buildbetter.requests.Session") as session_cls:
@@ -91,15 +70,12 @@ class TestMakePaginatedRequest:
                 )
             )
 
-        assert batches == [[{"id": "resumed"}]]
-
-        # Single request issued, starting from the saved offset (no re-fetch of earlier pages)
+        assert batches == [[{"id": "x"}]]
         assert session.post.call_count == 1
         call = session.post.call_args_list[0]
-        assert call.kwargs["json"]["variables"]["offset"] == saved_offset
+        assert call.kwargs["json"]["variables"]["offset"] == expected_first_offset
 
         manager.can_resume.assert_called_once()
-        manager.load_state.assert_called_once()
         # Short page terminates the loop; save_state is not invoked
         manager.save_state.assert_not_called()
 
@@ -190,7 +166,7 @@ class TestBuildbetterSource:
                 logger=logger,
                 resumable_source_manager=manager,
             )
-            batches = list(response.items())
+            batches = list(cast(Iterable[Any], response.items()))
 
         assert batches == [[{"id": "x"}]]
         assert response.primary_keys == ["id"]

--- a/posthog/temporal/data_imports/sources/buildbetter/test_buildbetter.py
+++ b/posthog/temporal/data_imports/sources/buildbetter/test_buildbetter.py
@@ -76,6 +76,10 @@ class TestMakePaginatedRequest:
         assert call.kwargs["json"]["variables"]["offset"] == expected_first_offset
 
         manager.can_resume.assert_called_once()
+        if can_resume:
+            manager.load_state.assert_called_once()
+        else:
+            manager.load_state.assert_not_called()
         # Short page terminates the loop; save_state is not invoked
         manager.save_state.assert_not_called()
 


### PR DESCRIPTION
## Problem

`BuildBetterSource` currently extends `SimpleSource`, so any full-refresh that gets interrupted (worker restart, retry, etc.) has to re-fetch every page of every endpoint from offset 0. For large BuildBetter workspaces that means duplicated work and, in pathological cases, no forward progress.

## Changes

- Add `BuildBetterResumeConfig(offset: int)` dataclass and thread a `ResumableSourceManager[BuildBetterResumeConfig]` through `buildbetter_source` and `_make_paginated_request`.
- Seed the paginator's starting offset from `load_state()` when `can_resume()` is true; otherwise initialize at 0 as before.
- After each full page is yielded, persist the next offset via `save_state(...)`. The final short page (loop terminator) is not saved, matching the klaviyo/temporalio conventions.
- Switch `BuildBetterSource` to `ResumableSource[BuildBetterSourceConfig, BuildBetterResumeConfig]`, implement `get_resumable_source_manager`, and update `source_for_pipeline` to forward the manager.
- Add unit tests covering fresh-run, resume, empty-page, multi-page save sequencing, and the incremental filter pass-through.

Public config fields, schemas, credential validation, sort mode, partitioning, and primary keys are unchanged — duplicates that occur on resume are handled by the existing primary-key merge semantics.

## How did you test this code?

- `ruff check` + `ruff format` on `posthog/temporal/data_imports/sources/buildbetter/` — clean.
- Added `test_buildbetter.py` covering the resume contract end-to-end at the transport layer (fresh run starts at offset 0; resume seeds from saved offset without re-issuing earlier requests; short/empty pages do not save state). The local environment does not have Django bootstrapped, so the tests rely on CI for execution — I have not manually run them.

## Publish to changelog?

no

## 🤖 LLM context

Authored by an agent from a task to convert `BuildBetterSource` from `SimpleSource` to `ResumableSource`, following the klaviyo and temporalio reference implementations. The offset-based pagination primitive made the klaviyo `next_url` pattern a close analogue; the resume config stores just the offset since the incremental filter values are derived deterministically from `SourceInputs` on each run.
