### PR TITLE
fix(llma): scope dark-mode sentiment fix to llma

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4307,59 +4307,59 @@ snapshots:
     scenes-app-llm-analytics-prompts--prompts-list--light:
         hash: v1.k794b7964.1ce620ee3e63dc2b2290f9c0b0463d0485d50239e6bf125dbff25622810a5f7a.91XhETznqXVy2VSur4Erhv91fkK60rh2qxBiwltzgtk
     scenes-app-llm-analytics-sentiment--bar-full-width--dark:
-        hash: v1.k794b7964.4fca19b23b87b69a07a66566c6b7044cab656a09cb1154d5e626f89cade35967.uEr388JM4s-MxNM1ZUBx7Qcu8n9bmLSbvQGtQpvwSPA
+        hash: v1.k794b7964.c85f4138877bf5f706d5675ad8ebca39a87300e45359ba3f5325551815fb5885.HF7-JnftydxamLDrTOBnjsRYzjh-2srau8EcHvZ4Hko
     scenes-app-llm-analytics-sentiment--bar-full-width--light:
         hash: v1.k794b7964.253731fd3f549dc1774f1d818cc141b323865326db1672e3ce879c5ce8e9a232.k6HgTr0KOB_QBwrVQh_rqvDBZxJPq8Ih3o6hXKwdOy8
     scenes-app-llm-analytics-sentiment--bar-loading--dark:
-        hash: v1.k794b7964.7a5e7322de191885e811a3f114ae4f19c1d1e70c18a48ef903a50474d3929b2a.Z2sXrPt9PyX0fNR7UsGgBjwV8V8ufjKqRpriwHTijTk
+        hash: v1.k794b7964.d15c0900170253f9b1f51c9f30a77ee6c6a00b429df8bc9f211d7524862a42db.R2JV6fdb3GB7QHmx_L9UZf50a2sM6f66MnO5oSoZV9A
     scenes-app-llm-analytics-sentiment--bar-loading--light:
         hash: v1.k794b7964.4d4834d311f46a530d5d0889a762856911940ecefc3405327752d874324673fc.Djuf_NoFFM2DFk8X0zew6l2gRYh5bqyhrop1rg0r-tk
     scenes-app-llm-analytics-sentiment--bar-loading-full-width--dark:
-        hash: v1.k794b7964.41ad5cbd293d8de5b2dc3bc5fd17d73df6be989c1dfc9377b9149575965a05ca.N0I3Hl4-vXeO7xKveVPILVRfNi9NTgL1q11HbtbE-_g
+        hash: v1.k794b7964.224b1cb37ccde69332afff5a5ae3c95483d4189f68f6a1909e7591c55f09465e.vGBrTrLrl0RSLx1oD8NO27qYLP3cei7wn9HAx-Wy7ko
     scenes-app-llm-analytics-sentiment--bar-loading-full-width--light:
         hash: v1.k794b7964.d1fa0d2a264a187e139d55783ccaf9c8283930392fa1ab05ed94f80417a0adb3.jkX3wK_KCkgPOzQZTPnMaKSWq5z-_sQoUCJ4QN1Smzs
     scenes-app-llm-analytics-sentiment--bar-negative--dark:
-        hash: v1.k794b7964.b4b12531a39227662fee37667500cc2a57f4b4a4a8b37bcea2ad6382e59a0ac6.xMzNk50pvWg4M6ESGUTllgiDKklu3WMD-Hr8c52FtLs
+        hash: v1.k794b7964.38cfba988c51ce10a97323e473b79b2367e40e1699fd3693ba0a4cb617deff3b.Dv4RvZ-4kZ9nIOOPu776LfiC0-pgRgTr_VO44ylKfPw
     scenes-app-llm-analytics-sentiment--bar-negative--light:
         hash: v1.k794b7964.6a6ba9f7d0df1c649bab8a2fc56d2028af1fa710ee573157651fb137a2ec10be.7TYz7CURuWjXWVtlfSSXMHE0pNxL1HFNSnfLZv2eQLI
     scenes-app-llm-analytics-sentiment--bar-neutral--dark:
-        hash: v1.k794b7964.e2c59e83fe67b892f417500fde8251541e552a169eeb75e1923f852033f41550.6r3ETaa_R3ne-qe7iBRyotSC_EJwTrbZ4oT2_LbXDGo
+        hash: v1.k794b7964.db4497af66f0247a131ff6880137a4e7891bfbdbe8b918bb961bfaa1372ca4b7.uMVrAnirQRB75mOvmjUskwD5qDN1dAKo8RP-Ew1hBJ4
     scenes-app-llm-analytics-sentiment--bar-neutral--light:
         hash: v1.k794b7964.b4223ad12305703c01e74d3506e3c3756a86e84464724766463168584ccddba5.7T2Kwh--7wIk-QoqW-ZUfG8FlZ_ScPZ1dtiWSDM0u1U
     scenes-app-llm-analytics-sentiment--bar-positive--dark:
-        hash: v1.k794b7964.c2b52418712c2acbedab103f2d81da723a58c64a0243ca3c90bdecc491d4cb1e.hvVALaER0iiyATtqjIKHnzFBfGxS16H-FMqDJI8E3KA
+        hash: v1.k794b7964.bb0c870a3d96c0e1906c07eba78b664e1ca712adc25f247c089a705496d08802.-XZblzp7rIo1Xq0TKSej1Zci65BbrceCm8li__WEtKQ
     scenes-app-llm-analytics-sentiment--bar-positive--light:
         hash: v1.k794b7964.7c8dc29b8d5026e6357c42897b082c2484c0a1c9509ccb1490c55428c5a75736.BhWLR6Xq4rbdn_F-PL4SeaL34mnCpDmIHqyCgIYjxic
     scenes-app-llm-analytics-sentiment--bar-with-tick-marks--dark:
-        hash: v1.k794b7964.9069ad4360e9bae3dfead6f2e73e6e09853a9528c0f217e97c3519cbecd4c4d1.4Um1pxEExrKhcnaNH9xwMXh5uR9kw2fzyfUvrQFjI2c
+        hash: v1.k794b7964.b59199fb526146d5e7dc88afac6b88b509ce4a160be03804c551e2567c639db2.G4fWhB6DXjI7QT3gXSx6zHShDKhqqks5hdffFyiMU6A
     scenes-app-llm-analytics-sentiment--bar-with-tick-marks--light:
         hash: v1.k794b7964.714727b4533f086ffe428765b34d3e623e384f2f2756bdc97474b9a8f032bd64.3ypQ1rdt6S9EPSy-c5bkV6GRBVjm3z8Rdv_CU5HDeZw
     scenes-app-llm-analytics-sentiment--message-bar-negative--dark:
-        hash: v1.k794b7964.74e7a50ed286cfa5d2b49a59971c939e4f7608974b4c7a79c766be012dab4abe.OHdfYhawVXCiMjP3l7u8n2Xrw6DaL8kbC-4csAgpChs
+        hash: v1.k794b7964.7f208aa3f4f82d0d6371e124fdc633800c5d4a2378c3d8edda05ae50d7d86345.Wrz8tD-WN8_cJzDBl8TmAOKWJJEiZOP1-S1HGpQozzg
     scenes-app-llm-analytics-sentiment--message-bar-negative--light:
         hash: v1.k794b7964.0cdb674a69cf13b022d04529c14b92a97d79d1979629a0e00775a72c63112053.wymF6DlZoR1k6dYJxXpyVg6MIJWXCcs_iCp61CDPNRg
     scenes-app-llm-analytics-sentiment--message-bar-neutral--dark:
-        hash: v1.k794b7964.389061641055959e10e73071cf4c1f10c03af2f8e4684c874b7579d324cee5b0.623nBo8Tmrkn0Lhai1QQz2tcVcvXF_5flYnV3x3IE0A
+        hash: v1.k794b7964.5c12900daeeefee6099c53e6809c70ad223868a69914d8520ee014b808424d61.-NlDNT2dAax-HfwAaZ3GdEDpVkup0STHHm-lZA-t_mw
     scenes-app-llm-analytics-sentiment--message-bar-neutral--light:
         hash: v1.k794b7964.545462ffda263267f86863d03d49a8e64fab4386f38cf34d9d0e1d96d7f64109.C9ajit_QprzfBmKmdvxdc3YISyjivQgSiOKR6wKsEwU
     scenes-app-llm-analytics-sentiment--message-bar-positive--dark:
-        hash: v1.k794b7964.e7821f682bdd160942b0fd53c7fc4d0731e2ae3efa593d288be8e116a089411e.LcLrjzMb6601GFMHZ6b7NK3j4JgBXqnHstmk4zzGop0
+        hash: v1.k794b7964.819c133d4b835720d0ebe6bf7e1e3a0dbffe50d2b052803823853c4d49ad79ab.5cLIFpAyNCvmg6Bxnq5eKvkHD-BcCHjhpxTrnE95pfA
     scenes-app-llm-analytics-sentiment--message-bar-positive--light:
         hash: v1.k794b7964.fd8d3a45beb7db2d22c8ce726a05275163f09e5b205994bef85cbafdc3ad52ac.vDfgC23T7mqVqXVVdiDZ6_2LTC4TVeGv6wCwDnOCtTA
     scenes-app-llm-analytics-sentiment--tag-loading--dark:
-        hash: v1.k794b7964.acba49e662049734dcc2b0071bd82df07d5792e5a512d9ae402a99c5cd770dda.rX6CuC7_6rUSBGlcRh9RhxMVFlI0XZgK_v-PQ1vRoSo
+        hash: v1.k794b7964.ff05242c60c4107d99322bbc0a5c6b1a2ec6a3b650b2b314b19491623b371c18.q5JXSXtIJoL8nc-8azHkgTg_nF366u8Jh-Rhqh-r6ts
     scenes-app-llm-analytics-sentiment--tag-loading--light:
         hash: v1.k794b7964.44ab1124e531ec3a61d0dab25ac8c4234fd0c5ff5f947b7fb5de17ef3105f6ff.lEUcKTGr7hzY-GptOk_IxDFOYxMEEW5aPbVfQgsEF-g
     scenes-app-llm-analytics-sentiment--tag-negative--dark:
-        hash: v1.k794b7964.be7f238e0057251c670f6de630c4aa88ecbd704cc21b001db1ac3335c98e7fc8.zY_jhFasx6j_ysIvuXBrE3d_rH364y0fJUGvQdZEMro
+        hash: v1.k794b7964.6d43d02bc8a14865960a82a96299ed0e43c570dad9a06b8dc454ce8c1106b553.hZ1sT3E0JK1NGvMyBV8rK6vz-2g2jALWrS35oU3IETQ
     scenes-app-llm-analytics-sentiment--tag-negative--light:
         hash: v1.k794b7964.2a4bce3f228a8a5362918badc632ee0bb308441d88ca19753a69c4f8fc44ff10.dwd_riZYhuR0LnwhjAJ5zJGO3u6ItUGctJ0wYOcATCs
     scenes-app-llm-analytics-sentiment--tag-neutral--dark:
-        hash: v1.k794b7964.92144990798bb91d37263404d6f8c3a13bba00129a7806b901727c935efaccaf.jSkCEWWYUzOaVnrHMN1txBfJ6Vck_RLBNuJKTiVG_VY
+        hash: v1.k794b7964.9884f3696f6c5e60daa4a25d59a3ba740111669e656b8b7170b25c8fb07e3e8e.anrYTnHEv0OACzemCdzi7p-SGG99kuPyaDVzSa8slVU
     scenes-app-llm-analytics-sentiment--tag-neutral--light:
         hash: v1.k794b7964.e699402b89ff0bfb1b8386f683dade74e24db97aeaf2c09cfb1cdb056e37770e.95XXgxGxD333LCi-1h3EhMWmF-T4ZxBqWo4cTP5F5_w
     scenes-app-llm-analytics-sentiment--tag-positive--dark:
-        hash: v1.k794b7964.9a189fd73a6bb92cd0d3c9d2959543e24d3a3251a04387ac65f608c3252c062d.ypGSxTPoIgY49Zf3tKqha1a2LUXbM1dff0xWOX36_ho
+        hash: v1.k794b7964.8ac25ec65efac59dc2aab2ea703fe00e8ddc78dcaf5bab53fd8daa0caebed92b.IDDbWQcNJsSDGIRlCPFu-4l1w0lFc8SB_xVPVYGS00c
     scenes-app-llm-analytics-sentiment--tag-positive--light:
         hash: v1.k794b7964.815de3d9207328cf5219021229f699cbcc1953137668b1896f387e7f862a2ee2.wQsMZxFINw08NQmkJwSv0pTi4l069nAOznu1A_6LXHM
     scenes-app-llm-analytics-trace--full--dark:

--- a/products/llm_analytics/frontend/components/SentimentTag.scss
+++ b/products/llm_analytics/frontend/components/SentimentTag.scss
@@ -1,0 +1,33 @@
+// Dark-mode contrast overrides scoped to the LLMA sentiment UI.
+//
+// SentimentTag and SentimentBar rely on deprecated global CSS vars
+// (--success, --danger, --border, --border-light) that don't have a
+// dark-mode override. Rather than patching the global tokens or the
+// shared LemonTag component, we scope the overrides to just these two
+// classes so the change stays within products/llm_analytics/.
+
+[theme='dark'] {
+    // Brighter success/danger tokens for legible text and border against
+    // the dark page background.
+    .LLMASentimentTag,
+    .LLMASentimentBar {
+        --success: var(--color-green-400);
+        --danger: var(--color-red-400);
+    }
+
+    // Matching border tokens for the sentiment bar track.
+    .LLMASentimentBar {
+        --border: rgb(255 255 255 / 15%);
+        --border-light: rgb(255 255 255 / 10%);
+    }
+
+    // Give the tag a subtle surface fill so it reads as a pill rather than
+    // a stroke-only outline on the dark background. Higher specificity than
+    // the base `.LemonTag.LemonTag--{variant}` rules so we win the cascade
+    // regardless of SCSS import order.
+    .LLMASentimentTag.LemonTag.LemonTag--success,
+    .LLMASentimentTag.LemonTag.LemonTag--danger,
+    .LLMASentimentTag.LemonTag.LemonTag--none {
+        background-color: var(--color-bg-surface-primary);
+    }
+}

--- a/products/llm_analytics/frontend/components/SentimentTag.tsx
+++ b/products/llm_analytics/frontend/components/SentimentTag.tsx
@@ -1,3 +1,5 @@
+import './SentimentTag.scss'
+
 import { LemonTag, LemonTagProps, Tooltip } from '@posthog/lemon-ui'
 
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
@@ -40,7 +42,7 @@ export function SentimentTag({ label, score, scores, loading }: SentimentTagProp
 
     return (
         <Tooltip title={<span className="whitespace-pre-line">{buildTagTooltip(label, scores)}</span>}>
-            <LemonTag type={tagType} size="small" className="cursor-default capitalize">
+            <LemonTag type={tagType} size="small" className="LLMASentimentTag cursor-default capitalize">
                 Sentiment: {label} ({formatScore(score)})
             </LemonTag>
         </Tooltip>
@@ -78,7 +80,9 @@ export function SentimentBar({ label, score, loading, size = 'sm', messages }: S
 
     return (
         <Tooltip title={tooltipText}>
-            <span className={`relative my-0.5 inline-block shrink-0 ${size === 'full' ? 'w-3/4' : 'w-10'}`}>
+            <span
+                className={`LLMASentimentBar relative my-0.5 inline-block shrink-0 ${size === 'full' ? 'w-3/4' : 'w-10'}`}
+            >
                 <span className="block h-1.5 bg-border-light rounded-full overflow-hidden">
                     <span
                         className={`block h-full rounded-full ${barColor}`}
@@ -137,7 +141,7 @@ export function MessageSentimentBar({ sentiment }: MessageSentimentBarProps): JS
 
     return (
         <Tooltip title={`${capitalize(sentimentLabel)}: ${formatScore(sentiment.score)}`}>
-            <span className="flex items-center gap-1">
+            <span className="LLMASentimentBar flex items-center gap-1">
                 <span className="w-10 h-1.5 bg-border-light rounded-full overflow-hidden inline-block">
                     <span
                         className={`block h-full rounded-full ${barColor}`}


### PR DESCRIPTION
## Problem

PR #54210 fixed LLMA sentiment-bar/tag contrast in dark mode by globally overriding deprecated color tokens in `base.scss` and patching the cross-team `LemonTag.scss`. That approach produced ~140 storybook visual regressions across unrelated components.

## Changes

Replaces the global approach with a colocated `products/llm_analytics/frontend/components/SentimentTag.scss` that:

- Scopes `--success` / `--danger` / `--border` / `--border-light` overrides to `.LLMASentimentTag` and `.LLMASentimentBar` classes only.
- Adds a subtle `--color-bg-surface-primary` background fill on the tag variants for legibility.
- Applies only under `[theme='dark']`.

Adds the `LLMASentimentTag` / `LLMASentimentBar` classnames to the `SentimentTag`, `SentimentBar`, and `MessageSentimentBar` components so the scoped rules can attach.

## How did you test this code?

This PR was authored by an autonomous agent (polecat `dementus`) and processed through the Gas Town refinery merge queue. No manual browser verification has been done on this branch — relying on the storybook visual regression suite in CI plus the scoped-selector approach to confirm zero impact outside LLMA.

## Publish to changelog?

no

## 🤖 LLM context

Polecat: dementus-llma-sentiment-dark. Refinery: posthog/refinery (session 597a6f24). MR: po-wisp-lvs. Rebased 1 commit onto master cleanly.