### PR TITLE
ci(codeql): speed up js/ts analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
         #   - https://gh.io/recommended-hardware-resources-for-running-codeql
         #   - https://gh.io/supported-runners-and-hardware-resources
         #   - https://gh.io/using-larger-runners
-        runs-on: ${{ matrix.runner }}
+        runs-on: 'ubuntu-latest'
         timeout-minutes: 30
         permissions:
             # required for all workflows
@@ -40,19 +40,14 @@ jobs:
                 include:
                     - language: actions
                       build-mode: none
-                      runner: ubuntu-latest
                     - language: c-cpp
                       build-mode: none
-                      runner: ubuntu-latest
                     - language: go
                       build-mode: autobuild
-                      runner: ubuntu-latest
                     - language: javascript-typescript
                       build-mode: none
-                      runner: depot-ubuntu-latest-4
                     - language: python
                       build-mode: none
-                      runner: ubuntu-latest
                 # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
                 # Use `c-cpp` to analyze code written in C, C++ or both
                 # Use 'java-kotlin' to analyze code written in Java, Kotlin or both

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,11 @@ on:
     schedule:
         - cron: '38 19 * * 1'
 
+# Cancel superseded PR runs; queue master/schedule so every commit gets scanned.
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
     analyze:
         name: Analyze (${{ matrix.language }})
@@ -15,8 +20,8 @@ jobs:
         #   - https://gh.io/recommended-hardware-resources-for-running-codeql
         #   - https://gh.io/supported-runners-and-hardware-resources
         #   - https://gh.io/using-larger-runners
-        runs-on: 'ubuntu-latest'
-        timeout-minutes: 15
+        runs-on: ${{ matrix.runner }}
+        timeout-minutes: 30
         permissions:
             # required for all workflows
             security-events: write
@@ -35,14 +40,19 @@ jobs:
                 include:
                     - language: actions
                       build-mode: none
+                      runner: ubuntu-latest
                     - language: c-cpp
                       build-mode: none
+                      runner: ubuntu-latest
                     - language: go
                       build-mode: autobuild
+                      runner: ubuntu-latest
                     - language: javascript-typescript
                       build-mode: none
+                      runner: depot-ubuntu-latest-4
                     - language: python
                       build-mode: none
+                      runner: ubuntu-latest
                 # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
                 # Use `c-cpp` to analyze code written in C, C++ or both
                 # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -102,3 +112,5 @@ jobs:
               uses: github/codeql-action/analyze@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
               with:
                   category: '/language:${{matrix.language}}'
+                  # Database bundle+upload adds ~1min; only do it weekly.
+                  upload-database: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
## Problem

The `CodeQL Advanced` workflow has been making master red intermittently. The `Analyze (javascript-typescript)` matrix entry keeps getting cancelled at the 15-minute job timeout. Examples on master:

- https://github.com/PostHog/posthog/actions/runs/24784467315/job/72524442334
- https://github.com/PostHog/posthog/actions/runs/24785231582/job/72527236818
- https://github.com/PostHog/posthog/actions/runs/24785255734/job/72527324520

From the logs the breakdown on `ubuntu-latest` (2 vCPU) is roughly:

| Phase | Duration |
|---|---|
| Extraction (~7,300 files) | 2m 40s |
| TRAP import | 45s |
| Running queries | **10m 30s** |
| Results upload + DB bundle | ~1m (killed at 15:00) |

Queries dominate wall time. The run actually finishes the scan and then gets killed while zipping the CodeQL database for post-analysis upload.

## Changes

Four changes to `.github/workflows/codeql.yml`:

1. **Larger runner only for JS/TS** (`depot-ubuntu-latest-4`) via per-matrix `runner` override. Other languages (actions, c-cpp, go, python) finish in 1–2 minutes and stay on `ubuntu-latest`.
2. **`timeout-minutes` 15 → 30** to give headroom against future growth.
3. **Concurrency group** that cancels superseded PR runs but queues master and scheduled runs, so every master commit still gets its own code scanning alerts. Pattern follows [`github/docs` CodeQL workflow][ghdocs] and GitHub's [concurrency docs][ghconc].
4. **`upload-database: false`** except on the weekly `schedule` cron. The `database bundle` + upload is what was getting killed at the timeout; the weekly run still produces a fresh DB for Copilot Autofix and post-hoc CLI analysis.

Note: per the [March 2026 CodeQL changelog][ghchg], incremental analysis for JS/TS is now GA and default-on for `build-mode: none`, so PR-side runs already reuse the overlay-base database uploaded by master runs. The master push path is what we're unblocking here.

## How did you test this code?

I'm an agent — I did not run the workflow end-to-end. Verified locally:

- `python -c "import yaml; yaml.safe_load(...)"` parses cleanly
- Repo's own `uv run .github/scripts/check-ci-timeouts.py` passes
- Diff review of the expanded YAML

End-to-end behavior will only be observable once this PR runs CodeQL against itself.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Code (Opus 4.7). Investigation traced the failures to the
15-min job timeout being exceeded during the `codeql database bundle` step
after analysis had already succeeded. Optimization choices informed by:

- [Faster incremental CodeQL in PRs — GitHub Changelog (2026-03-24)][ghchg]
- [codeql-action `analyze` action.yml][analyzeyml] (default `upload-database: true`)
- [codeql-action CHANGELOG][cqlchangelog] (v4.34 auto-disables TRAP caching when overlay is enabled)
- [Customizing advanced setup for code scanning][gh-cust] (GitHub's own guidance on `paths-ignore` — deliberately skipped as a lever since generated files are only ~3% of the scanned set)
- [Control workflow concurrency][ghconc]
- [`github/docs` CodeQL workflow][ghdocs] as a concurrency precedent

[ghchg]: https://github.blog/changelog/2026-03-24-faster-incremental-analysis-with-codeql-in-pull-requests/
[analyzeyml]: https://github.com/github/codeql-action/blob/main/analyze/action.yml
[cqlchangelog]: https://github.com/github/codeql-action/blob/main/CHANGELOG.md
[gh-cust]: https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning
[ghconc]: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency
[ghdocs]: https://github.com/github/docs/blob/main/.github/workflows/codeql.yml