### PR TITLE
feat(billing): add billing API scope and selective PAT/OAuth opt-in

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -98,6 +98,13 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
     scope_object = "INTERNAL"
 
+    def dangerously_get_required_scopes(self, request, view) -> list[str] | None:
+        # Selective opt-in for PAT/OAuth access. Only the listed actions are reachable via API token;
+        # all other billing endpoints stay session-only via the INTERNAL scope_object default.
+        if self.action in ("list", "usage", "spend"):
+            return ["billing:read"]
+        return None
+
     def get_billing_manager(self) -> BillingManager:
         license = get_cached_instance_license()
         user = (

--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -21,6 +21,7 @@ export const API_SCOPES: APIScope[] = [
     { key: 'annotation', objectName: 'Annotation', objectPlural: 'annotations' },
     { key: 'approvals', objectName: 'Approvals', objectPlural: 'approvals' },
     { key: 'batch_export', objectName: 'Batch export', objectPlural: 'batch exports' },
+    { key: 'billing', objectName: 'Billing', objectPlural: 'billing' },
     // `clickhouse_test_cluster_perf` is omitted — see `INTERNAL_API_SCOPE_OBJECTS` in posthog/scopes.py.
     { key: 'cohort', objectName: 'Cohort', objectPlural: 'cohorts' },
     { key: 'comment', objectName: 'Comment', objectPlural: 'comments' },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5284,6 +5284,7 @@ export type APIScopeObject =
     | 'annotation'
     | 'approvals'
     | 'batch_export'
+    | 'billing'
     | 'clickhouse_test_cluster_perf'
     | 'cohort'
     | 'comment'

--- a/posthog/scopes.py
+++ b/posthog/scopes.py
@@ -22,6 +22,7 @@ APIScopeObject = Literal[
     "approvals",
     "batch_export",
     "batch_import",
+    "billing",
     "clickhouse_test_cluster_perf",
     "cohort",
     "comment",


### PR DESCRIPTION
## Problem

- `BillingViewset` is `scope_object = "INTERNAL"`, which blocks Personal API Key and OAuth access - the only path to billing data is the web session
- This PR opens up read access selectively, with default-deny semantics so accidentally adding new endpoints doesn't expose them

## Changes

- New `billing` scope (`billing:read`, `billing:write`) added to the API scope registry - 3 files: backend literal in `posthog/scopes.py` plus the matching frontend entries in `frontend/src/lib/scopes.tsx` and `frontend/src/types.ts`
- `BillingViewset` opens up selectively via `dangerously_get_required_scopes()`, mirroring `posthog/api/user.py:640`. Only `list` (GET `/api/billing/`), `usage` (GET `/api/billing/usage/`), and `spend` (GET `/api/billing/spend/`) are reachable via PAT/OAuth - every other action stays `INTERNAL` because the viewset's `scope_object = "INTERNAL"` default takes over
- `IsOrganizationAdmin` permission_classes on `usage` and `spend` stay unchanged: a member with `billing:read` gets the main billing response but is blocked from per-team breakdowns, identical to web UI semantics
- `billing_manager.build_billing_token` already constructs the JWT from `request.user`, so the user's organization role propagates to the billing service unchanged

### Note on the centralized opt-in

- The same opt-in could equivalently be split: `@action(..., required_scopes=["billing:read"])` on `usage` and `spend` (more common in this codebase - see `posthog/api/feature_flag.py`, `posthog/api/person.py`), with `dangerously_get_required_scopes` handling only `list` (which can't carry `@action` kwargs since it's a built-in DRF action method, not a custom action)
- Went with the centralized form because the allowlist of PAT/OAuth-readable actions is a security-relevant surface and one place to audit is easier than two
- Happy to split if reviewers prefer per-action declarations

## How did you test this code?

Manually verified the four-case auth matrix end-to-end against local PostHog with a freshly created PAT containing `billing:read`:

- `GET /api/billing/` with `billing:read` (member) → 200, full billing JSON
- `GET /api/billing/usage/` with `billing:read` (admin/owner) → 200, usage breakdowns
- `GET /api/billing/` with no auth → 401
- `PATCH /api/billing/` with `billing:read` → 403 "This action does not support Personal API Key access"

## Publish to changelog?

no

## Docs update

- A follow-up should add `billing:read` / `billing:write` to the published API scope reference at [posthog.com](http://posthog.com)