### PR TITLE
fix(agentic-provisioning): add resolved team to token scopes when project exists

### DIFF
--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -254,24 +254,24 @@ class TestProvisioningResources(StripeProvisioningTestBase):
             organization=self.organization,
             name="Race winner",
         )
-        TeamProvisioningConfig.objects.update_or_create(
-            team=winner_team, defaults={"stripe_project_id": "proj_race_same_org"}
-        )
 
+        project_id = "proj_race_same_org"
         original_update_or_create = TeamProvisioningConfig.objects.update_or_create
-        calls: list[int] = []
+        raced: list[int] = []
 
-        def raise_once_then_passthrough(*args, **kwargs):
-            calls.append(1)
-            if len(calls) == 1:
+        def race_then_raise(*args, **kwargs):
+            defaults = kwargs.get("defaults", {})
+            if "stripe_project_id" in defaults and not raced:
+                raced.append(1)
+                original_update_or_create(team=winner_team, defaults={"stripe_project_id": project_id})
                 raise IntegrityError
             return original_update_or_create(*args, **kwargs)
 
         token = self._get_bearer_token()
-        with patch.object(TeamProvisioningConfig.objects, "update_or_create", side_effect=raise_once_then_passthrough):
+        with patch.object(TeamProvisioningConfig.objects, "update_or_create", side_effect=race_then_raise):
             res = self._post_signed_with_bearer(
                 "/api/agentic/provisioning/resources",
-                data={"service_id": "analytics", "project_id": "proj_race_same_org"},
+                data={"service_id": "analytics", "project_id": project_id},
                 token=token,
             )
 

--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -201,6 +201,36 @@ class TestProvisioningResources(StripeProvisioningTestBase):
         assert len(access_token.scoped_teams) == 2
         assert self.team.id in access_token.scoped_teams
 
+    def test_create_resource_race_winner_in_different_org_does_not_leak_cross_org(self):
+        from unittest.mock import patch
+
+        from django.db import IntegrityError
+
+        from posthog.models.organization import Organization
+        from posthog.models.team.team_provisioning_config import TeamProvisioningConfig
+
+        other_org = Organization.objects.create(name="Foreign Org")
+        foreign_team = Team.objects.create_with_data(
+            initiating_user=self.user,
+            organization=other_org,
+            name="Foreign project",
+        )
+        TeamProvisioningConfig.objects.create(team=foreign_team, stripe_project_id="proj_shared")
+
+        token = self._get_bearer_token()
+        with patch.object(TeamProvisioningConfig.objects, "update_or_create", side_effect=IntegrityError):
+            res = self._post_signed_with_bearer(
+                "/api/agentic/provisioning/resources",
+                data={"service_id": "analytics", "project_id": "proj_shared"},
+                token=token,
+            )
+
+        assert res.status_code == 200
+        assert res.json()["id"] != str(foreign_team.id)
+
+        access_token = OAuthAccessToken.objects.get(token=token)
+        assert foreign_team.id not in (access_token.scoped_teams or [])
+
     def test_create_resource_with_existing_project_id_adds_resolved_team_to_scoped_teams(self):
         from posthog.models.team.team_provisioning_config import TeamProvisioningConfig
 

--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -219,8 +219,17 @@ class TestProvisioningResources(StripeProvisioningTestBase):
             team=foreign_team, defaults={"stripe_project_id": "proj_shared"}
         )
 
+        original_update_or_create = TeamProvisioningConfig.objects.update_or_create
+        calls: list[int] = []
+
+        def raise_once_then_passthrough(*args, **kwargs):
+            calls.append(1)
+            if len(calls) == 1:
+                raise IntegrityError
+            return original_update_or_create(*args, **kwargs)
+
         token = self._get_bearer_token()
-        with patch.object(TeamProvisioningConfig.objects, "update_or_create", side_effect=IntegrityError):
+        with patch.object(TeamProvisioningConfig.objects, "update_or_create", side_effect=raise_once_then_passthrough):
             res = self._post_signed_with_bearer(
                 "/api/agentic/provisioning/resources",
                 data={"service_id": "analytics", "project_id": "proj_shared"},

--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -242,6 +242,46 @@ class TestProvisioningResources(StripeProvisioningTestBase):
         access_token = OAuthAccessToken.objects.get(token=token)
         assert foreign_team.id not in (access_token.scoped_teams or [])
 
+    def test_create_resource_race_winner_in_same_org_returns_winner_and_syncs_scopes(self):
+        from unittest.mock import patch
+
+        from django.db import IntegrityError
+
+        from posthog.models.team.team_provisioning_config import TeamProvisioningConfig
+
+        winner_team = Team.objects.create_with_data(
+            initiating_user=self.user,
+            organization=self.organization,
+            name="Race winner",
+        )
+        TeamProvisioningConfig.objects.update_or_create(
+            team=winner_team, defaults={"stripe_project_id": "proj_race_same_org"}
+        )
+
+        original_update_or_create = TeamProvisioningConfig.objects.update_or_create
+        calls: list[int] = []
+
+        def raise_once_then_passthrough(*args, **kwargs):
+            calls.append(1)
+            if len(calls) == 1:
+                raise IntegrityError
+            return original_update_or_create(*args, **kwargs)
+
+        token = self._get_bearer_token()
+        with patch.object(TeamProvisioningConfig.objects, "update_or_create", side_effect=raise_once_then_passthrough):
+            res = self._post_signed_with_bearer(
+                "/api/agentic/provisioning/resources",
+                data={"service_id": "analytics", "project_id": "proj_race_same_org"},
+                token=token,
+            )
+
+        assert res.status_code == 200
+        assert res.json()["id"] == str(winner_team.id)
+
+        access_token = OAuthAccessToken.objects.get(token=token)
+        assert winner_team.id in (access_token.scoped_teams or [])
+        assert self.team.id in (access_token.scoped_teams or [])
+
     def test_create_resource_with_existing_project_id_adds_resolved_team_to_scoped_teams(self):
         from posthog.models.team.team_provisioning_config import TeamProvisioningConfig
 

--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -215,7 +215,9 @@ class TestProvisioningResources(StripeProvisioningTestBase):
             organization=other_org,
             name="Foreign project",
         )
-        TeamProvisioningConfig.objects.create(team=foreign_team, stripe_project_id="proj_shared")
+        TeamProvisioningConfig.objects.update_or_create(
+            team=foreign_team, defaults={"stripe_project_id": "proj_shared"}
+        )
 
         token = self._get_bearer_token()
         with patch.object(TeamProvisioningConfig.objects, "update_or_create", side_effect=IntegrityError):
@@ -239,7 +241,9 @@ class TestProvisioningResources(StripeProvisioningTestBase):
             organization=self.organization,
             name="Pre-existing project",
         )
-        TeamProvisioningConfig.objects.create(team=existing_team, stripe_project_id="proj_existing")
+        TeamProvisioningConfig.objects.update_or_create(
+            team=existing_team, defaults={"stripe_project_id": "proj_existing"}
+        )
 
         token = self._get_bearer_token()
         access_token = OAuthAccessToken.objects.get(token=token)

--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -236,8 +236,8 @@ class TestProvisioningResources(StripeProvisioningTestBase):
                 token=token,
             )
 
-        assert res.status_code == 200
-        assert res.json()["id"] != str(foreign_team.id)
+        assert res.status_code == 409
+        assert res.json()["error"]["code"] == "project_id_conflict"
 
         access_token = OAuthAccessToken.objects.get(token=token)
         assert foreign_team.id not in (access_token.scoped_teams or [])

--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -201,6 +201,32 @@ class TestProvisioningResources(StripeProvisioningTestBase):
         assert len(access_token.scoped_teams) == 2
         assert self.team.id in access_token.scoped_teams
 
+    def test_create_resource_with_existing_project_id_adds_resolved_team_to_scoped_teams(self):
+        from posthog.models.team.team_provisioning_config import TeamProvisioningConfig
+
+        existing_team = Team.objects.create_with_data(
+            initiating_user=self.user,
+            organization=self.organization,
+            name="Pre-existing project",
+        )
+        TeamProvisioningConfig.objects.create(team=existing_team, stripe_project_id="proj_existing")
+
+        token = self._get_bearer_token()
+        access_token = OAuthAccessToken.objects.get(token=token)
+        assert access_token.scoped_teams == [self.team.id]
+
+        res = self._post_signed_with_bearer(
+            "/api/agentic/provisioning/resources",
+            data={"service_id": "analytics", "project_id": "proj_existing"},
+            token=token,
+        )
+        assert res.status_code == 200
+        assert res.json()["id"] == str(existing_team.id)
+
+        access_token.refresh_from_db()
+        assert existing_team.id in access_token.scoped_teams
+        assert self.team.id in access_token.scoped_teams
+
     def test_create_resource_without_project_id_returns_existing_team(self):
         token = self._get_bearer_token()
         res = self._post_signed_with_bearer(

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -1183,9 +1183,17 @@ def _resolve_or_create_project_team(
         )
         if race_winner:
             return _ensure_team_in_token_scopes(access_token, scoped_teams, race_winner.team)
-        return base_team, scoped_teams
+        raise _ProjectIdCollisionError(project_id)
 
     return _ensure_team_in_token_scopes(access_token, scoped_teams, new_team)
+
+
+class _ProjectIdCollisionError(Exception):
+    """Raised when a stripe_project_id is already in use by a team outside the caller's orgs."""
+
+    def __init__(self, project_id: str) -> None:
+        super().__init__(project_id)
+        self.project_id = project_id
 
 
 def _ensure_team_in_token_scopes(
@@ -1266,9 +1274,19 @@ def provisioning_resources_create(request: Request) -> Response:
     configuration = request.data.get("configuration") or {}
 
     if project_id:
-        team, scoped_teams = _resolve_or_create_project_team(
-            project_id, scoped_teams, user, configuration, access_token
-        )
+        try:
+            team, scoped_teams = _resolve_or_create_project_team(
+                project_id, scoped_teams, user, configuration, access_token
+            )
+        except _ProjectIdCollisionError:
+            _capture_provisioning_event(
+                "resource_created", "error", error_code="project_id_conflict", project_id=project_id
+            )
+            return _error_response(
+                "project_id_conflict",
+                "Project ID already linked to another organization",
+                status=409,
+            )
     else:
         team_id = scoped_teams[0]
         try:

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -1191,9 +1191,9 @@ def _resolve_or_create_project_team(
 def _ensure_team_in_token_scopes(
     access_token: OAuthAccessToken, scoped_teams: list[int], team: Team
 ) -> tuple[Team, list[int]]:
-    _add_team_to_token_scopes(access_token, team.id)
     if team.id in scoped_teams:
         return team, scoped_teams
+    _add_team_to_token_scopes(access_token, team.id)
     return team, [*scoped_teams, team.id]
 
 

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -1173,7 +1173,14 @@ def _resolve_or_create_project_team(
         )
     except IntegrityError:
         new_team.delete()
-        race_winner = TeamProvisioningConfig.objects.filter(stripe_project_id=project_id).select_related("team").first()
+        race_winner = (
+            TeamProvisioningConfig.objects.filter(
+                stripe_project_id=project_id,
+                team__organization_id__in=Team.objects.filter(id__in=scoped_teams).values("organization_id"),
+            )
+            .select_related("team")
+            .first()
+        )
         if race_winner:
             return _ensure_team_in_token_scopes(access_token, scoped_teams, race_winner.team)
         return base_team, scoped_teams

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -1156,7 +1156,7 @@ def _resolve_or_create_project_team(
         .first()
     )
     if existing:
-        return existing.team, scoped_teams
+        return _ensure_team_in_token_scopes(access_token, scoped_teams, existing.team)
 
     base_team = Team.objects.get(id=scoped_teams[0])
     project_name = configuration.get("project_name", "Default project")
@@ -1175,12 +1175,19 @@ def _resolve_or_create_project_team(
         new_team.delete()
         race_winner = TeamProvisioningConfig.objects.filter(stripe_project_id=project_id).select_related("team").first()
         if race_winner:
-            return race_winner.team, scoped_teams
+            return _ensure_team_in_token_scopes(access_token, scoped_teams, race_winner.team)
         return base_team, scoped_teams
 
-    _add_team_to_token_scopes(access_token, new_team.id)
+    return _ensure_team_in_token_scopes(access_token, scoped_teams, new_team)
 
-    return new_team, [*scoped_teams, new_team.id]
+
+def _ensure_team_in_token_scopes(
+    access_token: OAuthAccessToken, scoped_teams: list[int], team: Team
+) -> tuple[Team, list[int]]:
+    _add_team_to_token_scopes(access_token, team.id)
+    if team.id in scoped_teams:
+        return team, scoped_teams
+    return team, [*scoped_teams, team.id]
 
 
 def _add_team_to_token_scopes(access_token: OAuthAccessToken, team_id: int) -> None:

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -1206,19 +1206,22 @@ def _ensure_team_in_token_scopes(
 
 
 def _add_team_to_token_scopes(access_token: OAuthAccessToken, team_id: int) -> None:
-    teams = list(access_token.scoped_teams or [])
-    if team_id not in teams:
-        teams.append(team_id)
-        access_token.scoped_teams = teams
-        access_token.save(update_fields=["scoped_teams"])
+    with transaction.atomic():
+        locked_access_token = OAuthAccessToken.objects.select_for_update().get(pk=access_token.pk)
+        teams = list(locked_access_token.scoped_teams or [])
+        if team_id not in teams:
+            teams.append(team_id)
+            locked_access_token.scoped_teams = teams
+            locked_access_token.save(update_fields=["scoped_teams"])
+            access_token.scoped_teams = teams
 
-    refresh_tokens = OAuthRefreshToken.objects.filter(access_token=access_token)
-    for rt in refresh_tokens:
-        rt_teams = list(rt.scoped_teams or [])
-        if team_id not in rt_teams:
-            rt_teams.append(team_id)
-            rt.scoped_teams = rt_teams
-            rt.save(update_fields=["scoped_teams"])
+        refresh_tokens = OAuthRefreshToken.objects.select_for_update().filter(access_token=locked_access_token)
+        for rt in refresh_tokens:
+            rt_teams = list(rt.scoped_teams or [])
+            if team_id not in rt_teams:
+                rt_teams.append(team_id)
+                rt.scoped_teams = rt_teams
+                rt.save(update_fields=["scoped_teams"])
 
 
 def _get_provisioning_service_id(team: Team) -> str:


### PR DESCRIPTION
## Problem

Testers running `stripe projects update` / `stripe projects upgrade` on an agentic-provisioned PostHog plan hit:

```
✗ Updating posthog-plan to pay_as_you_go...
✗ The provider returned an error: updateService failed with status 403: forbidden: Resource not accessible with this token
```

Happens whenever the initial `add` resolves to an **existing** `TeamProvisioningConfig` (i.e. a Stripe project that already maps to a team in the same org) rather than creating a new team. Downstream endpoints reject the resolved team id because it was never added to the bearer token's `scoped_teams`.

## Changes

`_resolve_or_create_project_team` had three success paths. Only the new-team branch added the resolved team to `scoped_teams` via `_add_team_to_token_scopes`. The other two — "existing config matched by org" and "race-winner recovery on `IntegrityError`" — returned the team untouched, so `scoped_teams` still only contained the base team from initial auth. Downstream endpoints (`update_service`, `remove_resource`, `rotate_credentials`) then 403'd with `Resource not accessible with this token`. Token refresh preserves `scoped_teams` as-is (see `views.py:842`) so the tester couldn't work around it by re-authenticating.

- Extract `_ensure_team_in_token_scopes(access_token, scoped_teams, team)` — calls `_add_team_to_token_scopes` then returns the team plus a deduped `scoped_teams` list.
- All three resolved-team return paths now go through it.

## How did you test this code?

- Added `test_create_resource_with_existing_project_id_adds_resolved_team_to_scoped_teams` in `ee/api/agentic_provisioning/test/test_resources.py`. Pre-creates a `TeamProvisioningConfig` for a second team in the same org, posts `create_resource` with that `project_id` using a token scoped only to the base team, asserts both that the response returns the existing team and that `access_token.scoped_teams` now contains both team ids. Mirrors the pattern of the existing `test_create_resource_with_project_id_adds_to_scoped_teams` which already covered the new-team branch.
- Existing tests for `update_service` / `remove_resource` / `rotate_credentials` already assert the 403 behaviour when a team is not in scope — they still pass and validate the existing semantics of the check.
- Not manually reproed end-to-end with the Stripe CLI; agent-authored, relying on unit-test coverage + code reading.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 LLM context

Diagnosed from a bug report in the Stripe apps project channel. Repro: link the PostHog provider, then run `stripe projects add posthog/<service>` for a `project_id` whose `TeamProvisioningConfig` already points to a different team in the same org as the token's base team. The endpoint succeeds and returns the existing team, but any subsequent `update` / `upgrade` / `remove` against that team id hits `scoped_teams` check in `ee/api/agentic_provisioning/views.py` (pre-fix line 1302 in `provisioning_update_service`) and returns 403.