### PR TITLE
feat(gateway): Support billing period and renamed plan keys from seats API

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/usage.py
+++ b/services/llm-gateway/src/llm_gateway/api/usage.py
@@ -56,6 +56,7 @@ async def get_usage(
         end_user_id=str(user.user_id),
         plan_key=plan_info.plan_key,
         seat_created_at=plan_info.seat_created_at,
+        billing_period_start=plan_info.billing_period.current_period_start if plan_info.billing_period else None,
     )
 
     burst_status: CostLimitStatus | None = None

--- a/services/llm-gateway/src/llm_gateway/dependencies.py
+++ b/services/llm-gateway/src/llm_gateway/dependencies.py
@@ -167,6 +167,7 @@ async def enforce_throttles(
         end_user_id=end_user_id,
         plan_key=plan_info.plan_key,
         seat_created_at=plan_info.seat_created_at,
+        billing_period_start=plan_info.billing_period.current_period_start if plan_info.billing_period else None,
     )
     request.state.throttle_context = context
     set_throttle_context(runner, context)

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_throttles.py
@@ -256,7 +256,11 @@ class UserCostSustainedThrottle(_UserCostThrottleBase):
         if not base_key:
             return base_key
         if context.product == POSTHOG_CODE_PRODUCT:
-            period = get_billing_period_number(context.seat_created_at, get_settings().billing_period_days)
+            period = get_billing_period_number(
+                context.seat_created_at,
+                get_settings().billing_period_days,
+                billing_period_start=context.billing_period_start,
+            )
             return f"{base_key}:period:{period}"
         return base_key
 

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/throttles.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/throttles.py
@@ -22,6 +22,7 @@ class ThrottleContext:
     end_user_id: str | None = None
     plan_key: str | None = None
     seat_created_at: str | None = None
+    billing_period_start: str | None = None
 
 
 @dataclass

--- a/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
+++ b/services/llm-gateway/src/llm_gateway/services/plan_resolver.py
@@ -27,13 +27,21 @@ logger = structlog.get_logger(__name__)
 
 POSTHOG_CODE_PRODUCT = "posthog_code"
 PLAN_CACHE_PREFIX = f"plan:{POSTHOG_CODE_PRODUCT}"
-PRO_PLAN_PREFIX = "posthog-code-200"
+PRO_PLAN_PREFIXES = ("posthog-code-200", "posthog-code-pro-")
+
+
+@dataclass
+class BillingPeriod:
+    current_period_start: str
+    current_period_end: str
+    interval: str
 
 
 @dataclass
 class PlanInfo:
     plan_key: str | None
     seat_created_at: str | None
+    billing_period: BillingPeriod | None = None
 
 
 def _redis_key(user_id: int) -> str:
@@ -43,20 +51,38 @@ def _redis_key(user_id: int) -> str:
 def is_pro_plan(plan_key: str | None) -> bool:
     if not plan_key:
         return False
-    return plan_key.startswith(PRO_PLAN_PREFIX)
+    return any(plan_key.startswith(p) for p in PRO_PLAN_PREFIXES)
 
 
-def get_billing_period_number(seat_created_at: str | None, period_days: int = 30) -> int:
-    if not seat_created_at:
+def get_billing_period_number(
+    seat_created_at: str | None,
+    period_days: int = 30,
+    billing_period_start: str | None = None,
+) -> int:
+    anchor = billing_period_start or seat_created_at
+    if not anchor:
         return 0
     try:
-        created = datetime.fromisoformat(seat_created_at)
+        created = datetime.fromisoformat(anchor)
         if created.tzinfo is None:
             created = created.replace(tzinfo=UTC)
         elapsed = datetime.now(tz=UTC) - created
         return max(0, elapsed.days // period_days)
     except (ValueError, TypeError):
         return 0
+
+
+def _parse_billing_period(raw: object) -> BillingPeriod | None:
+    if not isinstance(raw, dict):
+        return None
+    try:
+        return BillingPeriod(
+            current_period_start=raw["current_period_start"],
+            current_period_end=raw["current_period_end"],
+            interval=raw["interval"],
+        )
+    except (KeyError, TypeError):
+        return None
 
 
 async def resolve_plan_info(
@@ -107,15 +133,16 @@ class PlanResolver:
             return cached
 
         try:
-            plan_key, seat_created_at = await self._fetch_plan(auth_header)
+            plan_key, seat_created_at, billing_period = await self._fetch_plan(auth_header)
         except Exception:
             logger.warning("seat_fetch_failed", user_id=user_id, exc_info=True)
             return PlanInfo(plan_key=None, seat_created_at=None)
 
-        await self._set_cached(user_id, plan_key, seat_created_at)
+        await self._set_cached(user_id, plan_key, seat_created_at, billing_period)
         return PlanInfo(
             plan_key=plan_key,
             seat_created_at=seat_created_at,
+            billing_period=billing_period,
         )
 
     async def _get_cached(self, user_id: int) -> PlanInfo | None:
@@ -127,33 +154,48 @@ class PlanResolver:
                 data = json.loads(val.decode())
                 plan_key = data.get("plan_key") or None
                 seat_created_at = data.get("created_at")
+                billing_period = _parse_billing_period(data.get("billing_period"))
                 return PlanInfo(
                     plan_key=plan_key,
                     seat_created_at=seat_created_at,
+                    billing_period=billing_period,
                 )
         except Exception:
             logger.debug("plan_cache_read_failed", user_id=user_id)
         return None
 
-    async def _set_cached(self, user_id: int, plan_key: str | None, seat_created_at: str | None) -> None:
+    async def _set_cached(
+        self,
+        user_id: int,
+        plan_key: str | None,
+        seat_created_at: str | None,
+        billing_period: BillingPeriod | None = None,
+    ) -> None:
         if not self._redis:
             return
         ttl = get_settings().plan_cache_ttl
         try:
-            data = json.dumps({"plan_key": plan_key, "created_at": seat_created_at})
+            payload: dict[str, object] = {"plan_key": plan_key, "created_at": seat_created_at}
+            if billing_period:
+                payload["billing_period"] = {
+                    "current_period_start": billing_period.current_period_start,
+                    "current_period_end": billing_period.current_period_end,
+                    "interval": billing_period.interval,
+                }
+            data = json.dumps(payload)
             await self._redis.set(_redis_key(user_id), data, ex=ttl)
         except Exception:
             logger.debug("plan_cache_write_failed", user_id=user_id)
 
-    async def _fetch_plan(self, auth_header: str) -> tuple[str | None, str | None]:
+    async def _fetch_plan(self, auth_header: str) -> tuple[str | None, str | None, BillingPeriod | None]:
         """Call the PostHog API seats endpoint to get the user's plan.
 
         Raises on transient HTTP failures so the caller can skip caching.
-        Returns (None, None) for legitimate "no plan" states (404, no API URL).
+        Returns (None, None, None) for legitimate "no plan" states (404, no API URL).
         """
         settings = get_settings()
         if not settings.posthog_api_base_url:
-            return None, None
+            return None, None, None
 
         url = f"{settings.posthog_api_base_url.rstrip('/')}/api/seats/me/"
         resp = await self._http.get(
@@ -163,7 +205,8 @@ class PlanResolver:
             timeout=2.0,
         )
         if resp.status_code == 404:
-            return None, None
+            return None, None, None
         resp.raise_for_status()
         data = resp.json()
-        return data.get("plan_key"), data.get("created_at")
+        billing_period = _parse_billing_period(data.get("billing_period"))
+        return data.get("plan_key"), data.get("created_at"), billing_period

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -347,8 +347,7 @@ class TestUserCostSustainedThrottle:
         key = throttle._get_cache_key(context)
         assert key == "cost:user:user_cost_sustained:posthog_code:42:period:1"
 
-    @pytest.mark.asyncio
-    async def test_cache_key_uses_billing_period_start_over_seat_created_at(self) -> None:
+    def test_cache_key_uses_billing_period_start_over_seat_created_at(self) -> None:
         from datetime import UTC, datetime, timedelta
 
         from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
@@ -367,8 +366,7 @@ class TestUserCostSustainedThrottle:
         key = throttle._get_cache_key(context)
         assert key == "cost:user:user_cost_sustained:posthog_code:42:period:0"
 
-    @pytest.mark.asyncio
-    async def test_cache_key_falls_back_to_seat_created_at_without_billing_period(self) -> None:
+    def test_cache_key_falls_back_to_seat_created_at_without_billing_period(self) -> None:
         from datetime import UTC, datetime, timedelta
 
         from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle

--- a/services/llm-gateway/tests/test_cost_throttles.py
+++ b/services/llm-gateway/tests/test_cost_throttles.py
@@ -21,6 +21,7 @@ def make_context(
     end_user_id: str | None = None,
     plan_key: str | None = "posthog-code-200-20260301",
     seat_created_at: str | None = None,
+    billing_period_start: str | None = None,
 ) -> ThrottleContext:
     user = user or make_user()
     if end_user_id is None and user.auth_method == "oauth_access_token":
@@ -31,6 +32,7 @@ def make_context(
         end_user_id=end_user_id,
         plan_key=plan_key,
         seat_created_at=seat_created_at,
+        billing_period_start=billing_period_start,
     )
 
 
@@ -340,6 +342,45 @@ class TestUserCostSustainedThrottle:
             end_user_id="42",
             plan_key="posthog-code-free-20260301",
             seat_created_at=created,
+        )
+
+        key = throttle._get_cache_key(context)
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:1"
+
+    @pytest.mark.asyncio
+    async def test_cache_key_uses_billing_period_start_over_seat_created_at(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
+
+        throttle = UserCostSustainedThrottle(redis=None)
+        old_seat = (datetime.now(tz=UTC) - timedelta(days=35)).isoformat()
+        recent_period = (datetime.now(tz=UTC) - timedelta(days=5)).isoformat()
+        context = make_context(
+            product="posthog_code",
+            end_user_id="42",
+            plan_key="posthog-code-pro-200-20260301",
+            seat_created_at=old_seat,
+            billing_period_start=recent_period,
+        )
+
+        key = throttle._get_cache_key(context)
+        assert key == "cost:user:user_cost_sustained:posthog_code:42:period:0"
+
+    @pytest.mark.asyncio
+    async def test_cache_key_falls_back_to_seat_created_at_without_billing_period(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        from llm_gateway.rate_limiting.cost_throttles import UserCostSustainedThrottle
+
+        throttle = UserCostSustainedThrottle(redis=None)
+        old_seat = (datetime.now(tz=UTC) - timedelta(days=35)).isoformat()
+        context = make_context(
+            product="posthog_code",
+            end_user_id="42",
+            plan_key="posthog-code-pro-200-20260301",
+            seat_created_at=old_seat,
+            billing_period_start=None,
         )
 
         key = throttle._get_cache_key(context)
@@ -1081,6 +1122,28 @@ class TestPlanAwareThrottling:
 
         throttle = UserCostBurstThrottle(redis=None)
         context = make_context(product="posthog_code", plan_key="posthog-code-200-20260301")
+
+        await throttle.record_cost(context, 50.0)
+        result = await throttle.allow_request(context)
+        assert result.allowed is True
+
+    @pytest.mark.asyncio
+    async def test_renamed_pro_plan_allows_higher_usage(self) -> None:
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        context = make_context(product="posthog_code", plan_key="posthog-code-pro-200-20260301")
+
+        await throttle.record_cost(context, 50.0)
+        result = await throttle.allow_request(context)
+        assert result.allowed is True
+
+    @pytest.mark.asyncio
+    async def test_zero_dollar_pro_plan_allows_higher_usage(self) -> None:
+        from llm_gateway.rate_limiting.cost_throttles import UserCostBurstThrottle
+
+        throttle = UserCostBurstThrottle(redis=None)
+        context = make_context(product="posthog_code", plan_key="posthog-code-pro-0-20260422")
 
         await throttle.record_cost(context, 50.0)
         result = await throttle.allow_request(context)

--- a/services/llm-gateway/tests/test_plan_resolver.py
+++ b/services/llm-gateway/tests/test_plan_resolver.py
@@ -16,6 +16,8 @@ class TestIsProPlan:
         [
             ("posthog-code-200-20260301", True),
             ("posthog-code-200-20260501", True),
+            ("posthog-code-pro-200-20260301", True),
+            ("posthog-code-pro-0-20260422", True),
             ("posthog-code-free-20260301", False),
             ("posthog-code-free-20260501", False),
             ("some-other-plan", False),
@@ -57,6 +59,15 @@ class TestGetBillingPeriodNumber:
     def test_just_under_boundary(self) -> None:
         created = (datetime.now(tz=UTC) - timedelta(days=29, hours=23)).isoformat()
         assert get_billing_period_number(created) == 0
+
+    def test_billing_period_start_overrides_seat_created_at(self) -> None:
+        old_seat = (datetime.now(tz=UTC) - timedelta(days=35)).isoformat()
+        recent_period = (datetime.now(tz=UTC) - timedelta(days=5)).isoformat()
+        assert get_billing_period_number(old_seat, billing_period_start=recent_period) == 0
+
+    def test_billing_period_start_none_falls_back_to_seat_created_at(self) -> None:
+        old_seat = (datetime.now(tz=UTC) - timedelta(days=35)).isoformat()
+        assert get_billing_period_number(old_seat, billing_period_start=None) == 1
 
 
 class TestPlanResolver:
@@ -111,7 +122,15 @@ class TestPlanResolver:
         created_at = datetime.now(tz=UTC).isoformat()
         mock_resp = MagicMock()
         mock_resp.status_code = 200
-        mock_resp.json.return_value = {"plan_key": "posthog-code-200-20260301", "created_at": created_at}
+        mock_resp.json.return_value = {
+            "plan_key": "posthog-code-pro-200-20260301",
+            "created_at": created_at,
+            "billing_period": {
+                "current_period_start": "2026-04-01T00:00:00+00:00",
+                "current_period_end": "2026-05-01T00:00:00+00:00",
+                "interval": "month",
+            },
+        }
         mock_resp.raise_for_status = MagicMock()
         resolver_with_redis._http.get = AsyncMock(return_value=mock_resp)  # type: ignore[method-assign]
 
@@ -120,7 +139,10 @@ class TestPlanResolver:
             mock_settings.return_value.plan_cache_ttl = 300
             result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
 
-        assert result.plan_key == "posthog-code-200-20260301"
+        assert result.plan_key == "posthog-code-pro-200-20260301"
+        assert result.billing_period is not None
+        assert result.billing_period.current_period_start == "2026-04-01T00:00:00+00:00"
+        assert result.billing_period.interval == "month"
         assert resolver_with_redis._redis is not None
         resolver_with_redis._redis.set.assert_called_once()  # type: ignore[attr-defined]
 
@@ -130,6 +152,21 @@ class TestPlanResolver:
             headers={"Authorization": "Bearer phx_test"},
             timeout=2.0,
         )
+
+    async def test_fetches_from_api_without_billing_period(self, resolver_with_redis: PlanResolver) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"plan_key": "posthog-code-200-20260301", "created_at": None}
+        mock_resp.raise_for_status = MagicMock()
+        resolver_with_redis._http.get = AsyncMock(return_value=mock_resp)  # type: ignore[method-assign]
+
+        with patch("llm_gateway.services.plan_resolver.get_settings") as mock_settings:
+            mock_settings.return_value.posthog_api_base_url = "https://app.posthog.com"
+            mock_settings.return_value.plan_cache_ttl = 300
+            result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
+
+        assert result.plan_key == "posthog-code-200-20260301"
+        assert result.billing_period is None
 
     async def test_forwards_auth_header(self, resolver: PlanResolver) -> None:
         mock_resp = MagicMock()
@@ -173,6 +210,36 @@ class TestPlanResolver:
         result = await resolver.get_plan(user_id=1, auth_header="")
         assert result.plan_key is None
         resolver._http.get.assert_not_called()  # type: ignore[attr-defined]
+
+    async def test_cached_plan_with_billing_period(self, resolver_with_redis: PlanResolver) -> None:
+        import json
+
+        cached = json.dumps(
+            {
+                "plan_key": "posthog-code-pro-200-20260301",
+                "created_at": None,
+                "billing_period": {
+                    "current_period_start": "2026-04-01T00:00:00+00:00",
+                    "current_period_end": "2026-05-01T00:00:00+00:00",
+                    "interval": "month",
+                },
+            }
+        )
+        assert resolver_with_redis._redis is not None
+        resolver_with_redis._redis.get = AsyncMock(return_value=cached.encode())  # type: ignore[method-assign]
+        result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
+        assert result.billing_period is not None
+        assert result.billing_period.current_period_start == "2026-04-01T00:00:00+00:00"
+        assert result.billing_period.interval == "month"
+
+    async def test_cached_plan_without_billing_period(self, resolver_with_redis: PlanResolver) -> None:
+        import json
+
+        cached = json.dumps({"plan_key": "posthog-code-200-20260301", "created_at": None})
+        assert resolver_with_redis._redis is not None
+        resolver_with_redis._redis.get = AsyncMock(return_value=cached.encode())  # type: ignore[method-assign]
+        result = await resolver_with_redis.get_plan(user_id=1, auth_header="Bearer phx_test")
+        assert result.billing_period is None
 
     async def test_api_error_not_cached(self, resolver_with_redis: PlanResolver) -> None:
         resolver_with_redis._http.get = AsyncMock(side_effect=Exception("connection refused"))  # type: ignore[method-assign]


### PR DESCRIPTION
## Problem

The billing seats API ([PostHog/billing#1862](https://github.com/PostHog/billing/issues/1862)) renames plan keys and adds a billing_period object to responses, aligning the usage window anchoring to the org's billing period.

## Changes

  1. Widen pro plan prefix matching to recognize both old (`posthog-code-200-*`) and new (`posthog-code-pro-*`) plan keys including the $0 alpha tier
  2. Add BillingPeriod dataclass and thread billing_period_start through PlanInfo, ThrottleContext and into the sustained throttle cache key
  3. Prefer billing_period.current_period_start over seat_created_at for usage window anchoring, with graceful fallback
  4. Parse and cache billing_period from seat API responses (backwards-compatible with old responses)
  5. Add tests for new plan keys, billing period override/fallback and cache round-trip

## How did you test this code?
Manually