### PR TITLE
feat(logs-alerts): switch from alert modal to alert page for creation and editing

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -100,10 +100,8 @@ export const productScenes: Record<string, () => Promise<any>> = {
     LLMAnalyticsClusters: () => import('../../products/llm_analytics/frontend/clusters/LLMAnalyticsClustersScene'),
     LLMAnalyticsCluster: () => import('../../products/llm_analytics/frontend/clusters/LLMAnalyticsClusterScene'),
     Logs: () => import('../../products/logs/frontend/LogsScene'),
-    LogsAlertNew: () =>
-        import('../../products/logs/frontend/scenes/LogsAlertNewScene/LogsAlertNewScene'),
-    LogsAlertDetail: () =>
-        import('../../products/logs/frontend/scenes/LogsAlertDetailScene/LogsAlertDetailScene'),
+    LogsAlertNew: () => import('../../products/logs/frontend/scenes/LogsAlertNewScene/LogsAlertNewScene'),
+    LogsAlertDetail: () => import('../../products/logs/frontend/scenes/LogsAlertDetailScene/LogsAlertDetailScene'),
     ManagedMigration: () => import('../../products/managed_migrations/frontend/ManagedMigration'),
     ManagedMigrationNew: () => import('../../products/managed_migrations/frontend/ManagedMigration'),
     Metrics: () => import('../../products/metrics/frontend/MetricsScene'),
@@ -467,20 +465,8 @@ export const productConfiguration: Record<string, any> = {
         iconType: 'logs',
         description: 'Monitor and analyze your logs to understand and fix issues.',
     },
-    LogsAlertNew: {
-        projectBased: true,
-        name: 'New log alert',
-        activityScope: ActivityScope.LOG,
-        layout: 'app-container',
-        iconType: 'logs',
-    },
-    LogsAlertDetail: {
-        projectBased: true,
-        name: 'Manage log alert',
-        activityScope: ActivityScope.LOG,
-        layout: 'app-container',
-        iconType: 'logs',
-    },
+    LogsAlertNew: { projectBased: true, name: 'New alert', activityScope: ActivityScope.LOG, layout: 'app-container' },
+    LogsAlertDetail: { projectBased: true, name: 'Alert', activityScope: ActivityScope.LOG, layout: 'app-container' },
     ManagedMigration: { name: 'Managed migrations', projectBased: true },
     ManagedMigrationNew: { name: 'Managed migrations', projectBased: true },
     Metrics: {
@@ -1490,7 +1476,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         iconColor: ['var(--color-product-logs-light)'] as FileSystemIconColor,
         href: urls.logs(),
         sceneKey: 'Logs',
-        sceneKeys: ['Logs'],
+        sceneKeys: ['Logs', 'LogsAlertNew', 'LogsAlertDetail'],
     },
     {
         path: 'Marketing analytics',

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -100,6 +100,10 @@ export const productScenes: Record<string, () => Promise<any>> = {
     LLMAnalyticsClusters: () => import('../../products/llm_analytics/frontend/clusters/LLMAnalyticsClustersScene'),
     LLMAnalyticsCluster: () => import('../../products/llm_analytics/frontend/clusters/LLMAnalyticsClusterScene'),
     Logs: () => import('../../products/logs/frontend/LogsScene'),
+    LogsAlertNew: () =>
+        import('../../products/logs/frontend/scenes/LogsAlertNewScene/LogsAlertNewScene'),
+    LogsAlertDetail: () =>
+        import('../../products/logs/frontend/scenes/LogsAlertDetailScene/LogsAlertDetailScene'),
     ManagedMigration: () => import('../../products/managed_migrations/frontend/ManagedMigration'),
     ManagedMigrationNew: () => import('../../products/managed_migrations/frontend/ManagedMigration'),
     Metrics: () => import('../../products/metrics/frontend/MetricsScene'),
@@ -188,6 +192,8 @@ export const productRoutes: Record<string, [string, string]> = {
     '/llm-analytics/clusters/:runId': ['LLMAnalyticsClusters', 'llmAnalyticsClusters'],
     '/llm-analytics/clusters/:runId/:clusterId': ['LLMAnalyticsCluster', 'llmAnalyticsCluster'],
     '/logs': ['Logs', 'logs'],
+    '/logs/alerts/new': ['LogsAlertNew', 'logsAlertNew'],
+    '/logs/alerts/:id': ['LogsAlertDetail', 'logsAlertDetail'],
     '/managed_migrations': ['ManagedMigration', 'managedMigration'],
     '/managed_migrations/new': ['ManagedMigration', 'managedMigration'],
     '/metrics': ['Metrics', 'metrics'],
@@ -460,6 +466,20 @@ export const productConfiguration: Record<string, any> = {
         layout: 'app-container',
         iconType: 'logs',
         description: 'Monitor and analyze your logs to understand and fix issues.',
+    },
+    LogsAlertNew: {
+        projectBased: true,
+        name: 'New log alert',
+        activityScope: ActivityScope.LOG,
+        layout: 'app-container',
+        iconType: 'logs',
+    },
+    LogsAlertDetail: {
+        projectBased: true,
+        name: 'Manage log alert',
+        activityScope: ActivityScope.LOG,
+        layout: 'app-container',
+        iconType: 'logs',
     },
     ManagedMigration: { name: 'Managed migrations', projectBased: true },
     ManagedMigrationNew: { name: 'Managed migrations', projectBased: true },
@@ -767,6 +787,9 @@ export const productUrls = {
     llmAnalyticsCluster: (runId: string, clusterId: number): string =>
         `/llm-analytics/clusters/${encodeURIComponent(runId)}/${clusterId}`,
     logs: (): string => '/logs',
+    logsAlertNew: (): string => '/logs/alerts/new',
+    logsAlertDetail: (id: string, tab?: string): string =>
+        tab ? `/logs/alerts/${id}?tab=${tab}` : `/logs/alerts/${id}`,
     managedMigration: (): string => '/managed_migrations',
     managedMigrationNew: (): string => '/managed_migrations/new',
     marketingAnalyticsApp: (): string => '/marketing',

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -186,6 +186,8 @@ export enum Scene {
     LLMAnalyticsTrace = 'LLMAnalyticsTrace',
     LLMAnalyticsUsers = 'LLMAnalyticsUsers',
     Logs = 'Logs',
+    LogsAlertNew = 'LogsAlertNew',
+    LogsAlertDetail = 'LogsAlertDetail',
     ManagedMigration = 'ManagedMigration',
     ManagedMigrationNew = 'ManagedMigrationNew',
     MarketingAnalytics = 'MarketingAnalytics',

--- a/playwright/e2e/logs/logs-alerts.spec.ts
+++ b/playwright/e2e/logs/logs-alerts.spec.ts
@@ -1,17 +1,19 @@
 import { randomString } from '../../utils'
+import { mockFeatureFlags } from '../../utils/mockApi'
 import { expect, test } from '../../utils/playwright-test-base'
 
-test.describe('Logs Alerts CRUD', () => {
+test.describe('Logs Alerts', () => {
     const ALERTS_API = '**/api/projects/*/logs/alerts/'
     const ALERTS_API_DETAIL = '**/api/projects/*/logs/alerts/*/'
+    const SPARKLINE_API = '**/api/environments/*/logs/sparkline/'
 
     const makeAlert = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
         id: '019d-test-alert-id',
         name: 'Test Alert',
-        enabled: true,
+        enabled: false,
         state: 'not_firing',
-        filters: { severityLevels: ['error'], serviceNames: ['api-gateway'] },
-        threshold_count: 50,
+        filters: { severityLevels: ['error'], serviceNames: [] },
+        threshold_count: 100,
         threshold_operator: 'above',
         window_minutes: 10,
         evaluation_periods: 1,
@@ -20,15 +22,11 @@ test.describe('Logs Alerts CRUD', () => {
         ...overrides,
     })
 
-    // The kea-forms <Form> renders as <form class="LemonModal__layout">
-    const formModal = 'form.LemonModal__layout'
-
-    test('creates an alert, verifies edit populates persisted values, edits, and deletes', async ({ page }) => {
+    test('creates, edits, and deletes an alert via the page-based flow', async ({ page }) => {
         const alertName = randomString('alert')
         let createdAlert: Record<string, unknown> | null = null
 
-        await test.step('mock APIs and navigate to alerts', async () => {
-            // Mock the alerts list and create endpoints
+        await test.step('mock APIs and navigate to alerts tab', async () => {
             await page.route(ALERTS_API, async (route) => {
                 const method = route.request().method()
                 if (method === 'GET') {
@@ -39,11 +37,7 @@ test.describe('Logs Alerts CRUD', () => {
                     })
                 } else if (method === 'POST') {
                     const body = route.request().postDataJSON()
-                    createdAlert = makeAlert({
-                        ...body,
-                        id: '019d-created-alert-id',
-                        name: body.name,
-                    })
+                    createdAlert = makeAlert({ ...body, id: '019d-created-alert-id', name: body.name })
                     await route.fulfill({
                         status: 201,
                         contentType: 'application/json',
@@ -56,7 +50,13 @@ test.describe('Logs Alerts CRUD', () => {
 
             await page.route(ALERTS_API_DETAIL, async (route) => {
                 const method = route.request().method()
-                if (method === 'PATCH') {
+                if (method === 'GET') {
+                    await route.fulfill({
+                        status: 200,
+                        contentType: 'application/json',
+                        body: JSON.stringify(createdAlert ?? {}),
+                    })
+                } else if (method === 'PATCH') {
                     const body = route.request().postDataJSON()
                     createdAlert = { ...createdAlert, ...body }
                     await route.fulfill({
@@ -67,118 +67,105 @@ test.describe('Logs Alerts CRUD', () => {
                 } else if (method === 'DELETE') {
                     createdAlert = null
                     await route.fulfill({ status: 204 })
-                } else if (method === 'GET') {
-                    if (!createdAlert) {
-                        await route.fulfill({ status: 404 })
-                        return
-                    }
-                    await route.fulfill({
-                        status: 200,
-                        contentType: 'application/json',
-                        body: JSON.stringify(createdAlert),
-                    })
                 } else {
                     await route.continue()
                 }
             })
 
-            // Inject the logs-alerting feature flag before the app hydrates.
-            // The settings map gates the Alerting section behind this flag.
-            await page.addInitScript(() => {
-                let _context: any
-                Object.defineProperty(window, 'POSTHOG_APP_CONTEXT', {
-                    get() {
-                        return _context
-                    },
-                    set(value: any) {
-                        if (value) {
-                            value.persisted_feature_flags = [
-                                ...(value.persisted_feature_flags || []),
-                                'logs-settings',
-                                'logs-alerting',
-                            ]
-                        }
-                        _context = value
-                    },
-                    configurable: true,
+            await page.route(SPARKLINE_API, async (route) => {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify([]),
                 })
             })
 
-            await page.goto('/project/1/settings/environment-logs')
-            await expect(page.getByRole('heading', { name: 'Alerting' })).toBeVisible({ timeout: 15000 })
-            // Wait for the mocked empty alerts list to render
-            await expect(page.getByText('No alerts configured yet.')).toBeVisible()
+            // logsAlertNotificationLogic fetches hog functions on mount; mocking it prevents
+            // the loadExistingHogFunctionsSuccess → loadAlert → resetAlertForm race that
+            // would wipe form changes made during the test.
+            await page.route(
+                (url) => url.pathname.includes('/hog_functions'),
+                async (route) => {
+                    await route.fulfill({
+                        status: 200,
+                        contentType: 'application/json',
+                        body: JSON.stringify({ results: [], count: 0 }),
+                    })
+                }
+            )
+
+            await mockFeatureFlags(page, { 'logs-tabbed-view': true, 'logs-alerting': true })
+
+            await page.goto('/project/1/logs?activeTab=alerts')
+            // loginBeforeTests navigates to the project root before our mocks are registered,
+            // so posthog-js may have already cached flags. Force a reload to pick up our mock.
+            await page.evaluate(() => void (window as any).posthog?.reloadFeatureFlags?.())
+            await expect(page.getByText('No alerts configured yet.')).toBeVisible({ timeout: 15000 })
         })
 
-        await test.step('create an alert with severity filter', async () => {
-            await page.getByRole('button', { name: 'New alert' }).click()
-            await expect(page.locator(formModal)).toBeVisible()
+        await test.step('navigate to the new alert page', async () => {
+            await page.getByRole('link', { name: 'New alert' }).click()
+            await page.waitForURL('**/logs/alerts/new')
+        })
 
-            // Fill in name
-            await page.locator(formModal).getByPlaceholder('e.g. API 5xx errors').fill(alertName)
+        await test.step('set name — Create draft stays disabled until a filter is added', async () => {
+            await page.getByTestId('scene-name').locator('button').first().click()
+            await expect(page.getByTestId('scene-title-textarea')).toBeVisible()
+            await page.getByTestId('scene-title-textarea').fill(alertName)
+            await page.keyboard.press('Tab')
 
-            // Select severity — panels are already expanded via defaultActiveKeys
-            await page.locator(formModal).getByTestId('logs-severity-filter').click()
+            await expect(page.getByRole('button', { name: 'Create draft' })).toBeDisabled()
+        })
+
+        await test.step('add severity filter and create the draft', async () => {
+            await page.getByTestId('logs-severity-filter').click()
             await page.locator('[data-attr="logs-severity-option-error"]').click()
-            // Close dropdown by clicking elsewhere in the modal, not Escape (which closes the modal)
-            await page.locator(formModal).getByPlaceholder('e.g. API 5xx errors').click()
+            // Close the dropdown by clicking the Filters heading
+            await page.getByRole('heading', { name: 'Filters' }).click()
 
-            // Submit the form
-            await page.locator(formModal).getByRole('button', { name: 'Create alert' }).click()
+            await expect(page.getByRole('button', { name: 'Create draft' })).toBeEnabled()
+            await page.getByRole('button', { name: 'Create draft' }).click()
 
-            // Assert modal closes and success toast
-            await expect(page.locator(formModal)).not.toBeVisible()
-            await expect(page.getByText('Alert created')).toBeVisible()
+            await page.waitForURL('**/logs/alerts/019d-created-alert-id')
+            await expect(page.getByText('Draft alert created')).toBeVisible()
         })
 
-        await test.step('verify alert appears in list', async () => {
-            await expect(page.getByRole('button', { name: alertName })).toBeVisible()
+        await test.step('detail page shows persisted name and settings', async () => {
+            await expect(page.getByTestId('scene-name')).toContainText(alertName)
+            // exact: true avoids matching the "This alert is disabled — no checks are running." banner
+            await expect(page.getByText('Disabled', { exact: true })).toBeVisible()
+            // Wait for the form to load, then check severity persisted from creation
+            await expect(page.getByTestId('logs-severity-filter')).toContainText('Error', { ignoreCase: true })
+            // Threshold count persists from the creation payload (default: 100)
+            await expect(page.locator('input[type="number"]').first()).toHaveValue('100')
+            // Save is disabled — no changes have been made since load
+            await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled()
         })
 
-        await test.step('edit modal populates persisted values', async () => {
-            await page.getByRole('button', { name: alertName }).click()
-            await expect(page.locator(formModal)).toBeVisible()
-            await expect(page.getByRole('heading', { name: 'Edit alert' })).toBeVisible()
+        await test.step('edit threshold and save', async () => {
+            // The threshold input is the first number spinbutton in the form (Rules section)
+            const thresholdInput = page.locator('input[type="number"]').first()
+            await thresholdInput.fill('50')
+            await page.keyboard.press('Tab')
 
-            // Verify name is populated
-            await expect(page.locator(formModal).getByPlaceholder('e.g. API 5xx errors')).toHaveValue(alertName)
-
-            // Verify severity filter shows "Error" (not "All levels")
-            await expect(page.locator(formModal).getByTestId('logs-severity-filter')).toContainText('error', {
-                ignoreCase: true,
-            })
-
-            // Verify save button is disabled (no changes)
-            await expect(page.locator(formModal).getByRole('button', { name: 'Save' })).toBeDisabled()
-        })
-
-        await test.step('edit the alert name and save', async () => {
-            const updatedName = alertName + '-updated'
-            await page.locator(formModal).getByPlaceholder('e.g. API 5xx errors').fill(updatedName)
-
-            // Save button should now be enabled
-            const saveButton = page.locator(formModal).getByRole('button', { name: 'Save' })
+            const saveButton = page.getByRole('button', { name: 'Save' })
             await expect(saveButton).toBeEnabled()
             await saveButton.click()
 
-            // Assert modal closes and success toast
-            await expect(page.locator(formModal)).not.toBeVisible()
             await expect(page.getByText('Alert updated')).toBeVisible()
-
-            // Verify updated name in list
-            await expect(page.getByRole('button', { name: updatedName })).toBeVisible()
+            // Wait for the form to reload before proceeding to delete
+            await expect(saveButton).toBeDisabled()
         })
 
         await test.step('delete the alert', async () => {
             await page.locator('[aria-label="more"]').click()
             await page.getByRole('menuitem', { name: 'Delete' }).click()
 
-            // Confirm in the deletion dialog
             await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click()
 
-            // Assert success
             await expect(page.getByText('Alert deleted')).toBeVisible()
-            await expect(page.getByText('No alerts configured yet.')).toBeVisible()
+            // Verify navigation back to the alerts list
+            await page.waitForURL(/logs.*activeTab=alerts/)
         })
     })
 })

--- a/products/logs/backend/alert_destinations.py
+++ b/products/logs/backend/alert_destinations.py
@@ -30,6 +30,7 @@ _FIRE_RESOLVE_DATA: dict[str, str] = {
     "service_names": "{event.properties.service_names}",
     "severity_levels": "{event.properties.severity_levels}",
     "logs_url": "{project.url}/logs?{event.properties.logs_url_params}",
+    "alert_url": "{project.url}/logs/alerts/{event.properties.alert_id}",
 }
 
 _BROKEN_ERRORED_BASE_DATA: dict[str, str] = {
@@ -38,7 +39,7 @@ _BROKEN_ERRORED_BASE_DATA: dict[str, str] = {
     "consecutive_failures": "{event.properties.consecutive_failures}",
     "service_names": "{event.properties.service_names}",
     "severity_levels": "{event.properties.severity_levels}",
-    "alert_url": "{project.url}/logs?alertId={event.properties.alert_id}",
+    "alert_url": "{project.url}/logs/alerts/{event.properties.alert_id}",
 }
 
 
@@ -84,9 +85,7 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
             "*Reason:* {event.properties.consecutive_failures} consecutive check failures.\n"
             "*Last error:* {event.properties.last_error_message}"
         ),
-        # Deep-link to the alert modal (via the ?alertId= param handled in logsSceneLogic) —
-        # a broken alert's viewer URL would show zero logs because the alert is no longer checking.
-        button_url="{project.url}/logs?alertId={event.properties.alert_id}",
+        button_url="{project.url}/logs/alerts/{event.properties.alert_id}",
         button_label="View alert",
         webhook_body={
             "id": "{event.uuid}",
@@ -102,7 +101,7 @@ EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
         event_id="$logs_alert_errored",
         header="🟡 Log alert '{event.properties.alert_name}' couldn't evaluate",
         body=("*Reason:* {event.properties.error_message}\n*Failure count:* {event.properties.consecutive_failures}"),
-        button_url="{project.url}/logs?alertId={event.properties.alert_id}",
+        button_url="{project.url}/logs/alerts/{event.properties.alert_id}",
         button_label="View alert",
         webhook_body={
             "id": "{event.uuid}",

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertEventHistory.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertEventHistory.tsx
@@ -20,27 +20,24 @@ interface LogsAlertEventHistoryModalProps {
 
 export function LogsAlertEventHistoryModal({ alert, onClose }: LogsAlertEventHistoryModalProps): JSX.Element {
     return (
-        <LemonModal isOpen={alert !== null} onClose={onClose} width={640} title="" simple>
+        <LemonModal
+            isOpen={alert !== null}
+            onClose={onClose}
+            width={640}
+            title={alert ? `Alert history · ${alert.name}` : 'Alert history'}
+            description="Transitions, errors, and user actions."
+        >
             {alert ? <LogsAlertEventHistoryContent alert={alert} /> : null}
         </LemonModal>
     )
 }
 
-function LogsAlertEventHistoryContent({ alert }: { alert: LogsAlertConfigurationApi }): JSX.Element {
+export function LogsAlertEventHistoryContent({ alert }: { alert: LogsAlertConfigurationApi }): JSX.Element {
     const logicProps: LogsAlertEventHistoryLogicProps = { alertId: alert.id }
 
     return (
         <BindLogic logic={logsAlertEventHistoryLogic} props={logicProps}>
-            <LemonModal.Header>
-                <h3 className="flex items-center gap-2">
-                    Alert history
-                    <span className="text-muted text-sm font-normal">· {alert.name}</span>
-                </h3>
-                <p className="text-muted text-sm m-0">Transitions, errors, and user actions.</p>
-            </LemonModal.Header>
-            <LemonModal.Content>
-                <LogsAlertEventTimeline />
-            </LemonModal.Content>
+            <LogsAlertEventTimeline />
         </BindLogic>
     )
 }

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertForm.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertForm.tsx
@@ -2,7 +2,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { memo, useCallback, useMemo, useRef, useState } from 'react'
 
 import { IconInfo } from '@posthog/icons'
-import { LemonCollapse, LemonDropdown, LemonInput, LemonSegmentedButton, LemonSelect } from '@posthog/lemon-ui'
+import { LemonDivider, LemonDropdown, LemonInput, LemonSegmentedButton, LemonSelect } from '@posthog/lemon-ui'
 
 import { InfiniteSelectResults } from 'lib/components/TaxonomicFilter/InfiniteSelectResults'
 import { TaxonomicFilterSearchInput } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
@@ -21,7 +21,6 @@ import { SeverityLevelsFilter } from 'products/logs/frontend/components/LogsView
 import { ThresholdOperatorEnumApi } from 'products/logs/frontend/generated/api.schemas'
 
 import { logsAlertFormLogic } from './logsAlertFormLogic'
-import { LogsAlertNotifications } from './LogsAlertNotifications'
 
 const WINDOW_OPTIONS = [
     { value: 5, label: '5 minutes' },
@@ -109,166 +108,129 @@ export function LogsAlertForm(): JSX.Element {
     )
 
     return (
-        <div className="space-y-4">
-            <LemonField name="name" label="Name">
-                <LemonInput placeholder="e.g. API 5xx errors" fullWidth />
-            </LemonField>
+        <div className="space-y-6 max-w-2xl">
+            <div className="space-y-3">
+                <h3 className="text-base font-semibold m-0">Filters</h3>
+                <p className="text-xs text-secondary m-0">Every 5 minutes, query for logs matching these filters.</p>
+                <LemonField name="severityLevels" label="Severity">
+                    <SeverityLevelsFilter
+                        value={alertForm.severityLevels}
+                        onChange={(levels) => setAlertFormValue('severityLevels', levels)}
+                    />
+                </LemonField>
+                <LemonField.Pure label="Service">
+                    <ServiceFilter
+                        value={alertForm.serviceNames}
+                        onChange={(names) => setAlertFormValue('serviceNames', names)}
+                    />
+                </LemonField.Pure>
+                <LemonField name="filterGroup" label="Attributes">
+                    <AlertFilterGroup filterGroup={alertForm.filterGroup} onChange={handleFilterGroupChange} />
+                </LemonField>
+            </div>
 
-            <LemonCollapse
-                multiple
-                defaultActiveKeys={['filters', 'rules']}
-                panels={[
-                    {
-                        key: 'filters',
-                        header: 'Filters',
-                        content: (
-                            <div className="space-y-2">
-                                <p className="text-xs text-secondary m-0">
-                                    Every minute, query for logs matching these filters.
-                                </p>
+            <LemonDivider />
 
-                                <LemonField name="severityLevels" label="Severity">
-                                    <SeverityLevelsFilter
-                                        value={alertForm.severityLevels}
-                                        onChange={(levels) => setAlertFormValue('severityLevels', levels)}
-                                    />
-                                </LemonField>
+            <div className="space-y-3">
+                <h3 className="text-base font-semibold m-0">Rules</h3>
+                <div className="flex items-center gap-2 flex-wrap">
+                    <span className="text-sm">Alert if count goes</span>
+                    <LemonSegmentedButton
+                        value={alertForm.thresholdOperator}
+                        onChange={(value) => setAlertFormValue('thresholdOperator', value)}
+                        options={[
+                            { value: ThresholdOperatorEnumApi.Above, label: 'above' },
+                            { value: ThresholdOperatorEnumApi.Below, label: 'below' },
+                        ]}
+                        size="small"
+                    />
+                    <LemonInput
+                        type="number"
+                        min={1}
+                        value={alertForm.thresholdCount}
+                        onChange={(val) => setAlertFormValue('thresholdCount', val ?? 1)}
+                        className="w-24"
+                        size="small"
+                    />
+                    <span className="text-sm">in the last</span>
+                    <LemonSelect
+                        value={alertForm.windowMinutes}
+                        onChange={(val) => setAlertFormValue('windowMinutes', val ?? 10)}
+                        options={WINDOW_OPTIONS}
+                        size="small"
+                    />
+                </div>
+            </div>
 
-                                <LemonField.Pure label="Service">
-                                    <ServiceFilter
-                                        value={alertForm.serviceNames}
-                                        onChange={(names) => setAlertFormValue('serviceNames', names)}
-                                    />
-                                </LemonField.Pure>
+            <LemonDivider />
 
-                                <LemonField name="filterGroup" label="Attributes">
-                                    <AlertFilterGroup
-                                        filterGroup={alertForm.filterGroup}
-                                        onChange={handleFilterGroupChange}
-                                    />
-                                </LemonField>
-                            </div>
-                        ),
-                    },
-                    {
-                        key: 'rules',
-                        header: 'Rules',
-                        content: (
-                            <div className="flex items-center gap-2 flex-wrap">
-                                <span className="text-sm">Alert if count goes</span>
-                                <LemonSegmentedButton
-                                    value={alertForm.thresholdOperator}
-                                    onChange={(value) => setAlertFormValue('thresholdOperator', value)}
-                                    options={[
-                                        {
-                                            value: ThresholdOperatorEnumApi.Above,
-                                            label: 'above',
-                                        },
-                                        {
-                                            value: ThresholdOperatorEnumApi.Below,
-                                            label: 'below',
-                                        },
-                                    ]}
-                                    size="small"
-                                />
-                                <LemonInput
-                                    type="number"
-                                    min={1}
-                                    value={alertForm.thresholdCount}
-                                    onChange={(val) => setAlertFormValue('thresholdCount', val ?? 1)}
-                                    className="w-24"
-                                    size="small"
-                                />
-                                <span className="text-sm">in the last</span>
-                                <LemonSelect
-                                    value={alertForm.windowMinutes}
-                                    onChange={(val) => setAlertFormValue('windowMinutes', val ?? 10)}
-                                    options={WINDOW_OPTIONS}
-                                    size="small"
-                                />
-                            </div>
-                        ),
-                    },
-                    {
-                        key: 'advanced',
-                        header: 'Advanced',
-                        content: (
-                            <div className="space-y-4">
-                                <LemonField.Pure
-                                    label={
-                                        <span className="inline-flex items-center gap-1">
-                                            Reduce noise
-                                            <Tooltip title="Require the condition to be met multiple times before the alert fires. This prevents notifications on brief, one-off spikes.">
-                                                <IconInfo className="text-base text-secondary" />
-                                            </Tooltip>
-                                        </span>
+            <div className="space-y-4">
+                <h3 className="text-base font-semibold m-0">Advanced</h3>
+                <LemonField.Pure
+                    label={
+                        <span className="inline-flex items-center gap-1">
+                            Reduce noise
+                            <Tooltip title="Require the condition to be met multiple times before the alert fires. This prevents notifications on brief, one-off spikes.">
+                                <IconInfo className="text-base text-secondary" />
+                            </Tooltip>
+                        </span>
+                    }
+                >
+                    <div className="space-y-2">
+                        <div className="flex items-center gap-2 flex-wrap">
+                            <LemonInput
+                                type="number"
+                                min={1}
+                                max={alertForm.evaluationPeriods}
+                                value={alertForm.datapointsToAlarm}
+                                onChange={(val) => setAlertFormValue('datapointsToAlarm', val ?? 1)}
+                                className="w-16"
+                                size="small"
+                            />
+                            <span className="text-sm">of</span>
+                            <LemonInput
+                                type="number"
+                                min={alertForm.datapointsToAlarm}
+                                max={10}
+                                value={alertForm.evaluationPeriods}
+                                onChange={(val) => {
+                                    const newPeriods = val ?? alertForm.datapointsToAlarm
+                                    setAlertFormValue('evaluationPeriods', newPeriods)
+                                    if (alertForm.datapointsToAlarm > newPeriods) {
+                                        setAlertFormValue('datapointsToAlarm', newPeriods)
                                     }
-                                >
-                                    <div className="space-y-2">
-                                        <div className="flex items-center gap-2 flex-wrap">
-                                            <LemonInput
-                                                type="number"
-                                                min={1}
-                                                max={alertForm.evaluationPeriods}
-                                                value={alertForm.datapointsToAlarm}
-                                                onChange={(val) => setAlertFormValue('datapointsToAlarm', val ?? 1)}
-                                                className="w-16"
-                                                size="small"
-                                            />
-                                            <span className="text-sm">of</span>
-                                            <LemonInput
-                                                type="number"
-                                                min={alertForm.datapointsToAlarm}
-                                                max={10}
-                                                value={alertForm.evaluationPeriods}
-                                                onChange={(val) => {
-                                                    const newPeriods = val ?? alertForm.datapointsToAlarm
-                                                    setAlertFormValue('evaluationPeriods', newPeriods)
-                                                    if (alertForm.datapointsToAlarm > newPeriods) {
-                                                        setAlertFormValue('datapointsToAlarm', newPeriods)
-                                                    }
-                                                }}
-                                                className="w-16"
-                                                size="small"
-                                            />
-                                            <span className="text-sm">checks must match to fire</span>
-                                            <CheckDotsTooltip
-                                                datapoints={alertForm.datapointsToAlarm}
-                                                periods={alertForm.evaluationPeriods}
-                                            />
-                                        </div>
-                                        <p className="text-xs text-secondary m-0">
-                                            The alert auto-resolves once the condition is no longer met.
-                                        </p>
-                                    </div>
-                                </LemonField.Pure>
-
-                                <LemonField.Pure
-                                    label="Notification cooldown"
-                                    help="After firing, wait this long before sending another notification. Set to 0 to notify on every check."
-                                >
-                                    <div className="flex items-center gap-2">
-                                        <LemonInput
-                                            type="number"
-                                            min={0}
-                                            value={alertForm.cooldownMinutes}
-                                            onChange={(val) => setAlertFormValue('cooldownMinutes', val ?? 0)}
-                                            className="w-24"
-                                            size="small"
-                                        />
-                                        <span className="text-sm">minutes</span>
-                                    </div>
-                                </LemonField.Pure>
-                            </div>
-                        ),
-                    },
-                    {
-                        key: 'notifications',
-                        header: 'Notifications',
-                        content: <LogsAlertNotifications />,
-                    },
-                ]}
-            />
+                                }}
+                                className="w-16"
+                                size="small"
+                            />
+                            <span className="text-sm">checks must match to fire</span>
+                            <CheckDotsTooltip
+                                datapoints={alertForm.datapointsToAlarm}
+                                periods={alertForm.evaluationPeriods}
+                            />
+                        </div>
+                        <p className="text-xs text-secondary m-0">
+                            The alert auto-resolves once the condition is no longer met.
+                        </p>
+                    </div>
+                </LemonField.Pure>
+                <LemonField.Pure
+                    label="Notification cooldown"
+                    help="After firing, wait this long before sending another notification. Set to 0 to notify on every check."
+                >
+                    <div className="flex items-center gap-2">
+                        <LemonInput
+                            type="number"
+                            min={0}
+                            value={alertForm.cooldownMinutes}
+                            onChange={(val) => setAlertFormValue('cooldownMinutes', val ?? 0)}
+                            className="w-24"
+                            size="small"
+                        />
+                        <span className="text-sm">minutes</span>
+                    </div>
+                </LemonField.Pure>
+            </div>
         </div>
     )
 }

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertList.tsx
@@ -1,5 +1,6 @@
 import { useActions, useValues } from 'kea'
 
+import { IconBell } from '@posthog/icons'
 import {
     LemonButton,
     LemonDialog,
@@ -17,6 +18,7 @@ import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { shortTimeZone } from 'lib/utils'
+import { urls } from 'scenes/urls'
 
 import IconSlack from 'public/services/slack.png'
 import IconWebhook from 'public/services/webhook.svg'
@@ -31,20 +33,16 @@ import {
 
 import { logsAlertingLogic } from './logsAlertingLogic'
 import { LogsAlertStateIndicator } from './LogsAlertStateIndicator'
+import { SNOOZE_DURATIONS } from './logsAlertUtils'
 
 function formatThreshold(alert: LogsAlertConfigurationApi): string {
     const operator = alert.threshold_operator === ThresholdOperatorEnumApi.Below ? '<' : '>'
     return `${operator} ${alert.threshold_count} in ${alert.window_minutes}m`
 }
 
-const SNOOZE_DURATIONS = [
-    { label: '30 minutes', minutes: 30 },
-    { label: '1 hour', minutes: 60 },
-    { label: '4 hours', minutes: 240 },
-    { label: '24 hours', minutes: 1440 },
-]
-
-function alertSparklineData(sparkline: readonly LogsAlertSparklineBucketApi[] | undefined): SparklineTimeSeries[] {
+export function alertSparklineData(
+    sparkline: readonly LogsAlertSparklineBucketApi[] | undefined
+): SparklineTimeSeries[] {
     if (!sparkline || sparkline.length === 0) {
         return []
     }
@@ -72,7 +70,7 @@ function alertSparklineData(sparkline: readonly LogsAlertSparklineBucketApi[] | 
     ]
 }
 
-function alertSparklineLabels(sparkline: readonly LogsAlertSparklineBucketApi[] | undefined): string[] {
+export function alertSparklineLabels(sparkline: readonly LogsAlertSparklineBucketApi[] | undefined): string[] {
     if (!sparkline) {
         return []
     }
@@ -90,7 +88,6 @@ export function LogsAlertList(): JSX.Element {
     const { alerts, alertsLoading, resettingAlertIds } = useValues(logsAlertingLogic)
     const {
         setEditingAlert,
-        setIsCreating,
         deleteAlert,
         toggleAlertEnabled,
         resetAlert,
@@ -104,7 +101,7 @@ export function LogsAlertList(): JSX.Element {
             title: 'Name',
             dataIndex: 'name',
             render: (_, alert) => (
-                <LemonButton type="tertiary" size="small" onClick={() => setEditingAlert(alert)}>
+                <LemonButton type="tertiary" size="small" to={urls.logsAlertDetail(alert.id)}>
                     {alert.name}
                 </LemonButton>
             ),
@@ -115,6 +112,7 @@ export function LogsAlertList(): JSX.Element {
             render: (_, alert) => (
                 <LogsAlertStateIndicator
                     state={alert.state}
+                    enabled={alert.enabled ?? true}
                     lastErrorMessage={alert.last_error_message}
                     snoozeUntil={alert.snooze_until}
                 />
@@ -156,23 +154,45 @@ export function LogsAlertList(): JSX.Element {
             dataIndex: 'destination_types',
             render: (_, alert) => {
                 const types = alert.destination_types ?? []
+                const notifUrl = urls.logsAlertDetail(alert.id, 'notifications')
                 if (types.length === 0) {
-                    return <LemonTag type="warning">None</LemonTag>
+                    return (
+                        <div className="flex items-center gap-1.5">
+                            <LemonTag type="warning">None</LemonTag>
+                            <span className="text-xs text-muted">— click bell to configure</span>
+                            <LemonButton
+                                size="small"
+                                type="tertiary"
+                                icon={<IconBell />}
+                                to={notifUrl}
+                                tooltip="Configure notifications"
+                            />
+                        </div>
+                    )
                 }
                 return (
-                    <div className="flex gap-1">
-                        {types.includes(DestinationTypesEnumApi.Slack) && (
-                            <LemonTag>
-                                <img src={IconSlack} alt="" className="h-3 w-3 object-contain" />
-                                Slack
-                            </LemonTag>
-                        )}
-                        {types.includes(DestinationTypesEnumApi.Webhook) && (
-                            <LemonTag>
-                                <img src={IconWebhook} alt="" className="h-3 w-3 object-contain" />
-                                Webhook
-                            </LemonTag>
-                        )}
+                    <div className="flex items-center gap-1">
+                        <div className="flex gap-1">
+                            {types.includes(DestinationTypesEnumApi.Slack) && (
+                                <LemonTag>
+                                    <img src={IconSlack} alt="" className="h-3 w-3 object-contain" />
+                                    Slack
+                                </LemonTag>
+                            )}
+                            {types.includes(DestinationTypesEnumApi.Webhook) && (
+                                <LemonTag>
+                                    <img src={IconWebhook} alt="" className="h-3 w-3 object-contain" />
+                                    Webhook
+                                </LemonTag>
+                            )}
+                        </div>
+                        <LemonButton
+                            size="small"
+                            type="tertiary"
+                            icon={<IconBell />}
+                            to={notifUrl}
+                            tooltip="Configure notifications"
+                        />
                     </div>
                 )
             },
@@ -274,7 +294,7 @@ export function LogsAlertList(): JSX.Element {
     return (
         <div className="space-y-2">
             <div className="flex justify-end">
-                <LemonButton type="primary" size="small" onClick={() => setIsCreating(true)}>
+                <LemonButton type="primary" size="small" to={urls.logsAlertNew()}>
                     New alert
                 </LemonButton>
             </div>

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertNotifications.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertNotifications.tsx
@@ -35,7 +35,7 @@ function resolveGroupLabel(group: LogsAlertDestinationGroup, slackChannels: Slac
     return group.label
 }
 
-export function LogsAlertNotifications(): JSX.Element {
+export function LogsAlertNotifications({ alertId }: { alertId?: string }): JSX.Element {
     const {
         existingHogFunctionsLoading,
         destinationGroups,
@@ -162,7 +162,9 @@ export function LogsAlertNotifications(): JSX.Element {
                         >
                             <span className="text-sm min-w-0 truncate flex flex-col">
                                 {getNotificationLabel(notification)}{' '}
-                                <span className="text-muted-alt">(pending - click Save to apply)</span>
+                                <span className="text-muted-alt">
+                                    {alertId ? '(saving…)' : '(pending — save alert to apply)'}
+                                </span>
                             </span>
                             <LemonButton
                                 icon={<IconTrash />}

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertStateIndicator.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertStateIndicator.tsx
@@ -21,13 +21,18 @@ const STATES_WITH_ERROR_TOOLTIP = new Set<LogsAlertConfigurationStateEnumApi>([
 
 export function LogsAlertStateIndicator({
     state,
+    enabled = true,
     lastErrorMessage,
     snoozeUntil,
 }: {
     state: LogsAlertConfigurationStateEnumApi
+    enabled?: boolean
     lastErrorMessage?: string | null
     snoozeUntil?: string | null
 }): JSX.Element {
+    if (!enabled) {
+        return <LemonTag type="muted">Disabled</LemonTag>
+    }
     const config = STATE_CONFIG[state] ?? { label: state, type: 'default' as LemonTagType }
     const tag = <LemonTag type={config.type}>{config.label}</LemonTag>
     if (lastErrorMessage && STATES_WITH_ERROR_TOOLTIP.has(state)) {

--- a/products/logs/frontend/components/LogsAlerting/logsAlertFormLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertFormLogic.ts
@@ -24,6 +24,7 @@ import {
 import type { logsAlertFormLogicType } from './logsAlertFormLogicType'
 import { logsAlertingLogic } from './logsAlertingLogic'
 import { logsAlertNotificationLogic } from './logsAlertNotificationLogic'
+import { buildAlertFilters, hasAnyFilter } from './logsAlertUtils'
 
 const EMPTY_FILTER_GROUP: UniversalFiltersGroup = {
     type: FilterLogicalOperator.And,
@@ -59,32 +60,7 @@ function extractFilterGroup(alert: LogsAlertConfigurationApi | null): UniversalF
     return EMPTY_FILTER_GROUP
 }
 
-function buildFilters(
-    severityLevels: string[],
-    serviceNames: string[],
-    filterGroup: UniversalFiltersGroup
-): Record<string, unknown> {
-    const filters: Record<string, unknown> = {}
-    if (severityLevels.length > 0) {
-        filters.severityLevels = severityLevels
-    }
-    if (serviceNames.length > 0) {
-        filters.serviceNames = serviceNames
-    }
-    if (filterGroup.values.length > 0) {
-        filters.filterGroup = {
-            type: FilterLogicalOperator.And,
-            values: [filterGroup],
-        }
-    }
-    return filters
-}
-
-function hasAnyFilter(severityLevels: string[], serviceNames: string[], filterGroup: UniversalFiltersGroup): boolean {
-    return severityLevels.length > 0 || serviceNames.length > 0 || filterGroup.values.length > 0
-}
-
-function buildFormDefaults(alert: LogsAlertConfigurationApi | null): LogsAlertFormType {
+export function buildFormDefaults(alert: LogsAlertConfigurationApi | null): LogsAlertFormType {
     return {
         name: alert?.name ?? '',
         severityLevels:
@@ -156,7 +132,7 @@ export const logsAlertFormLogic = kea<logsAlertFormLogicType>([
                     }
                     const projectId = String(values.currentTeamId)
                     return await logsAlertsSimulateCreate(projectId, {
-                        filters: buildFilters(form.severityLevels, form.serviceNames, form.filterGroup),
+                        filters: buildAlertFilters(form.severityLevels, form.serviceNames, form.filterGroup),
                         threshold_count: form.thresholdCount,
                         threshold_operator: form.thresholdOperator,
                         window_minutes: form.windowMinutes,
@@ -205,7 +181,7 @@ export const logsAlertFormLogic = kea<logsAlertFormLogicType>([
                 const projectId = String(values.currentTeamId)
                 const payload = {
                     name: form.name.trim(),
-                    filters: buildFilters(form.severityLevels, form.serviceNames, form.filterGroup),
+                    filters: buildAlertFilters(form.severityLevels, form.serviceNames, form.filterGroup),
                     threshold_count: form.thresholdCount,
                     threshold_operator: form.thresholdOperator,
                     window_minutes: form.windowMinutes,

--- a/products/logs/frontend/components/LogsAlerting/logsAlertNotificationLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertNotificationLogic.ts
@@ -116,6 +116,11 @@ export const logsAlertNotificationLogic = kea<logsAlertNotificationLogicType>([
     }),
 
     listeners(({ actions, values, props }) => ({
+        addPendingNotification: () => {
+            if (props.alertId) {
+                actions.createPendingHogFunctions(props.alertId)
+            }
+        },
         loadIntegrationsSuccess: () => {
             if (!values.firstSlackIntegration) {
                 actions.setSelectedType(LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK)

--- a/products/logs/frontend/components/LogsAlerting/logsAlertUtils.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertUtils.ts
@@ -1,4 +1,41 @@
+import { LemonDialog } from '@posthog/lemon-ui'
+
+import { FilterLogicalOperator, UniversalFiltersGroup } from '~/types'
 import { CyclotronJobFiltersType, HogFunctionType, PropertyFilterType, PropertyOperator } from '~/types'
+
+import { LogsAlertConfigurationApi } from 'products/logs/frontend/generated/api.schemas'
+
+export function withEnableNotificationGuard(
+    alert: LogsAlertConfigurationApi,
+    onConfirm: () => void,
+    onConfigureNotifications: () => void
+): void {
+    const isEnabling = !(alert.enabled ?? true)
+    if (isEnabling && (alert.destination_types ?? []).length === 0) {
+        LemonDialog.open({
+            title: 'No notifications configured',
+            description:
+                "This alert has no notification destinations. It will fire silently — you won't receive any alerts when conditions are met.",
+            primaryButton: {
+                children: 'Configure notifications',
+                onClick: onConfigureNotifications,
+            },
+            secondaryButton: {
+                children: 'Enable anyway',
+                onClick: onConfirm,
+            },
+        })
+        return
+    }
+    onConfirm()
+}
+
+export const SNOOZE_DURATIONS = [
+    { label: '30 minutes', minutes: 30 },
+    { label: '1 hour', minutes: 60 },
+    { label: '4 hours', minutes: 240 },
+    { label: '24 hours', minutes: 1440 },
+]
 
 export const LOGS_ALERT_NOTIFICATION_TYPE_SLACK = 'slack' as const
 export const LOGS_ALERT_NOTIFICATION_TYPE_WEBHOOK = 'webhook' as const
@@ -24,6 +61,35 @@ export type PendingLogsAlertNotification =
 // matching would require a HogFunction's `filters.events` to contain every event
 // we list — which no single HogFunction does post-fan-out. The `alert_id`
 // property alone uniquely identifies all HogFunctions belonging to the alert.
+export function hasAnyFilter(
+    severityLevels: string[],
+    serviceNames: string[],
+    filterGroup: UniversalFiltersGroup
+): boolean {
+    return severityLevels.length > 0 || serviceNames.length > 0 || filterGroup.values.length > 0
+}
+
+export function buildAlertFilters(
+    severityLevels: string[],
+    serviceNames: string[],
+    filterGroup: UniversalFiltersGroup
+): Record<string, unknown> {
+    const filters: Record<string, unknown> = {}
+    if (severityLevels.length > 0) {
+        filters.severityLevels = severityLevels
+    }
+    if (serviceNames.length > 0) {
+        filters.serviceNames = serviceNames
+    }
+    if (filterGroup.values.length > 0) {
+        filters.filterGroup = {
+            type: FilterLogicalOperator.And,
+            values: [filterGroup],
+        }
+    }
+    return filters
+}
+
 export function buildLogsAlertFilterConfig(alertId: string): CyclotronJobFiltersType {
     return {
         properties: [

--- a/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertingLogic.ts
@@ -6,6 +6,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
 import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
 
 import {
     logsAlertsDestroy,
@@ -16,6 +17,7 @@ import {
 import { LogsAlertConfigurationApi } from 'products/logs/frontend/generated/api.schemas'
 
 import type { logsAlertingLogicType } from './logsAlertingLogicType'
+import { withEnableNotificationGuard } from './logsAlertUtils'
 
 const ALERT_POLL_INTERVAL_MS = 30_000
 
@@ -82,18 +84,6 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
     })),
 
     listeners(({ actions, values }) => ({
-        loadAlertsSuccess: () => {
-            const params = router.values.searchParams
-            if (params.alertId && typeof params.alertId === 'string') {
-                const alert = values.alerts.find((a) => a.id === params.alertId)
-                if (alert) {
-                    actions.setEditingAlert(alert)
-                }
-                // Clear alertId from URL regardless of whether we found the alert
-                const { alertId: _, ...rest } = router.values.searchParams
-                router.actions.replace(router.values.location.pathname, rest, router.values.hashParams)
-            }
-        },
         deleteAlert: async ({ id }) => {
             const projectId = String(values.currentTeamId)
             try {
@@ -104,16 +94,22 @@ export const logsAlertingLogic = kea<logsAlertingLogicType>([
                 lemonToast.error('Failed to delete alert')
             }
         },
-        toggleAlertEnabled: async ({ alert }) => {
-            const projectId = String(values.currentTeamId)
-            try {
-                await logsAlertsPartialUpdate(projectId, alert.id, {
-                    enabled: !(alert.enabled ?? true),
-                })
-                actions.loadAlerts()
-            } catch {
-                lemonToast.error('Failed to update alert')
-            }
+        toggleAlertEnabled: ({ alert }) => {
+            withEnableNotificationGuard(
+                alert,
+                async () => {
+                    const projectId = String(values.currentTeamId)
+                    try {
+                        await logsAlertsPartialUpdate(projectId, alert.id, {
+                            enabled: !(alert.enabled ?? true),
+                        })
+                        actions.loadAlerts()
+                    } catch {
+                        lemonToast.error('Failed to update alert')
+                    }
+                },
+                () => router.actions.push(urls.logsAlertDetail(alert.id, 'notifications'))
+            )
         },
         resetAlert: async ({ id }) => {
             const projectId = String(values.currentTeamId)

--- a/products/logs/frontend/scenes/LogsAlertDetailScene/LogsAlertDetailScene.tsx
+++ b/products/logs/frontend/scenes/LogsAlertDetailScene/LogsAlertDetailScene.tsx
@@ -1,0 +1,349 @@
+import { BindLogic, useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
+
+import { IconChevronDown, IconTestTube } from '@posthog/icons'
+import { LemonBanner, LemonButton, LemonDialog, LemonModal, LemonTabs } from '@posthog/lemon-ui'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import { More } from 'lib/lemon-ui/LemonButton/More'
+import { LemonMenu, LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
+import { SceneExport } from 'scenes/sceneTypes'
+
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { UniversalFiltersGroup } from '~/types'
+
+import { LogsAlertEventHistoryContent } from 'products/logs/frontend/components/LogsAlerting/LogsAlertEventHistory'
+import { LogsAlertForm } from 'products/logs/frontend/components/LogsAlerting/LogsAlertForm'
+import { logsAlertFormLogic } from 'products/logs/frontend/components/LogsAlerting/logsAlertFormLogic'
+import { logsAlertNotificationLogic } from 'products/logs/frontend/components/LogsAlerting/logsAlertNotificationLogic'
+import { LogsAlertNotifications } from 'products/logs/frontend/components/LogsAlerting/LogsAlertNotifications'
+import { LogsAlertSimulation } from 'products/logs/frontend/components/LogsAlerting/LogsAlertSimulation'
+import { LogsAlertStateIndicator } from 'products/logs/frontend/components/LogsAlerting/LogsAlertStateIndicator'
+import { LogsViewer } from 'products/logs/frontend/components/LogsViewer'
+import {
+    LogsAlertConfigurationApi,
+    LogsAlertConfigurationStateEnumApi,
+} from 'products/logs/frontend/generated/api.schemas'
+
+import {
+    LogsAlertDetailSceneLogicProps,
+    LogsAlertDetailTab,
+    SNOOZE_DURATIONS,
+    logsAlertDetailSceneLogic,
+} from './logsAlertDetailSceneLogic'
+
+export const scene: SceneExport<LogsAlertDetailSceneLogicProps> = {
+    component: LogsAlertDetailScene,
+    logic: logsAlertDetailSceneLogic,
+    paramsToProps: ({ params: { id } }) => ({ id }),
+}
+
+export function LogsAlertDetailScene(): JSX.Element {
+    const { alert, alertId, alertLoading, activeTab } = useValues(logsAlertDetailSceneLogic)
+    const { setActiveTab } = useActions(logsAlertDetailSceneLogic)
+
+    const formLogicProps = { alert: alert ?? ({ id: alertId } as LogsAlertConfigurationApi) }
+    const notifLogicProps = { alertId }
+    const { isSimulationPanelOpen } = useValues(logsAlertFormLogic(formLogicProps))
+    const { closeSimulationPanel } = useActions(logsAlertFormLogic(formLogicProps))
+
+    if (!alert && !alertLoading) {
+        return (
+            <SceneContent>
+                <div className="p-8 text-muted text-center">Alert not found.</div>
+            </SceneContent>
+        )
+    }
+
+    return (
+        <BindLogic logic={logsAlertFormLogic} props={formLogicProps}>
+            <BindLogic logic={logsAlertNotificationLogic} props={notifLogicProps}>
+                <SceneContent>
+                    <AlertHeader />
+                    <div className="flex flex-col gap-4 p-4">
+                        {alert && <AlertStatusBand />}
+                        <LemonTabs
+                            activeKey={activeTab}
+                            onChange={(key) => setActiveTab(key as LogsAlertDetailTab)}
+                            tabs={[
+                                {
+                                    key: 'configuration',
+                                    label: 'Configuration',
+                                    content: <ConfigurationTab />,
+                                },
+                                {
+                                    key: 'notifications',
+                                    label: 'Notifications',
+                                    content: <NotificationsTab />,
+                                },
+                                {
+                                    key: 'history',
+                                    label: 'History',
+                                    content: alert ? <LogsAlertEventHistoryContent alert={alert} /> : null,
+                                },
+                                {
+                                    key: 'logs',
+                                    label: 'Observed logs',
+                                    content: alert ? <ObservedLogsTab alert={alert} /> : null,
+                                },
+                            ]}
+                        />
+                    </div>
+                    <LemonModal
+                        isOpen={isSimulationPanelOpen}
+                        onClose={closeSimulationPanel}
+                        title="Alert simulation"
+                        description="Run the alert against historical data to preview when it would have fired. Includes threshold evaluation, N-of-M noise reduction, and cooldown."
+                        width={960}
+                    >
+                        <LogsAlertSimulation />
+                    </LemonModal>
+                </SceneContent>
+            </BindLogic>
+        </BindLogic>
+    )
+}
+
+function AlertHeader(): JSX.Element {
+    const { alert, alertLoading } = useValues(logsAlertDetailSceneLogic)
+    const { toggleEnabled, snoozeAlert, unsnoozeAlert, resetAlert, deleteAlert, renameAlert } =
+        useActions(logsAlertDetailSceneLogic)
+
+    const { isAlertFormSubmitting, alertFormChanged } = useValues(logsAlertFormLogic)
+    const { submitAlertForm } = useActions(logsAlertFormLogic)
+    const { pendingNotifications } = useValues(logsAlertNotificationLogic)
+
+    const isEnabled = alert?.enabled ?? true
+    const isBroken = alert?.state === LogsAlertConfigurationStateEnumApi.Broken
+    const isSnoozed = alert?.state === LogsAlertConfigurationStateEnumApi.Snoozed
+
+    return (
+        <SceneTitleSection
+            name={alert?.name}
+            resourceType={{ type: 'logs' }}
+            isLoading={alertLoading && !alert}
+            canEdit={!!alert}
+            onNameChange={renameAlert}
+            renameDebounceMs={300}
+            actions={
+                alert ? (
+                    <div className="flex items-center gap-2">
+                        {isEnabled && alert.state !== LogsAlertConfigurationStateEnumApi.NotFiring && (
+                            <LogsAlertStateIndicator
+                                state={alert.state}
+                                lastErrorMessage={alert.last_error_message}
+                                snoozeUntil={alert.snooze_until}
+                            />
+                        )}
+                        <LemonButton
+                            size="small"
+                            type="secondary"
+                            status={isEnabled ? 'danger' : 'success'}
+                            onClick={toggleEnabled}
+                            disabledReason={isBroken ? 'Reset this alert to re-enable checks' : undefined}
+                        >
+                            {isEnabled ? 'Disable' : 'Enable'}
+                        </LemonButton>
+                        {isSnoozed ? (
+                            <LemonButton size="small" type="secondary" onClick={unsnoozeAlert}>
+                                Unsnooze
+                            </LemonButton>
+                        ) : (
+                            <LemonMenu
+                                placement="bottom-end"
+                                items={SNOOZE_DURATIONS.map((d) => ({
+                                    label: d.label,
+                                    onClick: () => snoozeAlert(d.minutes),
+                                }))}
+                            >
+                                <LemonButton size="small" type="secondary" sideIcon={<IconChevronDown />}>
+                                    Snooze
+                                </LemonButton>
+                            </LemonMenu>
+                        )}
+                        <LemonButton
+                            size="small"
+                            type="primary"
+                            onClick={submitAlertForm}
+                            loading={isAlertFormSubmitting}
+                            disabledReason={
+                                !alertFormChanged && pendingNotifications.length === 0
+                                    ? 'No changes to save'
+                                    : undefined
+                            }
+                        >
+                            Save
+                        </LemonButton>
+                        <More
+                            overlay={
+                                <LemonMenuOverlay
+                                    items={[
+                                        ...(isBroken ? [{ label: 'Reset alert', onClick: resetAlert }] : []),
+                                        {
+                                            label: 'Delete',
+                                            status: 'danger' as const,
+                                            onClick: () => {
+                                                LemonDialog.open({
+                                                    title: `Delete "${alert.name}"?`,
+                                                    description:
+                                                        'This alert will be permanently deleted. This action cannot be undone.',
+                                                    primaryButton: {
+                                                        children: 'Delete',
+                                                        type: 'primary',
+                                                        status: 'danger',
+                                                        onClick: deleteAlert,
+                                                    },
+                                                    secondaryButton: { children: 'Cancel' },
+                                                })
+                                            },
+                                        },
+                                    ]}
+                                />
+                            }
+                        />
+                    </div>
+                ) : undefined
+            }
+        />
+    )
+}
+
+function AlertStatusBand(): JSX.Element | null {
+    const { alert } = useValues(logsAlertDetailSceneLogic)
+    const { resetAlert, unsnoozeAlert, toggleEnabled, setActiveTab } = useActions(logsAlertDetailSceneLogic)
+    const { destinationGroups, existingHogFunctionsLoading } = useValues(logsAlertNotificationLogic)
+
+    if (!alert) {
+        return null
+    }
+
+    const banners: JSX.Element[] = []
+
+    if (!alert.enabled && alert.state !== LogsAlertConfigurationStateEnumApi.Broken) {
+        banners.push(
+            <LemonBanner key="disabled" type="warning" action={{ children: 'Enable', onClick: toggleEnabled }}>
+                This alert is disabled — no checks are running.
+            </LemonBanner>
+        )
+    }
+
+    if (alert.state === LogsAlertConfigurationStateEnumApi.Broken) {
+        banners.push(
+            <LemonBanner key="broken" type="error" action={{ children: 'Reset alert', onClick: resetAlert }}>
+                <div className="font-semibold">
+                    Auto-disabled after {alert.consecutive_failures ?? 'repeated'} consecutive check failures.
+                </div>
+                {alert.last_error_message && (
+                    <div className="text-xs font-mono mt-1 whitespace-pre-wrap break-words">
+                        {alert.last_error_message}
+                    </div>
+                )}
+            </LemonBanner>
+        )
+    }
+
+    if (alert.state === LogsAlertConfigurationStateEnumApi.Snoozed && alert.snooze_until) {
+        banners.push(
+            <LemonBanner key="snoozed" type="info" action={{ children: 'Unsnooze', onClick: unsnoozeAlert }}>
+                Snoozed until <TZLabel time={alert.snooze_until} timestampStyle="absolute" />.
+            </LemonBanner>
+        )
+    }
+
+    if (alert.state === LogsAlertConfigurationStateEnumApi.Firing) {
+        banners.push(
+            <LemonBanner key="firing" type="error">
+                <span className="font-semibold">Alert is currently firing.</span>
+                {alert.last_checked_at && (
+                    <span className="text-xs ml-2">
+                        Last checked <TZLabel time={alert.last_checked_at} />.
+                    </span>
+                )}
+            </LemonBanner>
+        )
+    }
+
+    if (alert.enabled && !existingHogFunctionsLoading && destinationGroups.length === 0) {
+        banners.push(
+            <LemonBanner
+                key="no-destinations"
+                type="warning"
+                action={{ children: 'Add notification', onClick: () => setActiveTab('notifications') }}
+            >
+                No notifications configured — this alert will fire silently.
+            </LemonBanner>
+        )
+    }
+
+    if (banners.length === 0) {
+        return null
+    }
+
+    return <div className="flex flex-col gap-2">{banners}</div>
+}
+
+function ConfigurationTab(): JSX.Element {
+    const { alert } = useValues(logsAlertDetailSceneLogic)
+    const { isSimulationPanelOpen } = useValues(logsAlertFormLogic)
+    const { openSimulationPanel } = useActions(logsAlertFormLogic)
+    const formLogicProps = { alert: alert ?? null }
+
+    if (!alert) {
+        return <div className="p-4 text-muted">Loading…</div>
+    }
+
+    return (
+        <div className="flex flex-col gap-4">
+            <div>
+                <LemonButton
+                    type="secondary"
+                    icon={<IconTestTube />}
+                    onClick={openSimulationPanel}
+                    active={isSimulationPanelOpen}
+                    tooltip="Run this alert against historical data to see when it would have fired"
+                >
+                    Simulate
+                </LemonButton>
+            </div>
+            <Form
+                logic={logsAlertFormLogic}
+                props={formLogicProps}
+                formKey="alertForm"
+                enableFormOnSubmit
+                className="flex flex-col gap-6"
+            >
+                <LogsAlertForm />
+            </Form>
+        </div>
+    )
+}
+
+function NotificationsTab(): JSX.Element {
+    const { alert } = useValues(logsAlertDetailSceneLogic)
+
+    if (!alert) {
+        return <div className="p-4 text-muted">Loading…</div>
+    }
+
+    return (
+        <div className="flex flex-col gap-4 max-w-xl">
+            <LogsAlertNotifications alertId={alert.id} />
+        </div>
+    )
+}
+
+function ObservedLogsTab({ alert }: { alert: LogsAlertConfigurationApi }): JSX.Element {
+    const filters = (alert.filters ?? {}) as Record<string, unknown>
+    const initialFilters = {
+        severityLevels: (filters.severityLevels as string[] | undefined) ?? [],
+        serviceNames: (filters.serviceNames as string[] | undefined) ?? [],
+        filterGroup: filters.filterGroup as UniversalFiltersGroup | undefined,
+    }
+
+    return (
+        <div className="h-[calc(100vh-20rem)] min-h-[400px]">
+            <LogsViewer id={`alert-${alert.id}-logs`} initialFilters={initialFilters} showSavedViewsButton={false} />
+        </div>
+    )
+}

--- a/products/logs/frontend/scenes/LogsAlertDetailScene/LogsAlertDetailScene.tsx
+++ b/products/logs/frontend/scenes/LogsAlertDetailScene/LogsAlertDetailScene.tsx
@@ -11,7 +11,8 @@ import { SceneExport } from 'scenes/sceneTypes'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
-import { UniversalFiltersGroup } from '~/types'
+import { LogSeverityLevel } from '~/queries/schema/schema-general'
+import { FilterLogicalOperator, UniversalFiltersGroup } from '~/types'
 
 import { LogsAlertEventHistoryContent } from 'products/logs/frontend/components/LogsAlerting/LogsAlertEventHistory'
 import { LogsAlertForm } from 'products/logs/frontend/components/LogsAlerting/LogsAlertForm'
@@ -80,12 +81,12 @@ export function LogsAlertDetailScene(): JSX.Element {
                                 {
                                     key: 'history',
                                     label: 'History',
-                                    content: alert ? <LogsAlertEventHistoryContent alert={alert} /> : null,
+                                    content: alert ? <LogsAlertEventHistoryContent alert={alert} /> : <></>,
                                 },
                                 {
                                     key: 'logs',
                                     label: 'Observed logs',
-                                    content: alert ? <ObservedLogsTab alert={alert} /> : null,
+                                    content: alert ? <ObservedLogsTab alert={alert} /> : <></>,
                                 },
                             ]}
                         />
@@ -129,9 +130,10 @@ function AlertHeader(): JSX.Element {
             actions={
                 alert ? (
                     <div className="flex items-center gap-2">
-                        {isEnabled && alert.state !== LogsAlertConfigurationStateEnumApi.NotFiring && (
+                        {(!isEnabled || alert.state !== LogsAlertConfigurationStateEnumApi.NotFiring) && (
                             <LogsAlertStateIndicator
                                 state={alert.state}
+                                enabled={isEnabled}
                                 lastErrorMessage={alert.last_error_message}
                                 snoozeUntil={alert.snooze_until}
                             />
@@ -139,7 +141,7 @@ function AlertHeader(): JSX.Element {
                         <LemonButton
                             size="small"
                             type="secondary"
-                            status={isEnabled ? 'danger' : 'success'}
+                            status={isEnabled ? 'danger' : undefined}
                             onClick={toggleEnabled}
                             disabledReason={isBroken ? 'Reset this alert to re-enable checks' : undefined}
                         >
@@ -336,9 +338,12 @@ function NotificationsTab(): JSX.Element {
 function ObservedLogsTab({ alert }: { alert: LogsAlertConfigurationApi }): JSX.Element {
     const filters = (alert.filters ?? {}) as Record<string, unknown>
     const initialFilters = {
-        severityLevels: (filters.severityLevels as string[] | undefined) ?? [],
+        severityLevels: ((filters.severityLevels as string[] | undefined) ?? []) as LogSeverityLevel[],
         serviceNames: (filters.serviceNames as string[] | undefined) ?? [],
-        filterGroup: filters.filterGroup as UniversalFiltersGroup | undefined,
+        filterGroup: (filters.filterGroup as UniversalFiltersGroup | undefined) ?? {
+            type: FilterLogicalOperator.And,
+            values: [],
+        },
     }
 
     return (

--- a/products/logs/frontend/scenes/LogsAlertDetailScene/logsAlertDetailSceneLogic.ts
+++ b/products/logs/frontend/scenes/LogsAlertDetailScene/logsAlertDetailSceneLogic.ts
@@ -11,6 +11,7 @@ import { Scene } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
+import { LogSeverityLevel } from '~/queries/schema/schema-general'
 import { Breadcrumb } from '~/types'
 
 import { logsAlertEventHistoryLogic } from 'products/logs/frontend/components/LogsAlerting/logsAlertEventHistoryLogic'
@@ -117,8 +118,9 @@ export const logsAlertDetailSceneLogic = kea<logsAlertDetailSceneLogicType>([
                     return api.logs.sparkline({
                         query: {
                             dateRange: { date_from: '-7d', date_to: null },
-                            severityLevels: filters.severityLevels as string[] | undefined,
-                            serviceNames: filters.serviceNames as string[] | undefined,
+                            severityLevels: ((filters.severityLevels as string[] | undefined) ??
+                                []) as LogSeverityLevel[],
+                            serviceNames: (filters.serviceNames as string[] | undefined) ?? [],
                             filterGroup: (filters.filterGroup as any) ?? { type: 'AND', values: [] },
                             sparklineBreakdownBy: 'severity',
                         },

--- a/products/logs/frontend/scenes/LogsAlertDetailScene/logsAlertDetailSceneLogic.ts
+++ b/products/logs/frontend/scenes/LogsAlertDetailScene/logsAlertDetailSceneLogic.ts
@@ -1,0 +1,337 @@
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import { actionToUrl, router, urlToAction } from 'kea-router'
+
+import { lemonToast } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+import { SparklineTimeSeries } from 'lib/components/Sparkline'
+import { dayjs } from 'lib/dayjs'
+import { Scene } from 'scenes/sceneTypes'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
+
+import { Breadcrumb } from '~/types'
+
+import { logsAlertEventHistoryLogic } from 'products/logs/frontend/components/LogsAlerting/logsAlertEventHistoryLogic'
+import {
+    buildFormDefaults,
+    logsAlertFormLogic,
+} from 'products/logs/frontend/components/LogsAlerting/logsAlertFormLogic'
+import { logsAlertingLogic } from 'products/logs/frontend/components/LogsAlerting/logsAlertingLogic'
+import { logsAlertNotificationLogic } from 'products/logs/frontend/components/LogsAlerting/logsAlertNotificationLogic'
+import {
+    SNOOZE_DURATIONS,
+    withEnableNotificationGuard,
+} from 'products/logs/frontend/components/LogsAlerting/logsAlertUtils'
+import {
+    logsAlertsDestroy,
+    logsAlertsPartialUpdate,
+    logsAlertsResetCreate,
+    logsAlertsRetrieve,
+} from 'products/logs/frontend/generated/api'
+import { LogsAlertConfigurationApi } from 'products/logs/frontend/generated/api.schemas'
+
+import type { logsAlertDetailSceneLogicType } from './logsAlertDetailSceneLogicType'
+
+export type LogsAlertDetailTab = 'configuration' | 'notifications' | 'history' | 'logs'
+const VALID_TABS: LogsAlertDetailTab[] = ['configuration', 'notifications', 'history', 'logs']
+const DEFAULT_TAB: LogsAlertDetailTab = 'configuration'
+
+export { SNOOZE_DURATIONS }
+
+export interface LogsAlertDetailSceneLogicProps {
+    id: string
+}
+
+export const logsAlertDetailSceneLogic = kea<logsAlertDetailSceneLogicType>([
+    path((key) => ['products', 'logs', 'frontend', 'scenes', 'LogsAlertDetailScene', 'logsAlertDetailSceneLogic', key]),
+    props({} as LogsAlertDetailSceneLogicProps),
+    key((props) => props.id),
+
+    connect((props: LogsAlertDetailSceneLogicProps) => ({
+        values: [
+            teamLogic,
+            ['currentTeamId'],
+            logsAlertFormLogic({ alert: { id: props.id } as LogsAlertConfigurationApi }),
+            ['alertFormChanged'],
+        ],
+        actions: [
+            logsAlertFormLogic({ alert: { id: props.id } as LogsAlertConfigurationApi }),
+            ['submitAlertFormSuccess', 'resetAlertForm'],
+            logsAlertNotificationLogic({ alertId: props.id }),
+            ['loadExistingHogFunctionsSuccess'],
+            logsAlertEventHistoryLogic({ alertId: props.id }),
+            ['loadEvents'],
+            logsAlertingLogic,
+            ['loadAlerts'],
+        ],
+    })),
+
+    actions({
+        setActiveTab: (tab: LogsAlertDetailTab) => ({ tab }),
+        renameAlert: (name: string) => ({ name }),
+        patchAlertLocally: (patch: Partial<LogsAlertConfigurationApi>) => ({ patch }),
+        toggleEnabled: true,
+        snoozeAlert: (durationMinutes: number) => ({ durationMinutes }),
+        unsnoozeAlert: true,
+        resetAlert: true,
+        deleteAlert: true,
+    }),
+
+    reducers({
+        alert: {
+            patchAlertLocally: (state, { patch }) => (state ? { ...state, ...patch } : null),
+        },
+        activeTab: [
+            DEFAULT_TAB as LogsAlertDetailTab,
+            {
+                setActiveTab: (_, { tab }) => tab,
+            },
+        ],
+        sparkline7dFetched: [
+            false as boolean,
+            {
+                loadSparkline7dSuccess: () => true,
+                loadSparkline7dFailure: () => true,
+                submitAlertFormSuccess: () => false,
+            },
+        ],
+    }),
+
+    loaders(({ values, props }) => ({
+        alert: [
+            null as LogsAlertConfigurationApi | null,
+            {
+                loadAlert: async () => logsAlertsRetrieve(String(values.currentTeamId), props.id),
+            },
+        ],
+        sparkline7d: [
+            [] as any[],
+            {
+                loadSparkline7d: async () => {
+                    if (!values.alert) {
+                        return []
+                    }
+                    const filters = (values.alert.filters ?? {}) as Record<string, unknown>
+                    return api.logs.sparkline({
+                        query: {
+                            dateRange: { date_from: '-7d', date_to: null },
+                            severityLevels: filters.severityLevels as string[] | undefined,
+                            serviceNames: filters.serviceNames as string[] | undefined,
+                            filterGroup: (filters.filterGroup as any) ?? { type: 'AND', values: [] },
+                            sparklineBreakdownBy: 'severity',
+                        },
+                    })
+                },
+            },
+        ],
+    })),
+
+    selectors({
+        alertId: [() => [(_, props) => props.id], (id: string): string => id],
+
+        breadcrumbs: [
+            (s) => [s.alert],
+            (alert: LogsAlertConfigurationApi | null): Breadcrumb[] => [
+                {
+                    key: Scene.Logs,
+                    name: 'Logs',
+                    path: `${urls.logs()}?activeTab=alerts`,
+                    iconType: 'logs',
+                },
+                {
+                    key: Scene.LogsAlertDetail,
+                    name: alert?.name ?? 'Alert',
+                    iconType: 'logs',
+                },
+            ],
+        ],
+
+        sparkline7dSeries: [
+            (s) => [s.sparkline7d],
+            (rows: any[]): { series: SparklineTimeSeries[]; labels: string[] } => {
+                if (!rows.length) {
+                    return { series: [], labels: [] }
+                }
+                const timeIndex = new Map<string, number>()
+                rows.forEach((row) => {
+                    if (!timeIndex.has(row.time)) {
+                        timeIndex.set(row.time, timeIndex.size)
+                    }
+                })
+                const times = Array.from(timeIndex.keys())
+                const bucketMap = new Map<string, number[]>()
+                rows.forEach((row) => {
+                    if (row.severity === '(no value)') {
+                        return
+                    }
+                    if (!bucketMap.has(row.severity)) {
+                        bucketMap.set(row.severity, Array(times.length).fill(0))
+                    }
+                    bucketMap.get(row.severity)![timeIndex.get(row.time)!] += row.count
+                })
+                const severityColor: Record<string, string> = {
+                    ERROR: 'danger',
+                    WARN: 'warning',
+                    INFO: 'success',
+                    DEBUG: 'muted',
+                }
+                const series: SparklineTimeSeries[] = Array.from(bucketMap.entries()).map(([sev, values]) => ({
+                    name: sev,
+                    values,
+                    color: severityColor[sev] ?? 'muted',
+                }))
+                const totalPerSlot = Array(times.length).fill(0)
+                for (const vals of bucketMap.values()) {
+                    vals.forEach((v, i) => (totalPerSlot[i] += v))
+                }
+                const quietValues = totalPerSlot.map((total) => (total === 0 ? 1 : 0))
+                if (quietValues.some(Boolean)) {
+                    series.push({ name: 'Quiet', values: quietValues, color: 'border' })
+                }
+                const labels = times.map((t) => dayjs(t).format('MMM D, HH:mm'))
+                return { series, labels }
+            },
+        ],
+
+        logsViewerUrl: [
+            (s) => [s.alert],
+            (alert: LogsAlertConfigurationApi | null): string => {
+                if (!alert) {
+                    return `${urls.logs()}?activeTab=viewer`
+                }
+                const filters = (alert.filters ?? {}) as Record<string, unknown>
+                const params: Record<string, string> = { activeTab: 'viewer' }
+                const severityLevels = filters.severityLevels as string[] | undefined
+                const serviceNames = filters.serviceNames as string[] | undefined
+                const filterGroup = filters.filterGroup as object | undefined
+                if (severityLevels?.length) {
+                    params.severityLevels = JSON.stringify(severityLevels)
+                }
+                if (serviceNames?.length) {
+                    params.serviceNames = JSON.stringify(serviceNames)
+                }
+                if (filterGroup) {
+                    params.filterGroup = JSON.stringify(filterGroup)
+                }
+                const query = new URLSearchParams(params).toString()
+                return `${urls.logs()}?${query}`
+            },
+        ],
+    }),
+
+    listeners(({ actions, values, props }) => ({
+        submitAlertFormSuccess: () => {
+            actions.loadAlert()
+        },
+        loadExistingHogFunctionsSuccess: () => {
+            if (!values.alertFormChanged) {
+                actions.loadAlert()
+            }
+        },
+        loadAlertSuccess: () => {
+            if (values.alert) {
+                actions.resetAlertForm(buildFormDefaults(values.alert))
+            }
+            if (!values.sparkline7dFetched) {
+                actions.loadSparkline7d()
+            }
+            actions.loadEvents()
+        },
+        renameAlert: async ({ name }) => {
+            try {
+                await logsAlertsPartialUpdate(String(values.currentTeamId), props.id, { name })
+                actions.patchAlertLocally({ name })
+            } catch {
+                lemonToast.error('Failed to rename alert')
+                actions.loadAlert()
+            }
+        },
+        toggleEnabled: () => {
+            if (!values.alert) {
+                return
+            }
+            withEnableNotificationGuard(
+                values.alert,
+                async () => {
+                    try {
+                        await logsAlertsPartialUpdate(String(values.currentTeamId), props.id, {
+                            enabled: !(values.alert!.enabled ?? true),
+                        })
+                        actions.loadAlert()
+                    } catch {
+                        lemonToast.error('Failed to update alert')
+                    }
+                },
+                () => actions.setActiveTab('notifications')
+            )
+        },
+        snoozeAlert: async ({ durationMinutes }) => {
+            const snoozeUntil = dayjs().add(durationMinutes, 'minute').toISOString()
+            try {
+                await logsAlertsPartialUpdate(String(values.currentTeamId), props.id, {
+                    snooze_until: snoozeUntil,
+                })
+                lemonToast.success('Alert snoozed')
+                actions.loadAlert()
+            } catch {
+                lemonToast.error('Failed to snooze alert')
+            }
+        },
+        unsnoozeAlert: async () => {
+            try {
+                await logsAlertsPartialUpdate(String(values.currentTeamId), props.id, { snooze_until: null })
+                lemonToast.success('Alert unsnoozed')
+                actions.loadAlert()
+            } catch {
+                lemonToast.error('Failed to unsnooze alert')
+            }
+        },
+        resetAlert: async () => {
+            try {
+                await logsAlertsResetCreate(String(values.currentTeamId), props.id)
+                lemonToast.success('Alert reset — next check will run shortly.')
+                actions.loadAlert()
+            } catch {
+                lemonToast.error('Failed to reset alert')
+            }
+        },
+        deleteAlert: async () => {
+            try {
+                await logsAlertsDestroy(String(values.currentTeamId), props.id)
+                lemonToast.success('Alert deleted')
+                actions.loadAlerts()
+                router.actions.push(`${urls.logs()}?activeTab=alerts`)
+            } catch {
+                lemonToast.error('Failed to delete alert')
+            }
+        },
+    })),
+
+    afterMount(({ actions }) => {
+        actions.loadAlert()
+    }),
+
+    urlToAction(({ actions, values }) => ({
+        '/logs/alerts/:id': (_, searchParams) => {
+            const tab = searchParams.tab as LogsAlertDetailTab | undefined
+            const resolved = tab && VALID_TABS.includes(tab) ? tab : DEFAULT_TAB
+            if (resolved !== values.activeTab) {
+                actions.setActiveTab(resolved)
+            }
+        },
+    })),
+
+    actionToUrl(({ values }) => ({
+        setActiveTab: () => {
+            const params = { ...router.values.searchParams }
+            if (values.activeTab === DEFAULT_TAB) {
+                delete params.tab
+            } else {
+                params.tab = values.activeTab
+            }
+            return [router.values.location.pathname, params, router.values.hashParams, { replace: true }]
+        },
+    })),
+])

--- a/products/logs/frontend/scenes/LogsAlertNewScene/LogsAlertNewScene.tsx
+++ b/products/logs/frontend/scenes/LogsAlertNewScene/LogsAlertNewScene.tsx
@@ -1,0 +1,83 @@
+import { BindLogic, useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
+
+import { IconTestTube } from '@posthog/icons'
+import { LemonButton, LemonModal } from '@posthog/lemon-ui'
+
+import { SceneExport } from 'scenes/sceneTypes'
+
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+
+import { LogsAlertForm } from 'products/logs/frontend/components/LogsAlerting/LogsAlertForm'
+import { logsAlertFormLogic } from 'products/logs/frontend/components/LogsAlerting/logsAlertFormLogic'
+import { LogsAlertSimulation } from 'products/logs/frontend/components/LogsAlerting/LogsAlertSimulation'
+
+import { logsAlertNewSceneLogic } from './logsAlertNewSceneLogic'
+
+export const scene: SceneExport = {
+    component: LogsAlertNewScene,
+    logic: logsAlertNewSceneLogic,
+}
+
+const FORM_PROPS = { alert: null }
+
+export function LogsAlertNewScene(): JSX.Element {
+    const { canCreateDraft, createdAlertLoading } = useValues(logsAlertNewSceneLogic)
+    const { createDraft } = useActions(logsAlertNewSceneLogic)
+    const { alertForm, isSimulationPanelOpen } = useValues(logsAlertFormLogic(FORM_PROPS))
+    const { setAlertFormValue, openSimulationPanel, closeSimulationPanel } = useActions(logsAlertFormLogic(FORM_PROPS))
+
+    return (
+        <BindLogic logic={logsAlertFormLogic} props={FORM_PROPS}>
+            <SceneContent>
+                <SceneTitleSection
+                    name={alertForm.name || 'New alert'}
+                    resourceType={{ type: 'logs' }}
+                    canEdit
+                    onNameChange={(name) => setAlertFormValue('name', name)}
+                    renameDebounceMs={0}
+                    actions={
+                        <div className="flex items-center gap-2">
+                            <LemonButton
+                                size="small"
+                                type="secondary"
+                                icon={<IconTestTube />}
+                                onClick={openSimulationPanel}
+                                active={isSimulationPanelOpen}
+                                tooltip="Run this alert against historical data to see when it would have fired"
+                            >
+                                Simulate
+                            </LemonButton>
+                            <LemonButton
+                                size="small"
+                                type="primary"
+                                onClick={createDraft}
+                                loading={createdAlertLoading}
+                                disabledReason={
+                                    !canCreateDraft ? 'Add a name and at least one filter to create' : undefined
+                                }
+                            >
+                                Create draft
+                            </LemonButton>
+                        </div>
+                    }
+                />
+                <div className="flex flex-col gap-6 p-4">
+                    <Form logic={logsAlertFormLogic} props={FORM_PROPS} formKey="alertForm" enableFormOnSubmit>
+                        <LogsAlertForm />
+                    </Form>
+                </div>
+                <LemonModal
+                    isOpen={isSimulationPanelOpen}
+                    onClose={closeSimulationPanel}
+                    title="Alert simulation"
+                    description="Run the alert against historical data to preview when it would have fired. Includes threshold evaluation, N-of-M noise reduction, and cooldown."
+                    width={960}
+                >
+                    <LogsAlertSimulation />
+                </LemonModal>
+            </SceneContent>
+        </BindLogic>
+    )
+}

--- a/products/logs/frontend/scenes/LogsAlertNewScene/logsAlertNewSceneLogic.ts
+++ b/products/logs/frontend/scenes/LogsAlertNewScene/logsAlertNewSceneLogic.ts
@@ -10,7 +10,10 @@ import { urls } from 'scenes/urls'
 
 import { Breadcrumb } from '~/types'
 
-import { logsAlertFormLogic } from 'products/logs/frontend/components/LogsAlerting/logsAlertFormLogic'
+import {
+    logsAlertFormLogic,
+    LogsAlertFormType,
+} from 'products/logs/frontend/components/LogsAlerting/logsAlertFormLogic'
 import { buildAlertFilters, hasAnyFilter } from 'products/logs/frontend/components/LogsAlerting/logsAlertUtils'
 import { logsAlertsCreate } from 'products/logs/frontend/generated/api'
 import { LogsAlertConfigurationApi } from 'products/logs/frontend/generated/api.schemas'

--- a/products/logs/frontend/scenes/LogsAlertNewScene/logsAlertNewSceneLogic.ts
+++ b/products/logs/frontend/scenes/LogsAlertNewScene/logsAlertNewSceneLogic.ts
@@ -1,0 +1,92 @@
+import { actions, connect, kea, listeners, path, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import { router } from 'kea-router'
+
+import { lemonToast } from '@posthog/lemon-ui'
+
+import { Scene } from 'scenes/sceneTypes'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
+
+import { Breadcrumb } from '~/types'
+
+import { logsAlertFormLogic } from 'products/logs/frontend/components/LogsAlerting/logsAlertFormLogic'
+import { buildAlertFilters, hasAnyFilter } from 'products/logs/frontend/components/LogsAlerting/logsAlertUtils'
+import { logsAlertsCreate } from 'products/logs/frontend/generated/api'
+import { LogsAlertConfigurationApi } from 'products/logs/frontend/generated/api.schemas'
+
+import type { logsAlertNewSceneLogicType } from './logsAlertNewSceneLogicType'
+
+export const logsAlertNewSceneLogic = kea<logsAlertNewSceneLogicType>([
+    path(['products', 'logs', 'frontend', 'scenes', 'LogsAlertNewScene', 'logsAlertNewSceneLogic']),
+
+    connect({
+        values: [teamLogic, ['currentTeamId'], logsAlertFormLogic({ alert: null }), ['alertForm']],
+    }),
+
+    actions({
+        createDraft: true,
+    }),
+
+    loaders(({ values }) => ({
+        createdAlert: [
+            null as LogsAlertConfigurationApi | null,
+            {
+                createDraft: async () => {
+                    const form = values.alertForm
+                    if (!form.name?.trim()) {
+                        lemonToast.error('Name is required')
+                        return null
+                    }
+                    if (!hasAnyFilter(form.severityLevels, form.serviceNames, form.filterGroup)) {
+                        lemonToast.error('At least one filter is required')
+                        return null
+                    }
+                    const projectId = String(values.currentTeamId)
+                    try {
+                        const created = await logsAlertsCreate(projectId, {
+                            name: form.name.trim(),
+                            filters: buildAlertFilters(form.severityLevels, form.serviceNames, form.filterGroup),
+                            threshold_count: form.thresholdCount,
+                            threshold_operator: form.thresholdOperator,
+                            window_minutes: form.windowMinutes,
+                            evaluation_periods: form.evaluationPeriods,
+                            datapoints_to_alarm: form.datapointsToAlarm,
+                            cooldown_minutes: form.cooldownMinutes,
+                            enabled: false,
+                        })
+                        return created
+                    } catch (e: any) {
+                        lemonToast.error(e?.detail ?? e?.message ?? 'Failed to create alert')
+                        return null
+                    }
+                },
+            },
+        ],
+    })),
+
+    selectors({
+        breadcrumbs: [
+            () => [],
+            (): Breadcrumb[] => [
+                { key: Scene.Logs, name: 'Logs', path: `${urls.logs()}?activeTab=alerts`, iconType: 'logs' },
+                { key: Scene.LogsAlertNew, name: 'New alert', iconType: 'logs' },
+            ],
+        ],
+
+        canCreateDraft: [
+            (s) => [s.alertForm],
+            (form: LogsAlertFormType): boolean =>
+                !!form.name?.trim() && hasAnyFilter(form.severityLevels, form.serviceNames, form.filterGroup),
+        ],
+    }),
+
+    listeners(() => ({
+        createDraftSuccess: ({ createdAlert }) => {
+            if (createdAlert) {
+                lemonToast.success('Draft alert created — enable it once notifications are configured.')
+                router.actions.push(urls.logsAlertDetail(createdAlert.id))
+            }
+        },
+    })),
+])

--- a/products/logs/manifest.tsx
+++ b/products/logs/manifest.tsx
@@ -16,12 +16,33 @@ export const manifest: ProductManifest = {
             iconType: 'logs',
             description: 'Monitor and analyze your logs to understand and fix issues.',
         },
+        LogsAlertNew: {
+            import: () => import('./frontend/scenes/LogsAlertNewScene/LogsAlertNewScene'),
+            projectBased: true,
+            name: 'New alert',
+            activityScope: ActivityScope.LOG,
+            layout: 'app-container',
+        },
+        LogsAlertDetail: {
+            import: () => import('./frontend/scenes/LogsAlertDetailScene/LogsAlertDetailScene'),
+            projectBased: true,
+            name: 'Alert',
+            activityScope: ActivityScope.LOG,
+            layout: 'app-container',
+        },
     },
     routes: {
         '/logs': ['Logs', 'logs'],
+        '/logs/alerts/new': ['LogsAlertNew', 'logsAlertNew'],
+        '/logs/alerts/:id': ['LogsAlertDetail', 'logsAlertDetail'],
     },
     redirects: {},
-    urls: { logs: (): string => '/logs' },
+    urls: {
+        logs: (): string => '/logs',
+        logsAlertNew: (): string => '/logs/alerts/new',
+        logsAlertDetail: (id: string, tab?: string): string =>
+            tab ? `/logs/alerts/${id}?tab=${tab}` : `/logs/alerts/${id}`,
+    },
     fileSystemTypes: {},
     treeItemsNew: [],
     treeItemsProducts: [


### PR DESCRIPTION
## Problem

Log alerts previously used a modal-based flow anchored to the Logs settings page, making it difficult to deep-link to a specific alert, navigate between alert configuration sections, or share alert URLs in notifications. Alert notification URLs also pointed to the wrong path (`/logs?alertId=...`).

## Changes

### New page-based alert flow  
![image.png](https://app.graphite.com/user-attachments/assets/2816e81f-dfa0-479c-b068-618c2da5a381.png)



- Adds two new scenes: `LogsAlertNewScene` (`/logs/alerts/new`) and `LogsAlertDetailScene` (`/logs/alerts/:id`), replacing the modal-based create/edit experience.
- The new alert creation page requires a name and at least one filter before the "Create draft" button is enabled. New alerts are created in a disabled state so notifications can be configured before the alert goes live.
- The detail page is organized into four tabs: **Configuration**, **Notifications**, **History**, and **Observed logs**.
- Status banners surface actionable warnings (disabled, broken, snoozed, firing, no destinations configured).
- Enabling an alert with no notification destinations now prompts a confirmation dialog offering to navigate to the Notifications tab instead.

### Alert list improvements

- Alert name cells now link directly to the detail page instead of opening a modal.
- Destination cells show a bell icon button linking to the Notifications tab of the detail page.
- `LogsAlertStateIndicator` now accepts an `enabled` prop and renders a "Disabled" tag when the alert is inactive.

### URL fixes

- All alert deep-link URLs in notification payloads and backend alert destinations updated from `/logs?alertId=<id>` to `/logs/alerts/<id>`.
- The `loadAlertsSuccess` listener that parsed `?alertId=` from the URL and opened the modal has been removed.

### Shared utilities extracted

- `buildAlertFilters`, `hasAnyFilter`, `SNOOZE_DURATIONS`, and `withEnableNotificationGuard` moved to `logsAlertUtils.ts` for reuse across the new scenes and existing logic.

## How did you test this code?

The Playwright end-to-end test (`logs-alerts.spec.ts`) has been updated to cover the new page-based flow: navigating to `/logs/alerts/new`, setting a name, adding a severity filter, creating a draft, verifying the detail page loads with persisted values, editing the threshold, saving, and deleting the alert with navigation back to the alerts list.

## Publish to changelog?

No