### PR TITLE
fix(tasks): add cloud run bootstrap flow for attachments

### DIFF
--- a/products/tasks/backend/api.py
+++ b/products/tasks/backend/api.py
@@ -3,7 +3,6 @@ import json
 import uuid
 import logging
 import builtins
-import traceback
 from collections.abc import AsyncGenerator
 from datetime import datetime
 from typing import Any, cast
@@ -65,6 +64,7 @@ from .serializers import (
     TaskRunArtifactsPrepareUploadResponseSerializer,
     TaskRunArtifactsUploadRequestSerializer,
     TaskRunArtifactsUploadResponseSerializer,
+    TaskRunBootstrapCreateRequestSerializer,
     TaskRunCommandRequestSerializer,
     TaskRunCommandResponseSerializer,
     TaskRunCreateRequestSchemaSerializer,
@@ -74,6 +74,7 @@ from .serializers import (
     TaskRunRelayMessageResponseSerializer,
     TaskRunSessionLogsQuerySerializer,
     TaskRunSetOutputRequestSerializer,
+    TaskRunStartRequestSerializer,
     TaskRunUpdateSerializer,
     TaskSerializer,
     TaskStagedArtifactsFinalizeUploadRequestSerializer,
@@ -88,7 +89,6 @@ from .services.staged_artifacts import (
     RUN_ARTIFACT_TTL_DAYS,
     STAGED_ARTIFACT_TTL_DAYS,
     build_task_artifact_entry,
-    build_task_run_artifact_storage_path,
     build_task_staged_artifact_cache_key,
     build_task_staged_artifact_storage_path,
     cache_task_staged_artifact,
@@ -267,8 +267,6 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             logger.info(f"Workflow trigger completed for task {task.id}, run {task_run.id}")
         except Exception as e:
             logger.exception(f"Failed to trigger task processing workflow for task {task.id}, run {task_run.id}: {e}")
-
-            logger.exception(f"Workflow error traceback: {traceback.format_exc()}")
 
     @validated_request(
         request_serializer=TaskStagedArtifactsPrepareUploadRequestSerializer,
@@ -577,21 +575,9 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if pending_user_artifact_ids:
             run_artifacts: list[dict] = []
             for staged_artifact in staged_artifacts:
-                run_storage_path = build_task_run_artifact_storage_path(
-                    task_run,
-                    str(staged_artifact["id"]),
-                    str(staged_artifact["name"]),
-                )
-                source_storage_path = str(staged_artifact["storage_path"])
-                if source_storage_path != run_storage_path:
-                    object_storage.copy(source_storage_path, run_storage_path)
-                tag_task_artifact(run_storage_path, ttl_days=RUN_ARTIFACT_TTL_DAYS, team_id=task.team_id)
-                run_artifacts.append(
-                    {
-                        **staged_artifact,
-                        "storage_path": run_storage_path,
-                    }
-                )
+                storage_path = str(staged_artifact["storage_path"])
+                tag_task_artifact(storage_path, ttl_days=RUN_ARTIFACT_TTL_DAYS, team_id=task.team_id)
+                run_artifacts.append(dict(staged_artifact))
 
             task_run.artifacts = run_artifacts
             task_run.save(update_fields=["artifacts", "updated_at"])
@@ -691,14 +677,185 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         return super().list(request, *args, **kwargs)
 
     @validated_request(
+        request_serializer=TaskRunBootstrapCreateRequestSerializer,
         responses={
             201: OpenApiResponse(response=TaskRunDetailSerializer, description="Created task run"),
+            400: OpenApiResponse(response=ErrorResponseSerializer, description="Invalid task run payload"),
         },
         summary="Create task run",
-        description="Create a new run for a specific task.",
+        description="Create a new run for a specific task without starting execution.",
     )
     def create(self, request, *args, **kwargs):
-        return super().create(request, *args, **kwargs)
+        task_id = self.kwargs.get("parent_lookup_task_id")
+        if not task_id:
+            raise NotFound("Task ID is required")
+
+        task = Task.objects.get(id=task_id, team=self.team)
+        environment = request.validated_data.get("environment", TaskRun.Environment.LOCAL)
+        mode = request.validated_data.get("mode", "background")
+        branch = request.validated_data.get("branch")
+        sandbox_environment_id = request.validated_data.get("sandbox_environment_id")
+        pr_authorship_mode = request.validated_data.get("pr_authorship_mode")
+        run_source = request.validated_data.get("run_source")
+        signal_report_id = request.validated_data.get("signal_report_id")
+        runtime_adapter = request.validated_data.get("runtime_adapter")
+        model = request.validated_data.get("model")
+        reasoning_effort = request.validated_data.get("reasoning_effort")
+        github_user_token = request.validated_data.get("github_user_token")
+        initial_permission_mode = request.validated_data.get("initial_permission_mode")
+
+        extra_state: dict[str, Any] | None = None
+        if initial_permission_mode is not None:
+            extra_state = {"initial_permission_mode": initial_permission_mode}
+
+        provider = get_provider_for_runtime_adapter(runtime_adapter)
+        for key, value in {
+            "pr_base_branch": branch,
+            "pr_authorship_mode": pr_authorship_mode,
+            "run_source": run_source,
+            "signal_report_id": signal_report_id,
+            "runtime_adapter": runtime_adapter,
+            "provider": provider,
+            "model": model,
+            "reasoning_effort": reasoning_effort,
+        }.items():
+            if value is not None:
+                extra_state = extra_state or {}
+                extra_state[key] = value.value if hasattr(value, "value") else value
+
+        reasoning_effort_error = get_reasoning_effort_error(
+            runtime_adapter=runtime_adapter,
+            model=model,
+            reasoning_effort=reasoning_effort,
+        )
+        if reasoning_effort_error is not None:
+            return Response(
+                {
+                    "type": "validation_error",
+                    "code": "invalid_input",
+                    "detail": reasoning_effort_error,
+                    "attr": "reasoning_effort",
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if pr_authorship_mode == PrAuthorshipMode.USER and task.repository and not github_user_token:
+            return Response(
+                {"detail": "github_user_token is required for user-authored cloud runs"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if sandbox_environment_id is not None:
+            sandbox_environment = SandboxEnvironment.objects.filter(id=sandbox_environment_id, team=task.team).first()
+            if not sandbox_environment:
+                return Response({"detail": "Invalid sandbox_environment_id"}, status=status.HTTP_400_BAD_REQUEST)
+
+            extra_state = extra_state or {}
+            extra_state["sandbox_environment_id"] = str(sandbox_environment.id)
+
+            logger.info(
+                "Applying sandbox environment to task run",
+                extra={
+                    "task_id": str(task.id),
+                    "sandbox_environment_id": str(sandbox_environment.id),
+                    "sandbox_environment_name": sandbox_environment.name,
+                    "network_access_level": sandbox_environment.network_access_level,
+                },
+            )
+
+        logger.info(
+            "Creating task run for task %s with mode=%s, branch=%s, environment=%s",
+            task.id,
+            mode,
+            branch,
+            environment,
+        )
+        task_run = task.create_run(
+            environment=environment,
+            mode=mode,
+            branch=branch,
+            extra_state=extra_state,
+        )
+
+        if github_user_token and pr_authorship_mode == PrAuthorshipMode.USER:
+            cache_github_user_token(str(task_run.id), github_user_token)
+
+        serializer = TaskRunDetailSerializer(task_run, context=self.get_serializer_context())
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    @validated_request(
+        request_serializer=TaskRunStartRequestSerializer,
+        responses={
+            200: OpenApiResponse(response=TaskSerializer, description="Task with updated latest run"),
+            400: OpenApiResponse(response=ErrorResponseSerializer, description="Invalid start payload"),
+            404: OpenApiResponse(description="Task run not found"),
+        },
+        summary="Start task run",
+        description="Start an existing cloud run after any initial run-scoped attachments have been uploaded.",
+    )
+    @action(detail=True, methods=["post"], url_path="start", required_scopes=["task:write"])
+    def start(self, request, pk=None, **kwargs):
+        task_run = cast(TaskRun, self.get_object())
+        task = task_run.task
+        pending_user_message = request.validated_data.get("pending_user_message")
+        pending_user_artifact_ids = request.validated_data.get("pending_user_artifact_ids") or []
+        startable_statuses = {TaskRun.Status.NOT_STARTED, TaskRun.Status.QUEUED}
+
+        if task_run.environment != TaskRun.Environment.CLOUD:
+            return Response(
+                ErrorResponseSerializer({"error": "Only cloud runs can be started via this endpoint"}).data,
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if task_run.status not in startable_statuses:
+            return Response(
+                ErrorResponseSerializer(
+                    {
+                        "error": f"Only queued or not_started cloud runs can be started (current status: {task_run.status})"
+                    }
+                ).data,
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if pending_user_artifact_ids:
+            _, missing_artifact_ids = get_task_run_artifacts_by_id(task_run, pending_user_artifact_ids)
+            if missing_artifact_ids:
+                return Response(
+                    {
+                        "detail": "Some pending_user_artifact_ids are invalid for this run",
+                        "missing_artifact_ids": missing_artifact_ids,
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+        state_updates: dict[str, Any] = {}
+        if pending_user_message is not None:
+            state_updates["pending_user_message"] = pending_user_message
+        if pending_user_artifact_ids:
+            state_updates["pending_user_artifact_ids"] = pending_user_artifact_ids
+
+        previous_state = dict(task_run.state or {})
+        try:
+            if state_updates:
+                TaskRun.update_state_atomic(task_run.id, updates=state_updates)
+                task_run.refresh_from_db()
+
+            logger.info("Triggering workflow for task %s, existing run %s", task.id, task_run.id)
+            self._trigger_workflow(task, task_run, raise_on_error=True)
+        except Exception:
+            if state_updates:
+                rollback_updates = {
+                    key: previous_state[key] for key in state_updates.keys() if key in previous_state
+                } or None
+                rollback_remove_keys = [key for key in state_updates.keys() if key not in previous_state] or None
+                TaskRun.update_state_atomic(
+                    task_run.id,
+                    updates=rollback_updates,
+                    remove_keys=rollback_remove_keys,
+                )
+            raise
+
+        task.refresh_from_db()
+        return Response(TaskSerializer(task, context=self.get_serializer_context()).data)
 
     @validated_request(
         request_serializer=TaskRunUpdateSerializer,
@@ -882,6 +1039,23 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             raise NotFound("Task ID is required")
         task = Task.objects.get(id=task_id, team=self.team)
         serializer.save(team=self.team, task=task)
+
+    def _trigger_workflow(self, task: Task, task_run: TaskRun, *, raise_on_error: bool = False) -> None:
+        try:
+            logger.info("Attempting to trigger task processing workflow for task %s, run %s", task.id, task_run.id)
+            execute_task_processing_workflow(
+                task_id=str(task.id),
+                run_id=str(task_run.id),
+                team_id=task.team.id,
+                user_id=getattr(self.request.user, "id", None),
+            )
+            logger.info("Workflow trigger completed for task %s, run %s", task.id, task_run.id)
+        except Exception as e:
+            logger.exception(
+                "Failed to trigger task processing workflow for task %s, run %s: %s", task.id, task_run.id, e
+            )
+            if raise_on_error:
+                raise
 
     def _build_artifact_storage_path(self, task_run: TaskRun, artifact_id: str, name: str) -> tuple[str, str]:
         safe_name = get_safe_artifact_name(name)

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -950,6 +950,161 @@ class TaskRunCreateRequestSerializer(serializers.Serializer):
         return attrs
 
 
+class TaskRunBootstrapCreateRequestSerializer(serializers.Serializer):
+    """Request body for creating a task run without starting execution yet."""
+
+    PR_AUTHORSHIP_MODE_CHOICES = [mode.value for mode in PrAuthorshipMode]
+    RUN_SOURCE_CHOICES = [source.value for source in RunSource]
+    RUNTIME_ADAPTER_CHOICES = [adapter.value for adapter in RuntimeAdapter]
+    REASONING_EFFORT_CHOICES = [effort.value for effort in PUBLIC_REASONING_EFFORTS]
+
+    environment = serializers.ChoiceField(
+        choices=[environment.value for environment in TaskRun.Environment],
+        required=False,
+        default=TaskRun.Environment.LOCAL,
+        help_text="Execution environment for the new run. Use 'cloud' for remote sandbox runs and 'local' for desktop sessions.",
+    )
+    mode = serializers.ChoiceField(
+        choices=["interactive", "background"],
+        required=False,
+        default="background",
+        help_text="Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs",
+    )
+    branch = serializers.CharField(
+        required=False,
+        allow_null=True,
+        default=None,
+        max_length=255,
+        help_text="Git branch to checkout in the sandbox",
+    )
+    sandbox_environment_id = serializers.UUIDField(
+        required=False,
+        default=None,
+        help_text="Optional sandbox environment to apply for this cloud run.",
+    )
+    pr_authorship_mode = serializers.ChoiceField(
+        choices=PR_AUTHORSHIP_MODE_CHOICES,
+        required=False,
+        default=None,
+        help_text="Whether pull requests for this run should be authored by the user or the bot.",
+    )
+    run_source = serializers.ChoiceField(
+        choices=RUN_SOURCE_CHOICES,
+        required=False,
+        default=None,
+        help_text="High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.",
+    )
+    signal_report_id = serializers.CharField(
+        required=False,
+        default=None,
+        allow_blank=False,
+        help_text="Optional signal report identifier when this run was started from Inbox.",
+    )
+    runtime_adapter = serializers.ChoiceField(
+        choices=RUNTIME_ADAPTER_CHOICES,
+        required=False,
+        default=None,
+        help_text="Agent runtime adapter to launch for this run. Use 'claude' for the Claude runtime or 'codex' for the Codex runtime.",
+    )
+    model = serializers.CharField(
+        required=False,
+        default=None,
+        allow_blank=False,
+        help_text="LLM model identifier to run in the selected runtime.",
+    )
+    reasoning_effort = serializers.ChoiceField(
+        choices=REASONING_EFFORT_CHOICES,
+        required=False,
+        default=None,
+        help_text="Reasoning effort to request for models that expose an effort control.",
+    )
+    github_user_token = serializers.CharField(
+        required=False,
+        default=None,
+        allow_blank=False,
+        write_only=True,
+        help_text="Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests.",
+    )
+    initial_permission_mode = serializers.ChoiceField(
+        choices=ALL_INITIAL_PERMISSION_MODE_CHOICES,
+        required=False,
+        default=None,
+        help_text=(
+            "Initial permission mode for the agent session. Claude runtimes accept PostHog permission "
+            "presets like 'plan'. Codex runtimes accept native Codex modes like 'auto' and "
+            "'read-only'."
+        ),
+    )
+
+    def validate(self, attrs):
+        errors: dict[str, str] = {}
+        initial_permission_mode = attrs.get("initial_permission_mode")
+        runtime_adapter = attrs.get("runtime_adapter")
+        if initial_permission_mode is not None:
+            if runtime_adapter is None:
+                errors["initial_permission_mode"] = "This field requires runtime_adapter to be set."
+            else:
+                allowed_permission_modes = (
+                    list(CODEX_INITIAL_PERMISSION_MODE_CHOICES)
+                    if runtime_adapter == RuntimeAdapter.CODEX.value
+                    else list(INITIAL_PERMISSION_MODE_CHOICES)
+                )
+
+                if initial_permission_mode not in allowed_permission_modes:
+                    allowed_values = ", ".join(f"'{value}'" for value in allowed_permission_modes)
+                    errors["initial_permission_mode"] = (
+                        f"Invalid choice '{initial_permission_mode}' for runtime_adapter "
+                        f"'{runtime_adapter}'. Supported values: {allowed_values}."
+                    )
+
+        runtime_fields = ("runtime_adapter", "model")
+        has_runtime_selection = any(attrs.get(field) is not None for field in (*runtime_fields, "reasoning_effort"))
+        if not has_runtime_selection:
+            if errors:
+                raise serializers.ValidationError(errors)
+            return attrs
+
+        for field in runtime_fields:
+            if attrs.get(field) is None:
+                errors[field] = "This field is required when selecting a cloud runtime."
+
+        reasoning_effort_error = get_reasoning_effort_error(
+            runtime_adapter=attrs.get("runtime_adapter"),
+            model=attrs.get("model"),
+            reasoning_effort=attrs.get("reasoning_effort"),
+        )
+        if reasoning_effort_error is not None:
+            errors["reasoning_effort"] = reasoning_effort_error
+
+        if errors:
+            raise serializers.ValidationError(errors)
+
+        return attrs
+
+
+class TaskRunStartRequestSerializer(serializers.Serializer):
+    pending_user_message = serializers.CharField(
+        required=False,
+        default=None,
+        allow_blank=True,
+        help_text="Initial or follow-up user message to include in the run prompt.",
+    )
+    pending_user_artifact_ids = serializers.ListField(
+        required=False,
+        default=list,
+        child=serializers.CharField(max_length=128),
+        help_text="Identifiers for run artifacts that should be attached to the next user message delivered to the sandbox.",
+    )
+
+    def validate(self, attrs):
+        pending_user_message = attrs.get("pending_user_message")
+        if pending_user_message is not None:
+            trimmed_message = pending_user_message.strip()
+            attrs["pending_user_message"] = trimmed_message or None
+
+        return attrs
+
+
 class ClaudeTaskRunCreateSchemaSerializer(TaskRunCreateRequestSerializer):
     runtime_adapter = serializers.ChoiceField(
         choices=[RuntimeAdapter.CLAUDE.value],

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -22,7 +22,6 @@ from posthog.models import Integration, Organization, OrganizationMembership, Pe
 from posthog.models.personal_api_key import hash_key_value
 from posthog.models.utils import generate_random_token_personal
 from posthog.storage import object_storage
-from posthog.storage.object_storage import ObjectStorageError
 
 from products.tasks.backend.models import (
     CodeInvite,
@@ -39,6 +38,7 @@ from products.tasks.backend.serializers import (
 )
 from products.tasks.backend.services.connection_token import get_sandbox_jwt_public_key
 from products.tasks.backend.services.staged_artifacts import (
+    RUN_ARTIFACT_TTL_DAYS,
     build_task_artifact_entry,
     cache_task_staged_artifact,
     get_task_staged_artifacts,
@@ -435,21 +435,25 @@ class TestTaskAPI(BaseTaskAPITest):
         self.assertEqual(artifact["name"], "spec.pdf")
         self.assertEqual(artifact["type"], "user_attachment")
         self.assertEqual(artifact["source"], "user_attachment")
-        self.assertIn(f"tasks/artifacts/team_{self.team.id}/task_{task.id}/run_{run_id}/", artifact["storage_path"])
-        mock_copy.assert_called_once_with(
+        self.assertEqual(artifact["storage_path"], staged_artifact["storage_path"])
+        mock_copy.assert_not_called()
+        mock_tag.assert_called_once_with(
             staged_artifact["storage_path"],
-            artifact["storage_path"],
+            {
+                "ttl_days": RUN_ARTIFACT_TTL_DAYS,
+                "team_id": str(self.team.id),
+            },
         )
-        mock_tag.assert_called_once()
         remaining_staged_artifacts, missing_artifact_ids = get_task_staged_artifacts(task, ["artifact-123"])
         self.assertEqual(remaining_staged_artifacts, [])
         self.assertEqual(missing_artifact_ids, ["artifact-123"])
         mock_workflow.assert_called_once()
 
     @patch("posthog.storage.object_storage.copy")
+    @patch("posthog.storage.object_storage.tag")
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
-    def test_run_endpoint_preserves_staged_artifacts_when_copy_fails(self, mock_workflow, mock_copy):
-        mock_copy.side_effect = ObjectStorageError("copy failed")
+    def test_run_endpoint_ignores_copy_failures_for_staged_artifacts(self, mock_workflow, mock_tag, mock_copy):
+        mock_copy.side_effect = AssertionError("copy should not be called")
         task = self.create_task()
         staged_artifact = build_task_artifact_entry(
             artifact_id="artifact-123",
@@ -471,15 +475,201 @@ class TestTaskAPI(BaseTaskAPITest):
             format="json",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
-
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(TaskRun.objects.filter(task=task).count(), 1)
         task_run = TaskRun.objects.get(task=task)
-        self.assertEqual(task_run.artifacts, [])
+        self.assertEqual(task_run.artifacts, [staged_artifact])
         remaining_staged_artifacts, missing_artifact_ids = get_task_staged_artifacts(task, ["artifact-123"])
-        self.assertEqual(remaining_staged_artifacts, [staged_artifact])
-        self.assertEqual(missing_artifact_ids, [])
+        self.assertEqual(remaining_staged_artifacts, [])
+        self.assertEqual(missing_artifact_ids, ["artifact-123"])
+        mock_copy.assert_not_called()
+        mock_tag.assert_called_once_with(
+            staged_artifact["storage_path"],
+            {
+                "ttl_days": RUN_ARTIFACT_TTL_DAYS,
+                "team_id": str(self.team.id),
+            },
+        )
+        mock_workflow.assert_called_once()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_create_run_endpoint_creates_cloud_run_without_triggering_workflow(self, mock_workflow):
+        task = self.create_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/",
+            {
+                "environment": "cloud",
+                "mode": "interactive",
+                "branch": "release/direct-upload",
+                "runtime_adapter": "codex",
+                "model": "gpt-5.4",
+                "reasoning_effort": "high",
+                "initial_permission_mode": "auto",
+                "run_source": "manual",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        task_run = TaskRun.objects.get(id=response.json()["id"])
+        self.assertEqual(task_run.environment, TaskRun.Environment.CLOUD)
+        self.assertEqual(task_run.status, TaskRun.Status.QUEUED)
+        self.assertEqual(task_run.branch, "release/direct-upload")
+        self.assertEqual(task_run.state["mode"], "interactive")
+        self.assertEqual(task_run.state["pr_base_branch"], "release/direct-upload")
+        self.assertEqual(task_run.state["runtime_adapter"], "codex")
+        self.assertEqual(task_run.state["provider"], "openai")
+        self.assertEqual(task_run.state["model"], "gpt-5.4")
+        self.assertEqual(task_run.state["reasoning_effort"], "high")
+        self.assertEqual(task_run.state["initial_permission_mode"], "auto")
+        self.assertEqual(task_run.state["run_source"], "manual")
         mock_workflow.assert_not_called()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_create_run_endpoint_caches_user_github_token(self, mock_workflow):
+        integration = Integration.objects.create(team=self.team, kind="github", config={"access_token": "token"})
+        task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="GitHub task",
+            description="Ship it",
+            origin_product=Task.OriginProduct.USER_CREATED,
+            repository="posthog/posthog",
+            github_integration=integration,
+        )
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/",
+            {
+                "environment": "cloud",
+                "pr_authorship_mode": "user",
+                "github_user_token": "ghu_test_token",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        task_run = TaskRun.objects.get(id=response.json()["id"])
+        self.assertEqual(get_cached_github_user_token(str(task_run.id)), "ghu_test_token")
+        mock_workflow.assert_not_called()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_start_run_endpoint_triggers_workflow_for_existing_cloud_run(self, mock_workflow):
+        task = self.create_task()
+        task_run = task.create_run(environment=TaskRun.Environment.CLOUD)
+        task_run.artifacts = [
+            build_task_artifact_entry(
+                artifact_id="artifact-123",
+                name="spec.pdf",
+                artifact_type="user_attachment",
+                source="user_attachment",
+                size=4096,
+                content_type="application/pdf",
+                storage_path=f"tasks/artifacts/team_{self.team.id}/task_{task.id}/run_{task_run.id}/artifact-123_spec.pdf",
+            )
+        ]
+        task_run.save(update_fields=["artifacts", "updated_at"])
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/{task_run.id}/start/",
+            {
+                "pending_user_message": "Read the file first",
+                "pending_user_artifact_ids": ["artifact-123"],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        task_run.refresh_from_db()
+        self.assertEqual(task_run.state["pending_user_message"], "Read the file first")
+        self.assertEqual(task_run.state["pending_user_artifact_ids"], ["artifact-123"])
+        mock_workflow.assert_called_once_with(
+            task_id=str(task.id),
+            run_id=str(task_run.id),
+            team_id=task.team.id,
+            user_id=self.user.id,
+        )
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_start_run_endpoint_rejects_missing_run_artifacts(self, mock_workflow):
+        task = self.create_task()
+        task_run = task.create_run(environment=TaskRun.Environment.CLOUD)
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/{task_run.id}/start/",
+            {"pending_user_artifact_ids": ["artifact-123"]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "detail": "Some pending_user_artifact_ids are invalid for this run",
+                "missing_artifact_ids": ["artifact-123"],
+            },
+        )
+        mock_workflow.assert_not_called()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_start_run_endpoint_rejects_non_startable_status(self, mock_workflow):
+        task = self.create_task()
+        task_run = task.create_run(environment=TaskRun.Environment.CLOUD)
+        task_run.status = TaskRun.Status.COMPLETED
+        task_run.save(update_fields=["status", "updated_at"])
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/{task_run.id}/start/",
+            {"pending_user_message": "Retry this"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {"error": "Only queued or not_started cloud runs can be started (current status: completed)"},
+        )
+        mock_workflow.assert_not_called()
+
+    @patch("products.tasks.backend.api.execute_task_processing_workflow")
+    def test_start_run_endpoint_rolls_back_pending_state_when_workflow_trigger_fails(self, mock_workflow):
+        mock_workflow.side_effect = RuntimeError("workflow start failed")
+        task = self.create_task()
+        task_run = task.create_run(environment=TaskRun.Environment.CLOUD)
+        task_run.state = {"existing_key": "keep-me"}
+        task_run.artifacts = [
+            build_task_artifact_entry(
+                artifact_id="artifact-123",
+                name="spec.pdf",
+                artifact_type="user_attachment",
+                source="user_attachment",
+                size=4096,
+                content_type="application/pdf",
+                storage_path=f"tasks/artifacts/team_{self.team.id}/task_{task.id}/run_{task_run.id}/artifact-123_spec.pdf",
+            )
+        ]
+        task_run.save(update_fields=["state", "artifacts", "updated_at"])
+
+        self.client.raise_request_exception = False
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/{task_run.id}/start/",
+            {
+                "pending_user_message": "Read the file first",
+                "pending_user_artifact_ids": ["artifact-123"],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        task_run.refresh_from_db()
+        self.assertEqual(task_run.state, {"existing_key": "keep-me"})
+        mock_workflow.assert_called_once_with(
+            task_id=str(task.id),
+            run_id=str(task_run.id),
+            team_id=task.team.id,
+            user_id=self.user.id,
+        )
 
     @parameterized.expand(
         [
@@ -3195,6 +3385,7 @@ class TestTasksAPIPermissions(BaseTaskAPITest):
             (f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/", "GET"),
             (f"/api/projects/@current/tasks/{task.id}/runs/", "POST"),
             (f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/", "PATCH"),
+            (f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/start/", "POST"),
             (f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/set_output/", "PATCH"),
             (f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/append_log/", "POST"),
             (f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/relay_message/", "POST"),
@@ -3333,6 +3524,7 @@ class TestTasksAPIPermissions(BaseTaskAPITest):
             ("task:write", "POST", f"/api/projects/@current/tasks/{{task_id}}/run/", True),
             ("task:write", "GET", f"/api/projects/@current/tasks/{{task_id}}/runs/", True),
             ("task:write", "GET", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/", True),
+            ("task:write", "POST", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/start/", True),
             ("task:write", "GET", "/api/projects/@current/task_automations/", True),
             ("task:write", "GET", "/api/projects/@current/task_automations/{automation_id}/", True),
             ("task:write", "POST", "/api/projects/@current/task_automations/", True),
@@ -3346,6 +3538,7 @@ class TestTasksAPIPermissions(BaseTaskAPITest):
             ("*", "POST", f"/api/projects/@current/tasks/{{task_id}}/run/", True),
             ("*", "GET", f"/api/projects/@current/tasks/{{task_id}}/runs/", True),
             ("*", "GET", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/", True),
+            ("*", "POST", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/start/", True),
             ("*", "GET", "/api/projects/@current/task_automations/", True),
             ("*", "GET", "/api/projects/@current/task_automations/{automation_id}/", True),
             ("*", "POST", "/api/projects/@current/task_automations/", True),

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -723,17 +723,21 @@ export const TaskRunDetailStatusEnumApi = {
  * * `local` - Local
  * `cloud` - Cloud
  */
-export type EnvironmentEnumApi = (typeof EnvironmentEnumApi)[keyof typeof EnvironmentEnumApi]
+export type TaskRunDetailEnvironmentEnumApi =
+    (typeof TaskRunDetailEnvironmentEnumApi)[keyof typeof TaskRunDetailEnvironmentEnumApi]
 
-export const EnvironmentEnumApi = {
+export const TaskRunDetailEnvironmentEnumApi = {
     Local: 'local',
     Cloud: 'cloud',
 } as const
 
-export type TaskRunDetailRuntimeAdapterEnumApi =
-    (typeof TaskRunDetailRuntimeAdapterEnumApi)[keyof typeof TaskRunDetailRuntimeAdapterEnumApi]
+/**
+ * * `claude` - claude
+ * `codex` - codex
+ */
+export type RuntimeAdapterB33EnumApi = (typeof RuntimeAdapterB33EnumApi)[keyof typeof RuntimeAdapterB33EnumApi]
 
-export const TaskRunDetailRuntimeAdapterEnumApi = {
+export const RuntimeAdapterB33EnumApi = {
     Claude: 'claude',
     Codex: 'codex',
 } as const
@@ -766,9 +770,9 @@ export interface TaskRunDetailApi {
 
 * `local` - Local
 * `cloud` - Cloud */
-    environment?: EnvironmentEnumApi
+    environment?: TaskRunDetailEnvironmentEnumApi
     /** Configured runtime adapter for this run, such as 'claude' or 'codex'. */
-    readonly runtime_adapter: TaskRunDetailRuntimeAdapterEnumApi | NullEnumApi | null
+    readonly runtime_adapter: RuntimeAdapterB33EnumApi | NullEnumApi | null
     /** Configured LLM provider for this run, such as 'anthropic' or 'openai'. */
     readonly provider: TaskRunDetailProviderEnumApi | NullEnumApi | null
     /**
@@ -806,6 +810,102 @@ export interface PaginatedTaskRunDetailListApi {
     /** @nullable */
     previous?: string | null
     results: TaskRunDetailApi[]
+}
+
+/**
+ * * `local` - local
+ * `cloud` - cloud
+ */
+export type TaskRunBootstrapCreateRequestEnvironmentEnumApi =
+    (typeof TaskRunBootstrapCreateRequestEnvironmentEnumApi)[keyof typeof TaskRunBootstrapCreateRequestEnvironmentEnumApi]
+
+export const TaskRunBootstrapCreateRequestEnvironmentEnumApi = {
+    Local: 'local',
+    Cloud: 'cloud',
+} as const
+
+/**
+ * * `default` - default
+ * `acceptEdits` - acceptEdits
+ * `plan` - plan
+ * `bypassPermissions` - bypassPermissions
+ * `auto` - auto
+ * `read-only` - read-only
+ * `full-access` - full-access
+ */
+export type TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi =
+    (typeof TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi)[keyof typeof TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi]
+
+export const TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi = {
+    Default: 'default',
+    AcceptEdits: 'acceptEdits',
+    Plan: 'plan',
+    BypassPermissions: 'bypassPermissions',
+    Auto: 'auto',
+    ReadOnly: 'read-only',
+    FullAccess: 'full-access',
+} as const
+
+/**
+ * Request body for creating a task run without starting execution yet.
+ */
+export interface TaskRunBootstrapCreateRequestApi {
+    /** Execution environment for the new run. Use 'cloud' for remote sandbox runs and 'local' for desktop sessions.
+
+* `local` - local
+* `cloud` - cloud */
+    environment?: TaskRunBootstrapCreateRequestEnvironmentEnumApi
+    /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
+
+* `interactive` - interactive
+* `background` - background */
+    mode?: Mode051EnumApi
+    /**
+     * Git branch to checkout in the sandbox
+     * @maxLength 255
+     * @nullable
+     */
+    branch?: string | null
+    /** Optional sandbox environment to apply for this cloud run. */
+    sandbox_environment_id?: string
+    /** Whether pull requests for this run should be authored by the user or the bot.
+
+* `user` - user
+* `bot` - bot */
+    pr_authorship_mode?: PrAuthorshipModeEnumApi
+    /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
+
+* `manual` - manual
+* `signal_report` - signal_report */
+    run_source?: RunSourceEnumApi
+    /** Optional signal report identifier when this run was started from Inbox. */
+    signal_report_id?: string
+    /** Agent runtime adapter to launch for this run. Use 'claude' for the Claude runtime or 'codex' for the Codex runtime.
+
+* `claude` - claude
+* `codex` - codex */
+    runtime_adapter?: RuntimeAdapterB33EnumApi
+    /** LLM model identifier to run in the selected runtime. */
+    model?: string
+    /** Reasoning effort to request for models that expose an effort control.
+
+* `low` - low
+* `medium` - medium
+* `high` - high
+* `max` - max */
+    reasoning_effort?: ReasoningEffortEnumApi
+    /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
+    github_user_token?: string
+    /** Initial permission mode for the agent session. Claude runtimes accept PostHog permission presets like 'plan'. Codex runtimes accept native Codex modes like 'auto' and 'read-only'.
+
+* `default` - default
+* `acceptEdits` - acceptEdits
+* `plan` - plan
+* `bypassPermissions` - bypassPermissions
+* `auto` - auto
+* `read-only` - read-only
+* `full-access` - full-access */
+    initial_permission_mode?: TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi
 }
 
 /**
@@ -1148,6 +1248,13 @@ export interface TaskRunRelayMessageResponseApi {
 export interface PatchedTaskRunSetOutputRequestApi {
     /** Output data from the run. Validated against the task's json_schema if one is set. */
     output?: unknown
+}
+
+export interface TaskRunStartRequestApi {
+    /** Initial or follow-up user message to include in the run prompt. */
+    pending_user_message?: string
+    /** Identifiers for run artifacts that should be attached to the next user message delivered to the sandbox. */
+    pending_user_artifact_ids?: string[]
 }
 
 /**

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -33,12 +33,14 @@ import type {
     TaskRunArtifactsPrepareUploadResponseApi,
     TaskRunArtifactsUploadRequestApi,
     TaskRunArtifactsUploadResponseApi,
+    TaskRunBootstrapCreateRequestApi,
     TaskRunCommandRequestApi,
     TaskRunCommandResponseApi,
     TaskRunCreateRequestSchemaApi,
     TaskRunDetailApi,
     TaskRunRelayMessageRequestApi,
     TaskRunRelayMessageResponseApi,
+    TaskRunStartRequestApi,
     TaskStagedArtifactsFinalizeUploadRequestApi,
     TaskStagedArtifactsFinalizeUploadResponseApi,
     TaskStagedArtifactsPrepareUploadRequestApi,
@@ -417,7 +419,7 @@ export const tasksRunsList = async (
 }
 
 /**
- * Create a new run for a specific task.
+ * Create a new run for a specific task without starting execution.
  * @summary Create task run
  */
 export const getTasksRunsCreateUrl = (projectId: string, taskId: string) => {
@@ -427,11 +429,14 @@ export const getTasksRunsCreateUrl = (projectId: string, taskId: string) => {
 export const tasksRunsCreate = async (
     projectId: string,
     taskId: string,
+    taskRunBootstrapCreateRequestApi: TaskRunBootstrapCreateRequestApi,
     options?: RequestInit
 ): Promise<TaskRunDetailApi> => {
     return apiMutator<TaskRunDetailApi>(getTasksRunsCreateUrl(projectId, taskId), {
         ...options,
         method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(taskRunBootstrapCreateRequestApi),
     })
 }
 
@@ -745,6 +750,29 @@ export const tasksRunsSetOutputPartialUpdate = async (
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(patchedTaskRunSetOutputRequestApi),
+    })
+}
+
+/**
+ * Start an existing cloud run after any initial run-scoped attachments have been uploaded.
+ * @summary Start task run
+ */
+export const getTasksRunsStartCreateUrl = (projectId: string, taskId: string, id: string) => {
+    return `/api/projects/${projectId}/tasks/${taskId}/runs/${id}/start/`
+}
+
+export const tasksRunsStartCreate = async (
+    projectId: string,
+    taskId: string,
+    id: string,
+    taskRunStartRequestApi: TaskRunStartRequestApi,
+    options?: RequestInit
+): Promise<TaskApi> => {
+    return apiMutator<TaskApi>(getTasksRunsStartCreateUrl(projectId, taskId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(taskRunStartRequestApi),
     })
 }
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14562,18 +14562,6 @@ export namespace Schemas {
       hidden?: boolean | null;
     }
 
-    /**
-     * * `local` - Local
-    * `cloud` - Cloud
-     */
-    export type EnvironmentEnum = typeof EnvironmentEnum[keyof typeof EnvironmentEnum];
-
-
-    export const EnvironmentEnum = {
-      Local: 'local',
-      Cloud: 'cloud',
-    } as const;
-
     export interface ErrorResponse {
       /** Error message */
       error: string;
@@ -23884,10 +23872,26 @@ export namespace Schemas {
       Cancelled: 'cancelled',
     } as const;
 
-    export type TaskRunDetailRuntimeAdapterEnum = typeof TaskRunDetailRuntimeAdapterEnum[keyof typeof TaskRunDetailRuntimeAdapterEnum];
+    /**
+     * * `local` - Local
+    * `cloud` - Cloud
+     */
+    export type TaskRunDetailEnvironmentEnum = typeof TaskRunDetailEnvironmentEnum[keyof typeof TaskRunDetailEnvironmentEnum];
 
 
-    export const TaskRunDetailRuntimeAdapterEnum = {
+    export const TaskRunDetailEnvironmentEnum = {
+      Local: 'local',
+      Cloud: 'cloud',
+    } as const;
+
+    /**
+     * * `claude` - claude
+    * `codex` - codex
+     */
+    export type RuntimeAdapterB33Enum = typeof RuntimeAdapterB33Enum[keyof typeof RuntimeAdapterB33Enum];
+
+
+    export const RuntimeAdapterB33Enum = {
       Claude: 'claude',
       Codex: 'codex',
     } as const;
@@ -23939,9 +23943,9 @@ export namespace Schemas {
 
     * `local` - Local
     * `cloud` - Cloud */
-      environment?: EnvironmentEnum;
+      environment?: TaskRunDetailEnvironmentEnum;
       /** Configured runtime adapter for this run, such as 'claude' or 'codex'. */
-      readonly runtime_adapter: TaskRunDetailRuntimeAdapterEnum | NullEnum | null;
+      readonly runtime_adapter: RuntimeAdapterB33Enum | NullEnum | null;
       /** Configured LLM provider for this run, such as 'anthropic' or 'openai'. */
       readonly provider: TaskRunDetailProviderEnum | NullEnum | null;
       /**
@@ -34733,6 +34737,102 @@ export namespace Schemas {
     }
 
     /**
+     * * `local` - local
+    * `cloud` - cloud
+     */
+    export type TaskRunBootstrapCreateRequestEnvironmentEnum = typeof TaskRunBootstrapCreateRequestEnvironmentEnum[keyof typeof TaskRunBootstrapCreateRequestEnvironmentEnum];
+
+
+    export const TaskRunBootstrapCreateRequestEnvironmentEnum = {
+      Local: 'local',
+      Cloud: 'cloud',
+    } as const;
+
+    /**
+     * * `default` - default
+    * `acceptEdits` - acceptEdits
+    * `plan` - plan
+    * `bypassPermissions` - bypassPermissions
+    * `auto` - auto
+    * `read-only` - read-only
+    * `full-access` - full-access
+     */
+    export type TaskRunBootstrapCreateRequestInitialPermissionModeEnum = typeof TaskRunBootstrapCreateRequestInitialPermissionModeEnum[keyof typeof TaskRunBootstrapCreateRequestInitialPermissionModeEnum];
+
+
+    export const TaskRunBootstrapCreateRequestInitialPermissionModeEnum = {
+      Default: 'default',
+      AcceptEdits: 'acceptEdits',
+      Plan: 'plan',
+      BypassPermissions: 'bypassPermissions',
+      Auto: 'auto',
+      ReadOnly: 'read-only',
+      FullAccess: 'full-access',
+    } as const;
+
+    /**
+     * Request body for creating a task run without starting execution yet.
+     */
+    export interface TaskRunBootstrapCreateRequest {
+      /** Execution environment for the new run. Use 'cloud' for remote sandbox runs and 'local' for desktop sessions.
+
+    * `local` - local
+    * `cloud` - cloud */
+      environment?: TaskRunBootstrapCreateRequestEnvironmentEnum;
+      /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
+
+    * `interactive` - interactive
+    * `background` - background */
+      mode?: Mode051Enum;
+      /**
+       * Git branch to checkout in the sandbox
+       * @maxLength 255
+       * @nullable
+       */
+      branch?: string | null;
+      /** Optional sandbox environment to apply for this cloud run. */
+      sandbox_environment_id?: string;
+      /** Whether pull requests for this run should be authored by the user or the bot.
+
+    * `user` - user
+    * `bot` - bot */
+      pr_authorship_mode?: PrAuthorshipModeEnum;
+      /** High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.
+
+    * `manual` - manual
+    * `signal_report` - signal_report */
+      run_source?: RunSourceEnum;
+      /** Optional signal report identifier when this run was started from Inbox. */
+      signal_report_id?: string;
+      /** Agent runtime adapter to launch for this run. Use 'claude' for the Claude runtime or 'codex' for the Codex runtime.
+
+    * `claude` - claude
+    * `codex` - codex */
+      runtime_adapter?: RuntimeAdapterB33Enum;
+      /** LLM model identifier to run in the selected runtime. */
+      model?: string;
+      /** Reasoning effort to request for models that expose an effort control.
+
+    * `low` - low
+    * `medium` - medium
+    * `high` - high
+    * `max` - max */
+      reasoning_effort?: ReasoningEffortEnum;
+      /** Ephemeral GitHub user token from PostHog Code for user-authored cloud pull requests. */
+      github_user_token?: string;
+      /** Initial permission mode for the agent session. Claude runtimes accept PostHog permission presets like 'plan'. Codex runtimes accept native Codex modes like 'auto' and 'read-only'.
+
+    * `default` - default
+    * `acceptEdits` - acceptEdits
+    * `plan` - plan
+    * `bypassPermissions` - bypassPermissions
+    * `auto` - auto
+    * `read-only` - read-only
+    * `full-access` - full-access */
+      initial_permission_mode?: TaskRunBootstrapCreateRequestInitialPermissionModeEnum;
+    }
+
+    /**
      * Parameters for the command
      */
     export type TaskRunCommandRequestParams = {[key: string]: unknown};
@@ -34829,6 +34929,13 @@ export namespace Schemas {
       status: string;
       /** Relay workflow ID when accepted */
       relay_id?: string;
+    }
+
+    export interface TaskRunStartRequest {
+      /** Initial or follow-up user message to include in the run prompt. */
+      pending_user_message?: string;
+      /** Identifiers for run artifacts that should be attached to the next user message delivered to the sandbox. */
+      pending_user_artifact_ids?: string[];
     }
 
     export interface TaskStagedArtifactFinalizeUpload {


### PR DESCRIPTION
 ## Problem

cloud task runs could fail when they were started with initial attachments.
The original bootstrap flow depended on staged task artifacts being promoted into the run as part of task start, which made initial attachment handling brittle and tied task start to staged artifact behavior. 
Locally it was working fine since S3 ops were more broadly scoped.

## Changes

- added a `start` action for existing task runs so initial prompt state can be attached after run-scoped uploads are finalized
- added a lot of tests

## Publish to changelog?

no