### PR TITLE
chore(error-tracking): use circuit breaker

### DIFF
--- a/nodejs/src/ingestion/error-tracking/config.ts
+++ b/nodejs/src/ingestion/error-tracking/config.ts
@@ -35,6 +35,17 @@ export type ErrorTrackingConsumerConfig = {
      *  split large batches before they hit Cymbal's body limit. */
     ERROR_TRACKING_CYMBAL_MAX_BODY_BYTES: number
 
+    /** Consecutive all-fail Cymbal calls before the circuit breaker opens.
+     *  Should match the retry wrapper's maxAttempts minus one so the circuit
+     *  trips before retries exhaust, preventing overflow. */
+    ERROR_TRACKING_CYMBAL_CIRCUIT_BREAKER_FAILURE_THRESHOLD: number
+    /** Initial backoff in ms between circuit breaker probes */
+    ERROR_TRACKING_CYMBAL_CIRCUIT_BREAKER_INITIAL_BACKOFF_MS: number
+    /** Maximum backoff in ms between circuit breaker probes */
+    ERROR_TRACKING_CYMBAL_CIRCUIT_BREAKER_MAX_BACKOFF_MS: number
+    /** Number of events to send in each circuit breaker probe */
+    ERROR_TRACKING_CYMBAL_CIRCUIT_BREAKER_PROBE_SIZE: number
+
     /** Pipeline name for metrics labeling */
     INGESTION_PIPELINE: string | null
     /** Lane identifier (main, overflow) for metrics labeling */
@@ -56,6 +67,10 @@ export function getDefaultErrorTrackingConsumerConfig(): ErrorTrackingConsumerCo
         ERROR_TRACKING_STATEFUL_OVERFLOW_REDIS_TTL_SECONDS: 300, // 5 minutes
         ERROR_TRACKING_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS: 60, // 1 minute
         ERROR_TRACKING_CYMBAL_MAX_BODY_BYTES: 1_800_000,
+        ERROR_TRACKING_CYMBAL_CIRCUIT_BREAKER_FAILURE_THRESHOLD: 3,
+        ERROR_TRACKING_CYMBAL_CIRCUIT_BREAKER_INITIAL_BACKOFF_MS: 1_000,
+        ERROR_TRACKING_CYMBAL_CIRCUIT_BREAKER_MAX_BACKOFF_MS: 5_000,
+        ERROR_TRACKING_CYMBAL_CIRCUIT_BREAKER_PROBE_SIZE: 10,
         INGESTION_PIPELINE: null,
         INGESTION_LANE: null,
     }

--- a/nodejs/src/ingestion/error-tracking/cymbal/client.test.ts
+++ b/nodejs/src/ingestion/error-tracking/cymbal/client.test.ts
@@ -752,6 +752,50 @@ describe('CymbalClient', () => {
             expect(results[0].status).toBe('failed')
         })
 
+        it('does not double-process probed events when batch is larger than probe size', async () => {
+            const client = new CymbalClient({
+                baseUrl: 'http://cymbal.example.com:8080',
+                timeoutMs: 5000,
+                maxBodyBytes: 1_800_000,
+                circuitBreaker: {
+                    name: 'test-cymbal',
+                    failureThreshold: 1,
+                    initialBackoffMs: 1,
+                    maxBackoffMs: 10,
+                    probeSize: 1, // Probe with 1 event, batch has 3
+                },
+                fetch: mockFetch as FetchFunction,
+                dnsResolve: jest.fn().mockResolvedValue(['1.2.3.4']) as DnsResolveFunction,
+            })
+
+            // Trip the circuit
+            mockFetch.mockResolvedValueOnce({ status: 500, json: () => Promise.resolve({}) })
+            await client.processExceptions(toItems([createRequest()]))
+
+            // Circuit is now open. Next call has 3 events — probe uses 1.
+            const requests = [createRequest({ uuid: 'a' }), createRequest({ uuid: 'b' }), createRequest({ uuid: 'c' })]
+            const fetchBodies: string[] = []
+            mockFetch.mockImplementation((_url: string, opts: { body: string }) => {
+                fetchBodies.push(opts.body)
+                const parsed = parseJSON(opts.body)
+                return Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve(parsed.map((r: any) => createResponse({ uuid: r.uuid }))),
+                })
+            })
+
+            const results = await client.processExceptions(toItems(requests))
+
+            // All 3 events should succeed
+            expect(results).toHaveLength(3)
+            expect(results.every((r) => r.status === 'success')).toBe(true)
+
+            // The probe should have sent 1 event, then the remainder sends 2.
+            // Without the fix, the remainder would re-send all 3.
+            const sentBatches = fetchBodies.map((b) => parseJSON(b).length)
+            expect(sentBatches).toEqual([1, 2])
+        })
+
         it('does not count non-retriable failures toward the threshold', async () => {
             const client = createCBClient(2)
 

--- a/nodejs/src/ingestion/error-tracking/cymbal/client.test.ts
+++ b/nodejs/src/ingestion/error-tracking/cymbal/client.test.ts
@@ -50,12 +50,22 @@ describe('CymbalClient', () => {
         ...overrides,
     })
 
+    // High threshold so the CB doesn't interfere with non-CB tests
+    const defaultCBConfig = {
+        name: 'test',
+        failureThreshold: 1000,
+        initialBackoffMs: 1,
+        maxBackoffMs: 10,
+        probeSize: 10,
+    }
+
     /** Create a client with a single-IP DNS response (no sticky routing). */
     const createClient = (fetchMock: jest.Mock = mockFetch) => {
         return new CymbalClient({
             baseUrl: 'http://cymbal.example.com:8080',
             timeoutMs: 5000,
             maxBodyBytes: 1_800_000,
+            circuitBreaker: defaultCBConfig,
             fetch: fetchMock as FetchFunction,
             dnsResolve: jest.fn().mockResolvedValue(['1.2.3.4']) as DnsResolveFunction,
         })
@@ -70,6 +80,7 @@ describe('CymbalClient', () => {
             baseUrl: 'http://cymbal.example.com:8080',
             timeoutMs: 5000,
             maxBodyBytes: 1_800_000,
+            circuitBreaker: defaultCBConfig,
             fetch: fetchMock as FetchFunction,
             dnsResolve: jest.fn().mockResolvedValue(pods) as DnsResolveFunction,
         })
@@ -280,7 +291,7 @@ describe('CymbalClient', () => {
                 baseUrl: 'http://cymbal.example.com:8080',
                 timeoutMs: 5000,
                 maxBodyBytes: 1_800_000,
-
+                circuitBreaker: defaultCBConfig,
                 fetch: mockFetch as FetchFunction,
                 dnsResolve: jest.fn().mockRejectedValue(new Error('DNS failed')) as DnsResolveFunction,
             })
@@ -317,7 +328,7 @@ describe('CymbalClient', () => {
                 baseUrl: 'http://cymbal.example.com:8080',
                 timeoutMs: 5000,
                 maxBodyBytes: 150,
-
+                circuitBreaker: defaultCBConfig,
                 fetch: mockFetch as FetchFunction,
                 dnsResolve: jest.fn().mockResolvedValue(['1.2.3.4']) as DnsResolveFunction,
             })
@@ -348,7 +359,7 @@ describe('CymbalClient', () => {
                 baseUrl: 'http://cymbal.example.com:8080',
                 timeoutMs: 5000,
                 maxBodyBytes: 500,
-
+                circuitBreaker: defaultCBConfig,
                 fetch: mockFetch as FetchFunction,
                 dnsResolve: jest.fn().mockResolvedValue(['1.2.3.4']) as DnsResolveFunction,
             })
@@ -379,7 +390,7 @@ describe('CymbalClient', () => {
                 baseUrl: 'http://cymbal.example.com:8080',
                 timeoutMs: 5000,
                 maxBodyBytes: 50,
-
+                circuitBreaker: defaultCBConfig,
                 fetch: mockFetch as FetchFunction,
                 dnsResolve: jest.fn().mockResolvedValue(['1.2.3.4']) as DnsResolveFunction,
             })
@@ -405,7 +416,7 @@ describe('CymbalClient', () => {
                 baseUrl: 'http://cymbal.example.com:8080',
                 timeoutMs: 5000,
                 maxBodyBytes: 150,
-
+                circuitBreaker: defaultCBConfig,
                 fetch: mockFetch as FetchFunction,
                 dnsResolve: jest.fn().mockResolvedValue(['1.2.3.4']) as DnsResolveFunction,
             })
@@ -665,6 +676,97 @@ describe('CymbalClient', () => {
             const client = createClient()
             mockFetch.mockRejectedValueOnce(new Error('Network error'))
             expect(await client.healthCheck()).toBe(false)
+        })
+    })
+
+    describe('circuit breaker', () => {
+        const createCBClient = (threshold: number = 3) => {
+            return new CymbalClient({
+                baseUrl: 'http://cymbal.example.com:8080',
+                timeoutMs: 5000,
+                maxBodyBytes: 1_800_000,
+                circuitBreaker: {
+                    name: 'test-cymbal',
+                    failureThreshold: threshold,
+                    initialBackoffMs: 1,
+                    maxBackoffMs: 10,
+                    probeSize: 10,
+                },
+                fetch: mockFetch as FetchFunction,
+                dnsResolve: jest.fn().mockResolvedValue(['1.2.3.4']) as DnsResolveFunction,
+            })
+        }
+
+        it('trips after consecutive all-fail retriable batches reach the threshold', async () => {
+            const client = createCBClient(2)
+
+            // All-fail with retriable errors (5xx)
+            mockFetch.mockResolvedValue({ status: 500, json: () => Promise.resolve({}) })
+
+            // First call — below threshold
+            await client.processExceptions(toItems([createRequest()]))
+            // Second call — reaches threshold, circuit opens
+            await client.processExceptions(toItems([createRequest()]))
+
+            // Third call — circuit is open, blocks in waitForRecovery.
+            // Probe succeeds, then full batch succeeds.
+            let callCount = 0
+            mockFetch.mockImplementation(() => {
+                callCount++
+                if (callCount <= 1) {
+                    // First probe fails
+                    return Promise.resolve({ status: 500, json: () => Promise.resolve({}) })
+                }
+                // Second probe + full batch succeed
+                return Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve([createResponse()]),
+                })
+            })
+
+            const results = await client.processExceptions(toItems([createRequest()]))
+            expect(results[0].status).toBe('success')
+        })
+
+        it('resets failure count when some events succeed', async () => {
+            const client = createCBClient(3)
+
+            // Two all-fail calls
+            mockFetch.mockResolvedValue({ status: 500, json: () => Promise.resolve({}) })
+            await client.processExceptions(toItems([createRequest()]))
+            await client.processExceptions(toItems([createRequest()]))
+
+            // Partial success — resets the counter
+            mockFetch.mockResolvedValueOnce({
+                status: 200,
+                json: () => Promise.resolve([createResponse()]),
+            })
+            await client.processExceptions(toItems([createRequest()]))
+
+            // Two more all-fails — still below threshold (count reset to 0)
+            mockFetch.mockResolvedValue({ status: 500, json: () => Promise.resolve({}) })
+            await client.processExceptions(toItems([createRequest()]))
+            const results = await client.processExceptions(toItems([createRequest()]))
+
+            // Should return failed, not block — circuit not open (only 2 failures)
+            expect(results[0].status).toBe('failed')
+        })
+
+        it('does not count non-retriable failures toward the threshold', async () => {
+            const client = createCBClient(2)
+
+            // 4xx errors are non-retriable — should not count
+            mockFetch.mockResolvedValue({ status: 400, json: () => Promise.resolve({}) })
+            await client.processExceptions(toItems([createRequest()]))
+            await client.processExceptions(toItems([createRequest()]))
+            await client.processExceptions(toItems([createRequest()]))
+
+            // Next call with retriable error — should be first failure, not third
+            mockFetch.mockResolvedValueOnce({ status: 500, json: () => Promise.resolve({}) })
+            const results = await client.processExceptions(toItems([createRequest()]))
+
+            // Should return failed without blocking (only 1 retriable failure, threshold is 2)
+            expect(results[0].status).toBe('failed')
         })
     })
 })

--- a/nodejs/src/ingestion/error-tracking/cymbal/client.ts
+++ b/nodejs/src/ingestion/error-tracking/cymbal/client.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 import { logger } from '~/utils/logger'
 import { FetchResponse, internalFetch } from '~/utils/request'
 
+import { CircuitBreaker, CircuitBreakerConfig } from '../../utils/circuit-breaker'
 import { CymbalRequest, CymbalResponse } from './types'
 
 /** Zod schema for validating Cymbal API responses */
@@ -68,6 +69,9 @@ export interface CymbalClientConfig {
     timeoutMs: number
     /** Target max body size in bytes for proactive chunking. */
     maxBodyBytes: number
+    /** Circuit breaker config. When the service is down, the client blocks
+     *  and probes rather than returning failures. */
+    circuitBreaker: CircuitBreakerConfig
     /** Custom fetch implementation for testing. Defaults to internalFetch. */
     fetch?: FetchFunction
     /** Custom DNS resolution function for testing. */
@@ -136,12 +140,14 @@ export class CymbalClient {
     private maxBodyBytes: number
     private fetch: FetchFunction
     private dnsResolve: DnsResolveFunction
+    private circuitBreaker: CircuitBreaker
 
     constructor(config: CymbalClientConfig) {
         this.timeoutMs = config.timeoutMs
         this.maxBodyBytes = config.maxBodyBytes
         this.fetch = config.fetch ?? internalFetch
         this.dnsResolve = config.dnsResolve ?? defaultDnsResolve
+        this.circuitBreaker = new CircuitBreaker(config.circuitBreaker)
 
         const parsed = new URL(config.baseUrl)
         this.hostname = parsed.hostname
@@ -180,6 +186,30 @@ export class CymbalClient {
         if (items.length === 0) {
             return []
         }
+
+        // If the circuit is open, block and probe until the service recovers
+        // rather than making a request that will almost certainly fail.
+        if (this.circuitBreaker.isOpen()) {
+            await this.circuitBreaker.waitForRecovery(async (probeSize) => {
+                const probeResults = await this.doProcessExceptions(items.slice(0, probeSize))
+                return probeResults.some((r) => r.status === 'success')
+            })
+        }
+
+        const results = await this.doProcessExceptions(items)
+
+        if (results.some((r) => r.status === 'success')) {
+            this.circuitBreaker.recordSuccess()
+        } else if (results.every((r) => r.status === 'failed' && r.retriable)) {
+            this.circuitBreaker.recordFailure()
+        }
+
+        return results
+    }
+
+    private async doProcessExceptions(
+        items: { request: CymbalRequest; estimatedSize: number }[]
+    ): Promise<CymbalEventResult[]> {
         cymbalBatchSizeHistogram.observe(items.length)
 
         let endpoints: string[]

--- a/nodejs/src/ingestion/error-tracking/cymbal/client.ts
+++ b/nodejs/src/ingestion/error-tracking/cymbal/client.ts
@@ -189,11 +189,24 @@ export class CymbalClient {
 
         // If the circuit is open, block and probe until the service recovers
         // rather than making a request that will almost certainly fail.
+        // NOTE: concurrent callers each probe independently. This is fine
+        // for now since the consumer processes one batch at a time, but if
+        // we move to concurrent batches we should serialize probing behind
+        // a shared promise.
         if (this.circuitBreaker.isOpen()) {
+            let probeResults: CymbalEventResult[] = []
             await this.circuitBreaker.waitForRecovery(async (probeSize) => {
-                const probeResults = await this.doProcessExceptions(items.slice(0, probeSize))
+                probeResults = await this.doProcessExceptions(items.slice(0, probeSize))
                 return probeResults.some((r) => r.status === 'success')
             })
+
+            // The probe already processed some events — only process the rest.
+            const remainingResults = await this.doProcessExceptions(items.slice(probeResults.length))
+            const combined = [...probeResults, ...remainingResults]
+            if (combined.some((r) => r.status === 'success')) {
+                this.circuitBreaker.recordSuccess()
+            }
+            return combined
         }
 
         const results = await this.doProcessExceptions(items)

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.test.ts
@@ -149,6 +149,10 @@ describe('ErrorTrackingConsumer', () => {
             cymbalBaseUrl: hub.ERROR_TRACKING_CYMBAL_BASE_URL,
             cymbalTimeoutMs: hub.ERROR_TRACKING_CYMBAL_TIMEOUT_MS,
             cymbalMaxBodyBytes: hub.ERROR_TRACKING_CYMBAL_MAX_BODY_BYTES,
+            cymbalCircuitBreakerFailureThreshold: 3,
+            cymbalCircuitBreakerInitialBackoffMs: 1_000,
+            cymbalCircuitBreakerMaxBackoffMs: 30_000,
+            cymbalCircuitBreakerProbeSize: 10,
             lane: hub.INGESTION_LANE ?? ('main' as const),
             overflowEnabled:
                 !!hub.ERROR_TRACKING_CONSUMER_OVERFLOW_TOPIC &&

--- a/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-consumer.ts
@@ -40,6 +40,10 @@ export interface ErrorTrackingConsumerOptions {
     cymbalBaseUrl: string
     cymbalTimeoutMs: number
     cymbalMaxBodyBytes: number
+    cymbalCircuitBreakerFailureThreshold: number
+    cymbalCircuitBreakerInitialBackoffMs: number
+    cymbalCircuitBreakerMaxBackoffMs: number
+    cymbalCircuitBreakerProbeSize: number
     lane: IngestionLane
     overflowEnabled: boolean
     overflowBucketCapacity: number
@@ -118,6 +122,13 @@ export class ErrorTrackingConsumer {
             baseUrl: config.cymbalBaseUrl,
             timeoutMs: config.cymbalTimeoutMs,
             maxBodyBytes: config.cymbalMaxBodyBytes,
+            circuitBreaker: {
+                name: 'cymbal',
+                failureThreshold: this.config.cymbalCircuitBreakerFailureThreshold,
+                initialBackoffMs: config.cymbalCircuitBreakerInitialBackoffMs,
+                maxBackoffMs: config.cymbalCircuitBreakerMaxBackoffMs,
+                probeSize: config.cymbalCircuitBreakerProbeSize,
+            },
         })
 
         this.promiseScheduler = new PromiseScheduler()

--- a/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.test.ts
+++ b/nodejs/src/ingestion/error-tracking/error-tracking-pipeline.test.ts
@@ -649,8 +649,9 @@ describe('ErrorTrackingPipeline', () => {
             // the service is fully down.
             await runErrorTrackingPipeline(pipeline, [message])
 
-            // Cymbal was retried (default 3 attempts)
-            expect(mockCymbalClient.processExceptions).toHaveBeenCalledTimes(3)
+            // Cymbal was retried (default 4 attempts — one more than the CB
+            // threshold so the final retry hits the open circuit)
+            expect(mockCymbalClient.processExceptions).toHaveBeenCalledTimes(4)
             // Processing should not continue past Cymbal
             expect(mockHogTransformer.transformEventAndProduceMessages).not.toHaveBeenCalled()
             // Event should not be produced to output topic

--- a/nodejs/src/ingestion/pipelines/batch-retry.ts
+++ b/nodejs/src/ingestion/pipelines/batch-retry.ts
@@ -23,7 +23,10 @@ export type BatchRetryStep<TIn, TOut, R extends string = never> = (
 ) => Promise<BatchRetryStepResult<TOut, R>[]>
 
 export interface BatchRetryOptions {
-    /** Total number of attempts per failed event group. Defaults to 3. */
+    /** Total number of attempts per failed event group. Defaults to 4.
+     *  Set one higher than the dependency's circuit breaker threshold so
+     *  the final retry hits the open circuit and blocks until recovery
+     *  instead of overflowing. */
     maxAttempts?: number
     /** Base sleep between retries in ms. Doubles each attempt. Defaults to 100. */
     retrySleepMs?: number
@@ -54,15 +57,17 @@ const dlqCounter = new Counter({
  *    - Non-retriable → DLQ (event is broken, retrying won't help)
  *    - Retriable → overflow (service may be degraded for these events)
  *
- * Designed to work with client-level resilience patterns: when a dependency
- * is down, the client can fast-fail or block, and the retry wrapper's
- * subsequent attempts will reflect the client's behavior.
+ * Works with a client-level circuit breaker: the client tracks failures
+ * from each call. When its threshold is reached, the circuit opens and
+ * subsequent calls block until recovery. This means the retry wrapper's
+ * later attempts hit an open circuit and wait rather than hammering a
+ * dead service.
  */
 export function withBatchRetry<TIn, TOut, R extends string = never>(
     step: BatchRetryStep<TIn, TOut, R>,
     options: BatchRetryOptions = {}
 ): BatchProcessingStep<TIn, TOut, OverflowOutput | DlqOutput | R> {
-    const maxAttempts = options.maxAttempts ?? 3
+    const maxAttempts = options.maxAttempts ?? 4
     const baseSleepMs = options.retrySleepMs ?? 100
     const maxSleepMs = options.maxRetrySleepMs ?? 10_000
     const stepName = step.name || 'anonymousBatchRetryStep'

--- a/nodejs/src/ingestion/utils/circuit-breaker.test.ts
+++ b/nodejs/src/ingestion/utils/circuit-breaker.test.ts
@@ -1,0 +1,119 @@
+import { CircuitBreaker } from './circuit-breaker'
+
+jest.mock('~/utils/logger', () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}))
+
+jest.mock('prom-client', () => {
+    const actual = jest.requireActual('prom-client')
+    const registry = new actual.Registry()
+    return {
+        ...actual,
+        Counter: class FakeCounter {
+            labels() {
+                return { inc: jest.fn() }
+            }
+        },
+        Gauge: class FakeGauge {
+            labels() {
+                return { set: jest.fn() }
+            }
+        },
+        register: registry,
+    }
+})
+
+const defaultConfig = {
+    name: 'test',
+    failureThreshold: 3,
+    initialBackoffMs: 1,
+    maxBackoffMs: 10,
+    probeSize: 10,
+}
+
+describe('CircuitBreaker', () => {
+    it('starts closed', () => {
+        const cb = new CircuitBreaker(defaultConfig)
+        expect(cb.isOpen()).toBe(false)
+        expect(cb.getState()).toBe('closed')
+    })
+
+    it('does not open below the failure threshold', () => {
+        const cb = new CircuitBreaker(defaultConfig)
+        cb.recordFailure()
+        cb.recordFailure()
+        expect(cb.isOpen()).toBe(false)
+    })
+
+    it('opens at the failure threshold', () => {
+        const cb = new CircuitBreaker(defaultConfig)
+        cb.recordFailure()
+        cb.recordFailure()
+        cb.recordFailure()
+        expect(cb.isOpen()).toBe(true)
+    })
+
+    it('closes on success', () => {
+        const cb = new CircuitBreaker({ ...defaultConfig, failureThreshold: 1 })
+        cb.recordFailure()
+        expect(cb.isOpen()).toBe(true)
+
+        cb.recordSuccess()
+        expect(cb.isOpen()).toBe(false)
+    })
+
+    it('resets failure count on success', () => {
+        const cb = new CircuitBreaker(defaultConfig)
+        cb.recordFailure()
+        cb.recordFailure()
+        cb.recordSuccess()
+
+        cb.recordFailure()
+        cb.recordFailure()
+        expect(cb.isOpen()).toBe(false)
+    })
+
+    describe('waitForRecovery', () => {
+        it('probes and closes circuit when probe succeeds', async () => {
+            const cb = new CircuitBreaker({ ...defaultConfig, failureThreshold: 1 })
+            cb.recordFailure()
+
+            const probe = jest.fn().mockResolvedValue(true)
+            await cb.waitForRecovery(probe)
+
+            expect(cb.isOpen()).toBe(false)
+            expect(probe).toHaveBeenCalledWith(defaultConfig.probeSize)
+        })
+
+        it('retries probe with backoff until success', async () => {
+            const cb = new CircuitBreaker({ ...defaultConfig, failureThreshold: 1 })
+            cb.recordFailure()
+
+            let callCount = 0
+            const probe = jest.fn().mockImplementation(() => {
+                callCount++
+                return Promise.resolve(callCount >= 3)
+            })
+
+            await cb.waitForRecovery(probe)
+
+            expect(probe).toHaveBeenCalledTimes(3)
+            expect(cb.isOpen()).toBe(false)
+        })
+
+        it('passes probeSize to the probe function', async () => {
+            const cb = new CircuitBreaker({ ...defaultConfig, failureThreshold: 1, probeSize: 42 })
+            cb.recordFailure()
+
+            const probe = jest.fn().mockResolvedValue(true)
+            await cb.waitForRecovery(probe)
+
+            expect(probe).toHaveBeenCalledWith(42)
+        })
+    })
+})

--- a/nodejs/src/ingestion/utils/circuit-breaker.ts
+++ b/nodejs/src/ingestion/utils/circuit-breaker.ts
@@ -1,0 +1,117 @@
+import { Counter, Gauge } from 'prom-client'
+
+import { logger } from '~/utils/logger'
+
+const circuitBreakerState = new Gauge({
+    name: 'ingestion_circuit_breaker_state',
+    help: 'Circuit breaker state: 0 = closed, 1 = open',
+    labelNames: ['name'],
+})
+
+const circuitBreakerProbeCounter = new Counter({
+    name: 'ingestion_circuit_breaker_probes_total',
+    help: 'Number of circuit breaker probes attempted',
+    labelNames: ['name', 'result'],
+})
+
+export interface CircuitBreakerConfig {
+    /** Identifier for metrics and logging. */
+    name: string
+    /** Consecutive failures before the circuit opens. Should match the
+     *  retry wrapper's maxAttempts so the circuit trips as retries exhaust. */
+    failureThreshold: number
+    /** Initial backoff in ms between probes when the circuit is open. */
+    initialBackoffMs: number
+    /** Maximum backoff in ms between probes. */
+    maxBackoffMs: number
+    /** Number of items to include in each probe attempt. */
+    probeSize: number
+}
+
+/**
+ * Circuit breaker for external service dependencies.
+ *
+ * Tracks consecutive failures. When the failure threshold is reached,
+ * the circuit opens. While open, callers should use waitForRecovery()
+ * to block until a probe succeeds.
+ *
+ * Designed to work with a retry wrapper: the wrapper retries N times,
+ * each retry increments the failure count, and the circuit trips on
+ * the Nth failure. The next call sees the circuit open and blocks
+ * instead of making another doomed request.
+ */
+export class CircuitBreaker {
+    private open: boolean = false
+    private consecutiveFailures: number = 0
+    private config: CircuitBreakerConfig
+
+    constructor(config: CircuitBreakerConfig) {
+        this.config = config
+    }
+
+    /**
+     * Record a failure. Opens the circuit when the threshold is reached.
+     */
+    recordFailure(): void {
+        this.consecutiveFailures++
+
+        if (this.consecutiveFailures >= this.config.failureThreshold && !this.open) {
+            this.open = true
+            circuitBreakerState.labels(this.config.name).set(1)
+            logger.warn('⚠️', 'circuit_breaker_opened', {
+                name: this.config.name,
+                consecutiveFailures: this.consecutiveFailures,
+            })
+        }
+    }
+
+    /**
+     * Record a success. Resets the failure count and closes the circuit.
+     */
+    recordSuccess(): void {
+        this.consecutiveFailures = 0
+        if (this.open) {
+            this.open = false
+            circuitBreakerState.labels(this.config.name).set(0)
+            logger.info('✅', 'circuit_breaker_closed', { name: this.config.name })
+        }
+    }
+
+    isOpen(): boolean {
+        return this.open
+    }
+
+    getState(): string {
+        return this.open ? 'open' : 'closed'
+    }
+
+    /**
+     * Block until the probe function returns true, indicating the service
+     * has recovered. Uses exponential backoff between probe attempts.
+     * Closes the circuit when the probe succeeds.
+     */
+    async waitForRecovery(probe: (probeSize: number) => Promise<boolean>): Promise<void> {
+        let backoffMs = this.config.initialBackoffMs
+
+        while (this.open) {
+            await new Promise((resolve) => setTimeout(resolve, backoffMs))
+
+            logger.info('🔍', 'circuit_breaker_probing', {
+                name: this.config.name,
+                probeSize: this.config.probeSize,
+                backoffMs,
+            })
+
+            const succeeded = await probe(this.config.probeSize)
+
+            if (succeeded) {
+                circuitBreakerProbeCounter.labels(this.config.name, 'success').inc()
+                this.recordSuccess()
+                return
+            }
+
+            circuitBreakerProbeCounter.labels(this.config.name, 'failed').inc()
+            backoffMs = Math.min(backoffMs * 2, this.config.maxBackoffMs)
+        }
+    }
+}

--- a/nodejs/src/servers/error-tracking-server.ts
+++ b/nodejs/src/servers/error-tracking-server.ts
@@ -194,6 +194,12 @@ export class ErrorTrackingServer implements NodeServer {
                     cymbalBaseUrl: this.config.ERROR_TRACKING_CYMBAL_BASE_URL,
                     cymbalTimeoutMs: this.config.ERROR_TRACKING_CYMBAL_TIMEOUT_MS,
                     cymbalMaxBodyBytes: this.config.ERROR_TRACKING_CYMBAL_MAX_BODY_BYTES,
+                    cymbalCircuitBreakerFailureThreshold:
+                        this.config.ERROR_TRACKING_CYMBAL_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+                    cymbalCircuitBreakerInitialBackoffMs:
+                        this.config.ERROR_TRACKING_CYMBAL_CIRCUIT_BREAKER_INITIAL_BACKOFF_MS,
+                    cymbalCircuitBreakerMaxBackoffMs: this.config.ERROR_TRACKING_CYMBAL_CIRCUIT_BREAKER_MAX_BACKOFF_MS,
+                    cymbalCircuitBreakerProbeSize: this.config.ERROR_TRACKING_CYMBAL_CIRCUIT_BREAKER_PROBE_SIZE,
                     lane: this.config.INGESTION_LANE ?? 'main',
                     overflowEnabled:
                         !!this.config.ERROR_TRACKING_CONSUMER_OVERFLOW_TOPIC &&


### PR DESCRIPTION
## Problem

building on top of https://github.com/PostHog/posthog/pull/54596 - add a circuit breaker within the cymbal client. this will need to be paired with an increase in the kafka consume timeout, future work can involve threading this up to the consumer so we can pause consumption without that contention.