### PR TITLE
feat(alerts): add resolved count to sparkline buckets and update tests

### DIFF
--- a/products/logs/backend/alerts_api.py
+++ b/products/logs/backend/alerts_api.py
@@ -68,12 +68,16 @@ class LogsAlertSparklineBucketSerializer(serializers.Serializer):
     timestamp = serializers.DateTimeField(help_text="Bucket start timestamp (UTC, hourly).")
     breached = serializers.IntegerField(help_text="Count of breached checks in this hour.")
     errored = serializers.IntegerField(help_text="Count of errored checks in this hour.")
+    resolved = serializers.IntegerField(
+        help_text="Count of checks that transitioned the alert from firing to resolved in this hour."
+    )
 
 
 class SparklineBucket(TypedDict):
     timestamp: datetime
     breached: int
     errored: int
+    resolved: int
 
 
 def _sparkline_window_start() -> datetime:
@@ -206,6 +210,7 @@ class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
                 "timestamp": start + dt.timedelta(hours=i),
                 "breached": 0,
                 "errored": 0,
+                "resolved": 0,
             }
             for i in range(SPARKLINE_LOOKBACK_HOURS)
         ]
@@ -225,6 +230,11 @@ class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
                     buckets[hour_offset]["errored"] += 1
                 elif event.threshold_breached:
                     buckets[hour_offset]["breached"] += 1
+                elif (
+                    event.state_before in (AlertState.FIRING, AlertState.PENDING_RESOLVE)
+                    and event.state_after == AlertState.NOT_FIRING
+                ):
+                    buckets[hour_offset]["resolved"] += 1
 
         return buckets
 

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -1041,7 +1041,9 @@ class TestLogsAlertAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         sparkline = response.json()["sparkline"]
         assert len(sparkline) == 24
-        assert all(bucket["breached"] == 0 and bucket["errored"] == 0 for bucket in sparkline)
+        assert all(
+            bucket["breached"] == 0 and bucket["errored"] == 0 and bucket["resolved"] == 0 for bucket in sparkline
+        )
         # Buckets are ordered oldest-first, hourly-aligned.
         timestamps = [bucket["timestamp"] for bucket in sparkline]
         assert timestamps == sorted(timestamps)
@@ -1105,7 +1107,7 @@ class TestLogsAlertAPI(APIBaseTest):
         response = self.client.get(f"{self.base_url}{alert_id}/")
 
         sparkline = response.json()["sparkline"]
-        assert all(b["breached"] == 0 and b["errored"] == 0 for b in sparkline)
+        assert all(b["breached"] == 0 and b["errored"] == 0 and b["resolved"] == 0 for b in sparkline)
 
     @freeze_time("2025-12-16T10:30:00Z")
     def test_sparkline_excludes_events_older_than_24h(self):
@@ -1123,7 +1125,31 @@ class TestLogsAlertAPI(APIBaseTest):
         response = self.client.get(f"{self.base_url}{alert_id}/")
 
         sparkline = response.json()["sparkline"]
-        assert all(b["breached"] == 0 and b["errored"] == 0 for b in sparkline)
+        assert all(b["breached"] == 0 and b["errored"] == 0 and b["resolved"] == 0 for b in sparkline)
+
+    @parameterized.expand(
+        [
+            ("firing_to_not_firing", "firing"),
+            ("pending_resolve_to_not_firing", "pending_resolve"),
+        ]
+    )
+    @freeze_time("2025-12-16T10:30:00Z")
+    def test_sparkline_buckets_resolved_events(self, _name: str, state_before: str):
+        created = self._create_via_api()
+        alert_id = created["id"]
+        self._make_event_at(
+            alert_id,
+            datetime(2025, 12, 16, 9, 5, tzinfo=UTC),
+            threshold_breached=False,
+            state_before=state_before,
+            state_after="not_firing",
+        )
+
+        response = self.client.get(f"{self.base_url}{alert_id}/")
+
+        assert response.status_code == status.HTTP_200_OK
+        sparkline = response.json()["sparkline"]
+        assert sum(b["resolved"] for b in sparkline) == 1
 
     # --- Simulate ---
 

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
@@ -60,8 +60,13 @@ function alertSparklineData(sparkline: readonly LogsAlertSparklineBucketApi[] | 
             color: 'warning',
         },
         {
+            name: 'Resolved',
+            values: sparkline.map((b) => b.resolved),
+            color: 'success',
+        },
+        {
             name: 'Quiet',
-            values: sparkline.map((b) => (b.breached === 0 && b.errored === 0 ? 1 : 0)),
+            values: sparkline.map((b) => (b.breached === 0 && b.errored === 0 && b.resolved === 0 ? 1 : 0)),
             color: 'border',
         },
     ]
@@ -131,7 +136,7 @@ export function LogsAlertList(): JSX.Element {
         },
         {
             title: (
-                <Tooltip title="Breached (red) and errored (yellow) checks over the last 24 hours. Grey bars mark quiet hours.">
+                <Tooltip title="Breached (red), errored (yellow), and resolved (green) checks over the last 24 hours. Grey bars mark quiet hours.">
                     <span className="cursor-help">Last 24h</span>
                 </Tooltip>
             ),

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -160,6 +160,8 @@ export interface LogsAlertSparklineBucketApi {
     breached: number
     /** Count of errored checks in this hour. */
     errored: number
+    /** Count of checks that transitioned the alert from firing to resolved in this hour. */
+    resolved: number
 }
 
 /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -20203,6 +20203,8 @@ export namespace Schemas {
       breached: number;
       /** Count of errored checks in this hour. */
       errored: number;
+      /** Count of checks that transitioned the alert from firing to resolved in this hour. */
+      resolved: number;
     }
 
     export interface LogsAlertConfiguration {


### PR DESCRIPTION
## Problem

Users viewing the alerts list can see breached and errored check counts in the sparkline, but there was no way to distinguish hours where an alert transitioned from firing back to a resolved state. This makes it harder to understand alert activity at a glance.

## Changes

Added a `resolved` field to the sparkline bucket data, which counts checks that transitioned the alert from `firing` or `pending_resolve` to `not_firing` within a given hour.

- The sparkline API now populates a `resolved` count per bucket alongside `breached` and `errored`
- The "Quiet" bar in the sparkline now only shows for hours with no breached, errored, or resolved events
- The frontend sparkline renders resolved events in green
- The tooltip on the "Last 24h" column header now mentions resolved (green) checks

## How did you test this code?

Covered by automated tests:
- Updated existing tests to assert `resolved == 0` in baseline/empty cases
- Added `test_sparkline_buckets_resolved_events` which creates events with `firing → not_firing` and `pending_resolve → not_firing` transitions and asserts both are counted in the sparkline's `resolved` totals

## Publish to changelog?

No

## Docs update

No docs update required.