### PR TITLE
fix(logs-alerts): give BROKEN and ERRORED notifications pre-commit retry semantics

### DIFF
--- a/products/logs/backend/alert_state_machine.py
+++ b/products/logs/backend/alert_state_machine.py
@@ -37,6 +37,7 @@ class NotificationAction(Enum):
     FIRE = "fire"
     RESOLVE = "resolve"
     ERROR = "error"
+    BROKEN = "broken"
 
 
 class InvalidTransition(Exception):
@@ -128,9 +129,16 @@ def evaluate_alert_check(
             and snapshot.state != AlertState.ERRORED  # prevents re-notification after snooze auto-expiry
             and new_state == AlertState.ERRORED
         )
+        first_broken = new_state == AlertState.BROKEN
+        if first_broken:
+            notification = NotificationAction.BROKEN
+        elif first_error:
+            notification = NotificationAction.ERROR
+        else:
+            notification = NotificationAction.NONE
         return AlertCheckOutcome(
             new_state=new_state,
-            notification=NotificationAction.ERROR if first_error else NotificationAction.NONE,
+            notification=notification,
             consecutive_failures=consecutive_failures,
             update_last_notified_at=False,
             error_message=check.error_message,

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -222,6 +222,28 @@ def _evaluate_single_alert(
             team_id=alert.team_id,
             notified=notified,
         )
+    elif outcome.notification == NotificationAction.ERROR:
+        notified = _emit_alert_errored_event(alert, outcome, now)
+        notification_failed = not notified
+        logger.info(
+            "Alert entered errored state",
+            alert_id=str(alert.id),
+            alert_name=alert.name,
+            team_id=alert.team_id,
+            consecutive_failures=outcome.consecutive_failures,
+            notified=notified,
+        )
+    elif outcome.notification == NotificationAction.BROKEN:
+        notified = _emit_auto_disabled_event(alert, outcome, now)
+        notification_failed = not notified
+        logger.warning(
+            "Alert broken after consecutive failures",
+            alert_id=str(alert.id),
+            alert_name=alert.name,
+            team_id=alert.team_id,
+            consecutive_failures=outcome.consecutive_failures,
+            notified=notified,
+        )
     # If the notification delivery failed, don't commit the state transition
     # so the next tick will re-evaluate and retry the notification.
     if notification_failed:
@@ -278,29 +300,6 @@ def _evaluate_single_alert(
             LogsAlertEvent.objects.filter(id__in=prunable_ids).delete()
     except Exception:
         logger.exception("Failed to prune non-event rows", alert_id=str(alert.id))
-
-    transitioned_to_broken = committed_state == AlertState.BROKEN and state_before != AlertState.BROKEN.value
-    if transitioned_to_broken:
-        logger.warning(
-            "Alert broken after consecutive failures",
-            alert_id=str(alert.id),
-            alert_name=alert.name,
-            team_id=alert.team_id,
-            consecutive_failures=outcome.consecutive_failures,
-        )
-        _emit_auto_disabled_event(alert, outcome, now)
-
-    if outcome.notification == NotificationAction.ERROR:
-        logger.info(
-            "Alert entered errored state",
-            alert_id=str(alert.id),
-            alert_name=alert.name,
-            team_id=alert.team_id,
-            consecutive_failures=outcome.consecutive_failures,
-        )
-        # Best-effort, consistent with _emit_auto_disabled_event — state is already committed
-        # so there is no retry path; a missed delivery is acceptable for this diagnostic event.
-        _emit_alert_errored_event(alert, outcome, now)
 
     stats["checked"] += 1
 
@@ -407,21 +406,21 @@ def _emit_auto_disabled_event(
     alert: LogsAlertConfiguration,
     outcome: AlertCheckOutcome,
     now: datetime,
-) -> None:
+) -> bool:
     properties = {
         **_base_failure_properties(alert, outcome, now),
         "last_error_message": outcome.error_message or "",
     }
-    _produce_alert_internal_event(alert, "$logs_alert_auto_disabled", properties, now)
+    return _produce_alert_internal_event(alert, "$logs_alert_auto_disabled", properties, now)
 
 
 def _emit_alert_errored_event(
     alert: LogsAlertConfiguration,
     outcome: AlertCheckOutcome,
     now: datetime,
-) -> None:
+) -> bool:
     properties = {
         **_base_failure_properties(alert, outcome, now),
         "error_message": outcome.error_message or "",
     }
-    _produce_alert_internal_event(alert, "$logs_alert_errored", properties, now)
+    return _produce_alert_internal_event(alert, "$logs_alert_errored", properties, now)


### PR DESCRIPTION
## Problem

Notification delivery for alert state transitions (errored and broken) was best-effort and fire-and-forget — if the notification failed, the state was already committed and there was no retry path. This meant missed notifications were silently accepted with no recovery mechanism.

## Changes

- Added a `BROKEN` value to `NotificationAction` so that transitioning to the broken state is treated as a first-class notification action, consistent with how `ERROR` and other transitions are handled.
- Moved the broken-state notification and logging into the pre-commit notification block, alongside the existing `ERROR` notification handling. Both now gate the state commit on successful delivery, enabling retries on the next tick if notification fails.
- Updated `_emit_auto_disabled_event` and `_emit_alert_errored_event` to return `bool` (propagated from `_produce_alert_internal_event`) so callers can determine whether delivery succeeded.
- Removed the post-commit broken-state detection block that previously called `_emit_auto_disabled_event` after the state was already written to the database.

## How did you test this code?

Local dev

## Publish to changelog?

No