### PR TITLE
fix(email): truncate matview error messages to 255 chars

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -593,6 +593,8 @@ def send_team_matview_failure_digest(team_id: int, failed_query_ids: list[str], 
             continue
         job: DataModelingJob | None = latest_jobs.get(qid)
         error = (job.error if job else None) or sq.latest_error or "Unknown error"
+        if len(error) > 255:
+            error = error[:252] + "..."
         run_at = (job.last_run_at if job else None) or sq.last_run_at
         views.append(
             {

--- a/posthog/tasks/test/test_email.py
+++ b/posthog/tasks/test/test_email.py
@@ -1479,3 +1479,34 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
         # Paused views render the check glyph; non-paused render an em-dash.
         assert "&#10003;" in html
         assert "&#8212;" in html
+
+    def test_send_matview_failure_digest_truncates_long_errors(self, MockEmailMessage: MagicMock) -> None:
+        from products.data_warehouse.backend.models import DataModelingJob, DataWarehouseSavedQuery
+
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+
+        self.user.partial_notification_settings = {"materialized_view_sync_failed": True}
+        self.user.save()
+
+        long_error = "A" * 500
+        sq = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="long_error_view",
+            query={"query": "SELECT 1"},
+            sync_frequency_interval=dt.timedelta(hours=1),
+        )
+        DataModelingJob.objects.create(
+            team=self.team,
+            saved_query=sq,
+            status=DataModelingJob.Status.FAILED,
+            error=long_error,
+            last_run_at=timezone.now() - dt.timedelta(hours=1),
+        )
+
+        send_matview_failure_digest()
+
+        assert len(mocked_email_messages) == 1
+        html = mocked_email_messages[0].html_body
+        assert "long_error_view" in html
+        assert long_error not in html
+        assert "AAA..." in html


### PR DESCRIPTION

## Problem

Error messages in the data modeling daily digest email were causing HTML form field exceptions when too long. Truncates errors to 255 characters with ellipsis to prevent the rendering issue.

Slack thread: https://posthog.slack.com/archives/C0A9BSVSE72/p1776867147176649

https://claude.ai/code/session_01VYrJGywskGknjXaePTTQ3A

## Changes

the bot did it. i blame the bot

## How did you test this code?

i didn't. its low stakes (an email)

## Publish to changelog?

no

## Docs update

no
