### PR TITLE
feat(mcp): Allow searching for alerts

### DIFF
--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -6,6 +6,7 @@ from django.db.models import OuterRef, QuerySet, Subquery
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
@@ -744,12 +745,35 @@ class AlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
 
+    @extend_schema(
+        summary="List insight alerts",
+        parameters=[
+            OpenApiParameter(
+                "insight_id",
+                OpenApiTypes.INT,
+                description="Only return alerts attached to this insight ID.",
+                required=False,
+            ),
+            OpenApiParameter(
+                "name",
+                OpenApiTypes.STR,
+                description="Case-insensitive substring match on alert name.",
+                required=False,
+            ),
+        ],
+    )
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
 
         insight_id = request.GET.get("insight_id")
         if insight_id is not None:
             queryset = queryset.filter(insight=insight_id)
+
+        name_substring = request.GET.get("name")
+        if name_substring is not None:
+            stripped = name_substring.strip()
+            if stripped:
+                queryset = queryset.filter(name__icontains=stripped)
 
         # Paginate first, then prefetch checks only for the page
         page = self.paginate_queryset(queryset)

--- a/posthog/api/test/test_alert.py
+++ b/posthog/api/test/test_alert.py
@@ -146,6 +146,29 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         assert list_for_another_insight.status_code == status.HTTP_200_OK
         assert len(list_for_another_insight.json()["results"]) == 0
 
+    def test_list_alerts_filter_by_name_and_insight_id(self) -> None:
+        creation_request = {
+            "insight": self.insight["id"],
+            "subscribed_users": [self.user.id],
+            "condition": {"type": AlertConditionType.ABSOLUTE_VALUE},
+            "config": {"type": "TrendsAlertConfig", "series_index": 0},
+            "threshold": {"configuration": {"type": InsightThresholdType.ABSOLUTE, "bounds": {}}},
+            "name": "Revenue spike monitor",
+        }
+        self.client.post(f"/api/projects/{self.team.id}/alerts", creation_request)
+        creation_request["name"] = "User churn alert"
+        self.client.post(f"/api/projects/{self.team.id}/alerts", creation_request)
+
+        by_name = self.client.get(f"/api/projects/{self.team.id}/alerts?name=revenue")
+        assert by_name.status_code == status.HTTP_200_OK
+        results = by_name.json()["results"]
+        assert len(results) == 1
+        assert results[0]["name"] == "Revenue spike monitor"
+
+        by_insight_id = self.client.get(f"/api/projects/{self.team.id}/alerts?insight_id={self.insight['id']}")
+        assert by_insight_id.status_code == status.HTTP_200_OK
+        assert len(by_insight_id.json()["results"]) == 2
+
     @parameterized.expand(
         [
             ("default_limit", 8, "", 5),

--- a/products/alerts/frontend/generated/api.schemas.ts
+++ b/products/alerts/frontend/generated/api.schemas.ts
@@ -832,9 +832,17 @@ export interface AlertSimulateResponseApi {
 
 export type AlertsListParams = {
     /**
+     * Only return alerts attached to this insight ID.
+     */
+    insight_id?: number
+    /**
      * Number of results to return per page.
      */
     limit?: number
+    /**
+     * Case-insensitive substring match on alert name.
+     */
+    name?: string
     /**
      * The initial index from which to return the results.
      */

--- a/products/alerts/frontend/generated/api.ts
+++ b/products/alerts/frontend/generated/api.ts
@@ -35,6 +35,9 @@ type NonReadonly<T> = [T] extends [UnionToIntersection<T>]
       }
     : DistributeReadOnlyOverUnions<T>
 
+/**
+ * @summary List insight alerts
+ */
 export const getAlertsListUrl = (projectId: string, params?: AlertsListParams) => {
     const normalizedParams = new URLSearchParams()
 

--- a/products/alerts/mcp/tools.yaml
+++ b/products/alerts/mcp/tools.yaml
@@ -21,9 +21,10 @@ tools:
         list: true
         title: List alerts
         description: >
-            List all insight alerts in the project. Returns alerts with their current state, threshold or detector
-            configuration, timing information, and firing check history. Supports filtering by insight ID via query
-            parameter. Alerts can use either threshold-based conditions (absolute_value, relative_increase,
+            List insight alerts in the project with limit/offset pagination. Filter by
+            insight_id to only alerts on a given insight, and/or by name for a case-insensitive substring search on
+            alert names. Returns alerts with their current state, threshold or detector configuration, timing information,
+            and firing check history. Alerts can use either threshold-based conditions (absolute_value, relative_increase,
             relative_decrease) or anomaly detection via detector_config (zscore, mad, iqr, isolation_forest, knn, etc.).
     alert-get:
         operation: alerts_retrieve

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -75,7 +75,7 @@
         }
     },
     "alerts-list": {
-        "description": "List all insight alerts in the project. Returns alerts with their current state, threshold or detector configuration, timing information, and firing check history. Supports filtering by insight ID via query parameter. Alerts can use either threshold-based conditions (absolute_value, relative_increase, relative_decrease) or anomaly detection via detector_config (zscore, mad, iqr, isolation_forest, knn, etc.).",
+        "description": "List insight alerts in the project with limit/offset pagination. Filter by insight_id to only alerts on a given insight, and/or by name for a case-insensitive substring search on alert names. Returns alerts with their current state, threshold or detector configuration, timing information, and firing check history. Alerts can use either threshold-based conditions (absolute_value, relative_increase, relative_decrease) or anomaly detection via detector_config (zscore, mad, iqr, isolation_forest, knn, etc.).",
         "category": "Alerts",
         "feature": "alerts",
         "summary": "List alerts",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -554,7 +554,7 @@
         }
     },
     "alerts-list": {
-        "description": "List all insight alerts in the project. Returns alerts with their current state, threshold or detector configuration, timing information, and firing check history. Supports filtering by insight ID via query parameter. Alerts can use either threshold-based conditions (absolute_value, relative_increase, relative_decrease) or anomaly detection via detector_config (zscore, mad, iqr, isolation_forest, knn, etc.).",
+        "description": "List insight alerts in the project with limit/offset pagination. Filter by insight_id to only alerts on a given insight, and/or by name for a case-insensitive substring search on alert names. Returns alerts with their current state, threshold or detector configuration, timing information, and firing check history. Alerts can use either threshold-based conditions (absolute_value, relative_increase, relative_decrease) or anomaly detection via detector_config (zscore, mad, iqr, isolation_forest, knn, etc.).",
         "category": "Alerts",
         "feature": "alerts",
         "summary": "List alerts",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -33488,9 +33488,17 @@ export namespace Schemas {
 
     export type EnvironmentsAlertsListParams = {
     /**
+     * Only return alerts attached to this insight ID.
+     */
+    insight_id?: number;
+    /**
      * Number of results to return per page.
      */
     limit?: number;
+    /**
+     * Case-insensitive substring match on alert name.
+     */
+    name?: string;
     /**
      * The initial index from which to return the results.
      */
@@ -37112,9 +37120,17 @@ export namespace Schemas {
 
     export type AlertsListParams = {
     /**
+     * Only return alerts attached to this insight ID.
+     */
+    insight_id?: number;
+    /**
      * Number of results to return per page.
      */
     limit?: number;
+    /**
+     * Case-insensitive substring match on alert name.
+     */
+    name?: string;
     /**
      * The initial index from which to return the results.
      */

--- a/services/mcp/src/generated/alerts/api.ts
+++ b/services/mcp/src/generated/alerts/api.ts
@@ -17,7 +17,9 @@ export const AlertsListParams = /* @__PURE__ */ zod.object({
 })
 
 export const AlertsListQueryParams = /* @__PURE__ */ zod.object({
+    insight_id: zod.number().optional().describe('Only return alerts attached to this insight ID.'),
     limit: zod.number().optional().describe('Number of results to return per page.'),
+    name: zod.string().optional().describe('Case-insensitive substring match on alert name.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
 })
 

--- a/services/mcp/src/generated/alerts/api.ts
+++ b/services/mcp/src/generated/alerts/api.ts
@@ -8,6 +8,9 @@
  */
 import * as zod from 'zod'
 
+/**
+ * @summary List insight alerts
+ */
 export const AlertsListParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()

--- a/services/mcp/src/tools/generated/alerts.ts
+++ b/services/mcp/src/tools/generated/alerts.ts
@@ -26,7 +26,9 @@ const alertsList = (): ToolBase<typeof AlertsListSchema, WithPostHogUrl<Schemas.
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/alerts/`,
             query: {
+                insight_id: params.insight_id,
                 limit: params.limit,
+                name: params.name,
                 offset: params.offset,
             },
         })

--- a/services/mcp/tests/tools/alerts.integration.test.ts
+++ b/services/mcp/tests/tools/alerts.integration.test.ts
@@ -103,6 +103,51 @@ describe('Alerts', { concurrent: false }, () => {
             expect(Array.isArray(data.results)).toBe(true)
             expect(data.results.length).toBeLessThanOrEqual(1)
         })
+
+        it('should filter by case-insensitive name substring', async () => {
+            const unique = generateUniqueKey('name-filter')
+            const a = parseToolResponse(
+                await createTool.handler(context, makeAlertParams({ name: `alpha-unicorn-${unique}`, enabled: false }))
+            )
+            const b = parseToolResponse(
+                await createTool.handler(context, makeAlertParams({ name: `beta-zebra-${unique}`, enabled: false }))
+            )
+            createdAlertIds.push(a.id, b.id)
+
+            const result = await listTool.handler(context, { name: `unicorn-${unique}` })
+            const data = parseToolResponse(result)
+            const ids = data.results.map((x: { id: string }) => x.id)
+
+            expect(ids).toContain(a.id)
+            expect(ids).not.toContain(b.id)
+        })
+
+        it('should filter by insight_id', async () => {
+            const otherInsight = await context.api.request<{ id: number }>({
+                method: 'POST',
+                path: `/api/projects/${TEST_PROJECT_ID}/insights/`,
+                body: {
+                    name: generateUniqueKey('alert-test-insight-b'),
+                    query: SAMPLE_TREND_QUERIES.basicPageviews,
+                },
+            })
+
+            const onDefault = parseToolResponse(await createTool.handler(context, makeAlertParams({ enabled: false })))
+            const onOther = parseToolResponse(
+                await createTool.handler(context, makeAlertParams({ insight: otherInsight.id, enabled: false }))
+            )
+            createdAlertIds.push(onDefault.id, onOther.id)
+
+            const forDefaultInsight = await listTool.handler(context, { insight_id: insightId })
+            const idsDefault = parseToolResponse(forDefaultInsight).results.map((x: { id: string }) => x.id)
+            expect(idsDefault).toContain(onDefault.id)
+            expect(idsDefault).not.toContain(onOther.id)
+
+            const forOtherInsight = await listTool.handler(context, { insight_id: otherInsight.id })
+            const idsOther = parseToolResponse(forOtherInsight).results.map((x: { id: string }) => x.id)
+            expect(idsOther).toContain(onOther.id)
+            expect(idsOther).not.toContain(onDefault.id)
+        })
     })
 
     describe('alert-create tool', () => {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alerts-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/alerts-list.json
@@ -1,9 +1,17 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "insight_id": {
+            "description": "Only return alerts attached to this insight ID.",
+            "type": "number"
+        },
         "limit": {
             "description": "Number of results to return per page.",
             "type": "number"
+        },
+        "name": {
+            "description": "Case-insensitive substring match on alert name.",
+            "type": "string"
         },
         "offset": {
             "description": "The initial index from which to return the results.",


### PR DESCRIPTION
## Summary
MCP for searching alerts was not available, now it is.

## Changes
- **API**: `AlertViewSet.list` — document `insight_id` + `name` (case-insensitive substring) in OpenAPI; apply name filter in the view.
- **MCP**: `AlertsListQueryParams` + `alerts-list` handler forward `insight_id` and `name`; refresh `products/alerts/mcp/tools.yaml` description.
- **Tests**: `test_list_alerts_filter_by_name_and_insight_id`; MCP integration tests for name + `insight_id`; update `tool-schemas/common/alerts-list.json` snapshot.

## How to test
- `pytest posthog/api/test/test_alert.py::TestAlert::test_list_alerts_filter_by_name_and_insight_id`
- `pnpm --filter=@posthog/mcp exec vitest run services/mcp/tests/unit/tool-schema-snapshots.test.ts services/mcp/tests/tools/alerts.integration.test.ts` (integration tests need env per repo docs)

Made with [Cursor](https://cursor.com)