### PR TITLE
feat(search): show unreleased products in cmd+k for staff

### DIFF
--- a/frontend/src/lib/components/Search/searchLogic.tsx
+++ b/frontend/src/lib/components/Search/searchLogic.tsx
@@ -10,6 +10,7 @@ import { toSentenceCase } from 'lib/utils'
 import { GroupQueryResult, mapGroupQueryResponse } from 'lib/utils/groups'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
 
 import { getDefaultTreePersons } from '~/layout/panel-layout/ProjectTree/defaultTree'
 import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
@@ -75,6 +76,8 @@ export const searchLogic = kea<searchLogicType>([
             ['featureFlags'],
             preflightLogic,
             ['isDev'],
+            userLogic,
+            ['user'],
             recentItemsModel,
             ['recents as cachedRecents', 'recentsHasLoaded', 'sceneLogViewsByRef', 'sceneLogViewsHasLoaded'],
             projectTreeDataLogic,
@@ -286,14 +289,14 @@ export const searchLogic = kea<searchLogicType>([
             },
         ],
         appsItems: [
-            (s) => [s.featureFlags, s.isDev, s.sceneLogViewsByRef],
-            (featureFlags, isDev, sceneLogViewsByRef): SearchItem[] => {
+            (s) => [s.featureFlags, s.isDev, s.user, s.sceneLogViewsByRef],
+            (featureFlags, isDev, user, sceneLogViewsByRef): SearchItem[] => {
                 const allProducts = getTreeItemsProducts()
                 const filteredProducts = allProducts.filter((product) => {
                     if (!product.href) {
                         return false
                     }
-                    if (!isDev && product.category === 'Unreleased') {
+                    if (!isDev && !user?.is_staff && product.category === 'Unreleased') {
                         return false
                     }
                     if (product.flag && !(featureFlags as Record<string, boolean>)[product.flag]) {
@@ -352,11 +355,11 @@ export const searchLogic = kea<searchLogicType>([
             },
         ],
         dataManagementItems: [
-            (s) => [s.featureFlags, s.isDev, s.sceneLogViewsByRef],
-            (featureFlags, isDev, sceneLogViewsByRef): SearchItem[] => {
+            (s) => [s.featureFlags, s.isDev, s.user, s.sceneLogViewsByRef],
+            (featureFlags, isDev, user, sceneLogViewsByRef): SearchItem[] => {
                 const allMetadata = getTreeItemsMetadata()
                 const filteredMetadata = allMetadata.filter((item) => {
-                    if (!isDev && item.category === 'Unreleased') {
+                    if (!isDev && !user?.is_staff && item.category === 'Unreleased') {
                         return false
                     }
                     if (item.flag && !(featureFlags as Record<string, boolean>)[item.flag]) {
@@ -403,11 +406,11 @@ export const searchLogic = kea<searchLogicType>([
             },
         ],
         newItems: [
-            (s) => [s.featureFlags, s.isDev],
-            (featureFlags, isDev): SearchItem[] => {
+            (s) => [s.featureFlags, s.isDev, s.user],
+            (featureFlags, isDev, user): SearchItem[] => {
                 const allNewItems = getTreeItemsNew()
                 const filteredItems = allNewItems.filter((item) => {
-                    if (!isDev && item.category === 'Unreleased') {
+                    if (!isDev && !user?.is_staff && item.category === 'Unreleased') {
                         return false
                     }
                     if (item.flag && !(featureFlags as Record<string, boolean>)[item.flag]) {


### PR DESCRIPTION
## Problem

The Tasks product (and other alpha/UNRELEASED products) doesn't appear in the cmd+k command palette for staff users in production, even when the feature flag is enabled and the product is already visible in the sidebar.

The command palette's `appsItems`, `dataManagementItems`, and `newItems` selectors in `searchLogic.tsx` filter out any entry whose `category === 'Unreleased'` unless `isDev` is true (which maps to `preflight.is_debug`, i.e. local dev). The sidebar filter only checks feature flags and ignores `category`, which is why products like Tasks show up there but not in cmd+k.

## Changes

Extend the three `Unreleased` guards in `frontend/src/lib/components/Search/searchLogic.tsx` to also pass for `user?.is_staff`:

```ts
if (!isDev && !user?.is_staff && item.category === 'Unreleased') { return false }
```

- Added `userLogic, ['user']` to the logic's `connect` block.
- Updated `appsItems`, `dataManagementItems`, and `newItems` selector input tuples with `s.user`.

The feature-flag check on the next line is unchanged, so non-staff users without the flag are unaffected.

## How did you test this code?

I'm an agent — this PR was authored without manual in-app verification. Verified:

- The changed file compiles: `pnpm typescript:check` reports no new errors for `searchLogic.tsx` after running `pnpm typegen:write`.
- Pre-commit (`bin/hogli format:js`) passed.

A human reviewer (or a follow-up manual run) should:

1. As a staff user with `FEATURE_FLAGS.TASKS` enabled, open cmd+k and confirm Tasks appears under *Apps* with the ALPHA chip.
2. As a non-staff user with the flag, confirm Tasks does not appear in cmd+k but still appears in the sidebar.
3. As a non-staff user without the flag, confirm Tasks appears in neither.

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code (Claude Opus 4.7) in a single task session. Single-file change; no backend, schema, or migration impact. Task ID: `308c8df3-b150-4c30-ab4f-7a7e1a26789d`.