### PR TITLE
perf(visual_review): lazy-load images and size thumbnails explicitly

### DIFF
--- a/frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.tsx
+++ b/frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.tsx
@@ -63,6 +63,8 @@ function ImagePanel({ url, label, emptyTitle, imgClassName, imgStyle }: ImagePan
                 <img
                     src={url}
                     alt={label}
+                    loading="lazy"
+                    decoding="async"
                     className={cn('h-auto bg-black/5', imgClassName || 'max-w-full')}
                     // eslint-disable-next-line react/forbid-dom-props
                     style={imgStyle}

--- a/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewRunScene.tsx
@@ -67,7 +67,15 @@ function SnapshotThumbnail({
             )}
             <div className="w-[104px] h-[72px] rounded-sm overflow-hidden bg-bg-3000">
                 {snapshot.current_artifact?.download_url ? (
-                    <img src={snapshot.current_artifact.download_url} alt="" className="w-full h-full object-contain" />
+                    <img
+                        src={snapshot.current_artifact.download_url}
+                        alt=""
+                        width={104}
+                        height={72}
+                        loading="lazy"
+                        decoding="async"
+                        className="w-full h-full object-contain"
+                    />
                 ) : (
                     <div className="w-full h-full flex items-center justify-center">
                         <span className="text-[10px] text-muted">No image</span>


### PR DESCRIPTION
## Problem

A Visual Review tab sitting in the background was observed growing from ~200MB to ~400MB of browser-reported footprint. Two V8 heap snapshots taken before and after that growth showed **the JS heap was stable** (143MB -> 142MB, zero new detached DOM nodes).

That means the 200MB of growth is happening outside V8 — in decoded image memory, compositor/paint layers, and renderer-internal buffers that heap snapshots don't capture.

## Root cause

`VisualReviewRunScene.tsx` renders a thumbnail strip where each `<img>` points at the full-resolution screenshot (`current_artifact.download_url`, typically 1440x900 and sometimes 2880x1800) and displays it at 104x72 via CSS.

- A decoded 1440x900 RGBA bitmap is ~5MB
- A decoded 2880x1800 RGBA bitmap is ~20MB
- A 40-snapshot run results in 80-800MB of decoded bitmap memory for the thumbnail strip alone

The main `VisualImageDiffViewer` panels have the same issue for images not in the viewport.

Backgrounded tabs don't evict decoded image layers aggressively, so the memory sticks around and matches the observed footprint growth pattern. When the tab returns to the foreground, paint re-runs and discards old decoded layers — which is why most of the growth is released on foreground, matching reported behavior.

## Fix

Small, low-risk changes:

1. Thumbnail strip (`VisualReviewRunScene.tsx`):
   - Explicit `width={104} height={72}` layout hints
   - `loading=\"lazy\"` so off-screen thumbnails don't decode
   - `decoding=\"async\"` so the browser can defer/parallelize decode
2. Main diff images (`VisualImageDiffViewer.tsx`):
   - `loading=\"lazy\"` and `decoding=\"async\"`

## Why not generate real thumbnails server-side

That's the proper fix, but it touches the CLI that writes artifacts and the signing flow. This PR is a stopgap that's shippable today. A follow-up can add a `thumbnail_url` on `SnapshotArtifactApi` populated at upload time.

## LLM context

Investigation was prompted by detached-element tracking in PostHog showing dashboard React fiber leaks. While looking at a background Visual Review tab growing to 1.6GB, two heap snapshots confirmed the JS heap was stable — so the Visual Review bloat is a separate, image-decode-memory problem from the dashboard React fiber leak. This PR addresses the image-decode side only.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*