### PR TITLE
fix(docker): build hogql-parser from the checkout in images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 !.kearc
 !bin
 !common/hogvm
+!common/hogql_parser
 !common/esbuilder
 !common/migration_utils
 !common/mosaic
@@ -72,6 +73,11 @@ common/*/*/node_modules
 common/*/node_modules
 common/*/*/dist
 common/*/dist
+# Local hogql-parser build artifacts (pip/setuptools/WASM) must not leak into image builds
+common/hogql_parser/build
+common/hogql_parser/build_wasm
+common/hogql_parser/*.egg-info
+common/hogql_parser/*.so
 packages/quill/**/node_modules
 packages/quill/**/dist
 products/**/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,59 @@ RUN cd /code/common/plugin_transpiler && \
 #
 # ---------------------------------------------------------
 #
+# Build the hogql-parser wheel from this checkout. The image must run the parser code of the
+# commit it packages — the PyPI pin in pyproject.toml stays for dev/CI convenience, but deploy
+# correctness must not depend on registry state. ANTLR is linked statically (see
+# bin/install-antlr4-cpp-runtime), so the wheel is self-contained and the runtime image
+# needs no extra shared libraries.
+FROM python:3.13.13-slim-bookworm@sha256:355bfa66770995d7e9a0da4b3473b44d0cb451f6b56f5615ad9c39e3c4eca03f AS hogql-parser-build
+WORKDIR /code
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    "build-essential" \
+    "ca-certificates" \
+    "cmake" \
+    "curl" \
+    "pkg-config" \
+    "unzip" \
+    "uuid-dev" \
+    && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY bin/install-antlr4-cpp-runtime bin/install-antlr4-cpp-runtime
+RUN bin/install-antlr4-cpp-runtime
+
+COPY common/hogql_parser common/hogql_parser/
+RUN pip wheel --no-deps --wheel-dir /wheels ./common/hogql_parser
+
+# Prove the wheel is loadable and self-contained before it reaches posthog-build: a dynamic
+# antlr4-runtime dependency or unresolved symbol here would only fail at runtime in the final
+# image. Module init imports posthog.hogql.errors, which doesn't exist in this stage — stub it;
+# Python dlopens extensions with RTLD_NOW, so the import still resolves every linked symbol.
+RUN <<'SMOKE'
+set -euo pipefail
+pip install --no-deps /wheels/*.whl
+so="$(python -c "import glob, sysconfig; print(glob.glob(sysconfig.get_paths()['platlib'] + '/hogql_parser*.so')[0])")"
+if ldd "$so" | grep antlr4-runtime; then
+    echo "hogql_parser extension dynamically links antlr4-runtime — expected static linking" >&2
+    exit 1
+fi
+ldd "$so" | (! grep "not found")
+python - <<'EOF'
+import sys, types
+for name in ("posthog", "posthog.hogql", "posthog.hogql.errors"):
+    sys.modules[name] = types.ModuleType(name)
+import hogql_parser
+print("hogql_parser loaded from", hogql_parser.__file__)
+EOF
+SMOKE
+
+
+#
+# ---------------------------------------------------------
+#
 FROM ghcr.io/astral-sh/uv:0.11.14 AS uv
 
 # Same as pyproject.toml so that uv can pick it up and doesn't need to download a different Python version.
@@ -167,6 +220,12 @@ RUN --mount=type=cache,id=uv-libxmlsec1.2.37-2,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=tools/hogli,target=tools/hogli \
     uv sync --locked --no-dev --no-install-project --no-binary-package lxml --no-binary-package xmlsec
+
+# Replace the PyPI-pinned hogql-parser with the wheel built from this checkout (see the
+# hogql-parser-build stage). --reinstall covers the case where the pinned version number
+# matches this source but the content differs.
+RUN --mount=type=bind,from=hogql-parser-build,source=/wheels,target=/wheels \
+    uv pip install --python /python-runtime/bin/python --reinstall --no-deps /wheels/*.whl
 
 ENV PATH=/python-runtime/bin:$PATH \
     PYTHONPATH=/python-runtime

--- a/Dockerfile.llm-analytics
+++ b/Dockerfile.llm-analytics
@@ -10,6 +10,32 @@
 # Same as pyproject.toml so that uv can pick it up and doesn't need to download a different Python version.
 FROM ghcr.io/astral-sh/uv:0.11.14 AS uv
 
+# Build the hogql-parser wheel from this checkout — same rationale and recipe as the
+# hogql-parser-build stage in the main Dockerfile: the image must run the parser code of
+# the commit it packages, independent of PyPI state. ANTLR is linked statically, so the
+# wheel is self-contained.
+FROM python:3.13.13-slim-bookworm@sha256:355bfa66770995d7e9a0da4b3473b44d0cb451f6b56f5615ad9c39e3c4eca03f AS hogql-parser-build
+WORKDIR /code
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    "build-essential" \
+    "ca-certificates" \
+    "cmake" \
+    "curl" \
+    "pkg-config" \
+    "unzip" \
+    "uuid-dev" \
+    && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY bin/install-antlr4-cpp-runtime bin/install-antlr4-cpp-runtime
+RUN bin/install-antlr4-cpp-runtime
+
+COPY common/hogql_parser common/hogql_parser/
+RUN pip wheel --no-deps --wheel-dir /wheels ./common/hogql_parser
+
 FROM python:3.13.13-slim-bookworm@sha256:355bfa66770995d7e9a0da4b3473b44d0cb451f6b56f5615ad9c39e3c4eca03f
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 
@@ -44,6 +70,10 @@ RUN --mount=type=cache,id=uv-libxmlsec1.2.37-2,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=tools/hogli,target=tools/hogli \
     uv sync --locked --no-dev --no-install-project --group sentiment --no-binary-package lxml --no-binary-package xmlsec
+
+# Replace the PyPI-pinned hogql-parser with the wheel built from this checkout.
+RUN --mount=type=bind,from=hogql-parser-build,source=/wheels,target=/wheels \
+    uv pip install --python /python-runtime/bin/python --reinstall --no-deps /wheels/*.whl
 
 # Copy project files
 COPY manage.py manage.py

--- a/bin/install-antlr4-cpp-runtime
+++ b/bin/install-antlr4-cpp-runtime
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Builds the ANTLR C++ runtime as a static, position-independent library and installs
+# headers + libantlr4-runtime.a system-wide. With only the static library present,
+# `pip install ./common/hogql_parser` links it into the extension, producing a
+# self-contained module that needs no ANTLR shared library at runtime.
+set -euo pipefail
+
+version="${ANTLR_CPP_RUNTIME_VERSION:-4.13.1}"
+expected_md5="${ANTLR_CPP_RUNTIME_MD5:-c875c148991aacd043f733827644a76f}"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+archive="$workdir/antlr4-cpp-runtime.zip"
+curl --fail --location "https://www.antlr.org/download/antlr4-cpp-runtime-${version}-source.zip" --output "$archive" ||
+    curl --fail --location "https://raw.githubusercontent.com/antlr/website-antlr4/gh-pages/download/antlr4-cpp-runtime-${version}-source.zip" --output "$archive"
+
+echo "$expected_md5  $archive" | md5sum --check -
+
+unzip -q "$archive" -d "$workdir/source"
+cmake -S "$workdir/source" -B "$workdir/build" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DANTLR_BUILD_SHARED=OFF \
+    -DANTLR_BUILD_STATIC=ON \
+    -DANTLR_BUILD_CPP_TESTS=OFF \
+    -DBUILD_TESTING=OFF \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+cmake --build "$workdir/build" --parallel "$(nproc)"
+DESTDIR="$workdir/install" cmake --install "$workdir/build"
+
+mkdir -p /usr/include /usr/lib
+cp -r "$workdir/install/usr/local/include/antlr4-runtime" /usr/include/
+find "$workdir/install" -name 'libantlr4-runtime.a' -exec cp {} /usr/lib/ \;
+test -f /usr/lib/libantlr4-runtime.a

--- a/common/hogql_parser/CONTRIBUTING.md
+++ b/common/hogql_parser/CONTRIBUTING.md
@@ -1,5 +1,12 @@
 # Developing `hogql-parser`
 
+## How the parser ships
+
+There are two distribution paths, and they serve different purposes:
+
+- **Production images build the parser from this checkout.** The `hogql-parser-build` stage in `Dockerfile` (and `Dockerfile.llm-analytics`) compiles a wheel from `common/hogql_parser` with a statically linked ANTLR runtime (`bin/install-antlr4-cpp-runtime`) and installs it over the `uv sync`-ed environment. A deployed image always runs the parser code of the commit it was built from — PyPI state never affects deploys.
+- **PyPI/npm packages are for development and CI convenience.** `pyproject.toml` pins `hogql-parser==X.Y.Z` so local dev and CI get prebuilt wheels. Backend CI builds the parser from source instead whenever `common/hogql_parser/` differs from master, so PRs are tested against their own parser code. The `Release hogql-parser` workflows publish to PyPI/npm and bump the pins when you change the parser — bump the version in `setup.py` and `package.json` so they trigger.
+
 ## Mandatory reading
 
 If you're new to Python C/C++ extensions, there are some things you must have in mind. The [Python/C API Reference Manual](https://docs.python.org/3/c-api/index.html) is worth a read as a whole.

--- a/common/hogql_parser/package.json
+++ b/common/hogql_parser/package.json
@@ -41,7 +41,7 @@
     },
     "scripts": {
         "build:compile": "emmake cmake --build build_wasm --config Release && cmake --install build_wasm",
-        "build:make": "emcmake cmake -S . -B build_wasm -DCMAKE_BUILD_TYPE=Release && npm run build:compile || echo 'Warning: hogql-parser build failed, skipping'",
-        "build": "emcmake cmake -S . -B build_wasm -G Ninja -DCMAKE_BUILD_TYPE=Release && npm run build:compile || echo 'Warning: hogql-parser build failed, skipping'"
+        "build:make": "emcmake cmake -S . -B build_wasm -DCMAKE_BUILD_TYPE=Release && npm run build:compile",
+        "build": "emcmake cmake -S . -B build_wasm -G Ninja -DCMAKE_BUILD_TYPE=Release && npm run build:compile"
     }
 }

--- a/common/hogql_parser/pyproject.toml
+++ b/common/hogql_parser/pyproject.toml
@@ -1,3 +1,9 @@
+[build-system]
+# Pinned so builds don't depend on whatever setuptools happens to be ambient —
+# matches the version the release workflow uses for the sdist.
+requires = ["setuptools==80.9.0"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 120
 target-version = ['py310']


### PR DESCRIPTION
## Problem

Production images install `hogql-parser` from PyPI at the version pinned in `pyproject.toml`. That pin is kept in sync by release workflows that publish from PR branches and auto-commit the pin bump — and nothing enforces that this automation completed before merge. When it is raced or fails, master contains code that depends on parser behavior the installed package doesn't have. This happened with the `WITH FILL` release: the wheel was published but the pin commit never landed (#55087 was the manual fix), and master CI went red on every Core shard while images would have shipped the stale parser. Backend CI builds the parser from source when it changed, so a PR's own CI can be green while the image is wrong.

## Changes

- New `hogql-parser-build` stage in `Dockerfile` and `Dockerfile.llm-analytics`: builds the `hogql-parser` wheel from `common/hogql_parser` in the checkout and installs it over the `uv sync`-ed environment. Images always run the parser code of the commit they package — PyPI state no longer affects deploys.
- `bin/install-antlr4-cpp-runtime`: builds ANTLR 4.13.1 (md5-pinned, same recipe as CI) as a **static** PIC library, so the extension is self-contained — no shared libraries shipped into runtime images, final stages untouched.
- In-stage smoke test: imports the extension under RTLD_NOW (catches unresolved symbols) and asserts no dynamic `antlr4-runtime` dependency.
- `[build-system]` pin for the parser package so local builds don't depend on ambient setuptools; WASM build scripts no longer swallow failures; `.dockerignore` allows `common/hogql_parser` while excluding local build artifacts.
- PyPI/npm publishing and pins are unchanged — they remain the distribution path for local dev and CI.

Compared to the previous iteration of this PR: the pnpm `workspace:*` conversion is dropped (it breaks jest and local dev unless everyone has an emscripten toolchain; the frontend's npm dependency is a lazy-loaded editor feature where one-version skew is acceptable), and shipping `libantlr4-runtime.so` + `ldconfig` into runtime images is replaced by static linking.

Follow-up (separate PR): make the existing version-bump/pin consistency rules a merge-blocking check instead of an advisory bot comment.

## How did you test this code?

Agent-validated locally (no full image build):

- `docker build --target hogql-parser-build` for both Dockerfiles: green, in-stage smoke test passes.
- The built wheel installed in a pristine `python:3.13-slim` container with no ANTLR present: `parse_expr_json` / `parse_select_json` return ASTs.
- `docker build --check` on both Dockerfiles; shellcheck on the installer script.

CI should validate the full image path (`uv sync`, parser overlay install, collectstatic).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`common/hogql_parser/CONTRIBUTING.md` now documents the two distribution paths (images build from source; PyPI/npm serve dev and CI).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session directed by @rnegron. The agent reconstructed the release flow (publish-from-PR workflows, pin automation, CI source-build fallback), audited the prior iteration of this branch, and rebuilt it minimal: static ANTLR linking was chosen over copying `libantlr4-runtime.so` into runtime images (rejected: touches the unit image) and over `auditwheel repair` (rejected: more moving parts for the same result). The npm/workspace changes from the prior iteration were rejected as breaking jest/local dev. Validation was done with targeted Docker stage builds plus a pristine-container parse test.
