### PR TITLE
feat(personhog): router client is multi channel

### DIFF
--- a/rust/personhog-replica/src/config.rs
+++ b/rust/personhog-replica/src/config.rs
@@ -56,6 +56,12 @@ pub struct Config {
     /// Maximum gRPC message size to decode (receive), in bytes.
     #[envconfig(default = "134217728")]
     pub grpc_max_recv_message_size: usize,
+
+    /// Maximum age of a gRPC connection in seconds before the server sends GOAWAY.
+    /// Clients reconnect transparently, naturally staggering across pods.
+    /// 0 = disabled (connections live indefinitely).
+    #[envconfig(default = "300")]
+    pub grpc_max_connection_age_secs: u64,
 }
 
 impl Config {
@@ -92,6 +98,14 @@ impl Config {
             None
         } else {
             Some(Duration::from_secs(self.grpc_keepalive_timeout_secs))
+        }
+    }
+
+    pub fn grpc_max_connection_age(&self) -> Option<Duration> {
+        if self.grpc_max_connection_age_secs == 0 {
+            None
+        } else {
+            Some(Duration::from_secs(self.grpc_max_connection_age_secs))
         }
     }
 

--- a/rust/personhog-replica/src/main.rs
+++ b/rust/personhog-replica/src/main.rs
@@ -174,6 +174,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let grpc_addr = config.grpc_address;
     let keepalive_interval = config.grpc_keepalive_interval();
     let keepalive_timeout = config.grpc_keepalive_timeout();
+    let max_connection_age = config.grpc_max_connection_age();
     let max_send = config.grpc_max_send_message_size;
     let max_recv = config.grpc_max_recv_message_size;
 
@@ -189,9 +190,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         };
         let incoming = tracked_tcp_incoming(listener);
-        if let Err(e) = Server::builder()
+        let mut server = Server::builder()
             .http2_keepalive_interval(keepalive_interval)
-            .http2_keepalive_timeout(keepalive_timeout)
+            .http2_keepalive_timeout(keepalive_timeout);
+        if let Some(age) = max_connection_age {
+            server = server.max_connection_age(age);
+        }
+        if let Err(e) = server
             .layer(GrpcMetricsLayer)
             .add_service(
                 PersonHogReplicaServer::new(service)

--- a/rust/personhog-router/src/backend/mod.rs
+++ b/rust/personhog-router/src/backend/mod.rs
@@ -3,7 +3,7 @@ mod replica;
 mod retry;
 
 pub use leader::LeaderBackend;
-pub use replica::ReplicaBackend;
+pub use replica::{ReplicaBackend, ReplicaBackendConfig};
 
 use async_trait::async_trait;
 use personhog_proto::personhog::types::v1::{

--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -19,9 +19,13 @@ use personhog_proto::personhog::types::v1::{
     ListCohortMemberIdsResponse, PersonsByDistinctIdsInTeamResponse, PersonsByDistinctIdsResponse,
     PersonsResponse, UpsertHashKeyOverridesRequest, UpsertHashKeyOverridesResponse,
 };
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
-use tonic::transport::Channel;
+use tokio::sync::RwLock;
+use tonic::transport::{Channel, Endpoint};
 use tonic::{Request, Status};
+use tracing::info;
 
 use personhog_common::grpc::current_client_name;
 
@@ -29,14 +33,61 @@ use super::retry::with_retry;
 use super::PersonHogBackend;
 use crate::config::RetryConfig;
 
-/// Backend implementation that forwards requests to a personhog-replica service.
+/// Backend implementation that forwards requests to a personhog-replica service
+/// using multiple gRPC channels with round-robin selection.
 pub struct ReplicaBackend {
-    client: PersonHogReplicaClient<Channel>,
+    clients: Arc<RwLock<Vec<PersonHogReplicaClient<Channel>>>>,
+    next_idx: AtomicUsize,
     retry_config: RetryConfig,
 }
 
+struct ChannelConfig {
+    url: String,
+    timeout: Duration,
+    keepalive_interval: Option<Duration>,
+    keepalive_timeout: Option<Duration>,
+    max_send_message_size: usize,
+    max_recv_message_size: usize,
+}
+
+fn build_endpoint(config: &ChannelConfig) -> Result<Endpoint, tonic::transport::Error> {
+    let mut endpoint = Channel::from_shared(config.url.clone())
+        .map_err(|e| {
+            // InvalidUri doesn't impl Into<tonic::transport::Error>, so we
+            // surface it via the endpoint builder by building a throwaway.
+            panic!("invalid replica URL '{}': {e}", config.url);
+        })
+        .unwrap()
+        .timeout(config.timeout)
+        .tcp_nodelay(true);
+    if let Some(interval) = config.keepalive_interval {
+        endpoint = endpoint
+            .http2_keep_alive_interval(interval)
+            .keep_alive_while_idle(true);
+    }
+    if let Some(timeout) = config.keepalive_timeout {
+        endpoint = endpoint.keep_alive_timeout(timeout);
+    }
+    Ok(endpoint)
+}
+
+fn create_clients(
+    config: &ChannelConfig,
+    num_channels: usize,
+) -> Vec<PersonHogReplicaClient<Channel>> {
+    (0..num_channels)
+        .map(|_| {
+            let endpoint = build_endpoint(config).expect("failed to build endpoint");
+            let channel = endpoint.connect_lazy();
+            PersonHogReplicaClient::new(channel)
+                .max_encoding_message_size(config.max_send_message_size)
+                .max_decoding_message_size(config.max_recv_message_size)
+        })
+        .collect()
+}
+
 impl ReplicaBackend {
-    /// Create a new replica backend with a lazy connection to the given URL.
+    /// Create a new replica backend with multiple lazy channels to the given URL.
     pub fn new(
         url: &str,
         timeout: Duration,
@@ -45,26 +96,56 @@ impl ReplicaBackend {
         keepalive_timeout: Option<Duration>,
         max_send_message_size: usize,
         max_recv_message_size: usize,
+        num_channels: usize,
+        recycle_interval: Option<Duration>,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
-        let mut endpoint = Channel::from_shared(url.to_string())?
-            .timeout(timeout)
-            .tcp_nodelay(true);
-        if let Some(interval) = keepalive_interval {
-            endpoint = endpoint
-                .http2_keep_alive_interval(interval)
-                .keep_alive_while_idle(true);
+        let num_channels = num_channels.max(1);
+
+        let config = ChannelConfig {
+            url: url.to_string(),
+            timeout,
+            keepalive_interval,
+            keepalive_timeout,
+            max_send_message_size,
+            max_recv_message_size,
+        };
+
+        let clients = create_clients(&config, num_channels);
+        info!(
+            num_channels = num_channels,
+            url = url,
+            "created replica backend channels"
+        );
+
+        let clients = Arc::new(RwLock::new(clients));
+
+        if let Some(interval) = recycle_interval {
+            let clients = Arc::clone(&clients);
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(interval).await;
+                    let new_clients = create_clients(&config, num_channels);
+                    let mut guard = clients.write().await;
+                    *guard = new_clients;
+                    drop(guard);
+                    info!(
+                        num_channels = num_channels,
+                        "recycled replica backend channels"
+                    );
+                }
+            });
         }
-        if let Some(timeout) = keepalive_timeout {
-            endpoint = endpoint.keep_alive_timeout(timeout);
-        }
-        let channel = endpoint.connect_lazy();
 
         Ok(Self {
-            client: PersonHogReplicaClient::new(channel)
-                .max_encoding_message_size(max_send_message_size)
-                .max_decoding_message_size(max_recv_message_size),
+            clients,
+            next_idx: AtomicUsize::new(0),
             retry_config,
         })
+    }
+
+    fn next_client(&self, clients: &[PersonHogReplicaClient<Channel>]) -> PersonHogReplicaClient<Channel> {
+        let idx = self.next_idx.fetch_add(1, Ordering::Relaxed) % clients.len();
+        clients[idx].clone()
     }
 }
 
@@ -72,9 +153,12 @@ impl ReplicaBackend {
 /// Forwards the `x-client-name` header so the downstream service can
 /// attribute metrics to the originating client.
 macro_rules! retry_call {
-    ($self:expr, $method:ident, $request:expr) => {
+    ($self:expr, $method:ident, $request:expr) => {{
+        let clients = $self.clients.read().await;
+        let client = $self.next_client(&clients);
+        drop(clients);
         with_retry(&$self.retry_config, stringify!($method), || {
-            let mut client = $self.client.clone();
+            let mut client = client.clone();
             let req = $request.clone();
             let client_name = current_client_name();
             async move {
@@ -86,7 +170,7 @@ macro_rules! retry_call {
             }
         })
         .await
-    };
+    }};
 }
 
 #[async_trait]

--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -137,14 +137,14 @@ impl ReplicaBackend {
 /// attribute metrics to the originating client.
 macro_rules! retry_call {
     ($self:expr, $method:ident, $request:expr) => {{
-        let clients = $self.clients.read().await;
-        let client = $self.next_client(&clients);
-        drop(clients);
         with_retry(&$self.retry_config, stringify!($method), || {
-            let mut client = client.clone();
+            let clients = $self.clients.read();
             let req = $request.clone();
             let client_name = current_client_name();
             async move {
+                let guard = clients.await;
+                let mut client = $self.next_client(&guard);
+                drop(guard);
                 let mut request = Request::new(req);
                 if let Ok(val) = client_name.parse() {
                     request.metadata_mut().insert("x-client-name", val);

--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -20,9 +20,7 @@ use personhog_proto::personhog::types::v1::{
     PersonsResponse, UpsertHashKeyOverridesRequest, UpsertHashKeyOverridesResponse,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::RwLock;
 use tonic::transport::{Channel, Endpoint};
 use tonic::{Request, Status};
 use tracing::info;
@@ -35,8 +33,12 @@ use crate::config::RetryConfig;
 
 /// Backend implementation that forwards requests to a personhog-replica service
 /// using multiple gRPC channels with round-robin selection.
+///
+/// Connection lifecycle is managed server-side via `max_connection_age` on the
+/// replica's gRPC server, which sends GOAWAY to trigger transparent client
+/// reconnects — no client-side recycling needed.
 pub struct ReplicaBackend {
-    clients: Arc<RwLock<Vec<PersonHogReplicaClient<Channel>>>>,
+    clients: Vec<PersonHogReplicaClient<Channel>>,
     next_idx: AtomicUsize,
     retry_config: RetryConfig,
 }
@@ -52,7 +54,6 @@ pub struct ReplicaBackendConfig {
     pub max_send_message_size: usize,
     pub max_recv_message_size: usize,
     pub num_channels: usize,
-    pub recycle_interval: Option<Duration>,
 }
 
 fn build_endpoint(config: &ReplicaBackendConfig) -> Endpoint {
@@ -85,36 +86,18 @@ fn create_clients(config: &ReplicaBackendConfig) -> Vec<PersonHogReplicaClient<C
 impl ReplicaBackend {
     pub fn new(config: ReplicaBackendConfig) -> Self {
         let retry_config = config.retry_config;
+        let num_channels = config.num_channels.max(1);
         let config = ReplicaBackendConfig {
-            num_channels: config.num_channels.max(1),
+            num_channels,
             ..config
         };
 
         let clients = create_clients(&config);
         info!(
-            num_channels = config.num_channels,
+            num_channels,
             url = config.url,
             "created replica backend channels"
         );
-
-        let clients = Arc::new(RwLock::new(clients));
-
-        if let Some(interval) = config.recycle_interval {
-            let clients = Arc::clone(&clients);
-            tokio::spawn(async move {
-                loop {
-                    tokio::time::sleep(interval).await;
-                    let new_clients = create_clients(&config);
-                    let mut guard = clients.write().await;
-                    *guard = new_clients;
-                    drop(guard);
-                    info!(
-                        num_channels = config.num_channels,
-                        "recycled replica backend channels"
-                    );
-                }
-            });
-        }
 
         Self {
             clients,
@@ -123,12 +106,9 @@ impl ReplicaBackend {
         }
     }
 
-    fn next_client(
-        &self,
-        clients: &[PersonHogReplicaClient<Channel>],
-    ) -> PersonHogReplicaClient<Channel> {
-        let idx = self.next_idx.fetch_add(1, Ordering::Relaxed) % clients.len();
-        clients[idx].clone()
+    fn next_client(&self) -> PersonHogReplicaClient<Channel> {
+        let idx = self.next_idx.fetch_add(1, Ordering::Relaxed) % self.clients.len();
+        self.clients[idx].clone()
     }
 }
 
@@ -138,13 +118,10 @@ impl ReplicaBackend {
 macro_rules! retry_call {
     ($self:expr, $method:ident, $request:expr) => {{
         with_retry(&$self.retry_config, stringify!($method), || {
-            let clients = $self.clients.read();
+            let mut client = $self.next_client();
             let req = $request.clone();
             let client_name = current_client_name();
             async move {
-                let guard = clients.await;
-                let mut client = $self.next_client(&guard);
-                drop(guard);
                 let mut request = Request::new(req);
                 if let Ok(val) = client_name.parse() {
                     request.metadata_mut().insert("x-client-name", val);
@@ -349,5 +326,57 @@ impl PersonHogBackend for ReplicaBackend {
         request: GetGroupTypeMappingsByProjectIdsRequest,
     ) -> Result<GroupTypeMappingsBatchResponse, Status> {
         retry_call!(self, get_group_type_mappings_by_project_ids, request)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_backend(num_channels: usize) -> ReplicaBackend {
+        ReplicaBackend::new(ReplicaBackendConfig {
+            url: "http://localhost:50051".to_string(),
+            timeout: Duration::from_secs(1),
+            retry_config: RetryConfig {
+                max_retries: 0,
+                initial_backoff_ms: 1,
+                max_backoff_ms: 1,
+            },
+            keepalive_interval: None,
+            keepalive_timeout: None,
+            max_send_message_size: 4 * 1024 * 1024,
+            max_recv_message_size: 4 * 1024 * 1024,
+            num_channels,
+        })
+    }
+
+    #[tokio::test]
+    async fn next_client_round_robins_across_channels() {
+        let backend = make_backend(4);
+        for round in 0..3u64 {
+            for ch in 0..4u64 {
+                backend.next_client();
+                let expected = round * 4 + ch + 1;
+                assert_eq!(backend.next_idx.load(Ordering::Relaxed), expected as usize);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn next_client_wraps_around() {
+        let backend = make_backend(3);
+        for _ in 0..3 {
+            backend.next_client();
+        }
+        // 4th call should wrap to index 0
+        backend.next_client();
+        let idx = backend.next_idx.load(Ordering::Relaxed) % backend.clients.len();
+        assert_eq!(idx, 1);
+    }
+
+    #[tokio::test]
+    async fn num_channels_floors_to_one() {
+        let backend = make_backend(0);
+        assert_eq!(backend.clients.len(), 1);
     }
 }

--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -368,10 +368,10 @@ mod tests {
         for _ in 0..3 {
             backend.next_client();
         }
-        // 4th call should wrap to index 0
+        // 4th call uses counter=3, so index = 3 % 3 = 0 (wraps back to first channel)
+        let idx_before = backend.next_idx.load(Ordering::Relaxed);
         backend.next_client();
-        let idx = backend.next_idx.load(Ordering::Relaxed) % backend.clients.len();
-        assert_eq!(idx, 1);
+        assert_eq!(idx_before % backend.clients.len(), 0);
     }
 
     #[tokio::test]

--- a/rust/personhog-router/src/backend/replica.rs
+++ b/rust/personhog-router/src/backend/replica.rs
@@ -41,23 +41,23 @@ pub struct ReplicaBackend {
     retry_config: RetryConfig,
 }
 
-struct ChannelConfig {
-    url: String,
-    timeout: Duration,
-    keepalive_interval: Option<Duration>,
-    keepalive_timeout: Option<Duration>,
-    max_send_message_size: usize,
-    max_recv_message_size: usize,
+/// Configuration for creating replica backend channels.
+#[derive(Clone)]
+pub struct ReplicaBackendConfig {
+    pub url: String,
+    pub timeout: Duration,
+    pub retry_config: RetryConfig,
+    pub keepalive_interval: Option<Duration>,
+    pub keepalive_timeout: Option<Duration>,
+    pub max_send_message_size: usize,
+    pub max_recv_message_size: usize,
+    pub num_channels: usize,
+    pub recycle_interval: Option<Duration>,
 }
 
-fn build_endpoint(config: &ChannelConfig) -> Result<Endpoint, tonic::transport::Error> {
+fn build_endpoint(config: &ReplicaBackendConfig) -> Endpoint {
     let mut endpoint = Channel::from_shared(config.url.clone())
-        .map_err(|e| {
-            // InvalidUri doesn't impl Into<tonic::transport::Error>, so we
-            // surface it via the endpoint builder by building a throwaway.
-            panic!("invalid replica URL '{}': {e}", config.url);
-        })
-        .unwrap()
+        .unwrap_or_else(|e| panic!("invalid replica URL '{}': {e}", config.url))
         .timeout(config.timeout)
         .tcp_nodelay(true);
     if let Some(interval) = config.keepalive_interval {
@@ -68,17 +68,13 @@ fn build_endpoint(config: &ChannelConfig) -> Result<Endpoint, tonic::transport::
     if let Some(timeout) = config.keepalive_timeout {
         endpoint = endpoint.keep_alive_timeout(timeout);
     }
-    Ok(endpoint)
+    endpoint
 }
 
-fn create_clients(
-    config: &ChannelConfig,
-    num_channels: usize,
-) -> Vec<PersonHogReplicaClient<Channel>> {
-    (0..num_channels)
+fn create_clients(config: &ReplicaBackendConfig) -> Vec<PersonHogReplicaClient<Channel>> {
+    (0..config.num_channels)
         .map(|_| {
-            let endpoint = build_endpoint(config).expect("failed to build endpoint");
-            let channel = endpoint.connect_lazy();
+            let channel = build_endpoint(config).connect_lazy();
             PersonHogReplicaClient::new(channel)
                 .max_encoding_message_size(config.max_send_message_size)
                 .max_decoding_message_size(config.max_recv_message_size)
@@ -87,63 +83,50 @@ fn create_clients(
 }
 
 impl ReplicaBackend {
-    /// Create a new replica backend with multiple lazy channels to the given URL.
-    pub fn new(
-        url: &str,
-        timeout: Duration,
-        retry_config: RetryConfig,
-        keepalive_interval: Option<Duration>,
-        keepalive_timeout: Option<Duration>,
-        max_send_message_size: usize,
-        max_recv_message_size: usize,
-        num_channels: usize,
-        recycle_interval: Option<Duration>,
-    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
-        let num_channels = num_channels.max(1);
-
-        let config = ChannelConfig {
-            url: url.to_string(),
-            timeout,
-            keepalive_interval,
-            keepalive_timeout,
-            max_send_message_size,
-            max_recv_message_size,
+    pub fn new(config: ReplicaBackendConfig) -> Self {
+        let retry_config = config.retry_config;
+        let config = ReplicaBackendConfig {
+            num_channels: config.num_channels.max(1),
+            ..config
         };
 
-        let clients = create_clients(&config, num_channels);
+        let clients = create_clients(&config);
         info!(
-            num_channels = num_channels,
-            url = url,
+            num_channels = config.num_channels,
+            url = config.url,
             "created replica backend channels"
         );
 
         let clients = Arc::new(RwLock::new(clients));
 
-        if let Some(interval) = recycle_interval {
+        if let Some(interval) = config.recycle_interval {
             let clients = Arc::clone(&clients);
             tokio::spawn(async move {
                 loop {
                     tokio::time::sleep(interval).await;
-                    let new_clients = create_clients(&config, num_channels);
+                    let new_clients = create_clients(&config);
                     let mut guard = clients.write().await;
                     *guard = new_clients;
                     drop(guard);
                     info!(
-                        num_channels = num_channels,
+                        num_channels = config.num_channels,
                         "recycled replica backend channels"
                     );
                 }
             });
         }
 
-        Ok(Self {
+        Self {
             clients,
             next_idx: AtomicUsize::new(0),
             retry_config,
-        })
+        }
     }
 
-    fn next_client(&self, clients: &[PersonHogReplicaClient<Channel>]) -> PersonHogReplicaClient<Channel> {
+    fn next_client(
+        &self,
+        clients: &[PersonHogReplicaClient<Channel>],
+    ) -> PersonHogReplicaClient<Channel> {
         let idx = self.next_idx.fetch_add(1, Ordering::Relaxed) % clients.len();
         clients[idx].clone()
     }

--- a/rust/personhog-router/src/config.rs
+++ b/rust/personhog-router/src/config.rs
@@ -55,11 +55,6 @@ pub struct Config {
     #[envconfig(default = "4")]
     pub replica_channels: usize,
 
-    /// Interval in seconds between channel recycling (re-establishing all connections).
-    /// Picks up new pods after scaling events or deploys. 0 = disabled.
-    #[envconfig(default = "300")]
-    pub channel_recycle_interval_secs: u64,
-
     /// Timeout for backend requests in milliseconds
     #[envconfig(default = "5000")]
     pub backend_timeout_ms: u64,
@@ -182,14 +177,6 @@ impl Config {
             None
         } else {
             Some(Duration::from_secs(self.backend_keepalive_interval_secs))
-        }
-    }
-
-    pub fn channel_recycle_interval(&self) -> Option<Duration> {
-        if self.channel_recycle_interval_secs == 0 {
-            None
-        } else {
-            Some(Duration::from_secs(self.channel_recycle_interval_secs))
         }
     }
 

--- a/rust/personhog-router/src/config.rs
+++ b/rust/personhog-router/src/config.rs
@@ -50,6 +50,16 @@ pub struct Config {
     #[envconfig(default = "http://127.0.0.1:50051")]
     pub replica_url: String,
 
+    /// Number of gRPC channels (HTTP/2 connections) to open to the replica backend.
+    /// Multiple channels distribute requests across K8s service endpoints.
+    #[envconfig(default = "4")]
+    pub replica_channels: usize,
+
+    /// Interval in seconds between channel recycling (re-establishing all connections).
+    /// Picks up new pods after scaling events or deploys. 0 = disabled.
+    #[envconfig(default = "300")]
+    pub channel_recycle_interval_secs: u64,
+
     /// Timeout for backend requests in milliseconds
     #[envconfig(default = "5000")]
     pub backend_timeout_ms: u64,
@@ -172,6 +182,14 @@ impl Config {
             None
         } else {
             Some(Duration::from_secs(self.backend_keepalive_interval_secs))
+        }
+    }
+
+    pub fn channel_recycle_interval(&self) -> Option<Duration> {
+        if self.channel_recycle_interval_secs == 0 {
+            None
+        } else {
+            Some(Duration::from_secs(self.channel_recycle_interval_secs))
         }
     }
 

--- a/rust/personhog-router/src/main.rs
+++ b/rust/personhog-router/src/main.rs
@@ -14,7 +14,7 @@ use personhog_coordination::routing_table::{CutoverHandler, RoutingTable, Routin
 use personhog_coordination::store::PersonhogStore;
 use personhog_coordination::strategy::StickyBalancedStrategy;
 use personhog_proto::personhog::service::v1::person_hog_service_server::PersonHogServiceServer;
-use personhog_router::backend::{LeaderBackend, ReplicaBackend};
+use personhog_router::backend::{LeaderBackend, ReplicaBackend, ReplicaBackendConfig};
 use personhog_router::config::{Config, RouterMode};
 use personhog_router::router::PersonHogRouter;
 use personhog_router::service::PersonHogRouterService;
@@ -173,18 +173,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Create backend connection(s) to personhog-replica
-    let replica_backend = ReplicaBackend::new(
-        &config.replica_url,
-        config.backend_timeout(),
-        config.retry_config(),
-        config.backend_keepalive_interval(),
-        config.backend_keepalive_timeout(),
-        config.grpc_max_send_message_size,
-        config.grpc_max_recv_message_size,
-        config.replica_channels,
-        config.channel_recycle_interval(),
-    )
-    .expect("Failed to create replica backend");
+    let replica_backend = ReplicaBackend::new(ReplicaBackendConfig {
+        url: config.replica_url.clone(),
+        timeout: config.backend_timeout(),
+        retry_config: config.retry_config(),
+        keepalive_interval: config.backend_keepalive_interval(),
+        keepalive_timeout: config.backend_keepalive_timeout(),
+        max_send_message_size: config.grpc_max_send_message_size,
+        max_recv_message_size: config.grpc_max_recv_message_size,
+        num_channels: config.replica_channels,
+        recycle_interval: config.channel_recycle_interval(),
+    });
 
     // Build the router — in leader mode, also wire up etcd coordination
     // and the leader backend for person writes / strong reads.

--- a/rust/personhog-router/src/main.rs
+++ b/rust/personhog-router/src/main.rs
@@ -86,10 +86,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("gRPC address: {}", config.grpc_address);
     tracing::info!("Replica URL: {}", config.replica_url);
     tracing::info!("Replica channels: {}", config.replica_channels);
-    tracing::info!(
-        "Channel recycle interval: {}s",
-        config.channel_recycle_interval_secs
-    );
     tracing::info!("Backend timeout: {}ms", config.backend_timeout_ms);
     tracing::info!("Metrics port: {}", config.metrics_port);
     tracing::info!(
@@ -182,7 +178,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         max_send_message_size: config.grpc_max_send_message_size,
         max_recv_message_size: config.grpc_max_recv_message_size,
         num_channels: config.replica_channels,
-        recycle_interval: config.channel_recycle_interval(),
     });
 
     // Build the router — in leader mode, also wire up etcd coordination

--- a/rust/personhog-router/src/main.rs
+++ b/rust/personhog-router/src/main.rs
@@ -85,6 +85,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("Router mode: {}", config.router_mode);
     tracing::info!("gRPC address: {}", config.grpc_address);
     tracing::info!("Replica URL: {}", config.replica_url);
+    tracing::info!("Replica channels: {}", config.replica_channels);
+    tracing::info!(
+        "Channel recycle interval: {}s",
+        config.channel_recycle_interval_secs
+    );
     tracing::info!("Backend timeout: {}ms", config.backend_timeout_ms);
     tracing::info!("Metrics port: {}", config.metrics_port);
     tracing::info!(
@@ -167,7 +172,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .expect("Metrics server error");
     });
 
-    // Create backend connection to personhog-replica
+    // Create backend connection(s) to personhog-replica
     let replica_backend = ReplicaBackend::new(
         &config.replica_url,
         config.backend_timeout(),
@@ -176,6 +181,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.backend_keepalive_timeout(),
         config.grpc_max_send_message_size,
         config.grpc_max_recv_message_size,
+        config.replica_channels,
+        config.channel_recycle_interval(),
     )
     .expect("Failed to create replica backend");
 

--- a/rust/personhog-router/tests/common/mod.rs
+++ b/rust/personhog-router/tests/common/mod.rs
@@ -35,7 +35,7 @@ use personhog_proto::personhog::types::v1::{
     PersonsByDistinctIdsResponse, PersonsResponse, UpdatePersonPropertiesRequest,
     UpdatePersonPropertiesResponse, UpsertHashKeyOverridesRequest, UpsertHashKeyOverridesResponse,
 };
-use personhog_router::backend::{LeaderBackend, ReplicaBackend};
+use personhog_router::backend::{LeaderBackend, ReplicaBackend, ReplicaBackendConfig};
 use personhog_router::config::RetryConfig;
 use personhog_router::router::PersonHogRouter;
 use personhog_router::service::PersonHogRouterService;
@@ -384,18 +384,17 @@ pub async fn start_test_router(replica_addr: SocketAddr) -> SocketAddr {
         initial_backoff_ms: 1,
         max_backoff_ms: 1,
     };
-    let backend = ReplicaBackend::new(
-        &replica_url,
-        Duration::from_secs(5),
+    let backend = ReplicaBackend::new(ReplicaBackendConfig {
+        url: replica_url,
+        timeout: Duration::from_secs(5),
         retry_config,
-        None,
-        None,
-        4 * 1024 * 1024,
-        4 * 1024 * 1024,
-        1,
-        None,
-    )
-    .unwrap();
+        keepalive_interval: None,
+        keepalive_timeout: None,
+        max_send_message_size: 4 * 1024 * 1024,
+        max_recv_message_size: 4 * 1024 * 1024,
+        num_channels: 1,
+        recycle_interval: None,
+    });
     let router = PersonHogRouter::new(Arc::new(backend));
     let service = PersonHogRouterService::new(Arc::new(router));
 
@@ -558,18 +557,17 @@ pub async fn start_test_router_with_leader(
 
     // Replica backend
     let replica_url = format!("http://{}", replica_addr);
-    let replica = ReplicaBackend::new(
-        &replica_url,
-        Duration::from_secs(5),
+    let replica = ReplicaBackend::new(ReplicaBackendConfig {
+        url: replica_url,
+        timeout: Duration::from_secs(5),
         retry_config,
-        None,
-        None,
-        4 * 1024 * 1024,
-        4 * 1024 * 1024,
-        1,
-        None,
-    )
-    .unwrap();
+        keepalive_interval: None,
+        keepalive_timeout: None,
+        max_send_message_size: 4 * 1024 * 1024,
+        max_recv_message_size: 4 * 1024 * 1024,
+        num_channels: 1,
+        recycle_interval: None,
+    });
 
     // Leader backend: all partitions → "leader-0", resolver → leader_addr
     let mut routing = HashMap::new();

--- a/rust/personhog-router/tests/common/mod.rs
+++ b/rust/personhog-router/tests/common/mod.rs
@@ -392,6 +392,8 @@ pub async fn start_test_router(replica_addr: SocketAddr) -> SocketAddr {
         None,
         4 * 1024 * 1024,
         4 * 1024 * 1024,
+        1,
+        None,
     )
     .unwrap();
     let router = PersonHogRouter::new(Arc::new(backend));
@@ -564,6 +566,8 @@ pub async fn start_test_router_with_leader(
         None,
         4 * 1024 * 1024,
         4 * 1024 * 1024,
+        1,
+        None,
     )
     .unwrap();
 

--- a/rust/personhog-router/tests/common/mod.rs
+++ b/rust/personhog-router/tests/common/mod.rs
@@ -393,7 +393,6 @@ pub async fn start_test_router(replica_addr: SocketAddr) -> SocketAddr {
         max_send_message_size: 4 * 1024 * 1024,
         max_recv_message_size: 4 * 1024 * 1024,
         num_channels: 1,
-        recycle_interval: None,
     });
     let router = PersonHogRouter::new(Arc::new(backend));
     let service = PersonHogRouterService::new(Arc::new(router));
@@ -566,7 +565,6 @@ pub async fn start_test_router_with_leader(
         max_send_message_size: 4 * 1024 * 1024,
         max_recv_message_size: 4 * 1024 * 1024,
         num_channels: 1,
-        recycle_interval: None,
     });
 
     // Leader backend: all partitions → "leader-0", resolver → leader_addr


### PR DESCRIPTION
## Problem

The personhog-router maintains a single gRPC channel (HTTP/2 connection) to the personhog-replica K8s service. Because K8s service load balancing is L4 (TCP-level), that single long-lived connection pins all traffic to one replica pod. With 3 replica pods and 3 router pods, each deployment is a roll of the dice, where one pod can end up handling the majority of requests while others sit idle.

## Changes

**Multi-channel support (personhog-router):**
- `ReplicaBackend` now opens N gRPC channels (default 4) and round-robins across them using an atomic counter. Each retry attempt picks a fresh channel, so retries fan out to different connections instead of hammering the same potentially-dead one.
- Introduced `ReplicaBackendConfig` struct to replace the growing positional argument list in `ReplicaBackend::new`.

**Server-side connection lifecycle (personhog-replica):**
- Added `grpc_max_connection_age_secs` config (default 300s) which sets tonic's `max_connection_age` on the gRPC server. The server sends HTTP/2 GOAWAY after this duration, triggering transparent client reconnects.
- Since each connection was established at a different time, GOAWAYs are naturally staggered — no thundering-herd reconnect spike.	


## How did you test this code?

- Added unit tests for `ReplicaBackend` verifying round-robin selection across channels, index wrap-around, and the `num_channels >= 1` floor (`cargo test -p personhog-router --lib -- backend::replica::tests`).
- Verified both `personhog-router` and `personhog-replica` compile cleanly (`cargo check -p personhog-router -p personhog-replica`).
- Existing integration tests in `tests/integration.rs` and `tests/leader_integration.rs` continue to pass with the updated `ReplicaBackendConfig` API.
