### PR TITLE
feat(sourcemaps): skip empty sourcemaps with bundler misconfiguration warning

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # posthog-cli
 
+# 0.7.9
+
+- feat: warn and skip empty sourcemaps (no mappings/sources/names) during upload to surface bundler misconfigurations instead of silently uploading useless symbol sets
+
 # 0.7.8
 
 - feat: add `--build` flag to all upload commands (hermes, dsym, proguard, sourcemap) via shared ReleaseArgs

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "posthog-cli"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "anyhow",
  "chrono",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posthog-cli"
-version = "0.7.8"
+version = "0.7.9"
 authors = [
     "David <david@posthog.com>",
     "Olly <oliver@posthog.com>",

--- a/cli/src/sourcemaps/content.rs
+++ b/cli/src/sourcemaps/content.rs
@@ -22,6 +22,30 @@ pub struct SourceMapContent {
     pub fields: BTreeMap<String, Value>,
 }
 
+impl SourceMapContent {
+    /// True when the sourcemap carries no symbolication payload — empty `mappings`,
+    /// no `sources`, and no `names`. Such maps upload successfully but are useless
+    /// for stack trace resolution, and usually indicate a bundler misconfiguration.
+    pub fn is_empty(&self) -> bool {
+        let mappings_empty = self
+            .fields
+            .get("mappings")
+            .and_then(|v| v.as_str())
+            .is_none_or(str::is_empty);
+        let sources_empty = self
+            .fields
+            .get("sources")
+            .and_then(|v| v.as_array())
+            .is_none_or(Vec::is_empty);
+        let names_empty = self
+            .fields
+            .get("names")
+            .and_then(|v| v.as_array())
+            .is_none_or(Vec::is_empty);
+        mappings_empty && sources_empty && names_empty
+    }
+}
+
 #[derive(Debug)]
 pub struct SourceMapFile {
     pub inner: SourceFile<SourceMapContent>,
@@ -113,6 +137,10 @@ impl SourceMapFile {
 
     pub fn set_release_id(&mut self, release_id: Option<String>) {
         self.inner.content.release_id = release_id;
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.content.is_empty()
     }
 }
 
@@ -310,5 +338,70 @@ impl TryInto<SymbolSetUpload> for SourceMapFile {
             release_id,
             data,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn content_from(value: Value) -> SourceMapContent {
+        serde_json::from_value(value).expect("Failed to build SourceMapContent")
+    }
+
+    #[test]
+    fn is_empty_true_for_all_empty_fields() {
+        let sm = content_from(json!({
+            "version": 3,
+            "file": "index-abc.js",
+            "mappings": "",
+            "names": [],
+            "sources": [],
+            "sourcesContent": [],
+        }));
+        assert!(sm.is_empty());
+    }
+
+    #[test]
+    fn is_empty_true_when_fields_missing() {
+        let sm = content_from(json!({
+            "version": 3,
+            "file": "index-abc.js",
+        }));
+        assert!(sm.is_empty());
+    }
+
+    #[test]
+    fn is_empty_false_with_mappings_only() {
+        let sm = content_from(json!({
+            "version": 3,
+            "mappings": "AAAA",
+            "names": [],
+            "sources": [],
+        }));
+        assert!(!sm.is_empty());
+    }
+
+    #[test]
+    fn is_empty_false_with_sources_only() {
+        let sm = content_from(json!({
+            "version": 3,
+            "mappings": "",
+            "names": [],
+            "sources": ["foo.ts"],
+        }));
+        assert!(!sm.is_empty());
+    }
+
+    #[test]
+    fn is_empty_false_with_names_only() {
+        let sm = content_from(json!({
+            "version": 3,
+            "mappings": "",
+            "names": ["x"],
+            "sources": [],
+        }));
+        assert!(!sm.is_empty());
     }
 }

--- a/cli/src/sourcemaps/hermes/upload.rs
+++ b/cli/src/sourcemaps/hermes/upload.rs
@@ -49,9 +49,18 @@ pub fn upload(args: &Args) -> Result<()> {
         get_release_for_maps(&directory, release.clone(), maps.iter())?.map(|r| r.id.to_string());
 
     let mut uploads: Vec<SymbolSetUpload> = Vec::new();
+    let mut empty_skipped = 0usize;
     for mut map in maps.into_iter() {
         if map.get_chunk_id().is_none() {
             warn!("Skipping map {}, no chunk ID", map.inner.path.display());
+            continue;
+        }
+        if map.is_empty() {
+            warn!(
+                "Skipping {}: sourcemap is empty (no mappings/sources/names) — likely a bundler misconfiguration",
+                map.inner.path.display()
+            );
+            empty_skipped += 1;
             continue;
         }
 
@@ -73,6 +82,7 @@ pub fn upload(args: &Args) -> Result<()> {
             ("type", json!("hermes")),
             ("file_count", json!(file_count)),
             ("total_bytes", json!(total_bytes)),
+            ("empty_skipped", json!(empty_skipped)),
         ],
     );
 

--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use anyhow::{Context, Result};
 use serde_json::json;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{
     api::symbol_sets::{self, SymbolSetUpload},
@@ -79,7 +79,18 @@ pub fn upload(args: &Args) -> Result<()> {
         }
     }
 
-    let uploads = pairs
+    let (empty_pairs, valid_pairs): (Vec<_>, Vec<_>) = pairs
+        .into_iter()
+        .partition(|pair| pair.sourcemap.is_empty());
+    for pair in &empty_pairs {
+        warn!(
+            "Skipping {}: sourcemap is empty (no mappings/sources/names) — likely a bundler misconfiguration",
+            pair.sourcemap.inner.path.display()
+        );
+    }
+    let empty_skipped = empty_pairs.len();
+
+    let uploads = valid_pairs
         .into_iter()
         .map(TryInto::try_into)
         .collect::<Result<Vec<SymbolSetUpload>>>()
@@ -93,6 +104,7 @@ pub fn upload(args: &Args) -> Result<()> {
             ("type", json!("plain")),
             ("file_count", json!(file_count)),
             ("total_bytes", json!(total_bytes)),
+            ("empty_skipped", json!(empty_skipped)),
         ],
     );
 


### PR DESCRIPTION
## TL;DR
Add detection and skipping of empty sourcemaps (with no mappings, sources, or names) in the PostHog CLI sourcemap upload process, which typically indicate bundler misconfiguration. Empty sourcemaps are now logged as warnings and excluded from uploads, with metrics tracked for observability.

## What changed?
- **SourceMapContent**: Added `is_empty()` method to detect sourcemaps with empty `mappings`, no `sources`, and no `names` fields
- **SourceMapFile**: Added `is_empty()` wrapper method delegating to content
- **Hermes upload**: Skip empty sourcemaps with warning, track count of skipped maps in upload metrics
- **Plain upload**: Partition sourcemap pairs into empty and valid sets, skip empty ones with warnings, track skipped count in metrics
- **Tests**: Added comprehensive unit tests covering:
  - All empty fields detection
  - Missing field detection
  - Non-empty detection for mappings-only, sources-only, and names-only cases

## How did you test this code?
Unit tests have been added covering all detection scenarios:
- Empty sourcemaps with all fields present but empty
- Empty sourcemaps with missing optional fields
- Non-empty sourcemaps with at least one populated field

The changes are agent-authored and include code-based unit tests validating the `is_empty()` logic across different field combinations. Manual testing of the CLI sourcemap upload process with real bundler output would be needed to validate the warning messages and metrics in production scenarios.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*