### PR TITLE
feat(integrations): add github repository search

### DIFF
--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -99,6 +99,12 @@ class GitHubRepoSerializer(serializers.Serializer):
 
 
 class GitHubReposQuerySerializer(serializers.Serializer):
+    search = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        default="",
+        help_text="Optional case-insensitive repository name search query.",
+    )
     limit = serializers.IntegerField(
         required=False,
         default=100,
@@ -675,11 +681,12 @@ class IntegrationViewSet(
     def github_repos(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         query_serializer = GitHubReposQuerySerializer(data=request.query_params)
         query_serializer.is_valid(raise_exception=True)
+        search = query_serializer.validated_data["search"]
         limit = query_serializer.validated_data["limit"]
         offset = query_serializer.validated_data["offset"]
 
         github = GitHubIntegration(self.get_object())
-        repositories, has_more = github.list_cached_repositories(limit=limit, offset=offset)
+        repositories, has_more = github.list_cached_repositories(search=search, limit=limit, offset=offset)
 
         return Response({"repositories": repositories, "has_more": has_more})
 

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -648,7 +648,7 @@ class TestIntegrationAPIKeyAccess:
         assert data["repositories"][0]["name"] == "repo1"
         assert data["repositories"][1]["name"] == "repo2"
         assert data["has_more"] is False
-        mock_list_repos.assert_called_once_with(limit=100, offset=0)
+        mock_list_repos.assert_called_once_with(search="", limit=100, offset=0)
 
     @patch("posthog.models.integration.GitHubIntegration.list_cached_repositories")
     def test_github_repos_pagination(self, mock_list_repos, client: HttpClient):
@@ -672,7 +672,7 @@ class TestIntegrationAPIKeyAccess:
         data = response.json()
         assert len(data["repositories"]) == 100
         assert data["has_more"] is True
-        mock_list_repos.assert_called_once_with(limit=100, offset=100)
+        mock_list_repos.assert_called_once_with(search="", limit=100, offset=100)
 
     @patch("posthog.models.integration.GitHubIntegration.list_cached_repositories")
     def test_github_repos_has_more_false_when_partial_page(self, mock_list_repos, client: HttpClient):
@@ -719,7 +719,31 @@ class TestIntegrationAPIKeyAccess:
         data = response.json()
         assert len(data["repositories"]) == 10
         assert data["has_more"] is True
-        mock_list_repos.assert_called_once_with(limit=10, offset=50)
+        mock_list_repos.assert_called_once_with(search="", limit=10, offset=50)
+
+    @patch("posthog.models.integration.GitHubIntegration.list_cached_repositories")
+    def test_github_repos_passes_search_before_pagination(self, mock_list_repos, client: HttpClient):
+        repos = [{"id": 2, "name": "posthog-js", "full_name": "org/posthog-js"}]
+        mock_list_repos.return_value = (repos, False)
+
+        key_value = "test_key_123"
+        PersonalAPIKey.objects.create(
+            label="Test Key",
+            user=self.user,
+            secure_value=hash_key_value(key_value),
+            scopes=["integration:read"],
+        )
+
+        response = client.get(
+            f"/api/environments/{self.team.pk}/integrations/{self.github_integration.id}/github_repos/?search=posthog&limit=1&offset=1",
+            HTTP_AUTHORIZATION=f"Bearer {key_value}",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["repositories"] == repos
+        assert data["has_more"] is False
+        mock_list_repos.assert_called_once_with(search="posthog", limit=1, offset=1)
 
     @patch("posthog.models.integration.GitHubIntegration.sync_repository_cache")
     def test_refresh_github_repos_with_write_scope_succeeds(self, mock_sync_repository_cache, client: HttpClient):

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2546,15 +2546,12 @@ class GitHubIntegration:
         return repositories
 
     def _filter_cached_repositories(self, repositories: list[dict], search: str) -> list[dict]:
-        search_query = search.strip().lower()
+        search_query = search.strip().casefold()
         if not search_query:
             return repositories
 
         return [
-            repository
-            for repository in repositories
-            if search_query in str(repository.get("full_name", "")).lower()
-            or search_query in str(repository.get("name", "")).lower()
+            repository for repository in repositories if search_query in str(repository.get("full_name", "")).casefold()
         ]
 
     def list_cached_repositories(

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2545,7 +2545,21 @@ class GitHubIntegration:
         self.integration.save(update_fields=update_fields)
         return repositories
 
-    def list_cached_repositories(self, *, limit: int = 100, offset: int = 0) -> tuple[list[dict], bool]:
+    def _filter_cached_repositories(self, repositories: list[dict], search: str) -> list[dict]:
+        search_query = search.strip().lower()
+        if not search_query:
+            return repositories
+
+        return [
+            repository
+            for repository in repositories
+            if search_query in str(repository.get("full_name", "")).lower()
+            or search_query in str(repository.get("name", "")).lower()
+        ]
+
+    def list_cached_repositories(
+        self, *, search: str = "", limit: int = 100, offset: int = 0
+    ) -> tuple[list[dict], bool]:
         cached_repositories = self._get_repository_cache()
         updated_at = self.integration.repository_cache_updated_at
         has_cached_snapshot = updated_at is not None
@@ -2567,8 +2581,9 @@ class GitHubIntegration:
         if cached_repositories is None:
             cached_repositories = []
 
-        result = cached_repositories[offset : offset + limit]
-        has_more = offset + limit < len(cached_repositories)
+        filtered_repositories = self._filter_cached_repositories(cached_repositories, search)
+        result = filtered_repositories[offset : offset + limit]
+        has_more = offset + limit < len(filtered_repositories)
         return result, has_more
 
     def list_all_cached_repositories(self, max_repos: int | None = None) -> list[dict]:
@@ -2599,8 +2614,10 @@ class GitHubIntegration:
         return cached_repositories
 
     @database_sync_to_async
-    def list_cached_repositories_async(self, *, limit: int = 100, offset: int = 0) -> tuple[list[dict], bool]:
-        return self.list_cached_repositories(limit=limit, offset=offset)
+    def list_cached_repositories_async(
+        self, *, search: str = "", limit: int = 100, offset: int = 0
+    ) -> tuple[list[dict], bool]:
+        return self.list_cached_repositories(search=search, limit=limit, offset=offset)
 
     @database_sync_to_async
     def list_all_cached_repositories_async(self, max_repos: int | None = None) -> list[dict]:

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -1054,6 +1054,26 @@ class TestGitHubIntegrationModel(BaseTest):
         assert has_more is True
         mock_list_all.assert_called_once_with()
 
+    @patch("posthog.models.integration.GitHubIntegration.list_all_repositories")
+    def test_list_cached_repositories_filters_search_before_pagination(self, mock_list_all):
+        fetched_repositories = [
+            {"id": 1, "name": "posthog", "full_name": "PostHog/posthog"},
+            {"id": 2, "name": "posthog-js", "full_name": "PostHog/posthog-js"},
+            {"id": 3, "name": "code", "full_name": "PostHog/code"},
+            {"id": 4, "name": "posthog-python", "full_name": "PostHog/posthog-python"},
+        ]
+        integration = self.create_integration(
+            {"installation_id": "INSTALL", "account": {"name": "PostHog"}},
+            {"access_token": "ACCESS_TOKEN"},
+        )
+        mock_list_all.return_value = fetched_repositories
+
+        repos, has_more = GitHubIntegration(integration).list_cached_repositories(search="posthog", limit=1, offset=1)
+
+        assert repos == [{"id": 2, "name": "posthog-js", "full_name": "PostHog/posthog-js"}]
+        assert has_more is True
+        mock_list_all.assert_called_once_with()
+
     @patch("posthog.models.integration.GitHubIntegration.list_branches")
     @patch("posthog.models.integration.GitHubIntegration.get_default_branch")
     def test_list_cached_branches_uses_cached_data_when_fresh(self, mock_default_branch, mock_list_branches):

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -1054,8 +1054,25 @@ class TestGitHubIntegrationModel(BaseTest):
         assert has_more is True
         mock_list_all.assert_called_once_with()
 
+    @parameterized.expand(
+        [
+            ("blank_search_returns_all", "   ", 10, 0, [1, 2, 3, 4], False),
+            ("no_match_returns_empty", "missing", 10, 0, [], False),
+            ("casefold_matches_owner_prefix", "POSTHOG", 10, 0, [1, 2, 3, 4], False),
+            ("pagination_applies_after_filter", "posthog", 1, 1, [2], True),
+        ]
+    )
     @patch("posthog.models.integration.GitHubIntegration.list_all_repositories")
-    def test_list_cached_repositories_filters_search_before_pagination(self, mock_list_all):
+    def test_list_cached_repositories_filters_search_before_pagination(
+        self,
+        _name,
+        search,
+        limit,
+        offset,
+        expected_ids,
+        expected_has_more,
+        mock_list_all,
+    ):
         fetched_repositories = [
             {"id": 1, "name": "posthog", "full_name": "PostHog/posthog"},
             {"id": 2, "name": "posthog-js", "full_name": "PostHog/posthog-js"},
@@ -1068,10 +1085,12 @@ class TestGitHubIntegrationModel(BaseTest):
         )
         mock_list_all.return_value = fetched_repositories
 
-        repos, has_more = GitHubIntegration(integration).list_cached_repositories(search="posthog", limit=1, offset=1)
+        repos, has_more = GitHubIntegration(integration).list_cached_repositories(
+            search=search, limit=limit, offset=offset
+        )
 
-        assert repos == [{"id": 2, "name": "posthog-js", "full_name": "PostHog/posthog-js"}]
-        assert has_more is True
+        assert [repo["id"] for repo in repos] == expected_ids
+        assert has_more is expected_has_more
         mock_list_all.assert_called_once_with()
 
     @patch("posthog.models.integration.GitHubIntegration.list_branches")

--- a/products/integrations/frontend/generated/api.schemas.ts
+++ b/products/integrations/frontend/generated/api.schemas.ts
@@ -305,4 +305,8 @@ export type IntegrationsGithubReposRetrieveParams = {
      * @minimum 0
      */
     offset?: number
+    /**
+     * Optional case-insensitive repository name search query.
+     */
+    search?: string
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -37080,6 +37080,10 @@ export namespace Schemas {
      * @minimum 0
      */
     offset?: number;
+    /**
+     * Optional case-insensitive repository name search query.
+     */
+    search?: string;
     };
 
     export type EnvironmentsLogsAlertsListParams = {
@@ -41224,6 +41228,10 @@ export namespace Schemas {
      * @minimum 0
      */
     offset?: number;
+    /**
+     * Optional case-insensitive repository name search query.
+     */
+    search?: string;
     };
 
     export type LiveDebuggerBreakpointsListParams = {


### PR DESCRIPTION
## Problem

GitHub repository cache endpoint supported pagination, but not server-side search. That forced clients to fetch full cached
repository lists and filter locally, which does not scale well for integrations with many repositories.
Let's replicate what we do already for branches.
