### PR TITLE
fix(dashboards): allow removing a tile whose insight is already soft-deleted

### DIFF
--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -745,6 +745,31 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         ).data
         assert len(dashboard_data["tiles"]) == 1
 
+    def test_removing_already_soft_deleted_tile_is_idempotent(self):
+        """
+        Regression test: removing a tile whose underlying insight was already soft-deleted
+        (so the tile row itself has deleted=True via cascade) used to 500 with
+        IntegrityError on dash_tile_exactly_one_related_object, because update_or_create
+        looked up through the default manager that hides soft-deleted rows and then fell
+        through to CREATE with only {id, dashboard, deleted} fields set.
+        """
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "d"})
+        insight_id, _ = self.dashboard_api.create_insight(
+            {"filters": {"hello": "test"}, "dashboards": [dashboard_id], "name": "i"}
+        )
+        tile = DashboardTile.objects.get(insight_id=insight_id, dashboard_id=dashboard_id)
+
+        self.dashboard_api.soft_delete(insight_id, "insights")
+        tile.refresh_from_db()
+        assert tile.deleted is True, "cascade should mark the tile as soft-deleted when its insight is deleted"
+
+        _, body = self.dashboard_api.update_dashboard(
+            dashboard_id,
+            {"tiles": [{"id": tile.id, "deleted": True}]},
+        )
+        assert body["id"] == dashboard_id
+        assert DashboardTile.objects_including_soft_deleted.get(id=tile.id).deleted is True
+
     def test_dashboard_insight_tiles_can_be_loaded_correct_context(self):
         dashboard_id, _ = self.dashboard_api.create_dashboard({"filters": {"date_from": "-14d"}})
         insight_id, _ = self.dashboard_api.create_insight(

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -737,8 +737,11 @@ class DashboardSerializer(DashboardMetadataSerializer):
     @staticmethod
     def _upsert_tile(instance: Dashboard, tile_data: dict, **extra_defaults: Any) -> tuple[DashboardTile, bool]:
         tile_defaults = {k: tile_data[k] for k in DashboardSerializer.TILE_DISPLAY_FIELDS if k in tile_data}
+        # Look up through the unfiltered manager so already-soft-deleted rows are found and
+        # updated in place, instead of falling through to CREATE and hitting the
+        # dash_tile_exactly_one_related_object check constraint.
         # nosemgrep: idor-lookup-without-team -- dashboard=instance constrains to team
-        return DashboardTile.objects.update_or_create(
+        return DashboardTile.objects_including_soft_deleted.update_or_create(
             id=tile_data.get("id", None),
             dashboard=instance,
             defaults={**tile_defaults, **extra_defaults, "dashboard": instance},

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -737,9 +737,6 @@ class DashboardSerializer(DashboardMetadataSerializer):
     @staticmethod
     def _upsert_tile(instance: Dashboard, tile_data: dict, **extra_defaults: Any) -> tuple[DashboardTile, bool]:
         tile_defaults = {k: tile_data[k] for k in DashboardSerializer.TILE_DISPLAY_FIELDS if k in tile_data}
-        # Look up through the unfiltered manager so already-soft-deleted rows are found and
-        # updated in place, instead of falling through to CREATE and hitting the
-        # dash_tile_exactly_one_related_object check constraint.
         # nosemgrep: idor-lookup-without-team -- dashboard=instance constrains to team
         return DashboardTile.objects_including_soft_deleted.update_or_create(
             id=tile_data.get("id", None),


### PR DESCRIPTION
## Problem

Users cannot remove a "ghost" dashboard tile whose insight has already been soft-deleted. The Remove from dashboard action returns a 500, producing a red toast of the form `Could not remove tile from dashboard error: a server error occurred`. Internal error tracking shows this has been happening since 2025-03-18: over 11,000 exceptions across 3,700+ distinct users, with 466 users affected in just the last 30 days. 

Root cause: `DashboardSerializer._upsert_tile` looked up existing `DashboardTile` rows through the default manager, which hides rows where `deleted=True`. When an insight is soft-deleted, `InsightSerializer.update` cascades `deleted=True` onto every `DashboardTile` that references it (`posthog/api/insight.py:587`). A later PATCH to remove that tile (`tiles: [{id, deleted: true}]`) could not find the row, fell through to `update_or_create`'s CREATE branch with only `{id, dashboard, deleted}` populated, and violated the `dash_tile_exactly_one_related_object` check constraint. Django returned a 500 and the user was stuck.

## Changes

- `products/dashboards/backend/api/dashboard.py`: switch the `update_or_create` lookup in `_upsert_tile` from `DashboardTile.objects` to `DashboardTile.objects_including_soft_deleted`. Now update_or_create finds the existing row (even if already `deleted=True`) and updates it in place, making the remove PATCH idempotent. No change to the CREATE path for genuinely new tiles, since those arrive without an `id`.
- `posthog/api/test/dashboards/test_dashboard.py`: regression test that creates an insight on a dashboard, soft-deletes the insight (exercising the cascade), then PATCHes the dashboard with `{tiles: [{id, deleted: true}]}` and asserts 200. The test fails on master and passes with the fix.

## How did you test this code?

- Regression test covering the 500 path: fails before the change, passes after.

To manually test:
1. open a dashboard with an insight tile in Tab A
2. delete the insight from the insights list in Tab B, 
3. refresh Tab A to see the ghost tile, click ⋯ then Remove from dashboard. 
4. On master this returns a 500 and leaves the tile on screen; on this branch the tile is removed cleanly with no error.

## Publish to changelog?

no

## Docs update

No docs changes needed.

## 🤖 LLM context

Co-authored with PostHog Code. 