### PR TITLE
fix(marketing-analytics): use team base currency symbol on trends chart

### DIFF
--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsTilesLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsTilesLogic.ts
@@ -1,12 +1,14 @@
 import { connect, kea, path, selectors } from 'kea'
 
 import { isNotNil } from 'lib/utils'
+import { getCurrencySymbol } from 'lib/utils/geography/currency'
 import { MARKETING_ANALYTICS_DEFAULT_QUERY_TAGS, QueryTile, TileId, loadPriorityMap } from 'scenes/web-analytics/common'
 import { getDashboardItemId } from 'scenes/web-analytics/insightsUtils'
 
 import {
     CompareFilter,
     ConversionGoalFilter,
+    CurrencyCode,
     DataTableNode,
     DataWarehouseNode,
     IntegrationFilter,
@@ -51,6 +53,7 @@ export const marketingAnalyticsTilesLogic = kea<marketingAnalyticsTilesLogicType
                 'tileColumnSelection',
                 'integrationFilter',
                 'drillDownLevel',
+                'baseCurrency',
             ],
             marketingAnalyticsTableLogic,
             ['query', 'defaultColumns'],
@@ -68,6 +71,7 @@ export const marketingAnalyticsTilesLogic = kea<marketingAnalyticsTilesLogicType
                 s.draftConversionGoal,
                 s.integrationFilter,
                 s.drillDownLevel,
+                s.baseCurrency,
             ],
             (
                 compareFilter: CompareFilter | null,
@@ -82,7 +86,8 @@ export const marketingAnalyticsTilesLogic = kea<marketingAnalyticsTilesLogicType
                 tileColumnSelection: validColumnsForTiles,
                 draftConversionGoal: ConversionGoalFilter | null,
                 integrationFilter: IntegrationFilter,
-                drillDownLevel: MarketingAnalyticsDrillDownLevel
+                drillDownLevel: MarketingAnalyticsDrillDownLevel,
+                baseCurrency: CurrencyCode
             ) => {
                 const createInsightProps = (tile: TileId, tab?: string): InsightLogicProps => {
                     return {
@@ -96,6 +101,8 @@ export const marketingAnalyticsTilesLogic = kea<marketingAnalyticsTilesLogicType
                     tileColumnSelection && isSchemaBackedMarketingColumn(tileColumnSelection)
                         ? MARKETING_ANALYTICS_SCHEMA[tileColumnSelection].isCurrency
                         : false
+
+                const { symbol: currencySymbol, isPrefix: currencyIsPrefix } = getCurrencySymbol(baseCurrency)
 
                 const tileColumnSelectionName = tileColumnSelection?.split('_').join(' ')
 
@@ -157,7 +164,9 @@ export const marketingAnalyticsTilesLogic = kea<marketingAnalyticsTilesLogicType
                                 trendsFilter: {
                                     display: chartDisplayType,
                                     aggregationAxisFormat: 'numeric',
-                                    aggregationAxisPrefix: isCurrency ? '$' : undefined,
+                                    aggregationAxisPrefix: isCurrency && currencyIsPrefix ? currencySymbol : undefined,
+                                    aggregationAxisPostfix:
+                                        isCurrency && !currencyIsPrefix ? ` ${currencySymbol}` : undefined,
                                 },
                             },
                         },


### PR DESCRIPTION
## Problem

The main trends chart in the **Marketing** tab hardcoded a `$` prefix on the Y-axis, regardless of the team's configured base currency. Teams with e.g. GBP as their base currency saw `$1000` next to values that were already correctly converted to GBP — visually misleading by the full FX delta.

Numbers coming from the backend are fine: HogQL `convertCurrency()` in the marketing analytics adapters (`adapters/base.py`, `adapters/linkedin_ads.py`, `self_managed.py`) already converts to `team.base_currency`. The KPI tiles (Overview) also pick up the correct symbol via `shared.tsx`. The trend chart was the single remaining spot with a hardcoded `$`.

## Changes

- `marketingAnalyticsTilesLogic.ts`:
  - Connect `baseCurrency` from `marketingAnalyticsLogic` (which already exposes it via `teamLogic`)
  - Derive `{ symbol, isPrefix }` from `getCurrencySymbol(baseCurrency)`
  - Replace hardcoded `aggregationAxisPrefix: isCurrency ? '$' : undefined` with prefix/postfix driven by the team currency, so e.g. GBP → `£`, and currencies that render as suffix use `aggregationAxisPostfix` instead.

## How did you test this code?

Manually verified in the browser: set base currency to GBP in environment settings, the Marketing trends chart Y-axis now renders `£` instead of `$`. Values themselves were already correctly converted by the backend.

No unit tests added — there are no existing tests for `marketingAnalyticsTilesLogic` and the change is a straightforward prop passthrough best validated visually.

<img width="563" height="159" alt="image" src="https://github.com/user-attachments/assets/0a98a814-e43b-4b4e-baa1-e25c50587168" />

## Publish to changelog?

no