### PR TITLE
fix(livestream): regenerate easyjson 

### DIFF
--- a/.github/workflows/ci-livestream.yml
+++ b/.github/workflows/ci-livestream.yml
@@ -33,5 +33,16 @@ jobs:
                   working-directory: livestream
                   args: --timeout=5m
 
+            - name: Check easyjson generated code is up to date
+              run: |
+                  go install github.com/mailru/easyjson/easyjson@latest
+                  cd livestream
+                  easyjson events/kafka.go
+                  easyjson events/filter.go
+                  git diff --exit-code -- events/*_easyjson.go || {
+                    echo "::error::easyjson generated files are out of date. Run 'easyjson events/kafka.go && easyjson events/filter.go' in livestream/ and commit the result."
+                    exit 1
+                  }
+
             - name: Run tests
               run: cd livestream && go test -v

--- a/.github/workflows/ci-livestream.yml
+++ b/.github/workflows/ci-livestream.yml
@@ -33,16 +33,5 @@ jobs:
                   working-directory: livestream
                   args: --timeout=5m
 
-            - name: Check easyjson generated code is up to date
-              run: |
-                  go install github.com/mailru/easyjson/easyjson@latest
-                  cd livestream
-                  easyjson events/kafka.go
-                  easyjson events/filter.go
-                  git diff --exit-code -- events/*_easyjson.go || {
-                    echo "::error::easyjson generated files are out of date. Run 'easyjson events/kafka.go && easyjson events/filter.go' in livestream/ and commit the result."
-                    exit 1
-                  }
-
             - name: Run tests
               run: cd livestream && go test -v

--- a/livestream/events/kafka_easyjson.go
+++ b/livestream/events/kafka_easyjson.go
@@ -181,6 +181,14 @@ func easyjsonB70d1354DecodeGithubComPosthogPosthogLivestreamEvents1(in *jlexer.L
 			out.Lng = float64(in.Float64())
 		case "CountryCode":
 			out.CountryCode = string(in.String())
+		case "IsBot":
+			out.IsBot = bool(in.Bool())
+		case "TrafficType":
+			out.TrafficType = string(in.String())
+		case "TrafficCategory":
+			out.TrafficCategory = string(in.String())
+		case "BotName":
+			out.BotName = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -273,6 +281,26 @@ func easyjsonB70d1354EncodeGithubComPosthogPosthogLivestreamEvents1(out *jwriter
 		const prefix string = ",\"CountryCode\":"
 		out.RawString(prefix)
 		out.String(string(in.CountryCode))
+	}
+	{
+		const prefix string = ",\"IsBot\":"
+		out.RawString(prefix)
+		out.Bool(bool(in.IsBot))
+	}
+	{
+		const prefix string = ",\"TrafficType\":"
+		out.RawString(prefix)
+		out.String(string(in.TrafficType))
+	}
+	{
+		const prefix string = ",\"TrafficCategory\":"
+		out.RawString(prefix)
+		out.String(string(in.TrafficCategory))
+	}
+	{
+		const prefix string = ",\"BotName\":"
+		out.RawString(prefix)
+		out.String(string(in.BotName))
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
## Summary
- Regenerate `kafka_easyjson.go` to include the `IsBot`, `TrafficType`, `TrafficCategory`, and `BotName` fields added in #55537
- The stale generated code meant these fields were silently dropped during Redis pub/sub serialization, potentially breaking event delivery on the live web analytics tab

## Test plan
- [ ] Verify livestream SSE events flow on the live web analytics tab after deploy
- [ ] Confirm bot classification properties appear in SSE events