### PR TITLE
fix(sql-editor): replace subquery wavy underline with gutter indicators

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/EditorScene.scss
+++ b/frontend/src/scenes/data-warehouse/editor/EditorScene.scss
@@ -33,10 +33,7 @@
         content: '';
         background-color: var(--warning);
         mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 2L1 21h22L12 2zm0 4.5L19.5 19h-15L12 6.5zm-1 6.5v3h2v-3h-2zm0 4v2h2v-2h-2z'/></svg>");
-        mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 2L1 21h22L12 2zm0 4.5L19.5 19h-15L12 6.5zm-1 6.5v3h2v-3h-2zm0 4v2h2v-2h-2z'/></svg>");
         mask-repeat: no-repeat;
-        mask-repeat: no-repeat;
-        mask-size: contain;
         mask-size: contain;
     }
 }

--- a/frontend/src/scenes/data-warehouse/editor/EditorScene.scss
+++ b/frontend/src/scenes/data-warehouse/editor/EditorScene.scss
@@ -18,9 +18,27 @@
     background-color: rgb(54 130 246 / 22%);
 }
 
-.active-subquery-underline-invalid {
-    text-decoration: underline wavy var(--warning) 1.5px;
-    text-underline-offset: 3px;
+.active-subquery-border-invalid {
+    width: 3px !important;
+    margin-left: 2px;
+    background-color: var(--warning);
+}
+
+.active-subquery-glyph-invalid {
+    &::before {
+        display: block;
+        width: 14px;
+        height: 14px;
+        margin: 3px auto 0;
+        content: '';
+        background-color: var(--warning);
+        mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 2L1 21h22L12 2zm0 4.5L19.5 19h-15L12 6.5zm-1 6.5v3h2v-3h-2zm0 4v2h2v-2h-2z'/></svg>");
+        mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 2L1 21h22L12 2zm0 4.5L19.5 19h-15L12 6.5zm-1 6.5v3h2v-3h-2zm0 4v2h2v-2h-2z'/></svg>");
+        mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        mask-size: contain;
+        mask-size: contain;
+    }
 }
 
 .active-query-highlight-flash {

--- a/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryPane.tsx
@@ -61,6 +61,7 @@ export function QueryPane(props: QueryPaneProps): JSX.Element {
                                             scrollBeyondLastLine: !!props.originalValue,
                                             automaticLayout: true,
                                             fixedOverflowWidgets: true,
+                                            glyphMargin: true,
                                             suggest: {
                                                 showInlineDetails: true,
                                             },

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -2589,31 +2589,51 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                 }
             }
 
-            // Helper to find subquery and build its decoration
+            // Helper to find subquery and build its decorations. Returns the range-wide
+            // background highlight plus, when the subquery can't run standalone, a subtle
+            // gutter glyph on the starting line — avoids painting every line with wavy
+            // underlines that read as errors.
             const buildSubqueryDecoration = async (
                 activeQuery: QueryRange,
                 offset: number
-            ): Promise<editor.IModelDeltaDecoration | null> => {
+            ): Promise<editor.IModelDeltaDecoration[]> => {
                 const subquery = await findInnermostSelectAtOffset(activeQuery.query, offset, activeQuery.start)
                 if (!subquery) {
-                    return null
+                    return []
                 }
                 const subStart = model.getPositionAt(subquery.start)
                 const subEnd = model.getPositionAt(subquery.end)
                 const { className, errorMessage } = await validateSubquery(subquery.query)
-                return {
-                    range: {
-                        startLineNumber: subStart.lineNumber,
-                        startColumn: subStart.column,
-                        endLineNumber: subEnd.lineNumber,
-                        endColumn: subEnd.column,
+                const decorations: editor.IModelDeltaDecoration[] = [
+                    {
+                        range: {
+                            startLineNumber: subStart.lineNumber,
+                            startColumn: subStart.column,
+                            endLineNumber: subEnd.lineNumber,
+                            endColumn: subEnd.column,
+                        },
+                        options: {
+                            className,
+                            linesDecorationsClassName: errorMessage ? 'active-subquery-border-invalid' : undefined,
+                            hoverMessage: errorMessage ? { value: errorMessage } : undefined,
+                        },
                     },
-                    options: {
-                        className,
-                        inlineClassName: errorMessage ? 'active-subquery-underline-invalid' : undefined,
-                        hoverMessage: errorMessage ? { value: errorMessage } : undefined,
-                    },
+                ]
+                if (errorMessage) {
+                    decorations.push({
+                        range: {
+                            startLineNumber: subStart.lineNumber,
+                            startColumn: 1,
+                            endLineNumber: subStart.lineNumber,
+                            endColumn: 1,
+                        },
+                        options: {
+                            glyphMarginClassName: 'active-subquery-glyph-invalid',
+                            glyphMarginHoverMessage: { value: errorMessage },
+                        },
+                    })
                 }
+                return decorations
             }
 
             // Single query — check for subqueries only
@@ -2622,14 +2642,14 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                 actions.setActiveQueryText(singleQuery?.query ?? null, 0)
 
                 if (singleQuery) {
-                    const subDeco = await buildSubqueryDecoration(singleQuery, cursorOffset)
+                    const subDecos = await buildSubqueryDecoration(singleQuery, cursorOffset)
                     if (isStale()) {
                         return
                     }
-                    if (subDeco) {
+                    if (subDecos.length > 0) {
                         cache.activeQueryDecorationIds = editorInstance.deltaDecorations(
                             cache.activeQueryDecorationIds ?? [],
-                            [subDeco]
+                            subDecos
                         )
                         return
                     }
@@ -2676,13 +2696,11 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                 },
             ]
 
-            const subDeco = await buildSubqueryDecoration(match, cursorOffset)
+            const subDecos = await buildSubqueryDecoration(match, cursorOffset)
             if (isStale()) {
                 return
             }
-            if (subDeco) {
-                decorations.push(subDeco)
-            }
+            decorations.push(...subDecos)
 
             cache.activeQueryDecorationIds = editorInstance.deltaDecorations(
                 cache.activeQueryDecorationIds ?? [],


### PR DESCRIPTION
## Problem

The SQL editor's "run subquery/CTE" feature validates the selected CTE standalone and, when references to earlier CTEs leave it un-runnable in isolation, paints the entire block with a yellow wavy underline. That decoration reads as a per-character lint error and makes the CTE look broken even though the full query is valid — in a tall editor pane the squiggles can be all the user sees, causing a false "something is wrong" reaction.

## Changes

Replace the inline wavy underline with two gutter-scoped indicators on the invalid-standalone case:

- **Warning triangle in the glyph margin** on the CTE's starting line (with the existing hover message — "This subquery may fail standalone: ...") — provides the semantic "what's wrong" without invading the code.
- **Warning-colored vertical bar** in the lines-decorations gutter spanning the full CTE — scopes the warning to the block without decorating every character inside it.

The range-wide background highlight that indicates the currently-selected runnable slice is unchanged (still blue), so the visual distinction is: valid subquery = blue highlight; invalid-standalone subquery = blue highlight + amber bar + amber triangle. No more per-line wavy underlines.

Also enables Monaco's glyph margin on the SQL editor pane (previously off) so the triangle has a slot to render in.

Before (yellow zigzags across every line of the CTE):
<img width="853" height="260" alt="image" src="https://github.com/user-attachments/assets/a7ef6ba4-beae-46f9-86e1-77338f783eae" />


After (colored gutter + little warning icon)
<img width="652" height="446" alt="image" src="https://github.com/user-attachments/assets/fd72927e-7e9e-4173-a44a-935f93cad41f" />

## How did you test this code?

👀 

## Publish to changelog?

no

## 🤖 LLM context

Co-authored with Claude Opus 4.7 (Claude Code CLI). The design iteration — squiggles → small dot → dot + bar + amber bg → final two-signal combination — was driven by user feedback on visual alarm levels in the editor. Only the three files touched here were modified; no other editor decorations or the main HogQL metadata marker path were changed.