### PR TITLE
refactor(flags): tighten scheduled change update validation

### DIFF
--- a/posthog/api/scheduled_change.py
+++ b/posthog/api/scheduled_change.py
@@ -70,7 +70,15 @@ class ScheduledChangeSerializer(serializers.ModelSerializer):
             "last_executed_at",
             "end_date",
         ]
-        read_only_fields = ["id", "created_at", "created_by", "updated_at", "last_executed_at"]
+        read_only_fields = [
+            "id",
+            "created_at",
+            "created_by",
+            "updated_at",
+            "last_executed_at",
+            "executed_at",
+            "failure_reason",
+        ]
 
     def get_failure_reason(self, obj: ScheduledChange) -> str | None:
         """Return the safely formatted failure reason instead of raw data."""
@@ -91,6 +99,11 @@ class ScheduledChangeSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(
                     {"model_name": "Cannot change the model type of an existing scheduled change."}
                 )
+
+            # A completed one-time schedule is immutable. Recurring schedules legitimately carry
+            # executed_at=NULL while active, so this guard only trips for one-time completions.
+            if instance.executed_at is not None and not instance.is_recurring:
+                raise serializers.ValidationError("Cannot modify a scheduled change that has already executed.")
 
         # For updates, merge with existing instance values
         is_recurring = data.get("is_recurring", getattr(instance, "is_recurring", False) if instance else False)
@@ -168,30 +181,38 @@ class ScheduledChangeSerializer(serializers.ModelSerializer):
 
         return data
 
+    def _check_target_edit_permission(self, model_name: str | None, record_id: Any, team_id: int) -> None:
+        """Raise ValidationError unless the request user can edit the target record."""
+        if model_name != "FeatureFlag" or not record_id:
+            return
+
+        from posthog.models import FeatureFlag
+
+        try:
+            feature_flag = FeatureFlag.objects.get(id=record_id, team_id=team_id)
+        except FeatureFlag.DoesNotExist:
+            raise serializers.ValidationError("Feature flag not found")
+
+        request = self.context["request"]
+        if not CanEditFeatureFlag().has_object_permission(request, None, feature_flag):
+            raise serializers.ValidationError("You don't have edit permissions for this feature flag")
+
     def create(self, validated_data: dict, *args: Any, **kwargs: Any) -> ScheduledChange:
         request = self.context["request"]
         validated_data["created_by"] = request.user
         validated_data["team_id"] = self.context["team_id"]
 
-        # Check permissions for feature flag changes
-        if validated_data.get("model_name") == "FeatureFlag":
-            record_id = validated_data.get("record_id")
-            if record_id:
-                # Get the feature flag to check permissions
-                from posthog.models import FeatureFlag
-
-                try:
-                    feature_flag = FeatureFlag.objects.get(id=record_id, team_id=validated_data["team_id"])
-
-                    # Use the permission class to check if user can edit this feature flag
-                    permission_check = CanEditFeatureFlag()
-                    if not permission_check.has_object_permission(request, None, feature_flag):
-                        raise serializers.ValidationError("You don't have edit permissions for this feature flag")
-
-                except FeatureFlag.DoesNotExist:
-                    raise serializers.ValidationError("Feature flag not found")
+        self._check_target_edit_permission(
+            validated_data.get("model_name"), validated_data.get("record_id"), validated_data["team_id"]
+        )
 
         return super().create(validated_data)
+
+    def update(self, instance: ScheduledChange, validated_data: dict) -> ScheduledChange:
+        # Enforce the same edit-permission check on updates. record_id/model_name can't be changed
+        # (blocked in validate()), so the instance's existing target is authoritative.
+        self._check_target_edit_permission(instance.model_name, instance.record_id, instance.team_id)
+        return super().update(instance, validated_data)
 
 
 @extend_schema(tags=["feature_flags"])

--- a/posthog/api/scheduled_change.py
+++ b/posthog/api/scheduled_change.py
@@ -77,7 +77,6 @@ class ScheduledChangeSerializer(serializers.ModelSerializer):
             "updated_at",
             "last_executed_at",
             "executed_at",
-            "failure_reason",
         ]
 
     def get_failure_reason(self, obj: ScheduledChange) -> str | None:

--- a/posthog/api/test/test_scheduled_change.py
+++ b/posthog/api/test/test_scheduled_change.py
@@ -570,8 +570,10 @@ class TestScheduledChange(APIBaseTest):
                 data=patch_body,
             )
 
-        # Read-only fields may be silently dropped (200); validate() rejects the rest (400).
-        # The invariant is that state is unchanged either way.
+        # validate() rejects all mutations of a completed one-time schedule.
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert "already executed" in str(response.json())
+
         scheduled_change.refresh_from_db()
         assert scheduled_change.executed_at == original_executed_at, (
             f"executed_at changed to {scheduled_change.executed_at} (status={response.status_code})"

--- a/posthog/api/test/test_scheduled_change.py
+++ b/posthog/api/test/test_scheduled_change.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
@@ -485,12 +487,98 @@ class TestScheduledChange(APIBaseTest):
             created_by=self.user,
         )
 
-        response = self.client.patch(
-            f"/api/projects/{self.team.id}/scheduled_changes/{scheduled_change.id}/",
-            data={"payload": {"operation": "update_status", "value": True}},
-        )
+        with patch("posthog.api.scheduled_change.CanEditFeatureFlag.has_object_permission", return_value=True):
+            response = self.client.patch(
+                f"/api/projects/{self.team.id}/scheduled_changes/{scheduled_change.id}/",
+                data={"payload": {"operation": "update_status", "value": True}},
+            )
 
         assert response.status_code == status.HTTP_200_OK, response.json()
 
         scheduled_change.refresh_from_db()
         assert scheduled_change.payload == {"operation": "update_status", "value": True}
+
+    @parameterized.expand(
+        [
+            ("denied_without_permission", False, status.HTTP_400_BAD_REQUEST, "You don't have edit permissions", False),
+            ("allowed_with_permission", True, status.HTTP_200_OK, None, True),
+        ]
+    )
+    def test_patch_respects_feature_flag_edit_permission(
+        self, _name, has_permission, expected_status, expected_error_fragment, payload_should_change
+    ):
+        """PATCH must enforce CanEditFeatureFlag, matching the create-time check."""
+        feature_flag = FeatureFlag.objects.create(
+            team=self.team, created_by=self.user, key=f"perm-flag-{_name}", name="Perm Flag"
+        )
+
+        original_payload = {"operation": "update_status", "value": False}
+        scheduled_change = ScheduledChange.objects.create(
+            team=self.team,
+            record_id=feature_flag.id,
+            model_name="FeatureFlag",
+            payload=original_payload,
+            scheduled_at="2024-01-15T09:00:00Z",
+            created_by=self.user,
+        )
+
+        new_payload = {"operation": "update_status", "value": True}
+        with patch(
+            "posthog.api.scheduled_change.CanEditFeatureFlag.has_object_permission", return_value=has_permission
+        ):
+            response = self.client.patch(
+                f"/api/projects/{self.team.id}/scheduled_changes/{scheduled_change.id}/",
+                data={"payload": new_payload},
+            )
+
+        assert response.status_code == expected_status, response.json()
+        if expected_error_fragment:
+            assert expected_error_fragment in str(response.json())
+
+        scheduled_change.refresh_from_db()
+        assert scheduled_change.payload == (new_payload if payload_should_change else original_payload)
+
+    @parameterized.expand(
+        [
+            ("reset_executed_at", {"executed_at": None}),
+            ("replace_payload", {"payload": {"operation": "update_status", "value": True}}),
+            ("reschedule", {"scheduled_at": "2030-01-15T09:00:00Z"}),
+        ]
+    )
+    def test_completed_one_time_scheduled_change_is_immutable(self, _name, patch_body):
+        """A one-time schedule that already executed cannot be mutated — blocks replay + privilege escalation."""
+        feature_flag = FeatureFlag.objects.create(
+            team=self.team, created_by=self.user, key=f"immutable-{_name}", name="Immutable Flag"
+        )
+
+        original_executed_at = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        original_payload = {"operation": "update_status", "value": False}
+        original_scheduled_at = datetime(2024, 1, 15, 9, 0, 0, tzinfo=UTC)
+        scheduled_change = ScheduledChange.objects.create(
+            team=self.team,
+            record_id=feature_flag.id,
+            model_name="FeatureFlag",
+            payload=original_payload,
+            scheduled_at=original_scheduled_at,
+            executed_at=original_executed_at,
+            created_by=self.user,
+        )
+
+        with patch("posthog.api.scheduled_change.CanEditFeatureFlag.has_object_permission", return_value=True):
+            response = self.client.patch(
+                f"/api/projects/{self.team.id}/scheduled_changes/{scheduled_change.id}/",
+                data=patch_body,
+            )
+
+        # Read-only fields may be silently dropped (200); validate() rejects the rest (400).
+        # The invariant is that state is unchanged either way.
+        scheduled_change.refresh_from_db()
+        assert scheduled_change.executed_at == original_executed_at, (
+            f"executed_at changed to {scheduled_change.executed_at} (status={response.status_code})"
+        )
+        assert scheduled_change.payload == original_payload, (
+            f"payload changed to {scheduled_change.payload} (status={response.status_code})"
+        )
+        assert scheduled_change.scheduled_at == original_scheduled_at, (
+            f"scheduled_at changed to {scheduled_change.scheduled_at} (status={response.status_code})"
+        )

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -988,7 +988,7 @@ export interface ScheduledChangeApi {
     /** ISO 8601 datetime when the change should be applied (e.g. '2025-06-01T14:00:00Z'). */
     scheduled_at: string
     /** @nullable */
-    executed_at?: string | null
+    readonly executed_at: string | null
     /**
      * Return the safely formatted failure reason instead of raw data.
      * @nullable
@@ -1046,7 +1046,7 @@ export interface PatchedScheduledChangeApi {
     /** ISO 8601 datetime when the change should be applied (e.g. '2025-06-01T14:00:00Z'). */
     scheduled_at?: string
     /** @nullable */
-    executed_at?: string | null
+    readonly executed_at?: string | null
     /**
      * Return the safely formatted failure reason instead of raw data.
      * @nullable

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -22755,7 +22755,7 @@ export namespace Schemas {
       /** ISO 8601 datetime when the change should be applied (e.g. '2025-06-01T14:00:00Z'). */
       scheduled_at: string;
       /** @nullable */
-      executed_at?: string | null;
+      readonly executed_at: string | null;
       /**
        * Return the safely formatted failure reason instead of raw data.
        * @nullable
@@ -27828,7 +27828,7 @@ export namespace Schemas {
       /** ISO 8601 datetime when the change should be applied (e.g. '2025-06-01T14:00:00Z'). */
       scheduled_at?: string;
       /** @nullable */
-      executed_at?: string | null;
+      readonly executed_at?: string | null;
       /**
        * Return the safely formatted failure reason instead of raw data.
        * @nullable


### PR DESCRIPTION
Lock executed_at/failure_reason as read-only, reject mutation of completed one-time schedules, and enforce the existing CanEditFeatureFlag check on PATCH/PUT.
