### PR TITLE
fix(endpoints): dont raise series mismatch when series just has no data

### DIFF
--- a/products/endpoints/backend/insight_transformers.py
+++ b/products/endpoints/backend/insight_transformers.py
@@ -153,35 +153,33 @@ def _transform_trends(result: dict, original_query: dict, team: Team, now: datet
 
     _coerce_temporal_columns(rows, result.get("types"))
 
-    # Group rows by __series_index (trends uses named column access in build_series_response)
     series_index_col = columns.index("__series_index") if "__series_index" in columns else None
     groups: dict[int, list] = defaultdict(list)
     for row in rows:
         idx = row[series_index_col] if series_index_col is not None else 0
         groups[idx].append(row)
 
-    per_series_responses: list[HogQLQueryResponse] = []
-    for series_idx in sorted(groups.keys()):
-        per_series_responses.append(
-            HogQLQueryResponse(
-                results=groups[series_idx],
-                columns=columns,
-            )
-        )
+    expected_series_count = len(runner.series)
 
-    if len(per_series_responses) != len(runner.series):
+    # A row tagged with a series index the current query no longer defines is real drift:
+    # the table was built for a superset. Missing indices are NOT drift — filters or sparse
+    # UNION ALL branches can legitimately leave a series with zero rows at read time.
+    if groups and max(groups.keys()) >= expected_series_count:
         raise MaterializedSeriesMismatchError(
-            f"Materialized table has {len(per_series_responses)} series "
-            f"but current query defines {len(runner.series)}. "
+            f"Materialized table has series index {max(groups.keys())} "
+            f"but current query defines only {expected_series_count} series. "
             f"The endpoint query was likely edited after materialization."
         )
 
-    # Call build_series_response per series, then format_results for post-processing
+    # Build one response per expected series (not per non-empty bucket) so filtered-to-empty
+    # series keep their positional slot — build_series_response handles empty results cleanly.
+    per_series_responses: list[HogQLQueryResponse] = [
+        HogQLQueryResponse(results=groups.get(i, []), columns=columns) for i in range(expected_series_count)
+    ]
+
     returned_results: list[list[dict[str, Any]]] = []
-    series_count = len(per_series_responses)
     for i, response in enumerate(per_series_responses):
-        series_with_extra = runner.series[i]
-        returned_results.append(runner.build_series_response(response, series_with_extra, series_count))
+        returned_results.append(runner.build_series_response(response, runner.series[i], expected_series_count))
 
     final_result, has_more = runner.format_results(returned_results)
 

--- a/products/endpoints/backend/tests/test_insight_response_parity.py
+++ b/products/endpoints/backend/tests/test_insight_response_parity.py
@@ -519,3 +519,93 @@ class TestInsightResponseParity(ClickhouseTestMixin, APIBaseTest):
         # Rows unchanged (still tuples, no substitution happened)
         assert rows == [("hello", 1.0)]
         assert isinstance(rows[0], tuple)
+
+    def test_materialized_trends_series_with_no_rows_is_not_a_mismatch(self):
+        """A WHERE clause (e.g. a breakdown filter) can legitimately drop every row
+        for one or more series. The materialized table still holds all series —
+        it's just that the filtered read returned zero rows for some of them.
+        That must be treated as an empty series, not as query/table drift.
+
+        Regression for MaterializedSeriesMismatchError being raised when a
+        breakdown-value filter eliminated a full series' rows.
+        """
+        endpoint = create_endpoint_with_version(
+            name="trends_sparse_series",
+            team=self.team,
+            query=TrendsQuery(
+                series=[
+                    EventsNode(event="$pageview"),
+                    EventsNode(event="$pageview", math="dau"),
+                    EventsNode(event="$pageleave"),  # third series with no matching rows
+                ],
+                dateRange={"date_from": "2026-01-01", "date_to": "2026-01-10"},
+            ).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+
+        self._materialize_endpoint(endpoint)
+
+        # Only series 0 and 1 have rows — series 2 got filtered out entirely.
+        dates = [date(2026, 1, d) for d in range(1, 11)]
+        flat_response = HogQLQueryResponse(
+            results=[
+                (0, dates, [1.0] * 10),
+                (1, dates, [1.0] * 10),
+            ],
+            columns=["__series_index", "date", "total"],
+            types=["Int64", "Array(Date)", "Array(Float64)"],
+            hasMore=False,
+        )
+
+        with mock.patch(
+            "products.endpoints.backend.api.process_query_model",
+            return_value=flat_response,
+        ):
+            mat_resp = self._run_endpoint(endpoint)
+
+        assert mat_resp.status_code == status.HTTP_200_OK, mat_resp.json()
+        mat_results = mat_resp.json()["results"]
+        # Two series have data, the third is empty — all three should be represented
+        # in the shape, but the empty one may collapse to no result rows.
+        assert len(mat_results) >= 2, f"Expected at least 2 series in response, got {len(mat_results)}"
+        for r in mat_results:
+            assert "data" in r and "labels" in r and "days" in r
+
+    def test_materialized_trends_extra_series_index_still_raises(self):
+        """Genuine drift — materialized table has a series index the current query
+        doesn't define — must still trip the mismatch guard so we re-materialize.
+        """
+        from products.endpoints.backend.insight_transformers import (
+            MaterializedSeriesMismatchError,
+            transform_materialized_insight_response,
+        )
+
+        endpoint = create_endpoint_with_version(
+            name="trends_genuine_drift",
+            team=self.team,
+            query=TrendsQuery(
+                series=[EventsNode(event="$pageview")],
+                dateRange={"date_from": "2026-01-01", "date_to": "2026-01-10"},
+            ).model_dump(),
+            created_by=self.user,
+            is_active=True,
+        )
+
+        dates = [date(2026, 1, d) for d in range(1, 11)]
+        # Materialized table contains 2 series (0 and 1) but current query only defines 1.
+        result_dict = {
+            "columns": ["__series_index", "date", "total"],
+            "types": ["Int64", "Array(Date)", "Array(Float64)"],
+            "results": [
+                [0, dates, [1.0] * 10],
+                [1, dates, [1.0] * 10],
+            ],
+        }
+
+        with pytest.raises(MaterializedSeriesMismatchError):
+            transform_materialized_insight_response(
+                result_dict,
+                endpoint.get_version().query,
+                self.team,
+            )


### PR DESCRIPTION
## Problem

when a materialized insight-based endpoint is being executed with a breakdow filter applied on the variable, and that variable value has no data on a series of the insight, we raise the mismatch error incorrectly.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

instead of raising, this should be handled gracefully as no data. the materialized table simply won't return data for that variable value, so we need to pass a `[]` to the insight response transformer

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

e2e with a local example and unit tests

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update