### PR TITLE
fix: Replace one-off trial with recurring free plan allowance

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/usage.py
+++ b/services/llm-gateway/src/llm_gateway/api/usage.py
@@ -55,7 +55,6 @@ async def get_usage(
         product=product,
         end_user_id=str(user.user_id),
         plan_key=plan_info.plan_key,
-        in_trial_period=plan_info.in_trial_period,
         seat_created_at=plan_info.seat_created_at,
     )
 

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -53,7 +53,7 @@ DEFAULT_USER_COST_LIMITS: dict[str, "UserCostLimit"] = {
 }
 
 FREE_PLAN_COST_LIMIT = UserCostLimit(
-    burst_limit_usd=10.0,
+    burst_limit_usd=50.0,
     burst_window_seconds=86400,
     sustained_limit_usd=50.0,
     sustained_window_seconds=2592000,

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -149,7 +149,7 @@ class Settings(BaseSettings):
 
     posthog_api_base_url: str = "https://us.posthog.com"
     plan_cache_ttl: int = 300  # 5 minutes
-    free_plan_trial_period_days: int = 30
+    billing_period_days: int = 30
 
     @field_validator("product_cost_limits", mode="before")
     @classmethod

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -52,17 +52,10 @@ DEFAULT_USER_COST_LIMITS: dict[str, "UserCostLimit"] = {
     ),
 }
 
-FREE_PLAN_TRIAL_COST_LIMIT = UserCostLimit(
-    burst_limit_usd=5.0,
+FREE_PLAN_COST_LIMIT = UserCostLimit(
+    burst_limit_usd=10.0,
     burst_window_seconds=86400,
     sustained_limit_usd=50.0,
-    sustained_window_seconds=2592000,
-)
-
-FREE_PLAN_EXPIRED_COST_LIMIT = UserCostLimit(
-    burst_limit_usd=0.0,
-    burst_window_seconds=86400,
-    sustained_limit_usd=0.0,
     sustained_window_seconds=2592000,
 )
 

--- a/services/llm-gateway/src/llm_gateway/dependencies.py
+++ b/services/llm-gateway/src/llm_gateway/dependencies.py
@@ -166,7 +166,6 @@ async def enforce_throttles(
         request_id=get_request_id() or None,
         end_user_id=end_user_id,
         plan_key=plan_info.plan_key,
-        in_trial_period=plan_info.in_trial_period,
         seat_created_at=plan_info.seat_created_at,
     )
     request.state.throttle_context = context

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -9,8 +9,7 @@ from redis.asyncio import Redis
 
 from llm_gateway.config import (
     DEFAULT_USER_COST_LIMIT,
-    FREE_PLAN_EXPIRED_COST_LIMIT,
-    FREE_PLAN_TRIAL_COST_LIMIT,
+    FREE_PLAN_COST_LIMIT,
     get_settings,
 )
 
@@ -205,9 +204,7 @@ class _UserCostThrottleBase(CostThrottle):
 
     def _get_config(self, context: ThrottleContext) -> UserCostLimit:
         if _is_free_plan_throttled(context):
-            if context.in_trial_period:
-                return FREE_PLAN_TRIAL_COST_LIMIT
-            return FREE_PLAN_EXPIRED_COST_LIMIT
+            return FREE_PLAN_COST_LIMIT
 
         config = get_settings().user_cost_limits.get(context.product)
         if not config:

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -256,7 +256,7 @@ class UserCostSustainedThrottle(_UserCostThrottleBase):
         if not base_key:
             return base_key
         if context.product == POSTHOG_CODE_PRODUCT:
-            period = get_billing_period_number(context.seat_created_at, get_settings().free_plan_trial_period_days)
+            period = get_billing_period_number(context.seat_created_at, get_settings().billing_period_days)
             return f"{base_key}:period:{period}"
         return base_key
 

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/throttles.py
@@ -21,7 +21,6 @@ class ThrottleContext:
     request_id: str | None = None
     end_user_id: str | None = None
     plan_key: str | None = None
-    in_trial_period: bool = True
     seat_created_at: str | None = None
 
 

--- a/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
+++ b/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import structlog
@@ -33,7 +33,6 @@ PRO_PLAN_PREFIX = "posthog-code-200"
 @dataclass
 class PlanInfo:
     plan_key: str | None
-    in_trial_period: bool
     seat_created_at: str | None
 
 
@@ -60,19 +59,6 @@ def get_billing_period_number(seat_created_at: str | None, period_days: int = 30
         return 0
 
 
-def _is_in_trial(seat_created_at: str | None) -> bool:
-    if not seat_created_at:
-        return True
-    try:
-        created = datetime.fromisoformat(seat_created_at)
-        if created.tzinfo is None:
-            created = created.replace(tzinfo=UTC)
-        trial_days = get_settings().free_plan_trial_period_days
-        return datetime.now(tz=UTC) - created < timedelta(days=trial_days)
-    except (ValueError, TypeError):
-        return True
-
-
 async def resolve_plan_info(
     request: Request,
     user_id: int,
@@ -80,7 +66,7 @@ async def resolve_plan_info(
 ) -> PlanInfo:
     """Resolve plan info, returning safe defaults on failure."""
     if product != POSTHOG_CODE_PRODUCT:
-        return PlanInfo(plan_key=None, in_trial_period=True, seat_created_at=None)
+        return PlanInfo(plan_key=None, seat_created_at=None)
 
     plan_resolver: PlanResolver = request.app.state.plan_resolver
     auth_header = request.headers.get("Authorization", "")
@@ -91,7 +77,7 @@ async def resolve_plan_info(
         )
     except Exception:
         logger.warning("plan_resolve_failed", user_id=user_id)
-        return PlanInfo(plan_key=None, in_trial_period=True, seat_created_at=None)
+        return PlanInfo(plan_key=None, seat_created_at=None)
 
 
 class PlanResolver:
@@ -114,7 +100,7 @@ class PlanResolver:
     async def get_plan(self, user_id: int, auth_header: str) -> PlanInfo:
         """Return the user's plan info, using cache when available."""
         if not auth_header:
-            return PlanInfo(plan_key=None, in_trial_period=True, seat_created_at=None)
+            return PlanInfo(plan_key=None, seat_created_at=None)
 
         cached = await self._get_cached(user_id)
         if cached is not None:
@@ -124,12 +110,11 @@ class PlanResolver:
             plan_key, seat_created_at = await self._fetch_plan(auth_header)
         except Exception:
             logger.warning("seat_fetch_failed", user_id=user_id, exc_info=True)
-            return PlanInfo(plan_key=None, in_trial_period=True, seat_created_at=None)
+            return PlanInfo(plan_key=None, seat_created_at=None)
 
         await self._set_cached(user_id, plan_key, seat_created_at)
         return PlanInfo(
             plan_key=plan_key,
-            in_trial_period=_is_in_trial(seat_created_at),
             seat_created_at=seat_created_at,
         )
 
@@ -144,7 +129,6 @@ class PlanResolver:
                 seat_created_at = data.get("created_at")
                 return PlanInfo(
                     plan_key=plan_key,
-                    in_trial_period=_is_in_trial(seat_created_at),
                     seat_created_at=seat_created_at,
                 )
         except Exception:

--- a/services/llm-gateway/tests/conftest.py
+++ b/services/llm-gateway/tests/conftest.py
@@ -39,9 +39,7 @@ def create_test_app(
         app.state.throttle_runner = ThrottleRunner(throttles=throttles if throttles is not None else default_throttles)
         app.state.http_client = MagicMock()
         app.state.plan_resolver = AsyncMock()
-        app.state.plan_resolver.get_plan = AsyncMock(
-            return_value=PlanInfo(plan_key=None, in_trial_period=True, seat_created_at=None)
-        )
+        app.state.plan_resolver.get_plan = AsyncMock(return_value=PlanInfo(plan_key=None, seat_created_at=None))
         yield
 
     app = FastAPI(title="LLM Gateway Test", lifespan=test_lifespan)

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -20,7 +20,6 @@ def make_context(
     product: str = "posthog_code",
     end_user_id: str | None = None,
     plan_key: str | None = "posthog-code-200-20260301",
-    in_trial_period: bool = True,
     seat_created_at: str | None = None,
 ) -> ThrottleContext:
     user = user or make_user()
@@ -31,7 +30,6 @@ def make_context(
         product=product,
         end_user_id=end_user_id,
         plan_key=plan_key,
-        in_trial_period=in_trial_period,
         seat_created_at=seat_created_at,
     )
 
@@ -323,7 +321,6 @@ class TestUserCostSustainedThrottle:
             product="posthog_code",
             end_user_id="42",
             plan_key="posthog-code-free-20260301",
-            in_trial_period=True,
             seat_created_at=created,
         )
 
@@ -342,7 +339,6 @@ class TestUserCostSustainedThrottle:
             product="posthog_code",
             end_user_id="42",
             plan_key="posthog-code-free-20260301",
-            in_trial_period=False,
             seat_created_at=created,
         )
 
@@ -1025,61 +1021,55 @@ class TestRateLimitPoisoningPrevention:
 
 class TestPlanAwareThrottling:
     @pytest.mark.asyncio
-    async def test_trial_user_gets_burst_limit_of_5(self) -> None:
+    async def test_free_user_gets_burst_limit_of_10(self) -> None:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         throttle = UserCostBurstThrottle(redis=None)
-        context = make_context(
-            product="posthog_code", plan_key=None, in_trial_period=True, seat_created_at="2026-01-01T00:00:00+00:00"
-        )
+        context = make_context(product="posthog_code", plan_key=None, seat_created_at="2026-01-01T00:00:00+00:00")
 
-        await throttle.record_cost(context, 5.0)
+        await throttle.record_cost(context, 10.0)
         result = await throttle.allow_request(context)
         assert result.allowed is False
 
     @pytest.mark.asyncio
-    async def test_trial_user_gets_sustained_limit_of_50(self) -> None:
+    async def test_free_user_gets_sustained_limit_of_50(self) -> None:
         from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
 
         throttle = UserCostSustainedThrottle(redis=None)
-        context = make_context(
-            product="posthog_code", plan_key=None, in_trial_period=True, seat_created_at="2026-01-01T00:00:00+00:00"
-        )
+        context = make_context(product="posthog_code", plan_key=None, seat_created_at="2026-01-01T00:00:00+00:00")
 
         await throttle.record_cost(context, 50.0)
         result = await throttle.allow_request(context)
         assert result.allowed is False
 
     @pytest.mark.asyncio
-    async def test_expired_trial_user_gets_zero_limit(self) -> None:
+    async def test_old_free_user_still_gets_burst_limit(self) -> None:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         throttle = UserCostBurstThrottle(redis=None)
-        context = make_context(
-            product="posthog_code", plan_key=None, in_trial_period=False, seat_created_at="2025-01-01T00:00:00+00:00"
-        )
+        context = make_context(product="posthog_code", plan_key=None, seat_created_at="2025-01-01T00:00:00+00:00")
 
+        await throttle.record_cost(context, 4.0)
         result = await throttle.allow_request(context)
-        assert result.allowed is False
+        assert result.allowed is True
 
     @pytest.mark.asyncio
-    async def test_expired_trial_sustained_also_zero(self) -> None:
+    async def test_old_free_user_still_gets_sustained_limit(self) -> None:
         from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
 
         throttle = UserCostSustainedThrottle(redis=None)
-        context = make_context(
-            product="posthog_code", plan_key=None, in_trial_period=False, seat_created_at="2025-01-01T00:00:00+00:00"
-        )
+        context = make_context(product="posthog_code", plan_key=None, seat_created_at="2025-01-01T00:00:00+00:00")
 
+        await throttle.record_cost(context, 49.0)
         result = await throttle.allow_request(context)
-        assert result.allowed is False
+        assert result.allowed is True
 
     @pytest.mark.asyncio
     async def test_no_seat_gets_pro_limits(self) -> None:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         throttle = UserCostBurstThrottle(redis=None)
-        context = make_context(product="posthog_code", plan_key=None, in_trial_period=True, seat_created_at=None)
+        context = make_context(product="posthog_code", plan_key=None, seat_created_at=None)
 
         await throttle.record_cost(context, 50.0)
         result = await throttle.allow_request(context)
@@ -1097,14 +1087,13 @@ class TestPlanAwareThrottling:
         assert result.allowed is True
 
     @pytest.mark.asyncio
-    async def test_free_plan_key_gets_trial_limits(self) -> None:
+    async def test_free_plan_key_gets_free_limits(self) -> None:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         throttle = UserCostBurstThrottle(redis=None)
         context = make_context(
             product="posthog_code",
             plan_key="posthog-code-free-20260301",
-            in_trial_period=True,
             seat_created_at="2026-01-01T00:00:00+00:00",
         )
 

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -1021,13 +1021,13 @@ class TestRateLimitPoisoningPrevention:
 
 class TestPlanAwareThrottling:
     @pytest.mark.asyncio
-    async def test_free_user_gets_burst_limit_of_10(self) -> None:
+    async def test_free_user_gets_limit_of_50(self) -> None:
         from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
 
         throttle = UserCostBurstThrottle(redis=None)
         context = make_context(product="posthog_code", plan_key=None, seat_created_at="2026-01-01T00:00:00+00:00")
 
-        await throttle.record_cost(context, 10.0)
+        await throttle.record_cost(context, 50.0)
         result = await throttle.allow_request(context)
         assert result.allowed is False
 

--- a/services/llm-gateway/tests/test_plan_resolver.py
+++ b/services/llm-gateway/tests/test_plan_resolver.py
@@ -118,7 +118,6 @@ class TestPlanResolver:
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
             mock_settings.return_value.posthog_api_base_url = "https://app.posthog.com"
             mock_settings.return_value.plan_cache_ttl = 300
-            mock_settings.return_value.free_plan_trial_period_days = 30
             result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
 
         assert result.plan_key == "posthog-code-200-20260301"
@@ -142,7 +141,6 @@ class TestPlanResolver:
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
             mock_settings.return_value.posthog_api_base_url = "https://app.posthog.com"
             mock_settings.return_value.plan_cache_ttl = 300
-            mock_settings.return_value.free_plan_trial_period_days = 30
             await resolver.get_plan(user_id=1, auth_header="Bearer phx_mysecretkey")
 
         resolver._http.get.assert_called_once()

--- a/services/llm-gateway/tests/test_plan_resolver.py
+++ b/services/llm-gateway/tests/test_plan_resolver.py
@@ -5,7 +5,6 @@ import pytest
 
 from llm_gateway.services.plan_resolver import (
     PlanResolver,
-    _is_in_trial,
     get_billing_period_number,
     is_pro_plan,
 )
@@ -26,30 +25,6 @@ class TestIsProPlan:
     )
     def test_is_pro_plan(self, plan_key: str | None, expected: bool) -> None:
         assert is_pro_plan(plan_key) is expected
-
-
-class TestIsInTrial:
-    def test_none_created_at_is_trial(self) -> None:
-        assert _is_in_trial(None) is True
-
-    def test_recent_date_is_trial(self) -> None:
-        recent = (datetime.now(tz=UTC) - timedelta(days=5)).isoformat()
-        assert _is_in_trial(recent) is True
-
-    def test_old_date_is_not_trial(self) -> None:
-        old = (datetime.now(tz=UTC) - timedelta(days=60)).isoformat()
-        assert _is_in_trial(old) is False
-
-    def test_exactly_30_days_is_not_trial(self) -> None:
-        boundary = (datetime.now(tz=UTC) - timedelta(days=30, seconds=1)).isoformat()
-        assert _is_in_trial(boundary) is False
-
-    def test_just_under_30_days_is_trial(self) -> None:
-        boundary = (datetime.now(tz=UTC) - timedelta(days=29, hours=23)).isoformat()
-        assert _is_in_trial(boundary) is True
-
-    def test_invalid_date_string_is_trial(self) -> None:
-        assert _is_in_trial("not-a-date") is True
 
 
 class TestGetBillingPeriodNumber:
@@ -100,10 +75,8 @@ class TestPlanResolver:
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
             mock_settings.return_value.posthog_api_base_url = ""
             mock_settings.return_value.plan_cache_ttl = 300
-            mock_settings.return_value.free_plan_trial_period_days = 30
             result = await resolver.get_plan(user_id=1, auth_header="Bearer phx_test")
         assert result.plan_key is None
-        assert result.in_trial_period is True
 
     async def test_returns_cached_plan(self, resolver_with_redis: PlanResolver) -> None:
         import json
@@ -111,9 +84,7 @@ class TestPlanResolver:
         cached = json.dumps({"plan_key": "posthog-code-200-20260301", "created_at": None})
         assert resolver_with_redis._redis is not None
         resolver_with_redis._redis.get = AsyncMock(return_value=cached.encode())  # type: ignore[method-assign]
-        with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
-            mock_settings.return_value.free_plan_trial_period_days = 30
-            result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
+        result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
         assert result.plan_key == "posthog-code-200-20260301"
 
     async def test_cached_null_plan_returns_none_plan_key(self, resolver_with_redis: PlanResolver) -> None:
@@ -122,24 +93,19 @@ class TestPlanResolver:
         cached = json.dumps({"plan_key": None, "created_at": None})
         assert resolver_with_redis._redis is not None
         resolver_with_redis._redis.get = AsyncMock(return_value=cached.encode())  # type: ignore[method-assign]
-        with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
-            mock_settings.return_value.free_plan_trial_period_days = 30
-            result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
+        result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
         assert result.plan_key is None
-        assert result.in_trial_period is True
 
-    async def test_cached_old_seat_is_not_trial(self, resolver_with_redis: PlanResolver) -> None:
+    async def test_cached_old_seat_returns_plan(self, resolver_with_redis: PlanResolver) -> None:
         import json
 
         old_date = (datetime.now(tz=UTC) - timedelta(days=60)).isoformat()
         cached = json.dumps({"plan_key": "posthog-code-free-20260301", "created_at": old_date})
         assert resolver_with_redis._redis is not None
         resolver_with_redis._redis.get = AsyncMock(return_value=cached.encode())  # type: ignore[method-assign]
-        with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
-            mock_settings.return_value.free_plan_trial_period_days = 30
-            result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
+        result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
         assert result.plan_key == "posthog-code-free-20260301"
-        assert result.in_trial_period is False
+        assert result.seat_created_at == old_date
 
     async def test_fetches_from_api_and_caches(self, resolver_with_redis: PlanResolver) -> None:
         created_at = datetime.now(tz=UTC).isoformat()
@@ -156,7 +122,6 @@ class TestPlanResolver:
             result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
 
         assert result.plan_key == "posthog-code-200-20260301"
-        assert result.in_trial_period is True
         assert resolver_with_redis._redis is not None
         resolver_with_redis._redis.set.assert_called_once()  # type: ignore[attr-defined]
 
@@ -192,11 +157,9 @@ class TestPlanResolver:
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
             mock_settings.return_value.posthog_api_base_url = "https://app.posthog.com"
             mock_settings.return_value.plan_cache_ttl = 300
-            mock_settings.return_value.free_plan_trial_period_days = 30
             result = await resolver.get_plan(user_id=1, auth_header="Bearer phx_test")
 
         assert result.plan_key is None
-        assert result.in_trial_period is True
 
     async def test_api_error_returns_none_plan(self, resolver: PlanResolver) -> None:
         resolver._http.get = AsyncMock(side_effect=Exception("connection refused"))  # type: ignore[method-assign]
@@ -204,16 +167,13 @@ class TestPlanResolver:
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
             mock_settings.return_value.posthog_api_base_url = "https://app.posthog.com"
             mock_settings.return_value.plan_cache_ttl = 300
-            mock_settings.return_value.free_plan_trial_period_days = 30
             result = await resolver.get_plan(user_id=1, auth_header="Bearer phx_test")
 
         assert result.plan_key is None
-        assert result.in_trial_period is True
 
     async def test_empty_auth_header_skips_fetch(self, resolver: PlanResolver) -> None:
         result = await resolver.get_plan(user_id=1, auth_header="")
         assert result.plan_key is None
-        assert result.in_trial_period is True
         resolver._http.get.assert_not_called()  # type: ignore[attr-defined]
 
     async def test_api_error_not_cached(self, resolver_with_redis: PlanResolver) -> None:
@@ -222,10 +182,8 @@ class TestPlanResolver:
         with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
             mock_settings.return_value.posthog_api_base_url = "https://app.posthog.com"
             mock_settings.return_value.plan_cache_ttl = 300
-            mock_settings.return_value.free_plan_trial_period_days = 30
             result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
 
         assert result.plan_key is None
-        assert result.in_trial_period is True
         assert resolver_with_redis._redis is not None
         resolver_with_redis._redis.set.assert_not_called()  # type: ignore[attr-defined]

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -77,7 +77,7 @@ class TestUsageEndpoint:
     def test_returns_trial_limits_for_free_plan_with_seat(self, authenticated_usage_client: TestClient) -> None:
         app = authenticated_usage_client.app
         app.state.plan_resolver.get_plan = AsyncMock(
-            return_value=PlanInfo(plan_key=None, in_trial_period=True, seat_created_at="2026-01-01T00:00:00+00:00")
+            return_value=PlanInfo(plan_key=None, seat_created_at="2026-01-01T00:00:00+00:00")
         )
 
         response = authenticated_usage_client.get(
@@ -90,12 +90,11 @@ class TestUsageEndpoint:
         assert data["burst"]["used_percent"] == 0
         assert data["sustained"]["used_percent"] == 0
 
-    def test_returns_zero_limits_when_trial_expired(self, authenticated_usage_client: TestClient) -> None:
+    def test_old_free_user_still_gets_limits(self, authenticated_usage_client: TestClient) -> None:
         app = authenticated_usage_client.app
         app.state.plan_resolver.get_plan = AsyncMock(
             return_value=PlanInfo(
                 plan_key="posthog-code-free-20260301",
-                in_trial_period=False,
                 seat_created_at="2025-01-01T00:00:00+00:00",
             )
         )
@@ -107,16 +106,16 @@ class TestUsageEndpoint:
         assert response.status_code == 200
         data = response.json()
 
-        assert data["burst"]["used_percent"] == 100.0
-        assert data["burst"]["exceeded"] is True
-        assert data["sustained"]["used_percent"] == 100.0
-        assert data["sustained"]["exceeded"] is True
-        assert data["is_rate_limited"] is True
+        assert data["burst"]["used_percent"] == 0
+        assert data["burst"]["exceeded"] is False
+        assert data["sustained"]["used_percent"] == 0
+        assert data["sustained"]["exceeded"] is False
+        assert data["is_rate_limited"] is False
 
     def test_returns_pro_limits_with_pro_plan(self, authenticated_usage_client: TestClient) -> None:
         app = authenticated_usage_client.app
         app.state.plan_resolver.get_plan = AsyncMock(
-            return_value=PlanInfo(plan_key="posthog-code-200-20260301", in_trial_period=False, seat_created_at=None)
+            return_value=PlanInfo(plan_key="posthog-code-200-20260301", seat_created_at=None)
         )
 
         response = authenticated_usage_client.get(

--- a/services/llm-gateway/tests/test_usage.py
+++ b/services/llm-gateway/tests/test_usage.py
@@ -74,7 +74,7 @@ class TestUsageEndpoint:
         assert data["sustained"]["used_percent"] == 0
         assert data["is_rate_limited"] is False
 
-    def test_returns_trial_limits_for_free_plan_with_seat(self, authenticated_usage_client: TestClient) -> None:
+    def test_returns_free_limits_for_free_plan_with_seat(self, authenticated_usage_client: TestClient) -> None:
         app = authenticated_usage_client.app
         app.state.plan_resolver.get_plan = AsyncMock(
             return_value=PlanInfo(plan_key=None, seat_created_at="2026-01-01T00:00:00+00:00")


### PR DESCRIPTION
## Problem

Free plan users were blocked after a 30-day trial expired, getting $0 limits. Instead they should receive a recurring monthly allowance indefinitely.

There is now only two scenarios a user can be in:
- Free plan: $10/day, $50/month
- Pro plan: $100/day, $1,000/month

## Changes

1. Remove trial expiry mechanism (_is_in_trial, in_trial_period, FREE_PLAN_EXPIRED_COST_LIMIT)
2. Give free plan users $10/day burst and $50/mo sustained limits with no expiry
3. Simplify _get_config to return a single FREE_PLAN_COST_LIMIT for all free users
4. Update tests to verify old free users still get limits instead of being blocked

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Manually

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->