### PR TITLE
chore: add yolo to end of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,5 @@ The pricing for our paid plan is completely transparent and available on [our pr
 Hey! If you're reading this, you've proven yourself as a dedicated README reader.
 
 You might also make a great addition to our team. We're growing fast [and would love for you to join us](https://posthog.com/careers).
+
+yolo


### PR DESCRIPTION
## Problem

Requested tweak to the repository README — appending a literal `yolo` marker at the end of the file.

## Changes

- Added a trailing `yolo` line at the end of `README.md`.

## How did you test this code?

Agent-authored PR. No manual testing; this is a README-only text change with no code paths affected.

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code agent in response to a user request to add `yolo` at the end of the README. No other files modified.