### PR TITLE
Change search-to-filter mode transition from Enter to Tab

### DIFF
--- a/tools/phrocs/README.md
+++ b/tools/phrocs/README.md
@@ -50,26 +50,26 @@ You typically run phrocs via `hogli start` rather than directly.
 
 ## Keybindings
 
-| Key    | Action                                                    |
-| ------ | --------------------------------------------------------- |
-| `tab`  | Swap focus sidebar/output                                 |
-| `↓/j`  | Next process (sidebar) / scroll down (output)             |
-| `↑/k`  | Previous process (sidebar) / scroll up (output)           |
-| `pgdn` | Scroll output down                                        |
-| `pgup` | Scroll output up                                          |
-| `home` | Jump to top of output                                     |
-| `end`  | Jump to bottom of output                                  |
-| `r`    | Restart selected process                                  |
-| `s`    | Stop selected process                                     |
-| `c`    | Enter copy mode                                           |
-| `i`    | Show process info in pager                                |
-| `o`    | Sort processes by <name/CPU/RAM/status>                   |
-| `g`    | Cycle process grouping (from config `groups` field)       |
-| `a`    | Toggle show all registry processes                        |
-| `/`    | Enter search mode (then `enter` to switch to filter mode) |
-| `esc`  | Exit copy, search, and filter modes                       |
-| `?`    | Toggle full help                                          |
-| `q`    | Quit                                                      |
+| Key    | Action                                                  |
+| ------ | ------------------------------------------------------- |
+| `tab`  | Swap focus sidebar/output                               |
+| `↓/j`  | Next process (sidebar) / scroll down (output)           |
+| `↑/k`  | Previous process (sidebar) / scroll up (output)         |
+| `pgdn` | Scroll output down                                      |
+| `pgup` | Scroll output up                                        |
+| `home` | Jump to top of output                                   |
+| `end`  | Jump to bottom of output                                |
+| `r`    | Restart selected process                                |
+| `s`    | Stop selected process                                   |
+| `c`    | Enter copy mode                                         |
+| `i`    | Show process info in pager                              |
+| `o`    | Sort processes by <name/CPU/RAM/status>                 |
+| `g`    | Cycle process grouping (from config `groups` field)     |
+| `a`    | Toggle show all registry processes                      |
+| `/`    | Enter search mode (then `tab` to switch to filter mode) |
+| `esc`  | Exit copy, search, and filter modes                     |
+| `?`    | Toggle full help                                        |
+| `q`    | Quit                                                    |
 
 Mouse clicks switch focus; mouse wheel scrolls the output pane.
 
@@ -82,8 +82,8 @@ Press `esc` to exit without copying.
 ### Search and filter modes
 
 Press `/` to enter search mode, type a query, then use `↓`/`↑` to jump between matches.
-Press `enter` to switch to **filter mode**, which hides all non-matching lines and shows a count of matches in the footer.
-Press `tab` in filter mode to return to search mode (the query is preserved).
+Press `tab` to switch to **filter mode**, which hides all non-matching lines and shows a count of matches in the footer.
+Press `tab` again in filter mode to return to search mode (the query is preserved).
 Press `esc` to exit and clear the query.
 
 Queries support multiple space-separated tokens — all must match for a line to be included:

--- a/tools/phrocs/internal/tui/app_test.go
+++ b/tools/phrocs/internal/tui/app_test.go
@@ -345,7 +345,7 @@ func TestSearch_matchesHighlighted(t *testing.T) {
 	}
 }
 
-func TestSearch_enterCommitsToFilter(t *testing.T) {
+func TestSearch_tabCommitsToFilter(t *testing.T) {
 	m := readyModel(t, "backend")
 	p, _ := m.mgr.Get("backend")
 	for _, line := range []string{"foo", "bar", "foo again"} {
@@ -356,12 +356,12 @@ func TestSearch_enterCommitsToFilter(t *testing.T) {
 	m = update(m, keypress('f'))
 	m = update(m, keypress('o'))
 	m = update(m, keypress('o'))
-	m = update(m, specialKey(tea.KeyEnter))
+	m = update(m, specialKey(tea.KeyTab))
 	if m.searchMode {
-		t.Error("search mode should be off after enter (committed)")
+		t.Error("search mode should be off after tab (committed)")
 	}
 	if !m.filterMode {
-		t.Error("filter mode should be on after enter")
+		t.Error("filter mode should be on after tab")
 	}
 	if m.searchQuery != "foo" {
 		t.Errorf("query should be preserved after commit, got %q", m.searchQuery)
@@ -536,10 +536,10 @@ func TestSearch_dockerIncrementalLogLineUpdatesMatches(t *testing.T) {
 
 // ── Filter ────────────────────────────────────────────────────────────────────
 
-// enterFilterMode opens search via / and commits to filter via enter.
+// enterFilterMode opens search via / and commits to filter via tab.
 func enterFilterMode(m Model) Model {
 	m = update(m, keypress('/'))
-	m = update(m, specialKey(tea.KeyEnter))
+	m = update(m, specialKey(tea.KeyTab))
 	return m
 }
 

--- a/tools/phrocs/internal/tui/keymap.go
+++ b/tools/phrocs/internal/tui/keymap.go
@@ -109,8 +109,8 @@ func defaultKeyMap() keyMap {
 			key.WithHelp("↑:", "prev match"),
 		),
 		CommitFilter: key.NewBinding(
-			key.WithKeys("enter"),
-			key.WithHelp("↵:", "filter"),
+			key.WithKeys("tab"),
+			key.WithHelp("↹:", "filter"),
 		),
 		ToggleFilter: key.NewBinding(
 			key.WithKeys("tab"),


### PR DESCRIPTION
## Problem

The current keybinding uses `enter` to transition from search mode to filter mode, which is inconsistent with the overall keybinding scheme and creates confusion with the `tab` key that's used elsewhere in the interface.

## Changes

- Updated the `CommitFilter` keybinding from `enter` to `tab` in `keymap.go`
- Updated all documentation in `README.md` to reflect the new keybinding
- Updated help text to use the tab symbol (↹) instead of enter symbol (↵)
- Updated test names and assertions in `app_test.go` to reflect the new behavior
- Updated helper function `enterFilterMode()` to use `tab` instead of `enter`

The change makes the search-to-filter transition more intuitive by using `tab` consistently across the interface.

## How did you test this code?

The changes include updated unit tests that verify the new keybinding behavior:
- `TestSearch_tabCommitsToFilter` (renamed from `TestSearch_enterCommitsToFilter`) validates that pressing `tab` in search mode correctly transitions to filter mode
- `enterFilterMode()` helper function updated to use the new keybinding
- All existing tests pass with the updated keybinding

## Docs update

No additional docs update needed beyond the README.md changes included in this PR.

https://claude.ai/code/session_01Hw1nSkWjvVR6yajUEntHFw