### PR TITLE
fix(marketing-analytics): return to marketing analytics after connecting a source in onboarding

### DIFF
--- a/frontend/src/scenes/marketing-analytics/Onboarding/AddSourceStep.tsx
+++ b/frontend/src/scenes/marketing-analytics/Onboarding/AddSourceStep.tsx
@@ -65,7 +65,7 @@ export function AddSourceStep({ onContinue, hasSources }: AddSourceStepProps): J
             intent_context: ProductIntentContext.MARKETING_ANALYTICS_DATA_SOURCE_CONNECTED,
             metadata: { source_type: sourceId },
         })
-        router.actions.push(urls.dataWarehouseSourceNew(sourceId))
+        router.actions.push(urls.dataWarehouseSourceNew(sourceId, urls.marketingAnalyticsApp(), 'Marketing analytics'))
     }
 
     const nativeSources = allSources.filter((s) => s.category === 'native')


### PR DESCRIPTION
## Problem

When a user is on the Marketing analytics onboarding and clicks a source chip to connect it, they are sent to the data warehouse source wizard with no context of where they came from. The wizard's final step falls back to its default button, `Return to sources`, dropping the user on `/data-management/sources` — outside of the onboarding flow they just abandoned.

The same call from inside the Marketing analytics app (`AddIntegrationButton.tsx`) already passes `returnUrl` + `returnLabel`, so that flow correctly shows `Return to Marketing analytics`. The onboarding flow was inconsistent with it.

## Changes

`AddSourceStep.tsx` now passes `urls.marketingAnalyticsApp()` as `returnUrl` and `'Marketing analytics'` as `returnLabel` when launching the wizard:

```tsx
router.actions.push(urls.dataWarehouseSourceNew(sourceId, urls.marketingAnalyticsApp(), 'Marketing analytics'))
```

The wizard's `sourceWizardLogic` already prefixes `Return to ` to the label, so the final-step button now reads `Return to Marketing analytics` and brings the user back to `/marketing`, where the onboarding picks up on the correct step thanks to existing logic in `Onboarding.tsx` that advances past `welcome` once a source is connected.

## How did you test this code?

Change-only verification — the existing behavior for adding a source from inside the Marketing analytics app already uses this exact pattern in `AddIntegrationButton.tsx:45`, so this is aligning the onboarding entry point with the known-working post-onboarding entry point. No new tests added; the fix is a one-argument change to an existing `router.actions.push` call.

<img width="1273" height="305" alt="image" src="https://github.com/user-attachments/assets/3ca938d8-6d69-4d69-a0c6-159091d684a4" />


## Publish to changelog?

no

## Docs update

skip-inkeep-docs