### PR TITLE
feat(max): move DPA + HIPAA text from popover into LemonDialog

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5378,6 +5378,22 @@ snapshots:
         hash: v1.k794b7964.d95b2089f09cc6d2bb9677fd26d4d346fa706bd3aae1e3f5eb8ddce6be982aa4.TiTGYPV1UsBLYZ6xsrmb7wceCMhVBvdq6MInjtWl1LA
     scenes-other-preflight--preflight--light:
         hash: v1.k794b7964.6ccf830c77c20e655c85034a351f628e6e150cc0785d14058aa15197b06452ce.pCIijcSjefHlbwUtC4DGvHUVxudZQMIsyUnKMFlTBU0
+    scenes-other-settings-organization-ai-consent-legal-dialog--default--dark:
+        hash: v1.k794b7964.e1bb02d400ee8d12ebefcabc4dce7e3b63e944043988e39c3b4f579cfca247bd.4oYDcvIUvrseWKH3xK9qfSAA8GpPAp5lO6HF_DD-XSI
+    scenes-other-settings-organization-ai-consent-legal-dialog--default--light:
+        hash: v1.k794b7964.9b52fdc0470804c094606795a2fd435a17d7e19f69f950eb490c2cf8d11c4fa9.a2t7f7HfstezBMjzBnml929VWukUQwcBMLt2rI-yASs
+    scenes-other-settings-organization-ai-consent-popover--default--dark:
+        hash: v1.k794b7964.decd50b7fae4d93a9d9db460c4d7ff90af0fa7fea52923b5aec705b5e4293b98.nnN8yhEaynHiRBoq6qAKribm2RyO9fli0LAJrjakU9k
+    scenes-other-settings-organization-ai-consent-popover--default--light:
+        hash: v1.k794b7964.2d3a2036a698736a89ba3e105000840303a45a9eb35fcba1df9c904c880f6295.-kAJ2_KTxh601qwqWXUWoT0Dw1n0Lq1zeEkl-wf4Zbc
+    scenes-other-settings-organization-ai-consent-popover--long-disabled-reason--dark:
+        hash: v1.k794b7964.939a2e34e816cba2b148c525f91a2db1b565afd6cf9489dea953f181bca05c1d.cQPWCV7WnoHRSD9sABJpO9_ULAsPvTUz-llMT-9f6YU
+    scenes-other-settings-organization-ai-consent-popover--long-disabled-reason--light:
+        hash: v1.k794b7964.1844c47146805ead9ef32a6d726e7b92abcbd51717949ba011baa2d31afda631.Vgb7TdG3c4ja1w_XB3TUSUupwBSs0OAp5eDAd_bJJ6c
+    scenes-other-settings-organization-ai-consent-popover--non-admin--dark:
+        hash: v1.k794b7964.9815f6429b926a920939b81a58f66f10e4a1a1fc3a4596f3fd4ddadcf4da73ae.LI4HuHYaTJ5CwcrCXtjKojRRQXbTC0c89vFgbqwT6JU
+    scenes-other-settings-organization-ai-consent-popover--non-admin--light:
+        hash: v1.k794b7964.665e40bd6c54436e733622bcb573de371f41ab668f2bb5bc8ed6b82bfdaca72c.opKVB9eD-xMIHJsP5ExBLz0CCkSUl7zH8_-xnBt3bF4
     scenes-other-settings-organization-oauth-apps--empty--dark:
         hash: v1.k794b7964.747dfc34f0ec91a2131f6287c1b04e091c648d3c0cc91e1116fae0617ebd1d3f.RBhpcvpynPpxDU8tIZhbhcnaY3BBkzQDuqAdqjJMKeg
     scenes-other-settings-organization-oauth-apps--empty--light:

--- a/frontend/src/scenes/settings/organization/AIConsentLegalDialog.stories.tsx
+++ b/frontend/src/scenes/settings/organization/AIConsentLegalDialog.stories.tsx
@@ -1,0 +1,26 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { LemonDialog } from '@posthog/lemon-ui'
+
+import { aiConsentLegalDialogProps } from './aiConsentCopy'
+
+const noop = (): void => {}
+
+const meta: Meta<typeof LemonDialog> = {
+    title: 'Scenes-Other/Settings/Organization/AI Consent Legal Dialog',
+    component: LemonDialog,
+    parameters: {
+        layout: 'centered',
+    },
+}
+export default meta
+
+type Story = StoryObj<typeof LemonDialog>
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-default p-4">
+            <LemonDialog {...aiConsentLegalDialogProps({ onConfirm: noop })} inline />
+        </div>
+    ),
+}

--- a/frontend/src/scenes/settings/organization/AIConsentPopoverWrapper.tsx
+++ b/frontend/src/scenes/settings/organization/AIConsentPopoverWrapper.tsx
@@ -4,10 +4,9 @@ import { useCallback } from 'react'
 import { IconArrowRight, IconLock } from '@posthog/icons'
 import { LemonButton, Popover, PopoverProps, Tooltip } from '@posthog/lemon-ui'
 
-import { Link } from 'lib/lemon-ui/Link'
 import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 
-import { AIHipaaDisclaimer, getExternalAIProvidersTooltipTitle } from './aiConsentCopy'
+import { getExternalAIProvidersTooltipTitle, openAIConsentLegalDialog } from './aiConsentCopy'
 
 export function AIConsentPopoverContent({
     onApprove,
@@ -31,15 +30,6 @@ export function AIConsentPopoverContent({
                 </Tooltip>
                 . <i>Your data won't be used for training models.</i>
             </p>
-            <p className="text-muted text-xs leading-relaxed">
-                If your org requires a Data Processing Agreement (DPA) for compliance (and your existing DPA doesn't
-                already cover AI subprocessors),{' '}
-                <Link to="https://posthog.com/dpa" target="_blank">
-                    you can get a fresh DPA here
-                </Link>
-                .
-            </p>
-            <AIHipaaDisclaimer />
             <div className="flex gap-1.5 self-end">
                 <LemonButton data-attr="ai-consent-cancel" type="secondary" size="xsmall" onClick={onDismiss}>
                     Cancel
@@ -48,7 +38,7 @@ export function AIConsentPopoverContent({
                     data-attr="ai-consent-approve"
                     type="primary"
                     size="xsmall"
-                    onClick={onApprove}
+                    onClick={() => openAIConsentLegalDialog({ onConfirm: onApprove })}
                     sideIcon={approvalDisabledReason ? <IconLock /> : <IconArrowRight />}
                     disabledReason={approvalDisabledReason}
                     tooltip={approvalDisabledReason ? undefined : 'You are approving this as an organization admin'}

--- a/frontend/src/scenes/settings/organization/AIConsentPopoverWrapper.tsx
+++ b/frontend/src/scenes/settings/organization/AIConsentPopoverWrapper.tsx
@@ -22,7 +22,7 @@ export function AIConsentPopoverContent({
     }, [])
 
     return (
-        <div className="flex flex-col gap-2 m-1.5 max-w-sm">
+        <div className="flex flex-col gap-2 m-1.5 max-w-prose">
             <p className="font-medium text-pretty">
                 PostHog AI needs your approval to potentially process identifying user data with{' '}
                 <Tooltip title={getExternalAIProvidersTooltipTitle()}>

--- a/frontend/src/scenes/settings/organization/aiConsentCopy.tsx
+++ b/frontend/src/scenes/settings/organization/aiConsentCopy.tsx
@@ -20,7 +20,7 @@ export function AIHipaaDisclaimer(): JSX.Element {
 export function aiConsentLegalDialogProps({ onConfirm }: { onConfirm: () => void }): LemonDialogProps {
     return {
         title: 'The legal bits',
-        maxWidth: 500,
+        maxWidth: '65ch',
         content: (
             <div className="flex flex-col gap-2">
                 <p className="mb-0">

--- a/frontend/src/scenes/settings/organization/aiConsentCopy.tsx
+++ b/frontend/src/scenes/settings/organization/aiConsentCopy.tsx
@@ -9,7 +9,7 @@ export function getExternalAIProvidersTooltipTitle(): string {
 
 export function AIHipaaDisclaimer(): JSX.Element {
     return (
-        <span className="block text-muted text-xs leading-relaxed">
+        <span className="block">
             This feature is not HIPAA-compliant and is not intended for the processing of Protected Health Information
             ("PHI"). Any Business Associate Agreement ("BAA") you may have entered into with PostHog does not apply to
             this functionality. You are responsible for ensuring your use complies with applicable laws and regulations.
@@ -20,9 +20,10 @@ export function AIHipaaDisclaimer(): JSX.Element {
 export function aiConsentLegalDialogProps({ onConfirm }: { onConfirm: () => void }): LemonDialogProps {
     return {
         title: 'The legal bits',
+        maxWidth: 500,
         content: (
             <div className="flex flex-col gap-2">
-                <p className="text-sm leading-relaxed mb-0">
+                <p className="mb-0">
                     If your org requires a Data Processing Agreement (DPA) for compliance (and your existing DPA doesn't
                     already cover AI subprocessors),{' '}
                     <Link to="https://posthog.com/dpa" target="_blank">

--- a/frontend/src/scenes/settings/organization/aiConsentCopy.tsx
+++ b/frontend/src/scenes/settings/organization/aiConsentCopy.tsx
@@ -1,4 +1,4 @@
-import { LemonDialog } from '@posthog/lemon-ui'
+import { LemonDialog, LemonDialogProps } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
 import { Link } from 'lib/lemon-ui/Link'
@@ -17,8 +17,8 @@ export function AIHipaaDisclaimer(): JSX.Element {
     )
 }
 
-export function openAIConsentLegalDialog({ onConfirm }: { onConfirm: () => void }): void {
-    LemonDialog.open({
+export function aiConsentLegalDialogProps({ onConfirm }: { onConfirm: () => void }): LemonDialogProps {
+    return {
         title: 'The legal bits',
         content: (
             <div className="flex flex-col gap-2">
@@ -42,5 +42,9 @@ export function openAIConsentLegalDialog({ onConfirm }: { onConfirm: () => void 
             children: 'Cancel',
             'data-attr': 'ai-consent-legal-cancel',
         },
-    })
+    }
+}
+
+export function openAIConsentLegalDialog(args: { onConfirm: () => void }): void {
+    LemonDialog.open(aiConsentLegalDialogProps(args))
 }

--- a/frontend/src/scenes/settings/organization/aiConsentCopy.tsx
+++ b/frontend/src/scenes/settings/organization/aiConsentCopy.tsx
@@ -1,4 +1,7 @@
+import { LemonDialog } from '@posthog/lemon-ui'
+
 import { dayjs } from 'lib/dayjs'
+import { Link } from 'lib/lemon-ui/Link'
 
 export function getExternalAIProvidersTooltipTitle(): string {
     return `As of ${dayjs().format('MMMM YYYY')}: Anthropic and OpenAI`
@@ -12,4 +15,32 @@ export function AIHipaaDisclaimer(): JSX.Element {
             this functionality. You are responsible for ensuring your use complies with applicable laws and regulations.
         </span>
     )
+}
+
+export function openAIConsentLegalDialog({ onConfirm }: { onConfirm: () => void }): void {
+    LemonDialog.open({
+        title: 'The legal bits',
+        content: (
+            <div className="flex flex-col gap-2">
+                <p className="text-sm leading-relaxed mb-0">
+                    If your org requires a Data Processing Agreement (DPA) for compliance (and your existing DPA doesn't
+                    already cover AI subprocessors),{' '}
+                    <Link to="https://posthog.com/dpa" target="_blank">
+                        you can get a fresh DPA here
+                    </Link>
+                    .
+                </p>
+                <AIHipaaDisclaimer />
+            </div>
+        ),
+        primaryButton: {
+            children: 'Enable AI analysis',
+            'data-attr': 'ai-consent-legal-confirm',
+            onClick: onConfirm,
+        },
+        secondaryButton: {
+            children: 'Cancel',
+            'data-attr': 'ai-consent-legal-cancel',
+        },
+    })
 }


### PR DESCRIPTION
## Problem

The AI consent popover had grown to carry a full prompt, a DPA paragraph, and a HIPAA disclaimer. That's a lot of copy for a popover — it defeats the "quick in-place approval" feel and pushes the consent buttons well down the page.

Stacked on top of #55549 (which constrains the popover width and keeps the shared HIPAA disclaimer rendering consistently in both the popover and the org-settings description).

## Changes

- `AIConsentPopoverContent` is now just the short prompt (`PostHog AI needs your approval to potentially process identifying user data with external AI providers. Your data won't be used for training models.`) + `Cancel` / `I allow AI analysis in this organization` buttons.
- Clicking the approve button now opens a `LemonDialog` titled **The legal bits** containing the DPA paragraph and `<AIHipaaDisclaimer />`. The dialog's primary action (`Enable AI analysis`) calls the real approval handler; its secondary action (`Cancel`) just dismisses the dialog.
- New `aiConsentLegalDialogProps({ onConfirm })` helper builds the dialog config so the imperative `openAIConsentLegalDialog()` path and the new Storybook story render from the exact same source.
- New Storybook entry `Scenes-Other/Settings/Organization/AI Consent Legal Dialog` renders `<LemonDialog inline {...props} />` so visual review picks up any regression to the dialog's title, legal copy, or footer buttons.
- Legal copy stays fully deduplicated: `<AIHipaaDisclaimer />` is rendered inside the new dialog AND still inside the org-settings description, both visually consistent.

## How did you test this code?

- [ ] (author) click through the consent flow locally: open popover → click approve → confirm dialog actually flips `is_ai_data_processing_approved` → popover closes
- [ ] (author) verify the `Cancel` button in the dialog doesn't approve
- [ ] (author) review the new Storybook story visually and approve the resulting snapshot in Visual Review
- [x] (agent) pnpm format + typescript:check pass on the changed files (the unrelated `products/workflows` pre-existing errors on master are untouched by this branch)

## Publish to changelog?

no

## Docs update

No docs change required — this is an internal UX tidy of an existing feature.

## 🤖 LLM context

Authored by PostHog Code (task id `8ac00cc2-de0e-4a8a-9797-54f3480568de`), stacked on top of #55549.

Reasoning trail:
1. Started from #55549 fixing popover width. QA swarm flagged the popover body was long and the HIPAA disclaimer rendering diverged between settings and popover.
2. Dedup + visual-consistency fix stayed on #55549 (commit `5131f71770b`).
3. This PR moves the DPA + HIPAA text out of the popover into a `LemonDialog` titled "The legal bits", triggered by the approve click (user's explicit UX call).
4. Added a Storybook story for the dialog so visual review covers its legal copy.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
