### PR TITLE
fix(admin): autocomplete invited_by in organization inline

### DIFF
--- a/posthog/admin/inlines/organization_member_inline.py
+++ b/posthog/admin/inlines/organization_member_inline.py
@@ -10,7 +10,7 @@ class OrganizationMemberInline(TabularInlinePaginated):
     pagination_key = "page-member"
     show_change_link = True
     readonly_fields = ("organization", "user", "joined_at", "updated_at")
-    autocomplete_fields = ("organization",)
+    autocomplete_fields = ("organization", "invited_by")
     ordering = ("-level",)  # Order by level descending (Owner -> Admin -> Member)
 
 


### PR DESCRIPTION
## Problem

The Django admin `Change organization` page was rendering **~56 MB of HTML** (1.94M lines) for orgs in large instances, making the page extremely slow to load.

## Changes

Root cause: `OrganizationMembership.invited_by` is a `ForeignKey` to `User`, but `OrganizationMemberInline` did not include it in `autocomplete_fields`. Django admin's default FK widget is a native `<select>` that dumps every target row as an `<option>`. For `invited_by`, that meant ~483k `<option>` tags per select, rendered twice (once for the existing row, once for the `__prefix__` inline template used to clone new rows) — ~968k `<option>` tags accounting for essentially all 56 MB.

Adding `invited_by` to `autocomplete_fields` switches it to a Select2 AJAX widget, which only fetches users as the admin searches. `UserAdmin` already declares `search_fields`, which is required for autocomplete_fields to function.

Diagnosed from a captured HTML dump of the page:

| Options | Select name |
|---------|-------------|
| 483,604 | `memberships-__prefix__-invited_by` |
| 483,602 | `memberships-0-invited_by` |
| 596 | `teams-*-timezone` (normal pytz list) |
| ≤ 4 | everything else |

## How did you test this code?

Agent-authored. The agent did not manually load the admin page. Verification plan for the human reviewer:

1. Load `/admin/posthog/organization/<id>/change/` for a large org.
2. Confirm the `invited_by` column renders a search-as-you-type widget instead of a native `<select>`.
3. Save the page HTML and confirm the response size drops from ~56 MB to well under 1 MB.
4. Search for and save an `invited_by` value; confirm it persists.

No unit tests added — this is a one-line Django admin configuration change.

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code (Claude Opus 4.7). Diagnosis was driven by counting HTML tag occurrences in a user-supplied page dump, then tracing the offending `<select name="...invited_by">` to `posthog/admin/inlines/organization_member_inline.py`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*