### PR TITLE
feat(llma): add file_edits partial-file updates to skill-update

### DIFF
--- a/products/llm_analytics/backend/api/skill_serializers.py
+++ b/products/llm_analytics/backend/api/skill_serializers.py
@@ -44,6 +44,16 @@ def validate_skill_name_value(value: str) -> str:
     return value
 
 
+def validate_skill_file_path(value: str) -> str:
+    normalized = value.replace("\\", "/")
+    parts = normalized.split("/")
+    if any(part == ".." for part in parts):
+        raise serializers.ValidationError("File paths must not contain '..' traversal segments.")
+    if normalized.startswith("/"):
+        raise serializers.ValidationError("File paths must be relative, not absolute.")
+    return value
+
+
 def _validate_files(files: list[dict[str, Any]]) -> list[dict[str, Any]]:
     if len(files) > MAX_SKILL_FILE_COUNT:
         raise serializers.ValidationError(
@@ -144,13 +154,7 @@ class LLMSkillFileInputSerializer(serializers.Serializer):
     )
 
     def validate_path(self, value: str) -> str:
-        normalized = value.replace("\\", "/")
-        parts = normalized.split("/")
-        if any(part == ".." for part in parts):
-            raise serializers.ValidationError("File paths must not contain '..' traversal segments.")
-        if normalized.startswith("/"):
-            raise serializers.ValidationError("File paths must be relative, not absolute.")
-        return value
+        return validate_skill_file_path(value)
 
     def validate_content(self, value: str) -> str:
         if len(value.encode("utf-8")) > MAX_SKILL_FILE_BYTES:
@@ -162,8 +166,10 @@ class LLMSkillFileInputSerializer(serializers.Serializer):
 
 
 class LLMSkillEditOperationSerializer(serializers.Serializer):
+    # Reused for both top-level body edits and per-file edits (LLMSkillFileEditSerializer.edits),
+    # so help_text must stay generic — the parent field's description provides the body/file context.
     old = serializers.CharField(
-        help_text="Text to find in the current skill body. Must match exactly once.",
+        help_text="Text to find in the target content. Must match exactly once.",
     )
     new = serializers.CharField(
         allow_blank=True,
@@ -180,6 +186,9 @@ class LLMSkillFileEditSerializer(serializers.Serializer):
         many=True,
         help_text="Sequential find/replace operations to apply to this file's content.",
     )
+
+    def validate_path(self, value: str) -> str:
+        return validate_skill_file_path(value)
 
     def validate_edits(self, value: list[dict[str, str]]) -> list[dict[str, str]]:
         if len(value) == 0:

--- a/products/llm_analytics/backend/api/skill_serializers.py
+++ b/products/llm_analytics/backend/api/skill_serializers.py
@@ -171,6 +171,22 @@ class LLMSkillEditOperationSerializer(serializers.Serializer):
     )
 
 
+class LLMSkillFileEditSerializer(serializers.Serializer):
+    path = serializers.CharField(
+        max_length=500,
+        help_text="Path of the bundled file to edit. Must match an existing file on the current skill version.",
+    )
+    edits = LLMSkillEditOperationSerializer(
+        many=True,
+        help_text="Sequential find/replace operations to apply to this file's content.",
+    )
+
+    def validate_edits(self, value: list[dict[str, str]]) -> list[dict[str, str]]:
+        if len(value) == 0:
+            raise serializers.ValidationError("At least one edit operation is required.")
+        return value
+
+
 class LLMSkillPublishSerializer(serializers.Serializer):
     body = serializers.CharField(
         required=False,
@@ -214,7 +230,19 @@ class LLMSkillPublishSerializer(serializers.Serializer):
     files = LLMSkillFileInputSerializer(
         many=True,
         required=False,
-        help_text="Bundled files to include with this version. Replaces all files from the previous version.",
+        help_text=(
+            "Bundled files to include with this version. Replaces all files from the previous "
+            "version. Mutually exclusive with file_edits."
+        ),
+    )
+    file_edits = LLMSkillFileEditSerializer(
+        many=True,
+        required=False,
+        help_text=(
+            "Per-file find/replace updates. Each entry targets one existing file by path and "
+            "applies sequential edits to its content. Non-targeted files carry forward unchanged. "
+            "Cannot add, remove, or rename files — use 'files' for that. Mutually exclusive with files."
+        ),
     )
     base_version = serializers.IntegerField(
         min_value=1,
@@ -232,9 +260,19 @@ class LLMSkillPublishSerializer(serializers.Serializer):
     def validate_files(self, value: list[dict[str, Any]]) -> list[dict[str, Any]]:
         return _validate_files(value)
 
+    def validate_file_edits(self, value: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        if len(value) == 0:
+            raise serializers.ValidationError("At least one file_edits entry is required.")
+        paths = [entry["path"] for entry in value]
+        if len(paths) != len(set(paths)):
+            raise serializers.ValidationError("Duplicate file paths are not allowed in file_edits.")
+        return value
+
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         if "body" in attrs and "edits" in attrs:
             raise serializers.ValidationError("Provide either 'body' or 'edits', not both.")
+        if "files" in attrs and "file_edits" in attrs:
+            raise serializers.ValidationError("Provide either 'files' or 'file_edits', not both.")
         return attrs
 
 

--- a/products/llm_analytics/backend/api/skill_services.py
+++ b/products/llm_analytics/backend/api/skill_services.py
@@ -29,8 +29,11 @@ class LLMSkillVersionLimitError(Exception):
 
 @dataclass
 class LLMSkillEditError(Exception):
+    # `file_path` extends this dataclass (rather than a subclass) so the publish view can catch a
+    # single exception type for both body edits and per-file edits. `edit_index` is optional because
+    # path-level failures (e.g. missing file) aren't tied to any particular edit.
     message: str
-    edit_index: int
+    edit_index: int | None = None
     file_path: str | None = None
 
 
@@ -249,7 +252,6 @@ def _resolve_file_edits(current_skill: LLMSkill, file_edits: list[dict[str, Any]
         if path not in source_files:
             raise LLMSkillEditError(
                 message=f"File '{path}' not found in the current skill version.",
-                edit_index=0,
                 file_path=path,
             )
         resolved[path] = apply_skill_file_edits(

--- a/products/llm_analytics/backend/api/skill_services.py
+++ b/products/llm_analytics/backend/api/skill_services.py
@@ -10,6 +10,7 @@ from ..models.skills import LLMSkill, LLMSkillFile, annotate_llm_skill_version_h
 
 MAX_SKILL_VERSION = 2000
 MAX_SKILL_BODY_BYTES = 1_000_000
+MAX_SKILL_FILE_BYTES = 1_000_000
 
 
 class LLMSkillNotFoundError(Exception):
@@ -30,6 +31,7 @@ class LLMSkillVersionLimitError(Exception):
 class LLMSkillEditError(Exception):
     message: str
     edit_index: int
+    file_path: str | None = None
 
 
 class LLMSkillDuplicateNameConflictError(Exception):
@@ -127,6 +129,43 @@ def _carry_forward(payload_value: Any, current_value: Any) -> Any:
     return payload_value if payload_value is not None else current_value
 
 
+def apply_skill_file_edits(file_content: str, edits: list[dict[str, str]], *, file_path: str) -> str:
+    """Apply sequential find/replace edits to a single bundled skill file.
+
+    Each edit's 'old' text must match exactly once. Result size capped at MAX_SKILL_FILE_BYTES.
+    """
+    text = file_content
+    for i, edit in enumerate(edits):
+        old = edit["old"]
+        new = edit["new"]
+        count = text.count(old)
+        if count == 0:
+            raise LLMSkillEditError(
+                message=f"Text to replace was not found in file '{file_path}'.",
+                edit_index=i,
+                file_path=file_path,
+            )
+        if count > 1:
+            raise LLMSkillEditError(
+                message=(
+                    f"Text to replace matches {count} times in file '{file_path}' — "
+                    "provide more context to make it unique."
+                ),
+                edit_index=i,
+                file_path=file_path,
+            )
+        text = text.replace(old, new, 1)
+
+    if len(text.encode("utf-8")) > MAX_SKILL_FILE_BYTES:
+        raise LLMSkillEditError(
+            message=f"Edited file '{file_path}' exceeds the {MAX_SKILL_FILE_BYTES} byte size limit.",
+            edit_index=len(edits) - 1,
+            file_path=file_path,
+        )
+
+    return text
+
+
 def publish_skill_version(
     team: Team,
     *,
@@ -140,6 +179,7 @@ def publish_skill_version(
     allowed_tools: list[str] | None = None,
     metadata: dict[str, Any] | None = None,
     files: list[dict[str, str]] | None = None,
+    file_edits: list[dict[str, Any]] | None = None,
     base_version: int,
 ) -> LLMSkill:
     with transaction.atomic():
@@ -161,6 +201,10 @@ def publish_skill_version(
             resolved_body = apply_skill_body_edits(current_latest.body, edits)
         else:
             resolved_body = _carry_forward(body, current_latest.body)
+
+        resolved_file_edits: dict[str, str] | None = None
+        if file_edits is not None:
+            resolved_file_edits = _resolve_file_edits(current_latest, file_edits)
 
         LLMSkill.objects.filter(pk=current_latest.pk).update(is_latest=False)
         published_skill = LLMSkill.objects.create(
@@ -190,26 +234,54 @@ def publish_skill_version(
                 ]
             )
         else:
-            _copy_files(current_latest, published_skill)
+            _copy_files(current_latest, published_skill, edited_content=resolved_file_edits)
 
         refreshed = get_active_skill_queryset(team).filter(pk=published_skill.pk).first()
         return refreshed if refreshed is not None else published_skill
 
 
-def _copy_files(source_skill: LLMSkill, target_skill: LLMSkill) -> None:
-    source_files = list(LLMSkillFile.objects.filter(skill=source_skill))
-    if source_files:
-        LLMSkillFile.objects.bulk_create(
-            [
-                LLMSkillFile(
-                    skill=target_skill,
-                    path=f.path,
-                    content=f.content,
-                    content_type=f.content_type,
-                )
-                for f in source_files
-            ]
+def _resolve_file_edits(current_skill: LLMSkill, file_edits: list[dict[str, Any]]) -> dict[str, str]:
+    """Apply each file's edits against the current file content; return {path: new_content}."""
+    source_files = {f.path: f for f in LLMSkillFile.objects.filter(skill=current_skill)}
+    resolved: dict[str, str] = {}
+    for entry in file_edits:
+        path = entry["path"]
+        if path not in source_files:
+            raise LLMSkillEditError(
+                message=f"File '{path}' not found in the current skill version.",
+                edit_index=0,
+                file_path=path,
+            )
+        resolved[path] = apply_skill_file_edits(
+            source_files[path].content,
+            entry["edits"],
+            file_path=path,
         )
+    return resolved
+
+
+def _copy_files(
+    source_skill: LLMSkill,
+    target_skill: LLMSkill,
+    *,
+    edited_content: dict[str, str] | None = None,
+) -> None:
+    """Carry files forward to the new version, optionally overriding content for specific paths."""
+    source_files = list(LLMSkillFile.objects.filter(skill=source_skill))
+    if not source_files:
+        return
+    overrides = edited_content or {}
+    LLMSkillFile.objects.bulk_create(
+        [
+            LLMSkillFile(
+                skill=target_skill,
+                path=f.path,
+                content=overrides.get(f.path, f.content),
+                content_type=f.content_type,
+            )
+            for f in source_files
+        ]
+    )
 
 
 def duplicate_skill(

--- a/products/llm_analytics/backend/api/skills.py
+++ b/products/llm_analytics/backend/api/skills.py
@@ -269,10 +269,9 @@ class LLMSkillViewSet(
                 status=status.HTTP_400_BAD_REQUEST,
             )
         except LLMSkillEditError as err:
-            error_body: dict[str, Any] = {
-                "detail": err.message,
-                "edit_index": err.edit_index,
-            }
+            error_body: dict[str, Any] = {"detail": err.message}
+            if err.edit_index is not None:
+                error_body["edit_index"] = err.edit_index
             if err.file_path is not None:
                 error_body["file_path"] = err.file_path
             return Response(error_body, status=status.HTTP_400_BAD_REQUEST)

--- a/products/llm_analytics/backend/api/skills.py
+++ b/products/llm_analytics/backend/api/skills.py
@@ -241,6 +241,7 @@ class LLMSkillViewSet(
                 allowed_tools=payload.validated_data.get("allowed_tools"),
                 metadata=payload.validated_data.get("metadata"),
                 files=payload.validated_data.get("files"),
+                file_edits=payload.validated_data.get("file_edits"),
                 base_version=payload.validated_data["base_version"],
             )
         except IntegrityError as err:
@@ -268,13 +269,13 @@ class LLMSkillViewSet(
                 status=status.HTTP_400_BAD_REQUEST,
             )
         except LLMSkillEditError as err:
-            return Response(
-                {
-                    "detail": err.message,
-                    "edit_index": err.edit_index,
-                },
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+            error_body: dict[str, Any] = {
+                "detail": err.message,
+                "edit_index": err.edit_index,
+            }
+            if err.file_path is not None:
+                error_body["file_path"] = err.file_path
+            return Response(error_body, status=status.HTTP_400_BAD_REQUEST)
 
         report_user_action(
             cast(User, request.user),

--- a/products/llm_analytics/backend/api/test/test_skills.py
+++ b/products/llm_analytics/backend/api/test/test_skills.py
@@ -388,7 +388,7 @@ class TestLLMSkillAPI(APIBaseTest):
             self._url("name/seq-edits"),
             data={
                 "edits": [
-                    {"old": "alpha", "new": "APLHA"},
+                    {"old": "alpha", "new": "ALPHA"},
                     {"old": "beta", "new": "BETA"},
                 ],
                 "base_version": 1,
@@ -397,7 +397,7 @@ class TestLLMSkillAPI(APIBaseTest):
         )
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.json()["body"] == "APLHA\nBETA\ngamma\n"
+        assert response.json()["body"] == "ALPHA\nBETA\ngamma\n"
 
     @parameterized.expand(
         [
@@ -542,6 +542,7 @@ class TestLLMSkillAPI(APIBaseTest):
                 [{"path": "references/missing.md", "edits": [{"old": "x", "new": "y"}]}],
                 "references/missing.md",
                 None,
+                None,
             ),
             (
                 "zero_matches",
@@ -550,6 +551,7 @@ class TestLLMSkillAPI(APIBaseTest):
                 [{"path": "references/a.md", "edits": [{"old": "missing", "new": "x"}]}],
                 "references/a.md",
                 None,
+                0,
             ),
             (
                 "multi_matches",
@@ -558,6 +560,7 @@ class TestLLMSkillAPI(APIBaseTest):
                 [{"path": "references/a.md", "edits": [{"old": "pick", "new": "chose"}]}],
                 "references/a.md",
                 "2 times",
+                0,
             ),
         ]
     )
@@ -570,6 +573,7 @@ class TestLLMSkillAPI(APIBaseTest):
         file_edits,
         expected_file_path,
         detail_fragment,
+        expected_edit_index,
     ):
         skill_name = f"file-edit-apply-err-{label.replace('_', '-')}"
         skill = self.create_skill(name=skill_name, body="# Body\n")
@@ -584,6 +588,10 @@ class TestLLMSkillAPI(APIBaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         body_resp = response.json()
         assert body_resp["file_path"] == expected_file_path
+        if expected_edit_index is None:
+            assert "edit_index" not in body_resp
+        else:
+            assert body_resp["edit_index"] == expected_edit_index
         if detail_fragment is not None:
             assert detail_fragment in body_resp["detail"]
 
@@ -608,6 +616,24 @@ class TestLLMSkillAPI(APIBaseTest):
                 },
             ),
             ("empty_file_edits_list", {"file_edits": [], "base_version": 1}),
+            (
+                "traversal_path",
+                {
+                    "file_edits": [
+                        {"path": "../escape.md", "edits": [{"old": "a", "new": "b"}]},
+                    ],
+                    "base_version": 1,
+                },
+            ),
+            (
+                "absolute_path",
+                {
+                    "file_edits": [
+                        {"path": "/absolute/path.md", "edits": [{"old": "a", "new": "b"}]},
+                    ],
+                    "base_version": 1,
+                },
+            ),
         ]
     )
     def test_publish_rejects_invalid_file_edit_requests(self, mock_feature_enabled, label, payload):

--- a/products/llm_analytics/backend/api/test/test_skills.py
+++ b/products/llm_analytics/backend/api/test/test_skills.py
@@ -520,7 +520,7 @@ class TestLLMSkillAPI(APIBaseTest):
             self._url("name/multi-patch"),
             data={
                 "file_edits": [
-                    {"path": "references/a.md", "edits": [{"old": "alpha", "new": "APLHA"}]},
+                    {"path": "references/a.md", "edits": [{"old": "alpha", "new": "ALPHA"}]},
                     {"path": "references/b.md", "edits": [{"old": "beta", "new": "BETA"}]},
                 ],
                 "base_version": 1,
@@ -530,102 +530,94 @@ class TestLLMSkillAPI(APIBaseTest):
 
         assert response.status_code == status.HTTP_200_OK
         new_skill = LLMSkill.objects.get(name="multi-patch", version=2, deleted=False)
-        assert LLMSkillFile.objects.get(skill=new_skill, path="references/a.md").content == "APLHA\n"
+        assert LLMSkillFile.objects.get(skill=new_skill, path="references/a.md").content == "ALPHA\n"
         assert LLMSkillFile.objects.get(skill=new_skill, path="references/b.md").content == "BETA\n"
 
-    def test_publish_with_file_edits_unknown_path_fails(self, mock_feature_enabled):
-        skill = self.create_skill(name="unknown-path", body="# Body\n")
-        LLMSkillFile.objects.create(skill=skill, path="references/exists.md", content="hello\n")
+    @parameterized.expand(
+        [
+            (
+                "unknown_path",
+                "references/exists.md",
+                "hello\n",
+                [{"path": "references/missing.md", "edits": [{"old": "x", "new": "y"}]}],
+                "references/missing.md",
+                None,
+            ),
+            (
+                "zero_matches",
+                "references/a.md",
+                "hello\n",
+                [{"path": "references/a.md", "edits": [{"old": "missing", "new": "x"}]}],
+                "references/a.md",
+                None,
+            ),
+            (
+                "multi_matches",
+                "references/a.md",
+                "pick pick\n",
+                [{"path": "references/a.md", "edits": [{"old": "pick", "new": "chose"}]}],
+                "references/a.md",
+                "2 times",
+            ),
+        ]
+    )
+    def test_publish_with_file_edits_apply_errors(
+        self,
+        mock_feature_enabled,
+        label,
+        seed_path,
+        seed_content,
+        file_edits,
+        expected_file_path,
+        detail_fragment,
+    ):
+        skill_name = f"file-edit-apply-err-{label.replace('_', '-')}"
+        skill = self.create_skill(name=skill_name, body="# Body\n")
+        LLMSkillFile.objects.create(skill=skill, path=seed_path, content=seed_content)
 
         response = self.client.patch(
-            self._url("name/unknown-path"),
-            data={
-                "file_edits": [{"path": "references/missing.md", "edits": [{"old": "x", "new": "y"}]}],
-                "base_version": 1,
-            },
+            self._url(f"name/{skill_name}"),
+            data={"file_edits": file_edits, "base_version": 1},
             format="json",
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        body = response.json()
-        assert body["file_path"] == "references/missing.md"
+        body_resp = response.json()
+        assert body_resp["file_path"] == expected_file_path
+        if detail_fragment is not None:
+            assert detail_fragment in body_resp["detail"]
 
-    def test_publish_with_file_edits_zero_matches_fails(self, mock_feature_enabled):
-        skill = self.create_skill(name="no-file-match", body="# Body\n")
+    @parameterized.expand(
+        [
+            (
+                "files_and_file_edits_conflict",
+                {
+                    "files": [{"path": "references/a.md", "content": "new"}],
+                    "file_edits": [{"path": "references/a.md", "edits": [{"old": "hello", "new": "bye"}]}],
+                    "base_version": 1,
+                },
+            ),
+            (
+                "duplicate_file_edit_paths",
+                {
+                    "file_edits": [
+                        {"path": "references/a.md", "edits": [{"old": "a", "new": "A"}]},
+                        {"path": "references/a.md", "edits": [{"old": "b", "new": "B"}]},
+                    ],
+                    "base_version": 1,
+                },
+            ),
+            ("empty_file_edits_list", {"file_edits": [], "base_version": 1}),
+        ]
+    )
+    def test_publish_rejects_invalid_file_edit_requests(self, mock_feature_enabled, label, payload):
+        skill_name = f"invalid-file-edit-{label.replace('_', '-')}"
+        skill = self.create_skill(name=skill_name, body="# Body\n")
         LLMSkillFile.objects.create(skill=skill, path="references/a.md", content="hello\n")
 
         response = self.client.patch(
-            self._url("name/no-file-match"),
-            data={
-                "file_edits": [{"path": "references/a.md", "edits": [{"old": "missing", "new": "x"}]}],
-                "base_version": 1,
-            },
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        body = response.json()
-        assert body["file_path"] == "references/a.md"
-        assert body["edit_index"] == 0
-
-    def test_publish_with_file_edits_multiple_matches_fails(self, mock_feature_enabled):
-        skill = self.create_skill(name="ambig-file", body="# Body\n")
-        LLMSkillFile.objects.create(skill=skill, path="references/a.md", content="pick pick\n")
-
-        response = self.client.patch(
-            self._url("name/ambig-file"),
-            data={
-                "file_edits": [{"path": "references/a.md", "edits": [{"old": "pick", "new": "chose"}]}],
-                "base_version": 1,
-            },
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        body = response.json()
-        assert body["file_path"] == "references/a.md"
-        assert "2 times" in body["detail"]
-
-    def test_publish_rejects_files_and_file_edits_together(self, mock_feature_enabled):
-        skill = self.create_skill(name="both-files", body="# Body\n")
-        LLMSkillFile.objects.create(skill=skill, path="references/a.md", content="hello\n")
-
-        response = self.client.patch(
-            self._url("name/both-files"),
-            data={
-                "files": [{"path": "references/a.md", "content": "new"}],
-                "file_edits": [{"path": "references/a.md", "edits": [{"old": "hello", "new": "bye"}]}],
-                "base_version": 1,
-            },
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-    def test_publish_rejects_duplicate_paths_in_file_edits(self, mock_feature_enabled):
-        skill = self.create_skill(name="dup-file-edits", body="# Body\n")
-        LLMSkillFile.objects.create(skill=skill, path="references/a.md", content="abc\n")
-
-        response = self.client.patch(
-            self._url("name/dup-file-edits"),
-            data={
-                "file_edits": [
-                    {"path": "references/a.md", "edits": [{"old": "a", "new": "A"}]},
-                    {"path": "references/a.md", "edits": [{"old": "b", "new": "B"}]},
-                ],
-                "base_version": 1,
-            },
-            format="json",
-        )
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-    def test_publish_rejects_empty_file_edits_list(self, mock_feature_enabled):
-        self.create_skill(name="empty-file-edits", body="# Body\n")
-
-        response = self.client.patch(
-            self._url("name/empty-file-edits"),
-            data={"file_edits": [], "base_version": 1},
+            self._url(f"name/{skill_name}"),
+            data=payload,
             format="json",
         )
 

--- a/products/llm_analytics/backend/api/test/test_skills.py
+++ b/products/llm_analytics/backend/api/test/test_skills.py
@@ -483,6 +483,173 @@ class TestLLMSkillAPI(APIBaseTest):
         assert new_skill.body == "edited\n"
         assert LLMSkillFile.objects.filter(skill=new_skill, path="references/a.md").exists()
 
+    # --- Publish with file_edits (per-file find/replace) ---
+
+    def test_publish_with_file_edits_patches_single_file(self, mock_feature_enabled):
+        skill = self.create_skill(name="file-patch", body="# Body\n")
+        LLMSkillFile.objects.create(skill=skill, path="references/ranking.md", content="rank high\n")
+        LLMSkillFile.objects.create(skill=skill, path="references/other.md", content="untouched\n")
+
+        response = self.client.patch(
+            self._url("name/file-patch"),
+            data={
+                "file_edits": [
+                    {
+                        "path": "references/ranking.md",
+                        "edits": [{"old": "rank high", "new": "rank higher"}],
+                    }
+                ],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        new_skill = LLMSkill.objects.get(name="file-patch", version=2, deleted=False)
+        ranking = LLMSkillFile.objects.get(skill=new_skill, path="references/ranking.md")
+        other = LLMSkillFile.objects.get(skill=new_skill, path="references/other.md")
+        assert ranking.content == "rank higher\n"
+        assert other.content == "untouched\n"
+
+    def test_publish_with_file_edits_patches_multiple_files(self, mock_feature_enabled):
+        skill = self.create_skill(name="multi-patch", body="# Body\n")
+        LLMSkillFile.objects.create(skill=skill, path="references/a.md", content="alpha\n")
+        LLMSkillFile.objects.create(skill=skill, path="references/b.md", content="beta\n")
+
+        response = self.client.patch(
+            self._url("name/multi-patch"),
+            data={
+                "file_edits": [
+                    {"path": "references/a.md", "edits": [{"old": "alpha", "new": "APLHA"}]},
+                    {"path": "references/b.md", "edits": [{"old": "beta", "new": "BETA"}]},
+                ],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        new_skill = LLMSkill.objects.get(name="multi-patch", version=2, deleted=False)
+        assert LLMSkillFile.objects.get(skill=new_skill, path="references/a.md").content == "APLHA\n"
+        assert LLMSkillFile.objects.get(skill=new_skill, path="references/b.md").content == "BETA\n"
+
+    def test_publish_with_file_edits_unknown_path_fails(self, mock_feature_enabled):
+        skill = self.create_skill(name="unknown-path", body="# Body\n")
+        LLMSkillFile.objects.create(skill=skill, path="references/exists.md", content="hello\n")
+
+        response = self.client.patch(
+            self._url("name/unknown-path"),
+            data={
+                "file_edits": [{"path": "references/missing.md", "edits": [{"old": "x", "new": "y"}]}],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert body["file_path"] == "references/missing.md"
+
+    def test_publish_with_file_edits_zero_matches_fails(self, mock_feature_enabled):
+        skill = self.create_skill(name="no-file-match", body="# Body\n")
+        LLMSkillFile.objects.create(skill=skill, path="references/a.md", content="hello\n")
+
+        response = self.client.patch(
+            self._url("name/no-file-match"),
+            data={
+                "file_edits": [{"path": "references/a.md", "edits": [{"old": "missing", "new": "x"}]}],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert body["file_path"] == "references/a.md"
+        assert body["edit_index"] == 0
+
+    def test_publish_with_file_edits_multiple_matches_fails(self, mock_feature_enabled):
+        skill = self.create_skill(name="ambig-file", body="# Body\n")
+        LLMSkillFile.objects.create(skill=skill, path="references/a.md", content="pick pick\n")
+
+        response = self.client.patch(
+            self._url("name/ambig-file"),
+            data={
+                "file_edits": [{"path": "references/a.md", "edits": [{"old": "pick", "new": "chose"}]}],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert body["file_path"] == "references/a.md"
+        assert "2 times" in body["detail"]
+
+    def test_publish_rejects_files_and_file_edits_together(self, mock_feature_enabled):
+        skill = self.create_skill(name="both-files", body="# Body\n")
+        LLMSkillFile.objects.create(skill=skill, path="references/a.md", content="hello\n")
+
+        response = self.client.patch(
+            self._url("name/both-files"),
+            data={
+                "files": [{"path": "references/a.md", "content": "new"}],
+                "file_edits": [{"path": "references/a.md", "edits": [{"old": "hello", "new": "bye"}]}],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_publish_rejects_duplicate_paths_in_file_edits(self, mock_feature_enabled):
+        skill = self.create_skill(name="dup-file-edits", body="# Body\n")
+        LLMSkillFile.objects.create(skill=skill, path="references/a.md", content="abc\n")
+
+        response = self.client.patch(
+            self._url("name/dup-file-edits"),
+            data={
+                "file_edits": [
+                    {"path": "references/a.md", "edits": [{"old": "a", "new": "A"}]},
+                    {"path": "references/a.md", "edits": [{"old": "b", "new": "B"}]},
+                ],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_publish_rejects_empty_file_edits_list(self, mock_feature_enabled):
+        self.create_skill(name="empty-file-edits", body="# Body\n")
+
+        response = self.client.patch(
+            self._url("name/empty-file-edits"),
+            data={"file_edits": [], "base_version": 1},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_publish_combines_body_edits_and_file_edits(self, mock_feature_enabled):
+        skill = self.create_skill(name="body-and-file", body="# Title\noriginal\n")
+        LLMSkillFile.objects.create(skill=skill, path="references/a.md", content="old\n")
+
+        response = self.client.patch(
+            self._url("name/body-and-file"),
+            data={
+                "edits": [{"old": "original", "new": "updated"}],
+                "file_edits": [{"path": "references/a.md", "edits": [{"old": "old", "new": "new"}]}],
+                "base_version": 1,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        new_skill = LLMSkill.objects.get(name="body-and-file", version=2, deleted=False)
+        assert new_skill.body == "# Title\nupdated\n"
+        assert LLMSkillFile.objects.get(skill=new_skill, path="references/a.md").content == "new\n"
+
     # --- Archive ---
 
     def test_archive_skill(self, mock_feature_enabled):

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -1745,7 +1745,7 @@ export interface LLMSkillApi {
 export type PatchedLLMSkillPublishApiMetadata = { [key: string]: unknown }
 
 export interface LLMSkillEditOperationApi {
-    /** Text to find in the current skill body. Must match exactly once. */
+    /** Text to find in the target content. Must match exactly once. */
     old: string
     /** Replacement text. */
     new: string

--- a/products/llm_analytics/frontend/generated/api.schemas.ts
+++ b/products/llm_analytics/frontend/generated/api.schemas.ts
@@ -1751,6 +1751,16 @@ export interface LLMSkillEditOperationApi {
     new: string
 }
 
+export interface LLMSkillFileEditApi {
+    /**
+     * Path of the bundled file to edit. Must match an existing file on the current skill version.
+     * @maxLength 500
+     */
+    path: string
+    /** Sequential find/replace operations to apply to this file's content. */
+    edits: LLMSkillEditOperationApi[]
+}
+
 export interface PatchedLLMSkillPublishApi {
     /** Full skill body (SKILL.md instruction content) to publish as a new version. Mutually exclusive with edits. */
     body?: string
@@ -1775,8 +1785,10 @@ export interface PatchedLLMSkillPublishApi {
     allowed_tools?: string[]
     /** Arbitrary key-value metadata. */
     metadata?: PatchedLLMSkillPublishApiMetadata
-    /** Bundled files to include with this version. Replaces all files from the previous version. */
+    /** Bundled files to include with this version. Replaces all files from the previous version. Mutually exclusive with file_edits. */
     files?: LLMSkillFileInputApi[]
+    /** Per-file find/replace updates. Each entry targets one existing file by path and applies sequential edits to its content. Non-targeted files carry forward unchanged. Cannot add, remove, or rename files — use 'files' for that. Mutually exclusive with files. */
+    file_edits?: LLMSkillFileEditApi[]
     /**
      * Latest version you are editing from. Used for optimistic concurrency checks.
      * @minimum 1

--- a/products/llm_analytics/mcp/skills.yaml
+++ b/products/llm_analytics/mcp/skills.yaml
@@ -80,6 +80,12 @@ tools:
             for incremental find/replace updates. Each edit must have 'old' (text to find,
             must match exactly once) and 'new' (replacement text). Edits are applied
             sequentially. Only one of 'body' or 'edits' may be provided.
+
+            For bundled files, use 'file_edits' to apply find/replace updates to individual
+            files without resending the full file set — each entry targets one existing file
+            by path. Non-targeted files carry forward unchanged. 'file_edits' cannot add,
+            remove, or rename files; use 'files' (replace-all) for that. 'files' and
+            'file_edits' are mutually exclusive.
         include_params:
             - body
             - edits
@@ -89,6 +95,7 @@ tools:
             - allowed_tools
             - metadata
             - files
+            - file_edits
             - base_version
     skill-duplicate:
         operation: llm_skills_name_duplicate_create

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -3231,7 +3231,7 @@
         }
     },
     "skill-update": {
-        "description": "Publish a new version of an existing agent skill by name. Any field not provided\nis carried forward from the current latest version. Requires base_version for\noptimistic concurrency. If files are provided, they replace all files from the\nprevious version; if omitted, files are carried forward.\n\nFor the body, you can either provide the full content via 'body', or use 'edits'\nfor incremental find/replace updates. Each edit must have 'old' (text to find,\nmust match exactly once) and 'new' (replacement text). Edits are applied\nsequentially. Only one of 'body' or 'edits' may be provided.",
+        "description": "Publish a new version of an existing agent skill by name. Any field not provided\nis carried forward from the current latest version. Requires base_version for\noptimistic concurrency. If files are provided, they replace all files from the\nprevious version; if omitted, files are carried forward.\n\nFor the body, you can either provide the full content via 'body', or use 'edits'\nfor incremental find/replace updates. Each edit must have 'old' (text to find,\nmust match exactly once) and 'new' (replacement text). Edits are applied\nsequentially. Only one of 'body' or 'edits' may be provided.\n\nFor bundled files, use 'file_edits' to apply find/replace updates to individual\nfiles without resending the full file set — each entry targets one existing file\nby path. Non-targeted files carry forward unchanged. 'file_edits' cannot add,\nremove, or rename files; use 'files' (replace-all) for that. 'files' and\n'file_edits' are mutually exclusive.",
         "category": "Skills",
         "feature": "skills",
         "summary": "Update skill",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -3633,7 +3633,7 @@
         }
     },
     "skill-update": {
-        "description": "Publish a new version of an existing agent skill by name. Any field not provided\nis carried forward from the current latest version. Requires base_version for\noptimistic concurrency. If files are provided, they replace all files from the\nprevious version; if omitted, files are carried forward.\n\nFor the body, you can either provide the full content via 'body', or use 'edits'\nfor incremental find/replace updates. Each edit must have 'old' (text to find,\nmust match exactly once) and 'new' (replacement text). Edits are applied\nsequentially. Only one of 'body' or 'edits' may be provided.",
+        "description": "Publish a new version of an existing agent skill by name. Any field not provided\nis carried forward from the current latest version. Requires base_version for\noptimistic concurrency. If files are provided, they replace all files from the\nprevious version; if omitted, files are carried forward.\n\nFor the body, you can either provide the full content via 'body', or use 'edits'\nfor incremental find/replace updates. Each edit must have 'old' (text to find,\nmust match exactly once) and 'new' (replacement text). Edits are applied\nsequentially. Only one of 'body' or 'edits' may be provided.\n\nFor bundled files, use 'file_edits' to apply find/replace updates to individual\nfiles without resending the full file set — each entry targets one existing file\nby path. Non-targeted files carry forward unchanged. 'file_edits' cannot add,\nremove, or rename files; use 'files' (replace-all) for that. 'files' and\n'file_edits' are mutually exclusive.",
         "category": "Skills",
         "feature": "skills",
         "summary": "Update skill",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -20036,7 +20036,7 @@ export namespace Schemas {
     }
 
     export interface LLMSkillEditOperation {
-      /** Text to find in the current skill body. Must match exactly once. */
+      /** Text to find in the target content. Must match exactly once. */
       old: string;
       /** Replacement text. */
       new: string;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -20050,6 +20050,16 @@ export namespace Schemas {
       content_type?: string;
     }
 
+    export interface LLMSkillFileEdit {
+      /**
+       * Path of the bundled file to edit. Must match an existing file on the current skill version.
+       * @maxLength 500
+       */
+      path: string;
+      /** Sequential find/replace operations to apply to this file's content. */
+      edits: LLMSkillEditOperation[];
+    }
+
     /**
      * Arbitrary key-value metadata.
      */
@@ -26453,8 +26463,10 @@ export namespace Schemas {
       allowed_tools?: string[];
       /** Arbitrary key-value metadata. */
       metadata?: PatchedLLMSkillPublishMetadata;
-      /** Bundled files to include with this version. Replaces all files from the previous version. */
+      /** Bundled files to include with this version. Replaces all files from the previous version. Mutually exclusive with file_edits. */
       files?: LLMSkillFileInput[];
+      /** Per-file find/replace updates. Each entry targets one existing file by path and applies sequential edits to its content. Non-targeted files carry forward unchanged. Cannot add, remove, or rename files — use 'files' for that. Mutually exclusive with files. */
+      file_edits?: LLMSkillFileEdit[];
       /**
        * Latest version you are editing from. Used for optimistic concurrency checks.
        * @minimum 1

--- a/services/mcp/src/generated/skills/api.ts
+++ b/services/mcp/src/generated/skills/api.ts
@@ -129,6 +129,8 @@ export const llmSkillsNamePartialUpdateBodyFilesItemPathMax = 500
 export const llmSkillsNamePartialUpdateBodyFilesItemContentTypeDefault = `text/plain`
 export const llmSkillsNamePartialUpdateBodyFilesItemContentTypeMax = 100
 
+export const llmSkillsNamePartialUpdateBodyFileEditsItemPathMax = 500
+
 export const LlmSkillsNamePartialUpdateBody = /* @__PURE__ */ zod.object({
     body: zod
         .string()
@@ -180,7 +182,34 @@ export const LlmSkillsNamePartialUpdateBody = /* @__PURE__ */ zod.object({
             })
         )
         .optional()
-        .describe('Bundled files to include with this version. Replaces all files from the previous version.'),
+        .describe(
+            'Bundled files to include with this version. Replaces all files from the previous version. Mutually exclusive with file_edits.'
+        ),
+    file_edits: zod
+        .array(
+            zod.object({
+                path: zod
+                    .string()
+                    .max(llmSkillsNamePartialUpdateBodyFileEditsItemPathMax)
+                    .describe(
+                        'Path of the bundled file to edit. Must match an existing file on the current skill version.'
+                    ),
+                edits: zod
+                    .array(
+                        zod.object({
+                            old: zod
+                                .string()
+                                .describe('Text to find in the current skill body. Must match exactly once.'),
+                            new: zod.string().describe('Replacement text.'),
+                        })
+                    )
+                    .describe("Sequential find/replace operations to apply to this file's content."),
+            })
+        )
+        .optional()
+        .describe(
+            "Per-file find/replace updates. Each entry targets one existing file by path and applies sequential edits to its content. Non-targeted files carry forward unchanged. Cannot add, remove, or rename files — use 'files' for that. Mutually exclusive with files."
+        ),
     base_version: zod
         .number()
         .min(1)

--- a/services/mcp/src/generated/skills/api.ts
+++ b/services/mcp/src/generated/skills/api.ts
@@ -141,7 +141,7 @@ export const LlmSkillsNamePartialUpdateBody = /* @__PURE__ */ zod.object({
     edits: zod
         .array(
             zod.object({
-                old: zod.string().describe('Text to find in the current skill body. Must match exactly once.'),
+                old: zod.string().describe('Text to find in the target content. Must match exactly once.'),
                 new: zod.string().describe('Replacement text.'),
             })
         )
@@ -197,9 +197,7 @@ export const LlmSkillsNamePartialUpdateBody = /* @__PURE__ */ zod.object({
                 edits: zod
                     .array(
                         zod.object({
-                            old: zod
-                                .string()
-                                .describe('Text to find in the current skill body. Must match exactly once.'),
+                            old: zod.string().describe('Text to find in the target content. Must match exactly once.'),
                             new: zod.string().describe('Replacement text.'),
                         })
                     )

--- a/services/mcp/src/tools/generated/skills.ts
+++ b/services/mcp/src/tools/generated/skills.ts
@@ -131,6 +131,9 @@ const skillUpdate = (): ToolBase<typeof SkillUpdateSchema, Schemas.LLMSkill> => 
         if (params.files !== undefined) {
             body['files'] = params.files
         }
+        if (params.file_edits !== undefined) {
+            body['file_edits'] = params.file_edits
+        }
         if (params.base_version !== undefined) {
             body['base_version'] = params.base_version
         }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/skill-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/skill-update.json
@@ -36,7 +36,7 @@
                         "type": "string"
                     },
                     "old": {
-                        "description": "Text to find in the current skill body. Must match exactly once.",
+                        "description": "Text to find in the target content. Must match exactly once.",
                         "type": "string"
                     }
                 },
@@ -58,7 +58,7 @@
                                     "type": "string"
                                 },
                                 "old": {
-                                    "description": "Text to find in the current skill body. Must match exactly once.",
+                                    "description": "Text to find in the target content. Must match exactly once.",
                                     "type": "string"
                                 }
                             },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/common/skill-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/common/skill-update.json
@@ -45,8 +45,41 @@
             },
             "type": "array"
         },
+        "file_edits": {
+            "description": "Per-file find/replace updates. Each entry targets one existing file by path and applies sequential edits to its content. Non-targeted files carry forward unchanged. Cannot add, remove, or rename files — use 'files' for that. Mutually exclusive with files.",
+            "items": {
+                "properties": {
+                    "edits": {
+                        "description": "Sequential find/replace operations to apply to this file's content.",
+                        "items": {
+                            "properties": {
+                                "new": {
+                                    "description": "Replacement text.",
+                                    "type": "string"
+                                },
+                                "old": {
+                                    "description": "Text to find in the current skill body. Must match exactly once.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["old", "new"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "path": {
+                        "description": "Path of the bundled file to edit. Must match an existing file on the current skill version.",
+                        "maxLength": 500,
+                        "type": "string"
+                    }
+                },
+                "required": ["path", "edits"],
+                "type": "object"
+            },
+            "type": "array"
+        },
         "files": {
-            "description": "Bundled files to include with this version. Replaces all files from the previous version.",
+            "description": "Bundled files to include with this version. Replaces all files from the previous version. Mutually exclusive with file_edits.",
             "items": {
                 "properties": {
                     "content": {


### PR DESCRIPTION
> Stacked on #55727 — set base branch back to `master` once PR1 merges.

## Problem

PR #55727 let agents patch the skill body without rewriting it, but bundled
files (e.g. `references/ranking.md`) still require the full `files` array
on every edit. To tweak one line in one reference, callers have to `skill-get`
the manifest, `skill-file-get` each file to reconstruct the full set, and
re-submit it — N+1 round trips and a lot of redundant bytes for a small
change.

## Changes

- New `file_edits: [{path, edits:[{old, new}]}]` field on
  `LLMSkillPublishSerializer`. Each entry targets one existing file by path
  and applies sequential find/replace edits to its content. Non-targeted
  files carry forward untouched. Mutually exclusive with the existing
  `files` (replace-all) payload; stackable with body `edits` / `body`.
- `LLMSkillEditError` now carries optional `file_path`; viewset includes
  it in the 400 payload when set, so callers know which file + which edit
  index failed.
- `apply_skill_file_edits()` + `_resolve_file_edits()` in the service
  mirror the body-edits helper shape. Size capped at `MAX_SKILL_FILE_BYTES`.
- `_copy_files()` gains an `edited_content: dict[str, str]` override so
  the carry-forward path can substitute new content for patched files
  while leaving the rest intact.
- MCP `skill-update` tool now includes `file_edits` in `include_params`;
  description explains the no-add/remove/rename scope.
- Regenerated OpenAPI schema (`api.schemas.ts`) and MCP tool definitions.
- 9 new tests: single-file patch, multi-file patch, unknown path → 400
  with `file_path`, zero match → 400, multi match → 400, files+file_edits
  conflict → 400, duplicate paths in file_edits → 400, empty list → 400,
  combined body edits + file_edits in one publish.

**Explicitly out of scope** (deferred): add new file, remove file, rename
file via `file_edits`. Those stay in the existing `files` replace-all
payload — the API surface would grow into a mini filesystem-diff protocol,
worth its own design pass if the pain is real.

## How did you test this code?

Automated only — I'm an agent; I ran `hogli test products/llm_analytics/backend/api/test/test_skills.py`
(47 passed, including the 9 new file_edits tests and the 12 body-edits
tests from PR1). Regenerated `hogli build:openapi` and confirmed
`file_edits` flows into `services/mcp/src/tools/generated/skills.ts` and
`products/llm_analytics/frontend/generated/api.schemas.ts`. Ruff + MCP
tsc clean. No manual browser testing.

## Publish to changelog?

no — developer-facing MCP tool enhancement

## 🤖 LLM context

Authored by Claude (opus-4.7). Follow-on to PR #55727; same author
session. Kept strict shape parity with body edits (same operation
serializer, same error type, same mutual-exclusion validation pattern).
One design choice worth calling out: extending the existing
`LLMSkillEditError` with an optional `file_path` rather than introducing
a new `LLMSkillFileEditError`. Lets the viewset handle both body and
file edit failures in one `except` clause; callers distinguish by the
presence of `file_path` in the response body.