### PR TITLE
feat(retention): add data warehouse feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -412,6 +412,7 @@ export const FEATURE_FLAGS = {
     PRODUCT_ANALYTICS_INSIGHT_HORIZONTAL_CONTROLS: 'insight-horizontal-controls', // owner: #team-product-analytics
     PRODUCT_ANALYTICS_PATHS_V2: 'paths-v2', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_ANALYTICS_RETENTION_AGGREGATION: 'retention-aggregation', // owner: @anirudhpillai #team-product-analytics
+    PRODUCT_ANALYTICS_RETENTION_DWH: 'retention-dwh', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_AUTONOMY: 'product-autonomy', // owner: #team-signals
     PRODUCT_CONVERSATIONS: 'product-conversations', // owner: @veryayskiy #team-conversations
     PRODUCT_SELECTION_SCREEN_VARIANT: 'product-selection-screen-variant', // owner: @fercgomes #team-growth multivariate=control,spotlight,multiproduct

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -32228,6 +32228,10 @@
         "RetentionEntity": {
             "additionalProperties": false,
             "properties": {
+                "aggregation_target_field": {
+                    "description": "Data warehouse field used as the actor identifier",
+                    "type": "string"
+                },
                 "custom_name": {
                     "type": "string"
                 },
@@ -32249,6 +32253,14 @@
                         "$ref": "#/definitions/AnyPropertyFilter"
                     },
                     "type": "array"
+                },
+                "table_name": {
+                    "description": "Data warehouse table name",
+                    "type": "string"
+                },
+                "timestamp_field": {
+                    "description": "Data warehouse timestamp field",
+                    "type": "string"
                 },
                 "type": {
                     "$ref": "#/definitions/EntityType"

--- a/frontend/src/scenes/insights/EditorFilters/RetentionCondition.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/RetentionCondition.tsx
@@ -5,6 +5,7 @@ import { toast } from 'react-toastify'
 import { IconInfo, IconPlusSmall, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonInput, LemonSelect } from '@posthog/lemon-ui'
 
+import { DataWarehousePopoverField, TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { getOrdinalSuffix } from 'lib/utils'
 import { AggregationSelect } from 'scenes/insights/filters/AggregationSelect'
@@ -19,12 +20,44 @@ import {
 import { MAX_BRACKETS, retentionLogic } from 'scenes/retention/retentionLogic'
 
 import { groupsModel } from '~/models/groupsModel'
-import { EditorFilterProps, FilterType, RetentionPeriod, RetentionType } from '~/types'
+import { EditorFilterProps, EntityTypes, FilterType, RetentionPeriod, RetentionType } from '~/types'
 
 import { ActionFilter } from '../filters/ActionFilter/ActionFilter'
 import { MathAvailability } from '../filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 
 const MAX_RANGE = 1000
+
+const retentionDataWarehousePopoverFields: DataWarehousePopoverField[] = [
+    { key: 'timestamp_field', label: 'Timestamp', allowHogQL: true },
+    { key: 'aggregation_target_field', label: 'Aggregation target', allowHogQL: true },
+]
+
+function retentionEntityToFilter(entity: Record<string, any> | undefined): FilterType {
+    if (!entity) {
+        return {}
+    }
+
+    if (entity.type === EntityTypes.ACTIONS) {
+        return { actions: [entity] }
+    }
+    if (entity.type === EntityTypes.DATA_WAREHOUSE) {
+        return { data_warehouse: [entity] }
+    }
+    return { events: [entity] }
+}
+
+function filterToRetentionEntity(newFilters: FilterType): Record<string, any> | undefined {
+    if (newFilters.events && newFilters.events.length > 0) {
+        return newFilters.events[0]
+    }
+    if (newFilters.actions && newFilters.actions.length > 0) {
+        return newFilters.actions[0]
+    }
+    if (newFilters.data_warehouse && newFilters.data_warehouse.length > 0) {
+        return newFilters.data_warehouse[0]
+    }
+    return undefined
+}
 
 function CustomBrackets({ insightProps }: { insightProps: EditorFilterProps['insightProps'] }): JSX.Element {
     const { retentionFilter, localCustomBrackets } = useValues(retentionLogic(insightProps))
@@ -127,10 +160,14 @@ function CustomBrackets({ insightProps }: { insightProps: EditorFilterProps['ins
 
 export function RetentionCondition({ insightProps }: EditorFilterProps): JSX.Element {
     const { showGroupsOptions } = useValues(groupsModel)
-    const { retentionFilter, dateRange } = useValues(retentionLogic(insightProps))
+    const { retentionFilter, dateRange, isRetentionDWHEnabled } = useValues(retentionLogic(insightProps))
     const { updateInsightFilter, updateDateRange } = useActions(retentionLogic(insightProps))
     const { targetEntity, returningEntity, retentionType, totalIntervals, period, retentionCustomBrackets } =
         retentionFilter || {}
+
+    const actionsTaxonomicGroupTypes = isRetentionDWHEnabled
+        ? [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions, TaxonomicFilterGroupType.DataWarehouse]
+        : [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions]
 
     return (
         <div className="deprecated-space-y-3 mb-4" data-attr="retention-condition">
@@ -147,18 +184,14 @@ export function RetentionCondition({ insightProps }: EditorFilterProps): JSX.Ele
                 entitiesLimit={1}
                 mathAvailability={MathAvailability.None}
                 hideRename
-                filters={{ events: [targetEntity] } as FilterType} // retention filters use target and returning entity instead of events
+                filters={retentionEntityToFilter(targetEntity)} // retention filters use target and returning entity instead of events
                 setFilters={(newFilters: FilterType) => {
-                    if (newFilters.events && newFilters.events.length > 0) {
-                        updateInsightFilter({ targetEntity: newFilters.events[0] })
-                    } else if (newFilters.actions && newFilters.actions.length > 0) {
-                        updateInsightFilter({ targetEntity: newFilters.actions[0] })
-                    } else {
-                        updateInsightFilter({ targetEntity: undefined })
-                    }
+                    updateInsightFilter({ targetEntity: filterToRetentionEntity(newFilters) })
                 }}
                 typeKey={`${keyForInsightLogicProps('new')(insightProps)}-targetEntity`}
                 propertiesTaxonomicGroupTypes={getRetentionPropertyFilterGroupTypes()}
+                actionsTaxonomicGroupTypes={actionsTaxonomicGroupTypes}
+                dataWarehousePopoverFields={retentionDataWarehousePopoverFields}
             />
             <LemonSelect
                 options={Object.entries(retentionOptions).map(([key, value]) => ({
@@ -189,18 +222,14 @@ export function RetentionCondition({ insightProps }: EditorFilterProps): JSX.Ele
                 mathAvailability={MathAvailability.None}
                 hideRename
                 buttonCopy="Add graph series"
-                filters={{ events: [returningEntity] } as FilterType}
+                filters={retentionEntityToFilter(returningEntity)}
                 setFilters={(newFilters: FilterType) => {
-                    if (newFilters.events && newFilters.events.length > 0) {
-                        updateInsightFilter({ returningEntity: newFilters.events[0] })
-                    } else if (newFilters.actions && newFilters.actions.length > 0) {
-                        updateInsightFilter({ returningEntity: newFilters.actions[0] })
-                    } else {
-                        updateInsightFilter({ returningEntity: undefined })
-                    }
+                    updateInsightFilter({ returningEntity: filterToRetentionEntity(newFilters) })
                 }}
                 typeKey={`${keyForInsightLogicProps('new')(insightProps)}-returningEntity`}
                 propertiesTaxonomicGroupTypes={getRetentionPropertyFilterGroupTypes()}
+                actionsTaxonomicGroupTypes={actionsTaxonomicGroupTypes}
+                dataWarehousePopoverFields={retentionDataWarehousePopoverFields}
             />
             <div className="flex items-center gap-2">
                 {!retentionCustomBrackets ? (

--- a/frontend/src/scenes/retention/retentionLogic.ts
+++ b/frontend/src/scenes/retention/retentionLogic.ts
@@ -2,7 +2,9 @@ import { mean, sum } from 'd3'
 import { actions, connect, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 
 import { CUSTOM_OPTION_KEY } from 'lib/components/DateFilter/types'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { formatDateRange } from 'lib/utils'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
@@ -42,6 +44,8 @@ export const retentionLogic = kea<retentionLogicType>([
             ['breakdownFilter', 'dateRange', 'insightQuery', 'insightData', 'querySource', 'retentionFilter'],
             teamLogic,
             ['timezone'],
+            featureFlagLogic,
+            ['featureFlags'],
             cohortsModel,
             ['cohortsById'],
         ],
@@ -146,6 +150,10 @@ export const retentionLogic = kea<retentionLogicType>([
     }),
     selectors({
         hasValidBreakdown: [(s) => [s.breakdownFilter], (breakdownFilter) => hasBreakdownFilter(breakdownFilter)],
+        isRetentionDWHEnabled: [
+            (s) => [s.featureFlags],
+            (featureFlags): boolean => !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_RETENTION_DWH],
+        ],
         isPropertyValueAggregation: [
             (s) => [s.retentionFilter],
             (retentionFilter: RetentionFilter | undefined) =>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2998,6 +2998,12 @@ export interface RetentionEntity {
     custom_name?: string
     /** filters on the event */
     properties?: AnyPropertyFilter[]
+    /** Data warehouse table name */
+    table_name?: string
+    /** Data warehouse timestamp field */
+    timestamp_field?: string
+    /** Data warehouse field used as the actor identifier */
+    aggregation_target_field?: string
 }
 
 export enum RetentionDashboardDisplayType {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -17190,6 +17190,9 @@ class RetentionEntity(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    aggregation_target_field: str | None = Field(
+        default=None, description="Data warehouse field used as the actor identifier"
+    )
     custom_name: str | None = None
     id: str | float | None = None
     kind: RetentionEntityKind | None = None
@@ -17220,6 +17223,8 @@ class RetentionEntity(BaseModel):
         ]
         | None
     ) = Field(default=None, description="filters on the event")
+    table_name: str | None = Field(default=None, description="Data warehouse table name")
+    timestamp_field: str | None = Field(default=None, description="Data warehouse timestamp field")
     type: EntityType | None = None
     uuid: str | None = None
 

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -2703,6 +2703,11 @@ export const EntityTypeApi = {
 } as const
 
 export interface RetentionEntityApi {
+    /**
+     * Data warehouse field used as the actor identifier
+     * @nullable
+     */
+    aggregation_target_field?: string | null
     /** @nullable */
     custom_name?: string | null
     id?: string | number | null
@@ -2739,6 +2744,16 @@ export interface RetentionEntityApi {
               | WorkflowVariablePropertyFilterApi
           )[]
         | null
+    /**
+     * Data warehouse table name
+     * @nullable
+     */
+    table_name?: string | null
+    /**
+     * Data warehouse timestamp field
+     * @nullable
+     */
+    timestamp_field?: string | null
     type?: EntityTypeApi | null
     /** @nullable */
     uuid?: string | null

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -3032,6 +3032,11 @@ export namespace Schemas {
     } as const;
 
     export interface RetentionEntity {
+      /**
+       * Data warehouse field used as the actor identifier
+       * @nullable
+       */
+      aggregation_target_field?: string | null;
       /** @nullable */
       custom_name?: string | null;
       id?: string | number | null;
@@ -3045,6 +3050,16 @@ export namespace Schemas {
        * @nullable
        */
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
+      /**
+       * Data warehouse table name
+       * @nullable
+       */
+      table_name?: string | null;
+      /**
+       * Data warehouse timestamp field
+       * @nullable
+       */
+      timestamp_field?: string | null;
       type?: EntityType | null;
       /** @nullable */
       uuid?: string | null;


### PR DESCRIPTION
## Problem

We want to add support for data warehouse tables to retention insights.

## Changes

This PR:
- adds a feature flag `retention-dwh` guarding the feature during implementation
- adapts the `RetentionEntity` type to support the required fields for data warehouse entities
- configures the `ActionFilter` for the starting and returning entity to allow selecting data warehouse tables
    <img width="980" height="552" alt="Screenshot 2026-04-23 at 12 17 08" src="https://github.com/user-attachments/assets/d3ddfaaf-2ba1-4ce6-87c9-6e9b861cdb42" />

## How did you test this code?

Enabled the feature flag locally and selected a data warehouse table