### PR TITLE
fix(data-warehouse): normalize corrupted vitally region in job_inputs

### DIFF
--- a/products/data_warehouse/backend/migrations/0046_fix_vitally_region_job_inputs.py
+++ b/products/data_warehouse/backend/migrations/0046_fix_vitally_region_job_inputs.py
@@ -1,0 +1,51 @@
+from django.db import migrations
+
+
+def _clean_subdomain(value: object) -> str | None:
+    # `str(None)` has been observed persisted in the outer `subdomain` slot on affected
+    # rows; treat it as absent so we don't carry garbage forward.
+    if isinstance(value, str) and value and value != "None":
+        return value
+    return None
+
+
+def forwards(apps, schema_editor):
+    ExternalDataSource = apps.get_model("data_warehouse", "ExternalDataSource")
+
+    for source in ExternalDataSource.objects.filter(source_type="Vitally"):
+        job_inputs = source.job_inputs
+        if not isinstance(job_inputs, dict):
+            continue
+
+        region = job_inputs.get("region")
+        if not isinstance(region, dict):
+            continue
+
+        selection = region.get("selection")
+        if not isinstance(selection, dict):
+            # Already in the canonical shape.
+            continue
+
+        inner_selection = selection.get("selection")
+        if inner_selection not in ("EU", "US"):
+            # Can't confidently recover — leave it so it shows up in any audit.
+            continue
+
+        # Prefer the outer subdomain if usable; fall back to the inner one.
+        subdomain = _clean_subdomain(region.get("subdomain")) or _clean_subdomain(selection.get("subdomain")) or ""
+
+        job_inputs["region"] = {"selection": inner_selection, "subdomain": subdomain}
+        source.job_inputs = job_inputs
+        source.save(update_fields=["job_inputs"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("data_warehouse", "0045_alter_externaldatasource_source_type"),
+    ]
+
+    operations = [
+        # Irreversible data fix — the corrupted shape is already the result of an
+        # earlier rewrite, so reversing would just re-corrupt.
+        migrations.RunPython(forwards, migrations.RunPython.noop),
+    ]

--- a/products/data_warehouse/backend/migrations/max_migration.txt
+++ b/products/data_warehouse/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0045_alter_externaldatasource_source_type
+0046_fix_vitally_region_job_inputs

--- a/products/data_warehouse/backend/migrations/test/test_migration_0046.py
+++ b/products/data_warehouse/backend/migrations/test/test_migration_0046.py
@@ -1,0 +1,163 @@
+import uuid
+import importlib
+
+import pytest
+
+from django.apps import apps
+
+from products.data_warehouse.backend.models import ExternalDataSource
+
+migration_module = importlib.import_module(
+    "products.data_warehouse.backend.migrations.0046_fix_vitally_region_job_inputs"
+)
+forwards = migration_module.forwards
+
+
+@pytest.fixture
+def vitally_source_factory(team):
+    def _create(job_inputs):
+        return ExternalDataSource.objects.create(
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            destination_id=str(uuid.uuid4()),
+            team=team,
+            status="running",
+            source_type="Vitally",
+            job_inputs=job_inputs,
+        )
+
+    return _create
+
+
+@pytest.mark.django_db
+class TestFixVitallyRegionJobInputs:
+    @pytest.mark.parametrize(
+        "input_job_inputs, expected_job_inputs",
+        [
+            (
+                # Exact shape reported from prod.
+                {
+                    "region": {
+                        "selection": {"selection": "EU", "subdomain": ""},
+                        "subdomain": "None",
+                    }
+                },
+                {"region": {"selection": "EU", "subdomain": ""}},
+            ),
+            (
+                # US variant — prefer the outer subdomain when it's a real value.
+                {
+                    "region": {
+                        "selection": {"selection": "US", "subdomain": ""},
+                        "subdomain": "acme",
+                    }
+                },
+                {"region": {"selection": "US", "subdomain": "acme"}},
+            ),
+            (
+                # Outer subdomain is garbage, inner has the real one.
+                {
+                    "region": {
+                        "selection": {"selection": "US", "subdomain": "acme"},
+                        "subdomain": "None",
+                    }
+                },
+                {"region": {"selection": "US", "subdomain": "acme"}},
+            ),
+            (
+                # Neither subdomain is usable — fall back to empty string.
+                {
+                    "region": {
+                        "selection": {"selection": "EU", "subdomain": ""},
+                        "subdomain": "",
+                    }
+                },
+                {"region": {"selection": "EU", "subdomain": ""}},
+            ),
+            (
+                # Other sibling keys on job_inputs are preserved.
+                {
+                    "secret_token": "sk_live_abc",
+                    "region": {
+                        "selection": {"selection": "EU", "subdomain": ""},
+                        "subdomain": "None",
+                    },
+                },
+                {
+                    "secret_token": "sk_live_abc",
+                    "region": {"selection": "EU", "subdomain": ""},
+                },
+            ),
+        ],
+        ids=[
+            "reported_eu_shape_heals",
+            "us_outer_subdomain_preserved",
+            "us_falls_back_to_inner_subdomain",
+            "no_usable_subdomain_defaults_to_empty",
+            "sibling_keys_preserved",
+        ],
+    )
+    def test_forward_migration_heals_corrupted_rows(
+        self, input_job_inputs, expected_job_inputs, vitally_source_factory
+    ):
+        source = vitally_source_factory(input_job_inputs)
+
+        forwards(apps, None)
+
+        source.refresh_from_db()
+        assert source.job_inputs == expected_job_inputs
+
+    @pytest.mark.parametrize(
+        "job_inputs",
+        [
+            # Canonical shape — no-op.
+            {"region": {"selection": "EU", "subdomain": ""}},
+            {"region": {"selection": "US", "subdomain": "acme"}},
+            # No region at all.
+            {"secret_token": "sk_live_abc"},
+            # region is not a dict.
+            {"region": "EU"},
+            # region.selection is a dict but the inner selection is unrecognised — leave it alone
+            # so it surfaces in an audit rather than being silently mangled.
+            {"region": {"selection": {"foo": "bar"}, "subdomain": ""}},
+            {"region": {"selection": {"selection": "ZZ", "subdomain": ""}, "subdomain": ""}},
+            # Non-dict job_inputs.
+            None,
+        ],
+        ids=[
+            "canonical_eu",
+            "canonical_us",
+            "no_region_key",
+            "region_is_string",
+            "inner_selection_not_a_region_key",
+            "inner_selection_unrecognised_literal",
+            "job_inputs_is_none",
+        ],
+    )
+    def test_forward_migration_leaves_other_shapes_untouched(self, job_inputs, vitally_source_factory):
+        source = vitally_source_factory(job_inputs)
+
+        forwards(apps, None)
+
+        source.refresh_from_db()
+        assert source.job_inputs == job_inputs
+
+    def test_non_vitally_sources_unaffected(self, team):
+        # Deliberately construct a non-Vitally source whose `region.selection` is a dict —
+        # the migration must not touch anything that isn't Vitally.
+        stripe_source = ExternalDataSource.objects.create(
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            destination_id=str(uuid.uuid4()),
+            team=team,
+            status="running",
+            source_type="Stripe",
+            job_inputs={"region": {"selection": {"selection": "EU", "subdomain": ""}, "subdomain": "None"}},
+        )
+
+        forwards(apps, None)
+
+        stripe_source.refresh_from_db()
+        assert stripe_source.job_inputs == {
+            "region": {"selection": {"selection": "EU", "subdomain": ""}, "subdomain": "None"}
+        }


### PR DESCRIPTION
## Problem

Editing a Vitally source at `/project/:id/data-management/sources/managed-<id>/configuration` crashed with React error #31 ("Objects are not valid as a React child") for at least one reported user. Decoded arg: `object with keys {selection, subdomain}`.

### Root cause

The affected rows have `job_inputs` corrupted at rest:

```json
"job_inputs": {
    "region": {
        "selection": { "selection": "EU", "subdomain": "" },
        "subdomain": "None"
    }
}
```

Per `VitallyRegionConfig`, `region.selection` should be a string (`"EU"` | `"US"`) and `region.subdomain` a string. Instead `selection` is the full nested region object, and `subdomain` is `str(None)`.

The shape matches what migration `0807_dwh_source_refactor.py` produces when run against a row whose `region` was **already** the new nested object (it does `selection = job_inputs.get("region", "EU")` which is the nested dict in that case). Most plausible causes: a double-apply of that migration, or a row a pre-deploy frontend already wrote in the new shape before the backfill ran.

Fresh sources created through the current wizard don't have this problem (verified locally).

### Why it crashed the page

The edit form sets `state.payload.region.selection` from the stored shape. Kea-forms' `Field` with `name={['region','selection']}` then reads the object (not a string) and hands it to `<LemonSelect value=...>`. No option matches, so the component falls through to rendering the raw value — and rendering an object as a React child is error #31.

## Changes

Add a one-off data migration that rewrites any Vitally `job_inputs` where `region.selection` is a dict back into the canonical shape:

```json
"region": { "selection": "EU"|"US", "subdomain": "<preserved or \"\">" }
```

- Extracts the string `selection` from the nested object.
- Prefers the outer `subdomain` if usable (`isinstance(str) and != "" and != "None"`), else the inner, else `""`.
- Skips rows already in the canonical shape.
- Skips rows where the inner `selection` isn't `"EU"`/`"US"` (no confident recovery — leaves them to be spotted in an audit).
- Reverse is a no-op: reversing would re-corrupt, and the starting state is itself the result of an earlier rewrite.

No frontend changes — `SourceForm.tsx` / `LemonSelect.tsx` left untouched.

## How did you test this code?

tested prod scenario locally

Authored by an agent; no manual browser testing was performed.

- Confirmed the prod source's `job_inputs` matches the described shape via the list endpoint.
- Confirmed a freshly-created local Vitally source has the canonical shape and the edit page renders cleanly — i.e. the bug is scoped to corrupted rows.
- Ran the migration logic against the corrupted shape in a Python REPL: produces `{"selection": "EU", "subdomain": ""}`. Verified the three skip conditions (already clean, non-dict region, non-EU/US inner selection) short-circuit correctly.
- Suggested manual verification before merging to prod: (a) dry-run locally by reproducing the shape via `./manage.py shell` on a local Vitally source, apply the migration, confirm `job_inputs` heals; (b) run `./manage.py sqlmigrate data_warehouse 0046` to confirm the SQL is just a no-op (this is pure `RunPython`).

## Publish to changelog?

no

## Docs update

no docs change needed

## 🤖 LLM context

Authored by PostHog Code. Initial hypothesis was a form-wiring bug and the PR first shipped a defensive unwrap in `SourceForm.tsx`; inspecting the affected row's stored `job_inputs` revealed the corruption was in the data, not the render path. Frontend change reverted in favour of this data migration, keeping the fix scoped to Vitally. A follow-up to harden migration 0807 against re-runs (guard each branch with `isinstance(existing, str)` before rewriting) would be worthwhile if re-applying migrations in unusual operational scenarios is a real concern — happy to open that separately.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*