### PR TITLE
feat(dashboards): display dwh series in details and fix "all events"

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -197,9 +197,9 @@ snapshots:
     components-cards-insight-details--trends-horizontal-bar--light:
         hash: v1.k794b7964.eb8b4e2da8c9ec22e0373b869d322462732d25da0a9c1ae92f40323b9b55d650.k5Cz4Lqet-1ykT5wUYh6RMGv3IcjIYUD-jOw4sKV5Fw
     components-cards-insight-details--trends-multi--dark:
-        hash: v1.k794b7964.9bd59da209ef002614d75cc140ef32ff24a36a6fd061cb70c2a7f6b127f177db.wVJ3Q68Tkjw670e0QPFHcGTTlyxzNbSTa_HRQoDaa7k
+        hash: v1.k794b7964.78df834f0b20a316667ad73c8d35bed184ac478af5dbb058a2309450d42ea617.bUTkvG4Mn6bxKHdWzMhXWEBAPENV_TDKCO2SWHt7wmc
     components-cards-insight-details--trends-multi--light:
-        hash: v1.k794b7964.a5681bb1eab2d0b16e6121710168635180a032faa4cd05dcc3103943b6a2ab9d.8O1JWNRFfr6JkvYWy3ILzLurOAr0QCJqFocksDvkiLE
+        hash: v1.k794b7964.4f5b573d92d9fd8d5807bf59f58a198944cfb99f846b7ff372c004867b4400d7.QfkAPM2yhi4SmYDeT26wXt87mfrkl1Dthwd-bIzqYHY
     components-cards-insight-details--trends-pie--dark:
         hash: v1.k794b7964.15dca2f44b1f412c45005ec60b5a7c2bd272842016ba1d2f8fd5ff940a01cefb.NVI3CwSyp9PGwqZVsTMCkEWCm0ChqpyfoMYjyzxKdUU
     components-cards-insight-details--trends-pie--light:

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.scss
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.scss
@@ -120,7 +120,8 @@
     border-radius: var(--radius-sm);
 
     &.SeriesDisplay__raw-name--event::before,
-    &.SeriesDisplay__raw-name--action::before {
+    &.SeriesDisplay__raw-name--action::before,
+    &.SeriesDisplay__raw-name--data-warehouse::before {
         display: flex;
         flex-shrink: 0;
         align-items: center;
@@ -145,6 +146,10 @@
 
     &.SeriesDisplay__raw-name--action::before {
         content: 'A';
+    }
+
+    &.SeriesDisplay__raw-name--data-warehouse::before {
+        content: 'D';
     }
 }
 

--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
@@ -50,6 +50,7 @@ import {
 } from '~/queries/schema/schema-general'
 import {
     isActionsNode,
+    isAnyDataWarehouseNode,
     isDataTableNodeWithHogQLQuery,
     isDataVisualizationNode,
     isEventsNode,
@@ -90,25 +91,49 @@ export function InsightDetailSectionDisplay({
     )
 }
 
+function assertNever(value: never): never {
+    throw new Error(`Unexpected entity node: ${(value as { kind?: string } | undefined)?.kind ?? 'unknown'}`)
+}
+
 function EntityDisplay({ entity }: { entity: AnyEntityNode<AnyDataWarehouseNode> }): JSX.Element {
+    let content: JSX.Element
+
+    if (isActionsNode(entity)) {
+        content = (
+            <Link
+                to={urls.action(entity.id)}
+                className="SeriesDisplay__raw-name SeriesDisplay__raw-name--action"
+                title="Action series"
+            >
+                {entity.name}
+            </Link>
+        )
+    } else if (isEventsNode(entity)) {
+        content = (
+            <span className="SeriesDisplay__raw-name SeriesDisplay__raw-name--event" title="Event series">
+                <PropertyKeyInfo value={entity.event || 'All events'} type={TaxonomicFilterGroupType.Events} />
+            </span>
+        )
+    } else if (isAnyDataWarehouseNode(entity)) {
+        content = (
+            <span
+                className="SeriesDisplay__raw-name SeriesDisplay__raw-name--data-warehouse"
+                title="Data warehouse series"
+            >
+                <PropertyKeyInfo
+                    value={entity.name || entity.table_name}
+                    type={TaxonomicFilterGroupType.DataWarehouse}
+                />
+            </span>
+        )
+    } else {
+        return assertNever(entity)
+    }
+
     return (
         <>
             {entity.custom_name && <b> "{entity.custom_name}"</b>}
-            {isActionsNode(entity) ? (
-                <Link
-                    to={urls.action(entity.id)}
-                    className="SeriesDisplay__raw-name SeriesDisplay__raw-name--action"
-                    title="Action series"
-                >
-                    {entity.name}
-                </Link>
-            ) : isEventsNode(entity) ? (
-                <span className="SeriesDisplay__raw-name SeriesDisplay__raw-name--event" title="Event series">
-                    <PropertyKeyInfo value={entity.event || '$pageview'} type={TaxonomicFilterGroupType.Events} />
-                </span>
-            ) : (
-                <i>{entity.kind /* TODO: Support DataWarehouseNode */}</i>
-            )}
+            {content}
         </>
     )
 }


### PR DESCRIPTION
## Problem

Data warehouse series weren't displaying in the details view, and "All events" were erreonously displayed as pageview events.

## Changes

- Adds support for data warehouse series
- Fixes the "All events" display
- Adds an exhaustiveness check

![Screenshot 2026-04-22 at 10.05.53.png](https://app.graphite.com/user-attachments/assets/6612501d-f888-4f78-b710-f4f9a7213217.png)


## How did you test this code?

Manual testing