### PR TITLE
chore(flags): tag auto-rollback ClickHouse queries for cost attribution

### DIFF
--- a/ee/tasks/auto_rollback_feature_flag.py
+++ b/ee/tasks/auto_rollback_feature_flag.py
@@ -3,7 +3,7 @@ from zoneinfo import ZoneInfo
 
 from celery import shared_task
 
-from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.models.feature_flag import FeatureFlag
 from posthog.models.filters.filter import Filter
 from posthog.models.team import Team
@@ -25,17 +25,16 @@ def check_flags_to_rollback():
 def check_feature_flag_rollback_conditions(feature_flag_id: int) -> None:
     flag: FeatureFlag = FeatureFlag.objects.get(pk=feature_flag_id)
 
-    tag_queries(
+    with tags_context(
         product=Product.FEATURE_FLAGS,
         feature=Feature.QUERY,
         team_id=flag.team_id,
         name="check_feature_flag_rollback_conditions",
-    )
-
-    if any(check_condition(condition, flag) for condition in flag.rollback_conditions or []):
-        flag.performed_rollback = True
-        flag.active = False
-        flag.save()
+    ):
+        if any(check_condition(condition, flag) for condition in flag.rollback_conditions or []):
+            flag.performed_rollback = True
+            flag.active = False
+            flag.save()
 
 
 def calculate_rolling_average(threshold_metric: dict, team: Team, timezone: str) -> float:

--- a/ee/tasks/auto_rollback_feature_flag.py
+++ b/ee/tasks/auto_rollback_feature_flag.py
@@ -3,6 +3,7 @@ from zoneinfo import ZoneInfo
 
 from celery import shared_task
 
+from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.models.feature_flag import FeatureFlag
 from posthog.models.filters.filter import Filter
 from posthog.models.team import Team
@@ -23,6 +24,13 @@ def check_flags_to_rollback():
 @shared_task(ignore_result=True, max_retries=2)
 def check_feature_flag_rollback_conditions(feature_flag_id: int) -> None:
     flag: FeatureFlag = FeatureFlag.objects.get(pk=feature_flag_id)
+
+    tag_queries(
+        product=Product.FEATURE_FLAGS,
+        feature=Feature.QUERY,
+        team_id=flag.team_id,
+        name="check_feature_flag_rollback_conditions",
+    )
 
     if any(check_condition(condition, flag) for condition in flag.rollback_conditions or []):
         flag.performed_rollback = True

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -2043,6 +2043,12 @@ class LocalEvaluationResponseSerializer(serializers.Serializer):
     )
 
 
+# ClickHouse cost attribution: this viewset currently has no direct ClickHouse calls —
+# all ClickHouse work is delegated to helpers (user_blast_radius.py, flag_analytics.py)
+# that already tag their queries. If you add a new ClickHouse query reachable from an
+# action on this viewset, wrap it with tag_queries(product=Product.FEATURE_FLAGS,
+# feature=Feature.QUERY, team_id=self.team_id) so query_log attribution stays correct.
+# See posthog/models/feature_flag/user_blast_radius.py for the pattern.
 @extend_schema(tags=[ProductKey.FEATURE_FLAGS])
 class FeatureFlagViewSet(
     ApprovalHandlingMixin,


### PR DESCRIPTION
## Problem

Feature flags' ClickHouse queries from the auto-rollback task aren't tagged with `product=feature_flags` in `query_log`, so they're missing from per-product cost attribution. This is part of the feature-flags-specific work for the [per-product cost & margin framework](https://posthog.com/handbook/product/per-product-cost-margin-analysis).

## Changes

- Tag the `check_feature_flag_rollback_conditions` Celery task with `product=FEATURE_FLAGS`, `feature=QUERY`, `name="check_feature_flag_rollback_conditions"` so `Trends().run(...)` queries dispatched from the task are attributable in `clickhouse.query_log`.
- Add an orientation comment to `FeatureFlagViewSet` documenting the tagging convention for future contributors. The viewset has no direct ClickHouse calls today — all ClickHouse work is delegated to helpers (`user_blast_radius.py`, `flag_analytics.py`) which already tag their queries.

## How did you test this code?

Agent-authored PR — no manual verification performed. The changes are additive metadata only: the new `tag_queries` call adds fields to `log_comment` in `clickhouse.query_log` and does not affect query logic or control flow. Will be verified in production by querying `clickhouse.query_log` for rows with `log_comment.name = 'check_feature_flag_rollback_conditions'` and confirming `log_comment.product = 'feature_flags'`.

## Publish to changelog?

no