### PR TITLE
feat(logs-alerts): add $logs_alert_errored notification and structured webhook envelope

### DIFF
--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -118,6 +118,13 @@ export const HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES: Record<
         filters: { events: [{ id: '$logs_alert_auto_disabled', type: 'events' }] },
         flag: FEATURE_FLAGS.LOGS_ALERTING,
     },
+    'logs-alert-errored': {
+        sub_template_id: 'logs-alert-errored',
+        type: 'internal_destination',
+        context_id: 'logs-alerting',
+        filters: { events: [{ id: '$logs_alert_errored', type: 'events' }] },
+        flag: FEATURE_FLAGS.LOGS_ALERTING,
+    },
 }
 
 export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, HogFunctionSubTemplateType[]> = {
@@ -973,6 +980,58 @@ export const HOG_FUNCTION_SUB_TEMPLATES: Record<HogFunctionSubTemplateIdType, Ho
             },
         },
     ],
+    'logs-alert-errored': [
+        {
+            ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['logs-alert-errored'],
+            template_id: 'template-webhook',
+            name: 'HTTP Webhook on log alert evaluation error',
+            description: 'Send a webhook when a log alert fails to evaluate',
+        },
+        {
+            ...HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['logs-alert-errored'],
+            template_id: 'template-slack',
+            name: 'Post to Slack on log alert evaluation error',
+            description: 'Post to Slack when a log alert fails to evaluate',
+            inputs: {
+                blocks: {
+                    value: [
+                        {
+                            type: 'header',
+                            text: {
+                                type: 'plain_text',
+                                text: "Log alert '{event.properties.alert_name}' couldn't evaluate",
+                            },
+                        },
+                        {
+                            type: 'section',
+                            text: {
+                                type: 'mrkdwn',
+                                text: '*Reason:* {event.properties.error_message}\n*Failure count:* {event.properties.consecutive_failures}',
+                            },
+                        },
+                        {
+                            type: 'context',
+                            elements: [{ type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' }],
+                        },
+                        { type: 'divider' },
+                        {
+                            type: 'actions',
+                            elements: [
+                                {
+                                    url: '{project.url}/logs?alertId={event.properties.alert_id}',
+                                    text: { text: 'View alert', type: 'plain_text' },
+                                    type: 'button',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                text: {
+                    value: "Log alert '{event.properties.alert_name}' couldn't evaluate: {event.properties.error_message}",
+                },
+            },
+        },
+    ],
 }
 
 export const getSubTemplate = (
@@ -999,6 +1058,7 @@ export const eventToHogFunctionContextId = (event: string | undefined): HogFunct
         case '$logs_alert_firing':
         case '$logs_alert_resolved':
         case '$logs_alert_auto_disabled':
+        case '$logs_alert_errored':
             return 'logs-alerting'
         default:
             return 'standard'

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6526,6 +6526,7 @@ export type HogFunctionSubTemplateIdType =
     | 'logs-alert-firing'
     | 'logs-alert-resolved'
     | 'logs-alert-auto-disabled'
+    | 'logs-alert-errored'
 
 export type HogFunctionConfigurationType = Omit<
     HogFunctionType,

--- a/products/logs/backend/alert_destinations.py
+++ b/products/logs/backend/alert_destinations.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 
 from products.logs.backend.models import LogsAlertConfiguration
 
-EventKind = Literal["firing", "resolved", "broken"]
+EventKind = Literal["firing", "resolved", "broken", "errored"]
 
 
 @dataclass(frozen=True)
@@ -17,10 +17,10 @@ class EventKindSpec:
     body: str
     button_url: str
     button_label: str
-    webhook_body: dict[str, str]
+    webhook_body: dict[str, Any]
 
 
-_FIRE_RESOLVE_WEBHOOK_BODY: dict[str, str] = {
+_FIRE_RESOLVE_DATA: dict[str, str] = {
     "alert_id": "{event.properties.alert_id}",
     "alert_name": "{event.properties.alert_name}",
     "result_count": "{event.properties.result_count}",
@@ -30,7 +30,15 @@ _FIRE_RESOLVE_WEBHOOK_BODY: dict[str, str] = {
     "service_names": "{event.properties.service_names}",
     "severity_levels": "{event.properties.severity_levels}",
     "logs_url": "{project.url}/logs?{event.properties.logs_url_params}",
-    "triggered_at": "{event.properties.triggered_at}",
+}
+
+_BROKEN_ERRORED_BASE_DATA: dict[str, str] = {
+    "alert_id": "{event.properties.alert_id}",
+    "alert_name": "{event.properties.alert_name}",
+    "consecutive_failures": "{event.properties.consecutive_failures}",
+    "service_names": "{event.properties.service_names}",
+    "severity_levels": "{event.properties.severity_levels}",
+    "alert_url": "{project.url}/logs?alertId={event.properties.alert_id}",
 }
 
 
@@ -45,7 +53,12 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
         ),
         button_url="{project.url}/logs?{event.properties.logs_url_params}",
         button_label="View logs",
-        webhook_body={"event": "firing", **_FIRE_RESOLVE_WEBHOOK_BODY},
+        webhook_body={
+            "id": "{event.uuid}",
+            "type": "logs_alert.firing",
+            "timestamp": "{event.properties.triggered_at}",
+            "data": _FIRE_RESOLVE_DATA,
+        },
     ),
     "resolved": EventKindSpec(
         event_id="$logs_alert_resolved",
@@ -57,7 +70,12 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
         ),
         button_url="{project.url}/logs?{event.properties.logs_url_params}",
         button_label="View logs",
-        webhook_body={"event": "resolved", **_FIRE_RESOLVE_WEBHOOK_BODY},
+        webhook_body={
+            "id": "{event.uuid}",
+            "type": "logs_alert.resolved",
+            "timestamp": "{event.properties.triggered_at}",
+            "data": _FIRE_RESOLVE_DATA,
+        },
     ),
     "broken": EventKindSpec(
         event_id="$logs_alert_auto_disabled",
@@ -71,15 +89,29 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
         button_url="{project.url}/logs?alertId={event.properties.alert_id}",
         button_label="View alert",
         webhook_body={
-            "event": "broken",
-            "alert_id": "{event.properties.alert_id}",
-            "alert_name": "{event.properties.alert_name}",
-            "consecutive_failures": "{event.properties.consecutive_failures}",
-            "last_error_message": "{event.properties.last_error_message}",
-            "service_names": "{event.properties.service_names}",
-            "severity_levels": "{event.properties.severity_levels}",
-            "alert_url": "{project.url}/logs?alertId={event.properties.alert_id}",
-            "triggered_at": "{event.properties.triggered_at}",
+            "id": "{event.uuid}",
+            "type": "logs_alert.auto_disabled",
+            "timestamp": "{event.properties.triggered_at}",
+            "data": {
+                **_BROKEN_ERRORED_BASE_DATA,
+                "last_error_message": "{event.properties.last_error_message}",
+            },
+        },
+    ),
+    "errored": EventKindSpec(
+        event_id="$logs_alert_errored",
+        header="🟡 Log alert '{event.properties.alert_name}' couldn't evaluate",
+        body=("*Reason:* {event.properties.error_message}\n*Failure count:* {event.properties.consecutive_failures}"),
+        button_url="{project.url}/logs?alertId={event.properties.alert_id}",
+        button_label="View alert",
+        webhook_body={
+            "id": "{event.uuid}",
+            "type": "logs_alert.errored",
+            "timestamp": "{event.properties.triggered_at}",
+            "data": {
+                **_BROKEN_ERRORED_BASE_DATA,
+                "error_message": "{event.properties.error_message}",
+            },
         },
     ),
 }
@@ -183,5 +215,6 @@ def build_webhook_config(
         "inputs": {
             "body": {"value": spec.webhook_body},
             "url": {"value": webhook_url},
+            "headers": {"value": {"Content-Type": "application/json", "X-PostHog-Webhook-Version": "1"}},
         },
     }

--- a/products/logs/backend/alert_state_machine.py
+++ b/products/logs/backend/alert_state_machine.py
@@ -36,6 +36,7 @@ class NotificationAction(Enum):
     NONE = "none"
     FIRE = "fire"
     RESOLVE = "resolve"
+    ERROR = "error"
 
 
 class InvalidTransition(Exception):
@@ -122,9 +123,14 @@ def evaluate_alert_check(
     if check.error_message is not None:
         consecutive_failures = snapshot.consecutive_failures + 1
         new_state = AlertState.BROKEN if consecutive_failures >= MAX_CONSECUTIVE_FAILURES else AlertState.ERRORED
+        first_error = (
+            effective_state != AlertState.ERRORED
+            and snapshot.state != AlertState.ERRORED  # prevents re-notification after snooze auto-expiry
+            and new_state == AlertState.ERRORED
+        )
         return AlertCheckOutcome(
             new_state=new_state,
-            notification=NotificationAction.NONE,
+            notification=NotificationAction.ERROR if first_error else NotificationAction.NONE,
             consecutive_failures=consecutive_failures,
             update_last_notified_at=False,
             error_message=check.error_message,

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -222,7 +222,6 @@ def _evaluate_single_alert(
             team_id=alert.team_id,
             notified=notified,
         )
-
     # If the notification delivery failed, don't commit the state transition
     # so the next tick will re-evaluate and retry the notification.
     if notification_failed:
@@ -290,6 +289,18 @@ def _evaluate_single_alert(
             consecutive_failures=outcome.consecutive_failures,
         )
         _emit_auto_disabled_event(alert, outcome, now)
+
+    if outcome.notification == NotificationAction.ERROR:
+        logger.info(
+            "Alert entered errored state",
+            alert_id=str(alert.id),
+            alert_name=alert.name,
+            team_id=alert.team_id,
+            consecutive_failures=outcome.consecutive_failures,
+        )
+        # Best-effort, consistent with _emit_auto_disabled_event — state is already committed
+        # so there is no retry path; a missed delivery is acceptable for this diagnostic event.
+        _emit_alert_errored_event(alert, outcome, now)
 
     stats["checked"] += 1
 
@@ -376,19 +387,41 @@ def _emit_alert_event(
     return _produce_alert_internal_event(alert, event_name, properties, now)
 
 
+def _base_failure_properties(
+    alert: LogsAlertConfiguration,
+    outcome: AlertCheckOutcome,
+    now: datetime,
+) -> dict:
+    return {
+        "alert_id": str(alert.id),
+        "alert_name": alert.name,
+        "team_id": alert.team_id,
+        "consecutive_failures": outcome.consecutive_failures,
+        "service_names": alert.filters.get("serviceNames", []),
+        "severity_levels": alert.filters.get("severityLevels", []),
+        "triggered_at": now.isoformat(),
+    }
+
+
 def _emit_auto_disabled_event(
     alert: LogsAlertConfiguration,
     outcome: AlertCheckOutcome,
     now: datetime,
 ) -> None:
-    properties: dict = {
-        "alert_id": str(alert.id),
-        "alert_name": alert.name,
-        "team_id": alert.team_id,
-        "consecutive_failures": outcome.consecutive_failures,
+    properties = {
+        **_base_failure_properties(alert, outcome, now),
         "last_error_message": outcome.error_message or "",
-        "service_names": alert.filters.get("serviceNames", []),
-        "severity_levels": alert.filters.get("severityLevels", []),
-        "triggered_at": now.isoformat(),
     }
     _produce_alert_internal_event(alert, "$logs_alert_auto_disabled", properties, now)
+
+
+def _emit_alert_errored_event(
+    alert: LogsAlertConfiguration,
+    outcome: AlertCheckOutcome,
+    now: datetime,
+) -> None:
+    properties = {
+        **_base_failure_properties(alert, outcome, now),
+        "error_message": outcome.error_message or "",
+    }
+    _produce_alert_internal_event(alert, "$logs_alert_errored", properties, now)

--- a/products/logs/backend/test/test_alert_state_machine.py
+++ b/products/logs/backend/test/test_alert_state_machine.py
@@ -217,7 +217,7 @@ class TestErrorHandling(TestCase):
         snapshot = _snapshot(state=NOT_FIRING)
         outcome = evaluate_alert_check(snapshot, _check(error="ClickHouse timeout"), NOW)
         assert outcome.new_state == ERRORED
-        assert outcome.notification == NotificationAction.NONE
+        assert outcome.notification == NotificationAction.ERROR
         assert outcome.error_message == "ClickHouse timeout"
 
     def test_error_increments_consecutive_failures(self) -> None:

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -601,11 +601,16 @@ class TestLogsAlertAPI(APIBaseTest):
         )
         assert response.status_code == status.HTTP_201_CREATED, response.json()
         ids = response.json()["hog_function_ids"]
-        assert len(ids) == 3  # firing + resolved + broken
+        assert len(ids) == 4  # firing + resolved + broken + errored
 
         hog_functions = HogFunction.objects.filter(id__in=ids).order_by("name")
         event_ids = sorted([(hf.filters or {})["events"][0]["id"] for hf in hog_functions])
-        assert event_ids == ["$logs_alert_auto_disabled", "$logs_alert_firing", "$logs_alert_resolved"]
+        assert event_ids == [
+            "$logs_alert_auto_disabled",
+            "$logs_alert_errored",
+            "$logs_alert_firing",
+            "$logs_alert_resolved",
+        ]
         for hf in hog_functions:
             assert hf.template_id == "template-slack"
             inputs = hf.inputs or {}
@@ -636,7 +641,7 @@ class TestLogsAlertAPI(APIBaseTest):
         )
         assert response.status_code == status.HTTP_201_CREATED, response.json()
         ids = response.json()["hog_function_ids"]
-        assert len(ids) == 3
+        assert len(ids) == 4  # firing + resolved + broken + errored
 
         hog_functions = HogFunction.objects.filter(id__in=ids)
         for hf in hog_functions:
@@ -644,7 +649,12 @@ class TestLogsAlertAPI(APIBaseTest):
             inputs = hf.inputs or {}
             assert inputs["url"]["value"] == "https://example.com/hook"
             body = inputs["body"]["value"]
-            assert body["event"] in ("firing", "resolved", "broken")
+            assert body["type"] in (
+                "logs_alert.firing",
+                "logs_alert.resolved",
+                "logs_alert.auto_disabled",
+                "logs_alert.errored",
+            )
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

When a log alert fails to evaluate, there was no way for users to be notified about the evaluation error until the alert was fully auto-disabled (after reaching the maximum consecutive failure threshold). Users had no visibility into transient evaluation errors.

## Changes

note: there are no existing webhooks so changing the structure now is no issue

Adds a new `errored` notification action and corresponding `$logs_alert_errored` event that fires the first time an alert enters the `ERRORED` state. This gives users early warning that something is wrong before the alert is fully auto-disabled.

- Introduces a new `logs-alert-errored` sub-template with Slack and webhook destination support, including a formatted Slack message showing the error reason, failure count, and a link to the alert
- Adds the `$logs_alert_errored` event to the event-to-context-id mapping
- Restructures webhook payloads for all alert event kinds to use a consistent envelope format with `id`, `type`, `timestamp`, and `data` fields, and adds `Content-Type: application/json` and `X-PostHog-Webhook-Version: 1` headers
- Extracts shared failure properties into a `_base_failure_properties` helper to reduce duplication between the auto-disabled and errored event emitters

## How did you test this code?

Local dev & webhook testing

## Publish to changelog?

No