### PR TITLE
fix(data-warehouse): flatten resource pages for tiktok/snapchat non-report endpoints

### DIFF
--- a/posthog/temporal/data_imports/sources/snapchat_ads/snapchat_ads.py
+++ b/posthog/temporal/data_imports/sources/snapchat_ads/snapchat_ads.py
@@ -131,10 +131,10 @@ def snapchat_ads_source(
     account_currency = None
     if endpoint_type == EndpointType.STATS:
         account_currency = fetch_account_currency(ad_account_id, access_token)
-        items = SnapchatStatsResource.process_resources(dlt_resources)
     else:
         assert len(dlt_resources) == 1, f"Expected 1 resource for {endpoint_type} endpoint, got {len(dlt_resources)}"
-        items = dlt_resources[0]
+
+    items = SnapchatStatsResource.process_resources(dlt_resources)
 
     items = SnapchatStatsResource.apply_stream_transformations(endpoint_type, items, currency=account_currency)
 

--- a/posthog/temporal/data_imports/sources/tiktok_ads/tiktok_ads.py
+++ b/posthog/temporal/data_imports/sources/tiktok_ads/tiktok_ads.py
@@ -119,11 +119,10 @@ def tiktok_ads_source(
         is_exception_retryable=TikTokErrorHandler.is_retryable,
     )()
 
-    if endpoint_type == EndpointType.REPORT:
-        items = TikTokReportResource.process_resources(dlt_resources)
-    else:
+    if endpoint_type != EndpointType.REPORT:
         assert len(dlt_resources) == 1, f"Expected 1 resource for {endpoint_type} endpoint, got {len(dlt_resources)}"
-        items = dlt_resources[0]
+
+    items = TikTokReportResource.process_resources(dlt_resources)
 
     # Apply appropriate transformations based on endpoint type
     items = TikTokReportResource.apply_stream_transformations(endpoint_type, items)


### PR DESCRIPTION
## Problem

After removing DLT from the rest_source (#54307), the custom `Resource.__iter__` yields **pages** (`list[dict]`), not individual dicts. TikTok and Snapchat Ads handled this correctly for report/stats endpoints (via `process_resources` which flattens pages), but the entity/account branch did `items = dlt_resources[0]`, leaving a raw `Resource`.

When downstream transforms iterated `items`, each element was a page (a list). Calls like `report.copy()` then produced a list copy, and `report["current_status"] = "ACTIVE"` crashed with:

```
TypeError: list indices must be integers or slices, not str
```

Reported via PostHog error tracking for TikTok Ads campaign/ad-group/ad endpoints. Snapchat Ads had the identical latent bug on its non-stats branch.

## Changes

- Route both endpoint branches through `process_resources(dlt_resources)` in `tiktok_ads.py` and `snapchat_ads.py` so pages are always flattened before transformations run.

## How did you test this code?

- Existing TikTok Ads unit tests pass (`pytest posthog/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads.py` — 28 passed).
- No manual end-to-end run against the TikTok/Snapchat APIs — this was authored by an agent and only verified via the existing unit test suite and linting.

## Publish to changelog?

no