### PR TITLE
feat(tasks): add sandbox git and filesystem commands to task run API

### DIFF
--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -749,6 +749,20 @@ class TaskRunCommandRequestSerializer(serializers.Serializer):
         "close",
         "permission_response",
         "set_config_option",
+        # Sandbox commands — operate on the sandbox filesystem/git directly
+        "git/changed_files",
+        "git/diff_cached",
+        "git/diff_unstaged",
+        "git/diff_head",
+        "git/diff_stats",
+        "git/current_branch",
+        "git/file_at_head",
+        "git/stage_files",
+        "git/unstage_files",
+        "git/discard_file",
+        "git/sync_status",
+        "git/repo_info",
+        "fs/read_file",
     ]
 
     jsonrpc = serializers.ChoiceField(
@@ -781,6 +795,21 @@ class TaskRunCommandRequestSerializer(serializers.Serializer):
         if not value or not isinstance(value, str) or not value.strip():
             raise serializers.ValidationError({"params": f"{key} is required and must be a non-empty string"})
 
+    @staticmethod
+    def _require_nonempty_string_list(params: dict, key: str) -> None:
+        value = params.get(key)
+        if not isinstance(value, list) or len(value) == 0:
+            raise serializers.ValidationError({"params": f"{key} is required and must be a non-empty list"})
+        if not all(isinstance(v, str) and v.strip() for v in value):
+            raise serializers.ValidationError({"params": f"{key} must contain only non-empty strings"})
+
+    @staticmethod
+    def _require_file_status(params: dict, key: str) -> None:
+        value = params.get(key)
+        allowed = ("modified", "added", "deleted", "renamed", "untracked")
+        if not isinstance(value, str) or value not in allowed:
+            raise serializers.ValidationError({"params": f"{key} must be one of: {', '.join(allowed)}"})
+
     def validate(self, attrs):
         method = attrs["method"]
         params = attrs.get("params", {})
@@ -792,6 +821,17 @@ class TaskRunCommandRequestSerializer(serializers.Serializer):
         elif method == "set_config_option":
             self._require_nonempty_string(params, "configId")
             self._require_nonempty_string(params, "value")
+        elif method == "git/file_at_head":
+            self._require_nonempty_string(params, "filePath")
+        elif method == "git/stage_files":
+            self._require_nonempty_string_list(params, "paths")
+        elif method == "git/unstage_files":
+            self._require_nonempty_string_list(params, "paths")
+        elif method == "git/discard_file":
+            self._require_nonempty_string(params, "filePath")
+            self._require_file_status(params, "fileStatus")
+        elif method == "fs/read_file":
+            self._require_nonempty_string(params, "filePath")
         return attrs
 
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -3245,6 +3245,131 @@ class TestTaskRunCommandAPI(BaseTaskAPITest):
         self.assertNotIn("DNS", response.json()["error"])
         self.assertEqual(response.json()["error"], "Failed to send command to agent server")
 
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
+    @patch("products.tasks.backend.api.http_requests.post")
+    def test_command_proxies_sandbox_git_changed_files(self, mock_post):
+        get_sandbox_jwt_public_key.cache_clear()
+        self._mock_agent_response(
+            mock_post,
+            {
+                "jsonrpc": "2.0",
+                "id": "req-sandbox",
+                "result": {"files": [{"path": "test.py", "status": "modified"}]},
+            },
+        )
+
+        task = self.create_task()
+        run = self._create_run_with_sandbox(task)
+
+        response = self.client.post(
+            self._command_url(task, run),
+            {"jsonrpc": "2.0", "method": "git/changed_files", "id": "req-sandbox"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["result"]["files"][0]["path"], "test.py")
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        self.assertEqual(call_kwargs[1]["json"]["method"], "git/changed_files")
+
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
+    @patch("products.tasks.backend.api.http_requests.post")
+    def test_command_proxies_sandbox_fs_read_file(self, mock_post):
+        get_sandbox_jwt_public_key.cache_clear()
+        self._mock_agent_response(
+            mock_post,
+            {"jsonrpc": "2.0", "id": "req-fs", "result": {"content": "hello"}},
+        )
+
+        task = self.create_task()
+        run = self._create_run_with_sandbox(task)
+
+        response = self.client.post(
+            self._command_url(task, run),
+            {
+                "jsonrpc": "2.0",
+                "method": "fs/read_file",
+                "params": {"filePath": "test.txt"},
+                "id": "req-fs",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    @parameterized.expand(
+        [
+            (
+                "fs_read_file_missing_path",
+                {"jsonrpc": "2.0", "method": "fs/read_file", "params": {}},
+            ),
+            (
+                "git_file_at_head_missing_path",
+                {"jsonrpc": "2.0", "method": "git/file_at_head", "params": {}},
+            ),
+            (
+                "git_stage_files_empty_paths",
+                {"jsonrpc": "2.0", "method": "git/stage_files", "params": {"paths": []}},
+            ),
+            (
+                "git_discard_file_missing_status",
+                {"jsonrpc": "2.0", "method": "git/discard_file", "params": {"filePath": "a.txt"}},
+            ),
+            (
+                "git_discard_file_invalid_status",
+                {
+                    "jsonrpc": "2.0",
+                    "method": "git/discard_file",
+                    "params": {"filePath": "a.txt", "fileStatus": "invalid"},
+                },
+            ),
+        ]
+    )
+    def test_command_rejects_invalid_sandbox_params(self, _name, payload):
+        task = self.create_task()
+        run = self._create_run_with_sandbox(task)
+
+        response = self.client.post(
+            self._command_url(task, run),
+            payload,
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
+    @patch("products.tasks.backend.api.http_requests.post")
+    def test_command_proxies_sandbox_git_no_params_methods(self, mock_post):
+        """Sandbox query methods that require no params should pass through."""
+        get_sandbox_jwt_public_key.cache_clear()
+        self._mock_agent_response(
+            mock_post,
+            {"jsonrpc": "2.0", "id": "req-1", "result": {"branch": "main"}},
+        )
+
+        task = self.create_task()
+        run = self._create_run_with_sandbox(task)
+
+        for method in [
+            "git/changed_files",
+            "git/diff_cached",
+            "git/diff_unstaged",
+            "git/diff_head",
+            "git/diff_stats",
+            "git/current_branch",
+            "git/sync_status",
+            "git/repo_info",
+        ]:
+            response = self.client.post(
+                self._command_url(task, run),
+                {"jsonrpc": "2.0", "method": method, "id": "req-1"},
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK, f"Failed for method {method}: {response.json()}")
+
 
 class TestSandboxEnvironmentAPI(BaseTaskAPITest):
     base_url = "/api/projects/@current/sandbox_environments/"

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -803,6 +803,19 @@ export const JsonrpcEnumApi = {
  * `close` - close
  * `permission_response` - permission_response
  * `set_config_option` - set_config_option
+ * `git/changed_files` - git/changed_files
+ * `git/diff_cached` - git/diff_cached
+ * `git/diff_unstaged` - git/diff_unstaged
+ * `git/diff_head` - git/diff_head
+ * `git/diff_stats` - git/diff_stats
+ * `git/current_branch` - git/current_branch
+ * `git/file_at_head` - git/file_at_head
+ * `git/stage_files` - git/stage_files
+ * `git/unstage_files` - git/unstage_files
+ * `git/discard_file` - git/discard_file
+ * `git/sync_status` - git/sync_status
+ * `git/repo_info` - git/repo_info
+ * `fs/read_file` - fs/read_file
  */
 export type MethodEnumApi = (typeof MethodEnumApi)[keyof typeof MethodEnumApi]
 
@@ -812,6 +825,19 @@ export const MethodEnumApi = {
     Close: 'close',
     PermissionResponse: 'permission_response',
     SetConfigOption: 'set_config_option',
+    GitChangedFiles: 'git/changed_files',
+    GitDiffCached: 'git/diff_cached',
+    GitDiffUnstaged: 'git/diff_unstaged',
+    GitDiffHead: 'git/diff_head',
+    GitDiffStats: 'git/diff_stats',
+    GitCurrentBranch: 'git/current_branch',
+    GitFileAtHead: 'git/file_at_head',
+    GitStageFiles: 'git/stage_files',
+    GitUnstageFiles: 'git/unstage_files',
+    GitDiscardFile: 'git/discard_file',
+    GitSyncStatus: 'git/sync_status',
+    GitRepoInfo: 'git/repo_info',
+    FsReadFile: 'fs/read_file',
 } as const
 
 /**
@@ -828,7 +854,20 @@ export interface TaskRunCommandRequestApi {
 * `cancel` - cancel
 * `close` - close
 * `permission_response` - permission_response
-* `set_config_option` - set_config_option */
+* `set_config_option` - set_config_option
+* `git/changed_files` - git/changed_files
+* `git/diff_cached` - git/diff_cached
+* `git/diff_unstaged` - git/diff_unstaged
+* `git/diff_head` - git/diff_head
+* `git/diff_stats` - git/diff_stats
+* `git/current_branch` - git/current_branch
+* `git/file_at_head` - git/file_at_head
+* `git/stage_files` - git/stage_files
+* `git/unstage_files` - git/unstage_files
+* `git/discard_file` - git/discard_file
+* `git/sync_status` - git/sync_status
+* `git/repo_info` - git/repo_info
+* `fs/read_file` - fs/read_file */
     method: MethodEnumApi
     /** Parameters for the command */
     params?: TaskRunCommandRequestApiParams

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -20858,6 +20858,19 @@ export namespace Schemas {
     * `close` - close
     * `permission_response` - permission_response
     * `set_config_option` - set_config_option
+    * `git/changed_files` - git/changed_files
+    * `git/diff_cached` - git/diff_cached
+    * `git/diff_unstaged` - git/diff_unstaged
+    * `git/diff_head` - git/diff_head
+    * `git/diff_stats` - git/diff_stats
+    * `git/current_branch` - git/current_branch
+    * `git/file_at_head` - git/file_at_head
+    * `git/stage_files` - git/stage_files
+    * `git/unstage_files` - git/unstage_files
+    * `git/discard_file` - git/discard_file
+    * `git/sync_status` - git/sync_status
+    * `git/repo_info` - git/repo_info
+    * `fs/read_file` - fs/read_file
      */
     export type MethodEnum = typeof MethodEnum[keyof typeof MethodEnum];
 
@@ -20868,6 +20881,19 @@ export namespace Schemas {
       Close: 'close',
       PermissionResponse: 'permission_response',
       SetConfigOption: 'set_config_option',
+      GitChangedFiles: 'git/changed_files',
+      GitDiffCached: 'git/diff_cached',
+      GitDiffUnstaged: 'git/diff_unstaged',
+      GitDiffHead: 'git/diff_head',
+      GitDiffStats: 'git/diff_stats',
+      GitCurrentBranch: 'git/current_branch',
+      GitFileAtHead: 'git/file_at_head',
+      GitStageFiles: 'git/stage_files',
+      GitUnstageFiles: 'git/unstage_files',
+      GitDiscardFile: 'git/discard_file',
+      GitSyncStatus: 'git/sync_status',
+      GitRepoInfo: 'git/repo_info',
+      FsReadFile: 'fs/read_file',
     } as const;
 
     export interface MinimalPerson {
@@ -34386,7 +34412,20 @@ export namespace Schemas {
     * `cancel` - cancel
     * `close` - close
     * `permission_response` - permission_response
-    * `set_config_option` - set_config_option */
+    * `set_config_option` - set_config_option
+    * `git/changed_files` - git/changed_files
+    * `git/diff_cached` - git/diff_cached
+    * `git/diff_unstaged` - git/diff_unstaged
+    * `git/diff_head` - git/diff_head
+    * `git/diff_stats` - git/diff_stats
+    * `git/current_branch` - git/current_branch
+    * `git/file_at_head` - git/file_at_head
+    * `git/stage_files` - git/stage_files
+    * `git/unstage_files` - git/unstage_files
+    * `git/discard_file` - git/discard_file
+    * `git/sync_status` - git/sync_status
+    * `git/repo_info` - git/repo_info
+    * `fs/read_file` - fs/read_file */
       method: MethodEnum;
       /** Parameters for the command */
       params?: TaskRunCommandRequestParams;


### PR DESCRIPTION
## Problem

  The cloud sandbox task runner needs to expose git and filesystem operations so the frontend can display file diffs, staging state, and file contents from the sandboxed environment. Currently only `close`, `permission_response`, and `set_config_option` commands are supported.

  ## Changes

  - Add 13 new sandbox commands to `TaskRunCommandRequestSerializer`: `git/changed_files`, `git/diff_cached`, `git/diff_unstaged`, `git/diff_head`, `git/diff_stats`, `git/current_branch`, `git/file_at_head`, `git/stage_files`, `git/unstage_files`, `git/discard_file`, `git/sync_status`, `git/repo_info`, `fs/read_file`
  - Add `_require_nonempty_string_list` and `_require_file_status` validation helpers for commands that take path lists or file status enums
  - Add parameter validation for commands that require specific params (`filePath`, `paths`, `fileStatus`)
  - Commands without required params (`git/changed_files`, `git/diff_*`, etc.) pass through with no extra validation

## Related PRs

[Posthog Code ](https://github.com/PostHog/code/pull/1829)

  ## How did you test this code?

  - Added parameterized tests for invalid parameter rejection across all validated commands
  - Added proxy tests verifying sandbox git and filesystem commands are forwarded correctly to the agent server
  - Added test covering all no-params git query methods pass through successfully

  ## Publish to changelog?

  No

  ## Docs update