### PR TITLE
fix(hogql): apply warehouse event modifiers across name collisions

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1157,7 +1157,7 @@ class Database(BaseModel):
 
             if "." in warehouse_modifier.table_name:
                 table_chain = warehouse_modifier.table_name.split(".")
-                if table_chain[0] not in root_node.children:
+                if not root_node.has_child(table_chain):
                     return root_node
 
                 _table = root_node.get_child(table_chain).get()
@@ -1233,36 +1233,33 @@ class Database(BaseModel):
             with timings.measure("data_warehouse_event_modifiers"):
                 for warehouse_modifier in modifiers.dataWarehouseEventsModifiers:
                     with timings.measure(f"data_warehouse_event_modifier_{warehouse_modifier.table_name}"):
-                        # TODO: add all field mappings
-                        is_view = views.has_child([warehouse_modifier.table_name])
-
-                        if is_view:
-                            views = define_mappings(
-                                views,
-                                lambda team, warehouse_modifier: DataWarehouseSavedQuery.objects.exclude(deleted=True)
-                                .filter(team_id=team.pk, name=warehouse_modifier.table_name)
-                                .latest("created_at"),
+                        # Apply mappings to every matching namespace. A saved query and a warehouse table can share a
+                        # name, and the final database may resolve that name to the table even if a view exists too.
+                        views = define_mappings(
+                            views,
+                            lambda team, warehouse_modifier: DataWarehouseSavedQuery.objects.exclude(deleted=True)
+                            .filter(team_id=team.pk, name=warehouse_modifier.table_name)
+                            .latest("created_at"),
+                        )
+                        warehouse_tables = define_mappings(
+                            warehouse_tables,
+                            lambda team, warehouse_modifier: DataWarehouseTable.objects.exclude(deleted=True)
+                            .filter(
+                                team_id=team.pk,
+                                name=warehouse_tables_dot_notation_mapping[warehouse_modifier.table_name]
+                                if warehouse_modifier.table_name in warehouse_tables_dot_notation_mapping
+                                else warehouse_modifier.table_name,
                             )
-                        else:
-                            warehouse_tables = define_mappings(
-                                warehouse_tables,
-                                lambda team, warehouse_modifier: DataWarehouseTable.objects.exclude(deleted=True)
-                                .filter(
-                                    team_id=team.pk,
-                                    name=warehouse_tables_dot_notation_mapping[warehouse_modifier.table_name]
-                                    if warehouse_modifier.table_name in warehouse_tables_dot_notation_mapping
-                                    else warehouse_modifier.table_name,
-                                )
-                                .select_related("credential", "external_data_source")
-                                .latest("created_at"),
-                            )
-                            self_managed_warehouse_tables = define_mappings(
-                                self_managed_warehouse_tables,
-                                lambda team, warehouse_modifier: DataWarehouseTable.objects.exclude(deleted=True)
-                                .filter(team_id=team.pk, name=warehouse_modifier.table_name)
-                                .select_related("credential", "external_data_source")
-                                .latest("created_at"),
-                            )
+                            .select_related("credential", "external_data_source")
+                            .latest("created_at"),
+                        )
+                        self_managed_warehouse_tables = define_mappings(
+                            self_managed_warehouse_tables,
+                            lambda team, warehouse_modifier: DataWarehouseTable.objects.exclude(deleted=True)
+                            .filter(team_id=team.pk, name=warehouse_modifier.table_name)
+                            .select_related("credential", "external_data_source")
+                            .latest("created_at"),
+                        )
 
         database._add_warehouse_tables(warehouse_tables)
         database._add_warehouse_self_managed_tables(self_managed_warehouse_tables)

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -1038,8 +1038,31 @@ class TestDatabase(BaseTest, QueryMatchingTest):
             parse_select("SELECT id, timestamp, distinct_id FROM stripe.table"), context, dialect="clickhouse"
         )
 
-    def test_data_warehouse_events_modifiers_when_view_and_table_share_a_name(self):
+    @parameterized.expand(
+        [
+            ("self_managed", False),
+            ("external_source", True),
+        ]
+    )
+    def test_data_warehouse_events_modifiers_when_view_and_table_share_a_name(
+        self, _name: str, use_external_source: bool
+    ):
         shared_name = "analytics_search_history"
+
+        warehouse_table_kwargs: dict[str, Any] = {}
+        if use_external_source:
+            credentials = DataWarehouseCredential.objects.create(
+                access_key="test_key", access_secret="test_secret", team=self.team
+            )
+            source = ExternalDataSource.objects.create(
+                team=self.team,
+                source_id="source_id",
+                source_type=ExternalDataSourceType.STRIPE,
+            )
+            warehouse_table_kwargs = {
+                "credential": credentials,
+                "external_data_source": source,
+            }
 
         DataWarehouseTable.objects.create(
             name=shared_name,
@@ -1054,6 +1077,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
                 "search_count": "Nullable(Float64)",
                 "search_source": "Nullable(String)",
             },
+            **warehouse_table_kwargs,
         )
         DataWarehouseSavedQuery.objects.create(
             team=self.team,

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -1038,6 +1038,62 @@ class TestDatabase(BaseTest, QueryMatchingTest):
             parse_select("SELECT id, timestamp, distinct_id FROM stripe.table"), context, dialect="clickhouse"
         )
 
+    def test_data_warehouse_events_modifiers_when_view_and_table_share_a_name(self):
+        shared_name = "analytics_search_history"
+
+        DataWarehouseTable.objects.create(
+            name=shared_name,
+            format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
+            team=self.team,
+            url_pattern=f"s3://test/{shared_name}",
+            queryable_folder=f"{shared_name}__query_1776789614",
+            columns={
+                "email": "Nullable(String)",
+                "user_name": "Nullable(String)",
+                "created_at": "Nullable(DateTime64(6))",
+                "search_count": "Nullable(Float64)",
+                "search_source": "Nullable(String)",
+            },
+        )
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name=shared_name,
+            query={"query": "SELECT 1 AS ignored_value", "kind": "HogQLQuery"},
+            columns={"ignored_value": "UInt8"},
+        )
+
+        modifiers = HogQLQueryModifiers(
+            dataWarehouseEventsModifiers=[
+                DataWarehouseEventsModifier(
+                    table_name=shared_name,
+                    id_field="user_name",
+                    timestamp_field="created_at",
+                    distinct_id_field="user_name",
+                )
+            ]
+        )
+
+        db = Database.create_for(team=self.team, modifiers=modifiers)
+        context = HogQLContext(
+            team_id=self.team.pk,
+            enable_select_queries=True,
+            database=db,
+        )
+
+        actual_table = db.get_table(shared_name)
+
+        assert isinstance(actual_table, Table)
+        assert isinstance(actual_table.fields.get("id"), ExpressionField)
+        assert isinstance(actual_table.fields.get("timestamp"), ExpressionField)
+        assert isinstance(actual_table.fields.get("distinct_id"), ExpressionField)
+        assert isinstance(actual_table.fields.get("person_id"), ExpressionField)
+
+        prepare_and_print_ast(
+            parse_select(f"SELECT id, timestamp, distinct_id, person_id FROM {shared_name}"),
+            context,
+            dialect="clickhouse",
+        )
+
     def test_direct_postgres_table_supports_properties_virtual_table(self):
         credentials = DataWarehouseCredential.objects.create(
             access_key="test_key", access_secret="test_secret", team=self.team


### PR DESCRIPTION
## Problem

Customers are reporting that insights with a data warehouse series that had been working started failing: https://github.com/PostHog/posthog/issues/55555.

Investigation shows that there is both a `DataWarehouseSavedQuery` and a `DataWarehouseTable` with the same name.

This PR https://github.com/PostHog/posthog/pull/52058 likely introduced a regression, by [removing a old guard that skipped adding a warehouse table when a saved query with the same name already existed](https://github.com/PostHog/posthog/pull/52058/changes#diff-54fe0950a168555472ac249d0ed1c1dcf3b9bff809fccd9d225966a2b7f241d9L1092-L1096).

## Changes

- Apply `DataWarehouseEventsModifier` mappings across all matching namespaces instead of preferring the view branch when a same-name view exists.
- Tighten dotted table-path lookup in `define_mappings` to check the full path before descending.
- Add a regression test covering a same-name saved query and warehouse table collision.

## How did you test this code?

Added a test case.