### PR TITLE
chore(deps): upgrade @base-ui/react 1.3.0 to 1.4.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,7 +49,7 @@
         "build:survey-sdk-docs": "ts-node -r tsconfig-paths/register --transpile-only ./bin/docs/build-survey-sdk-docs.ts"
     },
     "dependencies": {
-        "@base-ui/react": "^1.3.0",
+        "@base-ui/react": "^1.4.0",
         "@dagrejs/dagre": "^1.1.5",
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/modifiers": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -549,8 +549,8 @@ importers:
   frontend:
     dependencies:
       '@base-ui/react':
-        specifier: ^1.3.0
-        version: 1.3.0(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^1.4.0
+        version: 1.4.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@dagrejs/dagre':
         specifier: ^1.1.5
         version: 1.1.5


### PR DESCRIPTION
## Why

MemLens traced two separate detached fiber trees in production to **base-ui portal internals not being reclaimed when their children unmount**:

1. `NewAccountMenu` in the left-nav `PanelLayout` — 3 nested `Menu.Portal` instances leak on every open/close.
   - Stack: `InternalBackdrop -> MenuPositioner -> FloatingPortal -> MenuPortal -> FloatingTree -> MenuRoot -> NewAccountMenu`
2. `ViewRecordingButton` tooltip in every events-table row — since [#51653](https://github.com/PostHog/posthog/pull/51653) every row renders a tooltip, and each leaks.
   - Stack: `TooltipPopup -> TooltipPositioner -> FloatingPortalLite -> TooltipPortal -> TooltipRoot -> Tooltip -> LemonButton -> ViewRecordingButton -> EventRowActions -> TableRowRaw`

Both match the production `detached_elements` signal showing `LemonButton`, `Primitive.span.SlotClone`, `Dropdown`, and `MenuProvider` growing across pages. Our own React-level Tooltip lifecycle was clean, so the retention is below that layer — inside `@base-ui/react@1.3.0`.

## What

Bump `@base-ui/react` from `^1.3.0` to `^1.4.0`. Scoped to `frontend/package.json`. `@posthog/quill-primitives` was already on 1.4.0, so we're consolidating.

1.4.1 was released 34 hours ago and is blocked by pnpm's `minimumReleaseAge` policy — we'll revisit once it ages.

## Relevant 1.4.0 changelog items

Full notes: https://github.com/mui/base-ui/releases/tag/v1.4.0

Items most relevant to the leaks we see:

- **Alert Dialog / Dialog: Fix detached trigger HMR with recreated handles** (#4472)
- **General: Fix `Positioner` not repositioning to a different trigger when reopened with `keepMounted`** (#4407)
- **General: Fix outside-press dismissal in a shared shadow root** (#4333)
- **Menu: Fix `SubmenuTrigger` not respecting disabled state from `render`** (#3858) — matters for `NewAccountMenu` nested submenus
- **Menu: Preserve dialog focus on pointer leave** (#4581)
- **Popover: Remove stray focus guards around trigger when `modal`** (#4350)
- **Popover: Sync hover open event state** (#4526)
- **Select: Preserve touch exit animations** (#4325)
- **Drawer: Warn when a popup is missing `Viewport`** (#4495)

Everything else in the notes is component-specific and is either backwards-compatible or a bugfix we should pick up opportunistically.

## Risk

1.4.0 is a minor bump. Low-level primitives (Menu/Tooltip/Popover/Select/Dialog) are used across the app, so Visual Review diffs are expected. The upstream PRs listed above fix subtle positioning and focus behaviours that *should* only narrow existing edge cases — but snapshots will need reviewing.

## Test plan

- [ ] CI green
- [ ] Visual Review diffs reviewed — expect some positioning/dismiss-behaviour changes
- [ ] Manually confirm left-nav account menu, events-table tooltips, and session recording inspector menus still work
- [ ] Follow-up: watch `detached_elements` event in prod to confirm `MenuProvider` / `LemonButton` / `Primitive.span.SlotClone` counts drop

## LLM context

Part of the ongoing investigation into a cross-page React fiber leak surfaced via MemLens. Earlier PRs on the same trail: #54126 (Radix menu portals), #54299 (LemonTree AccordionPrimitive), #55313/#55314/#55315 (dashboard drag and react-grid-layout).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*