### PR TITLE
refactor(batch-exports): scope BatchExportDestination.integration field to requesting team

### DIFF
--- a/posthog/api/test/batch_exports/test_serializers.py
+++ b/posthog/api/test/batch_exports/test_serializers.py
@@ -11,7 +11,10 @@ from posthog.hogql.hogql import HogQLContext
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import prepare_ast_for_printing
 
-from posthog.batch_exports.http import BatchExportSerializer
+from posthog.api.scoped_related_fields import TeamScopedPrimaryKeyRelatedField
+from posthog.batch_exports.http import BatchExportDestinationSerializer, BatchExportSerializer
+from posthog.models import Organization, Team
+from posthog.models.integration import Integration
 
 
 def prepare_query(query: str, team_id: int) -> ast.SelectQuery:
@@ -130,3 +133,31 @@ class TestSerializeHogQLQueryToBatchExportSchema(BaseTest):
         # The alias must be wrapped in backticks, keeping the malicious string as a single identifier
         assert field["alias"] == "`x, (SELECT query FROM another_table LIMIT 100) AS leaked`"
         assert field["expression"] == "events.uuid"
+
+
+class TestBatchExportDestinationSerializerTeamScoping(BaseTest):
+    def _make_integration(self, team: Team) -> Integration:
+        return Integration.objects.create(team=team, kind="databricks", integration_id="server")
+
+    @parameterized.expand([("integration",), ("integration_id",)])
+    def test_field_rejects_cross_team_integration(self, field_name):
+        foreign_org = Organization.objects.create(name="Foreign")
+        foreign_team = Team.objects.create(organization=foreign_org, name="Foreign")
+        foreign_integration = self._make_integration(foreign_team)
+
+        serializer = BatchExportDestinationSerializer(
+            data={"type": "Databricks", "config": {}, field_name: foreign_integration.pk},
+            context={"team_id": self.team.pk},
+        )
+        assert not serializer.is_valid()
+        assert field_name in serializer.errors
+
+    @parameterized.expand([("integration",), ("integration_id",)])
+    def test_field_accepts_same_team_integration(self, field_name):
+        own_integration = self._make_integration(self.team)
+
+        serializer = BatchExportDestinationSerializer(context={"team_id": self.team.pk})
+        # Field-level queryset filter should include same-team integrations.
+        field = cast(TeamScopedPrimaryKeyRelatedField, serializer.fields[field_name])
+        queryset = field.get_queryset()
+        assert queryset is not None and own_integration in queryset

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -236,6 +236,7 @@ class BatchExportRunViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.Read
 class BatchExportDestinationSerializer(serializers.ModelSerializer):
     """Serializer for an BatchExportDestination model."""
 
+    integration = TeamScopedPrimaryKeyRelatedField(queryset=Integration.objects.all(), required=False, allow_null=True)
     integration_id = TeamScopedPrimaryKeyRelatedField(
         write_only=True, queryset=Integration.objects.all(), source="integration", required=False, allow_null=True
     )
@@ -243,15 +244,6 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
     class Meta:
         model = BatchExportDestination
         fields = ["type", "config", "integration", "integration_id"]
-
-    def get_fields(self):
-        fields = super().get_fields()
-        team_id = self.context.get("team_id")
-        if team_id:
-            fields["integration_id"].queryset = Integration.objects.filter(team_id=team_id)  # type: ignore[attr-defined]
-        else:
-            fields["integration_id"].queryset = Integration.objects.none()  # type: ignore[attr-defined]
-        return fields
 
     def create(self, validated_data: collections.abc.Mapping[str, typing.Any]) -> BatchExportDestination:
         """Create a BatchExportDestination."""

--- a/products/batch_exports/frontend/generated/api.schemas.ts
+++ b/products/batch_exports/frontend/generated/api.schemas.ts
@@ -77,10 +77,7 @@ export interface BatchExportDestinationApi {
     type: BatchExportDestinationTypeEnumApi
     /** A JSON field to store all configuration parameters required to access a BatchExportDestination. */
     config?: unknown
-    /**
-     * The integration for this destination.
-     * @nullable
-     */
+    /** @nullable */
     integration?: number | null
     /** @nullable */
     integration_id?: number | null

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -6504,10 +6504,7 @@ export namespace Schemas {
       type: BatchExportDestinationTypeEnum;
       /** A JSON field to store all configuration parameters required to access a BatchExportDestination. */
       config?: unknown;
-      /**
-       * The integration for this destination.
-       * @nullable
-       */
+      /** @nullable */
       integration?: number | null;
       /** @nullable */
       integration_id?: number | null;


### PR DESCRIPTION
The `integration` FK on `BatchExportDestinationSerializer` was auto-generated by DRF as an unscoped `PrimaryKeyRelatedField`, while the `integration_id` alias (source=integration) was already team-scoped. Declare `integration` explicitly as `TeamScopedPrimaryKeyRelatedField` so both input paths apply the same filter.
