### PR TITLE
fix(replay): flatten filter groups when building recordings query

### DIFF
--- a/frontend/src/scenes/session-recordings/utils.test.ts
+++ b/frontend/src/scenes/session-recordings/utils.test.ts
@@ -24,24 +24,29 @@ describe('session recording utils', () => {
     })
 
     describe('filtersFromUniversalFilterGroups', () => {
-        it('returns leaves from the canonical values: [{ values: [...] }] shape', () => {
-            const filters = withFilterGroup({
-                type: FilterLogicalOperator.And,
-                values: [{ type: FilterLogicalOperator.And, values: [event('a'), event('b'), event('c')] }],
-            })
-            expect(filtersFromUniversalFilterGroups(filters)).toEqual([event('a'), event('b'), event('c')])
-        })
-
-        it('flattens the broken per-event-group top-level shape seen in some saved filters', () => {
-            const filters = withFilterGroup({
-                type: FilterLogicalOperator.And,
-                values: [
-                    { type: FilterLogicalOperator.And, values: [] },
-                    { type: FilterLogicalOperator.And, values: [event('a')] },
-                    { type: FilterLogicalOperator.And, values: [event('b')] },
-                ],
-            })
-            expect(filtersFromUniversalFilterGroups(filters)).toEqual([event('a'), event('b')])
+        it.each([
+            [
+                'canonical values: [{ values: [...] }] shape',
+                {
+                    type: FilterLogicalOperator.And,
+                    values: [{ type: FilterLogicalOperator.And, values: [event('a'), event('b'), event('c')] }],
+                },
+                [event('a'), event('b'), event('c')],
+            ],
+            [
+                'broken per-event-group top-level shape seen in some saved filters',
+                {
+                    type: FilterLogicalOperator.And,
+                    values: [
+                        { type: FilterLogicalOperator.And, values: [] },
+                        { type: FilterLogicalOperator.And, values: [event('a')] },
+                        { type: FilterLogicalOperator.And, values: [event('b')] },
+                    ],
+                },
+                [event('a'), event('b')],
+            ],
+        ])('returns all leaves for the %s', (_label, filterGroup, expected) => {
+            expect(filtersFromUniversalFilterGroups(withFilterGroup(filterGroup))).toEqual(expected)
         })
     })
 })

--- a/frontend/src/scenes/session-recordings/utils.test.ts
+++ b/frontend/src/scenes/session-recordings/utils.test.ts
@@ -1,5 +1,17 @@
 import { defaultQuickEmojis } from 'lib/lemon-ui/LemonTextArea/emojiUsageLogic'
-import { isSingleEmoji } from 'scenes/session-recordings/utils'
+import { filtersFromUniversalFilterGroups, isSingleEmoji } from 'scenes/session-recordings/utils'
+
+import { FilterLogicalOperator, RecordingUniversalFilters } from '~/types'
+
+const withFilterGroup = (filterGroup: RecordingUniversalFilters['filter_group']): RecordingUniversalFilters => ({
+    date_from: '-3d',
+    date_to: null,
+    filter_test_accounts: false,
+    duration: [],
+    filter_group: filterGroup,
+})
+
+const event = (name: string): any => ({ id: name, name, type: 'events' })
 
 describe('session recording utils', () => {
     defaultQuickEmojis.forEach((quickEmoji) => {
@@ -8,6 +20,28 @@ describe('session recording utils', () => {
         })
         it(`can check ${quickEmoji}${quickEmoji} is not a single emoji`, () => {
             expect(isSingleEmoji(`${quickEmoji}${quickEmoji}`)).toBe(false)
+        })
+    })
+
+    describe('filtersFromUniversalFilterGroups', () => {
+        it('returns leaves from the canonical values: [{ values: [...] }] shape', () => {
+            const filters = withFilterGroup({
+                type: FilterLogicalOperator.And,
+                values: [{ type: FilterLogicalOperator.And, values: [event('a'), event('b'), event('c')] }],
+            })
+            expect(filtersFromUniversalFilterGroups(filters)).toEqual([event('a'), event('b'), event('c')])
+        })
+
+        it('flattens the broken per-event-group top-level shape seen in some saved filters', () => {
+            const filters = withFilterGroup({
+                type: FilterLogicalOperator.And,
+                values: [
+                    { type: FilterLogicalOperator.And, values: [] },
+                    { type: FilterLogicalOperator.And, values: [event('a')] },
+                    { type: FilterLogicalOperator.And, values: [event('b')] },
+                ],
+            })
+            expect(filtersFromUniversalFilterGroups(filters)).toEqual([event('a'), event('b')])
         })
     })
 })

--- a/frontend/src/scenes/session-recordings/utils.ts
+++ b/frontend/src/scenes/session-recordings/utils.ts
@@ -7,6 +7,7 @@ import {
     type SessionRecordingMaskingLevel,
     UniversalFilterValue,
     UniversalFiltersGroup,
+    UniversalFiltersGroupValue,
 } from '~/types'
 
 export const TimestampFormatToLabel = {
@@ -23,8 +24,21 @@ export const isUniversalFilters = (
 
 // TODO we shouldn't be ever converting to filters any more, but I won't unpick this in this PR
 export const filtersFromUniversalFilterGroups = (filters: RecordingUniversalFilters): UniversalFilterValue[] => {
-    const group = filters.filter_group.values[0] as UniversalFiltersGroup
-    return group.values as UniversalFilterValue[]
+    // Some saved filters store values at the top level rather than nested in values[0], so recurse.
+    const flatten = (items: UniversalFiltersGroupValue[] | undefined): UniversalFilterValue[] => {
+        if (!Array.isArray(items)) {
+            return []
+        }
+        return items.flatMap((item) =>
+            item &&
+            typeof item === 'object' &&
+            'values' in item &&
+            Array.isArray((item as UniversalFiltersGroup).values)
+                ? flatten((item as UniversalFiltersGroup).values)
+                : [item as UniversalFilterValue]
+        )
+    }
+    return flatten(filters.filter_group.values)
 }
 
 export const getMaskingLevelFromConfig = (config: SessionRecordingMaskingConfig): SessionRecordingMaskingLevel => {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
`filtersFromUniversalFilterGroups` only read `filter_group.values[0].values`, silently dropping any filter stored outside the first top-level group. Saved filters whose values are spread across multiple top-level groups sent almost no filters to the backend. Removing the event inside `values[0]` from such a filter made the result list go fully unfiltered because the emptied first group was all the query ever saw.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
Recursively flatten every nested group in `filter_group` so all leaf filters reach the backend regardless of how the saved filter is structured. Canonical `values: [{ values: [...] }]` filters behave identically to before.

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->
Tested locally by reproducing exact shape of customer's saved filter

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
