### PR TITLE
fix(personhog): new config for clamping db warm cnxs

### DIFF
--- a/rust/personhog-replica/src/config.rs
+++ b/rust/personhog-replica/src/config.rs
@@ -35,6 +35,12 @@ pub struct Config {
     #[envconfig(default = "5000")]
     pub statement_timeout_ms: u64,
 
+    /// Maximum number of server-side (PgBouncer → Postgres) connections to
+    /// warm at startup via SELECT 1. Clamped to min_pg_connections. Set to 0
+    /// to skip server-side warming entirely.
+    #[envconfig(default = "3")]
+    pub warmup_server_connections: u32,
+
     #[envconfig(default = "10")]
     pub pool_monitor_interval_secs: u64,
 

--- a/rust/personhog-replica/src/main.rs
+++ b/rust/personhog-replica/src/main.rs
@@ -158,8 +158,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // (TCP on 50051) can't pass until after this completes.
     if config.min_pg_connections > 0 {
         let warmup_count = config.min_pg_connections as usize;
-        let server_warmup_count =
-            (config.warmup_server_connections as usize).min(warmup_count);
+        let server_warmup_count = (config.warmup_server_connections as usize).min(warmup_count);
         tracing::info!(
             count = warmup_count,
             server_warmup = server_warmup_count,

--- a/rust/personhog-replica/src/main.rs
+++ b/rust/personhog-replica/src/main.rs
@@ -158,8 +158,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // (TCP on 50051) can't pass until after this completes.
     if config.min_pg_connections > 0 {
         let warmup_count = config.min_pg_connections as usize;
+        let server_warmup_count =
+            (config.warmup_server_connections as usize).min(warmup_count);
         tracing::info!(
             count = warmup_count,
+            server_warmup = server_warmup_count,
             "Warming database connection pools before accepting traffic"
         );
         let separate_replica = config.replica_database_url() != config.primary_database_url;
@@ -184,13 +187,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
             }
-            // Run a query on each held connection to warm PgBouncer → PG.
+            // Run a query on a subset of held connections to warm PgBouncer → PG.
             // acquire() only establishes app → PgBouncer; in transaction pooling
             // mode PgBouncer doesn't open a server connection until a query runs.
-            // Holding all N connections forces PgBouncer to assign N distinct
-            // server connections rather than reusing one.
+            // We cap this to warmup_server_connections to avoid pinning too many
+            // PgBouncer backend connections — the remaining client connections are
+            // still warm (app → PgBouncer) and will get a server connection on
+            // first real query.
             let mut server_warmed = 0u32;
-            for conn in &mut conns {
+            for conn in conns.iter_mut().take(server_warmup_count) {
                 match sqlx::query("SELECT 1").execute(&mut **conn).await {
                     Ok(_) => server_warmed += 1,
                     Err(e) => {


### PR DESCRIPTION
## Problem

We shouldn't warm every connection that we create to PG bouncer, from pg bouncer to the DB. 

## Changes

New env var to configure how many of the pg bouncer connections we end up warming from pg bouncer to the actual database

## How did you test this code?

small config change, will test when rolling out to production
