### PR TITLE
chore(endpoints): emit signal for endpoint execution failure

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -13956,6 +13956,65 @@
             },
             "type": "object"
         },
+        "EndpointExecutionFailedSignalExtra": {
+            "additionalProperties": false,
+            "properties": {
+                "endpoint_name": {
+                    "type": "string"
+                },
+                "endpoint_version": {
+                    "type": ["number", "null"]
+                },
+                "error_class": {
+                    "type": "string"
+                },
+                "error_message": {
+                    "type": "string"
+                },
+                "materialized": {
+                    "type": "boolean"
+                },
+                "saved_query_id": {
+                    "type": ["string", "null"]
+                }
+            },
+            "required": [
+                "endpoint_name",
+                "endpoint_version",
+                "materialized",
+                "saved_query_id",
+                "error_class",
+                "error_message"
+            ],
+            "type": "object"
+        },
+        "EndpointExecutionFailedSignalInput": {
+            "additionalProperties": false,
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "extra": {
+                    "$ref": "#/definitions/EndpointExecutionFailedSignalExtra"
+                },
+                "source_id": {
+                    "type": "string"
+                },
+                "source_product": {
+                    "const": "endpoints",
+                    "type": "string"
+                },
+                "source_type": {
+                    "const": "endpoint_execution_failed",
+                    "type": "string"
+                },
+                "weight": {
+                    "type": "number"
+                }
+            },
+            "required": ["source_type", "source_product", "source_id", "description", "weight", "extra"],
+            "type": "object"
+        },
         "EndpointLastExecutionTimesRequest": {
             "additionalProperties": false,
             "properties": {
@@ -34796,6 +34855,9 @@
                 },
                 {
                     "$ref": "#/definitions/ErrorTrackingSignalInput"
+                },
+                {
+                    "$ref": "#/definitions/EndpointExecutionFailedSignalInput"
                 }
             ],
             "required": ["source_product"],
@@ -34831,7 +34893,8 @@
                 "linear",
                 "zendesk",
                 "conversations",
-                "error_tracking"
+                "error_tracking",
+                "endpoints"
             ],
             "type": "string"
         },
@@ -34844,7 +34907,8 @@
                 "ticket",
                 "issue_created",
                 "issue_reopened",
-                "issue_spiking"
+                "issue_spiking",
+                "endpoint_execution_failed"
             ],
             "type": "string"
         },

--- a/frontend/src/queries/schema/schema-signals.ts
+++ b/frontend/src/queries/schema/schema-signals.ts
@@ -10,6 +10,7 @@ export enum SignalSourceProduct {
     ZENDESK = 'zendesk',
     CONVERSATIONS = 'conversations',
     ERROR_TRACKING = 'error_tracking',
+    ENDPOINTS = 'endpoints',
 }
 
 export enum SignalSourceType {
@@ -21,6 +22,7 @@ export enum SignalSourceType {
     ISSUE_CREATED = 'issue_created',
     ISSUE_REOPENED = 'issue_reopened',
     ISSUE_SPIKING = 'issue_spiking',
+    ENDPOINT_EXECUTION_FAILED = 'endpoint_execution_failed',
 }
 
 // ── Per-product signal extras & inputs ──────────────────────────────────────────
@@ -215,6 +217,26 @@ export interface ErrorTrackingSignalInput {
     extra: ErrorTrackingSignalExtra
 }
 
+// Endpoint execution failure
+
+export interface EndpointExecutionFailedSignalExtra {
+    endpoint_name: string
+    endpoint_version: number | null
+    materialized: boolean
+    saved_query_id: string | null
+    error_class: string
+    error_message: string
+}
+
+export interface EndpointExecutionFailedSignalInput {
+    source_type: 'endpoint_execution_failed'
+    source_product: 'endpoints'
+    source_id: string
+    description: string
+    weight: number
+    extra: EndpointExecutionFailedSignalExtra
+}
+
 // ── Report reviewer types ────────────────────────────────────────────────────────
 
 export interface RelevantCommit {
@@ -249,3 +271,4 @@ export type SignalInput =
     | LinearIssueSignalInput
     | ConversationsTicketSignalInput
     | ErrorTrackingSignalInput
+    | EndpointExecutionFailedSignalInput

--- a/posthog/hogql/database/schema/util/test/__snapshots__/test_session_v2_where_clause_extractor.ambr
+++ b/posthog/hogql/database/schema/util/test/__snapshots__/test_session_v2_where_clause_extractor.ambr
@@ -19,7 +19,6 @@
                   WHERE
                       and(equals(events.team_id, <TEAM_ID>), equals(events.event, %(hogql_val_4)s), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_5)s, 6, %(hogql_val_6)s)), lessOrEquals(events.timestamp, toDateTime64(%(hogql_val_7)s, 6, %(hogql_val_8)s))))))
       GROUP BY
-          raw_sessions.session_id_v7,
           raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
   WHERE
       and(equals(events.team_id, <TEAM_ID>), equals(events.event, %(hogql_val_9)s), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_10)s, 6, %(hogql_val_11)s)), lessOrEquals(events.timestamp, toDateTime64(%(hogql_val_12)s, 6, %(hogql_val_13)s)), ifNull(equals(events__session.`$entry_pathname`, %(hogql_val_14)s), 0))
@@ -41,7 +40,6 @@
       WHERE
           and(equals(raw_sessions.team_id, <TEAM_ID>), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_2)s, toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(%(hogql_val_3)s, toIntervalDay(3))))
       GROUP BY
-          raw_sessions.session_id_v7,
           raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
   WHERE
       and(equals(events.team_id, <TEAM_ID>), equals(events.event, %(hogql_val_4)s), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_5)s, 6, %(hogql_val_6)s)), lessOrEquals(events.timestamp, toDateTime64(%(hogql_val_7)s, 6, %(hogql_val_8)s)), ifNull(equals(events__session.`$entry_pathname`, %(hogql_val_9)s), 0))

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1535,6 +1535,30 @@ class EmptyPropertyFilter(BaseModel):
     type: Literal["empty"] = "empty"
 
 
+class EndpointExecutionFailedSignalExtra(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    endpoint_name: str
+    endpoint_version: float | None = None
+    error_class: str
+    error_message: str
+    materialized: bool
+    saved_query_id: str | None = None
+
+
+class EndpointExecutionFailedSignalInput(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    description: str
+    extra: EndpointExecutionFailedSignalExtra
+    source_id: str
+    source_product: Literal["endpoints"] = "endpoints"
+    source_type: Literal["endpoint_execution_failed"] = "endpoint_execution_failed"
+    weight: float
+
+
 class EndpointLastExecutionTimesRequest(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4348,6 +4372,7 @@ class SignalSourceProduct(StrEnum):
     ZENDESK = "zendesk"
     CONVERSATIONS = "conversations"
     ERROR_TRACKING = "error_tracking"
+    ENDPOINTS = "endpoints"
 
 
 class SignalSourceType(StrEnum):
@@ -4359,6 +4384,7 @@ class SignalSourceType(StrEnum):
     ISSUE_CREATED = "issue_created"
     ISSUE_REOPENED = "issue_reopened"
     ISSUE_SPIKING = "issue_spiking"
+    ENDPOINT_EXECUTION_FAILED = "endpoint_execution_failed"
 
 
 class SimilarIssue(BaseModel):
@@ -8116,6 +8142,7 @@ class SignalInput(
         | LinearIssueSignalInput
         | ConversationsTicketSignalInput
         | ErrorTrackingSignalInput
+        | EndpointExecutionFailedSignalInput
     ]
 ):
     root: (
@@ -8126,6 +8153,7 @@ class SignalInput(
         | LinearIssueSignalInput
         | ConversationsTicketSignalInput
         | ErrorTrackingSignalInput
+        | EndpointExecutionFailedSignalInput
     ) = Field(..., discriminator="source_product")
 
 

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 
 import structlog
 import posthoganalytics
+from asgiref.sync import async_to_sync
 from dateutil.parser import isoparse
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import OpenApiParameter, extend_schema_view
@@ -138,6 +139,85 @@ ENDPOINT_BREAKDOWN_LIMIT = 10_000
 ENDPOINT_NAME_REGEX = r"^[a-zA-Z][a-zA-Z0-9_-]{0,127}$"
 
 logger = structlog.get_logger(__name__)
+
+
+def _emit_endpoint_failure_signal(
+    team,
+    endpoint: "Endpoint",
+    exc: BaseException,
+    *,
+    materialized: bool,
+    version: int | None = None,
+    saved_query_id: Union[str, uuid.UUID, None] = None,
+    query_kind: str | None = None,
+    executed_sql: str | None = None,
+    saved_query_status: str | None = None,
+    saved_query_last_run_at: str | None = None,
+    saved_query_columns: dict | None = None,
+    endpoint_columns: list | None = None,
+) -> None:
+    """Fire a Signal when an endpoint execution fails, so the AI can reason about it later.
+
+    Fails silently — signal emission must never mask the underlying error.
+    """
+    from products.signals.backend.api import emit_signal
+
+    try:
+        error_class = type(exc).__name__
+        error_msg = str(exc)
+        version_str = f" v{version}" if version else ""
+
+        if materialized:
+            execution_mode = "materialized"
+            context = (
+                f"The materialized table (saved_query_id={saved_query_id}) may be stale, missing, or have a schema mismatch. "
+                f"Check whether the materialization refresh completed successfully and whether the underlying query still produces valid columns."
+            )
+            if saved_query_status:
+                context += f"\nSaved query status: {saved_query_status}"
+            if saved_query_last_run_at:
+                context += f", last materialized at: {saved_query_last_run_at}"
+            if saved_query_columns:
+                context += f"\nMaterialized table columns: {saved_query_columns}"
+            if endpoint_columns:
+                context += f"\nEndpoint version columns: {endpoint_columns}"
+        else:
+            execution_mode = "inline"
+            context = (
+                f"The query is executed on-demand against live data. "
+                f"Common causes: invalid HogQL syntax, missing or renamed properties, query timeout, or incompatible variable overrides."
+            )
+
+        parts = [
+            f"Endpoint '{endpoint.name}'{version_str} failed during {execution_mode} execution.",
+            f"Error: {error_class}: {error_msg}",
+        ]
+        if query_kind:
+            parts.append(f"Query kind: {query_kind}")
+        if executed_sql:
+            parts.append(f"Executed HogQL: {executed_sql}")
+        parts.append(context)
+        parts.append(f"Endpoint path: {endpoint.endpoint_path}")
+        description = "\n".join(parts)
+
+        async_to_sync(emit_signal)(
+            team=team,
+            source_product="endpoints",
+            source_type="endpoint_execution_failed",
+            source_id=f"{team.id}:{endpoint.name}",
+            description=description,
+            weight=0.5,
+            extra={
+                "endpoint_name": endpoint.name,
+                "endpoint_version": version,
+                "materialized": materialized,
+                "saved_query_id": str(saved_query_id) if saved_query_id else None,
+                "error_class": error_class,
+                "error_message": error_msg,
+            },
+        )
+    except Exception:
+        logger.exception("Failed to emit endpoint failure signal", endpoint_name=endpoint.name)
 
 
 def _add_where_condition(select_query: ast.SelectQuery, condition: ast.Expr) -> None:
@@ -1549,6 +1629,8 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
         offset: int | None = None,
     ) -> Response:
         """Execute against a materialized table in S3."""
+        materialized_hogql_query = None
+        query_kind = None
         try:
             version = version or endpoint.get_version()
             if not version.saved_query:
@@ -1705,6 +1787,22 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                     "materialized": True,
                     "saved_query_id": saved_query.id if saved_query else None,
                 },
+            )
+            _emit_endpoint_failure_signal(
+                self.team,
+                endpoint,
+                e,
+                materialized=True,
+                version=version.version if version else None,
+                saved_query_id=saved_query.id if saved_query else None,
+                query_kind=query_kind,
+                executed_sql=materialized_hogql_query.query if materialized_hogql_query else None,
+                saved_query_status=saved_query.status if saved_query else None,
+                saved_query_last_run_at=(
+                    saved_query.last_run_at.isoformat() if saved_query and saved_query.last_run_at else None
+                ),
+                saved_query_columns=saved_query.columns if saved_query else None,
+                endpoint_columns=version.columns if version else None,
             )
             raise
 
@@ -2008,6 +2106,16 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                     "materialized": False,
                     "endpoint_name": endpoint.name,
                 },
+            )
+            _emit_endpoint_failure_signal(
+                self.team,
+                endpoint,
+                e,
+                materialized=False,
+                version=version.version if version else None,
+                query_kind=query_kind,
+                executed_sql=query.get("query") if query_kind == "HogQLQuery" else None,
+                endpoint_columns=version.columns if version else None,
             )
             raise
 

--- a/products/endpoints/backend/tests/test_endpoint_execution.py
+++ b/products/endpoints/backend/tests/test_endpoint_execution.py
@@ -2156,3 +2156,38 @@ class TestEndpointExecution(ClickhouseTestMixin, APIBaseTest):
 
         after = REGISTRY.get_sample_value("posthog_endpoint_materialization_event_total", labels) or 0.0
         self.assertEqual(after - before, 0.0)
+
+    def test_inline_endpoint_failure_emits_signal(self):
+        """When inline execution raises, we emit a Signal for self-driving diagnostics."""
+        endpoint = self._make_simple_hogql_endpoint("failure_emits_signal")
+        boom = RuntimeError("synthetic failure")
+
+        with (
+            mock.patch("products.endpoints.backend.api.process_query_model", side_effect=boom),
+            mock.patch("products.endpoints.backend.api._emit_endpoint_failure_signal") as mock_emit,
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/",
+                {"refresh": "force"},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        mock_emit.assert_called_once()
+        args, kwargs = mock_emit.call_args
+        self.assertEqual(args[0].id, self.team.id)
+        self.assertEqual(args[1].name, endpoint.name)
+        self.assertIs(args[2], boom)
+        self.assertFalse(kwargs["materialized"])
+
+    def test_emit_failure_signal_swallows_errors(self):
+        """Signal emission must never mask the original exception."""
+        from products.endpoints.backend.api import _emit_endpoint_failure_signal
+
+        endpoint = self._make_simple_hogql_endpoint("failure_signal_swallow")
+
+        with mock.patch(
+            "products.signals.backend.api.emit_signal",
+            side_effect=RuntimeError("signal layer exploded"),
+        ):
+            _emit_endpoint_failure_signal(self.team, endpoint, RuntimeError("original"), materialized=False, version=1)

--- a/tach.toml
+++ b/tach.toml
@@ -14,12 +14,6 @@ source_roots = [
 [[modules]]
 path = "<root>"
 depends_on = [
-    "ee",
-    "posthog",
-    "products.error_tracking",
-    "products.event_definitions",
-    "products.llm_analytics",
-    "products.logs",
 ]
 layer = "modules"
 
@@ -40,7 +34,6 @@ utility = true
 [[modules]]
 path = "ee"
 depends_on = [
-    "<root>",
     "posthog",
     "products.alerts",
     "products.dashboards",
@@ -64,7 +57,6 @@ layer = "modules"
 [[modules]]
 path = "posthog"
 depends_on = [
-    "<root>",
     "ee",
     "products.analytics_platform",
     "products.batch_exports",
@@ -97,7 +89,6 @@ depends_on = [
     "products.signals",
     "products.slack_app",
     "products.surveys",
-    "products.streamlit_apps",
     "products.tasks",
     "products.tracing",
     "products.user_interviews",
@@ -202,6 +193,7 @@ depends_on = [
     "posthog",
     "products.data_modeling",
     "products.data_warehouse",
+    "products.signals",
 ]
 layer = "modules"
 
@@ -241,7 +233,6 @@ layer = "modules"
 [[modules]]
 path = "products.growth"
 depends_on = [
-    "ee",
     "posthog",
 ]
 layer = "modules"
@@ -316,7 +307,6 @@ layer = "modules"
 [[modules]]
 path = "products.metrics"
 depends_on = [
-    "posthog",
 ]
 layer = "modules"
 
@@ -333,7 +323,6 @@ layer = "modules"
 path = "products.streamlit_apps"
 depends_on = [
     "posthog",
-    "products.tasks",
 ]
 layer = "modules"
 
@@ -348,7 +337,6 @@ layer = "modules"
 [[modules]]
 path = "products.platform_features"
 depends_on = [
-    "posthog",
 ]
 layer = "modules"
 
@@ -372,7 +360,6 @@ layer = "modules"
 [[modules]]
 path = "products.product_tours"
 depends_on = [
-    "ee",
     "posthog",
     "products.surveys",
 ]


### PR DESCRIPTION
## Problem

execution shouldn't fail - i want to know when this happens, so PC can handle fixes on its own

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- emit signal on endpoint execution
    - maybe we find this is a bit too eager, and we only want to emit it on specific failures - let's see it run

## How did you test this code?

- tests

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->too 