### PR TITLE
fix(mcp): enable logs-alerts-list and logs-alerts-retrieve in new MCP server

### DIFF
--- a/products/logs/mcp/tools.yaml
+++ b/products/logs/mcp/tools.yaml
@@ -75,7 +75,6 @@ tools:
         description: >
             List log alert configurations in the current project, newest first. Returns alert name, state, threshold,
             filters, and scheduling details. Use this to review existing alerts before creating or modifying them.
-        mcp_version: 1
         response:
             include:
                 - id
@@ -148,7 +147,6 @@ tools:
         description: >
             Get a log alert configuration by ID. Returns full details including current state, threshold settings,
             filters, and scheduling information.
-        mcp_version: 1
         response:
             include:
                 - id

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2377,7 +2377,7 @@
         "summary": "List log alerts",
         "title": "List log alerts",
         "required_scopes": ["logs:read"],
-        "new_mcp": false,
+        "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -2409,7 +2409,7 @@
         "summary": "Get log alert",
         "title": "Get log alert",
         "required_scopes": ["logs:read"],
-        "new_mcp": false,
+        "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2779,7 +2779,7 @@
         "summary": "List log alerts",
         "title": "List log alerts",
         "required_scopes": ["logs:read"],
-        "new_mcp": false,
+        "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,
@@ -2811,7 +2811,7 @@
         "summary": "Get log alert",
         "title": "Get log alert",
         "required_scopes": ["logs:read"],
-        "new_mcp": false,
+        "new_mcp": true,
         "annotations": {
             "destructiveHint": false,
             "idempotentHint": true,

--- a/services/mcp/src/tools/generated/logs.ts
+++ b/services/mcp/src/tools/generated/logs.ts
@@ -95,7 +95,6 @@ const logsAlertsList = (): ToolBase<
 > => ({
     name: 'logs-alerts-list',
     schema: LogsAlertsListSchema,
-    mcpVersion: 1,
     handler: async (context: Context, params: z.infer<typeof LogsAlertsListSchema>) => {
         const projectId = await context.stateManager.getProjectId()
         const result = await context.api.request<Schemas.PaginatedLogsAlertConfigurationList>({
@@ -200,7 +199,6 @@ const LogsAlertsRetrieveSchema = LogsAlertsRetrieveParams.omit({ project_id: tru
 const logsAlertsRetrieve = (): ToolBase<typeof LogsAlertsRetrieveSchema, Schemas.LogsAlertConfiguration> => ({
     name: 'logs-alerts-retrieve',
     schema: LogsAlertsRetrieveSchema,
-    mcpVersion: 1,
     handler: async (context: Context, params: z.infer<typeof LogsAlertsRetrieveSchema>) => {
         const projectId = await context.stateManager.getProjectId()
         const result = await context.api.request<Schemas.LogsAlertConfiguration>({


### PR DESCRIPTION
## Problem

The `mcp_version: 1` field was incorrectly included on the `list` and `get` log alert configuration tool definitions in the MCP tools config.

## Changes

Removed the `mcp_version: 1` property from the list log alert configurations tool and the get log alert configuration by ID tool.

## How did you test this code?

local dev

## Publish to changelog?

No