### PR TITLE
fix(layout): release detached DOM nodes on scene and panel transitions

### DIFF
--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -59,9 +59,14 @@ export function Navigation({
     // SidePanelInfo overrides scenePanelElement while the Info tab is open and
     // clears it on unmount, leaving it null even though Navigation's inline
     // panel div is still in the DOM. Re-register it when the side panel closes.
+    // On Navigation unmount, null the registration so the detached div does
+    // not stay pinned by sceneLayoutLogic's reducer.
     useEffect(() => {
         if (!sidePanelOpen && inlinePanelRef.current) {
             registerScenePanelElement(inlinePanelRef.current)
+        }
+        return () => {
+            registerScenePanelElement(null)
         }
     }, [sidePanelOpen, registerScenePanelElement])
 

--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -59,16 +59,21 @@ export function Navigation({
     // SidePanelInfo overrides scenePanelElement while the Info tab is open and
     // clears it on unmount, leaving it null even though Navigation's inline
     // panel div is still in the DOM. Re-register it when the side panel closes.
-    // On Navigation unmount, null the registration so the detached div does
-    // not stay pinned by sceneLayoutLogic's reducer.
     useEffect(() => {
         if (!sidePanelOpen && inlinePanelRef.current) {
             registerScenePanelElement(inlinePanelRef.current)
         }
+    }, [sidePanelOpen, registerScenePanelElement])
+
+    // Null the registration on Navigation unmount so the detached inline
+    // panel div is not pinned by sceneLayoutLogic's reducer. Kept in its own
+    // empty-deps effect so it fires only on final unmount, not on every
+    // sidePanelOpen toggle (which would briefly blank SceneLayout's portal).
+    useEffect(() => {
         return () => {
             registerScenePanelElement(null)
         }
-    }, [sidePanelOpen, registerScenePanelElement])
+    }, [registerScenePanelElement])
 
     // Set container ref so we can measure the width of the scene layout in logic
     useEffect(() => {

--- a/frontend/src/layout/scenes/components/SceneTitleSection.tsx
+++ b/frontend/src/layout/scenes/components/SceneTitleSection.tsx
@@ -238,6 +238,7 @@ export function SceneTitleSection({
     const { toggleShowDescription } = useActions(sceneLayoutLogic)
     const willShowBreadcrumbs = forceBackTo || breadcrumbs.length > 2
     const [isScrolled, setIsScrolled] = useState(false)
+    const sentinelRef = useRef<HTMLDivElement>(null)
     const effectiveDescription = description
     const hasDescription = effectiveDescription != null && (effectiveDescription || canEdit)
 
@@ -251,7 +252,7 @@ export function SceneTitleSection({
     )
 
     useEffect(() => {
-        const stickyElement = document.querySelector('[data-sticky-sentinel]')
+        const stickyElement = sentinelRef.current
         if (!stickyElement) {
             return
         }
@@ -265,7 +266,7 @@ export function SceneTitleSection({
 
         observer.observe(stickyElement)
         return () => observer.disconnect()
-    }, [])
+    }, [noBorder])
 
     const icon = resourceType.forceIcon ? (
         <ProductIconWrapper type={resourceType.type} colorOverride={resourceType.forceIconColorOverride}>
@@ -283,7 +284,12 @@ export function SceneTitleSection({
         <>
             {!noBorder && (
                 // When this element scrolls out of view, the IntersectionObserver sets isScrolled=true to show the border
-                <div data-sticky-sentinel className="h-px w-px pointer-events-none absolute -top-4" aria-hidden />
+                <div
+                    ref={sentinelRef}
+                    data-sticky-sentinel
+                    className="h-px w-px pointer-events-none absolute -top-4"
+                    aria-hidden
+                />
             )}
 
             <div

--- a/frontend/src/lib/components/ResizeElement/ResizeElement.tsx
+++ b/frontend/src/lib/components/ResizeElement/ResizeElement.tsx
@@ -151,25 +151,39 @@ export function ResizableElement({
         }
     }, [applyWidth, defaultWidth, onResizeEnd, snapToDefault])
 
-    // Use effect for adding/removing global event listeners
+    // Keep latest handler implementations in refs so the document listeners
+    // below can be registered exactly once per mount, regardless of how
+    // often caller props change and rebuild the useCallbacks.
+    const handleMouseMoveRef = useRef(handleMouseMove)
+    const handleTouchMoveRef = useRef(handleTouchMove)
+    const handleEndRef = useRef(handleEnd)
     useEffect(() => {
-        document.addEventListener('mousemove', handleMouseMove)
-        document.addEventListener('mouseup', handleEnd)
-        document.addEventListener('touchmove', handleTouchMove, { passive: true })
-        document.addEventListener('touchend', handleEnd)
+        handleMouseMoveRef.current = handleMouseMove
+        handleTouchMoveRef.current = handleTouchMove
+        handleEndRef.current = handleEnd
+    }, [handleMouseMove, handleTouchMove, handleEnd])
+
+    useEffect(() => {
+        const onMouseMove = (e: MouseEvent): void => handleMouseMoveRef.current(e)
+        const onTouchMove = (e: TouchEvent): void => handleTouchMoveRef.current(e)
+        const onEnd = (): void => handleEndRef.current()
+
+        document.addEventListener('mousemove', onMouseMove)
+        document.addEventListener('mouseup', onEnd)
+        document.addEventListener('touchmove', onTouchMove, { passive: true })
+        document.addEventListener('touchend', onEnd)
 
         return () => {
-            document.removeEventListener('mousemove', handleMouseMove)
-            document.removeEventListener('mouseup', handleEnd)
-            document.removeEventListener('touchmove', handleTouchMove)
-            document.removeEventListener('touchend', handleEnd)
+            document.removeEventListener('mousemove', onMouseMove)
+            document.removeEventListener('mouseup', onEnd)
+            document.removeEventListener('touchmove', onTouchMove)
+            document.removeEventListener('touchend', onEnd)
 
-            // Clean up any pending animation frame
             if (rafRef.current !== null) {
                 cancelAnimationFrame(rafRef.current)
             }
         }
-    }, [handleEnd, handleMouseMove, handleTouchMove])
+    }, [])
 
     return (
         <div

--- a/frontend/src/scenes/sceneLogic.tsx
+++ b/frontend/src/scenes/sceneLogic.tsx
@@ -1131,7 +1131,11 @@ export const sceneLogic = kea<sceneLogicType>([
 
             const unmount = cache.mountedTabLogic[tabId]
             if (unmount) {
-                window.setTimeout(unmount, 50)
+                try {
+                    unmount()
+                } catch (error) {
+                    console.error('Error unmounting previous tab logic:', error)
+                }
                 delete cache.mountedTabLogic[tabId]
             }
             if (exportedScene?.logic) {


### PR DESCRIPTION
## Problem

A Chrome DevTools Detached Elements snapshot taken after normal app use
showed tens of thousands of retained DOM subtrees:

- ~8.5k copies of the 245 px resizable left-nav panel (with the full
  project tree inside)
- thousands of `scene-content` roots across several scene variants
  (dashboards list, saved insights, generic scenes)
- extra `scene-layout__content-panel` copies

The leak surface spans four files in the scene / navigation / layout
layer. Each on its own contributes; stacked together they produce the
observed growth.

## Changes

All fixes are surgical, local, and do not touch surrounding architecture.

- **`ResizableElement`** — global `document` mouse/touch listeners now
  attach exactly once per mount. Previously the listener effect had
  `[handleEnd, handleMouseMove, handleTouchMove]` deps; those callbacks
  depend on caller props (`onResize`, `defaultWidth`, etc.), so every
  parent rerender re-registered handlers that closed over the old
  container `div`. We now keep the latest handlers in refs and attach
  stable wrappers with `[]` deps.
- **`sceneLogic`** — remove the 50 ms `setTimeout` around the outgoing
  tab's `unmount()`. During that window both the outgoing and incoming
  scene's kea logics were mounted, and both subscribed React trees with
  them. Fast navigation stacked live trees. Unmount now runs
  synchronously before the new logic mounts.
- **`Navigation`** — register a cleanup that nulls
  `sceneLayoutLogic.scenePanelElement` on unmount (matches the pattern
  already in `SidePanelInfo`). Keeps the reducer-driven
  `createPortal` flow in `SceneLayout` working while releasing the
  inline panel `div` when Navigation disappears.
- **`SceneTitleSection`** — scope the `IntersectionObserver` target to
  a local `useRef` instead of `document.querySelector('[data-sticky-sentinel]')`,
  so concurrent commits cannot end up observing the wrong sentinel.

No changes to `panelLayoutLogic` (the `resizeObserver` disposable key
is already replace-by-key in `kea-disposables.ts`) or `sceneLayoutLogic`
(moving `scenePanelElement` out of the reducer would break
`SceneLayout`'s `createPortal` subscription).

## How did you test this code?

I'm an agent; I did not exercise this in a running browser. Static
verification only:

- Re-read each edited file end-to-end and confirmed matched
  cleanup/removal for every listener and observer added.
- `pnpm --filter=@posthog/frontend typescript:check` after `typegen:write`
  — no new errors introduced in the four edited files (remaining errors
  are pre-existing `@posthog/hogvm` module resolution issues unrelated
  to this change).
- `oxlint` on the four edited files — 0 warnings, 0 errors.

The user will verify the leak is gone by taking a fresh Detached
Elements snapshot after this branch is deployed to their dev session.

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code (Claude Opus 4.7) as Task
`633b1b89-7777-4de3-9b30-15ebeb6a0d1a`. The diagnosis and fix list came
from a handoff note that identified five leak causes from a DevTools
snapshot + code reading. During implementation two items from the
original handoff were dropped after the agent verified the code already
handled them correctly (`panelLayoutLogic` disposable replacement) or
that the proposed fix would break downstream portal reactivity
(`sceneLayoutLogic` reducer rewrite, replaced with the Navigation
unmount cleanup above).