### PR TITLE
fix(flags): allow renaming to key held by soft-deleted flag

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1552,6 +1552,23 @@ class FeatureFlagSerializer(
             validated_data["version"] = locked_version + 1
             old_key = instance.key
 
+            # If the key is changing, free it up by hard-deleting any soft-deleted
+            # flag that still holds the target key — the DB unique constraint on
+            # (team, key) spans soft-deleted rows, so without this the update
+            # would fail with an IntegrityError. Mirrors the behavior in create().
+            new_key = validated_data.get("key")
+            if new_key and new_key != old_key and validated_data.get("deleted", instance.deleted) is False:
+                try:
+                    FeatureFlag.objects_including_soft_deleted.filter(
+                        key=new_key,
+                        team__project_id=self.context["project_id"],
+                        deleted=True,
+                    ).exclude(pk=instance.pk).delete()
+                except deletion.RestrictedError:
+                    raise exceptions.ValidationError(
+                        "Feature flag with this key already exists and is used in an experiment. Please delete the experiment before renaming the flag."
+                    )
+
             with ImpersonatedContext(request):
                 instance = super().update(instance, validated_data)
 

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -3066,11 +3066,11 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
     def test_rename_flag_to_key_held_by_soft_deleted_flag(self):
         # Create a flag, soft-delete it, then create another flag and rename it
         # to the key held by the soft-deleted flag.
-        FeatureFlag.objects.create(team=self.team, created_by=self.user, key="56397-delete-flag")
+        first = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="56397-delete-flag")
         other = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="56397-delete-flag-v2")
 
         response = self.client.patch(
-            f"/api/projects/{self.team.id}/feature_flags/{FeatureFlag.objects.get(key='56397-delete-flag').id}/",
+            f"/api/projects/{self.team.id}/feature_flags/{first.id}/",
             {"deleted": True},
         )
         assert response.status_code == 200

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -3063,6 +3063,30 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         assert flag.deleted is False
         assert flag.key == "held-flag-2"
 
+    def test_rename_flag_to_key_held_by_soft_deleted_flag(self):
+        # Create a flag, soft-delete it, then create another flag and rename it
+        # to the key held by the soft-deleted flag.
+        FeatureFlag.objects.create(team=self.team, created_by=self.user, key="56397-delete-flag")
+        other = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="56397-delete-flag-v2")
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/feature_flags/{FeatureFlag.objects.get(key='56397-delete-flag').id}/",
+            {"deleted": True},
+        )
+        assert response.status_code == 200
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/feature_flags/{other.id}/",
+            {"key": "56397-delete-flag"},
+        )
+        assert response.status_code == 200, response.content
+        other.refresh_from_db()
+        assert other.key == "56397-delete-flag"
+        # The soft-deleted flag should have been hard-deleted to free up the key.
+        assert not FeatureFlag.objects_including_soft_deleted.filter(
+            team=self.team, key="56397-delete-flag", deleted=True
+        ).exists()
+
     def test_soft_delete_flag_blocked_with_active_experiment(self):
         flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="flag2")
         exp = Experiment.objects.create(team=self.team, created_by=self.user, feature_flag=flag)


### PR DESCRIPTION
## Problem

Resolves #55626.

When renaming a feature flag to a key that is held by a soft-deleted flag, the update fails with an IntegrityError because the database unique constraint on `(team, key)` includes soft-deleted rows. This prevents users from reclaiming keys from soft-deleted flags.

## Changes

Added logic to the `FeatureFlag` serializer's `update()` method to automatically hard-delete any soft-deleted flag holding the target key when renaming an active flag. This mirrors the existing behavior in the `create()` method and ensures the unique constraint is satisfied.

The implementation:
- Detects when a flag key is being changed to a different value
- Queries for any soft-deleted flags with the target key in the same team
- Hard-deletes those soft-deleted flags to free up the key
- Handles `RestrictedError` exceptions (when a soft-deleted flag is used in an experiment) with an appropriate validation error message

## How did you test this code?

Added a new test case `test_rename_flag_to_key_held_by_soft_deleted_flag` that:
1. Creates a flag and soft-deletes it
2. Creates another flag and attempts to rename it to the soft-deleted flag's key
3. Verifies the rename succeeds
4. Confirms the soft-deleted flag is hard-deleted to free up the key

The test validates both the happy path and the constraint that soft-deleted flags are properly cleaned up during the rename operation.

## Publish to changelog?

no

https://claude.ai/code/session_01NxQxREywGRXiNTonfyUQ68