### PR TITLE
fix(scim): normalize member ids before set diff in role membership update

### DIFF
--- a/ee/api/scim/group.py
+++ b/ee/api/scim/group.py
@@ -115,8 +115,18 @@ class PostHogSCIMGroup(SCIMGroup):
         """
         Update role membership based on SCIM members list.
         """
-        # Get list of user IDs from SCIM data
-        member_user_ids = {member.get("value") for member in members_data}
+        # Normalize SCIM `members[].value` to string form of integer IDs to match the always-string
+        # `current_user_ids` set below. Some IdPs send `value` as a JSON number; without this, the
+        # set diff would be type-asymmetric and silently delete the membership the IdP asked to keep.
+        member_user_ids: set[str] = set()
+        for member in members_data:
+            raw_member_id = member.get("value")
+            if raw_member_id is None:
+                continue
+            try:
+                member_user_ids.add(str(int(raw_member_id)))
+            except (TypeError, ValueError):
+                logger.warning("scim_group_skip_invalid_member_id", extra={"member_value": raw_member_id})
 
         # Get current role members
         current_memberships = RoleMembership.objects.filter(role=role).select_related("user", "organization_member")
@@ -125,9 +135,10 @@ class PostHogSCIMGroup(SCIMGroup):
         to_add = member_user_ids - current_user_ids
         to_remove = current_user_ids - member_user_ids
 
-        for user_id in to_add:
+        for raw_member_id in to_add:
+            user_pk = int(raw_member_id)
             try:
-                user = User.objects.get(id=user_id)
+                user = User.objects.get(id=user_pk)
                 org_membership = OrganizationMembership.objects.filter(
                     user=user, organization=organization_domain.organization
                 ).first()
@@ -138,10 +149,6 @@ class PostHogSCIMGroup(SCIMGroup):
                         role=role, user=user, defaults={"organization_member": org_membership}
                     )
             except User.DoesNotExist:
-                continue
-            except ValueError:
-                # Skip non-user members (e.g., nested group references from IdPs)
-                logger.warning("scim_group_skip_invalid_member_id", extra={"member_value": user_id})
                 continue
 
         # Remove members no longer in the group

--- a/ee/api/scim/test/test_groups_api.py
+++ b/ee/api/scim/test/test_groups_api.py
@@ -660,6 +660,71 @@ class TestSCIMGroupsAPI(APILicensedTest):
         assert RoleMembership.objects.filter(role=role, user=user).exists()
         assert RoleMembership.objects.filter(role=role).count() == 1
 
+    def test_put_preserves_member_when_value_is_integer(self):
+        # Some IdPs send `members[].value` as a JSON number rather than a string. The
+        # set-diff in `_update_members` previously compared int IDs against the
+        # always-string `current_user_ids`, so the membership the IdP asked to keep
+        # ended up in `to_remove` and was silently deleted.
+        user = User.objects.create_user(
+            email="intvalue@example.com", password=None, first_name="Int", is_email_verified=True
+        )
+        OrganizationMembership.objects.create(
+            user=user, organization=self.organization, level=OrganizationMembership.Level.MEMBER
+        )
+        role = Role.objects.create(name="IntValueRole", organization=self.organization)
+        membership = RoleMembership.objects.create(role=role, user=user)
+
+        put_data = {
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+            "displayName": "IntValueRole",
+            "members": [{"value": user.id}],  # int, not str
+        }
+
+        response = self.client.put(
+            f"/scim/v2/{self.domain.id}/Groups/{role.id}", data=put_data, content_type="application/scim+json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert RoleMembership.objects.filter(pk=membership.pk).exists(), (
+            "RoleMembership for the user the IdP asked to keep was incorrectly deleted"
+        )
+
+    def test_put_with_mixed_int_and_string_member_values(self):
+        # Mixed payload: keep one user (int value), keep another (str value), remove a third.
+        # Verifies the int-value path doesn't bleed into a spurious removal of a string-value member.
+        user_int = User.objects.create_user(
+            email="mixedint@example.com", password=None, first_name="MixedInt", is_email_verified=True
+        )
+        user_str = User.objects.create_user(
+            email="mixedstr@example.com", password=None, first_name="MixedStr", is_email_verified=True
+        )
+        user_removed = User.objects.create_user(
+            email="mixedrm@example.com", password=None, first_name="MixedRm", is_email_verified=True
+        )
+        for u in (user_int, user_str, user_removed):
+            OrganizationMembership.objects.create(
+                user=u, organization=self.organization, level=OrganizationMembership.Level.MEMBER
+            )
+        role = Role.objects.create(name="MixedRole", organization=self.organization)
+        for u in (user_int, user_str, user_removed):
+            RoleMembership.objects.create(role=role, user=u)
+
+        put_data = {
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+            "displayName": "MixedRole",
+            "members": [{"value": user_int.id}, {"value": str(user_str.id)}],
+        }
+
+        response = self.client.put(
+            f"/scim/v2/{self.domain.id}/Groups/{role.id}", data=put_data, content_type="application/scim+json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert RoleMembership.objects.filter(role=role, user=user_int).exists()
+        assert RoleMembership.objects.filter(role=role, user=user_str).exists()
+        assert not RoleMembership.objects.filter(role=role, user=user_removed).exists()
+        assert RoleMembership.objects.filter(role=role).count() == 2
+
     # ── Pagination tests ──
 
     def _create_groups(self, count: int) -> list[Role]:


### PR DESCRIPTION
Some IdPs send `members[].value` as a JSON number rather than a string. The set diff in `_update_members` was comparing those raw values against the always-string `current_user_ids`, so an integer-typed value the IdP asked to keep would land in `to_remove` and the membership would be silently deleted on PUT/replace.

Normalize incoming values to `str(int(...))` upfront, mirroring the current_user_ids form. Non-coercible values (e.g. nested-group UUIDs from Entra ID) are skipped + logged once at parse time, replacing the previous per-element ValueError catch.

This bug was caught by clauding. I confirmed the new tests fail without this code change.
