### PR TITLE
fix: clear filter_backends on logs action to fix search param shadowing

### DIFF
--- a/posthog/api/log_entries.py
+++ b/posthog/api/log_entries.py
@@ -125,7 +125,7 @@ class LogEntryMixin(viewsets.GenericViewSet):
         raise NotImplementedError()
 
     @extend_schema(parameters=[LogEntryRequestSerializer])
-    @action(detail=True, methods=["GET"])
+    @action(detail=True, methods=["GET"], filter_backends=[])
     def logs(self, request: Request, *args, **kwargs):
         obj = self.get_object()
 


### PR DESCRIPTION
## Problem

The MCP `cdp-functions-logs-retrieve` tool (and the logs endpoints more broadly) accept a `search` query param meant to do a case-insensitive substring match on log messages. In practice, the parent viewset's `SearchFilter` was intercepting the `search` param first and using it to filter by function name / other searchable fields on the parent queryset, so the ClickHouse log-message search never saw it.

Noticed while wiring up the MCP tool in #55154 - splitting the one-line fix out since #55154 is being closed (superseded by #53965 which already shipped the tool with the same bug).

## Changes

Add `filter_backends=[]` to the `@action` decorator on `LogEntryMixin.logs()` so the parent viewset's filter backends don't run on this detail action. Per [drf-spectacular#399](https://github.com/tfranzel/drf-spectacular/issues/399) this is the canonical DRF-level fix.

```diff
-    @action(detail=True, methods=["GET"])
+    @action(detail=True, methods=["GET"], filter_backends=[])
     def logs(self, request: Request, *args, **kwargs):
```

Affects every viewset that mixes in `LogEntryMixin` (hog functions, hog flows, batch exports) - `search` now correctly filters log message content via ClickHouse ILIKE on all of them.

## How did you test this code?

Agent-authored. No automated test added - the bug is in how DRF's SearchFilter shadows a per-action param, and there's no existing test harness covering the logs action's search behavior. Verified manually that the change is DRF's recommended pattern and scoped to the one action.

Reviewers: worth a quick manual check - hit `/api/projects/<id>/hog_functions/<id>/logs/?search=<substring>` before/after and confirm the param now hits the log message ILIKE instead of filtering by function name.

## Publish to changelog?

no

## 🤖 LLM context

Co-authored by Claude Opus 4.7. Split out of #55154 after that PR was superseded by #53965.