### PR TITLE
feat(notebooks): stream collab steps over SSE with redis streams

### DIFF
--- a/products/notebooks/backend/api/notebook.py
+++ b/products/notebooks/backend/api/notebook.py
@@ -1,7 +1,7 @@
 import math
 import hashlib
 from datetime import timedelta
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from django.db import transaction
 from django.db.models import Q, QuerySet
@@ -35,13 +35,15 @@ from posthog.renderers import SafeJSONRenderer, ServerSentEventRenderer
 from posthog.settings import SERVER_GATEWAY_INTERFACE
 from posthog.utils import relative_date_parse
 
-from products.notebooks.backend.collab import initialize_collab_session, submit_steps
+from products.notebooks.backend import collab
+from products.notebooks.backend.collab import submit_steps
 from products.notebooks.backend.kernel_runtime import build_notebook_sandbox_config, get_kernel_runtime
 from products.notebooks.backend.models import KernelRuntime, Notebook
 from products.notebooks.backend.python_analysis import analyze_python_globals, annotate_python_nodes
 from products.tasks.backend.services.sandbox import SandboxStatus
 from products.tasks.backend.temporal.exceptions import SandboxProvisionError
 
+from ee.hogai.utils.aio import async_to_sync
 from ee.hogai.utils.asgi import SyncIterableToAsync
 
 logger = structlog.get_logger(__name__)
@@ -292,6 +294,9 @@ class NotebookCollabSaveSerializer(serializers.Serializer):
     content = serializers.JSONField(help_text="The resulting ProseMirror document after applying the steps locally.")
     text_content = serializers.CharField(required=False, default="", help_text="Plain text for search indexing.")
     title = serializers.CharField(required=False, help_text="Updated notebook title.")
+    cursor_head = serializers.IntegerField(
+        required=False, allow_null=True, help_text="ProseMirror cursor head position after applying steps."
+    )
 
 
 def _format_hogql_response_payload(response: Any) -> dict[str, Any]:
@@ -742,7 +747,8 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
 
         notebook = self.get_object()
 
-        initialize_collab_session(notebook.team_id, str(notebook.short_id), notebook.version)
+        user = cast(User, request.user)
+        user_name = user.get_full_name() or "Wandering Hog"
 
         result = submit_steps(
             team_id=notebook.team_id,
@@ -750,9 +756,12 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
             client_id=data["client_id"],
             steps_json=data["steps"],
             last_seen_version=data["version"],
+            user_id=user.pk,
+            user_name=user_name,
+            cursor_head=data.get("cursor_head"),
         )
 
-        if result.accepted:
+        if result.status == "accepted":
             content = data["content"]
             Notebook.objects.filter(pk=notebook.pk).update(
                 content=annotate_python_nodes(content) if isinstance(content, dict) else content,
@@ -765,12 +774,14 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
             notebook.refresh_from_db()
             return Response(NotebookSerializer(notebook, context=self.get_serializer_context()).data)
 
-        if result.steps_since is None:
+        if result.status == "stale":
             return Response(
                 {"code": "conflict_stale", "detail": "Reload the notebook."},
                 status=410,
             )
 
+        # Carries the missed steps so the client can reconcile without depending on SSE
+        assert result.steps_since is not None  # status == "conflict" guarantees this
         return Response(
             {
                 "code": "conflict",
@@ -780,6 +791,34 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
             },
             status=409,
         )
+
+    @action(
+        methods=["GET"],
+        url_path="collab/stream",
+        detail=True,
+        renderer_classes=[ServerSentEventRenderer],
+        required_scopes=["notebook:read"],
+    )
+    def collab_stream(self, request: Request, **kwargs):
+        """SSE stream of accepted prosemirror-collab steps for this notebook."""
+        notebook = self.get_object()
+        team_id = notebook.team_id
+        notebook_id = str(notebook.short_id)
+        last_event_id = request.headers.get("Last-Event-ID")
+
+        # On ASGI (Granian in prod) the async generator runs as one cheap task per connection.
+        # On WSGI (tests, fallback) async_to_sync bridges it via a worker thread + queue.
+        response = StreamingHttpResponse(
+            streaming_content=(
+                collab.stream_collab_sse(team_id, notebook_id, last_event_id=last_event_id)
+                if SERVER_GATEWAY_INTERFACE == "ASGI"
+                else async_to_sync(lambda: collab.stream_collab_sse(team_id, notebook_id, last_event_id=last_event_id))
+            ),
+            content_type=ServerSentEventRenderer.media_type,
+        )
+        response["Cache-Control"] = "no-cache"
+        response["X-Accel-Buffering"] = "no"
+        return response
 
     @action(methods=["GET"], detail=False)
     def recording_comments(self, request: Request, **kwargs):

--- a/products/notebooks/backend/collab.py
+++ b/products/notebooks/backend/collab.py
@@ -1,62 +1,92 @@
 """
-Collaboration service for notebooks using Redis as the step buffer.
+Redis-stream backed buffer for prosemirror-collab steps.
 """
 
 import json
+import asyncio
+from collections.abc import AsyncGenerator
 from dataclasses import dataclass
+from typing import Any, Literal
 
-from posthog import redis
+import structlog
+import redis.exceptions as redis_exceptions
 
-TTL_SECONDS = 60 * 60 * 24  # 1 day
-VERSION_KEY = "notebook:collab:{team_id}:{notebook_id}:version"
-STEPS_KEY = "notebook:collab:{team_id}:{notebook_id}:steps"
+from posthog import redis as redis_module
 
-# Atomic operation: append steps only if the last_seen_version matches the current version in Redis.
-# Each step is stored individually in a sorted set (score=version), for example:
-#   score=3  {"step": {"stepType": "replace", "from": 0, "to": 0}, "client_id": "uuid1", "v": 3}
-# Returns {-1, 0} if not initialized, {0, current} if mismatch, {1, new} if accepted.
-_APPEND_STEPS_LUA = """
-local version_key, steps_key = KEYS[1], KEYS[2]
-local last_seen_version, ttl_seconds = tonumber(ARGV[1]), ARGV[2]
+logger = structlog.get_logger(__name__)
 
-local current_version = redis.call('GET', version_key)
-if not current_version then return {-1, 0} end
+STREAM_KEY_PATTERN = "notebook:collab:{{{team_id}:{notebook_id}}}:stream"
 
-if tonumber(current_version) ~= last_seen_version then
-    return {0, tonumber(current_version)}
-end
+STREAM_TTL_SECONDS = 60 * 60 * 24  # 1 day, refreshed on every XADD
+STREAM_MAX_LENGTH = 5000  # ~hour of heavy editing
+STREAM_READ_COUNT = 32
 
-local next_version = tonumber(current_version)
-for i = 3, #ARGV do
-    next_version = next_version + 1
-    redis.call('ZADD', steps_key, next_version, ARGV[i])
-end
+# Max XREAD wait, proxies idle-kill connections around 60s
+STREAM_BLOCK_MS = 15_000
 
-redis.call('SET', version_key, next_version, 'EX', ttl_seconds)
-redis.call('EXPIRE', steps_key, ttl_seconds)
-return {1, next_version}
-"""
+# SSE lifetime cap - browser auto-reconnects via Last-Event-ID
+STREAM_LIFETIME_SECONDS = 5 * 60
+
+DATA_KEY = b"data"
+KEEPALIVE_COMMENT = b": keepalive\n\n"
 
 
 @dataclass
 class StepEntry:
     step: dict
     client_id: str
-    v: int  # ensures ZADD doesn't dedup identical steps across versions
 
 
 @dataclass
 class SubmitResult:
-    accepted: bool
+    # "accepted" - steps appended; `version` is the new top
+    # "conflict" - caller is behind; `version` is the current top, `steps_since` is the missed range
+    # "stale"    - missed range was trimmed (MAXLEN/TTL); caller must reload from Postgres
+    status: Literal["accepted", "conflict", "stale"]
     version: int
     steps_since: list[StepEntry] | None = None
 
 
-def initialize_collab_session(team_id: int, notebook_id: str, version: int) -> None:
-    """Seed the Redis version from Postgres if not already present."""
-    client = redis.get_client()
-    version_key = VERSION_KEY.format(team_id=team_id, notebook_id=notebook_id)
-    client.set(version_key, str(version), ex=TTL_SECONDS, nx=True)
+# Atomically append N step entries if the latest stream version equals last_seen_version.
+# If the stream is empty we trust the caller's last_seen_version,
+# frontend always loads it from Postgres and seed the stream from there.
+#
+# ARGV:
+#   1: last_seen_version (int)
+#   2: ttl_seconds (int)
+#   3: max_length (int)
+#   4..N: step entry JSON strings (one per prosemirror step)
+#
+# Returns:
+#   {0, current_version}     -- conflict, caller should fetch missed steps
+#   {1, new_version}         -- accepted
+_APPEND_STEPS_LUA = """
+local stream_key = KEYS[1]
+local last_seen_version = tonumber(ARGV[1])
+local ttl = tonumber(ARGV[2])
+local max_length = tonumber(ARGV[3])
+
+local current_version = last_seen_version
+local last = redis.call('XREVRANGE', stream_key, '+', '-', 'COUNT', 1)
+if #last > 0 then
+    local id_str = last[1][1]
+    local dash = string.find(id_str, '-')
+    current_version = tonumber(string.sub(id_str, 1, dash - 1))
+end
+
+if current_version ~= last_seen_version then
+    return {0, current_version}
+end
+
+local next_version = current_version
+for i = 4, #ARGV do
+    next_version = next_version + 1
+    redis.call('XADD', stream_key, 'MAXLEN', '~', max_length, next_version .. '-0', 'data', ARGV[i])
+end
+
+redis.call('EXPIRE', stream_key, ttl)
+return {1, next_version}
+"""
 
 
 def submit_steps(
@@ -65,40 +95,93 @@ def submit_steps(
     client_id: str,
     steps_json: list[dict],
     last_seen_version: int,
+    *,
+    user_id: int | None = None,
+    user_name: str | None = None,
+    cursor_head: int | None = None,
 ) -> SubmitResult:
-    """Try to submit steps at last_seen_version.
-    Version increments by len(steps), matching Prosemirror's per-step versioning.
-    If rejected, steps_since contains missed StepEntry items for rebase.
-    """
-    client = redis.get_client()
-    version_key = VERSION_KEY.format(team_id=team_id, notebook_id=notebook_id)
-    steps_key = STEPS_KEY.format(team_id=team_id, notebook_id=notebook_id)
+    client = redis_module.get_client()
+    stream_key = STREAM_KEY_PATTERN.format(team_id=team_id, notebook_id=notebook_id)
 
-    step_entries = [
-        json.dumps({"step": s, "client_id": client_id, "v": last_seen_version + i + 1})
-        for i, s in enumerate(steps_json)
-    ]
+    # Presence (author + cursor) is constant for the whole batch — build once, spread per step.
+    presence: dict[str, Any] = {
+        k: v for k, v in (("user_id", user_id), ("user_name", user_name), ("cursor_head", cursor_head)) if v is not None
+    }
+    # Version isn't in the payload — the stream id (N-0) IS the version, and SSE delivers it as `id:`.
+    serialized = [json.dumps({"step": step, "client_id": client_id, **presence}) for step in steps_json]
 
     script = client.register_script(_APPEND_STEPS_LUA)
     accepted, version = script(
-        keys=[version_key, steps_key],
-        args=[last_seen_version, TTL_SECONDS, *step_entries],
+        keys=[stream_key],
+        args=[last_seen_version, STREAM_TTL_SECONDS, STREAM_MAX_LENGTH, *serialized],
     )
-
-    if accepted == -1:
-        return SubmitResult(accepted=False, version=0)
 
     if accepted == 1:
-        return SubmitResult(accepted=True, version=version)
+        return SubmitResult(status="accepted", version=version)
 
-    # Rejected - fetch steps the client missed
-    raw = client.zrangebyscore(steps_key, f"({last_seen_version}", version)
+    return _fetch_missed_steps(stream_key, last_seen_version=last_seen_version, current_version=version)
 
-    if len(raw) < version - last_seen_version:
-        return SubmitResult(accepted=False, version=version, steps_since=None)
 
-    return SubmitResult(
-        accepted=False,
-        version=version,
-        steps_since=[StepEntry(**json.loads(r)) for r in raw],
-    )
+def _fetch_missed_steps(stream_key: str, *, last_seen_version: int, current_version: int) -> SubmitResult:
+    client = redis_module.get_client()
+    raw = client.xrange(stream_key, min=f"({last_seen_version}-0", max=f"{current_version}-0")
+
+    missed_steps: list[StepEntry] = []
+    for _stream_id, fields in raw:
+        data = json.loads(fields[DATA_KEY])
+        missed_steps.append(StepEntry(step=data["step"], client_id=data["client_id"]))
+
+    # MAXLEN/TTL trimmed part of the gap - incomplete rebase set, reload from Postgres
+    gap_size = current_version - last_seen_version
+    if len(missed_steps) < gap_size:
+        return SubmitResult(status="stale", version=current_version)
+
+    return SubmitResult(status="conflict", version=current_version, steps_since=missed_steps)
+
+
+async def stream_collab_sse(
+    team_id: int,
+    notebook_id: str,
+    *,
+    last_event_id: str | None,
+) -> AsyncGenerator[bytes, None]:
+    """
+    Tail this notebook's Redis stream from last_event_id (or from now if None).
+    Yields one SSE frame per step, plus a keepalive comment during idle gaps.
+    """
+    client = redis_module.get_async_client()
+    stream_key = STREAM_KEY_PATTERN.format(team_id=team_id, notebook_id=notebook_id)
+    current_id = last_event_id or "$"
+
+    try:
+        async with asyncio.timeout(STREAM_LIFETIME_SECONDS):
+            while True:
+                try:
+                    messages = await client.xread(
+                        {stream_key: current_id}, block=STREAM_BLOCK_MS, count=STREAM_READ_COUNT
+                    )
+                except redis_exceptions.RedisError as err:
+                    logger.warning("notebook_collab_stream_error", notebook_short_id=notebook_id, error=str(err))
+                    yield b'event: error\ndata: {"error":"stream error"}\n\n'
+                    return
+
+                if not messages:
+                    yield KEEPALIVE_COMMENT
+                    continue
+
+                # We only XREAD one stream key, so messages is always [(key, entries)]
+                _, entries = messages[0]
+                for stream_id, fields in entries:
+                    current_id = stream_id.decode()
+                    try:
+                        data = json.loads(fields[DATA_KEY])
+                    except json.JSONDecodeError:
+                        logger.warning("notebook_collab_invalid_payload", stream_key=stream_key, stream_id=current_id)
+                        continue
+                    yield f"id: {current_id}\nevent: step\ndata: {json.dumps(data, separators=(',', ':'))}\n\n".encode()
+
+                # cooperative yield: prevents tight-loop monopolization when XREAD doesn't block
+                await asyncio.sleep(0)
+    except TimeoutError:
+        # Lifetime cap hit; client reconnects with Last-Event-ID against a fresh worker
+        return

--- a/products/notebooks/backend/test/test_collab.py
+++ b/products/notebooks/backend/test/test_collab.py
@@ -4,58 +4,39 @@ from parameterized import parameterized
 
 from posthog import redis
 
-from products.notebooks.backend.collab import STEPS_KEY, StepEntry, initialize_collab_session, submit_steps
+from products.notebooks.backend.collab import STREAM_KEY_PATTERN, STREAM_MAX_LENGTH, StepEntry, submit_steps
 
 
 class TestNotebookCollab(BaseTest):
-    def test_initialize_collab_session_sets_version(self):
-        initialize_collab_session(self.team.pk, "nb1", 5)
+    def test_submit_to_empty_stream_seeds_position_from_caller(self):
+        # No init endpoint anymore — first writer trusts last_seen_version (loaded from Postgres).
         result = submit_steps(self.team.pk, "nb1", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 5)
-        assert result.accepted is True
+        assert result.status == "accepted"
         assert result.version == 6
 
-    def test_initialize_collab_session_does_not_overwrite(self):
-        initialize_collab_session(self.team.pk, "nb2", 5)
-        submit_steps(self.team.pk, "nb2", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 5)
-        # Re-initializing must not reset the version back to 5
-        initialize_collab_session(self.team.pk, "nb2", 5)
-        result = submit_steps(self.team.pk, "nb2", "client2", [{"stepType": "replace", "from": 0, "to": 0}], 6)
-        assert result.accepted is True
-        assert result.version == 7
-
     def test_submit_steps_accepted(self):
-        initialize_collab_session(self.team.pk, "nb3", 0)
         result = submit_steps(self.team.pk, "nb3", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 0)
-        assert result.accepted is True
+        assert result.status == "accepted"
         assert result.version == 1
 
     def test_submit_steps_rejected_on_version_mismatch(self):
-        initialize_collab_session(self.team.pk, "nb4", 0)
-        # First client advances the version
         submit_steps(self.team.pk, "nb4", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 0)
-        # Second client tries with stale version
         result = submit_steps(self.team.pk, "nb4", "client2", [{"stepType": "replace", "from": 1, "to": 1}], 0)
-        assert result.accepted is False
+        assert result.status == "conflict"
         assert result.version == 1
         assert result.steps_since == [
-            StepEntry(step={"stepType": "replace", "from": 0, "to": 0}, client_id="client1", v=1),
+            StepEntry(step={"stepType": "replace", "from": 0, "to": 0}, client_id="client1"),
         ]
 
     def test_submit_multiple_steps_as_batch(self):
-        initialize_collab_session(self.team.pk, "nb5", 0)
         steps = [
             {"stepType": "replace", "from": 0, "to": 0},
             {"stepType": "replace", "from": 1, "to": 1},
             {"stepType": "replace", "from": 2, "to": 2},
         ]
         result = submit_steps(self.team.pk, "nb5", "client1", steps, 0)
-        assert result.accepted is True
+        assert result.status == "accepted"
         assert result.version == 3
-
-    def test_submit_to_uninitialized_session(self):
-        result = submit_steps(self.team.pk, "uninitialized", "client1", [{"stepType": "replace"}], 0)
-        assert result.accepted is False
-        assert result.version == 0
 
     @parameterized.expand(
         [
@@ -64,7 +45,6 @@ class TestNotebookCollab(BaseTest):
         ]
     )
     def test_multiple_clients_sequential(self, _name, notebook_id, num_clients):
-        initialize_collab_session(self.team.pk, notebook_id, 0)
         expected_version = 0
         for i in range(num_clients):
             result = submit_steps(
@@ -74,23 +54,27 @@ class TestNotebookCollab(BaseTest):
                 [{"stepType": "replace", "from": i, "to": i}],
                 expected_version,
             )
-            assert result.accepted is True
+            assert result.status == "accepted"
             expected_version += 1
 
         assert expected_version == num_clients
 
-    def test_submit_steps_returns_none_when_steps_expired(self):
-        initialize_collab_session(self.team.pk, "nb_expired", 0)
-        # Advance version by submitting steps
-        submit_steps(self.team.pk, "nb_expired", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 0)
-        submit_steps(self.team.pk, "nb_expired", "client1", [{"stepType": "replace", "from": 1, "to": 1}], 1)
+    def test_submit_steps_returns_stale_when_stream_trimmed(self):
+        submit_steps(self.team.pk, "nb_trimmed", "client1", [{"stepType": "replace", "from": 0, "to": 0}], 0)
+        submit_steps(self.team.pk, "nb_trimmed", "client1", [{"stepType": "replace", "from": 1, "to": 1}], 1)
 
-        # Simulate Redis expiry by deleting the steps key
         client = redis.get_client()
-        client.delete(STEPS_KEY.format(team_id=self.team.pk, notebook_id="nb_expired"))
+        # Force-trim past version 1 to simulate MAXLEN/TTL eviction; version 2 (id 2-0) survives.
+        client.xtrim(
+            STREAM_KEY_PATTERN.format(team_id=self.team.pk, notebook_id="nb_trimmed"),
+            minid="2-0",
+        )
 
-        # Submit with stale version - version key still exists but steps are gone
-        result = submit_steps(self.team.pk, "nb_expired", "client2", [{"stepType": "replace", "from": 2, "to": 2}], 0)
-        assert result.accepted is False
+        result = submit_steps(self.team.pk, "nb_trimmed", "client2", [{"stepType": "replace", "from": 2, "to": 2}], 0)
+        assert result.status == "stale"
         assert result.version == 2
         assert result.steps_since is None
+
+    def test_stream_maxlen_constant_is_sane(self):
+        # Sanity: MAXLEN must comfortably hold an hour of edits. Adjust deliberately if changed.
+        assert STREAM_MAX_LENGTH >= 1000

--- a/products/notebooks/backend/test/test_collab_api.py
+++ b/products/notebooks/backend/test/test_collab_api.py
@@ -201,7 +201,7 @@ class TestNotebookCollabStreamAPI(APIBaseTest):
         return f"/api/projects/{team_id or self.team.id}/notebooks/{short_id}/collab/stream/"
 
     def _consume_stream(self, response) -> str:
-        return b"".join(response.streaming_content).decode("utf-8")  # type: ignore[attr-defined]
+        return b"".join(response.streaming_content).decode("utf-8")
 
     def test_stream_happy_path_delivers_pre_populated_step(self):
         notebook = self._create_notebook()

--- a/products/notebooks/backend/test/test_collab_api.py
+++ b/products/notebooks/backend/test/test_collab_api.py
@@ -1,9 +1,17 @@
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from django.conf import settings
+
+import fakeredis
 from rest_framework import status
 
-from products.notebooks.backend.collab import SubmitResult
+from posthog import redis as redis_module
+from posthog.models import Team
+from posthog.models.personal_api_key import PersonalAPIKey
+from posthog.models.utils import generate_random_token_personal, hash_key_value
+
+from products.notebooks.backend.collab import SubmitResult, submit_steps
 from products.notebooks.backend.models import Notebook
 
 SAMPLE_DOC = {"type": "doc", "content": [{"type": "heading", "content": [{"type": "text", "text": "Test"}]}]}
@@ -161,3 +169,161 @@ class TestNotebookCollabSaveAPI(APIBaseTest):
         assert response.status_code == status.HTTP_410_GONE
         data = response.json()
         assert data["code"] == "conflict_stale"
+
+
+# Keep the SSE generator lifetime tiny so tests terminate deterministically.
+# XREAD blocks until we either see data or hit this window;
+# then the keepalive loop unwinds and the lifetime cap fires, closing the stream.
+_TEST_STREAM_LIFETIME = 0.3
+_TEST_STREAM_BLOCK_MS = 50
+
+
+@patch("products.notebooks.backend.collab.STREAM_LIFETIME_SECONDS", _TEST_STREAM_LIFETIME)
+@patch("products.notebooks.backend.collab.STREAM_BLOCK_MS", _TEST_STREAM_BLOCK_MS)
+class TestNotebookCollabStreamAPI(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        # posthog.redis builds FakeRedis / FakeAsyncRedis with independent servers by default,
+        # so submit_steps (sync) and stream_collab_sse (async) wouldn't see each other's writes.
+        # Pin both to a shared FakeServer for these tests.
+        redis_module.TEST_clear_clients()
+        server = fakeredis.FakeServer()
+        redis_module._client_map[settings.REDIS_URL] = fakeredis.FakeRedis(server=server)
+        redis_module._test_async_client_map[settings.REDIS_URL] = fakeredis.FakeAsyncRedis(server=server)
+        self.addCleanup(redis_module.TEST_clear_clients)
+
+    def _create_notebook(self):
+        response = self.client.post(f"/api/projects/{self.team.id}/notebooks/", data={}, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+        return response.json()
+
+    def _stream_url(self, short_id: str, team_id: int | None = None) -> str:
+        return f"/api/projects/{team_id or self.team.id}/notebooks/{short_id}/collab/stream/"
+
+    def _consume_stream(self, response) -> str:
+        return b"".join(response.streaming_content).decode("utf-8")  # type: ignore[attr-defined]
+
+    def test_stream_happy_path_delivers_pre_populated_step(self):
+        notebook = self._create_notebook()
+        submit_steps(
+            self.team.pk,
+            notebook["short_id"],
+            "client-1",
+            [{"stepType": "replace", "from": 0, "to": 0}],
+            notebook["version"],
+        )
+
+        # Last-Event-ID=0-0 means "from the beginning of the stream", so the pre-populated
+        # entry is replayed on connect — same path a reconnecting client takes.
+        response = self.client.get(self._stream_url(notebook["short_id"]), HTTP_LAST_EVENT_ID="0-0")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response["Content-Type"] == "text/event-stream"
+        assert response["Cache-Control"] == "no-cache"
+        assert response["X-Accel-Buffering"] == "no"
+
+        body = self._consume_stream(response)
+        assert "event: step" in body
+        assert f"id: {notebook['version'] + 1}-0" in body
+        assert '"client_id":"client-1"' in body
+        assert '"stepType":"replace"' in body
+
+    def test_stream_resumes_past_last_event_id(self):
+        notebook = self._create_notebook()
+        base_version = notebook["version"]
+
+        submit_steps(
+            self.team.pk,
+            notebook["short_id"],
+            "client-A",
+            [{"stepType": "replace", "from": 0, "to": 0}],
+            base_version,
+        )
+        submit_steps(
+            self.team.pk,
+            notebook["short_id"],
+            "client-B",
+            [{"stepType": "replace", "from": 1, "to": 1}],
+            base_version + 1,
+        )
+
+        first_step_id = f"{base_version + 1}-0"
+        response = self.client.get(
+            self._stream_url(notebook["short_id"]),
+            HTTP_LAST_EVENT_ID=first_step_id,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        body = self._consume_stream(response)
+        assert '"client_id":"client-B"' in body
+        assert '"client_id":"client-A"' not in body
+        assert f"id: {base_version + 2}-0" in body
+
+    def test_stream_idle_emits_only_keepalives(self):
+        notebook = self._create_notebook()
+
+        # Fresh stream, no Last-Event-ID → server tails from "$" (only new entries).
+        # Nothing has been submitted, so we should see keepalives but no step frames.
+        response = self.client.get(self._stream_url(notebook["short_id"]))
+
+        assert response.status_code == status.HTTP_200_OK
+        body = self._consume_stream(response)
+        assert "event: step" not in body
+        assert ": keepalive" in body
+
+    def test_stream_requires_authentication(self):
+        notebook = self._create_notebook()
+        self.client.logout()
+
+        response = self.client.get(self._stream_url(notebook["short_id"]))
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_stream_returns_404_for_notebook_in_other_team(self):
+        other_team = Team.objects.create(organization=self.organization, api_token=self.CONFIG_API_TOKEN + "2")
+        other_notebook = Notebook.objects.create(
+            team=other_team, created_by=self.user, short_id="other-nb", title="other"
+        )
+
+        # URL pinned to our team, short_id belongs to the other team — queryset filters by team_id.
+        response = self.client.get(self._stream_url(other_notebook.short_id))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_stream_rejects_personal_api_key_without_notebook_read_scope(self):
+        notebook = self._create_notebook()
+
+        key_value = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            user=self.user,
+            label="wrong-scope-key",
+            secure_value=hash_key_value(key_value),
+            scopes=["dashboard:read"],
+        )
+        self.client.logout()
+
+        response = self.client.get(
+            self._stream_url(notebook["short_id"]),
+            HTTP_AUTHORIZATION=f"Bearer {key_value}",
+        )
+        # 403 response goes through ServerSentEventRenderer (the action-level renderer),
+        # so the body isn't JSON — just assert the gate fired.
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_stream_allows_personal_api_key_with_notebook_read_scope(self):
+        notebook = self._create_notebook()
+
+        key_value = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            user=self.user,
+            label="read-scope-key",
+            secure_value=hash_key_value(key_value),
+            scopes=["notebook:read"],
+        )
+        self.client.logout()
+
+        response = self.client.get(
+            self._stream_url(notebook["short_id"]),
+            HTTP_AUTHORIZATION=f"Bearer {key_value}",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        # Drain the generator so the background bridge thread terminates before the test ends.
+        self._consume_stream(response)

--- a/products/notebooks/backend/test/test_collab_api.py
+++ b/products/notebooks/backend/test/test_collab_api.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from rest_framework import status
 
-from products.notebooks.backend.collab import SubmitResult, initialize_collab_session
+from products.notebooks.backend.collab import SubmitResult
 from products.notebooks.backend.models import Notebook
 
 SAMPLE_DOC = {"type": "doc", "content": [{"type": "heading", "content": [{"type": "text", "text": "Test"}]}]}
@@ -34,13 +34,9 @@ class TestNotebookCollabSaveAPI(APIBaseTest):
             format="json",
         )
 
-    def _init_collab(self, notebook) -> int:
-        initialize_collab_session(self.team.pk, notebook["short_id"], notebook["version"])
-        return notebook["version"]
-
     def test_collab_save_accepted(self):
         notebook = self._create_notebook(SAMPLE_DOC)
-        version = self._init_collab(notebook)
+        version = notebook["version"]
 
         response = self._collab_save(
             notebook,
@@ -55,7 +51,7 @@ class TestNotebookCollabSaveAPI(APIBaseTest):
 
     def test_collab_save_persists_to_postgres(self):
         notebook = self._create_notebook(SAMPLE_DOC)
-        version = self._init_collab(notebook)
+        version = notebook["version"]
 
         self._collab_save(
             notebook,
@@ -72,7 +68,7 @@ class TestNotebookCollabSaveAPI(APIBaseTest):
 
     def test_collab_save_updates_title(self):
         notebook = self._create_notebook(SAMPLE_DOC)
-        version = self._init_collab(notebook)
+        version = notebook["version"]
 
         self._collab_save(
             notebook,
@@ -98,7 +94,7 @@ class TestNotebookCollabSaveAPI(APIBaseTest):
 
     def test_collab_save_rejected_stale_version(self):
         notebook = self._create_notebook(SAMPLE_DOC)
-        version = self._init_collab(notebook)
+        version = notebook["version"]
 
         # First client advances the version
         self._collab_save(
@@ -109,6 +105,8 @@ class TestNotebookCollabSaveAPI(APIBaseTest):
         )
 
         # Second client submits with stale version - gets 409 with missed steps
+        # plus the new server version. Client dedupes against any SSE-delivered
+        # copies and retries.
         response = self._collab_save(
             notebook,
             version=version,
@@ -120,11 +118,11 @@ class TestNotebookCollabSaveAPI(APIBaseTest):
         assert data["code"] == "conflict"
         assert data["steps"] == [{"stepType": "replace", "from": 0, "to": 0}]
         assert data["client_ids"] == ["client-1"]
-        assert "version" in data
+        assert data["version"] == version + 1
 
     def test_collab_save_returns_full_notebook_on_success(self):
         notebook = self._create_notebook(SAMPLE_DOC)
-        version = self._init_collab(notebook)
+        version = notebook["version"]
 
         response = self._collab_save(
             notebook,
@@ -152,9 +150,8 @@ class TestNotebookCollabSaveAPI(APIBaseTest):
     @patch("products.notebooks.backend.api.notebook.submit_steps")
     def test_collab_save_returns_410_when_steps_expired(self, mock_submit):
         notebook = self._create_notebook(SAMPLE_DOC)
-        self._init_collab(notebook)
 
-        mock_submit.return_value = SubmitResult(accepted=False, version=5, steps_since=None)
+        mock_submit.return_value = SubmitResult(status="stale", version=5, steps_since=None)
 
         response = self._collab_save(
             notebook,

--- a/products/notebooks/frontend/generated/api.schemas.ts
+++ b/products/notebooks/frontend/generated/api.schemas.ts
@@ -188,6 +188,11 @@ export interface NotebookCollabSaveApi {
     text_content?: string
     /** Updated notebook title. */
     title?: string
+    /**
+     * ProseMirror cursor head position after applying steps.
+     * @nullable
+     */
+    cursor_head?: number | null
 }
 
 export type NotebooksListParams = {

--- a/products/notebooks/frontend/generated/api.ts
+++ b/products/notebooks/frontend/generated/api.ts
@@ -199,6 +199,24 @@ export const notebooksCollabSaveCreate = async (
 /**
  * The API for interacting with Notebooks. This feature is in early access and the API can have breaking changes without announcement.
  */
+export const getNotebooksCollabStreamRetrieveUrl = (projectId: string, shortId: string) => {
+    return `/api/projects/${projectId}/notebooks/${shortId}/collab/stream/`
+}
+
+export const notebooksCollabStreamRetrieve = async (
+    projectId: string,
+    shortId: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getNotebooksCollabStreamRetrieveUrl(projectId, shortId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+/**
+ * The API for interacting with Notebooks. This feature is in early access and the API can have breaking changes without announcement.
+ */
 export const getNotebooksHogqlExecuteCreateUrl = (projectId: string, shortId: string) => {
     return `/api/projects/${projectId}/notebooks/${shortId}/hogql/execute/`
 }

--- a/products/notebooks/frontend/generated/api.zod.ts
+++ b/products/notebooks/frontend/generated/api.zod.ts
@@ -96,6 +96,7 @@ export const NotebooksCollabSaveCreateBody = /* @__PURE__ */ zod.object({
         .default(notebooksCollabSaveCreateBodyTextContentDefault)
         .describe('Plain text for search indexing.'),
     title: zod.string().optional().describe('Updated notebook title.'),
+    cursor_head: zod.number().nullish().describe('ProseMirror cursor head position after applying steps.'),
 })
 
 /**

--- a/products/notebooks/mcp/tools.yaml
+++ b/products/notebooks/mcp/tools.yaml
@@ -128,3 +128,6 @@ tools:
     notebooks-all-activity-retrieve:
         operation: notebooks_all_activity_retrieve
         enabled: false
+    notebooks-collab-stream-retrieve:
+        operation: notebooks_collab_stream_retrieve
+        enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -21860,6 +21860,11 @@ export namespace Schemas {
       text_content?: string;
       /** Updated notebook title. */
       title?: string;
+      /**
+       * ProseMirror cursor head position after applying steps.
+       * @nullable
+       */
+      cursor_head?: number | null;
     }
 
     export interface NotebookMinimal {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

Notebooks step delivery is request/response only right now (clients POST and get a 409 with missing steps). That means late writers lose, and there's no presence. We need real-time push!

The previous Redis implementatino (sorted set keyed by version) doesn't really fit a push model. There's no native way to tail it, so we'd have to bolt Pub/Sub on top and reconcile two sources - a step that lands in the ZSET via the Lua CAS, then re-published to subscribers, with no replay if the subscriber wasn't connected.

## Changes

- One **Redis Stream per notebook** replaces the old ZSET+hash buffer. Entry id directly encodes the prosemirror version, so ordering, version, and the SSE `Last-Event-ID` resume token are all the same number - nothing to reconcile.
- Append goes through a Lua compare-and-swap. Three outcomes: `accepted`, `conflict` (server returns the missed range so the client rebases), `stale` (stream got trimmed or expired → 410, client reloads from Postgres).
- New SSE endpoint at `GET …/collab/stream` tails the stream with `XREAD BLOCK 15s`. The 15s block doubles as keepalive cadence. Generator self-terminates at 5min so the browser cycles to a fresh worker via `Last-Event-ID` — invisible to the user, caps per-worker resource use. Same pattern as Max conversation streaming. Native async on ASGI (Granian), `async_to_sync` fallback for WSGI on self-hosted.
- `initialize_collab_session` seeds the stream from the Postgres version using `XADD` with explicit id

### **Why Streams over Pub/Sub**

- **Persistence + replay.** Pub/Sub drops messages for anyone not currently subscribed. Streams keep them, so `Last-Event-ID` reconnects (after deploys, network blips, the 5-min lifetime cycle) resume exactly where they left off with zero events lost.
- **One source of truth.** With Pub/Sub we'd need ZSET-for-state + Pub/Sub-for-delivery, and a reconciliation path between them on every reconnect (ZRANGE since version, then subscribe, then dedupe). With Streams the same `XADD` that commits the step also delivers it.
- **Persistence + replay.** Pub/Sub drops messages for anyone not currently subscribed. Streams keep them, so `Last-Event-ID` reconnects (after deploys, network blips, the 5-min lifetime cycle) resume exactly where they left off with zero events lost.

### **Notebooks** **usage** **and** **rollout**

Notebooks today: ~80 concurrent connections at peak (UTC morning), ~110 on weekday peaks. ~660 DAU on busy weekdays. Avg session ~6min. 

Plan: ship to **team-2 first**, monitor `redis-py` pool exhaustion + Redis latency. There's a connection cost - each SSE generator holds one Redis connection for the duration of `XREAD BLOCK` (15s). 1k concurrent SSE = ~1k connections. We currently share the default ~50-conn pool with Max. 

When concurrency scales beyond a couple hundred:  bump `max_connections` on the global async pool, or spin up a dedicated `aioredis` pool for notebook collab. Premature for current load. 

## How did you test this code?

<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

Backend unit tests in `test_collab.py` and API tests in `test_collab_api.py`

Locally on the frontend branch (will make a separated stacked PR). 

![2026-04-22 15.11.51.gif](https://app.graphite.com/user-attachments/assets/b0dc8b24-f823-4134-9cb8-146eeead8234.gif)

## Publish to changelog?

Not