### PR TITLE
fix(experiments): include saved metrics in AI experiment summary

### DIFF
--- a/products/experiments/backend/experiment_summary_data_service.py
+++ b/products/experiments/backend/experiment_summary_data_service.py
@@ -175,8 +175,10 @@ class ExperimentSummaryDataService:
         # First, fetch the experiment (required to build queries)
         @database_sync_to_async(thread_sensitive=settings.TEST)
         def fetch_experiment():
-            return Experiment.objects.select_related("feature_flag", "holdout", "team").get(
-                id=experiment_id, team_id=team_id, deleted=False
+            return (
+                Experiment.objects.select_related("feature_flag", "holdout", "team")
+                .prefetch_related("experimenttosavedmetric_set__saved_metric")
+                .get(id=experiment_id, team_id=team_id, deleted=False)
             )
 
         try:
@@ -296,9 +298,21 @@ class ExperimentSummaryDataService:
             async with semaphore:
                 return await _run_query()
 
-        # Build list of all query tasks
-        primary_metrics = experiment.metrics or []
-        secondary_metrics = experiment.metrics_secondary or []
+        # Build list of all query tasks, combining inline metrics with saved metrics.
+        # Saved metrics are stored via ExperimentToSavedMetric junction records and
+        # classified as primary/secondary by the metadata.type field.
+        primary_metrics: list[dict] = list(experiment.metrics or [])
+        secondary_metrics: list[dict] = list(experiment.metrics_secondary or [])
+
+        for link in experiment.experimenttosavedmetric_set.all():
+            query = link.saved_metric.query
+            if not query:
+                continue
+            metric_type = (link.metadata or {}).get("type", "primary")
+            if metric_type == "primary":
+                primary_metrics.append(query)
+            else:
+                secondary_metrics.append(query)
 
         primary_metric_tasks = [
             run_metric_query_async(metric, i) for i, metric in enumerate(primary_metrics[:MAX_METRICS_TO_SUMMARIZE])

--- a/products/experiments/backend/test/test_experiment_summary_tool.py
+++ b/products/experiments/backend/test/test_experiment_summary_tool.py
@@ -516,6 +516,12 @@ class TestExperimentSummaryDataService(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(context.primary_metrics_results), 1)
         self.assertEqual(len(context.secondary_metrics_results), 1)
 
+        # Verify the saved metric queries were actually passed to the query runner
+        query_runner_calls = mock_query_runner_class.call_args_list
+        self.assertEqual(len(query_runner_calls), 2)
+        metrics_queried = [call.kwargs["query"].metric.metric_type for call in query_runner_calls]
+        self.assertEqual(metrics_queried, ["funnel", "funnel"])
+
     @freeze_time("2020-01-10T12:00:00Z")
     async def test_fetch_experiment_data_combines_inline_and_saved_metrics(self):
         experiment = await self.acreate_experiment(name="mixed-metrics-test", with_metrics=True)
@@ -610,3 +616,10 @@ class TestExperimentSummaryDataService(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(context.primary_metrics_results), 2)
         # 1 inline secondary + 1 saved secondary = 2
         self.assertEqual(len(context.secondary_metrics_results), 2)
+
+        # Verify all 4 metrics were passed to the query runner (2 primary + 2 secondary)
+        query_runner_calls = mock_query_runner_class.call_args_list
+        self.assertEqual(len(query_runner_calls), 4)
+        metrics_queried = [call.kwargs["query"].metric.metric_type for call in query_runner_calls]
+        # Inline funnel primary, saved mean primary, inline funnel secondary, saved funnel secondary
+        self.assertEqual(metrics_queried, ["funnel", "mean", "funnel", "funnel"])

--- a/products/experiments/backend/test/test_experiment_summary_tool.py
+++ b/products/experiments/backend/test/test_experiment_summary_tool.py
@@ -30,7 +30,7 @@ from products.experiments.backend.experiment_summary_data_service import (
     transform_variant_for_max,
 )
 from products.experiments.backend.metric_utils import get_default_metric_title
-from products.experiments.backend.models.experiment import Experiment
+from products.experiments.backend.models.experiment import Experiment, ExperimentSavedMetric, ExperimentToSavedMetric
 
 
 @override_settings(IN_UNIT_TESTING=True)
@@ -433,3 +433,180 @@ class TestExperimentSummaryDataService(ClickhouseTestMixin, APIBaseTest):
 
         self.assertFalse(pending_calculation)
         self.assertIsNotNone(last_refresh)
+
+    @freeze_time("2020-01-10T12:00:00Z")
+    async def test_fetch_experiment_data_includes_saved_metrics(self):
+        experiment = await self.acreate_experiment(name="saved-metrics-test", with_metrics=False)
+
+        # Create saved metrics and link them via ExperimentToSavedMetric
+        primary_saved = await ExperimentSavedMetric.objects.acreate(
+            team=self.team,
+            name="Team Growth NSM",
+            query={
+                "kind": "ExperimentMetric",
+                "metric_type": "funnel",
+                "series": [{"kind": "EventsNode", "event": "first team event ingested"}],
+                "uuid": "primary-saved-uuid",
+            },
+        )
+        secondary_saved = await ExperimentSavedMetric.objects.acreate(
+            team=self.team,
+            name="Onboarding Completion",
+            query={
+                "kind": "ExperimentMetric",
+                "metric_type": "funnel",
+                "series": [{"kind": "EventsNode", "event": "onboarding completed"}],
+                "uuid": "secondary-saved-uuid",
+            },
+        )
+        await ExperimentToSavedMetric.objects.acreate(
+            experiment=experiment, saved_metric=primary_saved, metadata={"type": "primary"}
+        )
+        await ExperimentToSavedMetric.objects.acreate(
+            experiment=experiment, saved_metric=secondary_saved, metadata={"type": "secondary"}
+        )
+
+        mock_query_result = MagicMock()
+        mock_query_result.variant_results = [
+            ExperimentVariantResultBayesian(
+                key="control",
+                method="bayesian",
+                chance_to_win=0.4,
+                credible_interval=[-0.05, 0.05],
+                significant=False,
+                number_of_samples=100,
+                sum=50,
+                sum_squares=2500,
+            ),
+            ExperimentVariantResultBayesian(
+                key="test",
+                method="bayesian",
+                chance_to_win=0.6,
+                credible_interval=[-0.02, 0.08],
+                significant=False,
+                number_of_samples=100,
+                sum=55,
+                sum_squares=3025,
+            ),
+        ]
+        mock_query_result.last_refresh = datetime(2020, 1, 10, 11, 0, tzinfo=ZoneInfo("UTC"))
+
+        mock_exposure_result = MagicMock()
+        mock_exposure_result.total_exposures = {"control": 500, "test": 500}
+        mock_exposure_result.last_refresh = datetime(2020, 1, 10, 11, 0, tzinfo=ZoneInfo("UTC"))
+
+        with (
+            patch(
+                "products.experiments.backend.experiment_summary_data_service.posthoganalytics.feature_enabled",
+                return_value=False,
+            ),
+            patch(
+                "products.experiments.backend.experiment_summary_data_service.ExperimentQueryRunner"
+            ) as mock_query_runner_class,
+            patch(
+                "products.experiments.backend.experiment_summary_data_service.ExperimentExposuresQueryRunner"
+            ) as mock_exposure_runner_class,
+        ):
+            mock_query_runner_class.return_value.run.return_value = mock_query_result
+            mock_exposure_runner_class.return_value.run.return_value = mock_exposure_result
+
+            data_service = ExperimentSummaryDataService(self.team)
+            context, _, _ = await data_service.fetch_experiment_data(experiment.id)
+
+        self.assertEqual(len(context.primary_metrics_results), 1)
+        self.assertEqual(len(context.secondary_metrics_results), 1)
+
+    @freeze_time("2020-01-10T12:00:00Z")
+    async def test_fetch_experiment_data_combines_inline_and_saved_metrics(self):
+        experiment = await self.acreate_experiment(name="mixed-metrics-test", with_metrics=True)
+        # experiment.metrics already has 1 inline primary metric from acreate_experiment
+
+        # Add 1 inline secondary
+        experiment.metrics_secondary = [
+            {
+                "metric_type": "funnel",
+                "series": [{"kind": "EventsNode", "event": "signup"}],
+                "name": "Signup conversion",
+            }
+        ]
+        await experiment.asave(update_fields=["metrics_secondary"])
+
+        # Add 1 saved primary + 1 saved secondary
+        saved_primary = await ExperimentSavedMetric.objects.acreate(
+            team=self.team,
+            name="Saved Primary",
+            query={
+                "kind": "ExperimentMetric",
+                "metric_type": "mean",
+                "source": {"kind": "EventsNode", "event": "revenue"},
+                "uuid": "saved-primary-uuid",
+            },
+        )
+        saved_secondary = await ExperimentSavedMetric.objects.acreate(
+            team=self.team,
+            name="Saved Secondary",
+            query={
+                "kind": "ExperimentMetric",
+                "metric_type": "funnel",
+                "series": [{"kind": "EventsNode", "event": "activation"}],
+                "uuid": "saved-secondary-uuid",
+            },
+        )
+        await ExperimentToSavedMetric.objects.acreate(
+            experiment=experiment, saved_metric=saved_primary, metadata={"type": "primary"}
+        )
+        await ExperimentToSavedMetric.objects.acreate(
+            experiment=experiment, saved_metric=saved_secondary, metadata={"type": "secondary"}
+        )
+
+        mock_query_result = MagicMock()
+        mock_query_result.variant_results = [
+            ExperimentVariantResultBayesian(
+                key="control",
+                method="bayesian",
+                chance_to_win=0.5,
+                credible_interval=[-0.03, 0.03],
+                significant=False,
+                number_of_samples=100,
+                sum=50,
+                sum_squares=2500,
+            ),
+            ExperimentVariantResultBayesian(
+                key="test",
+                method="bayesian",
+                chance_to_win=0.5,
+                credible_interval=[-0.03, 0.03],
+                significant=False,
+                number_of_samples=100,
+                sum=50,
+                sum_squares=2500,
+            ),
+        ]
+        mock_query_result.last_refresh = datetime(2020, 1, 10, 11, 0, tzinfo=ZoneInfo("UTC"))
+
+        mock_exposure_result = MagicMock()
+        mock_exposure_result.total_exposures = {"control": 500, "test": 500}
+        mock_exposure_result.last_refresh = datetime(2020, 1, 10, 11, 0, tzinfo=ZoneInfo("UTC"))
+
+        with (
+            patch(
+                "products.experiments.backend.experiment_summary_data_service.posthoganalytics.feature_enabled",
+                return_value=False,
+            ),
+            patch(
+                "products.experiments.backend.experiment_summary_data_service.ExperimentQueryRunner"
+            ) as mock_query_runner_class,
+            patch(
+                "products.experiments.backend.experiment_summary_data_service.ExperimentExposuresQueryRunner"
+            ) as mock_exposure_runner_class,
+        ):
+            mock_query_runner_class.return_value.run.return_value = mock_query_result
+            mock_exposure_runner_class.return_value.run.return_value = mock_exposure_result
+
+            data_service = ExperimentSummaryDataService(self.team)
+            context, _, _ = await data_service.fetch_experiment_data(experiment.id)
+
+        # 1 inline primary + 1 saved primary = 2
+        self.assertEqual(len(context.primary_metrics_results), 2)
+        # 1 inline secondary + 1 saved secondary = 2
+        self.assertEqual(len(context.secondary_metrics_results), 2)

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -90,7 +90,7 @@ tools:
             destructive: false
             idempotent: true
         title: Get project
-        description: >
+        description: |
             Retrieve a project and its settings. Pass `@current` as the ID to fetch the caller's active project.
         param_overrides:
             id:
@@ -115,11 +115,9 @@ tools:
             idempotent: true
         title: Update project settings
         description: >
-            Update a project's settings using PATCH semantics — only the fields included in the request body are changed.
-            Use `project-get` first to inspect current settings. Always confirm changes with the user before applying.
-        param_overrides:
-            id:
-                description: Project ID, or `@current` to target the caller's active project.
+            Update a project's settings using PATCH semantics — only the fields included in the request body are
+            changed. Use `project-get` first to inspect current settings. Always confirm changes with the user before
+            applying.
         exclude_params:
             - uuid
             - created_at
@@ -137,6 +135,9 @@ tools:
             - default_modifiers
             - person_on_events_querying_enabled
             - organization
+        param_overrides:
+            id:
+                description: Project ID, or `@current` to target the caller's active project.
     projects-destroy:
         operation: destroy_2
         enabled: false
@@ -579,8 +580,8 @@ tools:
             idempotent: true
         title: Get user
         description: >
-            Retrieve a user's profile and settings. Pass `@me` as the UUID to fetch the authenticated user —
-            non-staff callers may only access their own account.
+            Retrieve a user's profile and settings. Pass `@me` as the UUID to fetch the authenticated user — non-staff
+            callers may only access their own account.
         param_overrides:
             uuid:
                 description: User UUID, or `@me` to target the authenticated user.
@@ -605,13 +606,10 @@ tools:
         title: Update user settings
         description: >
             Update the authenticated user's profile and settings using PATCH semantics — only the fields included in the
-            request body are changed. Pass `@me` as the UUID; non-staff callers may only update their own account.
-            Use `user-get` first to inspect current settings. `notification_settings` merges key-by-key; changing `email`
+            request body are changed. Pass `@me` as the UUID; non-staff callers may only update their own account. Use
+            `user-get` first to inspect current settings. `notification_settings` merges key-by-key; changing `email`
             triggers a verification flow; changing `password` also requires `current_password`. Always confirm changes
             with the user before applying.
-        param_overrides:
-            uuid:
-                description: User UUID, or `@me` to target the authenticated user.
         exclude_params:
             - date_joined
             - uuid
@@ -632,6 +630,9 @@ tools:
             - has_sso_enforcement
             - is_2fa_enabled
             - scene_personalisation
+        param_overrides:
+            uuid:
+                description: User UUID, or `@me` to target the authenticated user.
     users-destroy:
         operation: users_destroy
         enabled: false
@@ -784,4 +785,7 @@ tools:
         enabled: false
     dashboard-templates-copy-between-projects-create:
         operation: dashboard_templates_copy_between_projects_create
+        enabled: false
+    legal-documents-download-retrieve:
+        operation: legal_documents_download_retrieve
         enabled: false


### PR DESCRIPTION
## Problem

`ExperimentSummaryDataService` only read inline metrics (`experiment.metrics` / `experiment.metrics_secondary`). Experiments using saved metrics (via `ExperimentToSavedMetric`) had their metrics silently dropped — the AI summary would show only whatever was in the inline fields.

## Changes

- Prefetch saved metrics in the experiment query to avoid N+1
- Iterate over `experimenttosavedmetric_set` and append saved metric queries to the appropriate primary/secondary list, matching the same pattern used by the frontend and Temporal worker

## How did you test this code?

Two new tests + all 29 existing tests pass:
- Experiment with only saved metrics (no inline)
- Experiment with both inline and saved metrics combined