### PR TITLE
fix(nav): port NewAccountMenu from base-ui Menu to Radix DropdownMenu

### DIFF
--- a/frontend/src/lib/components/Account/NewAccountMenu.tsx
+++ b/frontend/src/lib/components/Account/NewAccountMenu.tsx
@@ -1,4 +1,3 @@
-import { Menu } from '@base-ui/react/menu'
 import { useActions, useValues } from 'kea'
 
 import {
@@ -18,7 +17,16 @@ import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture/ProfilePicture'
 import { UploadedLogo } from 'lib/lemon-ui/UploadedLogo/UploadedLogo'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
-import { DropdownMenuSeparator } from 'lib/ui/DropdownMenu/DropdownMenu'
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuSub,
+    DropdownMenuSubContent,
+    DropdownMenuSubTrigger,
+    DropdownMenuTrigger,
+} from 'lib/ui/DropdownMenu/DropdownMenu'
 import { Label } from 'lib/ui/Label/Label'
 import { MenuOpenIndicator } from 'lib/ui/Menus/Menus'
 import { cn } from 'lib/utils/css-classes'
@@ -36,7 +44,6 @@ import { AvailableFeature } from '~/types'
 
 import { RenderKeybind } from '../AppShortcuts/AppShortcutMenu'
 import { keyBinds } from '../AppShortcuts/shortcuts'
-import { ScrollableShadows } from '../ScrollableShadows/ScrollableShadows'
 import { upgradeModalLogic } from '../UpgradeModal/upgradeModalLogic'
 import { newAccountMenuLogic } from './newAccountMenuLogic'
 import { OrgModal } from './OrgModal'
@@ -77,376 +84,294 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
 
     return (
         <>
-            <Menu.Root open={isAccountMenuOpen} onOpenChange={setAccountMenuOpen}>
-                <Menu.Trigger
-                    render={(props) => (
-                        <ButtonPrimitive
-                            {...props}
-                            iconOnly={isLayoutNavCollapsed}
-                            className={cn('relative flex-1 py-1 min-w-0 group', {
-                                'pl-[3px] gap-[6px]': !isLayoutNavCollapsed,
-                            })}
-                            data-attr="new-account-menu-button"
-                            tooltip={
-                                <div className="flex flex-col gap-1">
-                                    <div>
-                                        Account menu
-                                        <RenderKeybind keybind={[keyBinds.newAccountMenu]} className="ml-1" />
-                                    </div>
-                                    <div>
-                                        Organization:{' '}
-                                        {currentOrganization ? currentOrganization.name : 'Select organization'}
-                                    </div>
-                                    <div>Project: {currentTeam ? currentTeam.name : 'Select project'}</div>
-                                    {hasPendingInvites && <div>You have a pending invitation</div>}
+            <DropdownMenu open={isAccountMenuOpen} onOpenChange={setAccountMenuOpen}>
+                <DropdownMenuTrigger asChild>
+                    <ButtonPrimitive
+                        iconOnly={isLayoutNavCollapsed}
+                        className={cn('relative flex-1 py-1 min-w-0 group', {
+                            'pl-[3px] gap-[6px]': !isLayoutNavCollapsed,
+                        })}
+                        data-attr="new-account-menu-button"
+                        tooltip={
+                            <div className="flex flex-col gap-1">
+                                <div>
+                                    Account menu
+                                    <RenderKeybind keybind={[keyBinds.newAccountMenu]} className="ml-1" />
                                 </div>
-                            }
-                        >
-                            {currentOrganization ? (
-                                <UploadedLogo
-                                    name={currentOrganization.name}
-                                    entityId={currentOrganization.id}
-                                    mediaId={currentOrganization.logo_media_id}
-                                    size="small"
-                                />
-                            ) : (
-                                <UploadedLogo name="?" entityId="" mediaId="" size="xsmall" />
-                            )}
-                            {!isLayoutNavCollapsed && (
-                                <span
-                                    className={cn('truncate', isAiFirst && 'text-secondary group-hover:text-primary')}
-                                >
-                                    {isAuthenticatedTeam(currentTeam)
-                                        ? (projectNameWithoutFirstEmoji ?? 'Project')
-                                        : 'Account menu'}
-                                </span>
-                            )}
-                            {hasPendingInvites && (
-                                <PendingInviteDot
-                                    className={isLayoutNavCollapsed ? 'absolute top-0.5 right-0.5' : 'mr-0.5'}
-                                />
-                            )}
-                            {!isLayoutNavCollapsed && !isAiFirst && <MenuOpenIndicator />}
-                        </ButtonPrimitive>
-                    )}
-                />
+                                <div>
+                                    Organization:{' '}
+                                    {currentOrganization ? currentOrganization.name : 'Select organization'}
+                                </div>
+                                <div>Project: {currentTeam ? currentTeam.name : 'Select project'}</div>
+                                {hasPendingInvites && <div>You have a pending invitation</div>}
+                            </div>
+                        }
+                    >
+                        {currentOrganization ? (
+                            <UploadedLogo
+                                name={currentOrganization.name}
+                                entityId={currentOrganization.id}
+                                mediaId={currentOrganization.logo_media_id}
+                                size="small"
+                            />
+                        ) : (
+                            <UploadedLogo name="?" entityId="" mediaId="" size="xsmall" />
+                        )}
+                        {!isLayoutNavCollapsed && (
+                            <span className={cn('truncate', isAiFirst && 'text-secondary group-hover:text-primary')}>
+                                {isAuthenticatedTeam(currentTeam)
+                                    ? (projectNameWithoutFirstEmoji ?? 'Project')
+                                    : 'Account menu'}
+                            </span>
+                        )}
+                        {hasPendingInvites && (
+                            <PendingInviteDot
+                                className={isLayoutNavCollapsed ? 'absolute top-0.5 right-0.5' : 'mr-0.5'}
+                            />
+                        )}
+                        {!isLayoutNavCollapsed && !isAiFirst && <MenuOpenIndicator />}
+                    </ButtonPrimitive>
+                </DropdownMenuTrigger>
 
-                <Menu.Portal>
-                    <Menu.Backdrop className="fixed inset-0 z-[var(--z-modal)]" />
-
-                    <Menu.Positioner className="z-[var(--z-popover)]" sideOffset={4}>
-                        <Menu.Popup className="primitive-menu-content max-h-[calc(var(--available-height)-4px)] min-w-[250px] w-full">
-                            <ScrollableShadows
-                                direction="vertical"
-                                styledScrollbars
-                                className="flex flex-col gap-px overflow-x-hidden"
-                                innerClassName="primitive-menu-content-inner p-1 "
+                <DropdownMenuContent
+                    align="start"
+                    className="max-h-[calc(var(--radix-dropdown-menu-content-available-height)-4px)] min-w-[250px] w-full"
+                >
+                    <Label intent="menu" className="pl-2 relative">
+                        Project
+                        {preflight?.can_create_org && (
+                            <ButtonPrimitive
+                                iconOnly
+                                tooltip="Create a new project"
+                                size="xs"
+                                className="absolute -right-[2px] -top-[2px]"
+                                data-attr="new-account-menu-create-project-icon-button"
+                                onClick={() => {
+                                    guardAvailableFeature(
+                                        AvailableFeature.ORGANIZATIONS_PROJECTS,
+                                        () => {
+                                            setAccountMenuOpen(false)
+                                            showCreateProjectModal()
+                                        },
+                                        { currentUsage: currentOrganization?.teams?.length }
+                                    )
+                                }}
                             >
-                                <Label intent="menu" className="pl-2 relative">
-                                    Project
-                                    {preflight?.can_create_org && (
-                                        <ButtonPrimitive
-                                            iconOnly
-                                            tooltip="Create a new project"
-                                            size="xs"
-                                            className="absolute -right-[2px] -top-[2px]"
-                                            data-attr="new-account-menu-create-project-icon-button"
-                                            onClick={() => {
-                                                guardAvailableFeature(
-                                                    AvailableFeature.ORGANIZATIONS_PROJECTS,
-                                                    () => {
-                                                        setAccountMenuOpen(false)
-                                                        showCreateProjectModal()
-                                                    },
-                                                    { currentUsage: currentOrganization?.teams?.length }
-                                                )
-                                            }}
-                                        >
-                                            <IconPlusSmall className="text-tertiary size-4" />
-                                        </ButtonPrimitive>
-                                    )}
-                                </Label>
-                                <DropdownMenuSeparator />
+                                <IconPlusSmall className="text-tertiary size-4" />
+                            </ButtonPrimitive>
+                        )}
+                    </Label>
+                    <DropdownMenuSeparator />
 
-                                {isAuthenticatedTeam(currentTeam) && (
-                                    <Menu.SubmenuRoot>
-                                        <Menu.SubmenuTrigger
-                                            render={
-                                                <ButtonPrimitive
-                                                    menuItem
-                                                    data-attr="new-account-menu-all-projects-button"
-                                                >
-                                                    <div className="Lettermark bg-[var(--color-bg-fill-button-tertiary-active)] size-4 dark:text-tertiary text-[8px]">
-                                                        {String.fromCodePoint(
-                                                            currentTeam.name.codePointAt(0)!
-                                                        ).toLocaleUpperCase()}
-                                                    </div>
-                                                    <span className="truncate font-semibold">
-                                                        {currentTeam ? projectNameWithoutFirstEmoji : 'Select project'}
-                                                    </span>
-                                                    {hasPendingInvites && <PendingInviteDot className="mr-0.5" />}
-                                                    <MenuOpenIndicator intent="sub" className="ml-auto" />
-                                                </ButtonPrimitive>
-                                            }
-                                        />
-                                        <Menu.Portal>
-                                            <Menu.Positioner
-                                                className="z-[var(--z-popover)]"
-                                                collisionPadding={{ top: 50, bottom: 50 }}
-                                            >
-                                                <Menu.Popup className="primitive-menu-content w-min max-w-[var(--available-width)]">
-                                                    {/* We need to add a div here to prevent the keydown event from bubbling up to the menu. */}
-                                                    <div onKeyDown={(e) => e.stopPropagation()}>
-                                                        <ProjectSwitcher dialog={false} />
-                                                    </div>
-                                                </Menu.Popup>
-                                            </Menu.Positioner>
-                                        </Menu.Portal>
-                                    </Menu.SubmenuRoot>
-                                )}
+                    {isAuthenticatedTeam(currentTeam) && (
+                        <DropdownMenuSub>
+                            <DropdownMenuSubTrigger asChild>
+                                <ButtonPrimitive menuItem data-attr="new-account-menu-all-projects-button">
+                                    <div className="Lettermark bg-[var(--color-bg-fill-button-tertiary-active)] size-4 dark:text-tertiary text-[8px]">
+                                        {String.fromCodePoint(currentTeam.name.codePointAt(0)!).toLocaleUpperCase()}
+                                    </div>
+                                    <span className="truncate font-semibold">
+                                        {currentTeam ? projectNameWithoutFirstEmoji : 'Select project'}
+                                    </span>
+                                    {hasPendingInvites && <PendingInviteDot className="mr-0.5" />}
+                                    <MenuOpenIndicator intent="sub" className="ml-auto" />
+                                </ButtonPrimitive>
+                            </DropdownMenuSubTrigger>
+                            <DropdownMenuSubContent className="w-min max-w-[var(--radix-dropdown-menu-content-available-width)]">
+                                <div onKeyDown={(e) => e.stopPropagation()}>
+                                    <ProjectSwitcher dialog={false} />
+                                </div>
+                            </DropdownMenuSubContent>
+                        </DropdownMenuSub>
+                    )}
 
-                                <Menu.Item
-                                    onClick={() => {
-                                        showInviteModal()
-                                        reportInviteMembersButtonClicked()
-                                    }}
-                                    render={
-                                        <ButtonPrimitive
-                                            menuItem
-                                            tooltip="Invite members"
-                                            tooltipPlacement="right"
-                                            data-attr="new-account-menu-invite-team-members-button"
-                                        >
-                                            <IconPlusSmall />
-                                            Invite members
-                                        </ButtonPrimitive>
-                                    }
-                                />
+                    <DropdownMenuItem asChild onSelect={() => showInviteModal()}>
+                        <ButtonPrimitive
+                            menuItem
+                            tooltip="Invite members"
+                            tooltipPlacement="right"
+                            data-attr="new-account-menu-invite-team-members-button"
+                            onClick={() => {
+                                reportInviteMembersButtonClicked()
+                            }}
+                        >
+                            <IconPlusSmall />
+                            Invite members
+                        </ButtonPrimitive>
+                    </DropdownMenuItem>
 
-                                {currentTeam && (
-                                    <Menu.Item
-                                        render={
-                                            <Link
-                                                buttonProps={{
-                                                    menuItem: true,
-                                                }}
-                                                tooltip="Project settings"
-                                                tooltipPlacement="right"
-                                                data-attr="new-account-menu-project-settings-button"
-                                                to={urls.project(currentTeam.id, urls.settings('project'))}
-                                            >
-                                                <IconGear />
-                                                Project settings
-                                            </Link>
-                                        }
+                    {currentTeam && (
+                        <DropdownMenuItem asChild>
+                            <Link
+                                buttonProps={{ menuItem: true }}
+                                tooltip="Project settings"
+                                tooltipPlacement="right"
+                                data-attr="new-account-menu-project-settings-button"
+                                to={urls.project(currentTeam.id, urls.settings('project'))}
+                            >
+                                <IconGear />
+                                Project settings
+                            </Link>
+                        </DropdownMenuItem>
+                    )}
+
+                    <Label intent="menu" className="px-2 mt-2 relative">
+                        Organization
+                        {preflight?.can_create_org && (
+                            <ButtonPrimitive
+                                iconOnly
+                                tooltip="Create a new organization"
+                                size="xs"
+                                className="absolute right-0 -top-1 p-0"
+                                data-attr="new-account-menu-create-organization-icon-button"
+                                onClick={() => {
+                                    guardAvailableFeature(
+                                        AvailableFeature.ORGANIZATIONS_PROJECTS,
+                                        () => {
+                                            setAccountMenuOpen(false)
+                                            showCreateOrganizationModal()
+                                        },
+                                        { guardOnCloud: false }
+                                    )
+                                }}
+                            >
+                                <IconPlusSmall className="text-tertiary size-4" />
+                            </ButtonPrimitive>
+                        )}
+                    </Label>
+                    <DropdownMenuSeparator />
+
+                    <DropdownMenuSub>
+                        <DropdownMenuSubTrigger asChild>
+                            <ButtonPrimitive menuItem data-attr="new-account-menu-all-organizations-button">
+                                {currentOrganization ? (
+                                    <UploadedLogo
+                                        name={currentOrganization.name}
+                                        entityId={currentOrganization.id}
+                                        mediaId={currentOrganization.logo_media_id}
+                                        size="xsmall"
                                     />
+                                ) : (
+                                    <UploadedLogo name="?" entityId="" mediaId="" size="xsmall" />
                                 )}
+                                <span className="truncate font-semibold">
+                                    {currentOrganization ? currentOrganization.name : 'Select organization'}
+                                </span>
+                                <MenuOpenIndicator intent="sub" className="ml-auto" />
+                            </ButtonPrimitive>
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuSubContent className="w-min max-w-[var(--radix-dropdown-menu-content-available-width)]">
+                            <div onKeyDown={(e) => e.stopPropagation()}>
+                                <OrgSwitcher dialog={false} />
+                            </div>
+                        </DropdownMenuSubContent>
+                    </DropdownMenuSub>
 
-                                <Label intent="menu" className="px-2 mt-2 relative">
-                                    Organization
-                                    {preflight?.can_create_org && (
-                                        <ButtonPrimitive
-                                            iconOnly
-                                            tooltip="Create a new organization"
-                                            size="xs"
-                                            className="absolute right-0 -top-1 p-0"
-                                            data-attr="new-account-menu-create-organization-icon-button"
-                                            onClick={() => {
-                                                guardAvailableFeature(
-                                                    AvailableFeature.ORGANIZATIONS_PROJECTS,
-                                                    () => {
-                                                        setAccountMenuOpen(false)
-                                                        showCreateOrganizationModal()
-                                                    },
-                                                    { guardOnCloud: false }
-                                                )
-                                            }}
-                                        >
-                                            <IconPlusSmall className="text-tertiary size-4" />
-                                        </ButtonPrimitive>
-                                    )}
-                                </Label>
-                                <DropdownMenuSeparator />
-                                <Menu.SubmenuRoot>
-                                    <Menu.SubmenuTrigger
-                                        render={
-                                            <ButtonPrimitive
-                                                menuItem
-                                                data-attr="new-account-menu-all-organizations-button"
-                                            >
-                                                {currentOrganization ? (
-                                                    <UploadedLogo
-                                                        name={currentOrganization.name}
-                                                        entityId={currentOrganization.id}
-                                                        mediaId={currentOrganization.logo_media_id}
-                                                        size="xsmall"
-                                                    />
-                                                ) : (
-                                                    <UploadedLogo name="?" entityId="" mediaId="" size="xsmall" />
-                                                )}
-                                                <span className="truncate font-semibold">
-                                                    {currentOrganization
-                                                        ? currentOrganization.name
-                                                        : 'Select organization'}
-                                                </span>
-                                                <MenuOpenIndicator intent="sub" className="ml-auto" />
-                                            </ButtonPrimitive>
-                                        }
-                                    />
-                                    <Menu.Portal>
-                                        <Menu.Positioner
-                                            className="z-[var(--z-popover)]"
-                                            collisionPadding={{ top: 50, bottom: 50 }}
-                                        >
-                                            <Menu.Popup className="primitive-menu-content w-min max-w-[var(--available-width)]">
-                                                {/* We need to add a div here to prevent the keydown event from bubbling up to the menu. */}
-                                                <div onKeyDown={(e) => e.stopPropagation()}>
-                                                    <OrgSwitcher dialog={false} />
-                                                </div>
-                                            </Menu.Popup>
-                                        </Menu.Positioner>
-                                    </Menu.Portal>
-                                </Menu.SubmenuRoot>
+                    {isCloudOrDev && canAccessBilling ? (
+                        <DropdownMenuItem asChild>
+                            <Link
+                                to={
+                                    featureFlags[FEATURE_FLAGS.USAGE_SPEND_DASHBOARDS]
+                                        ? urls.organizationBillingSection('overview')
+                                        : urls.organizationBilling()
+                                }
+                                buttonProps={{
+                                    className: 'flex items-center gap-2',
+                                    menuItem: true,
+                                    truncate: true,
+                                }}
+                            >
+                                <IconReceipt />
+                                {featureFlags[FEATURE_FLAGS.USAGE_SPEND_DASHBOARDS] ? 'Billing & usage' : 'Billing'}
+                            </Link>
+                        </DropdownMenuItem>
+                    ) : null}
 
-                                {isCloudOrDev && canAccessBilling ? (
-                                    <Menu.Item
-                                        render={(props) => (
-                                            <Link
-                                                {...props}
-                                                to={
-                                                    featureFlags[FEATURE_FLAGS.USAGE_SPEND_DASHBOARDS]
-                                                        ? urls.organizationBillingSection('overview')
-                                                        : urls.organizationBilling()
-                                                }
-                                                buttonProps={{
-                                                    className: 'flex items-center gap-2',
-                                                    menuItem: true,
-                                                    truncate: true,
-                                                }}
-                                            >
-                                                <IconReceipt />
-                                                {featureFlags[FEATURE_FLAGS.USAGE_SPEND_DASHBOARDS]
-                                                    ? 'Billing & usage'
-                                                    : 'Billing'}
-                                            </Link>
-                                        )}
-                                    />
-                                ) : null}
+                    <DropdownMenuItem asChild>
+                        <Link
+                            to={urls.settings('organization')}
+                            buttonProps={{ menuItem: true }}
+                            tooltip="Organization settings"
+                            tooltipPlacement="right"
+                            data-attr="new-account-menu-organization-settings-button"
+                        >
+                            <IconGear />
+                            Organization settings
+                        </Link>
+                    </DropdownMenuItem>
 
-                                <Menu.Item
-                                    render={(props) => (
-                                        <Link
-                                            {...props}
-                                            to={urls.settings('organization')}
-                                            buttonProps={{
-                                                menuItem: true,
-                                            }}
-                                            tooltip="Organization settings"
-                                            tooltipPlacement="right"
-                                            data-attr="new-account-menu-organization-settings-button"
-                                        >
-                                            <IconGear />
-                                            Organization settings
-                                        </Link>
-                                    )}
-                                />
+                    {user?.is_staff && (
+                        <>
+                            <Label intent="menu" className="px-2 mt-2">
+                                Staff
+                            </Label>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem asChild>
+                                <Link
+                                    to="/admin/"
+                                    buttonProps={{ menuItem: true }}
+                                    data-attr="new-account-menu-django-admin"
+                                    disableClientSideRouting
+                                >
+                                    <IconShieldLock />
+                                    Django admin
+                                </Link>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem asChild>
+                                <Link
+                                    to={urls.instanceStatus()}
+                                    buttonProps={{ menuItem: true }}
+                                    data-attr="new-account-menu-instance-panel"
+                                >
+                                    <IconServer />
+                                    Instance panel
+                                </Link>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem asChild>
+                                <Link
+                                    to={urls.queryPerformance()}
+                                    buttonProps={{ menuItem: true }}
+                                    data-attr="new-account-menu-query-performance"
+                                >
+                                    <IconDatabase />
+                                    Query performance
+                                </Link>
+                            </DropdownMenuItem>
+                        </>
+                    )}
 
-                                {user?.is_staff && (
-                                    <>
-                                        <Label intent="menu" className="px-2 mt-2">
-                                            Staff
-                                        </Label>
-                                        <DropdownMenuSeparator />
-                                        <Menu.Item
-                                            render={(props) => (
-                                                <Link
-                                                    {...props}
-                                                    to="/admin/"
-                                                    buttonProps={{
-                                                        menuItem: true,
-                                                    }}
-                                                    data-attr="new-account-menu-django-admin"
-                                                    disableClientSideRouting
-                                                >
-                                                    <IconShieldLock />
-                                                    Django admin
-                                                </Link>
-                                            )}
-                                        />
-                                        <Menu.Item
-                                            render={(props) => (
-                                                <Link
-                                                    {...props}
-                                                    to={urls.instanceStatus()}
-                                                    buttonProps={{
-                                                        menuItem: true,
-                                                    }}
-                                                    data-attr="new-account-menu-instance-panel"
-                                                >
-                                                    <IconServer />
-                                                    Instance panel
-                                                </Link>
-                                            )}
-                                        />
-                                        <Menu.Item
-                                            render={(props) => (
-                                                <Link
-                                                    {...props}
-                                                    to={urls.queryPerformance()}
-                                                    buttonProps={{
-                                                        menuItem: true,
-                                                    }}
-                                                    data-attr="new-account-menu-query-performance"
-                                                >
-                                                    <IconDatabase />
-                                                    Query performance
-                                                </Link>
-                                            )}
-                                        />
-                                    </>
-                                )}
+                    <Label intent="menu" className="px-2 mt-2">
+                        Account
+                    </Label>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem asChild>
+                        <Link
+                            to={urls.settings(user?.organization?.id ? 'user' : 'user-danger-zone')}
+                            buttonProps={{
+                                className: 'flex items-center gap-2 h-fit',
+                                menuItem: true,
+                                truncate: true,
+                            }}
+                            tooltip="User settings"
+                            tooltipPlacement="right"
+                            data-attr="new-account-menu-account-owner-button"
+                        >
+                            <ProfilePicture user={user} size="xs" />
+                            <span className="flex flex-col truncate">
+                                <span className="font-semibold truncate">{user?.first_name}</span>
+                                <span className="text-tertiary text-xs truncate">{user?.email}</span>
+                            </span>
+                        </Link>
+                    </DropdownMenuItem>
 
-                                <Label intent="menu" className="px-2 mt-2">
-                                    Account
-                                </Label>
-                                <DropdownMenuSeparator />
-                                <Menu.Item
-                                    render={(props) => (
-                                        <Link
-                                            {...props}
-                                            to={urls.settings(user?.organization?.id ? 'user' : 'user-danger-zone')}
-                                            buttonProps={{
-                                                className: 'flex items-center gap-2 h-fit',
-                                                menuItem: true,
-                                                truncate: true,
-                                            }}
-                                            tooltip="User settings"
-                                            tooltipPlacement="right"
-                                            data-attr="new-account-menu-account-owner-button"
-                                        >
-                                            <ProfilePicture user={user} size="xs" />
-                                            <span className="flex flex-col truncate">
-                                                <span className="font-semibold truncate">{user?.first_name}</span>
-                                                <span className="text-tertiary text-xs truncate">{user?.email}</span>
-                                            </span>
-                                        </Link>
-                                    )}
-                                />
-
-                                <Menu.Item
-                                    onClick={() => logout()}
-                                    render={
-                                        <ButtonPrimitive menuItem data-attr="new-account-menu-logout-button">
-                                            <IconLeave />
-                                            Log out
-                                        </ButtonPrimitive>
-                                    }
-                                />
-                            </ScrollableShadows>
-                        </Menu.Popup>
-                    </Menu.Positioner>
-                </Menu.Portal>
-            </Menu.Root>
+                    <DropdownMenuItem asChild onSelect={() => logout()}>
+                        <ButtonPrimitive menuItem data-attr="new-account-menu-logout-button">
+                            <IconLeave />
+                            Log out
+                        </ButtonPrimitive>
+                    </DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
 
             <ProjectModal />
             <OrgModal />


### PR DESCRIPTION
## Why

MemLens production data showed the left-nav `NewAccountMenu` as a top source of detached fibers. Local validation with Playwright MCP + `window.__memlensScan()` reproduced the leak precisely and confirmed the fix:

| Implementation | Per-cycle leaked fibers (open + close) |
|---|---|
| base-ui `Menu` (current) | 22–80 |
| Radix `DropdownMenu` (this PR) | **0** |

Numbers from 5 clean open/close cycles on `/project/1/home` in dev.

## Root cause

`@base-ui/react`'s `Menu` imperatively inserts and removes DOM — focus-guard spans, backdrop, positioner, portal root — *outside* React's reconciliation. These nodes carry no React fiber keys. On menu close the elements are removed from the document, but internal refs keep them retained, giving us detached DOM per cycle. MemLens in production resolves these to component names like `InternalBackdrop`, `MenuPositioner`, `FloatingPortal`, `MenuPortal`, `FloatingTree`, `MenuRoot` — all base-ui internal components.

No amount of usage-level wrapping (conditional `{open && <Menu.Portal>}`, stripping tooltips/submenus, etc.) helps, because those elements aren't part of our React tree.

## Fix

Port this one file to our existing Radix `DropdownMenu` wrapper (`frontend/src/lib/ui/DropdownMenu/DropdownMenu.tsx`). That wrapper was fixed in #54126 to conditionally render `DropdownMenuContent` via an open-state context — the portal and all children unmount fully on close.

Mechanical primitive swap, no behavioural intent:

| base-ui | Radix |
|---|---|
| `Menu.Root` | `DropdownMenu` |
| `Menu.Trigger render={…}` | `DropdownMenuTrigger asChild` |
| `Menu.Portal` + `Backdrop` + `Positioner` + `Popup` | `DropdownMenuContent` |
| `Menu.Item render={…}` | `DropdownMenuItem asChild` |
| `Menu.SubmenuRoot` | `DropdownMenuSub` |
| `Menu.SubmenuTrigger render={…}` | `DropdownMenuSubTrigger asChild` |
| `Menu.Portal` (submenu) + `Positioner` + `Popup` | `DropdownMenuSubContent` |

All `data-attr` selectors are preserved for tests and analytics. The explicit `ScrollableShadows` wrapper inside `Menu.Popup` is now built into `DropdownMenuContent`, so it's removed.

## Out of scope

- Submenu internals (`ProjectSwitcher`, `OrgSwitcher`) still leak on submenu open/close (~118 fibers per interaction in local testing). That's a separate issue — those components have their own churn unrelated to the menu primitive.
- Other base-ui `Menu` consumers in the app (HelpMenu, NotificationsMenu, HealthMenu, ThemeMenu, PlayerShareMenu, etc.) are not touched here. Same pattern should work if they show up in MemLens data later.
- PR #55676 (the `window.__memlensScan` bridge) is unrelated but helpful for reproducing this style of fix-verification loop locally.

## Test plan

- [ ] CI green
- [ ] Visual Review diffs reviewed — expect minor positioning/animation differences between base-ui and Radix menus
- [ ] Manually smoke: open the menu, invite members, click through project/org submenus, log out
- [ ] Post-deploy: watch MemLens `detached_elements` event for drop in `InternalBackdrop` / `MenuPositioner` / `FloatingPortal` / `MenuPortal` / `MenuRoot` counts

## LLM context

Built with Playwright MCP driving a local dev server and a temporary `window.__memlensScan()` bridge (PR #55676) for per-cycle leak measurement. The loop: open menu, press Escape, scan, diff. Base-ui produced 22–80 detached per cycle with high variance; Radix produced 0 reliably.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*