### PR TITLE
fix(sql-editor): stop monaco find widget tooltip flicker

### DIFF
--- a/frontend/src/lib/monaco/CodeEditor.scss
+++ b/frontend/src/lib/monaco/CodeEditor.scss
@@ -14,6 +14,28 @@
     }
 }
 
+// Workaround for https://github.com/microsoft/monaco-editor/issues/5208 —
+// the find widget's action-bar tooltip flickers when its rich layout stacks
+// the label and keybinding onto two lines, making the container tall enough
+// to overlap the button. Force a single-row layout so the tooltip stays
+// short and clear of the button. Scoped to when the find widget is open so
+// tooltips on other action bars are unaffected.
+body:has(.monaco-editor .find-widget.visible) .workbench-hover-container {
+    pointer-events: none !important;
+
+    &,
+    .hover-row,
+    .hover-contents,
+    .action-container,
+    .actions-container {
+        display: flex !important;
+        flex-flow: row nowrap !important;
+        gap: 6px !important;
+        align-items: center !important;
+        white-space: nowrap !important;
+    }
+}
+
 .editor-wrapper .monaco-editor,
 .editor-wrapper .monaco-diff-editor,
 .editor-wrapper .overflow-guard {


### PR DESCRIPTION
## Problem

When using the SQL editor (or any Monaco-backed code editor), opening the find widget with <kbd>Cmd/Ctrl</kbd>+<kbd>F</kbd> and hovering the close <kbd>X</kbd> button — or the "Find in selection" button — triggers an infinite tooltip show/hide loop. While flickering, clicks on the button don't register, so the only way to close the find widget is with the <kbd>Escape</kbd> key.

This is the upstream Monaco bug tracked at [microsoft/monaco-editor#5208](https://github.com/microsoft/monaco-editor/issues/5208).

### Root cause

Monaco's workbench hover renders the action-bar button tooltip with the label and the keybinding as stacked flex items (e.g. `Close` / `(Escape)`). The resulting two-line container is tall enough to overlap the trigger button, which Monaco's internal hover tracker interprets as "mouse left the target" — it destroys the tooltip, the cursor is back on the button, a new tooltip is created, and the cycle repeats.

### Before / after

| Before | After |
| --- | --- |
| <img alt="ezgif-6a27b28411fc4ac4" src="https://github.com/user-attachments/assets/cd8472d7-6708-4dda-8e88-f8e327a34954" /> | <img alt="after" src="https://github.com/user-attachments/assets/31ffb953-3a47-4fc0-a15f-c12a6eb0b4bd" /> |

## Changes

`frontend/src/lib/monaco/CodeEditor.scss`: add a scoped CSS override that forces the workbench hover container (and its inner rows) into a single-row flex layout with `nowrap`, so the label + keybinding render side-by-side instead of stacking. With the container short enough to stay clear of the button, the flicker loop doesn't start.

Scoping notes:

- The rule only applies while the find widget is visible (`body:has(.monaco-editor .find-widget.visible) ...`), so tooltips on other Monaco action bars (suggest widget, parameter hints, peek, diff editor) are left untouched.
- `pointer-events: none` is a defence-in-depth addition so the tooltip can't intercept mouse events while shown.

Alternatives considered:

- `pointer-events: none` alone — didn't break the loop (confirmed here and in the upstream issue).
- Repositioning the container with `transform` / `margin` — didn't break the loop; the internal tracker still fired mouseleave.
- `display: none` on `.workbench-hover-container` — worked, but globally removes the tooltip everywhere action bars are used.

## How did you test this code?

👀 

## Publish to changelog?

no

## 🤖 LLM context

Co-authored with Claude Code. The fix went through several iterations — `pointer-events: none`, repositioning, and `display: none` were all tried before settling on the single-row flex layout, which keeps the tooltip visible without triggering the overlap that starts the flicker loop. See upstream issue [microsoft/monaco-editor#5208](https://github.com/microsoft/monaco-editor/issues/5208) for the underlying bug.