### PR TITLE
fix(session-replay): filter test accounts in video segment clustering by default

### DIFF
--- a/posthog/temporal/ai/video_segment_clustering/clustering_activities.py
+++ b/posthog/temporal/ai/video_segment_clustering/clustering_activities.py
@@ -126,7 +126,7 @@ if not settings.DEBUG:
             value=0,  # bool is represented as 0/1 in ClickHouse
         ),
     )
-_DEFAULT_FILTER_TEST_ACCOUNTS = False  # Summarize all sessions (it's also faster to skip this filter)
+_DEFAULT_FILTER_TEST_ACCOUNTS = True  # Exclude sessions from internal/test users (team test account filters)
 
 
 def _fetch_recent_session_ids(team: Team, lookback_hours: int) -> list[str]:


### PR DESCRIPTION
## Summary
Session analysis / video segment clustering priming now sets `filter_test_accounts=True` by default when building the `RecordingsQuery` for recent sessions (same idea as the session recordings UI). That excludes sessions matching the team’s internal and test account filters so those users are not used to seed session_problem signals.

Teams can still override this via `SignalSourceConfig` `recording_filters` when `filter_test_accounts` is explicitly set on the converted query.

## How did you test this code?
- Pre-commit hooks (ruff format, ty check) passed on commit.