### PR TITLE
fix(insights): stabilize tooltipId across renders to prevent portal leak

### DIFF
--- a/frontend/src/scenes/insights/useInsightTooltip.ts
+++ b/frontend/src/scenes/insights/useInsightTooltip.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useRef } from 'react'
 import { Root, createRoot } from 'react-dom/client'
 
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
@@ -326,7 +326,11 @@ export function useInsightTooltip(options?: { isPinnable?: boolean }): {
     pinTooltip: ((onUnpin?: () => void) => void) | null
 } {
     const isPinnable = options?.isPinnable ?? false
-    const tooltipId = useMemo(() => Math.random().toString(36).substring(2, 11), [])
+    const tooltipIdRef = useRef<string | null>(null)
+    if (tooltipIdRef.current === null) {
+        tooltipIdRef.current = Math.random().toString(36).substring(2, 11)
+    }
+    const tooltipId = tooltipIdRef.current
 
     useOnMountEffect(() => {
         if (isPinnable) {


### PR DESCRIPTION
## Problem

While investigating detached-element telemetry (`detached_elements` event) we traced a portion of the `InsightTooltipWrapper-*` portal-container leak to a stale-id race in `useInsightTooltip`.

`tooltipId` was derived via `useMemo(() => Math.random(), [])`. `useMemo` is **not guaranteed** to preserve its value across renders — React can discard memoized values. When the id regenerates between:

1. A Chart.js `external` hover callback firing and calling `ensureTooltip(idA)` (creating a DOM node + React root and storing in a module-scoped Map), and
2. The `useOnMountEffect` cleanup calling `cleanupTooltip(tooltipId)` on unmount with the new `idB`,

… the `idA` entry in the module Map is never cleaned. Its container div and React root stay resident for the life of the session.

## Changes

Replace `useMemo` with `useRef` for `tooltipId`. `useRef` is guaranteed stable for the life of the hook instance, eliminating the regeneration race.

## How did you test this code?

I'm an agent and I haven't done manual click-test QA beyond the measurement harness below.

Added dev-only lifecycle counters (not shipped in this PR) to confirm behaviour under a 10-cycle SPA navigation workload on a dashboard with two chart tiles:

| | ensured | cleaned | cleanedButMissing |
| --- | --- | --- | --- |
| before | 23 | 20 | 10 |
| after | 20 | 20 | 10 |

\`ensured > cleaned\` before the fix was the tell: 3 tooltip entries were created but never cleaned. After the fix every \`ensureTooltip\` pairs with a \`cleanupTooltip\` on the same id. (\`cleanedButMissing\` is strict-mode double-cleanup noise, unrelated to this leak path.)

There is a residual \`InsightTooltipWrapper\` leak on repeated SPA cycles that this fix doesn't cover — separate root cause, likely \`createRoot\`/container-retention ordering. That will be addressed in a follow-up PR.

## Docs update

no

## 🤖 LLM context

Authored by PostHog Code. The fix was discovered by instrumenting \`ensure\`/\`cleanup\` call counts under a driven Playwright workload against a dev dashboard, paired with aggregated \`detached_elements\` telemetry across the last 7 days (\`InsightTooltipWrapper\` and \`Tooltip*\` accounted for ~100% of post-GC detached nodes in the local repro). The telemetry also suggests a wider orphan-container pattern (\`undefined\` dominates global telemetry) that warrants a separate investigation into the manual \`document.createElement\` + \`createRoot(container)\` lifecycle used by both \`useInsightTooltip\` and the \`Tooltip\` primitive.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*