### PR TITLE
chore(tasks): add auto permission mode for Claude runtime

### DIFF
--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -1,6 +1,6 @@
 from typing import Literal, get_args
 
-ClaudePermissionMode = Literal["default", "acceptEdits", "plan", "bypassPermissions"]
+ClaudePermissionMode = Literal["default", "acceptEdits", "plan", "bypassPermissions", "auto"]
 CodexPermissionMode = Literal["auto", "read-only", "full-access"]
 InitialPermissionMode = ClaudePermissionMode | CodexPermissionMode
 

--- a/products/tasks/backend/serializers.py
+++ b/products/tasks/backend/serializers.py
@@ -889,9 +889,9 @@ class TaskRunCreateRequestSerializer(serializers.Serializer):
         required=False,
         default=None,
         help_text=(
-            "Initial permission mode for the agent session. Claude runtimes accept PostHog permission "
-            "presets like 'plan'. Codex runtimes accept native Codex modes like 'auto' and "
-            "'read-only'."
+            "Initial permission mode for the agent session. Claude runtimes accept "
+            "'default', 'acceptEdits', 'plan', 'bypassPermissions', and 'auto'. "
+            "Codex runtimes accept 'auto', 'read-only', and 'full-access'."
         ),
     )
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -487,6 +487,7 @@ class TestTaskAPI(BaseTaskAPITest):
             ("acceptEdits",),
             ("plan",),
             ("bypassPermissions",),
+            ("auto",),
         ]
     )
     @patch("products.tasks.backend.api.execute_task_processing_workflow")
@@ -636,8 +637,8 @@ class TestTaskAPI(BaseTaskAPITest):
                 "claude_rejects_codex_mode",
                 "claude",
                 "claude-opus-4-6",
-                "auto",
-                "Invalid choice 'auto' for runtime_adapter 'claude'. Supported values: 'default', 'acceptEdits', 'plan', 'bypassPermissions'.",
+                "full-access",
+                "Invalid choice 'full-access' for runtime_adapter 'claude'. Supported values: 'default', 'acceptEdits', 'plan', 'bypassPermissions', 'auto'.",
             ),
             (
                 "codex_rejects_claude_mode",

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -347,6 +347,7 @@ export const ReasoningEffortEnumApi = {
  * `acceptEdits` - acceptEdits
  * `plan` - plan
  * `bypassPermissions` - bypassPermissions
+ * `auto` - auto
  */
 export type ClaudeTaskRunCreateSchemaInitialPermissionModeEnumApi =
     (typeof ClaudeTaskRunCreateSchemaInitialPermissionModeEnumApi)[keyof typeof ClaudeTaskRunCreateSchemaInitialPermissionModeEnumApi]
@@ -356,6 +357,7 @@ export const ClaudeTaskRunCreateSchemaInitialPermissionModeEnumApi = {
     AcceptEdits: 'acceptEdits',
     Plan: 'plan',
     BypassPermissions: 'bypassPermissions',
+    Auto: 'auto',
 } as const
 
 /**
@@ -413,7 +415,8 @@ export interface ClaudeTaskRunCreateSchemaApi {
 * `default` - default
 * `acceptEdits` - acceptEdits
 * `plan` - plan
-* `bypassPermissions` - bypassPermissions */
+* `bypassPermissions` - bypassPermissions
+* `auto` - auto */
     initial_permission_mode?: ClaudeTaskRunCreateSchemaInitialPermissionModeEnumApi
 }
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7690,6 +7690,7 @@ export namespace Schemas {
     * `acceptEdits` - acceptEdits
     * `plan` - plan
     * `bypassPermissions` - bypassPermissions
+    * `auto` - auto
      */
     export type ClaudeTaskRunCreateSchemaInitialPermissionModeEnum = typeof ClaudeTaskRunCreateSchemaInitialPermissionModeEnum[keyof typeof ClaudeTaskRunCreateSchemaInitialPermissionModeEnum];
 
@@ -7699,6 +7700,7 @@ export namespace Schemas {
       AcceptEdits: 'acceptEdits',
       Plan: 'plan',
       BypassPermissions: 'bypassPermissions',
+      Auto: 'auto',
     } as const;
 
     /**
@@ -7756,7 +7758,8 @@ export namespace Schemas {
     * `default` - default
     * `acceptEdits` - acceptEdits
     * `plan` - plan
-    * `bypassPermissions` - bypassPermissions */
+    * `bypassPermissions` - bypassPermissions
+    * `auto` - auto */
       initial_permission_mode?: ClaudeTaskRunCreateSchemaInitialPermissionModeEnum;
     }
 


### PR DESCRIPTION
## Problem

  PostHog/code#1749 adds `auto` as a new Claude permission mode that uses a model classifier to approve/deny permission prompts. The backend task serializers don't yet accept `"auto"` as a valid Claude runtime permission mode.

  ## Changes

  - Add `"auto"` to `ClaudePermissionMode` in `constants.py`
  - Update `initial_permission_mode` help text in serializers to explicitly list valid modes per runtime
  - Update tests: add `"auto"` to Claude permission mode parameterized test, fix mismatch test to use `"full-access"` instead of `"auto"` (which is now valid for both runtimes)

  ## How did you test this code?

`hogli test products/tasks/backend/tests/test_api.py`

  ## Publish to changelog?

  No

  ## Docs update

  N/A