### PR TITLE
fix: prevent insight visualization from overlaying breakdown details

### DIFF
--- a/frontend/src/lib/components/Cards/CardMeta.scss
+++ b/frontend/src/lib/components/Cards/CardMeta.scss
@@ -280,7 +280,3 @@
     gap: 0.25rem;
     align-items: center;
 }
-
-.InsightCard__viz {
-    z-index: 0;
-}

--- a/frontend/src/lib/components/Cards/CardMeta.scss
+++ b/frontend/src/lib/components/Cards/CardMeta.scss
@@ -280,3 +280,7 @@
     gap: 0.25rem;
     align-items: center;
 }
+
+.InsightCard__viz {
+    z-index: 0;
+}

--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -2,8 +2,12 @@
     width: 100%; // This provides the width for the dashboard items grid
     padding-top: 0.5rem;
 
-    .InsightCard__viz .InsightVizDisplay .LineGraph {
-        padding: 0.25rem;
+    .InsightCard__viz {
+        z-index: 0; // Keep viz below CardMeta details overlay on dashboards
+
+        .InsightVizDisplay .LineGraph {
+            padding: 0.25rem;
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

Feature flag breakdown information was appearing above the insight details section instead of being properly layered within the card structure. This caused visual layout issues where breakdown content would overlay other elements.

<img width="1280" height="520" alt="chrome-capture-2026-04-22" src="https://github.com/user-attachments/assets/64c3a390-d211-46dc-b8bc-9db4a62e2fcc" />

## Changes

- Added `z-index: 0` to `.InsightCard__viz` to establish proper CSS stacking context
- Ensures insight visualization content stays in its proper layer relative to breakdown details

## How did you test this code?

- Verified the CSS change addresses the layering issue
- No breaking changes to existing insight card functionality