### PR TITLE
fix(posthog-code): Remove .flox from .worktreelink

### DIFF
--- a/.worktreelink
+++ b/.worktreelink
@@ -1,1 +1,2 @@
-.flox
+# This doesn't work currently, hardlinking the .flox directories between worktrees will break hogli scripts
+# .flox


### PR DESCRIPTION
## Problem

Hardlinking the .flox directory breaks hogli scripts

See in the screenshot below, one hogli command is setting up `/Users/robbie/.posthog-code/worktrees/4670/posthog/.posthog/.generated/mprocs.yaml`, the other reads from `/Users/robbie/.posthog-code/worktrees/9368/posthog/.posthog/.generated/mprocs.yaml` (the numbers in the path are different)

<img width="765" height="1273" alt="Screenshot 2026-04-22 at 22 29 37" src="https://github.com/user-attachments/assets/d7a0a15b-aaed-463c-a4a7-18ad64fe0bac" />


## Changes

Just remove this for now. If we want to add this hard linking back, it probably needs a pretty big rethink. I'm treating this as out of scope, I just want posthog code to be usable in this repo again :)

## How did you test this code?

n/a

## Publish to changelog?

<!-- For features only -->

<!-- If publishing, you must provide changelog details in the #changelog Slack channel. You will receive a follow-up PR comment or notification. -->

<!-- If not, write "no" or "do not publish to changelog" to explicitly opt-out of posting to #changelog. Removing this entire section will not prevent posting. -->

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

<!-- ## 🤖 LLM context -->

<!-- If an LLM agent co-authored or authored this PR, uncomment this section and leave any relevant context about the session, tools used, link to the session, or anything else that may help reviewers. -->
