### PR TITLE
feat(billing): add force_include_in_api_docs and opt billing into the OpenAPI schema

### DIFF
--- a/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
+++ b/docs/published/handbook/engineering/ai/implementing-mcp-tools.md
@@ -327,6 +327,18 @@ see the [`improving-drf-endpoints` skill](https://github.com/PostHog/posthog/blo
   and the generated tool gets an empty schema with zero parameters.
   `ModelViewSet` with `serializer_class` works automatically.
 
+### Root-router viewsets
+
+Viewsets mounted at root URLs (no `team_id`/`project_id` in the path) set
+`param_derived_from_user_current_team` and are excluded from the OpenAPI schema by default,
+which means they are invisible to frontend type generation and MCP tool scaffolding.
+If your viewset is one of these and you want to expose it,
+set `force_include_in_api_docs = True` on the class. See `ee/api/billing.py` for an example.
+The opt-in works alongside `scope_object = "INTERNAL"` plus per-action overrides via
+`@action(required_scopes=...)` or `dangerously_get_required_scopes` —
+a viewset can stay default-deny for PAT/OAuth at runtime
+while still surfacing its endpoints in the schema.
+
 ## HogQL query schemas (WIP)
 
 [`frontend/src/queries/schema/schema-assistant-queries.ts`](https://github.com/PostHog/posthog/blob/master/frontend/src/queries/schema/schema-assistant-queries.ts) defines structured query types

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -97,9 +97,8 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     param_derived_from_user_current_team = "team_id"
 
     scope_object = "INTERNAL"
-    force_include_in_api_docs = (
-        True  # surface in OpenAPI despite INTERNAL + root-router (see preprocess_exclude_path_format)
-    )
+    # Surface in OpenAPI despite INTERNAL + root-router. See preprocess_exclude_path_format.
+    force_include_in_api_docs = True
 
     def dangerously_get_required_scopes(self, request, view) -> list[str] | None:
         # Selective opt-in for PAT/OAuth access. Only the listed actions are reachable via API token;

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -97,10 +97,9 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     param_derived_from_user_current_team = "team_id"
 
     scope_object = "INTERNAL"
-    # Opt this viewset into the OpenAPI schema despite `INTERNAL` scope and `param_derived_from_user_current_team`,
-    # so the selectively exposed actions (see dangerously_get_required_scopes) are discoverable by frontend
-    # type generation and MCP tool scaffolding.
-    force_include_in_api_docs = True
+    force_include_in_api_docs = (
+        True  # surface in OpenAPI despite INTERNAL + root-router (see preprocess_exclude_path_format)
+    )
 
     def dangerously_get_required_scopes(self, request, view) -> list[str] | None:
         # Selective opt-in for PAT/OAuth access. Only the listed actions are reachable via API token;

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -97,6 +97,10 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     param_derived_from_user_current_team = "team_id"
 
     scope_object = "INTERNAL"
+    # Opt this viewset into the OpenAPI schema despite `INTERNAL` scope and `param_derived_from_user_current_team`,
+    # so the selectively exposed actions (see dangerously_get_required_scopes) are discoverable by frontend
+    # type generation and MCP tool scaffolding.
+    force_include_in_api_docs = True
 
     def dangerously_get_required_scopes(self, request, view) -> list[str] | None:
         # Selective opt-in for PAT/OAuth access. Only the listed actions are reachable via API token;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2087,6 +2087,8 @@ importers:
 
   products/batch_exports: {}
 
+  products/billing: {}
+
   products/business_knowledge: {}
 
   products/cdp: {}

--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -724,10 +724,8 @@ def preprocess_exclude_path_format(endpoints, **kwargs):
         force_include = getattr(callback.cls, "force_include_in_api_docs", False)
 
         if getattr(callback.cls, "param_derived_from_user_current_team", None) and not force_include:
-            # Root-router endpoints (no team_id/project_id in URL) are excluded by default because
-            # they don't fit the standard /api/projects/{team_id}/... pattern that frontend type
-            # generation and MCP tool scaffolding expect. Viewsets that explicitly want to be
-            # discoverable set `force_include_in_api_docs = True`.
+            # Root-router viewsets don't fit the /api/projects/{team_id}/... pattern; opt in via
+            # `force_include_in_api_docs = True` to surface in type-gen and MCP scaffolding.
             continue
         if not hasattr(callback.cls, "scope_object") or getattr(callback.cls, "hide_api_docs", False):
             continue

--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -721,12 +721,18 @@ def preprocess_exclude_path_format(endpoints, **kwargs):
     projects_suffixes: set[tuple[str, str]] = set()
 
     for path, path_regex, method, callback in endpoints:
-        if getattr(callback.cls, "param_derived_from_user_current_team", None):
+        force_include = getattr(callback.cls, "force_include_in_api_docs", False)
+
+        if getattr(callback.cls, "param_derived_from_user_current_team", None) and not force_include:
+            # Root-router endpoints (no team_id/project_id in URL) are excluded by default because
+            # they don't fit the standard /api/projects/{team_id}/... pattern that frontend type
+            # generation and MCP tool scaffolding expect. Viewsets that explicitly want to be
+            # discoverable set `force_include_in_api_docs = True`.
             continue
         if not hasattr(callback.cls, "scope_object") or getattr(callback.cls, "hide_api_docs", False):
             continue
         scope = callback.cls.scope_object
-        if scope == "INTERNAL" and not include_internal:
+        if scope == "INTERNAL" and not (include_internal or force_include):
             continue
 
         included.append((path, path_regex, method, callback))

--- a/products/billing/frontend/generated/api.schemas.ts
+++ b/products/billing/frontend/generated/api.schemas.ts
@@ -1,0 +1,40 @@
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * To modify these types, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */
+export interface BillingApi {
+    /** @maxLength 100 */
+    plan: string
+    billing_limit: number
+}
+
+export interface PaginatedBillingListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: BillingApi[]
+}
+
+export interface PatchedBillingApi {
+    /** @maxLength 100 */
+    plan?: string
+    billing_limit?: number
+}
+
+export type BillingListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}

--- a/products/billing/frontend/generated/api.ts
+++ b/products/billing/frontend/generated/api.ts
@@ -1,0 +1,272 @@
+import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
+/**
+ * Auto-generated from the Django backend OpenAPI schema.
+ * To modify these types, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */
+import type { BillingApi, BillingListParams, PaginatedBillingListApi, PatchedBillingApi } from './api.schemas'
+
+export const getBillingListUrl = (params?: BillingListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : value.toString())
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0 ? `/api/billing/?${stringifiedParams}` : `/api/billing/`
+}
+
+export const billingList = async (
+    params?: BillingListParams,
+    options?: RequestInit
+): Promise<PaginatedBillingListApi> => {
+    return apiMutator<PaginatedBillingListApi>(getBillingListUrl(params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getBillingPartialUpdateUrl = () => {
+    return `/api/billing///`
+}
+
+export const billingPartialUpdate = async (
+    patchedBillingApi: PatchedBillingApi,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getBillingPartialUpdateUrl(), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedBillingApi),
+    })
+}
+
+export const getBillingActivateCreateUrl = () => {
+    return `/api/billing/activate/`
+}
+
+export const billingActivateCreate = async (billingApi: BillingApi, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getBillingActivateCreateUrl(), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(billingApi),
+    })
+}
+
+export const getBillingActivateAuthorizeCreateUrl = () => {
+    return `/api/billing/activate/authorize/`
+}
+
+export const billingActivateAuthorizeCreate = async (billingApi: BillingApi, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getBillingActivateAuthorizeCreateUrl(), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(billingApi),
+    })
+}
+
+export const getBillingActivateAuthorizeStatusCreateUrl = () => {
+    return `/api/billing/activate/authorize/status/`
+}
+
+export const billingActivateAuthorizeStatusCreate = async (
+    billingApi: BillingApi,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getBillingActivateAuthorizeStatusCreateUrl(), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(billingApi),
+    })
+}
+
+export const getBillingCouponsClaimCreateUrl = () => {
+    return `/api/billing/coupons/claim/`
+}
+
+export const billingCouponsClaimCreate = async (billingApi: BillingApi, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getBillingCouponsClaimCreateUrl(), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(billingApi),
+    })
+}
+
+export const getBillingCouponsOverviewRetrieveUrl = () => {
+    return `/api/billing/coupons/overview/`
+}
+
+export const billingCouponsOverviewRetrieve = async (options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getBillingCouponsOverviewRetrieveUrl(), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getBillingCreditsOverviewRetrieveUrl = () => {
+    return `/api/billing/credits/overview/`
+}
+
+export const billingCreditsOverviewRetrieve = async (options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getBillingCreditsOverviewRetrieveUrl(), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getBillingCreditsPurchaseCreateUrl = () => {
+    return `/api/billing/credits/purchase/`
+}
+
+export const billingCreditsPurchaseCreate = async (billingApi: BillingApi, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getBillingCreditsPurchaseCreateUrl(), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(billingApi),
+    })
+}
+
+export const getBillingDeactivateCreateUrl = () => {
+    return `/api/billing/deactivate/`
+}
+
+export const billingDeactivateCreate = async (billingApi: BillingApi, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getBillingDeactivateCreateUrl(), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(billingApi),
+    })
+}
+
+export const getBillingGetInvoicesRetrieveUrl = () => {
+    return `/api/billing/get_invoices/`
+}
+
+export const billingGetInvoicesRetrieve = async (options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getBillingGetInvoicesRetrieveUrl(), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getBillingLicensePartialUpdateUrl = () => {
+    return `/api/billing/license/`
+}
+
+export const billingLicensePartialUpdate = async (
+    patchedBillingApi: PatchedBillingApi,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getBillingLicensePartialUpdateUrl(), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedBillingApi),
+    })
+}
+
+export const getBillingPortalRetrieveUrl = () => {
+    return `/api/billing/portal/`
+}
+
+export const billingPortalRetrieve = async (options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getBillingPortalRetrieveUrl(), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+/**
+ * Endpoint to fetch spend data (proxy to billing service).
+ */
+export const getBillingSpendRetrieveUrl = () => {
+    return `/api/billing/spend/`
+}
+
+export const billingSpendRetrieve = async (options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getBillingSpendRetrieveUrl(), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getBillingStartupsApplyCreateUrl = () => {
+    return `/api/billing/startups/apply/`
+}
+
+export const billingStartupsApplyCreate = async (billingApi: BillingApi, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getBillingStartupsApplyCreateUrl(), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(billingApi),
+    })
+}
+
+export const getBillingSubscriptionSwitchPlanCreateUrl = () => {
+    return `/api/billing/subscription/switch-plan/`
+}
+
+export const billingSubscriptionSwitchPlanCreate = async (
+    billingApi: BillingApi,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getBillingSubscriptionSwitchPlanCreateUrl(), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(billingApi),
+    })
+}
+
+export const getBillingTrialsActivateCreateUrl = () => {
+    return `/api/billing/trials/activate/`
+}
+
+export const billingTrialsActivateCreate = async (billingApi: BillingApi, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getBillingTrialsActivateCreateUrl(), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(billingApi),
+    })
+}
+
+export const getBillingTrialsCancelCreateUrl = () => {
+    return `/api/billing/trials/cancel/`
+}
+
+export const billingTrialsCancelCreate = async (billingApi: BillingApi, options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getBillingTrialsCancelCreateUrl(), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(billingApi),
+    })
+}
+
+export const getBillingUsageRetrieveUrl = () => {
+    return `/api/billing/usage/`
+}
+
+export const billingUsageRetrieve = async (options?: RequestInit): Promise<void> => {
+    return apiMutator<void>(getBillingUsageRetrieveUrl(), {
+        ...options,
+        method: 'GET',
+    })
+}

--- a/products/billing/frontend/generated/api.ts
+++ b/products/billing/frontend/generated/api.ts
@@ -39,7 +39,7 @@ export const getBillingPartialUpdateUrl = () => {
 }
 
 export const billingPartialUpdate = async (
-    patchedBillingApi: PatchedBillingApi,
+    patchedBillingApi?: PatchedBillingApi,
     options?: RequestInit
 ): Promise<void> => {
     return apiMutator<void>(getBillingPartialUpdateUrl(), {
@@ -169,7 +169,7 @@ export const getBillingLicensePartialUpdateUrl = () => {
 }
 
 export const billingLicensePartialUpdate = async (
-    patchedBillingApi: PatchedBillingApi,
+    patchedBillingApi?: PatchedBillingApi,
     options?: RequestInit
 ): Promise<void> => {
     return apiMutator<void>(getBillingLicensePartialUpdateUrl(), {
@@ -191,13 +191,13 @@ export const billingPortalRetrieve = async (options?: RequestInit): Promise<void
     })
 }
 
-/**
- * Endpoint to fetch spend data (proxy to billing service).
- */
 export const getBillingSpendRetrieveUrl = () => {
     return `/api/billing/spend/`
 }
 
+/**
+ * Endpoint to fetch spend data (proxy to billing service).
+ */
 export const billingSpendRetrieve = async (options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getBillingSpendRetrieveUrl(), {
         ...options,

--- a/products/billing/frontend/generated/api.zod.ts
+++ b/products/billing/frontend/generated/api.zod.ts
@@ -1,0 +1,94 @@
+/**
+ * Auto-generated Zod validation schemas from the Django backend OpenAPI schema.
+ * To modify these schemas, update the Django serializers or views, then run:
+ *   hogli build:openapi
+ * Questions or issues? #team-devex on Slack
+ *
+ * PostHog API - generated
+ * OpenAPI spec version: 1.0.0
+ */
+import * as zod from 'zod'
+
+export const billingPartialUpdateBodyPlanMax = 100
+
+export const BillingPartialUpdateBody = /* @__PURE__ */ zod.object({
+    plan: zod.string().max(billingPartialUpdateBodyPlanMax).optional(),
+    billing_limit: zod.number().optional(),
+})
+
+export const billingActivateCreateBodyPlanMax = 100
+
+export const BillingActivateCreateBody = /* @__PURE__ */ zod.object({
+    plan: zod.string().max(billingActivateCreateBodyPlanMax),
+    billing_limit: zod.number(),
+})
+
+export const billingActivateAuthorizeCreateBodyPlanMax = 100
+
+export const BillingActivateAuthorizeCreateBody = /* @__PURE__ */ zod.object({
+    plan: zod.string().max(billingActivateAuthorizeCreateBodyPlanMax),
+    billing_limit: zod.number(),
+})
+
+export const billingActivateAuthorizeStatusCreateBodyPlanMax = 100
+
+export const BillingActivateAuthorizeStatusCreateBody = /* @__PURE__ */ zod.object({
+    plan: zod.string().max(billingActivateAuthorizeStatusCreateBodyPlanMax),
+    billing_limit: zod.number(),
+})
+
+export const billingCouponsClaimCreateBodyPlanMax = 100
+
+export const BillingCouponsClaimCreateBody = /* @__PURE__ */ zod.object({
+    plan: zod.string().max(billingCouponsClaimCreateBodyPlanMax),
+    billing_limit: zod.number(),
+})
+
+export const billingCreditsPurchaseCreateBodyPlanMax = 100
+
+export const BillingCreditsPurchaseCreateBody = /* @__PURE__ */ zod.object({
+    plan: zod.string().max(billingCreditsPurchaseCreateBodyPlanMax),
+    billing_limit: zod.number(),
+})
+
+export const billingDeactivateCreateBodyPlanMax = 100
+
+export const BillingDeactivateCreateBody = /* @__PURE__ */ zod.object({
+    plan: zod.string().max(billingDeactivateCreateBodyPlanMax),
+    billing_limit: zod.number(),
+})
+
+export const billingLicensePartialUpdateBodyPlanMax = 100
+
+export const BillingLicensePartialUpdateBody = /* @__PURE__ */ zod.object({
+    plan: zod.string().max(billingLicensePartialUpdateBodyPlanMax).optional(),
+    billing_limit: zod.number().optional(),
+})
+
+export const billingStartupsApplyCreateBodyPlanMax = 100
+
+export const BillingStartupsApplyCreateBody = /* @__PURE__ */ zod.object({
+    plan: zod.string().max(billingStartupsApplyCreateBodyPlanMax),
+    billing_limit: zod.number(),
+})
+
+export const billingSubscriptionSwitchPlanCreateBodyPlanMax = 100
+
+export const BillingSubscriptionSwitchPlanCreateBody = /* @__PURE__ */ zod.object({
+    plan: zod.string().max(billingSubscriptionSwitchPlanCreateBodyPlanMax),
+    billing_limit: zod.number(),
+})
+
+export const billingTrialsActivateCreateBodyPlanMax = 100
+
+export const BillingTrialsActivateCreateBody = /* @__PURE__ */ zod.object({
+    plan: zod.string().max(billingTrialsActivateCreateBodyPlanMax),
+    billing_limit: zod.number(),
+})
+
+export const billingTrialsCancelCreateBodyPlanMax = 100
+
+export const BillingTrialsCancelCreateBody = /* @__PURE__ */ zod.object({
+    plan: zod.string().max(billingTrialsCancelCreateBodyPlanMax),
+    billing_limit: zod.number(),
+})

--- a/products/billing/mcp/tools.yaml
+++ b/products/billing/mcp/tools.yaml
@@ -1,0 +1,67 @@
+# MCP tool definition — tool entries are scaffolded from the OpenAPI schema.
+# The tool list and operation IDs are kept in sync automatically:
+#   pnpm --filter=@posthog/mcp run scaffold-yaml -- --sync-all
+#
+# To enable a tool, set enabled: true and add required scopes + annotations.
+# All other fields (title, description, enrich_url, etc.) are yours to configure.
+category: Billing
+feature: billing
+url_prefix: /billing
+tools:
+    billing-list:
+        operation: billing_list
+        enabled: false
+    billing-partial-update:
+        operation: billing_partial_update
+        enabled: false
+    billing-activate-create:
+        operation: billing_activate_create
+        enabled: false
+    billing-activate-authorize-create:
+        operation: billing_activate_authorize_create
+        enabled: false
+    billing-activate-authorize-status-create:
+        operation: billing_activate_authorize_status_create
+        enabled: false
+    billing-coupons-claim-create:
+        operation: billing_coupons_claim_create
+        enabled: false
+    billing-coupons-overview-retrieve:
+        operation: billing_coupons_overview_retrieve
+        enabled: false
+    billing-credits-overview-retrieve:
+        operation: billing_credits_overview_retrieve
+        enabled: false
+    billing-credits-purchase-create:
+        operation: billing_credits_purchase_create
+        enabled: false
+    billing-deactivate-create:
+        operation: billing_deactivate_create
+        enabled: false
+    billing-get-invoices-retrieve:
+        operation: billing_get_invoices_retrieve
+        enabled: false
+    billing-license-partial-update:
+        operation: billing_license_partial_update
+        enabled: false
+    billing-portal-retrieve:
+        operation: billing_portal_retrieve
+        enabled: false
+    billing-spend-retrieve:
+        operation: billing_spend_retrieve
+        enabled: false
+    billing-startups-apply-create:
+        operation: billing_startups_apply_create
+        enabled: false
+    billing-subscription-switch-plan-create:
+        operation: billing_subscription_switch_plan_create
+        enabled: false
+    billing-trials-activate-create:
+        operation: billing_trials_activate_create
+        enabled: false
+    billing-trials-cancel-create:
+        operation: billing_trials_cancel_create
+        enabled: false
+    billing-usage-retrieve:
+        operation: billing_usage_retrieve
+        enabled: false

--- a/products/billing/mcp/tools.yaml
+++ b/products/billing/mcp/tools.yaml
@@ -7,21 +7,16 @@
 category: Billing
 feature: billing
 url_prefix: /billing
+ui_apps: {}
 tools:
-    billing-list:
-        operation: billing_list
-        enabled: false
-    billing-partial-update:
-        operation: billing_partial_update
-        enabled: false
-    billing-activate-create:
-        operation: billing_activate_create
-        enabled: false
     billing-activate-authorize-create:
         operation: billing_activate_authorize_create
         enabled: false
     billing-activate-authorize-status-create:
         operation: billing_activate_authorize_status_create
+        enabled: false
+    billing-activate-create:
+        operation: billing_activate_create
         enabled: false
     billing-coupons-claim-create:
         operation: billing_coupons_claim_create
@@ -43,6 +38,12 @@ tools:
         enabled: false
     billing-license-partial-update:
         operation: billing_license_partial_update
+        enabled: false
+    billing-list:
+        operation: billing_list
+        enabled: false
+    billing-partial-update:
+        operation: billing_partial_update
         enabled: false
     billing-portal-retrieve:
         operation: billing_portal_retrieve

--- a/products/billing/package.json
+++ b/products/billing/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "@posthog/products-billing"
+}

--- a/products/billing/product.yaml
+++ b/products/billing/product.yaml
@@ -1,0 +1,3 @@
+name: Billing
+owners:
+    - team-billing

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -6227,6 +6227,12 @@ export namespace Schemas {
       BigQuery: 'BigQuery',
     } as const;
 
+    export interface Billing {
+      /** @maxLength 100 */
+      plan: string;
+      billing_limit: number;
+    }
+
     export interface BlastRadius {
       /** Number of users matching the filters */
       affected: number;
@@ -20623,6 +20629,15 @@ export namespace Schemas {
       results: BatchImport[];
     }
 
+    export interface PaginatedBillingList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: Billing[];
+    }
+
     export interface PaginatedCIMDVerificationTokenList {
       count: number;
       /** @nullable */
@@ -24451,6 +24466,12 @@ export namespace Schemas {
       /** @nullable */
       readonly display_status_message?: string | null;
       readonly import_config?: unknown;
+    }
+
+    export interface PatchedBilling {
+      /** @maxLength 100 */
+      plan?: string;
+      billing_limit?: number;
     }
 
     export interface PatchedClusteringJob {
@@ -35207,6 +35228,17 @@ export namespace Schemas {
       /** Date range for the query. Defaults to last 24 hours. */
       dateRange?: _TracingDateRange;
     }
+
+    export type BillingListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
 
     export type EnvironmentsAlertsListParams = {
     /**


### PR DESCRIPTION
## Problem

- `BillingViewset` is excluded from the OpenAPI schema because it sets both `param_derived_from_user_current_team` (root-router endpoint) and `scope_object = "INTERNAL"` (default-deny for PAT/OAuth)
- Without billing in the OpenAPI spec, MCP tool scaffolding finds no operations and we can't generate billing MCP tools
- Stacked on #55882

## Changes

- New `force_include_in_api_docs` viewset attribute in `posthog/api/documentation.py::preprocess_exclude_path_format` - when `True`, bypasses both the root-router skip and the `INTERNAL`-scope skip. `BillingViewset` opts in via this attribute
- New `products/billing/` folder (`__init__.py`, `package.json`, `mcp/tools.yaml`) - home for billing's MCP tool definitions and (later) skills. Billing's Django app stays in `ee/billing/` (no full Turborepo migration here)
- `tools.yaml` scaffolded with all 19 operations as `enabled: false` - actual tool wiring lands in the next PR up the stack
- Generated outputs committed: `services/mcp/src/api/generated.ts`, `products/billing/frontend/generated/api.ts`, `products/billing/frontend/generated/api.schemas.ts`, `pnpm-lock.yaml` (new workspace registration)
- Brief note added to `docs/published/handbook/engineering/ai/implementing-mcp-tools.md` about `force_include_in_api_docs` for owners of root-router viewsets

### Why an explicit opt-in vs broader change

- Considered: making the existing `OPENAPI_INCLUDE_INTERNAL=1` env var (already set by hogli's build) also bypass the `param_derived` skip. That would have automatically pulled in 5 other root-router viewsets (`LinksViewSet`, `LegacyDashboardsViewSet`, `LegacyInsightViewSet`, `LegacyEnterprisePersonViewSet`, `LegacyEventViewSet`) along with billing
- The explicit attribute keeps the change scoped to billing today and lets each viewset owner opt in for themselves

## How did you test this code?

- `./bin/hogli build:openapi-schema` before/after - billing contributes 19 paths after, legacy root-router viewsets still excluded (verified 0 paths under `/api/links/`, `/api/dashboards/{not project_id}/`, `/api/person/{not team_id}/`)
- `pnpm --filter=@posthog/mcp run scaffold-yaml -- --product billing` discovers all 19 operations
- `./bin/hogli build:openapi` runs cleanly through to MCP tool generation; 187 warnings / 357 errors summary identical to master baseline (no new schema-quality regressions introduced)
- `./bin/hogli product:lint billing` passes

## Publish to changelog?

no

## Docs update

- Added brief note to `docs/published/handbook/engineering/ai/implementing-mcp-tools.md` about `force_include_in_api_docs` for owners of root-router viewsets