### PR TITLE
chore: Update batch exports start jitter

### DIFF
--- a/posthog/api/test/batch_exports/conftest.py
+++ b/posthog/api/test/batch_exports/conftest.py
@@ -1,5 +1,4 @@
 import logging
-import datetime as dt
 
 import pytest
 
@@ -13,7 +12,7 @@ from temporalio.service import RPCError
 
 from posthog.api.test.batch_exports.fixtures import create_organization, create_team, create_user
 from posthog.api.test.batch_exports.operations import start_test_worker
-from posthog.batch_exports.models import BatchExport
+from posthog.batch_exports.models import BATCH_EXPORT_INTERVAL_TO_START_JITTER, BatchExport
 from posthog.temporal.common.client import sync_connect
 
 
@@ -96,7 +95,7 @@ def assert_is_daily_schedule(schedule: ScheduleDescription, expected_hour: int):
     # ensure it's running every day of the week
     assert calendars[0].day_of_week == (ScheduleRange(start=0, end=6),)
     assert calendars[0].hour == (ScheduleRange(start=expected_hour, end=expected_hour),)
-    assert schedule.schedule.spec.jitter == dt.timedelta(minutes=30)
+    assert schedule.schedule.spec.jitter == BATCH_EXPORT_INTERVAL_TO_START_JITTER["day"]
 
 
 def assert_is_weekly_schedule(schedule: ScheduleDescription, expected_day: int, expected_hour: int):
@@ -105,4 +104,4 @@ def assert_is_weekly_schedule(schedule: ScheduleDescription, expected_day: int, 
     assert len(calendars) == 1
     assert calendars[0].day_of_week == (ScheduleRange(start=expected_day, end=expected_day),)
     assert calendars[0].hour == (ScheduleRange(start=expected_hour, end=expected_hour),)
-    assert schedule.schedule.spec.jitter == dt.timedelta(hours=1)
+    assert schedule.schedule.spec.jitter == BATCH_EXPORT_INTERVAL_TO_START_JITTER["week"]

--- a/posthog/batch_exports/models.py
+++ b/posthog/batch_exports/models.py
@@ -306,9 +306,9 @@ class BatchExport(ModelActivityMixin, UUIDTModel):
         if self.interval == "hour":
             return timedelta(minutes=15)
         elif self.interval == "day":
-            return timedelta(minutes=30)
+            return timedelta(minutes=20)
         elif self.interval == "week":
-            return timedelta(hours=1)
+            return timedelta(minutes=30)
         elif self.interval.startswith("every"):
             # This yields 1 minute for 5 minute batch exports, which is the only
             # "every" interval in use currently.

--- a/posthog/batch_exports/models.py
+++ b/posthog/batch_exports/models.py
@@ -187,6 +187,12 @@ BATCH_EXPORT_INTERVALS = [
     ("every 15 minutes", "every 15 minutes"),
 ]
 
+BATCH_EXPORT_INTERVAL_TO_START_JITTER = {
+    "hour": timedelta(minutes=15),
+    "day": timedelta(minutes=20),
+    "week": timedelta(minutes=30),
+}
+
 
 class BatchExport(ModelActivityMixin, UUIDTModel):
     """
@@ -303,12 +309,8 @@ class BatchExport(ModelActivityMixin, UUIDTModel):
         the start hour of the export, therefore we don't want to make the jitter
         too large.
         """
-        if self.interval == "hour":
-            return timedelta(minutes=15)
-        elif self.interval == "day":
-            return timedelta(minutes=20)
-        elif self.interval == "week":
-            return timedelta(minutes=30)
+        if self.interval in ("hour", "day", "week"):
+            return BATCH_EXPORT_INTERVAL_TO_START_JITTER[self.interval]
         elif self.interval.startswith("every"):
             # This yields 1 minute for 5 minute batch exports, which is the only
             # "every" interval in use currently.


### PR DESCRIPTION
## Problem

Now that daily and weekly batch exports can set a different time to start, there is less thundering herd risk with everyone grouping around midnight UTC. Too much jitter can make batch exports feel unresponsive.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

So, this adjust the jitter down:
* Daily becomes 20 minutes.
* Weekly becomes 30 minutes.

Still arbitrary values just as before, but slightly more responsive from a user's perspective.

Maybe in the future we should display that the batch exports are running, even if they are in the jitter range.

Additionally: I made the jitter a global dictionary that we can import in tests. This makes it so it can be updated in just one place.


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran unit tests, had to update a couple to now use the configured jitter rather than a hardcoded value.
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

No
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

Yes, docs should mention the jitter if not there.

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
