### PR TITLE
fix(mcp): render the trends ui app for the query-trends tool response

### DIFF
--- a/services/mcp/src/ui-apps/components/types.ts
+++ b/services/mcp/src/ui-apps/components/types.ts
@@ -112,7 +112,7 @@ export interface TablePayload extends BasePayload {
 // ============================================================================
 
 export interface TrendsVisualizerProps {
-    query: TrendsQuery
+    query: TrendsQuery | undefined
     results: TrendsResult
 }
 

--- a/services/mcp/src/ui-apps/components/utils.ts
+++ b/services/mcp/src/ui-apps/components/utils.ts
@@ -1,7 +1,7 @@
 import type { ChartDisplayType, FunnelResult, TrendsQuery } from './types'
 
-export function getDisplayType(query: TrendsQuery): ChartDisplayType {
-    return query.trendsFilter?.display || 'ActionsLineGraph'
+export function getDisplayType(query: TrendsQuery | undefined): ChartDisplayType {
+    return query?.trendsFilter?.display || 'ActionsLineGraph'
 }
 
 export function isBarChart(displayType: ChartDisplayType): boolean {


### PR DESCRIPTION
## Problem

In MCP v2, the query tools do not return `query` in the response. This was only used in trends visualization to determine the display type. Fallback to `ActionsLineGraph` when the query is missing, instead of crashing, trying to access the `trendsFilter` property, and not loading the trends chart at all.

```TypeError: Cannot read properties of undefined (reading 'trendsFilter')```


## Changes

Add a fallback when the query is missing in the trends response

## How did you test this code?

Manually

## Publish to changelog?

no