### PR TITLE
feat(insights): add moving average overlay to TrendsLineChartD3

### DIFF
--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.test.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.test.tsx
@@ -165,6 +165,50 @@ describe('TrendsLineChartD3', () => {
         })
     })
 
+    describe('moving average overlay', () => {
+        it('adds a dashed moving-average series per result when enabled', async () => {
+            renderInsight({
+                query: buildTrendsQuery({
+                    trendsFilter: {
+                        showMovingAverage: true,
+                        movingAverageIntervals: 3,
+                    },
+                }),
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            // One data series + one moving-average overlay = 2 rendered series.
+            await waitFor(() => {
+                expect(screen.getByRole('img', { name: /chart with 2 data series/i })).toBeInTheDocument()
+            })
+        })
+
+        it('omits the moving-average series from tooltip rows', async () => {
+            renderInsight({
+                query: buildTrendsQuery({
+                    trendsFilter: {
+                        showMovingAverage: true,
+                        movingAverageIntervals: 3,
+                    },
+                }),
+                featureFlags: HOG_CHARTS_FLAG,
+            })
+
+            const tooltip = await chart.hoverTooltip(2)
+
+            expect(tooltip.row('Pageview')).toContain('134')
+            expect(tooltip.element.textContent).not.toContain('Moving avg')
+        })
+
+        it('renders only the main series when disabled', async () => {
+            renderInsight({ query: buildTrendsQuery(), featureFlags: HOG_CHARTS_FLAG })
+
+            await waitFor(() => {
+                expect(screen.getByRole('img', { name: /chart with 1 data series/i })).toBeInTheDocument()
+            })
+        })
+    })
+
     describe('click → persons modal', () => {
         it('single series: direct click shows the actors for the clicked day', async () => {
             renderInsight({ query: buildTrendsQuery(), featureFlags: HOG_CHARTS_FLAG })

--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
@@ -116,7 +116,7 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
                 // (LineChart.tsx), so a filled CI band would also reposition the main
                 // line. Adding CI requires a library primitive for fill-between-series.
 
-                if (showMovingAverage && r.data.length >= 2) {
+                if (showMovingAverage && r.data.length >= movingAverageIntervals) {
                     series.push({
                         key: `${r.id}-ma`,
                         label: `${r.label ?? ''} (Moving avg)`,

--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
@@ -7,6 +7,7 @@ import { DEFAULT_Y_AXIS_ID, LineChart } from 'lib/hog-charts'
 import type { LineChartConfig, PointClickData, Series } from 'lib/hog-charts'
 import type { TooltipContext } from 'lib/hog-charts/core/types'
 import { ReferenceLines } from 'lib/hog-charts/overlays/ReferenceLine'
+import { movingAverage } from 'lib/statistics'
 import { hexToRGBA } from 'lib/utils'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
@@ -57,6 +58,8 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
         hasPersonsModal,
         querySource,
         incompletenessOffsetFromEnd,
+        showMovingAverage,
+        movingAverageIntervals,
     } = useValues(trendsDataLogic(insightProps))
     const { timezone, weekStartDay, baseCurrency } = useValues(teamLogic)
     const { aggregationLabel } = useValues(groupsModel)
@@ -82,11 +85,20 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
 
     const hogSeries: Series<TrendsSeriesMeta>[] = useMemo(
         () =>
-            (indexedResults ?? []).map((r: IndexedTrendResult, index: number) => {
+            (indexedResults ?? []).flatMap((r: IndexedTrendResult, index: number) => {
                 const isActiveSeries = !r.compare || r.compare_label !== 'previous'
                 const dashedFromIndex =
                     isInProgress && isActiveSeries ? r.data.length + incompletenessOffsetFromEnd : undefined
-                return {
+                const yAxisId = showMultipleYAxes && index > 0 ? `y${index}` : DEFAULT_Y_AXIS_ID
+                const meta: TrendsSeriesMeta = {
+                    action: r.action,
+                    breakdown_value: r.breakdown_value,
+                    compare_label: r.compare_label,
+                    days: r.days,
+                    order: r.action?.order ?? r.id,
+                    filter: r.filter,
+                }
+                const mainSeries: Series<TrendsSeriesMeta> = {
                     key: `${r.id}`,
                     label: r.label ?? '',
                     data: r.data,
@@ -94,16 +106,32 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
                     fillArea: display === ChartDisplayType.ActionsAreaGraph,
                     dashedFromIndex,
                     hidden: getTrendsHidden(r),
-                    yAxisId: showMultipleYAxes && index > 0 ? `y${index}` : DEFAULT_Y_AXIS_ID,
-                    meta: {
-                        action: r.action,
-                        breakdown_value: r.breakdown_value,
-                        compare_label: r.compare_label,
-                        days: r.days,
-                        order: r.action?.order ?? r.id,
-                        filter: r.filter,
-                    },
+                    yAxisId,
+                    meta,
                 }
+                const series: Series<TrendsSeriesMeta>[] = [mainSeries]
+
+                // Confidence intervals are intentionally not rendered here. hog-charts
+                // stacks every visible series whenever any series has fillArea:true
+                // (LineChart.tsx), so a filled CI band would also reposition the main
+                // line. Adding CI requires a library primitive for fill-between-series.
+
+                if (showMovingAverage && r.data.length >= 2) {
+                    series.push({
+                        key: `${r.id}-ma`,
+                        label: `${r.label ?? ''} (Moving avg)`,
+                        data: movingAverage(r.data, movingAverageIntervals),
+                        color: getTrendsColor(r),
+                        fillArea: false,
+                        dashPattern: [10, 3],
+                        pointRadius: 0,
+                        hideFromTooltip: true,
+                        yAxisId,
+                        meta,
+                    })
+                }
+
+                return series
             }),
         [
             indexedResults,
@@ -113,6 +141,8 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
             isInProgress,
             incompletenessOffsetFromEnd,
             showMultipleYAxes,
+            showMovingAverage,
+            movingAverageIntervals,
         ]
     )
 

--- a/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
+++ b/frontend/src/scenes/trends/viz/TrendsLineChartD3.tsx
@@ -121,7 +121,7 @@ export function TrendsLineChartD3({ context }: TrendsLineChartD3Props): JSX.Elem
                         key: `${r.id}-ma`,
                         label: `${r.label ?? ''} (Moving avg)`,
                         data: movingAverage(r.data, movingAverageIntervals),
-                        color: getTrendsColor(r),
+                        color: r.compare_label === 'previous' ? hexToRGBA(getTrendsColor(r), 0.5) : getTrendsColor(r),
                         fillArea: false,
                         dashPattern: [10, 3],
                         pointRadius: 0,


### PR DESCRIPTION
## Problem

The D3-based `TrendsLineChartD3` adapter for line trends was missing the "Show moving average" and "Show confidence intervals" overlays that users can toggle in the chart options panel. The Chart.js-based `ActionsLineGraph` already derives these as extra datasets (see `ActionsLineGraph.tsx:100-158`), so users switching to the D3 renderer lost the overlays silently.

## Changes

- Pull `showMovingAverage` and `movingAverageIntervals` from `trendsDataLogic` into the adapter.
- In the `hogSeries` useMemo, switch `map` → `flatMap` so each result can expand into multiple `Series` entries.
- When `showMovingAverage` is on and `data.length >= 2`, append a dashed overlay series per result (same color, `dashPattern: [10, 3]`, `pointRadius: 0`, `hideFromTooltip: true`, matching `yAxisId`). Uses the existing pure `movingAverage` helper from `lib/statistics`.
- Add a short comment explaining why CI is not rendered here.
- Add three jest tests covering: MA series count via aria-label, tooltip omission, and the off-state default.

### Confidence intervals — deferred

`hog-charts` stacks every visible series whenever any series has `fillArea: true` (see `LineChart.tsx:45-55` → `computeStackData`). Replicating the Chart.js CI pattern (invisible lower bound + filled upper bound) would therefore reposition the main line via the global stack. Adding CI properly needs a small library primitive for fill-between-series (e.g. a `fillToSeriesKey` field on `Series`, or a dedicated band series). Tracked as a follow-up.

## How did you test this code?

- Added three jest tests in `TrendsLineChartD3.test.tsx`: aria-label goes from 1 → 2 data series when MA is enabled, tooltip rows exclude "Moving avg", and series count is unchanged when MA is off.
- Full suite: `pnpm exec jest src/scenes/trends/viz/TrendsLineChartD3.test.tsx --no-coverage` — 16/16 pass.
- Typecheck errors in the changed file: none (pre-existing errors elsewhere in the repo are unrelated).
- I'm an agent and have not performed manual/visual testing in a browser — only automated tests.

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored. The overlay pattern mirrors `ActionsLineGraph.tsx`; the MA helper is reused from `lib/statistics` unchanged. CI was intentionally deferred after analysis of the stacking behavior in `hog-charts` — see the inline comment in `TrendsLineChartD3.tsx`.