### PR TITLE
feat(legal-documents): split PandaDoc envelope creation and send via `document.draft` webhook

### DIFF
--- a/posthog/hogql/database/schema/util/test/__snapshots__/test_session_v2_where_clause_extractor.ambr
+++ b/posthog/hogql/database/schema/util/test/__snapshots__/test_session_v2_where_clause_extractor.ambr
@@ -19,7 +19,6 @@
                   WHERE
                       and(equals(events.team_id, <TEAM_ID>), equals(events.event, %(hogql_val_4)s), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_5)s, 6, %(hogql_val_6)s)), lessOrEquals(events.timestamp, toDateTime64(%(hogql_val_7)s, 6, %(hogql_val_8)s))))))
       GROUP BY
-          raw_sessions.session_id_v7,
           raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
   WHERE
       and(equals(events.team_id, <TEAM_ID>), equals(events.event, %(hogql_val_9)s), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_10)s, 6, %(hogql_val_11)s)), lessOrEquals(events.timestamp, toDateTime64(%(hogql_val_12)s, 6, %(hogql_val_13)s)), ifNull(equals(events__session.`$entry_pathname`, %(hogql_val_14)s), 0))
@@ -41,7 +40,6 @@
       WHERE
           and(equals(raw_sessions.team_id, <TEAM_ID>), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(%(hogql_val_2)s, toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(%(hogql_val_3)s, toIntervalDay(3))))
       GROUP BY
-          raw_sessions.session_id_v7,
           raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
   WHERE
       and(equals(events.team_id, <TEAM_ID>), equals(events.event, %(hogql_val_4)s), greaterOrEquals(events.timestamp, toDateTime64(%(hogql_val_5)s, 6, %(hogql_val_6)s)), lessOrEquals(events.timestamp, toDateTime64(%(hogql_val_7)s, 6, %(hogql_val_8)s)), ifNull(equals(events__session.`$entry_pathname`, %(hogql_val_9)s), 0))

--- a/products/legal_documents/backend/facade/api.py
+++ b/products/legal_documents/backend/facade/api.py
@@ -66,13 +66,42 @@ def create_document(data: contracts.CreateLegalDocumentInput) -> contracts.Legal
         representative_email=data.representative_email,
     )
 
-    # Fire and forget: PandaDoc + Slack never block the response. If PandaDoc
-    # fails we still 201 — ops gets a Slack ping (best-effort) and the row is
-    # left without a pandadoc_document_id for the admin "resend" action later.
-    logic.submit_to_pandadoc(document)
-    logic.notify_slack_on_submit(document)
+    # Fire and forget: PandaDoc never blocks the response. The envelope lands
+    # in `document.uploaded` state and becomes dispatchable asynchronously —
+    # the `document.draft` webhook triggers the actual send + Slack ping via
+    # `mark_envelope_ready_by_pandadoc_document_id`.
+    logic.create_pandadoc_envelope(document)
     logic.fire_legal_document_submitted_event(document, distinct_id=data.distinct_id)
 
+    return _to_dto(document)
+
+
+def mark_envelope_ready_by_pandadoc_document_id(
+    *,
+    pandadoc_document_id: str,
+    template_id: str,
+) -> contracts.LegalDocumentDTO | None:
+    """
+    Entry point from the PandaDoc `document.draft` webhook — the envelope
+    finished template processing and is ready to send. Dispatch the signing
+    email and fire the Slack "submitted" notification.
+
+    Idempotent: if the envelope has already been dispatched (row is already
+    signed, or the send call fails because PandaDoc has moved past draft)
+    we quietly skip the side effects.
+    """
+    document = logic.get_by_pandadoc_document_id(pandadoc_document_id)
+    if document is None:
+        return None
+    if not logic.template_id_matches_document(document, template_id):
+        return None
+    if document.status == LegalDocumentStatus.SIGNED:
+        # Envelope already completed — the draft event is a late/replayed
+        # delivery; nothing left for us to do.
+        return _to_dto(document)
+    sent = logic.send_pandadoc_envelope(document)
+    if sent:
+        logic.notify_slack_on_submit(document)
     return _to_dto(document)
 
 

--- a/products/legal_documents/backend/logic/__init__.py
+++ b/products/legal_documents/backend/logic/__init__.py
@@ -31,6 +31,10 @@ logger = structlog.get_logger(__name__)
 # Addon types that entitle an organization to a BAA.
 BAA_ADDON_TYPES = frozenset({"boost", "scale", "enterprise"})
 
+# PostHog-side CC on every signing envelope. Lives here rather than on the
+# PandaDoc client so the client stays generic and reusable.
+POSTHOG_SIGNING_CC_EMAIL = "sales@posthog.com"
+
 
 def _pandadoc_template_id_for(document_type: str) -> str:
     """
@@ -125,15 +129,20 @@ def set_pandadoc_document_id(document: LegalDocument, pandadoc_document_id: str)
     return document
 
 
-def submit_to_pandadoc(document: LegalDocument) -> str | None:
+def create_pandadoc_envelope(document: LegalDocument) -> str | None:
     """
-    Create the envelope on PandaDoc and send the signing email. Returns the
-    PandaDoc document id (also persisted on the row), or None if PandaDoc isn't
-    configured / the call failed — the caller decides what to do with the miss.
+    Create the envelope on PandaDoc and persist its uuid on the row.
 
-    We never re-raise to the caller: the document is already persisted, the
-    customer gets an error-free 201 from the API, and ops sees a Slack + log
-    trace when we couldn't reach PandaDoc so they can re-send manually.
+    The envelope lands in PandaDoc's `document.uploaded` state, which isn't
+    dispatchable yet — PandaDoc processes the template asynchronously and
+    emits a `document.draft` webhook once it's ready. `send_pandadoc_envelope`
+    runs from that webhook. We don't block the user's create call waiting for
+    it.
+
+    Returns the PandaDoc document id or None when PandaDoc isn't configured /
+    the call failed; the caller stays on the happy path either way so a
+    failure just leaves the row without a `pandadoc_document_id` (ops can
+    re-trigger later).
     """
     template_id = _pandadoc_template_id_for(document.document_type)
     if not template_id:
@@ -146,20 +155,25 @@ def submit_to_pandadoc(document: LegalDocument) -> str | None:
 
     client = pandadoc_client.PandaDocClient()
     try:
-        # Each PandaDoc template has one recipient with role "Client". PandaDoc
-        # fills the Client.Email / Client.Company / Client.StreetAddress fields
-        # in the document body directly from that recipient's contact data.
+        # The client-facing recipient has role "Client"; PandaDoc fills the
+        # template's `[Client.Email]` token from the recipient's email. The
+        # remaining template tokens (`[Client.Company]`, `[Client.StreetAddress]`)
+        # aren't auto-populated — we have to pass them explicitly.
         created = client.create_document_from_template(
             template_id=template_id,
             name=f"PostHog {document.document_type} — {document.company_name}",
             recipients=[
-                pandadoc_client.PandaDocSenderPostHog(),
                 pandadoc_client.PandaDocRecipient(
-                    email=document.representative_email,
-                    company=document.company_name,
-                    street_address=document.company_address,
+                    email=POSTHOG_SIGNING_CC_EMAIL, role=pandadoc_client.PandaDocRole.POSTHOG
+                ),
+                pandadoc_client.PandaDocRecipient(
+                    email=document.representative_email, role=pandadoc_client.PandaDocRole.CLIENT
                 ),
             ],
+            tokens={
+                "Client.Company": document.company_name,
+                "Client.StreetAddress": document.company_address,
+            },
             metadata={
                 "legal_document_id": str(document.id),
                 "organization_id": str(document.organization_id),
@@ -167,8 +181,35 @@ def submit_to_pandadoc(document: LegalDocument) -> str | None:
             },
         )
         set_pandadoc_document_id(document, created.id)
+        return created.id
+    except pandadoc_client.PandaDocError as exc:
+        logger.exception(
+            "legal_document_pandadoc_create_failed",
+            document_id=str(document.id),
+            error=str(exc),
+        )
+        capture_exception(exc, additional_properties={"legal_document_id": str(document.id)})
+        return None
+
+
+def send_pandadoc_envelope(document: LegalDocument) -> bool:
+    """
+    Dispatch the signing email for a previously-created PandaDoc envelope.
+    Called from the `document.draft` webhook once PandaDoc has finished
+    processing the template and the envelope is actually sendable.
+
+    Returns True when the send succeeded, False otherwise. Never re-raises:
+    PandaDoc will also reject a second send on a doc that's already past
+    `document.draft` (duplicate webhook delivery), which we silently swallow.
+    """
+    if not document.pandadoc_document_id:
+        logger.warning("legal_document_pandadoc_send_missing_envelope_id", document_id=str(document.id))
+        return False
+
+    client = pandadoc_client.PandaDocClient()
+    try:
         client.send_document(
-            document_id=created.id,
+            document_id=document.pandadoc_document_id,
             subject=f"Please sign: PostHog {document.document_type}",
             message=(
                 f"Hi,\n\n"
@@ -177,15 +218,22 @@ def submit_to_pandadoc(document: LegalDocument) -> str | None:
                 f"- The PostHog Team"
             ),
         )
-        return created.id
+        return True
     except pandadoc_client.PandaDocError as exc:
         logger.exception(
-            "legal_document_pandadoc_submit_failed",
+            "legal_document_pandadoc_send_failed",
             document_id=str(document.id),
+            pandadoc_document_id=document.pandadoc_document_id,
             error=str(exc),
         )
-        capture_exception(exc, additional_properties={"legal_document_id": str(document.id)})
-        return None
+        capture_exception(
+            exc,
+            additional_properties={
+                "legal_document_id": str(document.id),
+                "pandadoc_document_id": document.pandadoc_document_id,
+            },
+        )
+        return False
 
 
 def notify_slack_on_submit(document: LegalDocument) -> None:

--- a/products/legal_documents/backend/logic/pandadoc.py
+++ b/products/legal_documents/backend/logic/pandadoc.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import hmac
 import hashlib
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any
 
 from django.conf import settings
@@ -42,26 +43,20 @@ class PandaDocDocument:
     name: str
 
 
-@dataclass(frozen=True)
-class PandaDocSenderPostHog:
+class PandaDocRole(StrEnum):
     """
-    We wanna make sure we always have someone from our team attached as a CC
-    on the PandaDoc envelopes, so let's assign it here.
+    Roles PandaDoc templates bind recipients to. Must match the role names
+    configured on each template in the PandaDoc dashboard.
     """
 
-    email: str = "sales@posthog.com"
-    role: str = "PostHog"
+    CLIENT = "Client"
+    POSTHOG = "PostHog"
 
 
 @dataclass(frozen=True)
 class PandaDocRecipient:
     email: str
-    # Built-in recipient contact fields. PandaDoc auto-populates `Client.Email`,
-    # `Client.Company`, and `Client.StreetAddress` in the template body from
-    # these values, so no custom tokens are needed.
-    company: str = ""
-    street_address: str = ""
-    role: str = "Client"
+    role: PandaDocRole
 
 
 class PandaDocClient:
@@ -104,18 +99,26 @@ class PandaDocClient:
         *,
         template_id: str,
         name: str,
-        recipients: list[PandaDocRecipient | PandaDocSenderPostHog],
+        recipients: list[PandaDocRecipient],
+        tokens: dict[str, str] | None = None,
         metadata: dict[str, str] | None = None,
     ) -> PandaDocDocument:
         """
         Create a new document from a PandaDoc template. The returned document is in
         `document.uploaded` state — call `send_document` to dispatch the signing email.
+
+        `tokens` is a flat {name: value} map that maps onto the template's token
+        placeholders (`[Client.Company]`, `[Client.StreetAddress]`, etc.). Only
+        `Client.Email` is auto-populated from the recipient — everything else
+        the template references has to be passed explicitly here.
         """
         payload: dict[str, Any] = {
             "name": name,
             "template_uuid": template_id,
             "recipients": [_serialize_recipient(r) for r in recipients],
         }
+        if tokens:
+            payload["tokens"] = [{"name": name, "value": value} for name, value in tokens.items()]
         if metadata:
             payload["metadata"] = metadata
         data = self._post("/public/v1/documents", payload)
@@ -135,21 +138,8 @@ class PandaDocClient:
         )
 
 
-def _serialize_recipient(r: PandaDocRecipient | PandaDocSenderPostHog) -> dict[str, Any]:
-    payload: dict[str, Any] = {"email": r.email, "role": r.role}
-    # PandaDoc expects contact fields under `fields`, keyed by the snake_case
-    # field name (e.g. `Client.Company` → `company`). Only include fields we
-    # actually have a value for so we don't stomp existing template defaults,
-    # and only for recipient types that declare them (the PostHog sender doesn't).
-    fields: dict[str, dict[str, str]] = {}
-    if company := getattr(r, "company", ""):
-        fields["company"] = {"value": company}
-    if street_address := getattr(r, "street_address", ""):
-        fields["street_address"] = {"value": street_address}
-
-    if fields:
-        payload["fields"] = fields
-    return payload
+def _serialize_recipient(r: PandaDocRecipient) -> dict[str, Any]:
+    return {"email": r.email, "role": str(r.role)}
 
 
 def verify_webhook_signature(*, secret: str, body: bytes, signature: str) -> bool:

--- a/products/legal_documents/backend/presentation/webhook.py
+++ b/products/legal_documents/backend/presentation/webhook.py
@@ -28,8 +28,14 @@ class PandaDocWebhookSustainedThrottle(IPThrottle):
     rate = "30/hour"
 
 
-# PandaDoc's webhook event for "envelope completed". We ignore everything else.
-_PANDADOC_COMPLETED_EVENT = "document_state_changed"
+# PandaDoc state-change events we care about. Everything else is ignored.
+_PANDADOC_STATE_CHANGED_EVENT = "document_state_changed"
+
+# `draft` fires once PandaDoc has finished processing the template and the
+# envelope is ready to be sent to the signer — this is our cue to dispatch
+# the signing email.
+_PANDADOC_DRAFT_STATUS = "document.draft"
+# `completed` fires once every recipient has signed.
 _PANDADOC_COMPLETED_STATUS = "document.completed"
 
 
@@ -40,10 +46,13 @@ _PANDADOC_COMPLETED_STATUS = "document.completed"
     responses={200: OpenApiTypes.OBJECT, 204: OpenApiTypes.OBJECT, 400: OpenApiTypes.OBJECT, 404: OpenApiTypes.OBJECT},
     description=(
         "PandaDoc webhook receiver. Authenticates via HMAC-SHA256 over the raw "
-        "body. Returns 200 when a row was flipped to signed, 204 when the "
-        "request is valid but the document doesn't live on this cloud instance "
-        "(PandaDoc fans the webhook out to every instance, only one of which "
-        "owns the row), 404 on a bad signature, 400 on an unparseable body."
+        "body. Handles two `document_state_changed` events: `document.draft` "
+        "dispatches the signing email + Slack ping, and `document.completed` "
+        "flips the row to signed. Returns 200 when an event applied, 204 when "
+        "the request is valid but the document doesn't live on this cloud "
+        "instance (PandaDoc fans the webhook out to every instance, only one "
+        "of which owns the row), 404 on a bad signature, 400 on an "
+        "unparseable body."
     ),
 )
 @api_view(["POST"])
@@ -80,47 +89,58 @@ def legal_document_pandadoc_webhook(request: Request) -> Response:
     for event in events:
         if not isinstance(event, dict):
             continue
-        if event.get("event") != _PANDADOC_COMPLETED_EVENT:
+        if event.get("event") != _PANDADOC_STATE_CHANGED_EVENT:
             continue
         data = event.get("data") or {}
         if isinstance(data, list):
             data = data[0] if data else {}
         if not isinstance(data, dict):
             continue
-        if data.get("status") != _PANDADOC_COMPLETED_STATUS:
-            continue
 
+        event_status = data.get("status")
         pandadoc_document_id = data.get("id") or ""
         template_id = (data.get("template") or {}).get("id") if isinstance(data.get("template"), dict) else ""
-        # PandaDoc's completed payload carries the signed-PDF link under
-        # `download_link`. Fall back to the hosted `public_url` so the
-        # customer always has somewhere to click.
-        signed_url = data.get("download_link") or data.get("public_url") or ""
 
-        if not pandadoc_document_id or not signed_url:
-            logger.warning(
-                "pandadoc_webhook_event_missing_fields",
-                has_id=bool(pandadoc_document_id),
-                has_signed_url=bool(signed_url),
-            )
+        if not pandadoc_document_id:
+            logger.warning("pandadoc_webhook_event_missing_id", status=event_status)
             continue
 
-        dto = api.mark_signed_by_pandadoc_document_id(
-            pandadoc_document_id=pandadoc_document_id,
-            signed_document_url=signed_url,
-            template_id=template_id or "",
-        )
-        if dto is None:
-            # No matching row on this instance (the document likely belongs to
-            # a sibling cloud instance) or the template didn't match. Either
-            # way, there's nothing for us to do — the owning instance will
-            # handle its own copy of the webhook.
-            logger.info(
-                "pandadoc_webhook_no_matching_document",
+        if event_status == _PANDADOC_DRAFT_STATUS:
+            # Envelope just finished template processing — dispatch the send.
+            dto = api.mark_envelope_ready_by_pandadoc_document_id(
                 pandadoc_document_id=pandadoc_document_id,
+                template_id=template_id or "",
             )
+            if dto is None:
+                logger.info("pandadoc_webhook_no_matching_document", pandadoc_document_id=pandadoc_document_id)
+                continue
+            processed_any = True
             continue
-        processed_any = True
+
+        if event_status == _PANDADOC_COMPLETED_STATUS:
+            # PandaDoc's completed payload carries the signed-PDF link under
+            # `download_link`. Fall back to the hosted `public_url` so the
+            # customer always has somewhere to click.
+            signed_url = data.get("download_link") or data.get("public_url") or ""
+            if not signed_url:
+                logger.warning(
+                    "pandadoc_webhook_event_missing_fields",
+                    has_id=bool(pandadoc_document_id),
+                    has_signed_url=False,
+                )
+                continue
+            dto = api.mark_signed_by_pandadoc_document_id(
+                pandadoc_document_id=pandadoc_document_id,
+                signed_document_url=signed_url,
+                template_id=template_id or "",
+            )
+            if dto is None:
+                logger.info("pandadoc_webhook_no_matching_document", pandadoc_document_id=pandadoc_document_id)
+                continue
+            processed_any = True
+            continue
+
+        # Other states (document.sent, document.viewed, …) — nothing to do.
 
     if processed_any:
         return Response({"status": "ok"}, status=status.HTTP_200_OK)

--- a/products/legal_documents/backend/tests/test_api.py
+++ b/products/legal_documents/backend/tests/test_api.py
@@ -274,6 +274,18 @@ class TestLegalDocumentPandaDocWebhook(APIBaseTest):
             }
         ]
 
+    def _draft_payload(self, pandadoc_document_id: str = "doc_123", template_id: str | None = None) -> list[dict]:
+        return [
+            {
+                "event": "document_state_changed",
+                "data": {
+                    "id": pandadoc_document_id,
+                    "status": "document.draft",
+                    "template": {"id": template_id or self.DPA_TEMPLATE_ID},
+                },
+            }
+        ]
+
     def _post_raw(self, body: bytes, signature: str):
         # DRF's test client types `data` as str even though it accepts bytes at
         # runtime; decode so mypy doesn't complain while the wire payload stays
@@ -321,7 +333,8 @@ class TestLegalDocumentPandaDocWebhook(APIBaseTest):
             response = self._post_raw(body, self._sign(body))
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-    def test_non_completed_event_is_noop(self) -> None:
+    def test_uninteresting_state_event_is_noop(self) -> None:
+        # document.sent / document.viewed / etc. — we only act on draft + completed.
         payload = self._completed_payload()
         payload[0]["data"]["status"] = "document.sent"
         body = json.dumps(payload).encode("utf-8")
@@ -330,6 +343,52 @@ class TestLegalDocumentPandaDocWebhook(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.document.refresh_from_db()
         self.assertEqual(self.document.status, "submitted_for_signature")
+
+    def test_draft_event_dispatches_send_and_fires_slack(self) -> None:
+        body = json.dumps(self._draft_payload()).encode("utf-8")
+        with (
+            self._override(),
+            patch("products.legal_documents.backend.logic.pandadoc_client.PandaDocClient.send_document") as send_mock,
+            patch("products.legal_documents.backend.logic.notify_slack_on_submit") as slack_mock,
+        ):
+            response = self._post_raw(body, self._sign(body))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        send_mock.assert_called_once()
+        self.assertEqual(send_mock.call_args.kwargs["document_id"], "doc_123")
+        slack_mock.assert_called_once()
+
+    def test_draft_event_skips_slack_if_pandadoc_send_fails(self) -> None:
+        from products.legal_documents.backend.logic import pandadoc as pandadoc_client
+
+        body = json.dumps(self._draft_payload()).encode("utf-8")
+        with (
+            self._override(),
+            patch(
+                "products.legal_documents.backend.logic.pandadoc_client.PandaDocClient.send_document",
+                side_effect=pandadoc_client.PandaDocError("boom"),
+            ),
+            patch("products.legal_documents.backend.logic.notify_slack_on_submit") as slack_mock,
+        ):
+            response = self._post_raw(body, self._sign(body))
+        # Endpoint still 2xx (we don't want PandaDoc to retry) but Slack is skipped.
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        slack_mock.assert_not_called()
+
+    def test_draft_event_for_already_signed_document_is_a_noop(self) -> None:
+        self.document.status = "signed"
+        self.document.signed_document_url = "https://app.pandadoc.com/s/signed.pdf"
+        self.document.save()
+
+        body = json.dumps(self._draft_payload()).encode("utf-8")
+        with (
+            self._override(),
+            patch("products.legal_documents.backend.logic.pandadoc_client.PandaDocClient.send_document") as send_mock,
+            patch("products.legal_documents.backend.logic.notify_slack_on_submit") as slack_mock,
+        ):
+            response = self._post_raw(body, self._sign(body))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        send_mock.assert_not_called()
+        slack_mock.assert_not_called()
 
     def test_template_mismatch_does_not_flip_row(self) -> None:
         # Completed event with BAA template id for what's actually a DPA row in the DB

--- a/products/legal_documents/backend/tests/test_pandadoc.py
+++ b/products/legal_documents/backend/tests/test_pandadoc.py
@@ -16,7 +16,7 @@ class TestPandaDocClient(TestCase):
             client.create_document_from_template(
                 template_id="tpl",
                 name="doc",
-                recipients=[pandadoc.PandaDocRecipient(email="a@b.c")],
+                recipients=[pandadoc.PandaDocRecipient(email="a@b.c", role=pandadoc.PandaDocRole.CLIENT)],
             )
 
     @override_settings(PANDADOC_API_KEY="key", PANDADOC_API_BASE_URL="https://api.pandadoc.com")
@@ -33,13 +33,8 @@ class TestPandaDocClient(TestCase):
             result = client.create_document_from_template(
                 template_id="tpl",
                 name="PostHog BAA",
-                recipients=[
-                    pandadoc.PandaDocRecipient(
-                        email="ada@acme.example",
-                        company="Acme, Inc.",
-                        street_address="1 Analytics Way",
-                    )
-                ],
+                recipients=[pandadoc.PandaDocRecipient(email="ada@acme.example", role=pandadoc.PandaDocRole.CLIENT)],
+                tokens={"Client.Company": "Acme, Inc.", "Client.StreetAddress": "1 Analytics Way"},
                 metadata={"legal_document_id": "lid-1"},
             )
 
@@ -50,14 +45,14 @@ class TestPandaDocClient(TestCase):
         body = kwargs["json"]
         self.assertEqual(body["template_uuid"], "tpl")
         self.assertEqual(body["name"], "PostHog BAA")
-        recipient = body["recipients"][0]
-        self.assertEqual(recipient["email"], "ada@acme.example")
-        self.assertEqual(recipient["role"], "Client")
+        self.assertEqual(body["recipients"], [{"email": "ada@acme.example", "role": "Client"}])
         self.assertEqual(
-            recipient["fields"],
-            {"company": {"value": "Acme, Inc."}, "street_address": {"value": "1 Analytics Way"}},
+            body["tokens"],
+            [
+                {"name": "Client.Company", "value": "Acme, Inc."},
+                {"name": "Client.StreetAddress", "value": "1 Analytics Way"},
+            ],
         )
-        self.assertNotIn("tokens", body)
         self.assertEqual(body["metadata"], {"legal_document_id": "lid-1"})
         self.assertEqual(result.id, "doc_123")
 
@@ -85,29 +80,10 @@ class TestPandaDocClient(TestCase):
         self.assertFalse(pandadoc.verify_webhook_signature(secret="", body=b"{}", signature="abc"))
         self.assertFalse(pandadoc.verify_webhook_signature(secret="k", body=b"{}", signature=""))
 
-    def test_serialize_recipient_handles_posthog_sender_without_client_fields(self) -> None:
-        # The PostHog sender recipient doesn't carry Client.* fields, so
-        # _serialize_recipient must not blow up when it's passed — otherwise
-        # every real submission 500s (tests don't catch this on their own
-        # because submit_to_pandadoc short-circuits when template IDs are unset).
-        sender = pandadoc.PandaDocSenderPostHog()
-        payload = pandadoc._serialize_recipient(sender)
-        self.assertEqual(payload, {"email": sender.email, "role": "PostHog"})
-        self.assertNotIn("fields", payload)
-
-    def test_serialize_recipient_serializes_client_fields(self) -> None:
-        client = pandadoc.PandaDocRecipient(
-            email="ada@acme.example", company="Acme, Inc.", street_address="1 Analytics Way"
-        )
-        payload = pandadoc._serialize_recipient(client)
-        self.assertEqual(
-            payload,
-            {
-                "email": "ada@acme.example",
-                "role": "Client",
-                "fields": {
-                    "company": {"value": "Acme, Inc."},
-                    "street_address": {"value": "1 Analytics Way"},
-                },
-            },
-        )
+    def test_serialize_recipient_emits_flat_email_and_role_for_each_role(self) -> None:
+        # Both the Client signer and the PostHog CC serialize to the same
+        # minimal shape; tokens carry all template content.
+        client = pandadoc.PandaDocRecipient(email="ada@acme.example", role=pandadoc.PandaDocRole.CLIENT)
+        self.assertEqual(pandadoc._serialize_recipient(client), {"email": "ada@acme.example", "role": "Client"})
+        posthog = pandadoc.PandaDocRecipient(email="sales@posthog.com", role=pandadoc.PandaDocRole.POSTHOG)
+        self.assertEqual(pandadoc._serialize_recipient(posthog), {"email": "sales@posthog.com", "role": "PostHog"})


### PR DESCRIPTION
## Problem

PandaDoc processes templates asynchronously after document creation, meaning the envelope isn't actually sendable at the moment we call `create_document`. Previously, we were calling `send_document` immediately after `create_document`, which could fail or send prematurely before PandaDoc had finished processing the template. The Slack notification was also coupled to the initial create call rather than to a confirmed successful send.

## Changes

The PandaDoc integration now follows a two-phase flow driven by webhooks:

1. **`create_pandadoc_envelope`** — called during document creation, creates the envelope on PandaDoc and persists the `pandadoc_document_id`. The envelope lands in `document.uploaded` state and is not yet dispatched.
2. **`send_pandadoc_envelope`** — called from the new `document.draft` webhook handler once PandaDoc has finished template processing and the envelope is actually sendable. The Slack notification fires only after a confirmed successful send.

Additional changes:
- The webhook handler now handles two `document_state_changed` events: `document.draft` (dispatch signing email + Slack) and `document.completed` (mark row as signed). Previously only `document.completed` was handled.
- `PandaDocSenderPostHog` dataclass is replaced by a `PandaDocRole` `StrEnum` (`CLIENT`, `POSTHOG`), and the PostHog CC email is defined as a constant in the logic layer rather than baked into the client.
- Template content fields (`Client.Company`, `Client.StreetAddress`) are now passed as PandaDoc `tokens` rather than recipient `fields`, which is the correct PandaDoc API mechanism for populating template placeholders. Recipients now serialize to a minimal `{email, role}` shape only.
- `mark_envelope_ready_by_pandadoc_document_id` is idempotent: late or replayed `document.draft` deliveries for already-signed documents are silently skipped.

## How did you test this code?

New and updated unit tests cover:
- `document.draft` webhook dispatches `send_document` and fires the Slack notification.
- `document.draft` webhook skips the Slack notification when `send_document` raises a `PandaDocError`.
- `document.draft` webhook for an already-signed document is a no-op (no send, no Slack).
- `document.sent` and other uninteresting states remain no-ops.
- Recipient serialization produces the correct flat `{email, role}` shape for both `CLIENT` and `POSTHOG` roles.
- `tokens` are serialized correctly in the `create_document_from_template` API payload.

## Publish to changelog?

No