### PR TITLE
fix(worker): let celery drain in-flight tasks on deploy

### DIFF
--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -54,8 +54,16 @@ while test $# -gt 0; do
   esac
 done
 
-# Stop any background jobs on exit
-trap 'kill $(jobs -p)' EXIT
+# Forward SIGTERM to all background jobs and wait for them to finish.
+# Without the explicit wait, bash (PID 1) exits immediately after the
+# trap fires and the kernel tears down the container — killing in-flight
+# Celery tasks before they can drain, even though K8s gives us 1230s of
+# grace time via terminationGracePeriodSeconds.
+cleanup() {
+  kill $(jobs -p) 2>/dev/null
+  wait
+}
+trap cleanup EXIT
 
 if [ "$with_scheduler" == "true" ]; then
   ./bin/docker-worker-beat &

--- a/products/visual_review/backend/tasks/tasks.py
+++ b/products/visual_review/backend/tasks/tasks.py
@@ -16,7 +16,12 @@ from celery import shared_task
 logger = structlog.get_logger(__name__)
 
 
-@shared_task(name="products.visual_review.backend.tasks.process_run_diffs", ignore_result=True)
+@shared_task(
+    name="products.visual_review.backend.tasks.process_run_diffs",
+    ignore_result=True,
+    acks_late=True,
+    reject_on_worker_lost=True,
+)
 def process_run_diffs(run_id: str) -> None:
     """
     Process diffs for all snapshots in a run.


### PR DESCRIPTION
## Problem

Every deploy kills in-flight Celery tasks because the entrypoint script (`bin/docker-worker-celery`) doesn't wait for celery's warm shutdown. Bash (PID 1) sends SIGTERM to the celery worker but exits immediately — the container tears down before tasks can drain, wasting the 1230s `terminationGracePeriodSeconds` entirely.

This causes ClickHouse "Connection reset by peer" errors for queries that were in flight when the pod was terminated.

A second issue: `process_run_diffs` (visual review) has no deploy resilience — `acks_late` defaults to `False`, so the task is acked on pickup and silently lost when the worker dies mid-execution.

## Changes

**`bin/docker-worker-celery`**: Replace the bare `kill` EXIT trap with a `cleanup()` function that sends SIGTERM and then `wait`s for children to finish. This lets celery complete its warm shutdown (drain in-flight tasks, stop accepting new ones) before PID 1 exits.

**`products/visual_review/backend/tasks/tasks.py`**: Add `acks_late=True` and `reject_on_worker_lost=True` to `process_run_diffs` so the task is requeued on worker death instead of silently dropped.

## How did you test this code?

Simulated the exact scenario locally with a bash script mimicking the entrypoint + a Python child with a SIGTERM handler (simulating celery warm shutdown):

- **Old behavior**: parent exits instantly on SIGTERM, child drain never completes
- **New behavior**: parent blocks until child finishes draining, then exits

The `process_run_diffs` change is a decorator-only addition — the task body is already idempotent (`save(update_fields=...)`, `get_or_create` for tolerances).

## Publish to changelog?

no

## 🤖 LLM context

Investigated deploy-time task loss by correlating ClickHouse `query_log` errors against pod rollout events from Victoria Metrics. Also confirmed the entrypoint's PID 1 signal handling via `/proc/1/status` SigCgt mask on a running pod.