### PR TITLE
feat(billing): add investigating-billing-costs skill with references grounded in real API shapes

### DIFF
--- a/products/billing/mcp/tools.yaml
+++ b/products/billing/mcp/tools.yaml
@@ -50,18 +50,16 @@ tools:
             idempotent: true
         title: Get billing overview
         description: >
-            Fetch the organization's current billing state: subscribed products and addons,
-            available features, plan tier, usage summary against limits, spending limits, and
-            trial status. Use this to understand what the customer is paying for, which features
-            they have access to, or aggregate usage for the current billing period. For
-            time-series breakdowns of usage call billing-usage-retrieve; for cost (spend)
-            breakdowns call billing-spend-retrieve. To check whether the customer has access
-            to a specific feature (e.g. group analytics, white-labelling), inspect
-            `available_product_features` in the response.
-        url_prefix: /organization/billing/overview
+            Fetch the organization's current billing state: subscribed products and addons, available features, plan
+            tier, usage summary against limits, spending limits, and trial status. Use this to understand what the
+            customer is paying for, which features they have access to, or aggregate usage for the current billing
+            period. For time-series breakdowns of usage call billing-usage-retrieve; for cost (spend) breakdowns call
+            billing-spend-retrieve. To check whether the customer has access to a specific feature (e.g. group
+            analytics, white-labelling), inspect `available_product_features` in the response.
         exclude_params:
             - limit
             - offset
+        url_prefix: /organization/billing/overview
         response:
             exclude:
                 - license

--- a/products/billing/mcp/tools.yaml
+++ b/products/billing/mcp/tools.yaml
@@ -50,16 +50,18 @@ tools:
             idempotent: true
         title: Get billing overview
         description: >
-            Fetch the organization's current billing state: subscribed products and addons, available features, plan
-            tier, usage summary against limits, spending limits, and trial status. Use this to understand what the
-            customer is paying for, which features they have access to, or aggregate usage for the current billing
-            period. For time-series breakdowns of usage call billing-usage-retrieve; for cost (spend) breakdowns call
-            billing-spend-retrieve. To check whether the customer has access to a specific feature (e.g. group
-            analytics, white-labelling), inspect `available_features` in the response.
+            Fetch the organization's current billing state: subscribed products and addons,
+            available features, plan tier, usage summary against limits, spending limits, and
+            trial status. Use this to understand what the customer is paying for, which features
+            they have access to, or aggregate usage for the current billing period. For
+            time-series breakdowns of usage call billing-usage-retrieve; for cost (spend)
+            breakdowns call billing-spend-retrieve. To check whether the customer has access
+            to a specific feature (e.g. group analytics, white-labelling), inspect
+            `available_product_features` in the response.
+        url_prefix: /organization/billing/overview
         exclude_params:
             - limit
             - offset
-        url_prefix: /organization/billing/overview
         response:
             exclude:
                 - license

--- a/products/billing/skills/investigating-billing-costs/SKILL.md
+++ b/products/billing/skills/investigating-billing-costs/SKILL.md
@@ -117,22 +117,36 @@ maps to the ID.
 ### Step 5. Drill into specific events (events usage only)
 
 If the standout product is Events (product analytics), call `posthog:execute-sql` to find
-the top contributing event names for the suspect project and time window. A useful
-pattern:
+the top contributing event names for the suspect project and time window.
+
+**Before writing the query, read `references/billing-nuances.md` §"Events excluded from
+the billable events product"** and exclude those events from the query. Otherwise the
+top-N will be dominated by events that are billed under other products (flag calls,
+survey events, AI traces, exceptions) — and the recommendations that follow will be
+wrong (e.g. "disable `$feature_flag_called` capture" does not reduce the events bill).
+
+Canonical billable-events drill-down:
 
 ```sql
 SELECT event, count() AS c
 FROM events
-WHERE team_id = {team_id} AND timestamp >= {window_start} AND timestamp < {window_end}
+WHERE team_id = {team_id}
+  AND timestamp >= {window_start} AND timestamp < {window_end}
+  AND event NOT IN (
+    '$feature_flag_called', '$exception',
+    'survey sent', 'survey shown', 'survey dismissed',
+    '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric',
+    '$ai_feedback', '$ai_evaluation',
+    '$ai_trace_summary', '$ai_generation_summary',
+    '$ai_trace_clusters', '$ai_generation_clusters'
+  )
 GROUP BY event
 ORDER BY c DESC
 LIMIT 20
 ```
 
-Events prefixed with `$` are PostHog built-in events (e.g. `$pageview`, `$autocapture`).
-High `$autocapture` or `$pageview` counts are common cost drivers. See
-`references/billing-nuances.md` for why some `$`-prefixed events are billed in other
-products.
+Among remaining events, `$autocapture` and `$pageview`/`$pageleave` are the most common
+cost drivers on a typical account.
 
 For non-events products (recordings, feature flag requests, etc.), the `execute-sql`
 drill-down is less useful. Skip to step 6.

--- a/products/billing/skills/investigating-billing-costs/SKILL.md
+++ b/products/billing/skills/investigating-billing-costs/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: investigating-billing-costs
+description: >
+  Investigates PostHog billing costs and usage patterns. Use when the user asks why
+  their bill is high, what drove their spend, whether they can reduce costs, to
+  understand what they are paying for, investigate a usage spike, review plan
+  headroom, or any similar cost or billing question. Walks through: pull billing
+  context, pull time-series usage and spend, identify interesting patterns (spikes,
+  growth trends, one-project dominance, unused capacity, approaching limits),
+  attribute to projects and event types, and surface data-grounded cost reduction
+  tactics or upsell opportunities drawn from the billing docs.
+---
+
+# Investigating billing costs
+
+A broad cost and usage investigation workflow: why is my bill high, what am I paying
+for, is my usage growing, can I reduce costs, are there addons I am wasting, are
+there products I should add. All of these start from the same data (billing snapshot
+plus time-series usage and spend) and branch based on what the data shows.
+
+## Available tools
+
+| Tool                             | Purpose                                                                        |
+| -------------------------------- | ------------------------------------------------------------------------------ |
+| `posthog:billing-list`           | Org-level billing snapshot: products, addons, plan, limits, available features |
+| `posthog:billing-usage-retrieve` | Time-series usage breakdowns by day, usage type, and team                      |
+| `posthog:billing-spend-retrieve` | Time-series spend breakdowns (dollar amounts) with the same dimensions         |
+| `posthog:execute-sql`            | Ad-hoc HogQL for drilling into specific events in a project                    |
+
+See `references/usage-data-shape.md` for the exact response shapes and history-item structure.
+
+## When to use
+
+Trigger this skill when the user asks anything like:
+
+- "why is my bill higher than last month"
+- "what's driving my PostHog costs"
+- "can you help me reduce our PostHog spend"
+- "which project uses the most events"
+- "we had a usage spike on Thursday, what happened"
+- "our invoice jumped, walk me through it"
+- "what am I paying for"
+- "do I have headroom against my limits"
+- "are there addons I'm not using"
+- "should I upgrade my plan"
+
+If the question is narrowly about billing _structure_ ("what's on my plan", "do I have
+access to group analytics", "when does my period renew") and doesn't need time-series
+data, `billing-list` alone is usually enough and this skill is overkill.
+
+## Workflow
+
+Follow these steps in order. Each builds on the previous. Do not skip steps.
+
+### Step 1. Pull billing context
+
+Call `posthog:billing-list`. This establishes:
+
+- Which products are subscribed (decide which usage types are worth investigating)
+- Plan tier, billing period, startup program
+- `available_product_features` (confirms what the customer has access to before suggesting anything)
+- Current period aggregate usage from `usage_summary` and any custom spending limits
+- Trial state and projected total
+
+**Heads up: `usage_summary` reflects the CURRENT billing period only.** If the customer's
+billing period just rolled over (check `billing_period.current_period_start` against today),
+`usage_summary` will be all zeros. That is expected on day zero of a new cycle. Always pull
+the time-series via `billing-usage-retrieve` to see the prior period's story.
+
+If `billing-list` returns `has_active_subscription: false`, the customer is on the free
+plan. Most cost investigations are moot; focus on whether they are approaching limits.
+
+### Step 2. Pull the time-series
+
+Call `posthog:billing-usage-retrieve` with reasonable defaults:
+
+- `start_date`: 30 days ago (or further back if the user references a specific period)
+- `end_date`: today
+- `interval`: `day` unless the range is long enough that `week` reads better
+- `breakdowns`: `["type","team"]` to get per-product-per-project decomposition in one call
+- `usage_types`: omit for all types, OR scope to what the customer actually uses (see step 1)
+
+If the user specifically mentions cost rather than volume, call
+`posthog:billing-spend-retrieve` instead (or additionally). Same parameter shape.
+
+### Step 3. Scan for interesting patterns
+
+The pattern in the data tells you what story to tell. Look for:
+
+- **Sharp spike**: a single day (or short window) much higher than adjacent days. The user
+  likely noticed this already and wants explanation.
+- **Sustained growth**: a steady upward trend over weeks. Customer scaling up, no incident,
+  but worth discussing forecasts and limit headroom.
+- **Step change**: a new, higher plateau starting on a specific date. Often correlates
+  with a deploy, marketing push, or new customer onboard.
+- **One-project dominance**: one team accounts for the bulk of a product's usage. Worth
+  calling out for attribution or consolidation.
+- **Unused capacity**: a subscribed addon with zero or near-zero usage. Candidate to
+  remove (revenue-down), but worth confirming first whether the customer just hasn't
+  rolled it out yet.
+- **Approaching a limit**: aggregate usage at 80%+ of a custom or plan limit. Important
+  to surface even if the customer didn't ask.
+
+If nothing jumps out, say so honestly. Offer to look at a longer range or a different
+product. Don't fabricate a spike.
+
+See `references/usage-data-shape.md` for how to read `UsageHistoryItem.dates` and `data`
+arrays and how to interpret `breakdown_value` when multiple breakdowns are requested.
+
+### Step 4. Attribute to a project
+
+For the product that stood out, find the contributing project using the `team` breakdown.
+If the `team_ids` in `breakdown_value` are unfamiliar, look them up from `team_id_options`
+in the response, the user's current session context, or ask the user which project name
+maps to the ID.
+
+### Step 5. Drill into specific events (events usage only)
+
+If the standout product is Events (product analytics), call `posthog:execute-sql` to find
+the top contributing event names for the suspect project and time window. A useful
+pattern:
+
+```sql
+SELECT event, count() AS c
+FROM events
+WHERE team_id = {team_id} AND timestamp >= {window_start} AND timestamp < {window_end}
+GROUP BY event
+ORDER BY c DESC
+LIMIT 20
+```
+
+Events prefixed with `$` are PostHog built-in events (e.g. `$pageview`, `$autocapture`).
+High `$autocapture` or `$pageview` counts are common cost drivers. See
+`references/billing-nuances.md` for why some `$`-prefixed events are billed in other
+products.
+
+For non-events products (recordings, feature flag requests, etc.), the `execute-sql`
+drill-down is less useful. Skip to step 6.
+
+### Step 6. Summarize and suggest
+
+Produce a response that states:
+
+1. What the data shows (pattern type, magnitude, time range, products involved)
+2. Where it comes from (which project, which specific events if applicable)
+3. What the customer can do about it, or confirms (if nothing to act on)
+
+For the third part, pull relevant tactics from `references/cost-reduction-strategies.md`.
+Do not recite the whole list. Only include strategies that match the data you just
+observed. "Your `$autocapture` count is 80% of your events, and you could reduce that by
+setting up an allow/ignore list" is useful. "Here's a generic list of cost tips" is not.
+
+## Honesty rule
+
+Investigations often surface opportunities BOTH to reduce spend AND to use more of
+PostHog. Play both sides honestly:
+
+- If the customer is paying for a capability they are not using, say so.
+- If the customer would benefit from a feature they don't have, suggest it.
+- Do not systematically push spend up or spend down. The credible answer is the one that
+  matches their data.
+
+When suggesting a PostHog product or addon, always include a link to the relevant docs
+page. The `billing-list` response includes `docs_url` on each product and addon.
+
+## References
+
+- `references/cost-reduction-strategies.md` — per-product cost reduction playbook with docs links
+- `references/usage-data-shape.md` — response shape for `billing-list`, `billing-usage-retrieve`, `billing-spend-retrieve`
+- `references/billing-nuances.md` — non-obvious billing facts (special events, flag billing model, quota timing)

--- a/products/billing/skills/investigating-billing-costs/references/billing-nuances.md
+++ b/products/billing/skills/investigating-billing-costs/references/billing-nuances.md
@@ -1,0 +1,71 @@
+# Billing nuances
+
+Non-obvious facts about how PostHog bills that the agent should know before explaining
+costs to a customer. Each of these trips up first-time analyzers.
+
+## Special `$`-prefixed events are billed in the right product, not product analytics
+
+Some events starting with `$` are NOT counted against product analytics event volume:
+
+- `$feature_flag_called` — tracked in feature flags product (but see next point)
+- `$exception` — counted in error tracking product
+- `$survey_shown`, `$survey_sent`, `$survey_dismissed` — counted in surveys product
+
+When a customer asks "why is my event volume so high", inspect whether a lot of the counted
+events are these special ones. If so, the product analytics bill should not be affected;
+the real cost is in the other product.
+
+## Feature flags are billed by `/flags` requests, not events
+
+Feature flag cost comes from `/flags` endpoint requests (for flag evaluation), NOT from
+`$feature_flag_called` events. The event is optional. If the customer has disabled the event
+but is still making flag requests, they are still being billed.
+
+This matters because:
+
+- "Stop sending `$feature_flag_called`" does NOT reduce flag costs
+- Reducing flag costs requires reducing evaluation requests (local evaluation, bootstrapping,
+  disabling on first load, etc.)
+
+## Identified events cost 4x anonymous events
+
+In product analytics, identified events (those with a `distinct_id` that has been associated
+with a user via `identify()`) are priced at 4x the rate of anonymous events. If a spike is
+specifically in identified events, the relevant question is "does every event actually need
+to be identified".
+
+## Quota limit reset takes 15-30 minutes
+
+After a customer increases or removes their custom spending limit, the limit does not reset
+immediately. The quota-limiting job runs every 15 minutes, so it can take up to 30 minutes
+for the new limit to take effect. If the customer just changed limits and expects immediate
+results, warn them about this.
+
+## Startup program distorts the picture
+
+If `billing_context.startup_program_label` is set, the customer is getting credits under
+PostHog's startup program. Their effective cost does not fully reflect their usage until
+the program expires. When analyzing spend:
+
+- Normal cost-reduction tactics still work, but the urgency is lower
+- Tell the customer the program's expiry date and what their bill might look like then
+
+## `autocapture` is the single biggest event-volume driver on most accounts
+
+PostHog captures `$autocapture`, `$pageview`, `$pageleave`, `$rageclick`, etc. automatically.
+On a typical account these account for 60-80% of event volume. Before suggesting any of the
+subtler cost reductions, always verify what fraction of the customer's events are
+autocapture-generated.
+
+## Projections vs current usage
+
+`billing-list` returns both `total_current_amount_usd` (period-to-date) and
+`projected_total_amount_usd` (forecast for the full period). When a customer says "my bill
+is too high", clarify whether they mean:
+
+- Their period-to-date charge so far
+- The projected total they'll pay at the end of the period
+- The bill they already received for a previous period
+
+Spike investigation is most useful for case 1 and 2. For case 3, the data is in
+`billing-list.previous_bills` or in Stripe, not in the usage/spend endpoints.

--- a/products/billing/skills/investigating-billing-costs/references/billing-nuances.md
+++ b/products/billing/skills/investigating-billing-costs/references/billing-nuances.md
@@ -3,17 +3,46 @@
 Non-obvious facts about how PostHog bills that the agent should know before explaining
 costs to a customer. Each of these trips up first-time analyzers.
 
-## Special `$`-prefixed events are billed in the right product, not product analytics
+## Events excluded from the billable events product
 
-Some events starting with `$` are NOT counted against product analytics event volume:
+Several events are **dropped at usage-report time** and never counted toward the events
+product bill. Source of truth: `get_teams_with_billable_event_count_in_period` in
+`posthog/tasks/usage_report.py`.
 
-- `$feature_flag_called` — tracked in feature flags product (but see next point)
-- `$exception` — counted in error tracking product
-- `$survey_shown`, `$survey_sent`, `$survey_dismissed` — counted in surveys product
+- `$feature_flag_called` — billed under `feature_flag_requests` (see next section)
+- `$exception` — billed under error tracking
+- `survey sent`, `survey shown`, `survey dismissed` — billed under surveys. Note the event
+  names use spaces and have no `$` prefix.
+- AI analytics events — billed under `llm_analytics` / `ai_credits`:
+  - `$ai_generation`, `$ai_embedding`, `$ai_span`, `$ai_trace`, `$ai_metric`
+  - `$ai_feedback`, `$ai_evaluation`
+  - `$ai_trace_summary`, `$ai_generation_summary`, `$ai_trace_clusters`,
+    `$ai_generation_clusters`
 
-When a customer asks "why is my event volume so high", inspect whether a lot of the counted
-events are these special ones. If so, the product analytics bill should not be affected;
-the real cost is in the other product.
+**Practical consequence**: when drilling into raw `events` in ClickHouse to explain an
+events-product bill, always filter these out, or at minimum flag them separately in your
+summary. A raw `SELECT event, count() FROM events GROUP BY event` will overstate billable
+volume by whatever slice is flag-evaluations / survey events / AI traces — and recommending
+"disable `$feature_flag_called` capture" to lower the events bill is wrong advice (the
+event isn't in the events bill to begin with).
+
+Canonical SQL shape for a billable-events drill-down:
+
+```sql
+SELECT event, count() AS c
+FROM events
+WHERE team_id = {team_id}
+  AND timestamp >= {start} AND timestamp < {end}
+  AND event NOT IN (
+    '$feature_flag_called', '$exception',
+    'survey sent', 'survey shown', 'survey dismissed',
+    '$ai_generation', '$ai_embedding', '$ai_span', '$ai_trace', '$ai_metric',
+    '$ai_feedback', '$ai_evaluation',
+    '$ai_trace_summary', '$ai_generation_summary',
+    '$ai_trace_clusters', '$ai_generation_clusters'
+  )
+GROUP BY event ORDER BY c DESC LIMIT 20
+```
 
 ## Feature flags are billed by `/flags` requests, not events
 

--- a/products/billing/skills/investigating-billing-costs/references/billing-nuances.md
+++ b/products/billing/skills/investigating-billing-costs/references/billing-nuances.md
@@ -88,7 +88,7 @@ autocapture-generated.
 
 ## Projections vs current usage
 
-`billing-list` returns both `total_current_amount_usd` (period-to-date) and
+`billing-list` returns both `current_total_amount_usd` (period-to-date) and
 `projected_total_amount_usd` (forecast for the full period). When a customer says "my bill
 is too high", clarify whether they mean:
 

--- a/products/billing/skills/investigating-billing-costs/references/cost-reduction-strategies.md
+++ b/products/billing/skills/investigating-billing-costs/references/cost-reduction-strategies.md
@@ -101,9 +101,21 @@ General sources docs: https://posthog.com/docs/cdp/sources
 
 ## General considerations
 
-1. **Special events**. Some `$`-prefixed events are NOT billed in product analytics but in
-   their respective products: `$feature_flag_called` (feature flags), `$exception`
-   (error tracking), `$survey_*` events (surveys).
+1. **Special events**. Several events are excluded from the billable events product and
+   billed in their own product instead:
+   - `$feature_flag_called` → `feature_flag_requests`
+   - `$exception` → error tracking
+   - `survey sent`, `survey shown`, `survey dismissed` → surveys (note: no `$` prefix,
+     spaces in the name)
+   - `$ai_generation`, `$ai_embedding`, `$ai_span`, `$ai_trace`, `$ai_metric`,
+     `$ai_feedback`, `$ai_evaluation`, `$ai_trace_summary`, `$ai_generation_summary`,
+     `$ai_trace_clusters`, `$ai_generation_clusters` → `llm_analytics` / `ai_credits`
+
+   Do not recommend disabling any of these as an events-product cost reduction lever —
+   they already don't count toward that product. See
+   `references/billing-nuances.md` and `posthog/tasks/usage_report.py` for the source
+   of truth.
+
 2. **Billing limits**. Custom spending limits per product prevent unexpected costs.
 3. **Quota limiting timing**. After increasing or removing spending limits, it can take
    15-30 minutes for the limit to reset. The quota-limiting job runs every 15 minutes.

--- a/products/billing/skills/investigating-billing-costs/references/cost-reduction-strategies.md
+++ b/products/billing/skills/investigating-billing-costs/references/cost-reduction-strategies.md
@@ -1,0 +1,111 @@
+# Cost reduction strategies by product
+
+Use these strategies only when they map to what the customer's data actually shows.
+Do not recite the full list; pick the 2-4 tactics that are relevant to the pattern you just
+investigated. For every recommendation, include the docs link so the user can read more.
+
+## Product analytics
+
+1. **Event optimization**. `$autocapture` often drives 60-80% of event costs. The customer
+   can reduce event volume by setting an allow or ignore list.
+   See https://posthog.com/docs/product-analytics/autocapture#reducing-events-with-an-allow-and-ignorelist
+2. **Identified vs anonymous events**. Identified events are priced 4x anonymous. Check
+   whether every identified event actually needs the user context. Landing pages, public
+   marketing or docs traffic, and pre-signup activity are common candidates for being
+   anonymous. Each event moved from identified to anonymous saves 4x.
+   See https://posthog.com/docs/data/anonymous-vs-identified-events
+3. **`identify()` call frequency**. It is only necessary to identify a user once per session.
+   Check `posthog._isIdentified()` before calling `identify()` to avoid redundant events.
+   See https://posthog.com/docs/product-analytics/identify
+4. **`group()` call frequency**. If group analytics is enabled, client-side SDKs only need to
+   call `group()` once per session.
+   See https://posthog.com/docs/product-analytics/group-analytics
+5. **`$pageview` and `$pageleave`**. PostHog automatically captures these. For pages that
+   do not need them, disable them via `capture_pageview: false` and `capture_pageleave: false`
+   in `posthog.init()`, then capture manually only where needed.
+6. **Limits and sampling**. Custom spending limits and sampling reduce costs at the cost
+   of data fidelity. Discuss the tradeoff before suggesting.
+7. **Usage patterns**. Show the user the top 20 events by count for the affected project.
+   Events starting with `$` are PostHog defaults.
+
+General cost-reduction hub: https://posthog.com/docs/product-analytics/cutting-costs
+
+## Session replay
+
+1. **Disable automatic recording**. Turn off automatic recording and programmatically start
+   and stop recordings based on user behavior or conditions.
+   See https://posthog.com/docs/session-replay/how-to-control-which-sessions-you-record#programmatically-start-and-stop-recordings
+2. **Feature flag gating**. Use feature flags to control which users or sessions get recorded.
+   See https://posthog.com/docs/session-replay/how-to-control-which-sessions-you-record#with-feature-flags
+3. **Minimum recording duration**. Set a minimum session duration to avoid capturing very
+   short sessions that are unlikely to be useful.
+   See https://posthog.com/docs/session-replay/how-to-control-which-sessions-you-record#minimum-duration
+4. **Sampling**. Use sampling rates to record only a percentage of sessions.
+   See https://posthog.com/docs/session-replay/how-to-control-which-sessions-you-record#sampling
+
+General cost-reduction hub: https://posthog.com/docs/session-replay/cutting-costs
+
+## Feature flags
+
+Feature flags are billed based on `/flags` endpoint requests, NOT on `$feature_flag_called`
+events. The event is optional and only used for metrics.
+
+1. **Client-side request optimization**. Configure `advanced_disable_feature_flags_on_first_load: true`
+   to reduce redundant flag requests, especially when calling `posthog.identify()` immediately
+   after page load.
+2. **Bootstrap feature flags**. Use bootstrapping to load flags exactly once instead of
+   automatic requests. Set `advanced_disable_feature_flags: true` and implement bootstrapping.
+   See https://posthog.com/docs/feature-flags/bootstrapping
+3. **Survey-only evaluation**. If flags are only needed for surveys, set
+   `advanced_only_evaluate_survey_feature_flags: true` to disable other flag evaluations.
+4. **Local evaluation for server-side flags** (usually the biggest win). Evaluate flags
+   locally instead of making API requests per flag. Local evaluation requests cost 10 credits
+   but can evaluate flags for hundreds/thousands of users, far more efficient than individual
+   API calls. See https://posthog.com/docs/feature-flags/local-evaluation
+5. **Polling interval**. Increase the local-evaluation polling interval from the default
+   30 seconds to reduce definition fetch frequency.
+6. **Avoid edge/Lambda local evaluation**. Do not use local evaluation in edge or Lambda
+   environments, as it initializes PostHog on every call.
+7. **Audit forgotten environments**. Old demos, test apps, or staging servers can silently
+   make flag requests. Trend `$feature_flag_called` events broken down by `$lib`,
+   `$lib_version`, `$host` to identify unexpected environments.
+
+General cost-reduction hub: https://posthog.com/docs/feature-flags/cutting-costs
+
+## Error tracking
+
+1. **Configure exception autocapture**. Disable unnecessary exception types (e.g. console
+   errors) via `capture_exceptions` settings in the JS SDK.
+2. **Suppression rules**. Set up client-side suppression rules to filter unwanted exceptions
+   based on type and message.
+3. **Burst protection**. Adjust rate limiting settings (`__exceptionRateLimiterBucketSize` and
+   `__exceptionRateLimiterRefillRate`) to prevent excessive capturing from loops.
+4. **`before_send` hook**. Filter exceptions client-side before they are captured.
+5. **Issue suppression**. Mark recurring unwanted issues as "Suppressed" to prevent future
+   exceptions of the same type from being ingested.
+
+General cost-reduction hub: https://posthog.com/docs/error-tracking/cutting-costs
+
+## Data warehouse
+
+1. **Incremental syncing**. Use incremental over full table replication. Full replication
+   is only needed for syncing deletions or tables without incrementing fields.
+   See https://posthog.com/docs/cdp/sources#incremental-vs-full-table
+2. **Replication keys**. Use `updated_at` timestamps or autoincrementing IDs as replication
+   keys for incremental syncing.
+3. **Sync frequency**. Adjust how often tables sync on the sources page to reduce unnecessary
+   data transfers. See https://posthog.com/docs/cdp/sources#syncing
+4. **Disable unused tables**. Turn off syncing for tables the customer does not use.
+
+General sources docs: https://posthog.com/docs/cdp/sources
+
+## General considerations
+
+1. **Special events**. Some `$`-prefixed events are NOT billed in product analytics but in
+   their respective products: `$feature_flag_called` (feature flags), `$exception`
+   (error tracking), `$survey_*` events (surveys).
+2. **Billing limits**. Custom spending limits per product prevent unexpected costs.
+3. **Quota limiting timing**. After increasing or removing spending limits, it can take
+   15-30 minutes for the limit to reset. The quota-limiting job runs every 15 minutes.
+4. **Startup program**. If the customer is in the startup program, some billing tactics
+   matter less until the program expires. Check `billing_context.startup_program_label`.

--- a/products/billing/skills/investigating-billing-costs/references/usage-data-shape.md
+++ b/products/billing/skills/investigating-billing-costs/references/usage-data-shape.md
@@ -1,0 +1,138 @@
+# Billing response shapes
+
+Short reference for what each billing tool returns and how to read the time-series
+breakdowns. Field names below are verified against real API responses.
+
+## `billing-list`
+
+Single snapshot of the org's billing state. Key top-level fields:
+
+**Subscription and plan:**
+
+- `has_active_subscription` (bool) - paid vs free plan signal
+- `subscription_level` - e.g. `"free"`, `"paid"`, `"custom"`, `"enterprise"`
+- `billing_plan` - specific plan identifier string
+- `is_annual_plan_customer` (bool)
+- `deactivated` (bool)
+- `startup_program_label`, `startup_program_label_previous` (often null)
+- `free_trial_until` (timestamp or null)
+- `account_owner` - who owns the customer record
+- `customer_id` - Stripe customer id
+- `stripe_portal_url` - URL to Stripe customer portal
+
+**Period and costs:**
+
+- `billing_period.current_period_start`, `billing_period.current_period_end`, `billing_period.interval` (`"month"`, etc.)
+- `current_total_amount_usd` - period-to-date cost (note: `current_total_...`, NOT `total_current_...`)
+- `current_total_amount_usd_after_discount`
+- `projected_total_amount_usd` - forecast for the full period (without spending limits)
+- `projected_total_amount_usd_with_limit` - forecast clipped to spending limit
+- `projected_total_amount_usd_after_discount`, `projected_total_amount_usd_with_limit_after_discount`
+- `discount_amount_usd`, `discount_percent`, `amount_off_expires_at`
+
+**Limits:**
+
+- `custom_limits_usd` - dict keyed by product type (e.g. `{"product_analytics": 100}`). Top-level, NOT per-product.
+- `next_period_custom_limits_usd` - same shape
+- `never_drop_data` (bool)
+
+**Features:**
+
+- `available_product_features` - array of feature objects with `key`, `name`, `description`, `unit`, `limit`, `note`, `entitlement_only`, `is_plan_default`. **The key is `available_product_features`, not `available_features`.**
+
+**Products:**
+
+- `products` - array of all PostHog products (subscribed OR unsubscribed, with `subscribed` flag). Each has:
+  - `name`, `type`, `description`, `headline`, `icon_key`, `image_url`, `screenshot_url`, `docs_url`
+  - `subscribed` (bool), `contact_support` (bool), `inclusion_only`, `legacy_product`
+  - `current_usage`, `usage_limit`, `percentage_usage`, `has_exceeded_limit`, `projected_usage`
+  - `current_amount_usd`, `current_amount_usd_before_addons`, `projected_amount_usd`, `projected_amount_usd_with_limit`, `unit_amount_usd`
+  - `unit`, `display_unit`, `display_decimals`, `display_divisor`
+  - `free_allocation`, `price_description`, `tiered`, `tiers`, `plans`, `trial`, `usage_key`
+  - `features` - feature objects available on this product
+  - `addons` - array of addons with a similar shape, plus `included_with_main_product` and `included_if`
+
+**Aggregate usage (for the current period):**
+
+- `usage_summary` - dict keyed by the short usage identifier. Each value is `{usage: int, limit: int|null}`. Keys observed:
+  - `events`, `enhanced_persons_events`, `recordings`, `mobile_recordings`
+  - `exceptions`, `survey_responses`, `llm_events`, `ai_credits`, `feature_flag_requests`
+  - `rows_synced`, `historical_rows_synced`, `rows_exported`, `cdp_trigger_events`
+  - `workflow_emails`, `workflow_destinations`, `logs_mb_ingested`
+- **Naming mismatch**: `usage_summary` uses short keys like `events`, but the `usage_types` query param on `billing-usage-retrieve` expects the long form like `event_count_in_period`. See `ee.billing.billing_types.UsageType` for the canonical query-param values. The tool's input schema carries the list automatically.
+- **`usage_summary` is scoped to the current billing period only.** If the customer's period just rolled over (`billing_period.current_period_start` equals today or is very recent), every usage key will be 0 by design. That is not a bug. For the previous period's story, call `billing-usage-retrieve` with a date range covering the previous period.
+
+**Trial:**
+
+- `trial` - object with `is_active`, `expires_at`, `target`; or `null` if no trial.
+
+Treat `billing-list` as the "who is this customer and what do they pay for" call.
+
+## `billing-usage-retrieve` and `billing-spend-retrieve`
+
+Both return the same envelope:
+
+```json
+{
+  "status": "ok",
+  "customer_id": 135,
+  "type": "timeseries",
+  "results": [ ... ],
+  "team_id_options": [1659, ...]
+}
+```
+
+- `results` is the array of time-series items.
+- `team_id_options` lists team IDs the customer has usage for (useful for mapping team IDs back to project names when the agent doesn't have that context).
+
+### `results[]` item shape (verified)
+
+```json
+{
+  "id": 5,
+  "label": "Hedgebox::Identified Events",
+  "dates": ["2026-04-15", "2026-04-16"],
+  "data": [11667.0, 0.0],
+  "breakdown_type": "multiple",
+  "breakdown_value": ["enhanced_persons_event_count_in_period", "1659"]
+}
+```
+
+- `id` - integer, 0-indexed.
+- `label` - human-friendly label.
+  - With `breakdowns=["type"]` (or no breakdowns): just the usage type label, e.g. `"Identified Events"`.
+  - With `breakdowns=["type","team"]`: `"<ProjectName>::<UsageTypeLabel>"`, e.g. `"Hedgebox::Events"`.
+- `dates` - array of YYYY-MM-DD strings.
+- `data` - array of **floats** (not ints). Parallel to `dates`.
+- `breakdown_type`:
+  - Single breakdown: `"type"` or `"team"` (the breakdown name).
+  - Multiple breakdowns: the literal string `"multiple"` (NOT the second breakdown name).
+  - No breakdowns: defaults to `"type"` (the response looks identical to `breakdowns=["type"]`).
+- `breakdown_value`:
+  - Single breakdown or no breakdown: a **string**, e.g. `"enhanced_persons_event_count_in_period"`.
+  - Multiple breakdowns: an **array**. Order matches the breakdowns request. With `breakdowns=["type","team"]` the shape is `[usage_type_identifier, team_id_as_string]`, e.g. `["event_count_in_period", "1659"]`.
+
+**Practical consequence**: always branch on `isinstance(breakdown_value, list)` before indexing.
+
+**Important**: `breakdowns` must be a JSON-encoded array, not a comma-separated string.
+Agents should pass e.g. `breakdowns=["type","team"]`, URL-encoded as
+`breakdowns=%5B%22type%22%2C%22team%22%5D`. The tool's param description notes this.
+
+When a breakdown contains `team`, the team entry in `breakdown_value` is the team ID as a
+string. Look it up via the `team_id_options` field in the response, or map to project name
+via `posthog:organization-get` (or session context if the agent already has it).
+
+### Prefer `breakdown_value` over `label` for identifying the series
+
+`label` uses the friendly UI name (`"Events"`, `"Identified Events"`), which is lossy.
+`breakdown_value` carries the canonical identifier (`"event_count_in_period"`,
+`"enhanced_persons_event_count_in_period"`) and should be what the agent reasons on.
+
+## Drilling strategy
+
+A typical flow:
+
+1. Call `billing-usage-retrieve` with `breakdowns=["type","team"]` to get per-product-per-project.
+2. Find the item in `results` with the biggest anomaly in `data`.
+3. Read its `breakdown_value` to get the (usage type, team id) pair.
+4. For events specifically, call `execute-sql` against that team's `events` table in the anomaly's date range to find which specific events drove the volume.

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -454,7 +454,7 @@
         }
     },
     "billing-list": {
-        "description": "Fetch the organization's current billing state: subscribed products and addons, available features, plan tier, usage summary against limits, spending limits, and trial status. Use this to understand what the customer is paying for, which features they have access to, or aggregate usage for the current billing period. For time-series breakdowns of usage call billing-usage-retrieve; for cost (spend) breakdowns call billing-spend-retrieve. To check whether the customer has access to a specific feature (e.g. group analytics, white-labelling), inspect `available_features` in the response.",
+        "description": "Fetch the organization's current billing state: subscribed products and addons, available features, plan tier, usage summary against limits, spending limits, and trial status. Use this to understand what the customer is paying for, which features they have access to, or aggregate usage for the current billing period. For time-series breakdowns of usage call billing-usage-retrieve; for cost (spend) breakdowns call billing-spend-retrieve. To check whether the customer has access to a specific feature (e.g. group analytics, white-labelling), inspect `available_product_features` in the response.",
         "category": "Billing",
         "feature": "billing",
         "summary": "Get billing overview",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -471,7 +471,7 @@
         }
     },
     "billing-list": {
-        "description": "Fetch the organization's current billing state: subscribed products and addons, available features, plan tier, usage summary against limits, spending limits, and trial status. Use this to understand what the customer is paying for, which features they have access to, or aggregate usage for the current billing period. For time-series breakdowns of usage call billing-usage-retrieve; for cost (spend) breakdowns call billing-spend-retrieve. To check whether the customer has access to a specific feature (e.g. group analytics, white-labelling), inspect `available_features` in the response.",
+        "description": "Fetch the organization's current billing state: subscribed products and addons, available features, plan tier, usage summary against limits, spending limits, and trial status. Use this to understand what the customer is paying for, which features they have access to, or aggregate usage for the current billing period. For time-series breakdowns of usage call billing-usage-retrieve; for cost (spend) breakdowns call billing-spend-retrieve. To check whether the customer has access to a specific feature (e.g. group analytics, white-labelling), inspect `available_product_features` in the response.",
         "category": "Billing",
         "feature": "billing",
         "summary": "Get billing overview",


### PR DESCRIPTION
## Problem

- We now have billing tools wired up (#55919) but no skill teaching agents how to use them well
- Customer-facing cost questions ("why is my bill high", "what drove my spend", "can I reduce costs", "we had a usage spike") all share the same investigation workflow but agents need explicit guidance to follow it
- The legacy `ee/hogai/tools/read_billing_tool/` (a never-rolled-out LangChain MaxSubtool) contains useful billing domain knowledge that can be lifted into a proper agent-native skill

## Changes

- Adds `products/billing/skills/investigating-billing-costs/` with:
  - `SKILL.md` - 6-step investigation workflow (pull billing context, pull time-series, scan for patterns, attribute to project, drill into events via execute-sql, summarize honestly)
  - `references/cost-reduction-strategies.md` - per-product cost reduction playbook (product analytics, session replay, feature flags, error tracking, data warehouse) with docs links, lifted from the legacy `BILLING_CONTEXT_PROMPT`
  - `references/usage-data-shape.md` - response shape reference for `billing-list`, `billing-usage-retrieve`, `billing-spend-retrieve`, verified against real API responses (not just inferred from Pydantic models)
  - `references/billing-nuances.md` - non-obvious billing facts: special \`\$\`-prefixed events billed in their respective products, feature flags billed by \`/flags\` requests not events, quota limit reset takes 15-30 min, identified events priced 4x anonymous

### Reuse from the legacy `read_billing_tool`

- USAGE_TYPES list, cost reduction strategies, billing nuances, upselling rule, and history-table aggregation pattern all transferred from `ee/hogai/tools/read_billing_tool/{tool.py,prompts.py}`
- The orphan tool is not removed in this PR (separate cleanup); it could later import the same `UsageType` literal we centralized in #55919

## How did you test this code?

- `./bin/hogli lint:skills` passes
- Walked through the 6-step workflow manually against local PostHog + local billing (with usage data backfilled into the local UsageReport table)
- Verified `billing-list`, `billing-usage-retrieve` (with `breakdowns=["type","team"]`) and `execute-sql` chain together coherently end-to-end
- Confirmed the `billing-nuances.md` claim about \`\$feature_flag_called\` being billed in feature flags rather than events: raw ClickHouse events on the peak day = 2,471, billing events for the same day = 1,552, difference = 919 ≈ count of \`\$feature_flag_called\` events on that day
- Field shapes in `usage-data-shape.md` are based on real API responses, not Pydantic model speculation

## Publish to changelog?

no

## Docs update

- None. Skill content is self-documenting; once merged, CI publishes it to the `PostHog/skills` and `ai-plugin` distribution repos automatically.