### PR TITLE
feat(mcp): granular client capabilities detection

### DIFF
--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -63,7 +63,7 @@ export const POSTHOG_CODE_CONSUMER = 'posthog-code'
 export type ClientCapabilities = {
     // MCP `initialize` response includes an `instructions` field that most
     // clients inject into the model's system prompt. Codex discards it, so
-    // we skip the build + payload cost for those sessions.
+    // we skip sending it (saving the payload cost) for those sessions.
     supportsInstructions: boolean
 }
 

--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -52,6 +52,7 @@ export const CODING_AGENT_CLIENT_NAME_FRAGMENTS = [
     'zed',
     'aider',
     'copilot',
+    'gemini-cli',
 ] as const
 
 // Value sent in `x-posthog-mcp-consumer` by PostHog Code (the Tasks sandbox

--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -1,17 +1,26 @@
 /**
- * MCP client-name detection helpers.
+ * MCP client profiling and capability detection.
  *
  * `clientInfo.name` is what a client self-reports during the `initialize`
  * handshake. We use substring matching (with separators stripped and case
  * normalized) so variants like "claude-code", "Claude Code", "claude-code-cli",
  * and "claude-code/1.2.3" all resolve to the same form.
  *
- * `isCodingAgentClient` matches coding agents that surface `structuredContent`
- * to the model in preference to `content[].text`. Used to drop
- * `structuredContent` when a `formatted_results` override is set, otherwise
- * Claude Code (and friends) show raw JSON instead of the formatted table.
- * Cursor is deliberately excluded — it reads text for the model and renders
- * `structuredContent` in UI, so it does not need the workaround.
+ * The `MCPClientProfile` class owns all per-client behavior decisions:
+ *
+ * - `isCodingAgent()` matches coding agents that surface `structuredContent`
+ *   to the model in preference to `content[].text`. Used to drop
+ *   `structuredContent` when a `formatted_results` override is set, otherwise
+ *   Claude Code (and friends) show raw JSON instead of the formatted table.
+ *   Cursor is deliberately excluded — it reads text for the model and renders
+ *   `structuredContent` in UI, so it does not need the workaround.
+ *
+ * - `isPostHogCodeConsumer()` matches the `x-posthog-mcp-consumer` header
+ *   sent by the PostHog Code Tasks wrapper.
+ *
+ * - `capabilities` is a feature-flag-style object describing protocol
+ *   features the client actually implements (e.g. `supportsInstructions` —
+ *   Codex ignores the `instructions` field returned from `initialize`).
  */
 
 function normalizeClientName(s: string): string {
@@ -45,16 +54,84 @@ export const CODING_AGENT_CLIENT_NAME_FRAGMENTS = [
     'copilot',
 ] as const
 
-export function isCodingAgentClient(clientName: string | undefined): boolean {
-    return matchesAnyFragment(clientName, CODING_AGENT_CLIENT_NAME_FRAGMENTS)
-}
-
 // Value sent in `x-posthog-mcp-consumer` by PostHog Code (the Tasks sandbox
 // wrapper around the Claude Agent SDK) when the task was launched from the
 // PostHog Code UI. Used to force coding-agent behavior and to gate UI-apps
 // emission in single-exec mode. Slack-launched runs send `"slack"` instead.
 export const POSTHOG_CODE_CONSUMER = 'posthog-code'
 
+export type ClientCapabilities = {
+    // MCP `initialize` response includes an `instructions` field that most
+    // clients inject into the model's system prompt. Codex discards it, so
+    // we skip the build + payload cost for those sessions.
+    supportsInstructions: boolean
+}
+
+export const DEFAULT_CLIENT_CAPABILITIES: ClientCapabilities = {
+    supportsInstructions: true,
+}
+
+type CapabilityOverride = {
+    fragments: readonly string[]
+    capabilities: Partial<ClientCapabilities>
+}
+
+const CLIENT_CAPABILITY_OVERRIDES: readonly CapabilityOverride[] = [
+    {
+        fragments: ['codex'],
+        capabilities: { supportsInstructions: false },
+    },
+]
+
+type MCPClientProfileInput = {
+    clientName?: string | undefined
+    clientVersion?: string | undefined
+    consumer?: string | undefined
+}
+
+export class MCPClientProfile {
+    readonly clientName: string | undefined
+    readonly clientVersion: string | undefined
+    readonly consumer: string | undefined
+
+    private _capabilities: ClientCapabilities | undefined
+
+    constructor(input: MCPClientProfileInput) {
+        this.clientName = input.clientName
+        this.clientVersion = input.clientVersion
+        this.consumer = input.consumer
+    }
+
+    isCodingAgent(): boolean {
+        return matchesAnyFragment(this.clientName, CODING_AGENT_CLIENT_NAME_FRAGMENTS)
+    }
+
+    isPostHogCodeConsumer(): boolean {
+        return this.consumer === POSTHOG_CODE_CONSUMER
+    }
+
+    get capabilities(): ClientCapabilities {
+        if (!this._capabilities) {
+            this._capabilities = this._resolveCapabilities()
+        }
+        return this._capabilities
+    }
+
+    private _resolveCapabilities(): ClientCapabilities {
+        const resolved: ClientCapabilities = { ...DEFAULT_CLIENT_CAPABILITIES }
+        for (const override of CLIENT_CAPABILITY_OVERRIDES) {
+            if (matchesAnyFragment(this.clientName, override.fragments)) {
+                Object.assign(resolved, override.capabilities)
+            }
+        }
+        return resolved
+    }
+}
+
+export function isCodingAgentClient(clientName: string | undefined): boolean {
+    return new MCPClientProfile({ clientName }).isCodingAgent()
+}
+
 export function isPostHogCodeConsumer(mcpConsumer: string | undefined): boolean {
-    return mcpConsumer === POSTHOG_CODE_CONSUMER
+    return new MCPClientProfile({ consumer: mcpConsumer }).isPostHogCodeConsumer()
 }

--- a/services/mcp/src/mcp.ts
+++ b/services/mcp/src/mcp.ts
@@ -16,7 +16,7 @@ import {
 } from '@/lib/analytics'
 import { buildToolResultPayload, isToolCallPayload } from '@/lib/build-tool-result'
 import { DurableObjectCache } from '@/lib/cache/DurableObjectCache'
-import { isCodingAgentClient, isPostHogCodeConsumer } from '@/lib/client-detection'
+import { MCPClientProfile } from '@/lib/client-detection'
 import {
     CUSTOM_API_BASE_URL,
     POSTHOG_EU_BASE_URL,
@@ -477,6 +477,12 @@ export class MCP extends McpAgent<Env> {
         // registration decisions with an undefined client name.
         this._seedClientInfoFromProps()
 
+        const clientProfile = new MCPClientProfile({
+            clientName: this._mcpClientName,
+            clientVersion: this._mcpClientVersion,
+            consumer: this.requestProperties.mcpConsumer,
+        })
+
         // Start feature flag resolution in parallel with cache seeding
         const flagPromise = this.resolveVersionFlag()
         const toolFlagsPromise = this.resolveToolFeatureFlags(clientVersion)
@@ -521,8 +527,7 @@ export class MCP extends McpAgent<Env> {
         // wrapper self-identifies via the `x-posthog-mcp-consumer` header and forces
         // single-exec regardless of the wrapped client's reported name.
         const useSingleExec =
-            singleExecFlagOn &&
-            (isCodingAgentClient(this._mcpClientName) || isPostHogCodeConsumer(this.requestProperties.mcpConsumer))
+            singleExecFlagOn && (clientProfile.isCodingAgent() || clientProfile.isPostHogCodeConsumer())
         const version = useSingleExec ? 2 : (flagVersion ?? clientVersion ?? 1)
 
         // Fetch group types and metadata in parallel (cache is now seeded)
@@ -587,7 +592,8 @@ export class MCP extends McpAgent<Env> {
                       queryToolInfos
                   )
                 : buildInstructionsV1(INSTRUCTIONS_TEMPLATE_V1, metadata)
-        const instructions = useSingleExec ? '' : standardInstructions
+        const instructions =
+            useSingleExec || !clientProfile.capabilities.supportsInstructions ? '' : standardInstructions
 
         this.server = new McpServer({ name: 'PostHog', version: '1.0.0' }, { instructions })
 

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 
 import {
     CODING_AGENT_CLIENT_NAME_FRAGMENTS,
+    DEFAULT_CLIENT_CAPABILITIES,
+    MCPClientProfile,
     POSTHOG_CODE_CONSUMER,
     isCodingAgentClient,
     isPostHogCodeConsumer,
@@ -105,5 +107,89 @@ describe('isPostHogCodeConsumer', () => {
 
     it('returns false for undefined', () => {
         expect(isPostHogCodeConsumer(undefined)).toBe(false)
+    })
+})
+
+describe('MCPClientProfile', () => {
+    describe('isCodingAgent()', () => {
+        it.each([['claude-code'], ['Codex CLI'], ['cline'], ['zed-editor'], ['GitHub Copilot Chat']])(
+            'returns true for %s',
+            (clientName) => {
+                expect(new MCPClientProfile({ clientName }).isCodingAgent()).toBe(true)
+            }
+        )
+
+        it.each([['Claude Desktop'], ['cursor'], ['mcp-inspector'], [''], ['   ']])(
+            'returns false for %s',
+            (clientName) => {
+                expect(new MCPClientProfile({ clientName }).isCodingAgent()).toBe(false)
+            }
+        )
+
+        it('returns false when clientName is undefined', () => {
+            expect(new MCPClientProfile({}).isCodingAgent()).toBe(false)
+        })
+    })
+
+    describe('isPostHogCodeConsumer()', () => {
+        it('returns true for the exact consumer value', () => {
+            expect(new MCPClientProfile({ consumer: POSTHOG_CODE_CONSUMER }).isPostHogCodeConsumer()).toBe(true)
+        })
+
+        it.each([['slack'], ['posthog'], ['PostHog-Code'], ['']])('returns false for %s', (consumer) => {
+            expect(new MCPClientProfile({ consumer }).isPostHogCodeConsumer()).toBe(false)
+        })
+
+        it('returns false when consumer is undefined', () => {
+            expect(new MCPClientProfile({}).isPostHogCodeConsumer()).toBe(false)
+        })
+    })
+
+    describe('capabilities.supportsInstructions', () => {
+        it.each([['codex'], ['Codex'], ['CODEX'], ['codex-cli'], ['Codex CLI'], ['codex/1.2.3'], ['openai-codex']])(
+            'is false for Codex variant %s',
+            (clientName) => {
+                expect(new MCPClientProfile({ clientName }).capabilities.supportsInstructions).toBe(false)
+            }
+        )
+
+        it.each([
+            ['claude-code'],
+            ['Claude Code'],
+            ['Claude Desktop'],
+            ['cursor'],
+            ['cline'],
+            ['mcp-inspector'],
+            ['windsurf'],
+            ['zed'],
+        ])('is true for non-Codex client %s', (clientName) => {
+            expect(new MCPClientProfile({ clientName }).capabilities.supportsInstructions).toBe(true)
+        })
+
+        it.each([[undefined], [''], ['   ']])('defaults to true for %s', (clientName) => {
+            expect(new MCPClientProfile({ clientName }).capabilities.supportsInstructions).toBe(true)
+        })
+    })
+
+    it('caches capabilities across reads', () => {
+        const profile = new MCPClientProfile({ clientName: 'codex' })
+        expect(profile.capabilities).toBe(profile.capabilities)
+    })
+
+    it('exposes constructor inputs as readonly fields', () => {
+        const profile = new MCPClientProfile({
+            clientName: 'claude-code',
+            clientVersion: '1.2.3',
+            consumer: POSTHOG_CODE_CONSUMER,
+        })
+        expect(profile.clientName).toBe('claude-code')
+        expect(profile.clientVersion).toBe('1.2.3')
+        expect(profile.consumer).toBe(POSTHOG_CODE_CONSUMER)
+    })
+})
+
+describe('DEFAULT_CLIENT_CAPABILITIES', () => {
+    it('has supportsInstructions=true by default', () => {
+        expect(DEFAULT_CLIENT_CAPABILITIES.supportsInstructions).toBe(true)
     })
 })


### PR DESCRIPTION
## Problem

We need a way to detect capabilities and features available on specific clients so we can deliver the best experience. For example:
- Codex doesn't support the MCP instructions field – rely more on the tool descriptions.
- All other coding agents support the instructions field, meaning even if the single exec tool is offloaded, we can inject additional details about functionality available in the MCP to shortcut the exploratory phase.

## Changes

- **Introduced `MCPClientProfile` class** to centralize all per-client behavior decisions:
  - `isCodingAgent()` - identifies coding agents that need `structuredContent` handling
  - `isPostHogCodeConsumer()` - detects PostHog Code Tasks wrapper
  - `capabilities` - feature-flag-style object for protocol features clients implement

- **Added `ClientCapabilities` type** with `supportsInstructions` flag:
  - Defaults to `true` for all clients
  - Overridden to `false` for Codex variants (which discard the `instructions` field)
  - Capability overrides are extensible via `CLIENT_CAPABILITY_OVERRIDES`

- **Refactored existing functions** to use `MCPClientProfile`:
  - `isCodingAgentClient()` now delegates to `MCPClientProfile.isCodingAgent()`
  - `isPostHogCodeConsumer()` now delegates to `MCPClientProfile.isPostHogCodeConsumer()`

- **Updated MCP initialization** to:
  - Create a single `MCPClientProfile` instance with all available client info
  - Skip `instructions` field when `!clientProfile.capabilities.supportsInstructions`
  - Use profile methods instead of standalone functions

- **Updated documentation** to reflect the new architecture and explain each capability

## How did you test this code?

Added comprehensive unit tests covering:
- `MCPClientProfile.isCodingAgent()` with various client name variants
- `MCPClientProfile.isPostHogCodeConsumer()` with exact and non-matching consumer values
- `capabilities.supportsInstructions` behavior for Codex variants and other clients
- Capability caching across multiple reads
- Constructor input exposure as readonly fields
- `DEFAULT_CLIENT_CAPABILITIES` constant

All existing tests for `isCodingAgentClient()` and `isPostHogCodeConsumer()` continue to pass, ensuring backward compatibility.

## Publish to changelog?

No

https://claude.ai/code/session_015NtYKPxJkFmB7ZrUYx88nk