### PR TITLE
feat(llma): emit llma_clustering_* metrics for eval clustering

### DIFF
--- a/posthog/temporal/llm_analytics/evaluation_clustering/workflow.py
+++ b/posthog/temporal/llm_analytics/evaluation_clustering/workflow.py
@@ -23,6 +23,11 @@ from posthog.temporal.llm_analytics.evaluation_clustering.models import (
     SamplerWorkflowResult,
 )
 from posthog.temporal.llm_analytics.evaluation_clustering.sampling import sample_and_embed_for_job_activity
+from posthog.temporal.llm_analytics.trace_clustering.metrics import (
+    record_clusters_generated,
+    record_items_analyzed,
+    record_noise_points,
+)
 
 
 @workflow.defn(name=SAMPLER_WORKFLOW_NAME)
@@ -192,6 +197,9 @@ class LLMAEvaluationClusteringWorkflow(PostHogWorkflow):
                 window_end=window_end,
             )
 
+        record_items_analyzed(len(compute_result.eval_ids), "evaluation")
+        record_noise_points(compute_result.num_noise_points, "evaluation")
+
         # 2. Metadata
         metadata_result = await workflow.execute_activity(
             fetch_evaluation_metadata_activity,
@@ -275,6 +283,8 @@ class LLMAEvaluationClusteringWorkflow(PostHogWorkflow):
             heartbeat_timeout=EMIT_HEARTBEAT_TIMEOUT,
             retry_policy=EMIT_ACTIVITY_RETRY_POLICY,
         )
+
+        record_clusters_generated(emit_result.metrics.num_clusters, "evaluation")
 
         return SamplerWorkflowResult(
             team_id=inputs.team_id,

--- a/posthog/temporal/llm_analytics/trace_clustering/metrics.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/metrics.py
@@ -49,13 +49,22 @@ CLUSTERING_LATENCY_HISTOGRAM_BUCKETS = [
 # ---------------------------------------------------------------------------
 
 CLUSTERING_ACTIVITY_TYPES = {
+    # trace / generation clustering (shared module)
     "perform_clustering_compute_activity",
     "generate_cluster_labels_activity",
     "emit_cluster_events_activity",
+    # evaluation clustering (Stage B) — shares the llma_clustering_* metric family
+    # via analysis_level="evaluation"
+    "perform_evaluation_clustering_compute_activity",
+    "fetch_evaluation_metadata_activity",
+    "generate_evaluation_cluster_labels_activity",
+    "compute_evaluation_cluster_aggregates_activity",
+    "emit_evaluation_cluster_events_activity",
 }
 
 CLUSTERING_WORKFLOW_TYPES = {
     "llma-trace-clustering",
+    "llma-evaluation-clustering",
 }
 
 # ---------------------------------------------------------------------------
@@ -167,13 +176,19 @@ class _ClusteringWorkflowInterceptor(WorkflowInboundInterceptor):
         if workflow_info.workflow_type not in CLUSTERING_WORKFLOW_TYPES:
             return await super().execute_workflow(input)
 
-        # Parse analysis_level from workflow args for metric labels
-        analysis_level = "trace"
-        if input.args:
-            try:
-                analysis_level = input.args[0].analysis_level
-            except (IndexError, AttributeError):
-                pass
+        # analysis_level label: the trace/generation workflow carries it in the input
+        # (same workflow type handles both levels), while evaluation clustering is a
+        # distinct workflow type whose input shape has no such field — infer from the
+        # workflow name instead.
+        if workflow_info.workflow_type == "llma-evaluation-clustering":
+            analysis_level = "evaluation"
+        else:
+            analysis_level = "trace"
+            if input.args:
+                try:
+                    analysis_level = input.args[0].analysis_level
+                except (IndexError, AttributeError):
+                    pass
 
         increment_workflow_started(analysis_level)
 

--- a/posthog/temporal/llm_analytics/trace_clustering/metrics.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/metrics.py
@@ -20,6 +20,9 @@ from temporalio.worker import (
     WorkflowInterceptorClassInput,
 )
 
+from posthog.temporal.llm_analytics.evaluation_clustering.constants import (
+    CLUSTERING_WORKFLOW_NAME as EVAL_CLUSTERING_WORKFLOW_NAME,
+)
 from posthog.temporal.llm_analytics.metrics import ExecutionTimeRecorder, get_metric_meter
 
 # ---------------------------------------------------------------------------
@@ -64,7 +67,7 @@ CLUSTERING_ACTIVITY_TYPES = {
 
 CLUSTERING_WORKFLOW_TYPES = {
     "llma-trace-clustering",
-    "llma-evaluation-clustering",
+    EVAL_CLUSTERING_WORKFLOW_NAME,
 }
 
 # ---------------------------------------------------------------------------
@@ -180,7 +183,7 @@ class _ClusteringWorkflowInterceptor(WorkflowInboundInterceptor):
         # (same workflow type handles both levels), while evaluation clustering is a
         # distinct workflow type whose input shape has no such field — infer from the
         # workflow name instead.
-        if workflow_info.workflow_type == "llma-evaluation-clustering":
+        if workflow_info.workflow_type == EVAL_CLUSTERING_WORKFLOW_NAME:
             analysis_level = "evaluation"
         else:
             analysis_level = "trace"

--- a/posthog/temporal/llm_analytics/trace_clustering/tests/test_metrics.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/tests/test_metrics.py
@@ -66,11 +66,16 @@ class TestClusteringMetricsInterceptor:
 class TestCounterHelpers:
     @parameterized.expand(
         [
-            ("increment_workflow_started", increment_workflow_started, ["trace"]),
-            ("increment_workflow_finished", increment_workflow_finished, ["completed", "trace"]),
-            ("record_items_analyzed", record_items_analyzed, [100, "trace"]),
-            ("record_clusters_generated", record_clusters_generated, [5, "trace"]),
-            ("record_noise_points", record_noise_points, [10, "trace"]),
+            ("increment_workflow_started_trace", increment_workflow_started, ["trace"]),
+            ("increment_workflow_started_evaluation", increment_workflow_started, ["evaluation"]),
+            ("increment_workflow_finished_trace", increment_workflow_finished, ["completed", "trace"]),
+            ("increment_workflow_finished_evaluation", increment_workflow_finished, ["completed", "evaluation"]),
+            ("record_items_analyzed_trace", record_items_analyzed, [100, "trace"]),
+            ("record_items_analyzed_evaluation", record_items_analyzed, [100, "evaluation"]),
+            ("record_clusters_generated_trace", record_clusters_generated, [5, "trace"]),
+            ("record_clusters_generated_evaluation", record_clusters_generated, [5, "evaluation"]),
+            ("record_noise_points_trace", record_noise_points, [10, "trace"]),
+            ("record_noise_points_evaluation", record_noise_points, [10, "evaluation"]),
         ]
     )
     def test_counter_emits_in_temporal_context(self, _name, fn, args):

--- a/posthog/temporal/llm_analytics/trace_clustering/tests/test_metrics.py
+++ b/posthog/temporal/llm_analytics/trace_clustering/tests/test_metrics.py
@@ -17,6 +17,13 @@ from posthog.temporal.llm_analytics.trace_clustering.metrics import (
 
 class TestActivityAndWorkflowTypes:
     def test_activity_types_match_actual_defns(self):
+        from posthog.temporal.llm_analytics.evaluation_clustering.activities import (
+            compute_evaluation_cluster_aggregates_activity,
+            emit_evaluation_cluster_events_activity,
+            fetch_evaluation_metadata_activity,
+            generate_evaluation_cluster_labels_activity,
+            perform_evaluation_clustering_compute_activity,
+        )
         from posthog.temporal.llm_analytics.trace_clustering.activities import (
             emit_cluster_events_activity,
             generate_cluster_labels_activity,
@@ -27,13 +34,21 @@ class TestActivityAndWorkflowTypes:
             perform_clustering_compute_activity.__name__,
             generate_cluster_labels_activity.__name__,
             emit_cluster_events_activity.__name__,
+            perform_evaluation_clustering_compute_activity.__name__,
+            fetch_evaluation_metadata_activity.__name__,
+            generate_evaluation_cluster_labels_activity.__name__,
+            compute_evaluation_cluster_aggregates_activity.__name__,
+            emit_evaluation_cluster_events_activity.__name__,
         }
         assert CLUSTERING_ACTIVITY_TYPES == actual_names
 
     def test_workflow_types_match_actual_defns(self):
+        from posthog.temporal.llm_analytics.evaluation_clustering.constants import (
+            CLUSTERING_WORKFLOW_NAME as EVAL_CLUSTERING_WORKFLOW_NAME,
+        )
         from posthog.temporal.llm_analytics.trace_clustering.constants import WORKFLOW_NAME
 
-        assert CLUSTERING_WORKFLOW_TYPES == {WORKFLOW_NAME}
+        assert CLUSTERING_WORKFLOW_TYPES == {WORKFLOW_NAME, EVAL_CLUSTERING_WORKFLOW_NAME}
 
 
 class TestClusteringMetricsInterceptor:


### PR DESCRIPTION
## Problem

Stage B eval clustering (PR4 of the #54890–#54907 stack) was ported from `trace_clustering/` but the custom `llma_clustering_*` Prometheus metric calls weren't mirrored. Result: five panels on the `llma-summarization-clustering` Grafana dashboard stay dark for any `analysis_level="evaluation"` series:

- Clustering Items Analyzed
- Clusters Generated
- Noise Points
- Clustering Errors by Type
- Clustering Activity Latency

Gap surfaced while registering the eval clustering schedules in prod on 2026-04-23 — schedules fire fine, but the eval-specific clustering signal never reaches Grafana.

## Changes

Two production files:

**`trace_clustering/metrics.py`** — extend `ClusteringMetricsInterceptor` allow-lists to cover eval clustering:

- `CLUSTERING_WORKFLOW_TYPES` — add `llma-evaluation-clustering` (the Stage B per-job workflow; the sampler and both coordinators stay out since they're not clustering).
- `CLUSTERING_ACTIVITY_TYPES` — add the 5 eval Stage B activity names (`perform_evaluation_clustering_compute_activity`, `fetch_evaluation_metadata_activity`, `generate_evaluation_cluster_labels_activity`, `compute_evaluation_cluster_aggregates_activity`, `emit_evaluation_cluster_events_activity`).
- `_ClusteringWorkflowInterceptor` — infer `analysis_level="evaluation"` from the workflow type name. Trace/generation clustering uses a single workflow type and carries the level in the input; eval is a distinct workflow type whose input shape has no such field.

**`evaluation_clustering/workflow.py`** — mirror the three `record_*` call sites from `trace_clustering/workflow.py`:

- `record_items_analyzed(len(compute_result.eval_ids), "evaluation")` and `record_noise_points(compute_result.num_noise_points, "evaluation")` after the compute activity succeeds and we commit to clustering (past the `skip_reason` early return).
- `record_clusters_generated(emit_result.metrics.num_clusters, "evaluation")` after the emit activity.

Test update: `trace_clustering/tests/test_metrics.py::TestActivityAndWorkflowTypes` now reflects the widened allow-lists.

Dashboard widening (regex + `\$WorkflowType` options) was already applied directly to Grafana (`llma-summarization-clustering` v33 on 2026-04-23). This PR completes the other half so the custom metric panels populate too.

## How did you test this code?

- `hogli test posthog/temporal/llm_analytics/trace_clustering/tests/test_metrics.py posthog/temporal/llm_analytics/evaluation_clustering/tests/` — 88 tests pass.
- `ruff check` + `ruff format` clean.

No manual in-prod validation by the agent — this is a metric emission change, so the signal surfaces on the next Stage B run (daily schedule, next fire 2026-04-24 06:00Z). Tracked checkpoints in the `llma-eval-clustering` skill's Observability section.

## Publish to changelog?

no

## 🤖 LLM context

Agent-authored follow-up to the eval clustering 6-PR stack (#54890–#54907, all merged 2026-04-23). Gap identified while registering the two new Temporal schedules on the `temporal-worker-llm-analytics` workers (prod-eu and prod-us) — `llma_coordinator_*` counters emit fine, Temporal built-in metrics flow, but the five `llma_clustering_*` custom-counter panels stay dark for the new `analysis_level="evaluation"` series. Tracked as `beads-tracking-hvn2`; skill `llma-eval-clustering` v7+ covers it under Observability > Gap.