### PR TITLE
chore: ban useState import via oxlint

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -53,6 +53,7 @@ jobs:
                         - .github/workflows/ci-frontend.yml
                         # various JS config files
                         - .oxlintrc.json
+                        - .oxlintrc.strict.json
                         - .oxfmtrc*
                         - babel.config.js
                         - package.json
@@ -81,6 +82,7 @@ jobs:
                         - 'playwright/**'
                         - .github/workflows/ci-frontend.yml
                         - .oxlintrc.json
+                        - .oxlintrc.strict.json
                         - .oxfmtrc*
                         - babel.config.js
                         - package.json
@@ -99,6 +101,9 @@ jobs:
         timeout-minutes: 10
         steps:
             - uses: actions/checkout@v6
+              with:
+                  # Need full history so strict-lint can diff against the PR's merge base
+                  fetch-depth: 0
 
             - name: Install pnpm
               uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -128,6 +133,19 @@ jobs:
 
             - name: Lint with Oxlint
               run: pnpm exec oxlint --quiet
+
+            - name: Lint changed files with strict Oxlint rules
+              if: github.event_name == 'pull_request'
+              env:
+                  BASE_SHA: ${{ github.event.pull_request.base.sha }}
+                  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+              run: |
+                  mapfile -t CHANGED < <(git diff --name-only --diff-filter=ACMRT "$BASE_SHA...$HEAD_SHA" -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs')
+                  if [ ${#CHANGED[@]} -gt 0 ]; then
+                      pnpm exec oxlint --quiet --config .oxlintrc.strict.json "${CHANGED[@]}"
+                  else
+                      echo "No changed JS/TS files to lint with strict rules."
+                  fi
 
             - name: Check markdown formatting with oxfmt
               run: pnpm exec oxfmt --check "**/*.{md,mdx}"

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -135,16 +135,24 @@ jobs:
               run: pnpm exec oxlint --quiet
 
             - name: Lint changed files with strict Oxlint rules
+              # Scoped to frontend/ and products/ because those are the areas that use
+              # kea for state management. Stories and MCP apps are excluded — they run
+              # standalone and legitimately need useState.
               if: github.event_name == 'pull_request'
               env:
                   BASE_SHA: ${{ github.event.pull_request.base.sha }}
                   HEAD_SHA: ${{ github.event.pull_request.head.sha }}
               run: |
-                  mapfile -t CHANGED < <(git diff --name-only --diff-filter=ACMRT "$BASE_SHA...$HEAD_SHA" -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs')
+                  mapfile -t CHANGED < <(
+                      git diff --name-only --diff-filter=ACMRT "$BASE_SHA...$HEAD_SHA" -- 'frontend/' 'products/' \
+                      | grep -E '\.(ts|tsx|js|jsx|mjs)$' \
+                      | grep -vE '\.stories\.tsx$|^products/[^/]+/mcp/apps/' \
+                      || true
+                  )
                   if [ ${#CHANGED[@]} -gt 0 ]; then
                       pnpm exec oxlint --quiet --config .oxlintrc.strict.json "${CHANGED[@]}"
                   else
-                      echo "No changed JS/TS files to lint with strict rules."
+                      echo "No changed frontend/products files to lint with strict rules."
                   fi
 
             - name: Check markdown formatting with oxfmt

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -85,11 +85,6 @@
             {
                 "paths": [
                     {
-                        "name": "react",
-                        "importNames": ["useState"],
-                        "message": "Save state in state management instead."
-                    },
-                    {
                         "name": "dayjs",
                         "message": "Do not directly import dayjs. Only import the dayjs exported from 'lib/dayjs'."
                     },

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -85,6 +85,11 @@
             {
                 "paths": [
                     {
+                        "name": "react",
+                        "importNames": ["useState"],
+                        "message": "Save state in state management instead."
+                    },
+                    {
                         "name": "dayjs",
                         "message": "Do not directly import dayjs. Only import the dayjs exported from 'lib/dayjs'."
                     },

--- a/.oxlintrc.strict.json
+++ b/.oxlintrc.strict.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "./node_modules/oxlint/configuration_schema.json",
+    "extends": ["./.oxlintrc.json"],
+    "rules": {
+        "no-restricted-imports": [
+            "error",
+            {
+                "paths": [
+                    {
+                        "name": "react",
+                        "importNames": ["useState"],
+                        "message": "Save state in state management instead."
+                    },
+                    {
+                        "name": "dayjs",
+                        "message": "Do not directly import dayjs. Only import the dayjs exported from 'lib/dayjs'."
+                    },
+                    {
+                        "name": "chart.js",
+                        "message": "Do not directly import chart.js. Only import the Chart and friends exported from 'lib/Chart'."
+                    },
+                    {
+                        "name": "chart.js/auto",
+                        "message": "Do not directly import chart.js/auto. Only import the Chart and friends exported from 'lib/Chart'."
+                    },
+                    {
+                        "name": "~/queries/schema",
+                        "message": "Import from 'queries/schema/schema-foo' to avoid Webpack/Sucrase enum export issues."
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/.oxlintrc.strict.json
+++ b/.oxlintrc.strict.json
@@ -9,7 +9,7 @@
                     {
                         "name": "react",
                         "importNames": ["useState"],
-                        "message": "Save state in state management instead."
+                        "message": "Use kea for state management instead of React's useState. Otherwise, state will be lost when switching PostHog tabs."
                     },
                     {
                         "name": "dayjs",


### PR DESCRIPTION
## Problem

`useState` keeps biting teams across the codebase — experiments tab state, new warehouse source forms, etc. — because component-local state gets blown away on re-renders, tab switches, and mounts. Kea (our existing state management) handles all of that, but there's nothing stopping people from reaching for `useState` when they add new code.

Per discussion in [#team-platform-ux](https://posthog.slack.com/archives/C0ACRAMJUAG/p1776869999641659?thread_ts=1776867510.978579&cid=C0ACRAMJUAG), Q3 goal is to officially ban `useState` with a CI failure so new code has to use kea.

## Changes

Adds an oxlint rule that fails CI when `useState` is imported from `react`, with the message **"Save state in state management instead."**

### What's blocked

Importing `useState` from `react`:

```ts
import { useState } from 'react'                       // ❌ CI failure
import { useState as useLocalState } from 'react'      // ❌ CI failure
```

All other React hooks (`useEffect`, `useMemo`, `useRef`, etc.) are unaffected.

### How

Because the codebase already has ~1,900 existing `useState` usages, enforcing the rule globally would turn every PR red. Instead:

- Rule lives in a new **`.oxlintrc.strict.json`** that `extends` the base config.
- The existing `pnpm exec oxlint --quiet` step is **unchanged** — it runs on everything with the base config.
- A **new CI step** runs `oxlint --config .oxlintrc.strict.json` over just the files the PR touched, computed via three-dot diff: `git diff --name-only "$BASE_SHA...$HEAD_SHA"` using `github.event.pull_request.base.sha` and `github.event.pull_request.head.sha` (the lint job's checkout was bumped to `fetch-depth: 0` so the merge base is reachable).

### Scope

The strict lint is scoped to directories where kea is actually wired up, and excludes known standalone render areas that legitimately need local React state:

| Path                                        | Strict lint? | Why                                                                 |
| ------------------------------------------- | :----------: | ------------------------------------------------------------------- |
| `frontend/**/*.{ts,tsx,js,jsx,mjs}`         |     ✅       | Main app, kea-driven                                                |
| `products/**/*.{ts,tsx,js,jsx,mjs}`         |     ✅       | Product code, kea-driven                                            |
| `**/*.stories.tsx`                          |     ❌       | Storybook stories render outside the app shell                      |
| `products/*/mcp/apps/**`                    |     ❌       | MCP UI apps render standalone (base config already treats as exception) |
| `services/`, `docs/`, `common/`, `tools/`, `packages/` | ❌ | Not covered by kea; base config already disables related React rules here |

### When

| Event                                       | Strict lint runs? |
| ------------------------------------------- | :---------------: |
| `pull_request` (opened/updated)             |        ✅         |
| `push` to `master`                          |        ❌         |
| `merge_group` (merge queue)                 |        ❌         |

Scoping to `pull_request` only is deliberate: `master` already has ~1,900 existing `useState` usages, so running on `master` push or in the merge queue would fail the main branch. The base oxlint step still runs on those events — only the strict pass is gated.

### Behavior for developers

- **Adding `useState` in a new `frontend/` or `products/` file** → CI fails with the custom message. Expected — migrate to a kea logic.
- **Editing an existing file that already imports `useState`** → CI fails on that file. This is a forcing function: if you touch it, clean it up. Can be escaped with `// eslint-disable-next-line no-restricted-imports` when migration isn't practical in the PR.
- **Editing files that never imported `useState`** → unaffected.
- **Touching stories, MCP apps, or out-of-scope directories** → unaffected.

## How did you test this code?

- Ran `oxlint --config .oxlintrc.strict.json` locally against a synthetic file with `import { useState } from 'react'` → fails with the expected message.
- Ran the same against a file with `import { useEffect } from 'react'` → passes.
- Ran the default `pnpm exec oxlint` against `import { useState } from 'react'` → passes (confirms the rule is strict-config-only and won't break the master branch lint step).
- Verified the shell filter correctly includes `frontend/**` and `products/**` TS/JS files while excluding `*.stories.tsx` and `products/*/mcp/apps/**`.
- I'm an agent; I have not validated the actual GitHub Actions run yet. CI on this PR is the first real end-to-end test — reviewer should confirm (a) the base lint job is still green, (b) the new "Lint changed files with strict Oxlint rules" step runs and passes on a PR that doesn't touch any `useState`-containing file.

Reference: [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1776869999641659?thread_ts=1776867510.978579&cid=C0ACRAMJUAG)

## Publish to changelog?

no

## Docs update

no

## 🤖 LLM context

Authored by Claude via the [Slack → Claude Code integration](https://claude.ai/code/session_012bvC4GxVED8WchCRqC9Swt). Reviewer should scrutinize: (1) whether the scope carve-outs (stories, MCP apps) match the team's actual intent, (2) the three-dot diff behavior under unusual PR states (stacked branches, PR retargeted to a different base), (3) whether `fetch-depth: 0` on the `frontend-format` job adds noticeable checkout latency.
