### PR TITLE
fix(slack): resolve repo picker followup mentions

### DIFF
--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -27,7 +27,7 @@ POSTHOG_CODE_SLACK_PICKER_TIMEOUT_MINUTES = 15
 POSTHOG_CODE_SLACK_MENTION_PICKER_GUIDANCE = (
     "Please select the repository for this task. "
     "Or @mention me again and include the exact repository as `org/repo`. "
-    'You can also add routing rules with `@PostHog Code rules add "description" [org/repo]`.'
+    'You can also add routing rules with `@PostHog rules add "description" [org/repo]`.'
 )
 POSTHOG_CODE_SLACK_RULES_ADD_PICKER_GUIDANCE = "Select the repository for this routing rule."
 
@@ -347,15 +347,15 @@ def _handle_help(slack: Any, channel: str, thread_ts: str) -> None:
         thread_ts=thread_ts,
         text=(
             "*Available commands:*\n\n"
-            "`@PostHog Code <task description>` — Create a task for the agent to work on\n"
-            "`@PostHog Code rules list` — Show all routing rules\n"
-            '`@PostHog Code rules add "description" org/repo` — Add a routing rule\n'
-            '`@PostHog Code rules add "description"` — Add a routing rule (pick repo from list)\n'
-            "`@PostHog Code rules remove <number(s)>` — Remove routing rules by number (e.g. `remove 1` or `remove 1,2`)\n"
-            "`@PostHog Code default repo set org/repo` — Set your default repository for this channel\n"
-            "`@PostHog Code default repo show` — Show your default repository for this channel\n"
-            "`@PostHog Code default repo clear` — Clear your default repository for this channel\n"
-            "`@PostHog Code help` — Show this message\n\n"
+            "`@PostHog <task description>` — Create a task for the agent to work on\n"
+            "`@PostHog rules list` — Show all routing rules\n"
+            '`@PostHog rules add "description" org/repo` — Add a routing rule\n'
+            '`@PostHog rules add "description"` — Add a routing rule (pick repo from list)\n'
+            "`@PostHog rules remove <number(s)>` — Remove routing rules by number (e.g. `remove 1` or `remove 1,2`)\n"
+            "`@PostHog default repo set org/repo` — Set your default repository for this channel\n"
+            "`@PostHog default repo show` — Show your default repository for this channel\n"
+            "`@PostHog default repo clear` — Clear your default repository for this channel\n"
+            "`@PostHog help` — Show this message\n\n"
             "You can also reply in an active thread to send follow-up messages to the agent."
         ),
     )
@@ -369,7 +369,7 @@ def _handle_rules_list(slack: Any, integration: Any, channel: str, thread_ts: st
         slack.client.chat_postMessage(
             channel=channel,
             thread_ts=thread_ts,
-            text='No routing rules configured. Add one with `@PostHog Code rules add "description" [org/repo]`. Omit the repo to pick from a list.',
+            text='No routing rules configured. Add one with `@PostHog rules add "description" [org/repo]`. Omit the repo to pick from a list.',
         )
         return
 
@@ -446,7 +446,7 @@ def _handle_rules_remove(
         slack.client.chat_postMessage(
             channel=channel,
             thread_ts=thread_ts,
-            text="Please provide valid rule number(s). Use `@PostHog Code rules list` to see current rules.",
+            text="Please provide valid rule number(s). Use `@PostHog rules list` to see current rules.",
         )
         return
 
@@ -456,7 +456,7 @@ def _handle_rules_remove(
         slack.client.chat_postMessage(
             channel=channel,
             thread_ts=thread_ts,
-            text=f"Rule {'number' if len(invalid) == 1 else 'numbers'} {', '.join(f'#{n}' for n in invalid)} {'does' if len(invalid) == 1 else 'do'} not exist. There are {len(rules)} rule(s). Use `@PostHog Code rules list` to see them.",
+            text=f"Rule {'number' if len(invalid) == 1 else 'numbers'} {', '.join(f'#{n}' for n in invalid)} {'does' if len(invalid) == 1 else 'do'} not exist. There are {len(rules)} rule(s). Use `@PostHog rules list` to see them.",
         )
         return
 
@@ -537,7 +537,7 @@ def _handle_default_repo_show(
         slack.client.chat_postMessage(
             channel=channel,
             thread_ts=thread_ts,
-            text="No default repository set for this channel. Use `@PostHog Code default repo set org/repo` to set one.",
+            text="No default repository set for this channel. Use `@PostHog default repo set org/repo` to set one.",
         )
 
 
@@ -1332,7 +1332,17 @@ def post_posthog_code_picker_timeout_activity(
 ) -> None:
     from posthog.models.integration import Integration, SlackIntegration
 
+    from products.slack_app.backend.api import _clear_pending_repo_picker
     from products.slack_app.backend.models import SlackThreadTaskMapping
+
+    slack_user_id = inputs.event.get("user")
+    if isinstance(slack_user_id, str) and slack_user_id:
+        _clear_pending_repo_picker(
+            integration_id=inputs.integration_id,
+            channel=channel,
+            thread_ts=thread_ts,
+            slack_user_id=slack_user_id,
+        )
 
     # If another workflow already created a task for this thread (e.g. the user
     # sent a follow-up message instead of using the picker), skip the expired
@@ -1353,7 +1363,7 @@ def post_posthog_code_picker_timeout_activity(
     slack.client.chat_postMessage(
         channel=channel,
         thread_ts=thread_ts,
-        text="Repository selection expired. Please mention PostHog Code again to retry.",
+        text="Repository selection expired. Please mention PostHog again to retry.",
     )
 
 
@@ -1362,6 +1372,17 @@ def post_posthog_code_internal_error_activity(
     inputs: PostHogCodeSlackMentionWorkflowInputs, channel: str, thread_ts: str
 ) -> None:
     from posthog.models.integration import Integration, SlackIntegration
+
+    from products.slack_app.backend.api import _clear_pending_repo_picker
+
+    slack_user_id = inputs.event.get("user")
+    if isinstance(slack_user_id, str) and slack_user_id:
+        _clear_pending_repo_picker(
+            integration_id=inputs.integration_id,
+            channel=channel,
+            thread_ts=thread_ts,
+            slack_user_id=slack_user_id,
+        )
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,

--- a/posthog/temporal/ai/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/posthog_code_slack_mention.py
@@ -26,6 +26,7 @@ _RESUME_ERROR_MSG = "Sorry, I ran into an internal error restarting the agent. P
 POSTHOG_CODE_SLACK_PICKER_TIMEOUT_MINUTES = 15
 POSTHOG_CODE_SLACK_MENTION_PICKER_GUIDANCE = (
     "Please select the repository for this task. "
+    "Or click *No repo needed* to continue without one. "
     "Or @mention me again and include the exact repository as `org/repo`. "
     'You can also add routing rules with `@PostHog rules add "description" [org/repo]`.'
 )
@@ -57,11 +58,19 @@ class PostHogCodeRulesCommandResult:
 class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
     def __init__(self) -> None:
         self._selected_repo: str | None = None
+        self._repo_selection_resolved = False
 
     @workflow.signal
     async def repo_selected(self, repository: str) -> None:
-        if not self._selected_repo:
+        if not self._repo_selection_resolved:
+            self._repo_selection_resolved = True
             self._selected_repo = repository
+
+    @workflow.signal
+    async def no_repo_needed(self) -> None:
+        if not self._repo_selection_resolved:
+            self._repo_selection_resolved = True
+            self._selected_repo = None
 
     @staticmethod
     def parse_inputs(inputs: list[str]) -> PostHogCodeSlackMentionWorkflowInputs:
@@ -117,10 +126,11 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
                     event,
                     workflow.info().workflow_id,
                     POSTHOG_CODE_SLACK_RULES_ADD_PICKER_GUIDANCE,
+                    False,
                 )
                 try:
                     await workflow.wait_condition(
-                        lambda: self._selected_repo is not None,
+                        lambda: self._repo_selection_resolved,
                         timeout=timedelta(minutes=POSTHOG_CODE_SLACK_PICKER_TIMEOUT_MINUTES),
                     )
                 except TimeoutError:
@@ -207,19 +217,17 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
                     event,
                     workflow.info().workflow_id,
                     POSTHOG_CODE_SLACK_MENTION_PICKER_GUIDANCE,
+                    True,
                 )
                 try:
                     await workflow.wait_condition(
-                        lambda: self._selected_repo is not None,
+                        lambda: self._repo_selection_resolved,
                         timeout=timedelta(minutes=POSTHOG_CODE_SLACK_PICKER_TIMEOUT_MINUTES),
                     )
                 except TimeoutError:
                     await _execute_posthog_code_activity(
                         post_posthog_code_picker_timeout_activity, inputs, channel, thread_ts
                     )
-                    return
-
-                if not self._selected_repo:
                     return
 
                 await _execute_posthog_code_activity(
@@ -666,6 +674,7 @@ def post_posthog_code_repo_picker_activity(
     event: dict[str, Any],
     workflow_id: str,
     guidance: str,
+    allow_no_repo: bool,
 ) -> None:
     from posthog.models.integration import Integration, SlackIntegration
 
@@ -689,6 +698,7 @@ def post_posthog_code_repo_picker_activity(
         guidance=guidance,
         action_id="posthog_code_repo_select",
         workflow_id=workflow_id,
+        allow_no_repo=allow_no_repo,
     )
 
 

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -61,6 +61,7 @@ SLACK_USER_INFO_CACHE_TTL_SECONDS = 600
 
 _MAX_GITHUB_REPOS = 500
 REPO_LIST_CACHE_TTL_SECONDS = 300
+PENDING_REPO_PICKER_TTL_SECONDS = PICKER_TOKEN_MAX_AGE_SECONDS
 
 
 def _repo_list_cache_key(team_id: int) -> str:
@@ -69,6 +70,43 @@ def _repo_list_cache_key(team_id: int) -> str:
 
 def _invalidate_repo_list_cache(team_id: int) -> None:
     cache.delete(_repo_list_cache_key(team_id))
+
+
+def _pending_repo_picker_cache_key(integration_id: int, channel: str, thread_ts: str, slack_user_id: str) -> str:
+    raw_key = f"{integration_id}:{channel}:{thread_ts}:{slack_user_id}"
+    return f"posthog_code:pending_repo_picker:v1:{hashlib.sha256(raw_key.encode('utf-8')).hexdigest()}"
+
+
+def _set_pending_repo_picker(
+    *,
+    integration_id: int,
+    channel: str,
+    thread_ts: str,
+    slack_user_id: str,
+    workflow_id: str,
+    context_token: str,
+    message_ts: str | None,
+) -> None:
+    cache.set(
+        _pending_repo_picker_cache_key(integration_id, channel, thread_ts, slack_user_id),
+        {
+            "workflow_id": workflow_id,
+            "context_token": context_token,
+            "message_ts": message_ts,
+        },
+        timeout=PENDING_REPO_PICKER_TTL_SECONDS,
+    )
+
+
+def _get_pending_repo_picker(
+    *, integration_id: int, channel: str, thread_ts: str, slack_user_id: str
+) -> dict[str, Any] | None:
+    cached = cache.get(_pending_repo_picker_cache_key(integration_id, channel, thread_ts, slack_user_id))
+    return cached if isinstance(cached, dict) else None
+
+
+def _clear_pending_repo_picker(*, integration_id: int, channel: str, thread_ts: str, slack_user_id: str) -> None:
+    cache.delete(_pending_repo_picker_cache_key(integration_id, channel, thread_ts, slack_user_id))
 
 
 @dataclass
@@ -451,7 +489,7 @@ def _post_repo_picker_message(
     context_token = uuid.uuid4().hex
     cache.set(_picker_context_cache_key(context_token), context_data, timeout=PICKER_TOKEN_MAX_AGE_SECONDS)
 
-    slack.client.chat_postMessage(
+    response = slack.client.chat_postMessage(
         channel=channel,
         thread_ts=thread_ts,
         text=guidance,
@@ -473,6 +511,19 @@ def _post_repo_picker_message(
             "event_payload": {"context_token": context_token, "workflow_id": workflow_id},
         },
     )
+
+    if workflow_id:
+        response_data = _normalize_slack_response(response)
+        message_ts = response_data.get("ts") if isinstance(response_data.get("ts"), str) else None
+        _set_pending_repo_picker(
+            integration_id=integration.id,
+            channel=channel,
+            thread_ts=thread_ts,
+            slack_user_id=slack_user_id,
+            workflow_id=workflow_id,
+            context_token=context_token,
+            message_ts=message_ts,
+        )
 
     # Pre-warm the repo list cache so the external_select options request
     # is served from cache rather than hitting the GitHub API inline.
@@ -617,6 +668,126 @@ def select_repository(
         return RepoDecision(mode="auto", repository=matched, reason="rule_match", llm_found_match=True)
 
     return RepoDecision(mode="picker", repository=None, reason="no_rule_match", llm_found_match=False)
+
+
+def _replace_repo_picker_message_with_selection(
+    *,
+    integration_id: int,
+    slack_team_id: str,
+    channel: str,
+    message_ts: str,
+    selected_repo: str,
+) -> None:
+    try:
+        # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
+        integration = Integration.objects.get(
+            id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
+        )
+        slack = SlackIntegration(integration)
+        text = f"Repository selected: `{selected_repo}`"
+        slack.client.chat_update(
+            channel=channel,
+            ts=message_ts,
+            text=text,
+            blocks=[
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": f"*Repository selected:* `{selected_repo}`"},
+                }
+            ],
+        )
+    except Exception:
+        logger.warning(
+            "posthog_code_repo_submit_picker_update_failed",
+            integration_id=integration_id,
+            channel=channel,
+            message_ts=message_ts,
+        )
+
+
+def _resolve_pending_repo_picker_from_followup(event: dict[str, Any], integration: Integration) -> bool:
+    channel = event.get("channel")
+    thread_ts = event.get("thread_ts") or event.get("ts")
+    slack_user_id = event.get("user")
+    if not channel or not thread_ts or not slack_user_id:
+        return False
+
+    pending_picker = _get_pending_repo_picker(
+        integration_id=integration.id,
+        channel=channel,
+        thread_ts=thread_ts,
+        slack_user_id=slack_user_id,
+    )
+    if not pending_picker:
+        return False
+
+    workflow_id = pending_picker.get("workflow_id")
+    if not isinstance(workflow_id, str) or not workflow_id:
+        _clear_pending_repo_picker(
+            integration_id=integration.id,
+            channel=channel,
+            thread_ts=thread_ts,
+            slack_user_id=slack_user_id,
+        )
+        return False
+
+    try:
+        all_repos = _get_full_repo_names(integration)
+    except Exception:
+        logger.exception("posthog_code_pending_picker_repo_fetch_failed", integration_id=integration.id)
+        return False
+
+    selected_repo = _extract_explicit_repo(event.get("text", ""), all_repos)
+    if not selected_repo:
+        return False
+
+    try:
+        client = sync_connect()
+        handle = client.get_workflow_handle(workflow_id)
+        asyncio.run(handle.signal(PostHogCodeSlackMentionWorkflow.repo_selected, selected_repo))
+    except Exception as e:
+        logger.warning(
+            "posthog_code_pending_picker_signal_failed",
+            workflow_id=workflow_id,
+            integration_id=integration.id,
+            channel=channel,
+            thread_ts=thread_ts,
+            error=str(e),
+        )
+        _clear_pending_repo_picker(
+            integration_id=integration.id,
+            channel=channel,
+            thread_ts=thread_ts,
+            slack_user_id=slack_user_id,
+        )
+        return False
+
+    _clear_pending_repo_picker(
+        integration_id=integration.id,
+        channel=channel,
+        thread_ts=thread_ts,
+        slack_user_id=slack_user_id,
+    )
+
+    message_ts = pending_picker.get("message_ts")
+    if isinstance(message_ts, str) and message_ts:
+        _replace_repo_picker_message_with_selection(
+            integration_id=integration.id,
+            slack_team_id=integration.integration_id,
+            channel=channel,
+            message_ts=message_ts,
+            selected_repo=selected_repo,
+        )
+
+    logger.info(
+        "posthog_code_pending_picker_resolved_from_followup",
+        workflow_id=workflow_id,
+        integration_id=integration.id,
+        channel=channel,
+        thread_ts=thread_ts,
+        repository=selected_repo,
+    )
+    return True
 
 
 def _match_repo_rule(
@@ -824,6 +995,8 @@ def route_posthog_code_event_to_relevant_region(
                     slack_team_id=slack_team_id,
                     organization_id=str(local_match.team.organization_id),
                 )
+                return ROUTE_HANDLED_LOCALLY
+            if _resolve_pending_repo_picker_from_followup(event, local_match):
                 return ROUTE_HANDLED_LOCALLY
             workflow_inputs = PostHogCodeSlackMentionWorkflowInputs(
                 event=event,
@@ -1096,6 +1269,7 @@ def _handle_repo_picker_submit(payload: dict) -> HttpResponse:
 
     context_token = _extract_context_token(payload)
     context = _decode_picker_context(context_token) if context_token else None
+    pending_picker_user_id = context.get("mentioning_slack_user_id") if context else None
     workflow_id = None
     if context and isinstance(context.get("workflow_id"), str):
         workflow_id = context.get("workflow_id")
@@ -1118,6 +1292,14 @@ def _handle_repo_picker_submit(payload: dict) -> HttpResponse:
             )
             return
 
+        if isinstance(pending_picker_user_id, str) and pending_picker_user_id:
+            _clear_pending_repo_picker(
+                integration_id=integration_id,
+                channel=channel,
+                thread_ts=thread_ts,
+                slack_user_id=pending_picker_user_id,
+            )
+
         # If another workflow already created a task for this thread (e.g. the
         # user sent a follow-up message instead of using the picker), skip the
         # expired message.
@@ -1138,7 +1320,7 @@ def _handle_repo_picker_submit(payload: dict) -> HttpResponse:
             SlackIntegration(integration).client.chat_postMessage(
                 channel=channel,
                 thread_ts=thread_ts,
-                text="Repository selection expired. Please mention PostHog Code again to retry.",
+                text="Repository selection expired. Please mention PostHog again to retry.",
             )
         except Exception:
             logger.warning(
@@ -1160,6 +1342,13 @@ def _handle_repo_picker_submit(payload: dict) -> HttpResponse:
         client = sync_connect()
         handle = client.get_workflow_handle(workflow_id)
         asyncio.run(handle.signal(PostHogCodeSlackMentionWorkflow.repo_selected, selected_repo))
+        if context and pending_picker_user_id:
+            _clear_pending_repo_picker(
+                integration_id=context["integration_id"],
+                channel=context["channel"],
+                thread_ts=context["thread_ts"],
+                slack_user_id=pending_picker_user_id,
+            )
         _replace_repo_picker_with_selection(payload, context, selected_repo)
         return HttpResponse(status=200)
     except Exception as e:
@@ -1184,31 +1373,13 @@ def _replace_repo_picker_with_selection(payload: dict, context: dict | None, sel
         )
         return
 
-    try:
-        # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
-        integration = Integration.objects.get(
-            id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
-        )
-        slack = SlackIntegration(integration)
-        text = f"Repository selected: `{selected_repo}`"
-        slack.client.chat_update(
-            channel=channel,
-            ts=message_ts,
-            text=text,
-            blocks=[
-                {
-                    "type": "section",
-                    "text": {"type": "mrkdwn", "text": f"*Repository selected:* `{selected_repo}`"},
-                }
-            ],
-        )
-    except Exception:
-        logger.warning(
-            "posthog_code_repo_submit_picker_update_failed",
-            integration_id=integration_id,
-            channel=channel,
-            message_ts=message_ts,
-        )
+    _replace_repo_picker_message_with_selection(
+        integration_id=integration_id,
+        slack_team_id=slack_team_id,
+        channel=channel,
+        message_ts=message_ts,
+        selected_repo=selected_repo,
+    )
 
 
 def _handle_terminate_task_submit(payload: dict) -> HttpResponse:

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -475,6 +475,7 @@ def _post_repo_picker_message(
     guidance: str,
     action_id: str,
     workflow_id: str | None = None,
+    allow_no_repo: bool = False,
 ) -> None:
     context_data = {
         "integration_id": integration.id,
@@ -489,23 +490,42 @@ def _post_repo_picker_message(
     context_token = uuid.uuid4().hex
     cache.set(_picker_context_cache_key(context_token), context_data, timeout=PICKER_TOKEN_MAX_AGE_SECONDS)
 
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "section",
+            "block_id": f"posthog_code_repo_picker_v2:{integration.id}:{slack_user_id}:{context_token}",
+            "text": {"type": "mrkdwn", "text": guidance},
+            "accessory": {
+                "type": "external_select",
+                "action_id": action_id,
+                "placeholder": {"type": "plain_text", "text": "Search GitHub repositories..."},
+                "min_query_length": 0,
+            },
+        }
+    ]
+
+    if allow_no_repo:
+        blocks.append(
+            {
+                "type": "actions",
+                "block_id": f"posthog_code_repo_picker_v2:{integration.id}:{slack_user_id}:{context_token}:actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "action_id": "posthog_code_repo_none",
+                        "text": {"type": "plain_text", "text": "No repo needed"},
+                        "style": "primary",
+                        "value": "no_repo_needed",
+                    }
+                ],
+            }
+        )
+
     response = slack.client.chat_postMessage(
         channel=channel,
         thread_ts=thread_ts,
         text=guidance,
-        blocks=[
-            {
-                "type": "section",
-                "block_id": f"posthog_code_repo_picker_v2:{integration.id}:{slack_user_id}:{context_token}",
-                "text": {"type": "mrkdwn", "text": guidance},
-                "accessory": {
-                    "type": "external_select",
-                    "action_id": action_id,
-                    "placeholder": {"type": "plain_text", "text": "Search GitHub repositories..."},
-                    "min_query_length": 0,
-                },
-            },
-        ],
+        blocks=blocks,
         metadata={
             "event_type": "posthog_code_repo_picker",
             "event_payload": {"context_token": context_token, "workflow_id": workflow_id},
@@ -705,6 +725,40 @@ def _replace_repo_picker_message_with_selection(
         )
 
 
+def _replace_repo_picker_message_with_no_repo(
+    *,
+    integration_id: int,
+    slack_team_id: str,
+    channel: str,
+    message_ts: str,
+) -> None:
+    try:
+        # nosemgrep: idor-lookup-without-team — Slack webhook: no team context; scoped by PK + kind + Slack team ID
+        integration = Integration.objects.get(
+            id=integration_id, kind="slack-posthog-code", integration_id=slack_team_id
+        )
+        slack = SlackIntegration(integration)
+        text = "Continuing without a repository."
+        slack.client.chat_update(
+            channel=channel,
+            ts=message_ts,
+            text=text,
+            blocks=[
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": "*Continuing without a repository.*"},
+                }
+            ],
+        )
+    except Exception:
+        logger.warning(
+            "posthog_code_repo_none_picker_update_failed",
+            integration_id=integration_id,
+            channel=channel,
+            message_ts=message_ts,
+        )
+
+
 def _resolve_pending_repo_picker_from_followup(event: dict[str, Any], integration: Integration) -> bool:
     channel = event.get("channel")
     thread_ts = event.get("thread_ts") or event.get("ts")
@@ -874,11 +928,61 @@ def classify_task_needs_repo(
     Defaults to True on error (conservative — falls back to picker).
     """
     conversation = "\n".join(f"{msg['user']}: {msg['text']}" for msg in thread_messages)
+    normalized = f"{conversation}\nLatest message: {event_text}".lower()
+
+    product_debug_terms = (
+        "automation",
+        "destination",
+        "slack destination",
+        "posthog ai feedback",
+        "feature flag",
+        "experiment",
+        "survey",
+        "dashboard",
+        "insight",
+        "session replay",
+        "recording",
+        "trace",
+        "mcp",
+        "webhook",
+    )
+    explicit_code_patterns = (
+        r"\brepository\b",
+        r"\brepo\b",
+        r"\bpull request\b",
+        r"\bopen a pr\b",
+        r"\bcreate a pr\b",
+        r"\bcommit\b",
+        r"\bbranch\b",
+        r"\bmodify code\b",
+        r"\bchange code\b",
+        r"\bwrite code\b",
+        r"\bimplement\b",
+        r"\.py\b",
+        r"\.ts\b",
+        r"\.tsx\b",
+        r"\.js\b",
+        r"\bserializer\b",
+        r"\bviewset\b",
+        r"\bmigration\b",
+    )
+
+    if any(term in normalized for term in product_debug_terms) and not any(
+        re.search(pattern, normalized) for pattern in explicit_code_patterns
+    ):
+        logger.info("classify_task_needs_repo_heuristic_non_repo", event_text=event_text)
+        return False
+
     prompt = (
         "You are a task classifier. Given a Slack conversation, determine whether the task "
         "requires access to a code repository (e.g. writing code, fixing bugs, creating PRs, "
         "reviewing code, modifying files) or NOT (e.g. answering questions about analytics, "
-        "querying data, PostHog configuration, general knowledge questions, planning).\n\n"
+        "querying data, PostHog configuration, general knowledge questions, planning, or "
+        "investigating product behavior in a PostHog workspace using MCP/tools).\n\n"
+        "Return needs_repo=false for tasks that are primarily about debugging or investigating "
+        "automations, destinations, feature flags, experiments, surveys, dashboards, insights, "
+        "recordings, traces, or Slack integrations inside PostHog, unless the user explicitly "
+        "asks to change code, open a PR, edit files, or work in a specific repository.\n\n"
         f"Conversation:\n{conversation}\n\n"
         f"Latest message: {event_text}\n\n"
         'Respond with ONLY a JSON object: {{"needs_repo": true}} or {{"needs_repo": false}}'
@@ -1109,8 +1213,8 @@ def _extract_context_token(payload: dict) -> str:
         if not raw_block_id:
             return ""
         if raw_block_id.startswith("posthog_code_repo_picker_v2:"):
-            parts = raw_block_id.split(":", 3)
-            return parts[3] if len(parts) == 4 else ""
+            parts = raw_block_id.split(":")
+            return parts[3] if len(parts) >= 4 else ""
         if ":" in raw_block_id:
             return raw_block_id.split(":", 1)[1]
         return ""
@@ -1143,8 +1247,8 @@ def _extract_picker_hints(payload: dict) -> tuple[int | None, str | None]:
     if not block_id.startswith("posthog_code_repo_picker_v2:"):
         return None, None
 
-    parts = block_id.split(":", 3)
-    if len(parts) != 4:
+    parts = block_id.split(":")
+    if len(parts) < 4:
         return None, None
 
     try:
@@ -1382,6 +1486,46 @@ def _replace_repo_picker_with_selection(payload: dict, context: dict | None, sel
     )
 
 
+def _handle_no_repo_needed_submit(payload: dict) -> HttpResponse:
+    context_token = _extract_context_token(payload)
+    context = _decode_picker_context(context_token) if context_token else None
+    pending_picker_user_id = context.get("mentioning_slack_user_id") if context else None
+    workflow_id = None
+    if context and isinstance(context.get("workflow_id"), str):
+        workflow_id = context.get("workflow_id")
+    if not workflow_id:
+        workflow_id = payload.get("message", {}).get("metadata", {}).get("event_payload", {}).get("workflow_id")
+
+    if not workflow_id or not context:
+        logger.info("posthog_code_repo_none_missing_workflow_id")
+        return HttpResponse(status=200)
+
+    try:
+        client = sync_connect()
+        handle = client.get_workflow_handle(workflow_id)
+        asyncio.run(handle.signal(PostHogCodeSlackMentionWorkflow.no_repo_needed))
+        if pending_picker_user_id:
+            _clear_pending_repo_picker(
+                integration_id=context["integration_id"],
+                channel=context["channel"],
+                thread_ts=context["thread_ts"],
+                slack_user_id=pending_picker_user_id,
+            )
+        message_ts = payload.get("message", {}).get("ts")
+        slack_team_id = payload.get("team", {}).get("id")
+        if message_ts and slack_team_id:
+            _replace_repo_picker_message_with_no_repo(
+                integration_id=context["integration_id"],
+                slack_team_id=slack_team_id,
+                channel=context["channel"],
+                message_ts=message_ts,
+            )
+        return HttpResponse(status=200)
+    except Exception as e:
+        logger.warning("posthog_code_repo_none_signal_failed", workflow_id=workflow_id, error=str(e))
+        return HttpResponse(status=200)
+
+
 def _handle_terminate_task_submit(payload: dict) -> HttpResponse:
     """Start Temporal workflow for task termination and return 200 immediately."""
     action = next((a for a in payload.get("actions", []) if a.get("action_id") == "posthog_code_terminate_task"), None)
@@ -1505,6 +1649,8 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
         for action in actions:
             if action.get("action_id") == "posthog_code_repo_select":
                 return _handle_repo_picker_submit(payload)
+            if action.get("action_id") == "posthog_code_repo_none":
+                return _handle_no_repo_needed_submit(payload)
             if action.get("action_id") == "posthog_code_terminate_task":
                 return _handle_terminate_task_submit(payload)
 

--- a/products/slack_app/backend/tests/test_guess_repository.py
+++ b/products/slack_app/backend/tests/test_guess_repository.py
@@ -22,6 +22,7 @@ from products.slack_app.backend.api import (
     _match_repo_rule,
     _parse_rules_command,
     _repo_list_cache_key,
+    classify_task_needs_repo,
     select_repository,
 )
 
@@ -971,3 +972,33 @@ class TestRepoRoutingRuleModel:
         team_a_rules = list(RepoRoutingRule.objects.filter(team=self.team_a))
         assert len(team_a_rules) == 1
         assert team_a_rules[0].rule_text == "Team A rule"
+
+
+class TestClassifyTaskNeedsRepo:
+    @parameterized.expand(
+        [
+            (
+                "product_debug_automation",
+                "debug why the automation that sends PostHog AI Feedback always gives a thumbs down",
+                False,
+            ),
+            (
+                "product_debug_destination",
+                "investigate the slack destination configuration for this automation",
+                False,
+            ),
+            (
+                "product_debug_report_not_repo",
+                "debug why this dashboard report always shows a thumbs down",
+                False,
+            ),
+            (
+                "explicit_repo_request",
+                "open a PR in posthog/posthog to fix this serializer",
+                True,
+            ),
+        ]
+    )
+    def test_heuristic_classification(self, _name, text, expected):
+        result = classify_task_needs_repo(text, [{"user": "Alessandro", "text": text}])
+        assert result is expected

--- a/products/slack_app/backend/tests/test_guess_repository.py
+++ b/products/slack_app/backend/tests/test_guess_repository.py
@@ -785,6 +785,26 @@ class TestHandleRulesCommandActivity:
         assert "No routing rules" in msg.kwargs["text"]
 
     @patch("posthog.models.integration.SlackIntegration")
+    def test_help_uses_posthog_commands(self, mock_slack_cls):
+        mock_slack = MagicMock()
+        mock_slack_cls.return_value = mock_slack
+
+        from posthog.temporal.ai.posthog_code_slack_mention import handle_posthog_code_rules_command_activity
+
+        result = handle_posthog_code_rules_command_activity(
+            self._make_inputs("<@U123> help"),
+            self.channel,
+            self.thread_ts,
+            self.slack_user_id,
+            self.user.id,
+        )
+
+        assert result.status == "handled"
+        msg = mock_slack.client.chat_postMessage.call_args
+        assert "@PostHog <task description>" in msg.kwargs["text"]
+        assert "@PostHog Code" not in msg.kwargs["text"]
+
+    @patch("posthog.models.integration.SlackIntegration")
     def test_list_shows_rules(self, mock_slack_cls):
         mock_slack = MagicMock()
         mock_slack_cls.return_value = mock_slack

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from unittest.mock import patch
 
+from django.core.cache import cache
 from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 
@@ -102,6 +103,7 @@ class TestPostHogCodeEventHandler(TestCase):
 
 class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     def setUp(self):
+        cache.clear()
         self.factory = RequestFactory()
         self.organization = Organization.objects.create(name="Test Org")
         self.team = Team.objects.create(organization=self.organization, name="Test Team")
@@ -128,6 +130,115 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         mock_sync_connect.assert_called_once()
         mock_sync_connect.return_value.start_workflow.assert_called_once()
         mock_asyncio_run.assert_called_once()
+
+    @parameterized.expand(
+        [
+            (
+                "resolves_pending_picker",
+                True,
+                "<@U_BOT> use posthog/posthog-js",
+                ["posthog/posthog", "posthog/posthog-js"],
+                False,
+                True,
+            ),
+            (
+                "repo_not_in_connected_list_starts_new_workflow",
+                True,
+                "<@U_BOT> use posthog/unknown-repo",
+                ["posthog/posthog", "posthog/posthog-js"],
+                True,
+                False,
+            ),
+            (
+                "no_pending_picker_starts_new_workflow",
+                False,
+                "<@U_BOT> use posthog/posthog-js",
+                ["posthog/posthog", "posthog/posthog-js"],
+                True,
+                False,
+            ),
+        ]
+    )
+    @patch("products.slack_app.backend.api._get_full_repo_names")
+    @patch("products.slack_app.backend.api._posthog_code_enabled_for_integration", return_value=True)
+    @patch("products.slack_app.backend.api.SlackIntegration")
+    @patch("products.slack_app.backend.api.asyncio.run")
+    @patch("products.slack_app.backend.api.sync_connect")
+    @override_settings(DEBUG=False)
+    def test_explicit_repo_followup_handling(
+        self,
+        _name,
+        has_pending_picker: bool,
+        event_text: str,
+        repo_list: list[str],
+        expect_new_workflow: bool,
+        expect_picker_resolution: bool,
+        mock_sync_connect,
+        mock_asyncio_run,
+        mock_slack_cls,
+        _mock_flag,
+        mock_get_repos,
+    ):
+        request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
+        mock_get_repos.return_value = repo_list
+
+        from products.slack_app.backend.api import (
+            ROUTE_HANDLED_LOCALLY,
+            _get_pending_repo_picker,
+            _set_pending_repo_picker,
+            route_posthog_code_event_to_relevant_region,
+        )
+
+        if has_pending_picker:
+            _set_pending_repo_picker(
+                integration_id=self.posthog_code_integration.id,
+                channel="C001",
+                thread_ts="1234.5678",
+                slack_user_id="U123",
+                workflow_id="posthog-code-mention-T12345:pending",
+                context_token="ctx-1",
+                message_ts="1234.7777",
+            )
+        event = {
+            "type": "app_mention",
+            "channel": "C001",
+            "thread_ts": "1234.5678",
+            "user": "U123",
+            "text": event_text,
+            "ts": "1234.9999",
+        }
+
+        result = route_posthog_code_event_to_relevant_region(request, event, "T12345")
+
+        assert result == ROUTE_HANDLED_LOCALLY
+        mock_sync_connect.assert_called_once()
+        if expect_picker_resolution:
+            mock_sync_connect.return_value.get_workflow_handle.assert_called_once_with(
+                "posthog-code-mention-T12345:pending"
+            )
+            mock_sync_connect.return_value.start_workflow.assert_not_called()
+            mock_asyncio_run.assert_called_once()
+            mock_slack_cls.return_value.client.chat_update.assert_called_once()
+        else:
+            mock_sync_connect.return_value.get_workflow_handle.assert_not_called()
+            mock_sync_connect.return_value.start_workflow.assert_called_once()
+            mock_asyncio_run.assert_called_once()
+            mock_slack_cls.return_value.client.chat_update.assert_not_called()
+
+        pending_picker = _get_pending_repo_picker(
+            integration_id=self.posthog_code_integration.id,
+            channel="C001",
+            thread_ts="1234.5678",
+            slack_user_id="U123",
+        )
+        if expect_new_workflow:
+            if has_pending_picker:
+                assert pending_picker is not None
+                assert pending_picker["workflow_id"] == "posthog-code-mention-T12345:pending"
+            else:
+                assert pending_picker is None
+        else:
+            assert pending_picker is None
 
     @patch("products.slack_app.backend.api._posthog_code_enabled_for_integration", return_value=False)
     @patch("products.slack_app.backend.api.asyncio.run")

--- a/products/slack_app/backend/tests/test_posthog_code_interactivity.py
+++ b/products/slack_app/backend/tests/test_posthog_code_interactivity.py
@@ -198,6 +198,42 @@ class TestRepoPickerOptions(TestCase):
         mock_webclient_class.return_value.chat_update.assert_called_once()
 
     @patch("posthog.models.integration.WebClient")
+    @patch("products.slack_app.backend.api.asyncio.run")
+    @patch("products.slack_app.backend.api.sync_connect")
+    @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
+    def test_no_repo_button_signals_temporal_workflow(
+        self, mock_config, mock_sync_connect, mock_asyncio_run, mock_webclient_class
+    ):
+        mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}
+        mock_webclient_class.return_value = MagicMock()
+        self.context_payload["workflow_id"] = "posthog-code-mention-T12345:C001:1234.5678"
+        cache.set(f"posthog_code_repo_picker_ctx:{self.context_token}", self.context_payload, timeout=900)
+
+        payload = {
+            "type": "block_actions",
+            "user": {"id": "U123"},
+            "actions": [
+                {
+                    "action_id": "posthog_code_repo_none",
+                    "block_id": f"posthog_code_repo_picker_v2:{self.posthog_code_integration.id}:U123:{self.context_token}:actions",
+                    "value": "no_repo_needed",
+                    "action_ts": "1700000000.123",
+                }
+            ],
+            "message": {"ts": "1234.9999"},
+        }
+        response = self._post_interactivity(payload)
+        assert response.status_code == 200
+        mock_sync_connect.assert_called_once()
+        mock_sync_connect.return_value.get_workflow_handle.assert_called_once_with(
+            "posthog-code-mention-T12345:C001:1234.5678"
+        )
+        mock_asyncio_run.assert_called_once()
+        mock_webclient_class.return_value.chat_update.assert_called_once()
+        update_call = mock_webclient_class.return_value.chat_update.call_args.kwargs
+        assert "without a repository" in update_call["text"].lower()
+
+    @patch("posthog.models.integration.WebClient")
     @patch("products.slack_app.backend.api.SlackIntegration.posthog_code_slack_config")
     def test_submit_without_workflow_id_posts_expired(self, mock_config, mock_webclient_class):
         mock_config.return_value = {"SLACK_POSTHOG_CODE_SIGNING_SECRET": self.signing_secret}

--- a/products/slack_app/backend/tests/test_posthog_code_interactivity.py
+++ b/products/slack_app/backend/tests/test_posthog_code_interactivity.py
@@ -223,6 +223,7 @@ class TestRepoPickerOptions(TestCase):
         assert response.status_code == 200
         mock_client.chat_postMessage.assert_called_once()
         assert "selection expired" in mock_client.chat_postMessage.call_args.kwargs["text"].lower()
+        assert "posthog again" in mock_client.chat_postMessage.call_args.kwargs["text"].lower()
 
     @patch("posthog.models.integration.WebClient")
     @patch("products.slack_app.backend.api.asyncio.run")
@@ -260,6 +261,7 @@ class TestRepoPickerOptions(TestCase):
         mock_sync_connect.assert_called_once()
         mock_client.chat_postMessage.assert_called_once()
         assert "selection expired" in mock_client.chat_postMessage.call_args.kwargs["text"].lower()
+        assert "posthog again" in mock_client.chat_postMessage.call_args.kwargs["text"].lower()
 
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")


### PR DESCRIPTION
## Problem

updated the Slack coding-agent UX to use `@PostHog` in user-facing command/help.

fixed the repo picker flow so when a user replies in the same thread with an explicit org/repo, the existing pending picker workflow is resolved immediately instead of waiting until the 15-minute timeout. This also updates the original picker message to a resolved state and clears the pending picker state on submit, follow-up resolution, timeout, and error paths.

**Bonus**:

* improved task classification for PostHog product/debugging questions and adding a `No repo` needed action to the repository picker.