### PR TITLE
feat(retention): add custom entity for dwh-only insights

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -32357,6 +32357,10 @@
                 "cumulative": {
                     "type": "boolean"
                 },
+                "customAggregationTarget": {
+                    "description": "For data warehouse based retention insights when the aggregation target can't be mapped to persons or groups.",
+                    "type": "boolean"
+                },
                 "dashboardDisplay": {
                     "$ref": "#/definitions/RetentionDashboardDisplayType"
                 },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1643,6 +1643,8 @@ export type RetentionFilter = {
     /** @description The type of property to aggregate on (event or person). Defaults to event.
      * @default event */
     aggregationPropertyType?: 'event' | 'person'
+    /** For data warehouse based retention insights when the aggregation target can't be mapped to persons or groups. */
+    customAggregationTarget?: boolean
 
     //frontend only
     meanRetentionCalculation?: RetentionFilterLegacy['mean_retention_calculation']

--- a/frontend/src/scenes/insights/filters/AggregationSelect.tsx
+++ b/frontend/src/scenes/insights/filters/AggregationSelect.tsx
@@ -3,7 +3,9 @@ import { useActions, useValues } from 'kea'
 import { LemonSelect, LemonSelectSection } from '@posthog/lemon-ui'
 
 import { HogQLEditor } from 'lib/components/HogQLEditor/HogQLEditor'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { GroupIntroductionFooter } from 'scenes/groups/GroupsIntroduction'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
@@ -62,10 +64,13 @@ export function AggregationSelect({
 
     const { groupTypes, aggregationLabel } = useValues(groupsModel)
     const { needsUpgradeForGroups, canStartUsingGroups } = useValues(groupsAccessLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     if (!isInsightQueryNode(querySource)) {
         return null
     }
+
+    const isRetentionDWHEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_RETENTION_DWH]
 
     const value =
         (isLifecycleQuery(querySource) && querySource.customAggregationTarget) ||
@@ -167,7 +172,7 @@ export function AggregationSelect({
         })
     }
 
-    if (isFunnels || isLifecycle || isRetention) {
+    if (isFunnels || isLifecycle || (isRetention && isRetentionDWHEnabled)) {
         const hasOnlyDataWarehouseRetentionEntities =
             isRetentionQuery(querySource) &&
             querySource.retentionFilter &&

--- a/frontend/src/scenes/insights/filters/AggregationSelect.tsx
+++ b/frontend/src/scenes/insights/filters/AggregationSelect.tsx
@@ -8,8 +8,14 @@ import { GroupIntroductionFooter } from 'scenes/groups/GroupsIntroduction'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
 import { groupsModel } from '~/models/groupsModel'
-import { FunnelsQuery, LifecycleQuery } from '~/queries/schema/schema-general'
-import { isFunnelsQuery, isInsightQueryNode, isLifecycleQuery, isStickinessQuery } from '~/queries/utils'
+import { FunnelsQuery, LifecycleQuery, RetentionQuery } from '~/queries/schema/schema-general'
+import {
+    isFunnelsQuery,
+    isInsightQueryNode,
+    isLifecycleQuery,
+    isRetentionQuery,
+    isStickinessQuery,
+} from '~/queries/utils'
 import { InsightLogicProps } from '~/types'
 
 export function getHogQLValue(groupIndex?: number | null, aggregationQuery?: string | null): string {
@@ -49,7 +55,7 @@ export function AggregationSelect({
     className,
     hogqlAvailable,
 }: AggregationSelectProps): JSX.Element | null {
-    const { querySource, isFunnels, isLifecycle, hasOnlyDataWarehouseSeries } = useValues(
+    const { querySource, isFunnels, isLifecycle, isRetention, hasOnlyDataWarehouseSeries } = useValues(
         insightVizDataLogic(insightProps)
     )
     const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
@@ -63,7 +69,8 @@ export function AggregationSelect({
 
     const value =
         (isLifecycleQuery(querySource) && querySource.customAggregationTarget) ||
-        (isFunnelsQuery(querySource) && querySource.funnelsFilter?.customAggregationTarget)
+        (isFunnelsQuery(querySource) && querySource.funnelsFilter?.customAggregationTarget) ||
+        (isRetentionQuery(querySource) && querySource.retentionFilter?.customAggregationTarget)
             ? CUSTOM_DATA_WAREHOUSE_ITEMS
             : getHogQLValue(
                   isStickinessQuery(querySource) ? undefined : querySource.aggregation_group_type_index,
@@ -104,6 +111,24 @@ export function AggregationSelect({
                     customAggregationTarget: undefined,
                 } as LifecycleQuery)
             }
+        } else if (isRetentionQuery(querySource)) {
+            if (value === CUSTOM_DATA_WAREHOUSE_ITEMS) {
+                updateQuerySource({
+                    aggregation_group_type_index: undefined,
+                    retentionFilter: {
+                        ...querySource.retentionFilter,
+                        customAggregationTarget: true,
+                    },
+                } as RetentionQuery)
+            } else {
+                updateQuerySource({
+                    aggregation_group_type_index: groupIndex,
+                    retentionFilter: {
+                        ...querySource.retentionFilter,
+                        customAggregationTarget: undefined,
+                    },
+                } as RetentionQuery)
+            }
         } else {
             updateQuerySource({ aggregation_group_type_index: groupIndex } as FunnelsQuery)
         }
@@ -142,15 +167,22 @@ export function AggregationSelect({
         })
     }
 
-    if (isFunnels || isLifecycle) {
+    if (isFunnels || isLifecycle || isRetention) {
+        const hasOnlyDataWarehouseRetentionEntities =
+            isRetentionQuery(querySource) &&
+            querySource.retentionFilter &&
+            querySource.retentionFilter.targetEntity?.type === 'data_warehouse' &&
+            querySource.retentionFilter.returningEntity?.type === 'data_warehouse'
+
         optionSections[0].options.push({
             value: CUSTOM_DATA_WAREHOUSE_ITEMS,
             label: 'Custom entities',
             tooltip:
                 'Custom entities from your data warehouse instead of persons or groups. This mainly affects how aggregation labels are shown and disables the persons modal.',
-            disabledReason: hasOnlyDataWarehouseSeries
-                ? undefined
-                : 'This option is only available for insights with only data warehouse series.',
+            disabledReason:
+                hasOnlyDataWarehouseSeries || hasOnlyDataWarehouseRetentionEntities
+                    ? undefined
+                    : 'This option is only available for insights with only data warehouse series.',
         })
     }
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -17275,6 +17275,13 @@ class RetentionFilter(BaseModel):
         description="The aggregation type to use for retention",
     )
     cumulative: bool | None = None
+    customAggregationTarget: bool | None = Field(
+        default=None,
+        description=(
+            "For data warehouse based retention insights when the aggregation target"
+            " can't be mapped to persons or groups."
+        ),
+    )
     dashboardDisplay: RetentionDashboardDisplayType | None = None
     display: ChartDisplayType | None = Field(default=None, description="controls the display of the retention graph")
     goalLines: list[GoalLine] | None = None
@@ -17287,12 +17294,6 @@ class RetentionFilter(BaseModel):
     retentionReference: RetentionReference | None = Field(
         default=None,
         description=("Whether retention is with regard to initial cohort size, or that of the previous period."),
-    )
-    customAggregationTarget: bool | None = Field(
-        default=None,
-        description=(
-            "For data warehouse based retention insights when the aggregation target can't be mapped to persons or groups."
-        ),
     )
     retentionType: RetentionType | None = None
     returningEntity: RetentionEntity | None = None

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -17288,6 +17288,12 @@ class RetentionFilter(BaseModel):
         default=None,
         description=("Whether retention is with regard to initial cohort size, or that of the previous period."),
     )
+    customAggregationTarget: bool | None = Field(
+        default=None,
+        description=(
+            "For data warehouse based retention insights when the aggregation target can't be mapped to persons or groups."
+        ),
+    )
     retentionType: RetentionType | None = None
     returningEntity: RetentionEntity | None = None
     selectedInterval: int | None = Field(

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -2794,6 +2794,11 @@ export interface RetentionFilterApi {
     retentionCustomBrackets?: number[] | null
     /** Whether retention is with regard to initial cohort size, or that of the previous period. */
     retentionReference?: RetentionReferenceApi | null
+    /**
+     * For data warehouse based retention insights when the aggregation target can't be mapped to persons or groups.
+     * @nullable
+     */
+    customAggregationTarget?: boolean | null
     retentionType?: RetentionTypeApi | null
     returningEntity?: RetentionEntityApi | null
     /**

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -2778,6 +2778,11 @@ export interface RetentionFilterApi {
     aggregationType?: AggregationTypeApi | null
     /** @nullable */
     cumulative?: boolean | null
+    /**
+     * For data warehouse based retention insights when the aggregation target can't be mapped to persons or groups.
+     * @nullable
+     */
+    customAggregationTarget?: boolean | null
     dashboardDisplay?: RetentionDashboardDisplayTypeApi | null
     /** controls the display of the retention graph */
     display?: ChartDisplayTypeApi | null
@@ -2794,11 +2799,6 @@ export interface RetentionFilterApi {
     retentionCustomBrackets?: number[] | null
     /** Whether retention is with regard to initial cohort size, or that of the previous period. */
     retentionReference?: RetentionReferenceApi | null
-    /**
-     * For data warehouse based retention insights when the aggregation target can't be mapped to persons or groups.
-     * @nullable
-     */
-    customAggregationTarget?: boolean | null
     retentionType?: RetentionTypeApi | null
     returningEntity?: RetentionEntityApi | null
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -3085,6 +3085,11 @@ export namespace Schemas {
       aggregationType?: AggregationType | null;
       /** @nullable */
       cumulative?: boolean | null;
+      /**
+       * For data warehouse based retention insights when the aggregation target can't be mapped to persons or groups.
+       * @nullable
+       */
+      customAggregationTarget?: boolean | null;
       dashboardDisplay?: RetentionDashboardDisplayType | null;
       /** controls the display of the retention graph */
       display?: ChartDisplayType | null;
@@ -3101,11 +3106,6 @@ export namespace Schemas {
       retentionCustomBrackets?: number[] | null;
       /** Whether retention is with regard to initial cohort size, or that of the previous period. */
       retentionReference?: RetentionReference | null;
-      /**
-       * For data warehouse based retention insights when the aggregation target can't be mapped to persons or groups.
-       * @nullable
-       */
-      customAggregationTarget?: boolean | null;
       retentionType?: RetentionType | null;
       returningEntity?: RetentionEntity | null;
       /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -3101,6 +3101,11 @@ export namespace Schemas {
       retentionCustomBrackets?: number[] | null;
       /** Whether retention is with regard to initial cohort size, or that of the previous period. */
       retentionReference?: RetentionReference | null;
+      /**
+       * For data warehouse based retention insights when the aggregation target can't be mapped to persons or groups.
+       * @nullable
+       */
+      customAggregationTarget?: boolean | null;
       retentionType?: RetentionType | null;
       returningEntity?: RetentionEntity | null;
       /**


### PR DESCRIPTION
## Problem

Similar to other insight types, the retention insight should allow selecting "Custom entities" as aggregation option.

## Changes

Implements this.

## How did you test this code?

Manually selected it