### PR TITLE
feat: add SKIP_CLICKHOUSE_RESET environment variable support

### DIFF
--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -318,7 +318,9 @@ def _django_db_setup(django_db_keepdb, django_db_blocker):
 
     if django_db_keepdb:
         # Reset ClickHouse data, unless we're running AI evals, where we want to keep the DB between runs
-        if not settings.IN_EVAL_TESTING:
+        # Also allow skipping reset via environment variable for faster development iteration
+        skip_ch_reset = os.environ.get("SKIP_CLICKHOUSE_SETUP", "0").lower() in {"1", "true", "yes"}
+        if not settings.IN_EVAL_TESTING and not skip_ch_reset:
             reset_clickhouse_tables()
     else:
         database.drop_database()

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -319,7 +319,7 @@ def _django_db_setup(django_db_keepdb, django_db_blocker):
     if django_db_keepdb:
         # Reset ClickHouse data, unless we're running AI evals, where we want to keep the DB between runs
         # Also allow skipping reset via environment variable for faster development iteration
-        skip_ch_reset = os.environ.get("SKIP_CLICKHOUSE_SETUP", "0").lower() in {"1", "true", "yes"}
+        skip_ch_reset = os.environ.get("SKIP_CLICKHOUSE_RESET", "0").lower() in {"1", "true", "yes"}
         if not settings.IN_EVAL_TESTING and not skip_ch_reset:
             reset_clickhouse_tables()
     else:


### PR DESCRIPTION
## Problem

Running tests locally multiple times gets slow due to unnecessary ClickHouse table resets between runs.

## Changes

- Added `SKIP_CLICKHOUSE_RESET` environment variable to skip ClickHouse reset during test setup

## How did you test this code?

- Verified environment variable works locally to speed up test runs
- Confirmed no behavior change when variable is unset

## LLM context

Simple optimization for local development workflow to skip unnecessary database cleanup.