### PR TITLE
chore(rust): upgrade tokio to 1.51.1

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4420,7 +4420,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -5329,9 +5329,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libflate"
@@ -5765,9 +5765,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -7607,7 +7607,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7644,7 +7644,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7842,7 +7842,7 @@ dependencies = [
  "rustls-native-certs 0.8.3",
  "ryu",
  "sha1_smol",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-util",
@@ -8954,12 +8954,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10012,9 +10012,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -10022,7 +10022,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -10039,9 +10039,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10232,7 +10232,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-stream",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -136,7 +136,7 @@ time = { version = "0.3.36", features = [
     "serde",
 ] }
 thiserror = { version = "2.0" }
-tokio = { version = "1.34.0", features = ["full"] }
+tokio = { version = "1.51.1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["time"] }
 tower = { version = "0.4.13", features = ["limit", "timeout", "util"] }
 tower-http = { version = "0.5.2", features = ["cors", "decompression-br", "decompression-deflate", "decompression-gzip", "decompression-zstd", "limit", "trace"] }


### PR DESCRIPTION
## Problem

The Rust workspace declared `tokio = "1.34.0"` as the minimum version. Cargo's lockfile happened to resolve to 1.50.0, but the declared minimum did not enforce the soundness fix introduced in tokio 1.42.1 — that release fixed an unsoundness in the broadcast channel where `clone()` could be called on `Send + !Sync` values without proper synchronization. Raising the declared minimum guarantees the fix is in place across all consumers and prevents anyone from ever resolving back below it.

## Changes

- `rust/Cargo.toml`: bump workspace `tokio` declaration from `1.34.0` → `1.51.1`.
- `rust/Cargo.lock`: refreshed via `cargo update -p tokio`. Tokio resolves from `1.50.0` → `1.52.1`, with minor transitive bumps to `mio` (1.1.1 → 1.2.0), `socket2` (0.6.2 → 0.6.3), `tokio-macros` (2.6.0 → 2.7.0), and `libc` (0.2.182 → 0.2.185). All semver-compatible.

This is a workspace-wide change because `tokio` is a shared workspace dependency consumed by 35 crates — including `capture`, `capture-logs`, `batch-import-worker`, `ingestion-consumer`, `cyclotron-*`, `personhog-*`, `cymbal`, `hypercache-server`, `embedding-worker`, and `feature-flags`. Tokio 1.x is semver-stable, so no API changes are required at any call site. CI's Rust toolchain (1.91.1) is well above tokio 1.51's MSRV of 1.71.

### Note on the `socket2` resolver shuffle

The lockfile diff also shows `hyper-util`, `quinn`, and `quinn-udp` moving from `socket2 0.6.2` → `0.5.10`. Two things to note:

- **Two `socket2` majors already existed on `master`** (`0.5.10` via `hyper`/`tonic`; `0.6.2` via the others). This PR does not introduce a new duplicate — the count stays at two (`0.5.10` + `0.6.3`).
- The shuffle is **deterministic and unavoidable**. `tokio 1.51.1` requires `socket2 ^0.6.3`, forcing the `0.6.2 → 0.6.3` bump. When cargo re-resolves, its dedup heuristic reassigns `hyper-util`/`quinn`/`quinn-udp` onto the existing `0.5.10` copy. All three crates declare `socket2 = ">=0.5, <0.7"`, explicitly supporting both majors — this outcome is blessed by upstream. Tested: neither `cargo update -p tokio --precise 1.51.1` nor adding a direct `socket2 = "0.6"` workspace dep prevents the shuffle. The only way to collapse to a single `socket2` major is upgrading `hyper` past its `0.5` pin, which belongs in the upcoming axum/tower/hyper stack upgrade.

## How did you test this code?

- `cargo build --workspace` — clean build
- `cargo clippy --workspace --all-targets -- -D warnings` — passes with no new lints
- `cargo fmt --check` — clean
- `cargo test -p feature-flags --lib` — 1119 unit tests pass. The 12 failing tests are pre-existing infrastructure failures (missing GeoIP database file; tests requiring a running Postgres) and are not regressions — verified by running the same tests on the baseline (same failures, with variance from flaky parallel tests).
- Manually tested the feature-flags service locally.

## Publish to changelog?

no — internal dependency upgrade, not user-facing.