### PR TITLE
fix(hogli): trigger shell mode for commands with variable refs

### DIFF
--- a/common/hogli/core/command_types.py
+++ b/common/hogli/core/command_types.py
@@ -301,9 +301,8 @@ class DirectCommand(Command):
     def execute(self, *args: str) -> None:
         """Execute the shell command with any passed arguments."""
         cmd_str = self.config.get("cmd", "")
-        # Use shell=True if command contains shell operators, variable refs, or is multiline
-        has_operators = any(op in cmd_str for op in [" && ", " || ", "|", "\n", "$"])
-        if has_operators:
+        needs_shell = any(op in cmd_str for op in [" && ", " || ", "|", "\n", "$"])
+        if needs_shell:
             # For shell commands, pass args as positional parameters using sh -c
             if args:
                 # Pass args as positional parameters: _ is placeholder for $0, then actual args as $1, $2, etc.

--- a/common/hogli/core/command_types.py
+++ b/common/hogli/core/command_types.py
@@ -301,8 +301,8 @@ class DirectCommand(Command):
     def execute(self, *args: str) -> None:
         """Execute the shell command with any passed arguments."""
         cmd_str = self.config.get("cmd", "")
-        # Use shell=True if command contains shell operators or is multiline
-        has_operators = any(op in cmd_str for op in [" && ", " || ", "|", "\n"])
+        # Use shell=True if command contains shell operators, variable refs, or is multiline
+        has_operators = any(op in cmd_str for op in [" && ", " || ", "|", "\n", "$"])
         if has_operators:
             # For shell commands, pass args as positional parameters using sh -c
             if args:

--- a/common/hogli/tests/test_command_types.py
+++ b/common/hogli/tests/test_command_types.py
@@ -53,9 +53,19 @@ class TestDirectCommandExecution:
         assert "arg1" in cmd_str
         assert "'arg with spaces'" in cmd_str or '"arg with spaces"' in cmd_str
 
+    @pytest.mark.parametrize(
+        "cmd_str",
+        [
+            'pnpm exec oxfmt "$@"',
+            "echo $1",
+            "echo $HOME",
+        ],
+        ids=["dollar_at", "dollar_1", "dollar_env"],
+    )
     @patch("hogli.core.command_types._run")
-    def test_shell_variables_trigger_shell_mode(self, mock_run: MagicMock) -> None:
-        cmd = DirectCommand("test", {"cmd": 'pnpm exec oxfmt "$@"'})
+    def test_shell_variables_trigger_shell_mode(self, mock_run: MagicMock, cmd_str: str) -> None:
+        """Commands with shell variable references use shell=True."""
+        cmd = DirectCommand("test", {"cmd": cmd_str})
 
         cmd.execute("src/")
 

--- a/common/hogli/tests/test_command_types.py
+++ b/common/hogli/tests/test_command_types.py
@@ -54,6 +54,16 @@ class TestDirectCommandExecution:
         assert "'arg with spaces'" in cmd_str or '"arg with spaces"' in cmd_str
 
     @patch("hogli.core.command_types._run")
+    def test_shell_variables_trigger_shell_mode(self, mock_run: MagicMock) -> None:
+        cmd = DirectCommand("test", {"cmd": 'pnpm exec oxfmt "$@"'})
+
+        cmd.execute("src/")
+
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args
+        assert call_args[1]["shell"] is True
+
+    @patch("hogli.core.command_types._run")
     def test_appends_extra_args_to_simple_commands(self, mock_run: MagicMock) -> None:
         """Test extra args are appended to list-format commands."""
         cmd = DirectCommand("test", {"cmd": "pytest"})


### PR DESCRIPTION
## Problem

`DirectCommand.execute()` only uses `shell=True` when the command string contains operators (`&&`, `||`, `|`, `\n`). Commands that use `$@` or `$1` without those operators get run as a list — no shell expansion, so `$@` is passed as a literal string. `format:yaml` is affected today.

## Changes

Add `$` to the operator detection list so any command referencing shell variables gets routed through `shell=True`.

## How did you test this code?

Unit test added covering the fix. Existing tests pass.

Found during standalone wheel testing of the hogli framework — the bug affects the current master too.

no

## 🤖 LLM context

Found while reviewing #51686 (hogli-to-tools-v2). Built a wheel, installed in an isolated temp repo, and exercised all command types — this bug surfaced for any `cmd:` entry using `$@`/`$1` without shell operators.