### PR TITLE
fix(logs-alerts): extract notification dispatch and verify retry semantics in tests

### DIFF
--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -167,7 +167,7 @@ def _dispatch_notification(
             notified=notified,
         )
     else:
-        return False
+        raise ValueError(f"Unhandled NotificationAction: {action!r}")
 
     return not notified
 

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -125,6 +125,53 @@ def _check_alerts_sync() -> CheckAlertsOutput:
     )
 
 
+def _dispatch_notification(
+    outcome: AlertCheckOutcome,
+    alert: LogsAlertConfiguration,
+    check_result: CheckResult,
+    now: datetime,
+    stats: dict[str, int],
+    *,
+    date_from: datetime,
+    date_to: datetime,
+) -> bool:
+    """Emit the notification for this outcome. Returns True if delivery failed."""
+    action = outcome.notification
+    if action == NotificationAction.NONE:
+        return False
+
+    log = logger.bind(alert_id=str(alert.id), alert_name=alert.name, team_id=alert.team_id)
+
+    if action == NotificationAction.FIRE:
+        notified = _emit_alert_event(
+            alert, "$logs_alert_firing", check_result, now, date_from=date_from, date_to=date_to
+        )
+        if notified:
+            stats["fired"] += 1
+        log.info("Alert fired", result_count=check_result.result_count, notified=notified)
+    elif action == NotificationAction.RESOLVE:
+        notified = _emit_alert_event(
+            alert, "$logs_alert_resolved", check_result, now, date_from=date_from, date_to=date_to
+        )
+        if notified:
+            stats["resolved"] += 1
+        log.info("Alert resolved", notified=notified)
+    elif action == NotificationAction.ERROR:
+        notified = _emit_alert_errored_event(alert, outcome, now)
+        log.info("Alert entered errored state", consecutive_failures=outcome.consecutive_failures, notified=notified)
+    elif action == NotificationAction.BROKEN:
+        notified = _emit_auto_disabled_event(alert, outcome, now)
+        log.warning(
+            "Alert broken after consecutive failures",
+            consecutive_failures=outcome.consecutive_failures,
+            notified=notified,
+        )
+    else:
+        return False
+
+    return not notified
+
+
 def _evaluate_single_alert(
     alert: LogsAlertConfiguration,
     now: datetime,
@@ -181,69 +228,9 @@ def _evaluate_single_alert(
     # Attempt Kafka delivery BEFORE committing state transition.
     # If delivery fails and we needed to notify, keep old state so the
     # next tick retries the full transition (NOT_FIRING → FIRING again).
-    notified = False
-    notification_failed = False
-    if outcome.notification == NotificationAction.FIRE:
-        notified = _emit_alert_event(
-            alert,
-            "$logs_alert_firing",
-            check_result,
-            now,
-            date_from=date_from,
-            date_to=date_to,
-        )
-        notification_failed = not notified
-        if notified:
-            stats["fired"] += 1
-        logger.info(
-            "Alert fired",
-            alert_id=str(alert.id),
-            alert_name=alert.name,
-            team_id=alert.team_id,
-            result_count=check_result.result_count,
-            notified=notified,
-        )
-    elif outcome.notification == NotificationAction.RESOLVE:
-        notified = _emit_alert_event(
-            alert,
-            "$logs_alert_resolved",
-            check_result,
-            now,
-            date_from=date_from,
-            date_to=date_to,
-        )
-        notification_failed = not notified
-        if notified:
-            stats["resolved"] += 1
-        logger.info(
-            "Alert resolved",
-            alert_id=str(alert.id),
-            alert_name=alert.name,
-            team_id=alert.team_id,
-            notified=notified,
-        )
-    elif outcome.notification == NotificationAction.ERROR:
-        notified = _emit_alert_errored_event(alert, outcome, now)
-        notification_failed = not notified
-        logger.info(
-            "Alert entered errored state",
-            alert_id=str(alert.id),
-            alert_name=alert.name,
-            team_id=alert.team_id,
-            consecutive_failures=outcome.consecutive_failures,
-            notified=notified,
-        )
-    elif outcome.notification == NotificationAction.BROKEN:
-        notified = _emit_auto_disabled_event(alert, outcome, now)
-        notification_failed = not notified
-        logger.warning(
-            "Alert broken after consecutive failures",
-            alert_id=str(alert.id),
-            alert_name=alert.name,
-            team_id=alert.team_id,
-            consecutive_failures=outcome.consecutive_failures,
-            notified=notified,
-        )
+    notification_failed = _dispatch_notification(
+        outcome, alert, check_result, now, stats, date_from=date_from, date_to=date_to
+    )
     # If the notification delivery failed, don't commit the state transition
     # so the next tick will re-evaluate and retry the notification.
     if notification_failed:
@@ -271,7 +258,11 @@ def _evaluate_single_alert(
         alert.next_check_at = advance_next_check_at(alert.next_check_at, alert.check_interval_minutes, now)
         update_fields.extend(["last_checked_at", "next_check_at", "updated_at"])
 
-        if notified and outcome.update_last_notified_at:
+        if (
+            not notification_failed
+            and outcome.notification != NotificationAction.NONE
+            and outcome.update_last_notified_at
+        ):
             alert.last_notified_at = now
             update_fields.append("last_notified_at")
 

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -852,3 +852,102 @@ class TestEvaluateSingleAlert(APIBaseTest):
         kwargs = mock_query_cls.call_args.kwargs
         assert kwargs["date_to"] == now
         assert kwargs["date_from"] == now - dt.timedelta(minutes=5)
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event")
+    def test_errored_notification_emitted_on_first_error(self, mock_produce, mock_query_cls):
+        mock_query_cls.return_value.execute.side_effect = RuntimeError("CH down")
+        alert = self._make_alert()
+
+        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
+
+        alert.refresh_from_db()
+        assert alert.state == LogsAlertConfiguration.State.ERRORED
+        errored_calls = [
+            c
+            for c in mock_produce.call_args_list
+            if c.kwargs.get("event") and c.kwargs["event"].event == "$logs_alert_errored"
+        ]
+        assert len(errored_calls) == 1
+        assert errored_calls[0].kwargs["event"].properties["consecutive_failures"] == 1
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.capture_exception")
+    def test_errored_notification_retried_after_kafka_failure(self, _mock_capture, mock_query_cls):
+        mock_query_cls.return_value.execute.side_effect = RuntimeError("CH down")
+        alert = self._make_alert()
+        now1 = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+        now2 = datetime(2025, 1, 1, 0, 6, 0, tzinfo=UTC)
+
+        with patch("products.logs.backend.temporal.activities.produce_internal_event") as mock_produce:
+            mock_produce.side_effect = Exception("Kafka down")
+            _evaluate_single_alert(alert, now1, _make_stats())
+
+            mock_produce.side_effect = None
+            mock_produce.reset_mock()
+            _evaluate_single_alert(alert, now2, _make_stats())
+
+        errored_calls = [
+            c
+            for c in mock_produce.call_args_list
+            if c.kwargs.get("event") and c.kwargs["event"].event == "$logs_alert_errored"
+        ]
+        assert len(errored_calls) == 1
+
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.capture_exception")
+    def test_broken_notification_retried_after_kafka_failure(self, _mock_capture, mock_query_cls):
+        mock_query_cls.return_value.execute.side_effect = RuntimeError("CH down")
+        # 4 prior failures — one more pushes consecutive_failures to MAX (5) → BROKEN.
+        alert = self._make_alert(state=LogsAlertConfiguration.State.ERRORED, consecutive_failures=4)
+        now1 = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
+        now2 = datetime(2025, 1, 1, 0, 6, 0, tzinfo=UTC)
+
+        with patch("products.logs.backend.temporal.activities.produce_internal_event") as mock_produce:
+            mock_produce.side_effect = Exception("Kafka down")
+            _evaluate_single_alert(alert, now1, _make_stats())
+
+            mock_produce.side_effect = None
+            mock_produce.reset_mock()
+            _evaluate_single_alert(alert, now2, _make_stats())
+
+        auto_disabled_calls = [
+            c
+            for c in mock_produce.call_args_list
+            if c.kwargs.get("event") and c.kwargs["event"].event == "$logs_alert_auto_disabled"
+        ]
+        assert len(auto_disabled_calls) == 1
+
+    @parameterized.expand(
+        [
+            ("error", LogsAlertConfiguration.State.NOT_FIRING, 0, NotificationAction.ERROR),
+            ("broken", LogsAlertConfiguration.State.ERRORED, 4, NotificationAction.BROKEN),
+        ]
+    )
+    @freeze_time("2025-01-01T00:01:00Z")
+    @patch("products.logs.backend.temporal.activities.increment_notification_failures")
+    @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
+    @patch("products.logs.backend.temporal.activities.produce_internal_event", side_effect=Exception("Kafka down"))
+    @patch("products.logs.backend.temporal.activities.capture_exception")
+    def test_notification_failures_counter_for_error_and_broken(
+        self,
+        _name,
+        initial_state,
+        initial_failures,
+        expected_action,
+        _mock_capture,
+        _mock_produce,
+        mock_query_cls,
+        mock_notif_failures,
+    ):
+        mock_query_cls.return_value.execute.side_effect = RuntimeError("CH down")
+        self._make_alert(state=initial_state, consecutive_failures=initial_failures)
+
+        _evaluate_single_alert(
+            LogsAlertConfiguration.objects.get(), datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats()
+        )
+
+        mock_notif_failures.assert_called_once_with(expected_action)


### PR DESCRIPTION
## Problem

The notification dispatch logic inside `_evaluate_single_alert` was duplicated and verbose, making it harder to maintain and reason about. Additionally, the condition for updating `last_notified_at` incorrectly relied on a local `notified` variable that was only set within certain branches, meaning it could be unset (defaulting to `False`) even when a notification was successfully delivered in other branches.

## Changes

Extracted the notification dispatch logic into a dedicated `_dispatch_notification` helper function. This function handles all `NotificationAction` variants, uses bound logger context (`logger.bind`) to avoid repeating `alert_id`, `alert_name`, and `team_id` on every log call, and returns a boolean indicating whether delivery failed.

The `last_notified_at` update condition in `_evaluate_single_alert` was also corrected to use `not notification_failed and outcome.notification != NotificationAction.NONE` instead of the previously unreliable `notified` variable.

## How did you test this code?

New tests cover the following scenarios:

- `$logs_alert_errored` event is emitted on the first consecutive failure
- When Kafka delivery fails for an `ERROR` notification, the state transition is not committed and the notification is retried on the next tick
- When Kafka delivery fails for a `BROKEN` notification, the same retry behaviour applies
- The `increment_notification_failures` counter is called for both `ERROR` and `BROKEN` actions when Kafka is down (verified via parameterized test)

## Publish to changelog?

No