### PR TITLE
fix(replay): stop buffering session summary SSE stream at proxies

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -1443,10 +1443,13 @@ class SessionRecordingViewSet(
             session_ids=[session_id],
             video_based=True,
         )
-        return StreamingHttpResponse(
+        response = StreamingHttpResponse(
             self._generate_video_based_summary(session_id, user),
             content_type=ServerSentEventRenderer.media_type,
         )
+        response["Cache-Control"] = "no-cache"
+        response["X-Accel-Buffering"] = "no"
+        return response
 
     async def _stream_lts_blob_v2_to_client_async(
         self,


### PR DESCRIPTION
## Problem

The session summarization progress UI stops updating long before the workflow completes. During the `consolidating` phase the dock reverts to the "Use AI to summarize this session" button even though the summary is still being generated server-side.

The `summarize` action returns a `StreamingHttpResponse` without the `X-Accel-Buffering: no` / `Cache-Control: no-cache` headers that every other SSE endpoint in the repo sets:

- `posthog/api/query.py:417`
- `products/notebooks/backend/api/notebook.py:705`
- `products/tasks/backend/api.py:1254`
- `products/llm_analytics/backend/api/proxy.py:185`
- `products/mcp_store/backend/proxy.py:232`
- `services/llm-gateway/src/llm_gateway/api/handler.py:353`

Without those headers some proxies buffer the chunked response, which defeats the 2-second heartbeat cadence the backend polling loop relies on.

## Changes

Set `Cache-Control: no-cache` and `X-Accel-Buffering: no` on the `StreamingHttpResponse` returned from `SessionRecordingViewSet.summarize`, matching the pattern established by every other streaming endpoint in the codebase.

This is a convention fix, not the full resolution on its own — the remaining part of the fix is an edge timeout adjustment that lives outside this repo.

## How did you test this code?

I'm an agent. I have not manually run the summarization flow after this change. The change is mechanical: three lines that align this endpoint with six other streaming endpoints already in the repo, and there are no existing tests asserting on response headers for this endpoint.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Code. Investigation trace: reproduced the 120 s-ish cut-off of the progress UI, ruled out the frontend timeout (10 min) and workflow timeout (30 min), then surveyed streaming endpoints in the repo and noticed `summarize` was the only one missing these headers.
