### PR TITLE
feat(subscriptions): capture subscription_delete server-side event

### DIFF
--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -314,9 +314,35 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         return instance
 
     def update(self, instance: Subscription, validated_data: dict, *args, **kwargs) -> Subscription:
+        request = self.context["request"]
         previous_value = instance.target_value
+        is_delete = not instance.deleted and validated_data.get("deleted") is True
         invite_message = validated_data.pop("invite_message", "")
         dashboard_export_insight_ids = validated_data.pop("dashboard_export_insights", [])
+
+        if is_delete:
+            with slo_operation(
+                spec=SloSpec(
+                    distinct_id=str(request.user.distinct_id),
+                    area=SloArea.ANALYTIC_PLATFORM,
+                    operation=SloOperation.SUBSCRIPTION_DELETE,
+                    team_id=instance.team_id,
+                    resource_id=str(instance.id),
+                ),
+                properties={
+                    "subscription_id": instance.id,
+                    "target_type": instance.target_type,
+                    "frequency": instance.frequency,
+                    "resource_type": "dashboard"
+                    if instance.dashboard_id
+                    else "insight"
+                    if instance.insight_id
+                    else None,
+                },
+            ):
+                instance = super().update(instance, validated_data)
+            return instance
+
         instance = super().update(instance, validated_data)
 
         if dashboard_export_insight_ids:

--- a/posthog/slo/types.py
+++ b/posthog/slo/types.py
@@ -11,6 +11,7 @@ class SloOperation(StrEnum):
     EXPORT = "export"
     SUBSCRIPTION_DELIVERY = "subscription_delivery"
     SUBSCRIPTION_CREATE = "subscription_create"
+    SUBSCRIPTION_DELETE = "subscription_delete"
     ALERT_CHECK = "alert_check"
 
 


### PR DESCRIPTION
## TL;DR
Added server-side event tracking for subscription deletion operations to monitor and measure subscription deletion performance through SLO metrics.

## Problem
Subscription deletion events were not being tracked server-side, making it difficult to monitor subscription deletion operations and measure their performance against SLOs.

## Changes
- Added `SUBSCRIPTION_DELETE` operation to `SloOperation` enum in `posthog/slo/types.py`
- Implemented server-side event capture in `SubscriptionSerializer.update()` method:
  - Detects when a subscription is being deleted (when `deleted` changes from `False` to `True`)
  - Wraps the deletion operation with `slo_operation()` context manager to track metrics
  - Captures relevant properties including subscription ID, target type, frequency, and resource type (dashboard/insight/none)
  - Records user and team information for proper attribution

## How did you test this code?
This change adds telemetry instrumentation to an existing update operation. The subscription update functionality remains unchanged - the `slo_operation` wrapper is transparent to the operation logic. The deletion detection logic checks for the transition from non-deleted to deleted state, which correctly identifies deletion operations.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*