### PR TITLE
chore: add yolo to end of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,5 @@ The pricing for our paid plan is completely transparent and available on [our pr
 Hey! If you're reading this, you've proven yourself as a dedicated README reader.
 
 You might also make a great addition to our team. We're growing fast [and would love for you to join us](https://posthog.com/careers).
+
+yolo


### PR DESCRIPTION
## Problem

Small, intentionally trivial content addition to the top-level `README.md` requested for task tracking.

## Changes

- Appends a blank line and the literal word `yolo` to the end of `README.md`.
- No code, no dependencies, no schema changes.

## How did you test this code?

Authored by an automated agent. No manual testing performed. Visually verified the diff with `git diff` and `tail README.md`. No unit or integration tests apply to this markdown-only change.

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code (agent). The change was planned in plan mode, approved by the user, and applied as a single-file markdown append.