### PR TITLE
fix(llma): handle roleless Responses API items in playground input and output

### DIFF
--- a/products/llm_analytics/frontend/playground/llmPlaygroundLogic.test.ts
+++ b/products/llm_analytics/frontend/playground/llmPlaygroundLogic.test.ts
@@ -1004,6 +1004,91 @@ describe('llmPlaygroundLogic', () => {
             expect(llmPlaygroundPromptsLogic.values.messages[0].content).toBe('[Tool result]\nSome result')
         })
 
+        it('should handle OpenAI Responses API top-level function_call and function_call_output items in input', () => {
+            // The Responses API sends function_call and function_call_output items at the top level
+            // of the conversation array alongside regular role-bearing messages, but with no `role`.
+            const input = [
+                { role: 'system', content: 'You are a helpful assistant.' },
+                { role: 'user', content: 'What is the weather?' },
+                {
+                    type: 'function_call',
+                    name: 'ask_clarification',
+                    call_id: 'call_abc123',
+                    arguments: '{"question":"Which city?","options":["London","Paris"]}',
+                },
+                {
+                    type: 'function_call_output',
+                    call_id: 'call_abc123',
+                    output: 'London',
+                },
+            ]
+
+            llmPlaygroundPromptsLogic.actions.setupPlaygroundFromEvent({ input })
+
+            const messages = llmPlaygroundPromptsLogic.values.messages
+            // system is extracted, function_call_output merges into the assistant turn
+            expect(messages).toHaveLength(2)
+            expect(messages[0]).toEqual({ role: 'user', content: 'What is the weather?' })
+            expect(messages[1].role).toBe('assistant')
+            expect(messages[1].content).toContain('[Function call: ask_clarification]')
+            expect(messages[1].content).toContain('[Function output for call_abc123]')
+            expect(messages[1].content).toContain('London')
+        })
+
+        it('should handle OpenAI Responses API function_call item in output', () => {
+            // Matches $ai_output_choices shape when the model responds with a tool call
+            const input = [{ role: 'user', content: 'Find me some products' }]
+            const output = [
+                {
+                    type: 'function_call',
+                    name: 'search_products',
+                    call_id: 'call_def456',
+                    arguments: '{"queries":["blue widgets"]}',
+                    id: 'fc_001',
+                    status: 'completed',
+                },
+            ]
+
+            llmPlaygroundPromptsLogic.actions.setupPlaygroundFromEvent({ input, output })
+
+            const messages = llmPlaygroundPromptsLogic.values.messages
+            expect(messages).toHaveLength(2)
+            expect(messages[1].role).toBe('assistant')
+            expect(messages[1].content).toContain('[Function call: search_products]')
+            expect(messages[1].content).toContain('blue widgets')
+        })
+
+        it('should merge function_call_output in output into preceding assistant turn', () => {
+            // A function_call followed immediately by function_call_output in $ai_output_choices —
+            // the output item should be folded into the assistant turn, not emitted as a user bubble.
+            const input = [{ role: 'user', content: 'What is the weather in Paris?' }]
+            const output = [
+                {
+                    type: 'function_call',
+                    name: 'get_weather',
+                    call_id: 'call_ghi789',
+                    arguments: '{"city":"Paris"}',
+                    status: 'completed',
+                },
+                {
+                    type: 'function_call_output',
+                    call_id: 'call_ghi789',
+                    output: '22°C, sunny',
+                    status: 'completed',
+                },
+            ]
+
+            llmPlaygroundPromptsLogic.actions.setupPlaygroundFromEvent({ input, output })
+
+            const messages = llmPlaygroundPromptsLogic.values.messages
+            // function_call_output should merge into the function_call's assistant turn
+            expect(messages).toHaveLength(2)
+            expect(messages[1].role).toBe('assistant')
+            expect(messages[1].content).toContain('[Function call: get_weather]')
+            expect(messages[1].content).toContain('[Function output for call_ghi789]')
+            expect(messages[1].content).toContain('22°C, sunny')
+        })
+
         it('should not produce "null" string for messages with null content', () => {
             const input = [{ role: 'user', content: null, tool_calls: [] }]
 

--- a/products/llm_analytics/frontend/playground/llmPlaygroundPromptsLogic.ts
+++ b/products/llm_analytics/frontend/playground/llmPlaygroundPromptsLogic.ts
@@ -172,6 +172,7 @@ interface RawMessage {
     content: unknown
     tool_calls?: unknown
     tool_call_id?: unknown
+    type?: string
 }
 
 type ConversationRole = 'user' | 'assistant'
@@ -328,6 +329,20 @@ function flattenOutputMessages(output: unknown, depth: number = 0): RawMessage[]
         if (isObject(output.message)) {
             return flattenOutputMessages(output.message, depth + 1)
         }
+        // OpenAI Responses API top-level function_call / function_call_output items have no role.
+        // Convert them to synthetic RawMessages so extractConversationMessage can format them.
+        // Preserve `type` so isToolResultMessage can still identify function_call_output and fold
+        // it into the preceding assistant turn rather than emitting a standalone user bubble.
+        if (output.type === 'function_call' || output.type === 'function_call_output') {
+            return [
+                {
+                    role: output.type === 'function_call_output' ? InputMessageRole.User : InputMessageRole.Assistant,
+                    content: formatContentBlock(output) ?? '',
+                    tool_call_id: output.call_id,
+                    type: String(output.type),
+                },
+            ]
+        }
         return [
             {
                 role: typeof output.role === 'string' ? output.role : InputMessageRole.Assistant,
@@ -342,6 +357,21 @@ function flattenOutputMessages(output: unknown, depth: number = 0): RawMessage[]
 }
 
 function extractConversationMessage(rawMessage: RawMessage): { role: ConversationRole; content: string } {
+    // OpenAI Responses API sends function_call / function_call_output items at the top level of the
+    // conversation array with no `role`. Route them through formatContentBlock so they get the same
+    // `[Function call: name]` / `[Function output for id]` treatment as typed content blocks.
+    const rawAsBlock = rawMessage as unknown as Record<string, unknown>
+    const topLevelType = rawMessage.type
+    if (
+        typeof rawMessage.role !== 'string' &&
+        (topLevelType === 'function_call' || topLevelType === 'function_call_output')
+    ) {
+        const formatted = formatContentBlock(rawAsBlock) ?? ''
+        const role: ConversationRole =
+            topLevelType === 'function_call_output' ? InputMessageRole.User : InputMessageRole.Assistant
+        return { role, content: formatted }
+    }
+
     const normalizedMessageRole = normalizeRole(rawMessage.role, InputMessageRole.User)
     const enumMap: Partial<Record<string, ConversationRole>> = {
         [InputMessageRole.User]: InputMessageRole.User,
@@ -379,6 +409,10 @@ function extractConversationMessage(rawMessage: RawMessage): { role: Conversatio
 // assistant turn rather than rendered as standalone user bubbles in the playground.
 function isToolResultMessage(raw: RawMessage): boolean {
     if (normalizeRole(raw.role, '') === 'tool') {
+        return true
+    }
+    // OpenAI Responses API top-level function_call_output item (no role)
+    if (raw.type === 'function_call_output') {
         return true
     }
     if (Array.isArray(raw.content) && raw.content.length > 0) {
@@ -924,7 +958,14 @@ export const llmPlaygroundPromptsLogic = kea<llmPlaygroundPromptsLogicType>([
                     try {
                         if (
                             Array.isArray(input) &&
-                            input.every((msg) => msg.role && (msg.content != null || msg.tool_calls))
+                            input.every(
+                                (msg) =>
+                                    // Standard chat message: must have role + content/tool_calls
+                                    (msg.role && (msg.content != null || msg.tool_calls)) ||
+                                    // OpenAI Responses API top-level typed items have no role
+                                    msg.type === 'function_call' ||
+                                    msg.type === 'function_call_output'
+                            )
                         ) {
                             const systemContents = input
                                 .filter((msg) => msg.role === 'system')


### PR DESCRIPTION
## Problem

Follow-up to #55246. Generations using the OpenAI Responses API (endpoint `/v1/responses`) store `function_call` and `function_call_output` items at the **top level** of the `$ai_input` conversation array alongside regular messages — but unlike chat messages, these items carry no `role` field.

The playground's gate check rejected any input array containing such items (because `msg.role` was falsy), producing an empty playground. The same `function_call` shape can appear in `$ai_output_choices` too, which `flattenOutputMessages` returned as an empty assistant message.

## Changes

`llmPlaygroundPromptsLogic.ts`:

- **`RawMessage` interface** — added optional `type?: string` field so typed items can be identified after being converted to synthetic `RawMessage` objects
- **Gate check** — extended to also accept items with `type: "function_call"` or `type: "function_call_output"` alongside the existing role-based check
- **`extractConversationMessage()`** — early path for roleless typed items: routes through `formatContentBlock` and assigns `assistant` for `function_call`, `user` for `function_call_output`. The user role causes `appendRawMessage` to fold it into the preceding assistant turn, same as other tool-result types
- **`isToolResultMessage()`** — extended to identify top-level `function_call_output` items (no role, but `type` present)
- **`flattenOutputMessages()`** — handles top-level `function_call` / `function_call_output` items in output; produces synthetic `RawMessage` entries with `type` preserved so `isToolResultMessage` can still merge `function_call_output` into the preceding assistant turn

## How did you test this code?

Added three unit tests in `llmPlaygroundLogic.test.ts` using synthetic data:

1. Input with interleaved `function_call` + `function_call_output` — verifies gate passes, function_call renders as `[Function call: name]` in an assistant turn, and function_call_output merges into that turn
2. Output containing a `function_call` item — verifies it becomes an assistant message with `[Function call: name]` content
3. Output containing `function_call` followed by `function_call_output` — verifies the output item merges into the assistant turn rather than appearing as a standalone user bubble

91 tests pass. I'm an AI agent — I have not manually tested this in a browser.

## Publish to changelog?

no

## Docs update

N/A

## 🤖 LLM context

Third follow-up in a series starting from #54664. Each PR fixes a new real-world trace shape that produced an empty playground.