### PR TITLE
feat(notebooks): connect editor to collab SSE with cursor presence

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4584,6 +4584,21 @@ const api = {
         async kernelStatus(notebookId: NotebookType['short_id']): Promise<Record<string, any>> {
             return await new ApiRequest().notebook(notebookId).withAction('kernel/status').get()
         },
+        async collabStream(
+            notebookId: NotebookType['short_id'],
+            {
+                onMessage,
+                onError,
+                signal,
+            }: {
+                onMessage: (data: EventSourceMessage) => void
+                onError: (error: any) => void
+                signal?: AbortSignal
+            }
+        ): Promise<void> {
+            const url = new ApiRequest().notebook(notebookId).withAction('collab/stream').assembleFullUrl(true)
+            await api.stream(url, { method: 'GET', onMessage, onError, signal })
+        },
     },
 
     sessionGroupSummaries: {

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -65,6 +65,7 @@ import { notebookCollabLogic } from './notebookCollabLogic'
 import { NotebookDefaultBlockOnEnter } from './NotebookDefaultBlockOnEnter'
 import { notebookLogic } from './notebookLogic'
 import { NotebookTrailingParagraph } from './NotebookTrailingParagraph'
+import { RemotePresenceExtension } from './RemotePresenceExtension'
 import { SlashCommandsExtension } from './SlashCommands'
 import { TableMenu } from './TableMenu'
 
@@ -78,6 +79,7 @@ export function Editor(): JSX.Element {
         useActions(notebookLogic)
     const hasCollapsibleSections = useFeatureFlag('NOTEBOOKS_COLLAPSIBLE_SECTIONS')
     const { bindEditor } = useActions(notebookCollabLogic({ shortId }))
+    const { clientID } = useValues(notebookCollabLogic({ shortId }))
 
     const { resetSuggestions, setPreviousNode } = useActions(insertionSuggestionsLogic)
 
@@ -178,9 +180,10 @@ export function Editor(): JSX.Element {
             Extension.create({
                 name: 'collaboration',
                 addProseMirrorPlugins() {
-                    return [collab({ version: notebook.version, clientID: uuid() })]
+                    return [collab({ version: notebook.version, clientID })]
                 },
-            })
+            }),
+            RemotePresenceExtension
         )
     }
 

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -5,10 +5,9 @@ import { TaskItem, TaskList } from '@tiptap/extension-list'
 import { Table, TableCell, TableHeader, TableRow } from '@tiptap/extension-table'
 import TableOfContents, { getHierarchicalIndexes } from '@tiptap/extension-table-of-contents'
 import { Placeholder } from '@tiptap/extensions'
-import { collab, getVersion } from '@tiptap/pm/collab'
+import { collab } from '@tiptap/pm/collab'
 import StarterKit, { StarterKitOptions } from '@tiptap/starter-kit'
 import { useActions, useValues } from 'kea'
-import { useEffect, useState } from 'react'
 import { useThrottledCallback } from 'use-debounce'
 
 import { IconComment } from '@posthog/icons'
@@ -79,26 +78,8 @@ export function Editor(): JSX.Element {
     const { setEditor, onEditorUpdate, onEditorSelectionUpdate, setTableOfContents, insertComment } =
         useActions(notebookLogic)
     const hasCollapsibleSections = useFeatureFlag('NOTEBOOKS_COLLAPSIBLE_SECTIONS')
-    const { bindEditor, unbindEditor } = useActions(notebookCollabLogic({ shortId }))
-    const { editors } = useValues(notebookCollabLogic({ shortId }))
-
-    // Stable per-mount clientID
-    const [clientID] = useState(() => uuid())
-
-    // If another editor for this notebook is already mounted, copy its content + version.
-    // This avoids a race where `values.content` is ahead of `notebook.version` during save.
-    const [initial] = useState(() => {
-        const existing = Object.values(editors)[0]
-        return existing
-            ? { content: existing.state.doc.toJSON(), version: getVersion(existing.state) }
-            : { content, version: notebook?.version ?? 0 }
-    })
-
-    useEffect(() => {
-        return () => {
-            unbindEditor(clientID)
-        }
-    }, [clientID, unbindEditor])
+    const { bindEditor } = useActions(notebookCollabLogic({ shortId }))
+    const { clientID } = useValues(notebookCollabLogic({ shortId }))
 
     const { resetSuggestions, setPreviousNode } = useActions(insertionSuggestionsLogic)
 
@@ -199,7 +180,7 @@ export function Editor(): JSX.Element {
             Extension.create({
                 name: 'collaboration',
                 addProseMirrorPlugins() {
-                    return [collab({ version: initial.version, clientID })]
+                    return [collab({ version: notebook.version, clientID })]
                 },
             }),
             RemotePresenceExtension
@@ -217,8 +198,8 @@ export function Editor(): JSX.Element {
             extensions={extensions}
             disabled={!isEditable}
             className="NotebookEditor flex flex-col flex-1"
-            initialContent={initial.content}
-            onUpdate={() => onEditorUpdate(clientID)}
+            initialContent={content}
+            onUpdate={onEditorUpdate}
             onSelectionUpdate={onEditorSelectionUpdate}
             onCreate={(editor) => {
                 const notebookEditor: NotebookEditor = {
@@ -231,7 +212,7 @@ export function Editor(): JSX.Element {
                 setEditor(notebookEditor)
 
                 if (useCollab) {
-                    bindEditor(clientID, editor)
+                    bindEditor(editor)
                 }
             }}
         >

--- a/frontend/src/scenes/notebooks/Notebook/Editor.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Editor.tsx
@@ -5,9 +5,10 @@ import { TaskItem, TaskList } from '@tiptap/extension-list'
 import { Table, TableCell, TableHeader, TableRow } from '@tiptap/extension-table'
 import TableOfContents, { getHierarchicalIndexes } from '@tiptap/extension-table-of-contents'
 import { Placeholder } from '@tiptap/extensions'
-import { collab } from '@tiptap/pm/collab'
+import { collab, getVersion } from '@tiptap/pm/collab'
 import StarterKit, { StarterKitOptions } from '@tiptap/starter-kit'
 import { useActions, useValues } from 'kea'
+import { useEffect, useState } from 'react'
 import { useThrottledCallback } from 'use-debounce'
 
 import { IconComment } from '@posthog/icons'
@@ -78,8 +79,26 @@ export function Editor(): JSX.Element {
     const { setEditor, onEditorUpdate, onEditorSelectionUpdate, setTableOfContents, insertComment } =
         useActions(notebookLogic)
     const hasCollapsibleSections = useFeatureFlag('NOTEBOOKS_COLLAPSIBLE_SECTIONS')
-    const { bindEditor } = useActions(notebookCollabLogic({ shortId }))
-    const { clientID } = useValues(notebookCollabLogic({ shortId }))
+    const { bindEditor, unbindEditor } = useActions(notebookCollabLogic({ shortId }))
+    const { editors } = useValues(notebookCollabLogic({ shortId }))
+
+    // Stable per-mount clientID
+    const [clientID] = useState(() => uuid())
+
+    // If another editor for this notebook is already mounted, copy its content + version.
+    // This avoids a race where `values.content` is ahead of `notebook.version` during save.
+    const [initial] = useState(() => {
+        const existing = Object.values(editors)[0]
+        return existing
+            ? { content: existing.state.doc.toJSON(), version: getVersion(existing.state) }
+            : { content, version: notebook?.version ?? 0 }
+    })
+
+    useEffect(() => {
+        return () => {
+            unbindEditor(clientID)
+        }
+    }, [clientID, unbindEditor])
 
     const { resetSuggestions, setPreviousNode } = useActions(insertionSuggestionsLogic)
 
@@ -180,7 +199,7 @@ export function Editor(): JSX.Element {
             Extension.create({
                 name: 'collaboration',
                 addProseMirrorPlugins() {
-                    return [collab({ version: notebook.version, clientID })]
+                    return [collab({ version: initial.version, clientID })]
                 },
             }),
             RemotePresenceExtension
@@ -198,8 +217,8 @@ export function Editor(): JSX.Element {
             extensions={extensions}
             disabled={!isEditable}
             className="NotebookEditor flex flex-col flex-1"
-            initialContent={content}
-            onUpdate={onEditorUpdate}
+            initialContent={initial.content}
+            onUpdate={() => onEditorUpdate(clientID)}
             onSelectionUpdate={onEditorSelectionUpdate}
             onCreate={(editor) => {
                 const notebookEditor: NotebookEditor = {
@@ -212,7 +231,7 @@ export function Editor(): JSX.Element {
                 setEditor(notebookEditor)
 
                 if (useCollab) {
-                    bindEditor(editor)
+                    bindEditor(clientID, editor)
                 }
             }}
         >

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.scss
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.scss
@@ -623,3 +623,34 @@
         padding: 0;
     }
 }
+
+// Google-Docs-style remote presence carets + name flag.
+.NotebookRemotePresence {
+    position: relative;
+    display: inline-block;
+    width: 0;
+    height: 1.1em;
+    margin: 0;
+    vertical-align: text-bottom;
+    pointer-events: none;
+    border-left: 2px solid var(--remote-presence-color, currentColor);
+
+    &__flag {
+        position: absolute;
+        bottom: 100%;
+        left: -2px; // aligned with the bar's left edge
+        z-index: 5;
+        max-width: 12rem;
+        padding: 1px 6px;
+        overflow: hidden;
+        font-size: 0.7rem;
+        font-weight: 500;
+        line-height: 1.2;
+        color: #fff;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        user-select: none;
+        background: var(--remote-presence-color, currentColor);
+        border-radius: 3px 3px 3px 0;
+    }
+}

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.scss
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.scss
@@ -646,7 +646,7 @@
         font-size: 0.7rem;
         font-weight: 500;
         line-height: 1.2;
-        color: #fff;
+        color: var(--white);
         text-overflow: ellipsis;
         white-space: nowrap;
         user-select: none;

--- a/frontend/src/scenes/notebooks/Notebook/RemotePresenceExtension.ts
+++ b/frontend/src/scenes/notebooks/Notebook/RemotePresenceExtension.ts
@@ -2,18 +2,21 @@ import { Extension } from '@tiptap/core'
 import { EditorState, Plugin, PluginKey } from '@tiptap/pm/state'
 import { Decoration, DecorationSet } from '@tiptap/pm/view'
 
-export type RemotePresence = {
+import { getSeriesColor } from 'lib/colors'
+
+import type { RemotePresence } from './notebookCollabLogic'
+
+/** Meta payload dispatched to the plugin to upsert a remote caret. */
+export type RemotePresenceUpdate = {
     clientId: string
-    userId?: number | null
-    userName: string
-    userColor: string
-    head: number
-    lastSeenAt: number
+    presence: RemotePresence
 }
+
+type StoredPresence = RemotePresence & { lastSeenAt: number }
 
 type PluginState = {
     /** keyed by clientId */
-    presences: Map<string, RemotePresence>
+    presences: Map<string, StoredPresence>
 }
 
 export const REMOTE_PRESENCE_META = 'remote-presence-update'
@@ -21,23 +24,16 @@ const META_KEY = REMOTE_PRESENCE_META
 const PRESENCE_TTL_MS = 30_000
 const META_PRUNE = 'remote-presence-prune'
 
-export type RemotePresenceUpdate = UpdatePayload
-
 export const remotePresencePluginKey = new PluginKey<PluginState>('remote-presence')
 
-type UpdatePayload =
-    | { type: 'set'; presence: Omit<RemotePresence, 'lastSeenAt'> & { lastSeenAt?: number } }
-    | { type: 'remove'; clientId: string }
-    | { type: 'clear' }
-
-function buildDecorations(state: EditorState, presences: Map<string, RemotePresence>): DecorationSet {
+function buildDecorations(state: EditorState, presences: Map<string, StoredPresence>): DecorationSet {
     if (presences.size === 0) {
         return DecorationSet.empty
     }
     const docSize = state.doc.content.size
     const decorations: Decoration[] = []
 
-    for (const presence of presences.values()) {
+    for (const [clientId, presence] of presences) {
         const head = clamp(presence.head, 0, docSize)
 
         // Caret as a side-positioned widget. side:-1 keeps it in front of any
@@ -45,8 +41,8 @@ function buildDecorations(state: EditorState, presences: Map<string, RemotePrese
         // caret still wins visually. Range-selection highlights will land with
         // the separate :presence-stream (clicks/drags without edits).
         decorations.push(
-            Decoration.widget(head, () => buildCaretDom(presence), {
-                key: `presence-${presence.clientId}`,
+            Decoration.widget(head, () => buildCaretDom(clientId, presence), {
+                key: `presence-${clientId}`,
                 side: -1,
             })
         )
@@ -55,11 +51,11 @@ function buildDecorations(state: EditorState, presences: Map<string, RemotePrese
     return DecorationSet.create(state.doc, decorations)
 }
 
-function buildCaretDom(presence: RemotePresence): HTMLElement {
+function buildCaretDom(clientId: string, presence: StoredPresence): HTMLElement {
     const root = document.createElement('span')
     root.className = 'NotebookRemotePresence'
-    root.style.setProperty('--remote-presence-color', presence.userColor)
-    root.dataset.clientId = presence.clientId
+    root.style.setProperty('--remote-presence-color', getSeriesColor(presence.userId))
+    root.dataset.clientId = clientId
 
     const flag = document.createElement('span')
     flag.className = 'NotebookRemotePresence__flag'
@@ -79,8 +75,8 @@ function clamp(n: number, min: number, max: number): number {
     return n
 }
 
-function pruneStale(presences: Map<string, RemotePresence>, now: number): Map<string, RemotePresence> | null {
-    let next: Map<string, RemotePresence> | null = null
+function pruneStale(presences: Map<string, StoredPresence>, now: number): Map<string, StoredPresence> | null {
+    let next: Map<string, StoredPresence> | null = null
     for (const [id, p] of presences) {
         if (now - p.lastSeenAt > PRESENCE_TTL_MS) {
             if (!next) {
@@ -105,7 +101,7 @@ export const RemotePresenceExtension = Extension.create({
 
                     // 1. Project stored positions (pre-transaction coords) forward through any doc changes.
                     if (transaction.docChanged && presences.size > 0) {
-                        const mapped = new Map<string, RemotePresence>()
+                        const mapped = new Map<string, StoredPresence>()
                         for (const [id, p] of presences) {
                             mapped.set(id, { ...p, head: transaction.mapping.map(p.head) })
                         }
@@ -114,29 +110,10 @@ export const RemotePresenceExtension = Extension.create({
 
                     // 2. Apply meta after mapping: an upsert piggybacked on a remote step already
                     //    carries post-transaction coords, so mapping it again would double-shift.
-                    const meta = transaction.getMeta(META_KEY) as UpdatePayload | undefined
+                    const meta = transaction.getMeta(META_KEY) as RemotePresenceUpdate | undefined
                     if (meta) {
-                        switch (meta.type) {
-                            case 'set': {
-                                presences = new Map(presences)
-                                presences.set(meta.presence.clientId, {
-                                    ...meta.presence,
-                                    lastSeenAt: meta.presence.lastSeenAt ?? Date.now(),
-                                })
-                                break
-                            }
-                            case 'remove': {
-                                if (presences.has(meta.clientId)) {
-                                    presences = new Map(presences)
-                                    presences.delete(meta.clientId)
-                                }
-                                break
-                            }
-                            case 'clear': {
-                                presences = new Map()
-                                break
-                            }
-                        }
+                        presences = new Map(presences)
+                        presences.set(meta.clientId, { ...meta.presence, lastSeenAt: Date.now() })
                     } else if (transaction.getMeta(META_PRUNE)) {
                         const pruned = pruneStale(presences, Date.now())
                         if (pruned) {

--- a/frontend/src/scenes/notebooks/Notebook/RemotePresenceExtension.ts
+++ b/frontend/src/scenes/notebooks/Notebook/RemotePresenceExtension.ts
@@ -1,0 +1,182 @@
+import { Extension } from '@tiptap/core'
+import { EditorState, Plugin, PluginKey } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+
+export type RemotePresence = {
+    clientId: string
+    userId?: number | null
+    userName: string
+    userColor: string
+    head: number
+    lastSeenAt: number
+}
+
+type PluginState = {
+    /** keyed by clientId */
+    presences: Map<string, RemotePresence>
+}
+
+export const REMOTE_PRESENCE_META = 'remote-presence-update'
+const META_KEY = REMOTE_PRESENCE_META
+const PRESENCE_TTL_MS = 30_000
+const META_PRUNE = 'remote-presence-prune'
+
+export type RemotePresenceUpdate = UpdatePayload
+
+export const remotePresencePluginKey = new PluginKey<PluginState>('remote-presence')
+
+type UpdatePayload =
+    | { type: 'set'; presence: Omit<RemotePresence, 'lastSeenAt'> & { lastSeenAt?: number } }
+    | { type: 'remove'; clientId: string }
+    | { type: 'clear' }
+
+function buildDecorations(state: EditorState, presences: Map<string, RemotePresence>): DecorationSet {
+    if (presences.size === 0) {
+        return DecorationSet.empty
+    }
+    const docSize = state.doc.content.size
+    const decorations: Decoration[] = []
+
+    for (const presence of presences.values()) {
+        const head = clamp(presence.head, 0, docSize)
+
+        // Caret as a side-positioned widget. side:-1 keeps it in front of any
+        // text inserted at the same position by the local user, so the local
+        // caret still wins visually. Range-selection highlights will land with
+        // the separate :presence-stream (clicks/drags without edits).
+        decorations.push(
+            Decoration.widget(head, () => buildCaretDom(presence), {
+                key: `presence-${presence.clientId}`,
+                side: -1,
+            })
+        )
+    }
+
+    return DecorationSet.create(state.doc, decorations)
+}
+
+function buildCaretDom(presence: RemotePresence): HTMLElement {
+    const root = document.createElement('span')
+    root.className = 'NotebookRemotePresence'
+    root.style.setProperty('--remote-presence-color', presence.userColor)
+    root.dataset.clientId = presence.clientId
+
+    const flag = document.createElement('span')
+    flag.className = 'NotebookRemotePresence__flag'
+    flag.textContent = presence.userName
+    root.appendChild(flag)
+
+    return root
+}
+
+function clamp(n: number, min: number, max: number): number {
+    if (n < min) {
+        return min
+    }
+    if (n > max) {
+        return max
+    }
+    return n
+}
+
+function pruneStale(presences: Map<string, RemotePresence>, now: number): Map<string, RemotePresence> | null {
+    let next: Map<string, RemotePresence> | null = null
+    for (const [id, p] of presences) {
+        if (now - p.lastSeenAt > PRESENCE_TTL_MS) {
+            if (!next) {
+                next = new Map(presences)
+            }
+            next.delete(id)
+        }
+    }
+    return next
+}
+
+export const RemotePresenceExtension = Extension.create({
+    name: 'remotePresence',
+
+    addProseMirrorPlugins() {
+        const plugin = new Plugin<PluginState>({
+            key: remotePresencePluginKey,
+            state: {
+                init: () => ({ presences: new Map() }),
+                apply: (transaction, prev): PluginState => {
+                    let presences = prev.presences
+
+                    // 1. Project stored positions (pre-transaction coords) forward through any doc changes.
+                    if (transaction.docChanged && presences.size > 0) {
+                        const mapped = new Map<string, RemotePresence>()
+                        for (const [id, p] of presences) {
+                            mapped.set(id, { ...p, head: transaction.mapping.map(p.head) })
+                        }
+                        presences = mapped
+                    }
+
+                    // 2. Apply meta after mapping: an upsert piggybacked on a remote step already
+                    //    carries post-transaction coords, so mapping it again would double-shift.
+                    const meta = transaction.getMeta(META_KEY) as UpdatePayload | undefined
+                    if (meta) {
+                        switch (meta.type) {
+                            case 'set': {
+                                presences = new Map(presences)
+                                presences.set(meta.presence.clientId, {
+                                    ...meta.presence,
+                                    lastSeenAt: meta.presence.lastSeenAt ?? Date.now(),
+                                })
+                                break
+                            }
+                            case 'remove': {
+                                if (presences.has(meta.clientId)) {
+                                    presences = new Map(presences)
+                                    presences.delete(meta.clientId)
+                                }
+                                break
+                            }
+                            case 'clear': {
+                                presences = new Map()
+                                break
+                            }
+                        }
+                    } else if (transaction.getMeta(META_PRUNE)) {
+                        const pruned = pruneStale(presences, Date.now())
+                        if (pruned) {
+                            presences = pruned
+                        }
+                    }
+
+                    return presences === prev.presences ? prev : { presences }
+                },
+            },
+            props: {
+                decorations(state) {
+                    const pluginState = remotePresencePluginKey.getState(state)
+                    if (!pluginState) {
+                        return null
+                    }
+                    return buildDecorations(state, pluginState.presences)
+                },
+            },
+            view: (view) => {
+                // Periodic prune so abandoned remote carets fade out even if
+                // we never receive another transaction for the doc.
+                const interval = window.setInterval(() => {
+                    const pluginState = remotePresencePluginKey.getState(view.state)
+                    if (!pluginState || pluginState.presences.size === 0) {
+                        return
+                    }
+                    const stale = pruneStale(pluginState.presences, Date.now())
+                    if (stale) {
+                        view.dispatch(view.state.tr.setMeta(META_PRUNE, true))
+                    }
+                }, 5_000)
+                return {
+                    destroy() {
+                        window.clearInterval(interval)
+                    },
+                }
+            },
+        })
+
+        return [plugin]
+    },
+})

--- a/frontend/src/scenes/notebooks/Notebook/RemotePresenceExtension.ts
+++ b/frontend/src/scenes/notebooks/Notebook/RemotePresenceExtension.ts
@@ -6,34 +6,34 @@ import { getSeriesColor } from 'lib/colors'
 
 import type { RemotePresence } from './notebookCollabLogic'
 
-/** Meta payload dispatched to the plugin to upsert a remote caret. */
-export type RemotePresenceUpdate = {
+// Remote presence, used both as:
+// - the meta payload dispatched to the plugin `transaction.setMeta(REMOTE_PRESENCE_META, ...)`
+// - the per-client value stored in plugin state
+// `lastSeenAt` is stamped by the logic at dispatch time and used here only for TTL pruning.
+export type ClientPresence = RemotePresence & {
     clientId: string
-    presence: RemotePresence
+    lastSeenAt: number
 }
 
-type StoredPresence = RemotePresence & { lastSeenAt: number }
-
 type PluginState = {
-    /** keyed by clientId */
-    presences: Map<string, StoredPresence>
+    // keyed by clientId
+    clients: Map<string, ClientPresence>
 }
 
 export const REMOTE_PRESENCE_META = 'remote-presence-update'
-const META_KEY = REMOTE_PRESENCE_META
-const PRESENCE_TTL_MS = 30_000
 const META_PRUNE = 'remote-presence-prune'
+const PRESENCE_TTL_MS = 30_000
 
 export const remotePresencePluginKey = new PluginKey<PluginState>('remote-presence')
 
-function buildDecorations(state: EditorState, presences: Map<string, StoredPresence>): DecorationSet {
-    if (presences.size === 0) {
+function buildDecorations(state: EditorState, clients: Map<string, ClientPresence>): DecorationSet {
+    if (clients.size === 0) {
         return DecorationSet.empty
     }
     const docSize = state.doc.content.size
     const decorations: Decoration[] = []
 
-    for (const [clientId, presence] of presences) {
+    for (const presence of clients.values()) {
         const head = clamp(presence.head, 0, docSize)
 
         // Caret as a side-positioned widget. side:-1 keeps it in front of any
@@ -41,8 +41,8 @@ function buildDecorations(state: EditorState, presences: Map<string, StoredPrese
         // caret still wins visually. Range-selection highlights will land with
         // the separate :presence-stream (clicks/drags without edits).
         decorations.push(
-            Decoration.widget(head, () => buildCaretDom(clientId, presence), {
-                key: `presence-${clientId}`,
+            Decoration.widget(head, () => buildCaretDom(presence), {
+                key: `presence-${presence.clientId}`,
                 side: -1,
             })
         )
@@ -51,11 +51,11 @@ function buildDecorations(state: EditorState, presences: Map<string, StoredPrese
     return DecorationSet.create(state.doc, decorations)
 }
 
-function buildCaretDom(clientId: string, presence: StoredPresence): HTMLElement {
+function buildCaretDom(presence: ClientPresence): HTMLElement {
     const root = document.createElement('span')
     root.className = 'NotebookRemotePresence'
     root.style.setProperty('--remote-presence-color', getSeriesColor(presence.userId))
-    root.dataset.clientId = clientId
+    root.dataset.clientId = presence.clientId
 
     const flag = document.createElement('span')
     flag.className = 'NotebookRemotePresence__flag'
@@ -75,12 +75,12 @@ function clamp(n: number, min: number, max: number): number {
     return n
 }
 
-function pruneStale(presences: Map<string, StoredPresence>, now: number): Map<string, StoredPresence> | null {
-    let next: Map<string, StoredPresence> | null = null
-    for (const [id, p] of presences) {
+function pruneStale(clients: Map<string, ClientPresence>, now: number): Map<string, ClientPresence> | null {
+    let next: Map<string, ClientPresence> | null = null
+    for (const [id, p] of clients) {
         if (now - p.lastSeenAt > PRESENCE_TTL_MS) {
             if (!next) {
-                next = new Map(presences)
+                next = new Map(clients)
             }
             next.delete(id)
         }
@@ -95,33 +95,33 @@ export const RemotePresenceExtension = Extension.create({
         const plugin = new Plugin<PluginState>({
             key: remotePresencePluginKey,
             state: {
-                init: () => ({ presences: new Map() }),
+                init: () => ({ clients: new Map() }),
                 apply: (transaction, prev): PluginState => {
-                    let presences = prev.presences
+                    let clients = prev.clients
 
                     // 1. Project stored positions (pre-transaction coords) forward through any doc changes.
-                    if (transaction.docChanged && presences.size > 0) {
-                        const mapped = new Map<string, StoredPresence>()
-                        for (const [id, p] of presences) {
+                    if (transaction.docChanged && clients.size > 0) {
+                        const mapped = new Map<string, ClientPresence>()
+                        for (const [id, p] of clients) {
                             mapped.set(id, { ...p, head: transaction.mapping.map(p.head) })
                         }
-                        presences = mapped
+                        clients = mapped
                     }
 
                     // 2. Apply meta after mapping: an upsert piggybacked on a remote step already
                     //    carries post-transaction coords, so mapping it again would double-shift.
-                    const meta = transaction.getMeta(META_KEY) as RemotePresenceUpdate | undefined
+                    const meta = transaction.getMeta(REMOTE_PRESENCE_META) as ClientPresence | undefined
                     if (meta) {
-                        presences = new Map(presences)
-                        presences.set(meta.clientId, { ...meta.presence, lastSeenAt: Date.now() })
+                        clients = new Map(clients)
+                        clients.set(meta.clientId, meta)
                     } else if (transaction.getMeta(META_PRUNE)) {
-                        const pruned = pruneStale(presences, Date.now())
+                        const pruned = pruneStale(clients, Date.now())
                         if (pruned) {
-                            presences = pruned
+                            clients = pruned
                         }
                     }
 
-                    return presences === prev.presences ? prev : { presences }
+                    return clients === prev.clients ? prev : { clients }
                 },
             },
             props: {
@@ -130,7 +130,7 @@ export const RemotePresenceExtension = Extension.create({
                     if (!pluginState) {
                         return null
                     }
-                    return buildDecorations(state, pluginState.presences)
+                    return buildDecorations(state, pluginState.clients)
                 },
             },
             view: (view) => {
@@ -138,10 +138,10 @@ export const RemotePresenceExtension = Extension.create({
                 // we never receive another transaction for the doc.
                 const interval = window.setInterval(() => {
                     const pluginState = remotePresencePluginKey.getState(view.state)
-                    if (!pluginState || pluginState.presences.size === 0) {
+                    if (!pluginState || pluginState.clients.size === 0) {
                         return
                     }
-                    const stale = pruneStale(pluginState.presences, Date.now())
+                    const stale = pruneStale(pluginState.clients, Date.now())
                     if (stale) {
                         view.dispatch(view.state.tr.setMeta(META_PRUNE, true))
                     }

--- a/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.test.ts
@@ -79,7 +79,10 @@ describe('notebookCollabLogic', () => {
             const [tr] = (editor.view.dispatch as jest.Mock).mock.calls[0]
             expect(tr.getMeta(REMOTE_PRESENCE_META)).toEqual({
                 clientId: REMOTE_CLIENT_ID,
-                presence: { userId: 42, userName: 'Remote User', head: 2 },
+                userId: 42,
+                userName: 'Remote User',
+                head: 2,
+                lastSeenAt: expect.any(Number),
             })
             // doc and collab version should be untouched
             expect(editor.state.doc.textContent).toBe(startDoc)
@@ -125,7 +128,10 @@ describe('notebookCollabLogic', () => {
             const [tr] = (editor.view.dispatch as jest.Mock).mock.calls[0]
             expect(tr.getMeta(REMOTE_PRESENCE_META)).toEqual({
                 clientId: REMOTE_CLIENT_ID,
-                presence: { userId: 42, userName: 'Remote User', head: 5 },
+                userId: 42,
+                userName: 'Remote User',
+                head: 5,
+                lastSeenAt: expect.any(Number),
             })
             expect(tr.docChanged).toBe(true)
         })

--- a/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.test.ts
@@ -1,0 +1,218 @@
+import { collab, getVersion } from '@tiptap/pm/collab'
+import { schema } from '@tiptap/pm/schema-basic'
+import { EditorState } from '@tiptap/pm/state'
+
+import { TTEditor } from 'lib/components/RichContentEditor/types'
+
+import { applyRemoteStep, RemoteStep, streamEventToRemoteStep } from './notebookCollabLogic'
+import { REMOTE_PRESENCE_META } from './RemotePresenceExtension'
+
+jest.mock('posthog-js', () => ({ captureException: jest.fn() }))
+jest.mock('@posthog/lemon-ui', () => ({
+    ...jest.requireActual('@posthog/lemon-ui'),
+    lemonToast: { error: jest.fn() },
+}))
+
+const LOCAL_CLIENT_ID = 'local-client'
+const REMOTE_CLIENT_ID = 'remote-client'
+
+function createMockEditor(initialVersion: number = 0): TTEditor {
+    const doc = schema.node('doc', null, [schema.node('paragraph', null, [schema.text('abc')])])
+    let state = EditorState.create({
+        doc,
+        schema,
+        plugins: [collab({ version: initialVersion, clientID: LOCAL_CLIENT_ID })],
+    })
+    const dispatch = jest.fn((tr: any) => {
+        state = state.apply(tr)
+    })
+    return {
+        get state() {
+            return state
+        },
+        view: { dispatch },
+    } as unknown as TTEditor
+}
+
+function insertStepJSON(at: number, text: string): Record<string, any> {
+    return {
+        stepType: 'replace',
+        from: at,
+        to: at,
+        slice: { content: [{ type: 'text', text }] },
+    }
+}
+
+function presence(head: number): RemoteStep['presence'] {
+    return {
+        clientId: REMOTE_CLIENT_ID,
+        userId: 42,
+        userName: 'Remote User',
+        userColor: '#ff0000',
+        cursorHead: head,
+    }
+}
+
+describe('notebookCollabLogic', () => {
+    describe('applyRemoteStep', () => {
+        it('applies a step when remote.version matches local + 1', () => {
+            const editor = createMockEditor(0)
+            const startDoc = editor.state.doc.textContent
+
+            applyRemoteStep(editor, {
+                step: insertStepJSON(4, 'X'),
+                clientId: REMOTE_CLIENT_ID,
+                version: 1,
+            })
+
+            expect(editor.view.dispatch).toHaveBeenCalledTimes(1)
+            expect(getVersion(editor.state)).toBe(1)
+            expect(editor.state.doc.textContent).toBe(`${startDoc}X`)
+        })
+
+        it('skips the step when remote.version is behind, but still dispatches presence', () => {
+            const editor = createMockEditor(5)
+            const startDoc = editor.state.doc.textContent
+
+            applyRemoteStep(editor, {
+                step: insertStepJSON(4, 'X'),
+                clientId: REMOTE_CLIENT_ID,
+                version: 3,
+                presence: presence(2),
+            })
+
+            expect(editor.view.dispatch).toHaveBeenCalledTimes(1)
+            const [tr] = (editor.view.dispatch as jest.Mock).mock.calls[0]
+            expect(tr.getMeta(REMOTE_PRESENCE_META)).toEqual({
+                type: 'set',
+                presence: expect.objectContaining({ clientId: REMOTE_CLIENT_ID, head: 2 }),
+            })
+            // doc and collab version should be untouched
+            expect(editor.state.doc.textContent).toBe(startDoc)
+            expect(getVersion(editor.state)).toBe(5)
+        })
+
+        it('does nothing when remote.version is behind and no presence is attached', () => {
+            const editor = createMockEditor(5)
+
+            applyRemoteStep(editor, {
+                step: insertStepJSON(4, 'X'),
+                clientId: REMOTE_CLIENT_ID,
+                version: 3,
+            })
+
+            expect(editor.view.dispatch).not.toHaveBeenCalled()
+        })
+
+        it('skips entirely when remote.version is ahead (out of order)', () => {
+            const editor = createMockEditor(0)
+
+            applyRemoteStep(editor, {
+                step: insertStepJSON(4, 'X'),
+                clientId: REMOTE_CLIENT_ID,
+                version: 5,
+                presence: presence(2),
+            })
+
+            expect(editor.view.dispatch).not.toHaveBeenCalled()
+            expect(getVersion(editor.state)).toBe(0)
+        })
+
+        it('attaches presence meta to the applied step transaction', () => {
+            const editor = createMockEditor(0)
+
+            applyRemoteStep(editor, {
+                step: insertStepJSON(4, 'X'),
+                clientId: REMOTE_CLIENT_ID,
+                version: 1,
+                presence: presence(5),
+            })
+
+            const [tr] = (editor.view.dispatch as jest.Mock).mock.calls[0]
+            expect(tr.getMeta(REMOTE_PRESENCE_META)).toEqual({
+                type: 'set',
+                presence: expect.objectContaining({ clientId: REMOTE_CLIENT_ID, head: 5 }),
+            })
+            expect(tr.docChanged).toBe(true)
+        })
+
+        it('swallows errors from malformed steps instead of throwing', () => {
+            const editor = createMockEditor(0)
+
+            expect(() =>
+                applyRemoteStep(editor, {
+                    step: { stepType: 'totally-bogus' } as any,
+                    clientId: REMOTE_CLIENT_ID,
+                    version: 1,
+                })
+            ).not.toThrow()
+            expect(editor.view.dispatch).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('streamEventToRemoteStep', () => {
+        it('maps the step, clientId and version', () => {
+            const remote = streamEventToRemoteStep({ step: { stepType: 'replace' }, client_id: REMOTE_CLIENT_ID }, 7)
+            expect(remote).toEqual({
+                step: { stepType: 'replace' },
+                clientId: REMOTE_CLIENT_ID,
+                version: 7,
+                presence: undefined,
+            })
+        })
+
+        it('includes presence when user_name and cursor_head are set', () => {
+            const remote = streamEventToRemoteStep(
+                {
+                    step: {},
+                    client_id: REMOTE_CLIENT_ID,
+                    user_id: 42,
+                    user_name: 'Remote User',
+                    cursor_head: 10,
+                },
+                3
+            )
+            expect(remote.presence).toEqual({
+                clientId: REMOTE_CLIENT_ID,
+                userId: 42,
+                userName: 'Remote User',
+                userColor: expect.any(String),
+                cursorHead: 10,
+            })
+            expect(remote.presence!.userColor).toBeTruthy()
+        })
+
+        it.each([
+            { desc: 'missing user_name', event: { cursor_head: 10 } },
+            { desc: 'missing cursor_head', event: { user_name: 'Remote User' } },
+            { desc: 'neither user_name nor cursor_head', event: {} },
+        ])('omits presence when $desc', ({ event }) => {
+            const remote = streamEventToRemoteStep({ step: {}, client_id: REMOTE_CLIENT_ID, ...event }, 1)
+            expect(remote.presence).toBeUndefined()
+        })
+
+        it('produces a stable color for the same user_id', () => {
+            const a = streamEventToRemoteStep(
+                { step: {}, client_id: REMOTE_CLIENT_ID, user_id: 7, user_name: 'A', cursor_head: 0 },
+                1
+            )
+            const b = streamEventToRemoteStep(
+                { step: {}, client_id: 'other', user_id: 7, user_name: 'B', cursor_head: 0 },
+                2
+            )
+            expect(a.presence!.userColor).toBe(b.presence!.userColor)
+        })
+
+        it('falls back to slot 0 color for null user_id', () => {
+            const anon = streamEventToRemoteStep(
+                { step: {}, client_id: REMOTE_CLIENT_ID, user_id: null, user_name: 'Anon', cursor_head: 0 },
+                1
+            )
+            const slotZero = streamEventToRemoteStep(
+                { step: {}, client_id: 'other', user_id: 0, user_name: 'Zero', cursor_head: 0 },
+                2
+            )
+            expect(anon.presence!.userColor).toBe(slotZero.presence!.userColor)
+        })
+    })
+})

--- a/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.test.ts
@@ -4,7 +4,7 @@ import { EditorState } from '@tiptap/pm/state'
 
 import { TTEditor } from 'lib/components/RichContentEditor/types'
 
-import { applyRemoteStep, RemoteStep, streamEventToRemoteStep } from './notebookCollabLogic'
+import { applyRemoteStep, RemoteStep } from './notebookCollabLogic'
 import { REMOTE_PRESENCE_META } from './RemotePresenceExtension'
 
 jest.mock('posthog-js', () => ({ captureException: jest.fn() }))
@@ -44,13 +44,7 @@ function insertStepJSON(at: number, text: string): Record<string, any> {
 }
 
 function presence(head: number): RemoteStep['presence'] {
-    return {
-        clientId: REMOTE_CLIENT_ID,
-        userId: 42,
-        userName: 'Remote User',
-        userColor: '#ff0000',
-        cursorHead: head,
-    }
+    return { userId: 42, userName: 'Remote User', head }
 }
 
 describe('notebookCollabLogic', () => {
@@ -84,8 +78,8 @@ describe('notebookCollabLogic', () => {
             expect(editor.view.dispatch).toHaveBeenCalledTimes(1)
             const [tr] = (editor.view.dispatch as jest.Mock).mock.calls[0]
             expect(tr.getMeta(REMOTE_PRESENCE_META)).toEqual({
-                type: 'set',
-                presence: expect.objectContaining({ clientId: REMOTE_CLIENT_ID, head: 2 }),
+                clientId: REMOTE_CLIENT_ID,
+                presence: { userId: 42, userName: 'Remote User', head: 2 },
             })
             // doc and collab version should be untouched
             expect(editor.state.doc.textContent).toBe(startDoc)
@@ -130,8 +124,8 @@ describe('notebookCollabLogic', () => {
 
             const [tr] = (editor.view.dispatch as jest.Mock).mock.calls[0]
             expect(tr.getMeta(REMOTE_PRESENCE_META)).toEqual({
-                type: 'set',
-                presence: expect.objectContaining({ clientId: REMOTE_CLIENT_ID, head: 5 }),
+                clientId: REMOTE_CLIENT_ID,
+                presence: { userId: 42, userName: 'Remote User', head: 5 },
             })
             expect(tr.docChanged).toBe(true)
         })
@@ -147,72 +141,6 @@ describe('notebookCollabLogic', () => {
                 })
             ).not.toThrow()
             expect(editor.view.dispatch).not.toHaveBeenCalled()
-        })
-    })
-
-    describe('streamEventToRemoteStep', () => {
-        it('maps the step, clientId and version', () => {
-            const remote = streamEventToRemoteStep({ step: { stepType: 'replace' }, client_id: REMOTE_CLIENT_ID }, 7)
-            expect(remote).toEqual({
-                step: { stepType: 'replace' },
-                clientId: REMOTE_CLIENT_ID,
-                version: 7,
-                presence: undefined,
-            })
-        })
-
-        it('includes presence when user_name and cursor_head are set', () => {
-            const remote = streamEventToRemoteStep(
-                {
-                    step: {},
-                    client_id: REMOTE_CLIENT_ID,
-                    user_id: 42,
-                    user_name: 'Remote User',
-                    cursor_head: 10,
-                },
-                3
-            )
-            expect(remote.presence).toEqual({
-                clientId: REMOTE_CLIENT_ID,
-                userId: 42,
-                userName: 'Remote User',
-                userColor: expect.any(String),
-                cursorHead: 10,
-            })
-            expect(remote.presence!.userColor).toBeTruthy()
-        })
-
-        it.each([
-            { desc: 'missing user_name', event: { cursor_head: 10 } },
-            { desc: 'missing cursor_head', event: { user_name: 'Remote User' } },
-            { desc: 'neither user_name nor cursor_head', event: {} },
-        ])('omits presence when $desc', ({ event }) => {
-            const remote = streamEventToRemoteStep({ step: {}, client_id: REMOTE_CLIENT_ID, ...event }, 1)
-            expect(remote.presence).toBeUndefined()
-        })
-
-        it('produces a stable color for the same user_id', () => {
-            const a = streamEventToRemoteStep(
-                { step: {}, client_id: REMOTE_CLIENT_ID, user_id: 7, user_name: 'A', cursor_head: 0 },
-                1
-            )
-            const b = streamEventToRemoteStep(
-                { step: {}, client_id: 'other', user_id: 7, user_name: 'B', cursor_head: 0 },
-                2
-            )
-            expect(a.presence!.userColor).toBe(b.presence!.userColor)
-        })
-
-        it('falls back to slot 0 color for null user_id', () => {
-            const anon = streamEventToRemoteStep(
-                { step: {}, client_id: REMOTE_CLIENT_ID, user_id: null, user_name: 'Anon', cursor_head: 0 },
-                1
-            )
-            const slotZero = streamEventToRemoteStep(
-                { step: {}, client_id: 'other', user_id: 0, user_name: 'Zero', cursor_head: 0 },
-                2
-            )
-            expect(anon.presence!.userColor).toBe(slotZero.presence!.userColor)
         })
     })
 })

--- a/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
@@ -11,7 +11,7 @@ import { TTEditor } from 'lib/components/RichContentEditor/types'
 import { uuid } from 'lib/utils'
 
 import type { notebookCollabLogicType } from './notebookCollabLogicType'
-import { REMOTE_PRESENCE_META, RemotePresenceUpdate } from './RemotePresenceExtension'
+import { ClientPresence, REMOTE_PRESENCE_META } from './RemotePresenceExtension'
 
 /** SSE `event: step` body from the collab stream endpoint */
 type StreamStepEvent = {
@@ -45,11 +45,11 @@ export type RemoteStep = {
 export function applyRemoteStep(editor: TTEditor, remote: RemoteStep): void {
     const expected = getVersion(editor.state) + 1
 
-    const presenceMeta = (): RemotePresenceUpdate | null => {
+    const presenceMeta = (): ClientPresence | null => {
         if (!remote.presence) {
             return null
         }
-        return { clientId: remote.clientId, presence: remote.presence }
+        return { clientId: remote.clientId, ...remote.presence, lastSeenAt: Date.now() }
     }
 
     if (remote.version < expected) {

--- a/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
@@ -34,7 +34,7 @@ export type RemoteStep = {
     presence?: RemoteStepPresence
 }
 
-type StreamStepEvent = {
+export type StreamStepEvent = {
     step: Record<string, any>
     client_id: string
     user_id?: number | null
@@ -102,7 +102,7 @@ export function applyRemoteStep(editor: TTEditor, remote: RemoteStep): void {
     }
 }
 
-function streamEventToRemoteStep(parsed: StreamStepEvent, version: number): RemoteStep {
+export function streamEventToRemoteStep(parsed: StreamStepEvent, version: number): RemoteStep {
     return {
         step: parsed.step,
         clientId: parsed.client_id,

--- a/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
@@ -7,23 +7,26 @@ import posthog from 'posthog-js'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
-import { getSeriesColor } from 'lib/colors'
 import { TTEditor } from 'lib/components/RichContentEditor/types'
 import { uuid } from 'lib/utils'
 
 import type { notebookCollabLogicType } from './notebookCollabLogicType'
 import { REMOTE_PRESENCE_META, RemotePresenceUpdate } from './RemotePresenceExtension'
 
-export type NotebookCollabProps = {
-    shortId: string
+/** SSE `event: step` body from the collab stream endpoint */
+type StreamStepEvent = {
+    step: Record<string, any>
+    client_id: string
+    user_id: number
+    user_name: string
+    cursor_head: number
 }
 
-export type RemoteStepPresence = {
-    clientId: string
-    userId?: number | null
+/** Presence fields piggybacked on every SSE step event (`cursor_head` → `head`) */
+export type RemotePresence = {
+    userId: number
     userName: string
-    userColor: string
-    cursorHead: number
+    head: number
 }
 
 export type RemoteStep = {
@@ -31,20 +34,7 @@ export type RemoteStep = {
     clientId: string
     /** Resulting version after this step is applied (== local getVersion + 1 in normal flow) */
     version: number
-    presence?: RemoteStepPresence
-}
-
-export type StreamStepEvent = {
-    step: Record<string, any>
-    client_id: string
-    user_id?: number | null
-    user_name?: string
-    cursor_head?: number | null
-}
-
-/** Stable presence color from PostHog's data palette; anonymous users get slot 0 */
-function userColor(userId: number | null | undefined): string {
-    return getSeriesColor(typeof userId === 'number' ? userId : 0)
+    presence?: RemotePresence
 }
 
 /**
@@ -59,17 +49,7 @@ export function applyRemoteStep(editor: TTEditor, remote: RemoteStep): void {
         if (!remote.presence) {
             return null
         }
-        const p = remote.presence
-        return {
-            type: 'set',
-            presence: {
-                clientId: p.clientId,
-                userId: p.userId ?? null,
-                userName: p.userName,
-                userColor: p.userColor,
-                head: p.cursorHead,
-            },
-        }
+        return { clientId: remote.clientId, presence: remote.presence }
     }
 
     if (remote.version < expected) {
@@ -102,26 +82,8 @@ export function applyRemoteStep(editor: TTEditor, remote: RemoteStep): void {
     }
 }
 
-export function streamEventToRemoteStep(parsed: StreamStepEvent, version: number): RemoteStep {
-    return {
-        step: parsed.step,
-        clientId: parsed.client_id,
-        version,
-        presence:
-            parsed.user_name && typeof parsed.cursor_head === 'number'
-                ? {
-                      clientId: parsed.client_id,
-                      userId: parsed.user_id ?? null,
-                      userName: parsed.user_name,
-                      userColor: userColor(parsed.user_id),
-                      cursorHead: parsed.cursor_head,
-                  }
-                : undefined,
-    }
-}
-
 export const notebookCollabLogic = kea<notebookCollabLogicType>([
-    props({} as NotebookCollabProps),
+    props({} as { shortId: string }),
     path((key) => ['scenes', 'notebooks', 'Notebook', 'notebookCollabLogic', key]),
     key(({ shortId }) => shortId),
 
@@ -208,7 +170,7 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
                 }
                 let parsed: StreamStepEvent
                 try {
-                    parsed = JSON.parse(msg.data)
+                    parsed = JSON.parse(msg.data) as StreamStepEvent
                 } catch (e) {
                     posthog.captureException(e as Error, { action: 'notebook collab stream parse' })
                     return
@@ -220,7 +182,16 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
                 if (!editor) {
                     return
                 }
-                applyRemoteStep(editor, streamEventToRemoteStep(parsed, version))
+                applyRemoteStep(editor, {
+                    step: parsed.step,
+                    clientId: parsed.client_id,
+                    version,
+                    presence: {
+                        userId: parsed.user_id,
+                        userName: parsed.user_name,
+                        head: parsed.cursor_head,
+                    },
+                })
             }
 
             const onError = (error: any): void => {

--- a/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
@@ -9,6 +9,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 import api from 'lib/api'
 import { getSeriesColor } from 'lib/colors'
 import { TTEditor } from 'lib/components/RichContentEditor/types'
+import { uuid } from 'lib/utils'
 
 import type { notebookCollabLogicType } from './notebookCollabLogicType'
 import { REMOTE_PRESENCE_META, RemotePresenceUpdate } from './RemotePresenceExtension'
@@ -39,6 +40,11 @@ type StreamStepEvent = {
     user_id?: number | null
     user_name?: string
     cursor_head?: number | null
+}
+
+/** Stable presence color from PostHog's data palette; anonymous users get slot 0 */
+function userColor(userId: number | null | undefined): string {
+    return getSeriesColor(typeof userId === 'number' ? userId : 0)
 }
 
 /**
@@ -107,8 +113,7 @@ function streamEventToRemoteStep(parsed: StreamStepEvent, version: number): Remo
                       clientId: parsed.client_id,
                       userId: parsed.user_id ?? null,
                       userName: parsed.user_name,
-                      // Stable presence color from PostHog's data palette; anonymous users get slot 0.
-                      userColor: getSeriesColor(typeof parsed.user_id === 'number' ? parsed.user_id : 0),
+                      userColor: userColor(parsed.user_id),
                       cursorHead: parsed.cursor_head,
                   }
                 : undefined,
@@ -121,50 +126,40 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
     key(({ shortId }) => shortId),
 
     actions({
-        bindEditor: (clientID: string, editor: TTEditor) => ({ clientID, editor }),
-        unbindEditor: (clientID: string) => ({ clientID }),
+        bindEditor: (editor: TTEditor) => ({ editor }),
+        unbindEditor: true,
+        /** Ack our own saved steps so PM-collab advances its version (matching clientID = no-op apply). */
         ackLocalSteps: (steps: Record<string, any>[], clientID: string) => ({ steps, clientID }),
+        /** Apply steps received from SSE or a 409 body. Idempotent by version. */
         applyRemoteSteps: (steps: RemoteStep[]) => ({ steps }),
         connectStream: true,
         disconnectStream: true,
     }),
 
     reducers({
-        // Multiple instances of the same notebook can be mounted in one browser tab
-        // (e.g. within multiple PostHog tabs); each gets its own PM-collab clientID.
-        editors: [
-            {} as Record<string, TTEditor>,
+        ttEditor: [
+            null as TTEditor | null,
             {
-                bindEditor: (state, { clientID, editor }) => ({ ...state, [clientID]: editor }),
-                unbindEditor: (state, { clientID }) => {
-                    const next = { ...state }
-                    delete next[clientID]
-                    return next
-                },
+                bindEditor: (_, { editor }) => editor,
+                unbindEditor: () => null,
             },
         ],
+        // Stable per-logic clientID; shared with the PM collab plugin for self-event filtering.
+        clientID: [uuid() as string, {}],
     }),
 
     listeners(({ actions, values, props, cache }) => ({
         bindEditor: () => {
-            // Open the stream on the first bind; subsequent binds use the same connection.
-            if (Object.keys(values.editors).length === 1) {
-                actions.connectStream()
-            }
+            actions.connectStream()
         },
 
         unbindEditor: () => {
-            if (Object.keys(values.editors).length === 0) {
-                actions.disconnectStream()
-            }
+            actions.disconnectStream()
         },
 
         ackLocalSteps: ({ steps, clientID }) => {
-            if (!steps.length) {
-                return
-            }
-            const editor = values.editors[clientID]
-            if (!editor) {
+            const editor = values.ttEditor
+            if (!editor || !steps.length) {
                 return
             }
             try {
@@ -184,14 +179,15 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
         },
 
         applyRemoteSteps: ({ steps }) => {
-            // Fan out to every bound editor; each skips its own echo via clientID.
-            for (const [clientID, editor] of Object.entries(values.editors)) {
-                for (const remote of steps) {
-                    if (remote.clientId === clientID) {
-                        continue
-                    }
-                    applyRemoteStep(editor, remote)
+            const editor = values.ttEditor
+            if (!editor) {
+                return
+            }
+            for (const remote of steps) {
+                if (remote.clientId === values.clientID) {
+                    continue
                 }
+                applyRemoteStep(editor, remote)
             }
         },
 
@@ -217,7 +213,14 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
                     posthog.captureException(e as Error, { action: 'notebook collab stream parse' })
                     return
                 }
-                actions.applyRemoteSteps([streamEventToRemoteStep(parsed, version)])
+                if (parsed.client_id === values.clientID) {
+                    return
+                }
+                const editor = values.ttEditor
+                if (!editor) {
+                    return
+                }
+                applyRemoteStep(editor, streamEventToRemoteStep(parsed, version))
             }
 
             const onError = (error: any): void => {
@@ -252,5 +255,6 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
 
     beforeUnmount(({ actions }) => {
         actions.disconnectStream()
+        actions.unbindEditor()
     }),
 ])

--- a/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
@@ -1,16 +1,123 @@
-import { receiveTransaction } from '@tiptap/pm/collab'
+import { EventSourceMessage } from '@microsoft/fetch-event-source'
+import { getVersion, receiveTransaction } from '@tiptap/pm/collab'
 import { Step } from '@tiptap/pm/transform'
 import { actions, beforeUnmount, kea, key, listeners, path, props, reducers } from 'kea'
 import posthog from 'posthog-js'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
+import api from 'lib/api'
+import { getSeriesColor } from 'lib/colors'
 import { TTEditor } from 'lib/components/RichContentEditor/types'
+import { uuid } from 'lib/utils'
 
 import type { notebookCollabLogicType } from './notebookCollabLogicType'
+import { REMOTE_PRESENCE_META, RemotePresenceUpdate } from './RemotePresenceExtension'
 
 export type NotebookCollabProps = {
     shortId: string
+}
+
+export type RemoteStepPresence = {
+    clientId: string
+    userId?: number | null
+    userName: string
+    userColor: string
+    cursorHead: number
+}
+
+export type RemoteStep = {
+    step: Record<string, any>
+    clientId: string
+    /** Resulting version after this step is applied (== local getVersion + 1 in normal flow) */
+    version: number
+    presence?: RemoteStepPresence
+}
+
+type StreamStepEvent = {
+    step: Record<string, any>
+    client_id: string
+    user_id?: number | null
+    user_name?: string
+    cursor_head?: number | null
+}
+
+/** Stable presence color from PostHog's data palette; anonymous users get slot 0 */
+function userColor(userId: number | null | undefined): string {
+    return getSeriesColor(typeof userId === 'number' ? userId : 0)
+}
+
+/**
+ * Idempotent step apply. The same step may arrive via SSE *and* via the 409
+ * conflict body on a concurrent save; whichever lands first wins, the second
+ * skips by version. Presence is always propagated so the caret stays in sync.
+ */
+export function applyRemoteStep(editor: TTEditor, remote: RemoteStep): void {
+    const expected = getVersion(editor.state) + 1
+
+    const presenceMeta = (): RemotePresenceUpdate | null => {
+        if (!remote.presence) {
+            return null
+        }
+        const p = remote.presence
+        return {
+            type: 'set',
+            presence: {
+                clientId: p.clientId,
+                userId: p.userId ?? null,
+                userName: p.userName,
+                userColor: p.userColor,
+                head: p.cursorHead,
+            },
+        }
+    }
+
+    if (remote.version < expected) {
+        // Already applied via the other channel - still update presence so the caret tracks typing
+        const meta = presenceMeta()
+        if (meta) {
+            editor.view.dispatch(editor.state.tr.setMeta(REMOTE_PRESENCE_META, meta))
+        }
+        return
+    }
+
+    if (remote.version > expected) {
+        // Out-of-order; the next save's 409 carries the missed range, or 410 → reload
+        return
+    }
+
+    try {
+        const step = Step.fromJSON(editor.state.schema, remote.step)
+        let tr = receiveTransaction(editor.state, [step], [remote.clientId], {
+            mapSelectionBackward: true,
+        })
+        const meta = presenceMeta()
+        if (meta) {
+            tr = tr.setMeta(REMOTE_PRESENCE_META, meta)
+        }
+        editor.view.dispatch(tr)
+    } catch (e) {
+        posthog.captureException(e as Error, { action: 'notebook collab apply remote step' })
+        lemonToast.error('Failed to sync notebook changes. Please reload the page.')
+    }
+}
+
+function streamEventToRemoteStep(parsed: StreamStepEvent, version: number): RemoteStep {
+    return {
+        step: parsed.step,
+        clientId: parsed.client_id,
+        version,
+        presence:
+            parsed.user_name && typeof parsed.cursor_head === 'number'
+                ? {
+                      clientId: parsed.client_id,
+                      userId: parsed.user_id ?? null,
+                      userName: parsed.user_name,
+                      userColor: userColor(parsed.user_id),
+                      cursorHead: parsed.cursor_head,
+                  }
+                : undefined,
+    }
 }
 
 export const notebookCollabLogic = kea<notebookCollabLogicType>([
@@ -21,10 +128,12 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
     actions({
         bindEditor: (editor: TTEditor) => ({ editor }),
         unbindEditor: true,
-        rebaseFromSteps: (steps: Record<string, any>[], clientIDs: (string | number)[]) => ({
-            steps,
-            clientIDs,
-        }),
+        /** Ack our own saved steps so PM-collab advances its version (matching clientID = no-op apply). */
+        ackLocalSteps: (steps: Record<string, any>[], clientID: string) => ({ steps, clientID }),
+        /** Apply steps received from SSE or a 409 body. Idempotent by version. */
+        applyRemoteSteps: (steps: RemoteStep[]) => ({ steps }),
+        connectStream: true,
+        disconnectStream: true,
     }),
 
     reducers({
@@ -35,28 +144,117 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
                 unbindEditor: () => null,
             },
         ],
+        // Stable per-logic clientID; shared with the PM collab plugin for self-event filtering.
+        clientID: [uuid() as string, {}],
     }),
 
-    listeners(({ values }) => ({
-        rebaseFromSteps: ({ steps, clientIDs }) => {
+    listeners(({ actions, values, props, cache }) => ({
+        bindEditor: () => {
+            actions.connectStream()
+        },
+
+        unbindEditor: () => {
+            actions.disconnectStream()
+        },
+
+        ackLocalSteps: ({ steps, clientID }) => {
             const editor = values.ttEditor
             if (!editor || !steps.length) {
                 return
             }
             try {
-                const parsed = steps.map((s) => Step.fromJSON(editor.state.schema, s))
-                const tr = receiveTransaction(editor.state, parsed, clientIDs, {
-                    mapSelectionBackward: true,
-                })
+                const parsed = steps.map((s: Record<string, any>) => Step.fromJSON(editor.state.schema, s))
+                const tr = receiveTransaction(
+                    editor.state,
+                    parsed,
+                    parsed.map(() => clientID),
+                    {
+                        mapSelectionBackward: true,
+                    }
+                )
                 editor.view.dispatch(tr)
             } catch (e) {
-                posthog.captureException(e as Error, { action: 'notebook collab rebase' })
-                lemonToast.error('Failed to sync notebook changes. Please reload the page.')
+                posthog.captureException(e as Error, { action: 'notebook collab ack local steps' })
             }
+        },
+
+        applyRemoteSteps: ({ steps }) => {
+            const editor = values.ttEditor
+            if (!editor) {
+                return
+            }
+            for (const remote of steps) {
+                if (remote.clientId === values.clientID) {
+                    continue
+                }
+                applyRemoteStep(editor, remote)
+            }
+        },
+
+        connectStream: async () => {
+            cache.abortController?.abort()
+            const controller = new AbortController()
+            cache.abortController = controller
+
+            const onMessage = (msg: EventSourceMessage): void => {
+                if (msg.event !== 'step' || !msg.data) {
+                    return
+                }
+                // SSE id is the Redis stream id `N-0` and N is the prosemirror version.
+                // We use it for both reconnection (Last-Event-ID) and idempotency.
+                const version = parseInt(msg.id.split('-', 1)[0], 10)
+                if (!Number.isFinite(version)) {
+                    return
+                }
+                let parsed: StreamStepEvent
+                try {
+                    parsed = JSON.parse(msg.data)
+                } catch (e) {
+                    posthog.captureException(e as Error, { action: 'notebook collab stream parse' })
+                    return
+                }
+                if (parsed.client_id === values.clientID) {
+                    return
+                }
+                const editor = values.ttEditor
+                if (!editor) {
+                    return
+                }
+                applyRemoteStep(editor, streamEventToRemoteStep(parsed, version))
+            }
+
+            const onError = (error: any): void => {
+                if (controller.signal.aborted) {
+                    return
+                }
+                posthog.captureException(error instanceof Error ? error : new Error(String(error)), {
+                    action: 'notebook collab stream',
+                })
+            }
+
+            // fetchEventSource handles reconnection via Last-Event-ID; this awaits for the connection's lifetime.
+            try {
+                await api.notebooks.collabStream(props.shortId, {
+                    onMessage,
+                    onError,
+                    signal: controller.signal,
+                })
+            } catch (e) {
+                if (controller.signal.aborted) {
+                    return
+                }
+                posthog.captureException(e as Error, { action: 'notebook collab stream open' })
+            }
+        },
+
+        disconnectStream: () => {
+            cache.abortController?.abort()
+            cache.abortController = null
         },
     })),
 
     beforeUnmount(({ actions }) => {
+        actions.disconnectStream()
         actions.unbindEditor()
     }),
 ])

--- a/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookCollabLogic.ts
@@ -9,7 +9,6 @@ import { lemonToast } from '@posthog/lemon-ui'
 import api from 'lib/api'
 import { getSeriesColor } from 'lib/colors'
 import { TTEditor } from 'lib/components/RichContentEditor/types'
-import { uuid } from 'lib/utils'
 
 import type { notebookCollabLogicType } from './notebookCollabLogicType'
 import { REMOTE_PRESENCE_META, RemotePresenceUpdate } from './RemotePresenceExtension'
@@ -40,11 +39,6 @@ type StreamStepEvent = {
     user_id?: number | null
     user_name?: string
     cursor_head?: number | null
-}
-
-/** Stable presence color from PostHog's data palette; anonymous users get slot 0 */
-function userColor(userId: number | null | undefined): string {
-    return getSeriesColor(typeof userId === 'number' ? userId : 0)
 }
 
 /**
@@ -113,7 +107,8 @@ function streamEventToRemoteStep(parsed: StreamStepEvent, version: number): Remo
                       clientId: parsed.client_id,
                       userId: parsed.user_id ?? null,
                       userName: parsed.user_name,
-                      userColor: userColor(parsed.user_id),
+                      // Stable presence color from PostHog's data palette; anonymous users get slot 0.
+                      userColor: getSeriesColor(typeof parsed.user_id === 'number' ? parsed.user_id : 0),
                       cursorHead: parsed.cursor_head,
                   }
                 : undefined,
@@ -126,40 +121,50 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
     key(({ shortId }) => shortId),
 
     actions({
-        bindEditor: (editor: TTEditor) => ({ editor }),
-        unbindEditor: true,
-        /** Ack our own saved steps so PM-collab advances its version (matching clientID = no-op apply). */
+        bindEditor: (clientID: string, editor: TTEditor) => ({ clientID, editor }),
+        unbindEditor: (clientID: string) => ({ clientID }),
         ackLocalSteps: (steps: Record<string, any>[], clientID: string) => ({ steps, clientID }),
-        /** Apply steps received from SSE or a 409 body. Idempotent by version. */
         applyRemoteSteps: (steps: RemoteStep[]) => ({ steps }),
         connectStream: true,
         disconnectStream: true,
     }),
 
     reducers({
-        ttEditor: [
-            null as TTEditor | null,
+        // Multiple instances of the same notebook can be mounted in one browser tab
+        // (e.g. within multiple PostHog tabs); each gets its own PM-collab clientID.
+        editors: [
+            {} as Record<string, TTEditor>,
             {
-                bindEditor: (_, { editor }) => editor,
-                unbindEditor: () => null,
+                bindEditor: (state, { clientID, editor }) => ({ ...state, [clientID]: editor }),
+                unbindEditor: (state, { clientID }) => {
+                    const next = { ...state }
+                    delete next[clientID]
+                    return next
+                },
             },
         ],
-        // Stable per-logic clientID; shared with the PM collab plugin for self-event filtering.
-        clientID: [uuid() as string, {}],
     }),
 
     listeners(({ actions, values, props, cache }) => ({
         bindEditor: () => {
-            actions.connectStream()
+            // Open the stream on the first bind; subsequent binds use the same connection.
+            if (Object.keys(values.editors).length === 1) {
+                actions.connectStream()
+            }
         },
 
         unbindEditor: () => {
-            actions.disconnectStream()
+            if (Object.keys(values.editors).length === 0) {
+                actions.disconnectStream()
+            }
         },
 
         ackLocalSteps: ({ steps, clientID }) => {
-            const editor = values.ttEditor
-            if (!editor || !steps.length) {
+            if (!steps.length) {
+                return
+            }
+            const editor = values.editors[clientID]
+            if (!editor) {
                 return
             }
             try {
@@ -179,15 +184,14 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
         },
 
         applyRemoteSteps: ({ steps }) => {
-            const editor = values.ttEditor
-            if (!editor) {
-                return
-            }
-            for (const remote of steps) {
-                if (remote.clientId === values.clientID) {
-                    continue
+            // Fan out to every bound editor; each skips its own echo via clientID.
+            for (const [clientID, editor] of Object.entries(values.editors)) {
+                for (const remote of steps) {
+                    if (remote.clientId === clientID) {
+                        continue
+                    }
+                    applyRemoteStep(editor, remote)
                 }
-                applyRemoteStep(editor, remote)
             }
         },
 
@@ -213,14 +217,7 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
                     posthog.captureException(e as Error, { action: 'notebook collab stream parse' })
                     return
                 }
-                if (parsed.client_id === values.clientID) {
-                    return
-                }
-                const editor = values.ttEditor
-                if (!editor) {
-                    return
-                }
-                applyRemoteStep(editor, streamEventToRemoteStep(parsed, version))
+                actions.applyRemoteSteps([streamEventToRemoteStep(parsed, version)])
             }
 
             const onError = (error: any): void => {
@@ -255,6 +252,5 @@ export const notebookCollabLogic = kea<notebookCollabLogicType>([
 
     beforeUnmount(({ actions }) => {
         actions.disconnectStream()
-        actions.unbindEditor()
     }),
 ])

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -122,7 +122,7 @@ export const notebookLogic = kea<notebookLogicType>([
             notebookSettingsLogic,
             ['showKernelInfo', 'showTableOfContents'],
             notebookCollabLogic({ shortId: props.shortId }),
-            ['editors'],
+            ['ttEditor'],
         ],
         actions: [
             notebooksModel,
@@ -141,23 +141,19 @@ export const notebookLogic = kea<notebookLogicType>([
     actions({
         setEditor: (editor: NotebookEditor) => ({ editor }),
         editorIsReady: true,
-        onEditorUpdate: (clientID?: string) => ({ clientID }),
+        onEditorUpdate: true,
         onEditorSelectionUpdate: true,
-        setLocalContent: (jsonContent: JSONContent, updateEditor = false, skipCapture = false, clientID?: string) => ({
+        setLocalContent: (jsonContent: JSONContent, updateEditor = false, skipCapture = false) => ({
             jsonContent,
             updateEditor,
             skipCapture,
-            clientID,
         }),
         clearLocalContent: true,
         setPreviewContent: (jsonContent: JSONContent) => ({ jsonContent }),
         clearPreviewContent: true,
         loadNotebook: true,
         scheduleNotebookRefresh: true,
-        saveNotebook: (notebook: Pick<NotebookType, 'content' | 'title'>, clientID?: string) => ({
-            notebook,
-            clientID,
-        }),
+        saveNotebook: (notebook: Pick<NotebookType, 'content' | 'title'>) => ({ notebook }),
         renameNotebook: (title: string) => ({ title }),
         setEditingNodeEditing: (nodeId: string, editing: boolean) => ({ nodeId, editing }),
         exportJSON: true,
@@ -360,19 +356,13 @@ export const notebookLogic = kea<notebookLogicType>([
                     return notebook
                 },
 
-                saveNotebook: async ({ notebook, clientID }) => {
+                saveNotebook: async ({ notebook }) => {
                     if (!values.notebook) {
                         return values.notebook
                     }
 
-                    if (values.collabEnabled) {
-                        // Save the pending steps from the editor that fired onEditorUpdate;
-                        // this lets N editors in the same tab each save their own edits.
-                        const editor = clientID ? values.editors[clientID] : undefined
-                        if (!editor) {
-                            return values.notebook
-                        }
-                        const sendable = sendableSteps(editor.state)
+                    if (values.collabEnabled && values.ttEditor) {
+                        const sendable = sendableSteps(values.ttEditor.state)
                         if (!sendable) {
                             return values.notebook
                         }
@@ -385,10 +375,10 @@ export const notebookLogic = kea<notebookLogicType>([
                                     client_id: sendable.clientID,
                                     version: sendable.version,
                                     steps: stepsJson,
-                                    content: editor.getJSON(),
-                                    text_content: editor.getText() || '',
+                                    content: values.editor?.getJSON(),
+                                    text_content: values.editor?.getText() || '',
                                     title: notebook.title,
-                                    cursor_head: editor.state.selection.head,
+                                    cursor_head: values.ttEditor.state.selection.head,
                                 }
                             )
                             actions.ackLocalSteps(stepsJson, sendable.clientID)
@@ -412,13 +402,10 @@ export const notebookLogic = kea<notebookLogicType>([
                                         version: firstMissedVersion + i,
                                     }))
                                 )
-                                actions.saveNotebook(
-                                    {
-                                        content: editor.getJSON(),
-                                        title: notebook.title,
-                                    },
-                                    clientID
-                                )
+                                actions.saveNotebook({
+                                    content: values.editor?.getJSON() ?? notebook.content,
+                                    title: notebook.title,
+                                })
                                 return values.notebook
                             }
                             if (error.status === 410) {
@@ -807,7 +794,7 @@ export const notebookLogic = kea<notebookLogicType>([
                 lemonToast.warning('Could not add insight to notebook')
             }
         },
-        setLocalContent: async ({ updateEditor, jsonContent, skipCapture, clientID }, breakpoint) => {
+        setLocalContent: async ({ updateEditor, jsonContent, skipCapture }, breakpoint) => {
             if (
                 values.mode !== 'canvas' &&
                 !!values.notebook?.user_access_level &&
@@ -851,13 +838,10 @@ export const notebookLogic = kea<notebookLogicType>([
             }
 
             if (!values.isLocalOnly && values.content && !values.notebookLoading) {
-                actions.saveNotebook(
-                    {
-                        content: values.content,
-                        title: values.title,
-                    },
-                    clientID
-                )
+                actions.saveNotebook({
+                    content: values.content,
+                    title: values.title,
+                })
             }
         },
 
@@ -873,14 +857,13 @@ export const notebookLogic = kea<notebookLogicType>([
             }
         },
 
-        onEditorUpdate: ({ clientID }) => {
-            const editor = clientID ? values.editors[clientID] : null
-            if (!editor) {
+        onEditorUpdate: () => {
+            if (!values.editor) {
                 return
             }
-            const jsonContent = editor.getJSON()
+            const jsonContent = values.editor.getJSON()
 
-            actions.setLocalContent(jsonContent, false, false, clientID)
+            actions.setLocalContent(jsonContent)
             // Throttle onUpdateEditor to avoid performance issues with many notebook nodes
             if (cache.throttledOnUpdateEditorTimeout) {
                 clearTimeout(cache.throttledOnUpdateEditorTimeout)

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -135,7 +135,7 @@ export const notebookLogic = kea<notebookLogicType>([
             }),
             ['setItemContext', 'maybeLoadComments'],
             notebookCollabLogic({ shortId: props.shortId }),
-            ['rebaseFromSteps'],
+            ['ackLocalSteps', 'applyRemoteSteps'],
         ],
     })),
     actions({
@@ -378,13 +378,10 @@ export const notebookLogic = kea<notebookLogicType>([
                                     content: values.editor?.getJSON(),
                                     text_content: values.editor?.getText() || '',
                                     title: notebook.title,
+                                    cursor_head: values.ttEditor.state.selection.head,
                                 }
                             )
-                            // Mark sent steps as acknowledged so version update
-                            actions.rebaseFromSteps(
-                                stepsJson,
-                                stepsJson.map(() => sendable.clientID)
-                            )
+                            actions.ackLocalSteps(stepsJson, sendable.clientID)
                             if (notebook.content === values.localContent) {
                                 actions.clearLocalContent()
                             }
@@ -392,9 +389,19 @@ export const notebookLogic = kea<notebookLogicType>([
                             return response
                         } catch (error: any) {
                             if (error.status === 409 && error.data?.steps) {
-                                actions.rebaseFromSteps(error.data.steps, error.data.client_ids)
-
-                                // Retry after rebase
+                                // Apply the missed range (deduped by version against SSE), then retry
+                                // PM-collab rebases our pending steps against the new state
+                                const steps = error.data.steps as Record<string, any>[]
+                                const clientIds = error.data.client_ids as string[]
+                                const serverVersion = error.data.version as number
+                                const firstMissedVersion = serverVersion - steps.length + 1
+                                actions.applyRemoteSteps(
+                                    steps.map((step, i) => ({
+                                        step,
+                                        clientId: clientIds[i],
+                                        version: firstMissedVersion + i,
+                                    }))
+                                )
                                 actions.saveNotebook({
                                     content: values.editor?.getJSON() ?? notebook.content,
                                     title: notebook.title,
@@ -402,7 +409,6 @@ export const notebookLogic = kea<notebookLogicType>([
                                 return values.notebook
                             }
                             if (error.status === 410) {
-                                // Steps expired - gap too large to rebase, must reload
                                 actions.clearLocalContent()
                                 actions.loadNotebook()
                                 return values.notebook

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -381,7 +381,7 @@ export const notebookLogic = kea<notebookLogicType>([
                                     cursor_head: values.ttEditor.state.selection.head,
                                 }
                             )
-                            actions.ackLocalSteps(stepsJson, sendable.clientID)
+                            actions.ackLocalSteps(stepsJson, String(sendable.clientID))
                             if (notebook.content === values.localContent) {
                                 actions.clearLocalContent()
                             }

--- a/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
+++ b/frontend/src/scenes/notebooks/Notebook/notebookLogic.ts
@@ -122,7 +122,7 @@ export const notebookLogic = kea<notebookLogicType>([
             notebookSettingsLogic,
             ['showKernelInfo', 'showTableOfContents'],
             notebookCollabLogic({ shortId: props.shortId }),
-            ['ttEditor'],
+            ['editors'],
         ],
         actions: [
             notebooksModel,
@@ -141,19 +141,23 @@ export const notebookLogic = kea<notebookLogicType>([
     actions({
         setEditor: (editor: NotebookEditor) => ({ editor }),
         editorIsReady: true,
-        onEditorUpdate: true,
+        onEditorUpdate: (clientID?: string) => ({ clientID }),
         onEditorSelectionUpdate: true,
-        setLocalContent: (jsonContent: JSONContent, updateEditor = false, skipCapture = false) => ({
+        setLocalContent: (jsonContent: JSONContent, updateEditor = false, skipCapture = false, clientID?: string) => ({
             jsonContent,
             updateEditor,
             skipCapture,
+            clientID,
         }),
         clearLocalContent: true,
         setPreviewContent: (jsonContent: JSONContent) => ({ jsonContent }),
         clearPreviewContent: true,
         loadNotebook: true,
         scheduleNotebookRefresh: true,
-        saveNotebook: (notebook: Pick<NotebookType, 'content' | 'title'>) => ({ notebook }),
+        saveNotebook: (notebook: Pick<NotebookType, 'content' | 'title'>, clientID?: string) => ({
+            notebook,
+            clientID,
+        }),
         renameNotebook: (title: string) => ({ title }),
         setEditingNodeEditing: (nodeId: string, editing: boolean) => ({ nodeId, editing }),
         exportJSON: true,
@@ -356,13 +360,19 @@ export const notebookLogic = kea<notebookLogicType>([
                     return notebook
                 },
 
-                saveNotebook: async ({ notebook }) => {
+                saveNotebook: async ({ notebook, clientID }) => {
                     if (!values.notebook) {
                         return values.notebook
                     }
 
-                    if (values.collabEnabled && values.ttEditor) {
-                        const sendable = sendableSteps(values.ttEditor.state)
+                    if (values.collabEnabled) {
+                        // Save the pending steps from the editor that fired onEditorUpdate;
+                        // this lets N editors in the same tab each save their own edits.
+                        const editor = clientID ? values.editors[clientID] : undefined
+                        if (!editor) {
+                            return values.notebook
+                        }
+                        const sendable = sendableSteps(editor.state)
                         if (!sendable) {
                             return values.notebook
                         }
@@ -375,10 +385,10 @@ export const notebookLogic = kea<notebookLogicType>([
                                     client_id: sendable.clientID,
                                     version: sendable.version,
                                     steps: stepsJson,
-                                    content: values.editor?.getJSON(),
-                                    text_content: values.editor?.getText() || '',
+                                    content: editor.getJSON(),
+                                    text_content: editor.getText() || '',
                                     title: notebook.title,
-                                    cursor_head: values.ttEditor.state.selection.head,
+                                    cursor_head: editor.state.selection.head,
                                 }
                             )
                             actions.ackLocalSteps(stepsJson, sendable.clientID)
@@ -402,10 +412,13 @@ export const notebookLogic = kea<notebookLogicType>([
                                         version: firstMissedVersion + i,
                                     }))
                                 )
-                                actions.saveNotebook({
-                                    content: values.editor?.getJSON() ?? notebook.content,
-                                    title: notebook.title,
-                                })
+                                actions.saveNotebook(
+                                    {
+                                        content: editor.getJSON(),
+                                        title: notebook.title,
+                                    },
+                                    clientID
+                                )
                                 return values.notebook
                             }
                             if (error.status === 410) {
@@ -794,7 +807,7 @@ export const notebookLogic = kea<notebookLogicType>([
                 lemonToast.warning('Could not add insight to notebook')
             }
         },
-        setLocalContent: async ({ updateEditor, jsonContent, skipCapture }, breakpoint) => {
+        setLocalContent: async ({ updateEditor, jsonContent, skipCapture, clientID }, breakpoint) => {
             if (
                 values.mode !== 'canvas' &&
                 !!values.notebook?.user_access_level &&
@@ -838,10 +851,13 @@ export const notebookLogic = kea<notebookLogicType>([
             }
 
             if (!values.isLocalOnly && values.content && !values.notebookLoading) {
-                actions.saveNotebook({
-                    content: values.content,
-                    title: values.title,
-                })
+                actions.saveNotebook(
+                    {
+                        content: values.content,
+                        title: values.title,
+                    },
+                    clientID
+                )
             }
         },
 
@@ -857,13 +873,14 @@ export const notebookLogic = kea<notebookLogicType>([
             }
         },
 
-        onEditorUpdate: () => {
-            if (!values.editor) {
+        onEditorUpdate: ({ clientID }) => {
+            const editor = clientID ? values.editors[clientID] : null
+            if (!editor) {
                 return
             }
-            const jsonContent = values.editor.getJSON()
+            const jsonContent = editor.getJSON()
 
-            actions.setLocalContent(jsonContent)
+            actions.setLocalContent(jsonContent, false, false, clientID)
             // Throttle onUpdateEditor to avoid performance issues with many notebook nodes
             if (cache.throttledOnUpdateEditorTimeout) {
                 clearTimeout(cache.throttledOnUpdateEditorTimeout)


### PR DESCRIPTION
## Problem

Follow-up to the SSE backend PR: https://github.com/PostHog/posthog/pull/55752

The editor still relies on request/response for step delivery. We need to subscribe to the real-time stream, handle reconnects, and unify how remote steps are applied so we don’t double-apply or lose updates.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- Wire up SSE stream. Subscribe to `notebooks/<id>/collab/stream` on editor mount. `fetchEventSource` handles reconnects via Last-Event-ID, so missed steps are replayed automatically.
- Unify `applyRemoteStep`path. Same step can arrive via SSE or the 409 conflict body, dedup by version, the second one is a no-op.
- Stable per-tab `clientID` in `notebookCollabLogic` shared with the PM-collab plugin so self-events filter correctly.
- Cursor presence (piggybacked) - each step includes `cursor_head`, `user_id`, and name. Presence is mapped forward through local transactions in `RemotePresenceExtension` so cursors stay in sync.
- Caret UX is Google Docs-style.  
Cursor color is derived client-side via `getSeriesColor(user_id)`
- cursor_anchor is intentionally skipped for now - will make it separetely with a presence stream (needed for selections and non-edit interactions like clicks/drag).

## How did you test this code?

## ![2026-04-22 15.11.51.gif](https://app.graphite.com/user-attachments/assets/a17153c5-465f-4969-b58e-329473b79692.gif)

## Publish to changelog?

No