### PR TITLE
fix(ci): fix dorny paths-filter negation matching all changes

### DIFF
--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -23,7 +23,17 @@ jobs:
         if: github.event_name != 'merge_group'
         # Set job outputs to values from filter step
         outputs:
-            frontend: ${{ steps.filter.outputs.frontend || 'true' }}
+            # With dorny's default predicate-quantifier (some), '!path' matches
+            # every file NOT at that path — effectively matching ALL changes
+            # including backend files. Instead we use two positive filters and
+            # compare counts to exclude generated-only PRs.
+            frontend: >-
+                ${{
+                    github.event_name == 'push'
+                    || (steps.filter.outputs.frontend == 'true'
+                        && fromJSON(steps.filter.outputs.frontend_count || '0')
+                           > fromJSON(steps.filter.outputs.frontend_generated_count || '0'))
+                }}
         steps:
             - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
               id: filter
@@ -40,9 +50,9 @@ jobs:
                         - 'package.json'
                         - '.github/workflows/ci-storybook.yml'
                         - 'playwright.config.ts'
-                        # Generated API types should not trigger Storybook/VR checks on their own
-                        - '!frontend/src/generated/**'
-                        - '!products/**/frontend/generated/**'
+                      frontend_generated:
+                        - 'frontend/src/generated/**'
+                        - 'products/**/frontend/generated/**'
 
     build-storybook:
         name: Build Storybook (${{ matrix.runner }})


### PR DESCRIPTION
## Problem

The Storybook/VR CI workflow uses [dorny/paths-filter](https://github.com/dorny/paths-filter) to skip visual regression tests when no frontend files changed. However, the negation patterns used to exclude generated API types were broken:

```yaml
- '!frontend/src/generated/**'
- '!products/**/frontend/generated/**'
```

With dorny's default `predicate-quantifier: some`, each filter rule is OR'd independently. A negation pattern `!path` matches **every file NOT at that path** — which includes all backend files. This meant the storybook filter was triggering on essentially all PRs regardless of what changed.

## Changes

- Remove the broken negation patterns from the `frontend` filter
- Add a new `frontend_generated` positive filter matching only generated API type paths
- Use count comparison (`frontend_count > frontend_generated_count`) in the output expression to correctly detect non-generated frontend changes
- Preserve existing push-to-master behavior (always runs full suite)

## How did you test this code?

Logic validation of the count comparison against all scenarios:
- **Only generated types changed:** `frontend_count == frontend_generated_count` → `false`, skip VR
- **Mixed generated + real changes:** `frontend_count > frontend_generated_count` → `true`, run VR
- **Only real frontend changes:** `frontend_count > 0, frontend_generated_count == 0` → `true`, run VR
- **No frontend changes:** `frontend == 'false'` → short-circuits to `false`, skip VR
- **Push to master:** `github.event_name == 'push'` → short-circuits to `true`, always run

## 🤖 LLM context

Agent-authored PR. Identified the bug by reading dorny docs — negation with `predicate-quantifier: some` does not work as exclusion, it works as an independent OR'd rule that matches everything except the negated path.