### PR TITLE
fix(logs-alerts): transient errors don't count toward BROKEN threshold

### DIFF
--- a/products/logs/backend/alert_error_classifier.py
+++ b/products/logs/backend/alert_error_classifier.py
@@ -16,11 +16,19 @@ from posthog.errors import ExposedCHQueryError, QueryErrorCategory, classify_que
 
 AlertErrorCode = Literal["server_busy", "query_performance", "invalid_query", "cancelled", "unknown"]
 
+# Infrastructure errors that should not count toward the BROKEN auto-disable threshold.
+# These indicate a transient cluster problem rather than a misconfigured alert.
+TRANSIENT_ERROR_CODES: frozenset[AlertErrorCode] = frozenset({"server_busy", "cancelled", "unknown"})
+
 
 @dataclass(frozen=True)
 class ClassifiedAlertError:
     code: AlertErrorCode
     user_message: str
+
+    @property
+    def is_transient(self) -> bool:
+        return self.code in TRANSIENT_ERROR_CODES
 
 
 _UNKNOWN = ClassifiedAlertError(

--- a/products/logs/backend/alert_state_machine.py
+++ b/products/logs/backend/alert_state_machine.py
@@ -50,6 +50,7 @@ class CheckResult:
     threshold_breached: bool
     error_message: str | None = None
     query_duration_ms: int | None = None
+    is_transient_error: bool = False
 
 
 @dataclass(frozen=True)
@@ -122,7 +123,9 @@ def evaluate_alert_check(
         effective_state = snapshot.state
 
     if check.error_message is not None:
-        consecutive_failures = snapshot.consecutive_failures + 1
+        consecutive_failures = (
+            snapshot.consecutive_failures if check.is_transient_error else snapshot.consecutive_failures + 1
+        )
         new_state = AlertState.BROKEN if consecutive_failures >= MAX_CONSECUTIVE_FAILURES else AlertState.ERRORED
         first_error = (
             effective_state != AlertState.ERRORED

--- a/products/logs/backend/temporal/activities.py
+++ b/products/logs/backend/temporal/activities.py
@@ -221,6 +221,7 @@ def _evaluate_single_alert(
             result_count=None,
             threshold_breached=False,
             error_message=classified.user_message,
+            is_transient_error=classified.is_transient,
         )
 
     outcome = evaluate_alert_check(alert.to_snapshot(), check_result, now)

--- a/products/logs/backend/test/test_alert_error_classifier.py
+++ b/products/logs/backend/test/test_alert_error_classifier.py
@@ -7,7 +7,7 @@ from posthog.hogql.errors import ExposedHogQLError
 
 from posthog.errors import ExposedCHQueryError, InternalCHQueryError, QueryErrorCategory
 
-from products.logs.backend.alert_error_classifier import classify
+from products.logs.backend.alert_error_classifier import TRANSIENT_ERROR_CODES, classify
 
 
 def _with_category(category: QueryErrorCategory):
@@ -78,3 +78,32 @@ class TestClassifyAlertError(TestCase):
             result = classify(RuntimeError("something unexpected"))
 
         assert "PostHog" in result.user_message
+
+
+class TestIsTransient(TestCase):
+    @parameterized.expand(
+        [
+            (QueryErrorCategory.RATE_LIMITED, True),
+            (QueryErrorCategory.CANCELLED, True),
+            (QueryErrorCategory.ERROR, True),
+            (QueryErrorCategory.QUERY_PERFORMANCE_ERROR, False),
+        ]
+    )
+    def test_is_transient_matches_transient_error_codes(self, category: QueryErrorCategory, expected: bool) -> None:
+        with _with_category(category):
+            result = classify(Exception("whatever"))
+        assert result.is_transient is expected
+
+    def test_is_transient_false_for_invalid_query(self) -> None:
+        exc = ExposedCHQueryError("Unknown identifier", code=47)
+        with _with_category(QueryErrorCategory.USER_ERROR):
+            result = classify(exc)
+        assert result.code == "invalid_query"
+        assert result.is_transient is False
+
+    def test_transient_error_codes_covers_all_transient_categories(self) -> None:
+        transient_categories = {QueryErrorCategory.RATE_LIMITED, QueryErrorCategory.CANCELLED, QueryErrorCategory.ERROR}
+        for category in transient_categories:
+            with _with_category(category):
+                result = classify(Exception("x"))
+            assert result.code in TRANSIENT_ERROR_CODES, f"{category} should map to a transient code"

--- a/products/logs/backend/test/test_alert_state_machine.py
+++ b/products/logs/backend/test/test_alert_state_machine.py
@@ -248,6 +248,44 @@ class TestErrorHandling(TestCase):
         assert outcome.notification == NotificationAction.NONE
 
 
+class TestTransientErrors(TestCase):
+    def test_transient_error_does_not_increment_consecutive_failures(self) -> None:
+        snapshot = _snapshot(state=NOT_FIRING, consecutive_failures=2)
+        check = CheckResult(
+            result_count=None, threshold_breached=False, error_message="cluster busy", is_transient_error=True
+        )
+        outcome = evaluate_alert_check(snapshot, check, NOW)
+        assert outcome.consecutive_failures == 2
+
+    def test_transient_error_still_transitions_to_errored(self) -> None:
+        snapshot = _snapshot(state=NOT_FIRING)
+        check = CheckResult(
+            result_count=None, threshold_breached=False, error_message="cluster busy", is_transient_error=True
+        )
+        outcome = evaluate_alert_check(snapshot, check, NOW)
+        assert outcome.new_state == ERRORED
+        assert outcome.notification == NotificationAction.ERROR
+
+    def test_transient_error_does_not_push_counter_past_threshold(self) -> None:
+        # MAX_CONSECUTIVE_FAILURES - 1 non-transient errors → ERRORED, counter at 4.
+        # A transient error must NOT push it to 5 (BROKEN).
+        snapshot = _snapshot(state=ERRORED, consecutive_failures=4)
+        check = CheckResult(
+            result_count=None, threshold_breached=False, error_message="cancelled", is_transient_error=True
+        )
+        outcome = evaluate_alert_check(snapshot, check, NOW)
+        assert outcome.new_state == ERRORED
+        assert outcome.consecutive_failures == 4
+
+    def test_non_transient_error_still_increments_failures(self) -> None:
+        snapshot = _snapshot(state=NOT_FIRING, consecutive_failures=2)
+        check = CheckResult(
+            result_count=None, threshold_breached=False, error_message="invalid query", is_transient_error=False
+        )
+        outcome = evaluate_alert_check(snapshot, check, NOW)
+        assert outcome.consecutive_failures == 3
+
+
 class TestBrokenTransition(TestCase):
     @parameterized.expand(
         [

--- a/products/logs/backend/test/test_logs_alerting_activities.py
+++ b/products/logs/backend/test/test_logs_alerting_activities.py
@@ -857,10 +857,16 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.produce_internal_event")
     def test_errored_notification_emitted_on_first_error(self, mock_produce, mock_query_cls):
-        mock_query_cls.return_value.execute.side_effect = RuntimeError("CH down")
+        mock_query_cls.return_value.execute.side_effect = Exception(
+            "Code: 160. DB::Exception: Estimated query execution time is too long"
+        )
         alert = self._make_alert()
 
-        _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
+        with patch(
+            "products.logs.backend.alert_error_classifier.classify_query_error",
+            return_value=QueryErrorCategory.QUERY_PERFORMANCE_ERROR,
+        ):
+            _evaluate_single_alert(alert, datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats())
 
         alert.refresh_from_db()
         assert alert.state == LogsAlertConfiguration.State.ERRORED
@@ -900,13 +906,21 @@ class TestEvaluateSingleAlert(APIBaseTest):
     @patch("products.logs.backend.temporal.activities.AlertCheckQuery")
     @patch("products.logs.backend.temporal.activities.capture_exception")
     def test_broken_notification_retried_after_kafka_failure(self, _mock_capture, mock_query_cls):
-        mock_query_cls.return_value.execute.side_effect = RuntimeError("CH down")
+        mock_query_cls.return_value.execute.side_effect = Exception(
+            "Code: 160. DB::Exception: Estimated query execution time is too long"
+        )
         # 4 prior failures — one more pushes consecutive_failures to MAX (5) → BROKEN.
         alert = self._make_alert(state=LogsAlertConfiguration.State.ERRORED, consecutive_failures=4)
         now1 = datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC)
         now2 = datetime(2025, 1, 1, 0, 6, 0, tzinfo=UTC)
 
-        with patch("products.logs.backend.temporal.activities.produce_internal_event") as mock_produce:
+        with (
+            patch("products.logs.backend.temporal.activities.produce_internal_event") as mock_produce,
+            patch(
+                "products.logs.backend.alert_error_classifier.classify_query_error",
+                return_value=QueryErrorCategory.QUERY_PERFORMANCE_ERROR,
+            ),
+        ):
             mock_produce.side_effect = Exception("Kafka down")
             _evaluate_single_alert(alert, now1, _make_stats())
 
@@ -943,11 +957,17 @@ class TestEvaluateSingleAlert(APIBaseTest):
         mock_query_cls,
         mock_notif_failures,
     ):
-        mock_query_cls.return_value.execute.side_effect = RuntimeError("CH down")
+        mock_query_cls.return_value.execute.side_effect = Exception(
+            "Code: 160. DB::Exception: Estimated query execution time is too long"
+        )
         self._make_alert(state=initial_state, consecutive_failures=initial_failures)
 
-        _evaluate_single_alert(
-            LogsAlertConfiguration.objects.get(), datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats()
-        )
+        with patch(
+            "products.logs.backend.alert_error_classifier.classify_query_error",
+            return_value=QueryErrorCategory.QUERY_PERFORMANCE_ERROR,
+        ):
+            _evaluate_single_alert(
+                LogsAlertConfiguration.objects.get(), datetime(2025, 1, 1, 0, 1, 0, tzinfo=UTC), _make_stats()
+            )
 
         mock_notif_failures.assert_called_once_with(expected_action)

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -90,7 +90,7 @@ tools:
             destructive: false
             idempotent: true
         title: Get project
-        description: >
+        description: |
             Retrieve a project and its settings. Pass `@current` as the ID to fetch the caller's active project.
         param_overrides:
             id:
@@ -115,11 +115,9 @@ tools:
             idempotent: true
         title: Update project settings
         description: >
-            Update a project's settings using PATCH semantics — only the fields included in the request body are changed.
-            Use `project-get` first to inspect current settings. Always confirm changes with the user before applying.
-        param_overrides:
-            id:
-                description: Project ID, or `@current` to target the caller's active project.
+            Update a project's settings using PATCH semantics — only the fields included in the request body are
+            changed. Use `project-get` first to inspect current settings. Always confirm changes with the user before
+            applying.
         exclude_params:
             - uuid
             - created_at
@@ -137,6 +135,9 @@ tools:
             - default_modifiers
             - person_on_events_querying_enabled
             - organization
+        param_overrides:
+            id:
+                description: Project ID, or `@current` to target the caller's active project.
     projects-destroy:
         operation: destroy_2
         enabled: false
@@ -579,8 +580,8 @@ tools:
             idempotent: true
         title: Get user
         description: >
-            Retrieve a user's profile and settings. Pass `@me` as the UUID to fetch the authenticated user —
-            non-staff callers may only access their own account.
+            Retrieve a user's profile and settings. Pass `@me` as the UUID to fetch the authenticated user — non-staff
+            callers may only access their own account.
         param_overrides:
             uuid:
                 description: User UUID, or `@me` to target the authenticated user.
@@ -605,13 +606,10 @@ tools:
         title: Update user settings
         description: >
             Update the authenticated user's profile and settings using PATCH semantics — only the fields included in the
-            request body are changed. Pass `@me` as the UUID; non-staff callers may only update their own account.
-            Use `user-get` first to inspect current settings. `notification_settings` merges key-by-key; changing `email`
+            request body are changed. Pass `@me` as the UUID; non-staff callers may only update their own account. Use
+            `user-get` first to inspect current settings. `notification_settings` merges key-by-key; changing `email`
             triggers a verification flow; changing `password` also requires `current_password`. Always confirm changes
             with the user before applying.
-        param_overrides:
-            uuid:
-                description: User UUID, or `@me` to target the authenticated user.
         exclude_params:
             - date_joined
             - uuid
@@ -632,6 +630,9 @@ tools:
             - has_sso_enforcement
             - is_2fa_enabled
             - scene_personalisation
+        param_overrides:
+            uuid:
+                description: User UUID, or `@me` to target the authenticated user.
     users-destroy:
         operation: users_destroy
         enabled: false
@@ -784,4 +785,7 @@ tools:
         enabled: false
     dashboard-templates-copy-between-projects-create:
         operation: dashboard_templates_copy_between_projects_create
+        enabled: false
+    legal-documents-download-retrieve:
+        operation: legal_documents_download_retrieve
         enabled: false


### PR DESCRIPTION
## Problem

Errors caused by us (e.g. clickhouse downtime) lasting longer than the log alert auto-disable window, would cause all alerts to be disabled.

## Changes

Adds transient error classification, to only disable an alert when it's erroring because of a user configuration issue, e.g. large queries.

## How did you test this code?

New tests

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Publish to changelog?

no