### PR TITLE
Expand LLM clustering skill docs with pipeline details and helper scripts

### DIFF
--- a/products/llm_analytics/skills/README.md
+++ b/products/llm_analytics/skills/README.md
@@ -8,8 +8,10 @@ Also available to Claude Code / Codex via `hogli sync:skill`.
 
 - **exploring-llm-traces** — how to query, inspect, and debug LLM traces via MCP tools.
   Covers the `$ai_*` event schema, content detail levels, and step-by-step debugging workflows.
-- **exploring-llm-clusters** — how to investigate LLM analytics clustering results,
-  compare cluster behavior, compute metrics, and drill into individual traces.
+- **exploring-llm-clusters** — how to investigate LLM analytics clustering
+  results: discover usage patterns, compare clusters by cost/latency/errors/
+  sentiment, decode run IDs, diff runs over time, and drill into representative
+  or outlier traces.
 - **exploring-llm-evaluations** — how to manage and investigate LLM analytics
   evaluations (both `hog` and `llm_judge` types), run them on specific generations,
   query individual results, and generate AI-powered summaries of pass/fail/N/A patterns.

--- a/products/llm_analytics/skills/exploring-llm-clusters/SKILL.md
+++ b/products/llm_analytics/skills/exploring-llm-clusters/SKILL.md
@@ -1,104 +1,100 @@
 ---
 name: exploring-llm-clusters
-description: 'Investigate LLM analytics clusters — understand usage patterns in AI/LLM traffic, compare cluster behavior, compute cost/latency metrics, and drill into individual traces within clusters.'
+description: >
+  Investigate LLM analytics clusters — discover usage patterns in AI/LLM traffic,
+  compare cluster cost/latency/errors/sentiment, track clusters across runs,
+  inspect outliers, and drill into representative traces. Use when the user asks
+  "what kinds of LLM usage do we have?", "which cluster is most expensive?",
+  "what are the error-heavy patterns?", pastes a `/llm-analytics/clusters/...`
+  URL, or wants to understand clustering run results.
 ---
 
-# Exploring LLM clusters
+# Exploring LLM clusters with MCP tools
 
-Use this skill when investigating LLM analytics clusters —
-understanding what patterns exist in your AI/LLM traffic,
-comparing cluster behavior, and drilling into individual clusters.
+PostHog clusters LLM traces (or individual generations) by embedding similarity.
+A Temporal workflow (`llma-trace-clustering`) runs daily per team: it fetches
+recent trace summary embeddings, reduces dimensions, clusters with HDBSCAN,
+labels each cluster with an LLM agent, and emits **one event per run** to
+ClickHouse containing the full cluster structure.
 
-## Tools
+## Available tools
 
-| Tool                                             | Purpose                                         |
-| ------------------------------------------------ | ----------------------------------------------- |
-| `posthog:llm-analytics-clustering-jobs-list`     | List clustering job configurations for the team |
-| `posthog:llm-analytics-clustering-jobs-retrieve` | Get a specific clustering job by ID             |
-| `posthog:execute-sql`                            | Query cluster run events and compute metrics    |
-| `posthog:query-llm-traces-list`                  | Find traces belonging to a cluster              |
-| `posthog:query-llm-trace`                        | Inspect a specific trace in detail              |
+| Tool                                             | Purpose                                                |
+| ------------------------------------------------ | ------------------------------------------------------ |
+| `posthog:execute-sql`                            | Query cluster run events and join to traces/metrics    |
+| `posthog:llm-analytics-clustering-jobs-list`     | List clustering job configurations for the team        |
+| `posthog:llm-analytics-clustering-jobs-retrieve` | Get a specific clustering job by ID                    |
+| `posthog:query-llm-traces-list`                  | Search traces in the window, e.g. to sanity-check      |
+| `posthog:query-llm-trace`                        | Inspect a specific trace (use for representative ones) |
+| `posthog:read-data-schema`                       | Discover custom properties before filtering            |
 
 ## How clustering works
 
-PostHog clusters LLM traces (or individual generations) by embedding similarity.
-A Temporal workflow runs periodically or on-demand, producing cluster events stored as
-`$ai_trace_clusters` (trace-level) or `$ai_generation_clusters` (generation-level).
+See the [event reference](./references/cluster-events.md) for the full property schema.
 
-Each cluster event contains:
+### Pipeline (per team, per run)
 
-- `$ai_clustering_run_id` — unique run identifier (format: `<team_id>_<level>_<YYYYMMDD>_<HHMMSS>[_<job_id>]`)
-- `$ai_clustering_level` — `"trace"` or `"generation"`
-- `$ai_window_start` / `$ai_window_end` — time window analyzed
-- `$ai_total_items_analyzed` — number of traces/generations processed
-- `$ai_clusters` — JSON array of cluster objects
-- `$ai_clustering_params` — algorithm parameters used
-
-### Cluster object shape (inside `$ai_clusters`)
-
-```json
-{
-  "cluster_id": 0,
-  "size": 42,
-  "title": "User authentication flows",
-  "description": "Traces involving login, signup, and token refresh operations",
-  "traces": {
-    "<trace_or_generation_id>": {
-      "distance_to_centroid": 0.123,
-      "rank": 0,
-      "x": -2.34,
-      "y": 1.56,
-      "timestamp": "2026-03-28T10:00:00Z",
-      "trace_id": "abc-123",
-      "generation_id": "gen-456"
-    }
-  },
-  "centroid_x": -2.1,
-  "centroid_y": 1.4
-}
+```text
+  1. Fetch trace/generation summary embeddings from raw_document_embeddings
+       (filtered by document_type + optional job_id suffix on `rendering`)
+  2. Optional L2-normalize embeddings
+  3. Dimensionality reduction (UMAP→100d, PCA, or none) for clustering
+  4. Cluster (HDBSCAN default — auto-k, identifies outliers as cluster_id=-1;
+             or k-means with silhouette-optimized k)
+  5. Compute distance matrix + 2D projection (UMAP/PCA/t-SNE) for scatter plot
+  6. Label clusters with an LLM agent (gpt-5.4 via LangGraph, 10-min budget)
+  7. Aggregate per-cluster metrics (cost, latency, tokens, error_rate, sentiment)
+  8. Emit single $ai_trace_clusters or $ai_generation_clusters event
 ```
 
-- `cluster_id: -1` is the **noise/outlier** cluster (items that didn't fit any cluster)
-- Items in `traces` are keyed by trace ID (trace-level) or generation event UUID (generation-level)
-- `rank` orders items by proximity to centroid (0 = closest)
-- `x`, `y` are 2D coordinates for visualization (UMAP/PCA/t-SNE reduced)
+### Two levels
 
-## Clustering jobs
+- **Trace-level** (`$ai_trace_clusters`) — clusters whole traces; items keyed by `trace_id`
+- **Generation-level** (`$ai_generation_clusters`) — clusters individual LLM calls; items keyed by `$ai_generation` event UUID, and each item also carries its parent `trace_id`
 
-Each team can have up to 5 clustering jobs. A job defines:
+### Run ID format
 
-- **name** — human-readable label
-- **analysis_level** — `"trace"` or `"generation"`
-- **event_filters** — property filters scoping which traces are included
-- **enabled** — whether the job runs on schedule
+```text
+<team_id>_<level>_<YYYYMMDD>_<HHMMSS>[_<job_id>][_<run_label>]
+```
 
-Default jobs named `"Default - trace"` and `"Default - generation"` are auto-created
-and disabled when a custom job is created for the same level.
+- `level` is `trace` or `generation`
+- `job_id` is a UUID when the run was triggered by a saved `ClusteringJob`
+- `run_label` is a free-form experiment tag (rare — mostly for manual runs)
+- Example: `1_trace_20250123_000000_019cb7f3-a126-7809-bffc-7f13bffe1325`
+
+Use helpers from [`scripts/parse_run_id.py`](./scripts/parse_run_id.py) to decode.
+
+### Noise / outlier cluster (HDBSCAN only)
+
+- `cluster_id: -1` contains items HDBSCAN couldn't fit anywhere
+- Items are sorted by **max** distance-to-any-centroid (most anomalous first, rank 0)
+- Noise cluster has no real `centroid` (empty list); `centroid_x`/`centroid_y` is the mean of its points' 2D coords
+- k-means runs don't produce a noise cluster
 
 ## Workflow: explore clusters
 
-### Step 1 — List recent clustering runs
+### Step 1 — List recent runs
 
 ```sql
-posthog:execute-sql
 SELECT
     JSONExtractString(properties, '$ai_clustering_run_id') as run_id,
     JSONExtractString(properties, '$ai_clustering_level') as level,
+    JSONExtractString(properties, '$ai_clustering_job_name') as job_name,
     JSONExtractString(properties, '$ai_window_start') as window_start,
     JSONExtractString(properties, '$ai_window_end') as window_end,
     JSONExtractInt(properties, '$ai_total_items_analyzed') as total_items,
     timestamp
 FROM events
 WHERE event IN ('$ai_trace_clusters', '$ai_generation_clusters')
-    AND timestamp >= now() - INTERVAL 7 DAY
+    AND timestamp >= now() - INTERVAL 30 DAY
 ORDER BY timestamp DESC
-LIMIT 10
+LIMIT 20
 ```
 
-### Step 2 — Get clusters from a specific run
+### Step 2 — Load a specific run's cluster payload
 
 ```sql
-posthog:execute-sql
 SELECT
     JSONExtractString(properties, '$ai_clustering_run_id') as run_id,
     JSONExtractString(properties, '$ai_clustering_level') as level,
@@ -112,57 +108,39 @@ SELECT
 FROM events
 WHERE event IN ('$ai_trace_clusters', '$ai_generation_clusters')
     AND JSONExtractString(properties, '$ai_clustering_run_id') = '<run_id>'
+    AND timestamp >= parseDateTimeBestEffort('<day_start_utc>')
+    AND timestamp <= parseDateTimeBestEffort('<day_end_utc>')
 LIMIT 1
 ```
 
-The `clusters` field is a JSON array. Parse it to see cluster titles, sizes, and descriptions.
+**Always include a tight timestamp window** — the run ID is in UTC and encodes
+the window end date. Use `parse_run_id.py` to derive day bounds, otherwise the
+query scans ClickHouse unnecessarily.
 
-**Important:** The clusters JSON can be very large (thousands of trace IDs with coordinates).
-When the result is too large for inline display, it auto-persists to a file.
-Use `print_clusters.py` from [scripts/](./scripts/) to get a readable summary.
+The `clusters` JSON can be large (thousands of trace IDs with 2D coords and
+metrics per cluster). When the result is persisted to a file, use the helper
+scripts in [`scripts/`](./scripts/) to parse it.
 
-### Step 3 — Compute metrics for clusters
+### Step 3 — Summarize the run
 
-For trace-level clusters, compute cost/latency/token metrics:
+```bash
+# Overview: metadata, cluster sizes, titles, top traces per cluster
+python3 scripts/print_clusters.py /path/to/persisted-file.json
 
-```sql
-posthog:execute-sql
-SELECT
-    JSONExtractString(properties, '$ai_trace_id') as trace_id,
-    sum(toFloat(properties.$ai_total_cost_usd)) as total_cost,
-    max(toFloat(properties.$ai_latency)) as latency,
-    sum(toInt(properties.$ai_input_tokens)) as input_tokens,
-    sum(toInt(properties.$ai_output_tokens)) as output_tokens,
-    countIf(properties.$ai_is_error = 'true') as error_count
-FROM events
-WHERE event IN ('$ai_generation', '$ai_embedding', '$ai_span')
-    AND timestamp >= parseDateTimeBestEffort('<window_start>')
-    AND timestamp <= parseDateTimeBestEffort('<window_end>')
-    AND JSONExtractString(properties, '$ai_trace_id') IN ('<trace_id_1>', '<trace_id_2>', ...)
-GROUP BY trace_id
+# Cluster metrics (pre-aggregated) — cost, latency, error_rate, sentiment
+python3 scripts/print_cluster_metrics.py /path/to/persisted-file.json
+
+# Extract trace IDs from one cluster for drill-down
+CLUSTER_ID=0 python3 scripts/extract_cluster_items.py /path/to/persisted-file.json
+
+# Decode a run ID
+python3 scripts/parse_run_id.py '1_trace_20250123_000000_019cb7f3-...'
 ```
 
-For generation-level clusters, match by event UUID:
+### Step 4 — Drill into representative traces
 
-```sql
-posthog:execute-sql
-SELECT
-    toString(uuid) as generation_id,
-    toFloat(properties.$ai_total_cost_usd) as cost,
-    toFloat(properties.$ai_latency) as latency,
-    toInt(properties.$ai_input_tokens) as input_tokens,
-    toInt(properties.$ai_output_tokens) as output_tokens,
-    if(properties.$ai_is_error = 'true', 1, 0) as is_error
-FROM events
-WHERE event = '$ai_generation'
-    AND timestamp >= parseDateTimeBestEffort('<window_start>')
-    AND timestamp <= parseDateTimeBestEffort('<window_end>')
-    AND toString(uuid) IN ('<gen_uuid_1>', '<gen_uuid_2>', ...)
-```
-
-### Step 4 — Drill into specific traces
-
-Once you've identified interesting clusters, use the trace tools to inspect individual traces:
+Each cluster's `traces` map is keyed by item ID with a `rank` field (0 = closest
+to centroid = most representative). Pick the top 3–5 ranked items and inspect:
 
 ```json
 posthog:query-llm-trace
@@ -172,43 +150,149 @@ posthog:query-llm-trace
 }
 ```
 
+For generation-level clusters the item key is a `$ai_generation` event UUID —
+use the sibling `trace_id` field inside the item info to call `query-llm-trace`
+with the parent trace.
+
+### Step 5 — Read cluster metrics
+
+Recent clusters have **pre-aggregated** metrics baked in under a `metrics` field
+per cluster object:
+
+```json
+"metrics": {
+  "avg_cost": 0.0123,
+  "avg_latency": 2.45,
+  "avg_tokens": 1250.0,
+  "total_cost": 4.321,
+  "error_rate": 0.05,
+  "error_count": 2,
+  "item_count": 37,
+  "sentiment": {"label": "positive", "score": 0.7,
+                "counts": {"positive": 20, "neutral": 5, "negative": 2}, "total": 27}
+}
+```
+
+Older runs (before the aggregates activity was added) may not have this field.
+If missing, compute on-demand with the SQL in
+[`references/cluster-metrics-sql.md`](./references/cluster-metrics-sql.md) — it
+mirrors what the frontend does when the baked-in metrics are absent.
+
 ## Investigation patterns
 
 ### "What kinds of LLM usage do we have?"
 
-1. List recent clustering runs (Step 1)
-2. Load the latest run's clusters (Step 2)
-3. Review cluster titles and descriptions — each represents a distinct usage pattern
-4. Compare cluster sizes to understand traffic distribution
+1. List recent runs (Step 1), pick the most recent trace-level one
+2. Load its clusters (Step 2) and run `print_clusters.py`
+3. Review cluster `title` + `description` — each is a distinct usage pattern
+4. Compare cluster `size` fields to understand traffic distribution
+5. Don't forget cluster -1 (outliers) — this is where novel/rare patterns hide
 
-### "Which cluster is most expensive / slowest?"
+### "Which cluster is most expensive / slowest / errors the most?"
 
-1. Load clusters from a run (Step 2)
-2. Extract trace IDs from each cluster
-3. Compute metrics per cluster (Step 3)
-4. Aggregate: `avg(cost)`, `avg(latency)`, `sum(cost)` per cluster
-5. Compare across clusters
+1. Load the run (Step 2), run `print_cluster_metrics.py`
+2. It sorts clusters by `total_cost` desc, shows averages, error rate, and sentiment
+3. If the run predates baked-in metrics, fall back to the on-demand SQL in
+   [`references/cluster-metrics-sql.md`](./references/cluster-metrics-sql.md)
+4. Drill into the top 3 ranked traces of the offending cluster to see why
 
 ### "What's in this cluster?"
 
-1. Load the cluster's traces (from the `traces` field)
-2. Sort by `rank` (closest to centroid = most representative)
-3. Inspect the top 3-5 traces via `query-llm-trace` to understand the pattern
-4. Check the cluster `title` and `description` for the AI-generated summary
+1. `CLUSTER_ID=<id> python3 scripts/extract_cluster_items.py FILE` dumps item IDs in rank order
+2. Inspect the top 3–5 ranked items via `query-llm-trace` (rank 0 = closest to centroid)
+3. The cluster `title`/`description` is an LLM-generated summary — treat as a hypothesis and verify against real traces
 
 ### "Are there error-heavy clusters?"
 
-1. Compute metrics (Step 3) with `error_count`
-2. Calculate error rate per cluster: `items_with_errors / total_items`
-3. Focus on clusters with high error rates
-4. Drill into errored traces to find root causes
+1. From the metrics: sort clusters by `error_rate` descending, filter `item_count >= 5` to avoid tiny-sample noise
+2. For high-error clusters, drill into items ranked lowest (furthest from centroid) —
+   these are where the cluster's "edge" is, often where errors cluster
+3. Cross-reference with `$ai_generation` `$ai_is_error = 'true'` events in the window
+
+### "What's new or weird?" (outliers)
+
+1. Load the run, filter the clusters array to `cluster_id = -1`
+2. Noise items are sorted by `rank` ascending where rank 0 has the **highest** min-distance-to-any-centroid (most anomalous)
+3. Inspect the top-ranked noise items via `query-llm-trace` — these are candidate new usage patterns
 
 ### "How do clusters compare across runs?"
 
-1. List multiple runs (Step 1)
-2. Load clusters from each run
-3. Compare cluster titles — similar titles across runs indicate stable patterns
-4. Track cluster size changes to detect shifts in traffic patterns
+1. List multiple runs for the same level + job_id (Step 1)
+2. Load two runs and compare their cluster titles side-by-side — similar titles signal stable patterns
+3. Track cluster-size shifts to detect traffic pattern changes week-over-week
+4. Use `diff_runs.py` for a side-by-side summary
+
+```bash
+python3 scripts/diff_runs.py /path/to/run_a.json /path/to/run_b.json
+```
+
+### "Why did this specific trace end up here?"
+
+1. Find the trace ID inside `cluster.traces`; note its `distance_to_centroid` and `rank`
+2. High rank (far from centroid) = weakly representative → maybe it should be noise
+3. Inspect the `$ai_trace_summary` event for that trace — that's the text the embedding was computed from:
+
+   ```sql
+   SELECT properties.$ai_summary_title, properties.$ai_summary_bullets,
+          properties.$ai_batch_run_id, timestamp
+   FROM events
+   WHERE event = '$ai_trace_summary'
+     AND JSONExtractString(properties, '$ai_trace_id') = '<trace_id>'
+     AND timestamp >= now() - INTERVAL 30 DAY
+   ORDER BY timestamp DESC LIMIT 1
+   ```
+
+### "What params were used for this run?"
+
+The `$ai_clustering_params` property records the full config:
+
+```json
+{
+  "clustering_method": "hdbscan",
+  "clustering_method_params": { "min_cluster_size_fraction": 0.02, "min_samples": 5 },
+  "embedding_normalization": "l2",
+  "dimensionality_reduction_method": "umap",
+  "dimensionality_reduction_ndims": 100,
+  "visualization_method": "umap",
+  "max_samples": 1500
+}
+```
+
+Useful when comparing clustering runs that used different algorithms or samples.
+
+## Clustering jobs
+
+Each team can have up to 5 clustering jobs. A job defines:
+
+- **name** — human-readable label
+- **analysis_level** — `"trace"` or `"generation"`
+- **event_filters** — PostHog property filters (same shape as feature flags / evaluations) that scope which items are included
+- **enabled** — whether the scheduled run picks it up
+
+Defaults named `"Default - trace"` and `"Default - generation"` are auto-created
+and auto-disabled as soon as a custom job is created for the same level.
+
+```json
+posthog:llm-analytics-clustering-jobs-list {}
+posthog:llm-analytics-clustering-jobs-retrieve {"id": "<job_uuid>"}
+```
+
+Match a run to its job via the `$ai_clustering_job_id` / `$ai_clustering_job_name`
+properties on the cluster event, or decode the run ID with `parse_run_id.py`.
+
+## Trace summaries (what the clustering actually sees)
+
+Clustering does **not** embed raw trace data — it embeds a **summary** produced
+by a separate hourly workflow (`llma-trace-summarization`). Each trace gets:
+
+| Event                    | Emitted per | Key properties                                                                                                                              |
+| ------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `$ai_trace_summary`      | Trace       | `$ai_trace_id`, `$ai_batch_run_id`, `$ai_summary_title`, `$ai_summary_flow_diagram`, `$ai_summary_bullets`, `$ai_summary_interesting_notes` |
+| `$ai_generation_summary` | Generation  | Same as above plus `$ai_generation_id`                                                                                                      |
+
+If a cluster title feels "off", the root cause is often the summary — pull the
+summary event for a representative trace and confirm it captured the right
+semantic signal.
 
 ## Constructing UI links
 
@@ -216,14 +300,16 @@ posthog:query-llm-trace
 - **Specific run**: `https://app.posthog.com/llm-analytics/clusters/<url_encoded_run_id>`
 - **Cluster detail**: `https://app.posthog.com/llm-analytics/clusters/<url_encoded_run_id>/<cluster_id>`
 
-Always surface these links so the user can verify visually in the PostHog UI.
+URL-encode the run ID (it contains `_` and UUIDs). Always surface these links
+so the user can verify visually in the PostHog UI.
 
 ## Tips
 
-- Always set a time range in SQL queries — cluster events without time bounds are slow
-- Start with run listing to orient, then drill into specific clusters
-- Cluster titles and descriptions are AI-generated summaries — verify by inspecting traces
-- The noise cluster (`cluster_id: -1`) contains outliers that didn't fit any pattern
-- Use `llm-analytics-clustering-jobs-list` to understand what clustering configs are active
-- Trace IDs in clusters can be used directly with `query-llm-trace` for deep inspection
-- For large clusters, inspect the top-ranked traces (closest to centroid) for representative examples
+- **Always scope by timestamp** — cluster events exist in the regular `events` table, so unbounded queries are slow. Use `parse_run_id.py` to derive a tight day-window around the run
+- **One event per run** — no joins or per-cluster rows; the whole cluster payload is a single JSON blob on a single event
+- **Noise cluster items are ranked by anomaly, not proximity** — the most outlying item is rank 0
+- **Cluster titles/descriptions are AI-generated** — great starting hypothesis, but always verify by inspecting representative traces
+- **`metrics` may be missing on older runs** — check for the field before using; fall back to on-demand SQL
+- **For generation-level drill-downs, use `item.trace_id`** (the parent trace) with `query-llm-trace`, not the item key (which is the generation UUID)
+- **Minimum 20 items required** — teams with fewer traces in the window produce no cluster event (check with Step 1 and expect gaps)
+- **Run in UTC** — run IDs and windows are UTC; set `convertToProjectTimezone: false` if you construct HogQL that compares to them

--- a/products/llm_analytics/skills/exploring-llm-clusters/references/cluster-events.md
+++ b/products/llm_analytics/skills/exploring-llm-clusters/references/cluster-events.md
@@ -1,0 +1,170 @@
+# Clustering event and property reference
+
+Clustering results are written to the regular `events` table as one event per
+clustering run. The cluster payload is stored as **native JSON** on the event
+(not a JSON string).
+
+## Event types
+
+### `$ai_trace_clusters`
+
+Emitted by the trace-level clustering workflow. One event per run.
+
+### `$ai_generation_clusters`
+
+Emitted by the generation-level clustering workflow. Same shape as
+`$ai_trace_clusters` — the only difference is that item keys inside
+`cluster.traces` are `$ai_generation` event UUIDs, and each item carries its
+parent `trace_id`.
+
+## Event properties
+
+| Property                   | Type        | Description                                                                   |
+| -------------------------- | ----------- | ----------------------------------------------------------------------------- |
+| `$ai_clustering_run_id`    | string      | Unique run ID: `<team_id>_<level>_<YYYYMMDD>_<HHMMSS>[_<job_id>][_<label>]`   |
+| `$ai_clustering_level`     | string      | `"trace"` or `"generation"`                                                   |
+| `$ai_clustering_job_id`    | string      | `ClusteringJob` UUID (empty for legacy/manual runs without a job)             |
+| `$ai_clustering_job_name`  | string      | Friendly job name                                                             |
+| `$ai_window_start`         | string      | Inclusive window start, ISO 8601 UTC                                          |
+| `$ai_window_end`           | string      | Exclusive window end, ISO 8601 UTC                                            |
+| `$ai_total_items_analyzed` | int         | Number of traces/generations actually clustered after the item-minimum filter |
+| `$ai_clusters`             | JSON array  | Array of cluster objects (see below)                                          |
+| `$ai_clustering_params`    | JSON object | Algorithm parameters used (see below)                                         |
+
+## Cluster object (inside `$ai_clusters`)
+
+```json
+{
+  "cluster_id": 0,
+  "size": 42,
+  "title": "User authentication flows",
+  "description": "- Customer login and signup operations\n- Token refresh flows\n...",
+  "traces": {
+    "<item_key>": {
+      "distance_to_centroid": 0.123,
+      "rank": 0,
+      "x": -2.34,
+      "y": 1.56,
+      "timestamp": "2026-03-28T10:00:00Z",
+      "trace_id": "abc-123",
+      "generation_id": null
+    }
+  },
+  "centroid": [0.12, -0.45, ...],
+  "centroid_x": -2.2,
+  "centroid_y": 1.4,
+  "metrics": {
+    "avg_cost": 0.0123,
+    "avg_latency": 2.45,
+    "avg_tokens": 1250.0,
+    "total_cost": 4.321,
+    "error_rate": 0.05,
+    "error_count": 2,
+    "item_count": 37,
+    "sentiment": {
+      "label": "positive",
+      "score": 0.7,
+      "counts": {"positive": 20, "neutral": 5, "negative": 2},
+      "total": 27
+    }
+  }
+}
+```
+
+### Fields
+
+| Field         | Type        | Notes                                                                                                                 |
+| ------------- | ----------- | --------------------------------------------------------------------------------------------------------------------- |
+| `cluster_id`  | int         | `-1` for the noise/outlier cluster (HDBSCAN only)                                                                     |
+| `size`        | int         | Number of items in this cluster                                                                                       |
+| `title`       | string      | LLM-generated cluster title                                                                                           |
+| `description` | string      | LLM-generated description (often markdown bullets)                                                                    |
+| `traces`      | object      | Map of item key → item info. Item key is `trace_id` for trace-level, `$ai_generation` event UUID for generation-level |
+| `centroid`    | float array | Cluster centroid in reduced embedding space (empty for noise)                                                         |
+| `centroid_x`  | float       | 2D x coord for the scatter plot                                                                                       |
+| `centroid_y`  | float       | 2D y coord for the scatter plot                                                                                       |
+| `metrics`     | object      | Pre-aggregated cost/latency/tokens/errors/sentiment (may be missing on older runs)                                    |
+
+### Item info (inside `cluster.traces`)
+
+| Field                  | Type           | Notes                                                                                                             |
+| ---------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `distance_to_centroid` | float          | Distance from this item to its cluster's centroid. For noise items, it's the **min** distance to **any** centroid |
+| `rank`                 | int            | 0 = closest to centroid (most representative). For noise: 0 = most anomalous                                      |
+| `x`, `y`               | float          | 2D scatter plot coordinates (from UMAP/PCA/t-SNE visualization reduction)                                         |
+| `timestamp`            | string         | First event timestamp of the trace/generation, ISO 8601 (used for efficient lookup)                               |
+| `trace_id`             | string         | Always set — trace ID (or parent trace for generations)                                                           |
+| `generation_id`        | string \| null | Only set for generation-level clustering                                                                          |
+
+## `$ai_clustering_params` shape
+
+```json
+{
+  "clustering_method": "hdbscan",
+  "clustering_method_params": {
+    "min_cluster_size_fraction": 0.02,
+    "min_samples": 5
+  },
+  "embedding_normalization": "l2",
+  "dimensionality_reduction_method": "umap",
+  "dimensionality_reduction_ndims": 100,
+  "visualization_method": "umap",
+  "max_samples": 1500
+}
+```
+
+| Field                                                | Values                          | Notes                                                    |
+| ---------------------------------------------------- | ------------------------------- | -------------------------------------------------------- |
+| `clustering_method`                                  | `"hdbscan"` \| `"kmeans"`       | HDBSCAN auto-picks k and produces noise; k-means doesn't |
+| `clustering_method_params.min_cluster_size_fraction` | float (0.02–0.5)                | HDBSCAN: min cluster size as fraction of samples         |
+| `clustering_method_params.min_samples`               | int                             | HDBSCAN: min samples in neighborhood for core points     |
+| `clustering_method_params.min_k` / `max_k`           | int                             | k-means: silhouette-score search range                   |
+| `embedding_normalization`                            | `"none"` \| `"l2"`              | L2 = unit-length normalization (cosine-ish similarity)   |
+| `dimensionality_reduction_method`                    | `"none"` \| `"umap"` \| `"pca"` | Reduction for clustering, not visualization              |
+| `dimensionality_reduction_ndims`                     | int (default 100)               | Target dims for clustering                               |
+| `visualization_method`                               | `"umap"` \| `"pca"` \| `"tsne"` | 2D projection for the scatter plot                       |
+| `max_samples`                                        | int                             | Upper bound on items sampled per run                     |
+
+## Related events
+
+### `$ai_trace_summary` / `$ai_generation_summary`
+
+Emitted by the summarization workflow (`llma-trace-summarization`) that feeds
+clustering. Each run produces one summary per trace/generation. These are the
+text representations that get embedded and clustered.
+
+| Property                        | Type       | Description                                                           |
+| ------------------------------- | ---------- | --------------------------------------------------------------------- |
+| `$ai_trace_id`                  | string     | Original trace ID                                                     |
+| `$ai_generation_id`             | string     | Only on `$ai_generation_summary`                                      |
+| `$ai_batch_run_id`              | string     | Summary batch run ID (`<team>_<iso_ts>`); links summary → cluster run |
+| `$ai_summary_mode`              | string     | `"detailed"` by default                                               |
+| `$ai_summary_title`             | string     | Short title of the trace                                              |
+| `$ai_summary_flow_diagram`      | string     | Mermaid diagram of the trace flow                                     |
+| `$ai_summary_bullets`           | JSON array | Bulleted summary with line refs                                       |
+| `$ai_summary_interesting_notes` | JSON array | Notable observations                                                  |
+| `$ai_text_repr_length`          | int        | Length of the text that was embedded                                  |
+| `$ai_event_count`               | int        | Number of underlying events in the trace                              |
+| `trace_timestamp`               | string     | First event timestamp of the source trace                             |
+
+The cluster labeling agent reads `$ai_summary_title` and other fields when it
+generates cluster titles — so to understand "why did the cluster title say X",
+pull the summary events for the cluster's top-ranked items.
+
+## Noise cluster semantics (HDBSCAN)
+
+- Only HDBSCAN produces a noise cluster (`cluster_id: -1`)
+- Contains items that HDBSCAN couldn't fit into any dense region
+- `centroid` is an empty list; `centroid_x`/`centroid_y` is the mean of the noise points' 2D coordinates (for visualization only)
+- Items are sorted by **max** min-distance-to-any-centroid — rank 0 = most anomalous
+- The labeling agent usually titles this cluster "Outliers" but wording varies
+
+## Constants
+
+| Value                       | Meaning                                                        |
+| --------------------------- | -------------------------------------------------------------- |
+| `NOISE_CLUSTER_ID`          | `-1`                                                           |
+| `MIN_TRACES_FOR_CLUSTERING` | `20` — fewer than this in the window produces no cluster event |
+| `DEFAULT_MAX_SAMPLES`       | `1500`                                                         |
+| `DEFAULT_LOOKBACK_DAYS`     | `7`                                                            |
+| `LABELING_AGENT_MODEL`      | `gpt-5.4`                                                      |

--- a/products/llm_analytics/skills/exploring-llm-clusters/references/cluster-metrics-sql.md
+++ b/products/llm_analytics/skills/exploring-llm-clusters/references/cluster-metrics-sql.md
@@ -1,0 +1,103 @@
+# On-demand cluster metrics SQL
+
+Use this when the `metrics` field is missing from cluster objects (older runs
+that predate the aggregates activity) or when you want to compute metrics with
+a different definition than the baked-in one.
+
+The frontend uses the same queries when falling back from baked-in metrics. See
+`products/llm_analytics/frontend/clusters/clusterMetricsLoader.ts` for the
+canonical source.
+
+## Trace-level clusters
+
+Aggregate cost/latency/tokens/errors across every AI event in each trace.
+
+```sql
+SELECT
+    JSONExtractString(properties, '$ai_trace_id') AS item_id,
+    sum(toFloat(properties.$ai_total_cost_usd))  AS total_cost,
+    max(toFloat(properties.$ai_latency))         AS latency,
+    sum(toInt(properties.$ai_input_tokens))      AS input_tokens,
+    sum(toInt(properties.$ai_output_tokens))     AS output_tokens,
+    countIf(properties.$ai_is_error = 'true')    AS error_count
+FROM events
+WHERE event IN ('$ai_generation', '$ai_embedding', '$ai_span')
+    AND timestamp >= parseDateTimeBestEffort('<window_start>')
+    AND timestamp <= parseDateTimeBestEffort('<window_end>')
+    AND JSONExtractString(properties, '$ai_trace_id') IN (<trace_ids>)
+GROUP BY item_id
+```
+
+## Generation-level clusters
+
+Match each `$ai_generation` event directly by its UUID — no aggregation needed.
+
+```sql
+SELECT
+    toString(uuid)                          AS item_id,
+    toFloat(properties.$ai_total_cost_usd)  AS cost,
+    toFloat(properties.$ai_latency)         AS latency,
+    toInt(properties.$ai_input_tokens)      AS input_tokens,
+    toInt(properties.$ai_output_tokens)     AS output_tokens,
+    if(properties.$ai_is_error = 'true', 1, 0) AS error_count
+FROM events
+WHERE event = '$ai_generation'
+    AND timestamp >= parseDateTimeBestEffort('<window_start>')
+    AND timestamp <= parseDateTimeBestEffort('<window_end>')
+    AND toString(uuid) IN (<generation_uuids>)
+```
+
+## Aggregating per cluster
+
+Once you have per-item metrics, aggregate as follows (matches the backend in
+`posthog/temporal/llm_analytics/trace_clustering/aggregates.py`):
+
+- `avg_cost` = mean of non-null, positive `cost` values within the cluster
+- `avg_latency` = mean of non-null, positive `latency` values within the cluster
+- `avg_tokens` = mean of `input_tokens + output_tokens` for items with tokens > 0
+- `total_cost` = sum of cost values
+- `error_rate` = `items_with_errors / items_with_any_data`
+- `item_count` = items with any metrics data
+
+Items with no AI events in the window are skipped (they don't count toward the
+denominator) — otherwise old items could drag down averages.
+
+## Cluster-level rollup query (trace-level, one SQL hop)
+
+If you want to do everything in one query (no script), unnest the cluster JSON
+and join against metrics:
+
+```sql
+WITH run AS (
+    SELECT
+        JSONExtractRaw(properties, '$ai_clusters') AS clusters_json,
+        JSONExtractString(properties, '$ai_window_start') AS window_start,
+        JSONExtractString(properties, '$ai_window_end')   AS window_end
+    FROM events
+    WHERE event = '$ai_trace_clusters'
+      AND JSONExtractString(properties, '$ai_clustering_run_id') = '<run_id>'
+      AND timestamp >= parseDateTimeBestEffort('<day_start_utc>')
+      AND timestamp <= parseDateTimeBestEffort('<day_end_utc>')
+    LIMIT 1
+)
+SELECT
+    c.cluster_id,
+    c.title,
+    c.size,
+    avg(m.total_cost)  AS avg_cost_per_trace,
+    sum(m.total_cost)  AS total_cost,
+    avg(m.latency)     AS avg_latency,
+    sum(m.error_count) AS total_errors
+FROM run
+ARRAY JOIN arrayMap(x -> tuple(
+    JSONExtractInt(x, 'cluster_id'),
+    JSONExtractString(x, 'title'),
+    JSONExtractInt(x, 'size'),
+    JSONExtractKeys(JSONExtractRaw(x, 'traces'))
+), JSONExtractArrayRaw(clusters_json)) AS c
+-- ... join to per-trace metrics ...
+```
+
+In practice it's usually easier to use the two-step approach (pull the cluster
+event, run `print_cluster_metrics.py` or `extract_cluster_items.py`, then query
+metrics for specific trace IDs).

--- a/products/llm_analytics/skills/exploring-llm-clusters/scripts/diff_runs.py
+++ b/products/llm_analytics/skills/exploring-llm-clusters/scripts/diff_runs.py
@@ -1,0 +1,110 @@
+"""Side-by-side comparison of two clustering runs.
+
+Compares by cluster title (fuzzy-matched as case-insensitive substring containment
+after normalisation) and reports:
+
+  - stable clusters (similar titles, with size delta)
+  - clusters only in A (disappeared)
+  - clusters only in B (appeared)
+  - total item count delta and noise cluster size delta
+
+Usage:
+    python3 diff_runs.py <run_a.json> <run_b.json>
+"""
+
+import sys
+
+from print_clusters import load_result_file, parse_result
+
+
+def _normalize(s: str) -> str:
+    return " ".join((s or "").lower().split())
+
+
+def _title_match(a: str, b: str) -> bool:
+    a_n, b_n = _normalize(a), _normalize(b)
+    if not a_n or not b_n:
+        return False
+    if a_n == b_n:
+        return True
+    # Substring match either direction — catches minor wording drift in LLM labels
+    if len(a_n) > 6 and len(b_n) > 6 and (a_n in b_n or b_n in a_n):
+        return True
+    return False
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: python3 diff_runs.py <run_a.json> <run_b.json>")
+        sys.exit(1)
+
+    clusters_a, meta_a, _ = parse_result(load_result_file(sys.argv[1]))
+    clusters_b, meta_b, _ = parse_result(load_result_file(sys.argv[2]))
+
+    if not clusters_a or not clusters_b:
+        print("Both files must contain a clusters array.")
+        sys.exit(1)
+
+    bar = "=" * 80
+    print(f"\n{bar}")
+    print(f"  RUN A: {meta_a.get('run_id', sys.argv[1])}")
+    print(f"         items: {meta_a.get('total_items', '?')}  clusters: {len(clusters_a)}")
+    print(f"  RUN B: {meta_b.get('run_id', sys.argv[2])}")
+    print(f"         items: {meta_b.get('total_items', '?')}  clusters: {len(clusters_b)}")
+    print(bar)
+
+    # Skip noise for title matching — compare separately at the end
+    regular_a = [c for c in clusters_a if c.get("cluster_id", -1) != -1]
+    regular_b = [c for c in clusters_b if c.get("cluster_id", -1) != -1]
+
+    matched_b_ids: set[int] = set()
+    stable: list[tuple[dict, dict]] = []
+    only_in_a: list[dict] = []
+
+    for ca in regular_a:
+        partner = None
+        for cb in regular_b:
+            if cb.get("cluster_id") in matched_b_ids:
+                continue
+            if _title_match(ca.get("title", ""), cb.get("title", "")):
+                partner = cb
+                break
+        if partner is not None:
+            stable.append((ca, partner))
+            matched_b_ids.add(partner.get("cluster_id"))
+        else:
+            only_in_a.append(ca)
+
+    only_in_b = [c for c in regular_b if c.get("cluster_id") not in matched_b_ids]
+
+    print("\n  STABLE CLUSTERS (title match)")
+    if not stable:
+        print("    (none)")
+    for ca, cb in sorted(stable, key=lambda p: -p[1].get("size", 0)):
+        delta = cb.get("size", 0) - ca.get("size", 0)
+        title = (cb.get("title") or ca.get("title") or "?")[:60]
+        print(f"    {ca.get('size', 0):>5} → {cb.get('size', 0):>5}  ({delta:+d})  {title}")
+
+    print("\n  ONLY IN A (disappeared)")
+    if not only_in_a:
+        print("    (none)")
+    for c in sorted(only_in_a, key=lambda c: -c.get("size", 0)):
+        print(f"    -{c.get('size', 0):>4}  {(c.get('title') or '?')[:70]}")
+
+    print("\n  ONLY IN B (appeared)")
+    if not only_in_b:
+        print("    (none)")
+    for c in sorted(only_in_b, key=lambda c: -c.get("size", 0)):
+        print(f"    +{c.get('size', 0):>4}  {(c.get('title') or '?')[:70]}")
+
+    noise_a = next((c for c in clusters_a if c.get("cluster_id") == -1), None)
+    noise_b = next((c for c in clusters_b if c.get("cluster_id") == -1), None)
+    if noise_a or noise_b:
+        size_a = noise_a.get("size", 0) if noise_a else 0
+        size_b = noise_b.get("size", 0) if noise_b else 0
+        delta = size_b - size_a
+        print(f"\n  NOISE: {size_a} → {size_b}  ({delta:+d})")
+
+
+if __name__ == "__main__":
+    main()

--- a/products/llm_analytics/skills/exploring-llm-clusters/scripts/extract_cluster_items.py
+++ b/products/llm_analytics/skills/exploring-llm-clusters/scripts/extract_cluster_items.py
@@ -1,0 +1,78 @@
+"""Extract the items of one cluster in rank order (closest-to-centroid first).
+
+Usage:
+    CLUSTER_ID=0 python3 extract_cluster_items.py <result_file>
+    CLUSTER_ID=-1 python3 extract_cluster_items.py <result_file>   # noise cluster
+    CLUSTER_ID=0 LIMIT=10 python3 extract_cluster_items.py <file>
+
+Prints:
+    <rank>  <item_key>  trace=<trace_id> [gen=<gen_id>]  dist=<d>  ts=<iso>
+
+For trace-level clusters, item_key == trace_id.
+For generation-level clusters, item_key is the $ai_generation event UUID; the
+parent trace is reported as trace=<trace_id>.
+
+The "noise" cluster (CLUSTER_ID=-1) is sorted so that rank 0 = most anomalous
+(highest minimum distance to any centroid).
+"""
+
+import os
+import sys
+
+from print_clusters import load_result_file, parse_result
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: CLUSTER_ID=<id> python3 extract_cluster_items.py <result_file>")
+        sys.exit(1)
+
+    cluster_id_env = os.environ.get("CLUSTER_ID")
+    if cluster_id_env is None:
+        print("Set CLUSTER_ID env var (e.g. CLUSTER_ID=0, or -1 for noise)")
+        sys.exit(1)
+
+    try:
+        target_id = int(cluster_id_env)
+    except ValueError:
+        print(f"CLUSTER_ID must be an integer, got {cluster_id_env!r}")
+        sys.exit(1)
+
+    limit = int(os.environ.get("LIMIT", "0"))  # 0 = all
+
+    data = load_result_file(sys.argv[1])
+    clusters, _, _ = parse_result(data)
+    if not clusters:
+        print("No clusters in file.")
+        sys.exit(1)
+
+    match = next((c for c in clusters if c.get("cluster_id") == target_id), None)
+    if match is None:
+        ids = sorted({c.get("cluster_id") for c in clusters})
+        print(f"No cluster with id={target_id}. Available: {ids}")
+        sys.exit(1)
+
+    traces = match.get("traces", {})
+    ranked = sorted(traces.items(), key=lambda t: t[1].get("rank", 999))
+    if limit:
+        ranked = ranked[:limit]
+
+    bar = "=" * 80
+    print(f"\n{bar}")
+    print(f"  Cluster {target_id}: {match.get('title', '?')}")
+    print(f"  Size: {match.get('size', '?')} | showing {len(ranked)} items")
+    print(bar)
+
+    for key, info in ranked:
+        rank = info.get("rank", "?")
+        dist = info.get("distance_to_centroid")
+        dist_str = f"{dist:.4f}" if isinstance(dist, (int, float)) else "?"
+        trace_id = info.get("trace_id", key)
+        gen_id = info.get("generation_id")
+        ts = info.get("timestamp", "?")
+        tag = f"gen={gen_id} trace={trace_id}" if gen_id else f"trace={trace_id}"
+        print(f"  #{rank:>4}  {tag}  dist={dist_str}  ts={ts}")
+
+
+if __name__ == "__main__":
+    main()

--- a/products/llm_analytics/skills/exploring-llm-clusters/scripts/parse_run_id.py
+++ b/products/llm_analytics/skills/exploring-llm-clusters/scripts/parse_run_id.py
@@ -1,0 +1,66 @@
+"""Decode a clustering run ID into its components.
+
+Run ID format: <team_id>_<level>_<YYYYMMDD>_<HHMMSS>[_<job_id>][_<run_label>]
+
+- team_id: integer
+- level: "trace" or "generation"
+- timestamp: UTC, derived from the window_end of the run
+- job_id: optional UUID when a saved ClusteringJob triggered the run
+- run_label: free-form experiment tag (manual runs)
+"""
+
+import re
+import sys
+from datetime import UTC, datetime, timedelta
+
+UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
+
+
+def parse_run_id(run_id: str) -> dict:
+    parts = run_id.split("_")
+    result: dict = {"run_id": run_id}
+
+    if len(parts) < 4:
+        result["error"] = "run_id has fewer than 4 parts; cannot decode"
+        return result
+
+    result["team_id"] = parts[0]
+    result["level"] = parts[1]
+
+    try:
+        ts = datetime.strptime(f"{parts[2]}_{parts[3]}", "%Y%m%d_%H%M%S").replace(tzinfo=UTC)
+        result["timestamp_utc"] = ts.isoformat()
+        day_start = ts.replace(hour=0, minute=0, second=0, microsecond=0)
+        day_end = day_start + timedelta(days=1) - timedelta(seconds=1)
+        result["day_start_utc"] = day_start.isoformat()
+        result["day_end_utc"] = day_end.isoformat()
+    except ValueError as e:
+        result["timestamp_error"] = str(e)
+
+    if len(parts) >= 5:
+        suffix_parts = parts[4:]
+        # Reassemble UUID if it was split by underscores (UUIDs use hyphens so normally intact)
+        job_id = None
+        for i, part in enumerate(suffix_parts):
+            if UUID_RE.match(part):
+                job_id = part
+                remaining = suffix_parts[i + 1 :]
+                result["job_id"] = job_id
+                if remaining:
+                    result["run_label"] = "_".join(remaining)
+                break
+        if job_id is None:
+            result["run_label"] = "_".join(suffix_parts)
+
+    return result
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python parse_run_id.py <run_id>")
+        sys.exit(1)
+
+    decoded = parse_run_id(sys.argv[1])
+    width = max(len(k) for k in decoded)
+    for key, value in decoded.items():
+        print(f"  {key.ljust(width)}  {value}")

--- a/products/llm_analytics/skills/exploring-llm-clusters/scripts/print_cluster_metrics.py
+++ b/products/llm_analytics/skills/exploring-llm-clusters/scripts/print_cluster_metrics.py
@@ -1,0 +1,92 @@
+"""Print per-cluster aggregate metrics (cost, latency, tokens, errors, sentiment).
+
+Reads from the baked-in `metrics` field that the clustering workflow attaches to
+each cluster object. If the field is absent (older runs), this script prints a
+message pointing at references/cluster-metrics-sql.md for the on-demand query.
+
+Sorts clusters by total_cost desc; falls back to size desc when costs are missing.
+"""
+
+import json
+import sys
+
+from print_clusters import load_result_file, parse_result
+
+
+def fmt_num(v, fmt=".4f", suffix=""):
+    if v is None:
+        return "-"
+    try:
+        return f"{v:{fmt}}{suffix}"
+    except (ValueError, TypeError):
+        return str(v)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python print_cluster_metrics.py <result_file_path>")
+        sys.exit(1)
+
+    data = load_result_file(sys.argv[1])
+    clusters, meta, _ = parse_result(data)
+    if not clusters:
+        print("No clusters found in file.")
+        sys.exit(1)
+
+    has_metrics = any(isinstance(c.get("metrics"), dict) for c in clusters)
+    if not has_metrics:
+        print("No baked-in `metrics` field on any cluster.")
+        print("This run predates the aggregates activity.")
+        print("Run the SQL in references/cluster-metrics-sql.md to compute on-demand.")
+        sys.exit(0)
+
+    def sort_key(c):
+        m = c.get("metrics") or {}
+        total = m.get("total_cost")
+        return (-(total if total is not None else -1), -c.get("size", 0))
+
+    clusters = sorted(clusters, key=sort_key)
+
+    bar = "=" * 100
+    print(f"\n{bar}")
+    if meta.get("run_id"):
+        print(f"  Run: {meta['run_id']}")
+    if meta.get("level"):
+        print(f"  Level: {meta['level']}")
+    print(bar)
+    hdr = f"  {'CID':>4}  {'size':>5}  {'total$':>8}  {'avg$':>8}  {'avg_lat':>8}  {'avg_tok':>8}  {'err_rate':>8}  sentiment  title"
+    print(hdr)
+    print("  " + "-" * (len(hdr) - 2))
+
+    for c in clusters:
+        cid = c.get("cluster_id", "?")
+        m = c.get("metrics") or {}
+        sentiment = m.get("sentiment") or {}
+        sent_str = "-"
+        if isinstance(sentiment, dict) and sentiment.get("label"):
+            score = sentiment.get("score")
+            score_str = f"{score:.2f}" if isinstance(score, (int, float)) else "?"
+            sent_str = f"{sentiment['label'][:3]}({score_str})"
+
+        title = (c.get("title") or "").replace("\n", " ")
+        if len(title) > 40:
+            title = title[:37] + "..."
+
+        err_rate = m.get("error_rate")
+        err_str = f"{err_rate*100:.1f}%" if isinstance(err_rate, (int, float)) else "-"
+
+        print(
+            f"  {str(cid):>4}  "
+            f"{c.get('size', 0):>5}  "
+            f"{fmt_num(m.get('total_cost'), '.2f'):>8}  "
+            f"{fmt_num(m.get('avg_cost'), '.4f'):>8}  "
+            f"{fmt_num(m.get('avg_latency'), '.2f', 's'):>8}  "
+            f"{fmt_num(m.get('avg_tokens'), '.0f'):>8}  "
+            f"{err_str:>8}  "
+            f"{sent_str:>9}  "
+            f"{title}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/products/llm_analytics/skills/exploring-llm-clusters/scripts/print_clusters.py
+++ b/products/llm_analytics/skills/exploring-llm-clusters/scripts/print_clusters.py
@@ -1,4 +1,9 @@
-"""Print a summary of clusters from a clustering run result."""
+"""Print a summary of clusters from a clustering run result.
+
+Handles result shapes from execute-sql (rows + columns) and raw cluster arrays.
+Shows title/description, size, top-ranked items, and a one-line metrics preview
+when the event carries baked-in aggregates.
+"""
 
 import json
 import sys
@@ -15,35 +20,63 @@ def load_result_file(path):
 def parse_result(raw):
     """Extract clusters array and run metadata from various result shapes."""
     meta: dict[str, str | int | float] = {}
-    clusters = []
+    params: dict = {}
+    clusters: list = []
 
-    # Direct clusters array
     if isinstance(raw, list) and raw and isinstance(raw[0], dict) and "cluster_id" in raw[0]:
-        return raw, meta
+        return raw, meta, params
 
-    # SQL result — look for clusters JSON and metadata columns
     if isinstance(raw, dict) and "results" in raw:
         columns = raw.get("columns", [])
         for row in raw["results"]:
             for i, cell in enumerate(row):
                 col_name = columns[i] if i < len(columns) else ""
-                # Extract run metadata from known columns
-                if isinstance(cell, str) and col_name in (
+                if col_name in (
                     "run_id", "level", "job_id", "job_name",
                     "window_start", "window_end", "total_items",
-                ):
+                ) and isinstance(cell, (str, int, float)):
                     meta[col_name] = cell
-                elif isinstance(cell, (int, float)) and col_name == "total_items":
-                    meta[col_name] = cell
-                # Find the clusters JSON
-                if isinstance(cell, str) and cell.startswith("["):
+                if col_name == "params" and isinstance(cell, str):
+                    try:
+                        params = json.loads(cell)
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+                if col_name == "clusters" and isinstance(cell, str):
+                    try:
+                        parsed = json.loads(cell)
+                        if isinstance(parsed, list) and parsed and "cluster_id" in parsed[0]:
+                            clusters = parsed
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+                # Fallback: scan any string cell that looks like the clusters array
+                if not clusters and isinstance(cell, str) and cell.startswith("["):
                     try:
                         parsed = json.loads(cell)
                         if isinstance(parsed, list) and parsed and "cluster_id" in parsed[0]:
                             clusters = parsed
                     except (json.JSONDecodeError, TypeError):
                         continue
-    return clusters, meta
+    return clusters, meta, params
+
+
+def fmt_metrics_line(m):
+    if not isinstance(m, dict):
+        return ""
+    parts = []
+    if m.get("avg_cost") is not None:
+        parts.append(f"avg_cost=${m['avg_cost']:.4f}")
+    if m.get("total_cost") is not None:
+        parts.append(f"total=${m['total_cost']:.2f}")
+    if m.get("avg_latency") is not None:
+        parts.append(f"avg_lat={m['avg_latency']:.2f}s")
+    if m.get("avg_tokens") is not None:
+        parts.append(f"avg_tok={int(m['avg_tokens'])}")
+    if m.get("error_rate") is not None:
+        parts.append(f"err={m['error_rate']*100:.1f}%")
+    sentiment = m.get("sentiment")
+    if isinstance(sentiment, dict) and sentiment.get("label"):
+        parts.append(f"sent={sentiment['label']}({sentiment.get('score', 0):.2f})")
+    return "  ".join(parts)
 
 
 if __name__ == "__main__":
@@ -52,7 +85,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     data = load_result_file(sys.argv[1])
-    clusters, meta = parse_result(data)
+    clusters, meta, params = parse_result(data)
 
     if not clusters:
         print("No clusters found in file.")
@@ -60,44 +93,54 @@ if __name__ == "__main__":
 
     clusters.sort(key=lambda c: c.get("size", 0), reverse=True)
 
-    print(f"\n{'='*80}")
-    if meta:
-        if meta.get("job_name"):
-            print(f"  Job: {meta['job_name']}")
-        if meta.get("level"):
-            print(f"  Level: {meta['level']}")
-        if meta.get("run_id"):
-            print(f"  Run: {meta['run_id']}")
-        if meta.get("job_id"):
-            print(f"  Job ID: {meta['job_id']}")
-        if meta.get("window_start") or meta.get("window_end"):
-            print(f"  Window: {meta.get('window_start', '?')} → {meta.get('window_end', '?')}")
-        if meta.get("total_items"):
-            print(f"  Items analyzed: {meta['total_items']}")
-        print(f"  ---")
+    bar = "=" * 80
+    print(f"\n{bar}")
+    if meta.get("job_name"):
+        print(f"  Job:     {meta['job_name']}")
+    if meta.get("level"):
+        print(f"  Level:   {meta['level']}")
+    if meta.get("run_id"):
+        print(f"  Run:     {meta['run_id']}")
+    if meta.get("window_start") or meta.get("window_end"):
+        print(f"  Window:  {meta.get('window_start', '?')} → {meta.get('window_end', '?')}")
+    if meta.get("total_items") is not None:
+        print(f"  Items:   {meta['total_items']} analyzed")
+    if params:
+        method = params.get("clustering_method", "?")
+        ndim = params.get("dimensionality_reduction_ndims")
+        norm = params.get("embedding_normalization")
+        print(f"  Params:  method={method} ndim={ndim} norm={norm}")
+    print(f"  ---")
     print(f"  {len(clusters)} clusters, {sum(c.get('size', 0) for c in clusters)} total items")
-    print(f"{'='*80}")
+    print(bar)
 
     for c in clusters:
         cid = c.get("cluster_id", "?")
-        label = "(NOISE/OUTLIERS)" if cid == -1 else ""
+        label = " (NOISE/OUTLIERS)" if cid == -1 else ""
         title = c.get("title", f"Cluster {cid}")
         size = c.get("size", 0)
         desc = c.get("description", "")
 
-        print(f"\n  Cluster {cid} {label}")
+        print(f"\n  Cluster {cid}{label}")
         print(f"  Title: {title}")
         print(f"  Size:  {size} items")
         if desc:
-            print(f"  Desc:  {desc[:200]}{'...' if len(desc) > 200 else ''}")
+            snippet = desc[:300]
+            print(f"  Desc:  {snippet}{'...' if len(desc) > 300 else ''}")
 
-        # Show top 5 traces by rank
+        metrics_line = fmt_metrics_line(c.get("metrics"))
+        if metrics_line:
+            print(f"  Metrics: {metrics_line}")
+
         traces = c.get("traces", {})
         ranked = sorted(traces.items(), key=lambda t: t[1].get("rank", 999))[:5]
         if ranked:
-            print(f"  Top traces (by centroid proximity):")
+            print(f"  Top items (by centroid proximity):")
             for tid, info in ranked:
                 dist = info.get("distance_to_centroid")
                 ts = info.get("timestamp", "?")
                 dist_str = f"{dist:.4f}" if isinstance(dist, (int, float)) else "?"
-                print(f"    #{info.get('rank', '?'):>3}  {tid}  dist={dist_str}  {ts}")
+                trace_id = info.get("trace_id", tid)
+                gen_id = info.get("generation_id")
+                marker = f"gen={gen_id} trace={trace_id}" if gen_id else f"trace={trace_id}"
+                print(f"    #{info.get('rank', '?'):>3}  {marker}  dist={dist_str}  {ts}")


### PR DESCRIPTION
## Problem

The `exploring-llm-clusters` skill documentation was high-level and lacked:
- Clear explanation of the clustering pipeline and how it works
- Detailed event/property schema reference for cluster events
- Practical helper scripts for analyzing clustering results
- Guidance on computing metrics for older runs without baked-in aggregates
- Patterns for comparing clusters across runs

Users needed more concrete examples and tooling to effectively explore and understand clustering results.

## Changes

### Documentation updates
- **SKILL.md**: Restructured and expanded with:
  - Detailed pipeline explanation (7-step process from embeddings to labeled clusters)
  - Clear distinction between trace-level and generation-level clustering
  - Run ID format and decoding guidance
  - Noise/outlier cluster behavior (HDBSCAN vs k-means)
  - Improved workflow examples with tighter SQL queries (added timestamp windows)
  - Investigation patterns for common questions ("what's expensive?", "what's new?", "how do clusters compare?")
  - Guidance on pre-aggregated metrics vs on-demand computation

- **references/cluster-events.md** (new): Complete event and property reference
  - Event types (`$ai_trace_clusters`, `$ai_generation_clusters`)
  - All event properties with types and descriptions
  - Cluster object schema with all fields documented
  - Item info structure (distance, rank, coordinates, timestamps)
  - `$ai_clustering_params` shape and algorithm options

- **references/cluster-metrics-sql.md** (new): On-demand metrics computation
  - SQL templates for trace-level and generation-level metrics
  - Aggregation logic (how to compute avg_cost, error_rate, sentiment, etc.)
  - One-hop cluster-level rollup query example
  - Guidance on when to use (older runs without baked-in metrics)

### Helper scripts (new)
- **scripts/parse_run_id.py**: Decode run IDs into components (team_id, level, timestamp, job_id, run_label) with UTC day bounds for efficient querying
- **scripts/print_cluster_metrics.py**: Display per-cluster aggregates (cost, latency, tokens, errors, sentiment) sorted by total cost; falls back to on-demand SQL guidance when metrics are missing
- **scripts/extract_cluster_items.py**: Extract items from a specific cluster in rank order (closest-to-centroid first), with environment variable control (CLUSTER_ID, LIMIT)
- **scripts/diff_runs.py**: Side-by-side comparison of two clustering runs with fuzzy title matching to identify stable clusters, disappeared patterns, and new patterns

### Script improvements
- **scripts/print_clusters.py**: Enhanced to handle more result shapes, added metrics preview line, improved formatting

## How did you test this code?

- Reviewed the diff for consistency with the clustering workflow implementation
- Verified SQL query syntax and ClickHouse function usage
- Tested helper script logic (parsing, sorting, filtering) against expected cluster JSON structures
- Confirmed run ID format matches the backend encoding in `posthog/temporal/llm_analytics/trace_clustering/`
- Validated that metrics aggregation logic mirrors the backend in `aggregates.py`

No manual testing needed — these are documentation and utility scripts that support existing clustering functionality.

## Publish to changelog?

No — this is documentation and internal tooling for an existing feature.

https://claude.ai/code/session_01Nzbg5tnUpZxyZwBZuBtM4n