### PR TITLE
refactor(replay): Skip session problem emission when no need

### DIFF
--- a/posthog/temporal/session_replay/session_summary/activities/a6a_emit_session_problem_signals.py
+++ b/posthog/temporal/session_replay/session_summary/activities/a6a_emit_session_problem_signals.py
@@ -13,11 +13,7 @@ from posthog.models.exported_asset import ExportedAsset
 from posthog.models.team.team import Team
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
 from posthog.sync import database_sync_to_async
-from posthog.temporal.session_replay.session_summary.types.video import (
-    ConsolidatedVideoAnalysis,
-    ConsolidatedVideoSegment,
-    VideoSummarySingleSessionInputs,
-)
+from posthog.temporal.session_replay.session_summary.types.video import SessionProblem, VideoSummarySingleSessionInputs
 
 from products.signals.backend.api import emit_signal
 
@@ -29,12 +25,15 @@ logger = structlog.get_logger(__name__)
 @temporalio.activity.defn
 async def emit_session_problem_signals_activity(
     inputs: VideoSummarySingleSessionInputs,
-    analysis: ConsolidatedVideoAnalysis,
+    problems: list[SessionProblem],
 ) -> int:
     """Emit signals for consolidated segments that indicate user problems.
 
     Returns the number of signals emitted.
     """
+
+    if not problems:
+        return 0
 
     team = await Team.objects.select_related("organization").aget(id=inputs.team_id)
 
@@ -60,19 +59,15 @@ async def emit_session_problem_signals_activity(
 
     signals_emitted = 0
 
-    for segment in analysis.segments:
-        problem_type = _classify_problem(segment)
-        if problem_type is None:
-            continue
-
-        source_id = f"{inputs.session_id}:{segment.start_time}:{segment.end_time}"
+    for problem in problems:
+        source_id = f"{inputs.session_id}:{problem.start_time}:{problem.end_time}"
 
         extra: dict = {
             "session_id": inputs.session_id,
-            "segment_title": segment.title,
-            "start_time": segment.start_time,
-            "end_time": segment.end_time,
-            "problem_type": problem_type,
+            "segment_title": problem.title,
+            "start_time": problem.start_time,
+            "end_time": problem.end_time,
+            "problem_type": problem.problem_type,
             "distinct_id": session_metadata["distinct_id"] if session_metadata else "",
         }
         if session_metadata:
@@ -90,7 +85,7 @@ async def emit_session_problem_signals_activity(
                 source_product="session_replay",
                 source_type="session_problem",
                 source_id=source_id,
-                description=segment.description,
+                description=problem.description,
                 weight=1.0,  # Always research
                 extra=extra,
             )
@@ -98,7 +93,7 @@ async def emit_session_problem_signals_activity(
             logger.debug(
                 f"Emitted session problem signal for {source_id}",
                 session_id=inputs.session_id,
-                problem_type=problem_type,
+                problem_type=problem.problem_type,
                 signals_type="session-summaries",
             )
         except Exception:
@@ -117,18 +112,3 @@ async def emit_session_problem_signals_activity(
         )
 
     return signals_emitted
-
-
-def _classify_problem(segment: ConsolidatedVideoSegment) -> str | None:
-    """Return the most severe problem type for a segment, or None if no problem detected."""
-    if segment.exception == "blocking":
-        return "blocking_exception"
-    if segment.abandonment_detected:
-        return "abandonment"
-    if segment.exception == "non-blocking":
-        return "non_blocking_exception"
-    if segment.confusion_detected:
-        return "confusion"
-    if not segment.success:
-        return "failure"
-    return None

--- a/posthog/temporal/session_replay/session_summary/activities/a6a_emit_session_problem_signals.py
+++ b/posthog/temporal/session_replay/session_summary/activities/a6a_emit_session_problem_signals.py
@@ -8,6 +8,7 @@ instead of relying on the batch clustering pipeline.
 
 import structlog
 import temporalio
+from structlog.contextvars import bind_contextvars
 
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.team.team import Team
@@ -31,6 +32,7 @@ async def emit_session_problem_signals_activity(
 
     Returns the number of signals emitted.
     """
+    bind_contextvars(team_id=inputs.team_id, session_id=inputs.session_id)
 
     if not problems:
         return 0

--- a/posthog/temporal/session_replay/session_summary/summarize_session.py
+++ b/posthog/temporal/session_replay/session_summary/summarize_session.py
@@ -54,6 +54,7 @@ from posthog.temporal.session_replay.session_summary.types.video import (
     VideoSegmentOutput,
     VideoSegmentSpec,
     VideoSummarySingleSessionInputs,
+    collect_session_problems,
 )
 
 from ee.hogai.session_summaries.constants import DEFAULT_VIDEO_UNDERSTANDING_MODEL, SESSION_SUMMARIES_MODEL
@@ -645,36 +646,54 @@ async def ensure_llm_single_session_summary(
             retry_policy=retry_policy,
         )
 
-        # Activities 6a + 6b run in parallel:
-        # - 6a: Emit signals for issue-indicating segments
-        # - 6b: Store video-based summary in database
+        # Activities 6a + 6b run in parallel when some segment would emit a problem signal;
+        # otherwise skip 6a entirely.
         _set_phase(progress, "saving_summary")
-        emit_result, store_result = await asyncio.gather(
-            temporalio.workflow.execute_activity(
-                emit_session_problem_signals_activity,
-                args=(video_inputs, consolidated_analysis),
-                start_to_close_timeout=timedelta(minutes=5),
-                retry_policy=retry_policy,
-            ),
-            temporalio.workflow.execute_activity(
+        problems = collect_session_problems(consolidated_analysis.segments)
+        logger.info(
+            "session problem signals pre-emission",
+            session_id=inputs.session_id,
+            workflow_id=trace_id,
+            total_consolidated_segments=len(consolidated_analysis.segments),
+            problem_segment_count=len(problems),
+            problems=[p.model_dump(include={"problem_type", "start_time", "end_time"}) for p in problems[:30]],
+            will_run_emit_activity=bool(problems),
+            signals_type="session-summaries",
+        )
+        if problems:
+            emit_result, store_result = await asyncio.gather(
+                temporalio.workflow.execute_activity(
+                    emit_session_problem_signals_activity,
+                    args=(video_inputs, problems),
+                    start_to_close_timeout=timedelta(minutes=5),
+                    retry_policy=retry_policy,
+                ),
+                temporalio.workflow.execute_activity(
+                    store_video_session_summary_activity,
+                    args=(video_inputs, consolidated_analysis),
+                    start_to_close_timeout=timedelta(minutes=5),
+                    retry_policy=retry_policy,
+                ),
+                return_exceptions=True,
+            )
+            if isinstance(emit_result, Exception):
+                posthoganalytics.capture_exception(
+                    emit_result,
+                    distinct_id=inputs.user_distinct_id_to_log,
+                )
+                logger.exception(
+                    f"Error emitting session problem signals for session {inputs.session_id}: {emit_result}",
+                    signals_type="session-summaries",
+                )
+            if isinstance(store_result, BaseException):
+                raise store_result
+        else:
+            await temporalio.workflow.execute_activity(
                 store_video_session_summary_activity,
                 args=(video_inputs, consolidated_analysis),
                 start_to_close_timeout=timedelta(minutes=5),
                 retry_policy=retry_policy,
-            ),
-            return_exceptions=True,
-        )
-        if isinstance(emit_result, Exception):
-            posthoganalytics.capture_exception(
-                emit_result,
-                distinct_id=inputs.user_distinct_id_to_log,
             )
-            logger.exception(
-                f"Error emitting session problem signals for session {inputs.session_id}: {emit_result}",
-                signals_type="session-summaries",
-            )
-        if isinstance(store_result, BaseException):
-            raise store_result
 
         # Activity 7: Write tags and highlight flag to ClickHouse via Kafka
         _set_phase(progress, "tagging")

--- a/posthog/temporal/session_replay/session_summary/summarize_session.py
+++ b/posthog/temporal/session_replay/session_summary/summarize_session.py
@@ -652,6 +652,7 @@ async def ensure_llm_single_session_summary(
         problems = collect_session_problems(consolidated_analysis.segments)
         logger.info(
             "session problem signals pre-emission",
+            team_id=inputs.team_id,
             session_id=inputs.session_id,
             workflow_id=trace_id,
             total_consolidated_segments=len(consolidated_analysis.segments),
@@ -688,6 +689,14 @@ async def ensure_llm_single_session_summary(
             if isinstance(store_result, BaseException):
                 raise store_result
         else:
+            logger.info(
+                "Skipping session problem signals emission activity (no problems found)",
+                team_id=inputs.team_id,
+                session_id=inputs.session_id,
+                workflow_id=trace_id,
+                total_consolidated_segments=len(consolidated_analysis.segments),
+                signals_type="session-summaries",
+            )
             await temporalio.workflow.execute_activity(
                 store_video_session_summary_activity,
                 args=(video_inputs, consolidated_analysis),

--- a/posthog/temporal/session_replay/session_summary/types/video.py
+++ b/posthog/temporal/session_replay/session_summary/types/video.py
@@ -122,6 +122,52 @@ class ConsolidatedVideoSegment(BaseModel):
     abandonment_detected: bool = Field(default=False, description="User abandoned a flow")
 
 
+def classify_consolidated_segment_problem(segment: ConsolidatedVideoSegment) -> str | None:
+    """Return the most severe problem type for a segment, or None if no problem signal would be emitted."""
+    if segment.exception == "blocking":
+        return "blocking_exception"
+    if segment.abandonment_detected:
+        return "abandonment"
+    if segment.exception == "non-blocking":
+        return "non_blocking_exception"
+    if segment.confusion_detected:
+        return "confusion"
+    if not segment.success:
+        return "failure"
+    return None
+
+
+class SessionProblem(BaseModel):
+    """A segment that classifies as a problem and should be emitted as a session_problem signal."""
+
+    model_config = ConfigDict(frozen=True)
+
+    problem_type: str = Field(description="Output of classify_consolidated_segment_problem, e.g. 'blocking_exception'")
+    title: str
+    description: str
+    start_time: str = Field(description="Format: MM:SS or HH:MM:SS")
+    end_time: str = Field(description="Format: MM:SS or HH:MM:SS")
+
+
+def collect_session_problems(segments: list[ConsolidatedVideoSegment]) -> list[SessionProblem]:
+    """Classify segments and return only those that would emit a session_problem signal."""
+    problems: list[SessionProblem] = []
+    for segment in segments:
+        problem_type = classify_consolidated_segment_problem(segment)
+        if problem_type is None:
+            continue
+        problems.append(
+            SessionProblem(
+                problem_type=problem_type,
+                title=segment.title,
+                description=segment.description,
+                start_time=segment.start_time,
+                end_time=segment.end_time,
+            )
+        )
+    return problems
+
+
 class VideoSessionOutcome(BaseModel):
     """Overall session outcome determined from video analysis."""
 

--- a/posthog/temporal/tests/session_replay/session_summary/test_emit_session_problem_signals.py
+++ b/posthog/temporal/tests/session_replay/session_summary/test_emit_session_problem_signals.py
@@ -1,9 +1,10 @@
 import pytest
 
-from posthog.temporal.session_replay.session_summary.activities.a6a_emit_session_problem_signals import (
-    _classify_problem,
+from posthog.temporal.session_replay.session_summary.types.video import (
+    ConsolidatedVideoSegment,
+    classify_consolidated_segment_problem,
+    collect_session_problems,
 )
-from posthog.temporal.session_replay.session_summary.types.video import ConsolidatedVideoSegment
 
 
 def _make_segment(**kwargs) -> ConsolidatedVideoSegment:
@@ -35,7 +36,7 @@ class TestClassifyProblem:
         ids=["blocking", "abandonment", "non_blocking", "confusion", "failure", "no_problem"],
     )
     def test_single_flag(self, kwargs, expected):
-        assert _classify_problem(_make_segment(**kwargs)) == expected
+        assert classify_consolidated_segment_problem(_make_segment(**kwargs)) == expected
 
     @pytest.mark.parametrize(
         "kwargs, expected",
@@ -59,4 +60,52 @@ class TestClassifyProblem:
         ids=["blocking_wins_all", "abandonment_wins_lower", "non_blocking_wins_lower", "confusion_wins_failure"],
     )
     def test_priority_ordering(self, kwargs, expected):
-        assert _classify_problem(_make_segment(**kwargs)) == expected
+        assert classify_consolidated_segment_problem(_make_segment(**kwargs)) == expected
+
+
+class TestCollectSessionProblems:
+    def test_returns_empty_when_no_problematic_segments(self):
+        segments = [_make_segment(), _make_segment(title="Another fine segment")]
+        assert collect_session_problems(segments) == []
+
+    def test_filters_out_non_problem_segments_and_preserves_order(self):
+        segments = [
+            _make_segment(title="Healthy"),
+            _make_segment(
+                title="Blocking error",
+                description="Boom",
+                start_time="00:10",
+                end_time="00:20",
+                exception="blocking",
+            ),
+            _make_segment(title="Still healthy"),
+            _make_segment(
+                title="Abandoned flow",
+                description="User gave up",
+                start_time="00:30",
+                end_time="00:40",
+                abandonment_detected=True,
+            ),
+        ]
+        problems = collect_session_problems(segments)
+        assert [p.problem_type for p in problems] == ["blocking_exception", "abandonment"]
+        assert [p.title for p in problems] == ["Blocking error", "Abandoned flow"]
+        assert [p.start_time for p in problems] == ["00:10", "00:30"]
+        assert [p.end_time for p in problems] == ["00:20", "00:40"]
+        assert [p.description for p in problems] == ["Boom", "User gave up"]
+
+    def test_uses_most_severe_problem_type_when_multiple_flags_set(self):
+        segments = [
+            _make_segment(
+                title="Multi-problem",
+                description="...",
+                start_time="00:00",
+                end_time="00:05",
+                exception="non-blocking",
+                confusion_detected=True,
+                success=False,
+            ),
+        ]
+        problems = collect_session_problems(segments)
+        assert len(problems) == 1
+        assert problems[0].problem_type == "non_blocking_exception"


### PR DESCRIPTION
## Problem

Activity `emit_session_problem_signals_activity` was scheduled on every video-based session summary, even when no segment classified as a problem. Confused me when digging into which which session summarizations resulted in signals, vs. which didn't.

## Changes

Skipping `emit_session_problem_signals_activity` entirely when there are no problem segments. The activity now only gets the problems, not the whole session analysis.