### PR TITLE
chore(design-system): validate both dark mode selectors in storybook

### DIFF
--- a/packages/quill/apps/storybook/.storybook/preview.tsx
+++ b/packages/quill/apps/storybook/.storybook/preview.tsx
@@ -33,7 +33,14 @@ const preview: Preview = {
             const isDark = theme === 'dark'
 
             useEffect(() => {
+                // Set both .dark class and theme="dark" attribute so the
+                // toolbar toggle validates both dark mode selectors at once.
                 document.documentElement.classList.toggle('dark', isDark)
+                if (isDark) {
+                    document.documentElement.setAttribute('theme', 'dark')
+                } else {
+                    document.documentElement.removeAttribute('theme')
+                }
                 document.body.style.backgroundColor = ''
             }, [isDark])
 

--- a/packages/quill/apps/storybook/stories/layout.stories.tsx
+++ b/packages/quill/apps/storybook/stories/layout.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { Button, Card, CardContent, CardFooter, CardHeader, CardTitle, MenuLabel } from '../../../packages/primitives'
 import type { Meta, StoryObj } from '@storybook/react'
 
@@ -9,46 +10,53 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
+const Nav = (): React.ReactElement => (
+    <nav className="flex flex-col gap-2 p-2 rounded-lg w-[200px]">
+        <ul className="bg-muted p-4 flex flex-col gap-px [&>li]:w-full [&_button]:w-full rounded-lg">
+            <li><Button left variant="primary">Primary</Button></li>
+            <li><Button left aria-selected>Selected</Button></li>
+            <li><Button left>Contact</Button></li>
+            <li><MenuLabel>Settings</MenuLabel></li>
+            <li><Button left>Help</Button></li>
+            <li><Button left>Logout</Button></li>
+        </ul>
+    </nav>
+)
+
+const Main = (): React.ReactElement => (
+    <main className="flex flex-col gap-4 flex-1 rounded-lg p-4">
+        <h1 className="text-xl font-bold">Main content</h1>
+        <Card size="sm">
+            <CardHeader>
+                <CardTitle>Card Title</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <p>Card Content</p>
+            </CardContent>
+            <CardFooter>
+                <Button>Action</Button>
+            </CardFooter>
+        </Card>
+    </main>
+)
+
+const Aside = (): React.ReactElement => (
+    <aside className="p-2 rounded-lg w-[200px] [--theme-hue:570] [--theme-dark-hue:189]">
+        <ul className="flex flex-col gap-px [&>li]:w-full [&_button]:w-full bg-muted p-4 rounded-lg">
+            <li><MenuLabel>Sidenav</MenuLabel></li>
+            <li><Button left variant="primary">Help</Button></li>
+            <li><Button left aria-selected>Settings</Button></li>
+            <li><Button left>Contact</Button></li>
+        </ul>
+    </aside>
+)
+
 export const Default: Story = {
     render: () => (
         <div className="flex rounded-lg bg-background gap-4">
-            <nav className="flex flex-col gap-2 p-2 rounded-lg w-[200px]">
-                <ul className="bg-muted p-4 flex flex-col gap-px [&>li]:w-full [&_button]:w-full rounded-lg">
-                    <li><Button left variant="primary">Primary</Button></li>
-                    <li><Button left aria-selected>Selected</Button></li>
-                    <li><Button left>Contact</Button></li>
-                    <li><MenuLabel>Settings</MenuLabel></li>
-                    <li><Button left>Help</Button></li>
-                    <li><Button left>Logout</Button></li>
-                </ul>
-                <ul className="p-4 flex flex-col gap-px [&>li]:w-full [&_button]:w-full rounded-lg">
-                    <li><Button left variant="primary">Primary</Button></li>
-                    <li><Button left aria-selected>Selected</Button></li>
-                    <li><Button left>Contact</Button></li>
-                </ul>
-            </nav>
-            <main className="flex flex-col gap-4 flex-1 rounded-lg p-4">
-                <h1 className="text-xl font-bold">Main content</h1>
-                <Card size="sm">
-                    <CardHeader>
-                        <CardTitle>Card Title</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                        <p>Card Content</p>
-                    </CardContent>
-                    <CardFooter>
-                        <Button>Action</Button>
-                    </CardFooter>
-                </Card>
-            </main>
-            <aside className="p-2 rounded-lg w-[200px] [--theme-hue:570]">
-                <ul className="flex flex-col gap-px [&>li]:w-full [&_button]:w-full bg-muted p-4 rounded-lg">
-                    <li><MenuLabel>Sidenav</MenuLabel></li>
-                    <li><Button left variant="primary">Help</Button></li>
-                    <li><Button left aria-selected>Settings</Button></li>
-                    <li><Button left>Contact</Button></li>
-                </ul>
-            </aside>
+            <Nav />
+            <Main />
+            <Aside />
         </div>
     ),
 } satisfies Story


### PR DESCRIPTION
## Summary
- Storybook theme toggle now sets both `.dark` class and `theme="dark"` attribute, validating both dark mode selectors simultaneously
- Refactor layout story into composable Nav/Main/Aside sections
- Add `--theme-dark-hue` override on aside to demo per-subtree theming in dark mode

## Test plan
- [x] Toggle dark mode in storybook toolbar — both selectors applied to `<html>`
- [x] Layout story renders correctly in light and dark
- [x] `--theme-hue` / `--theme-dark-hue` override on aside works in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)