### PR TITLE
feat(data-warehouse): make Reddit Ads source resumable

### DIFF
--- a/posthog/temporal/data_imports/sources/common/rest_source/__init__.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/__init__.py
@@ -46,21 +46,42 @@ def convert_types(
 
 
 def rest_api_resource(
-    config: RESTAPIConfig, team_id: int, job_id: str, db_incremental_field_last_value: Optional[Any]
+    config: RESTAPIConfig,
+    team_id: int,
+    job_id: str,
+    db_incremental_field_last_value: Optional[Any],
+    resume_hook: Optional[Callable[[Optional[dict[str, Any]]], None]] = None,
+    initial_paginator_state: Optional[dict[str, Any]] = None,
 ) -> Resource:
     """Creates a single resource from a REST API configuration.
 
     Most sources define exactly one resource. Use ``rest_api_resources``
     (plural) only when the config contains multiple resources (e.g. date
     chunked report endpoints or parent/child fanout).
+
+    ``resume_hook`` and ``initial_paginator_state`` enable integration with
+    ``ResumableSourceManager``. They are only supported for non-dependent
+    resources (no ``data_from`` parent/child fanout).
     """
-    resources = rest_api_resources(config, team_id, job_id, db_incremental_field_last_value)
+    resources = rest_api_resources(
+        config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=resume_hook,
+        initial_paginator_state=initial_paginator_state,
+    )
     assert len(resources) == 1, f"Expected 1 resource, got {len(resources)}"
     return resources[0]
 
 
 def rest_api_resources(
-    config: RESTAPIConfig, team_id: int, job_id: str, db_incremental_field_last_value: Optional[Any]
+    config: RESTAPIConfig,
+    team_id: int,
+    job_id: str,
+    db_incremental_field_last_value: Optional[Any],
+    resume_hook: Optional[Callable[[Optional[dict[str, Any]]], None]] = None,
+    initial_paginator_state: Optional[dict[str, Any]] = None,
 ) -> list[Resource]:
     """Creates a list of resources from a REST API configuration.
 
@@ -89,6 +110,8 @@ def rest_api_resources(
         team_id=team_id,
         job_id=job_id,
         db_incremental_field_last_value=db_incremental_field_last_value,
+        resume_hook=resume_hook,
+        initial_paginator_state=initial_paginator_state,
     )
 
     return list(resources.values())
@@ -156,6 +179,8 @@ def create_resources(
     team_id: int,
     job_id: str,
     db_incremental_field_last_value: Optional[Any] = None,
+    resume_hook: Optional[Callable[[Optional[dict[str, Any]]], None]] = None,
+    initial_paginator_state: Optional[dict[str, Any]] = None,
 ) -> dict[str, Resource]:
     resources: dict[str, Resource] = {}
 
@@ -223,6 +248,8 @@ def create_resources(
                 incremental_object: Optional[Incremental] = incremental_object,
                 incremental_param: Optional[IncrementalParam] = incremental_param,
                 incremental_cursor_transform: Optional[Callable[..., Any]] = incremental_cursor_transform,
+                resume_hook: Optional[Callable[[Optional[dict[str, Any]]], None]] = resume_hook,
+                initial_paginator_state: Optional[dict[str, Any]] = initial_paginator_state,
             ) -> Iterator[list[Any]]:
                 if incremental_object:
                     params = _set_incremental_params(
@@ -241,6 +268,8 @@ def create_resources(
                     paginator=paginator,
                     data_selector=data_selector,
                     hooks=hooks,
+                    resume_hook=resume_hook,
+                    initial_paginator_state=initial_paginator_state,
                 ):
                     yield list(convert_types(page, columns_config))
 
@@ -261,6 +290,10 @@ def create_resources(
             )
 
         else:
+            if resume_hook is not None or initial_paginator_state is not None:
+                raise NotImplementedError(
+                    f"Resume is not supported for dependent REST resources (resource={resource_name!r})"
+                )
             predecessor = resources[resolved_param.resolve_config["resource"]]
 
             base_params = exclude_keys(request_params, {resolved_param.param_name})

--- a/posthog/temporal/data_imports/sources/common/rest_source/paginators.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/paginators.py
@@ -24,6 +24,18 @@ class BasePaginator(ABC):
     @abstractmethod
     def update_request(self, request: Request) -> None: ...
 
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        """Return a JSON-serializable snapshot pointing to the next page, or
+        ``None`` if this paginator does not support resume. Sources opt in by
+        overriding this together with ``set_resume_state``."""
+        return None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:  # noqa: B027
+        """Seed this paginator from a previously returned ``get_resume_state``
+        value. After seeding, ``init_request`` must emit a request that targets
+        the resumed page."""
+        pass
+
 
 class SinglePagePaginator(BasePaginator):
     def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:

--- a/posthog/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -1,6 +1,6 @@
 import copy
 import logging
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from typing import Any, Optional
 from urllib.parse import urljoin
 
@@ -50,6 +50,8 @@ class RESTClient:
         paginator: Optional[BasePaginator] = None,
         data_selector: Optional[TJsonPath] = None,
         hooks: Optional[Hooks] = None,
+        resume_hook: Optional[Callable[[Optional[dict[str, Any]]], None]] = None,
+        initial_paginator_state: Optional[dict[str, Any]] = None,
     ) -> Iterator[list[Any]]:
         paginator = copy.deepcopy(paginator) if paginator else copy.deepcopy(self.paginator)
         hooks = hooks or {}
@@ -68,6 +70,8 @@ class RESTClient:
         )
 
         if paginator:
+            if initial_paginator_state is not None:
+                paginator.set_resume_state(initial_paginator_state)
             paginator.init_request(request)
 
         while True:
@@ -83,6 +87,9 @@ class RESTClient:
                 paginator.update_request(request)
 
             yield data
+
+            if resume_hook is not None:
+                resume_hook(paginator.get_resume_state() if paginator is not None and paginator.has_next_page else None)
 
             if paginator is None or not paginator.has_next_page:
                 break

--- a/posthog/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
+++ b/posthog/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
@@ -119,6 +119,82 @@ class TestRESTClient:
         assert client._join_url("https://other.com/items") == "https://other.com/items"
 
     @patch("posthog.temporal.data_imports.sources.common.rest_source.rest_client.requests.Session")
+    def test_paginate_invokes_resume_hook_after_each_page(self, MockSession) -> None:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+
+        responses = [
+            _make_response([{"id": 1}]),
+            _make_response([{"id": 2}]),
+        ]
+        mock_session.send.side_effect = responses
+
+        class TwoPagePaginator(BasePaginator):
+            def __init__(self):
+                super().__init__()
+                self._page = 0
+
+            def update_state(self, response, data=None):
+                self._page += 1
+                self._has_next_page = self._page < 2
+
+            def update_request(self, request):
+                pass
+
+            def get_resume_state(self):
+                return {"page": self._page}
+
+        saved: list[Any] = []
+
+        client = RESTClient(base_url="https://api.example.com")
+        list(client.paginate(path="/items", paginator=TwoPagePaginator(), resume_hook=saved.append))
+
+        # Called once between page 1 and page 2 with the next-page state, and
+        # once on the terminal page with None (no more pages to resume to).
+        assert saved == [{"page": 1}, None]
+
+    @patch("posthog.temporal.data_imports.sources.common.rest_source.rest_client.requests.Session")
+    def test_paginate_seeds_initial_paginator_state(self, MockSession) -> None:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+        mock_session.send.return_value = _make_response([{"id": 99}])
+
+        class ResumablePaginator(BasePaginator):
+            def __init__(self):
+                super().__init__()
+                self._resume_url: str | None = None
+                self._has_next_page = False
+
+            def init_request(self, request):
+                if self._resume_url is not None:
+                    request.url = self._resume_url
+
+            def update_state(self, response, data=None):
+                self._has_next_page = False
+
+            def update_request(self, request):
+                pass
+
+            def set_resume_state(self, state):
+                self._resume_url = state["url"]
+                self._has_next_page = True
+
+        client = RESTClient(base_url="https://api.example.com")
+        list(
+            client.paginate(
+                path="/items",
+                paginator=ResumablePaginator(),
+                initial_paginator_state={"url": "https://api.example.com/resume-here"},
+            )
+        )
+
+        prepared_request = mock_session.prepare_request.call_args.args[0]
+        # The request URL should be the resumed URL, not the base "/items" path.
+        assert prepared_request.url == "https://api.example.com/resume-here"
+
+    @patch("posthog.temporal.data_imports.sources.common.rest_source.rest_client.requests.Session")
     def test_paginate_drops_none_params(self, MockSession) -> None:
         """``None`` values in ``params`` must be dropped before the request is
         prepared — otherwise ``requests`` serializes them as the literal string

--- a/posthog/temporal/data_imports/sources/reddit_ads/reddit_ads.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/reddit_ads.py
@@ -1,3 +1,4 @@
+import dataclasses
 from datetime import date, datetime, timedelta
 from typing import Any, Optional
 
@@ -10,9 +11,15 @@ from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceRespo
 from posthog.temporal.data_imports.sources.common.rest_source import RESTAPIConfig, rest_api_resource
 from posthog.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from posthog.temporal.data_imports.sources.common.rest_source.typing import EndpointResource
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.reddit_ads.settings import REDDIT_ADS_CONFIG
 
 logger = structlog.get_logger(__name__)
+
+
+@dataclasses.dataclass
+class RedditAdsResumeConfig:
+    next_url: str
 
 
 def _get_incremental_date_range(
@@ -114,8 +121,14 @@ class RedditAdsPaginator(BasePaginator):
 
     def __init__(self):
         super().__init__()
-        self._next_url = None
+        self._next_url: Optional[str] = None
         self._has_next_page = False
+
+    def init_request(self, request: Request) -> None:
+        # When seeded via set_resume_state, the paginator already holds the
+        # URL of the next page to fetch — redirect the initial request to it.
+        if self._next_url:
+            request.url = self._next_url
 
     def update_state(self, response: Response, data: Optional[Any] = None) -> None:
         """Update pagination state from response"""
@@ -136,6 +149,17 @@ class RedditAdsPaginator(BasePaginator):
         if self._next_url:
             request.url = self._next_url
 
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        if self._next_url and self._has_next_page:
+            return {"next_url": self._next_url}
+        return None
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        next_url = state.get("next_url")
+        if next_url:
+            self._next_url = next_url
+            self._has_next_page = True
+
 
 def reddit_ads_source(
     account_id: str,
@@ -144,6 +168,7 @@ def reddit_ads_source(
     job_id: str,
     access_token: str,
     db_incremental_field_last_value: Optional[Any],
+    resumable_source_manager: ResumableSourceManager[RedditAdsResumeConfig],
     should_use_incremental_field: bool = False,
 ):
     config: RESTAPIConfig = {
@@ -171,7 +196,26 @@ def reddit_ads_source(
         ],
     }
 
-    resource = rest_api_resource(config, team_id, job_id, db_incremental_field_last_value)
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume_config = resumable_source_manager.load_state()
+        if resume_config is not None:
+            initial_paginator_state = {"next_url": resume_config.next_url}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # Match klaviyo: only persist when there's a next page to resume to. The
+        # Redis TTL handles cleanup on completion.
+        if state and state.get("next_url"):
+            resumable_source_manager.save_state(RedditAdsResumeConfig(next_url=state["next_url"]))
+
+    resource = rest_api_resource(
+        config,
+        team_id,
+        job_id,
+        db_incremental_field_last_value,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    )
 
     endpoint_config = REDDIT_ADS_CONFIG[endpoint]
 

--- a/posthog/temporal/data_imports/sources/reddit_ads/source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/source.py
@@ -14,20 +14,21 @@ from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInput
 from posthog.temporal.data_imports.sources.common.base import (
     MARKETING_ANALYTICS_SUGGESTED_TABLE_TOOLTIP,
     FieldType,
-    SimpleSource,
+    ResumableSource,
 )
 from posthog.temporal.data_imports.sources.common.mixins import OAuthMixin
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import RedditAdsSourceConfig
-from posthog.temporal.data_imports.sources.reddit_ads.reddit_ads import reddit_ads_source
+from posthog.temporal.data_imports.sources.reddit_ads.reddit_ads import RedditAdsResumeConfig, reddit_ads_source
 from posthog.temporal.data_imports.sources.reddit_ads.settings import REDDIT_ADS_CONFIG
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class RedditAdsSource(SimpleSource[RedditAdsSourceConfig], OAuthMixin):
+class RedditAdsSource(ResumableSource[RedditAdsSourceConfig, RedditAdsResumeConfig], OAuthMixin):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.REDDITADS
@@ -106,7 +107,15 @@ class RedditAdsSource(SimpleSource[RedditAdsSourceConfig], OAuthMixin):
 
         return schemas
 
-    def source_for_pipeline(self, config: RedditAdsSourceConfig, inputs: SourceInputs) -> SourceResponse:
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[RedditAdsResumeConfig]:
+        return ResumableSourceManager[RedditAdsResumeConfig](inputs, RedditAdsResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: RedditAdsSourceConfig,
+        resumable_source_manager: ResumableSourceManager[RedditAdsResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
         integration = self.get_oauth_integration(config.reddit_integration_id, inputs.team_id)
 
         if not integration.access_token:
@@ -118,6 +127,7 @@ class RedditAdsSource(SimpleSource[RedditAdsSourceConfig], OAuthMixin):
             team_id=inputs.team_id,
             job_id=inputs.job_id,
             access_token=integration.access_token,
+            resumable_source_manager=resumable_source_manager,
             should_use_incremental_field=inputs.should_use_incremental_field,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value
             if inputs.should_use_incremental_field

--- a/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_ads.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_ads.py
@@ -1,7 +1,10 @@
 import datetime as dt
+from typing import Any, Optional
 
 import pytest
 from unittest import mock
+
+from parameterized import parameterized
 
 from posthog.temporal.data_imports.sources.reddit_ads.reddit_ads import (
     RedditAdsPaginator,
@@ -185,56 +188,52 @@ class TestRedditAdsPaginator:
         # URL should remain unchanged
         assert mock_request.url == original_url
 
-    def test_get_resume_state_fresh_paginator(self):
-        """A freshly constructed paginator has no page to resume to."""
+    @parameterized.expand(
+        [
+            ("fresh_paginator", None, None),
+            (
+                "after_update_with_next_url",
+                {"pagination": {"next_url": "https://api.reddit.com/page-2"}},
+                {"next_url": "https://api.reddit.com/page-2"},
+            ),
+            ("after_terminal_page", {"pagination": {}}, None),
+        ]
+    )
+    def test_get_resume_state(
+        self, _name: str, response_body: Optional[dict[str, Any]], expected: Optional[dict[str, Any]]
+    ) -> None:
         paginator = RedditAdsPaginator()
-        assert paginator.get_resume_state() is None
+        if response_body is not None:
+            mock_response = mock.MagicMock()
+            mock_response.json.return_value = response_body
+            paginator.update_state(mock_response)
 
-    def test_get_resume_state_after_update(self):
-        """Once update_state has parsed a next_url, it becomes the resume state."""
-        paginator = RedditAdsPaginator()
-
-        mock_response = mock.MagicMock()
-        mock_response.json.return_value = {"pagination": {"next_url": "https://api.reddit.com/page-2"}}
-        paginator.update_state(mock_response)
-
-        assert paginator.get_resume_state() == {"next_url": "https://api.reddit.com/page-2"}
-
-    def test_get_resume_state_after_terminal_page(self):
-        """On the terminal page there is nothing to resume to."""
-        paginator = RedditAdsPaginator()
-
-        mock_response = mock.MagicMock()
-        mock_response.json.return_value = {"pagination": {}}
-        paginator.update_state(mock_response)
-
-        assert paginator.get_resume_state() is None
+        assert paginator.get_resume_state() == expected
 
     def test_set_resume_state_round_trip(self):
         """set_resume_state then get_resume_state returns the same value."""
         paginator = RedditAdsPaginator()
         paginator.set_resume_state({"next_url": "https://api.reddit.com/page-5"})
 
-        assert paginator._next_url == "https://api.reddit.com/page-5"
-        assert paginator._has_next_page is True
+        assert paginator.has_next_page is True
         assert paginator.get_resume_state() == {"next_url": "https://api.reddit.com/page-5"}
 
-    def test_init_request_uses_seeded_next_url(self):
-        """A paginator seeded via set_resume_state rewrites the initial request URL."""
+    @parameterized.expand(
+        [
+            ("no_seed", None),
+            ("seeded", "https://api.reddit.com/page-3"),
+        ]
+    )
+    def test_init_request(self, _name: str, seed_url: Optional[str]) -> None:
         paginator = RedditAdsPaginator()
-        paginator.set_resume_state({"next_url": "https://api.reddit.com/page-3"})
-
-        mock_request = mock.MagicMock()
-        paginator.init_request(mock_request)
-
-        assert mock_request.url == "https://api.reddit.com/page-3"
-
-    def test_init_request_no_seeded_url(self):
-        """Without resume state the initial request URL is left untouched."""
-        paginator = RedditAdsPaginator()
+        if seed_url is not None:
+            paginator.set_resume_state({"next_url": seed_url})
 
         mock_request = mock.MagicMock()
         original_url = mock_request.url
         paginator.init_request(mock_request)
 
-        assert mock_request.url == original_url
+        if seed_url is not None:
+            assert mock_request.url == seed_url
+        else:
+            assert mock_request.url == original_url

--- a/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_ads.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_ads.py
@@ -184,3 +184,57 @@ class TestRedditAdsPaginator:
 
         # URL should remain unchanged
         assert mock_request.url == original_url
+
+    def test_get_resume_state_fresh_paginator(self):
+        """A freshly constructed paginator has no page to resume to."""
+        paginator = RedditAdsPaginator()
+        assert paginator.get_resume_state() is None
+
+    def test_get_resume_state_after_update(self):
+        """Once update_state has parsed a next_url, it becomes the resume state."""
+        paginator = RedditAdsPaginator()
+
+        mock_response = mock.MagicMock()
+        mock_response.json.return_value = {"pagination": {"next_url": "https://api.reddit.com/page-2"}}
+        paginator.update_state(mock_response)
+
+        assert paginator.get_resume_state() == {"next_url": "https://api.reddit.com/page-2"}
+
+    def test_get_resume_state_after_terminal_page(self):
+        """On the terminal page there is nothing to resume to."""
+        paginator = RedditAdsPaginator()
+
+        mock_response = mock.MagicMock()
+        mock_response.json.return_value = {"pagination": {}}
+        paginator.update_state(mock_response)
+
+        assert paginator.get_resume_state() is None
+
+    def test_set_resume_state_round_trip(self):
+        """set_resume_state then get_resume_state returns the same value."""
+        paginator = RedditAdsPaginator()
+        paginator.set_resume_state({"next_url": "https://api.reddit.com/page-5"})
+
+        assert paginator._next_url == "https://api.reddit.com/page-5"
+        assert paginator._has_next_page is True
+        assert paginator.get_resume_state() == {"next_url": "https://api.reddit.com/page-5"}
+
+    def test_init_request_uses_seeded_next_url(self):
+        """A paginator seeded via set_resume_state rewrites the initial request URL."""
+        paginator = RedditAdsPaginator()
+        paginator.set_resume_state({"next_url": "https://api.reddit.com/page-3"})
+
+        mock_request = mock.MagicMock()
+        paginator.init_request(mock_request)
+
+        assert mock_request.url == "https://api.reddit.com/page-3"
+
+    def test_init_request_no_seeded_url(self):
+        """Without resume state the initial request URL is left untouched."""
+        paginator = RedditAdsPaginator()
+
+        mock_request = mock.MagicMock()
+        original_url = mock_request.url
+        paginator.init_request(mock_request)
+
+        assert mock_request.url == original_url

--- a/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
@@ -1,12 +1,27 @@
+import json
+from typing import Any
+
 import pytest
 from unittest import mock
+from unittest.mock import MagicMock, patch
+
+from requests import Response
 
 from posthog.schema import SourceFieldInputConfig, SourceFieldOauthConfig
 
 from posthog.temporal.data_imports.sources.generated_configs import RedditAdsSourceConfig
+from posthog.temporal.data_imports.sources.reddit_ads.reddit_ads import RedditAdsResumeConfig
 from posthog.temporal.data_imports.sources.reddit_ads.source import RedditAdsSource
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
+
+
+def _make_response(json_body: Any, status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(json_body).encode()
+    resp.headers["Content-Type"] = "application/json"
+    return resp
 
 
 class TestRedditAdsSource:
@@ -106,6 +121,18 @@ class TestRedditAdsSource:
         for endpoint in expected_endpoints:
             assert endpoint in schema_names
 
+    def test_get_resumable_source_manager(self):
+        """The source must expose a resumable manager typed for its resume config."""
+        inputs = mock.MagicMock()
+        inputs.team_id = self.team_id
+        inputs.job_id = "test_job"
+        inputs.logger = mock.MagicMock()
+
+        manager = self.source.get_resumable_source_manager(inputs)
+
+        assert manager._data_class is RedditAdsResumeConfig
+        assert manager._inputs is inputs
+
     @mock.patch("posthog.temporal.data_imports.sources.reddit_ads.source.RedditAdsSource.get_oauth_integration")
     def test_source_for_pipeline_success(self, mock_get_oauth_integration):
         """Test source_for_pipeline with valid integration."""
@@ -127,7 +154,8 @@ class TestRedditAdsSource:
             inputs.should_use_incremental_field = False
             inputs.db_incremental_field_last_value = None
 
-            result = self.source.source_for_pipeline(self.config, inputs)
+            manager = mock.MagicMock()
+            result = self.source.source_for_pipeline(self.config, manager, inputs)
 
             assert result == mock_response
             mock_get_oauth_integration.assert_called_once_with(self.config.reddit_integration_id, self.team_id)
@@ -137,6 +165,7 @@ class TestRedditAdsSource:
                 team_id=self.team_id,
                 job_id="test_job",
                 access_token="test_token",
+                resumable_source_manager=manager,
                 should_use_incremental_field=False,
                 db_incremental_field_last_value=None,
             )
@@ -156,7 +185,7 @@ class TestRedditAdsSource:
         inputs.db_incremental_field_last_value = None
 
         with pytest.raises(ValueError, match="Reddit Ads access token not found for job test_job"):
-            self.source.source_for_pipeline(self.config, inputs)
+            self.source.source_for_pipeline(self.config, mock.MagicMock(), inputs)
 
     @mock.patch("posthog.temporal.data_imports.sources.reddit_ads.source.RedditAdsSource.get_oauth_integration")
     def test_source_for_pipeline_with_incremental(self, mock_get_oauth_integration):
@@ -178,7 +207,8 @@ class TestRedditAdsSource:
             inputs.should_use_incremental_field = True
             inputs.db_incremental_field_last_value = "2024-03-15"
 
-            result = self.source.source_for_pipeline(self.config, inputs)
+            manager = mock.MagicMock()
+            result = self.source.source_for_pipeline(self.config, manager, inputs)
 
             assert result == mock_response
             mock_reddit_ads_source.assert_called_once_with(
@@ -187,6 +217,92 @@ class TestRedditAdsSource:
                 team_id=self.team_id,
                 job_id="test_job",
                 access_token="test_token",
+                resumable_source_manager=manager,
                 should_use_incremental_field=True,
                 db_incremental_field_last_value="2024-03-15",
             )
+
+
+class TestRedditAdsResumeBehavior:
+    """End-to-end resume behavior of reddit_ads_source with a mocked HTTP session."""
+
+    def setup_method(self):
+        self.account_id = "789"
+        self.team_id = 123
+        self.job_id = "test_job"
+
+    def _run_campaigns(self, manager: MagicMock, responses: list[Response]) -> MagicMock:
+        from posthog.temporal.data_imports.sources.reddit_ads.reddit_ads import reddit_ads_source
+
+        with patch(
+            "posthog.temporal.data_imports.sources.common.rest_source.rest_client.requests.Session"
+        ) as MockSession:
+            mock_session = MockSession.return_value
+            mock_session.headers = {}
+            mock_session.prepare_request.side_effect = lambda req: req
+            mock_session.send.side_effect = responses
+
+            response = reddit_ads_source(
+                account_id=self.account_id,
+                endpoint="campaigns",
+                team_id=self.team_id,
+                job_id=self.job_id,
+                access_token="test_token",
+                db_incremental_field_last_value=None,
+                resumable_source_manager=manager,
+                should_use_incremental_field=False,
+            )
+            # Drain the resource to exercise the pagination loop.
+            list(response.items())
+            return mock_session
+
+    def test_fresh_run_saves_state_after_each_non_terminal_page(self):
+        """can_resume=False: first page yields, manager.save_state is called with the next_url."""
+        manager = MagicMock()
+        manager.can_resume.return_value = False
+
+        responses = [
+            _make_response(
+                {
+                    "data": [{"id": "c1", "modified_at": "2024-01-01T00:00:00Z"}],
+                    "pagination": {"next_url": "https://ads-api.reddit.com/api/v3/ad_accounts/789/campaigns?page=2"},
+                }
+            ),
+            _make_response({"data": [{"id": "c2", "modified_at": "2024-01-02T00:00:00Z"}], "pagination": {}}),
+        ]
+        self._run_campaigns(manager, responses)
+
+        # Resume state is persisted only once — after the first (non-terminal) page.
+        save_calls = manager.save_state.call_args_list
+        assert len(save_calls) == 1
+        saved_config = save_calls[0].args[0]
+        assert isinstance(saved_config, RedditAdsResumeConfig)
+        assert saved_config.next_url == "https://ads-api.reddit.com/api/v3/ad_accounts/789/campaigns?page=2"
+
+    def test_resume_uses_saved_cursor(self):
+        """can_resume=True: the first request goes to the saved next_url, not the initial path."""
+        manager = MagicMock()
+        manager.can_resume.return_value = True
+        manager.load_state.return_value = RedditAdsResumeConfig(
+            next_url="https://ads-api.reddit.com/api/v3/ad_accounts/789/campaigns?page=7"
+        )
+
+        responses = [
+            _make_response({"data": [{"id": "c7", "modified_at": "2024-01-07T00:00:00Z"}], "pagination": {}}),
+        ]
+        mock_session = self._run_campaigns(manager, responses)
+
+        sent_request = mock_session.send.call_args_list[0].args[0]
+        assert sent_request.url == "https://ads-api.reddit.com/api/v3/ad_accounts/789/campaigns?page=7"
+
+    def test_terminal_page_does_not_save_state(self):
+        """A single response with no next_url yields no save_state calls."""
+        manager = MagicMock()
+        manager.can_resume.return_value = False
+
+        responses = [
+            _make_response({"data": [{"id": "c1", "modified_at": "2024-01-01T00:00:00Z"}], "pagination": {}}),
+        ]
+        self._run_campaigns(manager, responses)
+
+        manager.save_state.assert_not_called()

--- a/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
@@ -9,6 +9,7 @@ from requests import Response
 
 from posthog.schema import SourceFieldInputConfig, SourceFieldOauthConfig
 
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.generated_configs import RedditAdsSourceConfig
 from posthog.temporal.data_imports.sources.reddit_ads.reddit_ads import RedditAdsResumeConfig
 from posthog.temporal.data_imports.sources.reddit_ads.source import RedditAdsSource
@@ -122,7 +123,7 @@ class TestRedditAdsSource:
             assert endpoint in schema_names
 
     def test_get_resumable_source_manager(self):
-        """The source must expose a resumable manager typed for its resume config."""
+        """The source must expose a ResumableSourceManager instance."""
         inputs = mock.MagicMock()
         inputs.team_id = self.team_id
         inputs.job_id = "test_job"
@@ -130,8 +131,7 @@ class TestRedditAdsSource:
 
         manager = self.source.get_resumable_source_manager(inputs)
 
-        assert manager._data_class is RedditAdsResumeConfig
-        assert manager._inputs is inputs
+        assert isinstance(manager, ResumableSourceManager)
 
     @mock.patch("posthog.temporal.data_imports.sources.reddit_ads.source.RedditAdsSource.get_oauth_integration")
     def test_source_for_pipeline_success(self, mock_get_oauth_integration):

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -379,6 +379,8 @@ async def _execute_run(workflow_id: str, inputs: ExternalDataWorkflowInputs, moc
         paginator: Optional[Any] = None,
         data_selector: Optional[Any] = None,
         hooks: Optional[Any] = None,
+        resume_hook: Optional[Any] = None,
+        initial_paginator_state: Optional[dict[str, Any]] = None,
     ):
         return iter(mock_data_response)
 
@@ -392,6 +394,8 @@ async def _execute_run(workflow_id: str, inputs: ExternalDataWorkflowInputs, moc
         paginator: Optional[Any] = None,
         data_selector: Optional[Any] = None,
         hooks: Optional[Any] = None,
+        resume_hook: Optional[Any] = None,
+        initial_paginator_state: Optional[dict[str, Any]] = None,
     ):
         # Yield each record as its own page so tests that probe chunking
         # by record size still see one call per record.


### PR DESCRIPTION
## Problem

`RedditAdsSource` was a `SimpleSource`, so a worker restart mid-sync forced the
endpoint to restart from scratch. Other sources (klaviyo, hubspot, temporalio,
stripe) already persist a per-job cursor to the data-warehouse Redis and
resume from the last yielded page on restart.

Since PR #54307 replaced the dlt-based REST framework with a PostHog-owned one
at `posthog/temporal/data_imports/sources/common/rest_source/`, no source had
yet combined `ResumableSource` with that framework — all current resumable
sources hand-write their loops. This PR wires a small generic resume hook into
the new REST framework and uses it to convert reddit_ads.

## Changes

**Framework (`common/rest_source/`)**

- `BasePaginator` gains optional no-op `get_resume_state()` /
  `set_resume_state(state)` methods. Paginators opt in by overriding.
- `RESTClient.paginate` accepts `resume_hook` and `initial_paginator_state`
  kwargs. After each page yields it calls
  `resume_hook(paginator.get_resume_state() if has_next_page else None)`;
  before the first request it calls `set_resume_state` when seeded.
- The kwargs are threaded through `rest_api_resource` / `rest_api_resources`
  / `create_resources`. Dependent (parent/child fanout) resources raise
  `NotImplementedError` if resume is enabled — out of scope for this PR.

**Reddit Ads (`reddit_ads/`)**

- New `RedditAdsResumeConfig(next_url: str)` dataclass.
- `RedditAdsPaginator` now overrides `init_request` (to honor a seeded
  `_next_url`), `get_resume_state`, and `set_resume_state`.
- `reddit_ads_source` takes a `ResumableSourceManager[RedditAdsResumeConfig]`,
  loads initial state when `can_resume()`, and saves the next_url after each
  non-terminal page. Matches klaviyo semantics: nothing is persisted on the
  terminal page; Redis TTL handles cleanup.
- `RedditAdsSource` now extends
  `ResumableSource[RedditAdsSourceConfig, RedditAdsResumeConfig]` (keeping
  `OAuthMixin`), implements `get_resumable_source_manager`, and threads the
  manager into `source_for_pipeline`.

No public config fields, schemas, credential validation, partitioning, or
primary keys were changed — fresh runs behave identically to before.

## How did you test this code?

Automated tests only — I'm an agent, no manual end-to-end run against the
live Reddit Ads API.

- **New framework tests** in
  `common/rest_source/tests/test_rest_client.py` covering the resume-hook
  call sequence and the initial-state seed of the request URL.
- **New paginator tests** in `reddit_ads/tests/test_reddit_ads.py` covering
  `get/set_resume_state` round-trip and `init_request` honoring a seeded URL.
- **New source-level tests** in `reddit_ads/tests/test_reddit_source.py`
  (`TestRedditAdsResumeBehavior`) that drive `reddit_ads_source` end-to-end
  with a mocked `requests.Session`: fresh-run saves state after the first
  non-terminal page, resume-run hits the saved URL on the first request,
  terminal-only page persists nothing.
- Full suite: `pytest posthog/temporal/data_imports/sources/reddit_ads/
  posthog/temporal/data_imports/sources/common/rest_source/tests/` — 98
  passed.
- `ruff check` and `ruff format --check` clean on the touched files.

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code. The REST framework has an existing `paginator`
abstraction but the pagination state was previously opaque to callers
(the paginator is deep-copied inside `RESTClient.paginate`), so adding an
explicit `get_resume_state` / `set_resume_state` protocol on the paginator
plus `resume_hook` / `initial_paginator_state` kwargs on `paginate` was the
smallest change that kept Redis / `ResumableSourceManager` out of the
framework layer. Parent/child fanout resume was deliberately left as a
follow-up — the framework raises `NotImplementedError` to keep the door
open without shipping untested behavior.