### PR TITLE
feat(workflows): add API endpoints to replay deduped workflows

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6084,7 +6084,7 @@ const api = {
         async replayBlockedRun(
             hogFlowId: HogFlow['id'],
             data: { event_uuid: string; action_id: string; instance_id: string }
-        ): Promise<{ status: string; invocation_id: string }> {
+        ): Promise<{ status: string }> {
             return await new ApiRequest().hogFlow(hogFlowId).withAction('replay_blocked_run').create({ data })
         },
         async replayAllBlockedRuns(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6059,6 +6059,39 @@ const api = {
         async deleteHogFlowSchedule(hogFlowId: HogFlow['id'], scheduleId: string): Promise<void> {
             return await new ApiRequest().hogFlow(hogFlowId).withAction('schedules').withAction(scheduleId).delete()
         },
+        async getBlockedRuns(
+            hogFlowId: HogFlow['id'],
+            limit = 100,
+            offset = 0
+        ): Promise<{
+            results: {
+                instance_id: string
+                timestamp: string
+                action_id: string | null
+                event_uuid: string | null
+                message: string
+            }[]
+            has_next: boolean
+            limit: number
+            offset: number
+        }> {
+            return await new ApiRequest()
+                .hogFlow(hogFlowId)
+                .withAction('blocked_runs')
+                .withQueryString(`limit=${limit}&offset=${offset}`)
+                .get()
+        },
+        async replayBlockedRun(
+            hogFlowId: HogFlow['id'],
+            data: { event_uuid: string; action_id: string; instance_id: string }
+        ): Promise<{ status: string; invocation_id: string }> {
+            return await new ApiRequest().hogFlow(hogFlowId).withAction('replay_blocked_run').create({ data })
+        },
+        async replayAllBlockedRuns(
+            hogFlowId: HogFlow['id']
+        ): Promise<{ succeeded: number; failed: number; skipped: number }> {
+            return await new ApiRequest().hogFlow(hogFlowId).withAction('replay_all_blocked_runs').create()
+        },
     },
     hogFlowTemplates: {
         async getHogFlowTemplates(): Promise<PaginatedResponse<HogFlowTemplate>> {

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -506,6 +506,7 @@ export const FEATURE_FLAGS = {
     WORKFLOWS_PERSON_TIMEZONE: 'workflows-person-timezone', // owner: #team-workflows
     WORKFLOWS_PUSH_NOTIFICATIONS: 'workflows-push-notifications', // owner: @Odin #team-workflows
     WORKFLOWS_RECURRING_SCHEDULES: 'workflows-recurring-schedules', // owner: #team-workflows
+    WORKFLOWS_REPLAY_BLOCKED_RUNS: 'workflows-replay-blocked-runs', // owner: #team-workflows
 } as const
 export type FeatureFlagLookupKey = keyof typeof FEATURE_FLAGS
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]

--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -862,4 +862,158 @@ describe('CDP API', () => {
             expect(mockQueueInvocations).toHaveBeenCalledTimes(1)
         })
     })
+
+    describe('replay hogflow invocations', () => {
+        let replayHogFlow: HogFlow
+        let mockQueueInvocations: jest.Mock
+
+        const clickhouseEvent = {
+            uuid: 'b3a1fe86-b10c-43cc-acaf-d208977608d0',
+            event: '$pageview',
+            properties: '{"url":"https://example.com"}',
+            timestamp: '2021-09-28T14:00:00.000Z',
+            team_id: 0, // set in beforeEach
+            distinct_id: 'user-1',
+            elements_chain: '',
+            person_id: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d',
+            person_properties: '{"email":"test@example.com"}',
+        }
+
+        beforeEach(async () => {
+            mockQueueInvocations = jest.fn().mockResolvedValue(undefined)
+            api['cyclotronJobQueue'] = { queueInvocations: mockQueueInvocations } as any
+
+            replayHogFlow = await insertHogFlow({
+                id: new UUIDT().toString(),
+                name: 'test replay flow',
+                status: 'active',
+                version: 1,
+                exit_condition: 'exit_on_conversion',
+                edges: [],
+                actions: [
+                    {
+                        id: 'trigger_node',
+                        type: 'trigger',
+                        name: 'trigger',
+                        config: { type: 'event', filters: { events: [{ id: '$pageview', type: 'events' }] } },
+                    },
+                    {
+                        id: 'action_1',
+                        type: 'function',
+                        name: 'webhook',
+                        config: { template_id: 'template-webhook', inputs: { url: { value: 'https://example.com' } } },
+                    },
+                ],
+                trigger: {
+                    type: 'event',
+                    filters: { events: [{ id: '$pageview', type: 'events' }] },
+                },
+            } as any)
+            clickhouseEvent.team_id = team.id
+        })
+
+        describe('bulk replay', () => {
+            it('queues multiple replay invocations in a single call', async () => {
+                const res = await supertest(app)
+                    .post(
+                        `/api/projects/${replayHogFlow.team_id}/hog_flows/${replayHogFlow.id}/bulk_replay_invocations`
+                    )
+                    .send({
+                        items: [
+                            {
+                                clickhouse_event: clickhouseEvent,
+                                action_id: 'action_1',
+                                instance_id: 'inv-001',
+                            },
+                            {
+                                clickhouse_event: { ...clickhouseEvent, uuid: 'c4b2fe97-c21d-54e5-bdbe-e319088719e1' },
+                                action_id: 'action_1',
+                                instance_id: 'inv-002',
+                            },
+                        ],
+                    })
+
+                expect(res.status).toEqual(200)
+                expect(res.body.succeeded).toEqual(2)
+                expect(res.body.failed).toEqual(0)
+                expect(mockQueueInvocations).toHaveBeenCalledTimes(1)
+
+                const queuedInvocations = mockQueueInvocations.mock.calls[0][0]
+                expect(queuedInvocations).toHaveLength(2)
+                expect(queuedInvocations[0].state.currentAction.id).toEqual('action_1')
+                expect(queuedInvocations[1].state.currentAction.id).toEqual('action_1')
+            })
+
+            it('skips items with invalid action_id and reports failures', async () => {
+                const res = await supertest(app)
+                    .post(
+                        `/api/projects/${replayHogFlow.team_id}/hog_flows/${replayHogFlow.id}/bulk_replay_invocations`
+                    )
+                    .send({
+                        items: [
+                            {
+                                clickhouse_event: clickhouseEvent,
+                                action_id: 'action_1',
+                                instance_id: 'inv-001',
+                            },
+                            {
+                                clickhouse_event: clickhouseEvent,
+                                action_id: 'nonexistent_action',
+                                instance_id: 'inv-002',
+                            },
+                        ],
+                    })
+
+                expect(res.status).toEqual(200)
+                expect(res.body.succeeded).toEqual(1)
+                expect(res.body.failed).toEqual(1)
+            })
+
+            it('errors if items array is empty', async () => {
+                const res = await supertest(app)
+                    .post(
+                        `/api/projects/${replayHogFlow.team_id}/hog_flows/${replayHogFlow.id}/bulk_replay_invocations`
+                    )
+                    .send({ items: [] })
+
+                expect(res.status).toEqual(400)
+            })
+
+            it('errors if workflow not found', async () => {
+                const res = await supertest(app)
+                    .post(
+                        `/api/projects/${replayHogFlow.team_id}/hog_flows/${new UUIDT().toString()}/bulk_replay_invocations`
+                    )
+                    .send({
+                        items: [
+                            {
+                                clickhouse_event: clickhouseEvent,
+                                action_id: 'action_1',
+                                instance_id: 'inv-001',
+                            },
+                        ],
+                    })
+
+                expect(res.status).toEqual(404)
+            })
+
+            it('skips items with missing required fields', async () => {
+                const res = await supertest(app)
+                    .post(
+                        `/api/projects/${replayHogFlow.team_id}/hog_flows/${replayHogFlow.id}/bulk_replay_invocations`
+                    )
+                    .send({
+                        items: [
+                            { clickhouse_event: clickhouseEvent, action_id: 'action_1', instance_id: 'inv-001' },
+                            { action_id: 'action_1', instance_id: 'inv-002' }, // missing clickhouse_event
+                            { clickhouse_event: clickhouseEvent, instance_id: 'inv-003' }, // missing action_id
+                        ],
+                    })
+
+                expect(res.status).toEqual(200)
+                expect(res.body.succeeded).toEqual(1)
+                expect(res.body.failed).toEqual(2)
+            })
+        })
+    })
 })

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -701,8 +701,8 @@ export class CdpApi {
                 // Only write replay markers after invocations are successfully queued,
                 // otherwise failed runs would disappear from the blocked list permanently
                 if (logEntries.length > 0) {
-                    this.hogFunctionMonitoringService.queueLogs(logEntries, 'hog_flow')
-                    await this.hogFunctionMonitoringService.flush()
+                    this.invocationResultsService.monitoringService.queueLogs(logEntries, 'hog_flow')
+                    await this.invocationResultsService.flush()
                 }
             }
 

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -175,6 +175,10 @@ export class CdpApi {
             '/api/projects/:team_id/hog_flows/:id/batch_invocations/:parent_run_id',
             asyncHandler(this.postHogFlowBatchInvocation)
         )
+        router.post(
+            '/api/projects/:team_id/hog_flows/:id/bulk_replay_invocations',
+            asyncHandler(this.postHogflowBulkReplayInvocations)
+        )
         router.get('/api/projects/:team_id/hog_functions/:id/status', asyncHandler(this.getFunctionStatus()))
         router.patch('/api/projects/:team_id/hog_functions/:id/status', asyncHandler(this.patchFunctionStatus()))
         router.get('/api/hog_functions/states', asyncHandler(this.getFunctionStates()))
@@ -604,6 +608,107 @@ export class CdpApi {
         } catch (e) {
             logger.error('Error handling hogflow scheduled invocation', { error: e })
             res.status(500).json({ error: [e.message] })
+        }
+    }
+
+    private postHogflowBulkReplayInvocations = async (req: ModifiedRequest, res: express.Response): Promise<any> => {
+        try {
+            const { id, team_id } = req.params
+            const { items } = req.body as {
+                items: Array<{
+                    clickhouse_event: any
+                    action_id: string
+                    instance_id: string
+                }>
+            }
+
+            if (!Array.isArray(items) || items.length === 0) {
+                return res.status(400).json({ error: 'Missing or empty items array' })
+            }
+
+            const team = await this.deps.teamManager.getTeam(parseInt(team_id)).catch(() => null)
+            if (!team) {
+                return res.status(404).json({ error: 'Team not found' })
+            }
+
+            const hogFlow = await this.hogFlowManager.getHogFlow(id)
+            if (!hogFlow || hogFlow.team_id !== team.id) {
+                return res.status(404).json({ error: 'Workflow not found' })
+            }
+
+            const siteUrl = this.config.SITE_URL ?? 'http://localhost:8000'
+            const invocations: any[] = []
+            const logEntries: any[] = []
+            let succeeded = 0
+            let failed = 0
+
+            for (const item of items) {
+                try {
+                    const { clickhouse_event, action_id, instance_id } = item
+
+                    if (!clickhouse_event || !action_id || !instance_id) {
+                        failed++
+                        continue
+                    }
+
+                    const actionExists = hogFlow.actions?.some((a: any) => a.id === action_id)
+                    if (!actionExists) {
+                        failed++
+                        continue
+                    }
+
+                    const globals = convertToHogFunctionInvocationGlobals(clickhouse_event, team, siteUrl)
+                    const triggerGlobals: HogFunctionInvocationGlobals = {
+                        ...globals,
+                        project: {
+                            id: team.id,
+                            name: team.name,
+                            url: `${siteUrl}/project/${team.id}`,
+                        },
+                    }
+                    const filterGlobals = convertToHogFunctionFilterGlobal({
+                        event: globals.event,
+                        person: globals.person,
+                        groups: globals.groups,
+                        variables: {},
+                    })
+
+                    const invocation = createHogFlowInvocation(triggerGlobals, hogFlow, filterGlobals)
+                    invocation.state.currentAction = {
+                        id: action_id,
+                        startedAtTimestamp: Date.now(),
+                    }
+                    invocations.push(invocation)
+
+                    logEntries.push({
+                        team_id: team.id,
+                        log_source: 'hog_flow' as const,
+                        log_source_id: id,
+                        instance_id,
+                        timestamp: DateTime.utc(),
+                        level: 'info' as const,
+                        message: `[Replay] Queued replay for event ${clickhouse_event.uuid ?? 'unknown'} from action ${action_id}. New invocation: ${invocation.id}`,
+                    })
+                    succeeded++
+                } catch {
+                    failed++
+                }
+            }
+
+            if (invocations.length > 0) {
+                await this.cyclotronJobQueue.queueInvocations(invocations)
+            }
+
+            if (logEntries.length > 0) {
+                this.hogFunctionMonitoringService.queueLogs(logEntries, 'hog_flow')
+                await this.hogFunctionMonitoringService.flush()
+            }
+
+            logger.info('⚡️', 'Bulk replay completed', { id, team_id, succeeded, failed })
+            res.json({ succeeded, failed })
+        } catch (e) {
+            logger.error('Error handling hogflow bulk replay', { error: e })
+            res.status(500).json({ error: e.message })
         }
     }
 

--- a/nodejs/src/cdp/cdp-api.ts
+++ b/nodejs/src/cdp/cdp-api.ts
@@ -697,11 +697,13 @@ export class CdpApi {
 
             if (invocations.length > 0) {
                 await this.cyclotronJobQueue.queueInvocations(invocations)
-            }
 
-            if (logEntries.length > 0) {
-                this.hogFunctionMonitoringService.queueLogs(logEntries, 'hog_flow')
-                await this.hogFunctionMonitoringService.flush()
+                // Only write replay markers after invocations are successfully queued,
+                // otherwise failed runs would disappear from the blocked list permanently
+                if (logEntries.length > 0) {
+                    this.hogFunctionMonitoringService.queueLogs(logEntries, 'hog_flow')
+                    await this.hogFunctionMonitoringService.flush()
+                }
             }
 
             logger.info('⚡️', 'Bulk replay completed', { id, team_id, succeeded, failed })

--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -561,14 +561,60 @@ class HogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMixin, vie
     _ACTION_ID_PATTERN = re.compile(r"\[Action:([a-zA-Z0-9_-]+)\]")
     _EVENT_UUID_PATTERN = re.compile(r"for event ([a-f0-9-]{36})")
 
-    BLOCKED_RUNS_SQL = """
+    # Restricted to the 2026-04 dedup incident fingerprint to avoid replaying legitimate
+    # dedup catches (ghost runs caused by Kafka rebalance re-deliveries). See inline
+    # comments on each clause for the reasoning.
+    BLOCKED_RUNS_SQL = r"""
         SELECT instance_id, timestamp, message
         FROM log_entries
         WHERE team_id = %(team_id)s
           AND log_source = 'hog_flow'
           AND log_source_id = %(log_source_id)s
           AND positionCaseInsensitiveUTF8(message, 'duplicate execution detected') > 0
-          AND timestamp >= toDate(NOW() - INTERVAL 30 DAY)
+
+          -- Incident window: dedup shipped 2026-03-30 evening UTC and was reverted on
+          -- 2026-04-22 morning UTC. No bug-pattern blocks can exist outside this window.
+          AND timestamp >= toDateTime('2026-03-30 00:00:00')
+          AND timestamp <= toDateTime('2026-04-23 00:00:00')
+
+          -- Clause 1: action restricted to wait_until_condition, the only "hold-state"
+          -- action where the bug could fire dedup falsely. Other actions (delay, function
+          -- async, conditional_branch with delay) advance state.currentAction on resume,
+          -- so dedup never re-checks the same key. Blocks on those action types in this
+          -- window were legitimate ghost catches and must NOT be replayed.
+          AND positionUTF8(message, '[Action:action_wait_until_condition_') > 0
+
+          -- Clause 2: blocked instance_id must be uuidv7. The bug rewrote the original
+          -- UUIDT id to uuidv7 when the paused invocation was re-queued through
+          -- Cyclotron's V1 Postgres path. Position 15 (1-indexed) is the version nibble;
+          -- position 20 is the RFC-4122 variant nibble.
+          AND lower(substring(instance_id, 15, 1)) = '7'
+          AND lower(substring(instance_id, 20, 1)) IN ('8', '9', 'a', 'b')
+
+          -- Clause 3: if the message exposes 'Another invocation (<uuid>)' (post-2026-04-21
+          -- log format), that stored id must be UUIDT, not uuidv7. Pre-2026-04-21 messages
+          -- don't include this clause; the extract returns empty and the row stays in via
+          -- clause 2 alone.
+          AND (
+              extract(message, 'Another invocation \(([a-fA-F0-9-]{36})\)') = ''
+              OR lower(substring(extract(message, 'Another invocation \(([a-fA-F0-9-]{36})\)'), 15, 1)) != '7'
+          )
+
+          -- Clause 4: the uuidv7's embedded ms timestamp (first 12 hex chars) must fall
+          -- within 15 minutes before the block. Real bug rewrites mint a fresh uuidv7 at
+          -- re-queue time, and wait_until_condition's re-check interval
+          -- (DEFAULT_WAIT_DURATION_SECONDS = 600s = 10 min) bounds the gap. This
+          -- proximity check guards against any non-uuidv7 id that happens to share the
+          -- version + variant nibble pattern by coincidence.
+          AND fromUnixTimestamp64Milli(
+                  reinterpretAsInt64(reverse(unhex(substring(replaceAll(instance_id, '-', ''), 1, 12))))
+              ) >= subtractMinutes(timestamp, 15)
+          AND fromUnixTimestamp64Milli(
+                  reinterpretAsInt64(reverse(unhex(substring(replaceAll(instance_id, '-', ''), 1, 12))))
+              ) <= timestamp
+
+          -- Exclude rows already queued for replay. The Node CDP API writes this marker
+          -- when bulk_replay_invocations succeeds.
           AND instance_id NOT IN (
               SELECT instance_id
               FROM log_entries
@@ -576,7 +622,6 @@ class HogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMixin, vie
                 AND log_source = 'hog_flow'
                 AND log_source_id = %(log_source_id)s
                 AND positionCaseInsensitiveUTF8(message, '[Replay] Queued') > 0
-                AND timestamp >= toDate(NOW() - INTERVAL 30 DAY)
           )
         ORDER BY timestamp DESC
     """

--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -711,6 +711,30 @@ class HogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMixin, vie
         if not event_uuid or not action_id or not instance_id:
             return Response({"error": "event_uuid, action_id, and instance_id are required"}, status=400)
 
+        # Validate instance_id belongs to a blocked run for this workflow
+        from posthog.clickhouse.client.execute import sync_execute
+
+        validation_result = sync_execute(
+            """
+            SELECT message
+            FROM log_entries
+            WHERE team_id = %(team_id)s
+              AND log_source = 'hog_flow'
+              AND log_source_id = %(log_source_id)s
+              AND instance_id = %(instance_id)s
+              AND positionCaseInsensitiveUTF8(message, 'duplicate execution detected') > 0
+              AND timestamp >= toDate(NOW() - INTERVAL 30 DAY)
+            LIMIT 1
+            """,
+            {"team_id": self.team_id, "log_source_id": str(hog_flow.id), "instance_id": instance_id},
+        )
+        if not validation_result:
+            return Response({"error": f"Blocked run {instance_id} not found for this workflow"}, status=404)
+
+        _, logged_event_uuid = self._parse_blocked_run_message(validation_result[0][0])
+        if logged_event_uuid != event_uuid:
+            return Response({"error": "event_uuid does not match the blocked run"}, status=400)
+
         clickhouse_event = self._fetch_clickhouse_event(event_uuid)
         if not clickhouse_event:
             return Response({"error": f"Event {event_uuid} not found"}, status=404)
@@ -739,11 +763,9 @@ class HogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMixin, vie
 
         hog_flow = self.get_object()
 
-        max_replay_batch = 1000
-        query = self.BLOCKED_RUNS_SQL + "\nLIMIT %(limit)s"
         results = sync_execute(
-            query,
-            {"team_id": self.team_id, "log_source_id": str(hog_flow.id), "limit": max_replay_batch},
+            self.BLOCKED_RUNS_SQL,
+            {"team_id": self.team_id, "log_source_id": str(hog_flow.id)},
         )
 
         # Parse blocked runs and collect event UUIDs

--- a/posthog/api/hog_flow.py
+++ b/posthog/api/hog_flow.py
@@ -40,7 +40,11 @@ from posthog.models.feature_flag.user_blast_radius import (
 )
 from posthog.models.hog_flow.hog_flow import BILLABLE_ACTION_TYPES, HogFlow
 from posthog.models.hog_function_template import HogFunctionTemplate
-from posthog.plugins.plugin_server_api import create_hog_flow_invocation_test, create_hog_flow_scheduled_invocation
+from posthog.plugins.plugin_server_api import (
+    bulk_replay_hog_flow_invocations,
+    create_hog_flow_invocation_test,
+    create_hog_flow_scheduled_invocation,
+)
 
 from products.workflows.backend.models.hog_flow_batch_job import HogFlowBatchJob
 from products.workflows.backend.models.hog_flow_schedule import SCHEDULED_TRIGGER_TYPES, HogFlowSchedule
@@ -553,6 +557,291 @@ class HogFlowViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMixin, vie
             return Response({"status": "error", "message": res.json()["error"]}, status=res.status_code)
 
         return Response(res.json())
+
+    _ACTION_ID_PATTERN = re.compile(r"\[Action:([a-zA-Z0-9_-]+)\]")
+    _EVENT_UUID_PATTERN = re.compile(r"for event ([a-f0-9-]{36})")
+
+    BLOCKED_RUNS_SQL = """
+        SELECT instance_id, timestamp, message
+        FROM log_entries
+        WHERE team_id = %(team_id)s
+          AND log_source = 'hog_flow'
+          AND log_source_id = %(log_source_id)s
+          AND positionCaseInsensitiveUTF8(message, 'duplicate execution detected') > 0
+          AND timestamp >= toDate(NOW() - INTERVAL 30 DAY)
+          AND instance_id NOT IN (
+              SELECT instance_id
+              FROM log_entries
+              WHERE team_id = %(team_id)s
+                AND log_source = 'hog_flow'
+                AND log_source_id = %(log_source_id)s
+                AND positionCaseInsensitiveUTF8(message, '[Replay] Queued') > 0
+                AND timestamp >= toDate(NOW() - INTERVAL 30 DAY)
+          )
+        ORDER BY timestamp DESC
+    """
+
+    REPLAY_EVENT_SQL = """
+        SELECT
+            uuid,
+            event,
+            properties,
+            timestamp,
+            team_id,
+            distinct_id,
+            elements_chain,
+            person_id,
+            person_properties,
+            group0_properties,
+            group1_properties,
+            group2_properties,
+            group3_properties,
+            group4_properties
+        FROM events
+        WHERE uuid = %(event_id)s AND team_id = %(team_id)s
+    """
+
+    def _is_replay_feature_enabled(self) -> bool:
+        from posthog.models.feature_flag import FeatureFlag
+
+        return FeatureFlag.objects.filter(
+            team_id=self.team_id, key="workflows-replay-blocked-runs", active=True
+        ).exists()
+
+    def _parse_blocked_run_message(self, message: str) -> tuple[Optional[str], Optional[str]]:
+        action_match = self._ACTION_ID_PATTERN.search(message)
+        event_match = self._EVENT_UUID_PATTERN.search(message)
+        return (
+            action_match.group(1) if action_match else None,
+            event_match.group(1) if event_match else None,
+        )
+
+    def _fetch_clickhouse_event(self, event_uuid: str) -> Optional[dict]:
+        """Fetch a single event from ClickHouse and return it as a dict for the Node CDP API."""
+        from posthog.clickhouse.client.execute import sync_execute
+
+        event_results = sync_execute(
+            self.REPLAY_EVENT_SQL,
+            {"event_id": event_uuid, "team_id": self.team_id},
+            with_column_types=True,
+        )
+
+        rows, columns = event_results
+        if not rows:
+            return None
+
+        col_names = [col[0] for col in columns]
+        row = dict(zip(col_names, rows[0]))
+
+        return {
+            "uuid": str(row["uuid"]),
+            "event": row["event"],
+            "properties": row["properties"],
+            "timestamp": row["timestamp"].isoformat()
+            if hasattr(row["timestamp"], "isoformat")
+            else str(row["timestamp"]),
+            "team_id": row["team_id"],
+            "distinct_id": row["distinct_id"],
+            "elements_chain": row["elements_chain"] or "",
+            "person_id": str(row["person_id"]) if row.get("person_id") else None,
+            "person_properties": row.get("person_properties", ""),
+            "group0_properties": row.get("group0_properties", ""),
+            "group1_properties": row.get("group1_properties", ""),
+            "group2_properties": row.get("group2_properties", ""),
+            "group3_properties": row.get("group3_properties", ""),
+            "group4_properties": row.get("group4_properties", ""),
+        }
+
+    @action(detail=True, methods=["GET"], url_path="blocked_runs")
+    def blocked_runs(self, request: Request, *args, **kwargs):
+        """List workflow runs that were blocked by the dedup bug."""
+        from posthog.clickhouse.client.execute import sync_execute
+
+        if not self._is_replay_feature_enabled():
+            return Response({"results": []})
+
+        hog_flow = self.get_object()
+
+        try:
+            limit = min(int(request.query_params.get("limit", 100)), 1000)
+        except ValueError:
+            return Response({"error": "limit must be an integer"}, status=400)
+
+        try:
+            offset = max(int(request.query_params.get("offset", 0)), 0)
+        except ValueError:
+            return Response({"error": "offset must be an integer"}, status=400)
+
+        query = self.BLOCKED_RUNS_SQL + "\nLIMIT %(limit)s\nOFFSET %(offset)s"
+        results = sync_execute(
+            query,
+            {"team_id": self.team_id, "log_source_id": str(hog_flow.id), "limit": limit + 1, "offset": offset},
+        )
+
+        has_next = len(results) > limit
+        results = results[:limit]
+
+        blocked_runs = []
+        for instance_id, timestamp, message in results:
+            action_id, event_uuid = self._parse_blocked_run_message(message)
+            blocked_runs.append(
+                {
+                    "instance_id": instance_id,
+                    "timestamp": timestamp.isoformat() if hasattr(timestamp, "isoformat") else str(timestamp),
+                    "action_id": action_id,
+                    "event_uuid": event_uuid,
+                    "message": message,
+                }
+            )
+
+        return Response({"results": blocked_runs, "has_next": has_next, "limit": limit, "offset": offset})
+
+    @action(detail=True, methods=["POST"], url_path="replay_blocked_run")
+    def replay_blocked_run(self, request: Request, *args, **kwargs):
+        """Replay a single blocked run. Django fetches the event, Node creates the invocation and writes the log."""
+        if not self._is_replay_feature_enabled():
+            return Response({"error": "This feature is not enabled"}, status=403)
+
+        hog_flow = self.get_object()
+
+        event_uuid = request.data.get("event_uuid")
+        action_id = request.data.get("action_id")
+        instance_id = request.data.get("instance_id")
+
+        if not event_uuid or not action_id or not instance_id:
+            return Response({"error": "event_uuid, action_id, and instance_id are required"}, status=400)
+
+        clickhouse_event = self._fetch_clickhouse_event(event_uuid)
+        if not clickhouse_event:
+            return Response({"error": f"Event {event_uuid} not found"}, status=404)
+
+        res = bulk_replay_hog_flow_invocations(
+            team_id=self.team_id,
+            hog_flow_id=str(hog_flow.id),
+            items=[{"clickhouse_event": clickhouse_event, "action_id": action_id, "instance_id": instance_id}],
+        )
+
+        if res.status_code != 200:
+            return Response({"status": "error", "message": res.json().get("error")}, status=res.status_code)
+
+        result = res.json()
+        if result.get("succeeded", 0) > 0:
+            return Response({"status": "queued"})
+        return Response({"status": "error", "message": "Failed to replay run"}, status=400)
+
+    @action(detail=True, methods=["POST"], url_path="replay_all_blocked_runs")
+    def replay_all_blocked_runs(self, request: Request, *args, **kwargs):
+        """Replay all blocked runs in a single bulk call to Node."""
+        from posthog.clickhouse.client.execute import sync_execute
+
+        if not self._is_replay_feature_enabled():
+            return Response({"error": "This feature is not enabled"}, status=403)
+
+        hog_flow = self.get_object()
+
+        max_replay_batch = 1000
+        query = self.BLOCKED_RUNS_SQL + "\nLIMIT %(limit)s"
+        results = sync_execute(
+            query,
+            {"team_id": self.team_id, "log_source_id": str(hog_flow.id), "limit": max_replay_batch},
+        )
+
+        # Parse blocked runs and collect event UUIDs
+        blocked_runs: list[tuple[str, str, str]] = []  # (instance_id, action_id, event_uuid)
+        skipped = 0
+        for instance_id, _timestamp, message in results:
+            action_id, event_uuid = self._parse_blocked_run_message(message)
+            if not action_id or not event_uuid:
+                skipped += 1
+                continue
+            blocked_runs.append((instance_id, action_id, event_uuid))
+
+        if not blocked_runs:
+            return Response({"succeeded": 0, "failed": 0, "skipped": skipped})
+
+        # Process in batches to avoid large ClickHouse IN clauses (uuid is not a primary key)
+        # and HTTP timeouts/memory pressure on the Node side
+        batch_size = 100
+        succeeded = 0
+        failed = 0
+        hog_flow_id = str(hog_flow.id)
+
+        batch_event_query = """
+            SELECT
+                uuid, event, properties, timestamp, team_id, distinct_id,
+                elements_chain, person_id, person_properties,
+                group0_properties, group1_properties, group2_properties,
+                group3_properties, group4_properties
+            FROM events
+            WHERE uuid IN %(event_ids)s AND team_id = %(team_id)s
+        """
+
+        for i in range(0, len(blocked_runs), batch_size):
+            batch = blocked_runs[i : i + batch_size]
+            unique_event_uuids = list({event_uuid for _, _, event_uuid in batch})
+
+            event_results = sync_execute(
+                batch_event_query,
+                {"event_ids": unique_event_uuids, "team_id": self.team_id},
+                with_column_types=True,
+            )
+
+            event_rows, event_columns = event_results
+            col_names = [col[0] for col in event_columns]
+            events_by_uuid: dict[str, dict] = {}
+            for row_data in event_rows:
+                row = dict(zip(col_names, row_data))
+                events_by_uuid[str(row["uuid"])] = {
+                    "uuid": str(row["uuid"]),
+                    "event": row["event"],
+                    "properties": row["properties"],
+                    "timestamp": row["timestamp"].isoformat()
+                    if hasattr(row["timestamp"], "isoformat")
+                    else str(row["timestamp"]),
+                    "team_id": row["team_id"],
+                    "distinct_id": row["distinct_id"],
+                    "elements_chain": row["elements_chain"] or "",
+                    "person_id": str(row["person_id"]) if row.get("person_id") else None,
+                    "person_properties": row.get("person_properties", ""),
+                    "group0_properties": row.get("group0_properties", ""),
+                    "group1_properties": row.get("group1_properties", ""),
+                    "group2_properties": row.get("group2_properties", ""),
+                    "group3_properties": row.get("group3_properties", ""),
+                    "group4_properties": row.get("group4_properties", ""),
+                }
+
+            items = []
+            for instance_id, action_id, event_uuid in batch:
+                clickhouse_event = events_by_uuid.get(event_uuid)
+                if not clickhouse_event:
+                    skipped += 1
+                    continue
+                items.append(
+                    {
+                        "clickhouse_event": clickhouse_event,
+                        "action_id": action_id,
+                        "instance_id": instance_id,
+                    }
+                )
+
+            if not items:
+                continue
+
+            res = bulk_replay_hog_flow_invocations(
+                team_id=self.team_id,
+                hog_flow_id=hog_flow_id,
+                items=items,
+            )
+
+            if res.status_code != 200:
+                failed += len(items)
+                continue
+
+            batch_result = res.json()
+            succeeded += batch_result.get("succeeded", 0)
+            failed += batch_result.get("failed", 0)
+
+        return Response({"succeeded": succeeded, "failed": failed, "skipped": skipped})
 
     @extend_schema(request=BlastRadiusRequestSerializer, responses=BlastRadiusSerializer)
     @action(methods=["POST"], detail=False)

--- a/posthog/api/test/test_hog_flow.py
+++ b/posthog/api/test/test_hog_flow.py
@@ -1,5 +1,5 @@
 import uuid as uuid_mod
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Optional
 
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
@@ -1517,6 +1517,8 @@ class TestHogFlowAPI(APIBaseTest):
 
 
 class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
+    INCIDENT_WINDOW_TIMESTAMP = "2026-04-15 12:00:00.000000"
+
     def setUp(self):
         super().setUp()
         sync_template_to_db(webhook_template)
@@ -1553,9 +1555,73 @@ class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
         assert response.status_code == status.HTTP_201_CREATED, response.json()
         return response.json()["id"]
 
-    def _insert_blocked_log(self, flow_id: str, instance_id: str, action_id: str, event_uuid: str):
+    def _uuidv7_like(self, embedded_at: Optional[datetime] = None) -> str:
+        # Version '7' at position 15, RFC-4122 variant at position 20 (1-indexed,
+        # matching ClickHouse substring offsets used by BLOCKED_RUNS_SQL). Default
+        # embedded timestamp is 5 minutes before the block so generated rows pass
+        # the SQL's proximity check.
+        if embedded_at is None:
+            embedded_at = self._incident_window_dt() - timedelta(minutes=5)
+        ms = int(embedded_at.timestamp() * 1000)
+        ts_hex = f"{ms:012x}"
+        rand_hex = uuid_mod.uuid4().hex
+        s = ts_hex + "7" + rand_hex[13:16] + "8" + rand_hex[17:32]
+        return f"{s[:8]}-{s[8:12]}-{s[12:16]}-{s[16:20]}-{s[20:]}"
+
+    def _uuidt_like(self) -> str:
+        # Version nibble '0' at position 15 mimics PostHog's UUIDT, not strict uuidv7.
+        u = list(str(uuid_mod.uuid4()))
+        u[14] = "0"
+        return "".join(u)
+
+    def _wait_until_action_id(self) -> str:
+        return f"action_wait_until_condition_{uuid_mod.uuid4().hex[:8]}"
+
+    def _incident_window_dt(self) -> datetime:
+        return datetime(2026, 4, 15, 12, 0, 0, tzinfo=UTC)
+
+    def _parse_block_ts(self, ts_str: str) -> datetime:
+        return datetime.strptime(ts_str, "%Y-%m-%d %H:%M:%S.%f").replace(tzinfo=UTC)
+
+    def _insert_blocked_log(
+        self,
+        flow_id: str,
+        *,
+        instance_id: Optional[str] = None,
+        action_id: Optional[str] = None,
+        event_uuid: Optional[str] = None,
+        other_inv_id: Optional[str] = None,
+        include_other_clause: bool = True,
+        timestamp: Optional[str] = None,
+    ) -> dict:
+        # Defaults produce a row that matches the 2026-04 dedup incident bug fingerprint:
+        # wait_until_condition action, blocked id is uuidv7, message cites a UUIDT "other".
         from posthog.clickhouse.client.execute import sync_execute
         from posthog.clickhouse.log_entries import INSERT_LOG_ENTRY_SQL
+
+        resolved_action_id = action_id if action_id is not None else self._wait_until_action_id()
+        resolved_event_uuid = event_uuid if event_uuid is not None else str(uuid_mod.uuid4())
+        resolved_timestamp = timestamp if timestamp is not None else self.INCIDENT_WINDOW_TIMESTAMP
+        if instance_id is not None:
+            resolved_instance_id = instance_id
+        else:
+            block_dt = self._parse_block_ts(resolved_timestamp)
+            resolved_instance_id = self._uuidv7_like(embedded_at=block_dt - timedelta(minutes=5))
+
+        resolved_other_inv_id: Optional[str]
+        if include_other_clause:
+            resolved_other_inv_id = other_inv_id if other_inv_id is not None else self._uuidt_like()
+            message = (
+                f"[Action:{resolved_action_id}] Skipped: duplicate execution detected "
+                f"for event {resolved_event_uuid}. "
+                f"Another invocation ({resolved_other_inv_id}) already executed this action."
+            )
+        else:
+            # Pre-2026-04-21 log format had no "Another invocation (<uuid>)" clause.
+            resolved_other_inv_id = None
+            message = (
+                f"[Action:{resolved_action_id}] Skipped: duplicate execution detected for event {resolved_event_uuid}."
+            )
 
         sync_execute(
             INSERT_LOG_ENTRY_SQL,
@@ -1563,32 +1629,37 @@ class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
                 "team_id": self.team.pk,
                 "log_source": "hog_flow",
                 "log_source_id": flow_id,
-                "instance_id": instance_id,
-                "timestamp": datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f"),
+                "instance_id": resolved_instance_id,
+                "timestamp": resolved_timestamp,
                 "level": "warn",
-                "message": (
-                    f"[Action:{action_id}] Skipped: duplicate execution detected "
-                    f"for event {event_uuid}. Another invocation (other-inv-id) already executed this action."
-                ),
+                "message": message,
             },
         )
+        return {
+            "instance_id": resolved_instance_id,
+            "action_id": resolved_action_id,
+            "event_uuid": resolved_event_uuid,
+            "other_inv_id": resolved_other_inv_id,
+            "timestamp": resolved_timestamp,
+        }
 
     def test_blocked_runs_returns_parsed_results(self):
         flow_id = self._create_flow()
-        event_uuid = "550e8400-e29b-41d4-a716-446655440000"
+        action_id = self._wait_until_action_id()
 
-        self._insert_blocked_log(flow_id, "inv-001", "action_1", event_uuid)
-        self._insert_blocked_log(flow_id, "inv-002", "action_1", "660e8400-e29b-41d4-a716-446655440000")
+        log_a = self._insert_blocked_log(flow_id, action_id=action_id)
+        log_b = self._insert_blocked_log(flow_id, action_id=action_id)
 
         response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs")
         assert response.status_code == status.HTTP_200_OK
         results = response.json()["results"]
         assert len(results) == 2
 
+        returned_instance_ids = {r["instance_id"] for r in results}
+        assert returned_instance_ids == {log_a["instance_id"], log_b["instance_id"]}
         for result in results:
-            assert result["action_id"] == "action_1"
+            assert result["action_id"] == action_id
             assert result["event_uuid"] is not None
-            assert result["instance_id"] is not None
 
     def test_blocked_runs_invalid_limit(self):
         flow_id = self._create_flow()
@@ -1608,13 +1679,13 @@ class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
         flow_a = self._create_flow()
         flow_b = self._create_flow()
 
-        self._insert_blocked_log(flow_a, "inv-001", "action_1", "550e8400-e29b-41d4-a716-446655440000")
-        self._insert_blocked_log(flow_b, "inv-002", "action_1", "660e8400-e29b-41d4-a716-446655440000")
+        log_a = self._insert_blocked_log(flow_a)
+        self._insert_blocked_log(flow_b)
 
         response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_a}/blocked_runs")
         results = response.json()["results"]
         assert len(results) == 1
-        assert results[0]["instance_id"] == "inv-001"
+        assert results[0]["instance_id"] == log_a["instance_id"]
 
     @patch("posthog.api.hog_flow.bulk_replay_hog_flow_invocations")
     def test_replay_blocked_run_success(self, mock_bulk_replay):
@@ -1637,11 +1708,11 @@ class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
             person_id=person_id,
             person_properties={"email": "test@example.com"},
         )
-        self._insert_blocked_log(flow_id, "inv-001", "action_1", str(event_uuid))
+        log = self._insert_blocked_log(flow_id, event_uuid=str(event_uuid))
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_flows/{flow_id}/replay_blocked_run",
-            {"event_uuid": str(event_uuid), "action_id": "action_1", "instance_id": "inv-001"},
+            {"event_uuid": str(event_uuid), "action_id": log["action_id"], "instance_id": log["instance_id"]},
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["status"] == "queued"
@@ -1650,30 +1721,34 @@ class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
         call_kwargs = mock_bulk_replay.call_args[1]
         items = call_kwargs["items"]
         assert len(items) == 1
-        assert items[0]["action_id"] == "action_1"
-        assert items[0]["instance_id"] == "inv-001"
+        assert items[0]["action_id"] == log["action_id"]
+        assert items[0]["instance_id"] == log["instance_id"]
         assert items[0]["clickhouse_event"]["uuid"] == str(event_uuid)
         assert items[0]["clickhouse_event"]["person_id"] == str(person_id)
         assert "person_properties" in items[0]["clickhouse_event"]
 
     def test_replay_blocked_run_invalid_instance_id(self):
         flow_id = self._create_flow()
-        self._insert_blocked_log(flow_id, "inv-001", "action_1", "550e8400-e29b-41d4-a716-446655440000")
+        log = self._insert_blocked_log(flow_id)
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_flows/{flow_id}/replay_blocked_run",
-            {"event_uuid": "550e8400-e29b-41d4-a716-446655440000", "action_id": "action_1", "instance_id": "bogus-id"},
+            {"event_uuid": log["event_uuid"], "action_id": log["action_id"], "instance_id": "bogus-id"},
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert "not found" in response.json()["error"]
 
     def test_replay_blocked_run_mismatched_event_uuid(self):
         flow_id = self._create_flow()
-        self._insert_blocked_log(flow_id, "inv-001", "action_1", "550e8400-e29b-41d4-a716-446655440000")
+        log = self._insert_blocked_log(flow_id)
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_flows/{flow_id}/replay_blocked_run",
-            {"event_uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "action_id": "action_1", "instance_id": "inv-001"},
+            {
+                "event_uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "action_id": log["action_id"],
+                "instance_id": log["instance_id"],
+            },
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "does not match" in response.json()["error"]
@@ -1695,11 +1770,17 @@ class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
 
     def test_replay_blocked_run_event_not_found(self):
         flow_id = self._create_flow()
+        log = self._insert_blocked_log(flow_id)
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_flows/{flow_id}/replay_blocked_run",
-            {"event_uuid": "550e8400-e29b-41d4-a716-446655440000", "action_id": "action_1", "instance_id": "inv-001"},
+            {
+                "event_uuid": log["event_uuid"],
+                "action_id": log["action_id"],
+                "instance_id": log["instance_id"],
+            },
         )
+        # event was never inserted into ClickHouse, so lookup returns None
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @patch("posthog.api.hog_flow.bulk_replay_hog_flow_invocations")
@@ -1712,6 +1793,7 @@ class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
         mock_bulk_replay.return_value = mock_response
 
         flow_id = self._create_flow()
+        action_id = self._wait_until_action_id()
         event_uuid_1 = uuid_mod.uuid4()
         event_uuid_2 = uuid_mod.uuid4()
         for eu in [event_uuid_1, event_uuid_2]:
@@ -1724,8 +1806,8 @@ class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
                 person_id=uuid_mod.uuid4(),
             )
 
-        self._insert_blocked_log(flow_id, "inv-001", "action_1", str(event_uuid_1))
-        self._insert_blocked_log(flow_id, "inv-002", "action_1", str(event_uuid_2))
+        self._insert_blocked_log(flow_id, action_id=action_id, event_uuid=str(event_uuid_1))
+        self._insert_blocked_log(flow_id, action_id=action_id, event_uuid=str(event_uuid_2))
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_flows/{flow_id}/replay_all_blocked_runs",
@@ -1739,7 +1821,7 @@ class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
         items = call_kwargs["items"]
         assert len(items) == 2
         assert all(item["clickhouse_event"]["uuid"] in [str(event_uuid_1), str(event_uuid_2)] for item in items)
-        assert all(item["action_id"] == "action_1" for item in items)
+        assert all(item["action_id"] == action_id for item in items)
 
     @patch("posthog.api.hog_flow.bulk_replay_hog_flow_invocations")
     def test_replay_all_skips_runs_with_missing_events(self, mock_bulk_replay):
@@ -1749,9 +1831,10 @@ class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
         mock_bulk_replay.return_value = mock_response
 
         flow_id = self._create_flow()
-        # Insert blocked logs but don't create the events — they should be skipped
-        self._insert_blocked_log(flow_id, "inv-001", "action_1", "550e8400-e29b-41d4-a716-446655440000")
-        self._insert_blocked_log(flow_id, "inv-002", "action_1", "660e8400-e29b-41d4-a716-446655440000")
+        # Logs without backing ClickHouse events: replay must skip these so we don't
+        # send invocations the executor would 404 on.
+        self._insert_blocked_log(flow_id)
+        self._insert_blocked_log(flow_id)
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_flows/{flow_id}/replay_all_blocked_runs",
@@ -1759,7 +1842,6 @@ class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["skipped"] == 2
 
-        # No items to send, so bulk_replay should not be called
         mock_bulk_replay.assert_not_called()
 
     def test_replay_all_empty_when_no_blocked_runs(self):
@@ -1777,7 +1859,7 @@ class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
         FeatureFlag.objects.filter(team=self.team, key="workflows-replay-blocked-runs").update(active=False)
 
         flow_id = self._create_flow()
-        self._insert_blocked_log(flow_id, "inv-001", "action_1", "550e8400-e29b-41d4-a716-446655440000")
+        self._insert_blocked_log(flow_id)
 
         response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs")
         assert response.status_code == status.HTTP_200_OK
@@ -1797,8 +1879,8 @@ class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
 
     def test_blocked_runs_pagination(self):
         flow_id = self._create_flow()
-        for i in range(3):
-            self._insert_blocked_log(flow_id, f"inv-{i:03d}", "action_1", f"550e8400-e29b-41d4-a716-44665544{i:04d}")
+        for _ in range(3):
+            self._insert_blocked_log(flow_id)
 
         response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs?limit=2&offset=0")
         assert response.status_code == status.HTTP_200_OK
@@ -1810,3 +1892,281 @@ class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
         data = response.json()
         assert len(data["results"]) == 1
         assert data["has_next"] is False
+
+    # bug-fingerprint filter: reject legitimate dedupes so they are not replayed
+
+    def test_blocked_runs_excludes_uuidt_blocked_instance_id(self):
+        # Both invocations in UUIDT format = classifier's "two distinct UUIDT" verdict,
+        # a genuine dedup catch. Must NOT be replayed.
+        flow_id = self._create_flow()
+
+        self._insert_blocked_log(flow_id, instance_id=self._uuidt_like())
+        valid = self._insert_blocked_log(flow_id)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs")
+        results = response.json()["results"]
+        assert len(results) == 1
+        assert results[0]["instance_id"] == valid["instance_id"]
+
+    def test_blocked_runs_excludes_uuidv7_in_another_invocation_clause(self):
+        # Both ids in uuidv7 = wait-through ghost (id rewritten on both sides). Too
+        # ambiguous to safely replay.
+        flow_id = self._create_flow()
+
+        self._insert_blocked_log(flow_id, other_inv_id=self._uuidv7_like())
+        valid = self._insert_blocked_log(flow_id)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs")
+        results = response.json()["results"]
+        assert len(results) == 1
+        assert results[0]["instance_id"] == valid["instance_id"]
+
+    def test_blocked_runs_includes_pre_4_21_format_without_another_invocation(self):
+        # Pre-2026-04-21 messages omitted "Another invocation (<uuid>)". These rows
+        # must still be included when the blocked id is uuidv7.
+        flow_id = self._create_flow()
+
+        pre = self._insert_blocked_log(flow_id, include_other_clause=False)
+        uuidt_pre = self._insert_blocked_log(flow_id, instance_id=self._uuidt_like(), include_other_clause=False)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs")
+        results = response.json()["results"]
+        assert len(results) == 1
+        assert results[0]["instance_id"] == pre["instance_id"]
+        assert uuidt_pre["instance_id"] not in {r["instance_id"] for r in results}
+
+    def test_blocked_runs_excludes_timestamps_outside_incident_window(self):
+        # Dedup only existed between 2026-03-30 and 2026-04-22.
+        flow_id = self._create_flow()
+
+        self._insert_blocked_log(flow_id, timestamp="2026-03-29 23:59:59.000000")
+        self._insert_blocked_log(flow_id, timestamp="2026-04-23 00:00:01.000000")
+        valid = self._insert_blocked_log(flow_id, timestamp="2026-04-10 12:00:00.000000")
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs")
+        results = response.json()["results"]
+        assert len(results) == 1
+        assert results[0]["instance_id"] == valid["instance_id"]
+
+    def test_blocked_runs_full_fingerprint_discrimination(self):
+        flow_id = self._create_flow()
+
+        bug_rows = [
+            self._insert_blocked_log(flow_id),
+            self._insert_blocked_log(flow_id, include_other_clause=False),
+        ]
+
+        legit_rows = [
+            self._insert_blocked_log(flow_id, instance_id=self._uuidt_like()),
+            self._insert_blocked_log(flow_id, other_inv_id=self._uuidv7_like()),
+            self._insert_blocked_log(flow_id, action_id=f"action_function_email_{uuid_mod.uuid4().hex[:8]}"),
+            self._insert_blocked_log(flow_id, timestamp="2026-03-29 12:00:00.000000"),
+        ]
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs")
+        returned = {r["instance_id"] for r in response.json()["results"]}
+
+        assert returned == {row["instance_id"] for row in bug_rows}
+        for legit in legit_rows:
+            assert legit["instance_id"] not in returned, (
+                f"Legit dedupe {legit['instance_id']} should not be returned for replay"
+            )
+
+    # uuidv7 embedded-timestamp proximity: bounded by the wait_until_condition re-check interval
+
+    def test_blocked_runs_excludes_when_uuidv7_timestamp_too_old(self):
+        # The wait_until_condition re-check interval is 10 min, so a real bug rewrite
+        # cannot have an embedded timestamp more than 15 min before the block.
+        flow_id = self._create_flow()
+        block_dt = self._parse_block_ts(self.INCIDENT_WINDOW_TIMESTAMP)
+        old_uuidv7 = self._uuidv7_like(embedded_at=block_dt - timedelta(hours=1))
+
+        self._insert_blocked_log(flow_id, instance_id=old_uuidv7)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs")
+        assert response.json()["results"] == []
+
+    def test_blocked_runs_excludes_when_uuidv7_timestamp_in_the_future(self):
+        # A uuidv7 cannot have been minted after the block that referenced it.
+        flow_id = self._create_flow()
+        block_dt = self._parse_block_ts(self.INCIDENT_WINDOW_TIMESTAMP)
+        future_uuidv7 = self._uuidv7_like(embedded_at=block_dt + timedelta(minutes=10))
+
+        self._insert_blocked_log(flow_id, instance_id=future_uuidv7)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs")
+        assert response.json()["results"] == []
+
+    def test_blocked_runs_includes_uuidv7_timestamp_at_window_boundary(self):
+        flow_id = self._create_flow()
+        block_dt = self._parse_block_ts(self.INCIDENT_WINDOW_TIMESTAMP)
+        included = self._uuidv7_like(embedded_at=block_dt - timedelta(minutes=14, seconds=30))
+        excluded = self._uuidv7_like(embedded_at=block_dt - timedelta(minutes=16))
+
+        self._insert_blocked_log(flow_id, instance_id=included)
+        self._insert_blocked_log(flow_id, instance_id=excluded)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs")
+        returned = {r["instance_id"] for r in response.json()["results"]}
+        assert included in returned
+        assert excluded not in returned
+
+    # end-to-end shapes observed during the 2026-04 dedup incident
+
+    def test_e2e_burst_of_bug_blocks_simultaneous_pause_resume(self):
+        # Batch trigger fans out: all invocations pause, all re-queues rewrite ids
+        # together, all re-checks hit dedup at the same minute. Verifies the SQL
+        # handles a tight burst (identical timestamp on many rows).
+        flow_id = self._create_flow()
+        action_id = self._wait_until_action_id()
+        burst_block_ts = "2026-04-15 09:56:00.000000"
+        burst_dt = self._parse_block_ts(burst_block_ts)
+        re_queue_dt = burst_dt - timedelta(minutes=10)
+
+        burst_size = 30
+        inserted_ids = []
+        for _ in range(burst_size):
+            log = self._insert_blocked_log(
+                flow_id,
+                action_id=action_id,
+                timestamp=burst_block_ts,
+                instance_id=self._uuidv7_like(embedded_at=re_queue_dt),
+                include_other_clause=False,  # pre-2026-04-21 message format
+            )
+            inserted_ids.append(log["instance_id"])
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs?limit=1000")
+        returned = {r["instance_id"] for r in response.json()["results"]}
+        assert returned == set(inserted_ids)
+        assert len(returned) == burst_size
+
+    def test_e2e_high_volume_bug_workflow_with_minor_ghost_noise(self):
+        flow_id = self._create_flow()
+        action_id = self._wait_until_action_id()
+
+        bug_rows = [
+            self._insert_blocked_log(flow_id, action_id=action_id, include_other_clause=False) for _ in range(50)
+        ]
+
+        legit_ghost_rows = [
+            self._insert_blocked_log(flow_id, action_id=action_id, instance_id=self._uuidt_like()),
+            self._insert_blocked_log(flow_id, action_id=action_id, instance_id=self._uuidt_like()),
+        ]
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs?limit=1000")
+        returned = {r["instance_id"] for r in response.json()["results"]}
+
+        for row in bug_rows:
+            assert row["instance_id"] in returned
+        for row in legit_ghost_rows:
+            assert row["instance_id"] not in returned
+
+    def test_e2e_mixed_pre_and_post_4_21_message_formats(self):
+        # The bug spanned a logging refactor: early blocks have generic messages,
+        # later blocks include "Another invocation (<uuid>)". Both shapes must match.
+        flow_id = self._create_flow()
+        action_id = self._wait_until_action_id()
+
+        pre_4_21_rows = [
+            self._insert_blocked_log(
+                flow_id,
+                action_id=action_id,
+                include_other_clause=False,
+                timestamp="2026-04-05 10:00:00.000000",
+            )
+            for _ in range(10)
+        ]
+        post_4_21_rows = [
+            self._insert_blocked_log(
+                flow_id,
+                action_id=action_id,
+                include_other_clause=True,
+                timestamp="2026-04-21 10:00:00.000000",
+            )
+            for _ in range(10)
+        ]
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs?limit=100")
+        returned = {r["instance_id"] for r in response.json()["results"]}
+        assert returned == {row["instance_id"] for row in pre_4_21_rows + post_4_21_rows}
+
+    def test_e2e_workflow_with_mixed_action_types_keeps_only_wait_until(self):
+        # Workflows hit dedup on multiple action types; only wait_until_condition rows
+        # are bug-affected, the replay tool must filter the rest out.
+        flow_id = self._create_flow()
+        wait_action_id = self._wait_until_action_id()
+
+        bug_rows = [self._insert_blocked_log(flow_id, action_id=wait_action_id) for _ in range(2)]
+
+        for prefix in ("action_delay_", "action_function_", "action_function_email_", "action_conditional_branch_"):
+            for _ in range(30):
+                self._insert_blocked_log(flow_id, action_id=f"{prefix}{uuid_mod.uuid4().hex[:8]}")
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs?limit=200")
+        returned = {r["instance_id"] for r in response.json()["results"]}
+        assert returned == {row["instance_id"] for row in bug_rows}
+
+    def test_e2e_replayed_runs_drop_off_the_list(self):
+        # The replay handler writes a "[Replay] Queued" log marker per instance_id.
+        # Subsequent list calls must exclude already-replayed runs.
+        from posthog.clickhouse.client.execute import sync_execute
+        from posthog.clickhouse.log_entries import INSERT_LOG_ENTRY_SQL
+
+        flow_id = self._create_flow()
+        already_replayed = self._insert_blocked_log(flow_id)
+        still_pending = self._insert_blocked_log(flow_id)
+
+        sync_execute(
+            INSERT_LOG_ENTRY_SQL,
+            {
+                "team_id": self.team.pk,
+                "log_source": "hog_flow",
+                "log_source_id": flow_id,
+                "instance_id": already_replayed["instance_id"],
+                "timestamp": self.INCIDENT_WINDOW_TIMESTAMP,
+                "level": "info",
+                "message": (
+                    f"[Replay] Queued replay for event {already_replayed['event_uuid']} "
+                    f"from action {already_replayed['action_id']}."
+                ),
+            },
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs")
+        returned = {r["instance_id"] for r in response.json()["results"]}
+        assert returned == {still_pending["instance_id"]}
+
+    def test_e2e_pagination_returns_stable_results_across_pages(self):
+        # Distinct timestamps per row so ORDER BY timestamp DESC is deterministic
+        # and pages don't overlap.
+        flow_id = self._create_flow()
+        action_id = self._wait_until_action_id()
+        base_dt = self._parse_block_ts(self.INCIDENT_WINDOW_TIMESTAMP)
+        total_rows = 25
+
+        inserted_ids = set()
+        for i in range(total_rows):
+            row_dt = base_dt - timedelta(seconds=i)
+            log = self._insert_blocked_log(
+                flow_id,
+                action_id=action_id,
+                timestamp=row_dt.strftime("%Y-%m-%d %H:%M:%S.%f"),
+            )
+            inserted_ids.add(log["instance_id"])
+
+        page_size = 10
+        seen: set[str] = set()
+        offset = 0
+        while True:
+            response = self.client.get(
+                f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs?limit={page_size}&offset={offset}"
+            )
+            data = response.json()
+            page_ids = {r["instance_id"] for r in data["results"]}
+            assert page_ids.isdisjoint(seen), "page contains an instance_id already seen on a prior page"
+            seen.update(page_ids)
+            if not data["has_next"]:
+                break
+            offset += page_size
+
+        assert seen == inserted_ids

--- a/posthog/api/test/test_hog_flow.py
+++ b/posthog/api/test/test_hog_flow.py
@@ -1637,6 +1637,7 @@ class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
             person_id=person_id,
             person_properties={"email": "test@example.com"},
         )
+        self._insert_blocked_log(flow_id, "inv-001", "action_1", str(event_uuid))
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_flows/{flow_id}/replay_blocked_run",
@@ -1654,6 +1655,28 @@ class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
         assert items[0]["clickhouse_event"]["uuid"] == str(event_uuid)
         assert items[0]["clickhouse_event"]["person_id"] == str(person_id)
         assert "person_properties" in items[0]["clickhouse_event"]
+
+    def test_replay_blocked_run_invalid_instance_id(self):
+        flow_id = self._create_flow()
+        self._insert_blocked_log(flow_id, "inv-001", "action_1", "550e8400-e29b-41d4-a716-446655440000")
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}/replay_blocked_run",
+            {"event_uuid": "550e8400-e29b-41d4-a716-446655440000", "action_id": "action_1", "instance_id": "bogus-id"},
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert "not found" in response.json()["error"]
+
+    def test_replay_blocked_run_mismatched_event_uuid(self):
+        flow_id = self._create_flow()
+        self._insert_blocked_log(flow_id, "inv-001", "action_1", "550e8400-e29b-41d4-a716-446655440000")
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}/replay_blocked_run",
+            {"event_uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "action_id": "action_1", "instance_id": "inv-001"},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "does not match" in response.json()["error"]
 
     def test_replay_blocked_run_missing_params(self):
         flow_id = self._create_flow()

--- a/posthog/api/test/test_hog_flow.py
+++ b/posthog/api/test/test_hog_flow.py
@@ -1,7 +1,9 @@
+import uuid as uuid_mod
+from datetime import UTC, datetime
 from typing import Optional
 
-from posthog.test.base import APIBaseTest
-from unittest.mock import patch
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+from unittest.mock import Mock, patch
 
 from parameterized import parameterized
 from rest_framework import status
@@ -1512,3 +1514,276 @@ class TestHogFlowAPI(APIBaseTest):
         assert response.status_code == expected_status, response.json()
         if expected_error:
             assert response.json()["detail"] == expected_error
+
+
+class TestHogFlowBlockedRuns(ClickhouseTestMixin, APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        sync_template_to_db(webhook_template)
+        from posthog.models.feature_flag import FeatureFlag
+
+        FeatureFlag.objects.create(
+            team=self.team,
+            key="workflows-replay-blocked-runs",
+            active=True,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
+            created_by=self.user,
+        )
+
+    def _create_flow(self) -> str:
+        trigger_action = {
+            "id": "trigger_node",
+            "name": "trigger_1",
+            "type": "trigger",
+            "config": {
+                "type": "event",
+                "filters": {
+                    "events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0}],
+                },
+            },
+        }
+        action = {
+            "id": "action_1",
+            "name": "action_1",
+            "type": "function",
+            "config": {"template_id": "template-webhook", "inputs": {"url": {"value": "https://example.com"}}},
+        }
+        hog_flow = {"name": "Test Flow", "actions": [trigger_action, action]}
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow)
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        return response.json()["id"]
+
+    def _insert_blocked_log(self, flow_id: str, instance_id: str, action_id: str, event_uuid: str):
+        from posthog.clickhouse.client.execute import sync_execute
+        from posthog.clickhouse.log_entries import INSERT_LOG_ENTRY_SQL
+
+        sync_execute(
+            INSERT_LOG_ENTRY_SQL,
+            {
+                "team_id": self.team.pk,
+                "log_source": "hog_flow",
+                "log_source_id": flow_id,
+                "instance_id": instance_id,
+                "timestamp": datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f"),
+                "level": "warn",
+                "message": (
+                    f"[Action:{action_id}] Skipped: duplicate execution detected "
+                    f"for event {event_uuid}. Another invocation (other-inv-id) already executed this action."
+                ),
+            },
+        )
+
+    def test_blocked_runs_returns_parsed_results(self):
+        flow_id = self._create_flow()
+        event_uuid = "550e8400-e29b-41d4-a716-446655440000"
+
+        self._insert_blocked_log(flow_id, "inv-001", "action_1", event_uuid)
+        self._insert_blocked_log(flow_id, "inv-002", "action_1", "660e8400-e29b-41d4-a716-446655440000")
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs")
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+        assert len(results) == 2
+
+        for result in results:
+            assert result["action_id"] == "action_1"
+            assert result["event_uuid"] is not None
+            assert result["instance_id"] is not None
+
+    def test_blocked_runs_invalid_limit(self):
+        flow_id = self._create_flow()
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs?limit=abc")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["error"] == "limit must be an integer"
+
+    def test_blocked_runs_empty_when_no_blocked_logs(self):
+        flow_id = self._create_flow()
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["results"] == []
+
+    def test_blocked_runs_scoped_to_workflow(self):
+        flow_a = self._create_flow()
+        flow_b = self._create_flow()
+
+        self._insert_blocked_log(flow_a, "inv-001", "action_1", "550e8400-e29b-41d4-a716-446655440000")
+        self._insert_blocked_log(flow_b, "inv-002", "action_1", "660e8400-e29b-41d4-a716-446655440000")
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_a}/blocked_runs")
+        results = response.json()["results"]
+        assert len(results) == 1
+        assert results[0]["instance_id"] == "inv-001"
+
+    @patch("posthog.api.hog_flow.bulk_replay_hog_flow_invocations")
+    def test_replay_blocked_run_success(self, mock_bulk_replay):
+        from posthog.models.event.util import create_event
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"succeeded": 1, "failed": 0}
+        mock_bulk_replay.return_value = mock_response
+
+        flow_id = self._create_flow()
+        event_uuid = uuid_mod.uuid4()
+        person_id = uuid_mod.uuid4()
+        create_event(
+            event_uuid=event_uuid,
+            event="$pageview",
+            team=self.team,
+            distinct_id="user-1",
+            properties={"url": "https://example.com"},
+            person_id=person_id,
+            person_properties={"email": "test@example.com"},
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}/replay_blocked_run",
+            {"event_uuid": str(event_uuid), "action_id": "action_1", "instance_id": "inv-001"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["status"] == "queued"
+
+        mock_bulk_replay.assert_called_once()
+        call_kwargs = mock_bulk_replay.call_args[1]
+        items = call_kwargs["items"]
+        assert len(items) == 1
+        assert items[0]["action_id"] == "action_1"
+        assert items[0]["instance_id"] == "inv-001"
+        assert items[0]["clickhouse_event"]["uuid"] == str(event_uuid)
+        assert items[0]["clickhouse_event"]["person_id"] == str(person_id)
+        assert "person_properties" in items[0]["clickhouse_event"]
+
+    def test_replay_blocked_run_missing_params(self):
+        flow_id = self._create_flow()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}/replay_blocked_run",
+            {"event_uuid": "550e8400-e29b-41d4-a716-446655440000"},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}/replay_blocked_run",
+            {"action_id": "action_1"},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_replay_blocked_run_event_not_found(self):
+        flow_id = self._create_flow()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}/replay_blocked_run",
+            {"event_uuid": "550e8400-e29b-41d4-a716-446655440000", "action_id": "action_1", "instance_id": "inv-001"},
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @patch("posthog.api.hog_flow.bulk_replay_hog_flow_invocations")
+    def test_replay_all_blocked_runs_sends_bulk_request(self, mock_bulk_replay):
+        from posthog.models.event.util import create_event
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"succeeded": 2, "failed": 0}
+        mock_bulk_replay.return_value = mock_response
+
+        flow_id = self._create_flow()
+        event_uuid_1 = uuid_mod.uuid4()
+        event_uuid_2 = uuid_mod.uuid4()
+        for eu in [event_uuid_1, event_uuid_2]:
+            create_event(
+                event_uuid=eu,
+                event="$pageview",
+                team=self.team,
+                distinct_id="user-1",
+                properties={},
+                person_id=uuid_mod.uuid4(),
+            )
+
+        self._insert_blocked_log(flow_id, "inv-001", "action_1", str(event_uuid_1))
+        self._insert_blocked_log(flow_id, "inv-002", "action_1", str(event_uuid_2))
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}/replay_all_blocked_runs",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["succeeded"] == 2
+        assert response.json()["failed"] == 0
+
+        mock_bulk_replay.assert_called_once()
+        call_kwargs = mock_bulk_replay.call_args[1]
+        items = call_kwargs["items"]
+        assert len(items) == 2
+        assert all(item["clickhouse_event"]["uuid"] in [str(event_uuid_1), str(event_uuid_2)] for item in items)
+        assert all(item["action_id"] == "action_1" for item in items)
+
+    @patch("posthog.api.hog_flow.bulk_replay_hog_flow_invocations")
+    def test_replay_all_skips_runs_with_missing_events(self, mock_bulk_replay):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"succeeded": 0, "failed": 0}
+        mock_bulk_replay.return_value = mock_response
+
+        flow_id = self._create_flow()
+        # Insert blocked logs but don't create the events — they should be skipped
+        self._insert_blocked_log(flow_id, "inv-001", "action_1", "550e8400-e29b-41d4-a716-446655440000")
+        self._insert_blocked_log(flow_id, "inv-002", "action_1", "660e8400-e29b-41d4-a716-446655440000")
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}/replay_all_blocked_runs",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["skipped"] == 2
+
+        # No items to send, so bulk_replay should not be called
+        mock_bulk_replay.assert_not_called()
+
+    def test_replay_all_empty_when_no_blocked_runs(self):
+        flow_id = self._create_flow()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}/replay_all_blocked_runs",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"succeeded": 0, "failed": 0, "skipped": 0}
+
+    def test_blocked_runs_returns_empty_when_feature_flag_disabled(self):
+        from posthog.models.feature_flag import FeatureFlag
+
+        FeatureFlag.objects.filter(team=self.team, key="workflows-replay-blocked-runs").update(active=False)
+
+        flow_id = self._create_flow()
+        self._insert_blocked_log(flow_id, "inv-001", "action_1", "550e8400-e29b-41d4-a716-446655440000")
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["results"] == []
+
+    def test_replay_blocked_run_returns_403_when_feature_flag_disabled(self):
+        from posthog.models.feature_flag import FeatureFlag
+
+        FeatureFlag.objects.filter(team=self.team, key="workflows-replay-blocked-runs").update(active=False)
+
+        flow_id = self._create_flow()
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_flows/{flow_id}/replay_blocked_run",
+            {"event_uuid": "550e8400-e29b-41d4-a716-446655440000", "action_id": "action_1", "instance_id": "inv-001"},
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_blocked_runs_pagination(self):
+        flow_id = self._create_flow()
+        for i in range(3):
+            self._insert_blocked_log(flow_id, f"inv-{i:03d}", "action_1", f"550e8400-e29b-41d4-a716-44665544{i:04d}")
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs?limit=2&offset=0")
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data["results"]) == 2
+        assert data["has_next"] is True
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows/{flow_id}/blocked_runs?limit=2&offset=2")
+        data = response.json()
+        assert len(data["results"]) == 1
+        assert data["has_next"] is False

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -564,115 +564,6 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestWebStatsTableQueryRunner.test_avg_time_on_page_multiple_users.2
-  '''
-  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
-         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
-         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
-         tuple(coalesce(time_on_page.avg_time_on_page, 0), coalesce(time_on_page.previous_avg_time_on_page, 0)) AS `context.columns.avg_time_on_page`,
-         tuple(coalesce(bounce.bounce_rate, 0), coalesce(bounce.previous_bounce_rate, 0)) AS `context.columns.bounce_rate`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT breakdown_value AS breakdown_value,
-            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS visitors,
-            uniqIf(filtered_person_id, 0) AS previous_visitors,
-            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS views,
-            sumIf(filtered_pageview_count, 0) AS previous_views
-     FROM
-       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-               count() AS filtered_pageview_count,
-               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.person_id,
-                  events.properties,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
-        LEFT JOIN
-          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        LEFT OUTER JOIN
-          (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS counts
-  LEFT JOIN
-    (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
-            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
-                            and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))))) AS avg_time_on_page,
-            quantileIf(0.9)(least(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', ''), 'Float64'), 86400),
-                            0) AS previous_avg_time_on_page
-     FROM
-       (SELECT events.`$session_id_uuid`,
-               events.distinct_id,
-               events.event,
-               events.properties,
-               events.timestamp
-        FROM events
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
-     WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_duration'), ''), 'null'), '^"|"$', '')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
-     GROUP BY breakdown_value) AS time_on_page ON equals(counts.breakdown_value, time_on_page.breakdown_value)
-  LEFT JOIN
-    (SELECT breakdown_value AS breakdown_value,
-            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), 0), ifNull(lessOrEquals(start_timestamp, assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC'))), 0))) AS bounce_rate,
-            avgIf(is_bounce, 0) AS previous_bounce_rate
-     FROM
-       (SELECT events__session.`$entry_pathname` AS breakdown_value,
-               any(events__session.`$is_bounce`) AS is_bounce,
-               events__session.session_id AS session_id,
-               min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
-        LEFT JOIN
-          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
-                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-                  raw_sessions.session_id_v7 AS session_id_v7
-           FROM raw_sessions
-           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
-           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
-        GROUP BY session_id,
-                 breakdown_value)
-     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
-  WHERE isNotNull(counts.breakdown_value)
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
 # name: TestWebStatsTableQueryRunner.test_avg_time_on_page_one_user
   '''
   
@@ -894,17 +785,6 @@
 # ---
 # name: TestWebStatsTableQueryRunner.test_bounce_rate.1
   '''
-  
-  SELECT timestamp
-  from events
-  WHERE team_id = 99999
-    AND timestamp > '2015-01-01'
-  order by timestamp
-  limit 1
-  '''
-# ---
-# name: TestWebStatsTableQueryRunner.test_bounce_rate.2
-  '''
   SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
          tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
          tuple(counts.views, counts.previous_views) AS `context.columns.views`,
@@ -922,15 +802,7 @@
                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.person_id,
-                  events.properties,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+        FROM events
         LEFT JOIN
           (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                   min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
@@ -945,7 +817,7 @@
            WHERE equals(person_distinct_id_overrides.team_id, 99999)
            GROUP BY person_distinct_id_overrides.distinct_id
            HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS counts
@@ -958,13 +830,7 @@
                any(events__session.`$is_bounce`) AS is_bounce,
                events__session.session_id AS session_id,
                min(events__session.`$start_timestamp`) AS start_timestamp
-        FROM
-          (SELECT events.`$session_id_uuid`,
-                  events.distinct_id,
-                  events.event,
-                  events.timestamp
-           FROM events
-           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toDate(events.timestamp), '2023-12-01'), lessOrEquals(toDate(events.timestamp), '2023-12-16'))) AS events
+        FROM events
         LEFT JOIN
           (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
                   if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
@@ -974,7 +840,7 @@
            FROM raw_sessions
            WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')), toIntervalDay(3))))
            GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-        WHERE and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-02 12:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2023-12-15 23:59:59', 'UTC')))), 0), 1, 1))
         GROUP BY session_id,
                  breakdown_value)
      GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)

--- a/posthog/plugins/plugin_server_api.py
+++ b/posthog/plugins/plugin_server_api.py
@@ -102,6 +102,15 @@ def create_hog_flow_scheduled_invocation(
     )
 
 
+def bulk_replay_hog_flow_invocations(team_id: int, hog_flow_id: str, items: list[dict]) -> requests.Response:
+    logger.info("Bulk replaying blocked hog flow invocations", hog_flow_id=hog_flow_id, count=len(items))
+    return internal_requests.post(
+        CDP_API_URL + f"/api/projects/{team_id}/hog_flows/{hog_flow_id}/bulk_replay_invocations",
+        json={"items": items},
+        headers=get_internal_api_headers(),
+    )
+
+
 def get_hog_function_status(team_id: int, hog_function_id: UUIDT) -> requests.Response:
     return internal_requests.get(
         CDP_API_URL + f"/api/projects/{team_id}/hog_functions/{hog_function_id}/status",

--- a/products/workflows/frontend/Workflows/BlockedRunsBanner.tsx
+++ b/products/workflows/frontend/Workflows/BlockedRunsBanner.tsx
@@ -1,0 +1,40 @@
+import { useValues } from 'kea'
+import { router } from 'kea-router'
+
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner/LemonBanner'
+import { urls } from 'scenes/urls'
+
+import { blockedRunsLogic } from './blockedRunsLogic'
+
+function BlockedRunsBannerInner({ id }: { id: string }): JSX.Element | null {
+    const { allBlockedRuns, blockedRunsLoading, hasMoreRuns } = useValues(blockedRunsLogic({ id }))
+
+    if (blockedRunsLoading || allBlockedRuns.length === 0) {
+        return null
+    }
+
+    const countLabel = hasMoreRuns ? `${allBlockedRuns.length}+` : `${allBlockedRuns.length}`
+
+    return (
+        <div className="px-4 pt-2">
+            <LemonBanner
+                type="warning"
+                action={{
+                    children: 'View blocked runs',
+                    onClick: () => router.actions.push(urls.workflow(id, 'blocked_runs')),
+                }}
+            >
+                {countLabel} workflow run{allBlockedRuns.length !== 1 ? 's were' : ' was'} blocked by a bug and did not
+                complete. You can review and replay them.
+            </LemonBanner>
+        </div>
+    )
+}
+
+export function BlockedRunsBanner({ id }: { id?: string }): JSX.Element | null {
+    const safeId = id && id !== 'new' ? id : undefined
+    if (!safeId) {
+        return null
+    }
+    return <BlockedRunsBannerInner id={safeId} />
+}

--- a/products/workflows/frontend/Workflows/BlockedRunsBanner.tsx
+++ b/products/workflows/frontend/Workflows/BlockedRunsBanner.tsx
@@ -2,9 +2,14 @@ import { useValues } from 'kea'
 import { router } from 'kea-router'
 
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner/LemonBanner'
+import { Link } from 'lib/lemon-ui/Link'
+import { pluralize } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
 import { blockedRunsLogic } from './blockedRunsLogic'
+
+// Status page entry where the public postmortem will live.
+const INCIDENT_2026_04_22_URL = 'https://www.posthogstatus.com/eu?incident=01KPSY5YTTB1MEZ5KZVQ0W8NDZ'
 
 function BlockedRunsBannerInner({ id }: { id: string }): JSX.Element | null {
     const { allBlockedRuns, blockedRunsLoading, hasMoreRuns } = useValues(blockedRunsLogic({ id }))
@@ -13,10 +18,14 @@ function BlockedRunsBannerInner({ id }: { id: string }): JSX.Element | null {
         return null
     }
 
-    const countLabel = hasMoreRuns ? `${allBlockedRuns.length}+` : `${allBlockedRuns.length}`
+    const isPlural = hasMoreRuns || allBlockedRuns.length !== 1
+    const runsLabel = hasMoreRuns
+        ? `${allBlockedRuns.length}+ ${pluralize(2, 'run', undefined, false)}`
+        : pluralize(allBlockedRuns.length, 'run')
+    const verbWord = isPlural ? 'were' : 'was'
 
     return (
-        <div className="px-4 pt-2">
+        <div className="py-2">
             <LemonBanner
                 type="warning"
                 action={{
@@ -24,8 +33,13 @@ function BlockedRunsBannerInner({ id }: { id: string }): JSX.Element | null {
                     onClick: () => router.actions.push(urls.workflow(id, 'blocked_runs')),
                 }}
             >
-                {countLabel} workflow run{allBlockedRuns.length !== 1 ? 's were' : ' was'} blocked by a bug and did not
-                complete. You can review and replay them.
+                {runsLabel} on this workflow {verbWord} silently blocked at a <strong>Wait until condition</strong> step
+                between March 30 and April 22, 2026, due to a bug that has since been fixed. You can review and replay
+                them.{' '}
+                <Link to={INCIDENT_2026_04_22_URL} target="_blank">
+                    Read more
+                </Link>
+                .
             </LemonBanner>
         </div>
     )

--- a/products/workflows/frontend/Workflows/BlockedRunsReplay.tsx
+++ b/products/workflows/frontend/Workflows/BlockedRunsReplay.tsx
@@ -1,0 +1,175 @@
+import { useActions, useValues } from 'kea'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner/LemonBanner'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonCheckbox } from 'lib/lemon-ui/LemonCheckbox'
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
+import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
+import { Spinner } from 'lib/lemon-ui/Spinner'
+
+import { BlockedRun, blockedRunsLogic } from './blockedRunsLogic'
+
+export function BlockedRunsReplay({ id }: { id: string }): JSX.Element {
+    const logic = blockedRunsLogic({ id })
+    const { allBlockedRuns, blockedRunsLoading, selectedRunIds, hasMoreRuns, replayAllLoading } = useValues(logic)
+    const {
+        toggleRunSelection,
+        setSelectedRunIds,
+        clearSelection,
+        replaySelectedRuns,
+        replayAllBlockedRuns,
+        loadMoreBlockedRuns,
+    } = useActions(logic)
+
+    const selectedCount = selectedRunIds.size
+    const allSelected = allBlockedRuns.length > 0 && allBlockedRuns.every((r) => selectedRunIds.has(r.instance_id))
+
+    const confirmReplay = (): void => {
+        LemonDialog.open({
+            title: `Replay ${selectedCount} blocked run${selectedCount !== 1 ? 's' : ''}?`,
+            description:
+                'This will re-execute each workflow starting from the action that was blocked. Actions that completed before the block will not be re-executed. Workflow variables from prior steps will not be available.',
+            primaryButton: {
+                children: 'Replay',
+                type: 'primary',
+                onClick: () => replaySelectedRuns(),
+            },
+            secondaryButton: {
+                children: 'Cancel',
+            },
+        })
+    }
+
+    const confirmReplayAll = (): void => {
+        LemonDialog.open({
+            title: 'Replay all blocked runs?',
+            description:
+                'This will re-execute all blocked workflow runs starting from their blocked action. This includes runs not yet loaded in this list. Actions that already completed will not be re-executed. Workflow variables from prior steps will not be available.',
+            primaryButton: {
+                children: 'Replay all',
+                type: 'primary',
+                status: 'danger',
+                onClick: () => replayAllBlockedRuns(),
+            },
+            secondaryButton: {
+                children: 'Cancel',
+            },
+        })
+    }
+
+    const columns: LemonTableColumns<BlockedRun> = [
+        {
+            title: (
+                <LemonCheckbox
+                    checked={allSelected ? true : selectedCount > 0 ? 'indeterminate' : false}
+                    onChange={(checked) =>
+                        checked
+                            ? setSelectedRunIds(new Set(allBlockedRuns.map((r) => r.instance_id)))
+                            : clearSelection()
+                    }
+                />
+            ),
+            width: 0,
+            render: (_, run) => (
+                <LemonCheckbox
+                    checked={selectedRunIds.has(run.instance_id)}
+                    onChange={() => toggleRunSelection(run.instance_id)}
+                />
+            ),
+        },
+        {
+            title: 'Run ID',
+            key: 'instance_id',
+            render: (_, run) => <code className="text-xs">{run.instance_id}</code>,
+        },
+        {
+            title: 'Event UUID',
+            key: 'event_uuid',
+            render: (_, run) =>
+                run.event_uuid ? (
+                    <code className="text-xs">{run.event_uuid}</code>
+                ) : (
+                    <span className="text-muted">-</span>
+                ),
+        },
+        {
+            title: 'Blocked action',
+            key: 'action_id',
+            render: (_, run) =>
+                run.action_id ? (
+                    <code className="text-xs">{run.action_id}</code>
+                ) : (
+                    <span className="text-muted">-</span>
+                ),
+        },
+        {
+            title: 'Blocked at',
+            key: 'timestamp',
+            render: (_, run) => <TZLabel time={run.timestamp} />,
+        },
+    ]
+
+    if (blockedRunsLoading && allBlockedRuns.length === 0) {
+        return (
+            <div className="flex items-center justify-center p-8">
+                <Spinner className="text-2xl" />
+            </div>
+        )
+    }
+
+    return (
+        <div className="space-y-4 p-4">
+            <LemonBanner type="info">
+                These workflow runs were blocked by a deduplication bug between March 30 and April 22. Replaying a run
+                will re-execute the workflow starting from the blocked action — actions that already completed (e.g.
+                emails sent) will not be re-executed. Note that workflow variables set by prior steps will not be
+                available.
+            </LemonBanner>
+
+            <div className="flex items-center gap-2">
+                <LemonButton
+                    type="secondary"
+                    status="danger"
+                    size="small"
+                    loading={replayAllLoading}
+                    onClick={confirmReplayAll}
+                >
+                    Replay all blocked runs
+                </LemonButton>
+            </div>
+
+            {selectedCount > 0 && (
+                <div className="flex items-center gap-2">
+                    <span className="text-muted text-sm">
+                        {selectedCount} run{selectedCount !== 1 ? 's' : ''} selected
+                    </span>
+                    <LemonButton type="primary" size="small" onClick={confirmReplay}>
+                        Replay selected
+                    </LemonButton>
+                    <LemonButton type="secondary" size="small" onClick={clearSelection}>
+                        Clear selection
+                    </LemonButton>
+                </div>
+            )}
+
+            <LemonTable
+                dataSource={allBlockedRuns}
+                loading={blockedRunsLoading}
+                columns={columns}
+                rowKey="instance_id"
+                pagination={{ pageSize: 20 }}
+                nouns={['blocked run', 'blocked runs']}
+                emptyState="No blocked runs found for this workflow"
+            />
+
+            {hasMoreRuns && (
+                <div className="flex justify-center">
+                    <LemonButton type="secondary" loading={blockedRunsLoading} onClick={loadMoreBlockedRuns}>
+                        Load more
+                    </LemonButton>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/products/workflows/frontend/Workflows/BlockedRunsReplay.tsx
+++ b/products/workflows/frontend/Workflows/BlockedRunsReplay.tsx
@@ -6,9 +6,12 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonCheckbox } from 'lib/lemon-ui/LemonCheckbox'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
+import { Link } from 'lib/lemon-ui/Link'
 import { Spinner } from 'lib/lemon-ui/Spinner'
+import { urls } from 'scenes/urls'
 
 import { BlockedRun, blockedRunsLogic } from './blockedRunsLogic'
+import { workflowLogic } from './workflowLogic'
 
 export function BlockedRunsReplay({ id }: { id: string }): JSX.Element {
     const logic = blockedRunsLogic({ id })
@@ -21,6 +24,17 @@ export function BlockedRunsReplay({ id }: { id: string }): JSX.Element {
         replayAllBlockedRuns,
         loadMoreBlockedRuns,
     } = useActions(logic)
+
+    // Map action_id -> action name from the current workflow definition. The action may
+    // have been edited or removed since the run was blocked (e.g., the customer reshuffled
+    // the workflow during incident triage), so we fall back gracefully when not found.
+    const { originalWorkflow } = useValues(workflowLogic)
+    const actionNameById = new Map<string, string>(
+        (originalWorkflow?.actions ?? []).map((action: { id: string; name?: string }) => [
+            action.id,
+            action.name ?? action.id,
+        ])
+    )
 
     const selectedCount = selectedRunIds.size
     const allSelected = allBlockedRuns.length > 0 && allBlockedRuns.every((r) => selectedRunIds.has(r.instance_id))
@@ -88,7 +102,9 @@ export function BlockedRunsReplay({ id }: { id: string }): JSX.Element {
             key: 'event_uuid',
             render: (_, run) =>
                 run.event_uuid ? (
-                    <code className="text-xs">{run.event_uuid}</code>
+                    <Link to={urls.event(run.event_uuid, run.timestamp)} target="_blank">
+                        <code className="text-xs">{run.event_uuid}</code>
+                    </Link>
                 ) : (
                     <span className="text-muted">-</span>
                 ),
@@ -96,12 +112,26 @@ export function BlockedRunsReplay({ id }: { id: string }): JSX.Element {
         {
             title: 'Blocked action',
             key: 'action_id',
-            render: (_, run) =>
-                run.action_id ? (
-                    <code className="text-xs">{run.action_id}</code>
-                ) : (
-                    <span className="text-muted">-</span>
-                ),
+            render: (_, run) => {
+                if (!run.action_id) {
+                    return <span className="text-muted">-</span>
+                }
+                const name = actionNameById.get(run.action_id)
+                if (name) {
+                    return (
+                        <div className="flex flex-col">
+                            <span className="text-xs">{name}</span>
+                            <code className="text-muted text-xs">{run.action_id}</code>
+                        </div>
+                    )
+                }
+                return (
+                    <div className="flex flex-col">
+                        <span className="text-muted text-xs italic">No longer in workflow</span>
+                        <code className="text-muted text-xs">{run.action_id}</code>
+                    </div>
+                )
+            },
         },
         {
             title: 'Blocked at',
@@ -122,7 +152,7 @@ export function BlockedRunsReplay({ id }: { id: string }): JSX.Element {
         <div className="space-y-4 p-4">
             <LemonBanner type="info">
                 These workflow runs were blocked by a deduplication bug between March 30 and April 22. Replaying a run
-                will re-execute the workflow starting from the blocked action — actions that already completed (e.g.
+                will re-execute the workflow starting from the blocked action. Actions that already completed (e.g.
                 emails sent) will not be re-executed. Note that workflow variables set by prior steps will not be
                 available.
             </LemonBanner>

--- a/products/workflows/frontend/Workflows/WorkflowScene.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowScene.tsx
@@ -5,7 +5,10 @@ import { router } from 'kea-router'
 import { SpinnerOverlay } from '@posthog/lemon-ui'
 
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
+import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { NotFound } from 'lib/components/NotFound'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -16,6 +19,8 @@ import { ProductKey } from '~/queries/schema/schema-general'
 import { ActivityScope } from '~/types'
 
 import { batchWorkflowJobsLogic } from './batchWorkflowJobsLogic'
+import { BlockedRunsBanner } from './BlockedRunsBanner'
+import { BlockedRunsReplay } from './BlockedRunsReplay'
 import { Workflow } from './Workflow'
 import { workflowLogic } from './workflowLogic'
 import { WorkflowLogs } from './WorkflowLogs'
@@ -49,6 +54,8 @@ export function WorkflowScene(props: WorkflowSceneLogicProps): JSX.Element {
 
     const logic = workflowLogic({ id: props.id, tabId: props.tabId, templateId, editTemplateId })
     const { workflowLoading, originalWorkflow } = useValues(logic)
+
+    const showBlockedRuns = useFeatureFlag('WORKFLOWS_REPLAY_BLOCKED_RUNS')
 
     // Attach child logics to the scene logic so they persist across tab switches
     useAttachedLogic(batchJobsLogic, sceneLogic)
@@ -92,12 +99,22 @@ export function WorkflowScene(props: WorkflowSceneLogicProps): JSX.Element {
              */
             content: <ActivityLog id={workflowSceneProps.id!} scope={ActivityScope.HOG_FLOW} />,
         },
+        showBlockedRuns
+            ? {
+                  label: 'Blocked runs',
+                  key: 'blocked_runs' as WorkflowTab,
+                  content: <BlockedRunsReplay id={workflowSceneProps.id!} />,
+              }
+            : null,
     ]
 
     return (
         <SceneContent className="h-full flex flex-col grow" data-attr="workflow-scene">
             <BindLogic logic={workflowLogic} props={{ id: props.id, tabId: props.tabId, templateId, editTemplateId }}>
                 <WorkflowSceneHeader {...props} />
+                <FlaggedFeature flag={FEATURE_FLAGS.WORKFLOWS_REPLAY_BLOCKED_RUNS}>
+                    <BlockedRunsBanner id={props.id} />
+                </FlaggedFeature>
                 {/* Only show Logs and Metrics tabs if the workflow has already been created */}
                 {!props.id || props.id === 'new' ? (
                     <Workflow {...props} />

--- a/products/workflows/frontend/Workflows/blockedRunsLogic.ts
+++ b/products/workflows/frontend/Workflows/blockedRunsLogic.ts
@@ -1,0 +1,148 @@
+import { actions, afterMount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+
+import type { blockedRunsLogicType } from './blockedRunsLogicType'
+
+export interface BlockedRun {
+    instance_id: string
+    timestamp: string
+    action_id: string | null
+    event_uuid: string | null
+    message: string
+}
+
+export interface BlockedRunsLogicProps {
+    id: string
+}
+
+const PAGE_SIZE = 100
+
+export const blockedRunsLogic = kea<blockedRunsLogicType>([
+    path(['products', 'workflows', 'frontend', 'Workflows', 'blockedRunsLogic']),
+    props({} as BlockedRunsLogicProps),
+    key((props) => props.id),
+    actions({
+        toggleRunSelection: (instanceId: string) => ({ instanceId }),
+        setSelectedRunIds: (ids: Set<string>) => ({ ids }),
+        clearSelection: true,
+        replaySelectedRuns: true,
+        replayAllBlockedRuns: true,
+        loadMoreBlockedRuns: true,
+    }),
+    loaders(({ props, values }) => ({
+        blockedRuns: [
+            { results: [] as BlockedRun[], hasNext: false, offset: 0 },
+            {
+                loadBlockedRuns: async () => {
+                    const response = await api.hogFlows.getBlockedRuns(props.id, PAGE_SIZE, 0)
+                    return {
+                        results: response.results,
+                        hasNext: response.has_next,
+                        offset: PAGE_SIZE,
+                    }
+                },
+                loadMoreBlockedRuns: async () => {
+                    const current = values.blockedRuns
+                    const response = await api.hogFlows.getBlockedRuns(props.id, PAGE_SIZE, current.offset)
+                    return {
+                        results: [...current.results, ...response.results],
+                        hasNext: response.has_next,
+                        offset: current.offset + PAGE_SIZE,
+                    }
+                },
+            },
+        ],
+    })),
+    selectors({
+        allBlockedRuns: [(s) => [s.blockedRuns], (blockedRuns) => blockedRuns.results],
+        hasMoreRuns: [(s) => [s.blockedRuns], (blockedRuns) => blockedRuns.hasNext],
+    }),
+    reducers({
+        selectedRunIds: [
+            new Set<string>() as Set<string>,
+            {
+                toggleRunSelection: (state, { instanceId }) => {
+                    const next = new Set(state)
+                    if (next.has(instanceId)) {
+                        next.delete(instanceId)
+                    } else {
+                        next.add(instanceId)
+                    }
+                    return next
+                },
+                setSelectedRunIds: (_, { ids }) => ids,
+                clearSelection: () => new Set<string>(),
+                loadBlockedRunsSuccess: () => new Set<string>(),
+            },
+        ],
+        replayAllLoading: [
+            false,
+            {
+                replayAllBlockedRuns: () => true,
+                loadBlockedRunsSuccess: () => false,
+                loadBlockedRunsFailure: () => false,
+            },
+        ],
+    }),
+    listeners(({ actions, values, props }) => ({
+        replaySelectedRuns: async () => {
+            const runs = values.allBlockedRuns.filter((r) => values.selectedRunIds.has(r.instance_id))
+            const replayable = runs.filter((r) => r.event_uuid && r.action_id)
+
+            if (replayable.length === 0) {
+                lemonToast.warning('No replayable runs selected (missing event UUID or action ID)')
+                return
+            }
+
+            let succeeded = 0
+            let failed = 0
+
+            for (const run of replayable) {
+                try {
+                    await api.hogFlows.replayBlockedRun(props.id, {
+                        event_uuid: run.event_uuid!,
+                        action_id: run.action_id!,
+                        instance_id: run.instance_id,
+                    })
+                    succeeded++
+                } catch {
+                    failed++
+                }
+            }
+
+            if (succeeded > 0) {
+                lemonToast.success(`Queued ${succeeded} run${succeeded !== 1 ? 's' : ''} for replay`)
+            }
+            if (failed > 0) {
+                lemonToast.error(`Failed to replay ${failed} run${failed !== 1 ? 's' : ''}`)
+            }
+
+            actions.loadBlockedRuns()
+        },
+        replayAllBlockedRuns: async () => {
+            try {
+                const result = await api.hogFlows.replayAllBlockedRuns(props.id)
+                if (result.succeeded > 0) {
+                    lemonToast.success(`Queued ${result.succeeded} run${result.succeeded !== 1 ? 's' : ''} for replay`)
+                }
+                if (result.failed > 0) {
+                    lemonToast.error(`Failed to replay ${result.failed} run${result.failed !== 1 ? 's' : ''}`)
+                }
+                if (result.skipped > 0) {
+                    lemonToast.warning(
+                        `Skipped ${result.skipped} run${result.skipped !== 1 ? 's' : ''} (missing event or action data)`
+                    )
+                }
+            } catch {
+                lemonToast.error('Failed to replay blocked runs')
+            }
+            actions.loadBlockedRuns()
+        },
+    })),
+    afterMount(({ actions }) => {
+        actions.loadBlockedRuns()
+    }),
+])

--- a/products/workflows/frontend/Workflows/blockedRunsLogic.ts
+++ b/products/workflows/frontend/Workflows/blockedRunsLogic.ts
@@ -14,11 +14,23 @@ export interface BlockedRun {
     message: string
 }
 
+export interface BlockedRunsState {
+    results: BlockedRun[]
+    hasNext: boolean
+    offset: number
+}
+
 export interface BlockedRunsLogicProps {
     id: string
 }
 
 const PAGE_SIZE = 100
+
+const DEFAULT_BLOCKED_RUNS_STATE: BlockedRunsState = {
+    results: [],
+    hasNext: false,
+    offset: 0,
+}
 
 export const blockedRunsLogic = kea<blockedRunsLogicType>([
     path(['products', 'workflows', 'frontend', 'Workflows', 'blockedRunsLogic']),
@@ -34,9 +46,9 @@ export const blockedRunsLogic = kea<blockedRunsLogicType>([
     }),
     loaders(({ props, values }) => ({
         blockedRuns: [
-            { results: [] as BlockedRun[], hasNext: false, offset: 0 },
+            DEFAULT_BLOCKED_RUNS_STATE,
             {
-                loadBlockedRuns: async () => {
+                loadBlockedRuns: async (): Promise<BlockedRunsState> => {
                     const response = await api.hogFlows.getBlockedRuns(props.id, PAGE_SIZE, 0)
                     return {
                         results: response.results,
@@ -44,7 +56,7 @@ export const blockedRunsLogic = kea<blockedRunsLogicType>([
                         offset: PAGE_SIZE,
                     }
                 },
-                loadMoreBlockedRuns: async () => {
+                loadMoreBlockedRuns: async (): Promise<BlockedRunsState> => {
                     const current = values.blockedRuns
                     const response = await api.hogFlows.getBlockedRuns(props.id, PAGE_SIZE, current.offset)
                     return {

--- a/products/workflows/frontend/Workflows/workflowSceneLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowSceneLogic.ts
@@ -8,7 +8,7 @@ import { Breadcrumb } from '~/types'
 
 import type { workflowSceneLogicType } from './workflowSceneLogicType'
 
-export const WorkflowTabs = ['workflow', 'logs', 'metrics', 'history'] as const
+export const WorkflowTabs = ['workflow', 'logs', 'metrics', 'history', 'blocked_runs'] as const
 export type WorkflowTab = (typeof WorkflowTabs)[number]
 
 export interface WorkflowSceneLogicProps {

--- a/products/workflows/frontend/generated/api.ts
+++ b/products/workflows/frontend/generated/api.ts
@@ -327,6 +327,24 @@ export const hogFlowsBatchJobsCreate = async (
     })
 }
 
+/**
+ * List workflow runs that were blocked by the dedup bug.
+ */
+export const getHogFlowsBlockedRunsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flows/${id}/blocked_runs/`
+}
+
+export const hogFlowsBlockedRunsRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<HogFlowApi> => {
+    return apiMutator<HogFlowApi>(getHogFlowsBlockedRunsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
 export const getHogFlowsInvocationsCreateUrl = (projectId: string, id: string) => {
     return `/api/projects/${projectId}/hog_flows/${id}/invocations/`
 }
@@ -434,6 +452,27 @@ export const hogFlowsMetricsTotalsRetrieve = async (
     return apiMutator<AppMetricsTotalsResponseApi>(getHogFlowsMetricsTotalsRetrieveUrl(projectId, id, params), {
         ...options,
         method: 'GET',
+    })
+}
+
+/**
+ * Replay a workflow run that was blocked by the dedup bug, starting from the blocked action.
+ */
+export const getHogFlowsReplayBlockedRunCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flows/${id}/replay_blocked_run/`
+}
+
+export const hogFlowsReplayBlockedRunCreate = async (
+    projectId: string,
+    id: string,
+    hogFlowApi: NonReadonly<HogFlowApi>,
+    options?: RequestInit
+): Promise<HogFlowApi> => {
+    return apiMutator<HogFlowApi>(getHogFlowsReplayBlockedRunCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(hogFlowApi),
     })
 }
 

--- a/products/workflows/frontend/generated/api.ts
+++ b/products/workflows/frontend/generated/api.ts
@@ -456,7 +456,28 @@ export const hogFlowsMetricsTotalsRetrieve = async (
 }
 
 /**
- * Replay a workflow run that was blocked by the dedup bug, starting from the blocked action.
+ * Replay all blocked runs in a single bulk call to Node.
+ */
+export const getHogFlowsReplayAllBlockedRunsCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/hog_flows/${id}/replay_all_blocked_runs/`
+}
+
+export const hogFlowsReplayAllBlockedRunsCreate = async (
+    projectId: string,
+    id: string,
+    hogFlowApi: NonReadonly<HogFlowApi>,
+    options?: RequestInit
+): Promise<HogFlowApi> => {
+    return apiMutator<HogFlowApi>(getHogFlowsReplayAllBlockedRunsCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(hogFlowApi),
+    })
+}
+
+/**
+ * Replay a single blocked run. Django fetches the event, Node creates the invocation and writes the log.
  */
 export const getHogFlowsReplayBlockedRunCreateUrl = (projectId: string, id: string) => {
     return `/api/projects/${projectId}/hog_flows/${id}/replay_blocked_run/`

--- a/products/workflows/frontend/generated/api.zod.ts
+++ b/products/workflows/frontend/generated/api.zod.ts
@@ -754,6 +754,186 @@ export const HogFlowsInvocationsCreateBody = /* @__PURE__ */ zod.object({
     variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
 })
 
+/**
+ * Replay all blocked runs in a single bulk call to Node.
+ */
+export const hogFlowsReplayAllBlockedRunsCreateBodyNameMax = 400
+
+export const hogFlowsReplayAllBlockedRunsCreateBodyTriggerMaskingOneTtlMin = 60
+export const hogFlowsReplayAllBlockedRunsCreateBodyTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsReplayAllBlockedRunsCreateBodyActionsItemNameMax = 400
+
+export const hogFlowsReplayAllBlockedRunsCreateBodyActionsItemDescriptionDefault = ``
+export const hogFlowsReplayAllBlockedRunsCreateBodyActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsReplayAllBlockedRunsCreateBodyActionsItemTypeMax = 100
+
+export const HogFlowsReplayAllBlockedRunsCreateBody = /* @__PURE__ */ zod.object({
+    name: zod.string().max(hogFlowsReplayAllBlockedRunsCreateBodyNameMax).nullish(),
+    description: zod.string().optional(),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .optional()
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+    trigger: zod.unknown().optional(),
+    trigger_masking: zod
+        .object({
+            ttl: zod
+                .number()
+                .min(hogFlowsReplayAllBlockedRunsCreateBodyTriggerMaskingOneTtlMin)
+                .max(hogFlowsReplayAllBlockedRunsCreateBodyTriggerMaskingOneTtlMax)
+                .nullish(),
+            threshold: zod.number().nullish(),
+            hash: zod.string(),
+            bytecode: zod.unknown().nullish(),
+        })
+        .nullish(),
+    conversion: zod.unknown().nullish(),
+    exit_condition: zod
+        .enum([
+            'exit_on_conversion',
+            'exit_on_trigger_not_matched',
+            'exit_on_trigger_not_matched_or_conversion',
+            'exit_only_at_end',
+        ])
+        .optional()
+        .describe(
+            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod.unknown().optional(),
+    actions: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(hogFlowsReplayAllBlockedRunsCreateBodyActionsItemNameMax),
+            description: zod.string().default(hogFlowsReplayAllBlockedRunsCreateBodyActionsItemDescriptionDefault),
+            on_error: zod
+                .union([
+                    zod
+                        .enum(['continue', 'abort', 'complete', 'branch'])
+                        .describe(
+                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                        ),
+                    zod.literal(null),
+                ])
+                .nullish(),
+            created_at: zod.number().optional(),
+            updated_at: zod.number().optional(),
+            filters: zod
+                .object({
+                    source: zod
+                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .describe(
+                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                        )
+                        .default(hogFlowsReplayAllBlockedRunsCreateBodyActionsItemFiltersOneSourceDefault),
+                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    bytecode: zod.unknown().nullish(),
+                    transpiled: zod.unknown().optional(),
+                    filter_test_accounts: zod.boolean().optional(),
+                    bytecode_error: zod.string().optional(),
+                })
+                .nullish(),
+            type: zod.string().max(hogFlowsReplayAllBlockedRunsCreateBodyActionsItemTypeMax),
+            config: zod.unknown(),
+            output_variable: zod.unknown().nullish(),
+        })
+    ),
+    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+})
+
+/**
+ * Replay a single blocked run. Django fetches the event, Node creates the invocation and writes the log.
+ */
+export const hogFlowsReplayBlockedRunCreateBodyNameMax = 400
+
+export const hogFlowsReplayBlockedRunCreateBodyTriggerMaskingOneTtlMin = 60
+export const hogFlowsReplayBlockedRunCreateBodyTriggerMaskingOneTtlMax = 94608000
+
+export const hogFlowsReplayBlockedRunCreateBodyActionsItemNameMax = 400
+
+export const hogFlowsReplayBlockedRunCreateBodyActionsItemDescriptionDefault = ``
+export const hogFlowsReplayBlockedRunCreateBodyActionsItemFiltersOneSourceDefault = `events`
+export const hogFlowsReplayBlockedRunCreateBodyActionsItemTypeMax = 100
+
+export const HogFlowsReplayBlockedRunCreateBody = /* @__PURE__ */ zod.object({
+    name: zod.string().max(hogFlowsReplayBlockedRunCreateBodyNameMax).nullish(),
+    description: zod.string().optional(),
+    status: zod
+        .enum(['draft', 'active', 'archived'])
+        .optional()
+        .describe('* `draft` - Draft\n* `active` - Active\n* `archived` - Archived'),
+    trigger: zod.unknown().optional(),
+    trigger_masking: zod
+        .object({
+            ttl: zod
+                .number()
+                .min(hogFlowsReplayBlockedRunCreateBodyTriggerMaskingOneTtlMin)
+                .max(hogFlowsReplayBlockedRunCreateBodyTriggerMaskingOneTtlMax)
+                .nullish(),
+            threshold: zod.number().nullish(),
+            hash: zod.string(),
+            bytecode: zod.unknown().nullish(),
+        })
+        .nullish(),
+    conversion: zod.unknown().nullish(),
+    exit_condition: zod
+        .enum([
+            'exit_on_conversion',
+            'exit_on_trigger_not_matched',
+            'exit_on_trigger_not_matched_or_conversion',
+            'exit_only_at_end',
+        ])
+        .optional()
+        .describe(
+            '* `exit_on_conversion` - Conversion\n* `exit_on_trigger_not_matched` - Trigger Not Matched\n* `exit_on_trigger_not_matched_or_conversion` - Trigger Not Matched Or Conversion\n* `exit_only_at_end` - Only At End'
+        ),
+    edges: zod.unknown().optional(),
+    actions: zod.array(
+        zod.object({
+            id: zod.string(),
+            name: zod.string().max(hogFlowsReplayBlockedRunCreateBodyActionsItemNameMax),
+            description: zod.string().default(hogFlowsReplayBlockedRunCreateBodyActionsItemDescriptionDefault),
+            on_error: zod
+                .union([
+                    zod
+                        .enum(['continue', 'abort', 'complete', 'branch'])
+                        .describe(
+                            '* `continue` - continue\n* `abort` - abort\n* `complete` - complete\n* `branch` - branch'
+                        ),
+                    zod.literal(null),
+                ])
+                .nullish(),
+            created_at: zod.number().optional(),
+            updated_at: zod.number().optional(),
+            filters: zod
+                .object({
+                    source: zod
+                        .enum(['events', 'person-updates', 'data-warehouse-table'])
+                        .describe(
+                            '* `events` - events\n* `person-updates` - person-updates\n* `data-warehouse-table` - data-warehouse-table'
+                        )
+                        .default(hogFlowsReplayBlockedRunCreateBodyActionsItemFiltersOneSourceDefault),
+                    actions: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    events: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    data_warehouse: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    properties: zod.array(zod.record(zod.string(), zod.unknown())).optional(),
+                    bytecode: zod.unknown().nullish(),
+                    transpiled: zod.unknown().optional(),
+                    filter_test_accounts: zod.boolean().optional(),
+                    bytecode_error: zod.string().optional(),
+                })
+                .nullish(),
+            type: zod.string().max(hogFlowsReplayBlockedRunCreateBodyActionsItemTypeMax),
+            config: zod.unknown(),
+            output_variable: zod.unknown().nullish(),
+        })
+    ),
+    variables: zod.array(zod.record(zod.string(), zod.string())).optional(),
+})
+
 export const hogFlowsSchedulesCreateBodyNameMax = 400
 
 export const hogFlowsSchedulesCreateBodyTriggerMaskingOneTtlMin = 60

--- a/products/workflows/mcp/tools.yaml
+++ b/products/workflows/mcp/tools.yaml
@@ -143,3 +143,6 @@ tools:
     hog-flows-replay-blocked-run-create:
         operation: hog_flows_replay_blocked_run_create
         enabled: false
+    hog-flows-replay-all-blocked-runs-create:
+        operation: hog_flows_replay_all_blocked_runs_create
+        enabled: false

--- a/products/workflows/mcp/tools.yaml
+++ b/products/workflows/mcp/tools.yaml
@@ -137,3 +137,9 @@ tools:
             List all workflows in the project. Returns workflows with their name, description, status
             (draft/active/archived), version, trigger configuration, and timestamps.
         ui_app: workflow-list
+    hog-flows-blocked-runs-retrieve:
+        operation: hog_flows_blocked_runs_retrieve
+        enabled: false
+    hog-flows-replay-blocked-run-create:
+        operation: hog_flows_replay_blocked_run_create
+        enabled: false

--- a/products/workflows/mcp/tools.yaml
+++ b/products/workflows/mcp/tools.yaml
@@ -42,6 +42,9 @@ tools:
     hog-flows-batch-jobs-retrieve:
         operation: hog_flows_batch_jobs_retrieve
         enabled: false
+    hog-flows-blocked-runs-retrieve:
+        operation: hog_flows_blocked_runs_retrieve
+        enabled: false
     hog-flows-bulk-delete-create:
         operation: hog_flows_bulk_delete_create
         enabled: false
@@ -88,6 +91,12 @@ tools:
         enabled: false
     hog-flows-partial-update:
         operation: hog_flows_partial_update
+        enabled: false
+    hog-flows-replay-all-blocked-runs-create:
+        operation: hog_flows_replay_all_blocked_runs_create
+        enabled: false
+    hog-flows-replay-blocked-run-create:
+        operation: hog_flows_replay_blocked_run_create
         enabled: false
     hog-flows-schedules-create:
         operation: hog_flows_schedules_create
@@ -137,12 +146,3 @@ tools:
             List all workflows in the project. Returns workflows with their name, description, status
             (draft/active/archived), version, trigger configuration, and timestamps.
         ui_app: workflow-list
-    hog-flows-blocked-runs-retrieve:
-        operation: hog_flows_blocked_runs_retrieve
-        enabled: false
-    hog-flows-replay-blocked-run-create:
-        operation: hog_flows_replay_blocked_run_create
-        enabled: false
-    hog-flows-replay-all-blocked-runs-create:
-        operation: hog_flows_replay_all_blocked_runs_create
-        enabled: false


### PR DESCRIPTION
Adds API endpoints and a feature-flagged UI to let customers replay workflow runs that were silently blocked by the dedup bug (#52776):   
                  
<img width="2258" height="1762" alt="2026-04-22 16 11 33" src="https://github.com/user-attachments/assets/90d38587-2bfc-45b9-b391-51274b1e5170" />

### API                                                                                                                         
  - GET `/api/projects/:id/hog_flows/:id/blocked_runs` — lists blocked runs with parsed action_id and event_uuid from log entries, excluding runs that have already been replayed                                                                     
  - `POST /api/projects/:id/hog_flows/:id/replay_blocked_run` — replays a blocked run starting from the blocked action (not the trigger) to avoid re-executing already-completed steps. Includes full person and group context from the original event. Inserts a marker log entry so replayed runs are excluded from future queries.                                               
  - Node `replay_invocation` endpoint that validates the action exists in the current workflow definition, builds the invocation from the original event, and queues it via Cyclotron                                                             
                                                                                                                              
### UI (behind workflows-replay-blocked-runs feature flag)
  - Warning banner on the workflow detail page when blocked runs exist                                                        
  - "Blocked runs" tab with a table showing all blocked invocations (run ID, event UUID, blocked action, timestamp)           
  - Batch selection with "Replay selected" button and confirmation dialog                                                     
  - Replayed runs automatically disappear from the list                                                                       
  - New invocations appear in the Invocations tab for tracking                                                                
                                                                                                                              
### Limitations communicated to users:                                                                                          
  - Workflow variables set by prior steps are not available during replay                                                     
  - If the workflow was modified since the incident, the blocked action must still exist in the current definition 