### PR TITLE
chore(ci): trigger sandbox image build when workflow file changes

### DIFF
--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -26,6 +26,7 @@ jobs:
               with:
                   filters: |
                       sandbox_image:
+                        - '.github/workflows/cd-sandbox-base-image.yml'
                         - 'products/tasks/backend/sandbox/images/**'
                         - 'products/*/skills/**'
                         - 'products/posthog_ai/scripts/**'


### PR DESCRIPTION
## Problem

The `cd-sandbox-base-image.yml` workflow only rebuilt sandbox images when files under `products/tasks/backend/sandbox/images/**` (and a couple of other paths) changed. A change to the workflow itself — for example adding a new image build step, as in #55821 — would not retrigger the build on the same PR, which makes it awkward to iterate on the workflow or verify that a new image step actually works.

## Changes

- Add `.github/workflows/cd-sandbox-base-image.yml` to the `sandbox_image` paths-filter so that editing the workflow itself causes the build jobs to run.
- The existing `products/tasks/backend/sandbox/images/**` entry already covers all sandbox Dockerfiles (`Dockerfile.sandbox-base`, `sandbox-notebook`, `sandbox-pi`, `sandbox-local`), so no additional entries are needed for those.

## How did you test this code?

I'm an agent — I haven't run the workflow end-to-end. This PR itself is the test: because it edits `cd-sandbox-base-image.yml`, the `changes` job should now output `sandbox_image == 'true'` and the downstream `build_skills` and `sandbox_base_build` jobs should run. Reviewer check: verify the `Tasks Sandbox Container Image CD` workflow runs on this PR and produces the three image builds (base, notebook, pi).

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code. Scope is intentionally minimal — just the one-line filter addition — because the Dockerfiles are already caught by the existing `images/**` glob.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*