### PR TITLE
fix(sql-editor): schema load race condition

### DIFF
--- a/frontend/src/scenes/data-management/database/databaseTableListLogic.test.ts
+++ b/frontend/src/scenes/data-management/database/databaseTableListLogic.test.ts
@@ -79,4 +79,60 @@ describe('databaseTableListLogic', () => {
         await Promise.all([firstRequest, secondRequest])
         expect(performQuery).toHaveBeenCalledTimes(1)
     })
+
+    it('does not let a stale schema response overwrite the selected connection schema', async () => {
+        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY], {
+            [FEATURE_FLAGS.DWH_POSTGRES_DIRECT_QUERY]: true,
+        })
+
+        let resolvePosthogQuery:
+            | ((value: { tables: Record<string, { name: string; type: 'posthog' }>; joins: never[] }) => void)
+            | undefined
+        let resolveDirectQuery:
+            | ((value: { tables: Record<string, { name: string; type: 'data_warehouse' }>; joins: never[] }) => void)
+            | undefined
+
+        ;(performQuery as jest.Mock)
+            .mockImplementationOnce(
+                () =>
+                    new Promise((resolve) => {
+                        resolvePosthogQuery = resolve
+                    })
+            )
+            .mockImplementationOnce(
+                () =>
+                    new Promise((resolve) => {
+                        resolveDirectQuery = resolve
+                    })
+            )
+
+        logic = databaseTableListLogic()
+        logic.mount()
+
+        const posthogRequest = logic.asyncActions.loadDatabase()
+
+        logic.actions.setConnection('conn-123')
+        const directRequest = logic.asyncActions.loadDatabase()
+
+        resolveDirectQuery?.({
+            tables: {
+                ducklake_accounts: { name: 'ducklake_accounts', type: 'data_warehouse' },
+            },
+            joins: [],
+        })
+        await directRequest
+
+        expect(logic.values.allTables.map((table) => table.name)).toEqual(['ducklake_accounts'])
+
+        resolvePosthogQuery?.({
+            tables: {
+                events: { name: 'events', type: 'posthog' },
+            },
+            joins: [],
+        })
+        await posthogRequest
+
+        expect(logic.values.connectionId).toEqual('conn-123')
+        expect(logic.values.allTables.map((table) => table.name)).toEqual(['ducklake_accounts'])
+    })
 })

--- a/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
+++ b/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
@@ -76,7 +76,16 @@ export const databaseTableListLogic = kea<databaseTableListLogicType>([
                     inFlightDatabaseLoadPromise = request
 
                     try {
-                        return await request
+                        const database = await request
+                        const currentConnectionId = isDirectQueryEnabled()
+                            ? (values.connectionId ?? undefined)
+                            : undefined
+
+                        if (currentConnectionId !== requestConnectionId) {
+                            return values.database
+                        }
+
+                        return database
                     } finally {
                         if (inFlightDatabaseLoadKey === requestKey) {
                             inFlightDatabaseLoadKey = null


### PR DESCRIPTION
## Problem

If you open the SQL editor and switch the connection before the schema loads, it might override the switched to connection's schema if it comes back later than that.

## Changes

Fix the race condition

## How did you test this code?

👀 

## Publish to changelog?

no

## Docs update

no