### PR TITLE
fix(dev): honor CADDY_HOST in docker-compose.dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,7 +29,7 @@ services:
                         trusted_proxies static ${CADDY_TRUSTED_PROXIES:-127.0.0.1/32 ::1/128}
                     }
                 }
-                http://localhost:8000 {
+                ${CADDY_HOST:-http://localhost:8000} {
                     @replay-capture {
                         path /s
                         path /s/*


### PR DESCRIPTION
## Problem

Follow-up to #54995. That PR added the `trusted_proxies` global block to `docker-compose.dev.yml` but left the site address hardcoded as `http://localhost:8000`. Because `dev.yml` overrides `environment.CADDYFILE` wholesale, the `${CADDY_HOST:-...}` substitution already present in `base.yml` is bypassed — so callers running dev behind a proxy (ngrok, Tailscale Funnel, Coder workspaces, etc.) that set `CADDY_HOST=:8000` were silently ignored, and non-localhost Host headers fell through to Caddy's empty-200 handler.

## Changes

One-line change in `docker-compose.dev.yml`: replace the hardcoded site address with `${CADDY_HOST:-http://localhost:8000}`, matching the idiom already used in `base.yml`. Default behavior is unchanged; the override now actually takes effect.

## How did you test this code?

Agent-authored, not manually run end-to-end.

- `docker compose -f docker-compose.dev.yml config` with no overrides renders `http://localhost:8000 {` (byte-identical to pre-patch).
- `CADDY_HOST=:8000 docker compose -f docker-compose.dev.yml config` renders `:8000 {` (bare-port form, valid Caddy).

## Docs update

no

## 🤖 LLM context

Authored in a Claude Code session following a scoped spec. Surgical fix only — sandbox compose left alone per request.