### PR TITLE
fix(auth): block unverified passkey logins

### DIFF
--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -194,6 +194,26 @@ class EmailMFARequired(APIException):
         super().__init__(detail=detail, code=self.default_code)
 
 
+def enforce_email_verification_login_policy(user: User) -> bool:
+    """
+    Send a verification email when the login policy requires it.
+
+    Returns whether login should be blocked for this user. Legacy users with a
+    null verification state are still allowed to sign in.
+    """
+    if not is_email_available():
+        return False
+
+    if user.is_email_verified is True:
+        return False
+
+    if is_email_verification_disabled(user):
+        return False
+
+    EmailVerifier.create_token_and_send_email_verification(user)
+    return user.is_email_verified is False
+
+
 class LoginSerializer(serializers.Serializer):
     email = serializers.EmailField()
     password = serializers.CharField()
@@ -300,16 +320,11 @@ class LoginSerializer(serializers.Serializer):
 
             raise serializers.ValidationError("Invalid email or password.", code="invalid_credentials")
 
-        # We still let them log in if is_email_verified is null so existing users don't get locked out
-        if is_email_available() and user.is_email_verified is not True and not is_email_verification_disabled(user):
-            EmailVerifier.create_token_and_send_email_verification(user)
-            # If it's None, we want to let them log in still since they are an existing user
-            # If it's False, we want to tell them to check their email
-            if user.is_email_verified is False:
-                raise serializers.ValidationError(
-                    "Your account is awaiting verification. Please check your email for a verification link.",
-                    code="not_verified",
-                )
+        if enforce_email_verification_login_policy(user):
+            raise serializers.ValidationError(
+                "Your account is awaiting verification. Please check your email for a verification link.",
+                code="not_verified",
+            )
 
         clear_two_factor_session_flags(request)
 

--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -907,12 +907,9 @@ class PasswordResetCompleteSerializer(serializers.Serializer):
         except ValidationError as e:
             raise serializers.ValidationError({"password": e.messages})
 
-        with transaction.atomic():
-            user.set_password(password)
-            user.requested_password_reset_at = None
-            user.passkeys_enabled_for_2fa = False
-            user.save()
-            WebauthnCredential.objects.filter(user=user).delete()
+        user.set_password(password)
+        user.requested_password_reset_at = None
+        user.save()
 
         report_user_password_reset(user)
         return {"email": user.email}

--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -907,9 +907,12 @@ class PasswordResetCompleteSerializer(serializers.Serializer):
         except ValidationError as e:
             raise serializers.ValidationError({"password": e.messages})
 
-        user.set_password(password)
-        user.requested_password_reset_at = None
-        user.save()
+        with transaction.atomic():
+            user.set_password(password)
+            user.requested_password_reset_at = None
+            user.passkeys_enabled_for_2fa = False
+            user.save()
+            WebauthnCredential.objects.filter(user=user).delete()
 
         report_user_password_reset(user)
         return {"email": user.email}

--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -194,24 +194,24 @@ class EmailMFARequired(APIException):
         super().__init__(detail=detail, code=self.default_code)
 
 
-def enforce_email_verification_login_policy(user: User) -> bool:
+def is_email_verified_for_login(user: User) -> bool:
     """
     Send a verification email when the login policy requires it.
 
-    Returns whether login should be blocked for this user. Legacy users with a
-    null verification state are still allowed to sign in.
+    Returns whether login may continue for this user. Legacy users with a null
+    verification state are still allowed to sign in.
     """
     if not is_email_available():
-        return False
+        return True
 
     if user.is_email_verified is True:
-        return False
+        return True
 
     if is_email_verification_disabled(user):
-        return False
+        return True
 
     EmailVerifier.create_token_and_send_email_verification(user)
-    return user.is_email_verified is False
+    return user.is_email_verified is not False
 
 
 class LoginSerializer(serializers.Serializer):
@@ -320,7 +320,7 @@ class LoginSerializer(serializers.Serializer):
 
             raise serializers.ValidationError("Invalid email or password.", code="invalid_credentials")
 
-        if enforce_email_verification_login_policy(user):
+        if not is_email_verified_for_login(user):
             raise serializers.ValidationError(
                 "Your account is awaiting verification. Please check your email for a verification link.",
                 code="not_verified",

--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -211,7 +211,11 @@ def is_email_verified_for_login(user: User) -> bool:
         return True
 
     EmailVerifier.create_token_and_send_email_verification(user)
-    return user.is_email_verified is not False
+    if user.is_email_verified is False:
+        return False
+
+    # legacy None users are still allowed to log in
+    return True
 
 
 class LoginSerializer(serializers.Serializer):

--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -43,6 +43,7 @@ from posthog.models.organization_domain import OrganizationDomain
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.team.team import Team
 from posthog.models.utils import generate_random_token_personal, hash_key_value
+from posthog.models.webauthn_credential import WebauthnCredential
 
 VALID_TEST_PASSWORD = "mighty-strong-secure-1337!!"
 
@@ -1406,6 +1407,30 @@ class TestPasswordResetAPI(APIBaseTest):
             },
         )
         self.assertEqual(mock_capture.call_count, 2)
+
+    def test_password_reset_revokes_existing_passkeys(self):
+        self.user.is_email_verified = False
+        self.user.passkeys_enabled_for_2fa = True
+        self.user.requested_password_reset_at = datetime.now()
+        self.user.save()
+        WebauthnCredential.objects.create(
+            user=self.user,
+            credential_id=b"test-credential-id",
+            label="Test Passkey",
+            public_key=b"test-public-key",
+            algorithm=-7,
+            counter=0,
+            transports=["internal"],
+            verified=True,
+        )
+
+        token = password_reset_token_generator.make_token(self.user)
+        response = self.client.post(f"/api/reset/{self.user.uuid}/", {"token": token, "password": VALID_TEST_PASSWORD})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.user.refresh_from_db()
+        self.assertFalse(WebauthnCredential.objects.filter(user=self.user).exists())
+        self.assertFalse(self.user.passkeys_enabled_for_2fa)
 
     def test_cant_set_short_password(self):
         token = password_reset_token_generator.make_token(self.user)

--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -43,7 +43,6 @@ from posthog.models.organization_domain import OrganizationDomain
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.team.team import Team
 from posthog.models.utils import generate_random_token_personal, hash_key_value
-from posthog.models.webauthn_credential import WebauthnCredential
 
 VALID_TEST_PASSWORD = "mighty-strong-secure-1337!!"
 
@@ -1407,30 +1406,6 @@ class TestPasswordResetAPI(APIBaseTest):
             },
         )
         self.assertEqual(mock_capture.call_count, 2)
-
-    def test_password_reset_revokes_existing_passkeys(self):
-        self.user.is_email_verified = False
-        self.user.passkeys_enabled_for_2fa = True
-        self.user.requested_password_reset_at = datetime.now()
-        self.user.save()
-        WebauthnCredential.objects.create(
-            user=self.user,
-            credential_id=b"test-credential-id",
-            label="Test Passkey",
-            public_key=b"test-public-key",
-            algorithm=-7,
-            counter=0,
-            transports=["internal"],
-            verified=True,
-        )
-
-        token = password_reset_token_generator.make_token(self.user)
-        response = self.client.post(f"/api/reset/{self.user.uuid}/", {"token": token, "password": VALID_TEST_PASSWORD})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        self.user.refresh_from_db()
-        self.assertFalse(WebauthnCredential.objects.filter(user=self.user).exists())
-        self.assertFalse(self.user.passkeys_enabled_for_2fa)
 
     def test_cant_set_short_password(self):
         token = password_reset_token_generator.make_token(self.user)

--- a/posthog/api/test/test_webauthn.py
+++ b/posthog/api/test/test_webauthn.py
@@ -233,6 +233,48 @@ class TestWebAuthnLogin(APIBaseTest):
         self.assertEqual(me_response.status_code, status.HTTP_200_OK)
         self.assertEqual(me_response.json()["email"], self.user.email)
 
+    @patch("posthog.api.webauthn.is_email_available", return_value=True)
+    @patch("posthog.api.webauthn.EmailVerifier.create_token_and_send_email_verification")
+    @patch("posthog.auth.verify_passkey_authentication_response")
+    def test_login_blocks_explicitly_unverified_email_accounts(
+        self, mock_verify, mock_send_email_verification, mock_is_email_available
+    ):
+        from webauthn.helpers import bytes_to_base64url
+
+        from posthog.api.webauthn import user_uuid_to_handle
+
+        self.user.is_email_verified = False
+        self.user.save()
+
+        self.client.post("/api/webauthn/login/begin/")
+        mock_verify.return_value = MagicMock(new_sign_count=1)
+
+        user_handle = user_uuid_to_handle(self.user.uuid)
+
+        response = self.client.post(
+            "/api/webauthn/login/complete/",
+            {
+                "id": bytes_to_base64url(self.credential.credential_id),
+                "rawId": bytes_to_base64url(self.credential.credential_id),
+                "type": "public-key",
+                "response": {
+                    "authenticatorData": "data",
+                    "clientDataJSON": "data",
+                    "signature": "sig",
+                    "userHandle": bytes_to_base64url(user_handle),
+                },
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("awaiting verification", response.json()["error"].lower())
+
+        me_response = self.client.get("/api/users/@me/")
+        self.assertEqual(me_response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        mock_is_email_available.assert_called_once()
+        mock_send_email_verification.assert_called_once_with(self.user)
+
     @patch("posthog.auth.verify_passkey_authentication_response")
     def test_login_with_unverified_credential_fails(self, mock_verify):
         from webauthn.helpers import bytes_to_base64url

--- a/posthog/api/test/test_webauthn.py
+++ b/posthog/api/test/test_webauthn.py
@@ -233,8 +233,8 @@ class TestWebAuthnLogin(APIBaseTest):
         self.assertEqual(me_response.status_code, status.HTTP_200_OK)
         self.assertEqual(me_response.json()["email"], self.user.email)
 
-    @patch("posthog.api.webauthn.is_email_available", return_value=True)
-    @patch("posthog.api.webauthn.EmailVerifier.create_token_and_send_email_verification")
+    @patch("posthog.api.authentication.is_email_available", return_value=True)
+    @patch("posthog.api.authentication.EmailVerifier.create_token_and_send_email_verification")
     @patch("posthog.auth.verify_passkey_authentication_response")
     def test_login_blocks_explicitly_unverified_email_accounts(
         self, mock_verify, mock_send_email_verification, mock_is_email_available

--- a/posthog/api/webauthn.py
+++ b/posthog/api/webauthn.py
@@ -18,7 +18,9 @@ from webauthn.helpers.decode_credential_public_key import decode_credential_publ
 from webauthn.helpers.structs import AuthenticatorTransport, PublicKeyCredentialDescriptor
 
 from posthog.api.authentication import axes_locked_out
+from posthog.api.email_verification import EmailVerifier, is_email_verification_disabled
 from posthog.auth import SessionAuthentication, WebAuthnAuthenticationResponse, WebauthnBackend
+from posthog.email import is_email_available
 from posthog.event_usage import report_user_logged_in
 from posthog.helpers.two_factor_session import set_two_factor_verified_in_session
 from posthog.models import User
@@ -351,6 +353,25 @@ class WebAuthnLoginViewSet(viewsets.ViewSet):
             # Check SSO enforcement against the verified user
             if sso_enforcement_response := self._check_sso_enforcement(verified_user):
                 return sso_enforcement_response
+
+            # Match the password login flow: legacy users with a null verification
+            # state can still sign in, but explicitly unverified accounts cannot.
+            if (
+                is_email_available()
+                and verified_user.is_email_verified is not True
+                and not is_email_verification_disabled(verified_user)
+            ):
+                EmailVerifier.create_token_and_send_email_verification(verified_user)
+                if verified_user.is_email_verified is False:
+                    return Response(
+                        {
+                            "error": (
+                                "Your account is awaiting verification. "
+                                "Please check your email for a verification link."
+                            )
+                        },
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
 
             # Login the user with the WebauthnBackend
             login(request, verified_user, backend="posthog.auth.WebauthnBackend")

--- a/posthog/api/webauthn.py
+++ b/posthog/api/webauthn.py
@@ -17,7 +17,7 @@ from webauthn.helpers import base64url_to_bytes, bytes_to_base64url, options_to_
 from webauthn.helpers.decode_credential_public_key import decode_credential_public_key
 from webauthn.helpers.structs import AuthenticatorTransport, PublicKeyCredentialDescriptor
 
-from posthog.api.authentication import axes_locked_out, enforce_email_verification_login_policy
+from posthog.api.authentication import axes_locked_out, is_email_verified_for_login
 from posthog.auth import SessionAuthentication, WebAuthnAuthenticationResponse, WebauthnBackend
 from posthog.event_usage import report_user_logged_in
 from posthog.helpers.two_factor_session import set_two_factor_verified_in_session
@@ -352,7 +352,7 @@ class WebAuthnLoginViewSet(viewsets.ViewSet):
             if sso_enforcement_response := self._check_sso_enforcement(verified_user):
                 return sso_enforcement_response
 
-            if enforce_email_verification_login_policy(verified_user):
+            if not is_email_verified_for_login(verified_user):
                 return Response(
                     {
                         "error": (

--- a/posthog/api/webauthn.py
+++ b/posthog/api/webauthn.py
@@ -17,10 +17,8 @@ from webauthn.helpers import base64url_to_bytes, bytes_to_base64url, options_to_
 from webauthn.helpers.decode_credential_public_key import decode_credential_public_key
 from webauthn.helpers.structs import AuthenticatorTransport, PublicKeyCredentialDescriptor
 
-from posthog.api.authentication import axes_locked_out
-from posthog.api.email_verification import EmailVerifier, is_email_verification_disabled
+from posthog.api.authentication import axes_locked_out, enforce_email_verification_login_policy
 from posthog.auth import SessionAuthentication, WebAuthnAuthenticationResponse, WebauthnBackend
-from posthog.email import is_email_available
 from posthog.event_usage import report_user_logged_in
 from posthog.helpers.two_factor_session import set_two_factor_verified_in_session
 from posthog.models import User
@@ -354,24 +352,15 @@ class WebAuthnLoginViewSet(viewsets.ViewSet):
             if sso_enforcement_response := self._check_sso_enforcement(verified_user):
                 return sso_enforcement_response
 
-            # Match the password login flow: legacy users with a null verification
-            # state can still sign in, but explicitly unverified accounts cannot.
-            if (
-                is_email_available()
-                and verified_user.is_email_verified is not True
-                and not is_email_verification_disabled(verified_user)
-            ):
-                EmailVerifier.create_token_and_send_email_verification(verified_user)
-                if verified_user.is_email_verified is False:
-                    return Response(
-                        {
-                            "error": (
-                                "Your account is awaiting verification. "
-                                "Please check your email for a verification link."
-                            )
-                        },
-                        status=status.HTTP_400_BAD_REQUEST,
-                    )
+            if enforce_email_verification_login_policy(verified_user):
+                return Response(
+                    {
+                        "error": (
+                            "Your account is awaiting verification. Please check your email for a verification link."
+                        )
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
             # Login the user with the WebauthnBackend
             login(request, verified_user, backend="posthog.auth.WebauthnBackend")


### PR DESCRIPTION
## Problem

Passkey login did not enforce the same email verification policy as password login.
That allowed users with `is_email_verified=False` to complete passkey authentication even though password login correctly blocks them.


## Changes

- Added a shared enforce_email_verification_login_policy(user) -> bool helper for login-time email verification checks.
- Updated password login to use the shared helper without changing its current behavior.
- Updated passkey login to use the same helper and block explicitly unverified users before login().

## How did you test this code?
Tests

## Publish to changelog?
No