### PR TITLE
feat(llma): add edits find/replace mode to skill-update

### DIFF
--- a/products/llm_analytics/backend/api/skill_serializers.py
+++ b/products/llm_analytics/backend/api/skill_serializers.py
@@ -161,10 +161,29 @@ class LLMSkillFileInputSerializer(serializers.Serializer):
         return value
 
 
+class LLMSkillEditOperationSerializer(serializers.Serializer):
+    old = serializers.CharField(
+        help_text="Text to find in the current skill body. Must match exactly once.",
+    )
+    new = serializers.CharField(
+        allow_blank=True,
+        help_text="Replacement text.",
+    )
+
+
 class LLMSkillPublishSerializer(serializers.Serializer):
     body = serializers.CharField(
         required=False,
-        help_text="Full skill body (SKILL.md instruction content) to publish as a new version.",
+        help_text="Full skill body (SKILL.md instruction content) to publish as a new version. Mutually exclusive with edits.",
+    )
+    edits = LLMSkillEditOperationSerializer(
+        many=True,
+        required=False,
+        help_text=(
+            "List of find/replace operations to apply to the current skill body. "
+            "Each edit's 'old' text must match exactly once. Edits are applied sequentially. "
+            "Mutually exclusive with body."
+        ),
     )
     description = serializers.CharField(
         max_length=4096,
@@ -205,8 +224,18 @@ class LLMSkillPublishSerializer(serializers.Serializer):
     def validate_body(self, value: str) -> str:
         return validate_skill_body_size(value)
 
+    def validate_edits(self, value: list[dict[str, str]]) -> list[dict[str, str]]:
+        if len(value) == 0:
+            raise serializers.ValidationError("At least one edit operation is required.")
+        return value
+
     def validate_files(self, value: list[dict[str, Any]]) -> list[dict[str, Any]]:
         return _validate_files(value)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if "body" in attrs and "edits" in attrs:
+            raise serializers.ValidationError("Provide either 'body' or 'edits', not both.")
+        return attrs
 
 
 class LLMSkillSerializer(serializers.ModelSerializer):

--- a/products/llm_analytics/backend/api/skill_services.py
+++ b/products/llm_analytics/backend/api/skill_services.py
@@ -9,6 +9,7 @@ from posthog.models import Team, User
 from ..models.skills import LLMSkill, LLMSkillFile, annotate_llm_skill_version_history_metadata
 
 MAX_SKILL_VERSION = 2000
+MAX_SKILL_BODY_BYTES = 1_000_000
 
 
 class LLMSkillNotFoundError(Exception):
@@ -25,8 +26,45 @@ class LLMSkillVersionLimitError(Exception):
     max_version: int
 
 
+@dataclass
+class LLMSkillEditError(Exception):
+    message: str
+    edit_index: int
+
+
 class LLMSkillDuplicateNameConflictError(Exception):
     pass
+
+
+def apply_skill_body_edits(body: str, edits: list[dict[str, str]]) -> str:
+    """Apply sequential find/replace edits to a skill body.
+
+    Each edit's 'old' text must match exactly once in the current body.
+    """
+    text = body
+    for i, edit in enumerate(edits):
+        old = edit["old"]
+        new = edit["new"]
+        count = text.count(old)
+        if count == 0:
+            raise LLMSkillEditError(
+                message="Text to replace was not found in the skill body.",
+                edit_index=i,
+            )
+        if count > 1:
+            raise LLMSkillEditError(
+                message=f"Text to replace matches {count} times — provide more context to make it unique.",
+                edit_index=i,
+            )
+        text = text.replace(old, new, 1)
+
+    if len(text.encode("utf-8")) > MAX_SKILL_BODY_BYTES:
+        raise LLMSkillEditError(
+            message=f"Resulting skill body exceeds the {MAX_SKILL_BODY_BYTES} byte size limit.",
+            edit_index=len(edits) - 1,
+        )
+
+    return text
 
 
 def get_active_skill_queryset(team: Team) -> QuerySet[LLMSkill]:
@@ -95,6 +133,7 @@ def publish_skill_version(
     user: User,
     skill_name: str,
     body: str | None = None,
+    edits: list[dict[str, str]] | None = None,
     description: str | None = None,
     license: str | None = None,
     compatibility: str | None = None,
@@ -118,12 +157,17 @@ def publish_skill_version(
         if current_latest.version >= MAX_SKILL_VERSION:
             raise LLMSkillVersionLimitError(max_version=MAX_SKILL_VERSION)
 
+        if edits is not None:
+            resolved_body = apply_skill_body_edits(current_latest.body, edits)
+        else:
+            resolved_body = _carry_forward(body, current_latest.body)
+
         LLMSkill.objects.filter(pk=current_latest.pk).update(is_latest=False)
         published_skill = LLMSkill.objects.create(
             team=team,
             name=current_latest.name,
             description=_carry_forward(description, current_latest.description),
-            body=_carry_forward(body, current_latest.body),
+            body=resolved_body,
             license=_carry_forward(license, current_latest.license),
             compatibility=_carry_forward(compatibility, current_latest.compatibility),
             allowed_tools=_carry_forward(allowed_tools, current_latest.allowed_tools),

--- a/products/llm_analytics/backend/api/skills.py
+++ b/products/llm_analytics/backend/api/skills.py
@@ -43,6 +43,7 @@ from .skill_serializers import (
 )
 from .skill_services import (
     LLMSkillDuplicateNameConflictError,
+    LLMSkillEditError,
     LLMSkillNotFoundError,
     LLMSkillVersionConflictError,
     LLMSkillVersionLimitError,
@@ -233,6 +234,7 @@ class LLMSkillViewSet(
                 user=cast(User, request.user),
                 skill_name=skill_name,
                 body=payload.validated_data.get("body"),
+                edits=payload.validated_data.get("edits"),
                 description=payload.validated_data.get("description"),
                 license=payload.validated_data.get("license"),
                 compatibility=payload.validated_data.get("compatibility"),
@@ -262,6 +264,14 @@ class LLMSkillViewSet(
                         f"Skill has reached the maximum of {err.max_version} versions. "
                         "Archive and recreate the skill to continue publishing."
                     ),
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except LLMSkillEditError as err:
+            return Response(
+                {
+                    "detail": err.message,
+                    "edit_index": err.edit_index,
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )

--- a/products/llm_analytics/backend/api/test/test_skills.py
+++ b/products/llm_analytics/backend/api/test/test_skills.py
@@ -399,63 +399,71 @@ class TestLLMSkillAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["body"] == "APLHA\nBETA\ngamma\n"
 
-    def test_publish_with_edits_zero_matches_fails(self, mock_feature_enabled):
-        self.create_skill(name="no-match", body="some content\n")
+    @parameterized.expand(
+        [
+            ("zero_matches", "some content\n", [{"old": "missing", "new": "x"}], None),
+            ("multi_matches", "pick pick pick\n", [{"old": "pick", "new": "chose"}], "3 times"),
+        ]
+    )
+    def test_publish_with_edits_apply_errors(self, mock_feature_enabled, label, initial_body, edits, detail_fragment):
+        skill_name = f"edit-apply-err-{label.replace('_', '-')}"
+        self.create_skill(name=skill_name, body=initial_body)
 
         response = self.client.patch(
-            self._url("name/no-match"),
+            self._url(f"name/{skill_name}"),
+            data={"edits": edits, "base_version": 1},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body_resp = response.json()
+        assert body_resp["edit_index"] == 0
+        if detail_fragment is not None:
+            assert detail_fragment in body_resp["detail"]
+
+    @parameterized.expand(
+        [
+            (
+                "body_and_edits_conflict",
+                {
+                    "body": "new content\n",
+                    "edits": [{"old": "content", "new": "other"}],
+                    "base_version": 1,
+                },
+            ),
+            ("empty_edits_list", {"edits": [], "base_version": 1}),
+        ]
+    )
+    def test_publish_rejects_invalid_edit_requests(self, mock_feature_enabled, label, payload):
+        skill_name = f"invalid-{label.replace('_', '-')}"
+        self.create_skill(name=skill_name, body="content\n")
+
+        response = self.client.patch(
+            self._url(f"name/{skill_name}"),
+            data=payload,
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_publish_with_edits_exceeding_body_size_limit_fails(self, mock_feature_enabled):
+        # Seed a body just under the 1 MB limit, then edit to push the result over.
+        seeded_body = "x" * (1_000_000 - len("MARKER")) + "MARKER"
+        self.create_skill(name="size-edit", body=seeded_body)
+
+        response = self.client.patch(
+            self._url("name/size-edit"),
             data={
-                "edits": [{"old": "missing", "new": "replacement"}],
+                "edits": [{"old": "MARKER", "new": "MARKER" + "y" * 100}],
                 "base_version": 1,
             },
             format="json",
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json()["edit_index"] == 0
-
-    def test_publish_with_edits_multiple_matches_fails(self, mock_feature_enabled):
-        self.create_skill(name="ambiguous", body="pick pick pick\n")
-
-        response = self.client.patch(
-            self._url("name/ambiguous"),
-            data={
-                "edits": [{"old": "pick", "new": "chose"}],
-                "base_version": 1,
-            },
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        body = response.json()
-        assert body["edit_index"] == 0
-        assert "3 times" in body["detail"]
-
-    def test_publish_rejects_body_and_edits_together(self, mock_feature_enabled):
-        self.create_skill(name="conflict-fields", body="content\n")
-
-        response = self.client.patch(
-            self._url("name/conflict-fields"),
-            data={
-                "body": "new content\n",
-                "edits": [{"old": "content", "new": "other"}],
-                "base_version": 1,
-            },
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-    def test_publish_rejects_empty_edits_list(self, mock_feature_enabled):
-        self.create_skill(name="empty-edits", body="content\n")
-
-        response = self.client.patch(
-            self._url("name/empty-edits"),
-            data={"edits": [], "base_version": 1},
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body_resp = response.json()
+        assert body_resp["edit_index"] == 0
+        assert "size limit" in body_resp["detail"]
 
     def test_publish_with_edits_carries_files_forward(self, mock_feature_enabled):
         skill = self.create_skill(name="edits-files", body="original\n")

--- a/products/llm_analytics/backend/api/test/test_skills.py
+++ b/products/llm_analytics/backend/api/test/test_skills.py
@@ -362,6 +362,119 @@ class TestLLMSkillAPI(APIBaseTest):
         assert LLMSkillFile.objects.filter(skill=new_skill).count() == 1
         assert LLMSkillFile.objects.get(skill=new_skill).path == "scripts/run.sh"
 
+    # --- Publish with edits (find/replace) ---
+
+    def test_publish_with_edits_applies_single_replacement(self, mock_feature_enabled):
+        self.create_skill(name="edit-me", body="# Title\n\nHello world.\n")
+
+        response = self.client.patch(
+            self._url("name/edit-me"),
+            data={
+                "edits": [{"old": "Hello world.", "new": "Hello there."}],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["version"] == 2
+        assert data["body"] == "# Title\n\nHello there.\n"
+
+    def test_publish_with_edits_applies_sequential_replacements(self, mock_feature_enabled):
+        self.create_skill(name="seq-edits", body="alpha\nbeta\ngamma\n")
+
+        response = self.client.patch(
+            self._url("name/seq-edits"),
+            data={
+                "edits": [
+                    {"old": "alpha", "new": "APLHA"},
+                    {"old": "beta", "new": "BETA"},
+                ],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["body"] == "APLHA\nBETA\ngamma\n"
+
+    def test_publish_with_edits_zero_matches_fails(self, mock_feature_enabled):
+        self.create_skill(name="no-match", body="some content\n")
+
+        response = self.client.patch(
+            self._url("name/no-match"),
+            data={
+                "edits": [{"old": "missing", "new": "replacement"}],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["edit_index"] == 0
+
+    def test_publish_with_edits_multiple_matches_fails(self, mock_feature_enabled):
+        self.create_skill(name="ambiguous", body="pick pick pick\n")
+
+        response = self.client.patch(
+            self._url("name/ambiguous"),
+            data={
+                "edits": [{"old": "pick", "new": "chose"}],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert body["edit_index"] == 0
+        assert "3 times" in body["detail"]
+
+    def test_publish_rejects_body_and_edits_together(self, mock_feature_enabled):
+        self.create_skill(name="conflict-fields", body="content\n")
+
+        response = self.client.patch(
+            self._url("name/conflict-fields"),
+            data={
+                "body": "new content\n",
+                "edits": [{"old": "content", "new": "other"}],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_publish_rejects_empty_edits_list(self, mock_feature_enabled):
+        self.create_skill(name="empty-edits", body="content\n")
+
+        response = self.client.patch(
+            self._url("name/empty-edits"),
+            data={"edits": [], "base_version": 1},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_publish_with_edits_carries_files_forward(self, mock_feature_enabled):
+        skill = self.create_skill(name="edits-files", body="original\n")
+        LLMSkillFile.objects.create(skill=skill, path="references/a.md", content="A")
+
+        response = self.client.patch(
+            self._url("name/edits-files"),
+            data={
+                "edits": [{"old": "original", "new": "edited"}],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        new_skill = LLMSkill.objects.get(name="edits-files", version=2, deleted=False)
+        assert new_skill.body == "edited\n"
+        assert LLMSkillFile.objects.filter(skill=new_skill, path="references/a.md").exists()
+
     # --- Archive ---
 
     def test_archive_skill(self, mock_feature_enabled):

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -1744,9 +1744,18 @@ export interface LLMSkillApi {
  */
 export type PatchedLLMSkillPublishApiMetadata = { [key: string]: unknown }
 
+export interface LLMSkillEditOperationApi {
+    /** Text to find in the current skill body. Must match exactly once. */
+    old: string
+    /** Replacement text. */
+    new: string
+}
+
 export interface PatchedLLMSkillPublishApi {
-    /** Full skill body (SKILL.md instruction content) to publish as a new version. */
+    /** Full skill body (SKILL.md instruction content) to publish as a new version. Mutually exclusive with edits. */
     body?: string
+    /** List of find/replace operations to apply to the current skill body. Each edit's 'old' text must match exactly once. Edits are applied sequentially. Mutually exclusive with body. */
+    edits?: LLMSkillEditOperationApi[]
     /**
      * Updated description for the new version.
      * @maxLength 4096

--- a/products/llm_analytics/mcp/skills.yaml
+++ b/products/llm_analytics/mcp/skills.yaml
@@ -70,13 +70,19 @@ tools:
             destructive: false
             idempotent: true
         title: Update skill
-        description: >
+        description: |
             Publish a new version of an existing agent skill by name. Any field not provided
             is carried forward from the current latest version. Requires base_version for
             optimistic concurrency. If files are provided, they replace all files from the
             previous version; if omitted, files are carried forward.
+
+            For the body, you can either provide the full content via 'body', or use 'edits'
+            for incremental find/replace updates. Each edit must have 'old' (text to find,
+            must match exactly once) and 'new' (replacement text). Edits are applied
+            sequentially. Only one of 'body' or 'edits' may be provided.
         include_params:
             - body
+            - edits
             - description
             - license
             - compatibility

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -3231,7 +3231,7 @@
         }
     },
     "skill-update": {
-        "description": "Publish a new version of an existing agent skill by name. Any field not provided is carried forward from the current latest version. Requires base_version for optimistic concurrency. If files are provided, they replace all files from the previous version; if omitted, files are carried forward.",
+        "description": "Publish a new version of an existing agent skill by name. Any field not provided\nis carried forward from the current latest version. Requires base_version for\noptimistic concurrency. If files are provided, they replace all files from the\nprevious version; if omitted, files are carried forward.\n\nFor the body, you can either provide the full content via 'body', or use 'edits'\nfor incremental find/replace updates. Each edit must have 'old' (text to find,\nmust match exactly once) and 'new' (replacement text). Edits are applied\nsequentially. Only one of 'body' or 'edits' may be provided.",
         "category": "Skills",
         "feature": "skills",
         "summary": "Update skill",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -3633,7 +3633,7 @@
         }
     },
     "skill-update": {
-        "description": "Publish a new version of an existing agent skill by name. Any field not provided is carried forward from the current latest version. Requires base_version for optimistic concurrency. If files are provided, they replace all files from the previous version; if omitted, files are carried forward.",
+        "description": "Publish a new version of an existing agent skill by name. Any field not provided\nis carried forward from the current latest version. Requires base_version for\noptimistic concurrency. If files are provided, they replace all files from the\nprevious version; if omitted, files are carried forward.\n\nFor the body, you can either provide the full content via 'body', or use 'edits'\nfor incremental find/replace updates. Each edit must have 'old' (text to find,\nmust match exactly once) and 'new' (replacement text). Edits are applied\nsequentially. Only one of 'body' or 'edits' may be provided.",
         "category": "Skills",
         "feature": "skills",
         "summary": "Update skill",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -20037,6 +20037,13 @@ export namespace Schemas {
       new_name: string;
     }
 
+    export interface LLMSkillEditOperation {
+      /** Text to find in the current skill body. Must match exactly once. */
+      old: string;
+      /** Replacement text. */
+      new: string;
+    }
+
     export interface LLMSkillFile {
       /** @maxLength 500 */
       path: string;
@@ -26425,8 +26432,10 @@ export namespace Schemas {
     export type PatchedLLMSkillPublishMetadata = {[key: string]: unknown};
 
     export interface PatchedLLMSkillPublish {
-      /** Full skill body (SKILL.md instruction content) to publish as a new version. */
+      /** Full skill body (SKILL.md instruction content) to publish as a new version. Mutually exclusive with edits. */
       body?: string;
+      /** List of find/replace operations to apply to the current skill body. Each edit's 'old' text must match exactly once. Edits are applied sequentially. Mutually exclusive with body. */
+      edits?: LLMSkillEditOperation[];
       /**
        * Updated description for the new version.
        * @maxLength 4096

--- a/services/mcp/src/generated/skills/api.ts
+++ b/services/mcp/src/generated/skills/api.ts
@@ -133,7 +133,20 @@ export const LlmSkillsNamePartialUpdateBody = /* @__PURE__ */ zod.object({
     body: zod
         .string()
         .optional()
-        .describe('Full skill body (SKILL.md instruction content) to publish as a new version.'),
+        .describe(
+            'Full skill body (SKILL.md instruction content) to publish as a new version. Mutually exclusive with edits.'
+        ),
+    edits: zod
+        .array(
+            zod.object({
+                old: zod.string().describe('Text to find in the current skill body. Must match exactly once.'),
+                new: zod.string().describe('Replacement text.'),
+            })
+        )
+        .optional()
+        .describe(
+            "List of find/replace operations to apply to the current skill body. Each edit's 'old' text must match exactly once. Edits are applied sequentially. Mutually exclusive with body."
+        ),
     description: zod
         .string()
         .max(llmSkillsNamePartialUpdateBodyDescriptionMax)

--- a/services/mcp/src/tools/generated/skills.ts
+++ b/services/mcp/src/tools/generated/skills.ts
@@ -110,6 +110,9 @@ const skillUpdate = (): ToolBase<typeof SkillUpdateSchema, Schemas.LLMSkill> => 
         if (params.body !== undefined) {
             body['body'] = params.body
         }
+        if (params.edits !== undefined) {
+            body['edits'] = params.edits
+        }
         if (params.description !== undefined) {
             body['description'] = params.description
         }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/skill-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/skill-update.json
@@ -14,7 +14,7 @@
             "type": "number"
         },
         "body": {
-            "description": "Full skill body (SKILL.md instruction content) to publish as a new version.",
+            "description": "Full skill body (SKILL.md instruction content) to publish as a new version. Mutually exclusive with edits.",
             "type": "string"
         },
         "compatibility": {
@@ -26,6 +26,24 @@
             "description": "Updated description for the new version.",
             "maxLength": 4096,
             "type": "string"
+        },
+        "edits": {
+            "description": "List of find/replace operations to apply to the current skill body. Each edit's 'old' text must match exactly once. Edits are applied sequentially. Mutually exclusive with body.",
+            "items": {
+                "properties": {
+                    "new": {
+                        "description": "Replacement text.",
+                        "type": "string"
+                    },
+                    "old": {
+                        "description": "Text to find in the current skill body. Must match exactly once.",
+                        "type": "string"
+                    }
+                },
+                "required": ["old", "new"],
+                "type": "object"
+            },
+            "type": "array"
         },
         "files": {
             "description": "Bundled files to include with this version. Replaces all files from the previous version.",


### PR DESCRIPTION
## Problem

Agents updating an agent skill via `skill-update` have to rewrite the whole
`body` (SKILL.md) on every change. The equivalent `prompt-update` tool already
supports a lightweight `edits: [{old, new}]` mode for incremental updates.
This PR ports that mode onto skills so agents can patch a section without
reconstructing the full body — removing a class of silent-drift bugs
(miscopied anchor text, stray character edits) and reducing payload size.

## Changes

- `LLMSkillPublishSerializer` now accepts `edits: [{old, new}]` in addition
  to `body`. They're mutually exclusive; at least one of the existing
  publishable fields must be provided (unchanged).
- New `apply_skill_body_edits()` in `skill_services.py` applies edits
  sequentially against the current latest body inside the same
  `select_for_update` + `base_version` transaction used today. Each `old`
  must match exactly once; zero or multiple matches raise `LLMSkillEditError`.
  Result is size-checked against `MAX_SKILL_BODY_BYTES`.
- Viewset maps `LLMSkillEditError` → HTTP 400 with `edit_index`, matching
  the prompt edit-error shape.
- MCP `skill-update` tool `include_params` now includes `edits`; description
  mirrors `prompt-update`'s guidance.
- Regenerated OpenAPI schema and MCP tool definitions.
- 7 new tests covering: single replacement, sequential replacements, zero
  matches → 400, multiple matches → 400, body+edits conflict, empty edits
  list, and files-carry-forward on edit-only publishes.

**Out of scope (noted for follow-ups):**
- `content=none|preview|full` query param on `skill-get` (parallel to prompts)
- File-level patch mode for bundled `references/*.md`

## How did you test this code?

Automated only — I'm an agent; I ran the full `test_skills.py` suite (38
passed, including the 12 publish-related tests) via `hogli test`. I
regenerated `hogli build:openapi` and confirmed the MCP `skill-update`
tool now emits `edits` in `services/mcp/src/tools/generated/skills.ts`.
Ruff check/format clean; MCP tsc clean. No manual browser testing.

## Publish to changelog?

no — developer-facing MCP tool enhancement

## 🤖 LLM context

Authored by Claude (opus-4.7). Scope was mirror `prompt-update`'s edits
mode onto `skill-update`, keeping strict parity with the prompt
implementation (same error shape, same size check, same mutual-exclusion
validation). Prompt reference files: `posthog/api/llm_prompt_serializers.py`
(LLMPromptEditOperationSerializer, LLMPromptPublishSerializer.validate),
`posthog/api/services/llm_prompt.py` (apply_prompt_edits, publish_prompt_version
edits branch), `posthog/api/llm_prompt.py` (LLMPromptEditError → 400).