### PR TITLE
fix(personhog): prewarm pg connections before signaling ready

### DIFF
--- a/rust/personhog-replica/src/main.rs
+++ b/rust/personhog-replica/src/main.rs
@@ -162,8 +162,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             count = warmup_count,
             "Warming database connection pools before accepting traffic"
         );
-        let start = std::time::Instant::now();
-
         let separate_replica = config.replica_database_url() != config.primary_database_url;
         let pools: Vec<(&sqlx::PgPool, &str)> = if separate_replica {
             vec![
@@ -175,6 +173,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
 
         for (pool, label) in &pools {
+            let pool_start = std::time::Instant::now();
             let mut conns = Vec::with_capacity(warmup_count);
             for _ in 0..warmup_count {
                 match pool.acquire().await {
@@ -185,10 +184,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
             }
+            // Run a query on each held connection to warm PgBouncer → PG.
+            // acquire() only establishes app → PgBouncer; in transaction pooling
+            // mode PgBouncer doesn't open a server connection until a query runs.
+            // Holding all N connections forces PgBouncer to assign N distinct
+            // server connections rather than reusing one.
+            let mut server_warmed = 0u32;
+            for conn in &mut conns {
+                match sqlx::query("SELECT 1").execute(&mut **conn).await {
+                    Ok(_) => server_warmed += 1,
+                    Err(e) => {
+                        tracing::warn!(pool = label, error = %e, "Failed to warm server-side connection");
+                    }
+                }
+            }
             tracing::info!(
                 pool = label,
-                warmed = conns.len(),
-                elapsed_ms = start.elapsed().as_millis() as u64,
+                client_conns = conns.len(),
+                server_conns = server_warmed,
+                elapsed_ms = pool_start.elapsed().as_millis() as u64,
                 "Pool warmup complete"
             );
             // Connections drop here, returning to the pool as idle

--- a/rust/personhog-replica/src/main.rs
+++ b/rust/personhog-replica/src/main.rs
@@ -150,6 +150,51 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // gRPC server
     let storage = create_storage(&config).await;
 
+    // Pre-warm DB connection pools before accepting traffic.
+    // connect_lazy() starts with zero connections; without this, the first
+    // burst of requests after K8s routes traffic all pay the cold-start cost
+    // (TCP + TLS + PgBouncer + SET statement_timeout). Warming here is safe
+    // because the gRPC server hasn't bound its port yet — the startup probe
+    // (TCP on 50051) can't pass until after this completes.
+    if config.min_pg_connections > 0 {
+        let warmup_count = config.min_pg_connections as usize;
+        tracing::info!(
+            count = warmup_count,
+            "Warming database connection pools before accepting traffic"
+        );
+        let start = std::time::Instant::now();
+
+        let separate_replica = config.replica_database_url() != config.primary_database_url;
+        let pools: Vec<(&sqlx::PgPool, &str)> = if separate_replica {
+            vec![
+                (&storage.primary_pool, "primary"),
+                (&storage.replica_pool, "replica"),
+            ]
+        } else {
+            vec![(&storage.primary_pool, "primary")]
+        };
+
+        for (pool, label) in &pools {
+            let mut conns = Vec::with_capacity(warmup_count);
+            for _ in 0..warmup_count {
+                match pool.acquire().await {
+                    Ok(conn) => conns.push(conn),
+                    Err(e) => {
+                        tracing::warn!(pool = label, error = %e, "Failed to warm connection");
+                        break;
+                    }
+                }
+            }
+            tracing::info!(
+                pool = label,
+                warmed = conns.len(),
+                elapsed_ms = start.elapsed().as_millis() as u64,
+                "Pool warmup complete"
+            );
+            // Connections drop here, returning to the pool as idle
+        }
+    }
+
     // Spawn background pool health monitor
     let mut pools = vec![MonitoredPool {
         pool: storage.primary_pool.clone(),


### PR DESCRIPTION
## Problem

During rolling deployments of personhog-replica, new pods start with completely cold DB connection pools.
The pool uses `connect_lazy()`, so zero connections exist at startup — even with `MIN_PG_CONNECTIONS` set, sqlx's background maintenance task only begins filling the pool after the first successful connection.
The readiness probe (`/_readiness`) only checks the shutdown token, not DB connectivity, so K8s routes traffic immediately while the pool is empty.
The first burst of requests all pay the full cold-start cost (TCP + TLS handshake to PgBouncer + server-side PgBouncer→RDS connection + `SET statement_timeout`), causing latency spikes during every deploy.

## Changes

Add a startup warmup routine in `main.rs` that explicitly acquires `min_pg_connections` connections from each pool before the gRPC server binds its port.
This is naturally safe because the startup probe (TCP on 50051) can't pass until after warmup completes and the gRPC server starts listening.

The warmup:
- Acquires connections sequentially, collecting them in a vec to prevent the pool from reusing a single connection
- Releases them back as idle when the loop ends (safe — `idle_timeout` is 300s, traffic arrives within seconds)
- Triggers sqlx's `min_connections` maintenance task so the pool floor is actively maintained going forward
- Handles separate vs shared primary/replica pools (skips duplicate warming when no replica URL is configured)
- Logs warmup count, elapsed time, and any failures per pool


## How did you test this code?

- `cargo check -p personhog-replica` passes
- `cargo clippy -p personhog-replica --all-targets` passes with zero warnings

- [ ] After deploy, check `personhog_db_pool_size` and `personhog_db_pool_idle` metrics — pools should show 20 connections before the first request arrives
- [ ] Pool acquisition latency (`personhog_replica_db_pool_acquire_duration_ms`) should not spike during rolling deploys
- [ ] Startup time increase is acceptable (20 sequential connection establishments to PgBouncer, expect ~100-500ms total)
