### PR TITLE
feat(tracing): add ability to filter on span name/kind/status

### DIFF
--- a/bin/clickhouse-logs.sql
+++ b/bin/clickhouse-logs.sql
@@ -299,7 +299,48 @@ ENGINE = AggregatingMergeTree
 PARTITION BY toDate(time_bucket)
 ORDER BY (team_id, attribute_type, time_bucket, resource_fingerprint, attribute_key, attribute_value);
 
-drop view if exists trace_span_to_resource_attributes;
+CREATE OR REPLACE TABLE trace_attributes_distributed AS trace_attributes ENGINE = Distributed('posthog', 'default', 'trace_attributes');
+
+drop view if exists trace_span_to_span_attributes;
+CREATE MATERIALIZED VIEW trace_span_to_span_attributes TO trace_attributes
+(
+    `team_id` Int32,
+    `time_bucket` DateTime64(0),
+    `service_name` LowCardinality(String),
+    `resource_fingerprint` UInt64,
+    `attribute_key` LowCardinality(String),
+    `attribute_value` String,
+    `attribute_type` LowCardinality(String),
+    `attribute_count` SimpleAggregateFunction(sum, UInt64)
+)
+AS SELECT
+    team_id,
+    time_bucket,
+    service_name,
+    resource_fingerprint,
+    attribute_key,
+    attribute_value,
+    'span' as attribute_type,
+    attribute_count
+FROM
+(
+    SELECT
+        team_id AS team_id,
+        toStartOfInterval(timestamp, toIntervalMinute(10)) AS time_bucket,
+        service_name AS service_name,
+        resource_fingerprint,
+        'name' AS attribute_key,
+        `name` AS attribute_value,
+        sumSimpleState(1) AS attribute_count
+    FROM trace_spans
+    GROUP BY
+        team_id,
+        time_bucket,
+        service_name,
+        resource_fingerprint,
+        `name`
+);
+
 CREATE MATERIALIZED VIEW trace_span_to_resource_attributes TO trace_attributes
 (
     `team_id` Int32,
@@ -318,7 +359,7 @@ AS SELECT
     resource_fingerprint,
     attribute_key,
     attribute_value,
-    'resource' as attribute_type,
+    'span_resource_attribute' as attribute_type,
     attribute_count
 FROM
 (
@@ -340,8 +381,8 @@ FROM
         attribute
 );
 
-drop view if exists trace_span_to_trace_attributes;
-CREATE MATERIALIZED VIEW trace_span_to_trace_attributes TO trace_attributes
+drop view if exists trace_span_to_attributes;
+CREATE MATERIALIZED VIEW trace_span_to_attributes TO trace_attributes
 (
     `team_id` Int32,
     `time_bucket` DateTime64(0),
@@ -359,7 +400,7 @@ AS SELECT
     resource_fingerprint,
     attribute_key,
     attribute_value,
-    'span' as attribute_type,
+    'span_attribute' as attribute_type,
     attribute_count
 FROM
 (

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -7,6 +7,7 @@ import { LemonBanner, LemonDropdownProps, LemonSelect, LemonSelectProps, LemonSe
 import { allOperatorsToHumanName } from 'lib/components/DefinitionPopover/utils'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
+import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
 import { Link } from 'lib/lemon-ui/Link'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import {
@@ -33,6 +34,65 @@ import {
 } from '~/types'
 
 import { PropertyValue } from './PropertyValue'
+
+// OTel span.kind enum (https://opentelemetry.io/docs/specs/otel/trace/api/#spankind).
+const SPAN_KIND_OPTIONS: { key: number; label: string }[] = [
+    { key: 0, label: 'Unspecified' },
+    { key: 1, label: 'Internal' },
+    { key: 2, label: 'Server' },
+    { key: 3, label: 'Client' },
+    { key: 4, label: 'Producer' },
+    { key: 5, label: 'Consumer' },
+]
+
+// OTel status_code. 'Unset' (0) is conflated with 'OK' (1) in the filter UI per product decision.
+const STATUS_CODE_OPTIONS: { key: number; label: string }[] = [
+    { key: 1, label: 'OK' },
+    { key: 2, label: 'Error' },
+]
+
+function SpanEnumValueSelect({
+    options,
+    value,
+    onChange,
+    isMultiSelect,
+    size,
+}: {
+    options: { key: number; label: string }[]
+    value?: PropertyFilterValue
+    onChange: (value: PropertyFilterValue) => void
+    isMultiSelect: boolean
+    size?: 'xsmall' | 'small' | 'medium'
+}): JSX.Element {
+    // Filter value stores labels (e.g. "Server", "OK") so the applied-filter chip renders
+    // human text. The backend maps labels back to ints before building the HogQL query.
+    const labels = new Set(options.map((o) => o.label))
+    const selectedRaw = value === null || value === undefined ? [] : Array.isArray(value) ? value : [value]
+    const selectedLabels = selectedRaw.map((v) => String(v)).filter((v) => labels.has(v))
+
+    return (
+        <LemonInputSelect
+            data-attr="prop-val"
+            mode={isMultiSelect ? 'multiple' : 'single'}
+            singleValueAsSnack
+            allowCustomValues={false}
+            value={selectedLabels}
+            onChange={(next) => {
+                const valid = next.map((v) => String(v)).filter((v) => labels.has(v))
+                if (isMultiSelect) {
+                    onChange(valid)
+                } else {
+                    onChange(valid.length > 0 ? valid[0] : null)
+                }
+            }}
+            options={options.map((o) => ({
+                key: o.label,
+                label: o.label,
+            }))}
+            size={size}
+        />
+    )
+}
 
 export interface OperatorValueSelectProps {
     type?: PropertyFilterType
@@ -208,6 +268,25 @@ export function OperatorValueSelect({
             )
         }
 
+        // Restrict span name to string equality/contains operators
+        if (propertyKey === 'name' && type === PropertyFilterType.Span) {
+            operators = operators.filter((op) =>
+                [
+                    PropertyOperator.Exact,
+                    PropertyOperator.IsNot,
+                    PropertyOperator.IContains,
+                    PropertyOperator.NotIContains,
+                    PropertyOperator.Regex,
+                    PropertyOperator.NotRegex,
+                ].includes(op)
+            )
+        }
+
+        // Restrict span kind and status_code (fixed int enums) to equality operators
+        if ((propertyKey === 'kind' || propertyKey === 'status_code') && type === PropertyFilterType.Span) {
+            operators = operators.filter((op) => [PropertyOperator.Exact, PropertyOperator.IsNot].includes(op))
+        }
+
         setOperators(operators)
         if ((currentOperator !== operator && operators.includes(startingOperator)) || !propertyDefinition) {
             setCurrentOperator(startingOperator)
@@ -276,28 +355,50 @@ export function OperatorValueSelect({
                     className="shrink grow-[1000] min-w-[10rem] overflow-hidden"
                     data-attr="taxonomic-value-select"
                 >
-                    <PropertyValue
-                        type={type}
-                        key={propertyKey}
-                        propertyKey={propertyKey}
-                        endpoint={endpoint}
-                        operator={currentOperator || PropertyOperator.Exact}
-                        placeholder={placeholder}
-                        value={value}
-                        eventNames={eventNames}
-                        onSet={(newValue: string | number | string[] | null) => {
-                            onChange(currentOperator || PropertyOperator.Exact, newValue)
-                        }}
-                        // open automatically only if new filter
-                        autoFocus={!isMobile() && value === null}
-                        addRelativeDateTimeOptions={addRelativeDateTimeOptions}
-                        groupTypeIndex={groupTypeIndex}
-                        groupKeyNames={groupKeyNames}
-                        editable={editable}
-                        size={size}
-                        forceSingleSelect={forceSingleSelect}
-                        validationError={validationError}
-                    />
+                    {type === PropertyFilterType.Span && (propertyKey === 'kind' || propertyKey === 'status_code') ? (
+                        editable ? (
+                            <SpanEnumValueSelect
+                                options={propertyKey === 'kind' ? SPAN_KIND_OPTIONS : STATUS_CODE_OPTIONS}
+                                value={value}
+                                isMultiSelect={
+                                    forceSingleSelect
+                                        ? false
+                                        : isOperatorMulti(currentOperator || PropertyOperator.Exact)
+                                }
+                                size={size}
+                                onChange={(newValue) => onChange(currentOperator || PropertyOperator.Exact, newValue)}
+                            />
+                        ) : (
+                            <span>
+                                {(Array.isArray(value) ? value : value == null ? [] : [value])
+                                    .map((v) => String(v))
+                                    .join(' or ')}
+                            </span>
+                        )
+                    ) : (
+                        <PropertyValue
+                            type={type}
+                            key={propertyKey}
+                            propertyKey={propertyKey}
+                            endpoint={endpoint}
+                            operator={currentOperator || PropertyOperator.Exact}
+                            placeholder={placeholder}
+                            value={value}
+                            eventNames={eventNames}
+                            onSet={(newValue: string | number | string[] | null) => {
+                                onChange(currentOperator || PropertyOperator.Exact, newValue)
+                            }}
+                            // open automatically only if new filter
+                            autoFocus={!isMobile() && value === null}
+                            addRelativeDateTimeOptions={addRelativeDateTimeOptions}
+                            groupTypeIndex={groupTypeIndex}
+                            groupKeyNames={groupKeyNames}
+                            editable={editable}
+                            size={size}
+                            forceSingleSelect={forceSingleSelect}
+                            validationError={validationError}
+                        />
+                    )}
                 </div>
             )}
             {validationError && (

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -821,10 +821,21 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         searchPlaceholder: 'spans',
                         type: TaxonomicFilterGroupType.Spans,
                         options: [
+                            { key: 'name', name: 'name', propertyFilterType: 'span' },
+                            { key: 'kind', name: 'kind', propertyFilterType: 'span' },
+                            { key: 'duration', name: 'duration (ms)', propertyFilterType: 'span' },
                             { key: 'trace_id', name: 'trace_id', propertyFilterType: 'span' },
                             { key: 'span_id', name: 'span_id', propertyFilterType: 'span' },
-                            { key: 'duration', name: 'duration (ms)', propertyFilterType: 'span' },
+                            { key: 'status_code', name: 'status code', propertyFilterType: 'span' },
                         ],
+                        valuesEndpoint: (key) =>
+                            key === 'name'
+                                ? combineUrl(`api/environments/${projectId}/tracing/spans/values`, {
+                                      attribute_type: 'span',
+                                      key: key,
+                                      ...endpointFilters,
+                                  }).url
+                                : undefined,
                         localItemsSearch: (items: any[], q: string): any[] => {
                             if (!q) {
                                 return items

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -413,7 +413,7 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
             { endpoint, type, newInput, propertyKey, eventNames, properties, refresh },
             breakpoint
         ) => {
-            if (['cohort', 'log', 'span', 'workflow_variable'].includes(type)) {
+            if (!endpoint && ['cohort', 'log', 'span', 'workflow_variable'].includes(type)) {
                 return
             }
             if (!propertyKey || values.currentTeamId === null) {

--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -178,13 +178,13 @@ class TraceSpansQueryRunnerMixin(QueryRunner):
                 # Filter UI stores human labels for kind/status_code so the applied-filter
                 # chip reads naturally. Translate labels to the integer column values here.
                 if span_filter.key == "kind":
-                    values = span_filter.value if isinstance(span_filter.value, list) else [span_filter.value]
+                    values = span_filter.value if isinstance(span_filter.value, list) else [str(span_filter.value)]
                     span_filter.value = [
                         _SPAN_KIND_LABEL_TO_INT[str(v)] for v in values if str(v) in _SPAN_KIND_LABEL_TO_INT
                     ]
 
                 if span_filter.key == "status_code":
-                    values = span_filter.value if isinstance(span_filter.value, list) else [span_filter.value]
+                    values = span_filter.value if isinstance(span_filter.value, list) else [str(span_filter.value)]
                     expanded: list[int] = []
                     for v in values:
                         if str(v) in _STATUS_CODE_LABEL_TO_INTS:

--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -56,6 +56,23 @@ def _is_number(value: str) -> bool:
         return False
 
 
+# OTel span.kind enum labels sent from the filter UI, mapped to their wire integer values.
+_SPAN_KIND_LABEL_TO_INT: dict[str, int] = {
+    "Unspecified": 0,
+    "Internal": 1,
+    "Server": 2,
+    "Client": 3,
+    "Producer": 4,
+    "Consumer": 5,
+}
+
+# OTel status_code label → int. 'OK' expands to {0, 1} so 'unset' spans match 'ok' filters.
+_STATUS_CODE_LABEL_TO_INTS: dict[str, list[int]] = {
+    "OK": [0, 1],
+    "Error": [2],
+}
+
+
 class TraceSpansQueryRunnerMixin(QueryRunner):
     """Shared WHERE clause and settings for all trace span query runners."""
 
@@ -157,6 +174,21 @@ class TraceSpansQueryRunnerMixin(QueryRunner):
                     else:
                         if _is_number(str(span_filter.value)):
                             span_filter.value = str(decimal.Decimal(str(span_filter.value)) * 1000000)
+
+                # Filter UI stores human labels for kind/status_code so the applied-filter
+                # chip reads naturally. Translate labels to the integer column values here.
+                if span_filter.key == "kind":
+                    values = span_filter.value if isinstance(span_filter.value, list) else [span_filter.value]
+                    span_filter.value = [
+                        _SPAN_KIND_LABEL_TO_INT[str(v)] for v in values if str(v) in _SPAN_KIND_LABEL_TO_INT
+                    ]
+
+                if span_filter.key == "status_code":
+                    values = span_filter.value if isinstance(span_filter.value, list) else [span_filter.value]
+                    expanded: list[int] = []
+                    for v in values:
+                        if str(v) in _STATUS_CODE_LABEL_TO_INTS:
+                            expanded.extend(_STATUS_CODE_LABEL_TO_INTS[str(v)])
 
                 exprs.append(property_to_expr(span_filter, team=self.team))
 
@@ -469,7 +501,9 @@ def run_attribute_names_query(
         timezone_info=ZoneInfo("UTC"),
     )
 
-    property_filter_type = "span_resource_attribute" if attribute_type == "resource" else "span_attribute"
+    property_filter_type = (
+        attribute_type if attribute_type in ("span", "span_attribute", "span_resource_attribute") else "span_attribute"
+    )
 
     query = parse_select(
         """

--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -189,6 +189,7 @@ class TraceSpansQueryRunnerMixin(QueryRunner):
                     for v in values:
                         if str(v) in _STATUS_CODE_LABEL_TO_INTS:
                             expanded.extend(_STATUS_CODE_LABEL_TO_INTS[str(v)])
+                    span_filter.value = [str(v) for v in expanded]
 
                 exprs.append(property_to_expr(span_filter, team=self.team))
 
@@ -502,14 +503,7 @@ def run_attribute_names_query(
     )
 
     property_filter_type = (
-        attribute_type
-        if attribute_type
-        in (
-            SpanPropertyFilterType.SPAN,
-            SpanPropertyFilterType.SPAN_ATTRIBUTE,
-            SpanPropertyFilterType.SPAN_RESOURCE_ATTRIBUTE,
-        )
-        else SpanPropertyFilterType.SPAN_ATTRIBUTE
+        attribute_type if attribute_type in ("span", "span_attribute", "span_resource_attribute") else "span_attribute"
     )
 
     query = parse_select(

--- a/products/tracing/backend/logic.py
+++ b/products/tracing/backend/logic.py
@@ -502,7 +502,14 @@ def run_attribute_names_query(
     )
 
     property_filter_type = (
-        attribute_type if attribute_type in ("span", "span_attribute", "span_resource_attribute") else "span_attribute"
+        attribute_type
+        if attribute_type
+        in (
+            SpanPropertyFilterType.SPAN,
+            SpanPropertyFilterType.SPAN_ATTRIBUTE,
+            SpanPropertyFilterType.SPAN_RESOURCE_ATTRIBUTE,
+        )
+        else SpanPropertyFilterType.SPAN_ATTRIBUTE
     )
 
     query = parse_select(

--- a/products/tracing/frontend/TracingScene.tsx
+++ b/products/tracing/frontend/TracingScene.tsx
@@ -123,7 +123,13 @@ export default function TracingScene(): JSX.Element {
                 rowKey="uuid"
                 emptyState="No spans found"
                 onRow={(span) => ({
-                    onClick: () => openTraceModal(span.trace_id),
+                    onClick: () => {
+                        // Clicking a row leaves the scrollable <main tabIndex="0"> as the active
+                        // element; react-modal then scrolls it back into view when restoring focus
+                        // on close. Blur so the restore target is <body>, which doesn't scroll.
+                        ;(document.activeElement as HTMLElement | null)?.blur?.()
+                        openTraceModal(span.trace_id)
+                    },
                     className: 'cursor-pointer',
                 })}
             />

--- a/products/tracing/frontend/types.ts
+++ b/products/tracing/frontend/types.ts
@@ -23,9 +23,11 @@ export const SPAN_KIND_LABELS: Record<number, string> = {
     5: 'Consumer',
 }
 
+// In the Otel standard, "unset" is treated as "OK".
+// It's stored separately in the backend but should be treated identically to the user
 export const STATUS_CODE_LABELS: Record<number, { label: string; type: 'success' | 'warning' | 'danger' | 'default' }> =
     {
-        0: { label: 'Unset', type: 'default' },
+        0: { label: 'OK', type: 'success' },
         1: { label: 'OK', type: 'success' },
         2: { label: 'Error', type: 'danger' },
     }

--- a/rust/capture-logs/src/trace_record.rs
+++ b/rust/capture-logs/src/trace_record.rs
@@ -263,10 +263,6 @@ mod tests {
             row.attributes.get("http.method").map(|s| s.as_str()),
             Some("\"GET\"")
         );
-        assert_eq!(
-            row.attributes.get("name").map(|s| s.as_str()),
-            Some("\"test.operation\"")
-        );
     }
 
     #[test]

--- a/rust/capture-logs/src/trace_record.rs
+++ b/rust/capture-logs/src/trace_record.rs
@@ -263,6 +263,10 @@ mod tests {
             row.attributes.get("http.method").map(|s| s.as_str()),
             Some("\"GET\"")
         );
+        assert_eq!(
+            row.attributes.get("name").map(|s| s.as_str()),
+            Some("\"test.operation\"")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

we were missing some pretty critical span filtering features

## Changes

add ability to filter on span name/kind/status
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
locally
<!-- Briefly describe the steps you took, and what steps reviewers must take to get to where changes are, and what is the expected behavior. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- If you are an agent writing this, do NOT include manual tasks you have NOT completed. You can clearly outline you're simply an agent and you haven't tested this manually except for code-based unit/integration tests -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?
no
<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
