### PR TITLE
feat(tasks): add sandbox-pi image with pi coding agent and autoresearch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 *
+!.github/clickhouse-versions.json
 !Dockerfile.recording-rasterizer
 !.devcontainer
 !.kearc

--- a/.github/clickhouse-versions.json
+++ b/.github/clickhouse-versions.json
@@ -1,6 +1,14 @@
 {
-    "production_eu": "clickhouse/clickhouse-server:25.12.8",
-    "production_us": "clickhouse/clickhouse-server:25.12.8",
-    "local": "clickhouse/clickhouse-server:26.3.9",
-    "oldest_supported": "clickhouse/clickhouse-server:25.12.8"
+    "versions": {
+        "production_eu": "clickhouse/clickhouse-server:25.12.8",
+        "production_us": "clickhouse/clickhouse-server:25.12.8",
+        "local": "clickhouse/clickhouse-server:26.3.9",
+        "oldest_supported": "clickhouse/clickhouse-server:25.12.8"
+    },
+    "source_tags": {
+        "production_eu": "v25.12.8.9-stable",
+        "production_us": "v25.12.8.9-stable",
+        "local": "v26.3.9.8-lts",
+        "oldest_supported": "v25.12.8.9-stable"
+    }
 }

--- a/.github/clickhouse-versions.json
+++ b/.github/clickhouse-versions.json
@@ -10,5 +10,11 @@
         "production_us": "v25.12.8.9-stable",
         "local": "v26.3.9.8-lts",
         "oldest_supported": "v25.12.8.9-stable"
+    },
+    "source_shas": {
+        "production_eu": "36747349fb542bdd401151a442253dfdc2c9891a",
+        "production_us": "36747349fb542bdd401151a442253dfdc2c9891a",
+        "local": "0d82c1998e3b4d54e110dd8a77a64d247c4bff4a",
+        "oldest_supported": "36747349fb542bdd401151a442253dfdc2c9891a"
     }
 }

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -211,3 +211,16 @@ jobs:
                   tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-notebook:master,ghcr.io/posthog/posthog-sandbox-notebook:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-notebook:{0}', github.sha) }}
                   platforms: linux/arm64,linux/amd64
                   build-args: COMMIT_HASH=${{ github.sha }}
+
+            - name: Build and push container image (pi)
+              id: build-pi
+              uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
+              with:
+                  context: . # use local checkout (includes downloaded artifact)
+                  file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
+                  buildx-fallback: false # the fallback is so slow it's better to just fail
+                  push: true
+                  tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-pi:master,ghcr.io/posthog/posthog-sandbox-pi:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-pi:{0}', github.sha) }}
+                  platforms: linux/arm64,linux/amd64
+                  build-args: |
+                      BASE_IMAGE=ghcr.io/posthog/posthog-sandbox-base:${{ github.sha }}

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -153,7 +153,7 @@ jobs:
                 contains(github.event.pull_request.labels.*.name, 'build-tasks-sandbox-image')
             )
         runs-on: depot-ubuntu-latest
-        timeout-minutes: 20
+        timeout-minutes: 10
         permissions:
             id-token: write # allow issuing OIDC tokens for this workflow run
             contents: read # allow at least reading the repo contents, add other permissions if necessary

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -236,21 +236,6 @@ jobs:
               with:
                   fetch-depth: 1
 
-            - name: Assert CLICKHOUSE_SRC_TAG matches production server version
-              run: |
-                  set -euo pipefail
-                  prod_image=$(jq -r '.production_us' .github/clickhouse-versions.json)
-                  prod_version=${prod_image##*:}
-                  src_tag=$(awk -F= '/^ARG CLICKHOUSE_SRC_TAG=/ {print $2}' \
-                      products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi)
-                  case "$src_tag" in
-                      v${prod_version}.*-stable) ;;
-                      *)
-                          echo "::error::CLICKHOUSE_SRC_TAG ($src_tag) does not match production ClickHouse $prod_version from .github/clickhouse-versions.json. Expected vX.Y.Z.W-stable where X.Y.Z matches."
-                          exit 1
-                          ;;
-                  esac
-
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -153,13 +153,11 @@ jobs:
                 contains(github.event.pull_request.labels.*.name, 'build-tasks-sandbox-image')
             )
         runs-on: depot-ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 20
         permissions:
             id-token: write # allow issuing OIDC tokens for this workflow run
             contents: read # allow at least reading the repo contents, add other permissions if necessary
             packages: write # allow push to ghcr.io
-        outputs:
-            base_digest: ${{ steps.build.outputs.digest }}
 
         steps:
             - name: Check out
@@ -214,55 +212,15 @@ jobs:
                   platforms: linux/arm64,linux/amd64
                   build-args: COMMIT_HASH=${{ github.sha }}
 
-    sandbox_pi_build:
-        needs: [changes, sandbox_base_build]
-        name: Build and push Tasks Sandbox pi image
-        if: |
-            github.repository == 'PostHog/posthog' && (
-                needs.changes.outputs.sandbox_image == 'true' ||
-                github.event_name == 'workflow_dispatch' ||
-                contains(github.event.pull_request.labels.*.name, 'build-tasks-sandbox-image')
-            )
-        runs-on: depot-ubuntu-latest
-        timeout-minutes: 20
-        permissions:
-            id-token: write
-            contents: read
-            packages: write
-
-        steps:
-            - name: Check out
-              uses: actions/checkout@v6
-              with:
-                  fetch-depth: 1
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
-            - name: Set up Depot CLI
-              uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
-
-            - name: Login to ghcr.io
-              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-                  logout: false
-
             - name: Build and push container image (pi)
               id: build-pi
               uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
               with:
-                  context: .
+                  context: . # use local checkout (includes downloaded artifact)
                   file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
                   buildx-fallback: false # the fallback is so slow it's better to just fail
                   push: true
                   tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-pi:master,ghcr.io/posthog/posthog-sandbox-pi:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-pi:{0}', github.sha) }}
                   platforms: linux/arm64,linux/amd64
-                  # Consuming base by digest avoids ghcr eventual-consistency races on Depot remote builders.
                   build-args: |
-                      BASE_IMAGE=ghcr.io/posthog/posthog-sandbox-base@${{ needs.sandbox_base_build.outputs.base_digest }}
+                      BASE_IMAGE=ghcr.io/posthog/posthog-sandbox-base:${{ github.sha }}

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -158,6 +158,8 @@ jobs:
             id-token: write # allow issuing OIDC tokens for this workflow run
             contents: read # allow at least reading the repo contents, add other permissions if necessary
             packages: write # allow push to ghcr.io
+        outputs:
+            base_digest: ${{ steps.build.outputs.digest }}
 
         steps:
             - name: Check out
@@ -212,15 +214,70 @@ jobs:
                   platforms: linux/arm64,linux/amd64
                   build-args: COMMIT_HASH=${{ github.sha }}
 
+    sandbox_pi_build:
+        needs: [changes, sandbox_base_build]
+        name: Build and push Tasks Sandbox pi image
+        if: |
+            github.repository == 'PostHog/posthog' && (
+                needs.changes.outputs.sandbox_image == 'true' ||
+                github.event_name == 'workflow_dispatch' ||
+                contains(github.event.pull_request.labels.*.name, 'build-tasks-sandbox-image')
+            )
+        runs-on: depot-ubuntu-latest
+        timeout-minutes: 20
+        permissions:
+            id-token: write
+            contents: read
+            packages: write
+
+        steps:
+            - name: Check out
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 1
+
+            - name: Assert CLICKHOUSE_SRC_TAG matches production server version
+              run: |
+                  set -euo pipefail
+                  prod_image=$(jq -r '.production_us' .github/clickhouse-versions.json)
+                  prod_version=${prod_image##*:}
+                  src_tag=$(awk -F= '/^ARG CLICKHOUSE_SRC_TAG=/ {print $2}' \
+                      products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi)
+                  case "$src_tag" in
+                      v${prod_version}.*-stable) ;;
+                      *)
+                          echo "::error::CLICKHOUSE_SRC_TAG ($src_tag) does not match production ClickHouse $prod_version from .github/clickhouse-versions.json. Expected vX.Y.Z.W-stable where X.Y.Z matches."
+                          exit 1
+                          ;;
+                  esac
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+            - name: Set up Depot CLI
+              uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
+
+            - name: Login to ghcr.io
+              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+                  logout: false
+
             - name: Build and push container image (pi)
               id: build-pi
               uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
               with:
-                  context: . # use local checkout (includes downloaded artifact)
+                  context: .
                   file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
                   buildx-fallback: false # the fallback is so slow it's better to just fail
                   push: true
                   tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-pi:master,ghcr.io/posthog/posthog-sandbox-pi:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-pi:{0}', github.sha) }}
                   platforms: linux/arm64,linux/amd64
+                  # Consuming base by digest avoids ghcr eventual-consistency races on Depot remote builders.
                   build-args: |
-                      BASE_IMAGE=ghcr.io/posthog/posthog-sandbox-base:${{ github.sha }}
+                      BASE_IMAGE=ghcr.io/posthog/posthog-sandbox-base@${{ needs.sandbox_base_build.outputs.base_digest }}

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1440,7 +1440,7 @@ jobs:
                   echo "Using $compat_shards shard(s) per compat version"
 
                   # Oldest supported version for main Django tests (for max compatibility, as JSON array for matrix)
-                  oldest_supported=$(jq -r '.oldest_supported' .github/clickhouse-versions.json)
+                  oldest_supported=$(jq -r '.versions.oldest_supported' .github/clickhouse-versions.json)
                   if [ -z "$oldest_supported" ] || [ "$oldest_supported" = "null" ]; then
                     echo "::error::No oldest_supported version found in .github/clickhouse-versions.json"
                     exit 1
@@ -1450,7 +1450,7 @@ jobs:
                   echo "Oldest supported version for Django tests: $oldest_supported"
 
                   # Read all unique versions so we can derive compat coverage.
-                  all=$(jq -c '[.[]] | unique' .github/clickhouse-versions.json)
+                  all=$(jq -c '[.versions[]] | unique' .github/clickhouse-versions.json)
                   if [ "$all" = "[]" ] || [ -z "$all" ]; then
                     echo "::error::No versions found in .github/clickhouse-versions.json"
                     exit 1
@@ -1458,7 +1458,7 @@ jobs:
                   echo "All CH versions found: $all"
 
                   # Compat coverage is only needed for non-oldest versions.
-                  compat_versions=$(jq -c --arg oldest "$oldest_supported" '[.[]] | unique | map(select(. != $oldest))' .github/clickhouse-versions.json)
+                  compat_versions=$(jq -c --arg oldest "$oldest_supported" '[.versions[]] | unique | map(select(. != $oldest))' .github/clickhouse-versions.json)
                   echo "Compat versions (excluding oldest): $compat_versions"
 
                   compat_count=$(jq -r 'length' <<< "$compat_versions")

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -152,7 +152,7 @@ jobs:
               id: read-versions
               if: github.event_name == 'push' || steps.filter.outputs.dagster == 'true'
               run: |
-                  oldest_supported=$(jq -r '.oldest_supported' .github/clickhouse-versions.json)
+                  oldest_supported=$(jq -r '.versions.oldest_supported' .github/clickhouse-versions.json)
                   if [ -z "$oldest_supported" ] || [ "$oldest_supported" = "null" ]; then
                     echo "::error::No oldest_supported version found in .github/clickhouse-versions.json"
                     exit 1

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -112,7 +112,7 @@ jobs:
               id: read-versions
               if: github.event_name == 'push' || steps.changes.outputs.shouldRun == 'true'
               run: |
-                  oldest_supported=$(jq -r '.oldest_supported' .github/clickhouse-versions.json)
+                  oldest_supported=$(jq -r '.versions.oldest_supported' .github/clickhouse-versions.json)
                   if [ -z "$oldest_supported" ] || [ "$oldest_supported" = "null" ]; then
                     echo "::error::No oldest_supported version found in .github/clickhouse-versions.json"
                     exit 1

--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
@@ -8,7 +8,7 @@ RUN npm install -g "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}"
 # on the personal upstream cannot affect what lands here. Install via the repo's documented
 # manual-copy path so nothing downstream re-resolves the SHA through a mutable name.
 ARG PI_AUTORESEARCH_SHA=56e9f2ec6f0dc6f9997126e4f1d8a4223de2a534
-RUN set -euxo pipefail; \
+RUN set -eux; \
     src=/tmp/pi-autoresearch; \
     git init -q "$src"; \
     git -C "$src" remote add origin https://github.com/davebcn87/pi-autoresearch.git; \
@@ -23,7 +23,7 @@ RUN set -euxo pipefail; \
 # production_us is the canonical source; US/EU/oldest share the pin today but can diverge.
 # Fetching the exact SHA eliminates the tag-force-move TOCTOU window that --branch would have.
 COPY .github/clickhouse-versions.json /tmp/clickhouse-versions.json
-RUN set -euxo pipefail; \
+RUN set -eux; \
     expected_sha=$(jq -r '.source_shas.production_us // empty' /tmp/clickhouse-versions.json); \
     [ -n "$expected_sha" ] || { echo "source_shas.production_us missing"; exit 1; }; \
     dst=/opt/clickhouse; \

--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
@@ -1,16 +1,17 @@
-# Dockerfile for the pi coding agent sandbox image.
-# Builds on top of sandbox-base and adds the pi coding agent plus the
-# pi-autoresearch extension. Versions are pinned for reproducible builds.
+# pi coding agent sandbox image: sandbox-base + pi + pi-autoresearch + ClickHouse source.
 
 ARG BASE_IMAGE=posthog-sandbox-base
 FROM ${BASE_IMAGE}
 
-# pi coding agent (https://pi.dev)
 ARG PI_CODING_AGENT_VERSION=0.68.1
 RUN npm install -g "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}"
 
-# pi-autoresearch extension (https://github.com/davebcn87/pi-autoresearch)
 ARG PI_AUTORESEARCH_TAG=v1.0.1
 RUN pi install "git:github.com/davebcn87/pi-autoresearch@${PI_AUTORESEARCH_TAG}"
+
+# Keep CLICKHOUSE_SRC_TAG in sync with the prod image in .github/clickhouse-versions.json.
+ARG CLICKHOUSE_SRC_TAG=v25.12.8.9-stable
+RUN git clone --depth 1 --branch "${CLICKHOUSE_SRC_TAG}" --single-branch \
+    https://github.com/ClickHouse/ClickHouse.git /opt/clickhouse
 
 CMD ["/bin/bash"]

--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
@@ -10,17 +10,12 @@ ARG PI_AUTORESEARCH_SHA=56e9f2ec6f0dc6f9997126e4f1d8a4223de2a534
 RUN set -eux; \
     actual="$(git ls-remote https://github.com/davebcn87/pi-autoresearch.git "refs/tags/${PI_AUTORESEARCH_TAG}" | cut -f1)"; \
     [ "$actual" = "$PI_AUTORESEARCH_SHA" ] || { echo "pi-autoresearch tag ${PI_AUTORESEARCH_TAG} moved: expected ${PI_AUTORESEARCH_SHA}, got ${actual}"; exit 1; }; \
-    for i in 1 2 3; do \
-        pi install "git:github.com/davebcn87/pi-autoresearch@${PI_AUTORESEARCH_TAG}" && break || sleep $((i * 5)); \
-    done
+    pi install "git:github.com/davebcn87/pi-autoresearch@${PI_AUTORESEARCH_TAG}"
 
 # CLICKHOUSE_SRC_TAG is asserted against .github/clickhouse-versions.json by the CI job before build.
 ARG CLICKHOUSE_SRC_TAG=v25.12.8.9-stable
-RUN set -eux; \
-    for i in 1 2 3; do \
-        git clone --depth 1 --branch "${CLICKHOUSE_SRC_TAG}" --single-branch \
-            https://github.com/ClickHouse/ClickHouse.git /opt/clickhouse && break || sleep $((i * 5)); \
-    done; \
+RUN git clone --depth 1 --branch "${CLICKHOUSE_SRC_TAG}" --single-branch \
+        https://github.com/ClickHouse/ClickHouse.git /opt/clickhouse && \
     rm -rf /opt/clickhouse/.git
 
 CMD ["/bin/bash"]

--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
@@ -1,17 +1,26 @@
-# pi coding agent sandbox image: sandbox-base + pi + pi-autoresearch + ClickHouse source.
-
-ARG BASE_IMAGE=posthog-sandbox-base
+ARG BASE_IMAGE=ghcr.io/posthog/posthog-sandbox-base:master
 FROM ${BASE_IMAGE}
 
 ARG PI_CODING_AGENT_VERSION=0.68.1
 RUN npm install -g "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}"
 
+# Pinned by tag (pi's install grammar) AND SHA (catches tag force-moves from the personal upstream).
 ARG PI_AUTORESEARCH_TAG=v1.0.1
-RUN pi install "git:github.com/davebcn87/pi-autoresearch@${PI_AUTORESEARCH_TAG}"
+ARG PI_AUTORESEARCH_SHA=56e9f2ec6f0dc6f9997126e4f1d8a4223de2a534
+RUN set -eux; \
+    actual="$(git ls-remote https://github.com/davebcn87/pi-autoresearch.git "refs/tags/${PI_AUTORESEARCH_TAG}" | cut -f1)"; \
+    [ "$actual" = "$PI_AUTORESEARCH_SHA" ] || { echo "pi-autoresearch tag ${PI_AUTORESEARCH_TAG} moved: expected ${PI_AUTORESEARCH_SHA}, got ${actual}"; exit 1; }; \
+    for i in 1 2 3; do \
+        pi install "git:github.com/davebcn87/pi-autoresearch@${PI_AUTORESEARCH_TAG}" && break || sleep $((i * 5)); \
+    done
 
-# Keep CLICKHOUSE_SRC_TAG in sync with the prod image in .github/clickhouse-versions.json.
+# CLICKHOUSE_SRC_TAG is asserted against .github/clickhouse-versions.json by the CI job before build.
 ARG CLICKHOUSE_SRC_TAG=v25.12.8.9-stable
-RUN git clone --depth 1 --branch "${CLICKHOUSE_SRC_TAG}" --single-branch \
-    https://github.com/ClickHouse/ClickHouse.git /opt/clickhouse
+RUN set -eux; \
+    for i in 1 2 3; do \
+        git clone --depth 1 --branch "${CLICKHOUSE_SRC_TAG}" --single-branch \
+            https://github.com/ClickHouse/ClickHouse.git /opt/clickhouse && break || sleep $((i * 5)); \
+    done; \
+    rm -rf /opt/clickhouse/.git
 
 CMD ["/bin/bash"]

--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
@@ -1,0 +1,16 @@
+# Dockerfile for the pi coding agent sandbox image.
+# Builds on top of sandbox-base and adds the pi coding agent plus the
+# pi-autoresearch extension. Versions are pinned for reproducible builds.
+
+ARG BASE_IMAGE=posthog-sandbox-base
+FROM ${BASE_IMAGE}
+
+# pi coding agent (https://pi.dev)
+ARG PI_CODING_AGENT_VERSION=0.68.1
+RUN npm install -g "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}"
+
+# pi-autoresearch extension (https://github.com/davebcn87/pi-autoresearch)
+ARG PI_AUTORESEARCH_TAG=v1.0.1
+RUN pi install "git:github.com/davebcn87/pi-autoresearch@${PI_AUTORESEARCH_TAG}"
+
+CMD ["/bin/bash"]

--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
@@ -8,7 +8,7 @@ RUN npm install -g "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}"
 # refs/tags/X^{} resolves annotated tags to their commit; fallback handles lightweight tags.
 ARG PI_AUTORESEARCH_TAG=v1.0.1
 ARG PI_AUTORESEARCH_SHA=56e9f2ec6f0dc6f9997126e4f1d8a4223de2a534
-RUN set -eux; \
+RUN set -euxo pipefail; \
     repo=https://github.com/davebcn87/pi-autoresearch.git; \
     actual=$(git ls-remote "$repo" "refs/tags/${PI_AUTORESEARCH_TAG}^{}" | cut -f1); \
     [ -n "$actual" ] || actual=$(git ls-remote "$repo" "refs/tags/${PI_AUTORESEARCH_TAG}" | cut -f1); \
@@ -18,7 +18,7 @@ RUN set -eux; \
 # production_us is the canonical source for this image; US/EU/oldest share the same pin today,
 # but if they ever diverge we want the tree that matches what US prod actually runs.
 COPY .github/clickhouse-versions.json /tmp/clickhouse-versions.json
-RUN set -eux; \
+RUN set -euxo pipefail; \
     tag=$(jq -r '.source_tags.production_us // empty' /tmp/clickhouse-versions.json); \
     expected_sha=$(jq -r '.source_shas.production_us // empty' /tmp/clickhouse-versions.json); \
     [ -n "$tag" ] && [ -n "$expected_sha" ] || { echo "source_tags.production_us or source_shas.production_us missing"; exit 1; }; \

--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
@@ -12,10 +12,12 @@ RUN set -eux; \
     [ "$actual" = "$PI_AUTORESEARCH_SHA" ] || { echo "pi-autoresearch tag ${PI_AUTORESEARCH_TAG} moved: expected ${PI_AUTORESEARCH_SHA}, got ${actual}"; exit 1; }; \
     pi install "git:github.com/davebcn87/pi-autoresearch@${PI_AUTORESEARCH_TAG}"
 
-# CLICKHOUSE_SRC_TAG is asserted against .github/clickhouse-versions.json by the CI job before build.
-ARG CLICKHOUSE_SRC_TAG=v25.12.8.9-stable
-RUN git clone --depth 1 --branch "${CLICKHOUSE_SRC_TAG}" --single-branch \
-        https://github.com/ClickHouse/ClickHouse.git /opt/clickhouse && \
-    rm -rf /opt/clickhouse/.git
+# Source tag is read from the same file the CI workflows use as the single source of truth.
+COPY .github/clickhouse-versions.json /tmp/clickhouse-versions.json
+RUN set -eux; \
+    tag=$(jq -r '.source_tags.production_us' /tmp/clickhouse-versions.json); \
+    git clone --depth 1 --branch "$tag" --single-branch \
+        https://github.com/ClickHouse/ClickHouse.git /opt/clickhouse; \
+    rm -rf /opt/clickhouse/.git /tmp/clickhouse-versions.json
 
 CMD ["/bin/bash"]

--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
@@ -4,20 +4,32 @@ FROM ${BASE_IMAGE}
 ARG PI_CODING_AGENT_VERSION=0.68.1
 RUN npm install -g "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}"
 
-# Pinned by tag (pi's install grammar) AND SHA (catches tag force-moves from the personal upstream).
+# Pinned by tag (pi's install grammar) AND SHA (catches tag force-moves).
+# refs/tags/X^{} resolves annotated tags to their commit; fallback handles lightweight tags.
 ARG PI_AUTORESEARCH_TAG=v1.0.1
 ARG PI_AUTORESEARCH_SHA=56e9f2ec6f0dc6f9997126e4f1d8a4223de2a534
 RUN set -eux; \
-    actual="$(git ls-remote https://github.com/davebcn87/pi-autoresearch.git "refs/tags/${PI_AUTORESEARCH_TAG}" | cut -f1)"; \
+    repo=https://github.com/davebcn87/pi-autoresearch.git; \
+    actual=$(git ls-remote "$repo" "refs/tags/${PI_AUTORESEARCH_TAG}^{}" | cut -f1); \
+    [ -n "$actual" ] || actual=$(git ls-remote "$repo" "refs/tags/${PI_AUTORESEARCH_TAG}" | cut -f1); \
     [ "$actual" = "$PI_AUTORESEARCH_SHA" ] || { echo "pi-autoresearch tag ${PI_AUTORESEARCH_TAG} moved: expected ${PI_AUTORESEARCH_SHA}, got ${actual}"; exit 1; }; \
     pi install "git:github.com/davebcn87/pi-autoresearch@${PI_AUTORESEARCH_TAG}"
 
-# Source tag is read from the same file the CI workflows use as the single source of truth.
+# production_us is the canonical source for this image; US/EU/oldest share the same pin today,
+# but if they ever diverge we want the tree that matches what US prod actually runs.
 COPY .github/clickhouse-versions.json /tmp/clickhouse-versions.json
 RUN set -eux; \
-    tag=$(jq -r '.source_tags.production_us' /tmp/clickhouse-versions.json); \
-    git clone --depth 1 --branch "$tag" --single-branch \
-        https://github.com/ClickHouse/ClickHouse.git /opt/clickhouse; \
+    tag=$(jq -r '.source_tags.production_us // empty' /tmp/clickhouse-versions.json); \
+    expected_sha=$(jq -r '.source_shas.production_us // empty' /tmp/clickhouse-versions.json); \
+    [ -n "$tag" ] && [ -n "$expected_sha" ] || { echo "source_tags.production_us or source_shas.production_us missing"; exit 1; }; \
+    repo=https://github.com/ClickHouse/ClickHouse.git; \
+    actual_sha=$(git ls-remote "$repo" "refs/tags/${tag}^{}" | cut -f1); \
+    [ -n "$actual_sha" ] || actual_sha=$(git ls-remote "$repo" "refs/tags/${tag}" | cut -f1); \
+    [ "$actual_sha" = "$expected_sha" ] || { echo "ClickHouse tag ${tag} moved: expected ${expected_sha}, got ${actual_sha}"; exit 1; }; \
+    git clone --depth 1 --branch "$tag" --single-branch "$repo" /opt/clickhouse; \
+    find /opt/clickhouse -maxdepth 2 -type d \
+        \( -name tests -o -name docs -o -name website -o -name contrib \) \
+        -prune -exec rm -rf {} +; \
     rm -rf /opt/clickhouse/.git /tmp/clickhouse-versions.json
 
 CMD ["/bin/bash"]

--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
@@ -9,17 +9,16 @@ RUN npm install -g "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}"
 # manual-copy path so nothing downstream re-resolves the SHA through a mutable name.
 ARG PI_AUTORESEARCH_SHA=56e9f2ec6f0dc6f9997126e4f1d8a4223de2a534
 RUN set -euxo pipefail; \
-    dir=/tmp/pi-autoresearch; \
-    mkdir -p "$dir" && cd "$dir"; \
-    git init -q; \
-    git remote add origin https://github.com/davebcn87/pi-autoresearch.git; \
-    git -c protocol.version=2 fetch --depth 1 origin "$PI_AUTORESEARCH_SHA"; \
-    git reset --hard FETCH_HEAD; \
+    src=/tmp/pi-autoresearch; \
+    git init -q "$src"; \
+    git -C "$src" remote add origin https://github.com/davebcn87/pi-autoresearch.git; \
+    git -C "$src" -c protocol.version=2 fetch --depth 1 origin "$PI_AUTORESEARCH_SHA"; \
+    git -C "$src" reset --hard FETCH_HEAD; \
     mkdir -p /root/.pi/agent/extensions /root/.pi/agent/skills; \
-    cp -r extensions/pi-autoresearch /root/.pi/agent/extensions/; \
-    cp -r skills/autoresearch-create /root/.pi/agent/skills/; \
-    cp -r skills/autoresearch-finalize /root/.pi/agent/skills/; \
-    rm -rf "$dir"
+    cp -r "$src/extensions/pi-autoresearch" /root/.pi/agent/extensions/; \
+    cp -r "$src/skills/autoresearch-create" /root/.pi/agent/skills/; \
+    cp -r "$src/skills/autoresearch-finalize" /root/.pi/agent/skills/; \
+    rm -rf "$src"
 
 # production_us is the canonical source; US/EU/oldest share the pin today but can diverge.
 # Fetching the exact SHA eliminates the tag-force-move TOCTOU window that --branch would have.
@@ -27,14 +26,14 @@ COPY .github/clickhouse-versions.json /tmp/clickhouse-versions.json
 RUN set -euxo pipefail; \
     expected_sha=$(jq -r '.source_shas.production_us // empty' /tmp/clickhouse-versions.json); \
     [ -n "$expected_sha" ] || { echo "source_shas.production_us missing"; exit 1; }; \
-    mkdir -p /opt/clickhouse && cd /opt/clickhouse; \
-    git init -q; \
-    git remote add origin https://github.com/ClickHouse/ClickHouse.git; \
-    git -c protocol.version=2 fetch --depth 1 origin "$expected_sha"; \
-    git reset --hard FETCH_HEAD; \
-    find /opt/clickhouse -maxdepth 2 -type d \
+    dst=/opt/clickhouse; \
+    git init -q "$dst"; \
+    git -C "$dst" remote add origin https://github.com/ClickHouse/ClickHouse.git; \
+    git -C "$dst" -c protocol.version=2 fetch --depth 1 origin "$expected_sha"; \
+    git -C "$dst" reset --hard FETCH_HEAD; \
+    find "$dst" -maxdepth 2 -type d \
         \( -name tests -o -name docs -o -name website -o -name contrib \) \
         -prune -exec rm -rf {} +; \
-    rm -rf /opt/clickhouse/.git /tmp/clickhouse-versions.json
+    rm -rf "$dst/.git" /tmp/clickhouse-versions.json
 
 CMD ["/bin/bash"]

--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
@@ -4,29 +4,34 @@ FROM ${BASE_IMAGE}
 ARG PI_CODING_AGENT_VERSION=0.68.1
 RUN npm install -g "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}"
 
-# Pinned by tag (pi's install grammar) AND SHA (catches tag force-moves).
-# refs/tags/X^{} resolves annotated tags to their commit; fallback handles lightweight tags.
-ARG PI_AUTORESEARCH_TAG=v1.0.1
+# Fetch-by-SHA (not by tag) means the server only returns the specified commit; tag force-moves
+# on the personal upstream cannot affect what lands here. Install via the repo's documented
+# manual-copy path so nothing downstream re-resolves the SHA through a mutable name.
 ARG PI_AUTORESEARCH_SHA=56e9f2ec6f0dc6f9997126e4f1d8a4223de2a534
 RUN set -euxo pipefail; \
-    repo=https://github.com/davebcn87/pi-autoresearch.git; \
-    actual=$(git ls-remote "$repo" "refs/tags/${PI_AUTORESEARCH_TAG}^{}" | cut -f1); \
-    [ -n "$actual" ] || actual=$(git ls-remote "$repo" "refs/tags/${PI_AUTORESEARCH_TAG}" | cut -f1); \
-    [ "$actual" = "$PI_AUTORESEARCH_SHA" ] || { echo "pi-autoresearch tag ${PI_AUTORESEARCH_TAG} moved: expected ${PI_AUTORESEARCH_SHA}, got ${actual}"; exit 1; }; \
-    pi install "git:github.com/davebcn87/pi-autoresearch@${PI_AUTORESEARCH_TAG}"
+    dir=/tmp/pi-autoresearch; \
+    mkdir -p "$dir" && cd "$dir"; \
+    git init -q; \
+    git remote add origin https://github.com/davebcn87/pi-autoresearch.git; \
+    git -c protocol.version=2 fetch --depth 1 origin "$PI_AUTORESEARCH_SHA"; \
+    git reset --hard FETCH_HEAD; \
+    mkdir -p /root/.pi/agent/extensions /root/.pi/agent/skills; \
+    cp -r extensions/pi-autoresearch /root/.pi/agent/extensions/; \
+    cp -r skills/autoresearch-create /root/.pi/agent/skills/; \
+    cp -r skills/autoresearch-finalize /root/.pi/agent/skills/; \
+    rm -rf "$dir"
 
-# production_us is the canonical source for this image; US/EU/oldest share the same pin today,
-# but if they ever diverge we want the tree that matches what US prod actually runs.
+# production_us is the canonical source; US/EU/oldest share the pin today but can diverge.
+# Fetching the exact SHA eliminates the tag-force-move TOCTOU window that --branch would have.
 COPY .github/clickhouse-versions.json /tmp/clickhouse-versions.json
 RUN set -euxo pipefail; \
-    tag=$(jq -r '.source_tags.production_us // empty' /tmp/clickhouse-versions.json); \
     expected_sha=$(jq -r '.source_shas.production_us // empty' /tmp/clickhouse-versions.json); \
-    [ -n "$tag" ] && [ -n "$expected_sha" ] || { echo "source_tags.production_us or source_shas.production_us missing"; exit 1; }; \
-    repo=https://github.com/ClickHouse/ClickHouse.git; \
-    actual_sha=$(git ls-remote "$repo" "refs/tags/${tag}^{}" | cut -f1); \
-    [ -n "$actual_sha" ] || actual_sha=$(git ls-remote "$repo" "refs/tags/${tag}" | cut -f1); \
-    [ "$actual_sha" = "$expected_sha" ] || { echo "ClickHouse tag ${tag} moved: expected ${expected_sha}, got ${actual_sha}"; exit 1; }; \
-    git clone --depth 1 --branch "$tag" --single-branch "$repo" /opt/clickhouse; \
+    [ -n "$expected_sha" ] || { echo "source_shas.production_us missing"; exit 1; }; \
+    mkdir -p /opt/clickhouse && cd /opt/clickhouse; \
+    git init -q; \
+    git remote add origin https://github.com/ClickHouse/ClickHouse.git; \
+    git -c protocol.version=2 fetch --depth 1 origin "$expected_sha"; \
+    git reset --hard FETCH_HEAD; \
     find /opt/clickhouse -maxdepth 2 -type d \
         \( -name tests -o -name docs -o -name website -o -name contrib \) \
         -prune -exec rm -rf {} +; \


### PR DESCRIPTION
## Problem

The sandbox fleet currently ships `posthog-sandbox-base` (general purpose) and `posthog-sandbox-notebook` (Python / Jupyter). We want a variant preloaded with the [pi coding agent](https://pi.dev) and the [`pi-autoresearch`](https://github.com/davebcn87/pi-autoresearch) extension so agent sessions that target pi don't pay the install cost at runtime. It should also include the clickhouse source code for the agent to read while researching

## Changes

- New `products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi` layered on top of `posthog-sandbox-base` via a `BASE_IMAGE` build-arg.
  - Installs `@mariozechner/pi-coding-agent@0.68.1` globally with npm (pinned).
  - Runs `pi install git:github.com/davebcn87/pi-autoresearch@v1.0.1` (pinned to the latest release tag).
  - Both versions exposed as `ARG`s so downstream bumps are one-line changes.
- Extends `.github/workflows/cd-sandbox-base-image.yml` with a third image build step that publishes to `ghcr.io/posthog/posthog-sandbox-pi`, passing the just-pushed base image tag through `BASE_IMAGE`. Trigger conditions (path filter + `build-tasks-sandbox-image` label) are inherited from the existing job.

## How did you test this code?

I'm an agent and have not exercised the full Depot CI build end-to-end. What I did run:

- `docker buildx build --check` on `Dockerfile.sandbox-pi` — passes with no warnings (parent image metadata lookup naturally fails locally; syntax is clean).
- Validated the updated workflow YAML parses cleanly.

Reviewer-side manual check I'd recommend before merge: push a commit with the `build-tasks-sandbox-image` label to confirm the new `build-pi` step pulls the freshly pushed base tag and that `pi install` succeeds at build time under Depot's egress constraints. A successful run should leave `pi` and the extension available in a shell:

```
docker run --rm ghcr.io/posthog/posthog-sandbox-pi:<sha> pi --version
```

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code. The "pi-autoresearch" install source was ambiguous in the original request (neither `pi-autoresearch` nor a scoped variant exists on npm); resolved with the user to `github.com/davebcn87/pi-autoresearch` at tag `v1.0.1`. During package discovery a prompt-injection attempt was detected inside a fetched web page and ignored.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*