### PR TITLE
feat(data-warehouse): add release status (alpha/beta/ga) to sources

### DIFF
--- a/.agents/skills/implementing-warehouse-sources/SKILL.md
+++ b/.agents/skills/implementing-warehouse-sources/SKILL.md
@@ -76,7 +76,7 @@ Follow this order. Each step maps to TODOs in `source.template`.
 10. **Add icon.** Place at `frontend/public/services/{source}.svg` (prefer SVG). If the logo isn't already committed, fetch from [Logo.dev](https://docs.logo.dev/introduction) — **ask the user for the Logo.dev API key**; do not hardcode one. Keep file size reasonable.
 11. **Run migrations.** `DEBUG=1 python manage.py makemigrations && DEBUG=1 ./bin/migrate` (only needed if a new enum value triggers a Django migration).
 12. **Rebuild schema types**: `pnpm run schema:build`. This updates `posthog/schema.py` from `schema-general.ts` and makes the source appear in frontend dropdowns. Re-run whenever `schema-general.ts` changes.
-13. **Release flag.** For unfinished work, set `unreleasedSource=True`. For beta, set `betaSource=True`. For controlled rollout, set `featureFlag="dwh-{source_name}"` (kebab-case). When fully releasing, remove `unreleasedSource` and optionally the feature flag.
+13. **Release status.** For unfinished work, set `unreleasedSource=True`. Set `releaseStatus="alpha"` for new sources that haven't been extensively tested, `releaseStatus="beta"` once most rough edges are ironed out, and leave `releaseStatus` unset for general availability. For controlled rollout, set `featureFlag="dwh-{source_name}"` (kebab-case). When fully releasing, remove `unreleasedSource`, set `releaseStatus` to the appropriate stage (or omit for GA), and optionally drop the feature flag.
 14. **Delete the template TODO comments** before PR.
 
 ## Source architecture contract
@@ -347,9 +347,11 @@ Tooling & assets:
 - [ ] Run `pnpm run schema:build`
 - [ ] Django migrations run if enum value requires it
 
-Release flag:
+Release status:
 - [ ] unreleasedSource=True while WIP
-- [ ] betaSource=True when releasing as beta
+- [ ] releaseStatus="alpha" for new sources not yet extensively tested
+- [ ] releaseStatus="beta" when most rough edges have been ironed out
+- [ ] Omit releaseStatus (or set to "ga") on full release
 - [ ] featureFlag="dwh-{source_name}" for controlled rollout
 - [ ] Flag removed / unreleasedSource removed on full release
 

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -35013,9 +35013,6 @@
         "SourceConfig": {
             "additionalProperties": false,
             "properties": {
-                "betaSource": {
-                    "type": "boolean"
-                },
                 "caption": {
                     "anyOf": [
                         {
@@ -35060,6 +35057,10 @@
                     "$ref": "#/definitions/ExternalDataSourceType"
                 },
                 "permissionsCaption": {
+                    "type": "string"
+                },
+                "releaseStatus": {
+                    "enum": ["alpha", "beta", "ga"],
                     "type": "string"
                 },
                 "suggestedTables": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -5434,7 +5434,7 @@ export interface SourceConfig {
     disabledReason?: string | null
     existingSource?: boolean
     unreleasedSource?: boolean
-    betaSource?: boolean
+    releaseStatus?: 'alpha' | 'beta' | 'ga'
     iconPath: string
     featureFlag?: string
     iconClassName?: string

--- a/frontend/src/scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic.tsx
@@ -47,7 +47,7 @@ function getSourceDisplayStatus(unreleased: boolean, featureFlag: boolean | unde
             descriptionEl: unreleasedDescriptionEl,
         }
     }
-    // undefined feature flag should see whatever the release status is
+    // if the feature flag is undefined, fall back to the source's unreleased state
     return {
         status: unreleased ? 'coming_soon' : 'stable',
         descriptionEl: unreleased ? unreleasedDescriptionEl : releasedDescriptionEl,
@@ -82,6 +82,12 @@ export const nonHogFunctionTemplatesLogic = kea<nonHogFunctionTemplatesLogicType
                     }
                     const unreleasedValue = !!connector.unreleasedSource
                     const { status, descriptionEl } = getSourceDisplayStatus(unreleasedValue, featureFlagValue)
+                    // Only surface alpha/beta while the source is actually connectable — a source
+                    // that renders as "coming_soon" (Roadmap tag) shouldn't also advertise "Beta".
+                    const releaseStatus =
+                        status === 'stable' && connector.releaseStatus && connector.releaseStatus !== 'ga'
+                            ? connector.releaseStatus
+                            : undefined
 
                     return {
                         id: `managed-${connector.name}`,
@@ -98,7 +104,7 @@ export const nonHogFunctionTemplatesLogic = kea<nonHogFunctionTemplatesLogicType
                         masking: null,
                         free: true,
                         featured: connector.featured ?? false,
-                        releaseStatus: connector.releaseStatus,
+                        releaseStatus,
                     }
                 })
                 const selfManaged = manualConnectors.map(

--- a/frontend/src/scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic.tsx
+++ b/frontend/src/scenes/data-pipelines/utils/nonHogFunctionTemplatesLogic.tsx
@@ -25,11 +25,7 @@ type SourceDisplayStatus = {
     descriptionEl: string | JSX.Element
 }
 
-function getSourceDisplayStatus(
-    connector: SourceConfig,
-    unreleased: boolean,
-    featureFlag: boolean | undefined
-): SourceDisplayStatus {
+function getSourceDisplayStatus(unreleased: boolean, featureFlag: boolean | undefined): SourceDisplayStatus {
     const unreleasedDescriptionEl = 'Get notified when this source is available to connect'
     const releasedDescriptionEl = (
         <>
@@ -40,7 +36,7 @@ function getSourceDisplayStatus(
     // regardless of release status, those passing the feature flag should see a released source
     if (featureFlag === true) {
         return {
-            status: connector.betaSource ? 'beta' : 'stable',
+            status: 'stable',
             descriptionEl: releasedDescriptionEl,
         }
     }
@@ -53,7 +49,7 @@ function getSourceDisplayStatus(
     }
     // undefined feature flag should see whatever the release status is
     return {
-        status: unreleased ? 'coming_soon' : connector.betaSource ? 'beta' : 'stable',
+        status: unreleased ? 'coming_soon' : 'stable',
         descriptionEl: unreleased ? unreleasedDescriptionEl : releasedDescriptionEl,
     }
 }
@@ -85,11 +81,7 @@ export const nonHogFunctionTemplatesLogic = kea<nonHogFunctionTemplatesLogicType
                         featureFlagValue = !!featureFlagRaw
                     }
                     const unreleasedValue = !!connector.unreleasedSource
-                    const { status, descriptionEl } = getSourceDisplayStatus(
-                        connector,
-                        unreleasedValue,
-                        featureFlagValue
-                    )
+                    const { status, descriptionEl } = getSourceDisplayStatus(unreleasedValue, featureFlagValue)
 
                     return {
                         id: `managed-${connector.name}`,
@@ -106,6 +98,7 @@ export const nonHogFunctionTemplatesLogic = kea<nonHogFunctionTemplatesLogicType
                         masking: null,
                         free: true,
                         featured: connector.featured ?? false,
+                        releaseStatus: connector.releaseStatus,
                     }
                 })
                 const selfManaged = manualConnectors.map(

--- a/frontend/src/scenes/hog-functions/list/HogFunctionTemplateList.tsx
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionTemplateList.tsx
@@ -9,6 +9,7 @@ import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
+import { SourceReleaseTag } from 'products/data_warehouse/frontend/shared/components/SourceReleaseTag'
 import { isManagedSourceTemplate } from 'products/data_warehouse/frontend/utils'
 
 import { HogFunctionIcon } from '../configuration/HogFunctionIcon'
@@ -87,6 +88,9 @@ export function HogFunctionTemplateList({
                                         <>
                                             {template.name}
                                             {template.status && <HogFunctionStatusTag status={template.status} />}
+                                            {template.releaseStatus && (
+                                                <SourceReleaseTag releaseStatus={template.releaseStatus} />
+                                            )}
                                         </>
                                     }
                                     description={template.description}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6569,6 +6569,8 @@ export type HogFunctionTemplateType = Pick<
     flag?: string
     /** Whether this is a featured/recommended source */
     featured?: boolean
+    /** Release status, only populated for `type: 'source'` templates */
+    releaseStatus?: 'alpha' | 'beta' | 'ga'
 }
 
 export type HogFunctionTemplateWithSubTemplateType = HogFunctionTemplateType & {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4438,6 +4438,12 @@ class SnapchatAdsTableKeywords(StrEnum):
     CAMPAIGNS = "campaigns"
 
 
+class ReleaseStatus(StrEnum):
+    ALPHA = "alpha"
+    BETA = "beta"
+    GA = "ga"
+
+
 class SourceFieldFileUploadJsonFormatConfig(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -23233,7 +23239,6 @@ class SourceConfig(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    betaSource: bool | None = None
     caption: str | Any | None = None
     disabledReason: str | None = None
     docsUrl: str | None = None
@@ -23256,6 +23261,7 @@ class SourceConfig(BaseModel):
     label: str | None = None
     name: ExternalDataSourceType
     permissionsCaption: str | None = None
+    releaseStatus: ReleaseStatus | None = None
     suggestedTables: list[SuggestedTable] | None = Field(
         default=[],
         description="Tables to suggest enabling, with optional tooltip explaining why",

--- a/posthog/temporal/data_imports/sources/bing_ads/source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/source.py
@@ -40,7 +40,7 @@ class BingAdsSource(ResumableSource[BingAdsSourceConfig, BingAdsResumeConfig], O
             name=SchemaExternalDataSourceType.BING_ADS,
             label="Bing Ads",
             caption="Ensure you have granted PostHog access to your Bing Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/bing-ads).",
-            betaSource=True,
+            releaseStatus="beta",
             iconPath="/static/services/bing-ads.svg",
             docsUrl="https://posthog.com/docs/cdp/sources/bing-ads",
             fields=cast(

--- a/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
@@ -33,7 +33,7 @@ class TestBingAdsSource:
 
         assert config.name.value == "BingAds"
         assert config.label == "Bing Ads"
-        assert config.betaSource is True
+        assert config.releaseStatus == "beta"
         assert config.iconPath == "/static/services/bing-ads.svg"
         assert len(config.fields) == 2
 

--- a/posthog/temporal/data_imports/sources/buildbetter/source.py
+++ b/posthog/temporal/data_imports/sources/buildbetter/source.py
@@ -85,7 +85,7 @@ class BuildBetterSource(ResumableSource[BuildBetterSourceConfig, BuildBetterResu
         return SourceConfig(
             name=SchemaExternalDataSourceType.BUILD_BETTER,
             label="BuildBetter",
-            betaSource=True,
+            releaseStatus="beta",
             caption="Connect your BuildBetter workspace to sync interviews, extractions, persons, and companies.",
             iconPath="/static/services/buildbetter.png",
             fields=cast(

--- a/posthog/temporal/data_imports/sources/clerk/source.py
+++ b/posthog/temporal/data_imports/sources/clerk/source.py
@@ -32,7 +32,7 @@ class ClerkSource(SimpleSource[ClerkSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.CLERK,
             label="Clerk",
-            betaSource=True,
+            releaseStatus="beta",
             caption="""Enter your Clerk secret key to automatically pull your Clerk data into the PostHog Data warehouse.
 
 You can find your secret key in your [Clerk Dashboard](https://dashboard.clerk.com/) under **API Keys**.

--- a/posthog/temporal/data_imports/sources/clickhouse/source.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/source.py
@@ -60,7 +60,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.CLICK_HOUSE,
-            betaSource=True,
+            releaseStatus="beta",
             caption="Enter your ClickHouse connection details to pull data into the PostHog Data warehouse. ClickHouse databases can be very large — we stream the data in Arrow batches to keep memory bounded.",
             iconPath="/static/services/clickhouse.png",
             docsUrl="https://posthog.com/docs/cdp/sources/clickhouse",

--- a/posthog/temporal/data_imports/sources/convex/source.py
+++ b/posthog/temporal/data_imports/sources/convex/source.py
@@ -33,7 +33,7 @@ class ConvexSource(SimpleSource[ConvexSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.CONVEX,
             label="Convex",
-            betaSource=True,
+            releaseStatus="beta",
             caption="""Enter your Convex deployment URL and deploy key to sync your Convex tables into PostHog.
 
 You can find your deployment URL and deploy key in your [Convex Dashboard](https://dashboard.convex.dev/) under **Settings** > **URL & Deploy Key**.

--- a/posthog/temporal/data_imports/sources/github/source.py
+++ b/posthog/temporal/data_imports/sources/github/source.py
@@ -39,7 +39,7 @@ class GithubSource(ResumableSource[GithubSourceConfig, GithubResumeConfig], OAut
         return SourceConfig(
             name=SchemaExternalDataSourceType.GITHUB,
             label="GitHub",
-            betaSource=True,
+            releaseStatus="beta",
             caption="Connect your GitHub repository to sync issues, pull requests, commits, and more.",
             iconPath="/static/services/github.png",
             iconClassName="dark:bg-white rounded",

--- a/posthog/temporal/data_imports/sources/google_ads/source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/source.py
@@ -111,7 +111,7 @@ class GoogleAdsSource(SimpleSource[GoogleAdsSourceConfig | GoogleAdsServiceAccou
             name=SchemaExternalDataSourceType.GOOGLE_ADS,
             label="Google Ads",
             caption="Ensure you have granted PostHog access to your Google Ads account, learn how to do this in [the docs](https://posthog.com/docs/cdp/sources/google-ads).",
-            betaSource=True,
+            releaseStatus="beta",
             iconPath="/static/services/google-ads.png",
             docsUrl="https://posthog.com/docs/cdp/sources/google-ads",
             fields=cast(

--- a/posthog/temporal/data_imports/sources/google_sheets/source.py
+++ b/posthog/temporal/data_imports/sources/google_sheets/source.py
@@ -101,7 +101,7 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
             name=SchemaExternalDataSourceType.GOOGLE_SHEETS,
             label="Google Sheets",
             caption="Ensure you have granted PostHog access to your Google Sheet as instructed in the [documentation](https://posthog.com/docs/cdp/sources/google-sheets)",
-            betaSource=True,
+            releaseStatus="beta",
             iconPath="/static/services/Google_Sheets.svg",
             docsUrl="https://posthog.com/docs/cdp/sources/google-sheets",
             fields=cast(

--- a/posthog/temporal/data_imports/sources/klaviyo/source.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/source.py
@@ -34,7 +34,7 @@ class KlaviyoSource(ResumableSource[KlaviyoSourceConfig, KlaviyoResumeConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.KLAVIYO,
             label="Klaviyo",
-            betaSource=True,
+            releaseStatus="beta",
             caption="""Enter your Klaviyo API key to automatically pull your Klaviyo data into the PostHog Data warehouse.
 
 You can create a private API key in your [Klaviyo account settings](https://www.klaviyo.com/settings/account/api-keys).

--- a/posthog/temporal/data_imports/sources/linear/source.py
+++ b/posthog/temporal/data_imports/sources/linear/source.py
@@ -35,7 +35,7 @@ class LinearSource(ResumableSource[LinearSourceConfig, LinearResumeConfig], OAut
         return SourceConfig(
             name=SchemaExternalDataSourceType.LINEAR,
             label="Linear",
-            betaSource=True,
+            releaseStatus="beta",
             caption="Connect your Linear workspace to sync issues, projects, teams, and more.",
             iconPath="/static/services/linear.png",
             fields=cast(

--- a/posthog/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/posthog/temporal/data_imports/sources/linkedin_ads/source.py
@@ -50,7 +50,7 @@ class LinkedInAdsSource(ResumableSource[LinkedinAdsSourceConfig, LinkedInAdsResu
             name=SchemaExternalDataSourceType.LINKEDIN_ADS,
             label="LinkedIn Ads",
             caption="Ensure you have granted PostHog access to your LinkedIn Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/linkedin-ads).",
-            betaSource=True,
+            releaseStatus="beta",
             iconPath="/static/services/linkedin.png",
             docsUrl="https://posthog.com/docs/cdp/sources/linkedin-ads",
             fields=cast(

--- a/posthog/temporal/data_imports/sources/mailchimp/source.py
+++ b/posthog/temporal/data_imports/sources/mailchimp/source.py
@@ -32,7 +32,7 @@ class MailchimpSource(SimpleSource[MailchimpSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.MAILCHIMP,
             label="Mailchimp",
-            betaSource=True,
+            releaseStatus="beta",
             caption="""Enter your Mailchimp API key to automatically pull your Mailchimp data into the PostHog Data warehouse.
 
 You can create an API key in your [Mailchimp account settings](https://us1.admin.mailchimp.com/account/api/).

--- a/posthog/temporal/data_imports/sources/meta_ads/source.py
+++ b/posthog/temporal/data_imports/sources/meta_ads/source.py
@@ -111,7 +111,7 @@ class MetaAdsSource(ResumableSource[MetaAdsSourceConfig, MetaAdsResumeConfig]):
                     ),
                 ],
             ),
-            betaSource=True,
+            releaseStatus="beta",
             suggestedTables=[
                 SuggestedTable(
                     table="campaigns",

--- a/posthog/temporal/data_imports/sources/mongodb/source.py
+++ b/posthog/temporal/data_imports/sources/mongodb/source.py
@@ -120,7 +120,7 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             name=SchemaExternalDataSourceType.MONGO_DB,
             label="MongoDB",
             caption="Enter your MongoDB connection string to automatically pull your MongoDB data into the PostHog Data warehouse.",
-            betaSource=True,
+            releaseStatus="beta",
             iconPath="/static/services/Mongodb.svg",
             docsUrl="https://posthog.com/docs/cdp/sources/mongodb",
             fields=cast(

--- a/posthog/temporal/data_imports/sources/pinterest_ads/source.py
+++ b/posthog/temporal/data_imports/sources/pinterest_ads/source.py
@@ -50,7 +50,7 @@ class PinterestAdsSource(ResumableSource[PinterestAdsSourceConfig, PinterestAdsR
             name=SchemaExternalDataSourceType.PINTEREST_ADS,
             label="Pinterest Ads",
             caption="Collect campaign data, ad performance, and advertising metrics from Pinterest Ads. Ensure you have granted PostHog access to your Pinterest Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/pinterest-ads).",
-            betaSource=True,
+            releaseStatus="beta",
             iconPath="/static/services/pinterest_ads.png",
             docsUrl="https://posthog.com/docs/cdp/sources/pinterest-ads",
             fields=cast(

--- a/posthog/temporal/data_imports/sources/pinterest_ads/tests/test_pinterest_source.py
+++ b/posthog/temporal/data_imports/sources/pinterest_ads/tests/test_pinterest_source.py
@@ -23,7 +23,7 @@ class TestPinterestAdsSource:
 
         assert config.name.value == "PinterestAds"
         assert config.label == "Pinterest Ads"
-        assert config.betaSource is True
+        assert config.releaseStatus == "beta"
         assert config.featureFlag is None
         assert len(config.fields) == 2
 

--- a/posthog/temporal/data_imports/sources/plain/source.py
+++ b/posthog/temporal/data_imports/sources/plain/source.py
@@ -32,7 +32,7 @@ class PlainSource(SimpleSource[PlainSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.PLAIN,
             label="Plain",
-            betaSource=True,
+            releaseStatus="beta",
             featureFlag="dwh_plain",
             caption="""Enter your Plain API key to automatically pull your Plain customer support data into the PostHog Data warehouse.
 

--- a/posthog/temporal/data_imports/sources/plain/tests/test_plain_source.py
+++ b/posthog/temporal/data_imports/sources/plain/tests/test_plain_source.py
@@ -23,7 +23,7 @@ class TestPlainSource:
 
         assert config.name.value == "Plain"
         assert config.label == "Plain"
-        assert config.betaSource is True
+        assert config.releaseStatus == "beta"
         assert config.featureFlag == "dwh_plain"
         assert config.iconPath == "/static/services/plain.png"
         assert len(config.fields) == 1

--- a/posthog/temporal/data_imports/sources/reddit_ads/source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/source.py
@@ -42,7 +42,7 @@ class RedditAdsSource(ResumableSource[RedditAdsSourceConfig, RedditAdsResumeConf
             name=SchemaExternalDataSourceType.REDDIT_ADS,
             label="Reddit Ads",
             caption="Collect campaign data, ad performance, and advertising metrics from Reddit Ads. Ensure you have granted PostHog access to your Reddit Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/reddit-ads).",
-            betaSource=True,
+            releaseStatus="beta",
             iconPath="/static/services/reddit.png",
             docsUrl="https://posthog.com/docs/cdp/sources/reddit-ads",
             fields=cast(

--- a/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
+++ b/posthog/temporal/data_imports/sources/reddit_ads/tests/test_reddit_source.py
@@ -44,7 +44,7 @@ class TestRedditAdsSource:
 
         assert config.name.value == "RedditAds"
         assert config.label == "Reddit Ads"
-        assert config.betaSource is True
+        assert config.releaseStatus == "beta"
         assert len(config.fields) == 2
 
         # Check account_id field

--- a/posthog/temporal/data_imports/sources/redshift/source.py
+++ b/posthog/temporal/data_imports/sources/redshift/source.py
@@ -57,7 +57,7 @@ class RedshiftSource(SimpleSource[RedshiftSourceConfig], SSHTunnelMixin, Validat
             caption="Enter your Redshift credentials to automatically pull your Redshift data into the PostHog Data warehouse",
             iconPath="/static/services/redshift.png",
             docsUrl="https://posthog.com/docs/cdp/sources/redshift",
-            betaSource=True,
+            releaseStatus="beta",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/sentry/source.py
+++ b/posthog/temporal/data_imports/sources/sentry/source.py
@@ -83,7 +83,7 @@ Create a token in Sentry and make sure it includes the scopes below if you want 
                     ),
                 ],
             ),
-            betaSource=True,
+            releaseStatus="beta",
         )
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:

--- a/posthog/temporal/data_imports/sources/shopify/source.py
+++ b/posthog/temporal/data_imports/sources/shopify/source.py
@@ -64,7 +64,7 @@ class ShopifySource(ResumableSource[ShopifySourceConfig, ShopifyResumeConfig]):
                     ),
                 ],
             ),
-            betaSource=True,
+            releaseStatus="beta",
         )
 
     def validate_credentials(

--- a/posthog/temporal/data_imports/sources/slack/source.py
+++ b/posthog/temporal/data_imports/sources/slack/source.py
@@ -38,7 +38,7 @@ class SlackSource(ResumableSource[SlackSourceConfig, SlackResumeConfig], OAuthMi
             iconPath="/static/services/slack.png",
             featureFlag="slack-dwh",
             unreleasedSource=True,
-            betaSource=True,
+            releaseStatus="beta",
             fields=cast(
                 list[FieldType],
                 [

--- a/posthog/temporal/data_imports/sources/snapchat_ads/source.py
+++ b/posthog/temporal/data_imports/sources/snapchat_ads/source.py
@@ -38,7 +38,7 @@ class SnapchatAdsSource(SimpleSource[SnapchatAdsSourceConfig], OAuthMixin):
             name=SchemaExternalDataSourceType.SNAPCHAT_ADS,
             label="Snapchat Ads",
             caption="Collect campaign data, ad performance, and advertising metrics from Snapchat Ads. Ensure you have granted PostHog access to your Snapchat Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/snapchat-ads).",
-            betaSource=True,
+            releaseStatus="beta",
             iconPath="/static/services/snapchat.png",
             docsUrl="https://posthog.com/docs/cdp/sources/snapchat-ads",
             fields=cast(

--- a/posthog/temporal/data_imports/sources/supabase/source.py
+++ b/posthog/temporal/data_imports/sources/supabase/source.py
@@ -34,6 +34,6 @@ class SupabaseSource(PostgresSource):
             caption="Enter your Supabase credentials to automatically pull your data into the PostHog Data warehouse",
             docsUrl="https://posthog.com/tutorials/supabase-query",
             fields=fields,
-            betaSource=True,
+            releaseStatus="beta",
             featureFlag="supabase-dwh",
         )

--- a/posthog/temporal/data_imports/sources/tiktok_ads/source.py
+++ b/posthog/temporal/data_imports/sources/tiktok_ads/source.py
@@ -38,7 +38,7 @@ class TikTokAdsSource(SimpleSource[TikTokAdsSourceConfig], OAuthMixin):
             name=SchemaExternalDataSourceType.TIK_TOK_ADS,
             label="TikTok Ads",
             caption="Collect campaign data, ad performance, and advertising metrics from TikTok Ads. Ensure you have granted PostHog access to your TikTok Ads account, learn how to do this in [the documentation](https://posthog.com/docs/cdp/sources/tiktok-ads).",
-            betaSource=True,
+            releaseStatus="beta",
             iconPath="/static/services/tiktok.png",
             docsUrl="https://posthog.com/docs/cdp/sources/tiktok-ads",
             fields=cast(

--- a/posthog/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
+++ b/posthog/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
@@ -44,7 +44,7 @@ class TestTikTokAdsSource:
 
         assert config.name.value == "TikTokAds"
         assert config.label == "TikTok Ads"
-        assert config.betaSource is True
+        assert config.releaseStatus == "beta"
         assert len(config.fields) == 2
 
         advertiser_field = config.fields[0]

--- a/posthog/temporal/data_imports/sources/typeform/source.py
+++ b/posthog/temporal/data_imports/sources/typeform/source.py
@@ -81,7 +81,7 @@ You can generate a personal access token in your [Typeform account settings](htt
                     ),
                 ],
             ),
-            betaSource=True,
+            releaseStatus="beta",
         )
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:

--- a/products/data_warehouse/frontend/shared/components/SourceReleaseTag.tsx
+++ b/products/data_warehouse/frontend/shared/components/SourceReleaseTag.tsx
@@ -1,0 +1,27 @@
+import { LemonTag } from '@posthog/lemon-ui'
+
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+
+import { SourceConfig } from '~/queries/schema/schema-general'
+
+export interface SourceReleaseTagProps {
+    releaseStatus?: SourceConfig['releaseStatus']
+}
+
+export function SourceReleaseTag({ releaseStatus }: SourceReleaseTagProps): JSX.Element | null {
+    if (releaseStatus === 'alpha') {
+        return (
+            <Tooltip title="Alpha means this is a new source and hasn't been extensively tested yet">
+                <LemonTag type="danger">Alpha</LemonTag>
+            </Tooltip>
+        )
+    }
+    if (releaseStatus === 'beta') {
+        return (
+            <Tooltip title="Beta means this source has been tested and most rough edges have been ironed out — getting ready for general availability">
+                <LemonTag type="completion">Beta</LemonTag>
+            </Tooltip>
+        )
+    }
+    return null
+}


### PR DESCRIPTION
## Problem

Data warehouse sources only had a single boolean `betaSource` flag on their `SourceConfig`, which rendered a "Beta" tag in the New source picker. There was no way to mark a source as "alpha" (brand-new, barely tested) short of hiding it behind `unreleasedSource`, and users had no indication of what "Beta" meant without hovering on docs.

## Changes

- Replace `SourceConfig.betaSource: bool` with `SourceConfig.releaseStatus: 'alpha' | 'beta' | 'ga'` in `frontend/src/queries/schema/schema-general.ts`, and regenerate `posthog/schema.py` + `schema.json` via `hogli build:schema`.
- Migrate all 25 `source.py` files that set `betaSource=True` to `releaseStatus="beta"`, plus the 5 tests that asserted on the old flag.
- Add a dedicated `SourceReleaseTag` component in `products/data_warehouse/frontend/shared/components/` that renders:
  - Alpha → red "Alpha" `LemonTag` with tooltip "Alpha means this is a new source and hasn't been extensively tested yet"
  - Beta → blue "Beta" `LemonTag` with tooltip explaining the stage
  - GA / unset → no tag (unchanged default)
- Thread `releaseStatus` through `HogFunctionTemplateType` and `nonHogFunctionTemplatesLogic` so the new tag renders alongside the existing `HogFunctionStatusTag` in `HogFunctionTemplateList`. The shared `HogFunctionStatusTag` is deliberately left untouched so hog function templates still render as "Experimental"/"Beta".
- Update `.agents/skills/implementing-warehouse-sources/SKILL.md` to document `releaseStatus` instead of `betaSource`.

## How did you test this code?

I'm an AI agent, so I haven't exercised the UI manually. I did run the following:

- `hogli build:schema` regenerates cleanly and produces `ReleaseStatus` as a `StrEnum` in `posthog/schema.py`.
- `ruff check posthog/temporal/data_imports/sources/` passes.
- `pytest` on all 5 touched source test modules — 26 tests pass.
- `tsc --noEmit` is clean for every file I touched (the only remaining errors in the repo are pre-existing `@posthog/hogvm` module-resolution issues unrelated to this PR).

A reviewer should sanity-check the picker UI — a beta source (e.g. Bing Ads) should show the blue "Beta" tag with a hover tooltip, and a GA source (e.g. Stripe) should show no tag.

## Publish to changelog?

no

## 🤖 LLM context

Authored by PostHog Code (Claude Opus 4.7). The task was to extend data source configs with an explicit alpha/beta/GA stage and render matching tags with tooltips, replacing the old `betaSource` boolean. I chose to introduce a dedicated `SourceReleaseTag` instead of modifying the shared `HogFunctionStatusTag` because the latter is used by 44+ hog function templates today and changing its label would have churned that UI out of scope for this task.