### PR TITLE
fix(mcp): remove 'introspection' from OAUTH_SCOPES_SUPPORTED (partial #55307)

### DIFF
--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -68,7 +68,6 @@ export const OAUTH_SCOPES_SUPPORTED = [
     'openid',
     'profile',
     'email',
-    'introspection',
     'alert:read',
     'alert:write',
     'annotation:read',


### PR DESCRIPTION
## Problem

Partial fix for #55307.

`mcp.posthog.com/.well-known/oauth-protected-resource` advertises `introspection` in `scopes_supported`, but the authorization server at `oauth.posthog.com/.well-known/oauth-authorization-server` does not recognize it as a grantable scope. Per RFC 9728, a spec-compliant MCP client (including Claude Code) reads `scopes_supported` from the protected resource and includes every listed scope in its `authorize` request. The auth server then rejects the flow with `?error=invalid_scope`, and sign-in is unrecoverable from the client side.

`introspection` is the name of the OAuth 2.0 Token Introspection endpoint (RFC 7662), not a grantable scope. It's already correctly exposed as `introspection_endpoint` in the authorization server metadata (RFC 8414). It should not also appear as a grantable scope.

### Reproduction (as of 2026-04-21)

```
$ curl -s https://mcp.posthog.com/.well-known/oauth-protected-resource \
    | jq -r '.scopes_supported[]' | sort > /tmp/resource.txt
$ curl -s https://oauth.posthog.com/.well-known/oauth-authorization-server \
    | jq -r '.scopes_supported[]' | sort > /tmp/authserver.txt
$ comm -23 /tmp/resource.txt /tmp/authserver.txt
introspection
```

(At issue-filing time `llm_skill:read` / `llm_skill:write` also appeared in that diff. Those are being handled separately by #55300. With `introspection` removed, the diff will be empty, unblocking OAuth for compliant clients.)

Claude Code 2.1.117 log line:

```
Error during auth completion: Error: OAuth error: invalid_scope
```

## Changes

Remove `'introspection'` from `OAUTH_SCOPES_SUPPORTED` in `services/mcp/src/lib/constants.ts` (1 line deleted).

## Why this passes the completeness test

`tests/unit/tool-filtering.test.ts` > `OAUTH_SCOPES_SUPPORTED completeness` enforces one direction: every scope referenced by a tool definition must appear in `OAUTH_SCOPES_SUPPORTED`. `introspection` is not listed in any tool's `required_scopes`, so removing it from the supported array does not break that test. The other references to `introspection` in the repo (`ApiOAuthIntrospection`, `StateManager._api.oauth().introspect()`, `api/client.ts oauth().introspect()`) all target the OAuth token introspection **endpoint** and are independent from the grantable-scope list.

## How did you test this code?

Relying on CI. The change is a single line removal from a constant; no tool tooling, routing, or auth code changes.

## Publish to changelog?

no

## Docs update

skip-inkeep-docs
