### PR TITLE
feat(data-warehouse): make Clerk source resumable

### DIFF
--- a/posthog/temporal/data_imports/sources/clerk/clerk.py
+++ b/posthog/temporal/data_imports/sources/clerk/clerk.py
@@ -17,8 +17,9 @@ class ClerkResumeConfig:
     """Resume state for Clerk endpoints.
 
     All Clerk endpoints use offset-based pagination, so the checkpoint is just
-    the next offset to fetch. On resume we re-request the saved page — duplicates
-    are deduped by the ``id`` primary key.
+    the next offset to fetch. On resume we start fetching from the saved offset
+    (at-least-once semantics): any duplicates from a batch that was yielded but
+    whose checkpoint did not persist are deduped by the ``id`` primary key.
     """
 
     offset: int
@@ -76,19 +77,28 @@ class ClerkPaginator(BasePaginator):
         # Clerk endpoints return either:
         # - Direct array: /users, /invitations
         # - Wrapped object {data: [...], total_count: ...}: /organizations, /organization_memberships
+        total_count: Optional[int] = None
         if isinstance(res, dict) and "data" in res:
             items = res["data"]
+            raw_total = res.get("total_count")
+            if isinstance(raw_total, int):
+                total_count = raw_total
         elif isinstance(res, list):
             items = res
         else:
             items = []
 
-        # If we got fewer items than the limit, we've reached the end
-        if len(items) < self._limit:
-            self._has_next_page = False
+        next_offset = self._offset + len(items)
+
+        # Prefer total_count for wrapped endpoints so we don't issue an extra
+        # empty request when total_count is exactly divisible by limit.
+        if total_count is not None:
+            self._has_next_page = next_offset < total_count
         else:
-            self._offset += len(items)
-            self._has_next_page = True
+            self._has_next_page = len(items) >= self._limit
+
+        if self._has_next_page:
+            self._offset = next_offset
 
     def update_request(self, request: Request) -> None:
         if self._has_next_page:

--- a/posthog/temporal/data_imports/sources/clerk/clerk.py
+++ b/posthog/temporal/data_imports/sources/clerk/clerk.py
@@ -1,4 +1,5 @@
-from typing import Any
+import dataclasses
+from typing import Any, Optional
 
 import requests
 from requests import Request, Response
@@ -8,6 +9,19 @@ from posthog.temporal.data_imports.sources.clerk.settings import CLERK_ENDPOINTS
 from posthog.temporal.data_imports.sources.common.rest_source import RESTAPIConfig, rest_api_resource
 from posthog.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
 from posthog.temporal.data_imports.sources.common.rest_source.typing import Endpoint, EndpointResource
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+
+
+@dataclasses.dataclass
+class ClerkResumeConfig:
+    """Resume state for Clerk endpoints.
+
+    All Clerk endpoints use offset-based pagination, so the checkpoint is just
+    the next offset to fetch. On resume we re-request the saved page — duplicates
+    are deduped by the ``id`` primary key.
+    """
+
+    offset: int
 
 
 def get_resource(name: str) -> EndpointResource:
@@ -43,6 +57,15 @@ class ClerkPaginator(BasePaginator):
         self._limit = limit
         self._offset = 0
 
+    def init_request(self, request: Request) -> None:
+        # Emit the seeded offset on the first request so resume starts from the
+        # saved page. Fresh runs (offset=0) omit the param to preserve the
+        # existing URL shape.
+        if self._offset > 0:
+            if request.params is None:
+                request.params = {}
+            request.params["offset"] = self._offset
+
     def update_state(self, response: Response, data: list[Any] | None = None) -> None:
         res = response.json()
 
@@ -72,6 +95,17 @@ class ClerkPaginator(BasePaginator):
             if request.params is None:
                 request.params = {}
             request.params["offset"] = self._offset
+
+    def get_resume_state(self) -> Optional[dict[str, Any]]:
+        # rest_client only calls this when has_next_page is True, so ``_offset``
+        # already points at the page we still need to fetch.
+        return {"offset": self._offset}
+
+    def set_resume_state(self, state: dict[str, Any]) -> None:
+        offset = state.get("offset")
+        if offset is not None:
+            self._offset = int(offset)
+            self._has_next_page = True
 
 
 # Timestamp fields that need conversion from milliseconds to seconds
@@ -129,6 +163,7 @@ def clerk_source(
     endpoint: str,
     team_id: int,
     job_id: str,
+    resumable_source_manager: ResumableSourceManager[ClerkResumeConfig],
 ) -> SourceResponse:
     endpoint_config = CLERK_ENDPOINTS[endpoint]
 
@@ -155,7 +190,26 @@ def clerk_source(
         "resources": [get_resource(endpoint)],
     }
 
-    resource = rest_api_resource(config, team_id, job_id, None).add_map(_convert_timestamps)
+    # Seed the paginator from the saved checkpoint when resuming.
+    initial_paginator_state: Optional[dict[str, Any]] = None
+    if resumable_source_manager.can_resume():
+        resume_config = resumable_source_manager.load_state()
+        if resume_config is not None and resume_config.offset > 0:
+            initial_paginator_state = {"offset": resume_config.offset}
+
+    def save_checkpoint(state: Optional[dict[str, Any]]) -> None:
+        # rest_client passes None once the paginator is exhausted; nothing to persist then.
+        if state and state.get("offset") is not None:
+            resumable_source_manager.save_state(ClerkResumeConfig(offset=int(state["offset"])))
+
+    resource = rest_api_resource(
+        config,
+        team_id,
+        job_id,
+        None,
+        resume_hook=save_checkpoint,
+        initial_paginator_state=initial_paginator_state,
+    ).add_map(_convert_timestamps)
 
     return SourceResponse(
         name=endpoint,

--- a/posthog/temporal/data_imports/sources/clerk/source.py
+++ b/posthog/temporal/data_imports/sources/clerk/source.py
@@ -9,12 +9,14 @@ from posthog.schema import (
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.clerk.clerk import (
+    ClerkResumeConfig,
     clerk_source,
     validate_credentials as validate_clerk_credentials,
 )
 from posthog.temporal.data_imports.sources.clerk.settings import ENDPOINTS
-from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from posthog.temporal.data_imports.sources.common.base import FieldType, ResumableSource
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.generated_configs import ClerkSourceConfig
 
@@ -22,7 +24,7 @@ from products.data_warehouse.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class ClerkSource(SimpleSource[ClerkSourceConfig]):
+class ClerkSource(ResumableSource[ClerkSourceConfig, ClerkResumeConfig]):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.CLERK
@@ -79,10 +81,19 @@ The secret key starts with `sk_live_`.
     ) -> tuple[bool, str | None]:
         return validate_clerk_credentials(config.secret_key)
 
-    def source_for_pipeline(self, config: ClerkSourceConfig, inputs: SourceInputs) -> SourceResponse:
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[ClerkResumeConfig]:
+        return ResumableSourceManager[ClerkResumeConfig](inputs, ClerkResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: ClerkSourceConfig,
+        resumable_source_manager: ResumableSourceManager[ClerkResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
         return clerk_source(
             secret_key=config.secret_key,
             endpoint=inputs.schema_name,
             team_id=inputs.team_id,
             job_id=inputs.job_id,
+            resumable_source_manager=resumable_source_manager,
         )

--- a/posthog/temporal/data_imports/sources/clerk/tests/test_clerk.py
+++ b/posthog/temporal/data_imports/sources/clerk/tests/test_clerk.py
@@ -25,6 +25,13 @@ class TestClerkPaginator:
             ("direct_array_full_page", [{"id": f"u{i}"} for i in range(100)], True, 100),
             ("direct_array_partial_page", [{"id": "u1"}, {"id": "u2"}], False, 0),
             ("wrapped_full_page", {"data": [{"id": f"o{i}"} for i in range(100)], "total_count": 250}, True, 100),
+            # total_count exactly divisible by limit: skip the extra empty request.
+            (
+                "wrapped_full_terminal_page",
+                {"data": [{"id": f"o{i}"} for i in range(100)], "total_count": 100},
+                False,
+                0,
+            ),
             ("wrapped_partial_page", {"data": [{"id": "o1"}], "total_count": 1}, False, 0),
             ("empty_body", None, False, 0),
             ("empty_dict", {}, False, 0),
@@ -198,16 +205,17 @@ class TestClerkSourceResumeBehavior:
 
         manager.save_state.assert_not_called()
 
-    def test_saved_state_with_zero_offset_is_ignored(self) -> None:
+    @pytest.mark.parametrize("endpoint", [_DIRECT_ARRAY_ENDPOINT, _WRAPPED_ENDPOINT])
+    def test_saved_state_with_zero_offset_is_ignored(self, endpoint: str) -> None:
         # A zero-offset checkpoint is equivalent to a fresh run — don't seed.
         manager = MagicMock(spec=ResumableSourceManager)
         manager.can_resume.return_value = True
         manager.load_state.return_value = ClerkResumeConfig(offset=0)
 
         responses = [
-            _make_http_response(_partial_page(_DIRECT_ARRAY_ENDPOINT, ["u1"])),
+            _make_http_response(_partial_page(endpoint, ["u1"])),
         ]
-        sent_params = self._drive(_DIRECT_ARRAY_ENDPOINT, manager, responses)
+        sent_params = self._drive(endpoint, manager, responses)
 
         assert [p.get("offset") for p in sent_params] == [None]
 

--- a/posthog/temporal/data_imports/sources/clerk/tests/test_clerk.py
+++ b/posthog/temporal/data_imports/sources/clerk/tests/test_clerk.py
@@ -1,0 +1,218 @@
+import json
+import dataclasses
+from collections.abc import Iterable
+from typing import Any, cast
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from requests import Request, Response
+
+from posthog.temporal.data_imports.sources.clerk.clerk import ClerkPaginator, ClerkResumeConfig, clerk_source
+from posthog.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+
+
+class TestClerkPaginator:
+    def test_initial_state(self) -> None:
+        paginator = ClerkPaginator(limit=100)
+        assert paginator._limit == 100
+        assert paginator._offset == 0
+        assert paginator.has_next_page is True
+
+    @pytest.mark.parametrize(
+        ("label", "response_body", "has_next", "expected_offset"),
+        [
+            ("direct_array_full_page", [{"id": f"u{i}"} for i in range(100)], True, 100),
+            ("direct_array_partial_page", [{"id": "u1"}, {"id": "u2"}], False, 0),
+            ("wrapped_full_page", {"data": [{"id": f"o{i}"} for i in range(100)], "total_count": 250}, True, 100),
+            ("wrapped_partial_page", {"data": [{"id": "o1"}], "total_count": 1}, False, 0),
+            ("empty_body", None, False, 0),
+            ("empty_dict", {}, False, 0),
+        ],
+    )
+    def test_update_state(self, label: str, response_body: Any, has_next: bool, expected_offset: int) -> None:
+        paginator = ClerkPaginator(limit=100)
+        response = MagicMock()
+        response.json.return_value = response_body
+        paginator.update_state(response)
+        assert paginator._has_next_page is has_next
+        assert paginator._offset == expected_offset
+
+    @pytest.mark.parametrize(
+        ("label", "seeded_offset", "expected_offset_param"),
+        [
+            ("fresh_run_omits_offset", None, None),
+            ("resumed_sets_offset", 500, 500),
+        ],
+    )
+    def test_init_request(self, label: str, seeded_offset: int | None, expected_offset_param: int | None) -> None:
+        paginator = ClerkPaginator(limit=100)
+        if seeded_offset is not None:
+            paginator.set_resume_state({"offset": seeded_offset})
+
+        request = Request(method="GET", url="https://api.clerk.com/v1/users", params={"limit": 100})
+        paginator.init_request(request)
+
+        if expected_offset_param is None:
+            assert "offset" not in (request.params or {})
+        else:
+            assert request.params["offset"] == expected_offset_param
+
+    def test_update_request_sets_offset_when_next_page(self) -> None:
+        paginator = ClerkPaginator(limit=100)
+        response = MagicMock()
+        response.json.return_value = [{"id": f"u{i}"} for i in range(100)]
+        paginator.update_state(response)
+
+        request = Request(method="GET", url="https://api.clerk.com/v1/users", params={"limit": 100})
+        paginator.update_request(request)
+
+        assert request.params["offset"] == 100
+
+    def test_get_resume_state_returns_current_offset(self) -> None:
+        paginator = ClerkPaginator(limit=100)
+        response = MagicMock()
+        response.json.return_value = [{"id": f"u{i}"} for i in range(100)]
+        paginator.update_state(response)  # _offset advances to 100
+        assert paginator.get_resume_state() == {"offset": 100}
+
+    def test_set_resume_state_round_trip(self) -> None:
+        paginator = ClerkPaginator(limit=100)
+        paginator.set_resume_state({"offset": 500})
+        assert paginator._offset == 500
+        assert paginator.has_next_page is True
+        assert paginator.get_resume_state() == {"offset": 500}
+
+    def test_set_resume_state_ignores_missing_offset(self) -> None:
+        paginator = ClerkPaginator(limit=100)
+        paginator.set_resume_state({})
+        assert paginator._offset == 0
+
+
+def _make_http_response(body: Any, status_code: int = 200) -> Response:
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = json.dumps(body).encode()
+    resp.headers["Content-Type"] = "application/json"
+    return resp
+
+
+# ``users``/``invitations`` return direct arrays; ``organizations``/``organization_memberships``
+# return ``{data: [...], total_count: N}`` wrapped responses. Both flavours share the same
+# paginator semantics; the only behavioural difference is how rest_source extracts rows.
+_DIRECT_ARRAY_ENDPOINT = "users"
+_WRAPPED_ENDPOINT = "organizations"
+
+
+def _full_page(endpoint: str, prefix: str) -> Any:
+    items = [{"id": f"{prefix}{i}"} for i in range(100)]
+    if endpoint == _WRAPPED_ENDPOINT:
+        return {"data": items, "total_count": 9999}
+    return items
+
+
+def _partial_page(endpoint: str, ids: list[str]) -> Any:
+    items = [{"id": i} for i in ids]
+    if endpoint == _WRAPPED_ENDPOINT:
+        return {"data": items, "total_count": len(items)}
+    return items
+
+
+class TestClerkSourceResumeBehavior:
+    """End-to-end resume behaviour through the shared ``rest_api_resource`` path."""
+
+    def _drive(self, endpoint: str, manager: MagicMock, responses: list[Response]) -> list[dict[str, Any]]:
+        """Drive ``clerk_source`` with a mocked HTTP session and return the
+        params dict sent with each request (shallow copies — the paginator
+        mutates the underlying Request in-place between pages)."""
+        sent_params: list[dict[str, Any]] = []
+        response_iter = iter(responses)
+
+        def fake_send(request: Any, *_args: Any, **_kwargs: Any) -> Response:
+            sent_params.append(dict(request.params))
+            return next(response_iter)
+
+        with patch(
+            "posthog.temporal.data_imports.sources.common.rest_source.rest_client.requests.Session"
+        ) as MockSession:
+            mock_session = MockSession.return_value
+            mock_session.headers = {}
+            mock_session.prepare_request.side_effect = lambda req: req
+            mock_session.send.side_effect = fake_send
+
+            source_response = clerk_source(
+                secret_key="sk_live_test",
+                endpoint=endpoint,
+                team_id=123,
+                job_id="test_job",
+                resumable_source_manager=manager,
+            )
+            list(cast(Iterable[Any], source_response.items()))
+            return sent_params
+
+    @pytest.mark.parametrize("endpoint", [_DIRECT_ARRAY_ENDPOINT, _WRAPPED_ENDPOINT])
+    def test_fresh_run_saves_offset_after_each_non_terminal_page(self, endpoint: str) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+
+        responses = [
+            _make_http_response(_full_page(endpoint, "a")),
+            _make_http_response(_full_page(endpoint, "b")),
+            _make_http_response(_partial_page(endpoint, ["c1", "c2"])),
+        ]
+        sent_params = self._drive(endpoint, manager, responses)
+
+        # First request omits offset (fresh run); subsequent requests include it.
+        assert [p.get("offset") for p in sent_params] == [None, 100, 200]
+
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert saved == [
+            ClerkResumeConfig(offset=100),
+            ClerkResumeConfig(offset=200),
+        ]
+
+    @pytest.mark.parametrize("endpoint", [_DIRECT_ARRAY_ENDPOINT, _WRAPPED_ENDPOINT])
+    def test_resume_seeds_paginator_with_saved_offset(self, endpoint: str) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = True
+        manager.load_state.return_value = ClerkResumeConfig(offset=200)
+
+        responses = [
+            _make_http_response(_partial_page(endpoint, ["c1", "c2"])),
+        ]
+        sent_params = self._drive(endpoint, manager, responses)
+
+        # The very first request goes out at the resumed offset — no initial
+        # offset-less call to re-fetch the already-synced pages.
+        assert [p.get("offset") for p in sent_params] == [200]
+
+    @pytest.mark.parametrize("endpoint", [_DIRECT_ARRAY_ENDPOINT, _WRAPPED_ENDPOINT])
+    def test_terminal_single_page_does_not_save_state(self, endpoint: str) -> None:
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+
+        responses = [
+            _make_http_response(_partial_page(endpoint, ["only"])),
+        ]
+        self._drive(endpoint, manager, responses)
+
+        manager.save_state.assert_not_called()
+
+    def test_saved_state_with_zero_offset_is_ignored(self) -> None:
+        # A zero-offset checkpoint is equivalent to a fresh run — don't seed.
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = True
+        manager.load_state.return_value = ClerkResumeConfig(offset=0)
+
+        responses = [
+            _make_http_response(_partial_page(_DIRECT_ARRAY_ENDPOINT, ["u1"])),
+        ]
+        sent_params = self._drive(_DIRECT_ARRAY_ENDPOINT, manager, responses)
+
+        assert [p.get("offset") for p in sent_params] == [None]
+
+    def test_resume_config_serialization_round_trip(self) -> None:
+        cfg = ClerkResumeConfig(offset=1500)
+        as_json = json.dumps(dataclasses.asdict(cfg))
+        reconstituted = ClerkResumeConfig(**json.loads(as_json))
+        assert reconstituted == cfg


### PR DESCRIPTION
## Problem

Long full-refresh Clerk imports have no way to survive a worker restart — if a sync is interrupted mid-way through a large endpoint (e.g. `users`, `organizations`), it starts the endpoint over. The existing `ClerkSource` uses offset-based pagination through the shared `rest_api_resource` framework, but the paginator state was ephemeral.

## Changes

Convert `ClerkSource` from `SimpleSource` to `ResumableSource`, following the same pattern already used by Mailchimp (which shares the same `rest_api_resource` + offset-pagination shape).

- Add `ClerkResumeConfig(offset: int)` dataclass for the persisted checkpoint.
- Extend `ClerkPaginator` with `get_resume_state`, `set_resume_state`, and an `init_request` that seeds the saved offset on the first request of a resumed run (fresh runs still omit `offset` from the initial URL to preserve existing behaviour).
- `clerk_source` now accepts a `ResumableSourceManager[ClerkResumeConfig]`, seeds `initial_paginator_state` from the saved offset when `can_resume()` is true, and registers a `resume_hook` that persists a checkpoint after each non-terminal page. Zero-offset checkpoints are treated as fresh runs.
- `ClerkSource` implements `get_resumable_source_manager` and threads the manager through `source_for_pipeline` to the transport module.

Public config fields, schemas, credential validation, partition keys and primary keys are unchanged — this is strictly about restart-safety. Duplicates on resume are deduped via the existing `id` primary key.

## How did you test this code?

Automated tests only. Added unit tests under `clerk/tests/test_clerk.py` covering:

- `ClerkPaginator` unit behaviour: direct-array vs wrapped-response endpoints, full vs partial pages, empty responses, `init_request`/`update_request` with and without seeded offset, round-trip for `get_resume_state`/`set_resume_state`.
- End-to-end through `rest_api_resource`: fresh run saves `ClerkResumeConfig` after each non-terminal page; resumed run seeds the first request with the saved offset and does not re-fetch earlier pages; terminal single-page runs do not save state; zero-offset is treated as fresh; dataclass JSON round-trip.

Both the direct-array (`users`) and wrapped-response (`organizations`) flavours of Clerk's endpoints are exercised.

This PR was authored by an agent; no manual / in-product verification was performed beyond the unit tests above.

## Publish to changelog?

no

## Docs update

No user-visible changes.

## 🤖 LLM context

Authored by PostHog Code (Claude) based on the \`ResumableSource\` migration pattern established for Mailchimp (same \`rest_api_resource\` + offset-pagination shape). Reference implementations consulted: \`posthog/temporal/data_imports/sources/mailchimp/\`, \`posthog/temporal/data_imports/sources/klaviyo/\`, and the \`ResumableSourceManager\` contract in \`posthog/temporal/data_imports/sources/common/resumable.py\`.