### PR TITLE
ci: read python version from pyproject.toml

### DIFF
--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -176,7 +176,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
-                  python-version: 3.12.12
+                  python-version-file: 'pyproject.toml'
 
             - name: Install uv
               id: setup-uv

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -341,9 +341,9 @@ jobs:
               run: pnpm install --frozen-lockfile --filter=@posthog/root
 
             - name: Set up Python
-              uses: actions/setup-python@v6
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
-                  python-version: 3.12.12
+                  python-version-file: 'pyproject.toml'
                   token: ${{ secrets.POSTHOG_BOT_PAT }}
 
             - name: Install uv
@@ -469,7 +469,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
-                  python-version: 3.12.12
+                  python-version-file: 'pyproject.toml'
 
             - name: Install uv
               uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
@@ -526,7 +526,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
-                  python-version: 3.12.12
+                  python-version-file: 'pyproject.toml'
 
             - name: Install uv
               id: setup-uv

--- a/.github/workflows/ci-blacksmith-shadow.yml
+++ b/.github/workflows/ci-blacksmith-shadow.yml
@@ -170,9 +170,9 @@ jobs:
                       pnpm-lock.yaml
                       .github/workflows/ci-backend.yml
             - run: pnpm install --frozen-lockfile --filter=@posthog/root
-            - uses: actions/setup-python@v6
+            - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
-                  python-version: 3.12.12
+                  python-version-file: 'pyproject.toml'
             - id: setup-uv
               uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
               with:
@@ -240,7 +240,7 @@ jobs:
               run: bin/ci-wait-for-docker launch --background --down
             - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
-                  python-version: 3.12.12
+                  python-version-file: 'pyproject.toml'
             - id: setup-uv
               uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
               with:
@@ -321,7 +321,7 @@ jobs:
             - run: echo "127.0.0.1 db redis7 kafka clickhouse clickhouse-coordinator objectstorage seaweedfs temporal" | sudo tee -a /etc/hosts
             - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
-                  python-version: 3.12.12
+                  python-version-file: 'pyproject.toml'
             - id: setup-uv
               uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
               with:

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -182,7 +182,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
-                  python-version: 3.12.12
+                  python-version-file: 'pyproject.toml'
 
             - name: Install uv
               id: setup-uv

--- a/.github/workflows/ci-llm-gateway.yml
+++ b/.github/workflows/ci-llm-gateway.yml
@@ -58,7 +58,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
-                  python-version: '3.12'
+                  python-version-file: 'pyproject.toml'
 
             - name: Install uv
               uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -86,7 +86,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
-                  python-version: 3.12.12
+                  python-version-file: 'pyproject.toml'
 
             - name: Install uv
               uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
@@ -300,7 +300,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
-                  python-version: 3.12.12
+                  python-version-file: 'pyproject.toml'
 
             - name: Install uv
               uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0

--- a/.github/workflows/ci-proto.yml
+++ b/.github/workflows/ci-proto.yml
@@ -102,9 +102,9 @@ jobs:
               with:
                   clean: false
 
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
-                  python-version: '3.12'
+                  python-version-file: 'pyproject.toml'
 
             - name: Install codegen tools
               run: pip install grpcio-tools protoletariat ruff

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -82,7 +82,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
-                  python-version: 3.12.12
+                  python-version-file: 'pyproject.toml'
 
             - name: Install uv
               id: setup-uv

--- a/.github/workflows/ci-rust-flags-integration.yml
+++ b/.github/workflows/ci-rust-flags-integration.yml
@@ -80,7 +80,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
-                  python-version: '3.12.12'
+                  python-version-file: 'pyproject.toml'
 
             - name: Install uv
               uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0


### PR DESCRIPTION
## Problem

`pyproject.toml` pins `requires-python = "==3.12.12"` as the canonical Python version, but 14 of 28 `actions/setup-python` callsites across 9 workflows hardcode it independently — 12 with literal `3.12.12`, and 2 with a floating `'3.12'` that silently tracks whatever the GitHub runner image ships. Future Python bumps became 15 file edits instead of 1.

Python-tier equivalent of #53463 (which centralised Node on `.nvmrc`).

## Changes

Switch those 14 callsites to `python-version-file: 'pyproject.toml'`. The pattern was already in use on 12 other callsites in this repo; total goes from 12/28 → 26/28.

Preserved intentionally:
- `build-hogql-parser.yml:99` — pinned `3.12.10` because no 3.12.11/3.12.12 mac/darwin wheel (inline-documented).
- `ci-backend.yml:1109` — `${{ matrix.python-version }}` for the Django compat matrix.

Folded in three same-block action-version fixes: `ci-proto.yml` `@v5` → SHA-pinned `v6.2.0` (the only `@v5` left in the repo), and floating `@v6` → SHA-pinned in `ci-backend.yml:344` and `ci-blacksmith-shadow.yml:173`.

Net: 9 files, 17+/17-.

## How did you test this code?

Agent-authored (Claude Code); no local CI run. Static verification:

- Remaining literal `python-version: 3.12.*` → only the mac exception at `build-hogql-parser.yml:99`.
- `python-version-file: 'pyproject.toml'` callsites → 26 (was 12).
- Remaining floating `actions/setup-python@v5`/`@v6` → 0.

Strongest runtime signal is `ci-proto.yml`'s `python-codegen` job: it regenerates protobuf stubs and fails on diff, so it'll flag any codegen change from swapping floating `'3.12'` → pinned `3.12.12`.

## Publish to changelog?

no

## Docs update

n/a — CI-only change.

## 🤖 LLM context

Authored by Claude Code (Opus 4.7) in a local worktree. Mirrors #53463's framing — same repo-wide convention pattern, one tier down.