### PR TITLE
fix(warehouse-sources): save direct postgres without schema

### DIFF
--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -31,6 +31,7 @@ from posthog.temporal.data_imports.sources.bigquery.bigquery import BigQuerySour
 from posthog.temporal.data_imports.sources.common.base import FieldType
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.postgres.postgres import PostgresDiscoveredSchema
+from posthog.temporal.data_imports.sources.postgres.source import PostgresSource
 from posthog.temporal.data_imports.sources.stripe.constants import (
     BALANCE_TRANSACTION_RESOURCE_NAME as STRIPE_BALANCE_TRANSACTION_RESOURCE_NAME,
     CHARGE_RESOURCE_NAME as STRIPE_CHARGE_RESOURCE_NAME,
@@ -1953,6 +1954,46 @@ class TestExternalDataSource(APIBaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json(), {"message": "Schema is required for warehouse imports."})
+
+    @patch("products.data_warehouse.backend.api.external_data_source.SourceRegistry.get_source")
+    def test_database_schema_postgres_direct_allows_blank_schema(self, mock_get_source):
+        source = PostgresSource()
+        mock_get_source.return_value = source
+
+        with (
+            patch.object(source, "validate_credentials_for_access_method", return_value=(True, None)) as validate,
+            patch.object(
+                source,
+                "get_schemas",
+                return_value=[
+                    SourceSchema(
+                        name="public.accounts",
+                        supports_incremental=False,
+                        supports_append=False,
+                        columns=[("id", "integer", False)],
+                        foreign_keys=[],
+                    )
+                ],
+            ),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_sources/database_schema/",
+                data={
+                    "source_type": "Postgres",
+                    "access_method": "direct",
+                    "host": "localhost",
+                    "port": 5432,
+                    "database": "app",
+                    "user": "user",
+                    "password": "pass",
+                    "schema": "",
+                },
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()[0]["table"], "public.accounts")
+        validate.assert_called_once()
+        self.assertEqual(validate.call_args.args[2], "direct")
 
     def test_database_schema(self):
         postgres_connection = psycopg.connect(

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -1224,7 +1224,7 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
             try {
                 const schemas = await api.externalDataSources.database_schema(
                     values.selectedConnector.name,
-                    values.source.payload ?? {}
+                    getDatabaseSchemaPayload(values.source)
                 )
 
                 let showToast = false
@@ -1541,6 +1541,13 @@ export const getInitialSourceConnectionDetailsValues = (
     ...savedValues,
     access_method:
         savedValues && typeof savedValues.access_method === 'string' ? savedValues.access_method : accessMethod,
+})
+
+export const getDatabaseSchemaPayload = (
+    source: Pick<ExternalDataSourceCreatePayload, 'access_method' | 'payload'>
+): Record<string, any> => ({
+    ...source.payload,
+    access_method: source.access_method ?? 'warehouse',
 })
 
 export const getErrorsForFields = (

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
@@ -1,10 +1,42 @@
 import {
     buildKeaFormDefaultFromSourceDetails,
+    getDatabaseSchemaPayload,
     getErrorsForFields,
     getInitialSourceConnectionDetailsValues,
 } from '../sourceWizardLogic'
 
 describe('sourceWizardLogic', () => {
+    describe('getDatabaseSchemaPayload', () => {
+        it('includes the selected access method for schema discovery', () => {
+            expect(
+                getDatabaseSchemaPayload({
+                    access_method: 'direct',
+                    payload: {
+                        host: 'localhost',
+                        schema: '',
+                    },
+                })
+            ).toEqual({
+                access_method: 'direct',
+                host: 'localhost',
+                schema: '',
+            })
+        })
+
+        it('defaults to warehouse mode', () => {
+            expect(
+                getDatabaseSchemaPayload({
+                    payload: {
+                        host: 'localhost',
+                    },
+                })
+            ).toEqual({
+                access_method: 'warehouse',
+                host: 'localhost',
+            })
+        })
+    })
+
     describe('getInitialSourceConnectionDetailsValues', () => {
         it('sets the access method when there are no saved values', () => {
             expect(getInitialSourceConnectionDetailsValues(undefined, 'direct')).toEqual({


### PR DESCRIPTION
## Problem

Adding a direct postgres query source with no schema produces this:

<img width="558" height="184" alt="Screenshot 2026-04-22 at 15 48 11" src="https://github.com/user-attachments/assets/b73723d1-ced4-4373-92a5-452ae6fb30c0" />


## Changes

Fix the bug.

## How did you test this code?

Clicked through the entire flow locally.

## Publish to changelog?
no

## Docs update
no