### PR TITLE
perf(account-menu): skip ContextMenu wrapper on dropdown Links

### DIFF
--- a/frontend/src/lib/components/Account/NewAccountMenu.tsx
+++ b/frontend/src/lib/components/Account/NewAccountMenu.tsx
@@ -234,6 +234,7 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                                 tooltipPlacement="right"
                                                 data-attr="new-account-menu-project-settings-button"
                                                 to={urls.project(currentTeam.id, urls.settings('project'))}
+                                                skipContext
                                             >
                                                 <IconGear />
                                                 Project settings
@@ -323,6 +324,7 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                                     menuItem: true,
                                                     truncate: true,
                                                 }}
+                                                skipContext
                                             >
                                                 <IconReceipt />
                                                 {featureFlags[FEATURE_FLAGS.USAGE_SPEND_DASHBOARDS]
@@ -344,6 +346,7 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                             tooltip="Organization settings"
                                             tooltipPlacement="right"
                                             data-attr="new-account-menu-organization-settings-button"
+                                            skipContext
                                         >
                                             <IconGear />
                                             Organization settings
@@ -367,6 +370,7 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                                     }}
                                                     data-attr="new-account-menu-django-admin"
                                                     disableClientSideRouting
+                                                    skipContext
                                                 >
                                                     <IconShieldLock />
                                                     Django admin
@@ -382,6 +386,7 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                                         menuItem: true,
                                                     }}
                                                     data-attr="new-account-menu-instance-panel"
+                                                    skipContext
                                                 >
                                                     <IconServer />
                                                     Instance panel
@@ -397,6 +402,7 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                                         menuItem: true,
                                                     }}
                                                     data-attr="new-account-menu-query-performance"
+                                                    skipContext
                                                 >
                                                     <IconDatabase />
                                                     Query performance
@@ -423,6 +429,7 @@ export function NewAccountMenu({ isLayoutNavCollapsed }: AccountMenuProps): JSX.
                                             tooltip="User settings"
                                             tooltipPlacement="right"
                                             data-attr="new-account-menu-account-owner-button"
+                                            skipContext
                                         >
                                             <ProfilePicture user={user} size="xs" />
                                             <span className="flex flex-col truncate">

--- a/frontend/src/lib/lemon-ui/Link/Link.tsx
+++ b/frontend/src/lib/lemon-ui/Link/Link.tsx
@@ -134,7 +134,7 @@ export const Link: React.FC<LinkProps & React.RefAttributes<HTMLElement>> = Reac
             tooltipCloseDelayMs,
             role,
             tabIndex,
-            skipContext,
+            skipContext = false,
             extraContextMenuItems,
             ...props
         },


### PR DESCRIPTION
## Problem

Every internal `Link` (`lib/lemon-ui/Link/Link.tsx`) wraps its `<a>` in a Radix `<ContextMenu>` (Root + Trigger + providers) so the user can right-click and get a browser-like menu (open in new tab, copy link, etc.). That's useful for links rendered inside pages, but not for links sitting inside a dropdown menu — the dropdown closes on right-click, so the nested context menu never actually surfaces.

`NewAccountMenu` renders 7 internal Links (Project settings, Billing, Org settings, User settings, Django admin, Instance panel, Query performance). Each open mounts and each close tears down the full ContextMenu provider subtree for all 7, which is what MemLens flagged when diagnosing transient detached-DOM during menu open/close cycles. The component stack it surfaced was `Link → ContextMenu → ContextMenuProvider → Popper → MenuProvider → ...`.

No actual memory leak — traces confirm listeners/nodes return to baseline after GC — but the transient spike and fiber churn are real.

## Changes

- `Link.tsx`: make `skipContext` default explicit (`false`) for clarity
- `NewAccountMenu.tsx`: set `skipContext` on all 7 internal `Link`s

## How did you test this code?

Agent-authored change. No manual verification yet. Traces taken before the change (`open/close ×5`) showed transient detached-DOM up to 470 elements mid-cycle, returning to baseline after teardown — expectation is the peak drops noticeably because the ContextMenu fiber subtree no longer mounts per item.

## Publish to changelog?

no

## 🤖 LLM context

Written with Claude Code. Root cause identified by cross-referencing the MemLens component stack against `Link.tsx` — the stack pointed at `ContextMenu` wrappers owned by `Link`, not `NewAccountMenu` itself as MemLens suggested.