### PR TITLE
fix(posthog-cli): skip synthetic CU names before joining with comp_dir

### DIFF
--- a/cli/src/dsym/source_bundle.rs
+++ b/cli/src/dsym/source_bundle.rs
@@ -227,6 +227,13 @@ fn cu_main_files_from_dwarf<'d>(obj: &impl DwarfObject<'d>) -> Vec<String> {
             .and_then(&resolve_str);
 
         let path = match (comp_dir, name) {
+            // Swift emits synthetic CUs with `DW_AT_name = "<swift-imported-modules>"`
+            // alongside a real `DW_AT_comp_dir`. Without this guard the join below
+            // produces e.g. `/…/Project.xcodeproj/<swift-imported-modules>`, which
+            // escapes the `EXCLUDED_SYNTHETIC_NAMES` `starts_with` check further down
+            // and ends up dominating the project-root prefix computation — causing
+            // every real source file to be rejected as "outside project prefix".
+            (_, Some(name)) if name.starts_with('<') => continue,
             (Some(dir), Some(name)) if !name.starts_with('/') => {
                 format!("{}/{}", dir.trim_end_matches('/'), name)
             }


### PR DESCRIPTION
## Introduction

Hey folks! Discovered a weird issue where the source code of iOS crashes wasn't being uploaded. What follows is my investigation that fixed it but perhaps you'd prefer it to be fixed in another way.

Note: CU is compilation unit (i.e. C/C++/Swift file after preprocessing has completed), was new to me 😅 

## Problem

`posthog-cli dsym upload --include-source` silently bundles **zero source files** for Swift iOS projects. Frames symbolicate normally, but every frame shows "Frame is resolved but source code is unavailable" in the error tracking UI, with no indication of what went wrong unless you run with `RUST_LOG=debug`.

Reproduced on `posthog-cli 0.7.9` against real dSYMs, Swift 6.x, Xcode 26.4.1 (17E202), XcodeGen-generated project.

**Root cause.** In `cli/src/dsym/source_bundle.rs`, `cu_main_files_from_dwarf` reads each compile unit's `DW_AT_comp_dir` and `DW_AT_name` and joins them. Swift emits synthetic CUs with `DW_AT_name = "<swift-imported-modules>"` alongside a real `DW_AT_comp_dir` (the enclosing `.xcodeproj` path). The join produces e.g. `/Users/me/project/ios/Project.xcodeproj/<swift-imported-modules>`. The post-assembly `EXCLUDED_SYNTHETIC_NAMES` filter uses `starts_with`, so these comp_dir-prefixed synthetics escape filtering. In projects where they dominate the CU list, `longest_common_prefix` collapses to `/…/Project.xcodeproj/`, and every real source at a sibling path (e.g. `/…/ios/Sources/…`) is then rejected by the `in_project` check in `extract_source_paths_from_dwarf` with `Skipped (outside project prefix)`.

## Changes

Drop synthetic angle-bracket `DW_AT_name` values before the comp_dir join so they never contribute to the prefix computation. 7-line change in `cu_main_files_from_dwarf`.

### Before and After

<img width="500" alt="source-code-missing" src="https://github.com/user-attachments/assets/444e677c-8d5c-41ca-a2d0-86cfa97737e4" />

<img width="500" alt="source-code-included" src="https://github.com/user-attachments/assets/c1b565ec-2535-4dbc-8fe1-e4fa7849c4b0" />



## How did you test this code?

Verified against a real dSYM from a Swift 6.x iOS project built with Xcode 26.4.1 (17E202) (XcodeGen-generated `.xcodeproj`). Same dSYM, same CLI args, before and after this patch:

Before:
```
INFO posthog_cli::dsym: Found 0 source paths in DWARF (0 after filtering)
INFO posthog_cli::dsym::upload: dSYM upload complete
```

After:
```
INFO posthog_cli::dsym: Found 1225 source paths in DWARF (104 after filtering)
INFO posthog_cli::dsym::source_bundle: Collected 93 source files (371822 bytes total)
INFO posthog_cli::dsym::upload: dSYM upload complete
```

End-to-end: after uploading with the patched binary, the source snippet now renders in the PostHog error tracking UI for the same crash frame that previously showed "Frame is resolved but source code is unavailable".

`cargo check`, `cargo clippy`, and `cargo fmt --check` all pass. No unit tests added. There are no existing inline tests in this module, and a DWARF fixture would be a larger scope than the one-hunk fix warrants. Happy to add one if a maintainer prefers.

## Publish to changelog?

no

## 🤖 LLM context

This PR was drafted by an agent (Claude Code) in collaboration with @ptrkstr, who was debugging a real-world occurrence of this bug in their own Swift iOS app. The agent located the root cause by running `posthog-cli` with `RUST_LOG=debug` against the affected dSYM, building a locally-patched binary to confirm the fix resolves the symptom end-to-end (including verifying source now renders in the PostHog error tracking UI), and then opening this minimal upstream PR.

## PostHog Cloud Info

```
Session: https://us.posthog.com/project/sTMFPsFhdP1Ssg/replay/019db55b-1144-71b4-a23c-3aa309262555?t=4882
Admin: http://go/adminOrgUS/019ab96d-b21b-0000-d424-390c4a7f47df (project ID 366255)
```
