### PR TITLE
fix(flags): allow regex input for numeric properties

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
@@ -7,7 +7,7 @@ import { Provider } from 'kea'
 import { useMocks } from '~/mocks/jest'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { initKeaTests } from '~/test/init'
-import { PropertyFilterType, PropertyOperator } from '~/types'
+import { PropertyFilterType, PropertyOperator, PropertyType } from '~/types'
 
 import { PropertyValue } from './PropertyValue'
 
@@ -120,5 +120,65 @@ describe('PropertyValue', () => {
         // Check that the error container has the danger class
         const errorContainer = screen.getByText('This is a test error').closest('div')
         expect(errorContainer).toHaveClass('text-danger')
+    })
+
+    it('allows regex input for numeric properties', async () => {
+        propertyDefinitionsModel.actions.updatePropertyDefinitions({
+            'event/userId': {
+                id: 'userId',
+                name: 'userId',
+                property_type: PropertyType.Numeric,
+                is_numerical: true,
+                is_seen_on_filtered_events: false,
+            },
+        })
+
+        const onSet = jest.fn()
+        render(
+            <Provider>
+                <PropertyValue
+                    propertyKey="userId"
+                    type={PropertyFilterType.Event}
+                    operator={PropertyOperator.Regex}
+                    onSet={onSet}
+                    value={[]}
+                />
+            </Provider>
+        )
+
+        const input = screen.getByRole('textbox')
+        await userEvent.type(input, 'user.*7$')
+
+        expect(input).toHaveValue('user.*7$')
+    })
+
+    it('keeps numeric-only input for non-regex numeric properties', async () => {
+        propertyDefinitionsModel.actions.updatePropertyDefinitions({
+            'event/userId': {
+                id: 'userId',
+                name: 'userId',
+                property_type: PropertyType.Numeric,
+                is_numerical: true,
+                is_seen_on_filtered_events: false,
+            },
+        })
+
+        const onSet = jest.fn()
+        render(
+            <Provider>
+                <PropertyValue
+                    propertyKey="userId"
+                    type={PropertyFilterType.Event}
+                    operator={PropertyOperator.Exact}
+                    onSet={onSet}
+                    value={[]}
+                />
+            </Provider>
+        )
+
+        const input = screen.getByRole('textbox')
+        await userEvent.type(input, '7a.8$')
+
+        expect(input).toHaveValue('7.8')
     })
 })

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -21,7 +21,15 @@ import { propertyFilterTypeToPropertyDefinitionType } from 'lib/components/Prope
 import { dayjs } from 'lib/dayjs'
 import { IconErrorOutline } from 'lib/lemon-ui/icons'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect/LemonInputSelect'
-import { formatDate, isOperatorBetween, isOperatorDate, isOperatorFlag, isOperatorMulti, toString } from 'lib/utils'
+import {
+    formatDate,
+    isOperatorBetween,
+    isOperatorDate,
+    isOperatorFlag,
+    isOperatorMulti,
+    isOperatorRegex,
+    toString,
+} from 'lib/utils'
 
 import {
     PROPERTY_FILTER_TYPES_WITH_ALL_TIME_SUGGESTIONS,
@@ -94,6 +102,7 @@ export function PropertyValue({
 
     const isNumericProperty =
         propertyKey && describeProperty(propertyKey, propertyDefinitionType) === PropertyType.Numeric
+    const shouldRestrictToNumericInput = isNumericProperty && !isOperatorRegex(operator)
 
     const isGroupKeyProperty = propertyKey === '$group_key' && groupTypeIndex != null
 
@@ -395,7 +404,7 @@ export function PropertyValue({
                 singleValueAsSnack
                 allowCustomValues={propertyOptions?.allowCustomValues ?? true}
                 inputTransform={
-                    isNumericProperty
+                    shouldRestrictToNumericInput
                         ? (input: string) => {
                               // Only allow numeric characters, decimal point, and +/- signs
                               return input.replace(/[^0-9+\-.]/g, '')


### PR DESCRIPTION
## Problem

Numeric properties can still be used as string-like identifiers in targeting rules, but the property editor currently forces numeric-only input whenever the property definition is typed as numeric.

That makes regex targeting hard to configure for cases like `userId`, where someone may want to match IDs ending in a specific digit. The feature flag matcher already supports regex evaluation against stringified numeric values, but the UI blocks entering the pattern.

## Changes

- allow `regex` and `not_regex` operators to bypass the numeric-only input transform in the shared property value editor
- keep numeric-only input behavior unchanged for non-regex operators on numeric properties
- add focused tests covering both regex input on numeric properties and the existing numeric-only behavior for exact matching
- confirm the existing flag matching logic stringifies numeric property values before regex evaluation in both the Python fallback and Rust service paths

## How did you test this code?

- ran `pnpm --filter=@posthog/frontend jest --runTestsByPath src/lib/components/PropertyFilters/components/PropertyValue.test.tsx`
- inspected the existing Python fallback matcher in `posthog/queries/base.py` and Rust matcher in `rust/feature-flags/src/properties/property_matching.rs` to confirm numeric values are coerced to strings before regex matching
- I did not perform manual UI testing

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Publish to changelog?

no

## Docs update

No docs update needed.

## 🤖 LLM context

This PR was authored by Codex.

Context:
- The reported issue was that regex targeting on numeric properties was blocked by the editor input, even though customers use numeric-looking identifiers such as `userId`.
- The change is intentionally limited to the shared property value editor so regex operators accept string input for numeric properties without changing other numeric operator behavior.
- Automated verification was limited to the focused frontend Jest test above.
- I also verified the backend behavior by inspecting the existing Python and Rust feature flag matchers. A local Rust test run was attempted, but the environment failed before compilation due to a linker configuration issue (`clang: invalid linker name in argument '-fuse-ld=lld'`).
