### PR TITLE
fix(mcp): fix ui-apps rendering

### DIFF
--- a/services/mcp/src/ui-apps/hooks/useToolResult.ts
+++ b/services/mcp/src/ui-apps/hooks/useToolResult.ts
@@ -29,15 +29,7 @@
  * }
  * ```
  */
-import {
-    type App,
-    McpUiHostContextChangedNotificationSchema,
-    McpUiToolCancelledNotificationSchema,
-    McpUiToolInputNotificationSchema,
-    McpUiToolResultNotificationSchema,
-    useApp,
-    useHostStyles,
-} from '@modelcontextprotocol/ext-apps/react'
+import { type App, useApp, useHostStyles } from '@modelcontextprotocol/ext-apps/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
@@ -160,47 +152,44 @@ export function useToolResult<T = unknown>({
         onAppCreated: (appInstance) => {
             log('App created', { appInstance })
 
-            // Register tool input handler
-            appInstance.setNotificationHandler(McpUiToolInputNotificationSchema, (notification) => {
-                // Extract toolName from params if available (may be in extended params)
-                const params = notification.params as Record<string, unknown>
+            // Register tool input handler (addEventListener allows multiple listeners)
+            appInstance.addEventListener('toolinput', (params) => {
+                const p = params as Record<string, unknown>
                 captureToolInput({
-                    toolName: typeof params.toolName === 'string' ? params.toolName : undefined,
-                    hasArguments: !!params.arguments,
+                    toolName: typeof p.toolName === 'string' ? p.toolName : undefined,
+                    hasArguments: !!p.arguments,
                 })
             })
 
             // Do NOT register partial tool input handler (streaming)
             // This is too noisy, happens for each chunk of input we get from the server
-            // appInstance.setNotificationHandler(McpUiToolInputPartialNotificationSchema, () => {})
 
             // Register tool cancelled handler
-            appInstance.setNotificationHandler(McpUiToolCancelledNotificationSchema, (notification) => {
-                const params = notification.params as Record<string, unknown>
+            appInstance.addEventListener('toolcancelled', (params) => {
+                const p = params as Record<string, unknown>
                 setIsCancelled(true)
                 captureToolCancelled({
-                    toolName: typeof params.toolName === 'string' ? params.toolName : undefined,
-                    reason: typeof params.reason === 'string' ? params.reason : undefined,
+                    toolName: typeof p.toolName === 'string' ? p.toolName : undefined,
+                    reason: typeof p.reason === 'string' ? p.reason : undefined,
                 })
             })
 
             // Register host context changed handler
-            appInstance.setNotificationHandler(McpUiHostContextChangedNotificationSchema, (notification) => {
-                // Cast to access theme which may be in notification params directly
-                const params = notification.params as typeof notification.params & { theme?: string }
+            appInstance.addEventListener('hostcontextchanged', (params) => {
+                const p = params as typeof params & { theme?: string }
                 captureHostContextChanged({
-                    hasStyles: !!notification.params.styles,
-                    hasFonts: !!notification.params.styles?.css?.fonts,
-                    theme: params.theme,
+                    hasStyles: !!params.styles,
+                    hasFonts: !!params.styles?.css?.fonts,
+                    theme: p.theme,
                 })
 
-                setContainerDimensions(extractContainerDimensions(params as unknown as Record<string, unknown>))
+                setContainerDimensions(extractContainerDimensions(p as unknown as Record<string, unknown>))
             })
 
             // Register tool result handler
-            appInstance.setNotificationHandler(McpUiToolResultNotificationSchema, (notification) => {
+            appInstance.addEventListener('toolresult', (params) => {
                 try {
-                    const parsed = parseToolResultContent<T>(notification.params.structuredContent)
+                    const parsed = parseToolResultContent<T>(params.structuredContent)
 
                     // Extract analytics metadata and identify the user
                     const analytics = extractAnalytics(parsed)
@@ -209,8 +198,8 @@ export function useToolResult<T = unknown>({
                     }
 
                     captureToolResult({
-                        hasStructuredContent: !!notification.params.structuredContent,
-                        contentLength: notification.params.content?.length,
+                        hasStructuredContent: !!params.structuredContent,
+                        contentLength: params.content?.length,
                     })
 
                     if (parsed !== null) {


### PR DESCRIPTION
## Problem

ui-app rendering failing locally with:  
`[PostHog MCP App UI] Connection error: Error: Handler for   "ui/notifications/host-context-changed" already registered   (via setNotificationHandler). Use addEventListener() to attach   multiple listeners, or the on* setter for replace semantics.`

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

setNotificationHandler --> addEventListener

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

reopened claude --> now chart renders:  
![Screenshot 2026-04-21 at 12.54.08 PM.png](https://app.graphite.com/user-attachments/assets/aa62279c-8d38-4e4b-891c-a388e684e563.png)



<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->g local withderse