### PR TITLE
chore: remove unused .env.local block from bin/start

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -71,12 +71,6 @@ if [ -f .env ]; then
     set +o allexport
 fi
 
-if [ -f .env.local ]; then
-    set -o allexport
-    source .env.local
-    set +o allexport
-fi
-
 # Ducklake
 export DUCKLAKE_RDS_HOST=${DUCKLAKE_RDS_HOST:-db}
 export DUCKLAKE_RDS_PORT=${DUCKLAKE_RDS_PORT:-5432}


### PR DESCRIPTION
## Problem

The `.env.local` sourcing block in `bin/start` was not picking up local env files in practice, so it's dead code that suggests support that doesn't actually work.

## Changes

- Remove the `.env.local` `[ -f ... ] && source` block from `bin/start`.

The `.env` block is left as-is.

## How did you test this code?

No manual testing — this is a mechanical removal of a block that wasn't functioning. I'm an agent and have not run `bin/start` to verify.

## Publish to changelog?

no

## 🤖 LLM context

Authored by Claude Code at the user's request after they noted `.env.local` wasn't being detected. Only the `.env.local` block was removed; the `.env` block was intentionally preserved per the user's direction.