### PR TITLE
fix(capture): only apply event restrictions to analytics-pipeline events

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1748,6 +1748,7 @@ dependencies = [
  "rdkafka",
  "redis",
  "reqwest 0.12.28",
+ "rstest",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -70,6 +70,7 @@ httparse = "1.8"
 metrics-util = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }
+rstest = "0.26"
 rdkafka = { workspace = true }
 reqwest = { workspace = true, features = ["multipart"] }
 serde_json = { workspace = true }

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -177,12 +177,26 @@ pub async fn process_events<'a>(
 
     debug_or_info!(chatty_debug_enabled, context=?context, event_count=?events.len(), "filtered by token_dropper");
 
-    // Apply event restrictions if service is configured
+    // Apply event restrictions if service is configured.
+    //
+    // The service is scoped to the analytics pipeline (loaded for
+    // `CaptureMode::Events` → pipeline name `"analytics"`), so restrictions
+    // only apply to events routed to the analytics pipeline. Non-analytics
+    // data types (exceptions, heatmaps, client ingestion warnings) flow to
+    // separate topics and separate consumers that own their own restriction
+    // scope — applying analytics restrictions here would cross pipelines
+    // (e.g. a DropEvent restriction would silently drop exception events
+    // before they reach the error tracking topic).
     if let Some(ref service) = restriction_service {
         let mut filtered_events = Vec::with_capacity(events.len());
         let now_ts = context.now.timestamp();
 
         for e in events {
+            if !e.metadata.data_type.is_analytics_pipeline() {
+                filtered_events.push(e);
+                continue;
+            }
+
             let uuid_str = e.event.uuid.to_string();
             let event_ctx = RestrictionEventContext {
                 distinct_id: Some(&e.event.distinct_id),
@@ -834,6 +848,197 @@ mod tests {
             captured[0].metadata.redirect_to_topic,
             Some("custom_events_topic".to_string())
         );
+    }
+
+    // ============ non-analytics data types bypass restrictions ============
+    // The `EventRestrictionService` in analytics handlers is scoped to the
+    // analytics pipeline. Events whose `data_type` belongs to a different
+    // pipeline (exceptions → error tracking, heatmaps, client ingestion
+    // warnings) must pass through the restriction stage untouched so that an
+    // analytics-scoped DropEvent/RedirectToDlq/etc. does not cross pipelines.
+
+    async fn process_single_with_drop_restriction(event_name: &str) -> Vec<ProcessedEvent> {
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let context = create_test_context(now, None);
+        let events = vec![create_test_event_with_name(
+            event_name,
+            Some("2023-01-01T11:00:00Z".to_string()),
+            None,
+            None,
+        )];
+
+        let sink = Arc::new(MockSink::new());
+        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
+        let historical_cfg = router::HistoricalConfig::new(false, 1);
+
+        let service = EventRestrictionService::new(CaptureMode::Events, Duration::from_secs(300));
+        let mut manager = RestrictionManager::new();
+        manager.restrictions.insert(
+            "test_token".to_string(),
+            vec![Restriction {
+                restriction_type: RestrictionType::DropEvent,
+                scope: RestrictionScope::AllEvents,
+                args: None,
+            }],
+        );
+        service.update(manager).await;
+
+        process_events(
+            sink.clone(),
+            dropper,
+            Some(service),
+            historical_cfg,
+            None,
+            None,
+            &events,
+            &context,
+        )
+        .await
+        .unwrap();
+
+        sink.get_events()
+    }
+
+    #[tokio::test]
+    async fn test_process_events_exception_bypasses_drop_restriction() {
+        let captured = process_single_with_drop_restriction("$exception").await;
+        assert_eq!(captured.len(), 1);
+        assert_eq!(
+            captured[0].metadata.data_type,
+            DataType::ExceptionErrorTracking
+        );
+    }
+
+    #[tokio::test]
+    async fn test_process_events_heatmap_bypasses_drop_restriction() {
+        let captured = process_single_with_drop_restriction("$$heatmap").await;
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].metadata.data_type, DataType::HeatmapMain);
+    }
+
+    #[tokio::test]
+    async fn test_process_events_client_ingestion_warning_bypasses_drop_restriction() {
+        let captured = process_single_with_drop_restriction("$$client_ingestion_warning").await;
+        assert_eq!(captured.len(), 1);
+        assert_eq!(
+            captured[0].metadata.data_type,
+            DataType::ClientIngestionWarning
+        );
+    }
+
+    #[tokio::test]
+    async fn test_process_events_exception_bypasses_force_overflow_restriction() {
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let context = create_test_context(now, None);
+        let events = vec![create_test_event_with_name(
+            "$exception",
+            Some("2023-01-01T11:00:00Z".to_string()),
+            None,
+            None,
+        )];
+
+        let sink = Arc::new(MockSink::new());
+        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
+        let historical_cfg = router::HistoricalConfig::new(false, 1);
+
+        let service = EventRestrictionService::new(CaptureMode::Events, Duration::from_secs(300));
+        let mut manager = RestrictionManager::new();
+        manager.restrictions.insert(
+            "test_token".to_string(),
+            vec![
+                Restriction {
+                    restriction_type: RestrictionType::ForceOverflow,
+                    scope: RestrictionScope::AllEvents,
+                    args: None,
+                },
+                Restriction {
+                    restriction_type: RestrictionType::SkipPersonProcessing,
+                    scope: RestrictionScope::AllEvents,
+                    args: None,
+                },
+                Restriction {
+                    restriction_type: RestrictionType::RedirectToDlq,
+                    scope: RestrictionScope::AllEvents,
+                    args: None,
+                },
+            ],
+        );
+        service.update(manager).await;
+
+        process_events(
+            sink.clone(),
+            dropper,
+            Some(service),
+            historical_cfg,
+            None,
+            None,
+            &events,
+            &context,
+        )
+        .await
+        .unwrap();
+
+        let captured = sink.get_events();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(
+            captured[0].metadata.data_type,
+            DataType::ExceptionErrorTracking
+        );
+        assert!(!captured[0].metadata.force_overflow);
+        assert!(!captured[0].metadata.skip_person_processing);
+        assert!(!captured[0].metadata.redirect_to_dlq);
+        assert!(captured[0].metadata.redirect_to_topic.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_process_events_analytics_historical_still_gets_restrictions() {
+        // AnalyticsHistorical is part of the analytics pipeline, so restrictions
+        // must still apply to it.
+        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let mut context = create_test_context(now, None);
+        context.historical_migration = true;
+        let events = vec![create_test_event(
+            Some("2023-01-01T11:00:00Z".to_string()),
+            None,
+            None,
+        )];
+
+        let sink = Arc::new(MockSink::new());
+        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
+        let historical_cfg = router::HistoricalConfig::new(false, 1);
+
+        let service = EventRestrictionService::new(CaptureMode::Events, Duration::from_secs(300));
+        let mut manager = RestrictionManager::new();
+        manager.restrictions.insert(
+            "test_token".to_string(),
+            vec![Restriction {
+                restriction_type: RestrictionType::DropEvent,
+                scope: RestrictionScope::AllEvents,
+                args: None,
+            }],
+        );
+        service.update(manager).await;
+
+        process_events(
+            sink.clone(),
+            dropper,
+            Some(service),
+            historical_cfg,
+            None,
+            None,
+            &events,
+            &context,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(sink.get_events().len(), 0);
     }
 
     // ============ overflow_reason stamping tests ============

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -470,6 +470,7 @@ mod tests {
         RestrictionScope, RestrictionType,
     };
     use crate::sinks::test_sink::MockSink;
+    use rstest::rstest;
     use std::time::Duration;
 
     #[tokio::test]
@@ -901,31 +902,18 @@ mod tests {
         sink.get_events()
     }
 
+    #[rstest]
+    #[case("$exception", DataType::ExceptionErrorTracking)]
+    #[case("$$heatmap", DataType::HeatmapMain)]
+    #[case("$$client_ingestion_warning", DataType::ClientIngestionWarning)]
     #[tokio::test]
-    async fn test_process_events_exception_bypasses_drop_restriction() {
-        let captured = process_single_with_drop_restriction("$exception").await;
+    async fn test_non_analytics_events_bypass_drop_restriction(
+        #[case] event_name: &str,
+        #[case] expected_data_type: DataType,
+    ) {
+        let captured = process_single_with_drop_restriction(event_name).await;
         assert_eq!(captured.len(), 1);
-        assert_eq!(
-            captured[0].metadata.data_type,
-            DataType::ExceptionErrorTracking
-        );
-    }
-
-    #[tokio::test]
-    async fn test_process_events_heatmap_bypasses_drop_restriction() {
-        let captured = process_single_with_drop_restriction("$$heatmap").await;
-        assert_eq!(captured.len(), 1);
-        assert_eq!(captured[0].metadata.data_type, DataType::HeatmapMain);
-    }
-
-    #[tokio::test]
-    async fn test_process_events_client_ingestion_warning_bypasses_drop_restriction() {
-        let captured = process_single_with_drop_restriction("$$client_ingestion_warning").await;
-        assert_eq!(captured.len(), 1);
-        assert_eq!(
-            captured[0].metadata.data_type,
-            DataType::ClientIngestionWarning
-        );
+        assert_eq!(captured[0].metadata.data_type, expected_data_type);
     }
 
     #[tokio::test]

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -168,6 +168,12 @@ pub enum DataType {
     SnapshotMain,
 }
 
+impl DataType {
+    pub fn is_analytics_pipeline(self) -> bool {
+        matches!(self, Self::AnalyticsMain | Self::AnalyticsHistorical)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ProcessedEvent {
     pub metadata: ProcessedEventMetadata,


### PR DESCRIPTION
## Problem

The `EventRestrictionService` in the analytics capture handler is loaded for `CaptureMode::Events` → pipeline name `"analytics"`, so the restrictions it holds are scoped to the analytics pipeline. But `process_events` applied those restrictions to every event in the batch regardless of `data_type`, which means analytics-scoped restrictions were leaking across pipelines:

- Exception events (`$exception`) are routed by the sink to a separate `error_tracking_topic` and consumed by the Node.js error-tracking consumer, which has its own restriction step scoped to a different pipeline. An analytics `DropEvent` restriction silently dropped exception events before they could reach the error tracking pipeline. `RedirectToDlq` / `RedirectToTopic` had the same cross-pipeline hazard.
- Heatmaps and client ingestion warnings also have their own topics and shouldn't be subject to analytics-scoped restrictions.

## Changes

- Added `DataType::is_analytics_pipeline()` (true for `AnalyticsMain` and `AnalyticsHistorical`).
- Gated the restriction loop in `events::analytics::process_events` so non-analytics events pass through untouched.
- This matches the convention already established by `events::overflow_stamping::stamp_overflow_reason`, which similarly skips non-analytics events on the grounds that those data types belong to other pipelines.

## How did you test this code?

Added unit tests in `events::analytics::tests`:

- `test_process_events_exception_bypasses_drop_restriction`
- `test_process_events_heatmap_bypasses_drop_restriction`
- `test_process_events_client_ingestion_warning_bypasses_drop_restriction`
- `test_process_events_exception_bypasses_force_overflow_restriction` (covers `ForceOverflow`, `SkipPersonProcessing`, `RedirectToDlq` all at once)
- `test_process_events_analytics_historical_still_gets_restrictions` (regression guard — `AnalyticsHistorical` must still be subject to analytics restrictions)

Existing tests for the analytics `process_events` (drop, force overflow, skip person, redirect-to-dlq, redirect-to-topic, filtered, multi) continue to pass unchanged, since they all exercise events with the default `AnalyticsMain` data type.

No manual testing beyond the automated unit tests.

## Publish to changelog?

no