### PR TITLE
fix(provisioning): require user consent for PKCE partners with existing users

### DIFF
--- a/ee/api/agentic_provisioning/test/test_account_requests.py
+++ b/ee/api/agentic_provisioning/test/test_account_requests.py
@@ -1,4 +1,6 @@
+import json
 from datetime import timedelta
+from urllib.parse import parse_qs, urlparse
 
 from unittest.mock import patch
 
@@ -280,8 +282,6 @@ class TestPKCEPartnerExistingUserConsent(StripeProvisioningTestBase):
         )
 
     def _post_as_pkce_partner(self, data: dict):
-        import json
-
         body = json.dumps(data).encode()
         return self.client.post(
             "/api/agentic/provisioning/account_requests",
@@ -324,21 +324,12 @@ class TestPKCEPartnerExistingUserConsent(StripeProvisioningTestBase):
         data = res.json()
 
         url = data["requires_auth"]["url"]
-        state = url.split("state=")[1].split("&")[0]
+        state = parse_qs(urlparse(url).query)["state"][0]
         pending = cache.get(f"{PENDING_AUTH_CACHE_PREFIX}{state}")
         assert pending is not None
         assert pending["email"] == "existing@example.com"
         assert pending["partner_id"] == str(self.pkce_partner.id)
         assert pending["scopes"] == ["query:read"]
-
-    def test_pkce_partner_existing_user_does_not_issue_code(self):
-        User.objects.create_and_join(
-            organization=self.organization, email="existing@example.com", password="testpass", first_name="Existing"
-        )
-        payload = self._account_request_payload()
-        res = self._post_as_pkce_partner(payload)
-        data = res.json()
-        assert "oauth" not in data
 
     def test_pkce_partner_new_user_still_gets_direct_code(self):
         payload = self._account_request_payload(email="brand_new@example.com")

--- a/ee/api/agentic_provisioning/test/test_account_requests.py
+++ b/ee/api/agentic_provisioning/test/test_account_requests.py
@@ -297,6 +297,8 @@ class TestPKCEPartnerExistingUserConsent(StripeProvisioningTestBase):
             "scopes": ["query:read"],
             "client_id": "pkce-test-partner",
             "confirmation_secret": "cs_test",
+            "code_challenge": "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+            "code_challenge_method": "S256",
             "expires_at": (timezone.now() + timedelta(minutes=10)).isoformat(),
             "orchestrator": {"type": "test", "account": "acct_123"},
         }
@@ -338,3 +340,14 @@ class TestPKCEPartnerExistingUserConsent(StripeProvisioningTestBase):
         data = res.json()
         assert data["type"] == "oauth"
         assert "code" in data["oauth"]
+
+    def test_pkce_partner_missing_code_challenge_returns_400(self):
+        User.objects.create_and_join(
+            organization=self.organization, email="existing@example.com", password="testpass", first_name="Existing"
+        )
+        payload = self._account_request_payload()
+        del payload["code_challenge"]
+        del payload["code_challenge_method"]
+        res = self._post_as_pkce_partner(payload)
+        assert res.status_code == 400
+        assert res.json()["error"]["code"] == "invalid_request"

--- a/ee/api/agentic_provisioning/test/test_account_requests.py
+++ b/ee/api/agentic_provisioning/test/test_account_requests.py
@@ -351,3 +351,17 @@ class TestPKCEPartnerExistingUserConsent(StripeProvisioningTestBase):
         res = self._post_as_pkce_partner(payload)
         assert res.status_code == 400
         assert res.json()["error"]["code"] == "invalid_request"
+
+    @parameterized.expand(
+        [
+            ("too_short", "abc"),
+            ("too_long", "A" * 129),
+            ("invalid_chars", "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw!cM"),
+        ]
+    )
+    def test_pkce_partner_malformed_code_challenge_returns_400(self, _name, challenge):
+        payload = self._account_request_payload(code_challenge=challenge)
+        res = self._post_as_pkce_partner(payload)
+        assert res.status_code == 400
+        assert res.json()["error"]["code"] == "invalid_request"
+        assert "code_challenge" in res.json()["error"]["message"]

--- a/ee/api/agentic_provisioning/test/test_account_requests.py
+++ b/ee/api/agentic_provisioning/test/test_account_requests.py
@@ -10,11 +10,12 @@ from django.utils import timezone
 from parameterized import parameterized
 from rest_framework.response import Response
 
+from posthog.models.oauth import OAuthApplication
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
 from posthog.models.user import User
 
-from ee.api.agentic_provisioning import AUTH_CODE_CACHE_PREFIX
+from ee.api.agentic_provisioning import AUTH_CODE_CACHE_PREFIX, PENDING_AUTH_CACHE_PREFIX
 from ee.api.agentic_provisioning.test.base import HMAC_SECRET, StripeProvisioningTestBase
 
 
@@ -246,3 +247,103 @@ class TestAccountRequests(StripeProvisioningTestBase):
         res = self._post_signed("/api/agentic/provisioning/account_requests", data=payload)
         assert res.status_code == 500
         assert res.json()["error"]["code"] == "account_creation_failed"
+
+    def test_hmac_partner_existing_user_still_gets_direct_code(self):
+        User.objects.create_and_join(
+            organization=self.organization, email="existing@example.com", password="testpass", first_name="Existing"
+        )
+        payload = self._account_request_payload(email="existing@example.com")
+        res = self._post_signed("/api/agentic/provisioning/account_requests", data=payload)
+        assert res.status_code == 200
+        assert res.json()["type"] == "oauth"
+        assert "code" in res.json()["oauth"]
+
+
+@override_settings(STRIPE_SIGNING_SECRET=HMAC_SECRET)
+class TestPKCEPartnerExistingUserConsent(StripeProvisioningTestBase):
+    def setUp(self):
+        super().setUp()
+        self.pkce_partner = OAuthApplication.objects.create(
+            client_id="pkce-test-partner",
+            name="PKCE Test Partner",
+            client_secret="",
+            client_type=OAuthApplication.CLIENT_PUBLIC,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://partner.example.com/callback",
+            algorithm="RS256",
+            is_first_party=True,
+            provisioning_auth_method="pkce",
+            provisioning_partner_type="test_partner",
+            provisioning_active=True,
+            provisioning_can_create_accounts=True,
+            provisioning_can_provision_resources=True,
+        )
+
+    def _post_as_pkce_partner(self, data: dict):
+        import json
+
+        body = json.dumps(data).encode()
+        return self.client.post(
+            "/api/agentic/provisioning/account_requests",
+            data=body,
+            content_type="application/json",
+            HTTP_API_VERSION="0.1d",
+        )
+
+    def _account_request_payload(self, **overrides):
+        payload = {
+            "id": "acctreq_pkce_test",
+            "email": "existing@example.com",
+            "scopes": ["query:read"],
+            "client_id": "pkce-test-partner",
+            "confirmation_secret": "cs_test",
+            "expires_at": (timezone.now() + timedelta(minutes=10)).isoformat(),
+            "orchestrator": {"type": "test", "account": "acct_123"},
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_pkce_partner_existing_user_returns_requires_auth(self):
+        User.objects.create_and_join(
+            organization=self.organization, email="existing@example.com", password="testpass", first_name="Existing"
+        )
+        payload = self._account_request_payload()
+        res = self._post_as_pkce_partner(payload)
+        assert res.status_code == 200
+        data = res.json()
+        assert data["type"] == "requires_auth"
+        assert "url" in data["requires_auth"]
+        assert "/api/agentic/authorize" in data["requires_auth"]["url"]
+
+    def test_pkce_partner_existing_user_creates_pending_auth(self):
+        User.objects.create_and_join(
+            organization=self.organization, email="existing@example.com", password="testpass", first_name="Existing"
+        )
+        payload = self._account_request_payload()
+        res = self._post_as_pkce_partner(payload)
+        data = res.json()
+
+        url = data["requires_auth"]["url"]
+        state = url.split("state=")[1].split("&")[0]
+        pending = cache.get(f"{PENDING_AUTH_CACHE_PREFIX}{state}")
+        assert pending is not None
+        assert pending["email"] == "existing@example.com"
+        assert pending["partner_id"] == str(self.pkce_partner.id)
+        assert pending["scopes"] == ["query:read"]
+
+    def test_pkce_partner_existing_user_does_not_issue_code(self):
+        User.objects.create_and_join(
+            organization=self.organization, email="existing@example.com", password="testpass", first_name="Existing"
+        )
+        payload = self._account_request_payload()
+        res = self._post_as_pkce_partner(payload)
+        data = res.json()
+        assert "oauth" not in data
+
+    def test_pkce_partner_new_user_still_gets_direct_code(self):
+        payload = self._account_request_payload(email="brand_new@example.com")
+        res = self._post_as_pkce_partner(payload)
+        assert res.status_code == 200
+        data = res.json()
+        assert data["type"] == "oauth"
+        assert "code" in data["oauth"]

--- a/ee/api/agentic_provisioning/test/test_e2e_flow.py
+++ b/ee/api/agentic_provisioning/test/test_e2e_flow.py
@@ -278,14 +278,26 @@ class TestE2EProvisioningFlow(StripeProvisioningTestBase):
         self.client.force_login(existing_user)
         res = self.client.get(auth_url)
 
-        # Single org + single team = auto-redirect to callback with auth code
+        # PKCE partners always go to the consent page, even for single-org/team
         assert res.status_code == 302
         redirect_url = res["Location"]
+        assert "/agentic/authorize?" in redirect_url
         parsed_redirect = urlparse(redirect_url)
-        assert parsed_redirect.netloc == "partner.example.com"
-        auth_code = parse_qs(parsed_redirect.query)["code"][0]
+        consent_state = parse_qs(parsed_redirect.query)["state"][0]
 
-        # 3. Partner exchanges auth code for tokens using PKCE
+        # 3. User approves on the consent page (simulated via agentic_authorize_confirm)
+        res = self.client.post(
+            "/api/agentic/authorize/confirm/",
+            data=json.dumps({"state": consent_state, "team_id": self.team.id}),
+            content_type="application/json",
+        )
+        assert res.status_code == 200
+        callback_redirect = res.json()["redirect_url"]
+        parsed_callback = urlparse(callback_redirect)
+        assert parsed_callback.netloc == "partner.example.com"
+        auth_code = parse_qs(parsed_callback.query)["code"][0]
+
+        # 4. Partner exchanges auth code for tokens using PKCE
         token_body = urlencode(
             {
                 "grant_type": "authorization_code",
@@ -305,7 +317,7 @@ class TestE2EProvisioningFlow(StripeProvisioningTestBase):
         access_token = token_data["access_token"]
         assert access_token.startswith("pha_")
 
-        # 4. Partner provisions a resource with the token
+        # 5. Partner provisions a resource with the token
         res = self.client.post(
             "/api/agentic/provisioning/resources",
             data=json.dumps({"service_id": "analytics"}).encode(),

--- a/ee/api/agentic_provisioning/test/test_e2e_flow.py
+++ b/ee/api/agentic_provisioning/test/test_e2e_flow.py
@@ -1,10 +1,15 @@
+import json
 import time
+import base64
+import hashlib
+import secrets
 from datetime import timedelta
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from django.test import override_settings
 from django.utils import timezone
 
+from posthog.models.oauth import OAuthApplication
 from posthog.models.user import User
 
 from ee.api.agentic_provisioning.signature import compute_signature
@@ -210,6 +215,103 @@ class TestE2EProvisioningFlow(StripeProvisioningTestBase):
             "/api/agentic/provisioning/resources",
             data={"service_id": "analytics"},
             token=access_token,
+        )
+        assert res.status_code == 200
+        assert res.json()["status"] == "complete"
+        assert "api_key" in res.json()["complete"]["access_configuration"]
+
+    def test_pkce_existing_user_consent_e2e(self):
+        """E2E: PKCE partner with existing user goes through browser consent flow."""
+        OAuthApplication.objects.create(
+            client_id="pkce-e2e-partner",
+            name="PKCE E2E Partner",
+            client_secret="",
+            client_type=OAuthApplication.CLIENT_PUBLIC,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://partner.example.com/callback",
+            algorithm="RS256",
+            is_first_party=True,
+            provisioning_auth_method="pkce",
+            provisioning_partner_type="test_partner",
+            provisioning_active=True,
+            provisioning_can_create_accounts=True,
+            provisioning_can_provision_resources=True,
+        )
+
+        existing_user = User.objects.create_and_join(
+            organization=self.organization,
+            email="consent-e2e@example.com",
+            password="testpass",
+            first_name="Consent",
+        )
+
+        # 1. Partner calls account_requests - gets requires_auth (not a direct code)
+        code_verifier = secrets.token_urlsafe(32)
+        code_challenge = (
+            base64.urlsafe_b64encode(hashlib.sha256(code_verifier.encode("ascii")).digest())
+            .rstrip(b"=")
+            .decode("ascii")
+        )
+        account_request = {
+            "id": "acctreq_consent_e2e",
+            "email": "consent-e2e@example.com",
+            "scopes": ["query:read"],
+            "client_id": "pkce-e2e-partner",
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "expires_at": (timezone.now() + timedelta(minutes=10)).isoformat(),
+            "orchestrator": {"type": "test", "account": "acct_e2e"},
+        }
+        res = self.client.post(
+            "/api/agentic/provisioning/account_requests",
+            data=json.dumps(account_request).encode(),
+            content_type="application/json",
+            HTTP_API_VERSION="0.1d",
+        )
+        assert res.status_code == 200
+        data = res.json()
+        assert data["type"] == "requires_auth"
+        auth_url = data["requires_auth"]["url"]
+        assert "/api/agentic/authorize" in auth_url
+
+        # 2. User logs in and visits the authorize URL
+        self.client.force_login(existing_user)
+        res = self.client.get(auth_url)
+
+        # Single org + single team = auto-redirect to callback with auth code
+        assert res.status_code == 302
+        redirect_url = res["Location"]
+        parsed_redirect = urlparse(redirect_url)
+        assert parsed_redirect.netloc == "partner.example.com"
+        auth_code = parse_qs(parsed_redirect.query)["code"][0]
+
+        # 3. Partner exchanges auth code for tokens using PKCE
+        token_body = urlencode(
+            {
+                "grant_type": "authorization_code",
+                "code": auth_code,
+                "code_verifier": code_verifier,
+            }
+        ).encode()
+        res = self.client.post(
+            "/api/agentic/oauth/token",
+            data=token_body,
+            content_type="application/x-www-form-urlencoded",
+            HTTP_API_VERSION="0.1d",
+        )
+        assert res.status_code == 200
+        token_data = res.json()
+        assert token_data["token_type"] == "bearer"
+        access_token = token_data["access_token"]
+        assert access_token.startswith("pha_")
+
+        # 4. Partner provisions a resource with the token
+        res = self.client.post(
+            "/api/agentic/provisioning/resources",
+            data=json.dumps({"service_id": "analytics"}).encode(),
+            content_type="application/json",
+            HTTP_API_VERSION="0.1d",
+            HTTP_AUTHORIZATION=f"Bearer {access_token}",
         )
         assert res.status_code == 200
         assert res.json()["status"] == "complete"

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -399,10 +399,19 @@ def _handle_existing_user(
     code_challenge: str = "",
     code_challenge_method: str = "S256",
 ) -> Response:
-    # PKCE/public clients must go through the browser consent flow so the
-    # user actively approves the partner.  Trusted server-to-server partners
-    # (HMAC) keep the direct-code path.
-    if partner and partner.provisioning_auth_method == "pkce":
+    # Only server-to-server partners with shared secrets skip consent.
+    # Everything else (pkce, future methods) requires browser approval.
+    TRUSTED_AUTH_METHODS = ("hmac", "bearer")
+    if partner and partner.provisioning_auth_method not in TRUSTED_AUTH_METHODS:
+        if not code_challenge:
+            return Response(
+                {
+                    "id": request_id,
+                    "type": "error",
+                    "error": {"code": "invalid_request", "message": "code_challenge is required for public clients"},
+                },
+                status=400,
+            )
         return _require_user_consent(
             request_id, user, scopes, partner_account_id, region, partner, code_challenge, code_challenge_method
         )
@@ -467,7 +476,7 @@ def _require_user_consent(
         timeout=PENDING_AUTH_TTL_SECONDS,
     )
 
-    auth_url = _build_authorize_url(state, scopes)
+    auth_url = _build_authorize_url(state, scopes, region=region)
 
     _capture_provisioning_event("account_request", "requires_auth", region=region)
 
@@ -596,8 +605,8 @@ def _handle_new_user(
     return Response({"id": request_id, "type": "oauth", "oauth": {"code": code}})
 
 
-def _build_authorize_url(confirmation_secret: str, scopes: list[str]) -> str:
-    base = settings.SITE_URL.rstrip("/")
+def _build_authorize_url(confirmation_secret: str, scopes: list[str], region: str = "") -> str:
+    base = _region_to_host(region).rstrip("/") if region else settings.SITE_URL.rstrip("/")
     params = urlencode({"state": confirmation_secret, "scope": " ".join(scopes)})
     return f"{base}/api/agentic/authorize?{params}"
 
@@ -644,19 +653,20 @@ def agentic_authorize(request: Any) -> HttpResponseBase:
         non_demo_teams = [team]
         _capture_provisioning_event("authorize", "auto_created_project", team_id=team.id)
 
-    # PKCE partners always show the consent page so the user explicitly approves.
-    # HMAC partners (Stripe) can auto-redirect for single-org/team users since
-    # they're trusted server-to-server integrations.
+    # Only trusted server-to-server partners can auto-redirect.
+    # All other partners (pkce, future methods) must see the consent page.
+    # No partner_id = legacy Stripe HMAC path (trusted).
+    TRUSTED_AUTH_METHODS = ("hmac", "bearer")
     partner_id = pending.get("partner_id", "")
-    is_pkce_partner = False
+    is_trusted_partner = not partner_id
     if partner_id:
         try:
             partner_app = OAuthApplication.objects.get(id=partner_id)
-            is_pkce_partner = partner_app.provisioning_auth_method == "pkce"
+            is_trusted_partner = partner_app.provisioning_auth_method in TRUSTED_AUTH_METHODS
         except OAuthApplication.DoesNotExist:
             pass
 
-    if not is_pkce_partner and len(memberships) == 1 and len(non_demo_teams) == 1:
+    if is_trusted_partner and len(memberships) == 1 and len(non_demo_teams) == 1:
         cache.delete(pending_key)
 
         organization = memberships[0].organization

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -399,6 +399,14 @@ def _handle_existing_user(
     code_challenge: str = "",
     code_challenge_method: str = "S256",
 ) -> Response:
+    # PKCE/public clients must go through the browser consent flow so the
+    # user actively approves the partner.  Trusted server-to-server partners
+    # (HMAC) keep the direct-code path.
+    if partner and partner.provisioning_auth_method == "pkce":
+        return _require_user_consent(
+            request_id, user, scopes, partner_account_id, region, partner, code_challenge, code_challenge_method
+        )
+
     team = _resolve_team_for_existing_user(user, team_id)
     if team is None:
         _capture_provisioning_event("account_request", "error", error_code="team_resolution_failed")
@@ -431,6 +439,45 @@ def _handle_existing_user(
     _capture_provisioning_event("account_request", "existing_user", region=region, team_id=team.id)
 
     return Response({"id": request_id, "type": "oauth", "oauth": {"code": code}})
+
+
+def _require_user_consent(
+    request_id: str,
+    user: User,
+    scopes: list[str],
+    partner_account_id: str,
+    region: str,
+    partner: OAuthApplication,
+    code_challenge: str,
+    code_challenge_method: str,
+) -> Response:
+    state = secrets.token_urlsafe(32)
+    pending_key = f"{PENDING_AUTH_CACHE_PREFIX}{state}"
+    cache.set(
+        pending_key,
+        {
+            "email": user.email,
+            "scopes": scopes,
+            "stripe_account_id": partner_account_id,
+            "partner_id": str(partner.id),
+            "region": region,
+            "code_challenge": code_challenge,
+            "code_challenge_method": code_challenge_method,
+        },
+        timeout=PENDING_AUTH_TTL_SECONDS,
+    )
+
+    auth_url = _build_authorize_url(state, scopes)
+
+    _capture_provisioning_event("account_request", "requires_auth", region=region)
+
+    return Response(
+        {
+            "id": request_id,
+            "type": "requires_auth",
+            "requires_auth": {"url": auth_url},
+        }
+    )
 
 
 def _resolve_team_for_existing_user(user: User, requested_team_id: int | None = None) -> Team | None:

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -663,8 +663,6 @@ def agentic_authorize(request: Any) -> HttpResponseBase:
         _capture_provisioning_event("authorize", "email_mismatch")
         return HttpResponseRedirect(f"{settings.SITE_URL}?error=email_mismatch")
 
-    scope = " ".join(pending.get("scopes", []))
-
     user = request.user
     memberships = list(user.organization_memberships.select_related("organization").all())
     if not memberships:
@@ -684,7 +682,6 @@ def agentic_authorize(request: Any) -> HttpResponseBase:
     TRUSTED_AUTH_METHODS = ("hmac", "bearer")
     partner_id = pending.get("partner_id", "")
     is_trusted_partner = not partner_id
-    partner_name = pending.get("partner_name", "")
     if partner_id:
         try:
             partner_app = OAuthApplication.objects.get(id=partner_id)
@@ -693,7 +690,6 @@ def agentic_authorize(request: Any) -> HttpResponseBase:
                 _capture_provisioning_event("authorize", "partner_deactivated")
                 return HttpResponseRedirect(f"{settings.SITE_URL}?error=partner_deactivated")
             is_trusted_partner = partner_app.provisioning_auth_method in TRUSTED_AUTH_METHODS
-            partner_name = partner_app.name
         except OAuthApplication.DoesNotExist:
             pass
 
@@ -730,11 +726,38 @@ def agentic_authorize(request: Any) -> HttpResponseBase:
 
     base = settings.SITE_URL.rstrip("/")
     sanitized_state = re.sub(r"[^A-Za-z0-9_\-]", "", state)
-    redirect_params: dict[str, str] = {"state": sanitized_state, "scope": scope}
-    if partner_name:
-        redirect_params["partner_name"] = partner_name
-    params = urlencode(redirect_params)
+    params = urlencode({"state": sanitized_state})
     return HttpResponseRedirect(f"{base}/agentic/authorize?{params}")
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def agentic_authorize_pending(request: Request) -> Response:
+    """Return server-verified partner name and scopes for a pending auth state.
+
+    The frontend calls this instead of reading from URL params, preventing
+    an attacker from spoofing the partner identity on the consent page.
+    """
+    state = request.query_params.get("state", "")
+    if not state or not _SAFE_STATE_RE.match(state):
+        return Response({"error": "invalid_state"}, status=400)
+
+    pending = cache.get(f"{PENDING_AUTH_CACHE_PREFIX}{state}")
+    if pending is None:
+        return Response({"error": "expired_or_invalid_state"}, status=400)
+
+    user = cast(User, request.user)
+    if user.email != pending["email"]:
+        return Response({"error": "email_mismatch"}, status=403)
+
+    return Response(
+        {
+            "partner_name": pending.get("partner_name", "the requesting app"),
+            "scopes": pending.get("scopes", []),
+        }
+    )
 
 
 @api_view(["POST"])

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -412,8 +412,25 @@ def _handle_existing_user(
                 },
                 status=400,
             )
+        validated_scopes = _validate_scopes(scopes)
+        if validated_scopes is None:
+            return Response(
+                {
+                    "id": request_id,
+                    "type": "error",
+                    "error": {"code": "invalid_scope", "message": "One or more requested scopes are not recognized"},
+                },
+                status=400,
+            )
         return _require_user_consent(
-            request_id, user, scopes, partner_account_id, region, partner, code_challenge, code_challenge_method
+            request_id,
+            user,
+            validated_scopes,
+            partner_account_id,
+            region,
+            partner,
+            code_challenge,
+            code_challenge_method,
         )
 
     team = _resolve_team_for_existing_user(user, team_id)
@@ -460,7 +477,16 @@ def _require_user_consent(
     code_challenge: str,
     code_challenge_method: str,
 ) -> Response:
+    # Dedup: overwrite any prior pending state for same partner+email so
+    # retries don't leave multiple live consent URLs.
+    dedup_key = f"pending_auth_state:{partner.id}:{user.email}"
+    old_state = cache.get(dedup_key)
+    if old_state:
+        cache.delete(f"{PENDING_AUTH_CACHE_PREFIX}{old_state}")
+
     state = secrets.token_urlsafe(32)
+    cache.set(dedup_key, state, timeout=PENDING_AUTH_TTL_SECONDS)
+
     pending_key = f"{PENDING_AUTH_CACHE_PREFIX}{state}"
     cache.set(
         pending_key,
@@ -469,6 +495,7 @@ def _require_user_consent(
             "scopes": scopes,
             "stripe_account_id": partner_account_id,
             "partner_id": str(partner.id),
+            "partner_name": partner.name,
             "region": region,
             "code_challenge": code_challenge,
             "code_challenge_method": code_challenge_method,
@@ -653,22 +680,24 @@ def agentic_authorize(request: Any) -> HttpResponseBase:
         non_demo_teams = [team]
         _capture_provisioning_event("authorize", "auto_created_project", team_id=team.id)
 
-    # Only trusted server-to-server partners can auto-redirect.
-    # All other partners (pkce, future methods) must see the consent page.
-    # No partner_id = legacy Stripe HMAC path (trusted).
+    # Re-check partner is still active (could have been deactivated since account_requests)
     TRUSTED_AUTH_METHODS = ("hmac", "bearer")
     partner_id = pending.get("partner_id", "")
     is_trusted_partner = not partner_id
+    partner_name = pending.get("partner_name", "")
     if partner_id:
         try:
             partner_app = OAuthApplication.objects.get(id=partner_id)
+            if not partner_app.provisioning_active:
+                cache.delete(pending_key)
+                _capture_provisioning_event("authorize", "partner_deactivated")
+                return HttpResponseRedirect(f"{settings.SITE_URL}?error=partner_deactivated")
             is_trusted_partner = partner_app.provisioning_auth_method in TRUSTED_AUTH_METHODS
+            partner_name = partner_app.name
         except OAuthApplication.DoesNotExist:
             pass
 
     if is_trusted_partner and len(memberships) == 1 and len(non_demo_teams) == 1:
-        cache.delete(pending_key)
-
         organization = memberships[0].organization
         team = non_demo_teams[0]
 
@@ -688,6 +717,7 @@ def agentic_authorize(request: Any) -> HttpResponseBase:
             },
             timeout=AUTH_CODE_TTL_SECONDS,
         )
+        cache.delete(pending_key)
 
         _capture_provisioning_event("authorize", "auto_redirect", team_id=team.id)
 
@@ -700,7 +730,10 @@ def agentic_authorize(request: Any) -> HttpResponseBase:
 
     base = settings.SITE_URL.rstrip("/")
     sanitized_state = re.sub(r"[^A-Za-z0-9_\-]", "", state)
-    params = urlencode({"state": sanitized_state, "scope": scope})
+    redirect_params: dict[str, str] = {"state": sanitized_state, "scope": scope}
+    if partner_name:
+        redirect_params["partner_name"] = partner_name
+    params = urlencode(redirect_params)
     return HttpResponseRedirect(f"{base}/agentic/authorize?{params}")
 
 
@@ -736,9 +769,20 @@ def agentic_authorize_confirm(request: Request) -> Response:
         _capture_provisioning_event("authorize_confirm", "team_not_accessible", team_id=team_id)
         return Response({"error": "team_not_accessible"}, status=403)
 
-    cache.delete(pending_key)
+    confirm_partner_id = pending.get("partner_id", "")
+    if confirm_partner_id:
+        try:
+            confirm_partner = OAuthApplication.objects.get(id=confirm_partner_id)
+            if not confirm_partner.provisioning_active:
+                cache.delete(pending_key)
+                _capture_provisioning_event("authorize_confirm", "partner_deactivated")
+                return Response({"error": "partner_deactivated"}, status=403)
+        except OAuthApplication.DoesNotExist:
+            pass
 
     code = secrets.token_urlsafe(32)
+    # Set auth code BEFORE deleting pending state so a cache hiccup
+    # between the two doesn't leave the user with no recovery path.
     cache.set(
         f"{AUTH_CODE_CACHE_PREFIX}{code}",
         {
@@ -754,6 +798,7 @@ def agentic_authorize_confirm(request: Request) -> Response:
         },
         timeout=AUTH_CODE_TTL_SECONDS,
     )
+    cache.delete(pending_key)
 
     callback_url = _get_callback_url(pending.get("partner_id", ""))
     sanitized_state = re.sub(r"[^A-Za-z0-9_\-]", "", state)
@@ -1665,6 +1710,35 @@ def _verify_hmac_if_present(request: Request) -> Response | None:
     if request.META.get("HTTP_STRIPE_SIGNATURE"):
         return verify_stripe_signature(request)
     return None
+
+
+ALLOWED_PROVISIONING_SCOPES = {
+    "customer_journey:read",
+    "query:read",
+    "conversation:read",
+    "conversation:write",
+    "experiment:read",
+    "feature_flag:read",
+    "insight:read",
+    "organization:read",
+    "person:read",
+    "project:read",
+    "ticket:read",
+    "ticket:write",
+    "user:read",
+    "hog_flow:read",
+    "hog_flow:write",
+}
+
+
+def _validate_scopes(scopes: list[str]) -> list[str] | None:
+    """Validate scopes against the allowlist. Returns filtered scopes or None if any are invalid."""
+    if not scopes:
+        return scopes
+    for scope in scopes:
+        if scope not in ALLOWED_PROVISIONING_SCOPES:
+            return None
+    return scopes
 
 
 def _error_response(code: str, message: str, resource_id: str = "", status: int = 400) -> Response:

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -349,11 +349,16 @@ def account_requests(request: Request) -> Response:
             },
             status=400,
         )
-    if code_challenge and (len(code_challenge) < 43 or len(code_challenge) > 128 or not re.fullmatch(r"[A-Za-z0-9_\-]+", code_challenge)):
+    if code_challenge and (
+        len(code_challenge) < 43 or len(code_challenge) > 128 or not re.fullmatch(r"[A-Za-z0-9_\-]+", code_challenge)
+    ):
         return Response(
             {
                 "type": "error",
-                "error": {"code": "invalid_request", "message": "code_challenge must be 43-128 characters using base64url charset"},
+                "error": {
+                    "code": "invalid_request",
+                    "message": "code_challenge must be 43-128 characters using base64url charset",
+                },
             },
             status=400,
         )

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -730,8 +730,6 @@ def agentic_authorize(request: Any) -> HttpResponseBase:
     return HttpResponseRedirect(f"{base}/agentic/authorize?{params}")
 
 
-@api_view(["POST"])
-@permission_classes([IsAuthenticated])
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def agentic_authorize_pending(request: Request) -> Response:

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -349,6 +349,14 @@ def account_requests(request: Request) -> Response:
             },
             status=400,
         )
+    if code_challenge and (len(code_challenge) < 43 or len(code_challenge) > 128 or not re.fullmatch(r"[A-Za-z0-9_\-]+", code_challenge)):
+        return Response(
+            {
+                "type": "error",
+                "error": {"code": "invalid_request", "message": "code_challenge must be 43-128 characters using base64url charset"},
+            },
+            status=400,
+        )
 
     region = (configuration.get("region") or "US").upper()
 

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -644,7 +644,19 @@ def agentic_authorize(request: Any) -> HttpResponseBase:
         non_demo_teams = [team]
         _capture_provisioning_event("authorize", "auto_created_project", team_id=team.id)
 
-    if len(memberships) == 1 and len(non_demo_teams) == 1:
+    # PKCE partners always show the consent page so the user explicitly approves.
+    # HMAC partners (Stripe) can auto-redirect for single-org/team users since
+    # they're trusted server-to-server integrations.
+    partner_id = pending.get("partner_id", "")
+    is_pkce_partner = False
+    if partner_id:
+        try:
+            partner_app = OAuthApplication.objects.get(id=partner_id)
+            is_pkce_partner = partner_app.provisioning_auth_method == "pkce"
+        except OAuthApplication.DoesNotExist:
+            pass
+
+    if not is_pkce_partner and len(memberships) == 1 and len(non_demo_teams) == 1:
         cache.delete(pending_key)
 
         organization = memberships[0].organization

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -281,6 +281,11 @@ urlpatterns: list[Any] = [
         name="agentic_authorize",
     ),
     path(
+        "api/agentic/authorize/pending/",
+        agentic_provisioning_views.agentic_authorize_pending,
+        name="agentic_authorize_pending",
+    ),
+    path(
         "api/agentic/authorize/confirm/",
         agentic_provisioning_views.agentic_authorize_confirm,
         name="agentic_authorize_confirm",

--- a/frontend/src/scenes/agentic/AgenticAuthorize.tsx
+++ b/frontend/src/scenes/agentic/AgenticAuthorize.tsx
@@ -22,6 +22,7 @@ export const AgenticAuthorize = (): JSX.Element => {
         allOrganizations,
         filteredTeams,
         allTeamsLoading,
+        pendingAuthLoading,
         state,
         partnerName,
         agenticAuthorization,
@@ -33,7 +34,7 @@ export const AgenticAuthorize = (): JSX.Element => {
         return <OAuthAuthorizeError title="Invalid request" description="Missing required state parameter." />
     }
 
-    if (allTeamsLoading) {
+    if (allTeamsLoading || pendingAuthLoading) {
         return (
             <div className="flex items-center justify-center h-full py-12">
                 <Spinner />

--- a/frontend/src/scenes/agentic/AgenticAuthorize.tsx
+++ b/frontend/src/scenes/agentic/AgenticAuthorize.tsx
@@ -23,6 +23,7 @@ export const AgenticAuthorize = (): JSX.Element => {
         filteredTeams,
         allTeamsLoading,
         state,
+        partnerName,
         agenticAuthorization,
         isAgenticAuthorizationSubmitting,
     } = useValues(agenticAuthorizeLogic)
@@ -47,10 +48,10 @@ export const AgenticAuthorize = (): JSX.Element => {
             <div className="max-w-2xl mx-auto py-8 px-4 sm:py-12 sm:px-6">
                 <div className="text-center mb-4 sm:mb-8">
                     <h2 className="text-xl sm:text-2xl font-semibold">
-                        Authorize <strong>Stripe</strong>
+                        Authorize <strong>{partnerName}</strong>
                     </h2>
                     <p className="text-muted mt-2 text-sm sm:text-base">
-                        Stripe is requesting access to your PostHog project.
+                        {partnerName} is requesting access to your PostHog project.
                     </p>
                 </div>
 
@@ -131,7 +132,7 @@ export const AgenticAuthorize = (): JSX.Element => {
                                 disabledReason={isAgenticAuthorizationSubmitting ? 'Authorizing...' : undefined}
                                 onClick={() => submitAgenticAuthorization()}
                             >
-                                Authorize Stripe
+                                Authorize {partnerName}
                             </LemonButton>
                         </div>
                     </LemonCard>

--- a/frontend/src/scenes/agentic/agenticAuthorizeLogic.ts
+++ b/frontend/src/scenes/agentic/agenticAuthorizeLogic.ts
@@ -103,7 +103,7 @@ export const agenticAuthorizeLogic = kea<agenticAuthorizeLogicType>([
                 if (!selectedOrgId) {
                     return []
                 }
-                return allTeams.filter((team) => String(team.organization) === String(selectedOrgId))
+                return allTeams.filter((team) => String(team.organization) === String(selectedOrgId) && !team.is_demo)
             },
         ],
         partnerName: [

--- a/frontend/src/scenes/agentic/agenticAuthorizeLogic.ts
+++ b/frontend/src/scenes/agentic/agenticAuthorizeLogic.ts
@@ -24,12 +24,10 @@ export const agenticAuthorizeLogic = kea<agenticAuthorizeLogicType>([
         values: [userLogic, ['user']],
     })),
     actions({
-        setScopes: (scopes: string[]) => ({ scopes }),
         setState: (state: string) => ({ state }),
-        setPartnerName: (partnerName: string) => ({ partnerName }),
         cancel: true,
     }),
-    loaders({
+    loaders(({ values }) => ({
         allTeams: [
             null as TeamBasicType[] | null,
             {
@@ -38,24 +36,20 @@ export const agenticAuthorizeLogic = kea<agenticAuthorizeLogicType>([
                 },
             },
         ],
-    }),
-    reducers({
-        scopes: [
-            [] as string[],
+        pendingAuth: [
+            null as { partner_name: string; scopes: string[] } | null,
             {
-                setScopes: (_, { scopes }) => scopes,
+                loadPendingAuth: async () => {
+                    return await api.get(`api/agentic/authorize/pending/?state=${encodeURIComponent(values.state)}`)
+                },
             },
         ],
+    })),
+    reducers({
         state: [
             '' as string,
             {
                 setState: (_, { state }) => state,
-            },
-        ],
-        partnerName: [
-            'the requesting app' as string,
-            {
-                setPartnerName: (_, { partnerName }) => partnerName,
             },
         ],
     }),
@@ -112,6 +106,18 @@ export const agenticAuthorizeLogic = kea<agenticAuthorizeLogicType>([
                 return allTeams.filter((team) => String(team.organization) === String(selectedOrgId))
             },
         ],
+        partnerName: [
+            (s) => [s.pendingAuth],
+            (pendingAuth: { partner_name: string; scopes: string[] } | null): string => {
+                return pendingAuth?.partner_name ?? 'the requesting app'
+            },
+        ],
+        scopes: [
+            (s) => [s.pendingAuth],
+            (pendingAuth: { partner_name: string; scopes: string[] } | null): string[] => {
+                return pendingAuth?.scopes ?? []
+            },
+        ],
         scopeDescriptions: [
             (s) => [s.scopes],
             (scopes: string[]): string[] => {
@@ -126,13 +132,10 @@ export const agenticAuthorizeLogic = kea<agenticAuthorizeLogicType>([
                 return
             }
             const state = (searchParams['state'] as string) ?? ''
-            const requestedScopes = searchParams['scope']?.split(' ')?.filter((scope: string) => scope.length) ?? []
-            const partnerName = (searchParams['partner_name'] as string) ?? ''
 
             actions.setState(state)
-            actions.setScopes(requestedScopes)
-            if (partnerName) {
-                actions.setPartnerName(partnerName)
+            if (state) {
+                actions.loadPendingAuth()
             }
             actions.loadAllTeams()
         }

--- a/frontend/src/scenes/agentic/agenticAuthorizeLogic.ts
+++ b/frontend/src/scenes/agentic/agenticAuthorizeLogic.ts
@@ -26,6 +26,7 @@ export const agenticAuthorizeLogic = kea<agenticAuthorizeLogicType>([
     actions({
         setScopes: (scopes: string[]) => ({ scopes }),
         setState: (state: string) => ({ state }),
+        setPartnerName: (partnerName: string) => ({ partnerName }),
         cancel: true,
     }),
     loaders({
@@ -49,6 +50,12 @@ export const agenticAuthorizeLogic = kea<agenticAuthorizeLogicType>([
             '' as string,
             {
                 setState: (_, { state }) => state,
+            },
+        ],
+        partnerName: [
+            'the requesting app' as string,
+            {
+                setPartnerName: (_, { partnerName }) => partnerName,
             },
         ],
     }),
@@ -120,9 +127,13 @@ export const agenticAuthorizeLogic = kea<agenticAuthorizeLogicType>([
             }
             const state = (searchParams['state'] as string) ?? ''
             const requestedScopes = searchParams['scope']?.split(' ')?.filter((scope: string) => scope.length) ?? []
+            const partnerName = (searchParams['partner_name'] as string) ?? ''
 
             actions.setState(state)
             actions.setScopes(requestedScopes)
+            if (partnerName) {
+                actions.setPartnerName(partnerName)
+            }
             actions.loadAllTeams()
         }
 


### PR DESCRIPTION
## Problem

When a provisioning partner calls `account_requests` with an email that matches an existing PostHog user, the API immediately returns an auth code giving the partner access to the user's project without any consent.

This was added in https://github.com/PostHog/posthog/pull/53348 specifically for Stripe (HMAC-signed, trusted). But the direct-code path was applied to ALL partners, not just HMAC ones. Any PKCE/public client partner could get an access token for an existing user's project just by knowing their email.

We confirmed the Wizard (the only active PKCE partner in prod) had this vulnerability live, verified it was only hit by test traffic, and disabled it in Django admin.

## Changes

### Core consent fix
- Non-trusted partners (anything not HMAC/bearer) now get `{"type": "requires_auth"}` instead of a direct auth code for existing users
- Uses a default-deny allowlist (`TRUSTED_AUTH_METHODS = ("hmac", "bearer")`) so new auth methods require consent by default
- PKCE partners always go through the frontend consent page, even for single-org/single-team users (no auto-redirect shortcut)

### Consent flow hardening
- **Scope validation**: scopes validated against an allowlist, returns `invalid_scope` for unrecognized values
- **code_challenge required**: PKCE partners without code_challenge rejected early with 400
- **State dedup**: pending auth keyed by `(partner_id, email)` so retries overwrite prior entries
- **Re-check provisioning_active**: both `agentic_authorize` and `agentic_authorize_confirm` re-check the partner is still active before minting codes
- **Cache ordering**: auth code set BEFORE pending state deleted to prevent unrecoverable state on cache failures
- **Region-aware URL**: authorize URL uses `_region_to_host(region)` instead of `settings.SITE_URL` so cache entry and user session land on the same region

### Frontend
- Consent page fetches partner name and scopes from new `GET /api/agentic/authorize/pending/` endpoint instead of URL params (prevents partner identity spoofing)
- Displays actual partner name instead of hardcoded "Stripe"
- Filters demo teams from project picker (backend rejects them, so they shouldn't appear in the UI)

## How did you test this code?

- 4 integration tests covering PKCE consent flow, code_challenge validation, and HMAC backward compatibility
- 1 e2e test: account_requests -> requires_auth -> authorize -> consent page -> authorize_confirm -> PKCE token exchange -> resource provisioning
- 199 existing provisioning tests pass
- Visually tested consent page in sandbox - confirmed partner name, scopes, org/project picker all render correctly
- Full browser click-through tested in sandbox: select org -> select project -> click Authorize -> redirected to partner callback with auth code
- Probed US production to confirm Wizard vulnerability existed and was only hit by test traffic

## Publish to changelog?

No

## Docs update

N/A

## LLM context

Security fix - must land before the CIMD self-serve provisioning branch (PR #55620). The Wizard app has been disabled in Django admin on US prod until this merges. Discovered via RFC review that PR #53348 accidentally applied a Stripe-specific optimization (direct auth codes for existing users) to all partner types.