### PR TITLE
fix(insights): hide legend-toggled series in TrendsLineChartD3

### DIFF
--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
@@ -46,6 +46,7 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
         showMultipleYAxes,
         goalLines,
         getTrendsColor,
+        getTrendsHidden,
         currentPeriodResult,
         breakdownFilter,
         insightData,
@@ -92,6 +93,7 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
                     color: r.compare_label === 'previous' ? hexToRGBA(getTrendsColor(r), 0.5) : getTrendsColor(r),
                     fillArea: display === ChartDisplayType.ActionsAreaGraph,
                     dashedFromIndex,
+                    hidden: getTrendsHidden(r),
                     yAxisId: showMultipleYAxes && index > 0 ? `y${index}` : DEFAULT_Y_AXIS_ID,
                     meta: {
                         action: r.action,
@@ -103,7 +105,15 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
                     },
                 }
             }),
-        [indexedResults, display, getTrendsColor, isInProgress, incompletenessOffsetFromEnd, showMultipleYAxes]
+        [
+            indexedResults,
+            display,
+            getTrendsColor,
+            getTrendsHidden,
+            isInProgress,
+            incompletenessOffsetFromEnd,
+            showMultipleYAxes,
+        ]
     )
 
     const chartConfig: LineChartConfig = useMemo(() => {


### PR DESCRIPTION
## Problem

`InsightLegend` toggles series visibility by mutating `resultCustomizations`
via `trendsDataLogic`, but the D3 adapter `TrendsLineChartD3.tsx` never read
that state. As a result, toggling a series in the legend had no effect on
the hog-chart, even though the hog-chart core already skips hidden series in
scales, rendering, and tooltips (see `lib/hog-charts/core/types.ts` —
`Series.hidden?: boolean`).

## Changes

Three-line fix in `frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx`:

- destructure `getTrendsHidden` from `trendsDataLogic`,
- set `hidden: getTrendsHidden(r)` on each mapped series,
- add `getTrendsHidden` to the `hogSeries` `useMemo` deps.

## How did you test this code?

- Ran the existing jest suite for this adapter: `jest --testPathPattern=TrendsLineChartD3 --no-coverage` — 13/13 pass.
- I'm an agent and did not manually exercise the UI in a browser; the hog-chart core already has unit coverage for `hidden` behavior in scales/rendering/tooltips.

## Publish to changelog?

no

## 🤖 LLM context

Authored by the PostHog Code agent. The change is intentionally minimal —
the hog-chart already honors `Series.hidden`; the only gap was the
trends-side adapter not forwarding that state.