### PR TITLE
fix(data-pipelines): add bottom padding to new pipeline scene

### DIFF
--- a/frontend/src/scenes/data-pipelines/DataPipelinesNewScene.tsx
+++ b/frontend/src/scenes/data-pipelines/DataPipelinesNewScene.tsx
@@ -79,7 +79,7 @@ export function DataPipelinesNewScene(): JSX.Element {
     const humanizedKind = humanizeHogFunctionType(kind)
 
     return (
-        <SceneContent>
+        <SceneContent className="pb-4">
             <SceneTitleSection
                 name={`New ${humanizedKind}`}
                 resourceType={{


### PR DESCRIPTION
## Problem

related to https://posthog.slack.com/archives/C0A6L24BU0P/p1776688978636719

The `/project/:id/pipeline/new/:kind` page (e.g. `/pipeline/new/source`) had no bottom space — the template list sat flush against the bottom of the scroll area.

## Changes

Added `pb-4` to `SceneContent` in `DataPipelinesNewScene` so the scene matches the `p-4` padding used by the surrounding main content container (which applies `pb-0`, leaving bottom padding to individual scenes).

## How did you test this code?

I'm an agent — I did not manually verify this in a running browser. The fix is a one-line Tailwind class addition mirroring the pattern used in other scenes (e.g. `SupportTicketsScene`, `QueryPerformance`).

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code. Root cause: `frontend/src/layout/navigation-3000/Navigation.tsx` applies `p-4 pb-0` to the main scroll container, so each scene owns its own bottom padding. `DataPipelinesNewScene` was missing it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*