### PR TITLE
chore(endpoints): add staff debug info panel for endpoints

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2364,6 +2364,7 @@ export interface EndpointType extends WithAccessControl {
     cache_age_seconds: number | null
     is_materialized: boolean
     current_version: number
+    current_version_id: string
     versions_count: number
     /** Purely local value to determine whether the query endpoint should be highlighted, e.g. as a fresh duplicate. */
     _highlight?: boolean
@@ -2390,6 +2391,7 @@ export interface EndpointVersionMaterializationType {
     error?: string
     last_materialized_at?: string
     sync_frequency?: DataModelingSyncInterval
+    saved_query_id?: string
 }
 
 export interface DashboardBasicType extends WithAccessControl {

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -454,6 +454,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
                 "sync_frequency": sync_frequency_interval_to_sync_frequency(
                     version.saved_query.sync_frequency_interval
                 ),
+                "saved_query_id": str(version.saved_query.id),
             }
         else:
             can_mat, reason = version.can_materialize()
@@ -504,6 +505,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             "created_by": UserBasicSerializer(endpoint.created_by).data if hasattr(endpoint, "created_by") else None,
             "is_materialized": version.is_materialized,
             "current_version": endpoint.current_version,
+            "current_version_id": str(version.id) if version else None,
             "versions_count": endpoint.versions.count(),
             "derived_from_insight": endpoint.derived_from_insight,
             "last_executed_at": endpoint.last_executed_at.isoformat() if endpoint.last_executed_at else None,

--- a/products/endpoints/backend/api.py
+++ b/products/endpoints/backend/api.py
@@ -505,7 +505,7 @@ class EndpointViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.Model
             "created_by": UserBasicSerializer(endpoint.created_by).data if hasattr(endpoint, "created_by") else None,
             "is_materialized": version.is_materialized,
             "current_version": endpoint.current_version,
-            "current_version_id": str(version.id) if version else None,
+            "current_version_id": str(version.id),
             "versions_count": endpoint.versions.count(),
             "derived_from_insight": endpoint.derived_from_insight,
             "last_executed_at": endpoint.last_executed_at.isoformat() if endpoint.last_executed_at else None,

--- a/products/endpoints/backend/serializers.py
+++ b/products/endpoints/backend/serializers.py
@@ -161,9 +161,13 @@ class EndpointResponseSerializer(serializers.Serializer):
         help_text="Whether the current version's results are pre-computed to S3.",
     )
     current_version = serializers.IntegerField(help_text="Latest version number.")
+
     current_version_id = serializers.UUIDField(
+        required=False,
+        allow_null=True,
         help_text="UUID of the current EndpointVersion row.",
     )
+
     versions_count = serializers.IntegerField(help_text="Total number of versions for this endpoint.")
     derived_from_insight = serializers.CharField(
         allow_null=True,

--- a/products/endpoints/backend/serializers.py
+++ b/products/endpoints/backend/serializers.py
@@ -104,6 +104,11 @@ class EndpointMaterializationSerializer(serializers.Serializer):
         allow_null=True,
         help_text="How often the materialization refreshes (e.g. 'every_hour').",
     )
+    saved_query_id = serializers.UUIDField(
+        required=False,
+        allow_null=True,
+        help_text="UUID of the underlying saved query backing this materialization. Only populated when the version is materialized.",
+    )
 
 
 class EndpointColumnSerializer(serializers.Serializer):
@@ -156,6 +161,9 @@ class EndpointResponseSerializer(serializers.Serializer):
         help_text="Whether the current version's results are pre-computed to S3.",
     )
     current_version = serializers.IntegerField(help_text="Latest version number.")
+    current_version_id = serializers.UUIDField(
+        help_text="UUID of the current EndpointVersion row.",
+    )
     versions_count = serializers.IntegerField(help_text="Total number of versions for this endpoint.")
     derived_from_insight = serializers.CharField(
         allow_null=True,

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -493,6 +493,11 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
         self.assertIn("status", response_data["materialization"])
         self.assertIn("sync_frequency", response_data["materialization"])
         self.assertEqual(response_data["materialization"]["sync_frequency"], "12hour")
+        self.assertIn("saved_query_id", response_data["materialization"])
+        version = endpoint.get_version()
+        assert version.saved_query is not None
+        self.assertEqual(response_data["materialization"]["saved_query_id"], str(version.saved_query.id))
+        self.assertEqual(response_data["current_version_id"], str(version.id))
 
     def test_materialization_status_endpoint(self):
         """Test the dedicated materialization_status endpoint returns only materialization data."""

--- a/products/endpoints/frontend/EndpointHeader.tsx
+++ b/products/endpoints/frontend/EndpointHeader.tsx
@@ -1,12 +1,16 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonButton } from '@posthog/lemon-ui'
+import { IconBug } from '@posthog/icons'
+import { LemonButton, LemonLabel, LemonSwitch } from '@posthog/lemon-ui'
 
+import { superpowersLogic } from 'lib/components/Superpowers/superpowersLogic'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { objectsEqual } from 'lib/utils'
 
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { EndpointRequest } from '~/queries/schema/schema-general'
 import { isInsightVizNode } from '~/queries/utils'
+import { EndpointType, EndpointVersionType } from '~/types'
 
 import { endpointLogic } from './endpointLogic'
 import { endpointSceneLogic } from './endpointSceneLogic'
@@ -25,12 +29,19 @@ export const EndpointSceneHeader = ({ tabId }: EndpointSceneHeaderProps): JSX.El
         isMaterialized,
         viewingVersion,
         bucketOverrides,
+        debugInfoExpanded,
     } = useValues(endpointSceneLogic({ tabId }))
     const { endpointName, endpointDescription } = useValues(endpointLogic({ tabId }))
     const { setEndpointDescription, updateEndpoint } = useActions(endpointLogic({ tabId }))
-    const { setLocalQuery, setCacheAge, setSyncFrequency, setIsMaterialized, resetBucketOverrides } = useActions(
-        endpointSceneLogic({ tabId })
-    )
+    const {
+        setLocalQuery,
+        setCacheAge,
+        setSyncFrequency,
+        setIsMaterialized,
+        resetBucketOverrides,
+        setDebugInfoExpanded,
+    } = useActions(endpointSceneLogic({ tabId }))
+    const { superpowersEnabled } = useValues(superpowersLogic)
 
     // When viewing a non-current version, target that version for updates
     const targetVersion =
@@ -113,6 +124,20 @@ export const EndpointSceneHeader = ({ tabId }: EndpointSceneHeaderProps): JSX.El
                 renameDebounceMs={200}
                 actions={
                     <>
+                        {superpowersEnabled && endpoint && (
+                            <LemonSwitch
+                                bordered
+                                checked={debugInfoExpanded}
+                                onChange={setDebugInfoExpanded}
+                                label={
+                                    <span className="inline-flex items-center gap-1">
+                                        <IconBug />
+                                        Debug info
+                                    </span>
+                                }
+                                tooltip="Visible to staff (and during impersonation) only"
+                            />
+                        )}
                         {endpoint && (
                             <LemonButton
                                 type="secondary"
@@ -140,6 +165,56 @@ export const EndpointSceneHeader = ({ tabId }: EndpointSceneHeaderProps): JSX.El
                     </>
                 }
             />
+            {superpowersEnabled && endpoint && debugInfoExpanded && (
+                <DebugInfoPanel endpoint={endpoint} viewingVersion={viewingVersion} />
+            )}
         </>
+    )
+}
+
+interface DebugInfoPanelProps {
+    endpoint: EndpointType
+    viewingVersion: EndpointVersionType | null
+}
+
+function DebugInfoPanel({ endpoint, viewingVersion }: DebugInfoPanelProps): JSX.Element {
+    const savedQueryId = endpoint.materialization?.saved_query_id
+    // Prefer the version being viewed; fall back to the endpoint's current version UUID.
+    const versionId = viewingVersion?.version_id ?? endpoint.current_version_id
+
+    return (
+        <div className="flex flex-col gap-2 border-dashed border rounded p-2 bg-bg-light">
+            <div className="inline-flex flex-wrap gap-6">
+                <DebugField label="Endpoint ID" value={endpoint.id} />
+                {versionId && <DebugField label="Version ID" value={versionId} />}
+                {savedQueryId ? (
+                    <DebugField label="Saved query ID" value={savedQueryId} />
+                ) : (
+                    <div className="flex flex-col">
+                        <LemonLabel>Saved query ID</LemonLabel>
+                        <span className="text-xs text-muted">Not materialized</span>
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}
+
+function DebugField({ label, value }: { label: string; value: string }): JSX.Element {
+    return (
+        <div className="flex flex-col">
+            <LemonLabel>{label}</LemonLabel>
+            <LemonButton
+                type="secondary"
+                size="xsmall"
+                onClick={() => {
+                    navigator.clipboard.writeText(value)
+                    lemonToast.success(`${label} copied to clipboard`)
+                }}
+                className="font-mono text-xs"
+            >
+                {value}
+            </LemonButton>
+        </div>
     )
 }

--- a/products/endpoints/frontend/endpointSceneLogic.tsx
+++ b/products/endpoints/frontend/endpointSceneLogic.tsx
@@ -143,6 +143,7 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
         setBucketOverride: (column: string, bucketFn: string) => ({ column, bucketFn }),
         resetBucketOverrides: (overrides: Record<string, string>) => ({ overrides }),
         setDebugMode: (debugMode: boolean) => ({ debugMode }),
+        setDebugInfoExpanded: (debugInfoExpanded: boolean) => ({ debugInfoExpanded }),
         loadMaterializationPreview: true,
         keepSqlEditorMounted: (editorTabId: string) => ({ editorTabId }),
     }),
@@ -217,6 +218,13 @@ export const endpointSceneLogic = kea<endpointSceneLogicType>([
             false,
             {
                 setDebugMode: (_, { debugMode }: { debugMode: boolean }) => debugMode,
+                loadEndpoint: () => false,
+            },
+        ],
+        debugInfoExpanded: [
+            false,
+            {
+                setDebugInfoExpanded: (_, { debugInfoExpanded }: { debugInfoExpanded: boolean }) => debugInfoExpanded,
                 loadEndpoint: () => false,
             },
         ],

--- a/products/endpoints/frontend/generated/api.schemas.ts
+++ b/products/endpoints/frontend/generated/api.schemas.ts
@@ -160,8 +160,11 @@ export interface EndpointResponseApi {
     is_materialized: boolean
     /** Latest version number. */
     current_version: number
-    /** UUID of the current EndpointVersion row. */
-    current_version_id: string
+    /**
+     * UUID of the current EndpointVersion row.
+     * @nullable
+     */
+    current_version_id?: string | null
     /** Total number of versions for this endpoint. */
     versions_count: number
     /**
@@ -308,8 +311,11 @@ export interface EndpointVersionResponseApi {
     is_materialized: boolean
     /** Latest version number. */
     current_version: number
-    /** UUID of the current EndpointVersion row. */
-    current_version_id: string
+    /**
+     * UUID of the current EndpointVersion row.
+     * @nullable
+     */
+    current_version_id?: string | null
     /** Total number of versions for this endpoint. */
     versions_count: number
     /**

--- a/products/endpoints/frontend/generated/api.schemas.ts
+++ b/products/endpoints/frontend/generated/api.schemas.ts
@@ -93,6 +93,11 @@ export interface EndpointMaterializationApi {
      * @nullable
      */
     sync_frequency?: string | null
+    /**
+     * UUID of the underlying saved query backing this materialization. Only populated when the version is materialized.
+     * @nullable
+     */
+    saved_query_id?: string | null
 }
 
 /**
@@ -155,6 +160,8 @@ export interface EndpointResponseApi {
     is_materialized: boolean
     /** Latest version number. */
     current_version: number
+    /** UUID of the current EndpointVersion row. */
+    current_version_id: string
     /** Total number of versions for this endpoint. */
     versions_count: number
     /**
@@ -301,6 +308,8 @@ export interface EndpointVersionResponseApi {
     is_materialized: boolean
     /** Latest version number. */
     current_version: number
+    /** UUID of the current EndpointVersion row. */
+    current_version_id: string
     /** Total number of versions for this endpoint. */
     versions_count: number
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14005,6 +14005,11 @@ export namespace Schemas {
        * @nullable
        */
       sync_frequency?: string | null;
+      /**
+       * UUID of the underlying saved query backing this materialization. Only populated when the version is materialized.
+       * @nullable
+       */
+      saved_query_id?: string | null;
     }
 
     export type EndpointRefreshMode = typeof EndpointRefreshMode[keyof typeof EndpointRefreshMode];
@@ -14130,6 +14135,8 @@ export namespace Schemas {
       is_materialized: boolean;
       /** Latest version number. */
       current_version: number;
+      /** UUID of the current EndpointVersion row. */
+      current_version_id: string;
       /** Total number of versions for this endpoint. */
       versions_count: number;
       /**
@@ -14276,6 +14283,8 @@ export namespace Schemas {
       is_materialized: boolean;
       /** Latest version number. */
       current_version: number;
+      /** UUID of the current EndpointVersion row. */
+      current_version_id: string;
       /** Total number of versions for this endpoint. */
       versions_count: number;
       /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14135,8 +14135,11 @@ export namespace Schemas {
       is_materialized: boolean;
       /** Latest version number. */
       current_version: number;
-      /** UUID of the current EndpointVersion row. */
-      current_version_id: string;
+      /**
+       * UUID of the current EndpointVersion row.
+       * @nullable
+       */
+      current_version_id?: string | null;
       /** Total number of versions for this endpoint. */
       versions_count: number;
       /**
@@ -14283,8 +14286,11 @@ export namespace Schemas {
       is_materialized: boolean;
       /** Latest version number. */
       current_version: number;
-      /** UUID of the current EndpointVersion row. */
-      current_version_id: string;
+      /**
+       * UUID of the current EndpointVersion row.
+       * @nullable
+       */
+      current_version_id?: string | null;
       /** Total number of versions for this endpoint. */
       versions_count: number;
       /**


### PR DESCRIPTION
## Problem

Staff members need visibility into endpoint debug information such as endpoint ID, version ID, and the underlying saved query ID for materialized endpoints. This information is useful for troubleshooting and understanding the relationship between endpoints and their backing queries.

## Changes

<img width="1482" height="250" alt="image" src="https://github.com/user-attachments/assets/1ef10290-ad1d-48b9-8b44-18821e82f3d6" />


- Added a new `DebugInfoPanel` component to `EndpointHeader` that displays debug information (endpoint ID, version ID, saved query ID) when superpowers are enabled
- The panel is collapsible and only visible to staff members (controlled by `superpowersEnabled`)
- Added `saved_query_id` and `current_version_id` fields to endpoint serializers across backend and frontend:
- Added `debugInfoExpanded` state to `endpointSceneLogic` to track the panel's expanded/collapsed state
- Debug field values are copyable to clipboard with toast confirmation

## How did you test this code?

- Added test case `test_materialization_status_in_response` that verifies `saved_query_id` is present in the materialization response and matches the underlying saved query ID
- Existing tests pass with the new serializer field
- The component is only rendered when `superpowersEnabled` is true, ensuring it's staff-only

## Publish to changelog?

no