### PR TITLE
fix(data-warehouse): persist new source form across tabs

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceScene.tsx
@@ -1,4 +1,5 @@
-import { BindLogic, useActions, useValues } from 'kea'
+import { BindLogic, kea, key, path, props, useActions, useValues } from 'kea'
+import type { Logic } from 'kea'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { IconCopy, IconQuestion } from '@posthog/icons'
@@ -18,6 +19,7 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { useFloatingContainer } from 'lib/hooks/useFloatingContainerContext'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { nonHogFunctionTemplatesLogic } from 'scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic'
 import { HogFunctionTemplateList } from 'scenes/hog-functions/list/HogFunctionTemplateList'
@@ -51,20 +53,40 @@ export const getEffectiveAccessMethod = (
     return persistedAccessMethod
 }
 
-export const scene: SceneExport = {
-    component: NewSourceScene,
-    // logic: sourceWizardLogic, // NOTE: We can't mount it here as it needs the availableSourcesLogic to be mounted first
+export interface NewSourceSceneProps {
+    tabId?: string
 }
 
-export function NewSourceScene(): JSX.Element {
+const newSourceSceneLogic = kea<Logic>([
+    path(['products', 'dataWarehouse', 'newSourceSceneLogic']),
+    props({} as NewSourceSceneProps),
+    key((props) => props.tabId ?? 'default'),
+])
+
+export const scene: SceneExport<NewSourceSceneProps> = {
+    component: NewSourceScene,
+    logic: newSourceSceneLogic,
+}
+
+export function NewSourceScene({ tabId }: NewSourceSceneProps): JSX.Element {
     const { availableSources, availableSourcesLoading } = useValues(availableSourcesLogic)
 
     if (availableSourcesLoading || availableSources === null) {
         return <LemonSkeleton />
     }
 
+    return <NewSourceSceneWithSources availableSources={availableSources} tabId={tabId} />
+}
+
+function NewSourceSceneWithSources({
+    availableSources,
+    tabId,
+}: NewSourceSceneProps & { availableSources: Record<string, SourceConfig> }): JSX.Element {
+    const logic = sourceWizardLogic({ availableSources, tabId })
+    useAttachedLogic(logic, newSourceSceneLogic({ tabId }))
+
     return (
-        <BindLogic logic={sourceWizardLogic} props={{ availableSources }}>
+        <BindLogic logic={sourceWizardLogic} props={{ availableSources, tabId }}>
             <InternalNewSourceScene />
         </BindLogic>
     )

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -1,7 +1,7 @@
-import { actions, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
-import { router, urlToAction } from 'kea-router'
+import { router } from 'kea-router'
 import posthog from 'posthog-js'
 
 import { LemonDialog, lemonToast } from '@posthog/lemon-ui'
@@ -10,6 +10,7 @@ import api from 'lib/api'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { tabAwareUrlToAction } from 'lib/logic/scenes/tabAwareUrlToAction'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
@@ -254,11 +255,13 @@ export interface SourceWizardLogicProps {
     availableSources: Record<string, SourceConfig>
     /** When set, only these tables will be pre-selected and they cannot be deselected */
     requiredTables?: string[]
+    tabId?: string
 }
 
 export const sourceWizardLogic = kea<sourceWizardLogicType>([
     path(['products', 'dataWarehouse', 'sourceWizardLogic']),
     props({} as SourceWizardLogicProps),
+    key((props) => props.tabId ?? 'default'),
     actions({
         selectConnector: (connector: SourceConfig | null) => ({ connector }),
         setInitialConnector: (connector: SourceConfig | null) => ({ connector }),
@@ -1364,7 +1367,7 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
             )
         },
     })),
-    urlToAction(({ actions, values }) => {
+    tabAwareUrlToAction(({ actions, values }) => {
         const handleUrlChange = (_: Record<string, string | undefined>, searchParams: Record<string, string>): void => {
             const kind = searchParams.kind?.toLowerCase()
             const accessMethod = searchParams.access_method === 'direct' ? 'direct' : 'warehouse'

--- a/products/data_warehouse/frontend/shared/components/forms/SourceForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SourceForm.tsx
@@ -38,6 +38,7 @@ export interface SourceFormProps {
     jobInputs?: Record<string, any>
     initialAccessMethod?: 'warehouse' | 'direct'
     setSourceConfigValue?: (key: FieldName, value: any) => void
+    setSourceConnectionDetailsValue?: (key: FieldName, value: any) => void
 }
 
 const CONNECTION_STRING_DEFAULT_PORT: Record<string, number> = {
@@ -97,7 +98,8 @@ export const sourceFieldToElement = (
     field: SourceFieldConfig,
     sourceConfig: SourceConfig,
     lastValue?: any,
-    isUpdateMode?: boolean
+    isUpdateMode?: boolean,
+    setSourceConnectionDetailsValue?: (key: FieldName, value: any) => void
 ): JSX.Element => {
     // It doesn't make sense for this to show on an update to an existing connection since we likely just want to change
     // a field or two. There is also some divergence in creates vs. updates that make this a bit more complex to handle.
@@ -121,26 +123,14 @@ export const sourceFieldToElement = (
                                     parseConnectionString(updatedConnectionString)
 
                                 if (isValid) {
-                                    sourceWizardLogic.actions.setSourceConnectionDetailsValue(
-                                        ['payload', 'database'],
-                                        database || ''
-                                    )
-                                    sourceWizardLogic.actions.setSourceConnectionDetailsValue(
-                                        ['payload', 'host'],
-                                        host || ''
-                                    )
-                                    sourceWizardLogic.actions.setSourceConnectionDetailsValue(
-                                        ['payload', 'user'],
-                                        user || ''
-                                    )
-                                    sourceWizardLogic.actions.setSourceConnectionDetailsValue(
+                                    setSourceConnectionDetailsValue?.(['payload', 'database'], database || '')
+                                    setSourceConnectionDetailsValue?.(['payload', 'host'], host || '')
+                                    setSourceConnectionDetailsValue?.(['payload', 'user'], user || '')
+                                    setSourceConnectionDetailsValue?.(
                                         ['payload', 'port'],
                                         port || CONNECTION_STRING_DEFAULT_PORT[sourceConfig.name]
                                     )
-                                    sourceWizardLogic.actions.setSourceConnectionDetailsValue(
-                                        ['payload', 'password'],
-                                        password || ''
-                                    )
+                                    setSourceConnectionDetailsValue?.(['payload', 'password'], password || '')
                                 }
                             }}
                         />
@@ -164,7 +154,13 @@ export const sourceFieldToElement = (
                             {isEnabled && (
                                 <Group name={field.name}>
                                     {field.fields.map((field) =>
-                                        sourceFieldToElement(field, sourceConfig, lastValue?.[field.name])
+                                        sourceFieldToElement(
+                                            field,
+                                            sourceConfig,
+                                            lastValue?.[field.name],
+                                            isUpdateMode,
+                                            setSourceConnectionDetailsValue
+                                        )
                                     )}
                                 </Group>
                             )}
@@ -182,7 +178,13 @@ export const sourceFieldToElement = (
             field.options
                 .find((n) => n.value === (value ?? field.defaultValue))
                 ?.fields?.map((optionField) =>
-                    sourceFieldToElement(optionField, sourceConfig, lastValue?.[optionField.name])
+                    sourceFieldToElement(
+                        optionField,
+                        sourceConfig,
+                        lastValue?.[optionField.name],
+                        isUpdateMode,
+                        setSourceConnectionDetailsValue
+                    )
                 )
 
         return (
@@ -264,7 +266,8 @@ export const sourceFieldToElement = (
             { ...SSH_FIELD, name: field.name, label: field.label },
             sourceConfig,
             lastValue,
-            isUpdateMode
+            isUpdateMode,
+            setSourceConnectionDetailsValue
         )
     }
 
@@ -617,9 +620,11 @@ function CDCConfigSection(): JSX.Element {
 }
 
 export default function SourceFormContainer(props: SourceFormProps): JSX.Element {
+    const { setSourceConnectionDetailsValue } = useActions(sourceWizardLogic)
+
     return (
         <Form logic={sourceWizardLogic} formKey="sourceConnectionDetails" enableFormOnSubmit>
-            <SourceFormComponent {...props} />
+            <SourceFormComponent {...props} setSourceConnectionDetailsValue={setSourceConnectionDetailsValue} />
         </Form>
     )
 }
@@ -632,6 +637,7 @@ export function SourceFormComponent({
     jobInputs,
     initialAccessMethod,
     setSourceConfigValue,
+    setSourceConnectionDetailsValue,
 }: SourceFormProps): JSX.Element {
     const { availableSources, availableSourcesLoading } = useValues(availableSourcesLogic)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -736,7 +742,15 @@ export function SourceFormComponent({
             <Group name="payload">
                 {availableSources[sourceConfig.name].fields
                     .filter((field) => !(isPostgresDirectQuery && field.type === 'ssh-tunnel'))
-                    .map((field) => sourceFieldToElement(field, sourceConfig, jobInputs?.[field.name], isUpdateMode))}
+                    .map((field) =>
+                        sourceFieldToElement(
+                            field,
+                            sourceConfig,
+                            jobInputs?.[field.name],
+                            isUpdateMode,
+                            setSourceConnectionDetailsValue
+                        )
+                    )}
             </Group>
             {!isUpdateMode &&
                 sourceConfig.name === 'Postgres' &&


### PR DESCRIPTION
## Problem

The new data warehouse source wizard kept its form logic mounted only with the rendered scene contents. When users switched between internal app tabs and returned to the new-source tab, the wizard remounted with fresh form state, blanking database connection inputs.

## Changes

- Add a small tab-keyed scene logic for the new-source scene.
- Keep `sourceWizardLogic` attached to that scene logic with `useAttachedLogic`, so form state survives scene content unmounts for the active internal tab.
- Key `sourceWizardLogic` by `tabId` and make its URL handling tab-aware.
- Route parsed connection string updates through the bound form logic instead of static logic actions, so keyed wizard instances receive updates correctly.

## How did you test this code?

- `pnpm --filter=@posthog/frontend jest -- products/data_warehouse/frontend/scenes/NewSourceScene/NewSourceWizard.test.ts`
- `git diff --check`

I also ran `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter=@posthog/frontend typescript:check`, but the current workspace reports existing generated product logic type resolution errors and an unrelated `src/scenes/billing/BillingLineGraph.tsx` chart type error before completing.

## Publish to changelog?

no

## Docs update

No docs update needed.

## LLM context

This PR was authored by an OpenAI coding agent. The change follows the existing `useAttachedLogic` pattern used elsewhere in PostHog to keep form logic alive across internal tab switches.