### PR TITLE
refactor(insights): share one hover portal and one pinned portal across charts

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -289,7 +289,7 @@ export const LineGraph = ({
                                     annotationsList[`line${curIndex}`].label.content = `${
                                         cur.label
                                     }: ${cur.value.toLocaleString()}`
-                                    const tooltipEl = document.getElementById(`InsightTooltipWrapper-${tooltipId}`)
+                                    const tooltipEl = document.getElementById('InsightTooltipWrapper-hover')
 
                                     if (tooltipEl) {
                                         tooltipEl.classList.add('opacity-0', 'invisible')
@@ -308,7 +308,7 @@ export const LineGraph = ({
                                 if (annotationsList[`line${curIndex}`]) {
                                     annotationsList[`line${curIndex}`].label.content = cur.label
 
-                                    const tooltipEl = document.getElementById(`InsightTooltipWrapper-${tooltipId}`)
+                                    const tooltipEl = document.getElementById('InsightTooltipWrapper-hover')
                                     if (tooltipEl) {
                                         tooltipEl.classList.remove('opacity-0', 'invisible')
                                     }

--- a/frontend/src/scenes/insights/useInsightTooltip.ts
+++ b/frontend/src/scenes/insights/useInsightTooltip.ts
@@ -17,6 +17,7 @@ interface HoverTooltipState extends SharedTooltipBase {
     hideTimeout: ReturnType<typeof setTimeout> | null
     interactiveTimeout: ReturnType<typeof setTimeout> | null
     lastRendered: ReactNode
+    lastRenderedOwner: string | null
 }
 
 interface PinnedTooltipState extends SharedTooltipBase {
@@ -31,6 +32,7 @@ const hover: HoverTooltipState = {
     hideTimeout: null,
     interactiveTimeout: null,
     lastRendered: null,
+    lastRenderedOwner: null,
 }
 
 const pinned: PinnedTooltipState = {
@@ -42,22 +44,29 @@ const pinned: PinnedTooltipState = {
 
 let activeRenderId: string | null = null
 
-const wrappedHoverRoot: Root = {
-    render: (children: ReactNode): void => {
-        if (activeRenderId === null || hover.owner !== activeRenderId) {
-            console.error('[useInsightTooltip] dropped render — caller no longer owns the hover tooltip', {
-                activeRenderId,
-                hoverOwner: hover.owner,
-                pinnedOwner: pinned.owner,
-            })
-            return
-        }
-        hover.lastRendered = children
-        hover.root?.render(children)
-    },
-    unmount: (): void => {
-        hover.root?.unmount()
-    },
+function createHoverRootForCaller(callerId: string, suppressed: boolean): Root {
+    return {
+        render: (children: ReactNode): void => {
+            if (suppressed) {
+                return
+            }
+            if (hover.owner !== callerId || activeRenderId !== callerId) {
+                console.error('[useInsightTooltip] dropped render — caller no longer owns the hover tooltip', {
+                    callerId,
+                    hoverOwner: hover.owner,
+                    activeRenderId,
+                    pinnedOwner: pinned.owner,
+                })
+                return
+            }
+            hover.lastRendered = children
+            hover.lastRenderedOwner = callerId
+            hover.root?.render(children)
+        },
+        unmount: (): void => {
+            // the shared hover root is never unmounted; cleanupTooltip clears state instead
+        },
+    }
 }
 
 function clearHoverHideTimeout(): void {
@@ -231,11 +240,11 @@ export function ensureTooltip(id: string): [Root, HTMLElement] {
     if (pinned.owner === id) {
         hideHoverNow()
         activeRenderId = null
-        return [wrappedHoverRoot, hover.element!]
+        return [createHoverRootForCaller(id, true), hover.element!]
     }
     hover.owner = id
     activeRenderId = id
-    return [wrappedHoverRoot, hover.element!]
+    return [createHoverRootForCaller(id, false), hover.element!]
 }
 
 export function showTooltip(id: string): void {
@@ -266,6 +275,9 @@ export function hideTooltip(id?: string): void {
 
 export function pinTooltip(id: string, onUnpin?: () => void): void {
     if (!hover.element) {
+        return
+    }
+    if (hover.lastRenderedOwner !== id || hover.lastRendered === null) {
         return
     }
     ensurePinnedDom()
@@ -315,8 +327,11 @@ export function cleanupTooltip(id: string): void {
         if (activeRenderId === id) {
             activeRenderId = null
         }
-        hover.lastRendered = null
-        hover.root?.render(null)
+        if (hover.lastRenderedOwner === id) {
+            hover.lastRendered = null
+            hover.lastRenderedOwner = null
+            hover.root?.render(null)
+        }
         hideHoverNow()
     }
     if (pinned.owner === id) {

--- a/frontend/src/scenes/insights/useInsightTooltip.ts
+++ b/frontend/src/scenes/insights/useInsightTooltip.ts
@@ -237,6 +237,7 @@ function initGlobalUnpinListeners(): void {
 
 export function ensureTooltip(id: string): [Root, HTMLElement] {
     ensureHoverDom()
+    clearHoverHideTimeout()
     if (pinned.owner === id) {
         hideHoverNow()
         activeRenderId = null

--- a/frontend/src/scenes/insights/useInsightTooltip.ts
+++ b/frontend/src/scenes/insights/useInsightTooltip.ts
@@ -1,25 +1,130 @@
-import { useCallback, useRef } from 'react'
+import { ReactNode, useCallback, useRef } from 'react'
 import { Root, createRoot } from 'react-dom/client'
 
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 
-type TooltipInstance = {
-    root: Root
-    element: HTMLElement
-    isMouseOver: boolean
-    isPinned: boolean
-    onUnpin: (() => void) | null
-    hideTimeout: NodeJS.Timeout | null
-    interactiveTimeout: NodeJS.Timeout | null
-    mouseEnterHandler: () => void
-    mouseLeaveHandler: () => void
+const INTERACTIVE_DELAY = 500
+const HIDE_DELAY = 100
+
+let hoverElement: HTMLElement | null = null
+let hoverRoot: Root | null = null
+let hoverOwner: string | null = null
+let hoverIsMouseOver = false
+let hoverHideTimeout: ReturnType<typeof setTimeout> | null = null
+let hoverInteractiveTimeout: ReturnType<typeof setTimeout> | null = null
+let lastRenderedHoverElement: ReactNode = null
+
+let pinnedElement: HTMLElement | null = null
+let pinnedRoot: Root | null = null
+let pinnedOwner: string | null = null
+let pinnedOnUnpin: (() => void) | null = null
+
+let activeRenderId: string | null = null
+
+const wrappedHoverRoot: Root = {
+    render: (children: ReactNode): void => {
+        if (activeRenderId === null || hoverOwner !== activeRenderId) {
+            return
+        }
+        lastRenderedHoverElement = children
+        hoverRoot?.render(children)
+    },
+    unmount: (): void => {
+        hoverRoot?.unmount()
+    },
 }
 
-const tooltipInstances = new Map<string, TooltipInstance>()
+function clearHoverHideTimeout(): void {
+    if (hoverHideTimeout) {
+        clearTimeout(hoverHideTimeout)
+        hoverHideTimeout = null
+    }
+}
+
+function clearHoverInteractiveTimeout(): void {
+    if (hoverInteractiveTimeout) {
+        clearTimeout(hoverInteractiveTimeout)
+        hoverInteractiveTimeout = null
+    }
+}
+
+function disableHoverInteractivity(): void {
+    if (hoverElement) {
+        hoverElement.style.pointerEvents = 'none'
+    }
+    clearHoverInteractiveTimeout()
+}
+
+function scheduleHoverInteractivity(): void {
+    clearHoverInteractiveTimeout()
+    hoverInteractiveTimeout = setTimeout(() => {
+        if (hoverElement) {
+            hoverElement.style.pointerEvents = 'auto'
+        }
+        hoverInteractiveTimeout = null
+    }, INTERACTIVE_DELAY)
+}
+
+function hideHoverNow(): void {
+    if (hoverElement) {
+        hoverElement.style.opacity = '0'
+    }
+    disableHoverInteractivity()
+}
+
+function onHoverMouseEnter(): void {
+    hoverIsMouseOver = true
+    clearHoverHideTimeout()
+}
+
+function onHoverMouseLeave(): void {
+    hoverIsMouseOver = false
+    disableHoverInteractivity()
+    clearHoverHideTimeout()
+    hoverHideTimeout = setTimeout(() => {
+        if (!hoverIsMouseOver) {
+            hideHoverNow()
+        }
+    }, HIDE_DELAY)
+}
+
+function ensureHoverDom(): void {
+    if (hoverElement) {
+        return
+    }
+    const el = document.createElement('div')
+    el.id = 'InsightTooltipWrapper-hover'
+    el.classList.add('InsightTooltipWrapper', 'ph-no-capture')
+    el.setAttribute('data-attr', 'insight-tooltip-wrapper')
+    el.style.pointerEvents = 'none'
+    el.style.opacity = '0'
+    el.style.position = 'absolute'
+    document.body.appendChild(el)
+    el.addEventListener('mouseenter', onHoverMouseEnter, { passive: true })
+    el.addEventListener('mouseleave', onHoverMouseLeave, { passive: true })
+    hoverElement = el
+    hoverRoot = createRoot(el)
+}
+
+function ensurePinnedDom(): void {
+    if (pinnedElement) {
+        return
+    }
+    const el = document.createElement('div')
+    el.id = 'InsightTooltipWrapper-pinned'
+    el.classList.add('InsightTooltipWrapper', 'InsightTooltipWrapper--pinned', 'ph-no-capture')
+    el.setAttribute('data-attr', 'insight-tooltip-wrapper-pinned')
+    el.style.pointerEvents = 'auto'
+    el.style.opacity = '0'
+    el.style.position = 'absolute'
+    document.body.appendChild(el)
+    pinnedElement = el
+    pinnedRoot = createRoot(el)
+}
 
 let globalScrollEndListenerActive = false
 
-function initGlobalScrollEndListener(onScrollEnd: (tooltipId: string) => void): void {
+function initGlobalScrollEndListener(onScrollEnd: (id: string) => void): void {
     if (globalScrollEndListenerActive) {
         return
     }
@@ -27,13 +132,13 @@ function initGlobalScrollEndListener(onScrollEnd: (tooltipId: string) => void): 
     document.addEventListener(
         'scrollend',
         (e) => {
-            for (const [id, instance] of tooltipInstances.entries()) {
-                if (e.target instanceof Node && instance.element.contains(e.target as Node)) {
-                    continue
-                }
-
-                onScrollEnd(id)
+            if (!pinnedOwner || !pinnedElement) {
+                return
             }
+            if (e.target instanceof Node && pinnedElement.contains(e.target as Node)) {
+                return
+            }
+            onScrollEnd(pinnedOwner)
         },
         { capture: true, passive: true }
     )
@@ -49,16 +154,13 @@ function initGlobalUnpinListeners(): void {
     document.addEventListener(
         'click',
         (e) => {
-            for (const [id, instance] of tooltipInstances.entries()) {
-                if (!instance.isPinned) {
-                    continue
-                }
-                if (e.target instanceof Node && instance.element.contains(e.target as Node)) {
-                    continue
-                }
-
-                unpinTooltip(id)
+            if (!pinnedOwner || !pinnedElement) {
+                return
             }
+            if (e.target instanceof Node && pinnedElement.contains(e.target as Node)) {
+                return
+            }
+            unpinTooltip(pinnedOwner)
         },
         { passive: true }
     )
@@ -66,191 +168,117 @@ function initGlobalUnpinListeners(): void {
     document.addEventListener(
         'keydown',
         (e) => {
-            if (e.key === 'Escape') {
-                for (const [id, instance] of tooltipInstances.entries()) {
-                    if (instance.isPinned) {
-                        unpinTooltip(id)
-                    }
-                }
+            if (e.key === 'Escape' && pinnedOwner) {
+                unpinTooltip(pinnedOwner)
             }
         },
         { passive: true }
     )
 }
 
-/** Time the tooltip must be stationary before it becomes interactive (ms) */
-const INTERACTIVE_DELAY = 500
-
-function disableInteractivity(instance: TooltipInstance): void {
-    instance.element.style.pointerEvents = 'none'
-    if (instance.interactiveTimeout) {
-        clearTimeout(instance.interactiveTimeout)
-        instance.interactiveTimeout = null
-    }
-}
-
-function scheduleInteractivity(instance: TooltipInstance): void {
-    if (instance.interactiveTimeout) {
-        clearTimeout(instance.interactiveTimeout)
-    }
-    instance.interactiveTimeout = setTimeout(() => {
-        instance.element.style.pointerEvents = 'auto'
-        instance.interactiveTimeout = null
-    }, INTERACTIVE_DELAY)
-}
-
 export function ensureTooltip(id: string): [Root, HTMLElement] {
-    let instance = tooltipInstances.get(id)
-
-    if (!instance) {
-        const tooltipEl = document.createElement('div')
-        tooltipEl.id = `InsightTooltipWrapper-${id}`
-        tooltipEl.classList.add('InsightTooltipWrapper', 'ph-no-capture')
-        tooltipEl.setAttribute('data-attr', 'insight-tooltip-wrapper')
-        tooltipEl.style.pointerEvents = 'none'
-        document.body.appendChild(tooltipEl)
-
-        const root = createRoot(tooltipEl)
-
-        const mouseEnterHandler = (): void => {
-            const inst = tooltipInstances.get(id)
-            if (inst) {
-                inst.isMouseOver = true
-                if (inst.hideTimeout) {
-                    clearTimeout(inst.hideTimeout)
-                    inst.hideTimeout = null
-                }
-            }
-        }
-
-        const mouseLeaveHandler = (): void => {
-            const inst = tooltipInstances.get(id)
-            if (inst) {
-                inst.isMouseOver = false
-                if (inst.isPinned) {
-                    return
-                }
-                disableInteractivity(inst)
-                inst.hideTimeout = setTimeout(() => {
-                    if (!inst.isMouseOver && !inst.isPinned) {
-                        inst.element.style.opacity = '0'
-                    }
-                }, 100)
-            }
-        }
-
-        instance = {
-            root,
-            element: tooltipEl,
-            isMouseOver: false,
-            isPinned: false,
-            onUnpin: null,
-            hideTimeout: null,
-            interactiveTimeout: null,
-            mouseEnterHandler,
-            mouseLeaveHandler,
-        }
-
-        tooltipInstances.set(id, instance)
-
-        tooltipEl.addEventListener('mouseenter', mouseEnterHandler, { passive: true })
-        tooltipEl.addEventListener('mouseleave', mouseLeaveHandler, { passive: true })
+    ensureHoverDom()
+    if (pinnedOwner === id) {
+        hideHoverNow()
+        activeRenderId = null
+        return [wrappedHoverRoot, hoverElement!]
     }
-
-    return [instance.root, instance.element]
+    hoverOwner = id
+    activeRenderId = id
+    return [wrappedHoverRoot, hoverElement!]
 }
 
 export function showTooltip(id: string): void {
-    const instance = tooltipInstances.get(id)
-    if (!instance) {
+    if (activeRenderId !== id || !hoverElement) {
         return
     }
-
-    // Cancel any pending hide so a returning mouse doesn't get hidden
-    if (instance.hideTimeout) {
-        clearTimeout(instance.hideTimeout)
-        instance.hideTimeout = null
-    }
-
-    instance.element.style.opacity = '1'
+    clearHoverHideTimeout()
+    hoverElement.style.opacity = '1'
 }
 
 export function hideTooltip(id?: string): void {
-    if (!id) {
-        // Fallback to old behavior - hide all tooltips
-        tooltipInstances.forEach((instance) => {
-            instance.element.style.opacity = '0'
-            disableInteractivity(instance)
-        })
+    if (id && activeRenderId !== id) {
         return
     }
-
-    const instance = tooltipInstances.get(id)
-    if (!instance) {
+    if (!hoverElement) {
         return
     }
-
-    if (instance.hideTimeout) {
-        clearTimeout(instance.hideTimeout)
-        instance.hideTimeout = null
-    }
-
-    if (instance.isMouseOver) {
+    clearHoverHideTimeout()
+    if (hoverIsMouseOver) {
         return
     }
-
-    instance.hideTimeout = setTimeout(() => {
-        if (!instance.isMouseOver) {
-            instance.element.style.opacity = '0'
-            disableInteractivity(instance)
+    hoverHideTimeout = setTimeout(() => {
+        if (!hoverIsMouseOver) {
+            hideHoverNow()
         }
-    }, 100)
-}
-
-export function unpinTooltip(id: string): void {
-    const instance = tooltipInstances.get(id)
-    if (!instance) {
-        return
-    }
-
-    instance.isPinned = false
-    instance.element.classList.remove('InsightTooltipWrapper--pinned')
-    disableInteractivity(instance)
-
-    const onUnpinCallback = instance.onUnpin
-    instance.onUnpin = null
-
-    instance.element.style.opacity = '0'
-
-    onUnpinCallback?.()
+    }, HIDE_DELAY)
 }
 
 export function pinTooltip(id: string, onUnpin?: () => void): void {
-    const instance = tooltipInstances.get(id)
-    if (!instance) {
+    if (!hoverElement) {
         return
     }
+    ensurePinnedDom()
+    if (pinnedOwner && pinnedOwner !== id) {
+        const previousOnUnpin = pinnedOnUnpin
+        pinnedOnUnpin = null
+        previousOnUnpin?.()
+    }
+    pinnedRoot?.render(lastRenderedHoverElement)
+    if (pinnedElement) {
+        pinnedElement.style.left = hoverElement.style.left
+        pinnedElement.style.top = hoverElement.style.top
+        pinnedElement.style.opacity = '1'
+        pinnedElement.style.pointerEvents = 'auto'
+    }
+    pinnedOwner = id
+    pinnedOnUnpin = onUnpin ?? null
 
-    instance.isPinned = true
-    instance.onUnpin = onUnpin ?? null
-    instance.element.style.pointerEvents = 'auto'
-    instance.element.classList.add('InsightTooltipWrapper--pinned')
+    hideHoverNow()
+    if (hoverOwner === id) {
+        hoverOwner = null
+    }
+    activeRenderId = null
+}
+
+export function unpinTooltip(id: string): void {
+    if (pinnedOwner !== id) {
+        return
+    }
+    const callback = pinnedOnUnpin
+    pinnedOnUnpin = null
+    pinnedOwner = null
+    pinnedRoot?.render(null)
+    if (pinnedElement) {
+        pinnedElement.style.opacity = '0'
+        pinnedElement.style.pointerEvents = 'none'
+    }
+    callback?.()
 }
 
 export function cleanupTooltip(id: string): void {
-    const instance = tooltipInstances.get(id)
-    if (instance) {
-        if (instance.hideTimeout) {
-            clearTimeout(instance.hideTimeout)
+    if (hoverOwner !== id && pinnedOwner !== id) {
+        return
+    }
+    if (hoverOwner === id) {
+        hoverOwner = null
+        if (activeRenderId === id) {
+            activeRenderId = null
         }
-        disableInteractivity(instance)
-        instance.element.removeEventListener('mouseenter', instance.mouseEnterHandler)
-        instance.element.removeEventListener('mouseleave', instance.mouseLeaveHandler)
-        tooltipInstances.delete(id)
-        queueMicrotask(() => {
-            instance.root.unmount()
-            instance.element.remove()
-        })
+        lastRenderedHoverElement = null
+        hoverRoot?.render(null)
+        hideHoverNow()
+    }
+    if (pinnedOwner === id) {
+        const callback = pinnedOnUnpin
+        pinnedOnUnpin = null
+        pinnedOwner = null
+        pinnedRoot?.render(null)
+        if (pinnedElement) {
+            pinnedElement.style.opacity = '0'
+            pinnedElement.style.pointerEvents = 'none'
+        }
+        callback?.()
     }
 }
 
@@ -290,27 +318,23 @@ export function positionTooltip(
     caretY: number,
     centerVertically = false
 ): void {
+    if (tooltipEl !== hoverElement) {
+        return
+    }
+    if (activeRenderId === null) {
+        return
+    }
+    const id = activeRenderId
     tooltipEl.style.position = 'absolute'
     tooltipEl.style.maxWidth = ''
-
-    // Each reposition means the mouse is still moving — reset interactivity timer
-    const id = tooltipEl.id.replace('InsightTooltipWrapper-', '')
-    const instance = tooltipInstances.get(id)
-    if (instance) {
-        // Don't reposition or reset interactivity while pinned
-        if (instance.isPinned) {
-            return
-        }
-        disableInteractivity(instance)
-        scheduleInteractivity(instance)
-    }
-
+    disableHoverInteractivity()
+    scheduleHoverInteractivity()
     applyPosition(tooltipEl, canvasBounds, caretX, caretY, centerVertically)
-
-    // On first render offsetWidth may be 0 since content hasn't painted yet.
-    // Re-run positioning after paint so boundary clamping uses real dimensions.
     if (tooltipEl.offsetWidth === 0) {
         requestAnimationFrame(() => {
+            if (activeRenderId !== id) {
+                return
+            }
             applyPosition(tooltipEl, canvasBounds, caretX, caretY, centerVertically)
         })
     }
@@ -337,7 +361,7 @@ export function useInsightTooltip(options?: { isPinnable?: boolean }): {
             initGlobalScrollEndListener((id) => unpinTooltip(id))
             initGlobalUnpinListeners()
         } else {
-            initGlobalScrollEndListener((id) => hideTooltip(id))
+            initGlobalScrollEndListener((id) => unpinTooltip(id))
         }
 
         return () => {

--- a/frontend/src/scenes/insights/useInsightTooltip.ts
+++ b/frontend/src/scenes/insights/useInsightTooltip.ts
@@ -6,120 +6,160 @@ import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 const INTERACTIVE_DELAY = 500
 const HIDE_DELAY = 100
 
-let hoverElement: HTMLElement | null = null
-let hoverRoot: Root | null = null
-let hoverOwner: string | null = null
-let hoverIsMouseOver = false
-let hoverHideTimeout: ReturnType<typeof setTimeout> | null = null
-let hoverInteractiveTimeout: ReturnType<typeof setTimeout> | null = null
-let lastRenderedHoverElement: ReactNode = null
+interface SharedTooltipBase {
+    element: HTMLElement | null
+    root: Root | null
+    owner: string | null
+}
 
-let pinnedElement: HTMLElement | null = null
-let pinnedRoot: Root | null = null
-let pinnedOwner: string | null = null
-let pinnedOnUnpin: (() => void) | null = null
+interface HoverTooltipState extends SharedTooltipBase {
+    isMouseOver: boolean
+    hideTimeout: ReturnType<typeof setTimeout> | null
+    interactiveTimeout: ReturnType<typeof setTimeout> | null
+    lastRendered: ReactNode
+}
+
+interface PinnedTooltipState extends SharedTooltipBase {
+    onUnpin: (() => void) | null
+}
+
+const hover: HoverTooltipState = {
+    element: null,
+    root: null,
+    owner: null,
+    isMouseOver: false,
+    hideTimeout: null,
+    interactiveTimeout: null,
+    lastRendered: null,
+}
+
+const pinned: PinnedTooltipState = {
+    element: null,
+    root: null,
+    owner: null,
+    onUnpin: null,
+}
 
 let activeRenderId: string | null = null
 
 const wrappedHoverRoot: Root = {
     render: (children: ReactNode): void => {
-        if (activeRenderId === null || hoverOwner !== activeRenderId) {
+        if (activeRenderId === null || hover.owner !== activeRenderId) {
             return
         }
-        lastRenderedHoverElement = children
-        hoverRoot?.render(children)
+        hover.lastRendered = children
+        hover.root?.render(children)
     },
     unmount: (): void => {
-        hoverRoot?.unmount()
+        hover.root?.unmount()
     },
 }
 
 function clearHoverHideTimeout(): void {
-    if (hoverHideTimeout) {
-        clearTimeout(hoverHideTimeout)
-        hoverHideTimeout = null
+    if (hover.hideTimeout) {
+        clearTimeout(hover.hideTimeout)
+        hover.hideTimeout = null
     }
 }
 
 function clearHoverInteractiveTimeout(): void {
-    if (hoverInteractiveTimeout) {
-        clearTimeout(hoverInteractiveTimeout)
-        hoverInteractiveTimeout = null
+    if (hover.interactiveTimeout) {
+        clearTimeout(hover.interactiveTimeout)
+        hover.interactiveTimeout = null
     }
 }
 
 function disableHoverInteractivity(): void {
-    if (hoverElement) {
-        hoverElement.style.pointerEvents = 'none'
+    if (hover.element) {
+        hover.element.style.pointerEvents = 'none'
     }
     clearHoverInteractiveTimeout()
 }
 
 function scheduleHoverInteractivity(): void {
     clearHoverInteractiveTimeout()
-    hoverInteractiveTimeout = setTimeout(() => {
-        if (hoverElement) {
-            hoverElement.style.pointerEvents = 'auto'
+    hover.interactiveTimeout = setTimeout(() => {
+        if (hover.element) {
+            hover.element.style.pointerEvents = 'auto'
         }
-        hoverInteractiveTimeout = null
+        hover.interactiveTimeout = null
     }, INTERACTIVE_DELAY)
 }
 
 function hideHoverNow(): void {
-    if (hoverElement) {
-        hoverElement.style.opacity = '0'
+    if (hover.element) {
+        hover.element.style.opacity = '0'
     }
     disableHoverInteractivity()
 }
 
 function onHoverMouseEnter(): void {
-    hoverIsMouseOver = true
+    hover.isMouseOver = true
     clearHoverHideTimeout()
 }
 
 function onHoverMouseLeave(): void {
-    hoverIsMouseOver = false
+    hover.isMouseOver = false
     disableHoverInteractivity()
     clearHoverHideTimeout()
-    hoverHideTimeout = setTimeout(() => {
-        if (!hoverIsMouseOver) {
+    hover.hideTimeout = setTimeout(() => {
+        if (!hover.isMouseOver) {
             hideHoverNow()
         }
     }, HIDE_DELAY)
 }
 
+interface SharedTooltipDomOptions {
+    id: string
+    extraClasses?: string[]
+    dataAttr: string
+    pointerEvents: 'none' | 'auto'
+    attachHoverHandlers: boolean
+}
+
+function createSharedTooltipElement(opts: SharedTooltipDomOptions): { element: HTMLElement; root: Root } {
+    const element = document.createElement('div')
+    element.id = opts.id
+    element.classList.add('InsightTooltipWrapper', 'ph-no-capture', ...(opts.extraClasses ?? []))
+    element.setAttribute('data-attr', opts.dataAttr)
+    element.style.pointerEvents = opts.pointerEvents
+    element.style.opacity = '0'
+    element.style.position = 'absolute'
+    document.body.appendChild(element)
+    if (opts.attachHoverHandlers) {
+        element.addEventListener('mouseenter', onHoverMouseEnter, { passive: true })
+        element.addEventListener('mouseleave', onHoverMouseLeave, { passive: true })
+    }
+    return { element, root: createRoot(element) }
+}
+
 function ensureHoverDom(): void {
-    if (hoverElement) {
+    if (hover.element) {
         return
     }
-    const el = document.createElement('div')
-    el.id = 'InsightTooltipWrapper-hover'
-    el.classList.add('InsightTooltipWrapper', 'ph-no-capture')
-    el.setAttribute('data-attr', 'insight-tooltip-wrapper')
-    el.style.pointerEvents = 'none'
-    el.style.opacity = '0'
-    el.style.position = 'absolute'
-    document.body.appendChild(el)
-    el.addEventListener('mouseenter', onHoverMouseEnter, { passive: true })
-    el.addEventListener('mouseleave', onHoverMouseLeave, { passive: true })
-    hoverElement = el
-    hoverRoot = createRoot(el)
+    const { element, root } = createSharedTooltipElement({
+        id: 'InsightTooltipWrapper-hover',
+        dataAttr: 'insight-tooltip-wrapper',
+        pointerEvents: 'none',
+        attachHoverHandlers: true,
+    })
+    hover.element = element
+    hover.root = root
 }
 
 function ensurePinnedDom(): void {
-    if (pinnedElement) {
+    if (pinned.element) {
         return
     }
-    const el = document.createElement('div')
-    el.id = 'InsightTooltipWrapper-pinned'
-    el.classList.add('InsightTooltipWrapper', 'InsightTooltipWrapper--pinned', 'ph-no-capture')
-    el.setAttribute('data-attr', 'insight-tooltip-wrapper-pinned')
-    el.style.pointerEvents = 'auto'
-    el.style.opacity = '0'
-    el.style.position = 'absolute'
-    document.body.appendChild(el)
-    pinnedElement = el
-    pinnedRoot = createRoot(el)
+    const { element, root } = createSharedTooltipElement({
+        id: 'InsightTooltipWrapper-pinned',
+        extraClasses: ['InsightTooltipWrapper--pinned'],
+        dataAttr: 'insight-tooltip-wrapper-pinned',
+        pointerEvents: 'auto',
+        attachHoverHandlers: false,
+    })
+    pinned.element = element
+    pinned.root = root
 }
 
 let globalScrollEndListenerActive = false
@@ -132,16 +172,16 @@ function initGlobalScrollEndListener(): void {
     document.addEventListener(
         'scrollend',
         (e) => {
-            if (pinnedOwner && pinnedElement) {
-                const scrolledInsidePinned = e.target instanceof Node && pinnedElement.contains(e.target as Node)
+            if (pinned.owner && pinned.element) {
+                const scrolledInsidePinned = e.target instanceof Node && pinned.element.contains(e.target as Node)
                 if (!scrolledInsidePinned) {
-                    unpinTooltip(pinnedOwner)
+                    unpinTooltip(pinned.owner)
                 }
             }
-            if (hoverOwner && hoverElement) {
-                const scrolledInsideHover = e.target instanceof Node && hoverElement.contains(e.target as Node)
+            if (hover.owner && hover.element) {
+                const scrolledInsideHover = e.target instanceof Node && hover.element.contains(e.target as Node)
                 if (!scrolledInsideHover) {
-                    hideTooltip(hoverOwner)
+                    hideTooltip(hover.owner)
                 }
             }
         },
@@ -159,13 +199,13 @@ function initGlobalUnpinListeners(): void {
     document.addEventListener(
         'click',
         (e) => {
-            if (!pinnedOwner || !pinnedElement) {
+            if (!pinned.owner || !pinned.element) {
                 return
             }
-            if (e.target instanceof Node && pinnedElement.contains(e.target as Node)) {
+            if (e.target instanceof Node && pinned.element.contains(e.target as Node)) {
                 return
             }
-            unpinTooltip(pinnedOwner)
+            unpinTooltip(pinned.owner)
         },
         { passive: true }
     )
@@ -173,8 +213,8 @@ function initGlobalUnpinListeners(): void {
     document.addEventListener(
         'keydown',
         (e) => {
-            if (e.key === 'Escape' && pinnedOwner) {
-                unpinTooltip(pinnedOwner)
+            if (e.key === 'Escape' && pinned.owner) {
+                unpinTooltip(pinned.owner)
             }
         },
         { passive: true }
@@ -183,107 +223,99 @@ function initGlobalUnpinListeners(): void {
 
 export function ensureTooltip(id: string): [Root, HTMLElement] {
     ensureHoverDom()
-    if (pinnedOwner === id) {
+    if (pinned.owner === id) {
         hideHoverNow()
         activeRenderId = null
-        return [wrappedHoverRoot, hoverElement!]
+        return [wrappedHoverRoot, hover.element!]
     }
-    hoverOwner = id
+    hover.owner = id
     activeRenderId = id
-    return [wrappedHoverRoot, hoverElement!]
+    return [wrappedHoverRoot, hover.element!]
 }
 
 export function showTooltip(id: string): void {
-    if (activeRenderId !== id || !hoverElement) {
+    if (activeRenderId !== id || !hover.element) {
         return
     }
     clearHoverHideTimeout()
-    hoverElement.style.opacity = '1'
+    hover.element.style.opacity = '1'
 }
 
 export function hideTooltip(id?: string): void {
     if (id && activeRenderId !== id) {
         return
     }
-    if (!hoverElement) {
+    if (!hover.element) {
         return
     }
     clearHoverHideTimeout()
-    if (hoverIsMouseOver) {
+    if (hover.isMouseOver) {
         return
     }
-    hoverHideTimeout = setTimeout(() => {
-        if (!hoverIsMouseOver) {
+    hover.hideTimeout = setTimeout(() => {
+        if (!hover.isMouseOver) {
             hideHoverNow()
         }
     }, HIDE_DELAY)
 }
 
 export function pinTooltip(id: string, onUnpin?: () => void): void {
-    if (!hoverElement) {
+    if (!hover.element) {
         return
     }
     ensurePinnedDom()
-    if (pinnedOwner && pinnedOwner !== id) {
-        const previousOnUnpin = pinnedOnUnpin
-        pinnedOnUnpin = null
+    if (pinned.owner && pinned.owner !== id) {
+        const previousOnUnpin = pinned.onUnpin
+        pinned.onUnpin = null
         previousOnUnpin?.()
     }
-    pinnedRoot?.render(lastRenderedHoverElement)
-    if (pinnedElement) {
-        pinnedElement.style.left = hoverElement.style.left
-        pinnedElement.style.top = hoverElement.style.top
-        pinnedElement.style.opacity = '1'
-        pinnedElement.style.pointerEvents = 'auto'
+    pinned.root?.render(hover.lastRendered)
+    if (pinned.element) {
+        pinned.element.style.left = hover.element.style.left
+        pinned.element.style.top = hover.element.style.top
+        pinned.element.style.opacity = '1'
+        pinned.element.style.pointerEvents = 'auto'
     }
-    pinnedOwner = id
-    pinnedOnUnpin = onUnpin ?? null
+    pinned.owner = id
+    pinned.onUnpin = onUnpin ?? null
 
     hideHoverNow()
-    if (hoverOwner === id) {
-        hoverOwner = null
+    if (hover.owner === id) {
+        hover.owner = null
     }
     activeRenderId = null
 }
 
 export function unpinTooltip(id: string): void {
-    if (pinnedOwner !== id) {
+    if (pinned.owner !== id) {
         return
     }
-    const callback = pinnedOnUnpin
-    pinnedOnUnpin = null
-    pinnedOwner = null
-    pinnedRoot?.render(null)
-    if (pinnedElement) {
-        pinnedElement.style.opacity = '0'
-        pinnedElement.style.pointerEvents = 'none'
+    const callback = pinned.onUnpin
+    pinned.onUnpin = null
+    pinned.owner = null
+    pinned.root?.render(null)
+    if (pinned.element) {
+        pinned.element.style.opacity = '0'
+        pinned.element.style.pointerEvents = 'none'
     }
     callback?.()
 }
 
 export function cleanupTooltip(id: string): void {
-    if (hoverOwner !== id && pinnedOwner !== id) {
+    if (hover.owner !== id && pinned.owner !== id) {
         return
     }
-    if (hoverOwner === id) {
-        hoverOwner = null
+    if (hover.owner === id) {
+        hover.owner = null
         if (activeRenderId === id) {
             activeRenderId = null
         }
-        lastRenderedHoverElement = null
-        hoverRoot?.render(null)
+        hover.lastRendered = null
+        hover.root?.render(null)
         hideHoverNow()
     }
-    if (pinnedOwner === id) {
-        const callback = pinnedOnUnpin
-        pinnedOnUnpin = null
-        pinnedOwner = null
-        pinnedRoot?.render(null)
-        if (pinnedElement) {
-            pinnedElement.style.opacity = '0'
-            pinnedElement.style.pointerEvents = 'none'
-        }
-        callback?.()
+    if (pinned.owner === id) {
+        unpinTooltip(id)
     }
 }
 
@@ -317,27 +349,27 @@ function applyPosition(
 }
 
 export function positionTooltipAt(id: string, left: number, top: number): void {
-    if (activeRenderId !== id || !hoverElement) {
+    if (activeRenderId !== id || !hover.element) {
         return
     }
-    hoverElement.style.position = 'absolute'
-    hoverElement.style.left = `${left}px`
-    hoverElement.style.top = `${top}px`
+    hover.element.style.position = 'absolute'
+    hover.element.style.left = `${left}px`
+    hover.element.style.top = `${top}px`
 }
 
 export function resetTooltipPosition(id: string): void {
-    if (activeRenderId !== id || !hoverElement) {
+    if (activeRenderId !== id || !hover.element) {
         return
     }
-    hoverElement.style.left = ''
-    hoverElement.style.top = ''
+    hover.element.style.left = ''
+    hover.element.style.top = ''
 }
 
 export function measureTooltip(id: string): DOMRect | null {
-    if (activeRenderId !== id || !hoverElement) {
+    if (activeRenderId !== id || !hover.element) {
         return null
     }
-    return hoverElement.getBoundingClientRect()
+    return hover.element.getBoundingClientRect()
 }
 
 export function positionTooltip(
@@ -347,7 +379,7 @@ export function positionTooltip(
     caretY: number,
     centerVertically = false
 ): void {
-    if (tooltipEl !== hoverElement) {
+    if (tooltipEl !== hover.element) {
         return
     }
     if (activeRenderId === null) {

--- a/frontend/src/scenes/insights/useInsightTooltip.ts
+++ b/frontend/src/scenes/insights/useInsightTooltip.ts
@@ -45,6 +45,11 @@ let activeRenderId: string | null = null
 const wrappedHoverRoot: Root = {
     render: (children: ReactNode): void => {
         if (activeRenderId === null || hover.owner !== activeRenderId) {
+            console.error('[useInsightTooltip] dropped render — caller no longer owns the hover tooltip', {
+                activeRenderId,
+                hoverOwner: hover.owner,
+                pinnedOwner: pinned.owner,
+            })
             return
         }
         hover.lastRendered = children

--- a/frontend/src/scenes/insights/useInsightTooltip.ts
+++ b/frontend/src/scenes/insights/useInsightTooltip.ts
@@ -124,7 +124,7 @@ function ensurePinnedDom(): void {
 
 let globalScrollEndListenerActive = false
 
-function initGlobalScrollEndListener(onScrollEnd: (id: string) => void): void {
+function initGlobalScrollEndListener(): void {
     if (globalScrollEndListenerActive) {
         return
     }
@@ -132,13 +132,18 @@ function initGlobalScrollEndListener(onScrollEnd: (id: string) => void): void {
     document.addEventListener(
         'scrollend',
         (e) => {
-            if (!pinnedOwner || !pinnedElement) {
-                return
+            if (pinnedOwner && pinnedElement) {
+                const scrolledInsidePinned = e.target instanceof Node && pinnedElement.contains(e.target as Node)
+                if (!scrolledInsidePinned) {
+                    unpinTooltip(pinnedOwner)
+                }
             }
-            if (e.target instanceof Node && pinnedElement.contains(e.target as Node)) {
-                return
+            if (hoverOwner && hoverElement) {
+                const scrolledInsideHover = e.target instanceof Node && hoverElement.contains(e.target as Node)
+                if (!scrolledInsideHover) {
+                    hideTooltip(hoverOwner)
+                }
             }
-            onScrollEnd(pinnedOwner)
         },
         { capture: true, passive: true }
     )
@@ -311,6 +316,30 @@ function applyPosition(
     tooltipEl.style.top = `${clampedTop}px`
 }
 
+export function positionTooltipAt(id: string, left: number, top: number): void {
+    if (activeRenderId !== id || !hoverElement) {
+        return
+    }
+    hoverElement.style.position = 'absolute'
+    hoverElement.style.left = `${left}px`
+    hoverElement.style.top = `${top}px`
+}
+
+export function resetTooltipPosition(id: string): void {
+    if (activeRenderId !== id || !hoverElement) {
+        return
+    }
+    hoverElement.style.left = ''
+    hoverElement.style.top = ''
+}
+
+export function measureTooltip(id: string): DOMRect | null {
+    if (activeRenderId !== id || !hoverElement) {
+        return null
+    }
+    return hoverElement.getBoundingClientRect()
+}
+
 export function positionTooltip(
     tooltipEl: HTMLElement,
     canvasBounds: DOMRect,
@@ -347,6 +376,9 @@ export function useInsightTooltip(options?: { isPinnable?: boolean }): {
     hideTooltip: () => void
     cleanupTooltip: () => void
     positionTooltip: typeof positionTooltip
+    positionTooltipAt: (left: number, top: number) => void
+    resetTooltipPosition: () => void
+    measureTooltip: () => DOMRect | null
     pinTooltip: ((onUnpin?: () => void) => void) | null
 } {
     const isPinnable = options?.isPinnable ?? false
@@ -357,11 +389,9 @@ export function useInsightTooltip(options?: { isPinnable?: boolean }): {
     const tooltipId = tooltipIdRef.current
 
     useOnMountEffect(() => {
+        initGlobalScrollEndListener()
         if (isPinnable) {
-            initGlobalScrollEndListener((id) => unpinTooltip(id))
             initGlobalUnpinListeners()
-        } else {
-            initGlobalScrollEndListener((id) => unpinTooltip(id))
         }
 
         return () => {
@@ -374,6 +404,12 @@ export function useInsightTooltip(options?: { isPinnable?: boolean }): {
     const hide = useCallback((): void => hideTooltip(tooltipId), [tooltipId])
     const cleanup = useCallback((): void => cleanupTooltip(tooltipId), [tooltipId])
     const pin = useCallback((onUnpin?: () => void): void => pinTooltip(tooltipId, onUnpin), [tooltipId])
+    const positionAt = useCallback(
+        (left: number, top: number): void => positionTooltipAt(tooltipId, left, top),
+        [tooltipId]
+    )
+    const resetPosition = useCallback((): void => resetTooltipPosition(tooltipId), [tooltipId])
+    const measure = useCallback((): DOMRect | null => measureTooltip(tooltipId), [tooltipId])
 
     return {
         tooltipId,
@@ -382,6 +418,9 @@ export function useInsightTooltip(options?: { isPinnable?: boolean }): {
         hideTooltip: hide,
         cleanupTooltip: cleanup,
         positionTooltip,
+        positionTooltipAt: positionAt,
+        resetTooltipPosition: resetPosition,
+        measureTooltip: measure,
         pinTooltip: isPinnable ? pin : null,
     }
 }

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -72,12 +72,14 @@ function useBoldNumberTooltip({
 
     const elementRef = useRef<HTMLDivElement>(null)
 
-    const { getTooltip } = useInsightTooltip()
-    const [tooltipRoot, tooltipEl] = getTooltip()
+    const { getTooltip, showTooltip, hideTooltip, positionTooltipAt, measureTooltip } = useInsightTooltip()
 
     useLayoutEffect(() => {
-        tooltipEl.style.opacity = isTooltipShown ? '1' : '0'
-
+        if (!isTooltipShown) {
+            hideTooltip()
+            return
+        }
+        const [tooltipRoot] = getTooltip()
         const seriesResult = insightData?.result?.[seriesIndex]
 
         tooltipRoot.render(
@@ -101,6 +103,7 @@ function useBoldNumberTooltip({
                 groupTypeLabel={groupTypeLabel || aggregationLabel(series?.[0]?.math_group_type_index).plural}
             />
         )
+        showTooltip()
     }, [isTooltipShown]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
@@ -108,12 +111,11 @@ function useBoldNumberTooltip({
             return
         }
         const elementRect = elementRef.current?.getBoundingClientRect()
-        const tooltipRect = tooltipEl.getBoundingClientRect()
-        if (elementRect) {
-            tooltipEl.style.top = `${
-                window.scrollY + elementRect.top - tooltipRect.height - BOLD_NUMBER_TOOLTIP_OFFSET_PX
-            }px`
-            tooltipEl.style.left = `${elementRect.left + elementRect.width / 2 - tooltipRect.width / 2}px`
+        const tooltipRect = measureTooltip()
+        if (elementRect && tooltipRect) {
+            const top = window.scrollY + elementRect.top - tooltipRect.height - BOLD_NUMBER_TOOLTIP_OFFSET_PX
+            const left = elementRect.left + elementRect.width / 2 - tooltipRect.width / 2
+            positionTooltipAt(left, top)
         }
     }, [isTooltipShown]) // oxlint-disable-line react-hooks/exhaustive-deps
 

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -796,13 +796,13 @@ export function LineGraph_({
                                     position: annotation.position ?? 'end',
                                 },
                                 enter: () => {
-                                    const tooltipEl = document.getElementById(`InsightTooltipWrapper-${tooltipId}`)
+                                    const tooltipEl = document.getElementById('InsightTooltipWrapper-hover')
                                     if (tooltipEl) {
                                         tooltipEl.classList.add('opacity-0', 'invisible')
                                     }
                                 },
                                 leave: () => {
-                                    const tooltipEl = document.getElementById(`InsightTooltipWrapper-${tooltipId}`)
+                                    const tooltipEl = document.getElementById('InsightTooltipWrapper-hover')
                                     if (tooltipEl) {
                                         tooltipEl.classList.remove('opacity-0', 'invisible')
                                     }

--- a/frontend/src/scenes/insights/views/RegionMap/RegionMap.tsx
+++ b/frontend/src/scenes/insights/views/RegionMap/RegionMap.tsx
@@ -49,20 +49,20 @@ function useRegionMapTooltip(showPersonsModal: boolean): React.RefObject<HTMLDiv
     const { baseCurrency } = useValues(teamLogic)
 
     const containerRef = useRef<HTMLDivElement>(null)
-    const { getTooltip } = useInsightTooltip()
-    const [tooltipRoot, tooltipEl] = getTooltip()
+    const { getTooltip, showTooltip, hideTooltip, positionTooltipAt, resetTooltipPosition, measureTooltip } =
+        useInsightTooltip()
     const groupTypeLabel = aggregationLabel(series?.[0].math_group_type_index).plural
 
     useEffect(() => {
-        tooltipEl.style.opacity = isTooltipShown ? '1' : '0'
-
         if (!isTooltipShown || !currentTooltip || !tooltipCoordinates) {
+            hideTooltip()
             return
         }
 
         const [subdivisionCode, subdivisionName, countryCode, regionSeries] = currentTooltip
         const aggregatedValue = getSeriesValue(regionSeries)
 
+        const [tooltipRoot] = getTooltip()
         tooltipRoot.render(
             <InsightTooltip
                 seriesData={[
@@ -93,6 +93,7 @@ function useRegionMapTooltip(showPersonsModal: boolean): React.RefObject<HTMLDiv
                 groupTypeLabel={groupTypeLabel}
             />
         )
+        showTooltip()
     }, [
         isTooltipShown,
         tooltipCoordinates,
@@ -100,30 +101,31 @@ function useRegionMapTooltip(showPersonsModal: boolean): React.RefObject<HTMLDiv
         breakdownFilter,
         trendsFilter,
         showPersonsModal,
-        tooltipRoot,
-        tooltipEl,
         groupTypeLabel,
         baseCurrency,
-    ])
+    ]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
         if (!isTooltipShown || !tooltipCoordinates || !currentTooltip) {
-            tooltipEl.style.left = 'revert'
-            tooltipEl.style.top = 'revert'
+            resetTooltipPosition()
             return
         }
 
         const containerRect = containerRef.current?.getBoundingClientRect()
-        const tooltipRect = tooltipEl.getBoundingClientRect()
+        const tooltipRect = measureTooltip()
+        if (!tooltipRect) {
+            return
+        }
         const [tooltipX, tooltipY] = tooltipCoordinates
         const shouldFlip =
             containerRect &&
             tooltipX + tooltipRect.width + REGION_MAP_TOOLTIP_OFFSET_PX > containerRect.x + containerRect.width
         const xOffset = shouldFlip ? -(tooltipRect.width + REGION_MAP_TOOLTIP_OFFSET_PX) : REGION_MAP_TOOLTIP_OFFSET_PX
 
-        tooltipEl.style.left = `${window.pageXOffset + tooltipX + xOffset}px`
-        tooltipEl.style.top = `${window.pageYOffset + tooltipY + REGION_MAP_TOOLTIP_OFFSET_PX}px`
-    }, [isTooltipShown, tooltipCoordinates, currentTooltip, tooltipEl])
+        const left = window.pageXOffset + tooltipX + xOffset
+        const top = window.pageYOffset + tooltipY + REGION_MAP_TOOLTIP_OFFSET_PX
+        positionTooltipAt(left, top)
+    }, [isTooltipShown, tooltipCoordinates, currentTooltip]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     return containerRef
 }

--- a/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
+++ b/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
@@ -38,73 +38,78 @@ function useWorldMapTooltip(showPersonsModal: boolean): React.RefObject<SVGSVGEl
     const svgRef = useRef<SVGSVGElement>(null)
 
     const svgRect = svgRef.current?.getBoundingClientRect()
-    const { getTooltip } = useInsightTooltip()
-    const [tooltipRoot, tooltipEl] = getTooltip()
+    const { getTooltip, showTooltip, hideTooltip, positionTooltipAt, resetTooltipPosition, measureTooltip } =
+        useInsightTooltip()
 
     useEffect(() => {
-        tooltipEl.style.opacity = isTooltipShown ? '1' : '0'
-
-        if (tooltipCoordinates) {
-            tooltipRoot.render(
-                <>
-                    {currentTooltip && (
-                        <InsightTooltip
-                            seriesData={[
-                                {
-                                    dataIndex: 1,
-                                    datasetIndex: 1,
-                                    id: 1,
-                                    order: 1,
-                                    breakdown_value: currentTooltip[0],
-                                    count: currentTooltip[1]?.aggregated_value || 0,
-                                },
-                            ]}
-                            breakdownFilter={breakdownFilter}
-                            renderSeries={(_: React.ReactNode, datum: SeriesDatum) =>
-                                typeof datum.breakdown_value === 'string' && (
-                                    <div className="flex items-center font-semibold">
-                                        <span className="text-xl mr-2">{countryCodeToFlag(datum.breakdown_value)}</span>
-                                        <span className="whitespace-nowrap">
-                                            {COUNTRY_CODE_TO_LONG_NAME[datum.breakdown_value]}
-                                        </span>
-                                    </div>
-                                )
-                            }
-                            renderCount={(value: number) => (
-                                <>{formatAggregationAxisValue(trendsFilter, value, baseCurrency)}</>
-                            )}
-                            showHeader={false}
-                            hideColorCol
-                            hideInspectActorsSection={!showPersonsModal || !currentTooltip[1]}
-                            groupTypeLabel={aggregationLabel(series?.[0]?.math_group_type_index).plural}
-                        />
-                    )}
-                </>
-            )
-        } else {
-            tooltipEl.style.left = 'revert'
-            tooltipEl.style.top = 'revert'
+        if (!isTooltipShown) {
+            hideTooltip()
+            return
         }
+        if (!tooltipCoordinates) {
+            resetTooltipPosition()
+            hideTooltip()
+            return
+        }
+        const [tooltipRoot] = getTooltip()
+        tooltipRoot.render(
+            <>
+                {currentTooltip && (
+                    <InsightTooltip
+                        seriesData={[
+                            {
+                                dataIndex: 1,
+                                datasetIndex: 1,
+                                id: 1,
+                                order: 1,
+                                breakdown_value: currentTooltip[0],
+                                count: currentTooltip[1]?.aggregated_value || 0,
+                            },
+                        ]}
+                        breakdownFilter={breakdownFilter}
+                        renderSeries={(_: React.ReactNode, datum: SeriesDatum) =>
+                            typeof datum.breakdown_value === 'string' && (
+                                <div className="flex items-center font-semibold">
+                                    <span className="text-xl mr-2">{countryCodeToFlag(datum.breakdown_value)}</span>
+                                    <span className="whitespace-nowrap">
+                                        {COUNTRY_CODE_TO_LONG_NAME[datum.breakdown_value]}
+                                    </span>
+                                </div>
+                            )
+                        }
+                        renderCount={(value: number) => (
+                            <>{formatAggregationAxisValue(trendsFilter, value, baseCurrency)}</>
+                        )}
+                        showHeader={false}
+                        hideColorCol
+                        hideInspectActorsSection={!showPersonsModal || !currentTooltip[1]}
+                        groupTypeLabel={aggregationLabel(series?.[0]?.math_group_type_index).plural}
+                    />
+                )}
+            </>
+        )
+        showTooltip()
     }, [isTooltipShown, tooltipCoordinates, currentTooltip]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
-        if (tooltipCoordinates) {
-            const tooltipRect = tooltipEl.getBoundingClientRect()
-            // Put the tooltip to the bottom right of the cursor, but flip to left if tooltip doesn't fit
-            let xOffset: number
-            if (
-                svgRect &&
-                tooltipRect &&
-                tooltipCoordinates[0] + tooltipRect.width + WORLD_MAP_TOOLTIP_OFFSET_PX > svgRect.x + svgRect.width
-            ) {
-                xOffset = -(tooltipRect.width + WORLD_MAP_TOOLTIP_OFFSET_PX)
-            } else {
-                xOffset = WORLD_MAP_TOOLTIP_OFFSET_PX
-            }
-            tooltipEl.style.left = `${window.pageXOffset + tooltipCoordinates[0] + xOffset}px`
-            tooltipEl.style.top = `${window.pageYOffset + tooltipCoordinates[1] + WORLD_MAP_TOOLTIP_OFFSET_PX}px`
+        if (!tooltipCoordinates) {
+            return
         }
-    }, [currentTooltip, tooltipEl]) // oxlint-disable-line react-hooks/exhaustive-deps
+        const tooltipRect = measureTooltip()
+        if (!tooltipRect) {
+            return
+        }
+        // Put the tooltip to the bottom right of the cursor, but flip to left if tooltip doesn't fit
+        const overflowsRight =
+            svgRect &&
+            tooltipCoordinates[0] + tooltipRect.width + WORLD_MAP_TOOLTIP_OFFSET_PX > svgRect.x + svgRect.width
+        const xOffset = overflowsRight
+            ? -(tooltipRect.width + WORLD_MAP_TOOLTIP_OFFSET_PX)
+            : WORLD_MAP_TOOLTIP_OFFSET_PX
+        const left = window.pageXOffset + tooltipCoordinates[0] + xOffset
+        const top = window.pageYOffset + tooltipCoordinates[1] + WORLD_MAP_TOOLTIP_OFFSET_PX
+        positionTooltipAt(left, top)
+    }, [currentTooltip, tooltipCoordinates]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     return svgRef
 }


### PR DESCRIPTION

<img width="800" height="556" alt="CleanShot 2026-04-23 at 14 12 36" src="https://github.com/user-attachments/assets/9a10c3be-5eb7-457c-b4f1-70761b07c27a" />


## Problem

Detached-element telemetry showed `InsightTooltipWrapper-*` divs leaking about two per dashboard SPA navigation cycle. After a per-insight repro we confirmed the per-chart `useInsightTooltip()` + `createRoot(document.createElement('div'))` pattern retains its container DOM node even after `root.unmount()` + `element.remove()`. Each chart tile allocated its own pair; on unmount the pair was orphaned.

The earlier useRef id fix (#55907) closed one race but did not release the DOM containers; this refactor supersedes it.

## Changes

Collapse to two module-scoped lifelong DOM nodes:

- one **hover** element for the follow-the-cursor tooltip
- one **pinned** element for the sticky tooltip

Both are lazy-initialised on first request, attached to `document.body`, and never destroyed. That matches the product's observable behaviour (screen has at most one hover tooltip plus at most one pinned tooltip at a time) — so a per-chart pair was always redundant.

The hook's public API (`tooltipId`, `getTooltip`, `showTooltip`, `hideTooltip`, `cleanupTooltip`, `positionTooltip`, `pinTooltip`) is unchanged. All seven call sites (`LineGraph.tsx` x2, `PieChart.tsx`, `BoxPlotChart.tsx`, `BoldNumber.tsx`, `RegionMap.tsx`, `WorldMap.tsx`, `lib/hog-charts/overlays/Tooltip.tsx`) compile with zero edits.

Key invariants:

- `ensureTooltip(id)` sets `hoverOwner = id` and returns a wrapped root + the hover element. If `pinnedOwner === id` (hovering your own pinned chart), hover is suppressed for that id and the wrapped root render becomes a no-op.
- `pinTooltip(id, onUnpin)` re-renders the last hover tree into the pinned root and copies position. Pinning B while A is pinned calls A's `onUnpin` and replaces ownership. This matches the product behaviour observed today.
- `cleanupTooltip(id)` clears any module slots the unmounting caller currently owns and calls `root.render(null)` to release captured closures (onClose, onRowClick). DOM is never destroyed.
- Document-level listeners (`scrollend`, `click`, `keydown`) branch on the single `pinnedOwner` slot instead of iterating a Map.

## How did you test this code?

I'm an agent and I haven't done full manual click-through QA. Automated measurement via a 10-cycle SPA navigation workload on a dashboard with two chart tiles, post-GC:

| metric                       | before | after |
| ---------------------------- | ------ | ----- |
| detached elements            | 26     | 6     |
| InsightTooltipWrapper leaked | 20     | 0     |
| live wrapper DOM nodes       | 2/tile | 1     |

The remaining 6 detached are `Tooltip / Tooltip__popup / Tooltip__arrow` from the base-ui primitive — separate concern from this PR. Hover path also verified end-to-end via synthetic mousemove on the canvas: the shared `InsightTooltipWrapper-hover` becomes opacity 1, gets positioned, and renders content.

Please click-test before merging: hover a data point; click-pin on a pin-capable chart (e.g. lifecycle graph); move to another chart and pin there to confirm the first pin closes; click outside / Escape to unpin; navigate away mid-pinned.

## Publish to changelog?

no

## Docs update

no

## 🤖 LLM context

Authored by PostHog Code. Identified via `detached_elements` telemetry (`InsightTooltipWrapper-*` signature), reproduced locally via an on-demand MemLens scanner + CDP forced-GC harness (kept out of this PR). Superseded the narrower useRef id fix in #55907.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*