### PR TITLE
fix(dags): retry sessions backfill on TOO_MANY_PARTS

### DIFF
--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -478,6 +478,56 @@ def _is_oom_error(exc: Exception) -> bool:
     return f"error code {ErrorCodes.MEMORY_LIMIT_EXCEEDED}" in error_str or "MEMORY_LIMIT_EXCEEDED" in error_str
 
 
+def _is_too_many_parts_error(exc: Exception) -> bool:
+    """Check if an exception is a ClickHouse TOO_MANY_PARTS error.
+
+    This can happen even after the preflight check passes — a single INSERT SELECT
+    can produce hundreds of parts (one per block), exceeding parts_to_throw_insert
+    before merges catch up.
+    """
+    error_str = str(exc)
+    return f"error code {ErrorCodes.TOO_MANY_PARTS}" in error_str or "TOO_MANY_PARTS" in error_str
+
+
+def _execute_with_too_many_parts_retry(
+    context: AssetExecutionContext,
+    config: ExperimentalSessionsBackfillConfig,
+    client: Client,
+    sql: str,
+    settings_: dict[str, Any],
+    table: str,
+    retry_state: dict[str, int],
+    retry_description: str,
+) -> None:
+    """Execute an INSERT, retrying by re-running the preflight wait on TOO_MANY_PARTS.
+
+    Uses a shared retry budget (retry_state['count'] / retry_state['max']) across
+    the whole backfill run so a single misbehaving partition can't loop forever.
+    Raises the original exception when the budget is exhausted (or on any other error).
+    """
+    while True:
+        try:
+            sync_execute(sql, settings=settings_, sync_client=client)
+            return
+        except Exception as e:
+            if not _is_too_many_parts_error(e):
+                raise
+
+            retry_state["count"] += 1
+            if retry_state["count"] > retry_state["max"]:
+                context.log.exception(
+                    f"TOO_MANY_PARTS retry budget exhausted ({retry_state['max']}) on {retry_description}; giving up"
+                )
+                raise
+
+            context.log.warning(
+                f"TOO_MANY_PARTS on {retry_description} "
+                f"(retry {retry_state['count']}/{retry_state['max']}), "
+                f"returning to preflight check and waiting for parts to merge: {e}"
+            )
+            wait_for_parts_to_merge(context, config, sync_client=client, table=table, use_cluster=False)
+
+
 def _sub_chunk_where(base_where: str, sub_chunk_i: int, total_sub_chunks: int) -> str:
     """Add a cityHash64(distinct_id) range filter for sub-chunk splitting on OOM retry."""
     max_uint64 = 2**64
@@ -603,6 +653,11 @@ def _do_experimental_backfill(
     # and is a standalone node not in the main ClickHouse cluster
     target_table = DISTRIBUTED_RAW_SESSIONS_TABLE_V3()
 
+    # Shared retry budget for TOO_MANY_PARTS across the whole run. Budget = num_chunks
+    # so on average each chunk can trigger one retry; a few bad chunks may burn through
+    # more, but the total is bounded so we fail fast if parts consistently aren't merging.
+    parts_retry_state = {"count": 0, "max": num_chunks}
+
     with get_http_client(**kwargs, **config.client_overrides) as client:
         tags = dagster_tags(context)
         with tags_context(kind="dagster", dagster=tags, product=ProductKey.WEB_ANALYTICS, feature=Feature.BACKFILL):
@@ -627,7 +682,16 @@ def _do_experimental_backfill(
                 context.log.info(backfill_sql)
 
                 try:
-                    sync_execute(backfill_sql, settings=merged_settings, sync_client=client)
+                    _execute_with_too_many_parts_retry(
+                        context,
+                        config,
+                        client,
+                        backfill_sql,
+                        merged_settings,
+                        target_table,
+                        parts_retry_state,
+                        f"chunk {chunk_i + 1}/{num_chunks}",
+                    )
                 except Exception as e:
                     if not _is_oom_error(e):
                         _raise_failure(context, chunk_i, num_chunks, partition_range_str, e)
@@ -664,7 +728,16 @@ def _do_experimental_backfill(
                         )
                         context.log.info(sub_sql)
                         try:
-                            sync_execute(sub_sql, settings=merged_settings, sync_client=client)
+                            _execute_with_too_many_parts_retry(
+                                context,
+                                config,
+                                client,
+                                sub_sql,
+                                merged_settings,
+                                target_table,
+                                parts_retry_state,
+                                f"chunk {chunk_i + 1}/{num_chunks} sub-chunk {sub_i + 1}/{OOM_RETRY_SUB_CHUNKS}",
+                            )
                         except Exception as sub_e:
                             _raise_failure(
                                 context,

--- a/posthog/dags/sessions.py
+++ b/posthog/dags/sessions.py
@@ -479,12 +479,7 @@ def _is_oom_error(exc: Exception) -> bool:
 
 
 def _is_too_many_parts_error(exc: Exception) -> bool:
-    """Check if an exception is a ClickHouse TOO_MANY_PARTS error.
-
-    This can happen even after the preflight check passes — a single INSERT SELECT
-    can produce hundreds of parts (one per block), exceeding parts_to_throw_insert
-    before merges catch up.
-    """
+    """Check if an exception is a ClickHouse TOO_MANY_PARTS error."""
     error_str = str(exc)
     return f"error code {ErrorCodes.TOO_MANY_PARTS}" in error_str or "TOO_MANY_PARTS" in error_str
 
@@ -499,12 +494,7 @@ def _execute_with_too_many_parts_retry(
     retry_state: dict[str, int],
     retry_description: str,
 ) -> None:
-    """Execute an INSERT, retrying by re-running the preflight wait on TOO_MANY_PARTS.
-
-    Uses a shared retry budget (retry_state['count'] / retry_state['max']) across
-    the whole backfill run so a single misbehaving partition can't loop forever.
-    Raises the original exception when the budget is exhausted (or on any other error).
-    """
+    """Run the INSERT, retrying via the preflight wait on TOO_MANY_PARTS until the shared budget is spent."""
     while True:
         try:
             sync_execute(sql, settings=settings_, sync_client=client)
@@ -653,9 +643,7 @@ def _do_experimental_backfill(
     # and is a standalone node not in the main ClickHouse cluster
     target_table = DISTRIBUTED_RAW_SESSIONS_TABLE_V3()
 
-    # Shared retry budget for TOO_MANY_PARTS across the whole run. Budget = num_chunks
-    # so on average each chunk can trigger one retry; a few bad chunks may burn through
-    # more, but the total is bounded so we fail fast if parts consistently aren't merging.
+    # Budget = num_chunks so a persistently un-merging partition fails fast instead of looping forever.
     parts_retry_state = {"count": 0, "max": num_chunks}
 
     with get_http_client(**kwargs, **config.client_overrides) as client:

--- a/posthog/dags/tests/test_sessions.py
+++ b/posthog/dags/tests/test_sessions.py
@@ -227,7 +227,6 @@ class TestExperimentalBackfillResume:
 class TestTooManyPartsRetry:
     @staticmethod
     def _too_many_parts_error() -> Exception:
-        # Match the detection string used in _is_too_many_parts_error.
         return RuntimeError("Code: 252. DB::Exception: error code 252 TOO_MANY_PARTS: Too many parts")
 
     def test_retries_on_too_many_parts_then_succeeds(self):
@@ -260,12 +259,10 @@ class TestTooManyPartsRetry:
         assert mock_wait.call_count == 5
 
     def test_retry_budget_equals_num_chunks(self):
-        """When retries exhaust the budget (= num_chunks), the job fails."""
         num_chunks = 3
         config = ExperimentalSessionsBackfillConfig(distinct_id_chunks=num_chunks, client_overrides={})
         context = _make_context()
 
-        # Always fail with TOO_MANY_PARTS so we blow through the retry budget.
         with (
             _patch_experimental_backfill_deps() as (mock_sync_execute, _mock_redis),
             patch("posthog.dags.sessions.wait_for_parts_to_merge"),
@@ -279,6 +276,5 @@ class TestTooManyPartsRetry:
                     config=config,
                 )
 
-        # First chunk: 1 initial call + num_chunks retries = num_chunks + 1 calls,
-        # then the next retry would exceed the budget and re-raises.
+        # 1 initial + num_chunks retries, then the next retry exceeds the budget and re-raises
         assert mock_sync_execute.call_count == num_chunks + 1

--- a/posthog/dags/tests/test_sessions.py
+++ b/posthog/dags/tests/test_sessions.py
@@ -222,3 +222,63 @@ class TestExperimentalBackfillResume:
         assert failure.metadata["failed_chunk_index"].value == 2
         assert failure.metadata["resume_from_chunk"].value == 2
         assert failure.metadata["total_chunks"].value == 4
+
+
+class TestTooManyPartsRetry:
+    @staticmethod
+    def _too_many_parts_error() -> Exception:
+        # Match the detection string used in _is_too_many_parts_error.
+        return RuntimeError("Code: 252. DB::Exception: error code 252 TOO_MANY_PARTS: Too many parts")
+
+    def test_retries_on_too_many_parts_then_succeeds(self):
+        config = ExperimentalSessionsBackfillConfig(distinct_id_chunks=4, client_overrides={})
+        context = _make_context()
+
+        call_count = 0
+
+        def fail_first_then_succeed(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise self._too_many_parts_error()
+
+        with (
+            _patch_experimental_backfill_deps() as (mock_sync_execute, _mock_redis),
+            patch("posthog.dags.sessions.wait_for_parts_to_merge") as mock_wait,
+        ):
+            mock_sync_execute.side_effect = fail_first_then_succeed
+            _do_experimental_backfill(
+                sql_template=_sql_template_stub,
+                timestamp_field="timestamp",
+                context=context,
+                config=config,
+            )
+
+        # 4 chunks, first one retried once = 5 executes total
+        assert mock_sync_execute.call_count == 5
+        # 4 preflight waits (one per chunk) + 1 retry wait = 5 waits
+        assert mock_wait.call_count == 5
+
+    def test_retry_budget_equals_num_chunks(self):
+        """When retries exhaust the budget (= num_chunks), the job fails."""
+        num_chunks = 3
+        config = ExperimentalSessionsBackfillConfig(distinct_id_chunks=num_chunks, client_overrides={})
+        context = _make_context()
+
+        # Always fail with TOO_MANY_PARTS so we blow through the retry budget.
+        with (
+            _patch_experimental_backfill_deps() as (mock_sync_execute, _mock_redis),
+            patch("posthog.dags.sessions.wait_for_parts_to_merge"),
+        ):
+            mock_sync_execute.side_effect = self._too_many_parts_error()
+            with pytest.raises(dagster.Failure):
+                _do_experimental_backfill(
+                    sql_template=_sql_template_stub,
+                    timestamp_field="timestamp",
+                    context=context,
+                    config=config,
+                )
+
+        # First chunk: 1 initial call + num_chunks retries = num_chunks + 1 calls,
+        # then the next retry would exceed the budget and re-raises.
+        assert mock_sync_execute.call_count == num_chunks + 1


### PR DESCRIPTION
## Problem

The experimental sessions v3 backfill occasionally hits `TOO_MANY_PARTS` even though the preflight `wait_for_parts_to_merge` check succeeded immediately beforehand.

After reviewing, the preflight query itself looks correct:
- filters `active = 1` parts (the metric `parts_to_throw_insert` actually cares about),
- groups by `(host, partition)` so we catch the worst single-host-per-partition case,
- partition literals match how `toYYYYMM(session_timestamp)` stores them in `system.parts.partition`.

The root cause is that a single `INSERT SELECT` can produce hundreds of parts (one per block) before merges catch up, so the partition can cross `parts_to_throw_insert = 1000` mid-insert even if we started comfortably below the `max_unmerged_parts` threshold.

## Changes

- Add `_is_too_many_parts_error` matching ClickHouse error code 252.
- Add `_execute_with_too_many_parts_retry`: wraps `sync_execute`, and on `TOO_MANY_PARTS` re-runs `wait_for_parts_to_merge` and retries the same insert.
- Retries share a budget across the whole backfill run; the cap is set to `num_chunks`, so a persistent problem fails fast instead of looping forever.
- Both the main chunk insert and the OOM sub-chunk inserts go through the wrapper, so they share the same budget.

## How did you test this code?

Unit tests only — I haven't run this against a real ClickHouse. Added two new tests in `posthog/dags/tests/test_sessions.py`:
- happy-path retry: first chunk raises `TOO_MANY_PARTS`, preflight is re-run, chunk succeeds on retry.
- budget exhaustion: every call raises `TOO_MANY_PARTS`; after `num_chunks` retries the job fails with `dagster.Failure`.

All 20 tests in `test_sessions.py` pass.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Opus 4.7. Scope was limited to verifying the preflight check and adding retry + retry-budget handling for `TOO_MANY_PARTS` in the experimental backfill path; the non-experimental `_do_backfill` was intentionally left untouched.